### PR TITLE
feat: add reading time progress badge with scroll-based countdown

### DIFF
--- a/submissions/examples/reading-time-badge-ms07/README.md
+++ b/submissions/examples/reading-time-badge-ms07/README.md
@@ -1,0 +1,30 @@
+# Reading Time Progress Badge
+
+1. **What does this do?**
+   A small fixed badge that shows an estimated reading time ("3 min read") on page load, fading in once. As the reader scrolls through the article, it switches to a live countdown ("2 min left", "1 min left"...), and a thin progress ring around the badge fills in to match how far through the content they've scrolled.
+
+2. **How is it used?**
+   Place a `.readbadge` element (containing the SVG ring and a text span) somewhere in the page, and wrap the article content in a container the included script can measure — in this demo, `.readbadge-article`.
+
+   ```html
+   <div class="readbadge">
+     <svg class="readbadge-ring" viewBox="0 0 44 44">
+       <circle class="readbadge-ring-track" cx="22" cy="22" r="19"></circle>
+       <circle class="readbadge-ring-progress" cx="22" cy="22" r="19"></circle>
+     </svg>
+     <span class="readbadge-text">Calculating…</span>
+   </div>
+   ```
+
+   A small vanilla JS snippet computes word count from the article's `innerText` at load (≈200 words per minute), sets the initial "X min read" label, then on scroll recalculates remaining time and updates both the label and the ring's `stroke-dashoffset`.
+
+3. **Why is this useful?**
+   Unlike a loading bar, nobody is blocked waiting on this — it's a lightweight, ambient orientation cue for long-form content, letting readers gauge how much is left without losing their place or being interrupted. Combining a live-updating label with a CSS-eased progress ring keeps the indicator informative without demanding attention, which fits EaseMotion CSS's animation-first but restraint-conscious philosophy.
+
+### Notes for the maintainer
+- This requires a small amount of vanilla JS (`scroll` listener + word-count calculation), since neither reading time estimation nor scroll-position tracking is something pure CSS can do — no frameworks or CDN dependencies are used, consistent with the repo's no-build-tool constraint.
+- Word count uses the standard ~200 words-per-minute assumption; the demo article (~676 words) was written to land on a clean "3 min read" at load, verified directly rather than left to chance.
+- The progress ring's fill direction was deliberately checked: `stroke-dashoffset = circumference * (1 - progress)` produces a ring that's empty at 0% scroll progress and fully drawn at 100%, with `rotate(-90deg)` on the SVG so the fill starts from 12 o'clock rather than 3 o'clock.
+- The badge label only switches from "X min read" to "X min left" after the reader has scrolled even slightly (so it doesn't immediately flip to a countdown before any actual reading has happened), and shows "Finished" once scroll progress is effectively complete.
+- `prefers-reduced-motion: reduce` keeps the one-time fade-in (low-intensity, not continuous) but removes the easing transition on the ring, so progress updates happen instantly rather than animating continuously while scrolling.
+- Tested in Chrome, Firefox, and Edge.

--- a/submissions/examples/reading-time-badge-ms07/demo.html
+++ b/submissions/examples/reading-time-badge-ms07/demo.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Reading Time Progress Badge — Demo</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <!-- The badge stays fixed in the corner and is the actual feature
+       being demonstrated; everything below it is just sample article
+       content so there's something to scroll through. -->
+  <div class="readbadge" id="readBadge">
+    <svg class="readbadge-ring" viewBox="0 0 44 44" aria-hidden="true">
+      <circle class="readbadge-ring-track" cx="22" cy="22" r="19"></circle>
+      <circle class="readbadge-ring-progress" id="readBadgeRingProgress" cx="22" cy="22" r="19"></circle>
+    </svg>
+    <span class="readbadge-text" id="readBadgeText">Calculating…</span>
+  </div>
+
+  <main class="readbadge-article">
+
+    <h1>Designing Calm Interfaces</h1>
+    <p>Scroll down to see the badge in the corner switch from an estimated reading time to a live countdown, with a thin progress ring tracking how far you've gotten.</p>
+
+    <p>Good interface design is rarely about adding more. It's about removing the friction between a person's intention and the outcome they're trying to reach. Every additional decision a screen asks someone to make — every extra click, every ambiguous icon, every menu nested three levels deep — is a small tax on their attention. Calm interfaces minimize that tax. They don't disappear; they simply stop demanding more attention than the task deserves.</p>
+
+    <p>One of the clearest signals of a calm interface is how it behaves when nothing is happening. Does it sit quietly, or does it animate, pulse, and notify for no reason? A loading spinner that never stops, a badge that blinks long after the new content has been seen, a tooltip that reappears every time the cursor drifts near it — these are all small violations of calm. They train people to distrust the interface's sense of timing, because it never seems to know when to stop talking.</p>
+
+    <p>Motion, used well, is one of the most powerful tools for building that trust back. A transition that eases in over 200 milliseconds tells the eye "something changed, and here's exactly what." A static cut, by contrast, asks the brain to do extra work reconciling two unrelated states. This is why thoughtful entrance and exit animations are not decoration — they're a form of explanation, delivered visually rather than in text.</p>
+
+    <p>The same principle applies to feedback. When someone fills out a form, submits a comment, or saves a draft, the interface needs to acknowledge that the action landed. A button that visibly depresses, a checkmark that draws itself in, a subtle pulse on a saved indicator — these are small, cheap signals that carry a disproportionate amount of reassurance. Their absence is rarely noticed consciously, but it accumulates as a vague sense that the product feels unfinished or unreliable.</p>
+
+    <p>Progress indicators deserve special care, because they sit at the intersection of information and reassurance. A progress bar that's purely decorative — one that doesn't actually track real progress — erodes trust the moment someone notices the mismatch. But a progress indicator that's accurate, even if the news is "this will take a while," tends to be received far better than no indicator at all. People are remarkably patient with processes they can see moving, and remarkably impatient with ones that give them nothing to watch.</p>
+
+    <p>Reading progress is a quieter, more personal version of the same idea. Unlike a loading bar, nobody is blocked waiting for it; it exists purely to orient the reader within a piece of content that might be longer than expected. A small badge that starts as an estimate — "4 min read" — and gradually resolves into a countdown as the person actually reads gives them a lightweight, ambient sense of where they are, without ever interrupting the reading itself.</p>
+
+    <p>What makes this kind of indicator work is restraint. It needs to update smoothly rather than in visible jumps, it needs to sit somewhere it can be ignored entirely if the reader doesn't care about it, and it needs to resolve its own state without asking for any interaction. The moment a "helpful" indicator demands attention or interrupts scrolling to recalibrate itself, it stops being calm and starts being one more thing competing for the reader's focus.</p>
+
+    <p>This is really the throughline across all of these examples: the best feedback mechanisms behave like good company. They're present when useful, quiet when not, and they never make the person ask "wait, what just happened?" Calm interfaces aren't the absence of motion or feedback — they're motion and feedback applied with enough judgment that they never need to explain themselves.</p>
+
+    <p>That's the bottom of the article — if the badge above now reads something close to "0 min left" with a nearly complete ring, the effect is working as intended.</p>
+
+  </main>
+
+  <script>
+    (function () {
+      const article = document.querySelector('.readbadge-article');
+      const badgeText = document.getElementById('readBadgeText');
+      const ringProgress = document.getElementById('readBadgeRingProgress');
+
+      // Reading-time estimate at a standard ~200 words-per-minute pace.
+      const WORDS_PER_MINUTE = 200;
+      const wordCount = article.innerText.trim().split(/\s+/).length;
+      const totalMinutes = Math.max(1, Math.round(wordCount / WORDS_PER_MINUTE));
+
+      // Ring geometry: r=19 -> circumference = 2 * PI * 19
+      const RADIUS = 19;
+      const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+      ringProgress.style.strokeDasharray = `${CIRCUMFERENCE}`;
+      ringProgress.style.strokeDashoffset = `${CIRCUMFERENCE}`;
+
+      // Initial state: full estimate, ring empty, no progress yet.
+      badgeText.textContent = `${totalMinutes} min read`;
+
+      let hasStartedReading = false;
+
+      function updateOnScroll() {
+        const articleTop = article.offsetTop;
+        const articleHeight = article.offsetHeight;
+        const scrollY = window.scrollY;
+        const viewportHeight = window.innerHeight;
+
+        // Treat "progress" as how far the reader has scrolled through
+        // the article's own height, clamped to [0, 1].
+        const scrolledPast = scrollY + viewportHeight * 0.5 - articleTop;
+        const progress = Math.min(1, Math.max(0, scrolledPast / articleHeight));
+
+        if (progress > 0.02 && !hasStartedReading) {
+          hasStartedReading = true;
+        }
+
+        const minutesLeft = Math.max(0, Math.ceil(totalMinutes * (1 - progress)));
+
+        if (hasStartedReading) {
+          badgeText.textContent = progress >= 0.98
+            ? 'Finished'
+            : `${minutesLeft} min left`;
+        }
+
+        const offset = CIRCUMFERENCE * (1 - progress);
+        ringProgress.style.strokeDashoffset = `${offset}`;
+      }
+
+      window.addEventListener('scroll', updateOnScroll, { passive: true });
+      updateOnScroll();
+    })();
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/reading-time-badge-ms07/style.css
+++ b/submissions/examples/reading-time-badge-ms07/style.css
@@ -1,0 +1,118 @@
+
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #0b0f19;
+  color: #e7e9ee;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+
+.readbadge {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 10;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px 6px 6px;
+  border-radius: 999px;
+  background: #161b29cc;
+  backdrop-filter: blur(8px);
+  border: 1px solid #ffffff14;
+  box-shadow: 0 8px 24px -10px #000000aa;
+  opacity: 0;
+  transform: translateY(-6px);
+  animation: readbadge-fade-in 0.5s ease 0.15s forwards;
+}
+
+@keyframes readbadge-fade-in {
+  from { opacity: 0; transform: translateY(-6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+
+.readbadge-ring {
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+  transform: rotate(-90deg);
+}
+
+.readbadge-ring-track,
+.readbadge-ring-progress {
+  fill: none;
+  stroke-width: 3;
+}
+
+.readbadge-ring-track {
+  stroke: #ffffff1a;
+}
+
+.readbadge-ring-progress {
+  stroke: #6c63ff;
+  stroke-linecap: round;
+  transition: stroke-dashoffset 0.25s ease-out;
+}
+
+/* ---------------------------------------------------------------
+   Badge label text
+   --------------------------------------------------------------- */
+
+.readbadge-text {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #d6dae5;
+  white-space: nowrap;
+}
+
+
+.readbadge-article {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 100px 24px 160px;
+}
+
+.readbadge-article h1 {
+  font-size: 1.9rem;
+  margin: 0 0 18px;
+}
+
+.readbadge-article p {
+  font-size: 1rem;
+  line-height: 1.75;
+  color: #c2c7d4;
+  margin: 0 0 22px;
+}
+
+/* ===================================================================
+   Responsive behavior
+   =================================================================== */
+
+@media (max-width: 480px) {
+  .readbadge {
+    top: 14px;
+    right: 14px;
+    padding: 5px 11px 5px 5px;
+  }
+
+  .readbadge-text {
+    font-size: 0.72rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .readbadge {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+
+  .readbadge-ring-progress {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a fixed reading-time badge that shows "X min read" on load
(fading in once), then switches to a live "X min left" countdown as
the reader scrolls, with a thin progress ring around it filling in to
match scroll progress through the article.

---

## Type of Change

- [x] 🧩 New component
- [x] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/reading-time-badge-ms07/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A scroll-aware reading-time badge: initial estimate on load, live
"time left" countdown while scrolling, and a CSS progress ring that
fills in proportionally to reading progress.

**How does a developer use it?**

```html
<div class="readbadge">
  <svg class="readbadge-ring" viewBox="0 0 44 44">
    <circle class="readbadge-ring-track" cx="22" cy="22" r="19"></circle>
    <circle class="readbadge-ring-progress" cx="22" cy="22" r="19"></circle>
  </svg>
  <span class="readbadge-text">Calculating…</span>
</div>
```

**Why does it fit EaseMotion CSS?**

It's a lightweight, ambient orientation cue for long-form content —
informative without demanding attention, combining a live-updating
label with a CSS-eased progress ring, consistent with the framework's
animation-first but restraint-conscious philosophy.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Requires a small amount of vanilla JS (scroll listener + word-count
calculation) since neither reading-time estimation nor scroll
tracking is achievable in pure CSS — no frameworks or CDN
dependencies used. Word count uses the standard ~200wpm assumption;
the demo article (~676 words) was written and verified to land
cleanly on "3 min read" at load. Ring fill direction was checked
explicitly: `stroke-dashoffset = circumference * (1 - progress)`
produces an empty-to-full fill as scroll progress increases, with
`rotate(-90deg)` so it starts from 12 o'clock. The label only
switches to "X min left" after the reader scrolls slightly, and shows
"Finished" near the end. `prefers-reduced-motion: reduce` keeps the
one-time fade-in but removes the ring's easing transition.


https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/20572