### PR TITLE
fix: add smooth height transition to .ease-accordion content panel

### DIFF
--- a/submissions/examples/accordion-transition-fix-ag/README.md
+++ b/submissions/examples/accordion-transition-fix-ag/README.md
@@ -1,0 +1,23 @@
+# Accordion Height Transition Fix (Issue #21061)
+
+## What does this do?
+Demonstrates a smooth accordion open/close animation using the `grid-template-rows: 0fr → 1fr` CSS transition technique, replacing the previous instant `display: none` / `display: block` toggle.
+
+## How is it used?
+```html
+<div class="ease-accordion-item">
+  <button class="ease-accordion-trigger" aria-expanded="false">
+    Title
+    <svg class="ease-accordion-icon">...</svg>
+  </button>
+  <div class="ease-accordion-content" role="region">
+    <div class="ease-accordion-inner">
+      <p>Panel content</p>
+    </div>
+  </div>
+</div>
+```
+Toggle `.is-open` on `.ease-accordion-item` to expand/collapse. Also toggles `aria-expanded` on the button for accessibility.
+
+## Why is it useful?
+The current `.ease-accordion` uses `display: none` toggling which produces an abrupt, jarring transition with zero animation — directly contradicting EaseMotion CSS's core motion philosophy. The `grid-template-rows` technique is the most reliable CSS-only approach to smooth height animation: it requires no JavaScript height calculations, works for any content size, and degrades gracefully for users who prefer reduced motion.

--- a/submissions/examples/accordion-transition-fix-ag/demo.html
+++ b/submissions/examples/accordion-transition-fix-ag/demo.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Accordion Transition Fix — Issue #21061</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main>
+    <h1>Accordion Height Transition Fix — Issue #21061</h1>
+    <p>Content panels now animate smoothly open and closed using a CSS grid-template-rows transition.</p>
+
+    <div class="demo-accordion">
+      <div class="demo-accordion-item">
+        <button class="demo-accordion-trigger" aria-expanded="false" onclick="toggleAccordion(this)">
+          <span>What is EaseMotion CSS?</span>
+          <svg class="demo-accordion-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <polyline points="6 9 12 15 18 9"></polyline>
+          </svg>
+        </button>
+        <div class="demo-accordion-content" role="region">
+          <div class="demo-accordion-inner">
+            <p>EaseMotion CSS is a curated, motion-first CSS framework that provides smooth, eased animations and transitions for common UI components without any JavaScript dependencies.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="demo-accordion-item">
+        <button class="demo-accordion-trigger" aria-expanded="false" onclick="toggleAccordion(this)">
+          <span>How do I contribute?</span>
+          <svg class="demo-accordion-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <polyline points="6 9 12 15 18 9"></polyline>
+          </svg>
+        </button>
+        <div class="demo-accordion-content" role="region">
+          <div class="demo-accordion-inner">
+            <p>Submit your raw HTML + CSS demo inside <code>submissions/examples/your-feature-name/</code> with the three required files: <code>demo.html</code>, <code>style.css</code>, and <code>README.md</code>.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="demo-accordion-item">
+        <button class="demo-accordion-trigger" aria-expanded="false" onclick="toggleAccordion(this)">
+          <span>Does this work without JavaScript?</span>
+          <svg class="demo-accordion-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <polyline points="6 9 12 15 18 9"></polyline>
+          </svg>
+        </button>
+        <div class="demo-accordion-content" role="region">
+          <div class="demo-accordion-inner">
+            <p>The CSS transition technique demonstrated here uses <code>grid-template-rows</code> toggled via a class, requiring minimal JavaScript only to toggle the state class. A pure CSS version using <code>:has()</code> is also possible.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <script>
+    function toggleAccordion(btn) {
+      const expanded = btn.getAttribute('aria-expanded') === 'true';
+      btn.setAttribute('aria-expanded', String(!expanded));
+      btn.closest('.demo-accordion-item').classList.toggle('is-open', !expanded);
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/accordion-transition-fix-ag/style.css
+++ b/submissions/examples/accordion-transition-fix-ag/style.css
@@ -1,0 +1,104 @@
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  padding: 2rem;
+  background: #f8fafc;
+  color: #1e293b;
+}
+h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
+p { color: #64748b; margin-bottom: 1.5rem; }
+code {
+  background: #e2e8f0;
+  padding: 0.1em 0.4em;
+  border-radius: 4px;
+  font-size: 0.875em;
+}
+
+/* ── Accordion container ── */
+.demo-accordion {
+  max-width: 600px;
+  border: 1.5px solid #e2e8f0;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  background: #fff;
+}
+
+.demo-accordion-item + .demo-accordion-item {
+  border-top: 1.5px solid #e2e8f0;
+}
+
+/* ── Trigger button ── */
+.demo-accordion-trigger {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  background: none;
+  border: none;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1e293b;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.15s ease;
+}
+
+.demo-accordion-trigger:hover { background: #f8fafc; }
+.demo-accordion-trigger:focus-visible {
+  outline: 2px solid #6c63ff;
+  outline-offset: -2px;
+}
+
+/* ── Chevron icon rotation ── */
+.demo-accordion-icon {
+  width: 1.125rem;
+  height: 1.125rem;
+  color: #94a3b8;
+  flex-shrink: 0;
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.demo-accordion-item.is-open .demo-accordion-icon {
+  transform: rotate(180deg);
+}
+
+/*
+ * THE FIX: use grid-template-rows transition from 0fr → 1fr
+ * This avoids the display:none jump and produces a smooth height animation
+ * without needing to know the explicit pixel height of the content.
+ */
+.demo-accordion-content {
+  display: grid;
+  grid-template-rows: 0fr;          /* collapsed: zero height */
+  transition: grid-template-rows 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.demo-accordion-item.is-open .demo-accordion-content {
+  grid-template-rows: 1fr;          /* expanded: full natural height */
+}
+
+/* Inner wrapper is required — overflow:hidden clips during animation */
+.demo-accordion-inner {
+  overflow: hidden;
+  padding: 0 1.25rem;
+  transition: padding 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.demo-accordion-item.is-open .demo-accordion-inner {
+  padding: 0.75rem 1.25rem 1.25rem;
+}
+
+.demo-accordion-inner p {
+  margin: 0;
+  color: #475569;
+  line-height: 1.7;
+  font-size: 0.9375rem;
+}
+
+/* Reduced motion: disable transition for accessibility */
+@media (prefers-reduced-motion: reduce) {
+  .demo-accordion-content,
+  .demo-accordion-inner,
+  .demo-accordion-icon {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## What this fixes

Closes #21061

**Bug:** `.ease-accordion` content panel uses `display: none` / `display: block` toggling which produces zero animation — an abrupt, jarring UX that contradicts EaseMotion CSS's motion-first philosophy.

**Fix demonstrated:** Uses the `grid-template-rows: 0fr → 1fr` CSS transition technique — the most reliable way to animate height without knowing the panel's exact pixel dimensions. Includes:
- Smooth chevron rotation via `transform: rotate(180deg)`
- Correct `aria-expanded` toggling for screen readers
- `prefers-reduced-motion` override to disable transitions for accessibility

## Checklist
- [x] Only files inside `submissions/examples/` are modified
- [x] All three required files included (`demo.html`, `style.css`, `README.md`)
- [x] PR is focused on one fix
- [x] No changes to `core/` or `components/`