### PR TITLE
feat: add ease-typewriter-mp CSS-only typewriter animation utility

### DIFF
--- a/submissions/examples/ease-typewriter-mp/README.md
+++ b/submissions/examples/ease-typewriter-mp/README.md
@@ -1,0 +1,27 @@
+# ease-typewriter-mp
+
+## What does this do?
+Animates text as if it is being typed character by character, with a blinking cursor — using pure CSS and no JavaScript.
+
+## How is it used?
+
+Add the `.ease-typewriter-mp` class to any inline or inline-block element and set two CSS variables to match your text:
+
+```html
+<span
+  class="ease-typewriter-mp"
+  style="--ease-typewriter-chars: 20; --ease-typewriter-speed: 2s;"
+>
+  Your text goes here.
+</span>
+```
+
+| Variable | Default | Description |
+|---|---|---|
+| `--ease-typewriter-chars` | `30` | Number of characters in the text |
+| `--ease-typewriter-speed` | `2s` | Total time to type the full string |
+
+**Important:** Set `--ease-typewriter-chars` to match the exact character count of your text for the stepping to align correctly.
+
+## Why is it useful?
+Typewriter effects are one of the most requested hero-section animations and are traditionally implemented with JavaScript libraries. This utility delivers the same effect using only `steps()` easing on `width`, an animated `border-right` cursor, `white-space: nowrap`, and `overflow: hidden` — keeping EaseMotion CSS dependency-free and true to its philosophy of expressive motion through pure CSS.

--- a/submissions/examples/ease-typewriter-mp/demo.html
+++ b/submissions/examples/ease-typewriter-mp/demo.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-typewriter-mp Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: monospace;
+      background: #0f0f0f;
+      color: #e0e0e0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      gap: 2rem;
+      margin: 0;
+      padding: 2rem;
+      box-sizing: border-box;
+    }
+
+    h1 {
+      color: #a78bfa;
+      margin: 0;
+      font-size: 1.2rem;
+      letter-spacing: 0.1em;
+    }
+
+    .demo-block {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .label {
+      font-size: 0.75rem;
+      color: #6b7280;
+    }
+
+    /* Example 1 — default speed */
+    .example-1 {
+      font-size: 1.5rem;
+      color: #34d399;
+      --ease-typewriter-chars: 24;
+      --ease-typewriter-speed: 2s;
+    }
+
+    /* Example 2 — slower, longer text */
+    .example-2 {
+      font-size: 1.2rem;
+      color: #60a5fa;
+      --ease-typewriter-chars: 38;
+      --ease-typewriter-speed: 3.8s;
+    }
+
+    /* Example 3 — fast, short */
+    .example-3 {
+      font-size: 2rem;
+      color: #f472b6;
+      --ease-typewriter-chars: 12;
+      --ease-typewriter-speed: 1s;
+    }
+  </style>
+</head>
+<body>
+  <h1>ease-typewriter-mp · Demo</h1>
+
+  <div class="demo-block">
+    <span class="label">Default (24 chars, 2s)</span>
+    <span class="ease-typewriter-mp example-1">Hello, EaseMotion CSS!</span>
+  </div>
+
+  <div class="demo-block">
+    <span class="label">Longer text (38 chars, 3.8s)</span>
+    <span class="ease-typewriter-mp example-2">Building the web one animation at a time.</span>
+  </div>
+
+  <div class="demo-block">
+    <span class="label">Fast &amp; short (12 chars, 1s)</span>
+    <span class="ease-typewriter-mp example-3">Open Source!</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-typewriter-mp/style.css
+++ b/submissions/examples/ease-typewriter-mp/style.css
@@ -1,0 +1,26 @@
+/* ease-typewriter-mp - CSS-only typewriter text animation utility */
+
+.ease-typewriter-mp {
+  --ease-typewriter-chars: 30;
+  --ease-typewriter-speed: 2s;
+
+  display: inline-block;
+  white-space: nowrap;
+  overflow: hidden;
+  width: 0;
+  border-right: 2px solid currentColor;
+
+  animation:
+    ease-typewriter-mp-type calc(var(--ease-typewriter-speed)) steps(var(--ease-typewriter-chars)) forwards,
+    ease-typewriter-mp-blink 0.75s step-end infinite;
+}
+
+@keyframes ease-typewriter-mp-type {
+  from { width: 0; }
+  to   { width: calc(var(--ease-typewriter-chars) * 1ch); }
+}
+
+@keyframes ease-typewriter-mp-blink {
+  0%, 100% { border-right-color: currentColor; }
+  50%       { border-right-color: transparent; }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a CSS-only typewriter text animation utility (`ease-typewriter-mp`) that types out text character by character with a blinking cursor — no JavaScript required.

Closes #19677

---
## Type of Change
- [x] ✨ New animation / hover effect

---
## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-typewriter-mp/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A pure CSS typewriter animation that reveals text character by character using `steps()` easing on `width`, with a blinking `border-right` cursor.

**How does a developer use it?**
```html
<span
  class="ease-typewriter-mp"
  style="--ease-typewriter-chars: 20; --ease-typewriter-speed: 2s;"
>
  Your text goes here.
</span>
```

**Why does it fit EaseMotion CSS?**
Typewriter effects are among the most requested hero-section animations yet typically require JavaScript. This utility achieves the same result with pure CSS variables and keyframes, staying true to EaseMotion CSS's animation-first, dependency-free philosophy.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---
## Notes for Maintainer
`--ease-typewriter-chars` should match the exact character count of the text for the `steps()` timing to align correctly. Feel free to adjust default values or cursor thickness during integration.