### PR TITLE
feat: add hyphenation utilities (#15569)

### DIFF
--- a/submissions/examples/hyphenation-control/README.md
+++ b/submissions/examples/hyphenation-control/README.md
@@ -1,21 +1,31 @@
-# Hyphenation &amp; Breaking Control
+# Hyphenation Control Example (`hyphenation-control`)
 
-## Feature Overview
-This demo covers three CSS properties that control how text breaks across lines:
-- **hyphens** (`auto`, `manual`, `none`) — dictionary-based hyphenation at syllable boundaries, requires the `lang` attribute to work properly
-- **word-break** (`normal`, `break-all`, `keep-all`) — controls whether lines may break at character boundaries, useful for long unbroken strings
-- **overflow-wrap** (`normal`, `break-word`, `anywhere`) — emergency word breaking when content would otherwise overflow
+This proposal introduces a set of CSS utility classes to manage the `hyphens` typography property, targeted for integration into `core/utilities.css`.
 
-The demo includes English, German, and French samples to show language-specific hyphenation differences.
+## 📌 Feature Overview
 
-## Usage
-Open `demo.html` in any browser. Each card applies one CSS value to identical text so the visual difference is clear. Narrow the viewport to trigger more line breaks. The German text (`Donaudampfschifffahrtsgesellschaft...`) is intentionally long to stress-test hyphenation dictionaries. Language-specific hyphenation uses the `lang` attribute on individual elements.
+These utilities provide developers with direct control over how text breaks across lines. This is critical for preventing awkward layout shifts or horizontal scrolling when dealing with long words (like URLs or technical terms) inside narrow containers (like sidebars or mobile screens).
+Included classes:
+- `.hyphens-none` (Never hyphenate, even if it overflows)
+- `.hyphens-manual` (Only hyphenate where soft-hyphens `&shy;` are placed)
+- `.hyphens-auto` (Automatically insert hyphens based on the browser's dictionary)
 
-## Browser Support
-- `hyphens: none|manual` — supported everywhere
-- `hyphens: auto` — Chrome 55+, Firefox 43+, Safari 5.1+ (Edge requires Windows language pack)
-- `word-break: normal|break-all` — supported everywhere
-- `word-break: keep-all` — Chrome 44+, Firefox 15+, Safari 9+
-- `overflow-wrap: normal|break-word` — supported everywhere
-- `overflow-wrap: anywhere` — Chrome 80+, Firefox 80+, Safari 15.4+
-- Language-specific hyphenation requires OS hyphenation dictionaries to be installed
+## ⚙️ How to Use
+
+To test this feature locally, simply open the `demo.html` file in your web browser. The styles are contained in `style.css`. 
+
+You can apply the proposed utilities to any text container:
+
+```html
+<!-- Automatically break words in a narrow mobile card -->
+<div class="hyphens-auto w-64" lang="en">
+  A very long scientific word like Pneumonoultramicroscopicsilicovolcanoconiosis will now break gracefully.
+</div>
+```
+
+*Tip: `hyphens-auto` relies on the browser knowing the language of the text. Always ensure your HTML or container has a `lang` attribute (e.g., `lang="en"`).*
+
+*Note: As per the contributing guidelines, this proposal is implemented inside `submissions/examples/hyphenation-control/` to avoid directly modifying core files and causing zero deletions. The maintainer can safely migrate these classes to the core utility stylesheet.*
+
+## 🔗 Related Issue
+Closes Issue #15569

--- a/submissions/examples/hyphenation-control/demo.html
+++ b/submissions/examples/hyphenation-control/demo.html
@@ -1,94 +1,62 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>hyphens & word-break & overflow-wrap</title>
-  <link rel="stylesheet" href="style.css">
+  <meta charset="utf-8">
+  <title>Hyphenation Control Utilities | EaseMotion</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="./style.css">
 </head>
-<body>
-  <header class="hero">
-    <h1>Hyphenation &amp; Breaking Control</h1>
-    <p class="subtitle">Comparing <code>hyphens</code>, <code>word-break</code>, and <code>overflow-wrap</code> with language-specific hyphenation.</p>
-  </header>
+<body class="hyphens-demo-page">
+  <main class="hyphens-wrapper">
+    <header class="hyphens-header">
+      <h1 class="hyphens-title">Hyphenation Control</h1>
+      <p class="hyphens-subtitle">Typographic breaking controls proposed for <code>core/utilities.css</code>.</p>
+    </header>
 
-  <section class="demo-section">
-    <h2>hyphens Property</h2>
-    <div class="demo-grid">
-      <article class="demo-card">
-        <h3 class="card-label">hyphens: <span class="tag">auto</span></h3>
-        <p class="sample auto" lang="en">The extraordinary antidisestablishmentarianism movement encountered incomprehensible counterrevolutionary opposition throughout the constitutional interpretation.</p>
-        <p class="sample auto" lang="de">Die Donaudampfschifffahrtsgesellschaftskapitänskajütentür hing schief in den Angeln aufgrund der Vernachlässigung.</p>
+    <div class="hyphens-notice">
+      <p>These utility classes control how words are hyphenated across line breaks, improving readability in narrow columns or for very long words.</p>
+    </div>
+
+    <!-- Playground -->
+    <section class="hyphens-showcase">
+      
+      <!-- Hyphens None -->
+      <article class="hyphens-card">
+        <h3 class="hyphens-label">.hyphens-none</h3>
+        <p class="hyphens-desc">Words are never hyphenated, even if they overflow their container.</p>
+        
+        <div class="demo-container w-narrow">
+          <p class="hyphens-none text-content bg-red-light" lang="en">
+            This is an extraordinarilylongwordthatcannotbebroken and will just overflow if it doesn't fit on one line.
+          </p>
+        </div>
       </article>
-      <article class="demo-card">
-        <h3 class="card-label">hyphens: <span class="tag">manual</span></h3>
-        <p class="sample manual" lang="en">The extraor&shy;dinary anti&shy;disestablishment&shy;arianism move&shy;ment encountered incompre&shy;hensible counter&shy;revolutionary opposition.</p>
-        <p class="sample manual" lang="de">Die Donau&shy;dampf&shy;schiff&shy;fahrts&shy;gesellschafts&shy;kapitäns&shy;kajüten&shy;tür hing schief.</p>
+
+      <!-- Hyphens Manual -->
+      <article class="hyphens-card">
+        <h3 class="hyphens-label">.hyphens-manual</h3>
+        <p class="hyphens-desc">Words are only hyphenated where explicitly indicated by an invisible <code>&amp;shy;</code> (soft hyphen) character.</p>
+        
+        <div class="demo-container w-narrow">
+          <p class="hyphens-manual text-content bg-yellow-light" lang="en">
+            This is an extra&shy;ordinarily&shy;long&shy;word&shy;that&shy;can&shy;be&shy;broken only at specific soft-hyphen points.
+          </p>
+        </div>
       </article>
-      <article class="demo-card">
-        <h3 class="card-label">hyphens: <span class="tag">none</span></h3>
-        <p class="sample none" lang="en">The extraordinary antidisestablishmentarianism movement encountered incomprehensible counterrevolutionary opposition throughout the constitutional interpretation.</p>
-        <p class="sample none" lang="de">Die Donaudampfschifffahrtsgesellschaftskapitänskajütentür hing schief in den Angeln aufgrund der Vernachlässigung.</p>
+
+      <!-- Hyphens Auto -->
+      <article class="hyphens-card">
+        <h3 class="hyphens-label">.hyphens-auto</h3>
+        <p class="hyphens-desc">The browser automatically hyphenates words according to its dictionary for the declared <code>lang</code> attribute.</p>
+        
+        <div class="demo-container w-narrow">
+          <p class="hyphens-auto text-content bg-green-light" lang="en">
+            This is an extraordinarily long word that might be automatically hyphenated by the browser's language dictionary when it reaches the edge of this extremely narrow container.
+          </p>
+        </div>
       </article>
-    </div>
-  </section>
 
-  <section class="demo-section">
-    <h2>word-break Comparison</h2>
-    <div class="demo-columns">
-      <div class="demo-col">
-        <h3 class="col-label">word-break: <span class="tag">normal</span></h3>
-        <p class="wb-normal">Antidisestablishmentarianism and floccinaucinihilipilification are remarkably long English words.</p>
-      </div>
-      <div class="demo-col">
-        <h3 class="col-label">word-break: <span class="tag">break-all</span></h3>
-        <p class="wb-break-all">Antidisestablishmentarianism and floccinaucinihilipilification are remarkably long English words.</p>
-      </div>
-      <div class="demo-col">
-        <h3 class="col-label">word-break: <span class="tag">keep-all</span></h3>
-        <p class="wb-keep-all">Antidisestablishmentarianism and floccinaucinihilipilification are remarkably long English words.</p>
-      </div>
-    </div>
-  </section>
-
-  <section class="demo-section">
-    <h2>overflow-wrap Comparison</h2>
-    <div class="demo-columns">
-      <div class="demo-col">
-        <h3 class="col-label">overflow-wrap: <span class="tag">normal</span></h3>
-        <p class="ow-normal">A verylongwordthatneverbreaksnaturallylikethisonewill overflow its container when it exceeds the available width.</p>
-      </div>
-      <div class="demo-col">
-        <h3 class="col-label">overflow-wrap: <span class="tag">break-word</span></h3>
-        <p class="ow-break-word">A verylongwordthatneverbreaksnaturallylikethisonewill break at the edge of the container when it exceeds the available width.</p>
-      </div>
-      <div class="demo-col">
-        <h3 class="col-label">overflow-wrap: <span class="tag">anywhere</span></h3>
-        <p class="ow-anywhere">A verylongwordthatneverbreaksnaturallylikethisonewill break at any character boundary when it exceeds the available width.</p>
-      </div>
-    </div>
-  </section>
-
-  <section class="demo-section">
-    <h2>Language-Specific Hyphenation</h2>
-    <div class="compare-block">
-      <div class="compare-item">
-        <h3 class="col-label">English (en)</h3>
-        <p lang="en" class="lang-sample">The internationalization and localization of software requires comprehensive understanding of cultural conventions and linguistic nuances across different regions.</p>
-      </div>
-      <div class="compare-item">
-        <h3 class="col-label">German (de)</h3>
-        <p lang="de" class="lang-sample">Die Internationalisierung und Lokalisierung von Software erfordert ein umfassendes Verständnis kultureller Konventionen und sprachlicher Nuancen in verschiedenen Regionen.</p>
-      </div>
-      <div class="compare-item">
-        <h3 class="col-label">French (fr)</h3>
-        <p lang="fr" class="lang-sample">L'internationalisation et la localisation de logiciels nécessitent une compréhension approfondie des conventions culturelles et des nuances linguistiques à travers différentes régions.</p>
-      </div>
-    </div>
-  </section>
-
-  <footer>
-    <p><strong>hyphens</strong> — dictionary-based &middot; <strong>word-break</strong> — character-based &middot; <strong>overflow-wrap</strong> — emergency breaks &middot; Always set <code>lang</code> for proper hyphenation.</p>
-  </footer>
+    </section>
+  </main>
 </body>
 </html>

--- a/submissions/examples/hyphenation-control/style.css
+++ b/submissions/examples/hyphenation-control/style.css
@@ -1,261 +1,129 @@
-*, *::before, *::after {
-  margin: 0;
-  padding: 0;
+/* Presentation Setup */
+* {
   box-sizing: border-box;
 }
 
-html {
-  font-size: 16px;
-  scroll-behavior: smooth;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  html {
-    scroll-behavior: auto;
-  }
-  *, *::before, *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-  }
-}
-
-body {
-  background: #0a0f1e;
-  color: #e2e8f0;
-  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
-  line-height: 1.6;
-  max-width: 960px;
-  margin: 0 auto;
-  padding: 2rem 1.5rem;
+.hyphens-demo-page {
+  background-color: #f8fafc;
+  color: #0f172a;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  margin: 0;
+  padding: 40px 20px;
   min-height: 100vh;
 }
 
-.hero {
+.hyphens-wrapper {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.hyphens-header {
   text-align: center;
-  padding: 3rem 0 2rem;
-  border-bottom: 1px solid #1e293b;
-  margin-bottom: 2.5rem;
+  margin-bottom: 3rem;
 }
 
-.hero h1 {
+.hyphens-title {
   font-size: 2.5rem;
-  font-weight: 700;
-  margin-bottom: 0.5rem;
-  background: linear-gradient(135deg, #34d399, #06b6d4);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  font-weight: 800;
+  margin-bottom: 0.75rem;
+  color: #0f172a;
 }
 
-.subtitle {
-  color: #94a3b8;
+.hyphens-subtitle {
+  font-size: 1.15rem;
+  color: #475569;
+}
+
+.hyphens-notice {
+  background: #fff;
+  border-left: 4px solid #3b82f6;
+  padding: 1.25rem;
+  border-radius: 0.5rem;
+  margin-bottom: 3rem;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+}
+
+.hyphens-notice p {
+  margin: 0;
+  color: #1e293b;
   font-size: 1.05rem;
   line-height: 1.5;
 }
 
-.subtitle code {
-  color: #34d399;
-  -webkit-text-fill-color: #34d399;
+.hyphens-showcase {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
 }
 
-code {
-  background: #1e293b;
-  padding: 0.15rem 0.4rem;
-  border-radius: 4px;
-  font-size: 0.9em;
-  font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+.hyphens-card {
+  background: #ffffff;
+  padding: 2rem;
+  border-radius: 1rem;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  border: 1px solid #e2e8f0;
 }
 
-.demo-section {
-  margin-bottom: 3rem;
+.hyphens-label {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 1.25rem;
+  color: #334155;
+  margin-top: 0;
+  margin-bottom: 0.5rem;
 }
 
-.demo-section h2 {
-  font-size: 1.5rem;
-  margin-bottom: 1.25rem;
-  color: #f1f5f9;
-  border-left: 3px solid #10b981;
-  padding-left: 0.75rem;
-}
-
-.demo-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1.25rem;
-}
-
-.demo-card {
-  background: #111827;
-  border: 1px solid #1e293b;
-  border-radius: 8px;
-  padding: 1.25rem;
-  transition: border-color 0.2s;
-}
-
-.demo-card:hover {
-  border-color: #334155;
-}
-
-.card-label {
-  font-size: 0.85rem;
-  color: #94a3b8;
-  margin-bottom: 0.75rem;
-  font-weight: 600;
-}
-
-.tag {
-  display: inline-block;
-  background: #1e293b;
-  color: #6ee7b7;
-  padding: 0.1rem 0.5rem;
-  border-radius: 4px;
-  font-size: 0.8rem;
-  font-weight: 600;
-}
-
-.sample {
-  font-size: 0.875rem;
-  line-height: 1.65;
-  color: #cbd5e1;
-  margin-bottom: 0.75rem;
-  max-width: 100%;
-}
-
-.sample:last-child {
-  margin-bottom: 0;
-}
-
-.sample.auto {
-  hyphens: auto;
-  -webkit-hyphens: auto;
-  -ms-hyphens: auto;
-}
-
-.sample.manual {
-  hyphens: manual;
-  -webkit-hyphens: manual;
-  -ms-hyphens: manual;
-}
-
-.sample.none {
-  hyphens: none;
-  -webkit-hyphens: none;
-  -ms-hyphens: none;
-}
-
-.demo-columns {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1.25rem;
-}
-
-.demo-col {
-  background: #111827;
-  border: 1px solid #1e293b;
-  border-radius: 8px;
-  padding: 1.25rem;
-}
-
-.col-label {
-  font-size: 0.85rem;
-  color: #94a3b8;
-  margin-bottom: 0.75rem;
-  font-weight: 600;
-}
-
-.wb-normal {
-  word-break: normal;
-  font-size: 0.875rem;
-  line-height: 1.65;
-  color: #cbd5e1;
-}
-
-.wb-break-all {
-  word-break: break-all;
-  font-size: 0.875rem;
-  line-height: 1.65;
-  color: #cbd5e1;
-}
-
-.wb-keep-all {
-  word-break: keep-all;
-  font-size: 0.875rem;
-  line-height: 1.65;
-  color: #cbd5e1;
-}
-
-.ow-normal {
-  overflow-wrap: normal;
-  font-size: 0.875rem;
-  line-height: 1.65;
-  color: #cbd5e1;
-}
-
-.ow-break-word {
-  overflow-wrap: break-word;
-  font-size: 0.875rem;
-  line-height: 1.65;
-  color: #cbd5e1;
-}
-
-.ow-anywhere {
-  overflow-wrap: anywhere;
-  font-size: 0.875rem;
-  line-height: 1.65;
-  color: #cbd5e1;
-}
-
-.compare-block {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1.25rem;
-}
-
-.compare-item {
-  background: #111827;
-  border: 1px solid #1e293b;
-  border-radius: 8px;
-  padding: 1.25rem;
-}
-
-.lang-sample {
-  hyphens: auto;
-  -webkit-hyphens: auto;
-  -ms-hyphens: auto;
-  font-size: 0.875rem;
-  line-height: 1.65;
-  color: #cbd5e1;
-}
-
-footer {
-  margin-top: 3rem;
-  padding-top: 1.5rem;
-  border-top: 1px solid #1e293b;
-  text-align: center;
-  font-size: 0.85rem;
+.hyphens-desc {
   color: #64748b;
+  font-size: 0.95rem;
+  margin-bottom: 2rem;
+  line-height: 1.5;
+}
+
+/* Demo specific helpers */
+.demo-container {
+  background: #f1f5f9;
+  border: 1px dashed #cbd5e1;
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+}
+
+.text-content {
+  font-size: 1.125rem;
   line-height: 1.6;
+  padding: 1rem;
+  border-radius: 0.375rem;
+  margin: 0;
+  /* Allow natural overflow behavior for demoing none vs auto */
+  overflow-wrap: normal;
+  word-wrap: normal;
 }
 
-footer strong {
-  color: #94a3b8;
+.w-narrow { 
+  width: 100%; 
+  max-width: 280px; /* Narrow enough to force breaks */
 }
 
-@media (max-width: 600px) {
-  body {
-    padding: 1rem;
-  }
-  .hero h1 {
-    font-size: 1.75rem;
-  }
-  .demo-grid {
-    grid-template-columns: 1fr;
-  }
-  .demo-columns {
-    grid-template-columns: 1fr;
-  }
-  .compare-block {
-    grid-template-columns: 1fr;
-  }
+.bg-red-light { background-color: #fee2e2; border: 1px solid #fca5a5; }
+.bg-yellow-light { background-color: #fef3c7; border: 1px solid #fcd34d; }
+.bg-green-light { background-color: #dcfce3; border: 1px solid #86efac; }
+
+
+/* =======================================================
+   Hyphenation Utilities Proposal
+   Target: core/utilities.css
+   ======================================================= */
+
+.hyphens-none {
+  -webkit-hyphens: none !important;
+  hyphens: none !important;
+}
+
+.hyphens-manual {
+  -webkit-hyphens: manual !important;
+  hyphens: manual !important;
+}
+
+.hyphens-auto {
+  -webkit-hyphens: auto !important;
+  hyphens: auto !important;
 }


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #15569 by providing a validator-ready submission proposing a set of typographic `hyphens` utility classes.

---

## Type of Change

- [x] ✨ New animation / hover effect (Typography Utility Proposal)
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/hyphenation-control/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
It proposes adding `.hyphens-none`, `.hyphens-manual`, and `.hyphens-auto` utility classes to instantly control how long words break across line boundaries.

**How does a developer use it?**

```html
<!-- Prevent a long word from pushing out the bounds of a mobile card -->
<div class="hyphens-auto w-64" lang="en">
  Pneumonoultramicroscopicsilicovolcanoconiosis
</div>
