### PR TITLE
resolve #23736: Asymmetric Bento Box Dashboard Layout

### DIFF
--- a/submissions/examples/new-bento-dashboard-grid-sn100/README.md
+++ b/submissions/examples/new-bento-dashboard-grid-sn100/README.md
@@ -1,0 +1,7 @@
+﻿# Asymmetric Bento Box Dashboard Layout
+
+Asymmetric layout portfolio displaying zoom panel items on hover.
+
+## How to use
+1. Link the component stylesheet `style.css` in your HTML header.
+2. Embed the structure code into your body sections.

--- a/submissions/examples/new-bento-dashboard-grid-sn100/demo.html
+++ b/submissions/examples/new-bento-dashboard-grid-sn100/demo.html
@@ -1,0 +1,23 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS: Asymmetric Bento Box Dashboard Layout</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      background-color: #0b0c10;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+  </style>
+</head>
+<body>
+<div class="ease-bento-box"><div class="box large">Large Core</div><div class="box">Metric</div><div class="box">Data</div></div>
+</body>
+</html>

--- a/submissions/examples/new-bento-dashboard-grid-sn100/style.css
+++ b/submissions/examples/new-bento-dashboard-grid-sn100/style.css
@@ -1,0 +1,7 @@
+﻿/* ==========================================================================
+   EaseMotion CSS: Asymmetric Bento Box Dashboard Layout
+   ========================================================================== */
+
+@layer components {
+.ease-bento-box { display: grid; grid-template-columns: repeat(2, 140px); gap: 12px; } .box { background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.08); border-radius: 12px; padding: 16px; color: #fff; font-weight: bold; transition: all 0.3s; cursor: pointer; } .box:hover { border-color: #7f00ff; transform: scale(1.02); } .box.large { grid-column: span 2; height: 100px; }
+}


### PR DESCRIPTION
﻿Closes #23736

## What this does
Asymmetric layout portfolio displaying zoom panel items on hover.

## Files
- `submissions/examples/new-bento-dashboard-grid-sn100/style.css`
- `submissions/examples/new-bento-dashboard-grid-sn100/demo.html`
- `submissions/examples/new-bento-dashboard-grid-sn100/README.md`
