### PR TITLE
feat: add focus ring showcase demo

### DIFF
--- a/submissions/examples/focus-ring-showcase/README.md
+++ b/submissions/examples/focus-ring-showcase/README.md
@@ -1,0 +1,13 @@
+# Focus Ring Showcase
+
+## What does this do?
+A set of animated focus-visible states for buttons, links, inputs, and focusable cards.
+
+## How is it used?
+```html
+<button class="focus-button">Primary action</button>
+<a class="focus-tile" href="#"><strong>Open report</strong></a>
+```
+
+## Why is it useful?
+It gives EaseMotion CSS an accessibility-focused pattern that makes keyboard navigation visible, polished, and consistent.

--- a/submissions/examples/focus-ring-showcase/demo.html
+++ b/submissions/examples/focus-ring-showcase/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Focus Ring Showcase Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="showcase" aria-labelledby="focus-title">
+    <section class="focus-card">
+      <p class="label">Accessibility motion</p>
+      <h1 id="focus-title">Focus Ring Showcase</h1>
+      <p class="intro">Keyboard-friendly focus states with animated outlines for common interactive elements.</p>
+
+      <div class="control-grid">
+        <button class="focus-button">Primary action</button>
+        <a class="focus-link" href="#">Text link</a>
+        <label class="focus-input">
+          <span>Email</span>
+          <input type="email" value="hello@example.dev">
+        </label>
+        <a class="focus-tile" href="#">
+          <strong>Open report</strong>
+          <small>Focusable card</small>
+        </a>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/focus-ring-showcase/style.css
+++ b/submissions/examples/focus-ring-showcase/style.css
@@ -1,0 +1,149 @@
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #0f172a, #7c3aed 50%, #22c55e);
+  color: #111827;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+.showcase {
+  width: min(92vw, 820px);
+  padding: 28px;
+}
+
+.focus-card {
+  border-radius: 28px;
+  padding: clamp(24px, 5vw, 46px);
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: 0 30px 86px rgba(15, 23, 42, 0.34);
+}
+
+.label {
+  margin: 0 0 10px;
+  color: #6d28d9;
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.2rem, 7vw, 4.7rem);
+  line-height: 0.92;
+}
+
+.intro {
+  max-width: 52ch;
+  margin: 16px 0 28px;
+  color: #4b5563;
+  line-height: 1.65;
+}
+
+.control-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.focus-button,
+.focus-link,
+.focus-input,
+.focus-tile {
+  position: relative;
+  border-radius: 20px;
+  background: #f8fafc;
+  box-shadow: inset 0 0 0 1px rgba(17, 24, 39, 0.08);
+}
+
+.focus-button,
+.focus-link,
+.focus-tile {
+  min-height: 82px;
+  display: grid;
+  place-items: center;
+  color: #111827;
+  text-decoration: none;
+  font-weight: 900;
+}
+
+.focus-button {
+  border: 0;
+  cursor: pointer;
+  font: inherit;
+}
+
+.focus-input {
+  display: grid;
+  gap: 8px;
+  padding: 16px;
+  font-weight: 800;
+}
+
+.focus-input input {
+  border: 0;
+  border-radius: 12px;
+  padding: 12px;
+  background: #ffffff;
+  color: #111827;
+  font: inherit;
+  outline: none;
+}
+
+.focus-tile {
+  align-content: center;
+  gap: 6px;
+}
+
+.focus-tile small {
+  color: #64748b;
+}
+
+.focus-button::after,
+.focus-link::after,
+.focus-input::after,
+.focus-tile::after {
+  content: "";
+  position: absolute;
+  inset: -5px;
+  border: 3px solid #22c55e;
+  border-radius: 24px;
+  opacity: 0;
+  transform: scale(0.96);
+  transition: opacity 160ms ease, transform 160ms ease;
+  pointer-events: none;
+}
+
+.focus-button:focus-visible,
+.focus-link:focus-visible,
+.focus-input:focus-within,
+.focus-tile:focus-visible {
+  outline: none;
+  transform: translateY(-4px);
+  transition: transform 160ms ease;
+}
+
+.focus-button:focus-visible::after,
+.focus-link:focus-visible::after,
+.focus-input:focus-within::after,
+.focus-tile:focus-visible::after {
+  opacity: 1;
+  transform: scale(1);
+  animation: focus-breathe 1.2s ease-in-out infinite;
+}
+
+@keyframes focus-breathe {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.28);
+  }
+  50% {
+    box-shadow: 0 0 0 10px rgba(34, 197, 94, 0);
+  }
+}
+
+@media (max-width: 640px) {
+  .control-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an accessibility-focused focus ring showcase submission with animated focus-visible states for common interactive elements.

---

## Type of Change

- [x] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/focus-ring-showcase/`
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A set of animated focus-visible states for buttons, links, inputs, and focusable cards.

**How does a developer use it?**

```html
<button class="focus-button">Primary action</button>
<a class="focus-tile" href="#"><strong>Open report</strong></a>
```

**Why does it fit EaseMotion CSS?**

It improves keyboard navigation visibility with a motion pattern that is clear, consistent, and CSS-only.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer

Local verification: `npm test` passed with 1 test file and 13 tests.
