### PR TITLE
feat: add list group component (issue #22853)

### DIFF
--- a/submissions/core_changes-issue-22853/README.md
+++ b/submissions/core_changes-issue-22853/README.md
@@ -1,0 +1,20 @@
+# ease-list-group — List Group Component
+
+## What does this do?
+Adds a list group component to EaseMotion CSS — displays lists of items with optional badges, icons, active states, and disabled states. Includes variants for flush (borderless), numbered (with CSS counters), and actionable list groups with staggered entrance animations.
+
+## How is it used?
+Open `demo.html` directly in a browser. The page demonstrates all list group variants with interactive hover effects and entrance animations powered by EaseMotion CSS utility classes.
+
+```html
+<ul class="ease-list-group">
+  <li class="ease-list-group-item">Item</li>
+  <li class="ease-list-group-item ease-list-group-active">Active</li>
+  <li class="ease-list-group-item ease-list-group-disabled">Disabled</li>
+</ul>
+```
+
+## Why is it useful?
+List groups are essential for categorization menus, settings pages, directory listings, and feature lists. This component provides a consistent, accessible, and animated list group pattern that integrates with existing EaseMotion design tokens (`--ease-color-*`, `--ease-space-*`, `--ease-radius-*`, etc.).
+
+Fixes #22853

--- a/submissions/core_changes-issue-22853/demo.html
+++ b/submissions/core_changes-issue-22853/demo.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>List Group Component — EaseMotion CSS</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
+  <link rel="stylesheet" href="./style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: 'Inter', system-ui, -apple-system, sans-serif;
+      background: var(--ease-color-bg, #f8fafc);
+      color: var(--ease-color-text, #334155);
+      padding: 2rem;
+    }
+    .container { max-width: 900px; margin: 0 auto; }
+    h1 { font-size: 1.75rem; font-weight: 700; margin-bottom: 0.5rem; }
+    .subtitle { color: var(--ease-color-muted, #64748b); margin-bottom: 2rem; font-size: 0.95rem; }
+    .page-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 2rem;
+    }
+    .issue-badge {
+      background: var(--ease-color-primary, #6c63ff);
+      color: #fff;
+      padding: 0.35rem 0.75rem;
+      border-radius: var(--ease-radius-full, 9999px);
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+    .demo-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 2rem;
+      margin-bottom: 2rem;
+    }
+    .demo-section {
+      background: var(--ease-color-surface, #ffffff);
+      border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+      border-radius: var(--ease-radius-lg, 1rem);
+      padding: 1.5rem;
+    }
+    .demo-section h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-bottom: 1rem;
+      color: var(--ease-color-muted, #64748b);
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    .demo-section.full-width {
+      grid-column: 1 / -1;
+    }
+    .demo-note {
+      font-size: 0.8rem;
+      color: var(--ease-color-neutral-400, #94a3b8);
+      margin-top: 1rem;
+      padding-top: 0.75rem;
+      border-top: 1px solid var(--ease-color-neutral-100, #f1f5f9);
+    }
+    footer {
+      margin-top: 3rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+      text-align: center;
+      font-size: 0.8rem;
+      color: var(--ease-color-muted, #64748b);
+    }
+    @media (max-width: 768px) {
+      .demo-grid { grid-template-columns: 1fr; }
+      body { padding: 1rem; }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="page-header ease-fade-in">
+      <div>
+        <h1>List Group Component</h1>
+        <p class="subtitle">EaseMotion CSS component submission — Issue #22853</p>
+      </div>
+      <span class="issue-badge">#22853</span>
+    </div>
+
+    <div class="demo-grid">
+
+      <div class="demo-section ease-slide-up ease-delay-100">
+        <h2>Basic List Group</h2>
+        <ul class="ease-list-group">
+          <li class="ease-list-group-item">
+            <span class="ease-list-group-icon">📁</span>
+            Documents
+          </li>
+          <li class="ease-list-group-item">
+            <span class="ease-list-group-icon">🖼️</span>
+            Images
+          </li>
+          <li class="ease-list-group-item">
+            <span class="ease-list-group-icon">🎵</span>
+            Music
+          </li>
+          <li class="ease-list-group-item">
+            <span class="ease-list-group-icon">🎬</span>
+            Videos
+          </li>
+        </ul>
+        <p class="demo-note">Basic list with icons and default border.</p>
+      </div>
+
+      <div class="demo-section ease-slide-up ease-delay-200">
+        <h2>Active &amp; Disabled States</h2>
+        <ul class="ease-list-group">
+          <li class="ease-list-group-item ease-list-group-active">
+            <span class="ease-list-group-icon">🏠</span>
+            Dashboard
+          </li>
+          <li class="ease-list-group-item">
+            <span class="ease-list-group-icon">👤</span>
+            Profile
+          </li>
+          <li class="ease-list-group-item">
+            <span class="ease-list-group-icon">⚙️</span>
+            Settings
+          </li>
+          <li class="ease-list-group-item ease-list-group-disabled">
+            <span class="ease-list-group-icon">🔒</span>
+            Premium (Locked)
+          </li>
+        </ul>
+        <p class="demo-note">Active item has primary color accent. Disabled is grayed out.</p>
+      </div>
+
+      <div class="demo-section ease-slide-up ease-delay-300">
+        <h2>Flush Variant</h2>
+        <ul class="ease-list-group ease-list-group-flush">
+          <li class="ease-list-group-item">Notifications</li>
+          <li class="ease-list-group-item">Security</li>
+          <li class="ease-list-group-item">Privacy</li>
+          <li class="ease-list-group-item">Help Center</li>
+        </ul>
+        <p class="demo-note">No outer border — sits flush with parent container.</p>
+      </div>
+
+      <div class="demo-section ease-slide-up ease-delay-400">
+        <h2>Numbered Variant</h2>
+        <ol class="ease-list-group ease-list-group-numbered">
+          <li class="ease-list-group-item">Create an account</li>
+          <li class="ease-list-group-item">Complete your profile</li>
+          <li class="ease-list-group-item">Choose a plan</li>
+          <li class="ease-list-group-item">Start building</li>
+        </ol>
+        <p class="demo-note">Auto-numbered circles using CSS counters.</p>
+      </div>
+
+      <div class="demo-section ease-slide-up ease-delay-500">
+        <h2>With Badges</h2>
+        <ul class="ease-list-group">
+          <li class="ease-list-group-item">
+            Inbox
+            <span style="margin-left:auto;padding:0.15rem 0.5rem;border-radius:9999px;background:var(--ease-color-primary,#6c63ff);color:#fff;font-size:0.7rem;font-weight:600;">12</span>
+          </li>
+          <li class="ease-list-group-item">
+            Unread
+            <span style="margin-left:auto;padding:0.15rem 0.5rem;border-radius:9999px;background:var(--ease-color-danger,#ef4444);color:#fff;font-size:0.7rem;font-weight:600;">5</span>
+          </li>
+          <li class="ease-list-group-item">
+            Drafts
+            <span style="margin-left:auto;padding:0.15rem 0.5rem;border-radius:9999px;background:var(--ease-color-warning,#f59e0b);color:#fff;font-size:0.7rem;font-weight:600;">3</span>
+          </li>
+          <li class="ease-list-group-item">
+            Spam
+            <span style="margin-left:auto;padding:0.15rem 0.5rem;border-radius:9999px;background:var(--ease-color-info,#3b82f6);color:#fff;font-size:0.7rem;font-weight:600;">2</span>
+          </li>
+        </ul>
+        <p class="demo-note">Badges aligned to the right of each list item.</p>
+      </div>
+
+      <div class="demo-section full-width ease-slide-up ease-delay-600">
+        <h2>Actionable List Group</h2>
+        <ul class="ease-list-group">
+          <li class="ease-list-group-item" onclick="alert('Navigation clicked')">
+            <span class="ease-list-group-icon">🌐</span>
+            Getting Started Guide
+          </li>
+          <li class="ease-list-group-item" onclick="alert('API clicked')">
+            <span class="ease-list-group-icon">🔌</span>
+            API Reference
+          </li>
+          <li class="ease-list-group-item" onclick="alert('Components clicked')">
+            <span class="ease-list-group-icon">🧩</span>
+            Component Library
+          </li>
+          <li class="ease-list-group-item" onclick="alert('Changelog clicked')">
+            <span class="ease-list-group-icon">📋</span>
+            Changelog
+          </li>
+        </ul>
+        <p class="demo-note">Clickable items with hover highlight — click any item.</p>
+      </div>
+
+    </div>
+
+    <footer>
+      <p>Submission for <strong>EaseMotion CSS</strong> — Issue <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/22853" target="_blank">#22853</a></p>
+      <p style="margin-top:0.25rem;">
+        Proposed: <code>.ease-list-group</code> · <code>.ease-list-group-item</code> ·
+        <code>.ease-list-group-active</code> · <code>.ease-list-group-disabled</code> ·
+        <code>.ease-list-group-flush</code> · <code>.ease-list-group-numbered</code>
+      </p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/submissions/core_changes-issue-22853/style.css
+++ b/submissions/core_changes-issue-22853/style.css
@@ -1,0 +1,193 @@
+/* ============================================================
+   List Group Component — Core CSS
+   Proposed for EaseMotion CSS
+   Issue: #22853
+   ============================================================ */
+
+/* ── Base List Group ──────────────────────────────────────── */
+
+.ease-list-group {
+  display: flex;
+  flex-direction: column;
+  border-radius: var(--ease-radius-lg, 1rem);
+  overflow: hidden;
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  background: var(--ease-color-surface, #ffffff);
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+/* ── List Group Item ──────────────────────────────────────── */
+
+.ease-list-group-item {
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-3, 0.75rem);
+  padding: var(--ease-space-4, 1rem) var(--ease-space-5, 1.25rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-text, #334155);
+  background: var(--ease-color-surface, #ffffff);
+  border-bottom: 1px solid var(--ease-color-neutral-100, #f1f5f9);
+  transition: background var(--ease-speed-fast, 150ms) var(--ease-ease),
+              color var(--ease-speed-fast, 150ms) var(--ease-ease);
+}
+
+.ease-list-group-item:last-child {
+  border-bottom: none;
+}
+
+/* ── Active State ─────────────────────────────────────────── */
+
+.ease-list-group-active {
+  background: var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.1));
+  color: var(--ease-color-primary, #6c63ff);
+  font-weight: 600;
+  border-left: 3px solid var(--ease-color-primary, #6c63ff);
+}
+
+/* ── Disabled State ───────────────────────────────────────── */
+
+.ease-list-group-disabled {
+  color: var(--ease-color-neutral-400, #94a3b8);
+  cursor: not-allowed;
+  background: var(--ease-color-neutral-50, #f8fafc);
+}
+
+/* ── Hover / Actionable ───────────────────────────────────── */
+
+.ease-list-group-item:not(.ease-list-group-disabled) {
+  cursor: pointer;
+}
+
+.ease-list-group-item:not(.ease-list-group-disabled):hover {
+  background: var(--ease-color-neutral-50, #f8fafc);
+}
+
+.ease-list-group-active:hover {
+  background: var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.15));
+}
+
+/* ── Flush Variant ────────────────────────────────────────── */
+
+.ease-list-group-flush {
+  border: none;
+  border-radius: 0;
+}
+
+/* ── Numbered Variant ─────────────────────────────────────── */
+
+.ease-list-group-numbered {
+  counter-reset: list-group-counter;
+}
+
+.ease-list-group-numbered .ease-list-group-item {
+  counter-increment: list-group-counter;
+}
+
+.ease-list-group-numbered .ease-list-group-item::before {
+  content: counter(list-group-counter);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--ease-radius-full, 9999px);
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 700;
+  color: var(--ease-color-neutral-600, #475569);
+  flex-shrink: 0;
+}
+
+/* ── Icon Slot ────────────────────────────────────────────── */
+
+.ease-list-group-icon {
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  flex-shrink: 0;
+  color: var(--ease-color-neutral-500, #64748b);
+}
+
+.ease-list-group-active .ease-list-group-icon {
+  color: var(--ease-color-primary, #6c63ff);
+}
+
+/* ── Badge Support ────────────────────────────────────────── */
+
+.ease-list-group-item .ease-badge {
+  margin-left: auto;
+}
+
+/* ── Staggered Entrance Animation ─────────────────────────── */
+
+.ease-list-group .ease-list-group-item {
+  animation: ease-kf-list-group-fade-in var(--ease-speed-medium, 300ms) var(--ease-ease) both;
+}
+
+.ease-list-group .ease-list-group-item:nth-child(1) { animation-delay: 0ms; }
+.ease-list-group .ease-list-group-item:nth-child(2) { animation-delay: 50ms; }
+.ease-list-group .ease-list-group-item:nth-child(3) { animation-delay: 100ms; }
+.ease-list-group .ease-list-group-item:nth-child(4) { animation-delay: 150ms; }
+.ease-list-group .ease-list-group-item:nth-child(5) { animation-delay: 200ms; }
+.ease-list-group .ease-list-group-item:nth-child(6) { animation-delay: 250ms; }
+.ease-list-group .ease-list-group-item:nth-child(7) { animation-delay: 300ms; }
+.ease-list-group .ease-list-group-item:nth-child(8) { animation-delay: 350ms; }
+.ease-list-group .ease-list-group-item:nth-child(9) { animation-delay: 400ms; }
+.ease-list-group .ease-list-group-item:nth-child(10) { animation-delay: 450ms; }
+
+@keyframes ease-kf-list-group-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ── Dark Mode ────────────────────────────────────────────── */
+
+@media (prefers-color-scheme: dark) {
+  .ease-list-group {
+    border-color: var(--ease-color-neutral-700, #334155);
+    background: var(--ease-color-surface, #141e33);
+  }
+
+  .ease-list-group-item {
+    color: var(--ease-color-text, #e2e8f0);
+    background: var(--ease-color-surface, #141e33);
+    border-bottom-color: var(--ease-color-neutral-700, #334155);
+  }
+
+  .ease-list-group-active {
+    background: rgba(108, 99, 255, 0.15);
+  }
+
+  .ease-list-group-item:not(.ease-list-group-disabled):hover {
+    background: var(--ease-color-neutral-800, #1e293b);
+  }
+
+  .ease-list-group-disabled {
+    color: var(--ease-color-neutral-600, #475569);
+    background: var(--ease-color-neutral-800, #1e293b);
+  }
+
+  .ease-list-group-numbered .ease-list-group-item::before {
+    background: var(--ease-color-neutral-700, #334155);
+    color: var(--ease-color-neutral-300, #cbd5e1);
+  }
+}
+
+/* ── Reduced Motion ───────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-list-group .ease-list-group-item {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a complete list group component to EaseMotion CSS with multiple variants: basic, active/disabled states, flush (borderless), numbered (CSS counters), badge-supporting, and actionable items. All items include a staggered fade-in entrance animation with dark mode and reduced motion support.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (submissions/core_changes-issue-22853/)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A list group component with `.ease-list-group` container, `.ease-list-group-item` items, and modifier classes for active, disabled, flush, and numbered variants.

**How does a developer use it?**

```html
<ul class="ease-list-group">
  <li class="ease-list-group-item">Item</li>
  <li class="ease-list-group-item ease-list-group-active">Active</li>
  <li class="ease-list-group-item ease-list-group-disabled">Disabled</li>
</ul>
```

**Why does it fit EaseMotion CSS?**

List groups are a fundamental UI pattern that fills a gap in EaseMotion CSS. The component is animation-first (staggered fade-in), uses CSS custom properties for theming, supports dark mode natively, and respects `prefers-reduced-motion` — all aligning with the framework's philosophy.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

All classes use the `ease-` prefix convention: `ease-list-group`, `ease-list-group-item`, `ease-list-group-active`, `ease-list-group-disabled`, `ease-list-group-flush`, `ease-list-group-numbered`, `ease-list-group-icon`. Custom properties reference existing EaseMotion CSS tokens (`--ease-color-*`, `--ease-space-*`, `--ease-radius-*`). The numbered variant uses `<ol>` with CSS `counter-reset`/`counter-increment` for semantic auto-numbering.

Fixes #22853