### PR TITLE
feat(a11y): add visible focus indicators

### DIFF
--- a/submissions/examples/focus-indicator/README.md
+++ b/submissions/examples/focus-indicator/README.md
@@ -1,0 +1,63 @@
+# Focus Indicator Demo
+
+## Overview
+
+Interactive elements need visible focus outlines for keyboard users. This demo showcases proper focus indicator styles for accessibility compliance.
+
+## Problem
+
+Interactive elements without focus indicators are inaccessible to:
+- Keyboard-only users
+- Users with motor impairments
+- Users navigating via screen readers
+
+## Solution
+
+Add visible focus styles to all interactive elements:
+
+```css
+/* Basic focus outline */
+button:focus-visible,
+a:focus-visible,
+input:focus-visible {
+  outline: 2px solid var(--ease-color-primary);
+  outline-offset: 2px;
+}
+```
+
+## Focus Style Options
+
+| Style | CSS | Use Case |
+|-------|-----|----------|
+| Outline | `outline: 2px solid var(--primary)` | Default, simple |
+| Ring | `box-shadow: 0 0 0 4px rgba(0,0,0,0.2)` | Modern, soft |
+| Glow | `box-shadow: 0 0 20px var(--primary)` | Emphasis |
+| Scale | `transform: scale(1.05)` | Subtle feedback |
+
+## Best Practices
+
+1. **Always provide focus styles** - Never use `outline: none` without alternative
+2. **Use sufficient contrast** - Focus indicator should be visible against background
+3. **Consider `:focus-visible`** - Only show for keyboard navigation
+4. **Offset properly** - Use `outline-offset` to separate from element
+
+## Using :focus-visible
+
+```css
+/* Hide focus for mouse users */
+button:focus:not(:focus-visible) {
+  outline: none;
+}
+
+/* Show focus for keyboard users */
+button:focus-visible {
+  outline: 2px solid var(--ease-color-primary);
+  outline-offset: 2px;
+}
+```
+
+## Files
+
+- `demo.html` - Interactive demonstration
+- `style.css` - Component styling
+- `README.md` - This documentation

--- a/submissions/examples/focus-indicator/demo.html
+++ b/submissions/examples/focus-indicator/demo.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Focus Indicator Demo</title>
+  <link rel="stylesheet" href="../../core/variables.css">
+  <link rel="stylesheet" href="../../core/base.css">
+  <link rel="stylesheet" href="../../core/utilities.css">
+  <link rel="stylesheet" href="../../components/buttons.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-container">
+    <h1>Focus Indicator Demo</h1>
+    <p class="description">
+      Interactive elements need visible focus outlines for keyboard users. 
+      This demo shows proper focus indicators for accessibility compliance.
+    </p>
+
+    <section class="demo-section">
+      <h2>Buttons with Focus</h2>
+      <div class="button-group">
+        <button class="ease-btn ease-btn-primary">Primary Button</button>
+        <button class="ease-btn ease-btn-secondary">Secondary Button</button>
+        <button class="ease-btn ease-btn-outline">Outline Button</button>
+        <button class="ease-btn ease-btn-icon" aria-label="Settings">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path></svg>
+        </button>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <h2>Interactive Elements</h2>
+      <div class="elements-grid">
+        <a href="#" class="focus-link">Link with Focus</a>
+        <input type="text" class="focus-input" placeholder="Input with focus">
+        <select class="focus-select">
+          <option>Select with focus</option>
+          <option>Option 1</option>
+          <option>Option 2</option>
+        </select>
+        <label class="focus-checkbox">
+          <input type="checkbox">
+          <span>Checkbox with focus</span>
+        </label>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <h2>Focus Styles Comparison</h2>
+      <div class="style-comparison">
+        <div class="style-card">
+          <h3>Default Browser Focus</h3>
+          <button class="btn-default-focus">Tab to me</button>
+          <p>Browser default outline</p>
+        </div>
+        <div class="style-card">
+          <h3>Custom Focus Ring</h3>
+          <button class="btn-custom-focus">Tab to me</button>
+          <p>Custom 2px outline</p>
+        </div>
+        <div class="style-card">
+          <h3>Focus with Shadow</h3>
+          <button class="btn-shadow-focus">Tab to me</button>
+          <p>Outline + box-shadow</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <h2>Custom Focus Styles</h2>
+      <div class="focus-examples">
+        <button class="focus-example-1">Outline Focus</button>
+        <button class="focus-example-2">Ring Focus</button>
+        <button class="focus-example-3">Glow Focus</button>
+        <button class="focus-example-4">Scale Focus</button>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <h2>Implementation</h2>
+      <div class="code-example">
+        <h3>CSS Focus Styles</h3>
+        <pre><code>/* Basic focus outline */
+:focus {
+  outline: 2px solid var(--ease-color-primary);
+  outline-offset: 2px;
+}
+
+/* Custom focus ring */
+.custom-focus:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.5);
+}
+
+/* Focus visible only for keyboard users */
+@media (focus-visible) {
+  :focus-visible {
+    outline: 2px solid var(--ease-color-primary);
+    outline-offset: 2px;
+  }
+}</code></pre>
+      </div>
+
+      <div class="code-example">
+        <h3>Best Practices</h3>
+        <pre><code>/* 1. Always provide visible focus styles */
+:focus {
+  outline: 2px solid var(--ease-color-primary);
+  outline-offset: 2px;
+}
+
+/* 2. Don't use outline: none without alternative */
+button:focus {
+  outline: none; /* ❌ Bad */
+  box-shadow: 0 0 0 3px var(--primary); /* ✅ Provide alternative */
+}
+
+/* 3. Use :focus-visible for keyboard-only focus */
+:focus:not(:focus-visible) {
+  outline: none; /* Hide for mouse users */
+}
+:focus-visible {
+  outline: 2px solid var(--primary); /* Show for keyboard */
+}</code></pre>
+      </div>
+    </section>
+  </div>
+</body>
+</html>

--- a/submissions/examples/focus-indicator/style.css
+++ b/submissions/examples/focus-indicator/style.css
@@ -1,0 +1,295 @@
+/* Focus Indicator Demo Styles */
+
+body {
+  background-color: var(--ease-color-bg, #0f0e17);
+  color: var(--ease-color-text, #fffffe);
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  line-height: 1.6;
+  margin: 0;
+  padding: 0;
+}
+
+/* ── Demo Container ───────────────────────────────────────── */
+.demo-container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: var(--ease-space-8, 2rem);
+}
+
+.demo-container h1 {
+  font-size: 1.75rem;
+  margin-bottom: var(--ease-space-4, 1rem);
+  color: var(--ease-color-text, #fff);
+}
+
+.demo-container h2 {
+  font-size: 1.25rem;
+  margin-top: var(--ease-space-8, 2rem);
+  margin-bottom: var(--ease-space-4, 1rem);
+  color: var(--ease-color-text, #fff);
+}
+
+.description {
+  color: var(--ease-color-muted, rgba(255, 255, 255, 0.65));
+  margin-bottom: var(--ease-space-6, 1.5rem);
+}
+
+/* ── Demo Section ────────────────────────────────────────── */
+.demo-section {
+  margin-bottom: var(--ease-space-8, 2rem);
+}
+
+/* ── Button Group ────────────────────────────────────────── */
+.button-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ease-space-3, 0.75rem);
+  align-items: center;
+}
+
+/* ── Buttons ─────────────────────────────────────────────── */
+.ease-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--ease-space-3, 0.75rem) var(--ease-space-4, 1rem);
+  font-size: 0.875rem;
+  font-weight: 500;
+  border-radius: var(--ease-radius-md, 8px);
+  cursor: pointer;
+  transition: all var(--ease-speed-fast, 150ms) var(--ease-ease);
+  border: 1px solid transparent;
+}
+
+.ease-btn-primary {
+  background: var(--ease-color-primary, #6c63ff);
+  color: #fff;
+  border-color: var(--ease-color-primary, #6c63ff);
+}
+
+.ease-btn-secondary {
+  background: var(--ease-color-surface, #1a1a2e);
+  color: var(--ease-color-text, #fff);
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.ease-btn-outline {
+  background: transparent;
+  color: var(--ease-color-primary, #6c63ff);
+  border-color: var(--ease-color-primary, #6c63ff);
+}
+
+.ease-btn-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  background: var(--ease-color-surface, #1a1a2e);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--ease-radius-md, 8px);
+  color: var(--ease-color-text, #fff);
+}
+
+/* ── FOCUS STYLES - THE KEY FIX ─────────────────────────── */
+
+/* All focusable elements get outline */
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+
+/* ── Elements Grid ──────────────────────────────────────── */
+.elements-grid {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-space-4, 1rem);
+}
+
+.focus-link {
+  display: inline-flex;
+  padding: var(--ease-space-3, 0.75rem) var(--ease-space-4, 1rem);
+  background: var(--ease-color-primary, #6c63ff);
+  color: #fff;
+  text-decoration: none;
+  border-radius: var(--ease-radius-md, 8px);
+  transition: all var(--ease-speed-fast, 150ms) var(--ease-ease);
+}
+
+.focus-input,
+.focus-select {
+  padding: var(--ease-space-3, 0.75rem) var(--ease-space-4, 1rem);
+  background: var(--ease-color-surface, #1a1a2e);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--ease-radius-md, 8px);
+  color: var(--ease-color-text, #fff);
+  font-size: 0.875rem;
+}
+
+.focus-checkbox {
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-2, 0.5rem);
+  cursor: pointer;
+}
+
+.focus-checkbox input {
+  width: 20px;
+  height: 20px;
+  accent-color: var(--ease-color-primary, #6c63ff);
+}
+
+/* ── Style Comparison ────────────────────────────────────── */
+.style-comparison {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--ease-space-4, 1rem);
+}
+
+.style-card {
+  padding: var(--ease-space-4, 1rem);
+  background: var(--ease-color-surface, rgba(255, 255, 255, 0.04));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--ease-radius-lg, 12px);
+  text-align: center;
+}
+
+.style-card h3 {
+  margin: 0 0 var(--ease-space-3, 0.75rem);
+  font-size: 0.875rem;
+  color: var(--ease-color-muted, rgba(255, 255, 255, 0.7));
+}
+
+.style-card p {
+  margin: var(--ease-space-3, 0.75rem) 0 0;
+  font-size: 0.75rem;
+  color: var(--ease-color-muted, rgba(255, 255, 255, 0.5));
+}
+
+.btn-default-focus {
+  padding: var(--ease-space-2, 0.5rem) var(--ease-space-4, 1rem);
+  background: var(--ease-color-surface, #1a1a2e);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--ease-radius-md, 8px);
+  color: var(--ease-color-text, #fff);
+  cursor: pointer;
+}
+
+.btn-custom-focus {
+  padding: var(--ease-space-2, 0.5rem) var(--ease-space-4, 1rem);
+  background: var(--ease-color-surface, #1a1a2e);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--ease-radius-md, 8px);
+  color: var(--ease-color-text, #fff);
+  cursor: pointer;
+}
+
+.btn-shadow-focus {
+  padding: var(--ease-space-2, 0.5rem) var(--ease-space-4, 1rem);
+  background: var(--ease-color-surface, #1a1a2e);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--ease-radius-md, 8px);
+  color: var(--ease-color-text, #fff);
+  cursor: pointer;
+}
+
+/* Default focus styles */
+.btn-default-focus:focus {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+
+/* Custom focus styles */
+.btn-custom-focus:focus {
+  outline: 3px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 4px;
+  border-color: var(--ease-color-primary-light, #a09af8);
+}
+
+/* Focus with shadow */
+.btn-shadow-focus:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.5), 0 0 0 5px rgba(108, 99, 255, 0.2);
+  border-color: var(--ease-color-primary, #6c63ff);
+}
+
+/* ── Focus Examples ──────────────────────────────────────── */
+.focus-examples {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ease-space-3, 0.75rem);
+}
+
+.focus-example-1,
+.focus-example-2,
+.focus-example-3,
+.focus-example-4 {
+  padding: var(--ease-space-3, 0.75rem) var(--ease-space-4, 1rem);
+  background: var(--ease-color-surface, #1a1a2e);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--ease-radius-md, 8px);
+  color: var(--ease-color-text, #fff);
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+
+/* Example 1: Outline */
+.focus-example-1:focus {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 3px;
+}
+
+/* Example 2: Ring */
+.focus-example-2:focus {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(108, 99, 255, 0.4);
+  border-color: var(--ease-color-primary, #6c63ff);
+}
+
+/* Example 3: Glow */
+.focus-example-3:focus {
+  outline: none;
+  box-shadow: 0 0 20px rgba(108, 99, 255, 0.5);
+  border-color: var(--ease-color-primary, #6c63ff);
+}
+
+/* Example 4: Scale */
+.focus-example-4:focus {
+  outline: none;
+  transform: scale(1.05);
+  border-color: var(--ease-color-primary, #6c63ff);
+}
+
+/* ── Code Example ────────────────────────────────────────── */
+.code-example {
+  background: var(--ease-color-surface, rgba(255, 255, 255, 0.04));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--ease-radius-md, 8px);
+  padding: var(--ease-space-4, 1rem);
+  margin-bottom: var(--ease-space-4, 1rem);
+}
+
+.code-example h3 {
+  margin-top: 0;
+  font-size: 0.875rem;
+  color: var(--ease-color-primary-light, #a78bfa);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.code-example pre {
+  margin: 0;
+  overflow-x: auto;
+}
+
+.code-example code {
+  font-family: 'Fira Code', 'Consolas', monospace;
+  font-size: 0.875rem;
+  color: var(--ease-color-text, #fff);
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
# Add visible focus outlines to interactive elements

Adds visible focus outlines to interactive elements, improving keyboard accessibility with clear focus indicators and accessible defaults.

Closes #23203

## Pull Request Description

Adds visible focus outlines to interactive elements to improve keyboard navigation and accessibility.

---

## Type of Change

* [ ] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [x] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

* [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] **No changes to `core/`**
* [x] **No changes to `components/`**
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds visible focus outlines to interactive elements for improved keyboard accessibility.

**How does a developer use it?**

```html
<button class="ease-btn">Button</button>

<a href="#" class="ease-link">Link</a>

<input type="text" placeholder="Input field">
```

**Why does it fit EaseMotion CSS?**

Provides accessible keyboard interactions while preserving EaseMotion CSS's clean, lightweight, and human-readable design philosophy.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This change enhances keyboard accessibility by adding clear focus indicators without affecting existing styles or animations.
