### PR TITLE
fix: add GitHub repository link to demo page navigation (issue #20345)

### DIFF
--- a/submissions/core_changes-issue-20345/README.md
+++ b/submissions/core_changes-issue-20345/README.md
@@ -1,0 +1,66 @@
+# Core Changes Proposal: Issue #20345
+
+## Problem Description
+
+Issue #20345 reports that the demo page (`docs/demo.html`) has no visible GitHub repository link. While a GitHub link exists in the hero section, it is not accessible from the navigation bar, making it harder for users to find the source code, report issues, or contribute.
+
+The current navigation bar at `docs/demo.html` (lines 297–332) contains:
+- Logo (left)
+- Nav links: Buttons, Cards, Animations, Layout, Docs
+- Theme toggle (right)
+
+No GitHub link is present in the nav.
+
+## Proposed Fix
+
+Add a GitHub icon button to the navigation bar's link list, positioned before the theme toggle. The button links to the project repository.
+
+### HTML to add to `<ul class="demo-nav-links">`
+
+```html
+<li>
+  <a
+    href="https://github.com/SAPTARSHI-coder/EaseMotion-css"
+    class="demo-gh-link ease-hover-grow"
+    aria-label="GitHub Repository"
+    title="GitHub Repository"
+    target="_blank"
+    rel="noopener"
+  >
+    <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
+      <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/>
+    </svg>
+  </a>
+</li>
+```
+
+### CSS to add to `docs/demo.html` `<style>` block
+
+```css
+.demo-gh-link {
+  display: flex;
+  align-items: center;
+  padding: 6px 8px;
+  color: rgba(255, 255, 255, 0.65);
+  border-radius: var(--ease-radius-md);
+  transition: color var(--ease-speed-fast) var(--ease-ease),
+              background-color var(--ease-speed-fast) var(--ease-ease);
+}
+
+.demo-gh-link:hover {
+  color: #ffffff;
+  background: rgba(108, 99, 255, 0.12);
+}
+```
+
+## Why this is submitted here
+
+Per `CONTRIBUTING.md` policy and Core Framework Protection, this fix is proposed as a formal submission in `submissions/` rather than modifying `docs/demo.html` directly.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `docs/demo.html` (nav section ~line 308) | Add GitHub icon link after "Docs" nav item |
+
+Fixes #20345

--- a/submissions/core_changes-issue-20345/demo.html
+++ b/submissions/core_changes-issue-20345/demo.html
@@ -1,0 +1,248 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Demo — GitHub Link in Nav | EaseMotion CSS</title>
+    <style>
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+        body {
+            font-family: system-ui, -apple-system, sans-serif;
+            background: #0c0f1e;
+            color: #e2e8f0;
+            min-height: 100vh;
+        }
+
+        /* ── Nav preview ── */
+        .demo-nav {
+            padding: 0.75rem 1.5rem;
+            background: rgba(14, 20, 40, 0.85);
+            border-bottom: 1px solid rgba(108, 99, 255, 0.12);
+            backdrop-filter: blur(20px);
+        }
+
+        .demo-nav-inner {
+            max-width: 1200px;
+            margin: 0 auto;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+
+        .demo-logo {
+            font-size: 1.2rem;
+            font-weight: 700;
+            color: #7c6cff;
+            text-decoration: none;
+        }
+
+        .demo-nav-links {
+            display: flex;
+            align-items: center;
+            gap: 0.25rem;
+            list-style: none;
+        }
+
+        .demo-nav-links a:not(.demo-gh-link) {
+            padding: 0.4rem 0.7rem;
+            border-radius: 6px;
+            font-size: 0.85rem;
+            color: rgba(255, 255, 255, 0.6);
+            text-decoration: none;
+            transition: color 0.2s, background 0.2s;
+        }
+
+        .demo-nav-links a:not(.demo-gh-link):hover {
+            color: #fff;
+            background: rgba(108, 99, 255, 0.08);
+        }
+
+        /* ── Proposed GitHub link style ── */
+        .demo-gh-link {
+            display: flex;
+            align-items: center;
+            padding: 6px 8px;
+            color: rgba(255, 255, 255, 0.65);
+            border-radius: 6px;
+            transition: color 0.2s, background-color 0.2s;
+        }
+
+        .demo-gh-link:hover {
+            color: #ffffff;
+            background: rgba(108, 99, 255, 0.12);
+        }
+
+        /* ── Theme toggle ── */
+        .theme-toggle-btn {
+            background: none;
+            border: none;
+            color: rgba(255, 255, 255, 0.65);
+            cursor: pointer;
+            padding: 6px 8px;
+            border-radius: 6px;
+            display: flex;
+            align-items: center;
+            transition: color 0.2s, background 0.2s;
+        }
+
+        .theme-toggle-btn:hover {
+            color: #fff;
+            background: rgba(108, 99, 255, 0.08);
+        }
+
+        /* ── Hero section ── */
+        .demo-hero {
+            text-align: center;
+            padding: 5rem 2rem 3rem;
+            max-width: 640px;
+            margin: 0 auto;
+        }
+
+        .demo-hero h1 {
+            font-size: 2.5rem;
+            font-weight: 800;
+            background: linear-gradient(135deg, #7c6cff, #a78bfa);
+            -webkit-background-clip: text;
+            background-clip: text;
+            color: transparent;
+            margin-bottom: 0.75rem;
+        }
+
+        .demo-hero p {
+            color: #8892b0;
+            font-size: 1rem;
+            line-height: 1.6;
+            margin-bottom: 1.5rem;
+        }
+
+        .demo-hero .btns {
+            display: flex;
+            gap: 0.75rem;
+            justify-content: center;
+        }
+
+        .btn {
+            display: inline-flex;
+            align-items: center;
+            padding: 0.6rem 1.25rem;
+            border-radius: 999px;
+            font-size: 0.9rem;
+            font-weight: 600;
+            text-decoration: none;
+            transition: transform 0.2s, box-shadow 0.2s;
+        }
+
+        .btn-primary {
+            background: #7c6cff;
+            color: #fff;
+        }
+
+        .btn-primary:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 4px 20px rgba(124, 108, 255, 0.35);
+        }
+
+        .btn-outline {
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            color: #e2e8f0;
+        }
+
+        .btn-outline:hover {
+            transform: translateY(-2px);
+            border-color: rgba(255, 255, 255, 0.4);
+        }
+
+        .demo-label {
+            margin-top: 3rem;
+            padding: 1rem;
+            background: rgba(124, 108, 255, 0.04);
+            border: 1px solid rgba(124, 108, 255, 0.1);
+            border-radius: 10px;
+            font-size: 0.8rem;
+            color: #8892b0;
+            text-align: center;
+            line-height: 1.6;
+        }
+
+        .demo-label code {
+            padding: 0.15rem 0.4rem;
+            background: rgba(124, 108, 255, 0.1);
+            border-radius: 4px;
+            font-size: 0.75rem;
+            color: #a78bfa;
+        }
+
+        .demo-label .highlight {
+            color: #7c6cff;
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body>
+
+    <!-- ════════════════════════════════════════════════
+         NAVIGATION (with GitHub link added)
+    ════════════════════════════════════════════════════ -->
+    <nav class="demo-nav">
+        <div class="demo-nav-inner">
+            <a href="#" class="demo-logo">EaseMotion</a>
+            <ul class="demo-nav-links">
+                <li><a href="#buttons">Buttons</a></li>
+                <li><a href="#cards">Cards</a></li>
+                <li><a href="#animations">Animations</a></li>
+                <li><a href="#layout">Layout</a></li>
+                <li><a href="#">Docs</a></li>
+                <li>
+                    <a
+                        href="https://github.com/SAPTARSHI-coder/EaseMotion-css"
+                        class="demo-gh-link"
+                        aria-label="GitHub Repository"
+                        title="GitHub Repository"
+                        target="_blank"
+                        rel="noopener"
+                    >
+                        <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
+                            <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/>
+                        </svg>
+                    </a>
+                </li>
+                <li>
+                    <button class="theme-toggle-btn" aria-label="Toggle theme">
+                        <svg viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                            <circle cx="12" cy="12" r="5"></circle>
+                            <line x1="12" y1="1" x2="12" y2="3"></line>
+                            <line x1="12" y1="21" x2="12" y2="23"></line>
+                            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+                            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+                            <line x1="1" y1="12" x2="3" y2="12"></line>
+                            <line x1="21" y1="12" x2="23" y2="12"></line>
+                            <line x1="4.22" y1="19.72" x2="5.64" y2="18.3"></line>
+                            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+                        </svg>
+                    </button>
+                </li>
+            </ul>
+        </div>
+    </nav>
+
+    <!-- ════════════════════════════════════════════════
+         HERO
+    ════════════════════════════════════════════════════ -->
+    <header class="demo-hero">
+        <h1>Build with EaseMotion</h1>
+        <p>Human-readable class names. Animation-first. No memorization required.</p>
+        <div class="btns">
+            <a href="#" class="btn btn-primary">Read Docs</a>
+            <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css" class="btn btn-outline">GitHub ↗</a>
+        </div>
+
+        <div class="demo-label">
+            <span class="highlight">Proposed change:</span> Added GitHub icon link to nav bar<br>
+            <code>&lt;li&gt;&lt;a href="https://github.com/SAPTARSHI-coder/EaseMotion-css" class="demo-gh-link" ...&gt;&lt;svg&gt;...&lt;/svg&gt;&lt;/a&gt;&lt;/li&gt;</code><br>
+            between "Docs" and the theme toggle button.
+        </div>
+    </header>
+
+</body>
+</html>

--- a/submissions/core_changes-issue-20345/style.css
+++ b/submissions/core_changes-issue-20345/style.css
@@ -1,0 +1,18 @@
+/* Issue #20345 — Add GitHub Repository Link to Demo Page
+   Proposed CSS to add to docs/demo.html <style> block */
+
+/* ── Proposed GitHub link style (for nav bar) ── */
+.demo-gh-link {
+  display: flex;
+  align-items: center;
+  padding: 6px 8px;
+  color: rgba(255, 255, 255, 0.65);
+  border-radius: var(--ease-radius-md, 6px);
+  transition: color var(--ease-speed-fast, 0.2s) var(--ease-ease, ease),
+              background-color var(--ease-speed-fast, 0.2s) var(--ease-ease, ease);
+}
+
+.demo-gh-link:hover {
+  color: #ffffff;
+  background: rgba(108, 99, 255, 0.12);
+}


### PR DESCRIPTION
## Description

Closes #20345

The demo page `docs/demo.html` navigation bar has no GitHub link, reducing discoverability of the project source code, issue tracker, and contribution guide.

While a GitHub link exists in the hero section, it is not persistently visible from the nav. Users who scroll down lose access to it.

**Proposed change for `docs/demo.html`:**
- Add a GitHub icon SVG button as a `<li>` in `demo-nav-links` between "Docs" and the theme toggle
- Link to `https://github.com/SAPTARSHI-coder/EaseMotion-css` with `target="_blank"`
- Style `.demo-gh-link` with hover glow effect (matches existing `.theme-toggle-btn` pattern)
- Proper `aria-label` and `title` for accessibility

See `submissions/core_changes-issue-20345/README.md` for the exact HTML and CSS to add.