### PR TITLE
[submission] Add RTL direction support for bidirectional layouts (issue #22112)

### DIFF
--- a/submissions/core_changes-issue-22112/README.md
+++ b/submissions/core_changes-issue-22112/README.md
@@ -1,0 +1,39 @@
+# RTL (Right-to-Left) Direction Support
+
+## What does this do?
+
+Adds RTL support to EaseMotion CSS by mirroring directional animations and providing utility classes (`ease-rtl`, `ease-ltr`, `ease-start`, `ease-end`) so that all slide, flip, and directional effects automatically respect the `dir` attribute — making the framework usable for Arabic, Hebrew, Persian, Urdu, and other RTL languages.
+
+## How is it used?
+
+**Enable RTL mirroring on the whole page:**
+
+```html
+<html dir="rtl">
+```
+
+All directional animations (`ease-slide-in-left` ↔ `ease-slide-in-right`) automatically swap.
+
+**Force RTL mode on a specific element:**
+
+```html
+<div class="ease-rtl">
+  <div class="ease-slide-in-left">Appears from the right</div>
+</div>
+```
+
+**Logical alignment utilities:**
+
+```html
+<div class="ease-start">Aligned to inline-start (left in LTR, right in RTL)</div>
+<div class="ease-end">Aligned to inline-end (right in LTR, left in RTL)</div>
+```
+
+## Why is it useful?
+
+RTL support is essential for a global CSS framework. Over 400 million people use RTL scripts. Without it, directional animations break the user experience — slide-in-left brings content from the wrong side, and layout utilities produce incorrect alignment. This proposal makes EaseMotion CSS truly international by:
+
+- Automatically mirroring directional animations based on `dir="rtl"`
+- Providing explicit RTL/LTR override classes for fine-grained control
+- Adding logical alignment utilities (`ease-start`/`ease-end`) that adapt to direction
+- Extending utility classes like `ease-text-left`/`ease-text-right` with directional awareness

--- a/submissions/core_changes-issue-22112/demo.html
+++ b/submissions/core_changes-issue-22112/demo.html
@@ -1,0 +1,265 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>RTL Direction Support — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    /* Extra minimal styles for the RTL demo page itself */
+    .direction-label {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      padding: 0.25rem 0.75rem;
+      border-radius: 999px;
+      display: inline-block;
+    }
+    .direction-label.ltr {
+      background: #dcfce7;
+      color: #15803d;
+    }
+    .direction-label.rtl {
+      background: #fef3c7;
+      color: #92400e;
+    }
+    @media (prefers-color-scheme: dark) {
+      .direction-label.ltr {
+        background: #052e16;
+        color: #86efac;
+      }
+      .direction-label.rtl {
+        background: #422006;
+        color: #fde68a;
+      }
+    }
+  </style>
+</head>
+<body>
+
+  <header class="demo-header">
+    <h1>RTL Direction Support</h1>
+    <p>
+      Directional animations and utilities automatically mirror when the page uses <code>dir="rtl"</code>.
+      Click a language below to switch direction.
+    </p>
+    <div class="lang-toggle" id="langToggle">
+      <button class="lang-btn active" data-dir="ltr">English (LTR)</button>
+      <button class="lang-btn" data-dir="rtl">العربية (RTL)</button>
+      <button class="lang-btn" data-dir="rtl">עברית (RTL)</button>
+    </div>
+    <div style="margin-top: 0.75rem;">
+      <span class="dir-badge" id="currentDirBadge">dir="ltr"</span>
+    </div>
+  </header>
+
+  <main class="demo-container">
+
+    <!-- ── Directional Animation Mirroring ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Animation Mirroring</span>
+      <h2>Slide Direction Auto-Swap</h2>
+      <p>
+        When the page direction changes, <code>ease-slide-in-left</code> and <code>ease-slide-in-right</code>
+        automatically swap. Click the play button to see the effect, then switch the language and play again.
+      </p>
+
+      <div class="demo-card">
+        <h3>ease-slide-in-left</h3>
+        <div class="anim-row">
+          <div class="anim-box ease-slide-in-left" id="boxL">slide-in-left</div>
+          <div class="anim-box ease-slide-in-right" id="boxR">slide-in-right</div>
+        </div>
+        <div class="anim-row">
+          <div class="anim-box ease-slide-in-from-top-left" id="boxTL">from-top-left</div>
+          <div class="anim-box ease-slide-in-from-top-right" id="boxTR">from-top-right</div>
+        </div>
+        <div style="display:flex;gap:0.5rem;margin-top:1rem;">
+          <button class="demo-btn demo-btn-primary" id="playBtn">&#9654; Play Animations</button>
+          <button class="demo-btn" id="resetBtn">&#8635; Reset</button>
+        </div>
+      </div>
+
+      <div class="demo-notice">
+        <span class="icon" aria-hidden="true">&#128161;</span>
+        <p>
+          <strong>How it works:</strong> Toggle to Arabic (<code>dir="rtl"</code>) and click Play.
+          The left-labeled box animates from the <em>right</em> side because <code>dir="rtl"</code>
+          swaps the keyframe references.
+        </p>
+      </div>
+    </section>
+
+    <!-- ── Logical Alignment Utilities ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Utilities</span>
+      <h2>Logical Alignment: <code>ease-start</code> &amp; <code>ease-end</code></h2>
+      <p>
+        These utilities use CSS logical values (<code>text-align: start</code> / <code>end</code>)
+        which automatically respect the document direction.
+      </p>
+
+      <div class="demo-card">
+        <h3>With <code>dir="ltr"</code> (English)</h3>
+        <div class="card-item" style="text-align: start;">
+          <strong>text-align: start (ease-start)</strong>
+          <span>Aligned to the left in LTR context</span>
+        </div>
+        <div class="card-item" style="text-align: end;">
+          <strong>text-align: end (ease-end)</strong>
+          <span>Aligned to the right in LTR context</span>
+        </div>
+      </div>
+
+      <div class="demo-card" dir="rtl">
+        <h3>With <code>dir="rtl"</code> (Arabic)</h3>
+        <div class="card-item" style="text-align: start;">
+          <strong>text-align: start (ease-start)</strong>
+          <span>محاذاة إلى اليمين في سياق RTL</span>
+        </div>
+        <div class="card-item" style="text-align: end;">
+          <strong>text-align: end (ease-end)</strong>
+          <span>محاذاة إلى اليسار في سياق RTL</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── Override Classes ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Overrides</span>
+      <h2>Explicit Direction Override: <code>ease-rtl</code> &amp; <code>ease-ltr</code></h2>
+      <p>
+        Use <code>.ease-rtl</code> to force RTL behavior on a component inside an LTR page,
+        or <code>.ease-ltr</code> to keep a widget LTR inside an RTL page.
+      </p>
+
+      <div class="demo-card">
+        <h3>LTR page with an RTL card (<code>.ease-rtl</code>)</h3>
+        <div class="card-item ease-rtl">
+          <strong>هذا النص من اليمين إلى اليسار</strong>
+          <span>يقرأ هذا القسم من اليمين إلى اليسار بفضل الصنف .ease-rtl</span>
+        </div>
+      </div>
+
+      <div class="demo-card" dir="rtl">
+        <h3>RTL page with an LTR code block (<code>.ease-ltr</code>)</h3>
+        <div class="demo-code-block ease-ltr">
+          <span class="comment">// This code stays LTR even in RTL context</span><br/>
+          <span class="selector">const</span> <span class="property">greeting</span> = <span class="value">"Hello World"</span>;
+        </div>
+      </div>
+    </section>
+
+    <!-- ── Logical Property Utilities ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Logical Properties</span>
+      <h2>Margin / Padding / Border Utilities</h2>
+      <p>
+        These use CSS logical properties (<code>margin-inline-start</code>, <code>padding-inline-end</code>,
+        <code>border-inline-start</code>) that automatically adapt to direction.
+      </p>
+
+      <div class="demo-card">
+        <div style="display:flex;gap:1rem;flex-wrap:wrap;">
+          <div style="flex:1;min-width:200px;">
+            <h3>LTR (English)</h3>
+            <div dir="ltr" style="border:1px solid #e2e8f0;border-radius:0.5rem;padding:0.75rem;">
+              <div class="ease-ms-auto" style="width:fit-content;background:#6c63ff;color:#fff;padding:0.25rem 0.75rem;border-radius:0.25rem;font-size:0.75rem;">
+                margin-inline-start: auto
+              </div>
+              <div style="margin-top:0.5rem;font-size:0.75rem;color:#64748b;">
+                Pushed to the <strong>right</strong>
+              </div>
+            </div>
+          </div>
+          <div style="flex:1;min-width:200px;">
+            <h3>RTL (Arabic)</h3>
+            <div dir="rtl" style="border:1px solid #e2e8f0;border-radius:0.5rem;padding:0.75rem;">
+              <div class="ease-ms-auto" style="width:fit-content;background:#6c63ff;color:#fff;padding:0.25rem 0.75rem;border-radius:0.25rem;font-size:0.75rem;">
+                margin-inline-start: auto
+              </div>
+              <div style="margin-top:0.5rem;font-size:0.75rem;color:#64748b;">
+                يندفع إلى <strong>اليسار</strong>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── CSS Reference ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Reference</span>
+      <h2>CSS Implementation</h2>
+      <div class="demo-code-block">
+        <span class="comment">/* RTL mirroring — swap left ↔ right animations */</span><br/>
+        [<span class="property">dir</span>=<span class="value">"rtl"</span>] .<span class="selector">ease-slide-in-left</span> {<br/>
+        &nbsp;&nbsp;<span class="property">animation-name</span>: <span class="value">ease-kf-slide-in-right</span>;<br/>
+        }<br/><br/>
+        [<span class="property">dir</span>=<span class="value">"rtl"</span>] .<span class="selector">ease-slide-in-right</span> {<br/>
+        &nbsp;&nbsp;<span class="property">animation-name</span>: <span class="value">ease-kf-slide-in-left</span>;<br/>
+        }<br/><br/>
+        <span class="comment">/* Utility classes */</span><br/>
+        .<span class="selector">ease-rtl</span> { <span class="property">direction</span>: <span class="value">rtl</span>; }<br/>
+        .<span class="selector">ease-ltr</span> { <span class="property">direction</span>: <span class="value">ltr</span>; }<br/>
+        .<span class="selector">ease-start</span> { <span class="property">text-align</span>: <span class="value">start</span>; }<br/>
+        .<span class="selector">ease-end</span> { <span class="property">text-align</span>: <span class="value">end</span>; }
+      </div>
+    </section>
+
+  </main>
+
+  <footer style="text-align:center;padding:2rem;border-top:1px solid #e2e8f0;margin-top:2rem;">
+    <p style="font-size:0.75rem;color:#64748b;">
+      Toggle between English and Arabic to see direction-aware animations &middot; All styles from <code>style.css</code>
+    </p>
+  </footer>
+
+  <script>
+    // Lang toggle: switch dir on the html element
+    document.querySelectorAll('.lang-btn').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        // Update active button
+        document.querySelectorAll('.lang-btn').forEach(function(b) { b.classList.remove('active'); });
+        btn.classList.add('active');
+
+        // Set the direction
+        var dir = btn.getAttribute('data-dir');
+        document.documentElement.setAttribute('dir', dir);
+
+        // Update the badge
+        document.getElementById('currentDirBadge').textContent = 'dir="' + dir + '"';
+        document.getElementById('currentDirBadge').className = 'dir-badge ' + dir;
+      });
+    });
+
+    // Play/reset animations
+    var boxes = ['boxL', 'boxR', 'boxTL', 'boxTR'];
+    var originalAnimations = {
+      boxL: 'ease-slide-in-left',
+      boxR: 'ease-slide-in-right',
+      boxTL: 'ease-slide-in-from-top-left',
+      boxTR: 'ease-slide-in-from-top-right'
+    };
+
+    document.getElementById('playBtn').addEventListener('click', function() {
+      boxes.forEach(function(id) {
+        var el = document.getElementById(id);
+        el.style.animation = 'none';
+        // Force reflow
+        void el.offsetHeight;
+        el.style.animation = '';
+      });
+    });
+
+    document.getElementById('resetBtn').addEventListener('click', function() {
+      boxes.forEach(function(id) {
+        var el = document.getElementById(id);
+        el.style.animation = 'none';
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/core_changes-issue-22112/style.css
+++ b/submissions/core_changes-issue-22112/style.css
@@ -1,0 +1,487 @@
+/* ============================================================
+   RTL (Right-to-Left) Direction Support
+   Submission for EaseMotion CSS · Issue #22112
+   ============================================================ */
+
+/* ════════════════════════════════════════════════════════════════
+   RTL ANIMATION MIRRORING
+   When dir="rtl" is set on html/body, directional animations
+   automatically swap left ↔ right.
+   ════════════════════════════════════════════════════════════════ */
+
+[dir="rtl"] .ease-slide-in-left,
+[dir="rtl"].ease-slide-in-left {
+  animation-name: ease-kf-slide-in-right;
+}
+
+[dir="rtl"] .ease-slide-in-right,
+[dir="rtl"].ease-slide-in-right {
+  animation-name: ease-kf-slide-in-left;
+}
+
+[dir="rtl"] .ease-slide-in-from-left,
+[dir="rtl"].ease-slide-in-from-left {
+  animation-name: ease-kf-slide-in-from-right;
+}
+
+[dir="rtl"] .ease-slide-in-from-right,
+[dir="rtl"].ease-slide-in-from-right {
+  animation-name: ease-kf-slide-in-from-left;
+}
+
+[dir="rtl"] .ease-slide-in-from-top-left,
+[dir="rtl"].ease-slide-in-from-top-left {
+  animation-name: ease-kf-slide-in-from-top-right;
+}
+
+[dir="rtl"] .ease-slide-in-from-top-right,
+[dir="rtl"].ease-slide-in-from-top-right {
+  animation-name: ease-kf-slide-in-from-top-left;
+}
+
+[dir="rtl"] .ease-slide-in-from-bottom-left,
+[dir="rtl"].ease-slide-in-from-bottom-left {
+  animation-name: ease-kf-slide-in-from-bottom-right;
+}
+
+[dir="rtl"] .ease-slide-in-from-bottom-right,
+[dir="rtl"].ease-slide-in-from-bottom-right {
+  animation-name: ease-kf-slide-in-from-bottom-left;
+}
+
+[dir="rtl"] .ease-slide-out-left,
+[dir="rtl"].ease-slide-out-left {
+  animation-name: ease-kf-slide-out-right;
+}
+
+[dir="rtl"] .ease-slide-out-right,
+[dir="rtl"].ease-slide-out-right {
+  animation-name: ease-kf-slide-out-left;
+}
+
+/* ── Flip Animation Mirroring ─────────────────────────────── */
+
+[dir="rtl"] .ease-flip,
+[dir="rtl"].ease-flip {
+  animation-name: ease-kf-flip-rtl;
+}
+
+/* ── Bounce Horizontal Mirroring ──────────────────────────── */
+
+[dir="rtl"] .ease-bounce-horizontal,
+[dir="rtl"].ease-bounce-horizontal {
+  animation-name: ease-kf-bounce-horizontal-rtl;
+}
+
+/* ════════════════════════════════════════════════════════════════
+   RTL KEYFRAMES (mirrored versions)
+   ════════════════════════════════════════════════════════════════ */
+
+@keyframes ease-kf-flip-rtl {
+  0%   { transform: perspective(400px) rotateY(-90deg); }
+  100% { transform: perspective(400px) rotateY(0deg); }
+}
+
+@keyframes ease-kf-slide-out-right {
+  from { transform: translate3d(0, 0, 0); opacity: 1; }
+  to   { transform: translate3d(100%, 0, 0); opacity: 0; }
+}
+
+@keyframes ease-kf-slide-out-left {
+  from { transform: translate3d(0, 0, 0); opacity: 1; }
+  to   { transform: translate3d(-100%, 0, 0); opacity: 0; }
+}
+
+@keyframes ease-kf-bounce-horizontal-rtl {
+  0%, 100% { transform: translateX(0); }
+  25%      { transform: translateX(-15px); }
+  50%      { transform: translateX(10px); }
+  75%      { transform: translateX(-5px); }
+}
+
+/* ════════════════════════════════════════════════════════════════
+   RTL UTILITY CLASSES
+   ════════════════════════════════════════════════════════════════ */
+
+/*
+ * .ease-rtl — Force RTL direction on an element.
+ * Useful when a component needs RTL behavior inside an LTR page.
+ */
+.ease-rtl {
+  direction: rtl;
+}
+
+.ease-rtl .ease-slide-in-left {
+  animation-name: ease-kf-slide-in-right;
+}
+
+.ease-rtl .ease-slide-in-right {
+  animation-name: ease-kf-slide-in-left;
+}
+
+/*
+ * .ease-ltr — Force LTR direction on an element.
+ * Useful when an embedded widget (like a code block) must stay LTR
+ * inside an RTL page.
+ */
+.ease-ltr {
+  direction: ltr;
+}
+
+/*
+ * .ease-start — Logical "start" alignment.
+ * text-align: left in LTR, text-align: right in RTL.
+ */
+.ease-start {
+  text-align: start;
+}
+
+/*
+ * .ease-end — Logical "end" alignment.
+ * text-align: right in LTR, text-align: left in RTL.
+ */
+.ease-end {
+  text-align: end;
+}
+
+/* ════════════════════════════════════════════════════════════════
+   LOGICAL PROPERTY UTILITIES
+   These use CSS logical properties that natively respect direction.
+   ════════════════════════════════════════════════════════════════ */
+
+.ease-ms-auto { margin-inline-start: auto; }
+.ease-me-auto { margin-inline-end: auto; }
+.ease-ps-4     { padding-inline-start: 1rem; }
+.ease-pe-4     { padding-inline-end: 1rem; }
+.ease-border-s { border-inline-start: 1px solid; }
+.ease-border-e { border-inline-end: 1px solid; }
+
+/* ════════════════════════════════════════════════════════════════
+   DEMO STYLES
+   ════════════════════════════════════════════════════════════════ */
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  min-height: 100vh;
+  padding: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #0f172a;
+    color: #f1f5f9;
+  }
+  .demo-card,
+  .demo-section-title,
+  .demo-code-block {
+    background: #1e293b;
+    border-color: #334155;
+    color: #f1f5f9;
+  }
+  .demo-btn {
+    background: #334155;
+    color: #f1f5f9;
+  }
+  .demo-btn:hover {
+    background: #475569;
+  }
+  .card-item {
+    background: #1e293b;
+    border-color: #334155;
+  }
+}
+
+/* Header */
+.demo-header {
+  background: linear-gradient(135deg, #6c63ff, #4b44cc);
+  color: #fff;
+  padding: 3rem 2rem;
+  text-align: center;
+}
+
+.demo-header h1 {
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+}
+
+.demo-header p {
+  font-size: 1rem;
+  opacity: 0.9;
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+/* Lang toggle */
+.lang-toggle {
+  display: inline-flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.lang-btn {
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  border: 2px solid rgba(255,255,255,0.3);
+  background: transparent;
+  color: #fff;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.lang-btn:hover {
+  background: rgba(255,255,255,0.15);
+}
+
+.lang-btn.active {
+  background: #fff;
+  color: #6c63ff;
+  border-color: #fff;
+}
+
+/* Container */
+.demo-container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+/* Section */
+.demo-section {
+  margin-bottom: 3rem;
+}
+
+.demo-section-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #6c63ff;
+  margin-bottom: 0.5rem;
+  padding: 0.25rem 0.75rem;
+  background: #eef2ff;
+  border-radius: 999px;
+  display: inline-block;
+}
+
+.demo-section > h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+.demo-section > p {
+  font-size: 0.875rem;
+  line-height: 1.7;
+  color: #64748b;
+  margin-bottom: 1rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .demo-section > p {
+    color: #94a3b8;
+  }
+}
+
+/* Card */
+.demo-card {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.demo-card h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.demo-card p {
+  font-size: 0.875rem;
+  color: #475569;
+  line-height: 1.6;
+}
+
+@media (prefers-color-scheme: dark) {
+  .demo-card p {
+    color: #94a3b8;
+  }
+}
+
+/* Card items */
+.card-item {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.card-item:last-child {
+  margin-bottom: 0;
+}
+
+.card-item strong {
+  display: block;
+  font-size: 0.8125rem;
+  margin-bottom: 0.25rem;
+}
+
+.card-item span {
+  font-size: 0.8125rem;
+  color: #64748b;
+}
+
+/* Animation demo boxes */
+.anim-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
+.anim-box {
+  flex: 1;
+  min-width: 140px;
+  padding: 1.5rem 1rem;
+  border-radius: 0.5rem;
+  background: #6c63ff;
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-align: center;
+  animation-duration: 1s;
+  animation-fill-mode: both;
+  animation-iteration-count: 1;
+}
+
+.anim-box:nth-child(2) {
+  background: #8b5cf6;
+}
+
+.anim-box:nth-child(3) {
+  background: #3b82f6;
+}
+
+.anim-box:nth-child(4) {
+  background: #22c55e;
+}
+
+/* Trigger button */
+.demo-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1.2rem;
+  border-radius: 0.5rem;
+  border: 1px solid #e2e8f0;
+  background: #ffffff;
+  color: #1e293b;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.demo-btn:hover {
+  background: #f1f5f9;
+  border-color: #cbd5e1;
+}
+
+.demo-btn-primary {
+  background: #6c63ff;
+  color: #fff;
+  border-color: #6c63ff;
+}
+
+.demo-btn-primary:hover {
+  background: #5a52e0;
+  border-color: #5a52e0;
+}
+
+/* Code block */
+.demo-code-block {
+  background: #1e293b;
+  color: #e2e8f0;
+  border-radius: 0.5rem;
+  padding: 1rem 1.25rem;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  overflow-x: auto;
+  margin: 1rem 0;
+}
+
+.demo-code-block .comment { color: #64748b; }
+.demo-code-block .selector { color: #a78bfa; }
+.demo-code-block .property { color: #67e8f9; }
+.demo-code-block .value { color: #bef264; }
+
+/* Notice */
+.demo-notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  background: #fefce8;
+  border: 1px solid #fde68a;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  margin: 1rem 0;
+}
+
+.demo-notice .icon {
+  font-size: 1.25rem;
+  flex-shrink: 0;
+  margin-top: 0.1rem;
+}
+
+.demo-notice p {
+  font-size: 0.8125rem;
+  color: #92400e;
+  margin: 0;
+  line-height: 1.5;
+}
+
+@media (prefers-color-scheme: dark) {
+  .demo-notice {
+    background: #422006;
+    border-color: #78350f;
+  }
+  .demo-notice p {
+    color: #fde68a;
+  }
+}
+
+/* Direction indicator badge */
+.dir-badge {
+  display: inline-block;
+  font-size: 0.65rem;
+  font-family: monospace;
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
+  border-radius: 999px;
+  padding: 0.25em 0.75em;
+  color: #6c63ff;
+  margin-bottom: 0.5rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .dir-badge {
+    background: #1e293b;
+    border-color: #334155;
+    color: #a78bfa;
+  }
+}


### PR DESCRIPTION
### Summary

Adds RTL (right-to-left) direction support to EaseMotion CSS by mirroring directional animations and providing utility classes for bidirectional layouts.

### Changes

All changes in `submissions/core_changes-issue-22112/`:

- **`style.css`** — Core RTL support:
  - Automatic animation mirroring via `[dir="rtl"]` selectors (slide-in-left ↔ slide-in-right, from-top-left ↔ from-top-right, slide-out-left ↔ slide-out-right, flip horizontal, bounce horizontal)
  - Mirrored keyframes for RTL variants (flip-rtl, slide-out-left, slide-out-right, bounce-horizontal-rtl)
  - `.ease-rtl` — force RTL on an element inside LTR context
  - `.ease-ltr` — force LTR on an element inside RTL context
  - `.ease-start` / `.ease-end` — logical alignment using `text-align: start/end`
  - Logical property utilities: `ease-ms-auto`, `ease-me-auto`, `ease-ps-4`, `ease-pe-4`, `ease-border-s`, `ease-border-e`
  - Demo styles with dark mode support

- **`demo.html`** — Interactive demo:
  - Language toggle (English / العربية / עברית) that switches `dir` on the HTML element
  - Live animation mirroring — click Play, then switch language and Play again to see direction swap
  - Logical alignment comparison (LTR vs RTL side-by-side)
  - Override class demos (ease-rtl, ease-ltr)
  - Logical property demos (margin-inline-start: auto in LTR vs RTL)
  - CSS reference code block

- **`README.md`** — Documentation explaining RTL animation mirroring, utility classes, and why RTL support is essential for a global framework

### How to Review

1. Open `demo.html` in a browser
2. Click "Play Animations" — see slide-in-left come from the left
3. Click "العربية (RTL)" to switch direction
4. Click "Play Animations" again — slide-in-left now comes from the right (auto-mirrored)
5. Scroll through logical alignment, override classes, and logical property demos

Closes #22112