### PR TITLE
feat(submission): add @property typed color design token animation

### DIFF
--- a/submissions/examples/property-color-token-anim-sk/README.md
+++ b/submissions/examples/property-color-token-anim-sk/README.md
@@ -1,0 +1,85 @@
+# @property Typed `<color>` Design Token Animation
+
+Registers CSS custom properties with `syntax: '<color>'` via `@property`, enabling native color interpolation in transitions and `@keyframes`. Without `@property`, CSS variables are opaque strings — they snap between values instead of interpolating.
+
+## Variants
+
+| Variant | Mechanism | Trigger |
+|---------|-----------|---------|
+| Token cascade | `@keyframes` animates one token; all consumers update | Continuous |
+| Theme switch | Class change triggers token transition across 3 tokens | Button click |
+| Per-element hover | Each element has its own typed `--ease-btn-bg` | `:hover` |
+
+## Why `@property` is required
+
+```css
+/* Without @property — snaps between values, no interpolation */
+:root { --color: #6c63ff; }
+.el { background: var(--color); transition: --color 0.4s; } /* does nothing */
+
+/* With @property — smooth color interpolation */
+@property --ease-btn-bg {
+  syntax: '<color>';
+  inherits: false;
+  initial-value: #6c63ff;
+}
+
+.ease-btn {
+  background-color: var(--ease-btn-bg);
+  transition: --ease-btn-bg 0.4s ease;
+}
+.ease-btn:hover { --ease-btn-bg: #a78bfa; }
+```
+
+## Token cascade pattern
+
+```css
+@property --ease-token-primary {
+  syntax: '<color>';
+  inherits: true;       /* cascades to all children */
+  initial-value: #6c63ff;
+}
+
+@keyframes ease-token-cycle {
+  0%   { --ease-token-primary: #6c63ff; }
+  25%  { --ease-token-primary: #ec4899; }
+  50%  { --ease-token-primary: #10b981; }
+  75%  { --ease-token-primary: #f59e0b; }
+  100% { --ease-token-primary: #6c63ff; }
+}
+
+.ease-token-cascade {
+  animation: ease-token-cycle 4s linear infinite;
+}
+```
+
+`inherits: true` means animating the token on a parent element updates all descendant elements that reference it — a single `@keyframes` drives the entire color system.
+
+## Theme switching
+
+```css
+@property --ease-token-bg { syntax: '<color>'; inherits: true; initial-value: #1a2035; }
+
+.ease-theme-switcher {
+  transition:
+    --ease-token-bg 0.5s ease,
+    --ease-token-primary 0.5s ease,
+    --ease-token-accent 0.5s ease;
+}
+
+.ease-theme-switcher.theme-warm {
+  --ease-token-bg: #1c1008;
+  --ease-token-primary: #f59e0b;
+}
+```
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables the cascade animation and removes all token transitions.
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .ease-token-cascade { animation: none; }
+  .ease-theme-switcher, .ease-btn { transition: none; }
+}
+```

--- a/submissions/examples/property-color-token-anim-sk/demo.html
+++ b/submissions/examples/property-color-token-anim-sk/demo.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>@property Typed Color Token Animation</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>@property Typed Color Token Animation</h1>
+    <p><code>@property</code> with <code>syntax: '&lt;color&gt;'</code> makes CSS custom properties type-aware — enabling native color interpolation in transitions and <code>@keyframes</code>.</p>
+  </header>
+
+  <!-- VARIANT 1: Animated token cascade -->
+  <section class="section">
+    <p class="section-label">Token cascade — one keyframe updates all consumers</p>
+    <div class="demo-card">
+      <div class="ease-token-cascade" aria-label="Animated color token cascade">
+        <div class="token-border-box">
+          <div class="token-swatch" aria-hidden="true"></div>
+          <div>
+            <span class="token-text">--ease-token-primary</span>
+            <p>Swatch background, border, and text all read the same token.</p>
+          </div>
+        </div>
+        <div class="token-border-box">
+          <div class="token-swatch" aria-hidden="true"></div>
+          <div>
+            <span class="token-text">One animation, many consumers</span>
+            <p>Change the token once — every element using it updates in sync.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <p class="note">
+      Without <code>@property</code>, animating a custom property is impossible — the browser treats
+      it as an opaque string and snaps between values. <code>syntax: '&lt;color&gt;'</code> enables true interpolation.
+    </p>
+  </section>
+
+  <!-- VARIANT 2: Theme-switch via token transition -->
+  <section class="section">
+    <p class="section-label">Theme switch — transition tokens between theme states</p>
+    <div class="ease-theme-switcher" id="themeSwitcher" aria-live="polite">
+      <div class="theme-accent-bar" aria-hidden="true"></div>
+      <h2 class="theme-heading">Design Token Theme</h2>
+      <p class="theme-subtext">Background, heading color, and accent bar all transition smoothly when a theme class is applied.</p>
+      <div class="theme-btn-row">
+        <button class="theme-btn" onclick="setTheme('')">Default</button>
+        <button class="theme-btn" onclick="setTheme('theme-warm')">Warm</button>
+        <button class="theme-btn" onclick="setTheme('theme-cool')">Cool</button>
+      </div>
+    </div>
+    <p class="note">
+      Toggling a class changes <code>--ease-token-bg</code>, <code>--ease-token-primary</code>, and
+      <code>--ease-token-accent</code>. Because they are typed as <code>&lt;color&gt;</code>, the transition
+      interpolates through LAB color space instead of snapping.
+    </p>
+  </section>
+
+  <!-- VARIANT 3: Per-element hover token -->
+  <section class="section">
+    <p class="section-label">Per-element typed token — hover to transition</p>
+    <div class="demo-card">
+      <div class="ease-btn-row">
+        <button class="ease-btn" aria-label="Purple button, hover to shift hue">Purple</button>
+        <button class="ease-btn btn-pink" aria-label="Pink button, hover to lighten">Pink</button>
+        <button class="ease-btn btn-green" aria-label="Green button, hover to lighten">Green</button>
+      </div>
+    </div>
+    <p class="note">
+      Each button uses its own <code>--ease-btn-bg</code> typed property.
+      <code>transition: --ease-btn-bg 0.4s ease</code> interpolates smoothly — try hovering.
+    </p>
+  </section>
+
+  <script>
+    function setTheme(cls) {
+      const el = document.getElementById('themeSwitcher');
+      el.className = 'ease-theme-switcher' + (cls ? ' ' + cls : '');
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/property-color-token-anim-sk/style.css
+++ b/submissions/examples/property-color-token-anim-sk/style.css
@@ -1,0 +1,300 @@
+/* ──────────────────────────────────────────────────
+   @property declarations — typed CSS custom properties
+   syntax: '<color>' enables native color interpolation
+────────────────────────────────────────────────── */
+@property --ease-token-primary {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #6c63ff;
+}
+
+@property --ease-token-accent {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #ec4899;
+}
+
+@property --ease-token-bg {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #1a2035;
+}
+
+@property --ease-btn-bg {
+  syntax: '<color>';
+  inherits: false;
+  initial-value: #6c63ff;
+}
+
+@property --ease-tag-color {
+  syntax: '<color>';
+  inherits: false;
+  initial-value: #6c63ff;
+}
+
+:root {
+  --bg-primary: #0a0e17;
+  --bg-card: #111827;
+  --border: rgba(255, 255, 255, 0.07);
+  --text-primary: #f1f5f9;
+  --text-muted: #64748b;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: system-ui, -apple-system, sans-serif;
+  min-height: 100vh;
+  padding: 2.5rem 1.5rem;
+  line-height: 1.6;
+}
+
+.page-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.page-header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  background: linear-gradient(135deg, #a78bfa, #f472b6);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 0.5rem;
+}
+
+.page-header p {
+  color: var(--text-muted);
+  font-size: 1rem;
+  max-width: 54ch;
+  margin: 0 auto;
+}
+
+/* ──────────────────────────────────────────────────
+   SECTION LAYOUT
+────────────────────────────────────────────────── */
+.section {
+  max-width: 900px;
+  margin: 0 auto 3.5rem;
+}
+
+.section-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--text-muted);
+  margin-bottom: 1.25rem;
+}
+
+.demo-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 2rem;
+}
+
+.note {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: 1rem;
+}
+
+.note code {
+  background: rgba(255, 255, 255, 0.07);
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+  font-size: 0.78rem;
+  color: #94a3b8;
+}
+
+/* ──────────────────────────────────────────────────
+   VARIANT 1: Animated color token cascade
+   --ease-token-primary animates; all children
+   that reference it update together
+────────────────────────────────────────────────── */
+@keyframes ease-token-cycle {
+  0%   { --ease-token-primary: #6c63ff; }
+  25%  { --ease-token-primary: #ec4899; }
+  50%  { --ease-token-primary: #10b981; }
+  75%  { --ease-token-primary: #f59e0b; }
+  100% { --ease-token-primary: #6c63ff; }
+}
+
+.ease-token-cascade {
+  animation: ease-token-cycle 4s linear infinite;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.token-swatch {
+  width: 48px;
+  height: 48px;
+  border-radius: 10px;
+  background-color: var(--ease-token-primary);
+  flex-shrink: 0;
+}
+
+.token-border-box {
+  border: 2px solid var(--ease-token-primary);
+  border-radius: 10px;
+  padding: 0.85rem 1.25rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  transition: none;
+}
+
+.token-border-box p {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.token-text {
+  color: var(--ease-token-primary);
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+/* ──────────────────────────────────────────────────
+   VARIANT 2: Theme-switch via token transition
+   toggling a class transitions the token to new value
+────────────────────────────────────────────────── */
+.ease-theme-switcher {
+  --ease-token-bg: #1a2035;
+  --ease-token-primary: #6c63ff;
+  --ease-token-accent: #ec4899;
+  border-radius: 16px;
+  padding: 1.75rem;
+  background-color: var(--ease-token-bg);
+  border: 1px solid var(--border);
+  transition:
+    --ease-token-bg 0.5s ease,
+    --ease-token-primary 0.5s ease,
+    --ease-token-accent 0.5s ease;
+}
+
+.ease-theme-switcher.theme-warm {
+  --ease-token-bg: #1c1008;
+  --ease-token-primary: #f59e0b;
+  --ease-token-accent: #ef4444;
+}
+
+.ease-theme-switcher.theme-cool {
+  --ease-token-bg: #081820;
+  --ease-token-primary: #06b6d4;
+  --ease-token-accent: #3b82f6;
+}
+
+.theme-heading {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--ease-token-primary);
+  margin-bottom: 0.5rem;
+  transition: color 0.5s ease;
+}
+
+.theme-subtext {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin-bottom: 1.25rem;
+}
+
+.theme-accent-bar {
+  height: 4px;
+  border-radius: 2px;
+  background-color: var(--ease-token-accent);
+  margin-bottom: 1.25rem;
+  transition: background-color 0.5s ease;
+}
+
+.theme-btn-row {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.theme-btn {
+  padding: 0.45em 1.1em;
+  border-radius: 8px;
+  border: none;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-primary);
+  transition: background-color 0.25s ease;
+}
+
+.theme-btn:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+/* ──────────────────────────────────────────────────
+   VARIANT 3: Per-element typed color token on hover
+   each button has its own --ease-btn-bg that transitions
+────────────────────────────────────────────────── */
+.ease-btn-row {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.ease-btn {
+  --ease-btn-bg: #6c63ff;
+  padding: 0.55em 1.4em;
+  border-radius: 10px;
+  border: none;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  color: #fff;
+  background-color: var(--ease-btn-bg);
+  transition: --ease-btn-bg 0.4s ease;
+}
+
+.ease-btn:hover {
+  --ease-btn-bg: #a78bfa;
+}
+
+.ease-btn.btn-pink {
+  --ease-btn-bg: #ec4899;
+}
+.ease-btn.btn-pink:hover {
+  --ease-btn-bg: #f9a8d4;
+}
+
+.ease-btn.btn-green {
+  --ease-btn-bg: #10b981;
+}
+.ease-btn.btn-green:hover {
+  --ease-btn-bg: #6ee7b7;
+}
+
+/* ──────────────────────────────────────────────────
+   ACCESSIBILITY
+────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-token-cascade {
+    animation: none;
+  }
+
+  .ease-theme-switcher,
+  .theme-heading,
+  .theme-accent-bar,
+  .ease-btn {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/property-color-token-anim-sk/` — three demos using `@property` with `syntax: '<color>'` to register typed CSS custom properties that interpolate natively in transitions and `@keyframes`.

## Why this matters

Without `@property`, CSS custom properties are opaque strings. Animating `--my-color: red` to `--my-color: blue` produces an instant snap, not a smooth transition. `@property` registers a type, giving the browser enough information to interpolate between color values.

## Technique

```css
@property --ease-token-primary {
  syntax: '<color>';
  inherits: true;
  initial-value: #6c63ff;
}

@keyframes ease-token-cycle {
  0%   { --ease-token-primary: #6c63ff; }
  25%  { --ease-token-primary: #ec4899; }
  100% { --ease-token-primary: #6c63ff; }
}
```

`inherits: true` means all child elements that reference the token update automatically from a single animation on the parent.

## Variants

1. **Token cascade** — one `@keyframes` animates `--ease-token-primary`; swatch background, border, and text color all update in sync
2. **Theme switch** — clicking a button toggles a class that changes 3 typed tokens (`--ease-token-bg`, `--ease-token-primary`, `--ease-token-accent`), all smoothly transitioning together
3. **Per-element hover** — each button has its own `--ease-btn-bg` with `inherits: false`, transitioning on `:hover`

## Files added

- `demo.html` — 3 sections, theme-switch buttons with inline script
- `style.css` — 5 `@property` declarations, `@keyframes ease-token-cycle`, `prefers-reduced-motion` override
- `README.md` — explains why `@property` is required, cascade pattern, theme switching

## Checklist

- [x] Only `submissions/examples/` touched
- [x] Exactly 3 files: `demo.html`, `style.css`, `README.md`
- [x] `prefers-reduced-motion: reduce` implemented
- [x] No changes to `core/`, `components/`, `docs/`
- [x] Closes #20795