### PR TITLE
feat: add multi-phrase typewriter loop with CSS cursor blink

### DIFF
--- a/submissions/examples/typewriter-loop-ms07/README.md
+++ b/submissions/examples/typewriter-loop-ms07/README.md
@@ -1,0 +1,33 @@
+# Typewriter Loop
+
+1. **What does this do?**
+   Types out a phrase character by character, pauses, deletes it, then types the next phrase from a list — looping indefinitely. A blinking text cursor (pure CSS) sits beside the typed text the whole time.
+
+2. **How is it used?**
+   Add a `.typewriter` element containing a `.typewriter-text` span (for the JS to fill in) and a `.typewriter-cursor` span (for the CSS blink), with the phrase list passed as a JSON array in `data-phrases`:
+
+   ```html
+   <span class="typewriter" data-phrases='["fast interfaces.", "calm transitions.", "delightful details."]'>
+     <span class="typewriter-text"></span>
+     <span class="typewriter-cursor" aria-hidden="true"></span>
+   </span>
+   ```
+
+   Retime the effect with two CSS custom properties on `.typewriter`:
+
+   ```css
+   .typewriter {
+     --ease-type-speed: 70ms;   /* ms per character while typing */
+     --ease-delete-speed: 40ms; /* ms per character while deleting */
+   }
+   ```
+
+3. **Why is this useful?**
+   A rotating multi-phrase typewriter is one of the most common hero-subheading treatments on marketing and landing pages, and this gives EaseMotion CSS a ready, dependency-free version: JS owns the array/typing state machine, CSS owns the cursor blink, and the whole thing is retunable through two named variables rather than buried magic numbers.
+
+### Notes for the maintainer
+- **JS manages the phrase array and typing/deleting** exactly as the issue specifies — a single recursive `setTimeout` loop (not `setInterval`) handles typing, pausing on the full phrase, deleting, pausing on empty, and advancing to the next phrase with wraparound. Traced by hand to confirm no off-by-one errors (deleting stops exactly at an empty string, never goes negative or skips the last character).
+- **CSS handles the cursor blink** independently of the JS loop — `.typewriter-cursor` blinks on its own fixed interval via `@keyframes`, not tied to each keystroke, so it reads as a steady text-cursor rather than a flicker.
+- **`--ease-type-speed` and `--ease-delete-speed`** are read directly from the computed style via `getComputedStyle` so a single CSS declaration controls the actual JS timing — no duplicated values between CSS and JS. The reader function accepts either `ms` or `s` units (e.g. `70ms` or `0.07s`) and normalizes to milliseconds, since a naive `parseFloat` alone would silently misinterpret `0.07s` as 0.07 milliseconds instead of 70.
+- `prefers-reduced-motion: reduce` stops the cursor's blink animation but keeps it visibly solid, so the live-typing text still reads as active without the continuous blinking motion.
+- Tested in Chrome, Firefox, and Edge.

--- a/submissions/examples/typewriter-loop-ms07/demo.html
+++ b/submissions/examples/typewriter-loop-ms07/demo.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Typewriter Loop — Demo</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <main class="typewriter-demo-wrapper">
+
+    <p class="typewriter-demo-eyebrow">EaseMotion CSS</p>
+
+    <h1 class="typewriter-demo-heading">
+      Built for developers who design
+      <span class="typewriter" data-phrases='["fast interfaces.", "calm transitions.", "delightful details.", "accessible motion."]'>
+        <span class="typewriter-text" id="typewriterText"></span>
+        <span class="typewriter-cursor" aria-hidden="true"></span>
+      </span>
+    </h1>
+
+    <p class="typewriter-demo-sub">A pure-CSS-and-vanilla-JS multi-phrase typewriter, ready to drop into any hero subheading.</p>
+
+  </main>
+
+  <script>
+    (function () {
+      const root = document.querySelector('.typewriter');
+      const textEl = document.getElementById('typewriterText');
+      const phrases = JSON.parse(root.dataset.phrases || '[]');
+
+      if (phrases.length === 0) return;
+
+      // Read the configurable timing from CSS custom properties so the
+      // same values used for the cursor blink (and any author overrides)
+      // also drive the JS typing/deleting cadence. Accepts either `ms`
+      // or `s` units (e.g. "70ms" or "0.07s") and normalizes to
+      // milliseconds, since a bare parseFloat() would silently treat
+      // "0.07s" as 0.07ms instead of 70ms.
+      function readSpeedVar(varName, fallbackMs) {
+        const raw = getComputedStyle(root).getPropertyValue(varName).trim();
+        const parsed = parseFloat(raw);
+        if (!Number.isFinite(parsed)) return fallbackMs;
+        return raw.endsWith('s') && !raw.endsWith('ms') ? parsed * 1000 : parsed;
+      }
+
+      const TYPE_SPEED = readSpeedVar('--ease-type-speed', 70);     // ms per character while typing
+      const DELETE_SPEED = readSpeedVar('--ease-delete-speed', 40); // ms per character while deleting
+      const PAUSE_FULL = 1400;  // how long to hold the fully-typed phrase
+      const PAUSE_EMPTY = 300;  // brief beat before the next phrase starts typing
+
+      let phraseIndex = 0;
+      let charIndex = 0;
+      let isDeleting = false;
+
+      function tick() {
+        const currentPhrase = phrases[phraseIndex];
+
+        if (!isDeleting) {
+          charIndex += 1;
+          textEl.textContent = currentPhrase.slice(0, charIndex);
+
+          if (charIndex === currentPhrase.length) {
+            isDeleting = true;
+            setTimeout(tick, PAUSE_FULL);
+            return;
+          }
+
+          setTimeout(tick, TYPE_SPEED);
+        } else {
+          charIndex -= 1;
+          textEl.textContent = currentPhrase.slice(0, charIndex);
+
+          if (charIndex === 0) {
+            isDeleting = false;
+            phraseIndex = (phraseIndex + 1) % phrases.length;
+            setTimeout(tick, PAUSE_EMPTY);
+            return;
+          }
+
+          setTimeout(tick, DELETE_SPEED);
+        }
+      }
+
+      tick();
+    })();
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/typewriter-loop-ms07/style.css
+++ b/submissions/examples/typewriter-loop-ms07/style.css
@@ -1,0 +1,86 @@
+
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0b0f19;
+  color: #e7e9ee;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+
+.typewriter-demo-wrapper {
+  max-width: 640px;
+  padding: 0 24px;
+  text-align: center;
+}
+
+.typewriter-demo-eyebrow {
+  margin: 0 0 10px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8b93a7;
+}
+
+.typewriter-demo-heading {
+  margin: 0 0 18px;
+  font-size: clamp(1.6rem, 4.5vw, 2.4rem);
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.typewriter-demo-sub {
+  margin: 0;
+  color: #aeb4c4;
+  font-size: 0.95rem;
+}
+
+
+.typewriter {
+  display: inline-flex;
+  align-items: baseline;
+  color: #8b93ff;
+
+  --ease-type-speed: 70ms;
+  --ease-delete-speed: 40ms;
+}
+
+.typewriter-text {
+  white-space: pre;
+}
+
+
+.typewriter-cursor {
+  display: inline-block;
+  width: 3px;
+  height: 1.1em;
+  margin-left: 2px;
+  background: currentColor;
+  animation: typewriter-blink 0.8s step-end infinite;
+}
+
+@keyframes typewriter-blink {
+  0%, 50%  { opacity: 1; }
+  50.01%, 100% { opacity: 0; }
+}
+
+
+@media (max-width: 480px) {
+  .typewriter-demo-heading {
+    line-height: 1.4;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .typewriter-cursor {
+    animation: none;
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a multi-phrase typewriter component: JS types out each phrase
from an array, pauses, deletes it, and moves to the next in a loop;
CSS handles an independent cursor blink. Timing is configurable via
`--ease-type-speed` and `--ease-delete-speed`.

---

## Type of Change

- [x] 🧩 New component
- [x] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/typewriter-loop-ms07/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A looping multi-phrase typewriter effect — type, pause, delete, next
phrase — with a CSS-only blinking cursor, good for hero subheadings.

**How does a developer use it?**

```html
<span class="typewriter" data-phrases='["fast interfaces.", "calm transitions.", "delightful details."]'>
  <span class="typewriter-text"></span>
  <span class="typewriter-cursor" aria-hidden="true"></span>
</span>
```

```css
.typewriter {
  --ease-type-speed: 70ms;
  --ease-delete-speed: 40ms;
}
```

**Why does it fit EaseMotion CSS?**

A rotating-phrase typewriter is one of the most common hero-subheading
treatments on landing pages. This keeps the split clean — JS owns the
array/state machine, CSS owns the cursor blink — and the whole effect
is retunable through two named variables instead of buried constants.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

JS uses a single recursive `setTimeout` loop (not `setInterval`) for
typing, pausing on the full phrase, deleting, pausing on empty, and
advancing with wraparound — traced by hand to confirm no off-by-one
errors. The cursor blinks on its own independent CSS interval, not
tied to each keystroke. `--ease-type-speed` / `--ease-delete-speed`
are read via `getComputedStyle` so one CSS declaration drives the
actual JS timing; the reader normalizes both `ms` and `s` units to
milliseconds, since a naive `parseFloat` alone would misread `0.07s`
as 0.07ms instead of 70ms. `prefers-reduced-motion: reduce` stops the
cursor blink but keeps it solid so the text still reads as live.

Closes https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/20566