### PR TITLE
feat: add SVG checkbox path-drawing micro-interaction

### DIFF
--- a/submissions/examples/draw-checkbox-ms07/README.md
+++ b/submissions/examples/draw-checkbox-ms07/README.md
@@ -1,0 +1,30 @@
+# SVG Checkbox Path-Drawing Micro-interaction
+
+1. **What does this do?**
+   A custom checkbox where checking it draws the checkmark's SVG path from start to end (via an animated `stroke-dashoffset`), and unchecking it reverses the drawing. The checkbox container also "pops" with a small bounce-scale animation the instant it's checked.
+
+2. **How is it used?**
+   Wrap a native `<input type="checkbox">` and the visual box in a `.draw-checkbox` label, with the checkmark as inline SVG inside `.draw-checkbox-box`:
+
+   ```html
+   <label class="draw-checkbox">
+     <input type="checkbox" class="draw-checkbox-input">
+     <div class="draw-checkbox-box">
+       <svg class="draw-checkbox-checkmark" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">
+         <path d="M20 6L9 17L4 12" stroke-linecap="round" stroke-linejoin="round"/>
+       </svg>
+     </div>
+     <span class="draw-checkbox-label">Subscribe to newsletter</span>
+   </label>
+   ```
+
+3. **Why is this useful?**
+   It's a high-fidelity micro-interaction that gives immediate, satisfying feedback on a control people interact with constantly, achieved with pure CSS (`stroke-dashoffset` transitions) and zero JavaScript — the underlying `<input type="checkbox">` does all the state-tracking natively. It also demonstrates full keyboard support and a clean `prefers-reduced-motion` fallback, in line with EaseMotion CSS's accessibility-conscious, animation-first philosophy.
+
+### Notes for the maintainer
+- The component CSS here matches the snippet proposed in the issue as closely as possible, since the class names (`draw-checkbox-*`) were already given unprefixed and ready for `ease-*` renaming on integration.
+- `stroke-dasharray: 24` was checked against the actual path length of `M20 6L9 17L4 12` (≈22.6 units) — close enough that the checkmark draws fully with no visible gap, so this value is intentional, not a placeholder.
+- One addition beyond the original snippet: a `:disabled` state (greyed-out box/label, `not-allowed` cursor, hover suppressed) was added since the demo includes a disabled checkbox example and the original snippet didn't cover that state. The `:has()` selector used for the label's cursor/hover override is supported in all major browsers as of 2026; the core disabled styling (box and label color) doesn't depend on it, so the example degrades gracefully even without `:has()` support.
+- Keyboard support comes for free from the native `<input type="checkbox">` plus the `:focus-visible` outline rule — no `tabindex` or custom key handling needed.
+- `prefers-reduced-motion: reduce` removes the draw transition and the pop animation, while keeping the background/border color change so the checked state is still clearly visible.
+- Tested in Chrome, Firefox, and Edge.

--- a/submissions/examples/draw-checkbox-ms07/demo.html
+++ b/submissions/examples/draw-checkbox-ms07/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>SVG Checkbox Path-Drawing Micro-interaction — Demo</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <main class="draw-checkbox-demo-wrapper">
+
+    <h1 class="draw-checkbox-demo-title">Notification Preferences</h1>
+    <p class="draw-checkbox-demo-hint">Check or uncheck any option below. Try Tab + Space for keyboard access.</p>
+
+    <div class="draw-checkbox-demo-list">
+
+      <label class="draw-checkbox">
+        <input type="checkbox" class="draw-checkbox-input" checked>
+        <div class="draw-checkbox-box">
+          <svg class="draw-checkbox-checkmark" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">
+            <path d="M20 6L9 17L4 12" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </div>
+        <span class="draw-checkbox-label">Subscribe to newsletter</span>
+      </label>
+
+      <label class="draw-checkbox">
+        <input type="checkbox" class="draw-checkbox-input">
+        <div class="draw-checkbox-box">
+          <svg class="draw-checkbox-checkmark" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">
+            <path d="M20 6L9 17L4 12" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </div>
+        <span class="draw-checkbox-label">Product updates</span>
+      </label>
+
+      <label class="draw-checkbox">
+        <input type="checkbox" class="draw-checkbox-input">
+        <div class="draw-checkbox-box">
+          <svg class="draw-checkbox-checkmark" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">
+            <path d="M20 6L9 17L4 12" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </div>
+        <span class="draw-checkbox-label">Security alerts</span>
+      </label>
+
+      <label class="draw-checkbox">
+        <input type="checkbox" class="draw-checkbox-input" disabled>
+        <div class="draw-checkbox-box">
+          <svg class="draw-checkbox-checkmark" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">
+            <path d="M20 6L9 17L4 12" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </div>
+        <span class="draw-checkbox-label">Required terms (disabled example)</span>
+      </label>
+
+    </div>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/draw-checkbox-ms07/style.css
+++ b/submissions/examples/draw-checkbox-ms07/style.css
@@ -1,0 +1,138 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #0b0f19;
+  color: #e7e9ee;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+
+.draw-checkbox-demo-wrapper {
+  max-width: 420px;
+  margin: 0 auto;
+  padding: 56px 24px 80px;
+}
+
+.draw-checkbox-demo-title {
+  margin: 0 0 6px;
+  font-size: 1.3rem;
+}
+
+.draw-checkbox-demo-hint {
+  margin: 0 0 28px;
+  font-size: 0.85rem;
+  color: #8b93a7;
+}
+
+.draw-checkbox-demo-list {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+
+.draw-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.draw-checkbox-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.draw-checkbox-box {
+  width: 24px;
+  height: 24px;
+  border: 2px solid #cbd5e1;
+  border-radius: 6px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: background-color 0.3s ease, border-color 0.3s ease, transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+  background-color: transparent;
+}
+
+.draw-checkbox-checkmark {
+  width: 16px;
+  height: 16px;
+  color: #ffffff;
+  stroke-dasharray: 24;
+  stroke-dashoffset: 24;
+  transition: stroke-dashoffset 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.draw-checkbox-label {
+  font-size: 0.92rem;
+  color: #e7e9ee;
+}
+
+/* Hover state scale animation */
+.draw-checkbox:hover .draw-checkbox-box {
+  border-color: #6c63ff;
+  transform: scale(1.05);
+}
+
+/* Checked state transitions */
+.draw-checkbox-input:checked + .draw-checkbox-box {
+  background-color: #6c63ff;
+  border-color: #6c63ff;
+  animation: draw-pop 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.draw-checkbox-input:checked + .draw-checkbox-box .draw-checkbox-checkmark {
+  stroke-dashoffset: 0;
+}
+
+/* Focus indicator */
+.draw-checkbox-input:focus-visible + .draw-checkbox-box {
+  outline: 2px solid #6c63ff;
+  outline-offset: 2px;
+}
+
+@keyframes draw-pop {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.15); }
+  100% { transform: scale(1); }
+}
+
+
+.draw-checkbox-input:disabled + .draw-checkbox-box {
+  border-color: #3a3f4d;
+  background-color: #1a1e29;
+  cursor: not-allowed;
+}
+
+.draw-checkbox-input:disabled ~ .draw-checkbox-label {
+  color: #5b6275;
+  cursor: not-allowed;
+}
+
+.draw-checkbox:has(.draw-checkbox-input:disabled) {
+  cursor: not-allowed;
+}
+
+.draw-checkbox:has(.draw-checkbox-input:disabled):hover .draw-checkbox-box {
+  border-color: #3a3f4d;
+  transform: none;
+}
+
+/* prefers-reduced-motion fallback */
+@media (prefers-reduced-motion: reduce) {
+  .draw-checkbox-checkmark {
+    transition: none;
+  }
+  .draw-checkbox-input:checked + .draw-checkbox-box {
+    animation: none;
+  }
+  .draw-checkbox-box {
+    transition: background-color 0.3s ease, border-color 0.3s ease;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a custom checkbox where checking it draws the checkmark's SVG
path from start to end via animated `stroke-dashoffset`, reverses on
uncheck, and pops with a small bounce-scale animation when activated
— pure CSS, no JavaScript.

---

## Type of Change

- [x] 🧩 New component
- [x] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/draw-checkbox-ms07/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A checkbox whose checkmark draws itself in via `stroke-dashoffset`
when checked (and reverses on uncheck), with a bounce "pop" on the
container — fully keyboard accessible, no JS.

**How does a developer use it?**

```html
<label class="draw-checkbox">
  <input type="checkbox" class="draw-checkbox-input">
  <div class="draw-checkbox-box">
    <svg class="draw-checkbox-checkmark" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">
      <path d="M20 6L9 17L4 12" stroke-linecap="round" stroke-linejoin="round"/>
    </svg>
  </div>
  <span class="draw-checkbox-label">Subscribe to newsletter</span>
</label>
```

**Why does it fit EaseMotion CSS?**

It's a high-fidelity, satisfying micro-interaction on a control used
constantly, achieved entirely with CSS transitions — no JS — plus
full keyboard support and a clean `prefers-reduced-motion` fallback,
matching the framework's accessibility-conscious, animation-first
philosophy.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Component CSS matches the snippet proposed in the issue closely,
since the class names (`draw-checkbox-*`) were already given
unprefixed. `stroke-dasharray: 24` was checked against the actual
path length of `M20 6L9 17L4 12` (≈22.6 units) — intentional, not a
placeholder, since it fully draws with no visible gap. One addition
beyond the original snippet: a `:disabled` state, since the demo
includes a disabled example the original snippet didn't cover. The
`:has()` selector used for the label's cursor/hover override is
supported in all major 2026 browsers; the core disabled styling
doesn't depend on it, so it degrades gracefully either way. Keyboard
support comes for free from the native checkbox input.

Closes https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/20576