### PR TITLE
feat: add copy success button demo

### DIFF
--- a/submissions/examples/copy-success-button/README.md
+++ b/submissions/examples/copy-success-button/README.md
@@ -1,0 +1,15 @@
+# Copy Success Button
+
+## What does this do?
+A feedback button that animates from a copy action label to a copied success state.
+
+## How is it used?
+```html
+<button class="copy-button">
+  <span>Copy link</span>
+  <strong>Copied</strong>
+</button>
+```
+
+## Why is it useful?
+It gives EaseMotion CSS a compact microinteraction for share links, tokens, and clipboard actions.

--- a/submissions/examples/copy-success-button/demo.html
+++ b/submissions/examples/copy-success-button/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Copy Success Button Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="copy-page" aria-labelledby="copy-title">
+    <section class="copy-card">
+      <p class="eyebrow">Feedback button</p>
+      <h1 id="copy-title">Copy Success Button</h1>
+      <button class="copy-button"><span>Copy link</span><strong>Copied</strong></button>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/copy-success-button/style.css
+++ b/submissions/examples/copy-success-button/style.css
@@ -1,0 +1,11 @@
+body { min-height: 100vh; margin: 0; display: grid; place-items: center; background: linear-gradient(135deg, #052e16, #0891b2 55%, #fef3c7); color: #111827; font-family: Arial, Helvetica, sans-serif; }
+.copy-page { width: min(92vw, 680px); padding: 28px; }
+.copy-card { border-radius: 28px; padding: clamp(24px, 5vw, 46px); background: rgba(255,255,255,.94); box-shadow: 0 30px 86px rgba(5,46,22,.34); }
+.eyebrow { margin: 0 0 10px; color: #0891b2; font-size: .78rem; font-weight: 900; text-transform: uppercase; }
+h1 { margin: 0 0 28px; font-size: clamp(2.2rem, 7vw, 4.8rem); line-height: .92; }
+.copy-button { position: relative; min-width: 168px; min-height: 54px; border: 0; border-radius: 999px; padding: 0 26px; background: #111827; color: #fff; cursor: pointer; font-weight: 900; overflow: hidden; box-shadow: 0 18px 34px rgba(17,24,39,.22); }
+.copy-button span, .copy-button strong { display: grid; place-items: center; transition: transform .22s ease, opacity .22s ease; }
+.copy-button strong { position: absolute; inset: 0; opacity: 0; transform: translateY(100%); color: #bbf7d0; }
+.copy-button:hover span, .copy-button:focus-visible span { opacity: 0; transform: translateY(-100%); }
+.copy-button:hover strong, .copy-button:focus-visible strong { opacity: 1; transform: translateY(0); }
+.copy-button:focus-visible { outline: 4px solid rgba(8,145,178,.28); outline-offset: 4px; }


### PR DESCRIPTION
## Pull Request Description

A feedback button that animates from a copy action label to a copied success state.

---

## Type of Change

- [x] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/copy-success-button/`
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A feedback button that animates from a copy action label to a copied success state.

**How does a developer use it?**

```html
<button class="copy-button"><span>Copy link</span><strong>Copied</strong></button>
```

**Why does it fit EaseMotion CSS?**

It provides a compact microinteraction for share links, tokens, and clipboard actions.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer

Created on top of latest upstream main via GitHub API because current upstream contains Windows-invalid paths. Submission only adds the three required files.
