### PR TITLE
feat: add status pill row demo

### DIFF
--- a/submissions/examples/status-pill-row/README.md
+++ b/submissions/examples/status-pill-row/README.md
@@ -1,0 +1,15 @@
+# Status Pill Row
+
+## What does this do?
+A responsive row of status pills with hover lift, active state, and visible keyboard focus.
+
+## How is it used?
+```html
+<div class="status-row">
+  <button class="active">Ready</button>
+  <button>Review</button>
+</div>
+```
+
+## Why is it useful?
+It gives EaseMotion CSS a compact filter and workflow-status control for dashboards and project views.

--- a/submissions/examples/status-pill-row/demo.html
+++ b/submissions/examples/status-pill-row/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Status Pill Row Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="status-page" aria-labelledby="status-title">
+    <section class="status-card">
+      <p class="eyebrow">Status chips</p>
+      <h1 id="status-title">Status Pill Row</h1>
+      <div class="status-row" aria-label="Project status filters">
+        <button class="active">Ready</button>
+        <button>Review</button>
+        <button>Blocked</button>
+        <button>Done</button>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/status-pill-row/style.css
+++ b/submissions/examples/status-pill-row/style.css
@@ -1,0 +1,17 @@
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #102a43, #0f766e 55%, #fef08a);
+  color: #111827;
+  font-family: Arial, Helvetica, sans-serif;
+}
+.status-page { width: min(92vw, 760px); padding: 28px; }
+.status-card { border-radius: 28px; padding: clamp(24px, 5vw, 46px); background: rgba(255,255,255,.94); box-shadow: 0 30px 86px rgba(16,42,67,.34); }
+.eyebrow { margin: 0 0 10px; color: #0f766e; font-size: .78rem; font-weight: 900; text-transform: uppercase; }
+h1 { margin: 0 0 28px; font-size: clamp(2.2rem, 7vw, 4.8rem); line-height: .92; }
+.status-row { display: flex; flex-wrap: wrap; gap: 12px; }
+.status-row button { min-height: 48px; border: 0; border-radius: 999px; padding: 0 20px; background: #f8fafc; color: #334155; cursor: pointer; font-weight: 900; box-shadow: inset 0 0 0 1px rgba(17,24,39,.08); transition: transform .18s ease, background .18s ease, color .18s ease; }
+.status-row button:hover, .status-row button:focus-visible, .status-row .active { background: #111827; color: #fff; transform: translateY(-4px); outline: none; }
+.status-row button:focus-visible { box-shadow: 0 0 0 4px rgba(15,118,110,.28); }


### PR DESCRIPTION
## Pull Request Description

A responsive row of status pills with hover lift, active state, and visible keyboard focus.

---

## Type of Change

- [x] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/status-pill-row/`
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A responsive row of status pills with hover lift, active state, and visible keyboard focus.

**How does a developer use it?**

```html
<div class="status-row"><button class="active">Ready</button><button>Review</button></div>
```

**Why does it fit EaseMotion CSS?**

It adds a compact filter and workflow-status control for dashboards and project views.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer

Created on top of latest upstream main via GitHub API because current upstream contains Windows-invalid paths. Submission only adds the three required files.
