### PR TITLE
fix(#20525): remove unsupported GitHub Raw CDN stylesheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,14 +253,6 @@ EaseMotion CSS can also be loaded using alternative CDN providers.
 />
 ```
 
-### GitHub Raw CDN
-
-```html
-<link
-  rel="stylesheet"
-  href="https://raw.githubusercontent.com/SAPTARSHI-coder/EaseMotion-css/main/easemotion.min.css"
-/>
-```
 
 > jsDelivr is recommended for production usage because it provides global caching and better reliability.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -308,10 +308,7 @@
 &lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css" /&gt;
 
 &lt;!-- unpkg --&gt;
-&lt;link rel="stylesheet" href="https://unpkg.com/easemotion-css/easemotion.min.css" /&gt;
-
-&lt;!-- GitHub Raw CDN --&gt;
-&lt;link rel="stylesheet" href="https://raw.githubusercontent.com/SAPTARSHI-coder/EaseMotion-css/main/easemotion.min.css" /&gt;</code></pre>
+&lt;link rel="stylesheet" href="https://unpkg.com/easemotion-css/easemotion.min.css" /&gt;</code></pre>
           </div>
 
           <h3 class="docs-h3">Option 2 — npm</h3>


### PR DESCRIPTION
## Pull Request Description

This PR fixes the documentation for the CDN installation instructions by removing the unsupported GitHub Raw stylesheet option.

The project already documents supported CDN providers (jsDelivr and unpkg), so removing the raw GitHub snippet prevents users from copying an installation method that browsers may reject because `raw.githubusercontent.com` does not reliably serve CSS with the correct MIME type.

Closes #20525

---

## Type of Change

* [ ] ✨ New animation / hover effect
* [ ] 🧩 New component
* [x] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [x] Other (Documentation bug fix)

---

## Submission Checklist

**Not applicable.** This PR only updates project documentation (`README.md` and `docs/index.html`) and does not add a new feature submission.

* [ ] All changes are inside `submissions/examples/your-feature-name/`
* [ ] Includes `demo.html`
* [ ] Includes `style.css`
* [ ] Includes `README.md`
* [x] No changes to `core/`
* [x] No changes to `components/`
* [x] One change only (documentation fix)

---

## Feature Description

**Not applicable.**

---

## Demo

Not applicable.

---

## Browser Testing

* [x] Chrome
* [ ] Firefox
* [ ] Edge
* [ ] Safari

Documentation verified by checking that supported CDN options remain while the unsupported GitHub Raw stylesheet snippet has been removed.

---

## Notes for Maintainer

* Removed the unsupported GitHub Raw CDN stylesheet snippet from `README.md`.
* Removed the corresponding snippet from `docs/index.html`.
* Existing jsDelivr and unpkg installation methods remain unchanged.
* No library code or functionality was modified.
