### PR TITLE
feat: add overscroll-behavior utilities

### DIFF
--- a/submissions/examples/overscroll-behavior-tm-mp/README.md
+++ b/submissions/examples/overscroll-behavior-tm-mp/README.md
@@ -1,0 +1,19 @@
+## overscroll-behavior-tm-mp
+
+**What does this do?**
+Provides utility classes to control the browser's overscroll (scroll chaining and bounce) behaviour on any scrollable element, including per-axis variants.
+
+**How is it used?**
+```html
+<!-- Shorthand (both axes) -->
+<div class="scroll-box overscroll-auto">...</div>     <!-- browser default -->
+<div class="scroll-box overscroll-contain">...</div>  <!-- no scroll chaining -->
+<div class="scroll-box overscroll-none">...</div>     <!-- no chaining, no bounce -->
+
+<!-- Per-axis -->
+<div class="overscroll-x-contain">...</div>   <!-- contain horizontal only -->
+<div class="overscroll-y-none">...</div>      <!-- disable vertical bounce only -->
+```
+
+**Why is it useful?**
+Scroll chaining causes unexpected page scrolls when a nested scrollable element is fully scrolled — a common UX bug in modals, sidebars, and chat windows. These utilities let developers fix that with a single readable class instead of writing `overscroll-behavior` every time, fitting EaseMotion CSS's human-readable, utility-first philosophy.

--- a/submissions/examples/overscroll-behavior-tm-mp/demo.html
+++ b/submissions/examples/overscroll-behavior-tm-mp/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Overscroll Behavior Utilities Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Overscroll Behavior Utilities</h1>
+  <p class="hint">Scroll to the end of each box to see the overscroll effect.</p>
+
+  <h2>overscroll-auto (browser default)</h2>
+  <div class="scroll-box overscroll-auto">
+    <p>Line 1 — scroll down inside this box.</p>
+    <p>Line 2</p><p>Line 3</p><p>Line 4</p><p>Line 5</p>
+    <p>Line 6</p><p>Line 7</p><p>Line 8</p><p>Line 9</p>
+    <p>Line 10 — end of content. Scrolling further triggers the page scroll (default behaviour).</p>
+  </div>
+
+  <h2>overscroll-contain (contained — no scroll chaining)</h2>
+  <div class="scroll-box overscroll-contain">
+    <p>Line 1 — scroll down inside this box.</p>
+    <p>Line 2</p><p>Line 3</p><p>Line 4</p><p>Line 5</p>
+    <p>Line 6</p><p>Line 7</p><p>Line 8</p><p>Line 9</p>
+    <p>Line 10 — end of content. Scrolling further is contained here; the page does NOT scroll.</p>
+  </div>
+
+  <h2>overscroll-none (no bounce / glow effect)</h2>
+  <div class="scroll-box overscroll-none">
+    <p>Line 1 — scroll down inside this box.</p>
+    <p>Line 2</p><p>Line 3</p><p>Line 4</p><p>Line 5</p>
+    <p>Line 6</p><p>Line 7</p><p>Line 8</p><p>Line 9</p>
+    <p>Line 10 — end of content. No bounce, no glow, no scroll chaining.</p>
+  </div>
+
+  <!-- Extra page content so the page itself is scrollable -->
+  <div class="spacer"></div>
+</body>
+</html>

--- a/submissions/examples/overscroll-behavior-tm-mp/style.css
+++ b/submissions/examples/overscroll-behavior-tm-mp/style.css
@@ -1,0 +1,72 @@
+/* Base demo styles */
+body {
+  font-family: sans-serif;
+  padding: 2rem;
+  background: #f5f5f5;
+  max-width: 680px;
+  margin: 0 auto;
+}
+
+h1 { margin-bottom: 0.5rem; }
+h2 { margin: 1.8rem 0 0.4rem; color: #333; font-size: 1rem; text-transform: uppercase; letter-spacing: 0.05em; }
+
+.hint {
+  color: #666;
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+}
+
+.scroll-box {
+  height: 160px;
+  overflow-y: scroll;
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  padding: 1rem 1.2rem;
+  line-height: 1.8;
+}
+
+.scroll-box p { margin: 0.2rem 0; }
+
+/* Extra height so the page itself is scrollable (needed to demo chaining) */
+.spacer {
+  height: 600px;
+  background: linear-gradient(to bottom, #e8f4fd, #f5f5f5);
+  border-radius: 6px;
+  margin-top: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #aaa;
+  font-size: 0.85rem;
+}
+
+.spacer::after {
+  content: "Extra page content — visible when scroll chaining is active";
+}
+
+/* ─── Overscroll Behavior Utilities ─────────────────────────────────── */
+
+/* Browser default: scroll chains to parent / triggers bounce on mobile */
+.overscroll-auto {
+  overscroll-behavior: auto;
+}
+
+/* Contain scroll inside the element — no chaining, bounce still possible */
+.overscroll-contain {
+  overscroll-behavior: contain;
+}
+
+/* No chaining and no bounce / pull-to-refresh / glow effect */
+.overscroll-none {
+  overscroll-behavior: none;
+}
+
+/* Axis-specific variants */
+.overscroll-x-auto     { overscroll-behavior-x: auto; }
+.overscroll-x-contain  { overscroll-behavior-x: contain; }
+.overscroll-x-none     { overscroll-behavior-x: none; }
+
+.overscroll-y-auto     { overscroll-behavior-y: auto; }
+.overscroll-y-contain  { overscroll-behavior-y: contain; }
+.overscroll-y-none     { overscroll-behavior-y: none; }


### PR DESCRIPTION
## Pull Request Description
Adds overscroll-behavior utility classes (`overscroll-auto`, `overscroll-contain`, `overscroll-none`) plus per-axis variants for both x and y, preventing unwanted scroll chaining in modals, sidebars, and chat windows.

Closes #19118

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/overscroll-behavior-tm-mp/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Three shorthand and six per-axis utility classes controlling overscroll (scroll chaining and bounce) behaviour on scrollable elements.

**How does a developer use it?**
```html
<div class="scroll-box overscroll-auto">...</div>     <!-- browser default -->
<div class="scroll-box overscroll-contain">...</div>  <!-- no scroll chaining -->
<div class="scroll-box overscroll-none">...</div>     <!-- no chaining, no bounce -->
<div class="overscroll-y-none">...</div>              <!-- vertical only -->
```

**Why does it fit EaseMotion CSS?**
Scroll chaining is one of the most common scroll UX bugs — this utility fixes it with a single human-readable class, consistent with EaseMotion CSS's utility-first philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
The demo includes extra page height so reviewers can clearly see the difference between `overscroll-auto` (page scrolls) and `overscroll-contain` / `overscroll-none` (page stays put). Per-axis variants are included in `style.css` but not demoed separately to keep the demo clean — feel free to expand during integration.