### PR TITLE
feat(submission): add filter drop-shadow stacked motion trail

### DIFF
--- a/submissions/examples/drop-shadow-motion-trail-sk/README.md
+++ b/submissions/examples/drop-shadow-motion-trail-sk/README.md
@@ -1,0 +1,67 @@
+# filter: drop-shadow() Stacked Motion Trail
+
+Stacks multiple `filter: drop-shadow()` layers with directional offsets that animate in sync with the element's motion — the shadow always trails behind the direction of travel, simulating a velocity-aware light trail without canvas, WebGL, or JavaScript.
+
+## Variants
+
+| Variant | Motion | Trail technique |
+|---------|--------|-----------------|
+| Horizontal bounce | `translateX` left↔right | Shadow offsets flip direction at each end |
+| Vertical oscillation | `translateY` up↔down | Vertical offsets point opposite to travel direction |
+| Orbital trail | `offset-path: circle()` | Second `@keyframes` rotates shadow offset in sync with orbit |
+
+## Core technique
+
+Three shadow layers create depth: near (high opacity, small blur), mid, and outer glow (low opacity, large blur):
+
+```css
+@keyframes ease-trail-bounce {
+  0% {
+    transform: translateX(-120px);
+    filter:
+      drop-shadow(12px 0 6px rgba(249, 115, 22, 0.70))   /* near trail */
+      drop-shadow(22px 0 10px rgba(249, 115, 22, 0.40))  /* mid trail */
+      drop-shadow(34px 0 16px rgba(249, 115, 22, 0.20)); /* outer glow */
+  }
+  50% {
+    transform: translateX(120px);
+    filter:
+      drop-shadow(-12px 0 6px rgba(236, 72, 153, 0.70))
+      drop-shadow(-22px 0 10px rgba(236, 72, 153, 0.40))
+      drop-shadow(-34px 0 16px rgba(236, 72, 153, 0.20));
+  }
+}
+```
+
+At `0%` (moving rightward), the offset is positive X (shadow trails to the right = behind the leftward direction). At `50%` (moving leftward), the offset flips.
+
+## `drop-shadow()` vs `box-shadow`
+
+`filter: drop-shadow()` traces the element's actual alpha channel — it follows the shape precisely, including transparent areas. `box-shadow` always follows the rectangular border box. For irregular shapes (circles, custom clip-paths), `drop-shadow()` produces correct contouring.
+
+## Orbital trail
+
+The orbital variant runs two synchronized `@keyframes` on the same element:
+
+```css
+.orbit-trail-dot {
+  animation:
+    ease-orbit-distance 3s linear infinite,  /* moves the dot along the path */
+    ease-trail-orbit 3s linear infinite;      /* rotates the shadow offset */
+}
+```
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` stops all animations and clears the filter, leaving the element visible without motion.
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .ease-trail-orb,
+  .ease-trail-square,
+  .orbit-trail-dot {
+    animation: none;
+    filter: none;
+  }
+}
+```

--- a/submissions/examples/drop-shadow-motion-trail-sk/demo.html
+++ b/submissions/examples/drop-shadow-motion-trail-sk/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>filter: drop-shadow() Stacked Motion Trail</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>drop-shadow() Motion Trail</h1>
+    <p>Stack multiple <code>filter: drop-shadow()</code> layers with directional offsets that reverse with the motion — simulating a velocity-aware light trail.</p>
+  </header>
+
+  <!-- VARIANT 1: Horizontal bounce -->
+  <section class="section">
+    <p class="section-label">Horizontal bounce — trailing shadow flips direction</p>
+    <div class="stage">
+      <div class="ease-trail-orb" aria-label="Bouncing orb with motion trail"></div>
+    </div>
+    <p class="note">
+      At <code>0%</code> the shadow offsets point right (trailing behind leftward motion).
+      At <code>50%</code> they flip left — matching the direction of travel.
+    </p>
+  </section>
+
+  <!-- VARIANT 2: Vertical fall -->
+  <section class="section">
+    <p class="section-label">Vertical oscillation — upward trail on descent</p>
+    <div class="stage">
+      <div class="ease-trail-square" aria-label="Square oscillating vertically with shadow trail"></div>
+    </div>
+    <p class="note">
+      Three stacked <code>drop-shadow()</code> calls: tight near-shadow at high opacity,
+      wider mid-shadow, and a large diffuse outer glow at low opacity.
+    </p>
+  </section>
+
+  <!-- VARIANT 3: Orbital trail -->
+  <section class="section">
+    <p class="section-label">Orbital — shadow direction rotates with the path</p>
+    <div class="stage">
+      <div class="orbit-stage" aria-label="Orbiting dot with trailing glow">
+        <div class="orbit-ring" aria-hidden="true"></div>
+        <div class="orbit-core" aria-hidden="true"></div>
+        <div class="orbit-trail-dot" aria-hidden="true"></div>
+      </div>
+    </div>
+    <p class="note">
+      A second <code>@keyframes</code> rotates the shadow offset to stay behind the
+      orbiting dot — the trail always points away from the direction of travel.
+    </p>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/drop-shadow-motion-trail-sk/style.css
+++ b/submissions/examples/drop-shadow-motion-trail-sk/style.css
@@ -1,0 +1,227 @@
+:root {
+  --bg-primary: #070b14;
+  --bg-card: #111827;
+  --border: rgba(255, 255, 255, 0.07);
+  --text-primary: #f1f5f9;
+  --text-muted: #64748b;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: system-ui, -apple-system, sans-serif;
+  min-height: 100vh;
+  padding: 2.5rem 1.5rem;
+  line-height: 1.6;
+}
+
+.page-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.page-header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  background: linear-gradient(135deg, #f97316, #ec4899);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 0.5rem;
+}
+
+.page-header p {
+  color: var(--text-muted);
+  font-size: 1rem;
+  max-width: 54ch;
+  margin: 0 auto;
+}
+
+/* ──────────────────────────────────────────────────
+   SECTION LAYOUT
+────────────────────────────────────────────────── */
+.section {
+  max-width: 900px;
+  margin: 0 auto 4rem;
+}
+
+.section-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--text-muted);
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+
+.stage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+  position: relative;
+}
+
+.note {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: 1.5rem;
+  text-align: center;
+}
+
+.note code {
+  background: rgba(255, 255, 255, 0.07);
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+  font-size: 0.78rem;
+  color: #94a3b8;
+}
+
+/* ──────────────────────────────────────────────────
+   VARIANT 1: Horizontal bounce with directional trail
+   filter: drop-shadow() offsets stack on the trailing side
+────────────────────────────────────────────────── */
+@keyframes ease-trail-bounce {
+  0%   {
+    transform: translateX(-120px);
+    filter:
+      drop-shadow(12px 0 6px rgba(249, 115, 22, 0.7))
+      drop-shadow(22px 0 10px rgba(249, 115, 22, 0.4))
+      drop-shadow(34px 0 16px rgba(249, 115, 22, 0.2));
+  }
+  50%  {
+    transform: translateX(120px);
+    filter:
+      drop-shadow(-12px 0 6px rgba(236, 72, 153, 0.7))
+      drop-shadow(-22px 0 10px rgba(236, 72, 153, 0.4))
+      drop-shadow(-34px 0 16px rgba(236, 72, 153, 0.2));
+  }
+  100% {
+    transform: translateX(-120px);
+    filter:
+      drop-shadow(12px 0 6px rgba(249, 115, 22, 0.7))
+      drop-shadow(22px 0 10px rgba(249, 115, 22, 0.4))
+      drop-shadow(34px 0 16px rgba(249, 115, 22, 0.2));
+  }
+}
+
+.ease-trail-orb {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 35%, #fdba74, #f97316);
+  animation: ease-trail-bounce 2.2s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+}
+
+/* ──────────────────────────────────────────────────
+   VARIANT 2: Vertical fall with downward shadow stack
+   shadows point up (trail behind the motion)
+────────────────────────────────────────────────── */
+@keyframes ease-trail-fall {
+  0%   {
+    transform: translateY(-80px);
+    filter:
+      drop-shadow(0 -10px 6px rgba(99, 102, 241, 0.75))
+      drop-shadow(0 -20px 12px rgba(99, 102, 241, 0.4))
+      drop-shadow(0 -32px 20px rgba(99, 102, 241, 0.18));
+  }
+  50%  {
+    transform: translateY(80px);
+    filter:
+      drop-shadow(0 10px 6px rgba(139, 92, 246, 0.75))
+      drop-shadow(0 20px 12px rgba(139, 92, 246, 0.4))
+      drop-shadow(0 32px 20px rgba(139, 92, 246, 0.18));
+  }
+  100% {
+    transform: translateY(-80px);
+    filter:
+      drop-shadow(0 -10px 6px rgba(99, 102, 241, 0.75))
+      drop-shadow(0 -20px 12px rgba(99, 102, 241, 0.4))
+      drop-shadow(0 -32px 20px rgba(99, 102, 241, 0.18));
+  }
+}
+
+.ease-trail-square {
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #818cf8, #6366f1);
+  animation: ease-trail-fall 1.8s ease-in-out infinite;
+}
+
+/* ──────────────────────────────────────────────────
+   VARIANT 3: Circular orbit with trailing glow
+   offset-path orbit + directional shadow
+────────────────────────────────────────────────── */
+@keyframes ease-orbit-distance {
+  from { offset-distance: 0%; }
+  to   { offset-distance: 100%; }
+}
+
+@keyframes ease-trail-orbit {
+  0%   { filter: drop-shadow(-8px  4px 8px rgba(52, 211, 153, 0.8)) drop-shadow(-14px 6px 14px rgba(52, 211, 153, 0.35)); }
+  25%  { filter: drop-shadow(-4px  8px 8px rgba(52, 211, 153, 0.8)) drop-shadow(-6px  14px 14px rgba(52, 211, 153, 0.35)); }
+  50%  { filter: drop-shadow( 8px -4px 8px rgba(52, 211, 153, 0.8)) drop-shadow(14px -6px 14px rgba(52, 211, 153, 0.35)); }
+  75%  { filter: drop-shadow( 4px -8px 8px rgba(52, 211, 153, 0.8)) drop-shadow( 6px -14px 14px rgba(52, 211, 153, 0.35)); }
+  100% { filter: drop-shadow(-8px  4px 8px rgba(52, 211, 153, 0.8)) drop-shadow(-14px 6px 14px rgba(52, 211, 153, 0.35)); }
+}
+
+.orbit-stage {
+  position: relative;
+  width: 220px;
+  height: 220px;
+}
+
+.orbit-ring {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  border: 1px dashed rgba(255, 255, 255, 0.1);
+}
+
+.orbit-core {
+  position: absolute;
+  inset: 50%;
+  transform: translate(-50%, -50%);
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 35%, #6ee7b7, #10b981);
+  box-shadow: 0 0 20px rgba(16, 185, 129, 0.4);
+  margin: 0;
+}
+
+.orbit-trail-dot {
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 35%, #a7f3d0, #34d399);
+  offset-path: circle(100px at 50% 50%);
+  offset-rotate: 0deg;
+  animation:
+    ease-orbit-distance 3s linear infinite,
+    ease-trail-orbit 3s linear infinite;
+}
+
+/* ──────────────────────────────────────────────────
+   ACCESSIBILITY
+────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-trail-orb,
+  .ease-trail-square,
+  .orbit-trail-dot {
+    animation: none;
+    filter: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/drop-shadow-motion-trail-sk/` — a velocity-aware motion trail effect built from stacked `filter: drop-shadow()` layers. The shadow offsets animate in sync with the element's direction of travel — pointing opposite to the motion at all times, so the trail always appears to stream behind.

## Technique

Three shadow layers create a depth gradient: near shadow (high opacity, small blur) → mid shadow → outer diffuse glow (low opacity, large blur). The offsets are baked into the same `@keyframes` as the `transform`:

```css
@keyframes ease-trail-bounce {
  0% {
    transform: translateX(-120px);
    filter:
      drop-shadow(12px 0 6px rgba(249, 115, 22, 0.70))
      drop-shadow(22px 0 10px rgba(249, 115, 22, 0.40))
      drop-shadow(34px 0 16px rgba(249, 115, 22, 0.20));
  }
  50% {
    transform: translateX(120px);
    filter:
      drop-shadow(-12px 0 6px rgba(236, 72, 153, 0.70))
      drop-shadow(-22px 0 10px rgba(236, 72, 153, 0.40))
      drop-shadow(-34px 0 16px rgba(236, 72, 153, 0.20));
  }
}
```

## Variants

1. **Horizontal bounce** — orange orb bounces left/right; shadow flips direction and color at each turnaround
2. **Vertical oscillation** — indigo square oscillates up/down; vertical offsets point opposite to travel
3. **Orbital trail** — dot orbits via `offset-path`; a second synchronized `@keyframes` rotates the shadow offset to stay behind the direction of travel

## `drop-shadow()` vs `box-shadow`

`filter: drop-shadow()` traces the element's actual alpha channel, not its border box — correct for circles and non-rectangular shapes.

## Files added

- `demo.html` — 3 animated sections with aria labels
- `style.css` — `@keyframes ease-trail-bounce`, `ease-trail-fall`, `ease-trail-orbit`, `prefers-reduced-motion` override
- `README.md` — technique explanation, layer structure, `drop-shadow` vs `box-shadow` comparison

## Checklist

- [x] Only `submissions/examples/` touched
- [x] Exactly 3 files: `demo.html`, `style.css`, `README.md`
- [x] `prefers-reduced-motion: reduce` implemented
- [x] No changes to `core/`, `components/`, `docs/`
- [x] Closes #20797