### PR TITLE
feat(submission): add @property length individual corner radius morphing

### DIFF
--- a/submissions/examples/property-corner-radius-morph-sk/README.md
+++ b/submissions/examples/property-corner-radius-morph-sk/README.md
@@ -1,0 +1,70 @@
+# @property `<length>` Individual Corner Radius Morphing
+
+Registers four typed CSS custom properties — one per `border-radius` corner — enabling independent per-corner animation in `@keyframes` and `transition`.
+
+## Why `@property` is required
+
+`border-radius` shorthand cannot be partially transitioned. Animating the full `border-radius` value interpolates all four corners together. With `@property`:
+
+```css
+@property --r-tl { syntax: '<length>'; inherits: false; initial-value: 16px; }
+@property --r-tr { syntax: '<length>'; inherits: false; initial-value: 16px; }
+@property --r-br { syntax: '<length>'; inherits: false; initial-value: 16px; }
+@property --r-bl { syntax: '<length>'; inherits: false; initial-value: 16px; }
+
+.shape {
+  border-radius: var(--r-tl) var(--r-tr) var(--r-br) var(--r-bl);
+}
+```
+
+Each corner is now a numeric `<length>` that the browser can interpolate independently.
+
+## Variants
+
+| Variant | Pattern | Keyframes |
+|---------|---------|-----------|
+| Corner ripple | Corners round sequentially | 8-step keyframe |
+| Square ↔ circle | All four together | 2-state ease-in-out |
+| Organic blob | Asymmetric, all different | 3-state ease-in-out |
+| Hover diagonal | `transition` on `:hover` | Transition only |
+
+## Corner ripple
+
+```css
+@keyframes ease-corner-ripple {
+  0%   { --r-tl: 16px; --r-tr: 16px; --r-br: 16px; --r-bl: 16px; }
+  12%  { --r-tl: 70px; --r-tr: 16px; --r-br: 16px; --r-bl: 16px; }
+  25%  { --r-tl: 70px; --r-tr: 70px; --r-br: 16px; --r-bl: 16px; }
+  50%  { --r-tl: 70px; --r-tr: 70px; --r-br: 70px; --r-bl: 70px; }
+  /* ... returns symmetrically */
+}
+```
+
+## Hover with spring easing
+
+```css
+.ease-morph-hover {
+  --r-tl: 8px; --r-tr: 8px; --r-br: 8px; --r-bl: 8px;
+  transition:
+    --r-tl 0.45s cubic-bezier(0.34, 1.56, 0.64, 1),
+    --r-tr 0.45s cubic-bezier(0.34, 1.56, 0.64, 1),
+    --r-br 0.45s cubic-bezier(0.34, 1.56, 0.64, 1),
+    --r-bl 0.45s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.ease-morph-hover:hover {
+  --r-tl: 50px; --r-tr: 12px; --r-br: 50px; --r-bl: 12px;
+}
+```
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` stops all animations and transitions. Shapes remain visible at their initial radius values.
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .ease-morph-ripple,
+  .ease-morph-circle,
+  .ease-morph-blob { animation: none; }
+  .ease-morph-hover { transition: none; }
+}
+```

--- a/submissions/examples/property-corner-radius-morph-sk/demo.html
+++ b/submissions/examples/property-corner-radius-morph-sk/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>@property Corner Radius Morphing</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>@property Corner Radius Morphing</h1>
+    <p>Register <code>--r-tl</code>, <code>--r-tr</code>, <code>--r-br</code>, <code>--r-bl</code> as typed <code>&lt;length&gt;</code> properties — then animate each corner independently in <code>@keyframes</code> or <code>transition</code>.</p>
+  </header>
+
+  <!-- VARIANT 1 & 2: Side by side -->
+  <section class="section">
+    <p class="section-label">Corner ripple &amp; square ↔ circle</p>
+    <div class="stage">
+      <div class="ease-morph ease-morph-ripple" aria-label="Corner ripple animation" role="img"></div>
+      <div class="ease-morph ease-morph-circle" aria-label="Square to circle morph" role="img"></div>
+    </div>
+    <p class="note">
+      Left: corners round one-by-one in sequence via 8-step keyframes.
+      Right: all four corners morph together — square to circle and back.
+    </p>
+  </section>
+
+  <!-- VARIANT 3 & 4: Side by side -->
+  <section class="section">
+    <p class="section-label">Organic blob &amp; hover diagonal</p>
+    <div class="stage">
+      <div class="ease-morph ease-morph-blob" aria-label="Organic blob morph animation" role="img"></div>
+      <div class="ease-morph ease-morph-hover" tabindex="0" role="button" aria-label="Hover for diagonal corner morph"></div>
+    </div>
+    <p class="note">
+      Left: asymmetric corner values produce an organic blob shape.
+      Right: hover to trigger diagonal morph with spring easing — each corner transitions independently.
+    </p>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/property-corner-radius-morph-sk/style.css
+++ b/submissions/examples/property-corner-radius-morph-sk/style.css
@@ -1,0 +1,215 @@
+/* ──────────────────────────────────────────────────
+   @property declarations — one per corner
+   syntax: '<length>' enables numeric interpolation
+────────────────────────────────────────────────── */
+@property --r-tl {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 16px;
+}
+
+@property --r-tr {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 16px;
+}
+
+@property --r-br {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 16px;
+}
+
+@property --r-bl {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 16px;
+}
+
+:root {
+  --bg-primary: #0a0e17;
+  --bg-card: #111827;
+  --border: rgba(255, 255, 255, 0.07);
+  --text-primary: #f1f5f9;
+  --text-muted: #64748b;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: system-ui, -apple-system, sans-serif;
+  min-height: 100vh;
+  padding: 2.5rem 1.5rem;
+  line-height: 1.6;
+}
+
+.page-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.page-header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  background: linear-gradient(135deg, #34d399, #6366f1);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 0.5rem;
+}
+
+.page-header p {
+  color: var(--text-muted);
+  font-size: 1rem;
+  max-width: 54ch;
+  margin: 0 auto;
+}
+
+/* ──────────────────────────────────────────────────
+   SECTION LAYOUT
+────────────────────────────────────────────────── */
+.section {
+  max-width: 900px;
+  margin: 0 auto 4rem;
+}
+
+.section-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--text-muted);
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+
+.stage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  min-height: 200px;
+  flex-wrap: wrap;
+}
+
+.note {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: 1.5rem;
+  text-align: center;
+}
+
+.note code {
+  background: rgba(255, 255, 255, 0.07);
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+  font-size: 0.78rem;
+  color: #94a3b8;
+}
+
+/* ──────────────────────────────────────────────────
+   BASE MORPH SHAPE
+   border-radius uses the 4 typed custom properties
+────────────────────────────────────────────────── */
+.ease-morph {
+  width: 140px;
+  height: 140px;
+  border-radius: var(--r-tl) var(--r-tr) var(--r-br) var(--r-bl);
+}
+
+/* ──────────────────────────────────────────────────
+   VARIANT 1: Continuous corner rotation
+   corners ripple in sequence — square → blob → square
+────────────────────────────────────────────────── */
+@keyframes ease-corner-ripple {
+  0%   { --r-tl: 16px;  --r-tr: 16px;  --r-br: 16px;  --r-bl: 16px;  }
+  12%  { --r-tl: 70px;  --r-tr: 16px;  --r-br: 16px;  --r-bl: 16px;  }
+  25%  { --r-tl: 70px;  --r-tr: 70px;  --r-br: 16px;  --r-bl: 16px;  }
+  37%  { --r-tl: 70px;  --r-tr: 70px;  --r-br: 70px;  --r-bl: 16px;  }
+  50%  { --r-tl: 70px;  --r-tr: 70px;  --r-br: 70px;  --r-bl: 70px;  }
+  62%  { --r-tl: 16px;  --r-tr: 70px;  --r-br: 70px;  --r-bl: 70px;  }
+  75%  { --r-tl: 16px;  --r-tr: 16px;  --r-br: 70px;  --r-bl: 70px;  }
+  87%  { --r-tl: 16px;  --r-tr: 16px;  --r-br: 16px;  --r-bl: 70px;  }
+  100% { --r-tl: 16px;  --r-tr: 16px;  --r-br: 16px;  --r-bl: 16px;  }
+}
+
+.ease-morph-ripple {
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  animation: ease-corner-ripple 3s ease-in-out infinite;
+}
+
+/* ──────────────────────────────────────────────────
+   VARIANT 2: Square ↔ circle morph
+────────────────────────────────────────────────── */
+@keyframes ease-square-circle {
+  0%, 100% { --r-tl: 8px;   --r-tr: 8px;   --r-br: 8px;   --r-bl: 8px;   }
+  50%       { --r-tl: 70px;  --r-tr: 70px;  --r-br: 70px;  --r-bl: 70px;  }
+}
+
+.ease-morph-circle {
+  background: linear-gradient(135deg, #10b981, #34d399);
+  animation: ease-square-circle 2s ease-in-out infinite;
+}
+
+/* ──────────────────────────────────────────────────
+   VARIANT 3: Organic blob — asymmetric corners
+────────────────────────────────────────────────── */
+@keyframes ease-blob-morph {
+  0%   { --r-tl: 60px;  --r-tr: 20px;  --r-br: 55px;  --r-bl: 15px;  }
+  33%  { --r-tl: 15px;  --r-tr: 65px;  --r-br: 20px;  --r-bl: 60px;  }
+  66%  { --r-tl: 40px;  --r-tr: 10px;  --r-br: 65px;  --r-bl: 30px;  }
+  100% { --r-tl: 60px;  --r-tr: 20px;  --r-br: 55px;  --r-bl: 15px;  }
+}
+
+.ease-morph-blob {
+  background: linear-gradient(135deg, #f59e0b, #ec4899);
+  animation: ease-blob-morph 4s ease-in-out infinite;
+}
+
+/* ──────────────────────────────────────────────────
+   VARIANT 4: Hover — diagonal morph on interaction
+────────────────────────────────────────────────── */
+.ease-morph-hover {
+  background: linear-gradient(135deg, #3b82f6, #06b6d4);
+  cursor: pointer;
+  transition:
+    --r-tl 0.45s cubic-bezier(0.34, 1.56, 0.64, 1),
+    --r-tr 0.45s cubic-bezier(0.34, 1.56, 0.64, 1),
+    --r-br 0.45s cubic-bezier(0.34, 1.56, 0.64, 1),
+    --r-bl 0.45s cubic-bezier(0.34, 1.56, 0.64, 1);
+  --r-tl: 8px;
+  --r-tr: 8px;
+  --r-br: 8px;
+  --r-bl: 8px;
+}
+
+.ease-morph-hover:hover {
+  --r-tl: 50px;
+  --r-tr: 12px;
+  --r-br: 50px;
+  --r-bl: 12px;
+}
+
+/* ──────────────────────────────────────────────────
+   ACCESSIBILITY
+────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-morph-ripple,
+  .ease-morph-circle,
+  .ease-morph-blob {
+    animation: none;
+  }
+
+  .ease-morph-hover {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/property-corner-radius-morph-sk/` — four `@property` typed `<length>` tokens (`--r-tl`, `--r-tr`, `--r-br`, `--r-bl`) that map to individual `border-radius` corners, enabling independent per-corner animation in `@keyframes` and `transition`.

## Why `@property` is needed

`border-radius` shorthand interpolation treats all four corners as a unit — you can't animate them at different rates or on different timings. By registering each corner as a typed `<length>`:

```css
@property --r-tl { syntax: '<length>'; inherits: false; initial-value: 16px; }
/* ... repeat for --r-tr, --r-br, --r-bl */

.shape {
  border-radius: var(--r-tl) var(--r-tr) var(--r-br) var(--r-bl);
}
```

Each corner becomes independently animatable and transitionable.

## Variants

1. **Corner ripple** — 8-step `@keyframes` rounds corners sequentially (TL → TR → BR → BL → back)
2. **Square ↔ circle** — all four corners morph together with `ease-in-out`
3. **Organic blob** — asymmetric values produce a natural blob shape that morphs continuously
4. **Hover diagonal** — `transition` on all four tokens with `cubic-bezier(0.34, 1.56, 0.64, 1)` spring easing

## Files added

- `demo.html` — 2 sections, 4 animated/interactive shapes with aria labels
- `style.css` — 4 `@property` declarations, 4 `@keyframes`, `prefers-reduced-motion` override
- `README.md` — explains why `@property` is needed, all variant patterns

## Checklist

- [x] Only `submissions/examples/` touched
- [x] Exactly 3 files: `demo.html`, `style.css`, `README.md`
- [x] `prefers-reduced-motion: reduce` implemented
- [x] No changes to `core/`, `components/`, `docs/`
- [x] Closes #20799