### PR TITLE
feat: add swipe reveal list demo

### DIFF
--- a/submissions/examples/swipe-reveal-list/README.md
+++ b/submissions/examples/swipe-reveal-list/README.md
@@ -1,0 +1,15 @@
+# Swipe Reveal List
+
+## What does this do?
+A list row pattern that slides content aside to reveal contextual actions on hover or keyboard focus.
+
+## How is it used?
+```html
+<article class="reveal-row" tabindex="0">
+  <div class="row-content"><strong>Design audit</strong></div>
+  <div class="row-actions"><button>Done</button></div>
+</article>
+```
+
+## Why is it useful?
+It adds a compact action-list interaction for task managers, inboxes, and dashboards while keeping the behavior CSS-only.

--- a/submissions/examples/swipe-reveal-list/demo.html
+++ b/submissions/examples/swipe-reveal-list/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Swipe Reveal List Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="list-page" aria-labelledby="list-title">
+    <section class="list-panel">
+      <p class="eyebrow">Action list</p>
+      <h1 id="list-title">Swipe Reveal List</h1>
+      <p class="intro">Hover or focus a row to slide the content aside and expose contextual actions.</p>
+
+      <div class="reveal-list" role="list">
+        <article class="reveal-row" role="listitem" tabindex="0">
+          <div class="row-content">
+            <strong>Design audit</strong>
+            <span>Due today</span>
+          </div>
+          <div class="row-actions" aria-label="Design audit actions">
+            <button>View</button>
+            <button>Done</button>
+          </div>
+        </article>
+        <article class="reveal-row" role="listitem" tabindex="0">
+          <div class="row-content">
+            <strong>Release notes</strong>
+            <span>Draft ready</span>
+          </div>
+          <div class="row-actions" aria-label="Release notes actions">
+            <button>Edit</button>
+            <button>Send</button>
+          </div>
+        </article>
+        <article class="reveal-row" role="listitem" tabindex="0">
+          <div class="row-content">
+            <strong>QA checklist</strong>
+            <span>3 items left</span>
+          </div>
+          <div class="row-actions" aria-label="QA checklist actions">
+            <button>Open</button>
+            <button>Pin</button>
+          </div>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/swipe-reveal-list/style.css
+++ b/submissions/examples/swipe-reveal-list/style.css
@@ -1,0 +1,143 @@
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #1e1b4b, #0f766e 50%, #facc15);
+  color: #111827;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+.list-page {
+  width: min(92vw, 760px);
+  padding: 28px;
+}
+
+.list-panel {
+  border-radius: 28px;
+  padding: clamp(24px, 5vw, 44px);
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: 0 30px 88px rgba(30, 27, 75, 0.34);
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: #0f766e;
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.2rem, 7vw, 4.8rem);
+  line-height: 0.92;
+}
+
+.intro {
+  max-width: 50ch;
+  margin: 16px 0 28px;
+  color: #4b5563;
+  line-height: 1.65;
+}
+
+.reveal-list {
+  display: grid;
+  gap: 14px;
+}
+
+.reveal-row {
+  position: relative;
+  overflow: hidden;
+  min-height: 88px;
+  border-radius: 20px;
+  background: #111827;
+  outline: none;
+  animation: row-enter 540ms both;
+}
+
+.reveal-row:nth-child(2) {
+  animation-delay: 90ms;
+}
+
+.reveal-row:nth-child(3) {
+  animation-delay: 180ms;
+}
+
+.row-content,
+.row-actions {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+}
+
+.row-content {
+  justify-content: space-between;
+  padding: 0 22px;
+  background: #f8fafc;
+  box-shadow: inset 0 0 0 1px rgba(17, 24, 39, 0.08);
+  transition: transform 240ms ease;
+  z-index: 1;
+}
+
+.row-content strong {
+  font-size: 1.05rem;
+}
+
+.row-content span {
+  color: #64748b;
+  font-weight: 700;
+}
+
+.row-actions {
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 0 18px;
+}
+
+.row-actions button {
+  min-height: 38px;
+  border: 0;
+  border-radius: 999px;
+  padding: 0 14px;
+  background: #facc15;
+  color: #111827;
+  cursor: pointer;
+  font-weight: 900;
+}
+
+.reveal-row:hover .row-content,
+.reveal-row:focus .row-content,
+.reveal-row:focus-within .row-content {
+  transform: translateX(-158px);
+}
+
+.reveal-row:focus {
+  box-shadow: 0 0 0 4px rgba(250, 204, 21, 0.55);
+}
+
+.row-actions button:focus-visible {
+  outline: 3px solid #ffffff;
+  outline-offset: 2px;
+}
+
+@keyframes row-enter {
+  from {
+    opacity: 0;
+    transform: translateX(24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@media (max-width: 560px) {
+  .row-content {
+    align-items: flex-start;
+    justify-content: center;
+    flex-direction: column;
+    gap: 5px;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a swipe reveal list submission where rows slide aside to expose contextual action buttons on hover or keyboard focus.

---

## Type of Change

- [x] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/swipe-reveal-list/`
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A list row pattern that slides content aside to reveal contextual actions on hover or keyboard focus.

**How does a developer use it?**

```html
<article class="reveal-row" tabindex="0">
  <div class="row-content"><strong>Design audit</strong></div>
  <div class="row-actions"><button>Done</button></div>
</article>
```

**Why does it fit EaseMotion CSS?**

It provides a compact CSS-only interaction for task lists, inboxes, and dashboard action rows.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer

Local verification: `npm test` passed with 1 test file and 13 tests.
