### PR TITLE
[Feat] #13308 — Add animated breadcrumb navigation with slide-in trail effect

### DIFF
--- a/submissions/examples/ease-breadcrumb/README.md
+++ b/submissions/examples/ease-breadcrumb/README.md
@@ -1,0 +1,50 @@
+# Animated Breadcrumb Navigation
+
+A premium animated breadcrumb trail with staggered slide-in effect per item and animated separators. Pure CSS, fully accessible, no JavaScript required.
+
+---
+
+## Overview
+
+This submission demonstrates the `.ease-breadcrumb` component:
+
+- **Animation technique:** Each `<li>` item slides in from left using `@keyframes ease-kf-breadcrumb-in` with staggered `animation-delay` via `nth-child` selectors.
+- **Separator animation:** `::before` pseudo-elements fade in between items using `@keyframes ease-kf-sep-fade`.
+- **Three separator variants:** Arrow (`›` — default), Slash (`/`), and Dot (`•`).
+- **Accessibility:** Uses `<nav aria-label="breadcrumb">`, `<ol>`, and `aria-current="page"` on the current item.
+- **Reduced motion:** Respects `prefers-reduced-motion` by skipping all animations.
+
+---
+
+## Usage
+
+```html
+<nav aria-label="breadcrumb">
+  <ol class="ease-breadcrumb">
+    <li class="ease-breadcrumb__item">
+      <a href="/" class="ease-breadcrumb__link">Home</a>
+    </li>
+    <li class="ease-breadcrumb__item">
+      <a href="/docs" class="ease-breadcrumb__link">Docs</a>
+    </li>
+    <li class="ease-breadcrumb__item ease-breadcrumb__item--current" aria-current="page">
+      Breadcrumb
+    </li>
+  </ol>
+</nav>
+```
+
+### Separator Variants
+
+| Class | Separator |
+|---|---|
+| `.ease-breadcrumb` (default) | `›` arrow |
+| `.ease-breadcrumb--slash` | `/` slash |
+| `.ease-breadcrumb--dot` | `•` dot |
+
+### CSS Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `--breadcrumb-duration` | `0.45s` | Per-item animation duration |
+| `--breadcrumb-stagger` | `0.08s` | Delay increment between items |

--- a/submissions/examples/ease-breadcrumb/demo.html
+++ b/submissions/examples/ease-breadcrumb/demo.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Animated Breadcrumb Navigation — EaseMotion CSS</title>
+  <meta name="description" content="A premium demo of animated breadcrumb navigation with staggered slide-in trail effect using EaseMotion CSS.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Component Showcase</span>
+      <h1>Animated Breadcrumb Navigation</h1>
+      <p class="description">
+        Staggered slide-in breadcrumb trails with animated separators. Pure CSS, fully
+        responsive, and screen-reader friendly via <code>aria-label="breadcrumb"</code>.
+      </p>
+    </header>
+
+    <!-- Variant 1: Arrow separator -->
+    <section class="demo-section">
+      <h2 class="variant-label">Arrow Separator</h2>
+      <nav aria-label="breadcrumb">
+        <ol class="ease-breadcrumb">
+          <li class="ease-breadcrumb__item">
+            <a href="#" class="ease-breadcrumb__link">Home</a>
+          </li>
+          <li class="ease-breadcrumb__item">
+            <a href="#" class="ease-breadcrumb__link">Components</a>
+          </li>
+          <li class="ease-breadcrumb__item">
+            <a href="#" class="ease-breadcrumb__link">Navigation</a>
+          </li>
+          <li class="ease-breadcrumb__item ease-breadcrumb__item--current" aria-current="page">
+            Breadcrumb
+          </li>
+        </ol>
+      </nav>
+    </section>
+
+    <!-- Variant 2: Slash separator -->
+    <section class="demo-section">
+      <h2 class="variant-label">Slash Separator</h2>
+      <nav aria-label="breadcrumb">
+        <ol class="ease-breadcrumb ease-breadcrumb--slash">
+          <li class="ease-breadcrumb__item">
+            <a href="#" class="ease-breadcrumb__link">Dashboard</a>
+          </li>
+          <li class="ease-breadcrumb__item">
+            <a href="#" class="ease-breadcrumb__link">Projects</a>
+          </li>
+          <li class="ease-breadcrumb__item">
+            <a href="#" class="ease-breadcrumb__link">EaseMotion CSS</a>
+          </li>
+          <li class="ease-breadcrumb__item ease-breadcrumb__item--current" aria-current="page">
+            Issue #13308
+          </li>
+        </ol>
+      </nav>
+    </section>
+
+    <!-- Variant 3: Dot separator, compact -->
+    <section class="demo-section">
+      <h2 class="variant-label">Dot Separator</h2>
+      <nav aria-label="breadcrumb">
+        <ol class="ease-breadcrumb ease-breadcrumb--dot">
+          <li class="ease-breadcrumb__item">
+            <a href="#" class="ease-breadcrumb__link">⌂ Home</a>
+          </li>
+          <li class="ease-breadcrumb__item">
+            <a href="#" class="ease-breadcrumb__link">Blog</a>
+          </li>
+          <li class="ease-breadcrumb__item ease-breadcrumb__item--current" aria-current="page">
+            Article
+          </li>
+        </ol>
+      </nav>
+    </section>
+
+    <!-- Long path demo -->
+    <section class="demo-section">
+      <h2 class="variant-label">Deep Path (5 levels)</h2>
+      <nav aria-label="breadcrumb">
+        <ol class="ease-breadcrumb">
+          <li class="ease-breadcrumb__item"><a href="#" class="ease-breadcrumb__link">Root</a></li>
+          <li class="ease-breadcrumb__item"><a href="#" class="ease-breadcrumb__link">Level 1</a></li>
+          <li class="ease-breadcrumb__item"><a href="#" class="ease-breadcrumb__link">Level 2</a></li>
+          <li class="ease-breadcrumb__item"><a href="#" class="ease-breadcrumb__link">Level 3</a></li>
+          <li class="ease-breadcrumb__item ease-breadcrumb__item--current" aria-current="page">Current</li>
+        </ol>
+      </nav>
+    </section>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-breadcrumb/style.css
+++ b/submissions/examples/ease-breadcrumb/style.css
@@ -1,0 +1,218 @@
+/* ============================================================
+   Animated Breadcrumb Navigation — style.css
+   Submission for EaseMotion CSS Issue #13308
+   Staggered slide-in trail with animated separators. Pure CSS.
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --accent-color: #06b6d4;
+  --bg-gradient: linear-gradient(135deg, #0f172a 0%, #1a1040 100%);
+  --card-bg: rgba(30, 41, 59, 0.6);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f8fafc;
+  --text-secondary: #94a3b8;
+  --text-muted: #64748b;
+  --link-color: #a78bfa;
+  --link-hover: #c4b5fd;
+  --separator-color: #475569;
+  --current-color: #f8fafc;
+  --breadcrumb-duration: 0.45s;
+  --breadcrumb-stagger: 0.08s;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 760px;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.18);
+  border: 1px solid rgba(124, 58, 237, 0.32);
+  border-radius: 999px;
+  color: #a78bfa;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.4rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  max-width: 560px;
+  margin: 0 auto;
+  line-height: 1.7;
+}
+
+.description code {
+  font-family: monospace;
+  background: rgba(124, 58, 237, 0.14);
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 0.88em;
+  color: #c4b5fd;
+}
+
+/* ── Demo sections ── */
+.demo-section {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  padding: 28px 32px;
+  backdrop-filter: blur(8px);
+}
+
+.variant-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  margin-bottom: 20px;
+}
+
+/* ============================================================
+   .ease-breadcrumb Component
+   ============================================================ */
+
+.ease-breadcrumb {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0;
+}
+
+/* ── Each breadcrumb item ── */
+.ease-breadcrumb__item {
+  display: flex;
+  align-items: center;
+  font-size: 0.9rem;
+  font-weight: 500;
+
+  /* Staggered slide-in via nth-child */
+  opacity: 0;
+  transform: translateX(-10px);
+  animation: ease-kf-breadcrumb-in var(--breadcrumb-duration) cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+/* Stagger delays for up to 8 items */
+.ease-breadcrumb__item:nth-child(1) { animation-delay: calc(var(--breadcrumb-stagger) * 0); }
+.ease-breadcrumb__item:nth-child(2) { animation-delay: calc(var(--breadcrumb-stagger) * 1); }
+.ease-breadcrumb__item:nth-child(3) { animation-delay: calc(var(--breadcrumb-stagger) * 2); }
+.ease-breadcrumb__item:nth-child(4) { animation-delay: calc(var(--breadcrumb-stagger) * 3); }
+.ease-breadcrumb__item:nth-child(5) { animation-delay: calc(var(--breadcrumb-stagger) * 4); }
+.ease-breadcrumb__item:nth-child(6) { animation-delay: calc(var(--breadcrumb-stagger) * 5); }
+.ease-breadcrumb__item:nth-child(7) { animation-delay: calc(var(--breadcrumb-stagger) * 6); }
+.ease-breadcrumb__item:nth-child(8) { animation-delay: calc(var(--breadcrumb-stagger) * 7); }
+
+@keyframes ease-kf-breadcrumb-in {
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+/* ── Links ── */
+.ease-breadcrumb__link {
+  color: var(--link-color);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.ease-breadcrumb__link:hover,
+.ease-breadcrumb__link:focus-visible {
+  color: var(--link-hover);
+  text-decoration: underline;
+  outline: none;
+}
+
+/* ── Current page item (non-linked) ── */
+.ease-breadcrumb__item--current {
+  color: var(--current-color);
+  font-weight: 600;
+  cursor: default;
+}
+
+/* ── Separator (arrow › by default) via ::before on non-first items ── */
+.ease-breadcrumb__item:not(:first-child)::before {
+  content: '›';
+  margin: 0 10px;
+  color: var(--separator-color);
+  font-size: 1.1em;
+  line-height: 1;
+
+  /* Separator fades in slightly after the item */
+  opacity: 0;
+  animation: ease-kf-sep-fade var(--breadcrumb-duration) cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.ease-breadcrumb__item:nth-child(2)::before { animation-delay: calc(var(--breadcrumb-stagger) * 0.5); }
+.ease-breadcrumb__item:nth-child(3)::before { animation-delay: calc(var(--breadcrumb-stagger) * 1.5); }
+.ease-breadcrumb__item:nth-child(4)::before { animation-delay: calc(var(--breadcrumb-stagger) * 2.5); }
+.ease-breadcrumb__item:nth-child(5)::before { animation-delay: calc(var(--breadcrumb-stagger) * 3.5); }
+.ease-breadcrumb__item:nth-child(6)::before { animation-delay: calc(var(--breadcrumb-stagger) * 4.5); }
+
+@keyframes ease-kf-sep-fade {
+  to { opacity: 1; }
+}
+
+/* ── Slash variant ── */
+.ease-breadcrumb--slash .ease-breadcrumb__item:not(:first-child)::before {
+  content: '/';
+  margin: 0 8px;
+  font-size: 0.9em;
+  color: var(--separator-color);
+}
+
+/* ── Dot variant ── */
+.ease-breadcrumb--dot .ease-breadcrumb__item:not(:first-child)::before {
+  content: '•';
+  margin: 0 10px;
+  font-size: 0.75em;
+  color: var(--separator-color);
+}
+
+/* ── Reduced motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-breadcrumb__item,
+  .ease-breadcrumb__item::before {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
Adds an animated breadcrumb navigation component with staggered slide-in trail effect. Each breadcrumb item slides in from the left with a configurable delay offset using CSS `nth-child` selectors. Separator characters (`›`, `/`, `•`) are animated in separately via `::before` pseudo-elements. Three separator variants are included: default arrow, slash, and dot. The component is fully accessible using `<nav aria-label="breadcrumb">`, `<ol>`, and `aria-current="page"`.

## Root Cause
EaseMotion CSS had no breadcrumb navigation component. Developers had to build custom staggered slide-in effects from scratch.

## Changes Made
- `submissions/examples/ease-breadcrumb/demo.html`: Shows four variants — arrow separator (4 items), slash separator (4 items), dot separator (3 items), and a deep 5-level path. Imports `../../easemotion.css` and `style.css`. No inline styles.
- `submissions/examples/ease-breadcrumb/style.css`: Defines `.ease-breadcrumb`, `.ease-breadcrumb--slash`, `.ease-breadcrumb--dot`, `.ease-breadcrumb__item` (with `nth-child` stagger delays for up to 8 items), `.ease-breadcrumb__link`, `.ease-breadcrumb__item--current`, and separator `::before` animations. Includes `prefers-reduced-motion` fallback.
- `submissions/examples/ease-breadcrumb/README.md`: Component overview, usage markup, separator variants table, and CSS variable reference.

## How to Test
1. Open `submissions/examples/ease-breadcrumb/demo.html` in a browser.
2. Verify each breadcrumb item slides in left-to-right with visible stagger on page load.
3. Verify separators fade in between items.
4. Check each of the four demo sections for arrow/slash/dot/deep variants.
5. Hover links — color should transition to `#c4b5fd`.
6. Current page items should be white and non-interactive.
7. Set `prefers-reduced-motion: reduce` in DevTools — all items should appear instantly.

## Related Issue
Closes #13308