### PR TITLE
feat: add expandable faq cards demo

### DIFF
--- a/submissions/examples/expandable-faq-cards/README.md
+++ b/submissions/examples/expandable-faq-cards/README.md
@@ -1,0 +1,15 @@
+# Expandable FAQ Cards
+
+## What does this do?
+A CSS-only FAQ card group using native details and summary elements with animated answer reveal.
+
+## How is it used?
+```html
+<details open>
+  <summary>Can this work without JavaScript?</summary>
+  <p>Yes. The native disclosure element handles the interaction.</p>
+</details>
+```
+
+## Why is it useful?
+It gives EaseMotion CSS an accessible disclosure pattern for FAQs, help centers, and onboarding content.

--- a/submissions/examples/expandable-faq-cards/demo.html
+++ b/submissions/examples/expandable-faq-cards/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Expandable FAQ Cards Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="faq-page" aria-labelledby="faq-title">
+    <section class="faq-card">
+      <p class="eyebrow">Disclosure pattern</p>
+      <h1 id="faq-title">Expandable FAQ Cards</h1>
+      <div class="faq-list">
+        <details open>
+          <summary>Can this work without JavaScript?</summary>
+          <p>Yes. The native details element handles disclosure while CSS adds motion and polish.</p>
+        </details>
+        <details>
+          <summary>Is it keyboard friendly?</summary>
+          <p>The summary element is naturally focusable and receives a visible focus ring.</p>
+        </details>
+        <details>
+          <summary>Where should I use it?</summary>
+          <p>Use it for product FAQs, settings help, onboarding notes, and compact documentation blocks.</p>
+        </details>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/expandable-faq-cards/style.css
+++ b/submissions/examples/expandable-faq-cards/style.css
@@ -1,0 +1,129 @@
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(140deg, #312e81, #0891b2 52%, #fef08a);
+  color: #111827;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+.faq-page {
+  width: min(92vw, 760px);
+  padding: 28px;
+}
+
+.faq-card {
+  border-radius: 28px;
+  padding: clamp(24px, 5vw, 46px);
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: 0 30px 86px rgba(49, 46, 129, 0.34);
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: #0e7490;
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 28px;
+  font-size: clamp(2.2rem, 7vw, 4.8rem);
+  line-height: 0.92;
+}
+
+.faq-list {
+  display: grid;
+  gap: 14px;
+}
+
+details {
+  border-radius: 22px;
+  background: #f8fafc;
+  box-shadow: inset 0 0 0 1px rgba(17, 24, 39, 0.08);
+  overflow: hidden;
+  animation: card-enter 560ms both;
+}
+
+details:nth-child(2) {
+  animation-delay: 90ms;
+}
+
+details:nth-child(3) {
+  animation-delay: 180ms;
+}
+
+summary {
+  position: relative;
+  min-height: 64px;
+  display: flex;
+  align-items: center;
+  padding: 0 58px 0 20px;
+  cursor: pointer;
+  font-weight: 900;
+  list-style: none;
+}
+
+summary::-webkit-details-marker {
+  display: none;
+}
+
+summary::after {
+  content: "+";
+  position: absolute;
+  right: 20px;
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: #0891b2;
+  color: #ffffff;
+  transition: transform 180ms ease, background 180ms ease;
+}
+
+details[open] summary::after {
+  background: #312e81;
+  transform: rotate(45deg);
+}
+
+details p {
+  margin: 0;
+  padding: 0 20px 22px;
+  color: #64748b;
+  line-height: 1.6;
+  animation: answer-slide 240ms ease both;
+}
+
+details[open] {
+  box-shadow: inset 0 0 0 2px rgba(49, 46, 129, 0.22), 0 16px 34px rgba(49, 46, 129, 0.14);
+}
+
+summary:focus-visible {
+  outline: 4px solid #facc15;
+  outline-offset: -4px;
+}
+
+@keyframes card-enter {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes answer-slide {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an expandable FAQ cards submission using native details and summary elements with animated answer reveal.

---

## Type of Change

- [x] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/expandable-faq-cards/`
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A CSS-only FAQ card group using native details and summary elements with animated answer reveal.

**How does a developer use it?**

```html
<details open>
  <summary>Can this work without JavaScript?</summary>
  <p>Yes. The native disclosure element handles the interaction.</p>
</details>
```

**Why does it fit EaseMotion CSS?**

It adds an accessible disclosure pattern for FAQs, help centers, and onboarding content.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer

Local verification: `npm test` passed with 1 test file and 13 tests.
