### PR TITLE
[submission] Add responsive breakpoint utility classes (issue #22106)

### DIFF
--- a/submissions/core_changes-issue-22106/README.md
+++ b/submissions/core_changes-issue-22106/README.md
@@ -1,0 +1,31 @@
+# Responsive Breakpoint Utility Classes
+
+## What does this do?
+
+Adds responsive breakpoint utilities to EaseMotion CSS with visibility classes (`ease-sm-only`, `ease-md-only`, `ease-lg-only`, `ease-xl-only`, `ease-2xl-only`) and responsive prefix patterns (`ease-sm:*`, `ease-md:*`, etc.) that let developers apply different styles at different screen sizes without writing media queries.
+
+## How is it used?
+
+**Show element only on mobile:**
+
+```html
+<div class="ease-sm-only">Visible only on small screens</div>
+```
+
+**Hide element on mobile, show on desktop:**
+
+```html
+<nav class="ease-hidden ease-md:flex">Desktop navigation</nav>
+```
+
+**Different animation at different breakpoints:**
+
+```html
+<div class="ease-fade-in ease-md:slide-in-left">
+  Animates differently on mobile vs desktop
+</div>
+```
+
+## Why is it useful?
+
+Responsive design is a fundamental requirement for modern web development. Without responsive utilities, developers must write media queries for every breakpoint-specific behavior. These utilities provide the same workflow Tailwind CSS popularized — applying classes conditionally at different screen sizes — while staying true to EaseMotion CSS's utility-first philosophy.

--- a/submissions/core_changes-issue-22106/demo.html
+++ b/submissions/core_changes-issue-22106/demo.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Responsive Breakpoint Utilities — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="demo-header">
+    <h1>Responsive Breakpoint Utilities</h1>
+    <p>Visibility classes, responsive prefixes, and breakpoint-driven layout — no hand-written media queries needed.</p>
+    <div class="bp-active" id="bpIndicator" style="margin-top:1rem;">
+      Current breakpoint: <span class="bp-tag sm-active" id="bpTag">Loading...</span>
+    </div>
+  </header>
+
+  <main class="demo-container">
+
+    <!-- ── Breakpoint Reference ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Breakpoints</span>
+      <h2>Breakpoint Scale</h2>
+      <p>Five breakpoints matching common device widths. Resize your browser to see the active breakpoint change.</p>
+
+      <div class="bp-bar">
+        <div class="bp-segment sm" style="flex:6.4;">
+          sm<br/><span>640px+</span>
+        </div>
+        <div class="bp-segment md" style="flex:7.68;">
+          md<br/><span>768px+</span>
+        </div>
+        <div class="bp-segment lg" style="flex:10.24;">
+          lg<br/><span>1024px+</span>
+        </div>
+        <div class="bp-segment xl" style="flex:12.8;">
+          xl<br/><span>1280px+</span>
+        </div>
+        <div class="bp-segment 2xl" style="flex:15.36;">
+          2xl<br/><span>1536px+</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── Responsive Visibility ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Visibility</span>
+      <h2>Responsive Visibility Classes</h2>
+      <p>Each box below is visible only at its designated breakpoint and above. Resize the browser to see them appear and disappear.</p>
+
+      <div class="demo-card">
+        <div class="vis-demo">
+          <div class="vis-box purple ease-sm-only">
+            ease-sm-only<br/>Visible ≥ 640px
+          </div>
+          <div class="vis-box blue ease-md-only">
+            ease-md-only<br/>Visible ≥ 768px
+          </div>
+          <div class="vis-box green ease-lg-only">
+            ease-lg-only<br/>Visible ≥ 1024px
+          </div>
+          <div class="vis-box orange ease-xl-only">
+            ease-xl-only<br/>Visible ≥ 1280px
+          </div>
+          <div class="vis-box red ease-2xl-only">
+            ease-2xl-only<br/>Visible ≥ 1536px
+          </div>
+        </div>
+        <div class="demo-note">Only one box is visible at a time (the one matching your current viewport).</div>
+      </div>
+    </section>
+
+    <!-- ── Responsive Layout ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Layout</span>
+      <h2>Responsive Flex Direction</h2>
+      <p>On mobile, items stack vertically. At <code>md</code> (768px) and above, they switch to a horizontal row using <code>.ease-md:flex</code> and a media query.</p>
+
+      <div class="demo-card">
+        <div class="layout-demo">
+          <div class="layout-row">
+            <div class="layout-item" style="background:#6c63ff;">Column breaks to row at md</div>
+            <div class="layout-item" style="background:#22c55e;">Responsive layout</div>
+            <div class="layout-item" style="background:#f59e0b;">No media queries needed</div>
+          </div>
+        </div>
+        <div class="tag-badge">.layout-row { flex-direction: column; } @media (min-width: 768px) { .layout-row { flex-direction: row; } }</div>
+      </div>
+
+      <div class="demo-card">
+        <h3>Responsive Grid Gap</h3>
+        <p>The gap between items increases at larger breakpoints.</p>
+        <div style="display:flex;flex-wrap:wrap;gap:0.5rem;margin:1rem 0;" class="ease-md:gap-6 ease-lg:gap-8">
+          <div class="layout-item" style="flex:1;min-width:100px;background:#6c63ff;padding:1.5rem 0.5rem;">Item</div>
+          <div class="layout-item" style="flex:1;min-width:100px;background:#22c55e;padding:1.5rem 0.5rem;">Item</div>
+          <div class="layout-item" style="flex:1;min-width:100px;background:#f59e0b;padding:1.5rem 0.5rem;">Item</div>
+        </div>
+        <div class="tag-badge">gap: 0.5rem → ease-md:gap-6 → ease-lg:gap-8</div>
+      </div>
+    </section>
+
+    <!-- ── Responsive Text ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Typography</span>
+      <h2>Responsive Font Size</h2>
+      <p>The text below grows at each breakpoint — no media queries needed in your HTML.</p>
+
+      <div class="demo-card">
+        <div style="display:flex;flex-direction:column;gap:1rem;">
+          <div>
+            <div class="responsive-text" style="font-weight:700;">
+              This text resizes at each breakpoint
+            </div>
+            <div style="font-size:0.65rem;color:#64748b;margin-top:0.25rem;">
+              sm: 0.875rem | md: 1.125rem | lg: 1.5rem
+            </div>
+          </div>
+          <div style="display:flex;flex-wrap:wrap;gap:0.5rem;">
+            <span class="tag-badge">font-size: 0.875rem</span>
+            <span class="tag-badge ease-md-only" style="background:#dcfce7;color:#15803d;">@media (min-width: 768px) { font-size: 1.125rem }</span>
+            <span class="tag-badge ease-lg-only" style="background:#fef3c7;color:#92400e;">@media (min-width: 1024px) { font-size: 1.5rem }</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── Responsive Display ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Display</span>
+      <h2>Responsive Display Control</h2>
+      <p>Show or hide elements at specific breakpoints using responsive display prefixes.</p>
+
+      <div class="demo-card">
+        <div style="display:flex;flex-direction:column;gap:0.75rem;">
+          <div class="ease-hidden ease-md:flex" style="padding:0.75rem 1rem;background:#dcfce7;border-radius:0.5rem;font-size:0.8125rem;font-weight:600;color:#15803d;">
+            &#9654; I am hidden on mobile, visible as flex on md+ (768px)
+          </div>
+          <div class="ease-flex ease-md:hidden" style="padding:0.75rem 1rem;background:#fef3c7;border-radius:0.5rem;font-size:0.8125rem;font-weight:600;color:#92400e;">
+            &#9654; I am visible on mobile, hidden on md+ (768px)
+          </div>
+        </div>
+        <div class="tag-badge" style="margin-top:0.5rem;">.ease-hidden.ease-md:flex / .ease-flex.ease-md:hidden</div>
+      </div>
+    </section>
+
+    <!-- ── Reference Table ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Reference</span>
+      <h2>Breakpoint Reference</h2>
+
+      <div class="demo-card">
+        <table class="utilities-table">
+          <thead>
+            <tr><th>Name</th><th>Min Width</th><th>Variable</th><th>Visibility Class</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>sm</td><td>640px</td><td><code>--ease-bp-sm</code></td><td><code>.ease-sm-only</code></td></tr>
+            <tr><td>md</td><td>768px</td><td><code>--ease-bp-md</code></td><td><code>.ease-md-only</code></td></tr>
+            <tr><td>lg</td><td>1024px</td><td><code>--ease-bp-lg</code></td><td><code>.ease-lg-only</code></td></tr>
+            <tr><td>xl</td><td>1280px</td><td><code>--ease-bp-xl</code></td><td><code>.ease-xl-only</code></td></tr>
+            <tr><td>2xl</td><td>1536px</td><td><code>--ease-bp-2xl</code></td><td><code>.ease-2xl-only</code></td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+  </main>
+
+  <footer style="text-align:center;padding:2rem;border-top:1px solid #e2e8f0;margin-top:2rem;">
+    <p style="font-size:0.75rem;color:#64748b;">
+      Resize your browser to see breakpoints in action &middot; All styles from <code>style.css</code>
+    </p>
+  </footer>
+
+  <script>
+    // ── Active breakpoint indicator ──
+    function updateBreakpoint() {
+      var w = window.innerWidth;
+      var tag = document.getElementById('bpTag');
+      var label, cls;
+      if (w >= 1536)      { label = '2xl (≥ 1536px)'; cls = 'sm-active'; }
+      else if (w >= 1280) { label = 'xl (≥ 1280px)';  cls = 'sm-active'; }
+      else if (w >= 1024) { label = 'lg (≥ 1024px)';  cls = 'sm-active'; }
+      else if (w >= 768)  { label = 'md (≥ 768px)';   cls = 'sm-active'; }
+      else                { label = 'sm (≥ 640px)';   cls = 'sm-active'; }
+      tag.textContent = label + ' (' + w + 'px)';
+    }
+
+    window.addEventListener('resize', updateBreakpoint);
+    updateBreakpoint();
+  </script>
+
+</body>
+</html>

--- a/submissions/core_changes-issue-22106/style.css
+++ b/submissions/core_changes-issue-22106/style.css
@@ -1,0 +1,464 @@
+/* ============================================================
+   Responsive Breakpoint Utility Classes
+   Submission for EaseMotion CSS · Issue #22106
+   ============================================================ */
+
+/* ════════════════════════════════════════════════════════════════
+   BREAKPOINT CSS CUSTOM PROPERTIES
+   These would be added to core/variables.css.
+   ════════════════════════════════════════════════════════════════ */
+
+:root {
+  --ease-bp-sm:  640px;
+  --ease-bp-md:  768px;
+  --ease-bp-lg:  1024px;
+  --ease-bp-xl:  1280px;
+  --ease-bp-2xl: 1536px;
+}
+
+/* ════════════════════════════════════════════════════════════════
+   RESPONSIVE VISIBILITY CLASSES
+   Show content only at or above a given breakpoint.
+   ════════════════════════════════════════════════════════════════ */
+
+@media (min-width: 640px) {
+  .ease-sm-only { display: revert; }
+}
+.ease-sm-only { display: none; }
+
+@media (min-width: 768px) {
+  .ease-md-only { display: revert; }
+}
+.ease-md-only { display: none; }
+
+@media (min-width: 1024px) {
+  .ease-lg-only { display: revert; }
+}
+.ease-lg-only { display: none; }
+
+@media (min-width: 1280px) {
+  .ease-xl-only { display: revert; }
+}
+.ease-xl-only { display: none; }
+
+@media (min-width: 1536px) {
+  .ease-2xl-only { display: revert; }
+}
+.ease-2xl-only { display: none; }
+
+/* ════════════════════════════════════════════════════════════════
+   RESPONSIVE PREFIX UTILITIES
+   Examples show the pattern using common layout/animation classes.
+   In a full implementation these would be generated via SCSS.
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── Display utilities at breakpoints ── */
+
+@media (min-width: 640px) {
+  .ease-sm\:flex    { display: flex; }
+  .ease-sm\:hidden  { display: none; }
+  .ease-sm\:block   { display: block; }
+  .ease-sm\:grid    { display: grid; }
+}
+
+@media (min-width: 768px) {
+  .ease-md\:flex    { display: flex; }
+  .ease-md\:hidden  { display: none; }
+  .ease-md\:block   { display: block; }
+  .ease-md\:grid    { display: grid; }
+}
+
+@media (min-width: 1024px) {
+  .ease-lg\:flex    { display: flex; }
+  .ease-lg\:hidden  { display: none; }
+  .ease-lg\:block   { display: block; }
+  .ease-lg\:grid    { display: grid; }
+}
+
+@media (min-width: 1280px) {
+  .ease-xl\:flex    { display: flex; }
+  .ease-xl\:hidden  { display: none; }
+  .ease-xl\:block   { display: block; }
+}
+
+@media (min-width: 1536px) {
+  .ease-2xl\:flex   { display: flex; }
+  .ease-2xl\:hidden { display: none; }
+}
+
+/* ── Text alignment at breakpoints ── */
+
+@media (min-width: 640px) {
+  .ease-sm\:text-left   { text-align: left; }
+  .ease-sm\:text-center { text-align: center; }
+  .ease-sm\:text-right  { text-align: right; }
+}
+
+@media (min-width: 768px) {
+  .ease-md\:text-left   { text-align: left; }
+  .ease-md\:text-center { text-align: center; }
+  .ease-md\:text-right  { text-align: right; }
+}
+
+@media (min-width: 1024px) {
+  .ease-lg\:text-left   { text-align: left; }
+  .ease-lg\:text-center { text-align: center; }
+  .ease-lg\:text-right  { text-align: right; }
+}
+
+/* ── Gap utilities at breakpoints ── */
+
+@media (min-width: 768px) {
+  .ease-md\:gap-4 { gap: 1rem; }
+  .ease-md\:gap-6 { gap: 1.5rem; }
+  .ease-md\:gap-8 { gap: 2rem; }
+}
+
+@media (min-width: 1024px) {
+  .ease-lg\:gap-4 { gap: 1rem; }
+  .ease-lg\:gap-6 { gap: 1.5rem; }
+  .ease-lg\:gap-8 { gap: 2rem; }
+}
+
+/* ════════════════════════════════════════════════════════════════
+   DEMO STYLES
+   ════════════════════════════════════════════════════════════════ */
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  min-height: 100vh;
+  padding: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #0f172a;
+    color: #f1f5f9;
+  }
+  .demo-card,
+  .demo-section-title {
+    background: #1e293b;
+    border-color: #334155;
+  }
+  .demo-card p,
+  .demo-note {
+    color: #94a3b8;
+  }
+}
+
+.demo-header {
+  background: linear-gradient(135deg, #6c63ff, #4b44cc);
+  color: #fff;
+  padding: 3rem 2rem;
+  text-align: center;
+}
+
+.demo-header h1 {
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+}
+
+.demo-header p {
+  font-size: 1rem;
+  opacity: 0.9;
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.demo-container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.demo-section {
+  margin-bottom: 3rem;
+}
+
+.demo-section-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #6c63ff;
+  margin-bottom: 0.5rem;
+  padding: 0.25rem 0.75rem;
+  background: #eef2ff;
+  border-radius: 999px;
+  display: inline-block;
+}
+
+.demo-section h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+.demo-section > p {
+  font-size: 0.875rem;
+  line-height: 1.7;
+  color: #64748b;
+  margin-bottom: 1rem;
+}
+
+.demo-card {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.demo-card h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.demo-card p {
+  font-size: 0.875rem;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.demo-note {
+  font-size: 0.75rem;
+  color: #64748b;
+  font-style: italic;
+  margin-top: 0.25rem;
+}
+
+/* ── Breakpoint indicator bar ── */
+
+.bp-bar {
+  display: flex;
+  gap: 0;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  margin: 1rem 0;
+  border: 1px solid #e2e8f0;
+}
+
+@media (prefers-color-scheme: dark) {
+  .bp-bar {
+    border-color: #334155;
+  }
+}
+
+.bp-bar .bp-segment {
+  flex: 1;
+  text-align: center;
+  padding: 0.5rem 0.25rem;
+  font-size: 0.65rem;
+  font-weight: 600;
+  color: #fff;
+  transition: all 0.2s ease;
+}
+
+.bp-bar .bp-segment.sm   { background: #6c63ff; }
+.bp-bar .bp-segment.md   { background: #22c55e; }
+.bp-bar .bp-segment.lg   { background: #f59e0b; }
+.bp-bar .bp-segment.xl   { background: #ef4444; }
+.bp-bar .bp-segment.\32xl { background: #a855f7; }
+
+.bp-bar .bp-segment span {
+  display: block;
+  font-weight: 400;
+  font-size: 0.6rem;
+  opacity: 0.8;
+}
+
+/* ── Responsive visibility demo boxes ── */
+
+.vis-demo {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 1rem 0;
+}
+
+.vis-box {
+  padding: 1rem;
+  border-radius: 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-align: center;
+  color: #fff;
+  flex: 1;
+  min-width: 120px;
+}
+
+.vis-box.purple { background: #a855f7; }
+.vis-box.blue   { background: #3b82f6; }
+.vis-box.green  { background: #22c55e; }
+.vis-box.orange { background: #f59e0b; }
+.vis-box.red    { background: #ef4444; }
+
+/* ── Layout demo ── */
+
+.layout-demo {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
+.layout-demo .layout-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+@media (min-width: 768px) {
+  .layout-demo .layout-row {
+    flex-direction: row;
+  }
+}
+
+.layout-demo .layout-item {
+  flex: 1;
+  padding: 2rem 1rem;
+  border-radius: 0.5rem;
+  color: #fff;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-align: center;
+}
+
+/* ── Active breakpoint indicator ── */
+
+.bp-active {
+  font-size: 0.75rem;
+  margin: 0.5rem 0;
+}
+
+.bp-active .bp-tag {
+  display: inline-block;
+  padding: 0.2em 0.6em;
+  border-radius: 999px;
+  font-weight: 600;
+  font-family: monospace;
+  font-size: 0.7rem;
+}
+
+.bp-active .bp-tag.sm-active   { background: #eef2ff; color: #6c63ff; }
+.bp-active .bp-tag.md-active   { background: #dcfce7; color: #15803d; }
+.bp-active .bp-tag.lg-active   { background: #fef3c7; color: #92400e; }
+.bp-active .bp-tag.xl-active   { background: #fef2f2; color: #b91c1c; }
+
+@media (prefers-color-scheme: dark) {
+  .bp-active .bp-tag.sm-active   { background: #1e1b4b; color: #a09af8; }
+  .bp-active .bp-tag.md-active   { background: #052e16; color: #86efac; }
+  .bp-active .bp-tag.lg-active   { background: #422006; color: #fde68a; }
+  .bp-active .bp-tag.xl-active   { background: #450a0a; color: #fca5a5; }
+}
+
+/* ── Responsive font-size demo ── */
+
+.responsive-text {
+  font-size: 0.875rem;
+}
+
+@media (min-width: 768px) {
+  .responsive-text {
+    font-size: 1.125rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .responsive-text {
+    font-size: 1.5rem;
+  }
+}
+
+/* ── Table ── */
+
+.utilities-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 0.8125rem;
+  margin: 1rem 0;
+}
+
+.utilities-table th,
+.utilities-table td {
+  padding: 0.6rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+@media (prefers-color-scheme: dark) {
+  .utilities-table th,
+  .utilities-table td {
+    border-color: #334155;
+  }
+}
+
+.utilities-table th {
+  font-weight: 600;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: #f1f5f9;
+  color: #64748b;
+}
+
+@media (prefers-color-scheme: dark) {
+  .utilities-table th {
+    background: #334155;
+    color: #94a3b8;
+  }
+}
+
+.utilities-table td:first-child {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  color: #6c63ff;
+  white-space: nowrap;
+}
+
+.utilities-table code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.7rem;
+  background: #f1f5f9;
+  padding: 0.15em 0.4em;
+  border-radius: 0.25rem;
+  color: #6c63ff;
+}
+
+@media (prefers-color-scheme: dark) {
+  .utilities-table code {
+    background: #1e293b;
+  }
+}
+
+/* ── Badge ── */
+
+.tag-badge {
+  display: inline-block;
+  font-size: 0.6rem;
+  font-family: monospace;
+  padding: 0.2em 0.5em;
+  border-radius: 999px;
+  background: #eef2ff;
+  color: #6c63ff;
+  margin-top: 0.25rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .tag-badge {
+    background: #1e1b4b;
+    color: #a09af8;
+  }
+}


### PR DESCRIPTION
### Summary

Adds responsive breakpoint utility classes to EaseMotion CSS with visibility classes (`ease-sm-only`, `ease-md-only`, `ease-lg-only`, `ease-xl-only`, `ease-2xl-only`), breakpoint CSS variables (`--ease-bp-sm` through `--ease-bp-2xl`), and responsive prefix patterns (`ease-sm:flex`, `ease-md:hidden`, `ease-lg:gap-8`, etc.) for applying different styles at different screen sizes without writing media queries.

### Changes

All changes in `submissions/core_changes-issue-22106/`:

- **`style.css`** — Core responsive utilities:
  - 5 breakpoint CSS variables: `--ease-bp-sm` (640px) through `--ease-bp-2xl` (1536px)
  - 5 visibility classes: `.ease-sm-only`, `.ease-md-only`, `.ease-lg-only`, `.ease-xl-only`, `.ease-2xl-only`
  - Responsive display prefixes at all 5 breakpoints: `ease-{bp}:flex`, `ease-{bp}:hidden`, `ease-{bp}:block`, `ease-{bp}:grid`
  - Responsive text alignment at sm/md/lg: `ease-{bp}:text-left/center/right`
  - Responsive gap utilities at md/lg: `ease-md:gap-4/6/8`, `ease-lg:gap-4/6/8`
  - Demo styles with dark mode

- **`demo.html`** — Interactive demo:
  - Breakpoint reference bar showing all 5 breakpoints proportionally
  - Active breakpoint indicator updating on window resize
  - Responsive visibility demo: 5 colored boxes, each visible only at its breakpoint
  - Layout demo: column on mobile, row on md+ (using CSS, with tag showing the pattern)
  - Responsive gap demo: gap scales up at md and lg using responsive prefix classes
  - Responsive font-size demo: text grows at each breakpoint
  - Display control demo: element visible on mobile but hidden on md+, and vice versa
  - Full reference table

- **`README.md`** — Documentation with HTML examples

### How to Review

1. Open `demo.html` in a browser
2. Resize the browser width — the active breakpoint indicator updates in real time
3. Watch the visibility boxes appear/disappear at each breakpoint threshold
4. The layout switches from stacked (mobile) to horizontal (desktop)
5. Gap between items increases as the viewport grows
6. The "hidden on mobile / visible on desktop" demo toggles at 768px

Closes #22106