### PR TITLE
feat: add transform-origin utilities (#16481)

### DIFF
--- a/submissions/examples/ease-transform-origins-proposal/README.md
+++ b/submissions/examples/ease-transform-origins-proposal/README.md
@@ -1,0 +1,34 @@
+# Transform Origin Utilities (`ease-transform-origins-proposal`)
+
+This proposal introduces a robust set of CSS utility classes to manage the `transform-origin` property, targeted for integration into `core/utilities.css`.
+
+## 📌 Feature Overview
+
+When utilizing standard CSS transforms (`rotate()`, `scale()`, etc.), the transform always occurs relative to the center of the element by default. These utility classes allow developers to change the anchor/pivot point of the transformation without writing custom CSS.
+Included classes:
+- `.origin-center` (default)
+- `.origin-top`
+- `.origin-top-right`
+- `.origin-right`
+- `.origin-bottom-right`
+- `.origin-bottom`
+- `.origin-bottom-left`
+- `.origin-left`
+- `.origin-top-left`
+
+## ⚙️ How to Use
+
+To test this feature locally, simply open the `demo.html` file in your web browser. The styles are contained in `style.css`. 
+
+You can apply the proposed utilities to any element that has a `transform` applied to it. For example, to make a dropdown menu scale out from the top-right corner instead of the center:
+
+```html
+<div class="dropdown-menu origin-top-right" style="transform: scale(0.5);">
+  <!-- Menu content -->
+</div>
+```
+
+*Note: As per the contributing guidelines, this proposal is implemented inside `submissions/examples/ease-transform-origins-proposal/` to avoid directly modifying core files and causing zero deletions. The maintainer can safely migrate these classes to the core utility stylesheet.*
+
+## 🔗 Related Issue
+Closes Issue #16481

--- a/submissions/examples/ease-transform-origins-proposal/demo.html
+++ b/submissions/examples/ease-transform-origins-proposal/demo.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Transform Origin Utilities | EaseMotion</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body class="origin-showcase">
+  <main class="showcase-container">
+    <header class="showcase-header">
+      <h1 class="showcase-title">Transform Origin Control</h1>
+      <p class="showcase-subtitle">Defining the pivot point for CSS transformations.</p>
+    </header>
+
+    <div class="info-banner">
+      <p>Hover over the squares below. They all have the exact same <code>rotate(45deg)</code> animation, but their <code>transform-origin</code> changes how they rotate!</p>
+    </div>
+
+    <!-- Interactive Grid -->
+    <section class="origin-grid">
+      
+      <div class="origin-cell">
+        <span class="origin-label">top-left</span>
+        <div class="box-container">
+          <div class="animated-box origin-top-left"></div>
+          <div class="pivot-point" style="top: 0; left: 0;"></div>
+        </div>
+      </div>
+
+      <div class="origin-cell">
+        <span class="origin-label">top</span>
+        <div class="box-container">
+          <div class="animated-box origin-top"></div>
+          <div class="pivot-point" style="top: 0; left: 50%; transform: translateX(-50%);"></div>
+        </div>
+      </div>
+
+      <div class="origin-cell">
+        <span class="origin-label">top-right</span>
+        <div class="box-container">
+          <div class="animated-box origin-top-right"></div>
+          <div class="pivot-point" style="top: 0; right: 0;"></div>
+        </div>
+      </div>
+
+      <div class="origin-cell">
+        <span class="origin-label">left</span>
+        <div class="box-container">
+          <div class="animated-box origin-left"></div>
+          <div class="pivot-point" style="top: 50%; left: 0; transform: translateY(-50%);"></div>
+        </div>
+      </div>
+
+      <div class="origin-cell">
+        <span class="origin-label">center</span>
+        <div class="box-container">
+          <div class="animated-box origin-center"></div>
+          <div class="pivot-point" style="top: 50%; left: 50%; transform: translate(-50%, -50%);"></div>
+        </div>
+      </div>
+
+      <div class="origin-cell">
+        <span class="origin-label">right</span>
+        <div class="box-container">
+          <div class="animated-box origin-right"></div>
+          <div class="pivot-point" style="top: 50%; right: 0; transform: translateY(-50%);"></div>
+        </div>
+      </div>
+
+      <div class="origin-cell">
+        <span class="origin-label">bottom-left</span>
+        <div class="box-container">
+          <div class="animated-box origin-bottom-left"></div>
+          <div class="pivot-point" style="bottom: 0; left: 0;"></div>
+        </div>
+      </div>
+
+      <div class="origin-cell">
+        <span class="origin-label">bottom</span>
+        <div class="box-container">
+          <div class="animated-box origin-bottom"></div>
+          <div class="pivot-point" style="bottom: 0; left: 50%; transform: translateX(-50%);"></div>
+        </div>
+      </div>
+
+      <div class="origin-cell">
+        <span class="origin-label">bottom-right</span>
+        <div class="box-container">
+          <div class="animated-box origin-bottom-right"></div>
+          <div class="pivot-point" style="bottom: 0; right: 0;"></div>
+        </div>
+      </div>
+
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-transform-origins-proposal/style.css
+++ b/submissions/examples/ease-transform-origins-proposal/style.css
@@ -1,0 +1,153 @@
+/* Core Page Layout */
+* {
+  box-sizing: border-box;
+}
+
+.origin-showcase {
+  background-color: #fafaf9;
+  color: #44403c;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  margin: 0;
+  padding: 40px 20px;
+}
+
+.showcase-container {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.showcase-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.showcase-title {
+  font-size: 2.5rem;
+  margin-bottom: 0.5rem;
+  color: #1c1917;
+}
+
+.showcase-subtitle {
+  font-size: 1.1rem;
+  color: #78716c;
+}
+
+.info-banner {
+  background: #fef3c7;
+  border-left: 4px solid #f59e0b;
+  padding: 1rem;
+  border-radius: 6px;
+  margin-bottom: 2.5rem;
+  font-size: 1rem;
+  color: #92400e;
+  text-align: center;
+}
+
+/* Grid System */
+.origin-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 30px;
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+.origin-cell {
+  background: white;
+  border: 1px solid #e7e5e4;
+  border-radius: 12px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
+}
+
+.origin-label {
+  font-family: monospace;
+  background: #f5f5f4;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  margin-bottom: 20px;
+  color: #57534e;
+}
+
+.box-container {
+  position: relative;
+  width: 80px;
+  height: 80px;
+  background: #f5f5f4; /* ghost outline of original position */
+  border: 1px dashed #d6d3d1;
+  border-radius: 8px;
+}
+
+.animated-box {
+  width: 100%;
+  height: 100%;
+  background: #3b82f6;
+  border-radius: 8px;
+  transition: transform 0.4s ease;
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0.8;
+}
+
+.origin-cell:hover .animated-box {
+  transform: rotate(45deg);
+  background: #2563eb;
+}
+
+.pivot-point {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  background: #ef4444;
+  border-radius: 50%;
+  z-index: 10;
+  pointer-events: none;
+  /* Adjusting so it sits exactly on the corner/edge visually */
+  margin: -5px; 
+}
+
+/* =======================================================
+   Transform Origin Utilities Proposal
+   Target: core/utilities.css
+   ======================================================= */
+
+.origin-center {
+  transform-origin: center !important;
+}
+
+.origin-top {
+  transform-origin: top !important;
+}
+
+.origin-top-right {
+  transform-origin: top right !important;
+}
+
+.origin-right {
+  transform-origin: right !important;
+}
+
+.origin-bottom-right {
+  transform-origin: bottom right !important;
+}
+
+.origin-bottom {
+  transform-origin: bottom !important;
+}
+
+.origin-bottom-left {
+  transform-origin: bottom left !important;
+}
+
+.origin-left {
+  transform-origin: left !important;
+}
+
+.origin-top-left {
+  transform-origin: top left !important;
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #16481 by providing a validator-ready submission proposing the usage of `transform-origin` utility classes.

---

## Type of Change

- [x] ✨ New animation / hover effect (Animation Utility Proposal)
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/ease-transform-origins-proposal/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
It proposes adding standard `transform-origin` utility classes (`.origin-top-left`, `.origin-center`, `.origin-bottom-right`, etc.) to control the pivot point for CSS animations and transforms.

**How does a developer use it?**

```html
<!-- Easily anchor a dropdown animation to the top-right corner -->
<div class="dropdown origin-top-right scale-up-animation">
  ...
</div>
