### PR TITLE
feat: add page transition slide using View Transitions API

### DIFF
--- a/submissions/examples/page-transition-I/README.md
+++ b/submissions/examples/page-transition-I/README.md
@@ -1,0 +1,31 @@
+ 
+# Page Transition Slide
+
+Current page slides left while new page slides in from the right using View Transitions API.
+
+## Files
+
+- demo.html - Interactive demo
+- style.css - Page transition styles
+- README.md - Documentation
+
+## How It Works
+
+```css
+::view-transition-old(root) {
+    animation: slideOutLeft 0.4s ease forwards;
+}
+
+::view-transition-new(root) {
+    animation: slideInRight 0.4s ease forwards;
+}
+
+@keyframes slideOutLeft {
+    from { transform: translateX(0); opacity: 1; }
+    to { transform: translateX(-100%); opacity: 0.5; }
+}
+
+@keyframes slideInRight {
+    from { transform: translateX(100%); opacity: 0.3; }
+    to { transform: translateX(0); opacity: 1; }
+}

--- a/submissions/examples/page-transition-I/demo.html
+++ b/submissions/examples/page-transition-I/demo.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EaseMotion - Page Transition Slide</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="app">
+        <!-- Page Navigation -->
+        <nav class="page-nav">
+            <button class="nav-btn" data-page="home">🏠 Home</button>
+            <button class="nav-btn" data-page="about">📖 About</button>
+            <button class="nav-btn" data-page="services">⚡ Services</button>
+            <button class="nav-btn" data-page="contact">📧 Contact</button>
+        </nav>
+
+        <!-- Pages Container -->
+        <div class="pages-container">
+            <!-- Home Page -->
+            <div id="page-home" class="page active">
+                <h1>🏠 Welcome Home</h1>
+                <p>This is the home page. Click the navigation buttons above to see the slide transition effect.</p>
+                <p>The current page slides left while the new page slides in from the right.</p>
+                <div class="page-content">
+                    <div class="feature-card">
+                        <span>✨</span>
+                        <h3>View Transitions API</h3>
+                        <p>Using the native View Transitions API for smooth page transitions.</p>
+                    </div>
+                    <div class="feature-card">
+                        <span>🚀</span>
+                        <h3>No JavaScript Framework</h3>
+                        <p>Pure vanilla JavaScript with CSS animations.</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- About Page -->
+            <div id="page-about" class="page">
+                <h1>📖 About Us</h1>
+                <p>We are a team of passionate developers building amazing experiences with the View Transitions API.</p>
+                <div class="page-content">
+                    <div class="feature-card">
+                        <span>💡</span>
+                        <h3>Our Mission</h3>
+                        <p>To create smooth, seamless user experiences.</p>
+                    </div>
+                    <div class="feature-card">
+                        <span>👥</span>
+                        <h3>Our Team</h3>
+                        <p>A diverse group of creative problem solvers.</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Services Page -->
+            <div id="page-services" class="page">
+                <h1>⚡ Our Services</h1>
+                <p>We offer a wide range of services to help your business grow.</p>
+                <div class="page-content">
+                    <div class="feature-card">
+                        <span>🎨</span>
+                        <h3>Design</h3>
+                        <p>Beautiful, user-centered design.</p>
+                    </div>
+                    <div class="feature-card">
+                        <span>💻</span>
+                        <h3>Development</h3>
+                        <p>Clean, efficient code.</p>
+                    </div>
+                    <div class="feature-card">
+                        <span>🚀</span>
+                        <h3>Deployment</h3>
+                        <p>Fast, reliable deployment.</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Contact Page -->
+            <div id="page-contact" class="page">
+                <h1>📧 Contact Us</h1>
+                <p>Get in touch with us for any inquiries or collaborations.</p>
+                <div class="contact-form">
+                    <input type="text" placeholder="Your Name" class="form-input">
+                    <input type="email" placeholder="Your Email" class="form-input">
+                    <textarea placeholder="Your Message" rows="4" class="form-input"></textarea>
+                    <button class="submit-btn">Send Message</button>
+                </div>
+            </div>
+        </div>
+
+        <!-- Transition Indicator -->
+        <div class="transition-indicator">
+            <span id="transitionStatus">⚡ View Transitions API</span>
+        </div>
+    </div>
+
+    <script>
+        // Check if View Transitions API is supported
+        const supportsViewTransitions = 'startViewTransition' in document;
+
+        // Show support status
+        const statusEl = document.getElementById('transitionStatus');
+        if (supportsViewTransitions) {
+            statusEl.textContent = '✅ View Transitions API supported';
+            statusEl.style.color = '#10b981';
+        } else {
+            statusEl.textContent = '⚠️ View Transitions API not supported (fallback enabled)';
+            statusEl.style.color = '#f59e0b';
+        }
+
+        // Navigation function with View Transitions
+        function navigateTo(pageId) {
+            const currentPage = document.querySelector('.page.active');
+            const newPage = document.getElementById(`page-${pageId}`);
+
+            if (!newPage || currentPage === newPage) return;
+
+            // Update active nav button
+            document.querySelectorAll('.nav-btn').forEach(btn => {
+                btn.classList.toggle('active', btn.dataset.page === pageId);
+            });
+
+            if (supportsViewTransitions) {
+                // Use View Transitions API
+                document.startViewTransition(() => {
+                    if (currentPage) currentPage.classList.remove('active');
+                    newPage.classList.add('active');
+                });
+            } else {
+                // Fallback: instant switch
+                if (currentPage) currentPage.classList.remove('active');
+                newPage.classList.add('active');
+            }
+        }
+
+        // Navigation button click handlers
+        document.querySelectorAll('.nav-btn').forEach(btn => {
+            btn.addEventListener('click', () => {
+                navigateTo(btn.dataset.page);
+            });
+        });
+
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            const pages = ['home', 'about', 'services', 'contact'];
+            const currentPage = document.querySelector('.page.active');
+            const currentId = currentPage ? currentPage.id.replace('page-', '') : 'home';
+            const currentIndex = pages.indexOf(currentId);
+
+            if (e.key === 'ArrowRight' && currentIndex < pages.length - 1) {
+                e.preventDefault();
+                navigateTo(pages[currentIndex + 1]);
+            } else if (e.key === 'ArrowLeft' && currentIndex > 0) {
+                e.preventDefault();
+                navigateTo(pages[currentIndex - 1]);
+            }
+        });
+
+        // Keyboard hint
+        console.log('Use ← → arrow keys to navigate pages!');
+    </script>
+</body>
+</html>

--- a/submissions/examples/page-transition-I/style.css
+++ b/submissions/examples/page-transition-I/style.css
@@ -1,0 +1,324 @@
+ 
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: linear-gradient(135deg, #0f0c29, #302b63, #24243e);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 2rem;
+}
+
+/* ========================================
+   APP CONTAINER
+   ======================================== */
+
+.app {
+    max-width: 900px;
+    width: 100%;
+    background: rgba(255, 255, 255, 0.05);
+    backdrop-filter: blur(10px);
+    border-radius: 1.5rem;
+    padding: 2rem;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+/* ========================================
+   NAVIGATION
+   ======================================== */
+
+.page-nav {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin-bottom: 2rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.nav-btn {
+    background: rgba(255, 255, 255, 0.1);
+    color: rgba(255, 255, 255, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    padding: 0.6rem 1.2rem;
+    border-radius: 2rem;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    font-size: 0.9rem;
+}
+
+.nav-btn:hover {
+    background: rgba(255, 255, 255, 0.2);
+    color: white;
+    transform: translateY(-2px);
+}
+
+.nav-btn.active {
+    background: #667eea;
+    color: white;
+    border-color: #667eea;
+    box-shadow: 0 4px 15px rgba(102, 126, 234, 0.4);
+}
+
+/* ========================================
+   PAGES CONTAINER
+   ======================================== */
+
+.pages-container {
+    position: relative;
+    min-height: 400px;
+}
+
+/* ========================================
+   PAGE STYLES
+   ======================================== */
+
+.page {
+    display: none;
+    opacity: 0;
+    color: white;
+    padding: 1rem;
+    border-radius: 0.75rem;
+    background: rgba(255, 255, 255, 0.05);
+    animation: none;
+}
+
+.page.active {
+    display: block;
+    opacity: 1;
+}
+
+.page h1 {
+    font-size: 2rem;
+    margin-bottom: 1rem;
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+
+.page p {
+    color: rgba(255, 255, 255, 0.8);
+    line-height: 1.6;
+    margin-bottom: 0.5rem;
+}
+
+/* ========================================
+   VIEW TRANSITIONS ANIMATIONS
+   ======================================== */
+
+/* Old page slides left */
+::view-transition-old(root) {
+    animation: slideOutLeft 0.4s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+
+/* New page slides in from right */
+::view-transition-new(root) {
+    animation: slideInRight 0.4s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+
+@keyframes slideOutLeft {
+    from {
+        transform: translateX(0);
+        opacity: 1;
+    }
+    to {
+        transform: translateX(-100%);
+        opacity: 0.5;
+    }
+}
+
+@keyframes slideInRight {
+    from {
+        transform: translateX(100%);
+        opacity: 0.3;
+    }
+    to {
+        transform: translateX(0);
+        opacity: 1;
+    }
+}
+
+/* ========================================
+   PAGE CONTENT
+   ======================================== */
+
+.page-content {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+    margin-top: 1.5rem;
+}
+
+.feature-card {
+    background: rgba(255, 255, 255, 0.08);
+    padding: 1.2rem;
+    border-radius: 0.75rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.feature-card span {
+    font-size: 2rem;
+    display: block;
+    margin-bottom: 0.5rem;
+}
+
+.feature-card h3 {
+    margin-bottom: 0.25rem;
+}
+
+.feature-card p {
+    font-size: 0.85rem;
+    opacity: 0.7;
+}
+
+/* ========================================
+   CONTACT FORM
+   ======================================== */
+
+.contact-form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-top: 1rem;
+}
+
+.form-input {
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    padding: 0.75rem;
+    border-radius: 0.5rem;
+    color: white;
+    font-family: inherit;
+    font-size: 0.9rem;
+    transition: border-color 0.3s;
+}
+
+.form-input:focus {
+    outline: none;
+    border-color: #667eea;
+}
+
+.form-input::placeholder {
+    color: rgba(255, 255, 255, 0.4);
+}
+
+.submit-btn {
+    background: #667eea;
+    color: white;
+    border: none;
+    padding: 0.75rem;
+    border-radius: 0.5rem;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background 0.3s, transform 0.2s;
+}
+
+.submit-btn:hover {
+    background: #5a67d8;
+    transform: translateY(-2px);
+}
+
+/* ========================================
+   TRANSITION INDICATOR
+   ======================================== */
+
+.transition-indicator {
+    text-align: center;
+    margin-top: 2rem;
+    padding-top: 1rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.transition-indicator span {
+    color: rgba(255, 255, 255, 0.5);
+    font-size: 0.8rem;
+}
+
+/* ========================================
+   FALLBACK ANIMATION (when View Transitions not supported)
+   ======================================== */
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        transform: scale(0.95);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+.page.active.fallback {
+    animation: fadeIn 0.3s ease forwards;
+}
+
+/* ========================================
+   RESPONSIVE
+   ======================================== */
+
+@media (max-width: 640px) {
+    body {
+        padding: 1rem;
+    }
+
+    .app {
+        padding: 1rem;
+    }
+
+    .page h1 {
+        font-size: 1.5rem;
+    }
+
+    .page-nav {
+        gap: 0.3rem;
+    }
+
+    .nav-btn {
+        padding: 0.4rem 0.8rem;
+        font-size: 0.75rem;
+    }
+
+    .page-content {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* ========================================
+   CODE DEMO STYLES (for PR)
+   ======================================== */
+
+.demo-code {
+    background: rgba(0, 0, 0, 0.3);
+    padding: 1rem;
+    border-radius: 0.5rem;
+    margin-top: 1rem;
+    font-family: monospace;
+    font-size: 0.75rem;
+    overflow-x: auto;
+    color: rgba(255, 255, 255, 0.8);
+}
+
+.demo-code .comment {
+    color: rgba(255, 255, 255, 0.4);
+}
+
+.demo-code .keyword {
+    color: #a78bfa;
+}
+
+.demo-code .string {
+    color: #34d399;
+}
+
+.demo-code .function {
+    color: #60a5fa;
+}


### PR DESCRIPTION
## Summary
Adds page transition where current page slides left while new page slides in from the right using View Transitions API.

## Details
- ::view-transition-old(root) slides left
- ::view-transition-new(root) slides from right
- Graceful fallback for unsupported browsers
- Arrow key navigation (← →)
- Smooth cubic-bezier easing

## Files
- demo.html - Interactive demo
- style.css - Page transition styles
- README.md - Documentation

## Testing
Click navigation buttons or use arrow keys to see slide transition.

## Related
Issue #20550