### PR TITLE
add quantum-ripple-toggle-qtx component

### DIFF
--- a/submissions/examples/quantum-ripple-toggle-qtx/README.md
+++ b/submissions/examples/quantum-ripple-toggle-qtx/README.md
@@ -1,0 +1,10 @@
+1. What does this do?
+A micro-interaction toggle switch that utilizes hardware-accelerated cubic-bezier curves to create an organic, liquid-like snapping transition without JavaScript dependencies.
+
+2. How is it used?
+```html
+<label class="quantum-toggle"><input type="checkbox" class="quantum-input"><span class="quantum-track"><span class="quantum-thumb"></span></span></label>
+```
+
+3. Why is it useful?
+It aligns perfectly with an animation-first philosophy by achieving high-fidelity, fluid UI feedback purely through native modern CSS transitions, maintaining zero dependencies and a microscopic file footprint.

--- a/submissions/examples/quantum-ripple-toggle-qtx/demo.html
+++ b/submissions/examples/quantum-ripple-toggle-qtx/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Quantum Ripple Toggle</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<div class="toggle-container">
+<label class="quantum-toggle">
+<input type="checkbox" class="quantum-input">
+<span class="quantum-track">
+<span class="quantum-thumb"></span>
+</span>
+</label>
+</div>
+</body>
+</html>

--- a/submissions/examples/quantum-ripple-toggle-qtx/style.css
+++ b/submissions/examples/quantum-ripple-toggle-qtx/style.css
@@ -1,0 +1,72 @@
+:root {
+  --bg-color: #0f172a;
+  --track-off: #1e293b;
+  --track-on: #6366f1;
+  --thumb-color: #ffffff;
+  --glow-color: rgba(99, 102, 241, 0.4);
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background-color: var(--bg-color);
+}
+
+.toggle-container {
+  position: relative;
+  filter: url('#quantum-goo'); /* Core for the liquid effect, fallback friendly */
+}
+
+.quantum-toggle {
+  position: relative;
+  display: inline-block;
+  width: 80px;
+  height: 44px;
+  cursor: pointer;
+}
+
+.quantum-input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.quantum-track {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--track-off);
+  border-radius: 44px;
+  transition: background-color 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+
+.quantum-thumb {
+  position: absolute;
+  content: "";
+  height: 36px;
+  width: 36px;
+  left: 4px;
+  bottom: 4px;
+  background-color: var(--thumb-color);
+  border-radius: 50%;
+  transition: transform 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55); /* Variation Target Line */
+}
+
+.quantum-input:checked + .quantum-track {
+  background-color: var(--track-on);
+  box-shadow: 0 0 20px var(--glow-color);
+}
+
+.quantum-input:checked + .quantum-track .quantum-thumb {
+  transform: translateX(36px);
+}
+
+.quantum-input:active + .quantum-track .quantum-thumb {
+  width: 46px;
+}


### PR DESCRIPTION
Introduces a lightweight, zero-dependency custom checkbox toggle that implements organic snap mechanics entirely via native CSS.