### PR TITLE
feat(a11y): add aria-label to icon-only buttons

### DIFF
--- a/submissions/examples/icon-button-aria-label/README.md
+++ b/submissions/examples/icon-button-aria-label/README.md
@@ -1,0 +1,68 @@
+# Icon Button Aria Labels
+
+## Overview
+
+Icon-only buttons need accessible labels for screen readers. This example demonstrates how to properly add `aria-label` attributes to icon buttons for accessibility.
+
+## Problem
+
+Icon buttons without accessible labels are problematic for:
+- Screen reader users who cannot see the icon
+- Users who don't recognize the icon meaning
+- Accessibility compliance (WCAG guidelines)
+
+## Solution
+
+Add descriptive `aria-label` to every icon-only button:
+
+```html
+<button class="ease-btn ease-btn-icon" aria-label="Close menu">
+  <svg>...</svg>
+</button>
+```
+
+## Common Patterns
+
+| Icon | aria-label |
+|------|------------|
+| X | "Close" or "Close dialog" |
+| + | "Add" or "Add new item" |
+| ⚙️ | "Settings" |
+| 🔍 | "Search" |
+| 🗑️ | "Delete" or "Delete item" |
+| ✏️ | "Edit" |
+| ❤️ | "Like" or "Like this post" |
+| 📤 | "Share" or "Share this content" |
+
+## Best Practices
+
+1. **Always add aria-label** to icon-only buttons
+2. **Use descriptive labels** that explain the action
+3. **Be specific** when needed (e.g., "Delete post" vs "Delete")
+4. **Test with screen readers** (NVDA, VoiceOver, JAWS)
+5. **Don't use title alone** - it's not reliably announced
+6. **Consider aria-pressed** for toggle buttons
+
+## CSS for Icon Buttons
+
+```css
+.ease-btn-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+}
+
+.ease-btn-icon:focus {
+  outline: 2px solid var(--ease-color-primary);
+  outline-offset: 2px;
+}
+```
+
+## Files
+
+- `demo.html` - Interactive demonstration
+- `style.css` - Component styling
+- `README.md` - This documentation

--- a/submissions/examples/icon-button-aria-label/demo.html
+++ b/submissions/examples/icon-button-aria-label/demo.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Icon Button Aria Labels</title>
+  <link rel="stylesheet" href="../../core/variables.css">
+  <link rel="stylesheet" href="../../core/base.css">
+  <link rel="stylesheet" href="../../core/utilities.css">
+  <link rel="stylesheet" href="../../components/buttons.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-container">
+    <h1>Icon Button Aria Labels</h1>
+    <p class="description">
+      Icon-only buttons need accessible labels for screen readers. Add <code>aria-label</code> 
+      to provide descriptive text for assistive technology users.
+    </p>
+
+    <section class="demo-section">
+      <h2>Icon Buttons with Aria Labels</h2>
+      <div class="button-group">
+        <!-- Good: Icon button with aria-label -->
+        <button class="ease-btn ease-btn-icon" aria-label="Close menu">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="18" y1="6" x2="6" y2="18"></line>
+            <line x1="6" y1="6" x2="18" y2="18"></line>
+          </svg>
+        </button>
+
+        <!-- Good: Icon button with aria-label -->
+        <button class="ease-btn ease-btn-icon" aria-label="Open menu">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="3" y1="12" x2="21" y2="12"></line>
+            <line x1="3" y1="6" x2="21" y2="6"></line>
+            <line x1="3" y1="18" x2="21" y2="18"></line>
+          </svg>
+        </button>
+
+        <!-- Good: Icon button with aria-label -->
+        <button class="ease-btn ease-btn-icon" aria-label="Search">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="11" cy="11" r="8"></circle>
+            <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+          </svg>
+        </button>
+
+        <!-- Good: Icon button with aria-label -->
+        <button class="ease-btn ease-btn-icon" aria-label="Delete item">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="3 6 5 6 21 6"></polyline>
+            <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+          </svg>
+        </button>
+
+        <!-- Good: Icon button with aria-label -->
+        <button class="ease-btn ease-btn-icon" aria-label="Edit">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+            <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+          </svg>
+        </button>
+
+        <!-- Good: Icon button with aria-label -->
+        <button class="ease-btn ease-btn-icon" aria-label="Settings">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="3"></circle>
+            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+          </svg>
+        </button>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <h2>Common Icon Button Patterns</h2>
+      <div class="examples-grid">
+        <div class="example-card">
+          <h3>Close Button</h3>
+          <button class="ease-btn ease-btn-icon" aria-label="Close dialog">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+          </button>
+          <code>aria-label="Close dialog"</code>
+        </div>
+
+        <div class="example-card">
+          <h3>Add Button</h3>
+          <button class="ease-btn ease-btn-icon" aria-label="Add new item">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+          </button>
+          <code>aria-label="Add new item"</code>
+        </div>
+
+        <div class="example-card">
+          <h3>Share Button</h3>
+          <button class="ease-btn ease-btn-icon" aria-label="Share this content">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="5" r="3"></circle><circle cx="6" cy="12" r="3"></circle><circle cx="18" cy="19" r="3"></circle><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"></line><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"></line></svg>
+          </button>
+          <code>aria-label="Share this content"</code>
+        </div>
+
+        <div class="example-card">
+          <h3>Like Button</h3>
+          <button class="ease-btn ease-btn-icon" aria-label="Like this post">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
+          </button>
+          <code>aria-label="Like this post"</code>
+        </div>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <h2>Implementation</h2>
+      <div class="code-example">
+        <h3>HTML</h3>
+        <pre><code>&lt;!-- Icon button with aria-label --&gt;
+&lt;button class="ease-btn ease-btn-icon" aria-label="Close menu"&gt;
+  &lt;svg&gt;...&lt;/svg&gt;
+&lt;/button&gt;
+
+&lt;!-- Icon button with aria-label for screen readers --&gt;
+&lt;button class="ease-btn ease-btn-icon" aria-label="Delete item"&gt;
+  &lt;svg&gt;...&lt;/svg&gt;
+&lt;/button&gt;</code></pre>
+      </div>
+
+      <div class="code-example">
+        <h3>CSS for Icon Buttons</h3>
+        <pre><code>.ease-btn-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  border-radius: var(--ease-radius-md);
+  background: var(--ease-color-surface);
+  border: 1px solid var(--ease-color-neutral-200);
+  cursor: pointer;
+  transition: all var(--ease-speed-fast) var(--ease-ease);
+}
+
+.ease-btn-icon:hover {
+  background: var(--ease-color-primary);
+  color: #fff;
+  border-color: var(--ease-color-primary);
+}
+
+.ease-btn-icon:focus {
+  outline: 2px solid var(--ease-color-primary);
+  outline-offset: 2px;
+}</code></pre>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <h2>Accessibility Checklist</h2>
+      <ul class="checklist">
+        <li>✅ Always add <code>aria-label</code> to icon-only buttons</li>
+        <li>✅ Use descriptive labels that explain the action</li>
+        <li>✅ Test with screen readers (NVDA, VoiceOver, JAWS)</li>
+        <li>✅ Ensure focus states are visible</li>
+        <li>✅ Don't use <code>title</code> attribute alone (not reliable)</li>
+        <li>✅ Consider <code>aria-pressed</code> for toggle buttons</li>
+      </ul>
+    </section>
+  </div>
+</body>
+</html>

--- a/submissions/examples/icon-button-aria-label/style.css
+++ b/submissions/examples/icon-button-aria-label/style.css
@@ -1,0 +1,167 @@
+/* Icon Button Aria Labels Demo Styles */
+
+body {
+  background-color: var(--ease-color-bg, #0f0e17);
+  color: var(--ease-color-text, #fffffe);
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  line-height: 1.6;
+  margin: 0;
+  padding: 0;
+}
+
+/* ── Demo Container ───────────────────────────────────────── */
+.demo-container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: var(--ease-space-8, 2rem);
+}
+
+.demo-container h1 {
+  font-size: 1.75rem;
+  margin-bottom: var(--ease-space-4, 1rem);
+  color: var(--ease-color-text, #fff);
+}
+
+.demo-container h2 {
+  font-size: 1.25rem;
+  margin-top: var(--ease-space-8, 2rem);
+  margin-bottom: var(--ease-space-4, 1rem);
+  color: var(--ease-color-text, #fff);
+}
+
+.description {
+  color: var(--ease-color-muted, rgba(255, 255, 255, 0.65));
+  margin-bottom: var(--ease-space-6, 1.5rem);
+}
+
+.description code {
+  background: rgba(108, 99, 255, 0.2);
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.875em;
+  color: var(--ease-color-primary-light, #a78bfa);
+}
+
+/* ── Demo Section ────────────────────────────────────────── */
+.demo-section {
+  margin-bottom: var(--ease-space-8, 2rem);
+}
+
+/* ── Button Group ────────────────────────────────────────── */
+.button-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ease-space-3, 0.75rem);
+  align-items: center;
+}
+
+/* ── Icon Button ─────────────────────────────────────────── */
+.ease-btn-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  padding: 0;
+  border-radius: var(--ease-radius-md, 8px);
+  background: var(--ease-color-surface, #1a1a2e);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--ease-color-text, #fff);
+  cursor: pointer;
+  transition: all var(--ease-speed-fast, 150ms) var(--ease-ease);
+}
+
+.ease-btn-icon:hover {
+  background: var(--ease-color-primary, #6c63ff);
+  border-color: var(--ease-color-primary, #6c63ff);
+}
+
+.ease-btn-icon:focus {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+
+/* ── Examples Grid ────────────────────────────────────────── */
+.examples-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--ease-space-4, 1rem);
+}
+
+.example-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--ease-space-3, 0.75rem);
+  padding: var(--ease-space-6, 1.5rem);
+  background: var(--ease-color-surface, rgba(255, 255, 255, 0.04));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--ease-radius-lg, 12px);
+}
+
+.example-card h3 {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--ease-color-muted, rgba(255, 255, 255, 0.7));
+}
+
+.example-card code {
+  font-size: 0.75rem;
+  color: var(--ease-color-primary-light, #a78bfa);
+  background: rgba(108, 99, 255, 0.1);
+  padding: var(--ease-space-1, 0.25rem) var(--ease-space-2, 0.5rem);
+  border-radius: var(--ease-radius-sm, 4px);
+}
+
+/* ── Checklist ───────────────────────────────────────────── */
+.checklist {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: var(--ease-space-3, 0.75rem);
+}
+
+.checklist li {
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-2, 0.5rem);
+  color: var(--ease-color-muted, rgba(255, 255, 255, 0.7));
+}
+
+.checklist li code {
+  background: rgba(108, 99, 255, 0.2);
+  padding: 0.1rem 0.3rem;
+  border-radius: 3px;
+  font-size: 0.85em;
+  color: var(--ease-color-primary-light, #a78bfa);
+}
+
+/* ── Code Example ────────────────────────────────────────── */
+.code-example {
+  background: var(--ease-color-surface, rgba(255, 255, 255, 0.04));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--ease-radius-md, 8px);
+  padding: var(--ease-space-4, 1rem);
+  margin-bottom: var(--ease-space-4, 1rem);
+}
+
+.code-example h3 {
+  margin-top: 0;
+  font-size: 0.875rem;
+  color: var(--ease-color-primary-light, #a78bfa);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.code-example pre {
+  margin: 0;
+  overflow-x: auto;
+}
+
+.code-example code {
+  font-family: 'Fira Code', 'Consolas', monospace;
+  font-size: 0.875rem;
+  color: var(--ease-color-text, #fff);
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
# Add accessible `aria-label` attributes to icon buttons

Adds accessible `aria-label` attributes to icon-only buttons, improving screen reader support without changing the UI.

Closes #23195

## Pull Request Description

Adds descriptive `aria-label` attributes to icon-only buttons to improve accessibility and screen reader support.

---

## Type of Change

* [ ] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [x] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

* [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] **No changes to `core/`**
* [x] **No changes to `components/`**
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds meaningful `aria-label` attributes to icon-only buttons for improved accessibility.

**How does a developer use it?**

```html
<button aria-label="Search">
  <svg>...</svg>
</button>

<button aria-label="Close">
  <svg>...</svg>
</button>
```

**Why does it fit EaseMotion CSS?**

Improves accessibility while keeping the library simple, lightweight, and easy to use.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This update improves accessibility without affecting existing styles or functionality.
