### PR TITLE
feat: add podcast analytics dashboard showcase

### DIFF
--- a/submissions/examples/u-podcast-analytics-dashboard-22037/README.md
+++ b/submissions/examples/u-podcast-analytics-dashboard-22037/README.md
@@ -1,0 +1,108 @@
+# Podcast Analytics Dashboard
+
+A responsive **Podcast Analytics Dashboard** built using **HTML5** and **CSS3** that visualizes podcast performance, listener engagement, downloads, subscriber growth, and audience insights through a clean, modern dashboard interface.
+
+---
+
+## Features
+
+- Responsive dashboard layout
+- Podcast overview cards
+- Listener growth tracker
+- Episode performance panel
+- Geographic audience insights
+- Recent episode activity
+- Notifications panel
+- Quick action buttons
+- Smooth hover animations
+- CSS keyframe animations
+- Accessibility support
+
+---
+
+## Dashboard Components
+
+### Overview Cards
+
+- Total Episodes
+- Active Listeners
+- Downloads
+- Subscribers
+
+### Analytics Widgets
+
+- Listener Growth
+- Episode Performance
+- Geographic Audience
+
+### Activity
+
+- Recent Episodes
+- Notifications Panel
+
+### Quick Actions
+
+- Upload Episode
+- Schedule Release
+- Export Analytics
+
+---
+
+## Technologies Used
+
+- HTML5
+- CSS3
+- CSS Grid
+- Flexbox
+- CSS Animations
+
+---
+
+## Browser Support
+
+- Google Chrome
+- Mozilla Firefox
+- Microsoft Edge
+- Safari
+
+---
+
+## Accessibility
+
+Supports:
+
+```css
+@media (prefers-reduced-motion: reduce)
+```
+
+to disable non-essential animations for users who prefer reduced motion.
+
+---
+
+## Folder Structure
+
+```
+u-podcast-analytics-dashboard-22037/
+│
+├── demo.html
+├── style.css
+└── README.md
+```
+
+---
+
+## Highlights
+
+- Responsive podcast analytics interface
+- Animated listener growth progress bars
+- Interactive hover effects
+- Modern creator analytics dashboard
+- Clean and reusable HTML/CSS structure
+- Pure HTML & CSS implementation
+- No JavaScript dependencies
+
+---
+
+## Issue Reference
+
+Created for **Issue #22037** in the EaseMotion CSS repository.

--- a/submissions/examples/u-podcast-analytics-dashboard-22037/demo.html
+++ b/submissions/examples/u-podcast-analytics-dashboard-22037/demo.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Podcast Analytics Dashboard</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="dashboard">
+
+    <!-- Header -->
+
+    <header class="dashboard-header">
+
+        <div>
+            <h1>Podcast Analytics Dashboard</h1>
+            <p>
+                Monitor podcast performance, audience
+                engagement, downloads, and subscriber
+                growth through one centralized dashboard.
+            </p>
+        </div>
+
+        <div class="profile-card">
+            <span>🎙️</span>
+            <div>
+                <h3>Podcast Studio</h3>
+                <small>Creator Analytics</small>
+            </div>
+        </div>
+
+    </header>
+
+    <!-- Overview Cards -->
+
+    <section class="metrics-grid">
+
+        <div class="metric-card episodes">
+            <h3>Total Episodes</h3>
+            <h2>248</h2>
+            <span>12 Published This Month</span>
+        </div>
+
+        <div class="metric-card listeners">
+            <h3>Active Listeners</h3>
+            <h2>84.6K</h2>
+            <span>+9% This Week</span>
+        </div>
+
+        <div class="metric-card downloads">
+            <h3>Total Downloads</h3>
+            <h2>1.82M</h2>
+            <span>Growing Daily</span>
+        </div>
+
+        <div class="metric-card subscribers">
+            <h3>Subscribers</h3>
+            <h2>32.4K</h2>
+            <span>+1.8K This Month</span>
+        </div>
+
+    </section>
+
+    <!-- Dashboard Widgets -->
+
+    <section class="widgets-grid">
+
+        <!-- Listener Growth -->
+
+        <div class="widget">
+
+            <h2>Listener Growth</h2>
+
+            <div class="progress-item">
+
+                <div class="progress-header">
+                    <span>Technology Podcast</span>
+                    <span>94%</span>
+                </div>
+
+                <div class="progress">
+                    <div class="progress-fill tech"></div>
+                </div>
+
+            </div>
+
+            <div class="progress-item">
+
+                <div class="progress-header">
+                    <span>Business Podcast</span>
+                    <span>82%</span>
+                </div>
+
+                <div class="progress">
+                    <div class="progress-fill business"></div>
+                </div>
+
+            </div>
+
+            <div class="progress-item">
+
+                <div class="progress-header">
+                    <span>Education Podcast</span>
+                    <span>71%</span>
+                </div>
+
+                <div class="progress">
+                    <div class="progress-fill education"></div>
+                </div>
+
+            </div>
+
+        </div>
+
+    </section>
+
+</div>
+
+</body>
+
+</html>

--- a/submissions/examples/u-podcast-analytics-dashboard-22037/style.css
+++ b/submissions/examples/u-podcast-analytics-dashboard-22037/style.css
@@ -1,0 +1,318 @@
+/* ==========================
+   RESET
+========================== */
+
+*{
+    margin:0;
+    padding:0;
+    box-sizing:border-box;
+}
+
+body{
+    min-height:100vh;
+    background:#0f172a;
+    color:#ffffff;
+    font-family:Arial,Helvetica,sans-serif;
+    padding:24px;
+}
+
+.dashboard{
+    max-width:1200px;
+    margin:auto;
+    display:flex;
+    flex-direction:column;
+    gap:24px;
+}
+
+/* ==========================
+   HEADER
+========================== */
+
+.dashboard-header{
+    display:flex;
+    justify-content:space-between;
+    align-items:center;
+    gap:20px;
+    background:#1e293b;
+    padding:24px;
+    border-radius:18px;
+}
+
+.dashboard-header p{
+    color:#cbd5e1;
+    margin-top:8px;
+    line-height:1.6;
+}
+
+.profile-card{
+    display:flex;
+    align-items:center;
+    gap:12px;
+    background:#334155;
+    padding:12px 18px;
+    border-radius:12px;
+}
+
+.profile-card span{
+    font-size:2rem;
+}
+
+/* ==========================
+   OVERVIEW CARDS
+========================== */
+
+.metrics-grid{
+    display:grid;
+    grid-template-columns:repeat(4,1fr);
+    gap:20px;
+}
+
+.metric-card{
+    background:#1e293b;
+    padding:22px;
+    border-radius:18px;
+    transition:.3s ease;
+    animation:floatCard 4s ease-in-out infinite;
+}
+
+.metric-card:hover{
+    transform:translateY(-6px);
+}
+
+.metric-card h3{
+    color:#cbd5e1;
+    margin-bottom:10px;
+}
+
+.metric-card h2{
+    margin-bottom:8px;
+}
+
+.episodes{
+    border-left:4px solid #8b5cf6;
+}
+
+.listeners{
+    border-left:4px solid #22c55e;
+}
+
+.downloads{
+    border-left:4px solid #3b82f6;
+}
+
+.subscribers{
+    border-left:4px solid #f59e0b;
+}
+
+/* ==========================
+   WIDGETS
+========================== */
+
+.widgets-grid{
+    display:grid;
+    grid-template-columns:repeat(3,1fr);
+    gap:20px;
+}
+
+.widget{
+    background:#1e293b;
+    padding:24px;
+    border-radius:18px;
+}
+
+.widget h2{
+    margin-bottom:20px;
+}
+
+/* ==========================
+   PROGRESS
+========================== */
+
+.progress-item{
+    margin-bottom:18px;
+}
+
+.progress-header{
+    display:flex;
+    justify-content:space-between;
+    margin-bottom:8px;
+}
+
+.progress{
+    height:12px;
+    background:#334155;
+    border-radius:999px;
+    overflow:hidden;
+}
+
+.progress-fill{
+    height:100%;
+    border-radius:999px;
+    animation:progressGlow 2s infinite alternate;
+}
+
+.tech{
+    width:94%;
+    background:#8b5cf6;
+}
+
+.business{
+    width:82%;
+    background:#22c55e;
+}
+
+.education{
+    width:71%;
+    background:#3b82f6;
+}
+
+/* ==========================
+   LISTS
+========================== */
+
+.episode-list,
+.audience-list,
+.activity-list,
+.notification-list{
+    display:flex;
+    flex-direction:column;
+    gap:10px;
+}
+
+.episode-item,
+.audience-item,
+.activity-item,
+.notification{
+    background:#334155;
+    padding:12px;
+    border-radius:10px;
+    transition:.3s;
+}
+
+.episode-item:hover,
+.audience-item:hover,
+.activity-item:hover,
+.notification:hover{
+    transform:translateX(8px);
+}
+
+/* ==========================
+   BUTTONS
+========================== */
+
+.action-buttons{
+    display:flex;
+    gap:16px;
+    flex-wrap:wrap;
+}
+
+.action-btn{
+    border:none;
+    cursor:pointer;
+    color:#fff;
+    font-weight:600;
+    padding:12px 18px;
+    border-radius:10px;
+    background:#8b5cf6;
+    transition:.3s;
+}
+
+.action-btn:hover{
+    transform:translateY(-4px);
+}
+
+.action-btn:nth-child(2){
+    background:#22c55e;
+}
+
+.action-btn:nth-child(3){
+    background:#3b82f6;
+}
+
+/* ==========================
+   FOOTER
+========================== */
+
+.dashboard-footer{
+    text-align:center;
+    color:#94a3b8;
+    padding:20px;
+}
+
+/* ==========================
+   ANIMATIONS
+========================== */
+
+@keyframes floatCard{
+    0%,100%{
+        transform:translateY(0);
+    }
+    50%{
+        transform:translateY(-6px);
+    }
+}
+
+@keyframes progressGlow{
+    from{
+        opacity:.7;
+    }
+    to{
+        opacity:1;
+    }
+}
+
+/* ==========================
+   RESPONSIVE
+========================== */
+
+@media(max-width:1000px){
+
+    .metrics-grid{
+        grid-template-columns:repeat(2,1fr);
+    }
+
+    .widgets-grid{
+        grid-template-columns:1fr;
+    }
+
+}
+
+@media(max-width:768px){
+
+    .dashboard-header{
+        flex-direction:column;
+        align-items:flex-start;
+    }
+
+    .metrics-grid{
+        grid-template-columns:1fr;
+    }
+
+    .action-buttons{
+        flex-direction:column;
+    }
+
+}
+
+@media(max-width:600px){
+
+    body{
+        padding:12px;
+    }
+
+}
+
+/* ==========================
+   ACCESSIBILITY
+========================== */
+
+@media(prefers-reduced-motion:reduce){
+
+    *,
+    *::before,
+    *::after{
+        animation:none!important;
+        transition:none!important;
+    }
+
+}


### PR DESCRIPTION
# Summary

This PR introduces a **Podcast Analytics Dashboard** built with HTML5 and CSS3 for monitoring podcast performance, listener engagement, downloads, subscriber growth, and audience insights.

## Type of Change

* [x] ✨ New showcase example
* [ ] 🐛 Bug fix
* [ ] 📝 Documentation

## Features

### Overview Cards

* Total Episodes
* Active Listeners
* Downloads
* Subscribers

### Widgets

* Listener Growth
* Episode Performance
* Geographic Audience

### Activity

* Recent Episodes
* Notifications Panel

### Quick Actions

* Upload Episode
* Schedule Release
* Export Analytics

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari (Not Tested)

Closes #22037
