### PR TITLE
feat(submission): add native CSS text-decoration animated underline collection

### DIFF
--- a/submissions/examples/text-decoration-anim-sk/README.md
+++ b/submissions/examples/text-decoration-anim-sk/README.md
@@ -1,0 +1,76 @@
+# CSS text-decoration Animation Collection
+
+Native CSS underline animation using `text-decoration-thickness`, `text-underline-offset`, and `text-decoration-color` — all three properties are animatable without pseudo-elements or transforms.
+
+## Variants
+
+| Variant | Property animated | Trigger |
+|---------|-------------------|---------|
+| Thickness hover | `text-decoration-thickness` | `:hover` |
+| Thickness pulse | `text-decoration-thickness` | `@keyframes` |
+| Offset float | `text-underline-offset` | `@keyframes` |
+| Offset spring | `text-underline-offset` | `:hover` |
+| Color cycle | `text-decoration-color` | `@keyframes` |
+| Color reveal | `text-decoration-color` | `:hover` |
+| Wavy pulse | `text-decoration-thickness` + `text-underline-offset` | `@keyframes` |
+| Wavy hover | `text-decoration-thickness` + `text-underline-offset` | `:hover` |
+
+## Key technique
+
+```css
+.ease-underline-thickness {
+  text-decoration: underline;
+  text-decoration-color: #6c63ff;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 4px;
+  transition:
+    text-decoration-thickness 0.3s ease,
+    text-underline-offset 0.3s ease;
+}
+
+.ease-underline-thickness:hover {
+  text-decoration-thickness: 8px;
+  text-underline-offset: 6px;
+}
+
+@keyframes ease-underline-pulse {
+  0%, 100% { text-decoration-thickness: 2px; }
+  50%       { text-decoration-thickness: 6px; }
+}
+```
+
+## Offset spring
+
+A spring-style overshoot on `text-underline-offset` using a custom bezier:
+
+```css
+.ease-offset-hover {
+  text-underline-offset: 4px;
+  transition: text-underline-offset 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.ease-offset-hover:hover {
+  text-underline-offset: 14px;
+}
+```
+
+## Browser support
+
+`text-decoration-thickness` and `text-underline-offset` are supported in all modern browsers (Chrome 89+, Firefox 70+, Safari 12.1+). Transitions and `@keyframes` on these properties work without prefixes.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables all animations and transitions. The underline decoration itself remains visible at rest.
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .ease-underline-pulse,
+  .ease-underline-float,
+  .ease-color-cycle,
+  .ease-wavy-pulse { animation: none; }
+
+  .ease-underline-thickness,
+  .ease-offset-hover,
+  .ease-color-hover,
+  .ease-wavy-hover { transition: none; }
+}
+```

--- a/submissions/examples/text-decoration-anim-sk/demo.html
+++ b/submissions/examples/text-decoration-anim-sk/demo.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS text-decoration Animation</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>CSS text-decoration Animation</h1>
+    <p>Native <code>text-decoration-thickness</code>, <code>text-underline-offset</code>, and <code>text-decoration-color</code> are all animatable — no pseudo-elements or transforms required.</p>
+  </header>
+
+  <!-- SECTION 1: Thickness -->
+  <section class="section">
+    <p class="section-label">Thickness — hover &amp; pulse</p>
+    <div class="demo-card">
+      <span class="ease-underline-thickness" tabindex="0">Hover to grow underline thickness</span>
+      <span class="ease-underline-pulse">Pulsing thickness via @keyframes</span>
+    </div>
+    <p class="note">
+      <code>text-decoration-thickness</code> accepts <code>px</code>, <code>em</code>, or <code>from-font</code>.
+      Transitions and animations work natively — no pseudo-element needed.
+    </p>
+  </section>
+
+  <!-- SECTION 2: Offset -->
+  <section class="section">
+    <p class="section-label">Offset — float &amp; spring</p>
+    <div class="demo-card">
+      <span class="ease-underline-float">Underline floating away</span>
+      <span class="ease-offset-hover" tabindex="0">Hover for spring offset jump</span>
+    </div>
+    <p class="note">
+      <code>text-underline-offset</code> moves the underline away from the text baseline.
+      Pair with <code>cubic-bezier(0.34, 1.56, 0.64, 1)</code> for a spring overshoot effect.
+    </p>
+  </section>
+
+  <!-- SECTION 3: Color -->
+  <section class="section">
+    <p class="section-label">Color — cycle &amp; reveal</p>
+    <div class="demo-card">
+      <span class="ease-color-cycle">Cycling underline color</span>
+      <span class="ease-color-hover" tabindex="0">Hover to reveal color</span>
+    </div>
+    <p class="note">
+      <code>text-decoration-color</code> interpolates between color values in both
+      <code>transition</code> and <code>@keyframes</code>. The text color stays untouched.
+    </p>
+  </section>
+
+  <!-- SECTION 4: Wavy style -->
+  <section class="section">
+    <p class="section-label">Wavy style — pulse &amp; hover</p>
+    <div class="demo-card">
+      <span class="ease-wavy-pulse">Wavy underline pulsing</span>
+      <span class="ease-wavy-hover" tabindex="0">Hover to animate wavy decoration</span>
+    </div>
+    <p class="note">
+      <code>text-decoration-style: wavy</code> combined with animated <code>text-decoration-thickness</code>
+      and <code>text-underline-offset</code> gives a dynamic squiggly underline effect.
+    </p>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/text-decoration-anim-sk/style.css
+++ b/submissions/examples/text-decoration-anim-sk/style.css
@@ -1,0 +1,269 @@
+:root {
+  --bg-primary: #0a0e17;
+  --bg-card: #1a2035;
+  --border: rgba(255, 255, 255, 0.07);
+  --text-primary: #f1f5f9;
+  --text-muted: #64748b;
+  --accent-1: #6c63ff;
+  --accent-2: #ec4899;
+  --accent-3: #10b981;
+  --accent-4: #f59e0b;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: system-ui, -apple-system, sans-serif;
+  min-height: 100vh;
+  padding: 2.5rem 1.5rem;
+  line-height: 1.6;
+}
+
+.page-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.page-header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  background: linear-gradient(135deg, #6c63ff, #ec4899);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 0.5rem;
+}
+
+.page-header p {
+  color: var(--text-muted);
+  font-size: 1rem;
+  max-width: 54ch;
+  margin: 0 auto;
+}
+
+/* ──────────────────────────────────────────────────
+   LAYOUT
+────────────────────────────────────────────────── */
+.section {
+  max-width: 900px;
+  margin: 0 auto 3rem;
+}
+
+.section-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--text-muted);
+  margin-bottom: 1.25rem;
+}
+
+.demo-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 2rem;
+  margin-bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.note {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: 0.5rem;
+  max-width: 900px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.note code {
+  background: rgba(255, 255, 255, 0.07);
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+  font-size: 0.78rem;
+  color: #94a3b8;
+}
+
+/* ──────────────────────────────────────────────────
+   VARIANT 1: Animated underline thickness
+   text-decoration-thickness transitions on hover
+────────────────────────────────────────────────── */
+@keyframes ease-underline-pulse {
+  0%, 100% { text-decoration-thickness: 2px; }
+  50%       { text-decoration-thickness: 6px; }
+}
+
+.ease-underline-thickness {
+  font-size: 1.4rem;
+  font-weight: 600;
+  text-decoration: underline;
+  text-decoration-color: var(--accent-1);
+  text-decoration-thickness: 2px;
+  text-underline-offset: 4px;
+  cursor: pointer;
+  transition:
+    text-decoration-thickness 0.3s ease,
+    text-underline-offset 0.3s ease;
+  width: fit-content;
+}
+
+.ease-underline-thickness:hover {
+  text-decoration-thickness: 8px;
+  text-underline-offset: 6px;
+}
+
+.ease-underline-pulse {
+  font-size: 1.4rem;
+  font-weight: 600;
+  text-decoration: underline;
+  text-decoration-color: var(--accent-2);
+  text-decoration-thickness: 2px;
+  text-underline-offset: 4px;
+  animation: ease-underline-pulse 1.6s ease-in-out infinite;
+  width: fit-content;
+}
+
+/* ──────────────────────────────────────────────────
+   VARIANT 2: Animated offset (underline float)
+────────────────────────────────────────────────── */
+@keyframes ease-underline-float {
+  0%, 100% { text-underline-offset: 2px; }
+  50%       { text-underline-offset: 12px; }
+}
+
+.ease-underline-float {
+  font-size: 1.4rem;
+  font-weight: 600;
+  text-decoration: underline;
+  text-decoration-color: var(--accent-3);
+  text-decoration-thickness: 2px;
+  text-underline-offset: 2px;
+  animation: ease-underline-float 2s ease-in-out infinite;
+  width: fit-content;
+}
+
+.ease-offset-hover {
+  font-size: 1.4rem;
+  font-weight: 600;
+  text-decoration: underline;
+  text-decoration-color: var(--accent-4);
+  text-decoration-thickness: 2px;
+  text-underline-offset: 4px;
+  cursor: pointer;
+  transition: text-underline-offset 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+  width: fit-content;
+}
+
+.ease-offset-hover:hover {
+  text-underline-offset: 14px;
+}
+
+/* ──────────────────────────────────────────────────
+   VARIANT 3: Animated decoration color
+────────────────────────────────────────────────── */
+@keyframes ease-underline-color {
+  0%   { text-decoration-color: #6c63ff; }
+  25%  { text-decoration-color: #ec4899; }
+  50%  { text-decoration-color: #10b981; }
+  75%  { text-decoration-color: #f59e0b; }
+  100% { text-decoration-color: #6c63ff; }
+}
+
+.ease-color-cycle {
+  font-size: 1.4rem;
+  font-weight: 600;
+  text-decoration: underline;
+  text-decoration-thickness: 3px;
+  text-underline-offset: 5px;
+  animation: ease-underline-color 3s linear infinite;
+  width: fit-content;
+}
+
+.ease-color-hover {
+  font-size: 1.4rem;
+  font-weight: 600;
+  text-decoration: underline;
+  text-decoration-color: var(--text-muted);
+  text-decoration-thickness: 2px;
+  text-underline-offset: 4px;
+  cursor: pointer;
+  transition: text-decoration-color 0.4s ease;
+  width: fit-content;
+}
+
+.ease-color-hover:hover {
+  text-decoration-color: var(--accent-1);
+}
+
+/* ──────────────────────────────────────────────────
+   VARIANT 4: Wavy decoration animation
+   text-decoration-style: wavy with thickness pulse
+────────────────────────────────────────────────── */
+@keyframes ease-wavy-grow {
+  0%, 100% { text-decoration-thickness: 1px; text-underline-offset: 4px; }
+  50%       { text-decoration-thickness: 3px; text-underline-offset: 7px; }
+}
+
+.ease-wavy-pulse {
+  font-size: 1.4rem;
+  font-weight: 600;
+  text-decoration: underline;
+  text-decoration-style: wavy;
+  text-decoration-color: var(--accent-2);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 4px;
+  animation: ease-wavy-grow 2s ease-in-out infinite;
+  width: fit-content;
+}
+
+.ease-wavy-hover {
+  font-size: 1.4rem;
+  font-weight: 600;
+  text-decoration: underline;
+  text-decoration-style: wavy;
+  text-decoration-color: var(--accent-3);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 4px;
+  cursor: pointer;
+  transition:
+    text-decoration-thickness 0.3s ease,
+    text-underline-offset 0.3s ease,
+    text-decoration-color 0.3s ease;
+  width: fit-content;
+}
+
+.ease-wavy-hover:hover {
+  text-decoration-thickness: 3px;
+  text-underline-offset: 8px;
+  text-decoration-color: var(--accent-1);
+}
+
+/* ──────────────────────────────────────────────────
+   ACCESSIBILITY
+────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-underline-pulse,
+  .ease-underline-float,
+  .ease-color-cycle,
+  .ease-wavy-pulse {
+    animation: none;
+  }
+
+  .ease-underline-thickness,
+  .ease-offset-hover,
+  .ease-color-hover,
+  .ease-wavy-hover {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/text-decoration-anim-sk/` — 8 underline animation variants built entirely from native `text-decoration-thickness`, `text-underline-offset`, and `text-decoration-color` properties. No pseudo-elements, no transforms, no JavaScript.

## Technique

All three properties accept `transition` and `@keyframes` natively in modern browsers:

```css
.ease-underline-thickness {
  text-decoration: underline;
  text-decoration-thickness: 2px;
  text-underline-offset: 4px;
  transition: text-decoration-thickness 0.3s ease,
              text-underline-offset 0.3s ease;
}
.ease-underline-thickness:hover {
  text-decoration-thickness: 8px;
  text-underline-offset: 6px;
}
```

Spring offset hover uses `cubic-bezier(0.34, 1.56, 0.64, 1)` for overshoot.

## Variants

- Thickness hover / thickness pulse via `@keyframes`
- Offset float (continuous) / offset spring on hover
- Color cycle via `@keyframes` / color reveal on hover
- Wavy style with thickness+offset pulse / wavy hover

## Files added

- `demo.html` — 4 sections, 8 interactive/animated text examples
- `style.css` — 4 `@keyframes`, CSS custom properties, `prefers-reduced-motion` override
- `README.md` — browser support table, code samples, accessibility section

## Checklist

- [x] Only `submissions/examples/` touched
- [x] Exactly 3 files: `demo.html`, `style.css`, `README.md`
- [x] `prefers-reduced-motion: reduce` implemented
- [x] No changes to `core/`, `components/`, `docs/`
- [x] Closes #20791