### PR TITLE
feat: manual implementation of fill-current utility #15096 (v2)

### DIFF
--- a/submissions/examples/fill-current-15096/README.md
+++ b/submissions/examples/fill-current-15096/README.md
@@ -1,0 +1,5 @@
+# Fill Current Utility
+Adds a utility class for the `fill: currentColor` CSS property.
+
+- **Effect**: Causes SVG elements to inherit the current `color` value of their parent.
+- **Use Case**: Allows icons to automatically change color based on text context or theme toggles without needing to redefine fill properties for every state.

--- a/submissions/examples/fill-current-15096/demo.html
+++ b/submissions/examples/fill-current-15096/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <link rel="stylesheet" href="style.css">
+  <title>Fill Current Demo</title>
+</head>
+<body>
+  <h1>Fill Current Utility</h1>
+  
+  <div style="color: #ef4444;">
+    <svg width="50" height="50" viewBox="0 0 24 24" class="fill-current">
+      <circle cx="12" cy="12" r="10" />
+    </svg>
+    <p>The SVG circle inherits the text color (red).</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fill-current-15096/style.css
+++ b/submissions/examples/fill-current-15096/style.css
@@ -1,0 +1,5 @@
+/* Fill Current Utility for #15096 */
+
+.fill-current {
+    fill: currentColor;
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the `fill-current` utility (Issue #15096). By mapping `fill` to `currentColor`, this utility enables SVG icons to inherit dynamic colors from the surrounding text, simplifying theme management.

---

## Type of Change
- [x] ✨ New feature/utility submission

## Submission Checklist
- [x] All changes are inside `submissions/examples/fill-current-15096/`
- [x] No modifications to existing `core/` or `components/` files.
- [x] `style.css` contains the fill utility.
- [x] `demo.html` includes full boilerplate.

## Feature Description
- Implements `fill: currentColor`.
- Enables contextual icon coloring.

Closes #15096