### PR TITLE
[submission] Add screen reader only (sr-only) utility (issue #22113)

### DIFF
--- a/submissions/core_changes-issue-22113/README.md
+++ b/submissions/core_changes-issue-22113/README.md
@@ -1,0 +1,44 @@
+# Screen Reader Only (sr-only) Utility
+
+## What does this do?
+
+Adds `ease-sr-only` and `ease-sr-only-focusable` utility classes that visually hide content while keeping it accessible to screen readers and assistive technologies, following the WCAG-compliant visually-hidden pattern.
+
+## How is it used?
+
+**Icon button with accessible label:**
+
+```html
+<button class="icon-btn" aria-label="Close dialog">
+  <span class="ease-sr-only">Close</span>
+  <svg>...</svg>
+</button>
+```
+
+**Skip-to-content navigation link:**
+
+```html
+<a href="#main-content" class="ease-sr-only-focusable">
+  Skip to main content
+</a>
+```
+
+**Screen reader only heading for section landmark:**
+
+```html
+<h2 class="ease-sr-only">Section Navigation</h2>
+<nav>...</nav>
+```
+
+## Why is it useful?
+
+Accessibility is a core requirement for modern web development. The `sr-only` pattern is one of the most fundamental accessibility utilities — it enables developers to provide screen reader text without affecting visual design. This utility is essential for:
+
+- Icon-only buttons (social media icons, close buttons, menu toggles)
+- Skip navigation links
+- Section labels for landmark regions
+- Form input labels when using placeholder-only designs
+- Table summaries and data descriptions
+- Status updates for screen readers during dynamic content changes
+
+Adding this to EaseMotion CSS aligns with the framework's utility-first philosophy and ensures developers have WCAG-compliant accessibility tools built in.

--- a/submissions/core_changes-issue-22113/demo.html
+++ b/submissions/core_changes-issue-22113/demo.html
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Screen Reader Only (sr-only) — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <!-- Skip Link (sr-only-focusable) — Press Tab to reveal -->
+  <a href="#main-content" class="skip-link ease-sr-only-focusable">Skip to main content</a>
+
+  <header class="demo-header">
+    <h1>Screen Reader Only (sr-only)</h1>
+    <p>Accessibility utilities for hiding content visually while keeping it available to assistive technologies. Press <kbd>Tab</kbd> to reveal the skip link.</p>
+  </header>
+
+  <main id="main-content" class="demo-container">
+
+    <!-- ── Why sr-only ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Overview</span>
+      <h2>Why sr-only Matters</h2>
+      <p>
+        The <code>.ease-sr-only</code> utility hides content from sighted users while keeping it
+        present in the accessibility tree. This is essential for WCAG 2.1 AA compliance and enables
+        developers to provide descriptive text for visual-only elements.
+      </p>
+
+      <table class="comparison-table">
+        <thead>
+          <tr>
+            <th>Display</th>
+            <th>Visual</th>
+            <th>Screen Reader</th>
+            <th>Method</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>display: none</code></td>
+            <td><span class="tag-visible tag-visible-no">Hidden</span></td>
+            <td><span class="tag-visible tag-visible-no">Hidden</span></td>
+            <td>Completely removed</td>
+          </tr>
+          <tr>
+            <td><code>visibility: hidden</code></td>
+            <td><span class="tag-visible tag-visible-no">Hidden</span></td>
+            <td><span class="tag-visible tag-visible-no">Hidden</span></td>
+            <td>Inaccessible to all</td>
+          </tr>
+          <tr>
+            <td><code>aria-hidden="true"</code></td>
+            <td><span class="tag-visible tag-visible-yes">Visible</span></td>
+            <td><span class="tag-visible tag-visible-no">Hidden</span></td>
+            <td>Decoration only</td>
+          </tr>
+          <tr>
+            <td><code>.ease-sr-only</code></td>
+            <td><span class="tag-visible tag-visible-no">Hidden</span></td>
+            <td><span class="tag-visible tag-visible-yes">Read</span></td>
+            <td>Accessible hidden</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <!-- ── Icon Buttons ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Use Case 1</span>
+      <h2>Icon-Only Buttons</h2>
+      <p>
+        Icon buttons need accessible labels. Without visible text, screen reader users cannot
+        determine the button's purpose. Use <code>.ease-sr-only</code> inside icon buttons to
+        provide a text label that only assistive technology reads.
+      </p>
+
+      <div class="demo-card">
+        <h3>Without sr-only ❌</h3>
+        <div class="demo-btn-group">
+          <button class="demo-btn demo-btn-icon" aria-label="Settings">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <circle cx="12" cy="12" r="3"/>
+              <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/>
+            </svg>
+          </button>
+          <span class="btn-label">No visible label — inaccessible</span>
+        </div>
+
+        <h3 style="margin-top:1.5rem;">With sr-only ✅</h3>
+        <div class="demo-btn-group">
+          <button class="demo-btn demo-btn-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <circle cx="12" cy="12" r="3"/>
+              <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/>
+            </svg>
+            <span class="ease-sr-only">Settings</span>
+          </button>
+          <span class="btn-label">Label hidden visually, read by screen readers</span>
+        </div>
+      </div>
+
+      <div class="accessibility-note">
+        <span class="icon" aria-hidden="true">&#9888;</span>
+        <p>
+          <strong>Tip:</strong> Even with <code>.ease-sr-only</code>, always pair with
+          <code>aria-label</code> on the button itself for maximum compatibility.
+        </p>
+      </div>
+    </section>
+
+    <!-- ── Skip Navigation ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Use Case 2</span>
+      <h2>Skip Navigation Links</h2>
+      <p>
+        Skip links let keyboard users bypass repetitive navigation. The link should be hidden
+        until focused. <code>.ease-sr-only-focusable</code> does exactly this — hidden by default,
+        visible on tab focus.
+      </p>
+
+      <div class="demo-card">
+        <h3>How it works</h3>
+        <p>
+          Press <kbd>Tab</kbd> right now. The "Skip to main content" link at the very top of
+          this page should become visible. This is the <code>.ease-sr-only-focusable</code>
+          pattern in action.
+        </p>
+      </div>
+
+      <div class="demo-code-block">
+        <span class="comment">&lt;!-- Hidden until focused --&gt;</span><br/>
+        &lt;<span class="selector">a</span> <span class="property">href</span>=<span class="value">"#main-content"</span> <span class="property">class</span>=<span class="value">"ease-sr-only-focusable"</span>&gt;<br/>
+        &nbsp;&nbsp;Skip to main content<br/>
+        &lt;/<span class="selector">a</span>&gt;
+      </div>
+    </section>
+
+    <!-- ── Form Labels ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Use Case 3</span>
+      <h2>Form Input Labels</h2>
+      <p>
+        When using placeholder-only inputs or icon-only form fields, always provide a visible
+        label for screen readers using <code>.ease-sr-only</code>.
+      </p>
+
+      <div class="demo-card">
+        <h3>Search with accessible label</h3>
+        <div style="display:flex;gap:0.5rem;align-items:center;">
+          <label for="demo-search" class="ease-sr-only">Search</label>
+          <input
+            id="demo-search"
+            type="search"
+            placeholder="Search..."
+            style="flex:1;padding:0.6rem 1rem;border:1px solid #e2e8f0;border-radius:0.5rem;font-size:0.875rem;"
+          />
+          <button class="demo-btn demo-btn-primary" style="padding:0.6rem 1rem;">
+            <span class="ease-sr-only">Submit search</span>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16">
+              <circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/>
+            </svg>
+          </button>
+        </div>
+        <p style="margin-top:0.75rem;font-size:0.75rem;color:#64748b;">
+          The label "Search" and button text "Submit search" use <code>.ease-sr-only</code>.
+        </p>
+      </div>
+    </section>
+
+    <!-- ── Section Landmarks ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Use Case 4</span>
+      <h2>Section Landmarks &amp; Headings</h2>
+      <p>
+        Screen reader users navigate via headings and landmarks. If a section is visually clear
+        but lacks a heading, add one with <code>.ease-sr-only</code> for assistive technology.
+      </p>
+
+      <div class="demo-card">
+        <h3>Example: Toolbar with hidden heading</h3>
+        <div role="toolbar" aria-label="Formatting" style=" display:flex;gap:0.25rem;padding:0.5rem;border:1px solid #e2e8f0;border-radius:0.5rem; background:#f8fafc;">
+          <h3 class="ease-sr-only">Text Formatting Options</h3>
+          <button class="demo-btn" style="padding:0.4rem 0.6rem;font-size:0.75rem;">B</button>
+          <button class="demo-btn" style="padding:0.4rem 0.6rem;font-size:0.75rem;"><em>I</em></button>
+          <button class="demo-btn" style="padding:0.4rem 0.6rem;font-size:0.75rem;"><u>U</u></button>
+        </div>
+        <p style="margin-top:0.75rem;font-size:0.75rem;color:#64748b;">
+          The heading "Text Formatting Options" is visually hidden but announced by screen readers.
+        </p>
+      </div>
+    </section>
+
+    <!-- ── CSS Reference ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Reference</span>
+      <h2>CSS Implementation</h2>
+      <div class="demo-code-block">
+        <span class="comment">/* Visually hidden, accessible to screen readers */</span><br/>
+        .<span class="selector">ease-sr-only</span> {<br/>
+        &nbsp;&nbsp;<span class="property">position</span>: <span class="value">absolute</span>;<br/>
+        &nbsp;&nbsp;<span class="property">width</span>: <span class="value">1px</span>;<br/>
+        &nbsp;&nbsp;<span class="property">height</span>: <span class="value">1px</span>;<br/>
+        &nbsp;&nbsp;<span class="property">padding</span>: <span class="value">0</span>;<br/>
+        &nbsp;&nbsp;<span class="property">margin</span>: <span class="value">-1px</span>;<br/>
+        &nbsp;&nbsp;<span class="property">overflow</span>: <span class="value">hidden</span>;<br/>
+        &nbsp;&nbsp;<span class="property">clip</span>: <span class="value">rect(0, 0, 0, 0)</span>;<br/>
+        &nbsp;&nbsp;<span class="property">white-space</span>: <span class="value">nowrap</span>;<br/>
+        &nbsp;&nbsp;<span class="property">border-width</span>: <span class="value">0</span>;<br/>
+        }<br/><br/>
+        <span class="comment">/* Hidden until focused (skip links) */</span><br/>
+        .<span class="selector">ease-sr-only-focusable</span>:not(:focus):not(:focus-within) {<br/>
+        &nbsp;&nbsp;<span class="comment">/* same as .ease-sr-only */</span><br/>
+        }<br/><br/>
+        .<span class="selector">ease-sr-only-focusable</span>:focus,<br/>
+        .<span class="selector">ease-sr-only-focusable</span>:focus-within {<br/>
+        &nbsp;&nbsp;<span class="property">position</span>: <span class="value">static</span>;<br/>
+        &nbsp;&nbsp;<span class="property">width</span>: <span class="value">auto</span>;<br/>
+        &nbsp;&nbsp;<span class="property">height</span>: <span class="value">auto</span>;<br/>
+        &nbsp;&nbsp;<span class="property">overflow</span>: <span class="value">visible</span>;<br/>
+        &nbsp;&nbsp;<span class="property">clip</span>: <span class="value">auto</span>;<br/>
+        &nbsp;&nbsp;<span class="property">white-space</span>: <span class="value">normal</span>;<br/>
+        }
+      </div>
+    </section>
+
+  </main>
+
+  <footer style="text-align:center;padding:2rem;border-top:1px solid #e2e8f0;margin-top:2rem;">
+    <p style="font-size:0.75rem;color:#64748b;">
+      <span class="ease-sr-only">End of demo.</span>
+      All styles from <code>style.css</code> &middot; Press <kbd>Tab</kbd> to test skip link
+    </p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/core_changes-issue-22113/style.css
+++ b/submissions/core_changes-issue-22113/style.css
@@ -1,0 +1,444 @@
+/* ============================================================
+   Screen Reader Only (sr-only) Utility
+   Submission for EaseMotion CSS · Issue #22113
+   ============================================================ */
+
+/* ── Core Utility: sr-only ───────────────────────────────── */
+
+/*
+ * Visually hides content while keeping it accessible to screen
+ * readers and assistive technologies. Follows the industry-standard
+ * WCAG-compliant visually-hidden pattern.
+ */
+.ease-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+/*
+ * Same as sr-only but becomes visible when focused (e.g., for
+ * skip-to-content links that should appear when tabbed to).
+ */
+.ease-sr-only-focusable:not(:focus):not(:focus-within) {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+.ease-sr-only-focusable:focus,
+.ease-sr-only-focusable:focus-within {
+  position: static;
+  width: auto;
+  height: auto;
+  padding: inherit;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+  white-space: normal;
+}
+
+/* ── Demo Styles ─────────────────────────────────────────── */
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  min-height: 100vh;
+  padding: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #0f172a;
+    color: #f1f5f9;
+  }
+  .demo-card,
+  .demo-section-title,
+  .demo-code-block,
+  .accessibility-note {
+    background: #1e293b;
+    border-color: #334155;
+    color: #f1f5f9;
+  }
+  .demo-btn {
+    background: #334155;
+    color: #f1f5f9;
+  }
+  .demo-btn:hover {
+    background: #475569;
+  }
+}
+
+/* Skip Link */
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: 1rem;
+  z-index: 1000;
+  background: #6c63ff;
+  color: #fff;
+  padding: 0.75rem 1.5rem;
+  border-radius: 0 0 0.5rem 0.5rem;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 0.875rem;
+  transition: top 0.2s ease;
+}
+
+.skip-link:focus {
+  top: 0;
+}
+
+/* Demo Header */
+.demo-header {
+  background: linear-gradient(135deg, #6c63ff, #4b44cc);
+  color: #fff;
+  padding: 3rem 2rem;
+  text-align: center;
+}
+
+.demo-header h1 {
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin-bottom: 0.75rem;
+}
+
+.demo-header p {
+  font-size: 1rem;
+  opacity: 0.9;
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+/* Demo Container */
+.demo-container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+/* Section */
+.demo-section {
+  margin-bottom: 3rem;
+}
+
+.demo-section-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #6c63ff;
+  margin-bottom: 0.5rem;
+  padding: 0.25rem 0.75rem;
+  background: #eef2ff;
+  border-radius: 999px;
+  display: inline-block;
+}
+
+.demo-section h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: inherit;
+}
+
+.demo-section p {
+  font-size: 0.875rem;
+  line-height: 1.7;
+  color: #64748b;
+  margin-bottom: 1rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .demo-section p {
+    color: #94a3b8;
+  }
+}
+
+/* Card */
+.demo-card {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.demo-card h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.demo-card p,
+.demo-card li {
+  font-size: 0.875rem;
+  line-height: 1.6;
+  color: #475569;
+  margin-bottom: 0.5rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .demo-card p,
+  .demo-card li {
+    color: #94a3b8;
+  }
+}
+
+.demo-card ul {
+  list-style: disc;
+  padding-left: 1.25rem;
+}
+
+/* Buttons */
+.demo-btn-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 1rem 0;
+}
+
+.demo-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1.2rem;
+  border-radius: 0.5rem;
+  border: 1px solid #e2e8f0;
+  background: #ffffff;
+  color: #1e293b;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  text-decoration: none;
+}
+
+.demo-btn:hover {
+  background: #f1f5f9;
+  border-color: #cbd5e1;
+}
+
+.demo-btn-primary {
+  background: #6c63ff;
+  color: #fff;
+  border-color: #6c63ff;
+}
+
+.demo-btn-primary:hover {
+  background: #5a52e0;
+  border-color: #5a52e0;
+}
+
+.demo-btn-icon {
+  padding: 0.6rem;
+  min-width: 2.5rem;
+  justify-content: center;
+}
+
+.demo-btn svg {
+  width: 1.25rem;
+  height: 1.25rem;
+  flex-shrink: 0;
+}
+
+/* Code Block */
+.demo-code-block {
+  background: #1e293b;
+  color: #e2e8f0;
+  border-radius: 0.5rem;
+  padding: 1rem 1.25rem;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  overflow-x: auto;
+  margin: 1rem 0;
+}
+
+.demo-code-block .comment {
+  color: #64748b;
+}
+
+.demo-code-block .selector {
+  color: #a78bfa;
+}
+
+.demo-code-block .property {
+  color: #67e8f9;
+}
+
+.demo-code-block .value {
+  color: #bef264;
+}
+
+/* Accessibility Note */
+.accessibility-note {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  background: #fefce8;
+  border: 1px solid #fde68a;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  margin: 1rem 0;
+}
+
+.accessibility-note .icon {
+  font-size: 1.25rem;
+  flex-shrink: 0;
+  margin-top: 0.1rem;
+}
+
+.accessibility-note p {
+  font-size: 0.8125rem;
+  color: #92400e;
+  margin: 0;
+  line-height: 1.5;
+}
+
+@media (prefers-color-scheme: dark) {
+  .accessibility-note {
+    background: #422006;
+    border-color: #78350f;
+  }
+  .accessibility-note p {
+    color: #fde68a;
+  }
+}
+
+/* Comparison Table */
+.comparison-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin: 1rem 0;
+  font-size: 0.8125rem;
+}
+
+.comparison-table th,
+.comparison-table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+@media (prefers-color-scheme: dark) {
+  .comparison-table th,
+  .comparison-table td {
+    border-color: #334155;
+  }
+}
+
+.comparison-table th {
+  font-weight: 600;
+  background: #f1f5f9;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #64748b;
+}
+
+@media (prefers-color-scheme: dark) {
+  .comparison-table th {
+    background: #1e293b;
+    color: #94a3b8;
+  }
+}
+
+.comparison-table tr:last-child td {
+  border-bottom: none;
+}
+
+.comparison-table code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  padding: 0.15em 0.4em;
+  background: #f1f5f9;
+  border-radius: 0.25rem;
+  color: #6c63ff;
+}
+
+@media (prefers-color-scheme: dark) {
+  .comparison-table code {
+    background: #334155;
+    color: #a78bfa;
+  }
+}
+
+.tag-visible {
+  display: inline-block;
+  padding: 0.2em 0.6em;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+
+.tag-visible-yes {
+  background: #dcfce7;
+  color: #15803d;
+}
+
+.tag-visible-no {
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+@media (prefers-color-scheme: dark) {
+  .tag-visible-yes {
+    background: #052e16;
+    color: #86efac;
+  }
+  .tag-visible-no {
+    background: #450a0a;
+    color: #fca5a5;
+  }
+}
+
+/* Icon Button with sr-only — Visual Demo */
+.icon-btn-demo {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  flex-wrap: wrap;
+  margin: 1rem 0;
+}
+
+.icon-btn-demo .btn-label {
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
+/* Visual separator */
+.demo-divider {
+  height: 1px;
+  background: #e2e8f0;
+  margin: 2rem 0;
+  border: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  .demo-divider {
+    background: #334155;
+  }
+}


### PR DESCRIPTION
### Summary

Adds `ease-sr-only` and `ease-sr-only-focusable` utility classes for WCAG-compliant visually-hidden content — hiding text visually while keeping it accessible to screen readers and assistive technologies.

### Changes

All changes in `submissions/core_changes-issue-22113/`:

- **`style.css`** — Core CSS for:
  - `.ease-sr-only` — visually hidden, readable by screen readers (position:absolute, clip:rect pattern)
  - `.ease-sr-only-focusable` — same but becomes visible on `:focus`/`:focus-within` (for skip navigation links)
  - Demo component styles (cards, buttons, code blocks, comparison table, dark mode)

- **`demo.html`** — Self-contained demo showing 4 use cases:
  1. Icon-only buttons with sr-only labels
  2. Skip-to-content navigation link (press Tab to reveal)
  3. Form input labels with sr-only text
  4. Section landmarks with sr-only headings
  Includes comparison table showing display:none vs visibility:hidden vs aria-hidden vs sr-only behavior

- **`README.md`** — Documentation explaining what sr-only does, how to use it, and why it matters for accessibility

### How to Review

1. Open `demo.html` in a browser
2. Press Tab — the "Skip to main content" link appears (sr-only-focusable demo)
3. Inspect icon buttons — they have invisible text labels readable by screen readers
4. Check search input — label is visually hidden but accessible
5. See the comparison table showing how sr-only differs from display:none and aria-hidden

Closes #22113