### PR TITLE
feat: add CSS-only accordion component with smooth height animation

### DIFF
--- a/submissions/examples/accordion-rb/README.md
+++ b/submissions/examples/accordion-rb/README.md
@@ -1,0 +1,33 @@
+# Accordion Component
+
+A pure CSS accordion using the native HTML `&lt;details&gt;` / `&lt;summary&gt;` elements with smooth height animation via CSS `grid-template-rows`.
+
+## Files
+
+- `demo.html` — Live preview with default and glassmorphism variants
+- `style.css` — All accordion styles, variants, and demo layout
+
+## Variants Included
+
+| Class | Description |
+|-------|-------------|
+| `.accordion` | Base container with default light theme |
+| `.accordion-item` | Individual collapsible section (`&lt;details&gt;`) |
+| `.accordion-header` | Clickable header (`&lt;summary&gt;`) with animated chevron |
+| `.accordion-content` | Smooth reveal wrapper using grid transition |
+| `.accordion-glass` | Glassmorphism variant with backdrop blur |
+
+## How It Works
+
+The smooth animation is achieved with the **CSS grid trick**:
+
+```css
+.accordion-content {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.4s ease;
+}
+
+.accordion-item[open] &gt; .accordion-content {
+  grid-template-rows: 1fr;
+}

--- a/submissions/examples/accordion-rb/demo.html
+++ b/submissions/examples/accordion-rb/demo.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Accordion Component Demo — EaseMotion CSS</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <!-- ===== DEFAULT VARIANT ===== -->
+  <section class="demo-section">
+    <h2 class="demo-title">Default Accordion</h2>
+
+    <div class="accordion">
+      <details class="accordion-item" open>
+        <summary class="accordion-header">
+          What is EaseMotion CSS?
+          <svg class="accordion-icon" viewBox="0 0 24 24">
+            <polyline points="6 9 12 15 18 9"></polyline>
+          </svg>
+        </summary>
+        <div class="accordion-content">
+          <div class="accordion-content-inner">
+            EaseMotion CSS is an animation-first CSS framework with zero dependencies. It gives you human-readable utility classes and curated UI components that just work by linking a single stylesheet.
+          </div>
+        </div>
+      </details>
+
+      <details class="accordion-item">
+        <summary class="accordion-header">
+          Does it require JavaScript?
+          <svg class="accordion-icon" viewBox="0 0 24 24">
+            <polyline points="6 9 12 15 18 9"></polyline>
+          </svg>
+        </summary>
+        <div class="accordion-content">
+          <div class="accordion-content-inner">
+            Nope! This accordion is built entirely with the native HTML <code>&lt;details&gt;</code> element and CSS grid transitions. No frameworks, no build steps, no runtime JS.
+          </div>
+        </div>
+      </details>
+
+      <details class="accordion-item">
+        <summary class="accordion-header">
+          How do I customize the speed?
+          <svg class="accordion-icon" viewBox="0 0 24 24">
+            <polyline points="6 9 12 15 18 9"></polyline>
+          </svg>
+        </summary>
+        <div class="accordion-content">
+          <div class="accordion-content-inner">
+            Override the CSS custom property <code>--accordion-speed</code> on the <code>.accordion</code> container. The default is <code>0.4s</code>.
+          </div>
+        </div>
+      </details>
+    </div>
+  </section>
+
+  <!-- ===== GLASSMORPHISM VARIANT ===== -->
+  <div class="demo-glass-bg">
+    <section class="demo-section">
+      <h2 class="demo-title">Glassmorphism Accordion</h2>
+
+      <div class="accordion accordion-glass">
+        <details class="accordion-item">
+          <summary class="accordion-header">
+            Glassmorphism Design
+            <svg class="accordion-icon" viewBox="0 0 24 24">
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </summary>
+          <div class="accordion-content">
+            <div class="accordion-content-inner">
+              This variant uses <code>backdrop-filter: blur()</code> and translucent backgrounds to create a modern frosted-glass look. Perfect for hero sections and dashboards.
+            </div>
+          </div>
+        </details>
+
+        <details class="accordion-item">
+          <summary class="accordion-header">
+            Accessibility Built-in
+            <svg class="accordion-icon" viewBox="0 0 24 24">
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </summary>
+          <div class="accordion-content">
+            <div class="accordion-content-inner">
+              Because we use the native <code>&lt;details&gt;</code> element, keyboard navigation (Enter / Space to toggle) and screen-reader announcements work out of the box.
+            </div>
+          </div>
+        </details>
+
+        <details class="accordion-item">
+          <summary class="accordion-header">
+            Composable with Cards
+            <svg class="accordion-icon" viewBox="0 0 24 24">
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </summary>
+          <div class="accordion-content">
+            <div class="accordion-content-inner">
+              Drop this accordion inside an <code>.ease-card</code> (once standardized) or any flex/grid container. It adapts to the parent width automatically.
+            </div>
+          </div>
+        </details>
+      </div>
+    </section>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/accordion-rb/style.css
+++ b/submissions/examples/accordion-rb/style.css
@@ -1,0 +1,173 @@
+/* ============================================
+   Accordion Component — submissions/examples/accordion-rb
+   Pure CSS smooth-height accordion using <details>
+   ============================================ */
+
+/* ---- Base Accordion ---- */
+.accordion {
+  --accordion-bg: #ffffff;
+  --accordion-border: #e5e7eb;
+  --accordion-text: #111827;
+  --accordion-muted: #6b7280;
+  --accordion-radius: 0.75rem;
+  --accordion-speed: 0.4s;
+  --accordion-ease: cubic-bezier(0.4, 0, 0.2, 1);
+  --accordion-icon-ease: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  max-width: 640px;
+  margin: 0 auto;
+  border: 1px solid var(--accordion-border);
+  border-radius: var(--accordion-radius);
+  overflow: hidden;
+  background: var(--accordion-bg);
+  font-family: 'Inter', system-ui, sans-serif;
+}
+
+/* ---- Accordion Item (<details>) ---- */
+.accordion-item {
+  border-bottom: 1px solid var(--accordion-border);
+}
+
+.accordion-item:last-child {
+  border-bottom: none;
+}
+
+/* ---- Header (<summary>) ---- */
+.accordion-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  cursor: pointer;
+  list-style: none;
+  font-weight: 500;
+  color: var(--accordion-text);
+  background: transparent;
+  transition: background 0.2s ease;
+  user-select: none;
+}
+
+/* Hide default disclosure marker across browsers */
+.accordion-header::-webkit-details-marker {
+  display: none;
+}
+
+.accordion-header:hover {
+  background: rgba(0, 0, 0, 0.03);
+}
+
+/* ---- Animated Chevron Icon ---- */
+.accordion-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  fill: none;
+  transition: transform var(--accordion-speed) var(--accordion-icon-ease);
+  flex-shrink: 0;
+  margin-left: 0.75rem;
+}
+
+/* Rotate icon when open */
+.accordion-item[open] > .accordion-header .accordion-icon {
+  transform: rotate(180deg);
+}
+
+/* ---- Smooth Height Reveal (Grid Technique) ---- */
+.accordion-content {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows var(--accordion-speed) var(--accordion-ease);
+}
+
+.accordion-item[open] > .accordion-content {
+  grid-template-rows: 1fr;
+}
+
+.accordion-content-inner {
+  overflow: hidden;
+  padding: 0 1.25rem;
+  color: var(--accordion-muted);
+  line-height: 1.6;
+}
+
+/* Add bottom padding only when expanded */
+.accordion-item[open] .accordion-content-inner {
+  padding-bottom: 1.25rem;
+}
+
+/* ============================================
+   GLASSMORPHISM VARIANT
+   ============================================ */
+
+.accordion-glass {
+  --glass-bg: rgba(255, 255, 255, 0.08);
+  --glass-border: rgba(255, 255, 255, 0.2);
+  --glass-text: #ffffff;
+  --glass-muted: rgba(255, 255, 255, 0.7);
+
+  background: transparent;
+  border: none;
+  border-radius: var(--accordion-radius);
+}
+
+.accordion-glass .accordion-item {
+  background: var(--glass-bg);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--accordion-radius);
+  margin-bottom: 0.75rem;
+  overflow: hidden;
+}
+
+.accordion-glass .accordion-item:last-child {
+  margin-bottom: 0;
+}
+
+.accordion-glass .accordion-header {
+  color: var(--glass-text);
+}
+
+.accordion-glass .accordion-header:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.accordion-glass .accordion-content-inner {
+  color: var(--glass-muted);
+}
+
+/* ============================================
+   DEMO LAYOUT HELPERS
+   ============================================ */
+body {
+  background: #f3f4f6;
+  padding: 2rem 1rem;
+  margin: 0;
+}
+
+.demo-section {
+  margin-bottom: 3rem;
+}
+
+.demo-title {
+  text-align: center;
+  font-family: 'Inter', system-ui, sans-serif;
+  font-weight: 600;
+  color: #111827;
+  margin-bottom: 1.5rem;
+  font-size: 1.5rem;
+}
+
+.demo-glass-bg {
+  background: linear-gradient(135deg, #1e1b4b 0%, #312e81 50%, #4c1d95 100%);
+  min-height: 100vh;
+  padding: 3rem 1rem;
+  margin: -2rem -1rem;
+}
+
+.demo-glass-bg .demo-title {
+  color: #ffffff;
+}


### PR DESCRIPTION
## Summary
Adds a pure CSS accordion component submitted inside `submissions/examples/accordion-rb/` as per the current contribution freeze policy.

## What's Included
- `demo.html` — Live preview with default + glassmorphism variants
- `style.css` — All styles, CSS variables, and transitions
- `README.md` — Usage docs and customization guide

## Key Features
- **Zero JavaScript** — Uses native `&lt;details&gt;` / `&lt;summary&gt;` elements
- **Smooth height animation** — Uses `grid-template-rows: 0fr` → `1fr` transition instead of max-height hacks
- **Animated chevron** — Rotates with bounce easing on open/close
- **Glassmorphism variant** — `backdrop-filter: blur()` with translucent borders
- **Accessible** — Keyboard navigation (Enter/Space) works out of the box
- **Customizable** — 6 CSS custom properties for theming

## Variants
| Class | Description |
|-------|-------------|
| `.accordion` | Base light-themed accordion |
| `.accordion-glass` | Frosted-glass dark variant |

## Checklist
- [x] Submitted inside `submissions/examples/` only
- [x] Does not modify `core/`, `components/`, or workflow files
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] One feature per PR
- [x] Commit message follows Conventional Commits format
- [x] Feature does not duplicate existing EaseMotion classes
- [x] I have read the [Contributing Guide](https://github.com/SAPTARSHI-coder/EaseMotion-css/blob/main/CONTRIBUTING.md)

## Related Issue
Closes #23188

---

**Note to maintainer:** This is a raw submission. I understand the naming will be standardized to the `ease-*` prefix during the curation pipeline if approved.