### PR TITLE
feat: add action button group demo

### DIFF
--- a/submissions/examples/action-button-group/README.md
+++ b/submissions/examples/action-button-group/README.md
@@ -1,0 +1,15 @@
+# Action Button Group
+
+## What does this do?
+A grouped action button pattern with primary styling, hover lift, and focus feedback.
+
+## How is it used?
+```html
+<div class="action-group">
+  <button>Save</button>
+  <button class="primary">Publish</button>
+</div>
+```
+
+## Why is it useful?
+It gives EaseMotion CSS a reusable action cluster for forms, editors, and dashboard toolbars.

--- a/submissions/examples/action-button-group/demo.html
+++ b/submissions/examples/action-button-group/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Action Button Group Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="action-page" aria-labelledby="action-title">
+    <section class="action-card">
+      <p class="eyebrow">Button pattern</p>
+      <h1 id="action-title">Action Button Group</h1>
+      <div class="action-group" aria-label="Document actions">
+        <button>Save</button>
+        <button class="primary">Publish</button>
+        <button>Share</button>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/action-button-group/style.css
+++ b/submissions/examples/action-button-group/style.css
@@ -1,0 +1,10 @@
+body { min-height: 100vh; margin: 0; display: grid; place-items: center; background: linear-gradient(135deg, #1f2937, #be123c 55%, #fed7aa); color: #111827; font-family: Arial, Helvetica, sans-serif; }
+.action-page { width: min(92vw, 760px); padding: 28px; }
+.action-card { border-radius: 28px; padding: clamp(24px, 5vw, 46px); background: rgba(255,255,255,.94); box-shadow: 0 30px 86px rgba(31,41,55,.34); }
+.eyebrow { margin: 0 0 10px; color: #be123c; font-size: .78rem; font-weight: 900; text-transform: uppercase; }
+h1 { margin: 0 0 28px; font-size: clamp(2.2rem, 7vw, 4.8rem); line-height: .92; }
+.action-group { display: inline-flex; flex-wrap: wrap; gap: 10px; border-radius: 24px; padding: 10px; background: #f1f5f9; }
+.action-group button { min-height: 50px; border: 0; border-radius: 16px; padding: 0 22px; background: #fff; color: #334155; cursor: pointer; font-weight: 900; box-shadow: 0 10px 22px rgba(17,24,39,.08); transition: transform .18s ease, background .18s ease, color .18s ease; }
+.action-group .primary { background: #111827; color: #fff; }
+.action-group button:hover, .action-group button:focus-visible { transform: translateY(-5px) scale(1.03); background: #be123c; color: #fff; outline: none; }
+.action-group button:focus-visible { box-shadow: 0 0 0 4px rgba(190,18,60,.22); }


### PR DESCRIPTION
## Pull Request Description

A grouped action button pattern with primary styling, hover lift, and focus feedback.

---

## Type of Change

- [x] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/action-button-group/`
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A grouped action button pattern with primary styling, hover lift, and focus feedback.

**How does a developer use it?**

```html
<div class="action-group"><button>Save</button><button class="primary">Publish</button></div>
```

**Why does it fit EaseMotion CSS?**

It provides a reusable action cluster for forms, editors, and dashboard toolbars.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer

Created on top of latest upstream main via GitHub API because current upstream contains Windows-invalid paths. Submission only adds the three required files.
