### PR TITLE
feat: add hover clip-reveal top animation

### DIFF
--- a/submissions/examples/clip-reveal-I/README.md
+++ b/submissions/examples/clip-reveal-I/README.md
@@ -1,0 +1,30 @@
+ 
+# Hover Clip-Reveal Top
+
+Content reveals downward from top via clip-path on hover — clip-path: inset(0 0 100% 0) → inset(0).
+
+## Files
+
+- demo.html - Interactive demo
+- style.css - Clip-reveal styles
+- README.md - Documentation
+
+## Classes
+
+| Class | Speed | Easing |
+|-------|-------|--------|
+| `ease-hover-clip-reveal-top` | 0.4s | Ease Out |
+| `ease-hover-clip-reveal-top-fast` | 0.2s | Ease Out |
+| `ease-hover-clip-reveal-top-slow` | 0.8s | Ease Out |
+| `ease-hover-clip-reveal-top-bounce` | 0.5s | Bounce |
+| `ease-hover-clip-reveal-top-spring` | 0.5s | Spring |
+
+## Usage
+
+```html
+<div class="ease-hover-clip-reveal-top">
+    <div class="reveal-content">
+        <h3>Title</h3>
+        <p>Content that reveals from top</p>
+    </div>
+</div>

--- a/submissions/examples/clip-reveal-I/demo.html
+++ b/submissions/examples/clip-reveal-I/demo.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EaseMotion - Hover Clip-Reveal Top</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>🎬 ease-hover-clip-reveal-top</h1>
+        <p>Content reveals downward from top via clip-path on hover — clip-path: inset(0 0 100% 0) → inset(0)</p>
+
+        <!-- Basic Example -->
+        <div class="demo-section">
+            <h2>Basic Clip-Reveal</h2>
+            <div class="ease-hover-clip-reveal-top">
+                <div class="reveal-content">
+                    <h3>✨ Reveal from Top</h3>
+                    <p>This content reveals downward from the top when you hover over the card.</p>
+                    <span class="hover-hint">← Hover me</span>
+                </div>
+            </div>
+        </div>
+
+        <!-- Card Grid -->
+        <div class="demo-section">
+            <h2>Card Grid with Clip-Reveal</h2>
+            <div class="card-grid">
+                <div class="ease-hover-clip-reveal-top card">
+                    <div class="reveal-content">
+                        <span>🎨</span>
+                        <h3>Creative Design</h3>
+                        <p>Beautiful designs with smooth reveal effects.</p>
+                    </div>
+                </div>
+                <div class="ease-hover-clip-reveal-top card">
+                    <div class="reveal-content">
+                        <span>💻</span>
+                        <h3>Web Development</h3>
+                        <p>Clean code with modern animations.</p>
+                    </div>
+                </div>
+                <div class="ease-hover-clip-reveal-top card">
+                    <div class="reveal-content">
+                        <span>🚀</span>
+                        <h3>Launch Ready</h3>
+                        <p>Production-ready components.</p>
+                    </div>
+                </div>
+                <div class="ease-hover-clip-reveal-top card">
+                    <div class="reveal-content">
+                        <span>📱</span>
+                        <h3>Responsive Design</h3>
+                        <p>Works on all screen sizes.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Different Speeds -->
+        <div class="demo-section">
+            <h2>Different Speeds</h2>
+            <div class="speed-grid">
+                <div class="ease-hover-clip-reveal-top-fast card">
+                    <div class="reveal-content">
+                        <h3>⚡ Fast</h3>
+                        <p>0.2s reveal</p>
+                    </div>
+                </div>
+                <div class="ease-hover-clip-reveal-top card">
+                    <div class="reveal-content">
+                        <h3>⏱️ Normal</h3>
+                        <p>0.4s reveal</p>
+                    </div>
+                </div>
+                <div class="ease-hover-clip-reveal-top-slow card">
+                    <div class="reveal-content">
+                        <h3>🐢 Slow</h3>
+                        <p>0.8s reveal</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Different Easing -->
+        <div class="demo-section">
+            <h2>Easing Variations</h2>
+            <div class="speed-grid">
+                <div class="ease-hover-clip-reveal-top-bounce card">
+                    <div class="reveal-content">
+                        <h3>🎾 Bounce</h3>
+                        <p>Elastic easing</p>
+                    </div>
+                </div>
+                <div class="ease-hover-clip-reveal-top card">
+                    <div class="reveal-content">
+                        <h3>📈 Ease Out</h3>
+                        <p>Smooth stop</p>
+                    </div>
+                </div>
+                <div class="ease-hover-clip-reveal-top-spring card">
+                    <div class="reveal-content">
+                        <h3>🌸 Spring</h3>
+                        <p>Overshoot effect</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Image Cards -->
+        <div class="demo-section">
+            <h2>Image Cards</h2>
+            <div class="image-grid">
+                <div class="ease-hover-clip-reveal-top image-card">
+                    <div class="reveal-content image-content">
+                        <span>🌄</span>
+                        <h3>Mountain View</h3>
+                        <p>Explore the beauty of nature</p>
+                    </div>
+                </div>
+                <div class="ease-hover-clip-reveal-top image-card">
+                    <div class="reveal-content image-content">
+                        <span>🏖️</span>
+                        <h3>Beach Sunset</h3>
+                        <p>Relax by the ocean</p>
+                    </div>
+                </div>
+                <div class="ease-hover-clip-reveal-top image-card">
+                    <div class="reveal-content image-content">
+                        <span>🏔️</span>
+                        <h3>Snow Peak</h3>
+                        <p>Adventure awaits</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Feature Cards -->
+        <div class="demo-section">
+            <h2>Feature Cards</h2>
+            <div class="feature-grid">
+                <div class="ease-hover-clip-reveal-top feature-card">
+                    <div class="reveal-content">
+                        <span>⚡</span>
+                        <h3>Lightweight</h3>
+                        <p>Zero dependencies</p>
+                    </div>
+                </div>
+                <div class="ease-hover-clip-reveal-top feature-card">
+                    <div class="reveal-content">
+                        <span>🎨</span>
+                        <h3>Animations</h3>
+                        <p>20+ animations</p>
+                    </div>
+                </div>
+                <div class="ease-hover-clip-reveal-top feature-card">
+                    <div class="reveal-content">
+                        <span>🔧</span>
+                        <h3>Components</h3>
+                        <p>Ready to use</p>
+                    </div>
+                </div>
+                <div class="ease-hover-clip-reveal-top feature-card">
+                    <div class="reveal-content">
+                        <span>📱</span>
+                        <h3>Responsive</h3>
+                        <p>Mobile first</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Usage Code -->
+        <div class="code-section">
+            <h2>Usage</h2>
+            <pre>&lt;div class="ease-hover-clip-reveal-top"&gt;
+    &lt;div class="reveal-content"&gt;
+        &lt;h3&gt;Title&lt;/h3&gt;
+        &lt;p&gt;Content that reveals from top&lt;/p&gt;
+    &lt;/div&gt;
+&lt;/div&gt;
+
+&lt;!-- Different speeds --&gt;
+&lt;div class="ease-hover-clip-reveal-top-fast"&gt;Fast reveal&lt;/div&gt;
+&lt;div class="ease-hover-clip-reveal-top-slow"&gt;Slow reveal&lt;/div&gt;
+
+&lt;!-- Different easing --&gt;
+&lt;div class="ease-hover-clip-reveal-top-bounce"&gt;Bounce&lt;/div&gt;
+&lt;div class="ease-hover-clip-reveal-top-spring"&gt;Spring&lt;/div&gt;</pre>
+        </div>
+
+        <div class="info">
+            <h3>🎬 Clip-Reveal Features</h3>
+            <ul>
+                <li>📐 clip-path: inset(0 0 100% 0) → inset(0) on hover</li>
+                <li>⬇️ Top-down reveal effect</li>
+                <li>⚡ Speed variations (fast, normal, slow)</li>
+                <li>🎭 Easing variations (bounce, spring)</li>
+                <li>🎨 Works on cards, images, features</li>
+                <li>💫 Smooth CSS transitions</li>
+            </ul>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/clip-reveal-I/style.css
+++ b/submissions/examples/clip-reveal-I/style.css
@@ -1,0 +1,281 @@
+ 
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: linear-gradient(135deg, #1a1a2e, #16213e);
+    padding: 2rem;
+    min-height: 100vh;
+}
+
+.container {
+    max-width: 1100px;
+    margin: 0 auto;
+    background: rgba(255, 255, 255, 0.05);
+    backdrop-filter: blur(10px);
+    border-radius: 1.5rem;
+    padding: 3rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+h1 {
+    text-align: center;
+    color: white;
+    margin-bottom: 0.5rem;
+    font-size: 2rem;
+}
+
+.container > p {
+    text-align: center;
+    color: rgba(255, 255, 255, 0.6);
+    margin-bottom: 2rem;
+}
+
+.demo-section {
+    margin-bottom: 2rem;
+}
+
+.demo-section h2 {
+    color: rgba(255, 255, 255, 0.8);
+    font-size: 1.2rem;
+    margin-bottom: 1rem;
+    border-left: 4px solid #667eea;
+    padding-left: 1rem;
+}
+
+/* ========================================
+   CLIP-REVEAL TOP ANIMATION
+   ======================================== */
+
+.ease-hover-clip-reveal-top {
+    clip-path: inset(0 0 100% 0);
+    transition: clip-path 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.ease-hover-clip-reveal-top:hover {
+    clip-path: inset(0);
+}
+
+/* Fast Variant */
+.ease-hover-clip-reveal-top-fast {
+    clip-path: inset(0 0 100% 0);
+    transition: clip-path 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.ease-hover-clip-reveal-top-fast:hover {
+    clip-path: inset(0);
+}
+
+/* Slow Variant */
+.ease-hover-clip-reveal-top-slow {
+    clip-path: inset(0 0 100% 0);
+    transition: clip-path 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.ease-hover-clip-reveal-top-slow:hover {
+    clip-path: inset(0);
+}
+
+/* Bounce Easing */
+.ease-hover-clip-reveal-top-bounce {
+    clip-path: inset(0 0 100% 0);
+    transition: clip-path 0.5s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+}
+
+.ease-hover-clip-reveal-top-bounce:hover {
+    clip-path: inset(0);
+}
+
+/* Spring Easing */
+.ease-hover-clip-reveal-top-spring {
+    clip-path: inset(0 0 100% 0);
+    transition: clip-path 0.5s cubic-bezier(0.5, 1.5, 0.5, 1);
+}
+
+.ease-hover-clip-reveal-top-spring:hover {
+    clip-path: inset(0);
+}
+
+/* ========================================
+   DEMO STYLES
+   ======================================== */
+
+.reveal-content {
+    padding: 1.5rem;
+    background: rgba(255, 255, 255, 0.06);
+    border-radius: 0.75rem;
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    text-align: center;
+    color: white;
+}
+
+.reveal-content h3 {
+    margin-bottom: 0.3rem;
+}
+
+.reveal-content p {
+    color: rgba(255, 255, 255, 0.6);
+    font-size: 0.85rem;
+}
+
+.reveal-content span {
+    font-size: 2rem;
+    display: block;
+    margin-bottom: 0.3rem;
+}
+
+.hover-hint {
+    display: inline-block;
+    margin-top: 0.5rem;
+    font-size: 0.7rem;
+    color: rgba(255, 255, 255, 0.3);
+    animation: pulseHint 2s ease-in-out infinite;
+}
+
+@keyframes pulseHint {
+    0%, 100% { opacity: 0.3; }
+    50% { opacity: 0.8; }
+}
+
+/* ========================================
+   CARD GRID
+   ======================================== */
+
+.card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+}
+
+.card {
+    cursor: pointer;
+}
+
+.speed-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+}
+
+.image-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1rem;
+}
+
+.image-card {
+    cursor: pointer;
+    min-height: 200px;
+}
+
+.image-content {
+    background: linear-gradient(135deg, rgba(102, 126, 234, 0.2), rgba(118, 75, 162, 0.2));
+    min-height: 200px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}
+
+.image-content span {
+    font-size: 3rem;
+}
+
+.feature-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+}
+
+.feature-card {
+    cursor: pointer;
+}
+
+.feature-card .reveal-content {
+    background: rgba(255, 255, 255, 0.04);
+}
+
+/* ========================================
+   CODE SECTION
+   ======================================== */
+
+.code-section {
+    background: rgba(0, 0, 0, 0.3);
+    padding: 1.5rem;
+    border-radius: 0.75rem;
+    margin: 2rem 0;
+}
+
+pre {
+    background: #1e293b;
+    color: #e2e8f0;
+    padding: 1rem;
+    border-radius: 0.5rem;
+    overflow-x: auto;
+    font-family: monospace;
+    font-size: 0.7rem;
+}
+
+.info {
+    background: rgba(0, 0, 0, 0.3);
+    padding: 1.5rem;
+    border-radius: 0.75rem;
+    margin-top: 2rem;
+}
+
+.info h3 {
+    margin-bottom: 1rem;
+    color: white;
+}
+
+.info ul {
+    margin-left: 1.5rem;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.info li {
+    margin-bottom: 0.5rem;
+}
+
+code {
+    background: rgba(0, 0, 0, 0.3);
+    padding: 0.2rem 0.4rem;
+    border-radius: 0.25rem;
+    font-family: monospace;
+    font-size: 0.875rem;
+    color: #a78bfa;
+}
+
+@media (max-width: 768px) {
+    body {
+        padding: 1rem;
+    }
+
+    .container {
+        padding: 1.5rem;
+    }
+
+    h1 {
+        font-size: 1.5rem;
+    }
+
+    .card-grid,
+    .speed-grid,
+    .image-grid,
+    .feature-grid {
+        grid-template-columns: 1fr 1fr;
+    }
+}
+
+@media (max-width: 480px) {
+    .card-grid,
+    .speed-grid,
+    .image-grid,
+    .feature-grid {
+        grid-template-columns: 1fr;
+    }
+}


### PR DESCRIPTION
## Summary
Adds content reveal downward from top via clip-path on hover.

## Details
- clip-path: inset(0 0 100% 0) → inset(0) on hover
- Top-down reveal effect
- Speed variants (fast, normal, slow)
- Easing variants (bounce, spring)

## Files
- demo.html - Interactive demo
- style.css - Clip-reveal styles
- README.md - Documentation

## Testing
Hover over cards to see content reveal from top.

## Related
Issue #19849