### PR TITLE
fix: add Help (?) button to demo page navigation (issue #20337)

### DIFF
--- a/submissions/core_changes-issue-20337/README.md
+++ b/submissions/core_changes-issue-20337/README.md
@@ -1,0 +1,87 @@
+# Core Changes Proposal: Issue #20337
+
+## Problem Description
+
+Issue [#20337](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/20337) reports that the demo page (`docs/demo.html`) is missing a Help (?) button, leaving users unable to access help information, FAQs, or guidance.
+
+The current navigation bar at `docs/demo.html` (lines 302–307) contains:
+
+```html
+<ul class="demo-nav-links">
+  <li><a href="#buttons">Buttons</a></li>
+  <li><a href="#cards">Cards</a></li>
+  <li><a href="#animations">Animations</a></li>
+  <li><a href="#layout">Layout</a></li>
+  <li><a href="./">Docs</a></li>
+</ul>
+```
+
+There is no help icon or link.
+
+## Proposed Fix
+
+Add a Help (?) button to the navigation bar, linking to a help modal or the project's documentation. Two options:
+
+### Option A: Simple link to FAQ/docs
+
+```html
+<li><a href="https://github.com/SAPTARSHI-coder/EaseMotion-css#readme" title="Help">?</a></li>
+```
+
+### Option B: Interactive help button with tooltip
+
+Replace the closing `</ul>` with an additional list item styled as a help button:
+
+```html
+<li>
+  <button
+    class="demo-help-btn ease-hover-grow"
+    aria-label="Help"
+    title="Help &amp; Support"
+    onclick="window.open('https://github.com/SAPTARSHI-coder/EaseMotion-css#readme', '_blank')"
+  >
+    <svg viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="12" cy="12" r="10"></circle>
+      <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"></path>
+      <line x1="12" y1="17" x2="12.01" y2="17"></line>
+    </svg>
+  </button>
+</li>
+```
+
+With the accompanying CSS added to the `docs/demo.html` `<style>` block:
+
+```css
+.demo-help-btn {
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.65);
+  cursor: pointer;
+  padding: 6px 10px;
+  border-radius: var(--ease-radius-md);
+  font-size: var(--ease-text-sm);
+  display: flex;
+  align-items: center;
+  transition: color var(--ease-speed-fast) var(--ease-ease),
+              background-color var(--ease-speed-fast) var(--ease-ease);
+}
+
+.demo-help-btn:hover {
+  color: #ffffff;
+  background: rgba(108, 99, 255, 0.12);
+}
+```
+
+This adds a visible `?` icon that links to the project's documentation, making help accessible from any page.
+
+## Why this is submitted here
+
+Per the `CONTRIBUTING.md` policy and Core Framework Protection, this fix is proposed as a formal submission in the `submissions/` directory rather than modifying `docs/demo.html` directly.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `docs/demo.html` (nav section) | Add Help (?) button with link to project docs |
+
+Fixes #20337

--- a/submissions/core_changes-issue-20337/demo.html
+++ b/submissions/core_changes-issue-20337/demo.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Issue #20337 — Missing Help (?) Button in Demo Page</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main>
+        <h1>Core Fix Proposal for Issue #20337</h1>
+        <p>
+            The demo page <code>docs/demo.html</code> navigation bar is missing a
+            Help (?) button, leaving users unable to easily access guidance.
+        </p>
+
+        <div class="comparison">
+            <div class="side bad">
+                <h2>Before (Missing)</h2>
+                <div class="nav-mock">
+                    <div class="nav-brand">EaseMotion</div>
+                    <div class="nav-items">
+                        <span>Buttons</span>
+                        <span>Cards</span>
+                        <span>Animations</span>
+                        <span>Layout</span>
+                        <span>Docs</span>
+                        <span class="theme-tog">🌙</span>
+                    </div>
+                </div>
+                <div class="code-block">
+                    <span class="line">&lt;li&gt;&lt;a href="#buttons"&gt;Buttons&lt;/a&gt;&lt;/li&gt;</span>
+                    <span class="line">&lt;li&gt;&lt;a href="./"&gt;Docs&lt;/a&gt;&lt;/li&gt;</span>
+                    <span class="line dim">&lt;!-- No help button --&gt;</span>
+                </div>
+                <p class="result fail">No help access available</p>
+            </div>
+
+            <div class="side good">
+                <h2>After (Fixed)</h2>
+                <div class="nav-mock">
+                    <div class="nav-brand">EaseMotion</div>
+                    <div class="nav-items">
+                        <span>Buttons</span>
+                        <span>Cards</span>
+                        <span>Animations</span>
+                        <span>Layout</span>
+                        <span>Docs</span>
+                        <span class="help-btn">?</span>
+                        <span class="theme-tog">🌙</span>
+                    </div>
+                </div>
+                <div class="code-block">
+                    <span class="line">&lt;li&gt;&lt;a href="#buttons"&gt;Buttons&lt;/a&gt;&lt;/li&gt;</span>
+                    <span class="line">&lt;li&gt;&lt;a href="./"&gt;Docs&lt;/a&gt;&lt;/li&gt;</span>
+                    <span class="line diff-add">+&lt;li&gt;</span>
+                    <span class="line diff-add">+  &lt;button class="demo-help-btn" aria-label="Help"&gt;?&lt;/button&gt;</span>
+                    <span class="line diff-add">+&lt;/li&gt;</span>
+                </div>
+                <p class="result pass">Help button visible and accessible</p>
+            </div>
+        </div>
+
+        <div class="preview-section">
+            <h2>Live Preview of Help Button</h2>
+            <div class="preview-bar">
+                <span class="p-brand">EaseMotion</span>
+                <div class="p-links">
+                    <span>Buttons</span>
+                    <span>Cards</span>
+                    <span>Animations</span>
+                    <span>Layout</span>
+                    <span>Docs</span>
+                    <button class="p-help" aria-label="Help">?</button>
+                </div>
+            </div>
+            <p class="preview-note">Hover the <strong>?</strong> button above to see the hover effect.</p>
+        </div>
+
+        <p class="note">See <code>README.md</code> for the full proposed changes to <code>docs/demo.html</code>.</p>
+    </main>
+</body>
+</html>

--- a/submissions/core_changes-issue-20337/style.css
+++ b/submissions/core_changes-issue-20337/style.css
@@ -1,0 +1,275 @@
+/* Issue #20337 — Missing Help (?) Button in Demo Page
+   Proposed fix: add Help button to docs/demo.html navigation */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0b1121;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+main {
+  max-width: 800px;
+  width: 100%;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: #f8fafc;
+}
+
+h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+p {
+  color: #94a3b8;
+  line-height: 1.6;
+  margin-bottom: 1.5rem;
+}
+
+code {
+  background: #1e293b;
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+  font-size: 0.875em;
+  color: #e2e8f0;
+}
+
+.comparison {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.side {
+  background: #1e293b;
+  border-radius: 8px;
+  padding: 1.25rem;
+  border: 1px solid #334155;
+}
+
+.side.bad { border-color: #ef4444; }
+.side.good { border-color: #22c55e; }
+
+.nav-mock {
+  background: #0f172a;
+  border-radius: 8px;
+  padding: 0.6rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+  font-size: 0.85rem;
+}
+
+.nav-brand {
+  font-weight: 700;
+  background: linear-gradient(135deg, #6c63ff, #a78bfa);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.nav-items {
+  display: flex;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.nav-items span {
+  color: #94a3b8;
+  font-size: 0.75rem;
+}
+
+.help-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 50%;
+  background: rgba(108, 99, 255, 0.15);
+  color: #a78bfa;
+  font-weight: 700;
+  font-size: 0.85rem;
+  cursor: pointer;
+  border: 1px solid rgba(108, 99, 255, 0.25);
+}
+
+.theme-tog {
+  font-size: 0.9rem;
+}
+
+.code-block {
+  background: #0f172a;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.82rem;
+  line-height: 1.6;
+  overflow-x: auto;
+}
+
+.line {
+  display: block;
+  white-space: pre;
+}
+
+.line.dim {
+  color: #475569;
+  font-style: italic;
+}
+
+.line.diff-add {
+  color: #86efac;
+  background: rgba(34, 197, 94, 0.1);
+}
+
+.result {
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.4rem 0.75rem;
+  border-radius: 4px;
+  text-align: center;
+  margin-top: 0.75rem;
+}
+
+.result.fail {
+  background: rgba(239, 68, 68, 0.15);
+  color: #fca5a5;
+}
+
+.result.pass {
+  background: rgba(34, 197, 94, 0.15);
+  color: #86efac;
+}
+
+/* ── Live Preview ── */
+.preview-section {
+  background: #1e293b;
+  border-radius: 8px;
+  padding: 1.25rem;
+  border: 1px solid #334155;
+  margin-bottom: 1.5rem;
+}
+
+.preview-bar {
+  background: #0f172a;
+  border-radius: 8px;
+  padding: 0.6rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid #1e293b;
+}
+
+.p-brand {
+  font-weight: 700;
+  background: linear-gradient(135deg, #6c63ff, #a78bfa);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  font-size: 0.9rem;
+}
+
+.p-links {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.p-links span {
+  color: #94a3b8;
+  font-size: 0.75rem;
+}
+
+.p-help {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 50%;
+  background: rgba(108, 99, 255, 0.12);
+  color: #a78bfa;
+  font-weight: 700;
+  font-size: 0.9rem;
+  cursor: pointer;
+  border: none;
+  transition: background 0.2s, color 0.2s, box-shadow 0.2s;
+}
+
+.p-help:hover {
+  background: rgba(108, 99, 255, 0.25);
+  color: #c4b5fd;
+  box-shadow: 0 0 12px rgba(108, 99, 255, 0.3);
+}
+
+.preview-note {
+  font-size: 0.8rem;
+  color: #64748b;
+  margin-top: 0.75rem;
+  margin-bottom: 0;
+  text-align: center;
+}
+
+.note {
+  text-align: center;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    transition: none !important;
+    animation: none !important;
+  }
+}
+
+/* PROPOSED FIX FOR docs/demo.html:
+
+   In the nav section (around line 307), add after the Docs link:
+
+   <li>
+     <button
+       class="demo-help-btn ease-hover-grow"
+       aria-label="Help"
+       title="Help & Support"
+       onclick="window.open('https://github.com/SAPTARSHI-coder/EaseMotion-css', '_blank')"
+     >
+       <svg viewBox="0 0 24 24" width="18" height="18"
+            stroke="currentColor" stroke-width="2" fill="none"
+            stroke-linecap="round" stroke-linejoin="round">
+         <circle cx="12" cy="12" r="10"></circle>
+         <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"></path>
+         <line x1="12" y1="17" x2="12.01" y2="17"></line>
+       </svg>
+     </button>
+   </li>
+
+   And add to the <style> block:
+
+   .demo-help-btn {
+     background: none; border: none;
+     color: rgba(255,255,255,0.65); cursor: pointer;
+     padding: 6px 10px; border-radius: var(--ease-radius-md);
+     display: flex; align-items: center;
+     transition: color var(--ease-speed-fast) var(--ease-ease),
+                 background-color var(--ease-speed-fast) var(--ease-ease);
+   }
+   .demo-help-btn:hover {
+     color: #fff; background: rgba(108,99,255,0.12);
+   }
+*/


### PR DESCRIPTION
## Description

Closes #20337

The demo page `docs/demo.html` navigation bar has no Help button, leaving users without easy access to guidance.

This submission proposes adding a `?` help button with an SVG help icon to the nav links area, linking to the project documentation. Includes CSS for hover styling and proper ARIA labeling.

See `submissions/core_changes-issue-20337/README.md` for details.