### PR TITLE
feat: manual implementation of widows utilities #22163

### DIFF
--- a/submissions/examples/widows-22163/README.md
+++ b/submissions/examples/widows-22163/README.md
@@ -1,0 +1,6 @@
+# Widows Utilities
+This submission introduces utilities to control the `widows` property, which specifies the minimum number of lines in a block container that must be shown at the bottom of a page or column.
+
+- `.widows-1` to `.widows-3`: Configures the minimum line count.
+
+Proper control of widows is essential for professional typesetting and preventing orphan/widow text issues in multi-column or paginated layouts.

--- a/submissions/examples/widows-22163/demo.html
+++ b/submissions/examples/widows-22163/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <link rel="stylesheet" href="style.css">
+  <title>Widows Demo</title>
+</head>
+<body>
+  <h1>Widows Utilities</h1>
+  
+  <div class="text-container widows-2">
+    This paragraph has a minimum of two lines at the very end of the block. 
+    This prevents awkward single words from appearing on their own line.
+  </div>
+</body>
+</html>

--- a/submissions/examples/widows-22163/style.css
+++ b/submissions/examples/widows-22163/style.css
@@ -1,0 +1,12 @@
+/* widows utilities for #22163 */
+
+.widows-1 { widows: 1; }
+.widows-2 { widows: 2; }
+.widows-3 { widows: 3; }
+
+.text-container {
+    width: 200px;
+    border: 1px solid #9ca3af;
+    padding: 10px;
+    font-family: sans-serif;
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements `widows` utilities (Issue #22163). These tokens allow developers to control the minimum number of lines allowed at the end of a block before a page or column break, which is a critical typographic control for print-to-web and long-form content layouts.

---

## Type of Change
- [x] ✨ New feature/utility submission

## Submission Checklist
- [x] All changes are inside `submissions/examples/widows-22163/`
- [x] No modifications to existing `core/` or `components/` files.
- [x] `style.css` contains sufficient CSS rules.
- [x] `demo.html` includes full boilerplate.

## Feature Description
- Adds classes for standard `widows` values.
- Includes a demo highlighting how the property manages trailing lines in text blocks.

Closes #22163