### PR TITLE
feat: add gradient border tabs demo

### DIFF
--- a/submissions/examples/gradient-border-tabs/README.md
+++ b/submissions/examples/gradient-border-tabs/README.md
@@ -1,0 +1,15 @@
+# Gradient Border Tabs
+
+## What does this do?
+A tab navigation pattern with animated gradient borders, focus-visible states, and a lifted content panel.
+
+## How is it used?
+```html
+<div class="tab-list" role="tablist">
+  <button class="tab active" role="tab">Overview</button>
+  <button class="tab" role="tab">Motion</button>
+</div>
+```
+
+## Why is it useful?
+It gives EaseMotion CSS a polished tab component for dashboards and settings screens with clear active-state motion.

--- a/submissions/examples/gradient-border-tabs/demo.html
+++ b/submissions/examples/gradient-border-tabs/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gradient Border Tabs Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="tabs-page" aria-labelledby="tabs-title">
+    <section class="tabs-card">
+      <p class="eyebrow">Navigation component</p>
+      <h1 id="tabs-title">Gradient Border Tabs</h1>
+      <div class="tab-list" role="tablist" aria-label="Feature sections">
+        <button class="tab active" role="tab" aria-selected="true">Overview</button>
+        <button class="tab" role="tab" aria-selected="false">Motion</button>
+        <button class="tab" role="tab" aria-selected="false">Tokens</button>
+      </div>
+      <article class="tab-panel">
+        <span class="panel-icon"></span>
+        <div>
+          <strong>Animated active state</strong>
+          <p>The selected tab uses a moving gradient border and the panel enters with a soft lift.</p>
+        </div>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/gradient-border-tabs/style.css
+++ b/submissions/examples/gradient-border-tabs/style.css
@@ -1,0 +1,133 @@
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(140deg, #172554, #be123c 54%, #fde68a);
+  color: #111827;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+.tabs-page {
+  width: min(92vw, 760px);
+  padding: 28px;
+}
+
+.tabs-card {
+  border-radius: 28px;
+  padding: clamp(24px, 5vw, 46px);
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: 0 30px 86px rgba(23, 37, 84, 0.34);
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: #be123c;
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 28px;
+  font-size: clamp(2.2rem, 7vw, 4.8rem);
+  line-height: 0.92;
+}
+
+.tab-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.tab {
+  position: relative;
+  min-height: 46px;
+  border: 2px solid transparent;
+  border-radius: 999px;
+  padding: 0 20px;
+  background:
+    linear-gradient(#f8fafc, #f8fafc) padding-box,
+    linear-gradient(90deg, #be123c, #f59e0b, #2563eb, #be123c) border-box;
+  background-size: 100% 100%, 220% 100%;
+  color: #334155;
+  cursor: pointer;
+  font: 900 0.95rem Arial, sans-serif;
+  overflow: hidden;
+}
+
+.tab.active,
+.tab:hover,
+.tab:focus-visible {
+  animation: border-flow 1.8s linear infinite;
+}
+
+.tab.active {
+  color: #111827;
+  background: #ffffff;
+  box-shadow: 0 10px 26px rgba(190, 18, 60, 0.18);
+}
+
+.tab:focus-visible {
+  outline: 3px solid #f59e0b;
+  outline-offset: 3px;
+}
+
+.tab-panel {
+  display: grid;
+  grid-template-columns: 72px 1fr;
+  align-items: center;
+  gap: 18px;
+  border-radius: 24px;
+  padding: 22px;
+  background: #f8fafc;
+  box-shadow: inset 0 0 0 1px rgba(17, 24, 39, 0.08);
+  animation: panel-enter 560ms ease both;
+}
+
+.panel-icon {
+  width: 58px;
+  height: 58px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, #be123c, #f59e0b);
+  box-shadow: 0 16px 32px rgba(190, 18, 60, 0.24);
+}
+
+.tab-panel strong {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 1.1rem;
+}
+
+.tab-panel p {
+  margin: 0;
+  color: #64748b;
+  line-height: 1.55;
+}
+
+@keyframes border-flow {
+  from {
+    background-position: 0 0;
+  }
+  to {
+    background-position: 220% 0;
+  }
+}
+
+@keyframes panel-enter {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 560px) {
+  .tab-panel {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a gradient border tabs submission with animated active states and a lifted content panel.

---

## Type of Change

- [x] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/gradient-border-tabs/`
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A tab navigation pattern with animated gradient borders, focus-visible states, and a lifted content panel.

**How does a developer use it?**

```html
<div class="tab-list" role="tablist">
  <button class="tab active" role="tab">Overview</button>
  <button class="tab" role="tab">Motion</button>
</div>
```

**Why does it fit EaseMotion CSS?**

It provides a clear animated active-state pattern for dashboards, settings screens, and product interfaces.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer

Local verification: `npm test` passed with 1 test file and 13 tests.
