### PR TITLE
feat(submission): add mix-blend-mode difference animated inversion sweep

### DIFF
--- a/submissions/examples/blend-difference-sweep-sk/README.md
+++ b/submissions/examples/blend-difference-sweep-sk/README.md
@@ -1,0 +1,75 @@
+# mix-blend-mode: difference Animated Inversion Sweep
+
+A pseudo-element sweeper that uses `mix-blend-mode: difference` to invert all colors beneath it as it passes — producing a color-complement sweep with no JavaScript and no hardcoded color values.
+
+## Variants
+
+| Variant | Trigger | Blend mode |
+|---------|---------|------------|
+| Hover sweep | `:hover` | `difference` |
+| Auto sweep | `@keyframes` infinite | `difference` |
+| Exclusion sweep | `:hover` | `exclusion` (softer) |
+| Isolation demo | `:hover` | `difference` — shows broken vs correct |
+
+## How it works
+
+```css
+.sweep-card {
+  position: relative;
+  isolation: isolate; /* required — see below */
+  overflow: hidden;
+}
+
+.sweep-card::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -110%;
+  width: 55%;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.92);
+  mix-blend-mode: difference;
+  transform: skewX(-12deg);
+  pointer-events: none;
+}
+
+/* hover variant */
+.sweep-hover::after {
+  transition: left 0.65s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.sweep-hover:hover::after { left: 150%; }
+
+/* auto loop variant */
+@keyframes ease-blend-sweep {
+  0%   { left: -110%; }
+  100% { left: 150%; }
+}
+.sweep-auto::after {
+  animation: ease-blend-sweep 2.4s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+}
+```
+
+## Why `isolation: isolate` is required
+
+`mix-blend-mode` composites against every layer below the element by default — including the page background. Without `isolation: isolate` on the parent, the white sweeper inverts against the `<body>` background color instead of the card's gradient, producing the wrong colors (or an entirely dark sweep on a dark background).
+
+`isolation: isolate` creates a new stacking context that caps compositing to the card's own pixels.
+
+## `difference` vs `exclusion`
+
+- **`difference`** — full mathematical complement. White over any color `C` produces `255 - C`. High contrast, dramatic.
+- **`exclusion`** — softer variant. Desaturates midtones instead of fully complementing them. More subtle.
+
+Both modes require `isolation: isolate` on the parent.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables the auto-loop animation and removes transitions from all hover variants.
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .sweep-auto::after { animation: none; }
+  .sweep-hover::after,
+  .sweep-exclusion::after { transition: none; }
+}
+```

--- a/submissions/examples/blend-difference-sweep-sk/demo.html
+++ b/submissions/examples/blend-difference-sweep-sk/demo.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>mix-blend-mode: difference Sweep</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>mix-blend-mode: difference Sweep</h1>
+    <p>A sweeping element with <code>mix-blend-mode: difference</code> inverts all colors beneath it as it passes — no color values touched.</p>
+  </header>
+
+  <!-- VARIANT 1 & 2 -->
+  <section class="section">
+    <p class="section-label">Hover-triggered &amp; Auto-sweep</p>
+    <div class="card-row">
+
+      <div class="sweep-card sweep-hover" role="button" tabindex="0" aria-label="Hover to trigger sweep">
+        <h2 class="card-title">Hover to sweep</h2>
+        <p class="card-body">mix-blend-mode: difference inverts every color the sweeper passes over.</p>
+      </div>
+
+      <div class="sweep-card sweep-auto" aria-label="Auto-sweeping card">
+        <h2 class="card-title">Auto sweep</h2>
+        <p class="card-body">Looping sweep via <code>@keyframes</code> — useful for loading highlights or attention draws.</p>
+      </div>
+
+    </div>
+    <p class="note">
+      The sweeper is a <code>::after</code> pseudo-element with <code>mix-blend-mode: difference</code>.
+      White sweeping over any color produces its visual complement.
+    </p>
+  </section>
+
+  <!-- VARIANT 3: exclusion -->
+  <section class="section">
+    <p class="section-label">Exclusion variant — softer inversion</p>
+    <div class="card-row">
+
+      <div class="sweep-card sweep-exclusion" role="button" tabindex="0" aria-label="Hover for exclusion sweep">
+        <h2 class="card-title">mix-blend-mode: exclusion</h2>
+        <p class="card-body">Produces a softer, lower-contrast inversion — desaturates instead of fully complementing.</p>
+      </div>
+
+    </div>
+    <p class="note">
+      Swap <code>mix-blend-mode: difference</code> for <code>exclusion</code> to reduce the intensity. Both modes
+      require <code>isolation: isolate</code> on the parent to work correctly.
+    </p>
+  </section>
+
+  <!-- ISOLATION BUG DEMO -->
+  <section class="section">
+    <p class="section-label">Why isolation: isolate matters</p>
+    <div class="demo-compare">
+
+      <div>
+        <p class="compare-label bad">Without isolation (broken)</p>
+        <div class="sweep-card sweep-no-isolation" role="button" tabindex="0" aria-label="Broken example without isolation">
+          <h2 class="card-title">No isolation</h2>
+          <p class="card-body">The blend bleeds to the page background instead of staying inside the card.</p>
+        </div>
+      </div>
+
+      <div>
+        <p class="compare-label good">With isolation: isolate (correct)</p>
+        <div class="sweep-card sweep-with-isolation" role="button" tabindex="0" aria-label="Correct example with isolation">
+          <h2 class="card-title">With isolation</h2>
+          <p class="card-body">The blend stays contained inside the card — inverts card colors only.</p>
+        </div>
+      </div>
+
+    </div>
+    <p class="note">
+      <code>isolation: isolate</code> creates a new stacking context that stops
+      <code>mix-blend-mode</code> from compositing against elements below. Always required on the
+      parent of a blend-mode element.
+    </p>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/blend-difference-sweep-sk/style.css
+++ b/submissions/examples/blend-difference-sweep-sk/style.css
@@ -1,0 +1,258 @@
+:root {
+  --bg-primary: #0a0e17;
+  --bg-card: #1a2035;
+  --bg-card-2: #111827;
+  --border: rgba(255, 255, 255, 0.07);
+  --text-primary: #f1f5f9;
+  --text-muted: #64748b;
+  --accent: #6c63ff;
+
+  --ease-sweep-color: rgba(255, 255, 255, 0.92);
+  --ease-sweep-width: 55%;
+  --ease-sweep-skew: -12deg;
+  --ease-sweep-duration: 0.65s;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: system-ui, -apple-system, sans-serif;
+  min-height: 100vh;
+  padding: 2.5rem 1.5rem;
+  line-height: 1.6;
+}
+
+.page-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.page-header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  background: linear-gradient(135deg, #ec4899, #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 0.5rem;
+}
+
+.page-header p {
+  color: var(--text-muted);
+  font-size: 1rem;
+  max-width: 52ch;
+  margin: 0 auto;
+}
+
+/* ──────────────────────────────────────────────────
+   SECTION LAYOUT
+────────────────────────────────────────────────── */
+.section {
+  max-width: 1000px;
+  margin: 0 auto 3rem;
+}
+
+.section-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--text-muted);
+  margin-bottom: 1rem;
+}
+
+.card-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.25rem;
+}
+
+.note {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: 1rem;
+  max-width: 1000px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.note code {
+  background: rgba(255, 255, 255, 0.07);
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+  font-size: 0.78rem;
+  color: #94a3b8;
+}
+
+/* ──────────────────────────────────────────────────
+   BASE CARD
+────────────────────────────────────────────────── */
+.sweep-card {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  border-radius: 16px;
+  padding: 2rem;
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  cursor: default;
+}
+
+.sweep-card .card-title {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin-bottom: 0.35rem;
+  line-height: 1.3;
+}
+
+.sweep-card .card-body {
+  font-size: 0.85rem;
+  opacity: 0.75;
+  line-height: 1.55;
+}
+
+/* ──────────────────────────────────────────────────
+   THE SWEEPER PSEUDO-ELEMENT
+   isolation: isolate on parent is REQUIRED —
+   without it the blend bleeds to the page bg.
+────────────────────────────────────────────────── */
+.sweep-card::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -110%;
+  width: var(--ease-sweep-width);
+  height: 100%;
+  background: var(--ease-sweep-color);
+  mix-blend-mode: difference;
+  transform: skewX(var(--ease-sweep-skew));
+  pointer-events: none;
+}
+
+/* ──────────────────────────────────────────────────
+   VARIANT 1: Hover-triggered sweep
+────────────────────────────────────────────────── */
+.sweep-hover {
+  background: linear-gradient(135deg, #1e1b4b 0%, #312e81 100%);
+  cursor: pointer;
+}
+
+.sweep-hover::after {
+  transition: left var(--ease-sweep-duration) cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.sweep-hover:hover::after {
+  left: 150%;
+}
+
+/* ──────────────────────────────────────────────────
+   VARIANT 2: Auto-sweep (infinite loop)
+────────────────────────────────────────────────── */
+@keyframes ease-blend-sweep {
+  0%   { left: -110%; }
+  100% { left: 150%; }
+}
+
+.sweep-auto {
+  background: linear-gradient(135deg, #134e4a 0%, #065f46 100%);
+}
+
+.sweep-auto::after {
+  animation: ease-blend-sweep 2.4s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+}
+
+/* ──────────────────────────────────────────────────
+   VARIANT 3: mix-blend-mode: exclusion (softer)
+────────────────────────────────────────────────── */
+.sweep-exclusion {
+  background: linear-gradient(135deg, #4c1d95 0%, #6d28d9 100%);
+  cursor: pointer;
+}
+
+.sweep-exclusion::after {
+  mix-blend-mode: exclusion;
+  background: rgba(255, 255, 255, 0.75);
+  transition: left var(--ease-sweep-duration) cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.sweep-exclusion:hover::after {
+  left: 150%;
+}
+
+/* ──────────────────────────────────────────────────
+   ISOLATION BUG DEMO SECTION
+   Shows what breaks without isolation: isolate
+────────────────────────────────────────────────── */
+.demo-compare {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+  max-width: 1000px;
+  margin: 0 auto 1rem;
+}
+
+.sweep-no-isolation {
+  background: linear-gradient(135deg, #7f1d1d 0%, #991b1b 100%);
+  cursor: pointer;
+  isolation: auto; /* override base class — blend bleeds to page bg */
+}
+
+.sweep-no-isolation::after {
+  transition: left var(--ease-sweep-duration) cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.sweep-no-isolation:hover::after {
+  left: 150%;
+}
+
+.sweep-with-isolation {
+  background: linear-gradient(135deg, #7f1d1d 0%, #991b1b 100%);
+  isolation: isolate;
+  cursor: pointer;
+}
+
+.sweep-with-isolation::after {
+  transition: left var(--ease-sweep-duration) cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.sweep-with-isolation:hover::after {
+  left: 150%;
+}
+
+.compare-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  margin-bottom: 0.5rem;
+}
+
+.compare-label.bad  { color: #f87171; }
+.compare-label.good { color: #4ade80; }
+
+/* ──────────────────────────────────────────────────
+   ACCESSIBILITY
+────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .sweep-auto::after {
+    animation: none;
+  }
+
+  .sweep-hover::after,
+  .sweep-exclusion::after,
+  .sweep-no-isolation::after,
+  .sweep-with-isolation::after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/blend-difference-sweep-sk/` — a `::after` pseudo-element sweeper that uses `mix-blend-mode: difference` to invert all colors beneath it as it passes. No JavaScript, no hardcoded complementary color values — the math is pure CSS compositing.

## Technique

The sweeper is a white `::after` pseudo-element positioned at `left: -110%`. On hover or via `@keyframes`, it translates to `left: 150%`. Because `mix-blend-mode: difference` computes `|destination - source|`, a white (255,255,255) overlay over any color `C` produces `(255-R, 255-G, 255-B)` — its exact visual complement.

`isolation: isolate` on the parent is **required** to cap compositing to the card's own pixel stack; without it the blend bleeds to the page background.

## Files added

- `demo.html` — 4 variants: hover sweep, auto-loop sweep, `exclusion` softer variant, and a side-by-side `isolation: isolate` comparison demo
- `style.css` — CSS custom properties for sweep width/skew/duration, `@keyframes ease-blend-sweep`, `prefers-reduced-motion` override
- `README.md` — explains `difference` vs `exclusion`, why `isolation: isolate` is required, and accessibility section

## Checklist

- [x] Only `submissions/examples/` touched
- [x] Exactly 3 files: `demo.html`, `style.css`, `README.md`
- [x] `prefers-reduced-motion: reduce` implemented
- [x] No changes to `core/`, `components/`, `docs/`
- [x] Closes #20790