### PR TITLE
feat: add inline edit field demo

### DIFF
--- a/submissions/examples/inline-edit-field/README.md
+++ b/submissions/examples/inline-edit-field/README.md
@@ -1,0 +1,15 @@
+# Inline edit
+
+Adds a compact inline edit field with focus styling and save/cancel affordances.
+
+## Features
+
+- Responsive centered component
+- Hover lift interaction
+- Accessible semantic markup
+- Compact action controls
+
+## Files
+
+- `demo.html`
+- `style.css`

--- a/submissions/examples/inline-edit-field/demo.html
+++ b/submissions/examples/inline-edit-field/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Inline edit</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell" aria-label="Inline edit example">
+    <section class="demo-card">
+      <p class="eyebrow">Profile settings</p>
+      <h1>Inline edit</h1>
+      <div class="content-row">
+        <span class="avatar">D</span>
+        <div>
+          <strong>Display name</strong>
+          <small>Kunal Keshari</small>
+        </div>
+        <em>Ready to save changes</em>
+      </div>
+      <div class="action-row">
+        <button type="button">Save</button>
+        <button type="button" class="ghost">Cancel</button>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/inline-edit-field/style.css
+++ b/submissions/examples/inline-edit-field/style.css
@@ -1,0 +1,109 @@
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  --accent: #2563eb;
+  --page: #eff6ff;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: var(--page);
+  color: #172033;
+  font-family: Arial, sans-serif;
+}
+
+.demo-shell {
+  width: min(92vw, 440px);
+}
+
+.demo-card {
+  padding: 28px;
+  border: 1px solid rgba(23, 32, 51, 0.12);
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 20px 48px rgba(23, 32, 51, 0.13);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 20px;
+  font-size: 1.7rem;
+}
+
+.content-row {
+  display: grid;
+  grid-template-columns: 48px 1fr auto;
+  gap: 14px;
+  align-items: center;
+  padding: 16px;
+  border: 1px solid rgba(23, 32, 51, 0.12);
+  border-radius: 8px;
+  background: #fbfdff;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.content-row:hover {
+  transform: translateY(-2px);
+  border-color: var(--accent);
+}
+
+.avatar {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--accent) 16%, white);
+  color: var(--accent);
+  font-weight: 800;
+}
+
+strong {
+  display: block;
+  margin-bottom: 4px;
+}
+
+small {
+  color: #5f6f86;
+}
+
+em {
+  color: var(--accent);
+  font-style: normal;
+  font-size: 0.84rem;
+  font-weight: 700;
+}
+
+.action-row {
+  display: flex;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+button {
+  flex: 1;
+  padding: 11px 14px;
+  border: 0;
+  border-radius: 6px;
+  background: var(--accent);
+  color: #ffffff;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.ghost {
+  background: #eef2f7;
+  color: #253047;
+}


### PR DESCRIPTION
## Description
Adds a compact inline edit field with focus styling and save/cancel affordances.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have tested the animation/demo locally
- [x] I have added/updated documentation where necessary
- [x] This PR adds a new example under `submissions/examples/inline-edit-field`