### PR TITLE
feat(examples): add Clip Reveal Right animation on hover

### DIFF
--- a/submissions/examples/ease-hover-clip-reveal-right/README.md
+++ b/submissions/examples/ease-hover-clip-reveal-right/README.md
@@ -1,0 +1,23 @@
+# Clip Reveal Right
+
+Content reveals from right to left on hover using `clip-path` — pure CSS.
+
+## Features
+- `clip-path: inset()` animation from right edge
+- Smooth cubic-bezier transition
+- Pure CSS, no JavaScript
+
+## Usage
+```css
+.clip-content { clip-path: inset(0 0 0 100%); transition: clip-path 0.5s; }
+.clip-card:hover .clip-content { clip-path: inset(0 0 0 0); }
+```
+
+## Browser Support
+- Chrome 1+, Firefox 3.5+, Safari 3.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-hover-clip-reveal-right/demo.html
+++ b/submissions/examples/ease-hover-clip-reveal-right/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Clip Reveal Right — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Clip Reveal Right</h1>
+  <p class="subtitle">Content reveals from right to left on hover — pure CSS.</p>
+  <section>
+    <h2>Demo</h2>
+    <p class="sec-desc">Hover the card to reveal content from the right</p>
+    <div class="clip-card"><div class="clip-content"><h3>Discover More</h3><p>Hover to reveal</p></div></div>
+  </section>
+  <section>
+    <h2>How It Works</h2>
+    <p>A <code>clip-path: inset()</code> animates from <code>0 0 0 100%</code> to <code>0 0 0 0</code> on hover, revealing content from right to left.</p>
+  </section>
+</body>
+</html>

--- a/submissions/examples/ease-hover-clip-reveal-right/style.css
+++ b/submissions/examples/ease-hover-clip-reveal-right/style.css
@@ -1,0 +1,18 @@
+/* ============================================================
+   EaseMotion CSS — Clip Reveal Right
+   Content reveals from right to left on hover
+   ============================================================ */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+body { background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; padding: 4rem 1rem; text-align: center; }
+h1 { color: #fff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+.subtitle { color: #9ca3af; margin-bottom: 2rem; }
+section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; max-width: 600px; margin-left: auto; margin-right: auto; }
+h2 { color: #fff; font-size: 1.1rem; margin-bottom: 0.75rem; }
+.sec-desc { font-size: 0.85rem; color: #9ca3af; margin-bottom: 1rem; }
+.clip-card { position: relative; width: 280px; height: 160px; margin: 0 auto; background: linear-gradient(135deg, #6366f1, #a78bfa); border-radius: 14px; overflow: hidden; cursor: pointer; }
+.clip-content { position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center; background: #1a1a1a; clip-path: inset(0 0 0 100%); transition: clip-path 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+.clip-card:hover .clip-content { clip-path: inset(0 0 0 0); }
+.clip-content h3 { color: #fff; font-size: 1.2rem; margin-bottom: 0.3rem; }
+.clip-content p { color: #9ca3af; font-size: 0.85rem; margin: 0; }
+p { color: #9ca3af; line-height: 1.8; margin-top: 1rem; }
+code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }


### PR DESCRIPTION
## Description

Content reveals from right to left on hover using clip-path — pure CSS.

## Related Issue
Closes #19851