### PR TITLE
[submission] Add stagger animation utility for sequenced child elements (issue #22102)

### DIFF
--- a/submissions/core_changes-issue-22102/README.md
+++ b/submissions/core_changes-issue-22102/README.md
@@ -1,0 +1,32 @@
+# Stagger Animation Utility
+
+## What does this do?
+
+Adds a stagger animation utility that automatically applies sequenced delays to child elements — creating ripple-like reveal effects for lists, grids, and galleries with a single parent class and no manual delay calculations.
+
+## How is it used?
+
+**Staggered fade-in for a grid:**
+
+```html
+<div class="ease-stagger ease-stagger-fade-in">
+  <div>Item 1</div>
+  <div>Item 2</div>
+  <div>Item 3</div>
+  <div>Item 4</div>
+</div>
+```
+
+**Custom stagger delay:**
+
+```html
+<div class="ease-stagger-200 ease-stagger-slide-in-up">
+  <div>Item 1</div>
+  <div>Item 2</div>
+  <div>Item 3</div>
+</div>
+```
+
+## Why is it useful?
+
+Stagger animations are one of the most common UI patterns — every list reveal, grid entrance, and accordion benefits from sequenced timing. Without a built-in utility, developers must manually calculate and apply `animation-delay` to every child element. This utility automates the entire process using CSS custom properties and optional IntersectionObserver-based JS for viewport-triggered reveals.

--- a/submissions/core_changes-issue-22102/demo.html
+++ b/submissions/core_changes-issue-22102/demo.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Stagger Animation Utility — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="demo-header">
+    <h1>Stagger Animation Utility</h1>
+    <p>Sequenced child element animations — a single parent class creates ripple-like reveals without manual delay calculations.</p>
+  </header>
+
+  <main class="demo-container">
+
+    <!-- ── Stagger Fade In ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Fade In</span>
+      <h2>ease-stagger-fade-in</h2>
+      <p>Each child fades in sequentially with a 100ms delay between items. The stagger starts when the element is scrolled into view.</p>
+
+      <div class="demo-card">
+        <div class="stagger-grid ease-stagger ease-stagger-fade-in" data-stagger>
+          <div class="stagger-item" style="background:#6c63ff;"><span class="num">1</span>Item 1</div>
+          <div class="stagger-item" style="background:#7c3aed;"><span class="num">2</span>Item 2</div>
+          <div class="stagger-item" style="background:#8b5cf6;"><span class="num">3</span>Item 3</div>
+          <div class="stagger-item" style="background:#a78bfa;"><span class="num">4</span>Item 4</div>
+          <div class="stagger-item" style="background:#6c63ff;"><span class="num">5</span>Item 5</div>
+          <div class="stagger-item" style="background:#7c3aed;"><span class="num">6</span>Item 6</div>
+          <div class="stagger-item" style="background:#8b5cf6;"><span class="num">7</span>Item 7</div>
+          <div class="stagger-item" style="background:#a78bfa;"><span class="num">8</span>Item 8</div>
+        </div>
+        <span class="tag-badge">.ease-stagger.ease-stagger-fade-in</span>
+      </div>
+    </section>
+
+    <!-- ── Stagger Slide In ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Slide In</span>
+      <h2>ease-stagger-slide-in-up</h2>
+      <p>Items slide up from below while fading in — a common pattern for list reveals and card grids.</p>
+
+      <div class="demo-card">
+        <div class="stagger-grid ease-stagger ease-stagger-slide-in-up" data-stagger>
+          <div class="stagger-item" style="background:#22c55e;"><span class="num">1</span>Card</div>
+          <div class="stagger-item" style="background:#16a34a;"><span class="num">2</span>Card</div>
+          <div class="stagger-item" style="background:#15803d;"><span class="num">3</span>Card</div>
+          <div class="stagger-item" style="background:#166534;"><span class="num">4</span>Card</div>
+          <div class="stagger-item" style="background:#14532d;"><span class="num">5</span>Card</div>
+          <div class="stagger-item" style="background:#22c55e;"><span class="num">6</span>Card</div>
+          <div class="stagger-item" style="background:#16a34a;"><span class="num">7</span>Card</div>
+          <div class="stagger-item" style="background:#15803d;"><span class="num">8</span>Card</div>
+        </div>
+        <span class="tag-badge">.ease-stagger.ease-stagger-slide-in-up</span>
+      </div>
+    </section>
+
+    <!-- ── Stagger Delay Comparison ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Delay Variants</span>
+      <h2>Custom Stagger Speeds</h2>
+      <p>Use <code>.ease-stagger-200</code>, <code>.ease-stagger-300</code>, or <code>.ease-stagger-500</code> to control the delay increment between children.</p>
+
+      <div class="demo-card">
+        <div class="compare-row">
+          <div class="compare-col">
+            <h4>100ms (default)</h4>
+            <div class="ease-stagger-100 ease-stagger-scale-in" data-stagger>
+              <div class="stagger-item" style="background:#f59e0b;"><span class="num">1</span></div>
+              <div class="stagger-item" style="background:#d97706;"><span class="num">2</span></div>
+              <div class="stagger-item" style="background:#b45309;"><span class="num">3</span></div>
+              <div class="stagger-item" style="background:#92400e;"><span class="num">4</span></div>
+            </div>
+          </div>
+          <div class="compare-col">
+            <h4>200ms</h4>
+            <div class="ease-stagger-200 ease-stagger-scale-in" data-stagger>
+              <div class="stagger-item" style="background:#3b82f6;"><span class="num">1</span></div>
+              <div class="stagger-item" style="background:#2563eb;"><span class="num">2</span></div>
+              <div class="stagger-item" style="background:#1d4ed8;"><span class="num">3</span></div>
+              <div class="stagger-item" style="background:#1e40af;"><span class="num">4</span></div>
+            </div>
+          </div>
+          <div class="compare-col">
+            <h4>300ms</h4>
+            <div class="ease-stagger-300 ease-stagger-scale-in" data-stagger>
+              <div class="stagger-item" style="background:#ef4444;"><span class="num">1</span></div>
+              <div class="stagger-item" style="background:#dc2626;"><span class="num">2</span></div>
+              <div class="stagger-item" style="background:#b91c1c;"><span class="num">3</span></div>
+              <div class="stagger-item" style="background:#991b1b;"><span class="num">4</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="demo-note">All three use <code>ease-stagger-scale-in</code> but with different delay increments. Click "Replay" to see them side by side.</div>
+        <button class="replay-btn" id="replayBtn" style="margin-top:0.75rem;padding:0.4rem 1rem;border-radius:0.5rem;border:1px solid #e2e8f0;background:#fff;font-size:0.8125rem;font-weight:500;cursor:pointer;">&#8635; Replay All</button>
+      </div>
+    </section>
+
+    <!-- ── Horizontal List ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Variants</span>
+      <h2>Slide In Left (Horizontal List)</h2>
+      <p>A horizontal row where items slide in from the left one after another.</p>
+
+      <div class="demo-card">
+        <div class="stagger-list ease-stagger ease-stagger-slide-in-left" data-stagger>
+          <div class="stagger-item" style="background:#a855f7;">First</div>
+          <div class="stagger-item" style="background:#9333ea;">Second</div>
+          <div class="stagger-item" style="background:#7e22ce;">Third</div>
+          <div class="stagger-item" style="background:#6b21a8;">Fourth</div>
+          <div class="stagger-item" style="background:#581c87;">Fifth</div>
+        </div>
+        <span class="tag-badge">.ease-stagger.ease-stagger-slide-in-left</span>
+      </div>
+    </section>
+
+    <!-- ── Reference Table ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Reference</span>
+      <h2>All Stagger Classes</h2>
+
+      <div class="demo-card">
+        <table class="utilities-table">
+          <thead>
+            <tr><th>Class</th><th>Delay Increment</th><th>Animation</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>.ease-stagger</td><td>100ms</td><td>Configured via compound class</td></tr>
+            <tr><td>.ease-stagger-100</td><td>100ms</td><td>Fast stagger</td></tr>
+            <tr><td>.ease-stagger-200</td><td>200ms</td><td>Medium stagger</td></tr>
+            <tr><td>.ease-stagger-300</td><td>300ms</td><td>Slow stagger</td></tr>
+            <tr><td>.ease-stagger-500</td><td>500ms</td><td>Very slow stagger</td></tr>
+            <tr><td>.ease-stagger-fade-in</td><td>100ms</td><td>Fade in only</td></tr>
+            <tr><td>.ease-stagger-fade-in-down</td><td>100ms</td><td>Fade in from top</td></tr>
+            <tr><td>.ease-stagger-fade-in-up</td><td>100ms</td><td>Fade in from bottom</td></tr>
+            <tr><td>.ease-stagger-slide-in-up</td><td>100ms</td><td>Slide up + fade in</td></tr>
+            <tr><td>.ease-stagger-slide-in-left</td><td>100ms</td><td>Slide left + fade in</td></tr>
+            <tr><td>.ease-stagger-scale-in</td><td>100ms</td><td>Scale in + fade in</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+  </main>
+
+  <footer style="text-align:center;padding:2rem;border-top:1px solid #e2e8f0;margin-top:2rem;">
+    <p style="font-size:0.75rem;color:#64748b;">
+      Scroll into view to trigger stagger animations &middot; All styles from <code>style.css</code>
+    </p>
+  </footer>
+
+  <script>
+    // ── Stagger JS: Assign custom property --ease-stagger-delay to each child ──
+    (function() {
+      var containers = document.querySelectorAll('[data-stagger]');
+
+      containers.forEach(function(container) {
+        var children = container.children;
+        var increment = 100; // default
+
+        // Detect increment from class
+        if (container.classList.contains('ease-stagger-100')) increment = 100;
+        else if (container.classList.contains('ease-stagger-200')) increment = 200;
+        else if (container.classList.contains('ease-stagger-300')) increment = 300;
+        else if (container.classList.contains('ease-stagger-500')) increment = 500;
+
+        Array.from(children).forEach(function(child, index) {
+          var delay = 0;
+          if (container.classList.contains('ease-stagger')) {
+            delay = index * increment;
+          }
+          child.style.setProperty('--ease-stagger-delay', delay + 'ms');
+        });
+      });
+    })();
+
+    // ── Replay button ──
+    document.getElementById('replayBtn').addEventListener('click', function() {
+      var staggerEls = document.querySelectorAll('[data-stagger] .stagger-item');
+      staggerEls.forEach(function(el) {
+        el.style.animation = 'none';
+        void el.offsetHeight;
+        el.style.animation = '';
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/core_changes-issue-22102/style.css
+++ b/submissions/core_changes-issue-22102/style.css
@@ -1,0 +1,352 @@
+/* ============================================================
+   Stagger Animation Utility
+   Submission for EaseMotion CSS · Issue #22102
+   ============================================================ */
+
+/* ════════════════════════════════════════════════════════════════
+   CORE STAGGER UTILITY
+   ════════════════════════════════════════════════════════════════ */
+
+/*
+ * .ease-stagger — enables stagger on child elements.
+ * Each child gets a progressively larger animation-delay via the
+ * CSS custom property --ease-stagger-delay, set by JavaScript.
+ * Default delay increment is 100ms between children.
+ */
+.ease-stagger > *,
+.ease-stagger-100 > *,
+.ease-stagger-200 > *,
+.ease-stagger-300 > *,
+.ease-stagger-500 > * {
+  animation-delay: var(--ease-stagger-delay, 0ms);
+}
+
+/* Delay increment variants (applied to children by JS) */
+.ease-stagger-100 { --ease-stagger-increment: 100ms; }
+.ease-stagger-200 { --ease-stagger-increment: 200ms; }
+.ease-stagger-300 { --ease-stagger-increment: 300ms; }
+.ease-stagger-500 { --ease-stagger-increment: 500ms; }
+
+/* Compound stagger + animation classes */
+.ease-stagger-fade-in > *,
+.ease-stagger-fade-in-down > *,
+.ease-stagger-fade-in-up > * {
+  opacity: 0;
+  animation-fill-mode: both;
+}
+
+.ease-stagger-fade-in > * {
+  animation: ease-kf-stagger-fade-in 0.5s ease-out forwards;
+}
+
+.ease-stagger-fade-in-down > * {
+  animation: ease-kf-stagger-fade-in-down 0.5s ease-out forwards;
+}
+
+.ease-stagger-fade-in-up > * {
+  animation: ease-kf-stagger-fade-in-up 0.5s ease-out forwards;
+}
+
+.ease-stagger-slide-in-up > * {
+  opacity: 0;
+  animation: ease-kf-stagger-slide-up 0.5s ease-out forwards;
+  animation-fill-mode: both;
+}
+
+.ease-stagger-slide-in-left > * {
+  opacity: 0;
+  animation: ease-kf-stagger-slide-left 0.5s ease-out forwards;
+  animation-fill-mode: both;
+}
+
+.ease-stagger-scale-in > * {
+  opacity: 0;
+  animation: ease-kf-stagger-scale-in 0.4s ease-out forwards;
+  animation-fill-mode: both;
+}
+
+/* ════════════════════════════════════════════════════════════════
+   STAGGER KEYFRAMES
+   ════════════════════════════════════════════════════════════════ */
+
+@keyframes ease-kf-stagger-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes ease-kf-stagger-fade-in-down {
+  from { opacity: 0; transform: translateY(-10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes ease-kf-stagger-fade-in-up {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes ease-kf-stagger-slide-up {
+  from { opacity: 0; transform: translateY(20px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes ease-kf-stagger-slide-left {
+  from { opacity: 0; transform: translateX(20px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes ease-kf-stagger-scale-in {
+  from { opacity: 0; transform: scale(0.8); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+/* ════════════════════════════════════════════════════════════════
+   DEMO STYLES
+   ════════════════════════════════════════════════════════════════ */
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  min-height: 100vh;
+  padding: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #0f172a;
+    color: #f1f5f9;
+  }
+  .demo-card,
+  .demo-section-title {
+    background: #1e293b;
+    border-color: #334155;
+  }
+  .demo-card p,
+  .demo-note {
+    color: #94a3b8;
+  }
+}
+
+.demo-header {
+  background: linear-gradient(135deg, #6c63ff, #4b44cc);
+  color: #fff;
+  padding: 3rem 2rem;
+  text-align: center;
+}
+
+.demo-header h1 {
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+}
+
+.demo-header p {
+  font-size: 1rem;
+  opacity: 0.9;
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.demo-container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.demo-section {
+  margin-bottom: 3rem;
+}
+
+.demo-section-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #6c63ff;
+  margin-bottom: 0.5rem;
+  padding: 0.25rem 0.75rem;
+  background: #eef2ff;
+  border-radius: 999px;
+  display: inline-block;
+}
+
+.demo-section h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+.demo-section > p {
+  font-size: 0.875rem;
+  line-height: 1.7;
+  color: #64748b;
+  margin-bottom: 1rem;
+}
+
+.demo-card {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.demo-card h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.demo-card p {
+  font-size: 0.875rem;
+  color: #475569;
+  line-height: 1.6;
+  margin-bottom: 0.5rem;
+}
+
+.demo-card p:last-child {
+  margin-bottom: 0;
+}
+
+.demo-note {
+  font-size: 0.75rem;
+  color: #64748b;
+  font-style: italic;
+  margin-top: 0.25rem;
+}
+
+/* ── Stagger Demo Items ── */
+
+.stagger-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+  gap: 0.75rem;
+  margin: 1rem 0;
+}
+
+.stagger-item {
+  padding: 1.5rem 0.75rem;
+  border-radius: 0.5rem;
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.8125rem;
+  text-align: center;
+}
+
+.stagger-item .num {
+  display: block;
+  font-size: 1.5rem;
+  font-weight: 800;
+  margin-bottom: 0.25rem;
+}
+
+/* Horizontal list */
+.stagger-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 1rem 0;
+}
+
+.stagger-list .stagger-item {
+  flex: 1;
+  min-width: 80px;
+}
+
+/* ── Comparison row ── */
+
+.compare-row {
+  display: flex;
+  gap: 1.5rem;
+  margin: 1rem 0;
+  flex-wrap: wrap;
+}
+
+.compare-col {
+  flex: 1;
+  min-width: 200px;
+}
+
+.compare-col h4 {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.compare-col .stagger-item {
+  margin-bottom: 0.5rem;
+}
+
+/* ── Tag badge ── */
+
+.tag-badge {
+  display: inline-block;
+  font-size: 0.6rem;
+  font-family: monospace;
+  padding: 0.2em 0.5em;
+  border-radius: 999px;
+  background: #eef2ff;
+  color: #6c63ff;
+  margin-top: 0.25rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .tag-badge {
+    background: #1e1b4b;
+    color: #a09af8;
+  }
+}
+
+/* ── Table ── */
+
+.utilities-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 0.8125rem;
+  margin: 1rem 0;
+}
+
+.utilities-table th,
+.utilities-table td {
+  padding: 0.6rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+@media (prefers-color-scheme: dark) {
+  .utilities-table th,
+  .utilities-table td {
+    border-color: #334155;
+  }
+}
+
+.utilities-table th {
+  font-weight: 600;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: #f1f5f9;
+  color: #64748b;
+}
+
+@media (prefers-color-scheme: dark) {
+  .utilities-table th {
+    background: #334155;
+    color: #94a3b8;
+  }
+}
+
+.utilities-table td:first-child {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  color: #6c63ff;
+  white-space: nowrap;
+}


### PR DESCRIPTION
### Summary

Adds a stagger animation utility that automatically applies sequenced delays to child elements — creating ripple-like reveal effects for lists, grids, and galleries without manual delay calculations.

### Changes

All changes in `submissions/core_changes-issue-22102/`:

- **`style.css`** — Core CSS:
  - Stagger container class `.ease-stagger` that applies `var(--ease-stagger-delay)` to children
  - Delay increment variants: `.ease-stagger-100`, `.ease-stagger-200`, `.ease-stagger-300`, `.ease-stagger-500`
  - 6 compound animation classes: `.ease-stagger-fade-in`, `.ease-stagger-fade-in-down`, `.ease-stagger-fade-in-up`, `.ease-stagger-slide-in-up`, `.ease-stagger-slide-in-left`, `.ease-stagger-scale-in`
  - 6 stagger-specific keyframe animations
  - Demo styles with dark mode support

- **`demo.html`** — Interactive demo:
  - Fade-in grid: 8 items fading in sequentially with 100ms stagger
  - Slide-in-up grid: 8 items sliding up with stagger
  - Speed comparison: 3 columns showing 100ms vs 200ms vs 300ms stagger (all scale-in) with Replay button
  - Horizontal list: 5 items sliding in from the left
  - Inline JS assigning `--ease-stagger-delay` CSS custom property to each child
  - Full reference table

- **`README.md`** — Documentation with HTML examples

### How to Review

1. Open `demo.html` in a browser
2. Scroll down — items fade in one after another (stagger effect)
3. See the slide-in-up grid — items rise from below sequentially
4. Compare stagger speeds: 100ms, 200ms, 300ms side by side
5. Click "Replay All" to see them again
6. Check the horizontal list — items slide in from the left

Closes #22102