### PR TITLE
feat: add vertical word cycling carousel for hero taglines

### DIFF
--- a/submissions/examples/word-carousel-ms07/README.md
+++ b/submissions/examples/word-carousel-ms07/README.md
@@ -1,0 +1,33 @@
+# Word Carousel
+
+1. **What does this do?**
+   A single word in a sentence cycles vertically through a list of alternatives — each word slides up and fades in from below, holds steady, then slides further up and fades out, before the next word in the array takes its place. Built for hero taglines like "We build **fast** interfaces" → "We build **accessible** interfaces" → ...
+
+2. **How is it used?**
+   Wrap a `.wordcarousel-track` span inside a fixed-height, clipped `.wordcarousel` container, with the word list passed as a JSON array in `data-words`:
+
+   ```html
+   <span class="wordcarousel" data-words='["fast", "accessible", "delightful", "composable"]'>
+     <span class="wordcarousel-track"></span>
+   </span>
+   ```
+
+   Retime the whole cycle with one CSS custom property:
+
+   ```css
+   .wordcarousel {
+     --ease-carousel-speed: 2200ms; /* full cycle: in, hold, out */
+   }
+   ```
+
+3. **Why is this useful?**
+   Cycling a single word while the rest of a sentence stays fixed is a very common, high-impact hero-section technique, and doing it with a real `overflow: hidden` clipped track (rather than just crossfading stacked absolute-positioned words) gives a more polished, genuinely "carousel" feel. JS only has to swap text and restart one animation class — all the actual motion lives in a single CSS keyframe.
+
+### Notes for the maintainer
+- **Words scroll vertically in an `overflow: hidden` container** — `.wordcarousel` is the fixed-height clipping box, `.wordcarousel-track` is the element that actually animates within it.
+- **Each word fades/slides in then out** within a single `@keyframes` cycle (`0–12%` slide+fade in, `12–78%` hold, `78–100%` slide+fade out), so JS never has to coordinate two separate "enter" and "exit" animations — it just swaps the text and restarts one class.
+- **Loops through the word array** via `(index + 1) % words.length`, wrapping back to the start indefinitely.
+- **`--ease-carousel-speed`** is read by JS via `getComputedStyle` (same unit-aware parser used in other recent submissions, handling both `ms` and `s`) so the `setInterval` delay and the CSS `animation-duration` always stay derived from the same single source — verified by tracing the timing across several cycles to confirm each animation completes exactly as the next word swap fires, with no visible gap or overlap.
+- One caveat worth noting: `setInterval` can drift slightly under heavy main-thread load, which is a general JS scheduling characteristic rather than a bug in this implementation — acceptable for a decorative hero element, but worth knowing if extremely precise long-run timing ever matters.
+- `prefers-reduced-motion: reduce` swaps to a fade-only variant of the keyframes (same timing, no vertical motion), so the word change is still visible without the continuous slide.
+- Tested in Chrome, Firefox, and Edge.

--- a/submissions/examples/word-carousel-ms07/demo.html
+++ b/submissions/examples/word-carousel-ms07/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Word Carousel — Demo</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <main class="wordcarousel-demo-wrapper">
+
+    <p class="wordcarousel-demo-eyebrow">EaseMotion CSS</p>
+
+    <h1 class="wordcarousel-demo-heading">
+      We build
+      <span class="wordcarousel" data-words='["fast", "accessible", "delightful", "composable"]'>
+        <span class="wordcarousel-track" id="wordcarouselTrack"></span>
+      </span>
+      interfaces.
+    </h1>
+
+    <p class="wordcarousel-demo-sub">A vertical word-cycling carousel for hero taglines — JS swaps the word, CSS handles the slide and fade.</p>
+
+  </main>
+
+  <script>
+    (function () {
+      const root = document.querySelector('.wordcarousel');
+      const track = document.getElementById('wordcarouselTrack');
+      const words = JSON.parse(root.dataset.words || '[]');
+
+      if (words.length === 0) return;
+
+      function readSpeedVar(varName, fallbackMs) {
+        const raw = getComputedStyle(root).getPropertyValue(varName).trim();
+        const parsed = parseFloat(raw);
+        if (!Number.isFinite(parsed)) return fallbackMs;
+        return raw.endsWith('s') && !raw.endsWith('ms') ? parsed * 1000 : parsed;
+      }
+
+      const CYCLE_MS = readSpeedVar('--ease-carousel-speed', 2200);
+
+      let index = 0;
+
+      function showWord(word) {
+        track.textContent = word;
+        track.classList.remove('wordcarousel-animate');
+        void track.offsetWidth;
+        track.classList.add('wordcarousel-animate');
+      }
+
+      showWord(words[index]);
+
+      setInterval(() => {
+        index = (index + 1) % words.length;
+        showWord(words[index]);
+      }, CYCLE_MS);
+    })();
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/word-carousel-ms07/style.css
+++ b/submissions/examples/word-carousel-ms07/style.css
@@ -1,0 +1,103 @@
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0b0f19;
+  color: #e7e9ee;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+
+.wordcarousel-demo-wrapper {
+  max-width: 640px;
+  padding: 0 24px;
+  text-align: center;
+}
+
+.wordcarousel-demo-eyebrow {
+  margin: 0 0 10px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8b93a7;
+}
+
+.wordcarousel-demo-heading {
+  margin: 0 0 18px;
+  font-size: clamp(1.6rem, 4.5vw, 2.4rem);
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.wordcarousel-demo-sub {
+  margin: 0;
+  color: #aeb4c4;
+  font-size: 0.95rem;
+}
+
+
+.wordcarousel {
+  display: inline-block;
+  position: relative;
+  height: 1.3em;
+  overflow: hidden;
+  vertical-align: bottom;
+  color: #8b93ff;
+
+  --ease-carousel-speed: 2200ms;
+}
+
+.wordcarousel-track {
+  display: inline-block;
+  white-space: nowrap;
+}
+
+
+.wordcarousel-track.wordcarousel-animate {
+  animation: wordcarousel-cycle var(--ease-carousel-speed, 2200ms) ease-in-out;
+}
+
+@keyframes wordcarousel-cycle {
+  0% {
+    transform: translateY(60%);
+    opacity: 0;
+  }
+  12% {
+    transform: translateY(0%);
+    opacity: 1;
+  }
+  78% {
+    transform: translateY(0%);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(-60%);
+    opacity: 0;
+  }
+}
+
+@media (max-width: 480px) {
+  .wordcarousel-demo-heading {
+    line-height: 1.45;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wordcarousel-track.wordcarousel-animate {
+    animation-name: wordcarousel-fade-only;
+  }
+
+  @keyframes wordcarousel-fade-only {
+    0%   { opacity: 0; transform: none; }
+    12%  { opacity: 1; transform: none; }
+    78%  { opacity: 1; transform: none; }
+    100% { opacity: 0; transform: none; }
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a vertical word-cycling carousel: a single word position in a
sentence cycles through a list, sliding/fading in from below, holding,
then sliding/fading out at the top before the next word takes its
place — built for hero taglines.

---

## Type of Change

- [x] 🧩 New component
- [x] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/word-carousel-ms07/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A clipped, fixed-height word carousel where JS swaps the word and
loops through an array, and a single CSS keyframe handles the
slide-in, hold, and slide-out for every word.

**How does a developer use it?**

```html
<span class="wordcarousel" data-words='["fast", "accessible", "delightful", "composable"]'>
  <span class="wordcarousel-track"></span>
</span>
```

```css
.wordcarousel {
  --ease-carousel-speed: 2200ms;
}
```

**Why does it fit EaseMotion CSS?**

Cycling a single word while the rest of a sentence stays fixed is a
high-impact, common hero technique. Using a real `overflow: hidden`
clipped track (not stacked crossfading words) gives it a genuine
carousel feel, while keeping JS minimal — it only swaps text and
restarts one animation class.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

One `@keyframes` cycle covers slide+fade in (0–12%), hold (12–78%),
and slide+fade out (78–100%), so JS never coordinates separate enter/
exit animations — it just swaps text and restarts one class. Loops
via `(index + 1) % words.length`. `--ease-carousel-speed` is read by
JS via `getComputedStyle` (unit-aware: handles both `ms` and `s`) so
the `setInterval` delay and the CSS `animation-duration` always derive
from the same source — timing traced across several cycles to confirm
each animation finishes exactly as the next swap fires, with no gap
or overlap. `setInterval` can drift slightly under heavy main-thread
load (general JS scheduling behavior, not specific to this code).
`prefers-reduced-motion: reduce` swaps to a fade-only keyframe variant.

Closes https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/20564