### PR TITLE
[submission] Add object-fit and object-position utility classes (issue #22109)

### DIFF
--- a/submissions/core_changes-issue-22109/README.md
+++ b/submissions/core_changes-issue-22109/README.md
@@ -1,0 +1,28 @@
+# Object-Fit and Object-Position Utilities
+
+## What does this do?
+
+Adds `ease-object-*` utility classes for controlling how replaced elements (images, videos) fill their containers using `object-fit` and `object-position`, ensuring media displays without distortion.
+
+## How is it used?
+
+**Responsive image gallery card:**
+
+```html
+<div class="card" style="width: 300px;">
+  <img class="ease-object-cover" src="photo.jpg" alt="" />
+  <div class="card-body">
+    <h3>Mountain View</h3>
+  </div>
+</div>
+```
+
+**Position a focal point in a hero image:**
+
+```html
+<img class="ease-object-cover ease-object-top" src="hero.jpg" alt="" />
+```
+
+## Why is it useful?
+
+Object-fit utilities are essential for any framework that deals with images. Without them, developers must repeatedly write `object-fit: cover` and `object-position: center` for every image in cards, galleries, hero sections, and avatars. These utilities complement the aspect-ratio utilities and make responsive media handling a single-class operation.

--- a/submissions/core_changes-issue-22109/demo.html
+++ b/submissions/core_changes-issue-22109/demo.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Object-Fit &amp; Object-Position Utilities — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="demo-header">
+    <h1>Object-Fit &amp; Object-Position</h1>
+    <p>Utility classes for controlling how images and videos fill their containers. No distortion, no manual CSS — just a single class.</p>
+  </header>
+
+  <main class="demo-container">
+
+    <!-- ── Object-Fit Reference ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Object-Fit</span>
+      <h2>How Each Value Behaves</h2>
+      <p>All images below use the <strong>same source image</strong> in a <strong>4:3 container</strong>. The class name tells the browser how to fit it.</p>
+
+      <div class="demo-card">
+        <div class="obj-grid">
+
+          <div class="obj-cell">
+            <div class="img-wrapper">
+              <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 300'%3E%3Crect width='400' height='300' fill='%236c63ff'/%3E%3Ccircle cx='200' cy='150' r='60' fill='%23fcd34d' stroke='%23fff' stroke-width='4'/%3E%3Ctext x='200' y='268' text-anchor='middle' fill='%23fff' font-size='24' font-weight='bold' font-family='system-ui'%3E400×300%3C/text%3E%3Ctext x='200' y='155' text-anchor='middle' fill='%231e293b' font-size='14' font-weight='bold'%3ELOGO%3C/text%3E%3C/svg%3E"
+                   alt="" class="ease-object-contain" />
+            </div>
+            <div class="img-label">.ease-object-contain</div>
+            <div class="img-desc">Fits inside with letterboxing</div>
+          </div>
+
+          <div class="obj-cell">
+            <div class="img-wrapper">
+              <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 300'%3E%3Crect width='400' height='300' fill='%236c63ff'/%3E%3Ccircle cx='200' cy='150' r='60' fill='%23fcd34d' stroke='%23fff' stroke-width='4'/%3E%3Ctext x='200' y='268' text-anchor='middle' fill='%23fff' font-size='24' font-weight='bold' font-family='system-ui'%3E400×300%3C/text%3E%3Ctext x='200' y='155' text-anchor='middle' fill='%231e293b' font-size='14' font-weight='bold'%3ELOGO%3C/text%3E%3C/svg%3E"
+                   alt="" class="ease-object-cover" />
+            </div>
+            <div class="img-label">.ease-object-cover</div>
+            <div class="img-desc">Fills container, crops excess</div>
+          </div>
+
+          <div class="obj-cell">
+            <div class="img-wrapper">
+              <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 300'%3E%3Crect width='400' height='300' fill='%236c63ff'/%3E%3Ccircle cx='200' cy='150' r='60' fill='%23fcd34d' stroke='%23fff' stroke-width='4'/%3E%3Ctext x='200' y='268' text-anchor='middle' fill='%23fff' font-size='24' font-weight='bold' font-family='system-ui'%3E400×300%3C/text%3E%3Ctext x='200' y='155' text-anchor='middle' fill='%231e293b' font-size='14' font-weight='bold'%3ELOGO%3C/text%3E%3C/svg%3E"
+                   alt="" class="ease-object-fill" />
+            </div>
+            <div class="img-label">.ease-object-fill</div>
+            <div class="img-desc">Stretches to fit (may distort)</div>
+          </div>
+
+          <div class="obj-cell">
+            <div class="img-wrapper">
+              <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 300'%3E%3Crect width='400' height='300' fill='%236c63ff'/%3E%3Ccircle cx='200' cy='150' r='60' fill='%23fcd34d' stroke='%23fff' stroke-width='4'/%3E%3Ctext x='200' y='268' text-anchor='middle' fill='%23fff' font-size='24' font-weight='bold' font-family='system-ui'%3E400×300%3C/text%3E%3Ctext x='200' y='155' text-anchor='middle' fill='%231e293b' font-size='14' font-weight='bold'%3ELOGO%3C/text%3E%3C/svg%3E"
+                   alt="" class="ease-object-none" />
+            </div>
+            <div class="img-label">.ease-object-none</div>
+            <div class="img-desc">Original size, no scaling</div>
+          </div>
+
+          <div class="obj-cell">
+            <div class="img-wrapper">
+              <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 300'%3E%3Crect width='400' height='300' fill='%236c63ff'/%3E%3Ccircle cx='200' cy='150' r='60' fill='%23fcd34d' stroke='%23fff' stroke-width='4'/%3E%3Ctext x='200' y='268' text-anchor='middle' fill='%23fff' font-size='24' font-weight='bold' font-family='system-ui'%3E400×300%3C/text%3E%3Ctext x='200' y='155' text-anchor='middle' fill='%231e293b' font-size='14' font-weight='bold'%3ELOGO%3C/text%3E%3C/svg%3E"
+                   alt="" class="ease-object-scale-down" />
+            </div>
+            <div class="img-label">.ease-object-scale-down</div>
+            <div class="img-desc">Smallest of none vs contain</div>
+          </div>
+
+        </div>
+      </div>
+    </section>
+
+    <!-- ── Object-Position Reference ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Object-Position</span>
+      <h2>Focal Point Control</h2>
+      <p>All images use <code>.ease-object-cover</code> plus a position class. The container is a narrow 4:3 box so the cropping effect is visible. The SVG has a centered logo and a directional arrow to make position shifts obvious.</p>
+
+      <div class="demo-card">
+        <div class="pos-grid">
+
+          <div class="pos-cell">
+            <div class="img-wrapper">
+              <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 300'%3E%3Crect width='400' height='300' fill='%236c63ff'/%3E%3Ccircle cx='200' cy='150' r='60' fill='%23fcd34d' stroke='%23fff' stroke-width='4'/%3E%3Ctext x='200' y='155' text-anchor='middle' fill='%231e293b' font-size='14' font-weight='bold'%3ELOGO%3C/text%3E%3C/svg%3E"
+                   alt="" class="ease-object-cover ease-object-top" />
+            </div>
+            <div class="pos-label">top</div>
+          </div>
+
+          <div class="pos-cell">
+            <div class="img-wrapper">
+              <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 300'%3E%3Crect width='400' height='300' fill='%236c63ff'/%3E%3Ccircle cx='200' cy='150' r='60' fill='%23fcd34d' stroke='%23fff' stroke-width='4'/%3E%3Ctext x='200' y='155' text-anchor='middle' fill='%231e293b' font-size='14' font-weight='bold'%3ELOGO%3C/text%3E%3C/svg%3E"
+                   alt="" class="ease-object-cover ease-object-bottom" />
+            </div>
+            <div class="pos-label">bottom</div>
+          </div>
+
+          <div class="pos-cell">
+            <div class="img-wrapper">
+              <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 300'%3E%3Crect width='400' height='300' fill='%236c63ff'/%3E%3Ccircle cx='200' cy='150' r='60' fill='%23fcd34d' stroke='%23fff' stroke-width='4'/%3E%3Ctext x='200' y='155' text-anchor='middle' fill='%231e293b' font-size='14' font-weight='bold'%3ELOGO%3C/text%3E%3C/svg%3E"
+                   alt="" class="ease-object-cover ease-object-left" />
+            </div>
+            <div class="pos-label">left</div>
+          </div>
+
+          <div class="pos-cell">
+            <div class="img-wrapper">
+              <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 300'%3E%3Crect width='400' height='300' fill='%236c63ff'/%3E%3Ccircle cx='200' cy='150' r='60' fill='%23fcd34d' stroke='%23fff' stroke-width='4'/%3E%3Ctext x='200' y='155' text-anchor='middle' fill='%231e293b' font-size='14' font-weight='bold'%3ELOGO%3C/text%3E%3C/svg%3E"
+                   alt="" class="ease-object-cover ease-object-right" />
+            </div>
+            <div class="pos-label">right</div>
+          </div>
+
+          <div class="pos-cell">
+            <div class="img-wrapper">
+              <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 300'%3E%3Crect width='400' height='300' fill='%236c63ff'/%3E%3Ccircle cx='200' cy='150' r='60' fill='%23fcd34d' stroke='%23fff' stroke-width='4'/%3E%3Ctext x='200' y='155' text-anchor='middle' fill='%231e293b' font-size='14' font-weight='bold'%3ELOGO%3C/text%3E%3C/svg%3E"
+                   alt="" class="ease-object-cover ease-object-center" />
+            </div>
+            <div class="pos-label">center</div>
+          </div>
+
+          <div class="pos-cell">
+            <div class="img-wrapper">
+              <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 300'%3E%3Crect width='400' height='300' fill='%236c63ff'/%3E%3Ccircle cx='200' cy='150' r='60' fill='%23fcd34d' stroke='%23fff' stroke-width='4'/%3E%3Ctext x='200' y='155' text-anchor='middle' fill='%231e293b' font-size='14' font-weight='bold'%3ELOGO%3C/text%3E%3C/svg%3E"
+                   alt="" class="ease-object-cover ease-object-left-top" />
+            </div>
+            <div class="pos-label">left-top</div>
+          </div>
+
+          <div class="pos-cell">
+            <div class="img-wrapper">
+              <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 300'%3E%3Crect width='400' height='300' fill='%236c63ff'/%3E%3Ccircle cx='200' cy='150' r='60' fill='%23fcd34d' stroke='%23fff' stroke-width='4'/%3E%3Ctext x='200' y='155' text-anchor='middle' fill='%231e293b' font-size='14' font-weight='bold'%3ELOGO%3C/text%3E%3C/svg%3E"
+                   alt="" class="ease-object-cover ease-object-right-top" />
+            </div>
+            <div class="pos-label">right-top</div>
+          </div>
+
+          <div class="pos-cell">
+            <div class="img-wrapper">
+              <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 300'%3E%3Crect width='400' height='300' fill='%236c63ff'/%3E%3Ccircle cx='200' cy='150' r='60' fill='%23fcd34d' stroke='%23fff' stroke-width='4'/%3E%3Ctext x='200' y='155' text-anchor='middle' fill='%231e293b' font-size='14' font-weight='bold'%3ELOGO%3C/text%3E%3C/svg%3E"
+                   alt="" class="ease-object-cover ease-object-left-bottom" />
+            </div>
+            <div class="pos-label">left-bottom</div>
+          </div>
+
+          <div class="pos-cell">
+            <div class="img-wrapper">
+              <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 300'%3E%3Crect width='400' height='300' fill='%236c63ff'/%3E%3Ccircle cx='200' cy='150' r='60' fill='%23fcd34d' stroke='%23fff' stroke-width='4'/%3E%3Ctext x='200' y='155' text-anchor='middle' fill='%231e293b' font-size='14' font-weight='bold'%3ELOGO%3C/text%3E%3C/svg%3E"
+                   alt="" class="ease-object-cover ease-object-right-bottom" />
+            </div>
+            <div class="pos-label">right-bottom</div>
+          </div>
+
+        </div>
+      </div>
+    </section>
+
+    <!-- ── Real-World Use Case: Card Thumbnails ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Use Case</span>
+      <h2>Card Thumbnails</h2>
+      <p>Without <code>.ease-object-cover</code>, images in cards distort or overflow. With it, they fill the thumbnail area cleanly.</p>
+
+      <div class="demo-card">
+        <div class="card-demo-row">
+
+          <div class="card-demo">
+            <div class="card-img">
+              <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 300'%3E%3Crect width='400' height='300' fill='%236c63ff'/%3E%3Ccircle cx='200' cy='150' r='60' fill='%23fcd34d' stroke='%23fff' stroke-width='4'/%3E%3Ctext x='200' y='268' text-anchor='middle' fill='%23fff' font-size='24' font-weight='bold' font-family='system-ui'%3E400×300%3C/text%3E%3Ctext x='200' y='155' text-anchor='middle' fill='%231e293b' font-size='14' font-weight='bold'%3ELOGO%3C/text%3E%3C/svg%3E"
+                   alt="" class="ease-object-cover" />
+            </div>
+            <div class="card-body">
+              <h4>Mountain Retreat</h4>
+              <p>With object-cover — fills perfectly</p>
+              <span class="badge">.ease-object-cover</span>
+            </div>
+          </div>
+
+          <div class="card-demo">
+            <div class="card-img">
+              <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 300'%3E%3Crect width='400' height='300' fill='%236c63ff'/%3E%3Ccircle cx='200' cy='150' r='60' fill='%23fcd34d' stroke='%23fff' stroke-width='4'/%3E%3Ctext x='200' y='268' text-anchor='middle' fill='%23fff' font-size='24' font-weight='bold' font-family='system-ui'%3E400×300%3C/text%3E%3Ctext x='200' y='155' text-anchor='middle' fill='%231e293b' font-size='14' font-weight='bold'%3ELOGO%3C/text%3E%3C/svg%3E"
+                   alt="" class="ease-object-contain" />
+            </div>
+            <div class="card-body">
+              <h4>Ocean View</h4>
+              <p>With object-contain — letterboxed</p>
+              <span class="badge">.ease-object-contain</span>
+            </div>
+          </div>
+
+          <div class="card-demo">
+            <div class="card-img">
+              <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 300'%3E%3Crect width='400' height='300' fill='%236c63ff'/%3E%3Ccircle cx='200' cy='150' r='60' fill='%23fcd34d' stroke='%23fff' stroke-width='4'/%3E%3Ctext x='200' y='268' text-anchor='middle' fill='%23fff' font-size='24' font-weight='bold' font-family='system-ui'%3E400×300%3C/text%3E%3Ctext x='200' y='155' text-anchor='middle' fill='%231e293b' font-size='14' font-weight='bold'%3ELOGO%3C/text%3E%3C/svg%3E"
+                   alt="" class="ease-object-cover ease-object-top" />
+            </div>
+            <div class="card-body">
+              <h4>City Sunset</h4>
+              <p>Top-aligned focal point</p>
+              <span class="badge">.ease-object-cover.ease-object-top</span>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </section>
+
+    <!-- ── Utility Reference Table ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Reference</span>
+      <h2>All Utility Classes</h2>
+
+      <div class="demo-card">
+        <h3>Object-Fit</h3>
+        <table class="utilities-table">
+          <thead>
+            <tr><th>Class</th><th>Value</th><th>Description</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>.ease-object-contain</td><td><code>contain</code></td><td>Fits inside container, may letterbox</td></tr>
+            <tr><td>.ease-object-cover</td><td><code>cover</code></td><td>Fills container, crops excess</td></tr>
+            <tr><td>.ease-object-fill</td><td><code>fill</code></td><td>Stretches to fill, may distort</td></tr>
+            <tr><td>.ease-object-none</td><td><code>none</code></td><td>Original size, no scaling</td></tr>
+            <tr><td>.ease-object-scale-down</td><td><code>scale-down</code></td><td>Smallest of none vs contain</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="demo-card">
+        <h3>Object-Position</h3>
+        <table class="utilities-table">
+          <thead>
+            <tr><th>Class</th><th>Value</th><th>Description</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>.ease-object-bottom</td><td><code>bottom</code></td><td>Align to bottom edge</td></tr>
+            <tr><td>.ease-object-center</td><td><code>center</code></td><td>Align to center (default)</td></tr>
+            <tr><td>.ease-object-left</td><td><code>left</code></td><td>Align to left edge</td></tr>
+            <tr><td>.ease-object-left-bottom</td><td><code>left bottom</code></td><td>Align to bottom-left corner</td></tr>
+            <tr><td>.ease-object-left-top</td><td><code>left top</code></td><td>Align to top-left corner</td></tr>
+            <tr><td>.ease-object-right</td><td><code>right</code></td><td>Align to right edge</td></tr>
+            <tr><td>.ease-object-right-bottom</td><td><code>right bottom</code></td><td>Align to bottom-right corner</td></tr>
+            <tr><td>.ease-object-right-top</td><td><code>right top</code></td><td>Align to top-right corner</td></tr>
+            <tr><td>.ease-object-top</td><td><code>top</code></td><td>Align to top edge</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+  </main>
+
+  <footer style="text-align:center;padding:2rem;border-top:1px solid #e2e8f0;margin-top:2rem;">
+    <p style="font-size:0.75rem;color:#64748b;">
+      <span class="ease-sr-only">End of demo.</span>
+      All images use inline SVGs (no external requests) &middot; All styles from <code>style.css</code>
+    </p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/core_changes-issue-22109/style.css
+++ b/submissions/core_changes-issue-22109/style.css
@@ -1,0 +1,456 @@
+/* ============================================================
+   Object-Fit & Object-Position Utility Classes
+   Submission for EaseMotion CSS · Issue #22109
+   ============================================================ */
+
+/* ════════════════════════════════════════════════════════════════
+   OBJECT-FIT UTILITIES
+   ════════════════════════════════════════════════════════════════ */
+
+.ease-object-contain   { object-fit: contain; }
+.ease-object-cover     { object-fit: cover; }
+.ease-object-fill      { object-fit: fill; }
+.ease-object-none      { object-fit: none; }
+.ease-object-scale-down { object-fit: scale-down; }
+
+/* ════════════════════════════════════════════════════════════════
+   OBJECT-POSITION UTILITIES
+   ════════════════════════════════════════════════════════════════ */
+
+.ease-object-bottom       { object-position: bottom; }
+.ease-object-center       { object-position: center; }
+.ease-object-left         { object-position: left; }
+.ease-object-left-bottom  { object-position: left bottom; }
+.ease-object-left-top     { object-position: left top; }
+.ease-object-right        { object-position: right; }
+.ease-object-right-bottom { object-position: right bottom; }
+.ease-object-right-top    { object-position: right top; }
+.ease-object-top          { object-position: top; }
+
+/* ════════════════════════════════════════════════════════════════
+   DEMO STYLES
+   ════════════════════════════════════════════════════════════════ */
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  min-height: 100vh;
+  padding: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #0f172a;
+    color: #f1f5f9;
+  }
+  .demo-card,
+  .demo-section-title {
+    background: #1e293b;
+    border-color: #334155;
+  }
+  .utilities-table th,
+  .utilities-table td {
+    border-color: #334155;
+  }
+  .utilities-table th {
+    background: #334155;
+  }
+  .utilities-table td {
+    background: #1e293b;
+    color: #e2e8f0;
+  }
+  .demo-card p,
+  .demo-note {
+    color: #94a3b8;
+  }
+}
+
+.demo-header {
+  background: linear-gradient(135deg, #6c63ff, #4b44cc);
+  color: #fff;
+  padding: 3rem 2rem;
+  text-align: center;
+}
+
+.demo-header h1 {
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+}
+
+.demo-header p {
+  font-size: 1rem;
+  opacity: 0.9;
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.demo-container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.demo-section {
+  margin-bottom: 3rem;
+}
+
+.demo-section-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #6c63ff;
+  margin-bottom: 0.5rem;
+  padding: 0.25rem 0.75rem;
+  background: #eef2ff;
+  border-radius: 999px;
+  display: inline-block;
+}
+
+.demo-section h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+.demo-section p {
+  font-size: 0.875rem;
+  line-height: 1.7;
+  color: #64748b;
+  margin-bottom: 1rem;
+}
+
+.demo-card {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.demo-card h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.demo-card p {
+  font-size: 0.875rem;
+  color: #475569;
+  line-height: 1.6;
+  margin-bottom: 0.5rem;
+}
+
+.demo-note {
+  font-size: 0.75rem;
+  color: #64748b;
+  font-style: italic;
+  margin-top: 0.5rem;
+}
+
+/* ── Object-fit Grid ── */
+
+.obj-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
+.obj-cell {
+  text-align: center;
+}
+
+.obj-cell .img-wrapper {
+  width: 100%;
+  height: 120px;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
+  margin-bottom: 0.4rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .obj-cell .img-wrapper {
+    background: #334155;
+    border-color: #475569;
+  }
+}
+
+.obj-cell .img-wrapper img {
+  width: 100%;
+  height: 100%;
+}
+
+.obj-cell .img-label {
+  font-size: 0.7rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 600;
+  color: #6c63ff;
+}
+
+.obj-cell .img-desc {
+  font-size: 0.65rem;
+  color: #94a3b8;
+  margin-top: 0.15rem;
+}
+
+/* ── Object-position Grid ── */
+
+.pos-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+  gap: 0.75rem;
+  margin: 1rem 0;
+}
+
+.pos-cell {
+  text-align: center;
+}
+
+.pos-cell .img-wrapper {
+  width: 100%;
+  height: 90px;
+  border-radius: 0.375rem;
+  overflow: hidden;
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
+}
+
+@media (prefers-color-scheme: dark) {
+  .pos-cell .img-wrapper {
+    background: #334155;
+    border-color: #475569;
+  }
+}
+
+.pos-cell .img-wrapper img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.pos-cell .pos-label {
+  font-size: 0.65rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 600;
+  color: #6c63ff;
+  margin-top: 0.25rem;
+}
+
+/* ── Comparison row ── */
+
+.compare-row {
+  display: flex;
+  gap: 1.5rem;
+  margin: 1rem 0;
+  flex-wrap: wrap;
+}
+
+.compare-item {
+  flex: 1;
+  min-width: 180px;
+}
+
+.compare-item h4 {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.compare-item .img-wrapper {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
+}
+
+@media (prefers-color-scheme: dark) {
+  .compare-item .img-wrapper {
+    background: #334155;
+    border-color: #475569;
+  }
+}
+
+.compare-item .img-wrapper img {
+  width: 100%;
+  height: 100%;
+}
+
+/* ── Card demo (card thumbnail use case) ── */
+
+.card-demo-row {
+  display: flex;
+  gap: 1.5rem;
+  margin: 1rem 0;
+  flex-wrap: wrap;
+}
+
+.card-demo {
+  flex: 1;
+  min-width: 200px;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  background: #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+  .card-demo {
+    background: #1e293b;
+    border-color: #334155;
+  }
+}
+
+.card-demo .card-img {
+  width: 100%;
+  height: 160px;
+  overflow: hidden;
+  background: #f1f5f9;
+}
+
+@media (prefers-color-scheme: dark) {
+  .card-demo .card-img {
+    background: #334155;
+  }
+}
+
+.card-demo .card-img img {
+  width: 100%;
+  height: 100%;
+}
+
+.card-demo .card-body {
+  padding: 0.75rem 1rem;
+}
+
+.card-demo .card-body h4 {
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.card-demo .card-body p {
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
+.card-demo .card-body .badge {
+  display: inline-block;
+  font-size: 0.6rem;
+  font-family: monospace;
+  padding: 0.2em 0.5em;
+  border-radius: 999px;
+  background: #eef2ff;
+  color: #6c63ff;
+  margin-top: 0.35rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .card-demo .card-body .badge {
+    background: #1e1b4b;
+    color: #a09af8;
+  }
+}
+
+/* ── Table ── */
+
+.utilities-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 0.8125rem;
+  margin: 1rem 0;
+}
+
+.utilities-table th,
+.utilities-table td {
+  padding: 0.6rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.utilities-table th {
+  font-weight: 600;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: #f1f5f9;
+  color: #64748b;
+}
+
+.utilities-table td:first-child {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  color: #6c63ff;
+  white-space: nowrap;
+}
+
+.utilities-table code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.7rem;
+  background: #f1f5f9;
+  padding: 0.15em 0.4em;
+  border-radius: 0.25rem;
+  color: #6c63ff;
+}
+
+/* ── Demo button ── */
+
+.demo-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1.2rem;
+  border-radius: 0.5rem;
+  border: 1px solid #e2e8f0;
+  background: #ffffff;
+  color: #1e293b;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.demo-btn:hover {
+  background: #f1f5f9;
+  border-color: #cbd5e1;
+}
+
+@media (prefers-color-scheme: dark) {
+  .demo-btn {
+    background: #334155;
+    border-color: #475569;
+    color: #f1f5f9;
+  }
+  .demo-btn:hover {
+    background: #475569;
+  }
+}
+
+/* ── SVG placeholder style for demo images ── */
+
+.demo-placeholder-svg {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  font-size: 0.6rem;
+  color: #64748b;
+  text-align: center;
+  padding: 0.25rem;
+  line-height: 1.3;
+}


### PR DESCRIPTION
### Summary

Adds `ease-object-*` utility classes for `object-fit` (contain, cover, fill, none, scale-down) and `object-position` (bottom, center, left, left-bottom, left-top, right, right-bottom, right-top, top) to control how replaced elements fill their containers.

### Changes

All changes in `submissions/core_changes-issue-22109/`:

- **`style.css`** — Core utilities:
  - 5 object-fit classes: `.ease-object-contain`, `.ease-object-cover`, `.ease-object-fill`, `.ease-object-none`, `.ease-object-scale-down`
  - 9 object-position classes: `.ease-object-bottom`, `.ease-object-center`, `.ease-object-left`, `.ease-object-left-bottom`, `.ease-object-left-top`, `.ease-object-right`, `.ease-object-right-bottom`, `.ease-object-right-top`, `.ease-object-top`
  - Demo card and gallery styles with dark mode support

- **`demo.html`** — Interactive demo:
  - Object-fit grid showing all 5 values applied to the same SVG image in identical 4:3 containers — visual comparison of contain vs cover vs fill vs none vs scale-down
  - Object-position grid showing all 9 position values with cover — see focal point shift (top, bottom, left, right, corners, center)
  - Card thumbnail use case: 3 cards comparing cover vs contain vs cover+top in real-world image card layout
  - Full reference tables for all utility classes
  - All images are inline SVGs (no external requests, works offline)

- **`README.md`** — Documentation with HTML examples and explanation

### How to Review

1. Open `demo.html` in a browser
2. See the object-fit comparison — same image, 5 different behaviors
3. Scroll to object-position grid — each cell shows a different focal point
4. Check the card thumbnails section — real-world usage with cover/contain/top
5. Reference tables at the bottom list all 14 utility classes

Closes #22109