### PR TITLE
feat(submission): add CSS motion path orbital elements

### DIFF
--- a/submissions/examples/offset-path-orbital-sk/README.md
+++ b/submissions/examples/offset-path-orbital-sk/README.md
@@ -1,0 +1,68 @@
+# CSS Motion Path Orbital Elements
+
+Animates elements along geometric paths using `offset-path`, `offset-distance`, and `offset-rotate` — the CSS Motion Path API. No trigonometry, no JavaScript `requestAnimationFrame`, no SVG `animateMotion`.
+
+## Variants
+
+| Variant | Path | `offset-rotate` |
+|---------|------|-----------------|
+| Single orbit | `circle(130px at 50% 50%)` | `0deg` (upright) |
+| Solar system | 3× `circle()` at different radii | `0deg` |
+| Elliptical comet | `ellipse(160px 100px at 50% 50%)` | `auto` (tangent-aligned) |
+
+## Core technique
+
+```css
+@keyframes ease-orbit {
+  from { offset-distance: 0%; }
+  to   { offset-distance: 100%; }
+}
+
+.orbit-body {
+  position: absolute;
+  offset-path: circle(130px at 50% 50%);
+  offset-rotate: 0deg;   /* keep element upright as it travels */
+  animation: ease-orbit 4s linear infinite;
+}
+```
+
+`offset-distance` is a percentage of the path's total length. Animating from `0%` to `100%` traverses the full path in one revolution.
+
+## Multi-body system
+
+Each planet uses the same `@keyframes ease-orbit` but with a different `offset-path` radius and `animation-duration`:
+
+```css
+.orbit-planet-a {
+  offset-path: circle(68px at 50% 50%);
+  animation-duration: 2.2s;  /* fast inner orbit */
+}
+
+.orbit-planet-b {
+  offset-path: circle(110px at 50% 50%);
+  animation-duration: 4s;
+}
+
+.orbit-planet-c {
+  offset-path: circle(148px at 50% 50%);
+  animation-duration: 7s;   /* slow outer orbit */
+}
+```
+
+## `offset-rotate: auto`
+
+When set to `auto`, the element rotates to align its local x-axis with the path tangent at every point. Useful for directional objects (comets, arrows, cars) where the shape should "face" the direction of travel.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` pauses all orbital animations via `animation-play-state: paused`. The elements remain visible at their initial positions.
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .orbit-body,
+  .orbit-planet,
+  .orbit-comet {
+    animation-play-state: paused;
+  }
+}
+```

--- a/submissions/examples/offset-path-orbital-sk/demo.html
+++ b/submissions/examples/offset-path-orbital-sk/demo.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Motion Path Orbital Elements</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>CSS Motion Path Orbital Elements</h1>
+    <p><code>offset-path</code> and <code>offset-distance</code> animate elements along geometric paths — no trigonometry, no JavaScript, no SVG <code>animateMotion</code>.</p>
+  </header>
+
+  <!-- VARIANT 1: Single circular orbit -->
+  <section class="section">
+    <p class="section-label">Single circular orbit — offset-path: circle()</p>
+    <div class="stage">
+      <div class="orbit-system-1" aria-label="Single circular orbit animation">
+        <div class="orbit-track" aria-hidden="true"></div>
+        <div class="orbit-center" aria-hidden="true"></div>
+        <div class="orbit-body orbit-body-1" aria-hidden="true"></div>
+      </div>
+    </div>
+    <p class="note">
+      <code>offset-path: circle(130px at 50% 50%)</code> defines the orbit.
+      <code>offset-rotate: 0deg</code> keeps the planet facing up as it travels.
+    </p>
+  </section>
+
+  <!-- VARIANT 2: Multi-body solar system -->
+  <section class="section">
+    <p class="section-label">Multi-body solar system — varied radius &amp; duration</p>
+    <div class="stage">
+      <div class="orbit-system-2" aria-label="Multi-planet solar system animation">
+        <div class="orbit-track-sm" aria-hidden="true"></div>
+        <div class="orbit-track-md" aria-hidden="true"></div>
+        <div class="orbit-track-lg" aria-hidden="true"></div>
+        <div class="orbit-center" aria-hidden="true"></div>
+        <div class="orbit-planet orbit-planet-a" aria-hidden="true"></div>
+        <div class="orbit-planet orbit-planet-b" aria-hidden="true"></div>
+        <div class="orbit-planet orbit-planet-c" aria-hidden="true"></div>
+      </div>
+    </div>
+    <p class="note">
+      Each planet has its own <code>offset-path</code> radius and <code>animation-duration</code>.
+      Inner planets orbit faster — no physics engine required.
+    </p>
+  </section>
+
+  <!-- VARIANT 3: Elliptical orbit with auto-rotate -->
+  <section class="section">
+    <p class="section-label">Elliptical orbit — offset-path: ellipse() + offset-rotate: auto</p>
+    <div class="stage">
+      <div class="orbit-system-3" aria-label="Elliptical comet orbit animation">
+        <div class="orbit-ellipse-track" aria-hidden="true"></div>
+        <div class="orbit-center" aria-hidden="true"></div>
+        <div class="orbit-comet" aria-hidden="true"></div>
+      </div>
+    </div>
+    <p class="note">
+      <code>offset-path: ellipse(160px 100px at 50% 50%)</code> for an elliptical track.
+      <code>offset-rotate: auto</code> makes the comet shape align to the path tangent as it travels.
+    </p>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/offset-path-orbital-sk/style.css
+++ b/submissions/examples/offset-path-orbital-sk/style.css
@@ -1,0 +1,274 @@
+:root {
+  --bg-primary: #070b14;
+  --bg-card: #111827;
+  --border: rgba(255, 255, 255, 0.07);
+  --text-primary: #f1f5f9;
+  --text-muted: #64748b;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: system-ui, -apple-system, sans-serif;
+  min-height: 100vh;
+  padding: 2.5rem 1.5rem;
+  line-height: 1.6;
+}
+
+.page-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.page-header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  background: linear-gradient(135deg, #60a5fa, #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 0.5rem;
+}
+
+.page-header p {
+  color: var(--text-muted);
+  font-size: 1rem;
+  max-width: 54ch;
+  margin: 0 auto;
+}
+
+/* ──────────────────────────────────────────────────
+   SECTION LAYOUT
+────────────────────────────────────────────────── */
+.section {
+  max-width: 900px;
+  margin: 0 auto 4rem;
+}
+
+.section-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--text-muted);
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+
+.stage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 340px;
+}
+
+.note {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: 1.5rem;
+  text-align: center;
+}
+
+.note code {
+  background: rgba(255, 255, 255, 0.07);
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+  font-size: 0.78rem;
+  color: #94a3b8;
+}
+
+/* ──────────────────────────────────────────────────
+   VARIANT 1: Single circular orbit
+   offset-path: circle() traces the orbit radius
+────────────────────────────────────────────────── */
+.orbit-system-1 {
+  position: relative;
+  width: 280px;
+  height: 280px;
+}
+
+/* Orbit track (visual guide only) */
+.orbit-track {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  border: 1px dashed rgba(255, 255, 255, 0.12);
+}
+
+/* Center body */
+.orbit-center {
+  position: absolute;
+  inset: 50%;
+  transform: translate(-50%, -50%);
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 35%, #fcd34d, #f59e0b);
+  box-shadow: 0 0 28px rgba(245, 158, 11, 0.55);
+  margin: 0;
+}
+
+/* Orbiting body — motion path drives position */
+@keyframes ease-orbit {
+  from { offset-distance: 0%; }
+  to   { offset-distance: 100%; }
+}
+
+.orbit-body {
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  offset-path: circle(130px at 50% 50%);
+  offset-rotate: 0deg; /* keep body upright */
+  animation: ease-orbit 4s linear infinite;
+}
+
+.orbit-body-1 {
+  background: radial-gradient(circle at 35% 35%, #93c5fd, #3b82f6);
+  box-shadow: 0 0 12px rgba(59, 130, 246, 0.65);
+}
+
+/* ──────────────────────────────────────────────────
+   VARIANT 2: Multi-body solar system
+   each planet has its own offset-path radius
+   and animation-duration for different speeds
+────────────────────────────────────────────────── */
+.orbit-system-2 {
+  position: relative;
+  width: 320px;
+  height: 320px;
+}
+
+.orbit-system-2 .orbit-center {
+  position: absolute;
+  inset: 50%;
+  transform: translate(-50%, -50%);
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 35%, #fde68a, #f59e0b);
+  box-shadow: 0 0 24px rgba(245, 158, 11, 0.5);
+  margin: 0;
+}
+
+.orbit-system-2 .orbit-track-sm {
+  position: absolute;
+  inset: calc(50% - 68px);
+  width: 136px;
+  height: 136px;
+  border-radius: 50%;
+  border: 1px dashed rgba(255, 255, 255, 0.1);
+}
+
+.orbit-system-2 .orbit-track-md {
+  position: absolute;
+  inset: calc(50% - 110px);
+  width: 220px;
+  height: 220px;
+  border-radius: 50%;
+  border: 1px dashed rgba(255, 255, 255, 0.08);
+}
+
+.orbit-system-2 .orbit-track-lg {
+  position: absolute;
+  inset: calc(50% - 148px);
+  width: 296px;
+  height: 296px;
+  border-radius: 50%;
+  border: 1px dashed rgba(255, 255, 255, 0.06);
+}
+
+.orbit-planet {
+  position: absolute;
+  border-radius: 50%;
+  offset-rotate: 0deg;
+  animation: ease-orbit linear infinite;
+}
+
+.orbit-planet-a {
+  width: 14px;
+  height: 14px;
+  offset-path: circle(68px at 50% 50%);
+  animation-duration: 2.2s;
+  background: radial-gradient(circle at 35% 35%, #f87171, #ef4444);
+  box-shadow: 0 0 10px rgba(239, 68, 68, 0.6);
+}
+
+.orbit-planet-b {
+  width: 18px;
+  height: 18px;
+  offset-path: circle(110px at 50% 50%);
+  animation-duration: 4s;
+  background: radial-gradient(circle at 35% 35%, #6ee7b7, #10b981);
+  box-shadow: 0 0 10px rgba(16, 185, 129, 0.6);
+}
+
+.orbit-planet-c {
+  width: 12px;
+  height: 12px;
+  offset-path: circle(148px at 50% 50%);
+  animation-duration: 7s;
+  background: radial-gradient(circle at 35% 35%, #c4b5fd, #8b5cf6);
+  box-shadow: 0 0 10px rgba(139, 92, 246, 0.6);
+}
+
+/* ──────────────────────────────────────────────────
+   VARIANT 3: Elliptical orbit + offset-rotate auto
+   offset-rotate: auto orients the body along the path
+────────────────────────────────────────────────── */
+.orbit-system-3 {
+  position: relative;
+  width: 340px;
+  height: 220px;
+}
+
+.orbit-system-3 .orbit-center {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 35%, #fcd34d, #f59e0b);
+  box-shadow: 0 0 22px rgba(245, 158, 11, 0.5);
+}
+
+.orbit-ellipse-track {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  border: 1px dashed rgba(255, 255, 255, 0.12);
+}
+
+.orbit-comet {
+  position: absolute;
+  width: 16px;
+  height: 10px;
+  border-radius: 50% 50% 50% 50% / 60% 60% 40% 40%;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.9), rgba(147, 197, 253, 0.4));
+  offset-path: ellipse(160px 100px at 50% 50%);
+  offset-rotate: auto; /* body aligns to path tangent */
+  animation: ease-orbit 5s linear infinite;
+}
+
+/* ──────────────────────────────────────────────────
+   ACCESSIBILITY
+────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .orbit-body,
+  .orbit-planet,
+  .orbit-comet {
+    animation-play-state: paused;
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/offset-path-orbital-sk/` — three orbital animation demos using the CSS Motion Path API (`offset-path`, `offset-distance`, `offset-rotate`). Animates elements along geometric paths without trigonometry, `requestAnimationFrame`, or SVG `animateMotion`.

## Technique

```css
@keyframes ease-orbit {
  from { offset-distance: 0%; }
  to   { offset-distance: 100%; }
}

.orbit-body {
  position: absolute;
  offset-path: circle(130px at 50% 50%);
  offset-rotate: 0deg;
  animation: ease-orbit 4s linear infinite;
}
```

`offset-distance` goes from `0%` to `100%` — the browser interpolates the element's position along the path at every frame.

## Variants

1. **Single circular orbit** — `circle()` path, `offset-rotate: 0deg` keeps planet upright
2. **Multi-body solar system** — 3 planets at different radii (`68px`, `110px`, `148px`) with different durations (`2.2s`, `4s`, `7s`) for realistic speed gradients
3. **Elliptical comet** — `ellipse(160px 100px)` path, `offset-rotate: auto` aligns comet shape to the path tangent

## Files added

- `demo.html` — 3 sections, accessible aria labels
- `style.css` — `@keyframes ease-orbit`, motion path properties, `prefers-reduced-motion` pause
- `README.md` — API explanation, multi-body pattern, `offset-rotate: auto` behavior

## Checklist

- [x] Only `submissions/examples/` touched
- [x] Exactly 3 files: `demo.html`, `style.css`, `README.md`
- [x] `prefers-reduced-motion: reduce` implemented (`animation-play-state: paused`)
- [x] No changes to `core/`, `components/`, `docs/`
- [x] Closes #20793