### PR TITLE
resolve #20827: Skip Navigation Accessibility Focus Link

### DIFF
--- a/submissions/examples/new-skip-main-link-sn100/README.md
+++ b/submissions/examples/new-skip-main-link-sn100/README.md
@@ -1,0 +1,7 @@
+﻿# Skip Navigation Accessibility Focus Link
+
+Skip to content accessibility link displaying only on tab focus.
+
+## How to use
+1. Link the component stylesheet `style.css` in your HTML header.
+2. Embed the structure code into your body sections.

--- a/submissions/examples/new-skip-main-link-sn100/demo.html
+++ b/submissions/examples/new-skip-main-link-sn100/demo.html
@@ -1,0 +1,23 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS: Skip Navigation Accessibility Focus Link</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      background-color: #0b0c10;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+  </style>
+</head>
+<body>
+<a href="#main-content" class="ease-skip-link">Skip to Main Content</a>
+</body>
+</html>

--- a/submissions/examples/new-skip-main-link-sn100/style.css
+++ b/submissions/examples/new-skip-main-link-sn100/style.css
@@ -1,0 +1,22 @@
+﻿/* ==========================================================================
+   EaseMotion CSS: Skip Navigation Accessibility Focus Link
+   ========================================================================== */
+
+@layer components {
+.ease-skip-link {
+  position: fixed;
+  top: -100px; left: 20px;
+  background: #7f00ff;
+  color: #fff;
+  padding: 0.75rem 1.5rem;
+  border-radius: 4px;
+  z-index: 9999;
+  text-decoration: none;
+  font-weight: bold;
+  box-shadow: 0 4px 15px rgba(127, 0, 255, 0.4);
+  transition: top 0.3s;
+}
+.ease-skip-link:focus {
+  top: 20px;
+}
+}


### PR DESCRIPTION
﻿Closes #20827

## What this does
Skip to content accessibility link displaying only on tab focus.

## Files
- `submissions/examples/new-skip-main-link-sn100/style.css`
- `submissions/examples/new-skip-main-link-sn100/demo.html`
- `submissions/examples/new-skip-main-link-sn100/README.md`
