### PR TITLE
test(react): write unit tests for useAnimation hook using Vitest #22943

### DIFF
--- a/submissions/react-test-use-animation-22943/README.md
+++ b/submissions/react-test-use-animation-22943/README.md
@@ -1,0 +1,25 @@
+# React useAnimation Hook Unit Tests (#22943)
+
+This submission introduces a comprehensive Vitest test suite for the `useAnimation` React hook, utilizing `@testing-library/react`.
+
+## Included Files
+
+- `useAnimation.js` - The source implementation of the hook (exported as an ES module for compatibility with standard testing environments).
+- `useAnimation.test.jsx` - The Vitest suite containing 6 distinct test cases evaluating state, configuration, and DOM event handling.
+
+## Test Coverage
+
+The test suite validates the following core behaviors:
+1. **Initialization**: Verifies that the hook initializes with `isPlaying: false` and an empty `className`.
+2. **Play Logic**: Ensures calling `play()` toggles state and generates the default sequence of EaseMotion CSS classes.
+3. **Custom Configurations**: Validates that passing custom animation, duration, curve, and fill modes correctly overrides the default CSS string.
+4. **Reset Logic**: Ensures the `reset()` method clears all animation classes.
+5. **Event Listening**: Mounts a mock DOM element to the `ref` and fires a synthetic `animationend` event, verifying the hook automatically resets itself.
+6. **Event Bubbling Prevention**: Simulates a child element firing an `animationend` event that bubbles up to the parent `ref`. The test ensures the hook correctly ignores these events (by comparing `e.target === node`), preventing premature animation resets.
+
+## Running Tests
+
+If your repository is configured with Vitest and `@testing-library/react`, you can drop these files in and run them via:
+```bash
+npm run test
+```

--- a/submissions/react-test-use-animation-22943/useAnimation.js
+++ b/submissions/react-test-use-animation-22943/useAnimation.js
@@ -1,0 +1,41 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+export const useAnimation = ({
+  animation = "ease-fade-in",
+  duration = "ease-duration-normal",
+  curve = "ease-curve-ease",
+  fill = "ease-fill-both"
+} = {}) => {
+  const ref = useRef(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  // Expose methods to control the animation state
+  const play = useCallback(() => setIsPlaying(true), []);
+  const reset = useCallback(() => setIsPlaying(false), []);
+
+  // Automatically listen to the native animationend event to reset state
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+
+    const handleAnimationEnd = (e) => {
+      // Ensure the event target is exactly our element, not a child bubbling up
+      if (e.target === node) {
+        setIsPlaying(false);
+      }
+    };
+    
+    node.addEventListener('animationend', handleAnimationEnd);
+    
+    return () => {
+      node.removeEventListener('animationend', handleAnimationEnd);
+    };
+  }, []);
+
+  // Generate the class string based on the playing state
+  const className = isPlaying 
+    ? `${animation} ${duration} ${curve} ${fill}`.trim() 
+    : "";
+
+  return { ref, play, reset, isPlaying, className };
+};

--- a/submissions/react-test-use-animation-22943/useAnimation.test.jsx
+++ b/submissions/react-test-use-animation-22943/useAnimation.test.jsx
@@ -1,0 +1,115 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { useAnimation } from './useAnimation';
+import React from 'react'; // React is required for testing-library to render hooks
+
+describe('useAnimation hook', () => {
+  it('should initialize with default values', () => {
+    const { result } = renderHook(() => useAnimation());
+
+    expect(result.current.isPlaying).toBe(false);
+    expect(result.current.className).toBe('');
+    expect(typeof result.current.play).toBe('function');
+    expect(typeof result.current.reset).toBe('function');
+    expect(result.current.ref).toEqual({ current: null });
+  });
+
+  it('should apply default CSS classes when play() is called', () => {
+    const { result } = renderHook(() => useAnimation());
+
+    act(() => {
+      result.current.play();
+    });
+
+    expect(result.current.isPlaying).toBe(true);
+    expect(result.current.className).toBe('ease-fade-in ease-duration-normal ease-curve-ease ease-fill-both');
+  });
+
+  it('should apply custom CSS classes when configured and play() is called', () => {
+    const customConfig = {
+      animation: 'ease-slide-up',
+      duration: 'ease-duration-slow',
+      curve: 'ease-curve-linear',
+      fill: 'ease-fill-forwards'
+    };
+
+    const { result } = renderHook(() => useAnimation(customConfig));
+
+    act(() => {
+      result.current.play();
+    });
+
+    expect(result.current.className).toBe('ease-slide-up ease-duration-slow ease-curve-linear ease-fill-forwards');
+  });
+
+  it('should clear CSS classes when reset() is called', () => {
+    const { result } = renderHook(() => useAnimation());
+
+    act(() => {
+      result.current.play();
+    });
+    expect(result.current.isPlaying).toBe(true);
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.isPlaying).toBe(false);
+    expect(result.current.className).toBe('');
+  });
+
+  it('should automatically reset isPlaying on native animationend event', () => {
+    // Create a mock DOM element to attach to the ref
+    const mockElement = document.createElement('div');
+    const { result } = renderHook(() => useAnimation());
+
+    // Assign the mock element to the ref manually
+    result.current.ref.current = mockElement;
+
+    // We must re-render the hook so the useEffect binds the event listener to the now-populated ref
+    const { rerender } = renderHook(() => useAnimation(), {
+      initialProps: result.current,
+    });
+    
+    // In our manual test setup, we can just invoke play
+    act(() => {
+      result.current.play();
+    });
+    expect(result.current.isPlaying).toBe(true);
+
+    // Simulate the animationend event directly on the bound node
+    act(() => {
+      const event = new Event('animationend', { bubbles: true });
+      mockElement.dispatchEvent(event);
+    });
+
+    expect(result.current.isPlaying).toBe(false);
+    expect(result.current.className).toBe('');
+  });
+
+  it('should ignore animationend events bubbling up from child elements', () => {
+    const parentElement = document.createElement('div');
+    const childElement = document.createElement('span');
+    parentElement.appendChild(childElement);
+
+    const { result } = renderHook(() => useAnimation());
+    result.current.ref.current = parentElement;
+    
+    // We must re-render to bind the event listener to the parent
+    renderHook(() => useAnimation(), { initialProps: result.current });
+
+    act(() => {
+      result.current.play();
+    });
+    expect(result.current.isPlaying).toBe(true);
+
+    // Dispatch the event from the CHILD element
+    act(() => {
+      const event = new Event('animationend', { bubbles: true });
+      childElement.dispatchEvent(event);
+    });
+
+    // isPlaying should REMAIN true because e.target (child) !== node (parent)
+    expect(result.current.isPlaying).toBe(true);
+    expect(result.current.className).not.toBe('');
+  });
+});


### PR DESCRIPTION
## Pull Request Description

Fixes #22943. Adds a comprehensive Vitest unit test suite for the React `useAnimation` hook utilizing `@testing-library/react`.

---

## Submission Checklist

- [x] All changes inside `submissions/react-test-use-animation-22943/`
- [x] Includes `useAnimation.test.jsx`
- [x] Includes `useAnimation.js` (Reference implementation exported as ES Module)
- [x] Includes `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

---

## Feature Description

- **Initialization & Reset** — Verifies default hook state and tests the explicit `play()` and `reset()` exposed methods.
- **Config Mappings** — Validates that passing custom animation, duration, curve, and fill modes correctly overrides the default CSS string generation.
- **Synthetic Event Triggering** — Validates the `useEffect` DOM listener by mounting a mock DOM element to the `ref` and dispatching a synthetic `animationend` event to verify automatic state resets.
- **Event Bubbling Guard** — Tests the hook's event safety check (`e.target === node`) by firing an `animationend` event from a child element and ensuring the hook correctly ignores it, preventing premature animation interruption.
