### PR TITLE
resolve #23740: Neon Copy Link Clipboard Button

### DIFF
--- a/submissions/examples/new-copy-clipboard-neon-sn100/README.md
+++ b/submissions/examples/new-copy-clipboard-neon-sn100/README.md
@@ -1,0 +1,7 @@
+﻿# Neon Copy Link Clipboard Button
+
+Copy shortcut button showing successful status glow toggle.
+
+## How to use
+1. Link the component stylesheet `style.css` in your HTML header.
+2. Embed the structure code into your body sections.

--- a/submissions/examples/new-copy-clipboard-neon-sn100/demo.html
+++ b/submissions/examples/new-copy-clipboard-neon-sn100/demo.html
@@ -1,0 +1,23 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS: Neon Copy Link Clipboard Button</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      background-color: #0b0c10;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+  </style>
+</head>
+<body>
+<button class="ease-neon-copy" onclick="this.classList.add('active'); setTimeout(() => this.classList.remove('active'), 2000)"><span class="label-normal">Copy link</span><span class="label-done">Success ✓</span></button>
+</body>
+</html>

--- a/submissions/examples/new-copy-clipboard-neon-sn100/style.css
+++ b/submissions/examples/new-copy-clipboard-neon-sn100/style.css
@@ -1,0 +1,7 @@
+﻿/* ==========================================================================
+   EaseMotion CSS: Neon Copy Link Clipboard Button
+   ========================================================================== */
+
+@layer components {
+.ease-neon-copy { background: #111; border: 1px solid #333; color: #fff; padding: 10px 20px; border-radius: 8px; cursor: pointer; position: relative; overflow: hidden; font-weight: bold; } .label-normal, .label-done { display: inline-block; transition: all 0.3s; } .label-done { position: absolute; left: 0; right: 0; opacity: 0; transform: translateY(20px); color: #00ff7f; } .ease-neon-copy.active .label-normal { transform: translateY(-20px); opacity: 0; } .ease-neon-copy.active .label-done { transform: translateY(0); opacity: 1; }
+}


### PR DESCRIPTION
﻿Closes #23740

## What this does
Copy shortcut button showing successful status glow toggle.

## Files
- `submissions/examples/new-copy-clipboard-neon-sn100/style.css`
- `submissions/examples/new-copy-clipboard-neon-sn100/demo.html`
- `submissions/examples/new-copy-clipboard-neon-sn100/README.md`
