### PR TITLE
resolve #23781: Image Card Caption Slide-Up Overlay

### DIFF
--- a/submissions/examples/new-slide-up-caption-card-sn250/README.md
+++ b/submissions/examples/new-slide-up-caption-card-sn250/README.md
@@ -1,0 +1,7 @@
+﻿# Image Card Caption Slide-Up Overlay
+
+Image widget displaying a blurred caption panel sliding up to overlay text content on hover.
+
+## How to use
+1. Link the component stylesheet `style.css` in your HTML header.
+2. Embed the structure code into your body sections.

--- a/submissions/examples/new-slide-up-caption-card-sn250/demo.html
+++ b/submissions/examples/new-slide-up-caption-card-sn250/demo.html
@@ -1,0 +1,23 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS: Image Card Caption Slide-Up Overlay</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      background-color: #0b0c10;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+  </style>
+</head>
+<body>
+<div class="ease-slide-up-card"><img src="https://images.unsplash.com/photo-1550751827-4bd374c3f58b?w=400" alt="Tech"><div class="caption"><h5>Cyber Node</h5><p>Encrypted telemetry node active.</p></div></div>
+</body>
+</html>

--- a/submissions/examples/new-slide-up-caption-card-sn250/style.css
+++ b/submissions/examples/new-slide-up-caption-card-sn250/style.css
@@ -1,0 +1,7 @@
+﻿/* ==========================================================================
+   EaseMotion CSS: Image Card Caption Slide-Up Overlay
+   ========================================================================== */
+
+@layer components {
+.ease-slide-up-card { position: relative; width: 280px; height: 180px; border-radius: 12px; overflow: hidden; border: 1px solid #222; } .ease-slide-up-card img { width: 100%; height: 100%; object-fit: cover; } .caption { position: absolute; bottom: 0; left: 0; right: 0; background: rgba(11, 12, 16, 0.85); backdrop-filter: blur(8px); padding: 16px; color: #fff; transform: translateY(100%); transition: transform 0.3s cubic-bezier(0.25, 0.8, 0.25, 1); } .ease-slide-up-card:hover .caption { transform: translateY(0); }
+}


### PR DESCRIPTION
﻿Closes #23781

## What this does
Image widget displaying a blurred caption panel sliding up to overlay text content on hover.

## Files
- `submissions/examples/new-slide-up-caption-card-sn250/style.css`
- `submissions/examples/new-slide-up-caption-card-sn250/demo.html`
- `submissions/examples/new-slide-up-caption-card-sn250/README.md`
