### PR TITLE
[submission] Add aspect ratio utility classes (issue #22107)

### DIFF
--- a/submissions/core_changes-issue-22107/README.md
+++ b/submissions/core_changes-issue-22107/README.md
@@ -1,0 +1,33 @@
+# Aspect Ratio Utility Classes
+
+## What does this do?
+
+Adds `ease-aspect-*` utility classes for maintaining consistent proportions in images, videos, embeds, and cards using the CSS `aspect-ratio` property — making responsive media embeds and fixed-ratio containers a single class away.
+
+## How is it used?
+
+**Responsive YouTube embed:**
+
+```html
+<div class="ease-aspect-video">
+  <iframe src="https://www.youtube.com/embed/..." allowfullscreen></iframe>
+</div>
+```
+
+**Square avatar container:**
+
+```html
+<img class="ease-aspect-square" src="avatar.jpg" alt="" style="width: 200px;" />
+```
+
+**Card with consistent thumbnail ratio:**
+
+```html
+<div class="card">
+  <img class="ease-aspect-4/3" src="thumbnail.jpg" alt="" />
+</div>
+```
+
+## Why is it useful?
+
+Aspect ratio utilities are essential for responsive media. Without them, developers must either use the traditional padding-bottom hack or repeatedly write `aspect-ratio: 16/9`. These single-class utilities make responsive video embeds, image galleries, and card thumbnails trivial — complementing the object-fit utilities for complete media control.

--- a/submissions/core_changes-issue-22107/demo.html
+++ b/submissions/core_changes-issue-22107/demo.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Aspect Ratio Utilities — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="demo-header">
+    <h1>Aspect Ratio Utilities</h1>
+    <p>Maintain consistent proportions in images, videos, and embeds with a single class — no padding-bottom hacks needed.</p>
+  </header>
+
+  <main class="demo-container">
+
+    <!-- ── Aspect Ratio Grid ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Ratios</span>
+      <h2>Available Aspect Ratios</h2>
+      <p>Each box has a different <code>aspect-ratio</code> applied but the same width. The height is determined automatically by the ratio.</p>
+
+      <div class="demo-card">
+        <div class="aspect-grid">
+
+          <div class="aspect-cell">
+            <div class="ratio-box ease-aspect-square" style="background:#6c63ff;">
+              Square<br/>1:1
+            </div>
+            <span class="ratio-label">.ease-aspect-square</span>
+            <span class="ratio-desc">1 / 1</span>
+          </div>
+
+          <div class="aspect-cell">
+            <div class="ratio-box ease-aspect-video" style="background:#22c55e;">
+              Video<br/>16:9
+            </div>
+            <span class="ratio-label">.ease-aspect-video</span>
+            <span class="ratio-desc">16 / 9</span>
+          </div>
+
+          <div class="aspect-cell">
+            <div class="ratio-box ease-aspect-4\/3" style="background:#f59e0b;">
+              4:3
+            </div>
+            <span class="ratio-label">.ease-aspect-4/3</span>
+            <span class="ratio-desc">4 / 3</span>
+          </div>
+
+          <div class="aspect-cell">
+            <div class="ratio-box ease-aspect-3\/2" style="background:#ef4444;">
+              3:2
+            </div>
+            <span class="ratio-label">.ease-aspect-3/2</span>
+            <span class="ratio-desc">3 / 2</span>
+          </div>
+
+          <div class="aspect-cell">
+            <div class="ratio-box ease-aspect-21\/9" style="background:#a855f7;">
+              Ultrawide<br/>21:9
+            </div>
+            <span class="ratio-label">.ease-aspect-21/9</span>
+            <span class="ratio-desc">21 / 9</span>
+          </div>
+
+          <div class="aspect-cell">
+            <div class="ratio-box ease-aspect-1\/2" style="background:#3b82f6;">
+              Portrait<br/>1:2
+            </div>
+            <span class="ratio-label">.ease-aspect-1/2</span>
+            <span class="ratio-desc">1 / 2</span>
+          </div>
+
+        </div>
+        <div class="demo-note">Resize the browser — heights adjust automatically while widths fill the column.</div>
+      </div>
+    </section>
+
+    <!-- ── Video Embed ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Use Case 1</span>
+      <h2>Responsive Video Embeds</h2>
+      <p>Wrap an iframe (or any embed) in a container with <code>.ease-aspect-video</code> to get a perfect 16:9 responsive embed without the old padding-bottom trick.</p>
+
+      <div class="demo-card">
+        <div class="embed-demo">
+          <div class="embed-container ease-aspect-video">
+            <div class="embed-placeholder">
+              <div class="play-icon">&#9654;</div>
+              <span>YouTube Video Placeholder</span>
+              <span style="font-size:0.6rem;opacity:0.5;">iframe with .ease-aspect-video parent</span>
+            </div>
+          </div>
+        </div>
+        <div style="text-align:center;">
+          <span class="badge" style="display:inline-block;font-size:0.6rem;font-family:monospace;padding:0.2em 0.5em;border-radius:999px;background:#eef2ff;color:#6c63ff;margin-top:0.5rem;">.ease-aspect-video</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── Card Thumbnails ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Use Case 2</span>
+      <h2>Card Thumbnails with Consistent Ratios</h2>
+      <p>Each card below uses a different aspect ratio for its thumbnail — the images maintain their proportions regardless of card width.</p>
+
+      <div class="demo-card">
+        <div class="card-demo-row">
+
+          <div class="card-demo">
+            <div class="card-img ease-aspect-video">
+              <div class="ratio-placeholder" style="background:#6c63ff;">
+                16:9 Video Thumbnail
+              </div>
+            </div>
+            <div class="card-body">
+              <h4>Video Tutorial</h4>
+              <p>16:9 thumbnail with .ease-aspect-video</p>
+              <span class="badge">.ease-aspect-video</span>
+            </div>
+          </div>
+
+          <div class="card-demo">
+            <div class="card-img ease-aspect-square">
+              <div class="ratio-placeholder" style="background:#22c55e;">
+                1:1 Product Photo
+              </div>
+            </div>
+            <div class="card-body">
+              <h4>Product Card</h4>
+              <p>Square thumbnail with .ease-aspect-square</p>
+              <span class="badge">.ease-aspect-square</span>
+            </div>
+          </div>
+
+          <div class="card-demo">
+            <div class="card-img ease-aspect-4\/3">
+              <div class="ratio-placeholder" style="background:#f59e0b;">
+                4:3 Blog Cover
+              </div>
+            </div>
+            <div class="card-body">
+              <h4>Blog Post</h4>
+              <p>Classic 4:3 thumbnail with .ease-aspect-4/3</p>
+              <span class="badge">.ease-aspect-4/3</span>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </section>
+
+    <!-- ── Image Gallery ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Use Case 3</span>
+      <h2>Image Gallery Grid</h2>
+      <p>Mixed aspect ratios in a responsive grid — all images fill their cells without distortion.</p>
+
+      <div class="demo-card">
+        <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:0.75rem;">
+          <div class="ease-aspect-square" style="border-radius:0.5rem;overflow:hidden;background:#6c63ff;display:flex;align-items:center;justify-content:center;color:#fff;font-size:0.65rem;font-weight:600;">Square</div>
+          <div class="ease-aspect-video" style="border-radius:0.5rem;overflow:hidden;background:#22c55e;display:flex;align-items:center;justify-content:center;color:#fff;font-size:0.65rem;font-weight:600;">16:9</div>
+          <div class="ease-aspect-4\/3" style="border-radius:0.5rem;overflow:hidden;background:#f59e0b;display:flex;align-items:center;justify-content:center;color:#fff;font-size:0.65rem;font-weight:600;">4:3</div>
+          <div class="ease-aspect-square" style="border-radius:0.5rem;overflow:hidden;background:#ef4444;display:flex;align-items:center;justify-content:center;color:#fff;font-size:0.65rem;font-weight:600;">Square</div>
+          <div class="ease-aspect-3\/2" style="border-radius:0.5rem;overflow:hidden;background:#a855f7;display:flex;align-items:center;justify-content:center;color:#fff;font-size:0.65rem;font-weight:600;">3:2</div>
+          <div class="ease-aspect-21\/9" style="border-radius:0.5rem;overflow:hidden;background:#3b82f6;display:flex;align-items:center;justify-content:center;color:#fff;font-size:0.65rem;font-weight:600;">21:9</div>
+        </div>
+        <div class="demo-note">A mix of square, video, 4:3, 3:2, and ultrawide ratios in a responsive grid layout.</div>
+      </div>
+    </section>
+
+    <!-- ── Reference Table ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Reference</span>
+      <h2>All Utility Classes</h2>
+
+      <div class="demo-card">
+        <table class="utilities-table">
+          <thead>
+            <tr><th>Class</th><th>Ratio</th><th>Description</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>.ease-aspect-auto</td><td><code>auto</code></td><td>Default — no fixed ratio</td></tr>
+            <tr><td>.ease-aspect-square</td><td><code>1 / 1</code></td><td>Perfect square — avatars, thumbnails, galleries</td></tr>
+            <tr><td>.ease-aspect-video</td><td><code>16 / 9</code></td><td>Widescreen video — YouTube embeds, hero sections</td></tr>
+            <tr><td>.ease-aspect-4/3</td><td><code>4 / 3</code></td><td>Standard photo — cameras, tablets, presentations</td></tr>
+            <tr><td>.ease-aspect-3/2</td><td><code>3 / 2</code></td><td>Classic photo — DSLR cameras, prints</td></tr>
+            <tr><td>.ease-aspect-21/9</td><td><code>21 / 9</code></td><td>Ultrawide — cinema, panoramic banners</td></tr>
+            <tr><td>.ease-aspect-1/2</td><td><code>1 / 2</code></td><td>Portrait — mobile banners, Instagram Stories</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+  </main>
+
+  <footer style="text-align:center;padding:2rem;border-top:1px solid #e2e8f0;margin-top:2rem;">
+    <p style="font-size:0.75rem;color:#64748b;">
+      No external dependencies &middot; Works with images, videos, iframes, and any block-level element &middot; All styles from <code>style.css</code>
+    </p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/core_changes-issue-22107/style.css
+++ b/submissions/core_changes-issue-22107/style.css
@@ -1,0 +1,376 @@
+/* ============================================================
+   Aspect Ratio Utility Classes
+   Submission for EaseMotion CSS · Issue #22107
+   ============================================================ */
+
+/* ════════════════════════════════════════════════════════════════
+   ASPECT RATIO UTILITIES
+   Uses the native CSS aspect-ratio property (browser support:
+   Chrome 88+, Firefox 87+, Safari 15+, Edge 88+).
+   ════════════════════════════════════════════════════════════════ */
+
+.ease-aspect-auto   { aspect-ratio: auto; }
+.ease-aspect-square { aspect-ratio: 1 / 1; }
+.ease-aspect-video  { aspect-ratio: 16 / 9; }
+.ease-aspect-4\/3   { aspect-ratio: 4 / 3; }
+.ease-aspect-3\/2   { aspect-ratio: 3 / 2; }
+.ease-aspect-21\/9  { aspect-ratio: 21 / 9; }
+.ease-aspect-1\/2   { aspect-ratio: 1 / 2; }
+
+/* ════════════════════════════════════════════════════════════════
+   DEMO STYLES
+   ════════════════════════════════════════════════════════════════ */
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  min-height: 100vh;
+  padding: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #0f172a;
+    color: #f1f5f9;
+  }
+  .demo-card,
+  .demo-section-title {
+    background: #1e293b;
+    border-color: #334155;
+  }
+  .demo-card p,
+  .demo-note {
+    color: #94a3b8;
+  }
+  .demo-btn {
+    background: #334155;
+    border-color: #475569;
+    color: #f1f5f9;
+  }
+  .demo-btn:hover {
+    background: #475569;
+  }
+}
+
+.demo-header {
+  background: linear-gradient(135deg, #6c63ff, #4b44cc);
+  color: #fff;
+  padding: 3rem 2rem;
+  text-align: center;
+}
+
+.demo-header h1 {
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+}
+
+.demo-header p {
+  font-size: 1rem;
+  opacity: 0.9;
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.demo-container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.demo-section {
+  margin-bottom: 3rem;
+}
+
+.demo-section-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #6c63ff;
+  margin-bottom: 0.5rem;
+  padding: 0.25rem 0.75rem;
+  background: #eef2ff;
+  border-radius: 999px;
+  display: inline-block;
+}
+
+.demo-section h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+.demo-section > p {
+  font-size: 0.875rem;
+  line-height: 1.7;
+  color: #64748b;
+  margin-bottom: 1rem;
+}
+
+.demo-card {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.demo-card h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.demo-card p {
+  font-size: 0.875rem;
+  color: #475569;
+  line-height: 1.6;
+  margin-bottom: 0.5rem;
+}
+
+.demo-card p:last-child {
+  margin-bottom: 0;
+}
+
+.demo-note {
+  font-size: 0.75rem;
+  color: #64748b;
+  font-style: italic;
+  margin-top: 0.25rem;
+}
+
+/* ── Aspect Ratio Grid ── */
+
+.aspect-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
+.aspect-cell {
+  text-align: center;
+}
+
+.aspect-cell .ratio-box {
+  width: 100%;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-align: center;
+  line-height: 1.3;
+  padding: 0.5rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .aspect-cell .ratio-box {
+    background: #334155;
+    border-color: #475569;
+  }
+}
+
+.aspect-cell .ratio-label {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 0.7rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 600;
+  color: #6c63ff;
+}
+
+.aspect-cell .ratio-desc {
+  display: block;
+  font-size: 0.65rem;
+  color: #94a3b8;
+  margin-top: 0.1rem;
+}
+
+/* ── Card demo (card thumbnail ratios) ── */
+
+.card-demo-row {
+  display: flex;
+  gap: 1.5rem;
+  margin: 1rem 0;
+  flex-wrap: wrap;
+}
+
+.card-demo {
+  flex: 1;
+  min-width: 180px;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  background: #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+  .card-demo {
+    background: #1e293b;
+    border-color: #334155;
+  }
+}
+
+.card-demo .card-img {
+  overflow: hidden;
+  background: #f1f5f9;
+}
+
+@media (prefers-color-scheme: dark) {
+  .card-demo .card-img {
+    background: #334155;
+  }
+}
+
+.card-demo .card-img .ratio-placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-align: center;
+}
+
+.card-demo .card-body {
+  padding: 0.75rem 1rem;
+}
+
+.card-demo .card-body h4 {
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.card-demo .card-body p {
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
+.card-demo .card-body .badge {
+  display: inline-block;
+  font-size: 0.6rem;
+  font-family: monospace;
+  padding: 0.2em 0.5em;
+  border-radius: 999px;
+  background: #eef2ff;
+  color: #6c63ff;
+  margin-top: 0.35rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .card-demo .card-body .badge {
+    background: #1e1b4b;
+    color: #a09af8;
+  }
+}
+
+/* ── Embed demo (video) ── */
+
+.embed-demo {
+  max-width: 560px;
+  margin: 1rem auto;
+}
+
+.embed-demo .embed-container {
+  border-radius: 0.5rem;
+  overflow: hidden;
+  background: #1e293b;
+  position: relative;
+}
+
+.embed-demo .embed-container .embed-placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  color: #fff;
+  gap: 0.5rem;
+}
+
+.embed-demo .embed-container .embed-placeholder .play-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: rgba(255,255,255,0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+}
+
+.embed-demo .embed-container .embed-placeholder span {
+  font-size: 0.75rem;
+  opacity: 0.7;
+}
+
+/* ── Table ── */
+
+.utilities-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 0.8125rem;
+  margin: 1rem 0;
+}
+
+.utilities-table th,
+.utilities-table td {
+  padding: 0.6rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+@media (prefers-color-scheme: dark) {
+  .utilities-table th,
+  .utilities-table td {
+    border-color: #334155;
+  }
+}
+
+.utilities-table th {
+  font-weight: 600;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: #f1f5f9;
+  color: #64748b;
+}
+
+@media (prefers-color-scheme: dark) {
+  .utilities-table th {
+    background: #334155;
+    color: #94a3b8;
+  }
+}
+
+.utilities-table td:first-child {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  color: #6c63ff;
+  white-space: nowrap;
+}
+
+/* ── Width control ── */
+
+.w-40 { width: 40%; }
+@media (max-width: 640px) { .w-40 { width: 100%; } }


### PR DESCRIPTION
### Summary

Adds `ease-aspect-*` utility classes for maintaining consistent proportions in images, videos, embeds, and cards using the CSS `aspect-ratio` property.

### Changes

All changes in `submissions/core_changes-issue-22107/`:

- **`style.css`** — Core utilities:
  - 7 aspect ratio classes: `.ease-aspect-auto`, `.ease-aspect-square` (1:1), `.ease-aspect-video` (16:9), `.ease-aspect-4/3`, `.ease-aspect-3/2`, `.ease-aspect-21/9` (ultrawide), `.ease-aspect-1/2` (portrait)
  - Demo styles with dark mode support

- **`demo.html`** — Interactive demo:
  - Ratio grid: all 6 non-auto ratios displayed as colored boxes at the same width — heights determined purely by aspect-ratio
  - Responsive video embed (use case 1): 16:9 container simulating a YouTube embed
  - Card thumbnails (use case 2): 3 cards with different ratios (video, square, 4:3) showing real-world usage
  - Image gallery grid (use case 3): mixed ratios in a responsive grid layout
  - Full reference table
  - No external assets — all visual content is inline

- **`README.md`** — Documentation with HTML examples for embeds, avatars, and cards

### How to Review

1. Open `demo.html` in a browser
2. See the ratio grid — all boxes share the same width, heights vary by ratio class
3. Check the video embed demo — 16:9 container with play button overlay
4. Browse the card thumbnails — consistent ratios make the grid uniform
5. See the mixed-ratio gallery — different aspect ratios side by side
6. Resize the browser — all containers stay responsive

Closes #22107