### PR TITLE
[Feat] #17972 — KPI Stat Cards with Grid Layout, Icons, Trend Badges & Sparklines

### DIFF
--- a/submissions/examples/17972-stat-cards-kpi/README.md
+++ b/submissions/examples/17972-stat-cards-kpi/README.md
@@ -1,0 +1,80 @@
+# KPI Stat Cards
+
+> **Issue:** [#17972](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/17972)  
+> **Category:** Enhancement · Animation · CSS Grid  
+> **Level:** Intermediate
+
+---
+
+## Overview
+
+Upgrades plain, full-width stat blocks into polished KPI cards with:
+- **CSS Grid layout** — responsive 4-col → 2-col → 1-col
+- **Icon badges** with per-card accent colors
+- **Trend indicators** (up / down / neutral) with directional arrows and percentage
+- **Sparkline bar charts** using CSS custom property `--h` for bar height
+- **Hover animations** — lift, accent border glow, icon bounce, color transition
+- **Animated counter** via `IntersectionObserver` + `setInterval`
+
+---
+
+## Demos Included
+
+| Demo | Description |
+|------|-------------|
+| **Library Overview** | 4 EaseMotion stat cards (Utilities, Animations, Dependencies, Contributors) with sparklines |
+| **Dashboard KPI Row** | Compact 4-column row suitable for a dashboard header |
+
+---
+
+## Files
+
+```
+submissions/examples/17972-stat-cards-kpi/
+├── demo.html   — Full showcase with 2 demo variants
+├── style.css   — All component styling, no inline styles
+└── README.md   — This file
+```
+
+---
+
+## CSS Techniques
+
+| Technique | Implementation |
+|-----------|----------------|
+| Responsive grid | `grid-template-columns: repeat(auto-fit, minmax(240px, 1fr))` |
+| Per-card accent colors | CSS custom properties `--card-accent`, `--card-accent-light` |
+| Hover lift | `transform: translateY(-6px)` + `box-shadow` transition |
+| Accent border glow | `box-shadow: 0 0 0 1px var(--card-accent)` on hover |
+| Icon bounce | `transform: scale(1.1) rotate(-5deg)` on hover |
+| Accent stripe | `::before` pseudo-element, left edge, opacity 0→1 on hover |
+| Sparkline bars | Flex row of `div`s with `height: var(--h)` |
+| Number counter | `IntersectionObserver` + JS `setInterval` |
+
+---
+
+## Usage
+
+```html
+<div class="stat-card stat-card--blue">
+  <div class="stat-card__header">
+    <div class="stat-icon stat-icon--blue"><!-- SVG icon --></div>
+    <div class="trend-badge trend-badge--up">+12%</div>
+  </div>
+  <div class="stat-card__value" data-target="84">0</div>
+  <div class="stat-card__label">Utility Classes</div>
+  <div class="stat-card__sub">vs. 75 last month</div>
+  <div class="stat-sparkline">
+    <div class="sparkline-bar" style="--h: 60%"></div>
+    <div class="sparkline-bar active" style="--h: 100%"></div>
+  </div>
+</div>
+```
+
+Available color variants: `stat-card--blue`, `--purple`, `--green`, `--orange`, `--red`
+
+---
+
+## Browser Support
+
+All modern browsers. CSS Grid and custom properties supported in Chrome, Firefox, Safari, Edge.

--- a/submissions/examples/17972-stat-cards-kpi/demo.html
+++ b/submissions/examples/17972-stat-cards-kpi/demo.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>KPI Stat Cards — EaseMotion</title>
+  <meta name="description" content="An enhanced, grid-based KPI stat card component with icons, trend indicators, and smooth hover animations. Part of the EaseMotion CSS library." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="glow-sphere sphere-1" aria-hidden="true"></div>
+  <div class="glow-sphere sphere-2" aria-hidden="true"></div>
+
+  <header class="app-header">
+    <nav class="nav-container">
+      <a href="../../" class="logo"><span class="logo-dot"></span>EaseMotion</a>
+      <div class="nav-menu">
+        <a href="../../" class="nav-link">Home</a>
+        <a href="../../submissions/" class="nav-link">Examples</a>
+        <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css" class="nav-link" target="_blank" rel="noopener">GitHub</a>
+      </div>
+      <button class="dark-mode-toggle" id="themeToggle" aria-label="Toggle dark mode">
+        <svg class="moon-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z" /></svg>
+        <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" /></svg>
+      </button>
+    </nav>
+  </header>
+
+  <main class="showcase-container">
+    <section class="hero-section">
+      <span class="badge">Enhancement &middot; CSS Grid &middot; Animations</span>
+      <h1 class="hero-title">KPI Stat&nbsp;Cards</h1>
+      <p class="hero-subtitle">An upgraded stat card component: from flat full-width blocks to a polished grid layout with icon badges, trend indicators, sparkline bars, and smooth hover interactions.</p>
+    </section>
+
+    <section class="demo-section">
+      <h2 class="section-title">Library Overview</h2>
+      <p class="section-desc">The EaseMotion library stats as proper KPI cards &mdash; hover to see the interaction.</p>
+      <div class="stat-grid">
+        <div class="stat-card stat-card--blue">
+          <div class="stat-card__header">
+            <div class="stat-icon stat-icon--blue">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M11.42 15.17 17.25 21A2.652 2.652 0 0 0 21 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 1 1-3.586-3.586l5.654-4.654m5.14-5.306 2.626 2.626m-5.14 5.306-5.14-5.306m5.14 5.306 2.626-2.626M12 12l.01-.01"/></svg>
+            </div>
+            <div class="trend-badge trend-badge--up"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="trend-icon"><path fill-rule="evenodd" d="M10 17a.75.75 0 0 1-.75-.75V5.612L5.29 9.77a.75.75 0 0 1-1.08-1.04l5.25-5.5a.75.75 0 0 1 1.08 0l5.25 5.5a.75.75 0 1 1-1.08 1.04l-3.96-4.158V16.25A.75.75 0 0 1 10 17Z" clip-rule="evenodd"/></svg>+12%</div>
+          </div>
+          <div class="stat-card__value" data-target="84">0</div>
+          <div class="stat-card__label">Utility Classes</div>
+          <div class="stat-card__sub">vs. 75 last month</div>
+          <div class="stat-sparkline" aria-hidden="true">
+            <div class="sparkline-bar" style="--h:40%"></div><div class="sparkline-bar" style="--h:55%"></div><div class="sparkline-bar" style="--h:48%"></div><div class="sparkline-bar" style="--h:62%"></div><div class="sparkline-bar" style="--h:70%"></div><div class="sparkline-bar" style="--h:65%"></div><div class="sparkline-bar" style="--h:80%"></div><div class="sparkline-bar active" style="--h:100%"></div>
+          </div>
+        </div>
+
+        <div class="stat-card stat-card--purple">
+          <div class="stat-card__header">
+            <div class="stat-icon stat-icon--purple">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09Z" /></svg>
+            </div>
+            <div class="trend-badge trend-badge--up"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="trend-icon"><path fill-rule="evenodd" d="M10 17a.75.75 0 0 1-.75-.75V5.612L5.29 9.77a.75.75 0 0 1-1.08-1.04l5.25-5.5a.75.75 0 0 1 1.08 0l5.25 5.5a.75.75 0 1 1-1.08 1.04l-3.96-4.158V16.25A.75.75 0 0 1 10 17Z" clip-rule="evenodd"/></svg>+28%</div>
+          </div>
+          <div class="stat-card__value" data-target="36">0</div>
+          <div class="stat-card__label">Animations</div>
+          <div class="stat-card__sub">vs. 28 last month</div>
+          <div class="stat-sparkline" aria-hidden="true">
+            <div class="sparkline-bar" style="--h:30%"></div><div class="sparkline-bar" style="--h:42%"></div><div class="sparkline-bar" style="--h:38%"></div><div class="sparkline-bar" style="--h:55%"></div><div class="sparkline-bar" style="--h:60%"></div><div class="sparkline-bar" style="--h:72%"></div><div class="sparkline-bar" style="--h:85%"></div><div class="sparkline-bar active" style="--h:100%"></div>
+          </div>
+        </div>
+
+        <div class="stat-card stat-card--green">
+          <div class="stat-card__header">
+            <div class="stat-icon stat-icon--green">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" /></svg>
+            </div>
+            <div class="trend-badge trend-badge--neutral"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="trend-icon"><path fill-rule="evenodd" d="M4 10a.75.75 0 0 1 .75-.75h10.5a.75.75 0 0 1 0 1.5H4.75A.75.75 0 0 1 4 10Z" clip-rule="evenodd" /></svg>0%</div>
+          </div>
+          <div class="stat-card__value" data-target="0">0</div>
+          <div class="stat-card__label">Dependencies</div>
+          <div class="stat-card__sub">Pure CSS &mdash; no deps ever</div>
+          <div class="stat-sparkline" aria-hidden="true">
+            <div class="sparkline-bar" style="--h:20%"></div><div class="sparkline-bar" style="--h:20%"></div><div class="sparkline-bar" style="--h:20%"></div><div class="sparkline-bar" style="--h:20%"></div><div class="sparkline-bar" style="--h:20%"></div><div class="sparkline-bar" style="--h:20%"></div><div class="sparkline-bar" style="--h:20%"></div><div class="sparkline-bar active" style="--h:20%"></div>
+          </div>
+        </div>
+
+        <div class="stat-card stat-card--orange">
+          <div class="stat-card__header">
+            <div class="stat-icon stat-icon--orange">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15 19.128a9.38 9.38 0 0 0 2.625.372 9.337 9.337 0 0 0 4.121-.952 4.125 4.125 0 0 0-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 0 1 8.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0 1 11.964-3.07M12 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0Zm8.25 2.25a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z" /></svg>
+            </div>
+            <div class="trend-badge trend-badge--up"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="trend-icon"><path fill-rule="evenodd" d="M10 17a.75.75 0 0 1-.75-.75V5.612L5.29 9.77a.75.75 0 0 1-1.08-1.04l5.25-5.5a.75.75 0 0 1 1.08 0l5.25 5.5a.75.75 0 1 1-1.08 1.04l-3.96-4.158V16.25A.75.75 0 0 1 10 17Z" clip-rule="evenodd"/></svg>+41%</div>
+          </div>
+          <div class="stat-card__value" data-target="247">0</div>
+          <div class="stat-card__label">Contributors</div>
+          <div class="stat-card__sub">vs. 175 last month</div>
+          <div class="stat-sparkline" aria-hidden="true">
+            <div class="sparkline-bar" style="--h:25%"></div><div class="sparkline-bar" style="--h:35%"></div><div class="sparkline-bar" style="--h:42%"></div><div class="sparkline-bar" style="--h:50%"></div><div class="sparkline-bar" style="--h:60%"></div><div class="sparkline-bar" style="--h:75%"></div><div class="sparkline-bar" style="--h:88%"></div><div class="sparkline-bar active" style="--h:100%"></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <h2 class="section-title">Dashboard KPI Row</h2>
+      <p class="section-desc">A compact 4-column row of KPI cards ideal for a dashboard header.</p>
+      <div class="stat-grid stat-grid--compact">
+        <div class="stat-card stat-card--compact stat-card--blue">
+          <div class="stat-card__header">
+            <div class="stat-icon stat-icon--sm stat-icon--blue"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18 9 11.25l4.306 4.306a11.95 11.95 0 0 1 5.814-5.518l2.74-1.22m0 0-5.94-2.281m5.94 2.28-2.28 5.941" /></svg></div>
+            <div class="trend-badge trend-badge--up trend-badge--sm">+8.2%</div>
+          </div>
+          <div class="stat-card__value stat-card__value--lg" data-target="12480">0</div>
+          <div class="stat-card__label">Monthly Views</div>
+        </div>
+        <div class="stat-card stat-card--compact stat-card--purple">
+          <div class="stat-card__header">
+            <div class="stat-icon stat-icon--sm stat-icon--purple"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" /><path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7Z" /></svg></div>
+            <div class="trend-badge trend-badge--up trend-badge--sm">+5.1%</div>
+          </div>
+          <div class="stat-card__value stat-card__value--lg" data-target="3920">0</div>
+          <div class="stat-card__label">Unique Visitors</div>
+        </div>
+        <div class="stat-card stat-card--compact stat-card--red">
+          <div class="stat-card__header">
+            <div class="stat-icon stat-icon--sm stat-icon--red"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 6 9 12.75l4.286-4.286a11.948 11.948 0 0 1 4.306 6.43l.776 2.898m0 0 3.182-5.511m-3.182 5.51-5.511-3.181" /></svg></div>
+            <div class="trend-badge trend-badge--down trend-badge--sm">-2.4%</div>
+          </div>
+          <div class="stat-card__value stat-card__value--lg" data-target="58">0</div>
+          <div class="stat-card__label">Bounce Rate %</div>
+        </div>
+        <div class="stat-card stat-card--compact stat-card--green">
+          <div class="stat-card__header">
+            <div class="stat-icon stat-icon--sm stat-icon--green"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.563.563 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z" /></svg></div>
+            <div class="trend-badge trend-badge--up trend-badge--sm">+0.3</div>
+          </div>
+          <div class="stat-card__value stat-card__value--lg" data-target="48">0</div>
+          <div class="stat-card__label stat-card__label--raw">4.8 / 5.0 Rating</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <h2 class="section-title">CSS Techniques Used</h2>
+      <p class="section-desc">The hover lift effect, trend badges, and sparkline bars are all pure CSS.</p>
+      <div class="code-block-wrapper"><pre>
+<span class="token-comment">/* Hover lift + glow */</span>
+<span class="token-selector">.stat-card:hover</span> {
+  <span class="token-property">transform</span>: <span class="token-value">translateY(-6px)</span>;
+  <span class="token-property">box-shadow</span>: <span class="token-value">var(--ease-card-hover-shadow), 0 0 0 1px var(--card-accent)</span>;
+}
+
+<span class="token-comment">/* Sparkline bars via CSS custom property */</span>
+<span class="token-selector">.sparkline-bar</span> {
+  <span class="token-property">height</span>: <span class="token-value">var(--h, 50%)</span>;
+}
+
+<span class="token-comment">/* Number counter animation (JS IntersectionObserver) */</span>
+<span class="token-selector">.stat-card__value</span> {
+  <span class="token-property">font-variant-numeric</span>: <span class="token-value">tabular-nums</span>;
+}</pre></div>
+    </section>
+  </main>
+
+  <footer class="app-footer">
+    <p>KPI Stat Cards &middot; <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/17972" target="_blank" rel="noopener">Issue #17972</a> &middot; Part of the <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css" target="_blank" rel="noopener">EaseMotion CSS</a> library</p>
+  </footer>
+
+  <script>
+    const toggle = document.getElementById('themeToggle');
+    const html = document.documentElement;
+    if (localStorage.getItem('theme') === 'dark') html.classList.add('dark');
+    toggle.addEventListener('click', () => {
+      html.classList.toggle('dark');
+      localStorage.setItem('theme', html.classList.contains('dark') ? 'dark' : 'light');
+    });
+
+    function animateCount(el) {
+      const target = parseInt(el.dataset.target, 10);
+      if (isNaN(target) || target === 0) return;
+      const duration = 1200;
+      const step = 16;
+      const increment = target / (duration / step);
+      let current = 0;
+      const timer = setInterval(() => {
+        current = Math.min(current + increment, target);
+        el.textContent = Math.floor(current).toLocaleString();
+        if (current >= target) clearInterval(timer);
+      }, step);
+    }
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          animateCount(entry.target);
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.3 });
+
+    document.querySelectorAll('.stat-card__value[data-target]').forEach(el => observer.observe(el));
+  </script>
+</body>
+</html>

--- a/submissions/examples/17972-stat-cards-kpi/style.css
+++ b/submissions/examples/17972-stat-cards-kpi/style.css
@@ -1,0 +1,241 @@
+/* ============================================================
+   EaseMotion — KPI Stat Cards
+   Issue: #17972
+   Enhancement: Grid layout, icon badges, trend indicators,
+   sparkline bars, hover lift/glow, counter animation
+   ============================================================ */
+
+:root {
+  --ease-font-sans: 'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --ease-font-mono: 'Space Grotesk', monospace;
+  --ease-bg: hsl(220, 20%, 97%);
+  --ease-panel-bg: hsl(0, 0%, 100%);
+  --ease-border: hsl(220, 15%, 90%);
+  --ease-text: hsl(222, 47%, 11%);
+  --ease-text-muted: hsl(220, 10%, 40%);
+  --ease-primary: hsl(221, 83%, 53%);
+  --ease-primary-text: hsl(0, 0%, 100%);
+  --ease-card-shadow: 0 4px 20px -2px rgba(0, 0, 0, 0.05), 0 2px 8px -1px rgba(0, 0, 0, 0.02);
+  --ease-card-hover-shadow: 0 24px 48px -8px rgba(0, 0, 0, 0.1), 0 8px 20px -4px rgba(0, 0, 0, 0.04);
+}
+
+html.dark {
+  --ease-bg: hsl(222, 47%, 6%);
+  --ease-panel-bg: hsl(222, 47%, 10%);
+  --ease-border: hsl(222, 40%, 16%);
+  --ease-text: hsl(210, 40%, 98%);
+  --ease-text-muted: hsl(215, 20%, 65%);
+  --ease-primary: hsl(217, 91%, 60%);
+  --ease-card-shadow: 0 4px 20px -2px rgba(0, 0, 0, 0.3), 0 2px 8px -1px rgba(0, 0, 0, 0.2);
+  --ease-card-hover-shadow: 0 24px 48px -8px rgba(0, 0, 0, 0.5), 0 8px 20px -4px rgba(0, 0, 0, 0.3);
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: var(--ease-font-sans);
+  background-color: var(--ease-bg);
+  color: var(--ease-text);
+  line-height: 1.6;
+  min-height: 100vh;
+  position: relative;
+  overflow-x: hidden;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.glow-sphere { position: absolute; width: 500px; height: 500px; border-radius: 50%; filter: blur(100px); opacity: 0.15; z-index: -2; pointer-events: none; }
+.sphere-1 { background: radial-gradient(circle, var(--ease-primary) 0%, transparent 70%); top: -100px; right: -100px; }
+.sphere-2 { background: radial-gradient(circle, hsl(280, 80%, 60%) 0%, transparent 70%); bottom: -150px; left: -150px; }
+
+.app-header { border-bottom: 1px solid var(--ease-border); background: rgba(255,255,255,0.01); backdrop-filter: blur(12px); position: sticky; top: 0; z-index: 50; }
+.nav-container { max-width: 1200px; margin: 0 auto; padding: 1.25rem 2rem; display: flex; justify-content: space-between; align-items: center; }
+.logo { display: flex; align-items: center; gap: 0.5rem; text-decoration: none; font-family: var(--ease-font-mono); font-weight: 700; font-size: 1.25rem; color: var(--ease-text); }
+.logo-dot { width: 10px; height: 10px; border-radius: 50%; background-color: var(--ease-primary); }
+.nav-menu { display: flex; gap: 0.5rem; }
+.nav-link { text-decoration: none; font-size: 0.9rem; font-weight: 500; color: var(--ease-text-muted); padding: 0.4rem 0.9rem; border-radius: 9999px; transition: color 0.2s, background 0.2s; }
+.nav-link:hover { color: var(--ease-text); background: var(--ease-border); }
+.dark-mode-toggle { background: none; border: 1px solid var(--ease-border); padding: 0.5rem; border-radius: 50%; cursor: pointer; color: var(--ease-text); display: flex; align-items: center; justify-content: center; width: 38px; height: 38px; transition: border-color 0.2s; }
+.dark-mode-toggle:hover { border-color: var(--ease-primary); }
+.dark-mode-toggle svg { width: 18px; height: 18px; }
+.sun-icon { display: none; }
+html.dark .sun-icon { display: block; }
+html.dark .moon-icon { display: none; }
+
+.showcase-container { max-width: 1200px; margin: 0 auto; padding: 4rem 2rem; }
+.hero-section { text-align: center; max-width: 700px; margin: 0 auto 5rem; }
+.badge { display: inline-block; padding: 0.25rem 0.75rem; border-radius: 9999px; font-size: 0.8rem; font-weight: 600; background-color: rgba(59,130,246,0.1); color: var(--ease-primary); margin-bottom: 1rem; border: 1px solid rgba(59,130,246,0.15); }
+.hero-title { font-size: 3.5rem; font-weight: 800; letter-spacing: -0.03em; margin-bottom: 1.25rem; line-height: 1.1; }
+.hero-subtitle { font-size: 1.1rem; color: var(--ease-text-muted); line-height: 1.7; }
+.demo-section { margin-bottom: 5rem; }
+.section-title { font-size: 1.75rem; font-weight: 700; margin-bottom: 0.5rem; }
+.section-desc { color: var(--ease-text-muted); margin-bottom: 2rem; }
+
+/* ============================================================
+   CORE: Stat Card Component
+   ============================================================ */
+
+.stat-card--blue   { --card-accent: hsl(221,83%,53%); --card-accent-light: hsl(221,83%,96%); }
+.stat-card--purple { --card-accent: hsl(262,83%,58%); --card-accent-light: hsl(262,83%,96%); }
+.stat-card--green  { --card-accent: hsl(142,71%,45%); --card-accent-light: hsl(142,71%,95%); }
+.stat-card--orange { --card-accent: hsl(25,95%,53%);  --card-accent-light: hsl(25,95%,95%);  }
+.stat-card--red    { --card-accent: hsl(0,72%,51%);   --card-accent-light: hsl(0,72%,95%);   }
+
+html.dark .stat-card--blue   { --card-accent-light: hsl(221,83%,14%); }
+html.dark .stat-card--purple { --card-accent-light: hsl(262,83%,14%); }
+html.dark .stat-card--green  { --card-accent-light: hsl(142,71%,10%); }
+html.dark .stat-card--orange { --card-accent-light: hsl(25,95%,11%);  }
+html.dark .stat-card--red    { --card-accent-light: hsl(0,72%,11%);   }
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+.stat-grid--compact {
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.stat-card {
+  background-color: var(--ease-panel-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 20px;
+  padding: 1.75rem;
+  box-shadow: var(--ease-card-shadow);
+  transition:
+    transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    border-color 0.3s;
+  position: relative;
+  overflow: hidden;
+  cursor: default;
+}
+
+.stat-card::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 20%;
+  bottom: 20%;
+  width: 3px;
+  border-radius: 0 3px 3px 0;
+  background: var(--card-accent, var(--ease-primary));
+  opacity: 0;
+  transition: opacity 0.3s, top 0.3s, bottom 0.3s;
+}
+
+.stat-card:hover {
+  transform: translateY(-6px);
+  box-shadow: var(--ease-card-hover-shadow), 0 0 0 1px var(--card-accent, var(--ease-primary));
+  border-color: transparent;
+}
+
+.stat-card:hover::before { opacity: 1; top: 10%; bottom: 10%; }
+
+.stat-card--compact { padding: 1.25rem 1.5rem; border-radius: 16px; }
+
+.stat-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.25rem;
+}
+
+.stat-icon {
+  width: 46px;
+  height: 46px;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--card-accent-light);
+  color: var(--card-accent);
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), background 0.3s;
+  flex-shrink: 0;
+}
+.stat-icon svg { width: 22px; height: 22px; }
+.stat-icon--sm { width: 36px; height: 36px; border-radius: 10px; }
+.stat-icon--sm svg { width: 18px; height: 18px; }
+
+.stat-card:hover .stat-icon { transform: scale(1.1) rotate(-5deg); }
+
+.trend-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.3rem 0.65rem;
+  border-radius: 9999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  font-family: var(--ease-font-mono);
+  letter-spacing: -0.01em;
+}
+.trend-icon { width: 12px; height: 12px; }
+
+.trend-badge--up { background: hsl(142,71%,94%); color: hsl(142,71%,32%); }
+html.dark .trend-badge--up { background: hsl(142,71%,10%); color: hsl(142,71%,58%); }
+.trend-badge--down { background: hsl(0,72%,94%); color: hsl(0,72%,42%); }
+html.dark .trend-badge--down { background: hsl(0,72%,11%); color: hsl(0,72%,65%); }
+.trend-badge--neutral { background: var(--ease-border); color: var(--ease-text-muted); }
+.trend-badge--sm { padding: 0.2rem 0.5rem; font-size: 0.72rem; }
+
+.stat-card__value {
+  font-size: 2.5rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  line-height: 1;
+  margin-bottom: 0.4rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--ease-text);
+  transition: color 0.3s;
+}
+.stat-card__value--lg { font-size: 2rem; }
+.stat-card:hover .stat-card__value { color: var(--card-accent, var(--ease-primary)); }
+
+.stat-card__label { font-size: 0.88rem; font-weight: 600; color: var(--ease-text-muted); text-transform: uppercase; letter-spacing: 0.04em; margin-bottom: 0.25rem; }
+.stat-card__label--raw { text-transform: none; letter-spacing: 0; font-size: 0.85rem; }
+.stat-card__sub { font-size: 0.8rem; color: var(--ease-text-muted); margin-bottom: 1.25rem; }
+
+.stat-sparkline {
+  display: flex;
+  align-items: flex-end;
+  gap: 3px;
+  height: 36px;
+  margin-top: 0.5rem;
+}
+
+.sparkline-bar {
+  flex: 1;
+  background: var(--card-accent-light);
+  border-radius: 3px 3px 0 0;
+  height: var(--h, 50%);
+  transition: height 0.5s cubic-bezier(0.4, 0, 0.2, 1), background 0.3s;
+}
+.sparkline-bar.active { background: var(--card-accent); }
+.stat-card:hover .sparkline-bar { opacity: 0.7; }
+.stat-card:hover .sparkline-bar.active { background: var(--card-accent); opacity: 1; }
+
+.code-block-wrapper { background-color: var(--ease-panel-bg); border: 1px solid var(--ease-border); border-radius: 16px; padding: 2rem; overflow-x: auto; font-family: var(--ease-font-mono); font-size: 0.9rem; }
+.code-block-wrapper pre { white-space: pre; line-height: 1.8; }
+.token-comment { color: var(--ease-text-muted); font-style: italic; }
+.token-selector { color: hsl(295,70%,55%); }
+.token-property { color: hsl(207,90%,50%); }
+.token-value { color: hsl(140,60%,45%); }
+html.dark .token-selector { color: hsl(295,75%,70%); }
+html.dark .token-property { color: hsl(207,95%,70%); }
+html.dark .token-value { color: hsl(140,70%,60%); }
+
+footer.app-footer { text-align: center; padding: 3rem; border-top: 1px solid var(--ease-border); color: var(--ease-text-muted); font-size: 0.9rem; }
+footer.app-footer a { color: var(--ease-primary); text-decoration: none; }
+footer.app-footer a:hover { text-decoration: underline; }
+
+@media (max-width: 768px) {
+  .hero-title { font-size: 2.25rem; }
+  .nav-menu { display: none; }
+  .stat-grid { grid-template-columns: repeat(2, 1fr); gap: 1rem; }
+  .stat-grid--compact { grid-template-columns: repeat(2, 1fr); }
+  .stat-card__value { font-size: 2rem; }
+}
+@media (max-width: 480px) {
+  .stat-grid, .stat-grid--compact { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
## Summary
Upgrades the plain, full-width stat card blocks (Utilities, Animations, Dependencies) into a polished KPI card grid. The redesign introduces CSS Grid for a responsive 4→2→1 column layout, per-card accent color theming via CSS custom properties, icon badge with hover bounce animation, trend indicator badges (up/down/neutral), sparkline bar charts using the `--h` CSS custom property for bar heights, a left-edge accent stripe visible on hover, and an animated number counter powered by `IntersectionObserver`.

## Root Cause
The original stat blocks were unstyled full-width elements that provided no visual hierarchy, iconography, trend context, or interactivity; this submission adds a full KPI card design as a self-contained EaseMotion example.

## Changes Made
- `submissions/examples/17972-stat-cards-kpi/demo.html`: Two demo sections — a 4-card library overview grid (Utilities, Animations, Dependencies, Contributors with sparklines) and a compact 4-column dashboard KPI row. Dark mode support included. Zero inline styles.
- `submissions/examples/17972-stat-cards-kpi/style.css`: Full component stylesheet — CSS Grid layout, per-card `--card-accent` and `--card-accent-light` custom properties, `.stat-card` hover lift + glow + stripe, `.stat-icon` bounce, `.trend-badge` (up/down/neutral), `.stat-sparkline` bar chart, `.stat-card__value` tabular-nums counter, responsive breakpoints for mobile.
- `submissions/examples/17972-stat-cards-kpi/README.md`: Documentation covering overview, demos, CSS techniques table, usage snippet, and browser support.

## How to Test
1. Open `submissions/examples/17972-stat-cards-kpi/demo.html` in any modern browser.
2. Verify the cards render in a responsive grid (4 columns on desktop, 2 on tablet, 1 on mobile).
3. Hover over each card — it should lift, show an accent border glow, the icon should bounce, the value should change color to the accent.
4. Scroll to the section — number counters should animate from 0 to their target values.
5. Toggle dark mode — all cards, badges, and sparklines should update correctly.
6. Verify no inline style attributes exist on `.stat-card` or child elements (only `--h` custom property on sparkline bars is in inline `style` as a data value, which is the intended CSS technique).

## Related Issue
Closes #17972