### PR TITLE
feat: manual implementation of animation-fill-mode utilities #16414

### DIFF
--- a/submissions/examples/animation-fill-mode-16414/README.md
+++ b/submissions/examples/animation-fill-mode-16414/README.md
@@ -1,0 +1,9 @@
+# Animation-Fill-Mode Utilities
+This submission introduces utility classes for controlling how an animation applies styles to its target before and after execution.
+
+- `.fill-none`: Default behavior.
+- `.fill-forwards`: Element retains styles from the last keyframe.
+- `.fill-backwards`: Element applies styles from the first keyframe during delay.
+- `.fill-both`: Combines forwards and backwards behavior.
+
+These utilities are critical for managing the state of elements after complex animation sequences.

--- a/submissions/examples/animation-fill-mode-16414/demo.html
+++ b/submissions/examples/animation-fill-mode-16414/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <link rel="stylesheet" href="style.css">
+  <title>Animation Fill Mode Demo</title>
+</head>
+<body>
+  <h1>Animation-Fill-Mode Utilities</h1>
+  
+  <div class="box fill-none">None</div>
+  <div class="box fill-forwards">Forwards</div>
+  <div class="box fill-both">Both</div>
+</body>
+</html>

--- a/submissions/examples/animation-fill-mode-16414/style.css
+++ b/submissions/examples/animation-fill-mode-16414/style.css
@@ -1,0 +1,19 @@
+/* animation-fill-mode utilities for #16414 */
+
+.fill-none { animation-fill-mode: none; }
+.fill-forwards { animation-fill-mode: forwards; }
+.fill-backwards { animation-fill-mode: backwards; }
+.fill-both { animation-fill-mode: both; }
+
+@keyframes slide {
+    from { transform: translateX(0); opacity: 0; }
+    to { transform: translateX(50px); opacity: 1; }
+}
+
+.box {
+    width: 50px;
+    height: 50px;
+    background: #ec4899;
+    animation: slide 2s ease-out 1s;
+    margin-bottom: 10px;
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements `animation-fill-mode` utilities (Issue #16414). These tokens allow developers to specify whether an element should retain the styles defined in the keyframes after an animation finishes, or apply them before it begins, which is essential for polished UI transitions.

---

## Type of Change
- [x] ✨ New feature/utility submission

## Submission Checklist
- [x] All changes are inside `submissions/examples/animation-fill-mode-16414/`
- [x] No modifications to existing `core/` or `components/` files.
- [x] `style.css` contains 5+ lines of meaningful CSS.
- [x] `demo.html` includes full boilerplate.

## Feature Description
- Adds utility classes for `none`, `forwards`, `backwards`, and `both` fill modes.
- Includes a demo showing the final state of elements after the animation concludes.

Closes #16414