### PR TITLE
feat: add Scroll Reveal Animation Utility Classes (issue #20415)

### DIFF
--- a/submissions/core_changes-issue-20415/README.md
+++ b/submissions/core_changes-issue-20415/README.md
@@ -1,0 +1,110 @@
+# Core Changes Proposal: Issue #20415
+
+## Feature Overview
+Issue #20415 requests dedicated **Scroll Reveal Animation Utility Classes** for EaseMotion CSS.
+This submission proposes adding 7 reveal utility classes to `core/animations.css`:
+
+| Class | Effect |
+|-------|--------|
+| `.ease-reveal-fade` | Smooth opacity fade-in |
+| `.ease-reveal-up` | Fade-in with upward slide |
+| `.ease-reveal-down` | Fade-in with downward slide |
+| `.ease-reveal-left` | Fade-in with left-to-right slide |
+| `.ease-reveal-right` | Fade-in with right-to-left slide |
+| `.ease-reveal-zoom` | Fade-in with scale-up (0.8 → 1) |
+| `.ease-reveal-rotate` | Fade-in with subtle 3D rotation |
+
+## Proposed Implementation
+All classes use CSS `@keyframes` with `animation-fill-mode: both` so elements stay at their final visible state after the animation completes. Developers use IntersectionObserver (or a scroll library) to trigger the animation by adding the class on scroll.
+
+### Proposed CSS to add to `core/animations.css`
+
+```css
+/* ── Scroll Reveal Keyframes ── */
+@keyframes ease-reveal-fade-kf {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+@keyframes ease-reveal-up-kf {
+  from { opacity: 0; transform: translateY(40px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes ease-reveal-down-kf {
+  from { opacity: 0; transform: translateY(-40px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes ease-reveal-left-kf {
+  from { opacity: 0; transform: translateX(-40px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+@keyframes ease-reveal-right-kf {
+  from { opacity: 0; transform: translateX(40px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+@keyframes ease-reveal-zoom-kf {
+  from { opacity: 0; transform: scale(0.8); }
+  to { opacity: 1; transform: scale(1); }
+}
+@keyframes ease-reveal-rotate-kf {
+  from { opacity: 0; transform: perspective(600px) rotateX(-15deg); }
+  to { opacity: 1; transform: perspective(600px) rotateX(0); }
+}
+
+/* ── Scroll Reveal Utility Classes ── */
+.ease-reveal-fade,
+.ease-reveal-up,
+.ease-reveal-down,
+.ease-reveal-left,
+.ease-reveal-right,
+.ease-reveal-zoom,
+.ease-reveal-rotate {
+  opacity: 0;
+  animation-fill-mode: both;
+  animation-duration: 0.7s;
+  animation-timing-function: ease-out;
+}
+.ease-reveal-fade   { animation-name: ease-reveal-fade-kf; }
+.ease-reveal-up     { animation-name: ease-reveal-up-kf; }
+.ease-reveal-down   { animation-name: ease-reveal-down-kf; }
+.ease-reveal-left   { animation-name: ease-reveal-left-kf; }
+.ease-reveal-right  { animation-name: ease-reveal-right-kf; }
+.ease-reveal-zoom   { animation-name: ease-reveal-zoom-kf; }
+.ease-reveal-rotate { animation-name: ease-reveal-rotate-kf; }
+```
+
+### Usage
+```html
+<div class="ease-reveal-up">Content slides up on scroll</div>
+```
+Trigger with IntersectionObserver:
+```js
+const observer = new IntersectionObserver(entries => {
+  entries.forEach(e => { if (e.isIntersecting) e.target.style.animationPlayState = 'running'; });
+});
+document.querySelectorAll('.ease-reveal-up').forEach(el => {
+  el.style.animationPlayState = 'paused';
+  observer.observe(el);
+});
+```
+
+### Accessibility
+```css
+@media (prefers-reduced-motion: reduce) {
+  .ease-reveal-fade,
+  .ease-reveal-up,
+  .ease-reveal-down,
+  .ease-reveal-left,
+  .ease-reveal-right,
+  .ease-reveal-zoom,
+  .ease-reveal-rotate {
+    opacity: 1 !important;
+    animation: none !important;
+  }
+}
+```
+
+## Why this is submitted here
+Per CONTRIBUTING.md policy and Core Framework Protection, this feature is proposed
+as a formal submission in `submissions/` rather than modifying `core/animations.css` directly.
+
+Fixes #20415

--- a/submissions/core_changes-issue-20415/demo.html
+++ b/submissions/core_changes-issue-20415/demo.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Scroll Reveal Utilities — EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header class="demo-header">
+        <h1>Scroll Reveal<span>Utility Classes</span></h1>
+        <p>Scroll down to see each reveal effect in action</p>
+    </header>
+
+    <section class="reveal-demo" id="demo-fade">
+        <div class="reveal-card ease-reveal-fade" tabindex="0">
+            <span class="rc-icon">&#x2728;</span>
+            <h2>ease-reveal-fade</h2>
+            <p>Smooth opacity fade-in from transparent to fully visible.</p>
+            <code>&lt;div class="ease-reveal-fade"&gt;</code>
+        </div>
+    </section>
+
+    <section class="reveal-demo alt" id="demo-up">
+        <div class="reveal-card ease-reveal-up" tabindex="0">
+            <span class="rc-icon">&#x2B06;</span>
+            <h2>ease-reveal-up</h2>
+            <p>Fades in while sliding upward by 40px — great for staggered content.</p>
+            <code>&lt;div class="ease-reveal-up"&gt;</code>
+        </div>
+    </section>
+
+    <section class="reveal-demo" id="demo-down">
+        <div class="reveal-card ease-reveal-down" tabindex="0">
+            <span class="rc-icon">&#x2B07;</span>
+            <h2>ease-reveal-down</h2>
+            <p>Fades in while sliding downward. Ideal for header or hero elements.</p>
+            <code>&lt;div class="ease-reveal-down"&gt;</code>
+        </div>
+    </section>
+
+    <section class="reveal-demo alt" id="demo-left">
+        <div class="reveal-card ease-reveal-left" tabindex="0">
+            <span class="rc-icon">&#x2B05;</span>
+            <h2>ease-reveal-left</h2>
+            <p>Fades in while sliding in from the left. Works well for sidebars and panels.</p>
+            <code>&lt;div class="ease-reveal-left"&gt;</code>
+        </div>
+    </section>
+
+    <section class="reveal-demo" id="demo-right">
+        <div class="reveal-card ease-reveal-right" tabindex="0">
+            <span class="rc-icon">&#x27A1;</span>
+            <h2>ease-reveal-right</h2>
+            <p>Fades in while sliding in from the right. Pairs with ease-reveal-left for symmetry.</p>
+            <code>&lt;div class="ease-reveal-right"&gt;</code>
+        </div>
+    </section>
+
+    <section class="reveal-demo alt" id="demo-zoom">
+        <div class="reveal-card ease-reveal-zoom" tabindex="0">
+            <span class="rc-icon">&#x1F50D;</span>
+            <h2>ease-reveal-zoom</h2>
+            <p>Fades in while scaling up from 0.8x. Great for galleries and feature highlights.</p>
+            <code>&lt;div class="ease-reveal-zoom"&gt;</code>
+        </div>
+    </section>
+
+    <section class="reveal-demo" id="demo-rotate">
+        <div class="reveal-card ease-reveal-rotate" tabindex="0">
+            <span class="rc-icon">&#x1F504;</span>
+            <h2>ease-reveal-rotate</h2>
+            <p>Fades in with a subtle 3D X-axis rotation for a polished entrance.</p>
+            <code>&lt;div class="ease-reveal-rotate"&gt;</code>
+        </div>
+    </section>
+
+    <footer class="demo-footer">
+        <span>EaseMotion CSS — Scroll Reveal Utilities &middot; See README.md for proposal details</span>
+    </footer>
+
+    <script>
+    (function() {
+        var cards = document.querySelectorAll('.reveal-card');
+        cards.forEach(function(c) {
+            c.style.animationPlayState = 'paused';
+        });
+        var observer = new IntersectionObserver(function(entries) {
+            entries.forEach(function(e) {
+                if (e.isIntersecting) {
+                    e.target.style.animationPlayState = 'running';
+                }
+            });
+        }, { threshold: 0.3 });
+        cards.forEach(function(c) { observer.observe(c); });
+    })();
+    </script>
+</body>
+</html>

--- a/submissions/core_changes-issue-20415/style.css
+++ b/submissions/core_changes-issue-20415/style.css
@@ -1,0 +1,194 @@
+/* Issue #20415 — Scroll Reveal Animation Utility Classes
+   Proposal for adding 7 reveal utility classes to core/animations.css */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg-body: #0a0e1a;
+  --bg-card: rgba(14, 20, 40, 0.75);
+  --border-col: rgba(108, 99, 255, 0.12);
+  --text-primary: #e2e8f0;
+  --text-secondary: #8892b0;
+  --accent: #7c6cff;
+  --accent-dim: rgba(124, 108, 255, 0.12);
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: var(--bg-body);
+  color: var(--text-primary);
+  min-height: 100vh;
+}
+
+/* ── Proposed Core Keyframes (as they would appear in core/animations.css) ── */
+@keyframes ease-reveal-fade-kf {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes ease-reveal-up-kf {
+  from { opacity: 0; transform: translateY(40px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes ease-reveal-down-kf {
+  from { opacity: 0; transform: translateY(-40px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes ease-reveal-left-kf {
+  from { opacity: 0; transform: translateX(-40px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes ease-reveal-right-kf {
+  from { opacity: 0; transform: translateX(40px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes ease-reveal-zoom-kf {
+  from { opacity: 0; transform: scale(0.8); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+@keyframes ease-reveal-rotate-kf {
+  from { opacity: 0; transform: perspective(600px) rotateX(-15deg); }
+  to { opacity: 1; transform: perspective(600px) rotateX(0); }
+}
+
+/* ── Proposed Core Utility Classes (as they would appear in core/animations.css) ── */
+.ease-reveal-fade,
+.ease-reveal-up,
+.ease-reveal-down,
+.ease-reveal-left,
+.ease-reveal-right,
+.ease-reveal-zoom,
+.ease-reveal-rotate {
+  opacity: 0;
+  animation-fill-mode: both;
+  animation-duration: 0.7s;
+  animation-timing-function: ease-out;
+}
+
+.ease-reveal-fade   { animation-name: ease-reveal-fade-kf; }
+.ease-reveal-up     { animation-name: ease-reveal-up-kf; }
+.ease-reveal-down   { animation-name: ease-reveal-down-kf; }
+.ease-reveal-left   { animation-name: ease-reveal-left-kf; }
+.ease-reveal-right  { animation-name: ease-reveal-right-kf; }
+.ease-reveal-zoom   { animation-name: ease-reveal-zoom-kf; }
+.ease-reveal-rotate { animation-name: ease-reveal-rotate-kf; }
+
+/* ── Demo Styles ── */
+.demo-header {
+  text-align: center;
+  padding: 4rem 2rem 3rem;
+}
+
+.demo-header h1 {
+  font-size: 2.4rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #7c6cff, #a78bfa);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  line-height: 1.2;
+}
+
+.demo-header h1 span {
+  display: block;
+  font-size: 1rem;
+  font-weight: 400;
+  color: var(--text-secondary);
+  background: none;
+  -webkit-background-clip: unset;
+  background-clip: unset;
+}
+
+.demo-header p {
+  margin-top: 0.75rem;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+/* ── Reveal Sections ── */
+.reveal-demo {
+  min-height: 70vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 2rem;
+}
+
+.reveal-demo.alt {
+  background: rgba(124, 108, 255, 0.03);
+}
+
+.reveal-card {
+  max-width: 520px;
+  width: 100%;
+  padding: 2.5rem 2rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border-col);
+  border-radius: 20px;
+  backdrop-filter: blur(16px);
+  text-align: center;
+  outline: none;
+}
+
+.rc-icon {
+  font-size: 2.5rem;
+  display: block;
+  margin-bottom: 1rem;
+}
+
+.reveal-card h2 {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--accent);
+  margin-bottom: 0.75rem;
+  font-family: monospace;
+}
+
+.reveal-card p {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin-bottom: 1.25rem;
+}
+
+.reveal-card code {
+  display: inline-block;
+  padding: 0.4rem 0.8rem;
+  background: var(--accent-dim);
+  border: 1px solid rgba(124, 108, 255, 0.15);
+  border-radius: 8px;
+  font-size: 0.78rem;
+  color: #a78bfa;
+  font-family: monospace;
+}
+
+/* ── Spacer hints ── */
+.demo-footer {
+  text-align: center;
+  padding: 2rem;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  border-top: 1px solid rgba(124, 108, 255, 0.06);
+}
+
+/* ── prefers-reduced-motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-reveal-fade,
+  .ease-reveal-up,
+  .ease-reveal-down,
+  .ease-reveal-left,
+  .ease-reveal-right,
+  .ease-reveal-zoom,
+  .ease-reveal-rotate {
+    opacity: 1 !important;
+    animation: none !important;
+  }
+}
+
+/* Submission for issue #20415 — Scroll Reveal Animation Utility Classes
+   All styles are self-contained demo styles; no core framework files are modified. */


### PR DESCRIPTION
## Description

Closes #20415

Proposes 7 scroll reveal utility classes for `core/animations.css`:

| Class | Effect |
|-------|--------|
| `.ease-reveal-fade` | Smooth opacity fade-in |
| `.ease-reveal-up` | Fade-in with upward slide |
| `.ease-reveal-down` | Fade-in with downward slide |
| `.ease-reveal-left` | Fade-in with left-to-right slide |
| `.ease-reveal-right` | Fade-in with right-to-left slide |
| `.ease-reveal-zoom` | Fade-in with scale-up (0.8 to 1) |
| `.ease-reveal-rotate` | Fade-in with subtle 3D rotation |

**Demo**: A scrollable showcase with IntersectionObserver triggering each effect. Each card demonstrates one utility class with description and usage code.

**Key design decisions**:
- Animation duration 0.7s with `ease-out` timing
- `animation-fill-mode: both` keeps elements at final visible state
- Starts with `opacity: 0` for graceful degradation
- `prefers-reduced-motion: reduce` respected disables all animations, shows full opacity
- GPU-accelerated transforms (`translate`, `scale`, `rotateX`)
- Zero JS required in the utility classes themselves (IntersectionObserver is the users concern)
- See `submissions/core_changes-issue-20415/README.md` for the exact CSS to add