### PR TITLE
[FEATURE] Toggle Switch with Smooth Slide Animation

### DIFF
--- a/submissions/component-changes-issue-23234/README.md
+++ b/submissions/component-changes-issue-23234/README.md
@@ -1,0 +1,25 @@
+# Toggle Switch
+
+A pure-CSS toggle switch (checkbox + label) with a sliding knob and animated track color.
+
+## Usage
+See `demo.html` for three variants: default, small, large.
+
+```html
+<label class="toggle">
+  <input type="checkbox" />
+  <span class="toggle-track">
+    <span class="toggle-knob"></span>
+  </span>
+</label>
+```
+
+## Features
+- No JS required, built on a native checkbox for accessibility
+- Knob slides via `transform: translateX()`
+- Track color transitions on check/uncheck
+- `:focus-visible` outline for keyboard users
+- Respects `prefers-reduced-motion` (disables transition, snaps state instead)
+
+## Suggested class name
+`ease-toggle` (per issue referenced in PR description)

--- a/submissions/component-changes-issue-23234/demo.html
+++ b/submissions/component-changes-issue-23234/demo.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Toggle Switch Demo</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      padding: 40px;
+      display: flex;
+      gap: 24px;
+      align-items: center;
+    }
+
+    /* Base toggle wrapper */
+    .toggle {
+      display: inline-flex;
+      align-items: center;
+      cursor: pointer;
+      position: relative;
+    }
+
+    /* Hide the real checkbox but keep it focusable/clickable */
+    .toggle input {
+      position: absolute;
+      opacity: 0;
+      width: 100%;
+      height: 100%;
+      margin: 0;
+      cursor: pointer;
+    }
+
+    /* Track = the pill background */
+    .toggle-track {
+      --toggle-w: 48px;
+      --toggle-h: 26px;
+      --toggle-pad: 3px;
+      --toggle-off: #cbd5e1;
+      --toggle-on: #3b82f6;
+      --toggle-speed: 250ms;
+
+      display: inline-block;
+      width: var(--toggle-w);
+      height: var(--toggle-h);
+      background-color: var(--toggle-off);
+      border-radius: var(--toggle-h);
+      position: relative;
+      transition: background-color var(--toggle-speed) ease;
+    }
+
+    /* Knob = the sliding circle */
+    .toggle-knob {
+      position: absolute;
+      top: var(--toggle-pad);
+      left: var(--toggle-pad);
+      width: calc(var(--toggle-h) - (var(--toggle-pad) * 2));
+      height: calc(var(--toggle-h) - (var(--toggle-pad) * 2));
+      background-color: #fff;
+      border-radius: 50%;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+      transition: transform var(--toggle-speed) ease;
+    }
+
+    /* Checked state: move track color + slide knob */
+    .toggle input:checked + .toggle-track {
+      background-color: var(--toggle-on);
+    }
+
+    .toggle input:checked + .toggle-track .toggle-knob {
+      transform: translateX(calc(var(--toggle-w) - var(--toggle-h)));
+    }
+
+    /* Keyboard focus ring */
+    .toggle input:focus-visible + .toggle-track {
+      outline: 2px solid var(--toggle-on);
+      outline-offset: 2px;
+    }
+
+    /* Size variants */
+    .toggle-sm .toggle-track {
+      --toggle-w: 36px;
+      --toggle-h: 20px;
+    }
+
+    .toggle-lg .toggle-track {
+      --toggle-w: 60px;
+      --toggle-h: 32px;
+    }
+
+    /* Respect reduced motion: snap instead of slide */
+    @media (prefers-reduced-motion: reduce) {
+      .toggle-track,
+      .toggle-knob {
+        transition: none;
+      }
+    }
+  </style>
+</head>
+<body>
+
+  <label class="toggle">
+    <input type="checkbox" />
+    <span class="toggle-track">
+      <span class="toggle-knob"></span>
+    </span>
+  </label>
+
+  <label class="toggle toggle-sm">
+    <input type="checkbox" />
+    <span class="toggle-track">
+      <span class="toggle-knob"></span>
+    </span>
+  </label>
+
+  <label class="toggle toggle-lg">
+    <input type="checkbox" checked />
+    <span class="toggle-track">
+      <span class="toggle-knob"></span>
+    </span>
+  </label>
+
+</body>
+</html>

--- a/submissions/component-changes-issue-23234/style.css
+++ b/submissions/component-changes-issue-23234/style.css
@@ -1,0 +1,82 @@
+/* Base toggle wrapper */
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  position: relative;
+}
+
+/* Hide the real checkbox but keep it focusable/clickable */
+.toggle input {
+  position: absolute;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  cursor: pointer;
+}
+
+/* Track = the pill background */
+.toggle-track {
+  --toggle-w: 48px;
+  --toggle-h: 26px;
+  --toggle-pad: 3px;
+  --toggle-off: #cbd5e1;
+  --toggle-on: #3b82f6;
+  --toggle-speed: 250ms;
+
+  display: inline-block;
+  width: var(--toggle-w);
+  height: var(--toggle-h);
+  background-color: var(--toggle-off);
+  border-radius: var(--toggle-h);
+  position: relative;
+  transition: background-color var(--toggle-speed) ease;
+}
+
+/* Knob = the sliding circle */
+.toggle-knob {
+  position: absolute;
+  top: var(--toggle-pad);
+  left: var(--toggle-pad);
+  width: calc(var(--toggle-h) - (var(--toggle-pad) * 2));
+  height: calc(var(--toggle-h) - (var(--toggle-pad) * 2));
+  background-color: #fff;
+  border-radius: 50%;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+  transition: transform var(--toggle-speed) ease;
+}
+
+/* Checked state: move track color + slide knob */
+.toggle input:checked + .toggle-track {
+  background-color: var(--toggle-on);
+}
+
+.toggle input:checked + .toggle-track .toggle-knob {
+  transform: translateX(calc(var(--toggle-w) - var(--toggle-h)));
+}
+
+/* Keyboard focus ring */
+.toggle input:focus-visible + .toggle-track {
+  outline: 2px solid var(--toggle-on);
+  outline-offset: 2px;
+}
+
+/* Size variants */
+.toggle-sm .toggle-track {
+  --toggle-w: 36px;
+  --toggle-h: 20px;
+}
+
+.toggle-lg .toggle-track {
+  --toggle-w: 60px;
+  --toggle-h: 32px;
+}
+
+/* Respect reduced motion: snap instead of slide */
+@media (prefers-reduced-motion: reduce) {
+  .toggle-track,
+  .toggle-knob {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #23234 

Pull Request Description

This PR adds a new component submission: a pure-CSS toggle switch (ease-toggle) with a smoothly sliding knob and animated track color, built on a native checkbox so it works without any JavaScript. It solves the lack of a reusable switch component in the framework — currently anyone needing one has to hand-roll the checkbox-hiding trick from scratch.

---

Type of Change

- [x] 🧩 New component

Submission Checklist


- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

 Feature Description

What does this add?
A checkbox-based toggle switch with a sliding knob, animated track color, two size variants (sm/lg), keyboard focus styling, and prefers-reduced-motion support.

**How does a developer use it?**

<label class="toggle">
  <input type="checkbox" />
  <span class="toggle-track">
    <span class="toggle-knob"></span>
  </span>
</label>

<!-- Size variants -->
<label class="toggle toggle-sm">...</label>
<label class="toggle toggle-lg">...</label>

**Why does it fit EaseMotion CSS?**

It's built on a native <input type="checkbox">, so it needs zero JavaScript and stacks cleanly with other utility classes with no specificity conflicts. The class names (toggle, toggle-track, toggle-knob) read like plain English describing exactly what each part does, matching the human-readable philosophy. The slide and color transition are the core feature, not decoration, keeping it animation-first. It also respects prefers-reduced-motion, consistent with how other entrance animations in the framework already handle accessibility.

---

Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

Browser Testing

- [x] Chrome

---

Notes for Maintainer

Class names are intentionally unprefixed (toggle, toggle-track, toggle-knob) per CONTRIBUTING.md — happy to have these renamed to ease-toggle / ease-toggle-track / ease-toggle-knob during integration. Default colors (--toggle-off: #cbd5e1, --toggle-on: #3b82f6) are placeholders — feel free to swap in the framework's existing --ease-color-* variables if that's preferred over local custom properties. Closes #<issue-number> (replace with the actual issue number you opened/picked up).

---
