### PR TITLE
fix: add role=alert and aria-live to .ease-alert for screen reader accessibility

### DIFF
--- a/submissions/examples/alert-aria-fix-ag/README.md
+++ b/submissions/examples/alert-aria-fix-ag/README.md
@@ -1,0 +1,20 @@
+# Alert ARIA Live Region Fix (Issue #21062)
+
+## What does this do?
+Demonstrates the correct accessibility pattern for `.ease-alert` by adding `role="alert"` (for errors/warnings) or `role="status"` (for success/info) and dedicated `aria-live` regions, ensuring dynamically injected alerts are announced by screen readers.
+
+## How is it used?
+```html
+<!-- For errors and warnings — assertive announcement -->
+<div class="ease-alert ease-alert-error" role="alert" aria-live="assertive" aria-atomic="true">
+  ❌ Something went wrong. Please try again.
+</div>
+
+<!-- For success and info — polite announcement -->
+<div class="ease-alert ease-alert-success" role="status" aria-live="polite" aria-atomic="true">
+  ✅ Changes saved successfully!
+</div>
+```
+
+## Why is it useful?
+Without `role="alert"` or an `aria-live` region, dynamically injected alerts are completely invisible to screen reader users — a critical accessibility failure for error messages and status updates. Adding the correct ARIA roles ensures all users, including those relying on assistive technology, receive the same information as sighted users.

--- a/submissions/examples/alert-aria-fix-ag/demo.html
+++ b/submissions/examples/alert-aria-fix-ag/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Alert ARIA Fix — Issue #21062</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main>
+    <h1>Alert ARIA Live Region Fix — Issue #21062</h1>
+    <p>Click the buttons below to inject alerts dynamically. Screen readers will announce them correctly.</p>
+
+    <div class="demo-controls">
+      <button class="demo-btn demo-btn--success" onclick="showAlert('success', '✅ Action completed successfully!')">
+        Trigger Success Alert
+      </button>
+      <button class="demo-btn demo-btn--error" onclick="showAlert('error', '❌ Something went wrong. Please try again.')">
+        Trigger Error Alert
+      </button>
+      <button class="demo-btn demo-btn--warning" onclick="showAlert('warning', '⚠️ Your session will expire in 5 minutes.')">
+        Trigger Warning Alert
+      </button>
+    </div>
+
+    <!-- FIX: role="status" for polite announcements (success/info) -->
+    <div id="alert-polite" role="status" aria-live="polite" aria-atomic="true" class="demo-sr-live"></div>
+
+    <!-- FIX: role="alert" for assertive announcements (errors/warnings) -->
+    <div id="alert-assertive" role="alert" aria-live="assertive" aria-atomic="true" class="demo-sr-live"></div>
+
+    <div id="alert-container" class="alert-container"></div>
+  </main>
+
+  <script>
+    function showAlert(type, message) {
+      const container = document.getElementById('alert-container');
+      const alert = document.createElement('div');
+      alert.className = `demo-alert demo-alert--${type}`;
+      // FIX: add role="alert" on the element itself for screen readers
+      alert.setAttribute('role', type === 'error' || type === 'warning' ? 'alert' : 'status');
+      alert.setAttribute('aria-live', type === 'error' || type === 'warning' ? 'assertive' : 'polite');
+      alert.textContent = message;
+
+      // Also announce via dedicated live region for maximum compatibility
+      const liveRegion = type === 'error' || type === 'warning'
+        ? document.getElementById('alert-assertive')
+        : document.getElementById('alert-polite');
+      liveRegion.textContent = '';
+      setTimeout(() => { liveRegion.textContent = message; }, 50);
+
+      container.appendChild(alert);
+      setTimeout(() => alert.remove(), 4000);
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/alert-aria-fix-ag/style.css
+++ b/submissions/examples/alert-aria-fix-ag/style.css
@@ -1,0 +1,94 @@
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  padding: 2rem;
+  background: #f8fafc;
+  color: #1e293b;
+}
+h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
+p { color: #64748b; margin-bottom: 1.5rem; }
+
+/* ── Control buttons ── */
+.demo-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 2rem;
+}
+
+.demo-btn {
+  padding: 0.5rem 1.25rem;
+  border: none;
+  border-radius: 0.5rem;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+.demo-btn:hover { opacity: 0.88; transform: translateY(-1px); }
+.demo-btn:active { transform: translateY(0); }
+
+.demo-btn--success { background: #22c55e; color: #fff; }
+.demo-btn--error   { background: #ef4444; color: #fff; }
+.demo-btn--warning { background: #f59e0b; color: #fff; }
+
+/* ── FIX: Hidden but accessible live region ── */
+.demo-sr-live {
+  position: absolute;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ── Alert component ── */
+.alert-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 500px;
+}
+
+.demo-alert {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.875rem 1.125rem;
+  border-radius: 0.625rem;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  line-height: 1.5;
+  border-left: 4px solid transparent;
+
+  /* Entrance animation */
+  animation: alertSlideIn 0.3s cubic-bezier(0.4, 0, 0.2, 1) both;
+}
+
+@keyframes alertSlideIn {
+  from { opacity: 0; transform: translateY(-8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.demo-alert--success {
+  background: #f0fdf4;
+  color: #166534;
+  border-left-color: #22c55e;
+}
+
+.demo-alert--error {
+  background: #fef2f2;
+  color: #991b1b;
+  border-left-color: #ef4444;
+}
+
+.demo-alert--warning {
+  background: #fffbeb;
+  color: #92400e;
+  border-left-color: #f59e0b;
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .demo-alert { animation: none; }
+}


### PR DESCRIPTION
## What this fixes

Closes #21062

**Bug:** `.ease-alert` does not define `role="alert"` or `aria-live` in its documented HTML pattern. Dynamically injected alerts are completely invisible to screen readers — a critical accessibility failure for error messages and status notifications.

**Fix demonstrated:** Shows the correct ARIA pattern:
- `role="alert"` + `aria-live="assertive"` for errors and warnings (interrupts the screen reader immediately)
- `role="status"` + `aria-live="polite"` for success and info (waits for the user to finish reading)
- A dedicated off-screen live region for maximum browser/assistive technology compatibility

## Checklist
- [x] Only files inside `submissions/examples/` are modified
- [x] All three required files included (`demo.html`, `style.css`, `README.md`)
- [x] PR is focused on one fix
- [x] No changes to `core/` or `components/`