### PR TITLE
feat: add empty state prompt demo

### DIFF
--- a/submissions/examples/empty-state-prompt/README.md
+++ b/submissions/examples/empty-state-prompt/README.md
@@ -1,0 +1,15 @@
+# Empty State Prompt
+
+## What does this do?
+A centered empty-state prompt with floating icon motion and a focused call-to-action.
+
+## How is it used?
+```html
+<section class="empty-card">
+  <span class="empty-icon"></span>
+  <button>Create report</button>
+</section>
+```
+
+## Why is it useful?
+It gives EaseMotion CSS a polished empty-state pattern for dashboards, reports, and onboarding screens.

--- a/submissions/examples/empty-state-prompt/demo.html
+++ b/submissions/examples/empty-state-prompt/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Empty State Prompt Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="empty-page" aria-labelledby="empty-title">
+    <section class="empty-card">
+      <span class="empty-icon"></span>
+      <p class="eyebrow">Empty state</p>
+      <h1 id="empty-title">Empty State Prompt</h1>
+      <p>No saved reports yet. Create a report to start tracking your workspace metrics.</p>
+      <button>Create report</button>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/empty-state-prompt/style.css
+++ b/submissions/examples/empty-state-prompt/style.css
@@ -1,0 +1,12 @@
+body { min-height: 100vh; margin: 0; display: grid; place-items: center; background: linear-gradient(135deg, #134e4a, #4f46e5 55%, #fef9c3); color: #111827; font-family: Arial, Helvetica, sans-serif; }
+.empty-page { width: min(92vw, 720px); padding: 28px; }
+.empty-card { text-align: center; border-radius: 28px; padding: clamp(28px, 6vw, 56px); background: rgba(255,255,255,.94); box-shadow: 0 30px 86px rgba(19,78,74,.34); animation: empty-enter .6s ease both; }
+.empty-icon { display: inline-block; width: 92px; height: 92px; border-radius: 28px; background: linear-gradient(135deg, #14b8a6, #4f46e5); box-shadow: 0 22px 42px rgba(79,70,229,.24); animation: icon-float 2.4s ease-in-out infinite; }
+.eyebrow { margin: 24px 0 10px; color: #4f46e5; font-size: .78rem; font-weight: 900; text-transform: uppercase; }
+h1 { margin: 0; font-size: clamp(2.2rem, 7vw, 4.8rem); line-height: .92; }
+p:last-of-type { max-width: 42ch; margin: 18px auto 24px; color: #64748b; line-height: 1.6; }
+button { min-height: 48px; border: 0; border-radius: 999px; padding: 0 22px; background: #111827; color: #fff; cursor: pointer; font-weight: 900; transition: transform .18s ease, background .18s ease; }
+button:hover, button:focus-visible { background: #4f46e5; transform: translateY(-4px); outline: none; }
+button:focus-visible { box-shadow: 0 0 0 4px rgba(79,70,229,.24); }
+@keyframes empty-enter { from { opacity: 0; transform: translateY(18px) scale(.96); } to { opacity: 1; transform: translateY(0) scale(1); } }
+@keyframes icon-float { 50% { transform: translateY(-10px); } }


### PR DESCRIPTION
## Pull Request Description

A centered empty-state prompt with floating icon motion and a focused call-to-action.

---

## Type of Change

- [x] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/empty-state-prompt/`
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A centered empty-state prompt with floating icon motion and a focused call-to-action.

**How does a developer use it?**

```html
<section class="empty-card"><span class="empty-icon"></span><button>Create report</button></section>
```

**Why does it fit EaseMotion CSS?**

It adds a polished empty-state pattern for dashboards, reports, and onboarding screens.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer

Created on top of latest upstream main via GitHub API because current upstream contains Windows-invalid paths. Submission only adds the three required files.
