### PR TITLE
feat: add progress step cards demo

### DIFF
--- a/submissions/examples/progress-step-cards/README.md
+++ b/submissions/examples/progress-step-cards/README.md
@@ -1,0 +1,14 @@
+# Progress Step Cards
+
+## What does this do?
+A three-step progress card layout with staggered entry motion and hover lift states.
+
+## How is it used?
+```html
+<div class="step-grid">
+  <article><span>1</span><strong>Plan</strong></article>
+</div>
+```
+
+## Why is it useful?
+It gives EaseMotion CSS a process-step pattern for onboarding, setup flows, and workflow pages.

--- a/submissions/examples/progress-step-cards/demo.html
+++ b/submissions/examples/progress-step-cards/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Progress Step Cards Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="steps-page" aria-labelledby="steps-title">
+    <section class="steps-card">
+      <p class="eyebrow">Process steps</p>
+      <h1 id="steps-title">Progress Step Cards</h1>
+      <div class="step-grid"><article><span>1</span><strong>Plan</strong></article><article><span>2</span><strong>Build</strong></article><article><span>3</span><strong>Ship</strong></article></div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/progress-step-cards/style.css
+++ b/submissions/examples/progress-step-cards/style.css
@@ -1,0 +1,14 @@
+body { min-height: 100vh; margin: 0; display: grid; place-items: center; background: linear-gradient(135deg, #0f172a, #15803d 55%, #facc15); color: #111827; font-family: Arial, Helvetica, sans-serif; }
+.steps-page { width: min(92vw, 840px); padding: 28px; }
+.steps-card { border-radius: 28px; padding: clamp(24px, 5vw, 46px); background: rgba(255,255,255,.94); box-shadow: 0 30px 86px rgba(15,23,42,.34); }
+.eyebrow { margin: 0 0 10px; color: #15803d; font-size: .78rem; font-weight: 900; text-transform: uppercase; }
+h1 { margin: 0 0 28px; font-size: clamp(2.2rem, 7vw, 4.8rem); line-height: .92; }
+.step-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 16px; }
+.step-grid article { position: relative; overflow: hidden; min-height: 150px; border-radius: 24px; padding: 22px; background: #f8fafc; box-shadow: inset 0 0 0 1px rgba(17,24,39,.08); animation: step-in .58s ease both; }
+.step-grid article:nth-child(2) { animation-delay: .1s; }
+.step-grid article:nth-child(3) { animation-delay: .2s; }
+.step-grid span { width: 44px; height: 44px; display: grid; place-items: center; border-radius: 50%; background: #111827; color: #fff; font-weight: 900; }
+.step-grid strong { display: block; margin-top: 34px; font-size: 1.35rem; }
+.step-grid article:hover { transform: translateY(-6px); transition: transform .18s ease; }
+@keyframes step-in { from { opacity: 0; transform: translateY(18px) scale(.96); } to { opacity: 1; transform: translateY(0) scale(1); } }
+@media (max-width: 680px) { .step-grid { grid-template-columns: 1fr; } }


### PR DESCRIPTION
## Pull Request Description

A three-step progress card layout with staggered entry motion and hover lift states.

---

## Type of Change

- [x] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/progress-step-cards/`
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A three-step progress card layout with staggered entry motion and hover lift states.

**How does a developer use it?**

```html
<div class="step-grid"><article><span>1</span><strong>Plan</strong></article></div>
```

**Why does it fit EaseMotion CSS?**

It provides a process-step pattern for onboarding, setup flows, and workflow pages.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer

Created on top of latest upstream main via GitHub API because current upstream contains Windows-invalid paths. Submission only adds the three required files.
