### PR TITLE
[submission] Add comprehensive exit animations: slide-out, zoom-out, flip-out, fade-out variants (issue #22099)

### DIFF
--- a/submissions/core_changes-issue-22099/README.md
+++ b/submissions/core_changes-issue-22099/README.md
@@ -1,0 +1,20 @@
+# Exit Animations: Slide-out, Zoom-out, Flip-out, Fade-out
+
+## What does this do?
+
+Adds a full suite of exit animation utilities (slide-out, zoom-out, flip-out, fade-out) that mirror the existing entrance animations. Each exit pairs naturally with its entrance counterpart — `ease-fade-in` gets `ease-fade-out`, `ease-slide-in-up` gets `ease-slide-out-down`, and so on.
+
+## How is it used?
+
+```html
+<div class="ease-fade-out">Fades out</div>
+<div class="ease-slide-out-up">Slides up and out</div>
+<div class="ease-zoom-out">Zooms out</div>
+<div class="ease-flip-out">Flips out (3D rotate)</div>
+```
+
+Exit classes are most useful when combined with JS for triggered dismissal (modals, toasts, notifications).
+
+## Why is it useful?
+
+Exit animations make UIs feel complete — what enters should also exit gracefully. Without these, the framework had only `ease-fade-out` and `ease-expand-border-exit`, leaving common needs like `slide-out-down` (for notifications) and `zoom-out` (for modals) unaddressed. These pair 1:1 with existing entrance animations for polished transitions.

--- a/submissions/core_changes-issue-22099/demo.html
+++ b/submissions/core_changes-issue-22099/demo.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Exit Animations — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="demo-header">
+    <h1>Exit Animations</h1>
+    <p>Slide-out, zoom-out, flip-out, and fade-out variants — perfectly paired with existing entrance animations.</p>
+  </header>
+
+  <main class="demo-container">
+
+    <!-- ── Fade-out variants ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Fade-out</span>
+      <h2>ease-fade-out &amp; directional variants</h2>
+      <p>Element fades away, optionally sliding in a direction at the same time. Pairs with <code>ease-fade-in</code> / <code>ease-fade-in-*</code>.</p>
+
+      <div class="card-grid" id="fadeOutGrid">
+        <div class="demo-card">
+          <div class="card-label">.ease-fade-out</div>
+          <div class="card-box fade-out-box" id="fo1">Fade</div>
+          <div class="controls"><button class="btn btn-play" data-target="fo1" data-class="ease-fade-out">Play</button></div>
+        </div>
+        <div class="demo-card">
+          <div class="card-label">.ease-fade-out-up</div>
+          <div class="card-box fade-out-box" id="fo2">Up</div>
+          <div class="controls"><button class="btn btn-play" data-target="fo2" data-class="ease-fade-out-up">Play</button></div>
+        </div>
+        <div class="demo-card">
+          <div class="card-label">.ease-fade-out-down</div>
+          <div class="card-box fade-out-box" id="fo3">Down</div>
+          <div class="controls"><button class="btn btn-play" data-target="fo3" data-class="ease-fade-out-down">Play</button></div>
+        </div>
+        <div class="demo-card">
+          <div class="card-label">.ease-fade-out-left</div>
+          <div class="card-box fade-out-box" id="fo4">Left</div>
+          <div class="controls"><button class="btn btn-play" data-target="fo4" data-class="ease-fade-out-left">Play</button></div>
+        </div>
+        <div class="demo-card">
+          <div class="card-label">.ease-fade-out-right</div>
+          <div class="card-box fade-out-box" id="fo5">Right</div>
+          <div class="controls"><button class="btn btn-play" data-target="fo5" data-class="ease-fade-out-right">Play</button></div>
+        </div>
+      </div>
+      <span class="pair-badge">Pairs with: .ease-fade-in, .ease-fade-in-*</span>
+    </section>
+
+    <!-- ── Slide-out variants ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Slide-out</span>
+      <h2>ease-slide-out-up / -down / -left / -right</h2>
+      <p>Element slides off-screen in the chosen direction while fading. Pairs with <code>ease-slide-in-*</code>.</p>
+
+      <div class="card-grid" id="slideOutGrid">
+        <div class="demo-card">
+          <div class="card-label">.ease-slide-out-up</div>
+          <div class="card-box fade-out-box" id="so1">Up</div>
+          <div class="controls"><button class="btn btn-play" data-target="so1" data-class="ease-slide-out-up">Play</button></div>
+        </div>
+        <div class="demo-card">
+          <div class="card-label">.ease-slide-out-down</div>
+          <div class="card-box fade-out-box" id="so2">Down</div>
+          <div class="controls"><button class="btn btn-play" data-target="so2" data-class="ease-slide-out-down">Play</button></div>
+        </div>
+        <div class="demo-card">
+          <div class="card-label">.ease-slide-out-left</div>
+          <div class="card-box fade-out-box" id="so3">Left</div>
+          <div class="controls"><button class="btn btn-play" data-target="so3" data-class="ease-slide-out-left">Play</button></div>
+        </div>
+        <div class="demo-card">
+          <div class="card-label">.ease-slide-out-right</div>
+          <div class="card-box fade-out-box" id="so4">Right</div>
+          <div class="controls"><button class="btn btn-play" data-target="so4" data-class="ease-slide-out-right">Play</button></div>
+        </div>
+      </div>
+      <span class="pair-badge">Pairs with: .ease-slide-in-*</span>
+    </section>
+
+    <!-- ── Zoom-out & Flip-out ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Zoom &amp; Flip</span>
+      <h2>ease-zoom-out &amp; ease-flip-out</h2>
+      <p>Zooms out (scale + fade) or flips out (3D X-axis rotation). Pairs with <code>ease-zoom-in</code> and <code>ease-flip-in</code>.</p>
+
+      <div class="card-grid" id="zoomFlipGrid">
+        <div class="demo-card">
+          <div class="card-label">.ease-zoom-out</div>
+          <div class="card-box fade-out-box" id="zf1">Zoom</div>
+          <div class="controls"><button class="btn btn-play" data-target="zf1" data-class="ease-zoom-out">Play</button></div>
+        </div>
+        <div class="demo-card">
+          <div class="card-label">.ease-flip-out</div>
+          <div class="card-box fade-out-box" id="zf2">Flip</div>
+          <div class="controls"><button class="btn btn-play" data-target="zf2" data-class="ease-flip-out">Play</button></div>
+        </div>
+      </div>
+      <span class="pair-badge">Pairs with: .ease-zoom-in, .ease-flip-in</span>
+    </section>
+
+    <!-- ── Modal demo ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Real-world demo</span>
+      <h2>Modal with entrance &amp; exit</h2>
+      <p>A modal that enters with <code>ease-fade-in</code> + <code>ease-zoom-in</code> and exits with <code>ease-fade-out</code> + <code>ease-zoom-out</code>.</p>
+
+      <div class="demo-card" style="text-align:center;">
+        <button class="btn btn-play" id="openModalBtn">Open Modal</button>
+      </div>
+    </section>
+
+    <!-- ── Modal overlay ── -->
+    <div id="modalOverlay" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,0.6);z-index:999;justify-content:center;align-items:center;">
+      <div id="modalContent" style="background:#1e293b;border:1px solid #334155;border-radius:1rem;padding:2rem;max-width:400px;width:90%;text-align:center;">
+        <h3 style="margin-bottom:0.75rem;font-size:1.25rem;">Hello!</h3>
+        <p style="color:#94a3b8;font-size:0.875rem;margin-bottom:1.5rem;">I fade in + zoom in, then exit with fade-out + zoom-out.</p>
+        <button class="btn" id="closeModalBtn" style="margin:0 auto;">Close Modal</button>
+      </div>
+    </div>
+
+    <!-- ── Reference Table ── -->
+    <section class="demo-section">
+      <span class="demo-section-title">Reference</span>
+      <h2>All Exit Animation Classes</h2>
+
+      <div class="demo-card" style="text-align:left;">
+        <table class="utilities-table">
+          <thead>
+            <tr><th>Class</th><th>Keyframe</th><th>Entrance Pair</th><th>Duration</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>.ease-fade-out</td><td>ease-kf-fade-out</td><td>.ease-fade-in</td><td>0.3s</td></tr>
+            <tr><td>.ease-fade-out-up</td><td>ease-kf-fade-out-up</td><td>.ease-fade-in-down</td><td>0.35s</td></tr>
+            <tr><td>.ease-fade-out-down</td><td>ease-kf-fade-out-down</td><td>.ease-fade-in-up</td><td>0.35s</td></tr>
+            <tr><td>.ease-fade-out-left</td><td>ease-kf-fade-out-left</td><td>.ease-fade-in-right</td><td>0.35s</td></tr>
+            <tr><td>.ease-fade-out-right</td><td>ease-kf-fade-out-right</td><td>.ease-fade-in-left</td><td>0.35s</td></tr>
+            <tr><td>.ease-slide-out-up</td><td>ease-kf-slide-out-up</td><td>.ease-slide-in-down</td><td>0.4s</td></tr>
+            <tr><td>.ease-slide-out-down</td><td>ease-kf-slide-out-down</td><td>.ease-slide-in-up</td><td>0.4s</td></tr>
+            <tr><td>.ease-slide-out-left</td><td>ease-kf-slide-out-left</td><td>.ease-slide-in-right</td><td>0.4s</td></tr>
+            <tr><td>.ease-slide-out-right</td><td>ease-kf-slide-out-right</td><td>.ease-slide-in-left</td><td>0.4s</td></tr>
+            <tr><td>.ease-zoom-out</td><td>ease-kf-zoom-out</td><td>.ease-zoom-in</td><td>0.35s</td></tr>
+            <tr><td>.ease-flip-out</td><td>ease-kf-flip-out</td><td>.ease-flip-in</td><td>0.5s</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+  </main>
+
+  <footer style="text-align:center;padding:2rem;border-top:1px solid #334155;margin-top:2rem;">
+    <p style="font-size:0.75rem;color:#64748b;">
+      All exit animations set <code>animation-fill-mode: forwards</code> to stay at the final state. Dark theme by default.
+    </p>
+  </footer>
+
+  <script>
+    // ── Card replay buttons ──
+    var btns = document.querySelectorAll('.btn-play');
+    btns.forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        var targetId = this.getAttribute('data-target');
+        var className = this.getAttribute('data-class');
+        var el = document.getElementById(targetId);
+
+        el.style.animation = 'none';
+        el.style.opacity = '1';
+        el.style.transform = '';
+        void el.offsetWidth;
+        el.className = 'card-box fade-out-box ' + className;
+      });
+    });
+
+    // ── Modal ──
+    var overlay = document.getElementById('modalOverlay');
+    var modalContent = document.getElementById('modalContent');
+
+    document.getElementById('openModalBtn').addEventListener('click', function() {
+      overlay.style.display = 'flex';
+      modalContent.className = 'ease-fade-in ease-zoom-in';
+      modalContent.style.opacity = '1';
+      modalContent.style.transform = '';
+    });
+
+    document.getElementById('closeModalBtn').addEventListener('click', function() {
+      modalContent.className = 'ease-fade-out ease-zoom-out';
+      setTimeout(function() {
+        overlay.style.display = 'none';
+      }, 400);
+    });
+
+    overlay.addEventListener('click', function(e) {
+      if (e.target === overlay) {
+        modalContent.className = 'ease-fade-out ease-zoom-out';
+        setTimeout(function() {
+          overlay.style.display = 'none';
+        }, 400);
+      }
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/core_changes-issue-22099/style.css
+++ b/submissions/core_changes-issue-22099/style.css
@@ -1,0 +1,329 @@
+/* ============================================================
+   Exit Animation Utilities
+   Submission for EaseMotion CSS · Issue #22099
+   ============================================================ */
+
+/* ════════════════════════════════════════════════════════════════
+   FADE-OUT VARIANTS
+   ════════════════════════════════════════════════════════════════ */
+
+.ease-fade-out {
+  animation: ease-kf-fade-out 0.3s ease-out forwards;
+}
+
+@keyframes ease-kf-fade-out {
+  from { opacity: 1; }
+  to   { opacity: 0; }
+}
+
+.ease-fade-out-up {
+  animation: ease-kf-fade-out-up 0.35s ease-out forwards;
+}
+
+@keyframes ease-kf-fade-out-up {
+  from { opacity: 1; transform: translateY(0); }
+  to   { opacity: 0; transform: translateY(-1.5rem); }
+}
+
+.ease-fade-out-down {
+  animation: ease-kf-fade-out-down 0.35s ease-out forwards;
+}
+
+@keyframes ease-kf-fade-out-down {
+  from { opacity: 1; transform: translateY(0); }
+  to   { opacity: 0; transform: translateY(1.5rem); }
+}
+
+.ease-fade-out-left {
+  animation: ease-kf-fade-out-left 0.35s ease-out forwards;
+}
+
+@keyframes ease-kf-fade-out-left {
+  from { opacity: 1; transform: translateX(0); }
+  to   { opacity: 0; transform: translateX(-1.5rem); }
+}
+
+.ease-fade-out-right {
+  animation: ease-kf-fade-out-right 0.35s ease-out forwards;
+}
+
+@keyframes ease-kf-fade-out-right {
+  from { opacity: 1; transform: translateX(0); }
+  to   { opacity: 0; transform: translateX(1.5rem); }
+}
+
+/* ════════════════════════════════════════════════════════════════
+   SLIDE-OUT VARIANTS
+   ════════════════════════════════════════════════════════════════ */
+
+.ease-slide-out-up {
+  animation: ease-kf-slide-out-up 0.4s ease-in forwards;
+}
+
+@keyframes ease-kf-slide-out-up {
+  from { opacity: 1; transform: translateY(0); }
+  to   { opacity: 0; transform: translateY(-100vh); }
+}
+
+.ease-slide-out-down {
+  animation: ease-kf-slide-out-down 0.4s ease-in forwards;
+}
+
+@keyframes ease-kf-slide-out-down {
+  from { opacity: 1; transform: translateY(0); }
+  to   { opacity: 0; transform: translateY(100vh); }
+}
+
+.ease-slide-out-left {
+  animation: ease-kf-slide-out-left 0.4s ease-in forwards;
+}
+
+@keyframes ease-kf-slide-out-left {
+  from { opacity: 1; transform: translateX(0); }
+  to   { opacity: 0; transform: translateX(-100vw); }
+}
+
+.ease-slide-out-right {
+  animation: ease-kf-slide-out-right 0.4s ease-in forwards;
+}
+
+@keyframes ease-kf-slide-out-right {
+  from { opacity: 1; transform: translateX(0); }
+  to   { opacity: 0; transform: translateX(100vw); }
+}
+
+/* ════════════════════════════════════════════════════════════════
+   ZOOM-OUT
+   ════════════════════════════════════════════════════════════════ */
+
+.ease-zoom-out {
+  animation: ease-kf-zoom-out 0.35s ease-out forwards;
+}
+
+@keyframes ease-kf-zoom-out {
+  from { opacity: 1; transform: scale(1); }
+  to   { opacity: 0; transform: scale(0.5); }
+}
+
+/* ════════════════════════════════════════════════════════════════
+   FLIP-OUT
+   ════════════════════════════════════════════════════════════════ */
+
+.ease-flip-out {
+  perspective: 600px;
+  animation: ease-kf-flip-out 0.5s ease-in forwards;
+}
+
+@keyframes ease-kf-flip-out {
+  from { opacity: 1; transform: rotateX(0); }
+  to   { opacity: 0; transform: rotateX(90deg); }
+}
+
+/* ════════════════════════════════════════════════════════════════
+   DEMO STYLES
+   ════════════════════════════════════════════════════════════════ */
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  color: #f1f5f9;
+  min-height: 100vh;
+  padding: 0;
+}
+
+.demo-header {
+  background: linear-gradient(135deg, #6c63ff, #4b44cc);
+  color: #fff;
+  padding: 3rem 2rem;
+  text-align: center;
+}
+
+.demo-header h1 {
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+}
+
+.demo-header p {
+  font-size: 1rem;
+  opacity: 0.9;
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.demo-container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.demo-section {
+  margin-bottom: 3rem;
+}
+
+.demo-section-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #a09af8;
+  margin-bottom: 0.5rem;
+  padding: 0.25rem 0.75rem;
+  background: #1e1b4b;
+  border-radius: 999px;
+  display: inline-block;
+}
+
+.demo-section h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.demo-section > p {
+  font-size: 0.875rem;
+  line-height: 1.7;
+  color: #94a3b8;
+  margin-bottom: 1rem;
+}
+
+/* ── Card ── */
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.demo-card {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.demo-card .card-label {
+  font-size: 0.7rem;
+  font-family: 'JetBrains Mono', monospace;
+  color: #a09af8;
+  margin-bottom: 1rem;
+  word-break: break-all;
+}
+
+.demo-card .card-box {
+  width: 80px;
+  height: 80px;
+  background: linear-gradient(135deg, #6c63ff, #4b44cc);
+  border-radius: 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 0.6rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.demo-card .card-box.card-out {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 80px;
+  height: 80px;
+}
+
+/* ── Action buttons ── */
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+  justify-content: center;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  border: 1px solid #334155;
+  background: #1e293b;
+  color: #f1f5f9;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.btn:hover {
+  background: #334155;
+}
+
+.btn-play {
+  border-color: #6c63ff;
+  background: rgba(108, 99, 255, 0.15);
+}
+
+.btn-play:hover {
+  background: rgba(108, 99, 255, 0.25);
+}
+
+/* ── Table ── */
+
+.utilities-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 0.8125rem;
+  margin: 1rem 0;
+}
+
+.utilities-table th,
+.utilities-table td {
+  padding: 0.6rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #334155;
+}
+
+.utilities-table th {
+  font-weight: 600;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: #1e293b;
+  color: #94a3b8;
+}
+
+.utilities-table td:first-child {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  color: #a09af8;
+  white-space: nowrap;
+}
+
+/* ── Pair badge ── */
+
+.pair-badge {
+  display: inline-block;
+  font-size: 0.6rem;
+  padding: 0.15em 0.5em;
+  border-radius: 999px;
+  background: #1e1b4b;
+  color: #6c63ff;
+  margin-top: 0.25rem;
+  font-family: 'JetBrains Mono', monospace;
+}


### PR DESCRIPTION
### Summary

Adds a full suite of exit animation utilities that mirror the existing entrance animations: fade-out (5 variants), slide-out (4 directional variants), zoom-out, and flip-out. Each exit pairs naturally with its entrance counterpart.

### Changes

All changes in `submissions/core_changes-issue-22099/`:

- **`style.css`** — Core CSS:
  - `.ease-fade-out`, `.ease-fade-out-up`, `.ease-fade-out-down`, `.ease-fade-out-left`, `.ease-fade-out-right` with directional fade keyframes
  - `.ease-slide-out-up`, `.ease-slide-out-down`, `.ease-slide-out-left`, `.ease-slide-out-right` — slide off-screen with fade
  - `.ease-zoom-out` — scale(1) → scale(0.5) with fade
  - `.ease-flip-out` — 3D rotateX(0) → rotateX(90deg) with perspective
  - All use `animation-fill-mode: forwards` to keep final state
  - Demo styles with dark mode

- **`demo.html`** — Interactive demo:
  - Fade-out grid: 5 cards (plain + 4 directional) with Play buttons
  - Slide-out grid: 4 directional cards with Play buttons
  - Zoom-out & Flip-out: 2 cards with Play buttons
  - Real-world modal: opens with entrance animation combo, closes with exit animations
  - Full reference table listing all 11 classes with keyframes, entrance pairs, and durations

- **`README.md`** — Documentation with examples

### How to Review

1. Open `demo.html` in a browser
2. Click Play on each exit card to see it animate out
3. Click Play again to reset and replay
4. Click "Open Modal" — modal fades in + zooms in
5. Click "Close Modal" — modal exits with fade-out + zoom-out
6. Check the reference table for all 11 exit classes with their entrance pairs

Closes #22099