### PR TITLE
feat(scss): add print stylesheet partial

### DIFF
--- a/scss/_index.scss
+++ b/scss/_index.scss
@@ -4,3 +4,4 @@
 
 @forward 'variables';
 @forward 'mixins';
+@forward 'print';

--- a/scss/_print.scss
+++ b/scss/_print.scss
@@ -1,0 +1,24 @@
+// Print stylesheet
+// Disable all animations and transitions during printing
+
+@media print {
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    animation-delay: 0s !important;
+    animation-duration: 0s !important;
+    animation-iteration-count: 1 !important;
+
+    transition: none !important;
+    transform: none !important;
+    filter: none !important;
+
+    box-shadow: none !important;
+    text-shadow: none !important;
+  }
+
+  html {
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a new SCSS partial for print stylesheets that disables animations and transitions during printing.

### Changes
- Added `scss/_print.scss`
- Disabled animations during print
- Disabled transitions during print
- Disabled transforms while printing
- Exported the partial through `scss/_index.scss`

Fixes #23097