### PR TITLE
resolve #23761: Perspective Text Base Reflection

### DIFF
--- a/submissions/examples/new-reflection-text-hover-sn250/README.md
+++ b/submissions/examples/new-reflection-text-hover-sn250/README.md
@@ -1,0 +1,7 @@
+﻿# Perspective Text Base Reflection
+
+Hover text highlighting a flipped perspective reflection fade underneath the title.
+
+## How to use
+1. Link the component stylesheet `style.css` in your HTML header.
+2. Embed the structure code into your body sections.

--- a/submissions/examples/new-reflection-text-hover-sn250/demo.html
+++ b/submissions/examples/new-reflection-text-hover-sn250/demo.html
@@ -1,0 +1,23 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS: Perspective Text Base Reflection</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      background-color: #0b0c10;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+  </style>
+</head>
+<body>
+<div class="ease-reflect-wrap"><h2 class="ease-reflect-title">REFLECT</h2></div>
+</body>
+</html>

--- a/submissions/examples/new-reflection-text-hover-sn250/style.css
+++ b/submissions/examples/new-reflection-text-hover-sn250/style.css
@@ -1,0 +1,7 @@
+﻿/* ==========================================================================
+   EaseMotion CSS: Perspective Text Base Reflection
+   ========================================================================== */
+
+@layer components {
+.ease-reflect-wrap { position: relative; } .ease-reflect-title { font-size: 3rem; color: #fff; text-transform: uppercase; transition: transform 0.3s; } .ease-reflect-title::after { content: "REFLECT"; position: absolute; top: 90%; left: 0; transform: scaleY(-0.8) rotateX(40deg); opacity: 0.15; transition: 0.3s; background: linear-gradient(to bottom, #fff, transparent); -webkit-background-clip: text; -webkit-text-fill-color: transparent; } .ease-reflect-wrap:hover .ease-reflect-title { transform: translateY(-5px); } .ease-reflect-wrap:hover .ease-reflect-title::after { opacity: 0.3; transform: scaleY(-0.8) rotateX(40deg) translateY(4px); }
+}


### PR DESCRIPTION
﻿Closes #23761

## What this does
Hover text highlighting a flipped perspective reflection fade underneath the title.

## Files
- `submissions/examples/new-reflection-text-hover-sn250/style.css`
- `submissions/examples/new-reflection-text-hover-sn250/demo.html`
- `submissions/examples/new-reflection-text-hover-sn250/README.md`
