### PR TITLE
feat: add keyboard shortcut row demo

### DIFF
--- a/submissions/examples/keyboard-shortcut-row/README.md
+++ b/submissions/examples/keyboard-shortcut-row/README.md
@@ -1,0 +1,15 @@
+# Keyboard Shortcut Row
+
+A compact CSS-only shortcut list with tactile keycap styling and row hover feedback.
+
+## Features
+
+- Responsive centered panel
+- Semantic `kbd` elements for shortcuts
+- Hover animation for interactive polish
+- Clean spacing and contrast for dashboard-style UIs
+
+## Files
+
+- `demo.html`
+- `style.css`

--- a/submissions/examples/keyboard-shortcut-row/demo.html
+++ b/submissions/examples/keyboard-shortcut-row/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Keyboard Shortcut Row</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="shortcut-panel" aria-label="Keyboard shortcut examples">
+    <p class="eyebrow">Command center</p>
+    <h1>Keyboard shortcuts</h1>
+    <div class="shortcut-row">
+      <span>Open search</span>
+      <kbd>Ctrl</kbd><kbd>K</kbd>
+    </div>
+    <div class="shortcut-row">
+      <span>Switch project</span>
+      <kbd>Alt</kbd><kbd>P</kbd>
+    </div>
+    <div class="shortcut-row">
+      <span>Quick save</span>
+      <kbd>Ctrl</kbd><kbd>S</kbd>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/keyboard-shortcut-row/style.css
+++ b/submissions/examples/keyboard-shortcut-row/style.css
@@ -1,0 +1,61 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #f4f7fb;
+  color: #162033;
+  font-family: Arial, sans-serif;
+}
+
+.shortcut-panel {
+  width: min(92vw, 430px);
+  padding: 28px;
+  border: 1px solid #d8e0ee;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 18px 40px rgba(34, 46, 70, 0.12);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #52647d;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 20px;
+  font-size: 1.65rem;
+}
+
+.shortcut-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 10px;
+  align-items: center;
+  padding: 14px 0;
+  border-top: 1px solid #e7edf5;
+}
+
+kbd {
+  min-width: 42px;
+  padding: 8px 10px;
+  border: 1px solid #b9c5d6;
+  border-bottom-width: 3px;
+  border-radius: 6px;
+  background: #f9fbff;
+  text-align: center;
+  font-weight: 700;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.shortcut-row:hover kbd {
+  transform: translateY(-2px);
+  border-color: #4f7cff;
+}


### PR DESCRIPTION
## Description
Adds a responsive keyboard shortcut row with tactile keycaps and hover focus states.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have tested the animation/demo locally
- [x] I have added/updated documentation where necessary
- [x] This PR adds a new example under `submissions/examples/keyboard-shortcut-row`