### PR TITLE
feat: implement per-section entrance with scroll-snap and view-timeline #20800

### DIFF
--- a/submissions/examples/scroll-snap-view-20800/demo.html
+++ b/submissions/examples/scroll-snap-view-20800/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="snap-container">
+    <section class="snap-section">
+      <div class="animate-reveal">Section 1 Entrance</div>
+    </section>
+    <section class="snap-section">
+      <div class="animate-reveal">Section 2 Entrance</div>
+    </section>
+  </div>
+</body>
+</html>

--- a/submissions/examples/scroll-snap-view-20800/style.css
+++ b/submissions/examples/scroll-snap-view-20800/style.css
@@ -1,0 +1,27 @@
+/* Scroll-snap & View-timeline implementation for #20800 */
+
+.snap-container {
+  height: 100vh;
+  overflow-y: auto;
+  scroll-snap-type: y mandatory;
+}
+
+.snap-section {
+  height: 100vh;
+  scroll-snap-align: start;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Entrance animation linked to view timeline */
+@keyframes reveal {
+  from { opacity: 0; transform: translateY(50px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.animate-reveal {
+  animation: reveal linear forwards;
+  animation-timeline: view();
+  animation-range: entry 10% cover 30%;
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements native per-section entrance animations (Issue #20800) using `animation-timeline: view()` and `scroll-snap`. This removes the need for JavaScript scroll-listener overhead.

---

## Type of Change
- [x] ✨ New feature/utility submission

## Submission Checklist
- [x] All changes are inside `submissions/examples/scroll-snap-view-20800/`
- [x] No modifications to existing `core/` or `components/` files.

## Feature Description
- Combines `scroll-snap-type` for structural locking.
- Utilizes CSS-native `animation-timeline` for scroll-driven animations.
- Eliminates main-thread blocking associated with JS-based scroll intersection observers.

Closes #20800