### PR TITLE
feat: add hyphens text layout utilities

### DIFF
--- a/submissions/examples/hyphens-text-layout-tm-mp/README.md
+++ b/submissions/examples/hyphens-text-layout-tm-mp/README.md
@@ -1,0 +1,16 @@
+## hyphens-text-layout-tm-mp
+
+**What does this do?**
+Provides three utility classes to control CSS hyphenation behaviour — none, manual (soft-hyphen hints only), and automatic — with vendor-prefix fallbacks for broad browser support.
+
+**How is it used?**
+```html
+<p class="hyphens-none" lang="en">...</p>    <!-- no word breaking -->
+<p class="hyphens-manual" lang="en">Inter&shy;nation&shy;al&shy;iz&shy;ation</p>  <!-- break only at &shy; -->
+<p class="hyphens-auto" lang="en">...</p>    <!-- browser inserts hyphens automatically -->
+```
+
+> **Note:** `lang` attribute is required on the element (or an ancestor) for `hyphens: auto` to work correctly — the browser uses the language to pick the right hyphenation dictionary.
+
+**Why is it useful?**
+Long words in narrow containers (cards, sidebars, mobile viewports) frequently break layouts. These utilities give developers precise, readable control over hyphenation with a single class, consistent with EaseMotion CSS's human-readable, utility-first philosophy.

--- a/submissions/examples/hyphens-text-layout-tm-mp/demo.html
+++ b/submissions/examples/hyphens-text-layout-tm-mp/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Hyphens Text Layout Utilities Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Hyphens Text Layout Utilities</h1>
+  <p class="hint">Resize the browser window to see hyphenation in action.</p>
+
+  <h2>hyphens-none (no hyphenation)</h2>
+  <div class="text-box hyphens-none" lang="en">
+    Internationalization and localization are extraordinarily important considerations
+    when building multilingual web applications for a worldwide audience.
+  </div>
+
+  <h2>hyphens-manual (only at &amp;shy; hints)</h2>
+  <div class="text-box hyphens-manual" lang="en">
+    Inter&shy;nation&shy;al&shy;iz&shy;ation and loc&shy;al&shy;iz&shy;ation are extra&shy;ordin&shy;arily
+    important con&shy;sid&shy;er&shy;ations when building multi&shy;lingual web applications.
+  </div>
+
+  <h2>hyphens-auto (browser decides)</h2>
+  <div class="text-box hyphens-auto" lang="en">
+    Internationalization and localization are extraordinarily important considerations
+    when building multilingual web applications for a worldwide audience.
+  </div>
+</body>
+</html>

--- a/submissions/examples/hyphens-text-layout-tm-mp/style.css
+++ b/submissions/examples/hyphens-text-layout-tm-mp/style.css
@@ -1,0 +1,52 @@
+/* Base demo styles */
+body {
+  font-family: Georgia, serif;
+  padding: 2rem;
+  background: #f5f5f5;
+  max-width: 420px; /* narrow to make hyphenation visible */
+  margin: 0 auto;
+}
+
+h1 { font-size: 1.3rem; margin-bottom: 0.5rem; }
+h2 { margin: 1.6rem 0 0.4rem; color: #444; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.06em; font-family: sans-serif; }
+
+.hint {
+  color: #888;
+  font-size: 0.85rem;
+  margin-bottom: 1rem;
+  font-family: sans-serif;
+}
+
+.text-box {
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  padding: 1rem 1.2rem;
+  font-size: 1rem;
+  line-height: 1.7;
+  color: #222;
+  word-wrap: break-word;
+}
+
+/* ─── Hyphens Text Layout Utilities ─────────────────────────────────── */
+
+/* No hyphenation — words never break */
+.hyphens-none {
+  hyphens: none;
+  -webkit-hyphens: none;
+  -ms-hyphens: none;
+}
+
+/* Only break at explicit soft-hyphen hints (&shy;) */
+.hyphens-manual {
+  hyphens: manual;
+  -webkit-hyphens: manual;
+  -ms-hyphens: manual;
+}
+
+/* Browser automatically inserts hyphens where needed */
+.hyphens-auto {
+  hyphens: auto;
+  -webkit-hyphens: auto;
+  -ms-hyphens: auto;
+}


### PR DESCRIPTION
## Pull Request Description
Adds three hyphens utility classes (`hyphens-none`, `hyphens-manual`, `hyphens-auto`) with `-webkit-` and `-ms-` vendor prefix fallbacks, giving developers readable control over word hyphenation in narrow containers.

Closes #19116

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/hyphens-text-layout-tm-mp/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Three utility classes controlling CSS hyphenation — no breaking, manual soft-hyphen hints, and fully automatic browser hyphenation.

**How does a developer use it?**
```html
<p class="hyphens-none" lang="en">...</p>
<p class="hyphens-manual" lang="en">Inter&shy;nation&shy;al&shy;iz&shy;ation</p>
<p class="hyphens-auto" lang="en">...</p>
```

**Why does it fit EaseMotion CSS?**
Long words in cards, sidebars, and mobile viewports frequently break layouts — these utilities fix that with a single human-readable class, consistent with EaseMotion CSS's utility-first philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
The demo uses a narrow max-width (420px) so hyphenation is clearly visible without resizing. Vendor prefixes (`-webkit-hyphens`, `-ms-hyphens`) are included for Safari and older Edge support. The `lang` attribute is required on the element for `hyphens: auto` to work — this is noted in the README.