### PR TITLE
[Feat] #23649 — Add ease-drawer off-canvas panel component

### DIFF
--- a/components/drawer.css
+++ b/components/drawer.css
@@ -1,0 +1,65 @@
+/* ============================================================
+   EaseMotion CSS — drawer.css
+   Off-canvas drawer panel component with left/right variants,
+   smooth slide transitions, and a backdrop overlay.
+   ============================================================ */
+
+@layer easemotion-components {
+  /* ── Drawer Base ──────────────────────────────────────────── */
+  .ease-drawer {
+    position: fixed;
+    top: 0;
+    height: 100vh;
+    width: min(320px, 85vw);
+    background: var(--ease-color-surface, #ffffff);
+    z-index: var(--ease-z-drawer, 1000);
+    transition: transform var(--ease-speed-medium, 300ms) var(--ease-ease, ease);
+    box-shadow: var(--ease-shadow-xl, 0 20px 60px rgba(0, 0, 0, 0.3));
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+
+  /* ── Directional Variants ───────────────────────────────────── */
+  .ease-drawer-left {
+    left: 0;
+    transform: translateX(-100%);
+  }
+
+  .ease-drawer-right {
+    right: 0;
+    transform: translateX(100%);
+  }
+
+  /* ── Open State ────────────────────────────────────────────── */
+  .ease-drawer-open {
+    transform: translateX(0);
+  }
+
+  /* ── Overlay Backdrop ──────────────────────────────────────── */
+  .ease-drawer-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: calc(var(--ease-z-drawer, 1000) - 1);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--ease-speed-medium, 300ms) var(--ease-ease, ease);
+  }
+
+  .ease-drawer-overlay.ease-drawer-open {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  /* ── Width Variants ─────────────────────────────────────────── */
+  .ease-drawer-sm { width: min(240px, 85vw); }
+  .ease-drawer-lg { width: min(480px, 90vw); }
+
+  /* ── Reduced Motion ────────────────────────────────────────── */
+  @media (prefers-reduced-motion: reduce) {
+    .ease-drawer,
+    .ease-drawer-overlay {
+      transition: none;
+    }
+  }
+}

--- a/easemotion.css
+++ b/easemotion.css
@@ -12,13 +12,13 @@
 
    ============================================================ */
 
-/* ── Cascade Layers ──────────────────────────────────────── */
+/* ── Cascade Layers ──────────────────────────────────────────── */
 
 /* Unique names prefixed with 'easemotion-' to avoid cascade
    conflicts with other frameworks using generic @layer names. */
 @layer easemotion-base, easemotion-components, easemotion-utilities;
 
-/* ── Core (required, load in this order) ─────────────────── */
+/* ── Core (required, load in this order) ─────────────────────── */
 
 /* variables.css is left unlayered so custom properties are globally defined.
    base.css is wrapped in easemotion-base layer. */
@@ -28,7 +28,7 @@
 @import "./core/utilities.css";
 @import "./components/ease-marquee.css";
 
-/* ── Components (tree-shakeable in future versions) ──────── */
+/* ── Components (tree-shakeable in future versions) ───────────────── */
 @import "./components/buttons.css";
 @import "./components/cards.css";
 @import "./components/navbar.css";
@@ -36,6 +36,7 @@
 @import "./components/chip.css";
 @import "./components/footer.css";
 @import "./components/sidebar.css";
+@import "./components/drawer.css";
 @import "./components/scroll-progress.css";
 @import "./components/tabs.css";
 @import "./components/badges.css";
@@ -76,8 +77,3 @@
     scroll-behavior: auto !important;
   }
 }
-
-
-
-
-


### PR DESCRIPTION
## Summary
The EaseMotion CSS framework had a `sidebar.css` component for static sidebar layouts, but no off-canvas drawer. Drawers are essential for mobile navigation panels, shopping carts, and filter panels. This PR adds a new `components/drawer.css` file with left/right variants, smooth slide-in/out transitions, and a semi-transparent overlay backdrop. The new component is registered in `easemotion.css` via an `@import` line placed immediately after `sidebar.css`.

## Root Cause
No off-canvas drawer component existed; the existing `sidebar.css` provides only static positioning, not animated slide-in/out behavior.

## Changes Made
- `components/drawer.css` (new): Defines `.ease-drawer` base, `.ease-drawer-left` / `.ease-drawer-right` directional variants, `.ease-drawer-open` active state, `.ease-drawer-overlay` backdrop, `.ease-drawer-sm` / `.ease-drawer-lg` width variants, and a `prefers-reduced-motion` fallback. Uses `@layer easemotion-components` and CSS custom properties consistent with the rest of the framework.
- `easemotion.css`: Added `@import "./components/drawer.css";` after the `sidebar.css` import.

## How to Test
1. Include `easemotion.css` in an HTML page.
2. Add a drawer element:
   ```html
   <div class="ease-drawer-overlay" id="overlay"></div>
   <div class="ease-drawer ease-drawer-left" id="myDrawer">
     <p>Drawer content here</p>
   </div>
   <button onclick="document.getElementById('myDrawer').classList.toggle('ease-drawer-open'); document.getElementById('overlay').classList.toggle('ease-drawer-open');">Toggle Drawer</button>
   ```
3. Click the button — the drawer should slide in from the left with the overlay fading in.
4. Click the button again — drawer slides back out and overlay fades.
5. Replace `.ease-drawer-left` with `.ease-drawer-right` and verify it slides in from the right.
6. Test `.ease-drawer-sm` and `.ease-drawer-lg` width variants.
7. Verify `prefers-reduced-motion` disables transitions when system setting is active.

## Related Issue
Closes #23649