### PR TITLE
feat: manual implementation of individual translate transform utilities #13369

### DIFF
--- a/submissions/examples/translate-13369/README.md
+++ b/submissions/examples/translate-13369/README.md
@@ -1,0 +1,5 @@
+# Individual Translate Utilities
+Adds utility classes for the CSS `translate` property.
+
+- **Purpose**: Provides a modern, cleaner alternative to `transform: translate()` by isolating X and Y axis translations.
+- **Use Case**: Simplifies layout adjustments and animations, avoiding the need to overwrite the entire `transform` stack.

--- a/submissions/examples/translate-13369/demo.html
+++ b/submissions/examples/translate-13369/demo.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <link rel="stylesheet" href="style.css">
+  <title>Translate Utility Demo</title>
+</head>
+<body>
+  <h1>Individual Translate Utilities</h1>
+  <div class="box translate-x-10"></div>
+  <div class="box translate-y-10"></div>
+</body>
+</html>

--- a/submissions/examples/translate-13369/style.css
+++ b/submissions/examples/translate-13369/style.css
@@ -1,0 +1,14 @@
+/* Individual Translate Transform Utilities for #13369 */
+
+.translate-x-10 { translate: 10px 0; }
+.translate-y-10 { translate: 0 10px; }
+.translate-x-full { translate: 100% 0; }
+.translate-y-full { translate: 0 100%; }
+
+/* Demo setup */
+.box {
+    width: 50px;
+    height: 50px;
+    background: #f472b6;
+    transition: translate 0.3s ease;
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements individual `translate` utility classes (Issue #13369). By using the CSS `translate` property instead of `transform`, these utilities prevent common conflicts that occur when multiple transform functions are applied to a single element.

---

## Type of Change
- [x] ✨ New feature/utility submission

## Submission Checklist
- [x] All changes are inside `submissions/examples/translate-13369/`
- [x] No modifications to existing `core/` or `components/` files.
- [x] `style.css` contains the translate utility mapping.
- [x] `demo.html` includes full boilerplate.

## Feature Description
- Implements `translate-x` and `translate-y` variants.
- Improves CSS transform management by avoiding the `transform` shorthand conflict.

Closes #13369