### PR TITLE
add day-night-toggle-qn animation to submissions/examples

### DIFF
--- a/submissions/examples/day-night-toggle-qn/README.md
+++ b/submissions/examples/day-night-toggle-qn/README.md
@@ -1,0 +1,18 @@
+# Day/Night Theme Toggle Switch
+
+## Description
+A beautiful, interactive Day/Night toggle switch built entirely with pure CSS. It features a smooth transition where the sky changes color, the sun morphs into a crescent moon, clouds fade out, and stars fade in. It uses the "checkbox hack" for state management, requiring absolutely zero JavaScript.
+
+## Files
+- `demo.html`: Contains the HTML structure using a hidden checkbox and label for the toggle mechanism.
+- `style.css`: Contains the styling, transitions, and state-based animations for the sky, sun/moon, clouds, and stars.
+
+## How to use
+1. Open `demo.html` in your browser and click the toggle to see the smooth day/night transition.
+2. Copy the HTML and CSS into your project.
+3. Apply the `.theme-toggle-qn` class to a `<label>` element, and include the hidden checkbox and track structure.
+4. **Customization:**
+   - Change the "Day" sky color by modifying the `background-color` in `.toggle-track-qn`.
+   - Change the "Night" sky color by modifying the `background-color` in `.theme-checkbox-qn:checked + .toggle-track-qn`.
+   - Adjust the transition speed by changing the `0.4s` duration in the `transition` properties.
+   - Change the sun/moon colors by modifying the `background-color` in `.toggle-knob-qn`.

--- a/submissions/examples/day-night-toggle-qn/demo.html
+++ b/submissions/examples/day-night-toggle-qn/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Day/Night Toggle Switch - EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <!-- The Toggle Switch -->
+    <label class="theme-toggle-qn">
+        <!-- Hidden checkbox to handle the state -->
+        <input type="checkbox" class="theme-checkbox-qn">
+        
+        <!-- The visual track and elements -->
+        <span class="toggle-track-qn">
+            <!-- The Sun/Moon knob -->
+            <span class="toggle-knob-qn"></span>
+            
+            <!-- Day elements (Clouds) -->
+            <span class="cloud-qn cloud-1-qn"></span>
+            <span class="cloud-qn cloud-2-qn"></span>
+            
+            <!-- Night elements (Stars) -->
+            <span class="star-qn star-1-qn"></span>
+            <span class="star-qn star-2-qn"></span>
+            <span class="star-qn star-3-qn"></span>
+        </span>
+    </label>
+</body>
+</html>

--- a/submissions/examples/day-night-toggle-qn/style.css
+++ b/submissions/examples/day-night-toggle-qn/style.css
@@ -1,0 +1,149 @@
+/* Basic Reset and Layout */
+body {
+    background-color: #f4f4f9;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    margin: 0;
+    font-family: sans-serif;
+}
+
+/* Toggle Container */
+.theme-toggle-qn {
+    position: relative;
+    display: inline-block;
+    width: 80px;
+    height: 40px;
+}
+
+/* Hide the actual checkbox */
+.theme-checkbox-qn {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+/* The Track (Sky) */
+.toggle-track-qn {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #87CEEB; /* Day sky blue */
+    transition: background-color 0.4s ease;
+    border-radius: 40px;
+    overflow: hidden;
+    box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.2);
+}
+
+/* Night Sky State */
+.theme-checkbox-qn:checked + .toggle-track-qn {
+    background-color: #1a1a2e; /* Night sky dark blue */
+}
+
+/* The Knob (Sun/Moon) */
+.toggle-knob-qn {
+    position: absolute;
+    height: 32px;
+    width: 32px;
+    left: 4px;
+    bottom: 4px;
+    background-color: #FFD700; /* Sun yellow */
+    transition: transform 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55), background-color 0.4s ease;
+    border-radius: 50%;
+    z-index: 2;
+    box-shadow: 0 0 10px rgba(255, 215, 0, 0.8);
+}
+
+/* Moon State (Moves right and changes color) */
+.theme-checkbox-qn:checked + .toggle-track-qn .toggle-knob-qn {
+    transform: translateX(40px);
+    background-color: #f4f6f9; /* Moon white */
+    box-shadow: 0 0 10px rgba(255, 255, 255, 0.8);
+}
+
+/* Crescent Moon Cutout (Overlaps the knob to create the crescent shape) */
+.toggle-knob-qn::before {
+    content: '';
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    background: #1a1a2e; /* Matches the night sky */
+    transform: translate(10px, -10px) scale(0);
+    transition: transform 0.4s ease;
+}
+
+.theme-checkbox-qn:checked + .toggle-track-qn .toggle-knob-qn::before {
+    transform: translate(10px, -10px) scale(1);
+}
+
+/* --- Clouds (Day Elements) --- */
+.cloud-qn {
+    position: absolute;
+    background: #ffffff;
+    border-radius: 50px;
+    opacity: 0.9;
+    transition: opacity 0.4s ease, transform 0.4s ease;
+    z-index: 1;
+}
+
+.cloud-1-qn {
+    width: 20px;
+    height: 10px;
+    top: 10px;
+    left: 45px;
+}
+
+.cloud-2-qn {
+    width: 15px;
+    height: 8px;
+    top: 22px;
+    left: 55px;
+}
+
+/* Hide clouds at night */
+.theme-checkbox-qn:checked + .toggle-track-qn .cloud-qn {
+    opacity: 0;
+    transform: translateX(-20px);
+}
+
+/* --- Stars (Night Elements) --- */
+.star-qn {
+    position: absolute;
+    background: #ffffff;
+    border-radius: 50%;
+    opacity: 0;
+    transition: opacity 0.4s ease;
+    z-index: 1;
+    box-shadow: 0 0 4px #ffffff;
+}
+
+.star-1-qn {
+    width: 4px;
+    height: 4px;
+    top: 10px;
+    left: 15px;
+}
+
+.star-2-qn {
+    width: 3px;
+    height: 3px;
+    top: 25px;
+    left: 25px;
+}
+
+.star-3-qn {
+    width: 2px;
+    height: 2px;
+    top: 12px;
+    left: 35px;
+}
+
+/* Show stars at night */
+.theme-checkbox-qn:checked + .toggle-track-qn .star-qn {
+    opacity: 1;
+}


### PR DESCRIPTION

## Description
This PR adds a new "Day/Night Theme Toggle Switch" component to the repository. It creates a smooth, interactive transition between day and night states, featuring a morphing sun/moon, moving clouds, and fading stars, all built with pure CSS.

## Changes
- Added `submissions/examples/day-night-toggle-qn/` folder.
- Added `demo.html` with the HTML structure (utilizing the checkbox hack).
- Added `style.css` with the styling, transitions, and state-based animations.
- Added `README.md` with usage instructions and customization tips.

## Related Issue
Closes #21338

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] I have placed my files in the `submissions/examples/day-night-toggle-qn/` directory.
- [x] I have not modified any files in `core/` or `components/`.
- [x] My submission includes `demo.html`, `style.css`, and `README.md`.
- [x] I have appended a unique identifier (`-qn`) to the feature name to avoid conflicts.
- [x] My commits are squashed into a single meaningful commit with a clear message.