### PR TITLE
fix: update dark color tokensUpdate variables.css

### DIFF
--- a/core/variables.css
+++ b/core/variables.css
@@ -31,13 +31,13 @@
   --ease-color-secondary-dark:  #7c3aed;
   --ease-color-success:       #15803d;
   --ease-color-success-light: #86efac;
-  --ease-color-success-dark:  #15803d;
+  --ease-color-success-dark:  #166534;
   --ease-color-danger:        #b91c1c;
   --ease-color-danger-light:  #fca5a5;
-  --ease-color-danger-dark:   #b91c1c;
+  --ease-color-danger-dark:   #991b1b;
   --ease-color-warning:       #b45309;
   --ease-color-warning-light: #fcd34d;
-  --ease-color-warning-dark:  #b45309;
+  --ease-color-warning-dark:  #92400e;
   --ease-color-info:          #3b82f6;
   --ease-color-info-light:    #93c5fd;
   --ease-color-info-dark:     #1d4ed8;


### PR DESCRIPTION

## Description

### What changed
- Updated `--ease-color-success-dark` to a darker shade.
- Updated `--ease-color-danger-dark` to a darker shade.
- Updated `--ease-color-warning-dark` to a darker shade.

### Why
Previously, the dark variants used the same hex values as their base colors, making them visually identical. This change assigns darker shades so the dark tokens are distinguishable and consistent with the existing color system.

### Testing
- [x] npm run build
- [x] npm test

Closes #12756