### PR TITLE
feat: add scroll-triggered floating CTA with dismiss

### DIFF
--- a/submissions/examples/floating-cta-ms07/README.md
+++ b/submissions/examples/floating-cta-ms07/README.md
@@ -1,0 +1,31 @@
+# Floating Scroll CTA
+
+1. **What does this do?**
+   A call-to-action button fixed to the bottom-right of the viewport, hidden until the reader scrolls past the hero section, at which point it fades and slides in. Scrolling back up past that threshold fades it back out. A small dismiss (×) button lets the reader close it permanently for the rest of the page session, even if they keep scrolling afterward.
+
+2. **How is it used?**
+   Place a `.floatcta` container (containing the dismiss button and the CTA link) anywhere in the page — it's fixed-positioned, so placement in the DOM doesn't matter:
+
+   ```html
+   <div class="floatcta">
+     <button class="floatcta-dismiss" aria-label="Dismiss">×</button>
+     <a class="floatcta-button" href="#top">Get Started</a>
+   </div>
+   ```
+
+   A small vanilla JS snippet measures the hero section's height, listens for scroll, and toggles `floatcta-visible` / `floatcta-hidden` on the container based on a scroll threshold; clicking dismiss adds `floatcta-dismissed` and detaches the scroll listener entirely.
+
+3. **Why is this useful?**
+   Scroll-triggered floating CTAs are a common conversion pattern on marketing and landing pages — present once the reader has shown intent (scrolled past the fold) but absent during the first impression. Handling the dismiss state correctly (so the button can't reappear mid-session after being closed) is the detail that's easy to get wrong in a naive implementation, and is handled explicitly here.
+
+### Notes for the maintainer
+- The original issue names the three states as `ease-fade-in`, `ease-hover-lift`, and `ease-fade-out`. Since this is a `submissions/examples/` build, the equivalent behavior is implemented under unprefixed names, with this mapping for integration:
+  - `ease-fade-in` → `.floatcta-visible` (opacity + translateY transition on scroll past threshold)
+  - `ease-hover-lift` → `.floatcta-button:hover` (translateY + shadow lift)
+  - `ease-fade-out` → `.floatcta-hidden` (reverse of the above, on scroll back to top)
+- **Dismissal is handled defensively in two layers**: an `isDismissed` flag is checked at the top of the scroll handler (in case any stray scroll event fires mid-transition), and the scroll listener is also fully removed via `removeEventListener` on dismiss — so there's no code path where a dismissed button can become visible again later in the same session.
+- The dismissed state (`.floatcta-dismissed`) also strips the CSS transition entirely, so closing the button feels immediate and decisive rather than easing out like a normal scroll-triggered hide.
+- The button starts with `pointer-events: none` while hidden, so it can't be clicked or tab-focused before it's actually visible.
+- `hero.offsetHeight` is read synchronously since the script tag sits at the end of `<body>`, after the hero section has already been parsed and laid out — verified this is safe rather than assumed.
+- `prefers-reduced-motion: reduce` keeps the opacity fade (it conveys real state) but removes the vertical slide and the hover-lift's transform, both of which are purely decorative motion.
+- Tested in Chrome, Firefox, and Edge.

--- a/submissions/examples/floating-cta-ms07/demo.html
+++ b/submissions/examples/floating-cta-ms07/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Floating Scroll CTA — Demo</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <section class="floatcta-hero">
+    <h1>Scroll past this hero section</h1>
+    <p>The floating CTA in the bottom-right corner appears once you scroll past here, and disappears again if you scroll back up to the top.</p>
+  </section>
+
+  <main class="floatcta-article">
+    <p>This is just filler content so there's something to scroll through while testing the button below.</p>
+    <p>Keep scrolling — the button should fade in shortly after the hero section above leaves the viewport.</p>
+    <p>Try clicking the small × to dismiss it. Once dismissed, it should stay hidden even if you keep scrolling up and down, until you reload the page.</p>
+    <p>More filler paragraph content to give the page enough height to actually scroll.</p>
+    <p>Still scrolling. The button should already be visible by now if it isn't dismissed.</p>
+    <p>Almost at the bottom of this short demo article.</p>
+    <p>End of the sample content — scroll back up to see the button fade back out near the top.</p>
+  </main>
+
+  <!-- The floating CTA itself -->
+  <div class="floatcta" id="floatCta">
+    <button class="floatcta-dismiss" id="floatCtaDismiss" type="button" aria-label="Dismiss">×</button>
+    <a class="floatcta-button" href="#top">
+      Get Started
+    </a>
+  </div>
+
+  <script>
+    (function () {
+      const cta = document.getElementById('floatCta');
+      const dismissBtn = document.getElementById('floatCtaDismiss');
+      const hero = document.querySelector('.floatcta-hero');
+
+      const SCROLL_THRESHOLD = hero.offsetHeight * 0.6;
+
+      let isDismissed = false;
+      let isVisible = false;
+
+      function updateOnScroll() {
+        if (isDismissed) return;
+
+        const pastThreshold = window.scrollY > SCROLL_THRESHOLD;
+
+        if (pastThreshold && !isVisible) {
+          isVisible = true;
+          cta.classList.remove('floatcta-hidden');
+          cta.classList.add('floatcta-visible');
+        } else if (!pastThreshold && isVisible) {
+          isVisible = false;
+          cta.classList.remove('floatcta-visible');
+          cta.classList.add('floatcta-hidden');
+        }
+      }
+
+      dismissBtn.addEventListener('click', () => {
+        isDismissed = true;
+        isVisible = false;
+        cta.classList.remove('floatcta-visible');
+        cta.classList.add('floatcta-hidden', 'floatcta-dismissed');
+        // Stop listening entirely once dismissed, so no later scroll
+        // event can bring the button back during this page session.
+        window.removeEventListener('scroll', updateOnScroll);
+      });
+
+      window.addEventListener('scroll', updateOnScroll, { passive: true });
+      updateOnScroll();
+    })();
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/floating-cta-ms07/style.css
+++ b/submissions/examples/floating-cta-ms07/style.css
@@ -1,0 +1,192 @@
+/* ===================================================================
+   Floating Scroll CTA — raw demo styles
+   Class names are unprefixed on purpose; the maintainer will rename
+   everything to the ease-* convention during integration. See the
+   README for the exact mapping to ease-fade-in / ease-hover-lift /
+   ease-fade-out as referenced in the original issue.
+   =================================================================== */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #0b0f19;
+  color: #e7e9ee;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+
+.floatcta-hero {
+  min-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 24px;
+  border-bottom: 1px solid #ffffff14;
+}
+
+.floatcta-hero h1 {
+  font-size: clamp(1.6rem, 4.5vw, 2.4rem);
+  margin: 0 0 14px;
+}
+
+.floatcta-hero p {
+  max-width: 480px;
+  color: #aeb4c4;
+  margin: 0;
+}
+
+.floatcta-article {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 64px 24px 200px;
+}
+
+.floatcta-article p {
+  font-size: 1rem;
+  line-height: 1.75;
+  color: #c2c7d4;
+  margin: 0 0 22px;
+}
+
+/* ---------------------------------------------------------------
+   The floating CTA container — fixed bottom-right.
+   Starts fully hidden (not just opacity:0, but also non-interactive
+   and shifted down) so it can't be clicked or tabbed into before the
+   scroll threshold is reached.
+   --------------------------------------------------------------- */
+
+.floatcta {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  opacity: 0;
+  transform: translateY(16px);
+  pointer-events: none;
+  transition: opacity 0.35s ease, transform 0.35s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* ease-fade-in: scroll past threshold */
+.floatcta.floatcta-visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+/* ease-fade-out: scroll back to top */
+.floatcta.floatcta-hidden {
+  opacity: 0;
+  transform: translateY(16px);
+  pointer-events: none;
+}
+
+/* Once dismissed, skip the transition entirely so it disappears
+   immediately on click rather than easing out like a normal scroll
+   hide — dismissal should feel decisive, not like a delayed fade. */
+.floatcta.floatcta-dismissed {
+  transition: none;
+}
+
+/* ---------------------------------------------------------------
+   The CTA button itself
+   --------------------------------------------------------------- */
+
+.floatcta-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 13px 24px;
+  border-radius: 999px;
+  background: #6c63ff;
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.9rem;
+  text-decoration: none;
+  box-shadow: 0 10px 28px -10px #6c63ffaa;
+  transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.2s ease;
+}
+
+/* ease-hover-lift */
+.floatcta-button:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 16px 32px -10px #6c63ffcc;
+}
+
+.floatcta-button:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 3px;
+}
+
+/* ---------------------------------------------------------------
+   Dismiss control
+   --------------------------------------------------------------- */
+
+.floatcta-dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: 1px solid #ffffff2a;
+  background: #161b29cc;
+  backdrop-filter: blur(6px);
+  color: #aeb4c4;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.18s ease, color 0.18s ease, transform 0.18s ease;
+}
+
+.floatcta-dismiss:hover {
+  background: #1f2433;
+  color: #fff;
+  transform: scale(1.08);
+}
+
+.floatcta-dismiss:focus-visible {
+  outline: 2px solid #6c63ff;
+  outline-offset: 2px;
+}
+
+/* ===================================================================
+   Responsive behavior
+   =================================================================== */
+
+@media (max-width: 480px) {
+  .floatcta {
+    right: 14px;
+    bottom: 14px;
+  }
+
+  .floatcta-button {
+    padding: 11px 18px;
+    font-size: 0.85rem;
+  }
+}
+
+/* Respect users who prefer reduced motion: keep the fade (opacity)
+   since it conveys real state, but skip the vertical slide and the
+   hover-lift's transform, which are purely decorative motion. */
+@media (prefers-reduced-motion: reduce) {
+  .floatcta {
+    transition: opacity 0.35s ease;
+    transform: none !important;
+  }
+
+  .floatcta.floatcta-visible,
+  .floatcta.floatcta-hidden {
+    transform: none !important;
+  }
+
+  .floatcta-button:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a fixed bottom-right call-to-action button that fades/slides in
once the reader scrolls past the hero section, fades back out on
scroll back to top, lifts on hover, and can be permanently dismissed
for the rest of the session via a close button.

---

## Type of Change

- [x] 🧩 New component
- [x] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/floating-cta-ms07/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A scroll-triggered floating CTA: hidden in the hero, fades/slides in
past a scroll threshold, fades back out near the top, lifts on hover,
and stays dismissed for the session once closed.

**How does a developer use it?**

```html
<div class="floatcta">
  <button class="floatcta-dismiss" aria-label="Dismiss">×</button>
  <a class="floatcta-button" href="#top">Get Started</a>
</div>
```

**Why does it fit EaseMotion CSS?**

Scroll-triggered floating CTAs are a common conversion pattern on
landing pages — present once the reader shows intent, absent on first
impression. Handling dismissal correctly (so it can't silently
reappear) is the detail most naive implementations get wrong, and is
handled explicitly here.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The issue names the three states as `ease-fade-in`, `ease-hover-lift`,
and `ease-fade-out`. As a `submissions/examples/` build, the
equivalent behavior is implemented under unprefixed names — mapping
for integration: `ease-fade-in` → `.floatcta-visible`,
`ease-hover-lift` → `.floatcta-button:hover`, `ease-fade-out` →
`.floatcta-hidden`. Dismissal is handled in two layers: an
`isDismissed` flag checked in the scroll handler, plus the scroll
listener is fully removed via `removeEventListener` — no code path
lets a dismissed button reappear later in the session. The dismissed
state also strips the transition so closing feels immediate. The
button is `pointer-events: none` while hidden so it can't be clicked
or tab-focused early. `prefers-reduced-motion: reduce` keeps the
opacity fade but removes the slide and hover-lift transforms.

Closes https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/20574