### PR TITLE
feat: add page zoom view transition example

### DIFF
--- a/submissions/examples/page-zoom-view-transition-ms07/README.md
+++ b/submissions/examples/page-zoom-view-transition-ms07/README.md
@@ -1,0 +1,49 @@
+# Page Zoom View Transition
+
+A lightweight page transition powered by the View Transitions API.
+
+## Features
+
+- Uses the native View Transitions API
+- Current page zooms away while fading out
+- Incoming page scales from the center while fading in
+- 300ms animation duration
+- Pure HTML, CSS and minimal JavaScript
+- No dependencies
+
+## Files
+
+```
+demo.html
+style.css
+README.md
+```
+
+## How to Use
+
+Open `demo.html` in a browser that supports the View Transitions API (latest Chromium-based browsers).
+
+Click the button to transition between pages.
+
+## Animation
+
+Outgoing Page
+
+- Scale: `1 → 1.15`
+- Opacity: `1 → 0`
+
+Incoming Page
+
+- Scale: `0.82 → 1`
+- Opacity: `0 → 1`
+
+Duration
+
+- **300ms**
+
+## Why it fits EaseMotion CSS
+
+- Clean and reusable page transition
+- Uses native browser View Transitions
+- Smooth zoom-based navigation animation
+- Lightweight and easy to integrate into existing projects

--- a/submissions/examples/page-zoom-view-transition-ms07/demo.html
+++ b/submissions/examples/page-zoom-view-transition-ms07/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Page Zoom View Transition</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="page page-one">
+    <h1>Home Page</h1>
+    <p>Current page zooms away while the next page zooms in.</p>
+    <button id="nextBtn">Go To Details</button>
+</div>
+
+<div class="page page-two hidden">
+    <h1>Details Page</h1>
+    <p>This page scales in from the center.</p>
+    <button id="backBtn">Back</button>
+</div>
+
+<script>
+const pageOne = document.querySelector(".page-one");
+const pageTwo = document.querySelector(".page-two");
+
+async function switchPage(showSecond) {
+
+    if (!document.startViewTransition) {
+        pageOne.classList.toggle("hidden", showSecond);
+        pageTwo.classList.toggle("hidden", !showSecond);
+        return;
+    }
+
+    document.startViewTransition(() => {
+        pageOne.classList.toggle("hidden", showSecond);
+        pageTwo.classList.toggle("hidden", !showSecond);
+    });
+}
+
+document.getElementById("nextBtn").onclick = () => switchPage(true);
+document.getElementById("backBtn").onclick = () => switchPage(false);
+</script>
+
+</body>
+</html>

--- a/submissions/examples/page-zoom-view-transition-ms07/style.css
+++ b/submissions/examples/page-zoom-view-transition-ms07/style.css
@@ -1,0 +1,78 @@
+*{
+    margin:0;
+    padding:0;
+    box-sizing:border-box;
+    font-family:Arial,Helvetica,sans-serif;
+}
+
+body{
+    height:100vh;
+    display:flex;
+    justify-content:center;
+    align-items:center;
+    background:#111827;
+    overflow:hidden;
+}
+
+.page{
+    position:absolute;
+    width:420px;
+    padding:40px;
+    border-radius:18px;
+    background:#1f2937;
+    color:white;
+    text-align:center;
+    box-shadow:0 20px 45px rgba(0,0,0,.3);
+}
+
+button{
+    margin-top:25px;
+    padding:12px 24px;
+    border:none;
+    border-radius:8px;
+    cursor:pointer;
+    background:#3b82f6;
+    color:white;
+    font-size:16px;
+}
+
+.hidden{
+    display:none;
+}
+
+
+::view-transition-old(root){
+    animation:zoom-out 300ms ease forwards;
+}
+
+::view-transition-new(root){
+    animation:zoom-in 300ms ease forwards;
+}
+
+@keyframes zoom-out{
+
+    from{
+        opacity:1;
+        transform:scale(1);
+    }
+
+    to{
+        opacity:0;
+        transform:scale(1.15);
+    }
+
+}
+
+@keyframes zoom-in{
+
+    from{
+        opacity:0;
+        transform:scale(.82);
+    }
+
+    to{
+        opacity:1;
+        transform:scale(1);
+    }
+
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a **Page Zoom View Transition** example using the **View Transitions API**.

The transition creates a smooth navigation effect where the current page scales up while fading out, and the incoming page scales in from the center while fading in. The animation lasts **300ms**, providing a clean and modern page-switching experience.

---

## Type of Change

* [x] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

* [x] All changes are inside `submissions/examples/page-zoom-view-transition-ms07/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, and why it fits EaseMotion CSS
* [x] **No changes to `core/`**
* [x] **No changes to `components/`**
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

### What does this add?

A smooth **zoom-based page transition** powered by the **View Transitions API**, where the outgoing page scales up and fades away while the incoming page scales in from the center.

### How does a developer use it?

```html
<button id="nextBtn">Go To Details</button>
<button id="backBtn">Back</button>
```

The example demonstrates how to trigger page transitions using `document.startViewTransition()` together with the provided CSS animations.

### Why does it fit EaseMotion CSS?

* Lightweight and dependency-free
* Uses the native View Transitions API
* Clean, reusable zoom transition
* Easy to understand and customize
* Matches EaseMotion CSS's animation-first philosophy

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This submission demonstrates a reusable page transition effect using the View Transitions API with a **300ms** duration. The example is self-contained and follows the repository structure without modifying any existing library files.

Closes https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/20551
