### PR TITLE
feat(submission): add :has() parent selector gallery hover cascade animation

### DIFF
--- a/submissions/examples/has-gallery-cascade-sk/README.md
+++ b/submissions/examples/has-gallery-cascade-sk/README.md
@@ -1,0 +1,58 @@
+# :has() Parent Selector Gallery Hover Cascade
+
+Uses CSS `:has()` to let a parent container react to descendant hover state — dimming all sibling items when any one child is hovered. Zero JavaScript.
+
+## Variants
+
+| Variant | Effect on hover | Selector pattern |
+|---------|-----------------|------------------|
+| Photo gallery | Hovered item scales up, siblings dim + shrink | `:has(.item:hover) .item:not(:hover)` |
+| Card list | Hovered card slides left, siblings slide right | `:has(.card:hover) .card:not(:hover)` |
+| Tag cloud | Hovered tag scales up, siblings shrink + dim | `:has(.tag:hover) .tag:not(:hover)` |
+
+## Key selector pattern
+
+```css
+/* Parent reacts when any child is hovered */
+.ease-gallery:has(.item:hover) .item:not(:hover) {
+  opacity: 0.38;
+  transform: scale(0.94);
+}
+
+/* Active (hovered) item */
+.ease-gallery:has(.item:hover) .item:hover {
+  transform: scale(1.06);
+  z-index: 1;
+}
+```
+
+The two-part pattern:
+1. `.parent:has(.child:hover)` — selects the parent when any `.child` inside it is hovered
+2. `.child:not(:hover)` — within that context, targets all children that are NOT the hovered one
+
+## Why `:has()` over JavaScript
+
+Before `:has()`, cross-sibling state animations required JavaScript to toggle a class on the parent (`gallery.classList.add('has-hover')`). With `:has()`, the browser's selector engine handles it natively — no event listeners, no JS bundle cost.
+
+## CSS custom properties
+
+```css
+:root {
+  --ease-scale-active: 1.06;
+  --ease-scale-dim: 0.94;
+  --ease-opacity-dim: 0.38;
+  --ease-transition: 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+}
+```
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` removes all transitions. The items remain fully interactive without motion.
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .ease-gallery .item,
+  .ease-card-list .card,
+  .ease-tag-cloud .tag { transition: none; }
+}
+```

--- a/submissions/examples/has-gallery-cascade-sk/demo.html
+++ b/submissions/examples/has-gallery-cascade-sk/demo.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>:has() Gallery Hover Cascade</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>:has() Gallery Hover Cascade</h1>
+    <p>CSS <code>:has()</code> lets a parent react to descendant hover state — dim all siblings when any one item is hovered, with zero JavaScript.</p>
+  </header>
+
+  <!-- VARIANT 1: Photo gallery -->
+  <section class="section">
+    <p class="section-label">Gallery — hover one, dim siblings</p>
+    <div class="ease-gallery">
+      <div class="item" tabindex="0" role="button" aria-label="Gallery item 1">
+        <div class="item-inner">01</div>
+      </div>
+      <div class="item" tabindex="0" role="button" aria-label="Gallery item 2">
+        <div class="item-inner">02</div>
+      </div>
+      <div class="item" tabindex="0" role="button" aria-label="Gallery item 3">
+        <div class="item-inner">03</div>
+      </div>
+      <div class="item" tabindex="0" role="button" aria-label="Gallery item 4">
+        <div class="item-inner">04</div>
+      </div>
+      <div class="item" tabindex="0" role="button" aria-label="Gallery item 5">
+        <div class="item-inner">05</div>
+      </div>
+      <div class="item" tabindex="0" role="button" aria-label="Gallery item 6">
+        <div class="item-inner">06</div>
+      </div>
+    </div>
+    <p class="note">
+      <code>.ease-gallery:has(.item:hover) .item:not(:hover)</code> — the parent selects itself
+      when a child is hovered, then targets all non-hovered children.
+    </p>
+  </section>
+
+  <!-- VARIANT 2: Card list -->
+  <section class="section">
+    <p class="section-label">Card list — hover to shift focus</p>
+    <div class="ease-card-list">
+      <div class="card" tabindex="0" role="button">
+        <h3>Design Systems</h3>
+        <p>Tokens, components, patterns — the foundation of scalable UI.</p>
+      </div>
+      <div class="card" tabindex="0" role="button">
+        <h3>Motion Design</h3>
+        <p>Purposeful animation communicates state and guides attention.</p>
+      </div>
+      <div class="card" tabindex="0" role="button">
+        <h3>Accessibility</h3>
+        <p>Keyboard navigation and reduced-motion support are not optional.</p>
+      </div>
+      <div class="card" tabindex="0" role="button">
+        <h3>Performance</h3>
+        <p>CSS transforms and opacity stay on the GPU compositor thread.</p>
+      </div>
+    </div>
+    <p class="note">
+      Hovered card slides left; siblings slide right and dim. All driven by
+      <code>:has(.card:hover)</code> on the list container — no class toggling.
+    </p>
+  </section>
+
+  <!-- VARIANT 3: Tag cloud -->
+  <section class="section">
+    <p class="section-label">Tag cloud — hover to isolate</p>
+    <div class="ease-tag-cloud">
+      <span class="tag" tabindex="0">CSS</span>
+      <span class="tag" tabindex="0">Animation</span>
+      <span class="tag" tabindex="0">:has()</span>
+      <span class="tag" tabindex="0">Selectors</span>
+      <span class="tag" tabindex="0">Cascade</span>
+      <span class="tag" tabindex="0">Motion</span>
+      <span class="tag" tabindex="0">Design</span>
+      <span class="tag" tabindex="0">UI</span>
+      <span class="tag" tabindex="0">Hover</span>
+      <span class="tag" tabindex="0">EaseMotion</span>
+    </div>
+    <p class="note">
+      Hovering any tag scales it up and dims all others.
+      <code>:has(.tag:hover) .tag:not(:hover)</code> targets exactly the right elements.
+    </p>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/has-gallery-cascade-sk/style.css
+++ b/submissions/examples/has-gallery-cascade-sk/style.css
@@ -1,0 +1,224 @@
+:root {
+  --bg-primary: #0a0e17;
+  --bg-card: #111827;
+  --border: rgba(255, 255, 255, 0.07);
+  --text-primary: #f1f5f9;
+  --text-muted: #64748b;
+
+  --ease-scale-active: 1.06;
+  --ease-scale-dim: 0.94;
+  --ease-opacity-dim: 0.38;
+  --ease-transition: 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: system-ui, -apple-system, sans-serif;
+  min-height: 100vh;
+  padding: 2.5rem 1.5rem;
+  line-height: 1.6;
+}
+
+.page-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.page-header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  background: linear-gradient(135deg, #a78bfa, #34d399);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 0.5rem;
+}
+
+.page-header p {
+  color: var(--text-muted);
+  font-size: 1rem;
+  max-width: 54ch;
+  margin: 0 auto;
+}
+
+/* ──────────────────────────────────────────────────
+   SECTION LAYOUT
+────────────────────────────────────────────────── */
+.section {
+  max-width: 1000px;
+  margin: 0 auto 3.5rem;
+}
+
+.section-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--text-muted);
+  margin-bottom: 1.25rem;
+}
+
+.note {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: 1rem;
+}
+
+.note code {
+  background: rgba(255, 255, 255, 0.07);
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+  font-size: 0.78rem;
+  color: #94a3b8;
+}
+
+/* ──────────────────────────────────────────────────
+   VARIANT 1: Photo gallery — hover one, dim siblings
+   :has(.item:hover) selects the parent grid,
+   then .item:not(:hover) targets non-hovered siblings
+────────────────────────────────────────────────── */
+.ease-gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.ease-gallery .item {
+  aspect-ratio: 4 / 3;
+  border-radius: 12px;
+  overflow: hidden;
+  cursor: pointer;
+  transition:
+    transform var(--ease-transition),
+    opacity var(--ease-transition);
+}
+
+.ease-gallery .item-inner {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+/* when ANY item in the gallery is hovered… */
+.ease-gallery:has(.item:hover) .item:not(:hover) {
+  opacity: var(--ease-opacity-dim);
+  transform: scale(var(--ease-scale-dim));
+}
+
+.ease-gallery:has(.item:hover) .item:hover {
+  transform: scale(var(--ease-scale-active));
+  z-index: 1;
+}
+
+/* gallery item color palette */
+.ease-gallery .item:nth-child(1) .item-inner { background: linear-gradient(135deg, #6c63ff, #a78bfa); }
+.ease-gallery .item:nth-child(2) .item-inner { background: linear-gradient(135deg, #ec4899, #f472b6); }
+.ease-gallery .item:nth-child(3) .item-inner { background: linear-gradient(135deg, #10b981, #34d399); }
+.ease-gallery .item:nth-child(4) .item-inner { background: linear-gradient(135deg, #f59e0b, #fbbf24); }
+.ease-gallery .item:nth-child(5) .item-inner { background: linear-gradient(135deg, #ef4444, #f87171); }
+.ease-gallery .item:nth-child(6) .item-inner { background: linear-gradient(135deg, #3b82f6, #60a5fa); }
+
+/* ──────────────────────────────────────────────────
+   VARIANT 2: Card list — hover one to highlight row
+   :has(.card:hover) on the list dims all siblings
+────────────────────────────────────────────────── */
+.ease-card-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.ease-card-list .card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+  cursor: pointer;
+  transition:
+    opacity var(--ease-transition),
+    transform var(--ease-transition),
+    border-color var(--ease-transition);
+}
+
+.ease-card-list:has(.card:hover) .card:not(:hover) {
+  opacity: var(--ease-opacity-dim);
+  transform: translateX(8px);
+}
+
+.ease-card-list:has(.card:hover) .card:hover {
+  border-color: rgba(167, 139, 250, 0.55);
+  transform: translateX(-4px);
+}
+
+.ease-card-list .card h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.ease-card-list .card p {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+}
+
+/* ──────────────────────────────────────────────────
+   VARIANT 3: Tag cloud — hover one tag,
+   :has(.tag:hover) dims all other tags
+────────────────────────────────────────────────── */
+.ease-tag-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.ease-tag-cloud .tag {
+  padding: 0.35em 0.85em;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  font-size: 0.82rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    opacity var(--ease-transition),
+    transform var(--ease-transition),
+    background-color var(--ease-transition),
+    border-color var(--ease-transition);
+}
+
+.ease-tag-cloud:has(.tag:hover) .tag:not(:hover) {
+  opacity: var(--ease-opacity-dim);
+  transform: scale(0.92);
+}
+
+.ease-tag-cloud:has(.tag:hover) .tag:hover {
+  background-color: rgba(167, 139, 250, 0.18);
+  border-color: rgba(167, 139, 250, 0.55);
+  transform: scale(1.08);
+}
+
+/* ──────────────────────────────────────────────────
+   ACCESSIBILITY
+────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-gallery .item,
+  .ease-card-list .card,
+  .ease-tag-cloud .tag {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/has-gallery-cascade-sk/` — three interactive demos that use the CSS `:has()` relational pseudo-class to trigger cascade animations across sibling elements when any one child is hovered. No JavaScript, no class toggling.

## Technique

The core pattern is a two-rule combination:

```css
/* dim all non-hovered siblings */
.ease-gallery:has(.item:hover) .item:not(:hover) {
  opacity: 0.38;
  transform: scale(0.94);
}

/* lift the hovered item */
.ease-gallery:has(.item:hover) .item:hover {
  transform: scale(1.06);
  z-index: 1;
}
```

`:has(.item:hover)` selects the parent when any child matches `:hover`. The parent then re-targets its children via `.item:not(:hover)` — letting the full sibling set respond to a single hover event using only selector logic.

## Variants

1. **Photo gallery** — 6-item color grid; hovered tile scales up, siblings dim and shrink
2. **Card list** — hovered card shifts left, siblings shift right and dim
3. **Tag cloud** — hovered tag pops up, all others recede

## Files added

- `demo.html` — 3 sections with aria labels and keyboard focus support
- `style.css` — CSS custom properties for scale/opacity/timing, `prefers-reduced-motion` override
- `README.md` — pattern explanation, before/after JS vs `:has()` comparison

## Checklist

- [x] Only `submissions/examples/` touched
- [x] Exactly 3 files: `demo.html`, `style.css`, `README.md`
- [x] `prefers-reduced-motion: reduce` implemented
- [x] No changes to `core/`, `components/`, `docs/`
- [x] Closes #20792