### PR TITLE
feat: add ease-popover-confirm component

### DIFF
--- a/submissions/examples/ease-popover-confirm/README.md
+++ b/submissions/examples/ease-popover-confirm/README.md
@@ -1,0 +1,87 @@
+# ease-popover-confirm
+
+A lightweight inline confirmation popover component built with HTML, CSS, and vanilla JavaScript.
+This submission provides a reusable confirmation dialog that opens close to a trigger button and supports accessible keyboard navigation.
+
+## Features
+
+- Accessible inline dialog with `role="dialog"`
+- `aria-expanded`, `aria-labelledby`, and `aria-describedby` support
+- Smooth fade and scale animation for open/close transitions
+- Close on cancel, confirm, outside click, or Escape key
+- Focus is moved into the popover when opened and returned to the trigger when closed
+- Keyboard-friendly: Enter/Space opens trigger, Tab cycles inside the popover, Escape closes
+- Responsive layout for narrow screens
+- Clean rounded design with subtle shadows and a red destructive action button
+
+## Folder structure
+
+```text
+submissions/examples/ease-popover-confirm/
+├── demo.html
+├── style.css
+├── script.js
+└── README.md
+```
+
+## Installation
+
+No build tools are required. Open `demo.html` directly in a browser to view the component.
+
+## Usage
+
+1. Open `demo.html` in a browser.
+2. Click the **Delete item** button to open the popover.
+3. Choose **Cancel** or **Delete** to close the popover.
+
+### Example HTML
+
+```html
+<button
+  id="popover-trigger"
+  type="button"
+  aria-haspopup="dialog"
+  aria-expanded="false"
+  aria-controls="confirm-popover"
+>
+  Delete item
+</button>
+
+<div
+  id="confirm-popover"
+  class="confirm-popover"
+  role="dialog"
+  aria-labelledby="popover-title"
+  aria-describedby="popover-description"
+  hidden
+>
+  <!-- content -->
+</div>
+```
+
+### Example JavaScript
+
+```js
+triggerButton.addEventListener('click', togglePopover);
+confirmButton.addEventListener('click', closePopover);
+cancelButton.addEventListener('click', closePopover);
+```
+
+## Accessibility
+
+- Uses `role="dialog"` for the popover container
+- `aria-labelledby` and `aria-describedby` provide a title and description
+- Trigger button uses `aria-expanded` and `aria-controls`
+- Escape key closes the popover
+- Focus is trapped inside the popover while open
+- Focus returns to the trigger after close
+
+## Customization
+
+- Update button colors in `style.css` to match your brand palette
+- Adjust the `popover-content` width or border radius for tighter layouts
+- Add additional dialog actions by extending the `.popover-actions` container
+
+## Browser compatibility
+
+Tested with modern browsers that support CSS transitions, `position: absolute`, and standard DOM focus management. The example is designed for production-ready behavior in Chrome, Firefox, Safari, and Edge.

--- a/submissions/examples/ease-popover-confirm/demo.html
+++ b/submissions/examples/ease-popover-confirm/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ease-popover-confirm</title>
+    <meta
+      name="description"
+      content="A reusable inline confirmation popover with accessible focus management, keyboard support, and smooth scale/fade animation."
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="page-shell">
+      <section class="demo-card" aria-labelledby="demo-heading">
+        <header class="demo-header">
+          <p class="eyebrow">EaseMotion component</p>
+          <h1 id="demo-heading">ease-popover-confirm</h1>
+          <p class="demo-copy">
+            A compact inline confirmation popover that opens beside the trigger, supports keyboard navigation, and closes on cancel, confirm, outside click, or Escape.
+          </p>
+        </header>
+
+        <div class="trigger-panel">
+          <p class="trigger-note">Click the button below to open the confirmation popover.</p>
+          <div class="popover-frame">
+            <button
+              id="popover-trigger"
+              type="button"
+              class="trigger-button"
+              aria-haspopup="dialog"
+              aria-expanded="false"
+              aria-controls="confirm-popover"
+            >
+              Delete item
+            </button>
+
+            <div
+              id="confirm-popover"
+              class="confirm-popover"
+              role="dialog"
+              aria-labelledby="popover-title"
+              aria-describedby="popover-description"
+              hidden
+            >
+              <div class="popover-arrow" aria-hidden="true"></div>
+              <div class="popover-content">
+                <div class="popover-copy">
+                  <h2 id="popover-title">Are you sure?</h2>
+                  <p id="popover-description">This action cannot be undone.</p>
+                </div>
+                <div class="popover-actions">
+                  <button type="button" class="button button--neutral" data-action="cancel">Cancel</button>
+                  <button type="button" class="button button--destructive" data-action="confirm">Delete</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/submissions/examples/ease-popover-confirm/script.js
+++ b/submissions/examples/ease-popover-confirm/script.js
@@ -1,0 +1,103 @@
+const triggerButton = document.getElementById('popover-trigger');
+const popover = document.getElementById('confirm-popover');
+const cancelButton = popover.querySelector('[data-action="cancel"]');
+const confirmButton = popover.querySelector('[data-action="confirm"]');
+const focusableButtons = [cancelButton, confirmButton];
+let lastFocusedElement = null;
+
+function openPopover() {
+  if (!popover.hidden) {
+    return;
+  }
+
+  lastFocusedElement = document.activeElement;
+  popover.hidden = false;
+  requestAnimationFrame(() => popover.classList.add('is-open'));
+  triggerButton.setAttribute('aria-expanded', 'true');
+  cancelButton.focus();
+  document.addEventListener('click', handleDocumentClick);
+  document.addEventListener('keydown', handleKeyDown);
+}
+
+function closePopover() {
+  if (popover.hidden) {
+    return;
+  }
+
+  popover.classList.remove('is-open');
+  triggerButton.setAttribute('aria-expanded', 'false');
+
+  const hideAfterTransition = () => {
+    popover.hidden = true;
+    popover.removeEventListener('transitionend', hideAfterTransition);
+  };
+
+  popover.addEventListener('transitionend', hideAfterTransition);
+  document.removeEventListener('click', handleDocumentClick);
+  document.removeEventListener('keydown', handleKeyDown);
+  if (lastFocusedElement instanceof HTMLElement) {
+    lastFocusedElement.focus();
+  }
+}
+
+function togglePopover() {
+  if (popover.hidden) {
+    openPopover();
+  } else {
+    closePopover();
+  }
+}
+
+function handleDocumentClick(event) {
+  if (popover.contains(event.target) || triggerButton.contains(event.target)) {
+    return;
+  }
+
+  closePopover();
+}
+
+function handleKeyDown(event) {
+  if (event.key === 'Escape') {
+    event.preventDefault();
+    closePopover();
+    return;
+  }
+
+  if (event.key === 'Tab' && !popover.hidden) {
+    trapFocus(event);
+  }
+}
+
+function trapFocus(event) {
+  const currentIndex = focusableButtons.indexOf(document.activeElement);
+  if (event.shiftKey && currentIndex === 0) {
+    event.preventDefault();
+    focusableButtons[focusableButtons.length - 1].focus();
+    return;
+  }
+
+  if (!event.shiftKey && currentIndex === focusableButtons.length - 1) {
+    event.preventDefault();
+    focusableButtons[0].focus();
+  }
+}
+
+triggerButton.addEventListener('click', (event) => {
+  event.stopPropagation();
+  togglePopover();
+});
+
+triggerButton.addEventListener('keydown', (event) => {
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault();
+    togglePopover();
+  }
+});
+
+cancelButton.addEventListener('click', () => {
+  closePopover();
+});
+
+confirmButton.addEventListener('click', () => {
+  closePopover();
+});

--- a/submissions/examples/ease-popover-confirm/style.css
+++ b/submissions/examples/ease-popover-confirm/style.css
@@ -1,0 +1,226 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  color: #111827;
+  background: #f7f8fb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top left, rgba(99, 102, 241, 0.12), transparent 32%),
+    radial-gradient(circle at bottom right, rgba(236, 72, 153, 0.12), transparent 30%),
+    #f7f8fb;
+}
+
+button {
+  font: inherit;
+}
+
+.page-shell {
+  min-height: 100vh;
+  padding: 2.5rem 1.5rem;
+  display: grid;
+  place-items: center;
+}
+
+.demo-card {
+  width: min(100%, 44rem);
+  padding: 2rem;
+  border-radius: 1.5rem;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 30px 80px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+}
+
+.demo-header {
+  display: grid;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  background: #eef2ff;
+  color: #4338ca;
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  max-width: fit-content;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 2.6vw, 2.6rem);
+  letter-spacing: -0.04em;
+}
+
+.demo-copy {
+  margin: 0;
+  color: #475569;
+  max-width: 42rem;
+}
+
+.trigger-panel {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.trigger-note {
+  margin: 0;
+  color: #64748b;
+}
+
+.popover-frame {
+  position: relative;
+  display: inline-flex;
+}
+
+.trigger-button {
+  cursor: pointer;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  border-radius: 999px;
+  background: #ffffff;
+  color: #111827;
+  padding: 0.95rem 1.4rem;
+  font-weight: 600;
+  transition: background 180ms ease, border-color 180ms ease, transform 180ms ease;
+}
+
+.trigger-button:hover,
+.trigger-button:focus-visible {
+  background: #f8fafc;
+  border-color: rgba(15, 23, 42, 0.18);
+}
+
+.trigger-button:focus-visible {
+  outline: 3px solid rgba(59, 130, 246, 0.35);
+  outline-offset: 4px;
+}
+
+.confirm-popover {
+  position: absolute;
+  z-index: 10;
+  top: calc(100% + 0.85rem);
+  left: 50%;
+  width: min(21.5rem, 100vw - 2rem);
+  transform: translateX(-50%) scale(0.92);
+  opacity: 0;
+  pointer-events: none;
+  transition: transform 180ms ease, opacity 180ms ease;
+}
+
+.confirm-popover.is-open {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateX(-50%) scale(1);
+}
+
+.popover-arrow {
+  position: absolute;
+  left: 50%;
+  top: 0;
+  width: 1rem;
+  height: 1rem;
+  transform: translate(-50%, -50%) rotate(45deg);
+  background: #ffffff;
+  border-left: 1px solid rgba(15, 23, 42, 0.08);
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
+}
+
+.popover-content {
+  border-radius: 1.25rem;
+  background: #ffffff;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 22px 42px rgba(15, 23, 42, 0.12);
+  padding: 1.25rem 1.25rem 1rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.popover-copy h2 {
+  margin: 0;
+  font-size: 1.125rem;
+}
+
+.popover-copy p {
+  margin: 0.5rem 0 0;
+  color: #475569;
+}
+
+.popover-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.button {
+  min-width: 8rem;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 0.9rem 1.15rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 160ms ease, background-color 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+}
+
+.button:hover,
+.button:focus-visible {
+  transform: translateY(-1px);
+}
+
+.button:focus-visible {
+  outline: 3px solid rgba(59, 130, 246, 0.35);
+  outline-offset: 3px;
+}
+
+.button--neutral {
+  background: #f8fafc;
+  color: #334155;
+}
+
+.button--neutral:hover {
+  background: #eef2ff;
+}
+
+.button--destructive {
+  background: #fef2f2;
+  color: #b91c1c;
+  border-color: rgba(185, 28, 28, 0.18);
+}
+
+.button--destructive:hover {
+  background: #fee2e2;
+}
+
+@media (max-width: 520px) {
+  .demo-card {
+    padding: 1.5rem;
+  }
+
+  .confirm-popover {
+    left: 0;
+    right: 0;
+    width: auto;
+    transform: translateX(0) scale(0.95);
+  }
+
+  .confirm-popover.is-open {
+    transform: translateX(0) scale(1);
+  }
+
+  .popover-arrow {
+    left: 1.5rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a new **ease-popover-confirm** component under:

`submissions/examples/ease-popover-confirm/`

It provides an accessible inline confirmation popover for destructive actions such as deleting an item.

---

## Type of Change

* [ ] ✨ New animation / hover effect
* [x] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other

---

## Submission Checklist

* [x] All changes are inside `submissions/examples/ease-popover-confirm/`
* [x] Includes `demo.html`
* [x] Includes `style.css`
* [x] Includes `README.md`
* [x] No changes to `core/`
* [x] No changes to `components/`
* [x] One feature per PR

---

## Feature Description

### What does this add?

A lightweight inline confirmation popover that appears near the trigger button with smooth animations, keyboard accessibility, and outside-click dismissal.

### How does a developer use it?

Open `demo.html` in a browser and click the **Delete Item** button to see the component in action.

### Why does it fit EaseMotion CSS?

It provides a reusable, animation-first confirmation component with clean styling and smooth motion that aligns with the project's UI component library.

---

## Demo

* [x] Demo added (`demo.html` works directly in the browser)

---

## Browser Testing

* [x] Chrome
* [ ] Firefox
* [x] Edge
* [ ] Safari

---

## Notes for Maintainer

Implemented using HTML, CSS, and vanilla JavaScript with accessibility support including keyboard navigation, Escape key handling, focus management, and ARIA attributes.

Fixes #19895
