### PR TITLE
feat: add vertical text orientation example

### DIFF
--- a/submissions/examples/vertical-text-orientation-sm/README.md
+++ b/submissions/examples/vertical-text-orientation-sm/README.md
@@ -1,0 +1,25 @@
+# Vertical Text Orientation Demo
+
+## What does this do?
+
+This submission demonstrates vertical text layouts with mixed Latin text, rotated UI labels, magazine-style sidebars, and upright CJK typography for issue #20456.
+
+## How is it used?
+
+Add the relevant vertical text class to the element that should become a compact rail, label, or upright column:
+
+```html
+<div class="vt-sidebar">Issue 20456</div>
+<div class="vt-upright" lang="ja">東京設計</div>
+<span class="vt-rotated-label">Beta</span>
+```
+
+## Why is it useful?
+
+Vertical orientation utilities fit EaseMotion CSS by turning plain HTML into expressive, responsive visual patterns without JavaScript, build tools, or external frameworks.
+
+## Included files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the vertical text patterns
+- `README.md` - usage and rationale

--- a/submissions/examples/vertical-text-orientation-sm/demo.html
+++ b/submissions/examples/vertical-text-orientation-sm/demo.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Vertical Text Orientation Demo</title>
+  <meta name="description" content="Self-contained EaseMotion CSS submission demonstrating vertical text layouts, rotated UI labels, and upright CJK typography.">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="vt-shell">
+    <section class="vt-hero" aria-labelledby="page-title">
+      <p class="vt-kicker">EaseMotion CSS Example</p>
+      <h1 id="page-title">Vertical Text Orientation</h1>
+      <p class="vt-lede">
+        A compact layout kit for editorial sidebars, rotated interface labels,
+        mixed-orientation callouts, and upright CJK typography.
+      </p>
+    </section>
+
+    <section class="vt-grid" aria-label="Vertical text orientation examples">
+      <article class="vt-card vt-card-feature">
+        <div class="vt-sidebar" aria-label="Magazine section label">Issue 20456</div>
+        <div class="vt-card-copy">
+          <span class="vt-pill">Magazine Sidebar</span>
+          <h2>Editorial rail</h2>
+          <p>
+            Uses <code>writing-mode: vertical-rl</code> with mixed orientation,
+            ideal for compact article labels and decorative page rails.
+          </p>
+        </div>
+      </article>
+
+      <article class="vt-card vt-cjk-card">
+        <div class="vt-upright" lang="ja" aria-label="Tokyo design system">
+          東京設計
+        </div>
+        <div class="vt-card-copy">
+          <span class="vt-pill">CJK Upright</span>
+          <h2>Upright typography</h2>
+          <p>
+            Pairs vertical writing mode with <code>text-orientation: upright</code>
+            so each ideograph stays readable in a vertical column.
+          </p>
+        </div>
+      </article>
+
+      <article class="vt-label-card">
+        <span class="vt-rotated-label">Beta</span>
+        <div>
+          <span class="vt-pill">Rotated UI Label</span>
+          <h2>Badge without layout shift</h2>
+          <p>
+            A rotated label creates a strong visual marker while the card content
+            remains in a normal reading flow.
+          </p>
+        </div>
+      </article>
+
+      <article class="vt-strip" aria-labelledby="mixed-title">
+        <div class="vt-mixed-text">CSS 2026</div>
+        <div>
+          <span class="vt-pill">Mixed Blocks</span>
+          <h2 id="mixed-title">Latin and numbers</h2>
+          <p>
+            Mixed orientation keeps Latin text and numbers grouped naturally,
+            useful for compact stats, dates, and issue tags.
+          </p>
+        </div>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/vertical-text-orientation-sm/style.css
+++ b/submissions/examples/vertical-text-orientation-sm/style.css
@@ -1,0 +1,241 @@
+:root {
+  --ease-vt-bg: #0c1222;
+  --ease-vt-surface: rgba(255, 255, 255, 0.08);
+  --ease-vt-surface-strong: rgba(255, 255, 255, 0.14);
+  --ease-vt-text: #f8fafc;
+  --ease-vt-muted: #aeb9cf;
+  --ease-vt-accent: #73f6d3;
+  --ease-vt-accent-strong: #f5c76b;
+  --ease-vt-border: rgba(255, 255, 255, 0.16);
+  --ease-vt-shadow: 0 26px 70px rgba(0, 0, 0, 0.38);
+  --ease-vt-radius: 28px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ease-vt-text);
+  font-family: "Segoe UI", "Noto Sans", "Noto Sans JP", sans-serif;
+  background:
+    radial-gradient(circle at 18% 20%, rgba(115, 246, 211, 0.22), transparent 32rem),
+    radial-gradient(circle at 78% 8%, rgba(245, 199, 107, 0.18), transparent 28rem),
+    linear-gradient(135deg, #07101f 0%, var(--ease-vt-bg) 52%, #121427 100%);
+}
+
+code {
+  color: var(--ease-vt-accent);
+}
+
+.vt-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 56px 0;
+}
+
+.vt-hero {
+  max-width: 780px;
+  margin-bottom: 32px;
+}
+
+.vt-kicker,
+.vt-pill {
+  color: var(--ease-vt-accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.vt-hero h1,
+.vt-card h2,
+.vt-label-card h2,
+.vt-strip h2 {
+  margin: 0;
+  line-height: 1.05;
+}
+
+.vt-hero h1 {
+  max-width: 720px;
+  font-size: clamp(2.7rem, 8vw, 6.8rem);
+  letter-spacing: -0.07em;
+}
+
+.vt-lede,
+.vt-card p,
+.vt-label-card p,
+.vt-strip p {
+  color: var(--ease-vt-muted);
+  line-height: 1.7;
+}
+
+.vt-lede {
+  max-width: 620px;
+  font-size: 1.08rem;
+}
+
+.vt-grid {
+  display: grid;
+  grid-template-columns: 1.15fr 0.85fr;
+  gap: 22px;
+}
+
+.vt-card,
+.vt-label-card,
+.vt-strip {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--ease-vt-border);
+  border-radius: var(--ease-vt-radius);
+  background: var(--ease-vt-surface);
+  box-shadow: var(--ease-vt-shadow);
+}
+
+.vt-card {
+  display: grid;
+  min-height: 320px;
+  grid-template-columns: 96px 1fr;
+}
+
+.vt-card-feature {
+  grid-row: span 2;
+}
+
+.vt-card::before,
+.vt-label-card::before,
+.vt-strip::before {
+  position: absolute;
+  inset: 0;
+  content: "";
+  pointer-events: none;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.13), transparent 42%);
+}
+
+.vt-sidebar,
+.vt-upright,
+.vt-mixed-text {
+  display: grid;
+  place-items: center;
+  min-height: 100%;
+  color: #07101f;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+  background: linear-gradient(180deg, var(--ease-vt-accent), var(--ease-vt-accent-strong));
+}
+
+.vt-sidebar,
+.vt-mixed-text {
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+}
+
+.vt-upright {
+  writing-mode: vertical-rl;
+  text-orientation: upright;
+  font-size: clamp(2.4rem, 5vw, 4.4rem);
+  letter-spacing: 0.18em;
+}
+
+.vt-card-copy {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 32px;
+}
+
+.vt-card-copy h2,
+.vt-label-card h2,
+.vt-strip h2 {
+  margin-top: 10px;
+  font-size: clamp(1.65rem, 3vw, 2.6rem);
+}
+
+.vt-label-card,
+.vt-strip {
+  min-height: 236px;
+  padding: 34px 34px 34px 86px;
+}
+
+.vt-rotated-label {
+  position: absolute;
+  top: 28px;
+  left: 26px;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 108px;
+  border-radius: 999px;
+  color: #06111f;
+  font-weight: 900;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  background: var(--ease-vt-accent-strong);
+  transform: rotate(180deg);
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+}
+
+.vt-label-card > div,
+.vt-strip > div {
+  position: relative;
+  z-index: 1;
+}
+
+.vt-strip {
+  display: grid;
+  grid-template-columns: 64px 1fr;
+  gap: 24px;
+  padding-left: 24px;
+}
+
+.vt-mixed-text {
+  min-height: 168px;
+  border-radius: 999px;
+}
+
+@media (max-width: 820px) {
+  .vt-shell {
+    padding: 36px 0;
+  }
+
+  .vt-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .vt-card-feature {
+    grid-row: auto;
+  }
+}
+
+@media (max-width: 560px) {
+  .vt-card {
+    grid-template-columns: 72px 1fr;
+  }
+
+  .vt-card-copy,
+  .vt-label-card,
+  .vt-strip {
+    padding: 24px;
+  }
+
+  .vt-label-card {
+    padding-left: 72px;
+  }
+
+  .vt-strip {
+    grid-template-columns: 52px 1fr;
+    gap: 16px;
+  }
+
+  .vt-rotated-label {
+    left: 18px;
+    height: 92px;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained vertical text orientation example for #20456, including mixed writing mode blocks, magazine-style sidebars, rotated UI labels, and upright CJK typography.

Closes #20456

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A responsive vertical text orientation demo using CSS `writing-mode` and `text-orientation`.

**How does a developer use it?**
```html
<div class=vt-sidebar>Issue 20456</div>
<div class=vt-upright lang=ja>東京設計</div>
<span class=vt-rotated-label>Beta</span>
```

**Why does it fit EaseMotion CSS?**
It provides a self-contained, no-dependency visual pattern for expressive editorial and UI layouts using plain HTML/CSS.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

## Notes for Maintainer

Validated required files, no external demo dependencies, valid UTF-8 CJK text, and CSS brace balance via local Node checks.