### PR TITLE
feat: add appearance-textfield utility (#15073)

### DIFF
--- a/submissions/examples/ease-appearance-textfield-utility-proposal/README.md
+++ b/submissions/examples/ease-appearance-textfield-utility-proposal/README.md
@@ -1,0 +1,28 @@
+# Appearance Textfield Utility (`ease-appearance-textfield-utility-proposal`)
+
+This proposal introduces the `.appearance-textfield` utility class to override default browser element rendering, targeted for integration into `core/utilities.css`.
+
+## 📌 Feature Overview
+
+The CSS `appearance` property is used to control native UI controls. Setting it to `textfield` instructs the browser to render the element exactly like a standard `<input type="text">`. 
+
+The most common modern use case for this is **removing the annoying spinner arrows from `<input type="number">` fields**, giving designers total control over the input's aesthetics while preserving the semantic and validation benefits of the number type.
+
+Included class:
+- `.appearance-textfield`
+
+## ⚙️ How to Use
+
+To test this feature locally, simply open the `demo.html` file in your web browser. The styles are contained in `style.css`. 
+
+Apply the utility directly to your number inputs:
+
+```html
+<!-- The browser's default up/down arrows will be hidden -->
+<input type="number" class="appearance-textfield border rounded p-2" value="100">
+```
+
+*Note: As per the contributing guidelines, this proposal is implemented inside a unique `submissions/examples/ease-appearance-textfield-utility-proposal/` directory to avoid directly modifying core files and causing zero deletions. The maintainer can safely migrate this utility to the core stylesheet.*
+
+## 🔗 Related Issue
+Closes Issue #15073

--- a/submissions/examples/ease-appearance-textfield-utility-proposal/demo.html
+++ b/submissions/examples/ease-appearance-textfield-utility-proposal/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Appearance Textfield Utility | EaseMotion</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body class="appearance-demo-page">
+  <main class="appearance-wrapper">
+    <header class="appearance-header">
+      <h1 class="appearance-title">Appearance Textfield</h1>
+      <p class="appearance-subtitle">CSS appearance control proposed for <code>core/utilities.css</code>.</p>
+    </header>
+
+    <div class="appearance-notice">
+      <p>The <code>.appearance-textfield</code> utility applies <code>appearance: textfield;</code> to custom elements or inputs. It is most commonly used to remove the default increment/decrement spinners from <code>type="number"</code> inputs, making them behave and look like standard text inputs.</p>
+    </div>
+
+    <!-- Playground -->
+    <section class="appearance-showcase">
+      
+      <!-- Default Behavior -->
+      <article class="appearance-card">
+        <h3 class="appearance-label">Default Browser Behavior</h3>
+        <p class="appearance-desc">Standard number input with default browser spinners (arrows on hover/focus).</p>
+        
+        <div class="input-container">
+          <label for="default-input">Amount:</label>
+          <input type="number" id="default-input" value="1000" class="base-input">
+        </div>
+      </article>
+
+      <!-- Utility Applied -->
+      <article class="appearance-card">
+        <h3 class="appearance-label">.appearance-textfield Applied</h3>
+        <p class="appearance-desc">The utility is applied, removing the spinners and making it render like a standard text field while retaining number-type validation.</p>
+        
+        <div class="input-container">
+          <label for="utility-input">Amount:</label>
+          <input type="number" id="utility-input" value="1000" class="base-input appearance-textfield">
+        </div>
+      </article>
+
+      <!-- Div acting as input -->
+      <article class="appearance-card">
+        <h3 class="appearance-label">Custom Element (contenteditable)</h3>
+        <p class="appearance-desc">Applying the appearance to a standard div.</p>
+        
+        <div class="input-container">
+          <label for="div-input">Content:</label>
+          <div id="div-input" contenteditable="true" class="base-input appearance-textfield">
+            I am a div styled like an input!
+          </div>
+        </div>
+      </article>
+
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-appearance-textfield-utility-proposal/style.css
+++ b/submissions/examples/ease-appearance-textfield-utility-proposal/style.css
@@ -1,0 +1,133 @@
+/* =======================================================
+   Appearance Textfield Utility Proposal
+   Target: core/utilities.css
+   ======================================================= */
+
+.appearance-textfield {
+  -webkit-appearance: textfield !important;
+  -moz-appearance: textfield !important;
+  appearance: textfield !important;
+}
+
+/* Specific fix to ensure spinners are truly hidden in Webkit browsers when this class is applied */
+.appearance-textfield::-webkit-outer-spin-button,
+.appearance-textfield::-webkit-inner-spin-button {
+  -webkit-appearance: none !important;
+  margin: 0;
+}
+
+
+/* =======================================================
+   Presentation Setup (Demo Only)
+   ======================================================= */
+* {
+  box-sizing: border-box;
+}
+
+.appearance-demo-page {
+  background-color: #f8fafc;
+  color: #0f172a;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  margin: 0;
+  padding: 40px 20px;
+  min-height: 100vh;
+}
+
+.appearance-wrapper {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.appearance-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.appearance-title {
+  font-size: 2.5rem;
+  font-weight: 800;
+  margin-bottom: 0.75rem;
+  color: #0f172a;
+}
+
+.appearance-subtitle {
+  font-size: 1.15rem;
+  color: #475569;
+}
+
+.appearance-notice {
+  background: #fff;
+  border-left: 4px solid #3b82f6;
+  padding: 1.25rem;
+  border-radius: 0.5rem;
+  margin-bottom: 3rem;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+}
+
+.appearance-notice p {
+  margin: 0;
+  color: #1e293b;
+  font-size: 1.05rem;
+  line-height: 1.5;
+}
+
+.appearance-showcase {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.appearance-card {
+  background: #ffffff;
+  padding: 2rem;
+  border-radius: 1rem;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  border: 1px solid #e2e8f0;
+}
+
+.appearance-label {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 1.25rem;
+  color: #334155;
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.appearance-desc {
+  color: #64748b;
+  font-size: 0.95rem;
+  margin-bottom: 1.5rem;
+  line-height: 1.5;
+}
+
+/* Base input styling for the demo */
+.input-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.input-container label {
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: #475569;
+}
+
+.base-input {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #1e293b;
+  background-color: #fff;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.5rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  font-family: inherit;
+}
+
+.base-input:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #15073 by providing a validator-ready submission proposing a utility class to control the `appearance` property, specifically targeting `textfield` behavior.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (Appearance Utility Proposal)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/ease-appearance-textfield-utility-proposal/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
It introduces the `.appearance-textfield` utility class which forces an element (most notably `<input type="number">`) to render as a standard text input, overriding default native UI controls (like increment/decrement spinners).

**How does a developer use it?**

```html
<!-- Remove the default up/down arrows from a number input -->
<input type="number" class="appearance-textfield border rounded p-
