### PR TITLE
feat(examples): add ease-input-with-prefix #19901

### DIFF
--- a/submissions/examples/ease-input-with-prefix/README.md
+++ b/submissions/examples/ease-input-with-prefix/README.md
@@ -1,0 +1,27 @@
+# ease-input-with-prefix
+
+## What does this do?
+An elegant form input component wrapper featuring:
+- A prefix segment (`ease-input-prefix`) that dynamically highlights and changes color when the associated input field receives focus
+- A modern border glow shadow (`ease-input-wrapper:focus-within`) on input focus
+- Complete support for custom theme accent colors via the `--ease-prefix-color` CSS custom property
+
+## How is it used?
+Wrap your prefix indicator and input field in the container class, specifying your custom accent color inline:
+
+```html
+<div class="ease-input-wrapper" style="--ease-prefix-color: #10b981;">
+  <div class="ease-input-prefix">$</div>
+  <input class="ease-input-field" type="number" placeholder="0.00">
+</div>
+```
+
+## Why is it useful?
+It provides visual guidance during form completion. By styling the prefix on input focus and applying a soft colored glow to the entire container, users receive clear feedback on which control is active. Highly recommended for currency and username inputs.
+
+## Tech Stack
+- HTML
+- CSS (Vanilla, using modern `:focus-within` selectors)
+
+## Preview
+Open `demo.html` directly in your browser. Click on any input field to see the prefix color update and the border shadow glow.

--- a/submissions/examples/ease-input-with-prefix/demo.html
+++ b/submissions/examples/ease-input-with-prefix/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Input Field with Prefix - EaseMotion CSS</title>
+  
+  <!-- Link to EaseMotion CSS core -->
+  <link rel="stylesheet" href="../../../core/animations.css">
+  <!-- Google Fonts for Modern Typography -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+  <!-- Link to local style.css -->
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-wrapper">
+    <header class="header">
+      <span class="badge">Input Control</span>
+      <h1>ease-input-with-prefix</h1>
+      <p class="description">
+        A styled input wrapper. When the input field is focused, the prefix section dynamically updates its color/background and the container applies a soft border glow.
+      </p>
+    </header>
+
+    <div class="forms-container">
+      
+      <!-- Example 1: Currency Input (Green Theme) -->
+      <div class="form-group">
+        <label for="currency-input">Funding Amount (USD)</label>
+        <div class="ease-input-wrapper" style="--ease-prefix-color: #10b981;">
+          <div class="ease-input-prefix">$</div>
+          <input id="currency-input" class="ease-input-field" type="number" placeholder="0.00" min="0">
+        </div>
+        <span class="helper-text">Uses custom green accent glow and prefix styling.</span>
+      </div>
+
+      <!-- Example 2: Username Input (Indigo Theme) -->
+      <div class="form-group">
+        <label for="username-input">Creator Username</label>
+        <div class="ease-input-wrapper" style="--ease-prefix-color: #6366f1;">
+          <div class="ease-input-prefix">@</div>
+          <input id="username-input" class="ease-input-field" type="text" placeholder="saptarshi_coder">
+        </div>
+        <span class="helper-text">Uses custom indigo accent glow and prefix styling.</span>
+      </div>
+
+      <!-- Example 3: Domain Link Input (Pink Theme) -->
+      <div class="form-group">
+        <label for="link-input">Repository Branch URL</label>
+        <div class="ease-input-wrapper" style="--ease-prefix-color: #ec4899;">
+          <div class="ease-input-prefix">https://</div>
+          <input id="link-input" class="ease-input-field" type="text" placeholder="github.com/itssagarK/EaseMotion-css">
+        </div>
+        <span class="helper-text">Uses custom pink accent glow and prefix styling.</span>
+      </div>
+
+    </div>
+
+    <footer class="footer">
+      <p>Part of <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css" target="_blank">EaseMotion CSS</a> library.</p>
+    </footer>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-input-with-prefix/style.css
+++ b/submissions/examples/ease-input-with-prefix/style.css
@@ -1,0 +1,182 @@
+/* ==========================================================================
+   EaseMotion CSS - ease-input-with-prefix
+   Input wrapper container that highlights its prefix and glows on focus
+   ========================================================================== */
+
+/* Base Page Styles */
+body {
+  font-family: 'Outfit', sans-serif;
+  margin: 0;
+  padding: 0;
+  background: radial-gradient(circle at top, #1e1e2e 0%, #0d0e15 100%);
+  color: #f8f9fa;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.demo-wrapper {
+  max-width: 550px;
+  width: 90%;
+  margin: 2rem auto;
+  text-align: center;
+}
+
+.header {
+  margin-bottom: 3rem;
+}
+
+.header h1 {
+  font-size: 2.6rem;
+  font-weight: 800;
+  margin: 0.5rem 0 1rem 0;
+  background: linear-gradient(135deg, #38bdf8 0%, #818cf8 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  letter-spacing: -1px;
+}
+
+.badge {
+  background: rgba(129, 140, 248, 0.15);
+  color: #a5b4fc;
+  padding: 0.4rem 1rem;
+  border-radius: 50px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  border: 1px solid rgba(129, 140, 248, 0.3);
+}
+
+.description {
+  font-size: 1.05rem;
+  color: #94a3b8;
+  line-height: 1.6;
+  margin: 0 auto;
+}
+
+/* Forms Grid Container */
+.forms-container {
+  background: rgba(30, 41, 59, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 24px;
+  padding: 2.5rem 2rem;
+  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.3);
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-group label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #94a3b8;
+  letter-spacing: 0.5px;
+}
+
+.helper-text {
+  font-size: 0.8rem;
+  color: #64748b;
+  margin-top: 0.25rem;
+}
+
+/* ==========================================================================
+   THE CORE COMPONENT: ease-input-with-prefix
+   ========================================================================== */
+
+.ease-input-wrapper {
+  --ease-prefix-color: #6366f1; /* Default fallback prefix color */
+  
+  display: flex;
+  align-items: center;
+  background: rgba(15, 23, 42, 0.45);
+  border: 1.5px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  overflow: hidden;
+  transition: border-color 0.25s cubic-bezier(0.16, 1, 0.3, 1),
+              box-shadow 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.ease-input-prefix {
+  padding: 0.75rem 1rem;
+  background: rgba(255, 255, 255, 0.02);
+  color: #64748b;
+  font-weight: 600;
+  border-right: 1.5px solid rgba(255, 255, 255, 0.08);
+  user-select: none;
+  font-size: 0.95rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.25s cubic-bezier(0.16, 1, 0.3, 1),
+              background-color 0.25s cubic-bezier(0.16, 1, 0.3, 1),
+              border-color 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.ease-input-field {
+  flex-grow: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  padding: 0.75rem 1rem;
+  font-family: inherit;
+  font-size: 0.95rem;
+  color: #ffffff;
+}
+
+.ease-input-field::placeholder {
+  color: #4b5563;
+}
+
+/* 1. Container Border Highlight & Box Shadow Glow on focus */
+.ease-input-wrapper:focus-within {
+  border-color: var(--ease-prefix-color);
+  box-shadow: 0 0 16px rgba(255, 255, 255, 0.02),
+              0 0 12px var(--ease-prefix-color);
+  /* Apply opacity to the box shadow color internally */
+}
+
+/* For specific browser support where hex alpha might be needed, 
+   we overlay a soft shadow blending with the background */
+.ease-input-wrapper:focus-within {
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.01),
+              0 0 14px rgba(99, 102, 241, 0.15); /* Fallback */
+}
+
+/* Dynamic color definitions using wrapper var values */
+.ease-input-wrapper[style*="--ease-prefix-color"]:focus-within {
+  box-shadow: 0 0 0 1px var(--ease-prefix-color), 
+              0 0 14px var(--ease-prefix-color);
+}
+
+/* 2. Prefix Section: Color Changes on input focus */
+.ease-input-wrapper:focus-within .ease-input-prefix {
+  color: var(--ease-prefix-color);
+  background: rgba(255, 255, 255, 0.04);
+  border-right-color: var(--ease-prefix-color);
+}
+
+/* Footer Style */
+.footer {
+  margin-top: 4rem;
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+.footer a {
+  color: #818cf8;
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.footer a:hover {
+  color: #f472b6;
+}


### PR DESCRIPTION
closes #19901 
  Input Field with Focus Prefix ( ease-input-with-prefix  #19901)
      • Branch:  feat/ease-input-with-prefix 
      • Features: Created standard inputs (Currency, Username, Web URL) where the prefix
      icon/text segment changes color (using  --ease-prefix-color ) and the container
      applies a soft border shadow glow when focused via CSS  :focus-within  selectors