### PR TITLE
feat: add empty-cells showcase utilities

### DIFF
--- a/submissions/examples/empty-cells-showcase-ap/README.md
+++ b/submissions/examples/empty-cells-showcase-ap/README.md
@@ -1,0 +1,120 @@
+# EaseMotion CSS — Empty-Cells Showcase
+
+This directory implements core utility classes for controlling the CSS `empty-cells` property in EaseMotion CSS, allowing you to manage the rendering of borders and backgrounds around empty cells in tabular layouts.
+
+---
+
+## What is Empty Cells?
+
+The `empty-cells` property determines whether cells with no visible content should render their borders and backgrounds:
+
+- **show** (Shorthand `.empty-cells-show`): Borders and backgrounds are fully rendered around empty cells (default browser behavior).
+- **hide** (Shorthand `.empty-cells-hide`): Borders and backgrounds are completely hidden, leaving empty slots open.
+
+> [!IMPORTANT]
+> The `empty-cells` property is only effective when `border-collapse` is set to `separate`. If the table uses `border-collapse: collapse;`, empty-cell styles are merged into adjacent boundaries and the property has no effect.
+
+---
+
+## Utility Classes Reference
+
+EaseMotion CSS provides empty-cells selectors, border-collapse settings, border-spacing coordinates, and responsive breakpoint overrides:
+
+### 1. Empty-Cells Utilities
+
+| Utility Class       | CSS Equivalent                  | Description                                 |
+| :------------------ | :------------------------------ | :------------------------------------------ |
+| `.empty-cells-show` | `empty-cells: show !important;` | Renders borders/backgrounds on empty cells. |
+| `.empty-cells-hide` | `empty-cells: hide !important;` | Hides borders/backgrounds on empty cells.   |
+
+### 2. Border Collapse Utilities
+
+- `.border-collapse` (`border-collapse: collapse !important;`)
+- `.border-separate` (`border-collapse: separate !important;`)
+
+### 3. Border Spacing Utilities (Requires separate borders)
+
+Set horizontal/vertical spacing gaps between cell borders:
+
+- Axis-Both: `.border-spacing-0` (0px) to `.border-spacing-16` (64px)
+- Horizontal: `.border-spacing-x-0` (0px) to `.border-spacing-x-8` (32px)
+- Vertical: `.border-spacing-y-0` (0px) to `.border-spacing-y-8` (32px)
+
+### 4. Responsive Breakpoints
+
+Adjust table rendering modes dynamically on mobile and tablet viewport sizes:
+
+- `.sm-empty-cells-show`, `.sm-empty-cells-hide` (Mobile viewports, `max-width: 768px`).
+- `.md-empty-cells-show`, `.md-empty-cells-hide` (Tablet viewports, `max-width: 1024px`).
+
+---
+
+## Usage Examples
+
+### 1. Cleaning up Calendar/Schedule Grids (Hide Empty Cells)
+
+```html
+<table class="border-separate border-spacing-1 empty-cells-hide">
+  <thead>
+    <tr>
+      <th>Time</th>
+      <th>Monday</th>
+      <th>Tuesday</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>10:00 AM</td>
+      <td style="background-color: var(--color-bg-surface-hover);">
+        Gym Session
+      </td>
+      <!-- Empty cell borders/background will be hidden cleanly -->
+      <td></td>
+    </tr>
+  </tbody>
+</table>
+```
+
+### 2. Feature Checklist Matrices (Show Empty Cells)
+
+```html
+<table class="border-separate border-spacing-1 empty-cells-show">
+  <thead>
+    <tr>
+      <th>Feature</th>
+      <th>Free Plan</th>
+      <th>Pro Plan</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Dashboard Export</td>
+      <!-- Empty cell remains visible to maintain tabular row visual structure -->
+      <td></td>
+      <td>✔</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+---
+
+## CRITICAL ACCESSIBILITY (WCAG 2.1) BENEFITS
+
+> [!IMPORTANT]
+> Hiding empty cells visually does not alter how screen readers or keyboard navigation interact with the layout cells.
+
+1. **Success Criterion 1.3.1 - Info and Relationships**: Screen readers traverse tables sequentially. Visually hidden empty cells still exist in the DOM structure. Ensure that empty cells have placeholder text (such as "N/A" or "-") or are marked with `aria-hidden="true"` to prevent confusion during keyboard reading flows.
+2. **Maintains Tabular Grid References**: Using `.empty-cells-show` in dense checklists preserves grid coordinates, helping users with screen magnifiers track feature items across rows.
+
+---
+
+## Verification & Testing
+
+Verify visual empty-cells behavior by launching `demo.html` in your browser. Toggle the dropdown parameters to observe table grid changes.
+
+To run the project test suite, execute:
+
+```bash
+npm test
+```

--- a/submissions/examples/empty-cells-showcase-ap/demo.html
+++ b/submissions/examples/empty-cells-showcase-ap/demo.html
@@ -1,0 +1,299 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EaseMotion CSS — Empty-Cells Utilities Sandbox</title>
+    <!-- Outfit & Fira Code Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;600&family=Outfit:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="app-container">
+      <!-- Header Section -->
+      <header class="header">
+        <h1>Empty-Cells & Border-Spacing</h1>
+        <p>
+          Control whether borders and backgrounds are rendered around empty
+          table cells. Pair with separate border modes and adjustable
+          border-spacing coordinates to construct clean, modular grid tables.
+        </p>
+      </header>
+
+      <!-- Sandbox Section -->
+      <h2 class="section-title">Interactive Table Sandbox</h2>
+      <div class="sandbox">
+        <!-- Control Panel -->
+        <aside class="controls-pane">
+          <div class="control-group">
+            <label class="control-label" for="empty-cells-select"
+              >Empty Cells Mode</label
+            >
+            <select id="empty-cells-select" class="control-select">
+              <option value="empty-cells-show" selected>
+                empty-cells-show (default)
+              </option>
+              <option value="empty-cells-hide">empty-cells-hide</option>
+            </select>
+          </div>
+
+          <div class="control-group">
+            <label class="control-label" for="collapse-select"
+              >Border Collapse</label
+            >
+            <select id="collapse-select" class="control-select">
+              <option value="border-separate" selected>
+                border-separate (required for empty-cells)
+              </option>
+              <option value="border-collapse">border-collapse</option>
+            </select>
+          </div>
+
+          <div class="control-group">
+            <label class="control-label" for="spacing-select"
+              >Border Spacing</label
+            >
+            <select id="spacing-select" class="control-select">
+              <option value="border-spacing-0">border-spacing-0 (0px)</option>
+              <option value="border-spacing-1">border-spacing-1 (4px)</option>
+              <option value="border-spacing-2" selected>
+                border-spacing-2 (8px)
+              </option>
+              <option value="border-spacing-3">border-spacing-3 (12px)</option>
+              <option value="border-spacing-4">border-spacing-4 (16px)</option>
+              <option value="border-spacing-6">border-spacing-6 (24px)</option>
+              <option value="border-spacing-8">border-spacing-8 (32px)</option>
+            </select>
+          </div>
+        </aside>
+
+        <!-- Sandbox Visualizer Display -->
+        <div class="sandbox-display">
+          <table
+            id="visual-table"
+            class="visual-table border-separate border-spacing-2 empty-cells-show"
+          >
+            <thead>
+              <tr>
+                <th>Column A</th>
+                <th>Column B</th>
+                <th>Column C</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Data Cell 1</td>
+                <td>Data Cell 2</td>
+                <td>Data Cell 3</td>
+              </tr>
+              <tr>
+                <td>Data Cell 4</td>
+                <!-- Target Empty Cell -->
+                <td id="empty-cell-1" class="empty-cell-target"></td>
+                <td>Data Cell 5</td>
+              </tr>
+              <tr>
+                <!-- Target Empty Cell -->
+                <td id="empty-cell-2" class="empty-cell-target"></td>
+                <td>Data Cell 6</td>
+                <td>Data Cell 7</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Code Preview -->
+        <div class="code-preview-pane">
+          <h4>Generated CSS Classes</h4>
+          <pre id="code-preview" class="code-preview">
+&lt;table class="border-separate border-spacing-2 empty-cells-show"&gt;\n  &lt;!-- Columns and Rows --&gt;\n&lt;/table&gt;</pre
+          >
+        </div>
+      </div>
+
+      <!-- Real-World Layout Applications -->
+      <h2 class="section-title">Design Use-Cases</h2>
+      <div class="use-cases-grid">
+        <!-- Weekly schedule card -->
+        <div class="demo-card">
+          <h3 class="demo-card-title">1. Clean Fitness Class Schedules</h3>
+          <p class="demo-card-desc">
+            Hiding empty slots (<code>empty-cells-hide</code>) in a weekly
+            schedule creates a lightweight, uncluttered card grid where empty
+            blocks simply dissolve into the background.
+          </p>
+          <div class="demo-card-render">
+            <table
+              class="schedule-table border-separate border-spacing-1 empty-cells-hide"
+              style="width: 100%"
+            >
+              <thead>
+                <tr>
+                  <th>Time</th>
+                  <th>Mon</th>
+                  <th>Tue</th>
+                  <th>Wed</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>09:00</td>
+                  <td style="background-color: rgba(59, 130, 246, 0.2)">
+                    Yoga
+                  </td>
+                  <!-- Empty -->
+                  <td></td>
+                  <td style="background-color: rgba(59, 130, 246, 0.2)">
+                    Pilates
+                  </td>
+                </tr>
+                <tr>
+                  <td>11:00</td>
+                  <!-- Empty -->
+                  <td></td>
+                  <td style="background-color: rgba(16, 185, 129, 0.2)">
+                    Zumba
+                  </td>
+                  <!-- Empty -->
+                  <td></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <!-- Pricing Checklist Matrix -->
+        <div class="demo-card">
+          <h3 class="demo-card-title">2. SaaS Features Checklist Matrix</h3>
+          <p class="demo-card-desc">
+            In pricing matrices, keeping empty feature indicators visible
+            (<code>empty-cells-show</code>) preserves grid rows, aligning
+            checkmarks across rows.
+          </p>
+          <div class="demo-card-render">
+            <table
+              class="comparison-table border-separate border-spacing-1 empty-cells-show"
+              style="width: 100%"
+            >
+              <thead>
+                <tr>
+                  <th>Feature</th>
+                  <th>Free</th>
+                  <th>Pro</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Analytics</td>
+                  <!-- Empty shown -->
+                  <td></td>
+                  <td class="feature-check">✔</td>
+                </tr>
+                <tr>
+                  <td>API Access</td>
+                  <!-- Empty shown -->
+                  <td></td>
+                  <td class="feature-check">✔</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <!-- Accessibility Rules Panel -->
+      <h2 class="section-title">Accessibility Guidance (WCAG 2.1)</h2>
+      <div class="a11y-grid">
+        <div class="a11y-panel">
+          <div class="a11y-badge">Success Criterion 1.3.1</div>
+          <h3>Grid & Info Relationships</h3>
+          <p>
+            Hiding an empty cell visually does <strong>not</strong> remove it
+            from the accessibility DOM tree. Screen readers will still read out
+            hidden table cells during keyboard navigation. Ensure empty cells
+            have placeholder labels (like "N/A" or "-") or
+            <code>aria-hidden="true"</code> if they are purely decorative layout
+            boxes.
+          </p>
+        </div>
+
+        <div class="a11y-panel">
+          <div class="a11y-badge success">Prerequisites</div>
+          <h3>Border Collapse Rules</h3>
+          <p>
+            The <code>empty-cells</code> property only functions when
+            <code>border-collapse</code> is set to <code>separate</code>. If the
+            table uses <code>border-collapse: collapse;</code>, empty-cell
+            borders are merged into adjacent cells, making empty-cell rules
+            ineffective.
+          </p>
+        </div>
+      </div>
+
+      <!-- Footer Section -->
+      <footer class="footer">
+        <p>
+          EaseMotion CSS — Created for GSSoC 2026. View issue on
+          <a
+            href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/16560"
+            target="_blank"
+            rel="noopener noreferrer"
+            >GitHub #16560</a
+          >.
+        </p>
+      </footer>
+    </div>
+
+    <!-- JavaScript Interactive Logic -->
+    <script>
+      (function () {
+        const emptyCellsSelect = document.getElementById("empty-cells-select");
+        const collapseSelect = document.getElementById("collapse-select");
+        const spacingSelect = document.getElementById("spacing-select");
+        const visualTable = document.getElementById("visual-table");
+        const emptyCell1 = document.getElementById("empty-cell-1");
+        const emptyCell2 = document.getElementById("empty-cell-2");
+        const codePreview = document.getElementById("code-preview");
+
+        function updateSandbox() {
+          const emptyCellsClass = emptyCellsSelect.value;
+          const collapseClass = collapseSelect.value;
+          const spacingClass = spacingSelect.value;
+
+          // Clear previous classes
+          visualTable.className = "visual-table";
+
+          // Add selected classes
+          visualTable.classList.add(emptyCellsClass);
+          visualTable.classList.add(collapseClass);
+          visualTable.classList.add(spacingClass);
+
+          // Update empty cells content labels
+          if (emptyCellsClass === "empty-cells-show") {
+            emptyCell1.textContent = "empty";
+            emptyCell2.textContent = "empty";
+          } else {
+            emptyCell1.textContent = "";
+            emptyCell2.textContent = "";
+          }
+
+          // Update code preview
+          codePreview.textContent = `<table class="${collapseClass} ${spacingClass} ${emptyCellsClass}">\n  <thead>\n    <tr>\n      <th>Column A</th>\n      <th>Column B</th>\n      <th>Column C</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <td>Data Cell 1</td>\n      <td>Data Cell 2</td>\n      <td>Data Cell 3</td>\n    </tr>\n    <tr>\n      <td>Data Cell 4</td>\n      <td></td> <!-- Empty Cell -->\n      <td>Data Cell 5</td>\n    </tr>\n  </tbody>\n</table>`;
+        }
+
+        // Add event listeners
+        emptyCellsSelect.addEventListener("change", updateSandbox);
+        collapseSelect.addEventListener("change", updateSandbox);
+        spacingSelect.addEventListener("change", updateSandbox);
+
+        // Initial setup
+        updateSandbox();
+      })();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/empty-cells-showcase-ap/style.css
+++ b/submissions/examples/empty-cells-showcase-ap/style.css
@@ -1,0 +1,539 @@
+/* ============================================================
+   EaseMotion CSS — Empty-Cells & Border-Spacing Utilities
+   Controls visibility of borders/backgrounds for empty table cells.
+   ============================================================ */
+
+/* ------------------------------------------------------------
+   DESIGN SYSTEM TOKENS & SYSTEM PROPERTIES
+   ------------------------------------------------------------ */
+:root {
+  --color-bg-base: #030712;
+  --color-bg-surface: #0b0f19;
+  --color-bg-surface-hover: #111827;
+  --color-border-subtle: #1f2937;
+  --color-border-hover: #374151;
+
+  --color-text-primary: #f9fafb;
+  --color-text-secondary: #9ca3af;
+  --color-text-muted: #6b7280;
+
+  --color-accent-pink: #ec4899;
+  --color-accent-blue: #3b82f6;
+  --color-accent-violet: #8b5cf6;
+  --color-accent-emerald: #10b981;
+  --color-accent-amber: #f59e0b;
+
+  --color-brand-gradient: linear-gradient(
+    135deg,
+    #3b82f6 0%,
+    #8b5cf6 50%,
+    #ec4899 100%
+  );
+
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  --shadow-md:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+  --shadow-lg:
+    0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+
+  --transition-smooth: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  --font-display:
+    "Outfit", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-mono: "Fira Code", "Courier New", Courier, monospace;
+
+  /* Spacing scale */
+  --ease-space-0: 0rem;
+  --ease-space-1: 0.25rem;
+  --ease-space-2: 0.5rem;
+  --ease-space-3: 0.75rem;
+  --ease-space-4: 1rem;
+  --ease-space-5: 1.25rem;
+  --ease-space-6: 1.5rem;
+  --ease-space-8: 2rem;
+  --ease-space-10: 2.5rem;
+  --ease-space-12: 3rem;
+  --ease-space-16: 4rem;
+}
+
+/* ------------------------------------------------------------
+   CORE EMPTY-CELLS UTILITIES
+   ------------------------------------------------------------ */
+.empty-cells-show {
+  empty-cells: show !important;
+}
+
+.empty-cells-hide {
+  empty-cells: hide !important;
+}
+
+/* ------------------------------------------------------------
+   BORDER COLLAPSE UTILITIES
+   ------------------------------------------------------------ */
+.border-collapse {
+  border-collapse: collapse !important;
+}
+
+.border-separate {
+  border-collapse: separate !important;
+}
+
+/* ------------------------------------------------------------
+   BORDER SPACING UTILITIES (Requires separate borders)
+   ------------------------------------------------------------ */
+
+/* Axis-both border spacing */
+.border-spacing-0 {
+  border-spacing: var(--ease-space-0) var(--ease-space-0) !important;
+}
+.border-spacing-1 {
+  border-spacing: var(--ease-space-1) var(--ease-space-1) !important;
+}
+.border-spacing-2 {
+  border-spacing: var(--ease-space-2) var(--ease-space-2) !important;
+}
+.border-spacing-3 {
+  border-spacing: var(--ease-space-3) var(--ease-space-3) !important;
+}
+.border-spacing-4 {
+  border-spacing: var(--ease-space-4) var(--ease-space-4) !important;
+}
+.border-spacing-5 {
+  border-spacing: var(--ease-space-5) var(--ease-space-5) !important;
+}
+.border-spacing-6 {
+  border-spacing: var(--ease-space-6) var(--ease-space-6) !important;
+}
+.border-spacing-8 {
+  border-spacing: var(--ease-space-8) var(--ease-space-8) !important;
+}
+.border-spacing-10 {
+  border-spacing: var(--ease-space-10) var(--ease-space-10) !important;
+}
+.border-spacing-12 {
+  border-spacing: var(--ease-space-12) var(--ease-space-12) !important;
+}
+.border-spacing-16 {
+  border-spacing: var(--ease-space-16) var(--ease-space-16) !important;
+}
+
+/* Horizontal border spacing */
+.border-spacing-x-0 {
+  border-spacing: var(--ease-space-0) 0px !important;
+}
+.border-spacing-x-1 {
+  border-spacing: var(--ease-space-1) 0px !important;
+}
+.border-spacing-x-2 {
+  border-spacing: var(--ease-space-2) 0px !important;
+}
+.border-spacing-x-3 {
+  border-spacing: var(--ease-space-3) 0px !important;
+}
+.border-spacing-x-4 {
+  border-spacing: var(--ease-space-4) 0px !important;
+}
+.border-spacing-x-6 {
+  border-spacing: var(--ease-space-6) 0px !important;
+}
+.border-spacing-x-8 {
+  border-spacing: var(--ease-space-8) 0px !important;
+}
+
+/* Vertical border spacing */
+.border-spacing-y-0 {
+  border-spacing: 0px var(--ease-space-0) !important;
+}
+.border-spacing-y-1 {
+  border-spacing: 0px var(--ease-space-1) !important;
+}
+.border-spacing-y-2 {
+  border-spacing: 0px var(--ease-space-2) !important;
+}
+.border-spacing-y-3 {
+  border-spacing: 0px var(--ease-space-3) !important;
+}
+.border-spacing-y-4 {
+  border-spacing: 0px var(--ease-space-4) !important;
+}
+.border-spacing-y-6 {
+  border-spacing: 0px var(--ease-space-6) !important;
+}
+.border-spacing-y-8 {
+  border-spacing: 0px var(--ease-space-8) !important;
+}
+
+/* ------------------------------------------------------------
+   RESPONSIVE BREAKPOINTS (sm: <= 768px, md: <= 1024px)
+   ------------------------------------------------------------ */
+@media (max-width: 1024px) {
+  .md-empty-cells-show {
+    empty-cells: show !important;
+  }
+  .md-empty-cells-hide {
+    empty-cells: hide !important;
+  }
+  .md-border-spacing-2 {
+    border-spacing: var(--ease-space-2) var(--ease-space-2) !important;
+  }
+  .md-border-spacing-4 {
+    border-spacing: var(--ease-space-4) var(--ease-space-4) !important;
+  }
+}
+
+@media (max-width: 768px) {
+  .sm-empty-cells-show {
+    empty-cells: show !important;
+  }
+  .sm-empty-cells-hide {
+    empty-cells: hide !important;
+  }
+  .sm-border-spacing-1 {
+    border-spacing: var(--ease-space-1) var(--ease-space-1) !important;
+  }
+  .sm-border-spacing-2 {
+    border-spacing: var(--ease-space-2) var(--ease-space-2) !important;
+  }
+}
+
+/* ============================================================
+   DEMO PLAYGROUND SANDBOX STYLING
+   ============================================================ */
+
+body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--color-bg-base);
+  color: var(--color-text-primary);
+  font-family: var(--font-display);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+.app-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem;
+}
+
+/* Header styling */
+.header {
+  margin-bottom: 3.5rem;
+  border-bottom: 1px solid var(--color-border-subtle);
+  padding-bottom: 2rem;
+}
+
+.header h1 {
+  font-size: 2.8rem;
+  font-weight: 800;
+  margin: 0 0 0.5rem 0;
+  background: var(--color-brand-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  letter-spacing: -0.025em;
+}
+
+.header p {
+  font-size: 1.1rem;
+  color: var(--color-text-secondary);
+  max-width: 800px;
+  margin: 0;
+}
+
+/* Section Title */
+.section-title {
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin: 3rem 0 1.5rem 0;
+  letter-spacing: -0.02em;
+  color: var(--color-text-primary);
+  border-left: 4px solid var(--color-accent-violet);
+  padding-left: 0.75rem;
+}
+
+/* Interactive Sandbox Grid */
+.sandbox {
+  display: grid;
+  grid-template-columns: 350px 1fr;
+  gap: 2rem;
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 12px;
+  padding: 2rem;
+  box-shadow: var(--shadow-lg);
+  margin-bottom: 3rem;
+}
+
+/* Controls Pane */
+.controls-pane {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.control-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.control-select {
+  background-color: var(--color-bg-base);
+  border: 1px solid var(--color-border-subtle);
+  color: var(--color-text-primary);
+  padding: 0.6rem 0.8rem;
+  border-radius: 6px;
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  outline: none;
+  transition: var(--transition-smooth);
+}
+
+.control-select:focus {
+  border-color: var(--color-accent-violet);
+}
+
+/* Sandbox Visualizer Display */
+.sandbox-display {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(3, 7, 18, 0.6);
+  border-radius: 8px;
+  border: 1px dashed var(--color-border-subtle);
+  min-height: 400px;
+  padding: 2rem;
+  position: relative;
+  overflow-x: auto;
+}
+
+/* Table styling for visual target */
+.visual-table {
+  width: 100%;
+  max-width: 500px;
+  border-collapse: separate;
+  border-spacing: 8px;
+  transition:
+    border-collapse 0.25s ease,
+    border-spacing 0.25s ease;
+}
+
+.visual-table th,
+.visual-table td {
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--color-border-hover);
+  background-color: var(--color-bg-surface);
+  text-align: center;
+  font-size: 0.9rem;
+  border-radius: 6px;
+  transition: all 0.25s ease;
+}
+
+.visual-table th {
+  background-color: rgba(139, 92, 246, 0.15);
+  color: var(--color-accent-violet);
+  font-weight: 700;
+  border-color: rgba(139, 92, 246, 0.3);
+}
+
+/* Highlight custom visual guides for empty cells */
+.visual-table td.empty-cell-target {
+  background-color: rgba(236, 72, 153, 0.05);
+  border: 1px dashed rgba(236, 72, 153, 0.3);
+  color: var(--color-accent-pink);
+  font-style: italic;
+  font-size: 0.8rem;
+}
+
+/* Live Code Block */
+.code-preview-pane {
+  grid-column: 1 / -1;
+  background-color: rgba(3, 7, 18, 0.9);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  margin-top: 1rem;
+}
+
+.code-preview-pane h4 {
+  margin: 0 0 0.5rem 0;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.code-preview {
+  font-family: var(--font-mono);
+  color: var(--color-accent-pink);
+  margin: 0;
+  font-size: 0.9rem;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+/* ------------------------------------------------------------
+   USE CASE DEMO CARDS
+   ------------------------------------------------------------ */
+.use-cases-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 3rem;
+}
+
+.demo-card {
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 10px;
+  padding: 1.5rem;
+  transition: var(--transition-smooth);
+}
+
+.demo-card:hover {
+  border-color: var(--color-border-hover);
+}
+
+.demo-card-title {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin: 0 0 0.5rem 0;
+  color: var(--color-text-primary);
+}
+
+.demo-card-desc {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.demo-card-render {
+  background-color: rgba(3, 7, 18, 0.4);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 6px;
+  padding: 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 220px;
+}
+
+/* Schedule and Comparison Tables */
+.schedule-table,
+.comparison-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 4px;
+}
+
+.schedule-table th,
+.schedule-table td,
+.comparison-table th,
+.comparison-table td {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-border-subtle);
+  font-size: 0.8rem;
+  text-align: center;
+  border-radius: 4px;
+}
+
+.schedule-table th,
+.comparison-table th {
+  background-color: var(--color-bg-surface-hover);
+  color: var(--color-text-primary);
+  font-weight: 600;
+}
+
+.comparison-table td.feature-check {
+  color: var(--color-accent-emerald);
+  font-weight: 700;
+}
+
+/* ------------------------------------------------------------
+   ACCESSIBILITY GRID
+   ------------------------------------------------------------ */
+.a11y-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-bottom: 4rem;
+}
+
+.a11y-panel {
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 10px;
+  padding: 1.75rem;
+}
+
+.a11y-panel h3 {
+  font-size: 1.3rem;
+  margin: 0 0 1rem 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.a11y-panel p {
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+  line-height: 1.6;
+  margin: 0 0 1rem 0;
+}
+
+.a11y-badge {
+  display: inline-block;
+  padding: 0.2rem 0.6rem;
+  background-color: rgba(245, 158, 11, 0.1);
+  color: var(--color-accent-amber);
+  border: 1px solid rgba(245, 158, 11, 0.2);
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+.a11y-badge.success {
+  background-color: rgba(16, 185, 129, 0.1);
+  color: var(--color-accent-emerald);
+  border-color: rgba(16, 185, 129, 0.2);
+}
+
+/* ------------------------------------------------------------
+   FOOTER SECTION
+   ------------------------------------------------------------ */
+.footer {
+  text-align: center;
+  border-top: 1px solid var(--color-border-subtle);
+  padding-top: 2rem;
+  margin-top: 4rem;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+.footer a {
+  color: var(--color-accent-blue);
+  text-decoration: none;
+  transition: var(--transition-smooth);
+}
+
+.footer a:hover {
+  text-decoration: underline;
+}
+
+/* Responsive adjustment for app layout */
+@media (max-width: 900px) {
+  .sandbox {
+    grid-template-columns: 1fr;
+  }
+  .a11y-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
### Description
This PR adds native, comprehensive empty-cells and border-spacing utilities to EaseMotion CSS. These classes configure border/background visibility for empty table cells (`empty-cells-show` and `empty-cells-hide`), border-collapse toggles, and detailed border-spacing coordinates scales.

This submission has **958 lines of changes**, which satisfies the line count requirement (500+ lines) for the level:advanced badge.

### Checklist
- [x] Folder added inside `submissions/examples/` with name `empty-cells-showcase-ap`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Verified with `npm test`

Closes #16560