### PR TITLE
feat: add layered alert banner demo

### DIFF
--- a/submissions/examples/layered-alert-banner/README.md
+++ b/submissions/examples/layered-alert-banner/README.md
@@ -1,0 +1,15 @@
+# Layered Alert Banner
+
+## What does this do?
+A layered alert banner with entrance motion, accent stripe, and a soft sweep highlight.
+
+## How is it used?
+```html
+<aside class="alert-banner" role="status">
+  <strong>Review needed</strong>
+  <span>Three deployments are waiting for approval.</span>
+</aside>
+```
+
+## Why is it useful?
+It gives EaseMotion CSS a reusable status alert for dashboards, admin tools, and workflow screens.

--- a/submissions/examples/layered-alert-banner/demo.html
+++ b/submissions/examples/layered-alert-banner/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Layered Alert Banner Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="alert-page" aria-labelledby="alert-title">
+    <section class="alert-card">
+      <p class="eyebrow">Alert component</p>
+      <h1 id="alert-title">Layered Alert Banner</h1>
+      <aside class="alert-banner" role="status"><strong>Review needed</strong><span>Three deployments are waiting for approval.</span></aside>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/layered-alert-banner/style.css
+++ b/submissions/examples/layered-alert-banner/style.css
@@ -1,0 +1,13 @@
+body { min-height: 100vh; margin: 0; display: grid; place-items: center; background: linear-gradient(135deg, #431407, #b45309 55%, #cffafe); color: #111827; font-family: Arial, Helvetica, sans-serif; }
+.alert-page { width: min(92vw, 780px); padding: 28px; }
+.alert-card { border-radius: 28px; padding: clamp(24px, 5vw, 46px); background: rgba(255,255,255,.94); box-shadow: 0 30px 86px rgba(67,20,7,.34); }
+.eyebrow { margin: 0 0 10px; color: #b45309; font-size: .78rem; font-weight: 900; text-transform: uppercase; }
+h1 { margin: 0 0 28px; font-size: clamp(2.2rem, 7vw, 4.8rem); line-height: .92; }
+.alert-banner { position: relative; display: grid; gap: 6px; border-radius: 22px; padding: 20px 22px; background: #fff7ed; color: #431407; box-shadow: inset 0 0 0 1px rgba(180,83,9,.18); overflow: hidden; animation: banner-in .58s ease both; }
+.alert-banner::before { content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 8px; background: #f97316; }
+.alert-banner::after { content: ""; position: absolute; inset: 0; background: linear-gradient(90deg, transparent, rgba(249,115,22,.18), transparent); transform: translateX(-100%); animation: banner-sweep 2.2s ease-in-out infinite; }
+.alert-banner strong, .alert-banner span { position: relative; z-index: 1; }
+.alert-banner strong { font-size: 1.1rem; }
+.alert-banner span { color: #7c2d12; }
+@keyframes banner-in { from { opacity: 0; transform: translateY(16px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes banner-sweep { 60%, 100% { transform: translateX(100%); } }


### PR DESCRIPTION
## Pull Request Description

A layered alert banner with entrance motion, accent stripe, and a soft sweep highlight.

---

## Type of Change

- [x] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/layered-alert-banner/`
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A layered alert banner with entrance motion, accent stripe, and a soft sweep highlight.

**How does a developer use it?**

```html
<aside class="alert-banner" role="status"><strong>Review needed</strong></aside>
```

**Why does it fit EaseMotion CSS?**

It adds a reusable status alert for dashboards, admin tools, and workflow screens.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer

Created on top of latest upstream main via GitHub API because current upstream contains Windows-invalid paths. Submission only adds the three required files.
