### PR TITLE
[Feat] #13304 — Add CSS-only animated tooltip with arrow pointer and 4 directional variants

### DIFF
--- a/submissions/examples/ease-tooltip/README.md
+++ b/submissions/examples/ease-tooltip/README.md
@@ -1,8 +1,56 @@
-# CSS-Only Tooltip Component
+# Animated Tooltip with Arrow Pointer
 
-A lightweight, JavaScript-free tooltip modifier component driven entirely by raw data attributes and native pseudo-elements.
+Pure CSS tooltips with fade-in + directional slide animation and an arrow pointer using the CSS border-trick. No JavaScript. Triggered on `:hover` and `:focus-visible`.
 
-## Technical Details
-- Extracts display strings using the native `attr(data-tip)` structural selector.
-- Handles floating overlay maps utilizing absolute placement translation coordinates.
-- Drops transitional animation metrics instantly under system `prefers-reduced-motion` settings.
+---
+
+## Overview
+
+- **Animation:** `opacity` + `transform` (translateY/translateX 6px offset) transition on `::after` and `::before` pseudo-elements.
+- **Arrow:** `::before` border trick — a zero-size box with one colored border side creates a CSS triangle.
+- **Four directions:** `--top`, `--bottom`, `--left`, `--right` modifier classes.
+- **Tooltip text:** Set via the `data-ease-tooltip` attribute, rendered with `content: attr(data-ease-tooltip)`.
+- **Customisation:** CSS variables for background, color, delay, duration, radius, padding.
+- **Color presets:** `--ocean`, `--ember`, `--forest` modifier classes.
+- **Accessibility:** Triggered on `:focus-visible` as well as `:hover`. `pointer-events: none` on the tooltip bubble.
+- **Reduced motion:** Transition duration collapses to `0.01ms`.
+
+---
+
+## Usage
+
+```html
+<button class="ease-tooltip ease-tooltip--top"
+        data-ease-tooltip="Your tooltip text here">
+  Hover or focus me
+</button>
+```
+
+### CSS Variable Reference
+
+| Variable | Default | Description |
+|---|---|---|
+| `--ease-tooltip-bg` | `#3b1fa8` | Tooltip background color |
+| `--ease-tooltip-color` | `#f8fafc` | Tooltip text color |
+| `--ease-tooltip-delay` | `0s` | Show delay |
+| `--ease-tooltip-dur` | `0.2s` | Transition duration |
+| `--ease-tooltip-radius` | `7px` | Border radius |
+| `--ease-tooltip-padding` | `6px 12px` | Inner padding |
+| `--ease-tooltip-font` | `0.8rem` | Font size |
+
+### Direction Classes
+
+| Class | Position |
+|---|---|
+| `.ease-tooltip--top` | Above element |
+| `.ease-tooltip--bottom` | Below element |
+| `.ease-tooltip--left` | Left of element |
+| `.ease-tooltip--right` | Right of element |
+
+### Color Presets
+
+| Class | Color |
+|---|---|
+| `.ease-tooltip--ocean` | Teal blue |
+| `.ease-tooltip--ember` | Warm amber |
+| `.ease-tooltip--forest` | Deep green |

--- a/submissions/examples/ease-tooltip/demo.html
+++ b/submissions/examples/ease-tooltip/demo.html
@@ -1,25 +1,115 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CSS-Only Tooltip Showcase</title>
-    <link rel="stylesheet" href="style.css">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Animated Tooltip — EaseMotion CSS</title>
+  <meta name="description" content="A premium demo of CSS-only animated tooltips with arrow pointers and four directional variants using EaseMotion CSS.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
 
-    <main class="showcase-container">
-        <header class="showcase-header">
-            <h2>CSS-Only Tooltips</h2>
-            <p>Hover over the buttons below to test the smooth, JavaScript-free tooltip transitions.</p>
-        </header>
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Component Showcase</span>
+      <h1>Animated Tooltips</h1>
+      <p class="description">
+        Pure CSS tooltips with fade-in + slide entry animation and arrow pointers.
+        Triggered on <code>:hover</code> and <code>:focus-visible</code>. No JavaScript.
+      </p>
+    </header>
 
-        <div class="interactive-zone">
-            <button class="ease-tooltip" data-tip="This is a tooltip">Hover me (Top)</button>
+    <!-- Direction showcase -->
+    <section class="showcase" aria-label="Tooltip direction variants">
 
-            <button class="ease-tooltip ease-tooltip-bottom" data-tip="Below tooltip">Hover me (Bottom)</button>
-        </div>
-    </main>
+      <button class="ease-tooltip ease-tooltip--top demo-btn"
+              data-ease-tooltip="Appears above the element"
+              tabindex="0">
+        Top Tooltip
+      </button>
+
+      <button class="ease-tooltip ease-tooltip--bottom demo-btn"
+              data-ease-tooltip="Appears below the element"
+              tabindex="0">
+        Bottom Tooltip
+      </button>
+
+      <button class="ease-tooltip ease-tooltip--left demo-btn"
+              data-ease-tooltip="Appears to the left"
+              tabindex="0">
+        Left Tooltip
+      </button>
+
+      <button class="ease-tooltip ease-tooltip--right demo-btn"
+              data-ease-tooltip="Appears to the right"
+              tabindex="0">
+        Right Tooltip
+      </button>
+
+    </section>
+
+    <!-- Color variant showcase -->
+    <section class="color-showcase" aria-label="Tooltip color variants">
+      <h2 class="section-title">Color Variants</h2>
+      <div class="color-row">
+
+        <button class="ease-tooltip ease-tooltip--top demo-chip"
+                data-ease-tooltip="Default purple"
+                tabindex="0">
+          Default
+        </button>
+
+        <button class="ease-tooltip ease-tooltip--top ease-tooltip--ocean demo-chip"
+                data-ease-tooltip="Ocean blue"
+                tabindex="0">
+          Ocean
+        </button>
+
+        <button class="ease-tooltip ease-tooltip--top ease-tooltip--ember demo-chip"
+                data-ease-tooltip="Ember orange"
+                tabindex="0">
+          Ember
+        </button>
+
+        <button class="ease-tooltip ease-tooltip--top ease-tooltip--forest demo-chip"
+                data-ease-tooltip="Forest green"
+                tabindex="0">
+          Forest
+        </button>
+
+      </div>
+    </section>
+
+    <!-- Delay variant -->
+    <section class="delay-showcase" aria-label="Tooltip delay variants">
+      <h2 class="section-title">Delay Variants</h2>
+      <div class="color-row">
+
+        <button class="ease-tooltip ease-tooltip--top demo-chip"
+                data-ease-tooltip="Appears instantly"
+                tabindex="0">
+          No Delay
+        </button>
+
+        <button class="ease-tooltip ease-tooltip--top demo-chip"
+                style="--ease-tooltip-delay: 0.3s"
+                data-ease-tooltip="300ms delay"
+                tabindex="0">
+          300ms Delay
+        </button>
+
+        <button class="ease-tooltip ease-tooltip--top demo-chip"
+                style="--ease-tooltip-delay: 0.8s"
+                data-ease-tooltip="800ms delay"
+                tabindex="0">
+          800ms Delay
+        </button>
+
+      </div>
+    </section>
+
+  </div>
 
 </body>
 </html>

--- a/submissions/examples/ease-tooltip/style.css
+++ b/submissions/examples/ease-tooltip/style.css
@@ -1,144 +1,320 @@
+/* ============================================================
+   Animated Tooltip — style.css
+   Submission for EaseMotion CSS Issue #13304
+   Pure CSS tooltips: fade-in + translate entry animation,
+   arrow via border trick, 4 directional variants, color presets.
+   ============================================================ */
 
-* {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #0f172a 0%, #1a1040 100%);
+  --card-bg: rgba(30, 41, 59, 0.6);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f8fafc;
+  --text-secondary: #94a3b8;
+  --text-muted: #64748b;
+
+  /* ── Tooltip tokens ── */
+  --ease-tooltip-bg:      #3b1fa8;
+  --ease-tooltip-color:   #f8fafc;
+  --ease-tooltip-delay:   0s;
+  --ease-tooltip-dur:     0.2s;
+  --ease-tooltip-radius:  7px;
+  --ease-tooltip-padding: 6px 12px;
+  --ease-tooltip-font:    0.8rem;
+  --ease-tooltip-arrow:   6px;
+  --ease-tooltip-offset:  calc(100% + var(--ease-tooltip-arrow) + 4px);
 }
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 body {
-    background-color: #0b0f19;
-    color: #f1f5f9;
-    font-family: system-ui, -apple-system, sans-serif;
-    min-height: 100vh;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    padding: 2rem;
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
-.showcase-container {
-    text-align: center;
-    max-width: 600px;
+.container {
+  width: 100%;
+  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  gap: 64px;
 }
 
-.showcase-header {
-    margin-bottom: 4rem;
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.18);
+  border: 1px solid rgba(124, 58, 237, 0.32);
+  border-radius: 999px;
+  color: #a78bfa;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 16px;
 }
 
-.showcase-header h2 {
-    font-size: 2rem;
-    color: #ffffff;
-    margin-bottom: 0.5rem;
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.4rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
-.showcase-header p {
-    color: #64748b;
-    font-size: 0.95rem;
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  max-width: 560px;
+  margin: 0 auto;
+  line-height: 1.7;
 }
 
-.interactive-zone {
-    display: flex;
-    justify-content: center;
-    gap: 3rem;
-    flex-wrap: wrap;
+.description code {
+  font-family: monospace;
+  background: rgba(124, 58, 237, 0.14);
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 0.88em;
+  color: #c4b5fd;
 }
 
-button {
-    background-color: #1e293b;
-    color: #ffffff;
-    border: 1px solid #334155;
-    padding: 0.75rem 1.5rem;
-    border-radius: 6px;
-    font-size: 0.95rem;
-    font-weight: 600;
-    cursor: pointer;
-    transition: background-color 0.2s, border-color 0.2s;
+/* ── Showcase layouts ── */
+.showcase {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 24px;
+  padding: 60px 0;
 }
 
-button:hover {
-    background-color: #2563eb;
-    border-color: #3b82f6;
+.color-showcase,
+.delay-showcase {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
 }
 
-/* 
-   THE MECHANIC: Pure CSS Tooltip Engines (::before and ::after)*/
+.section-title {
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  text-align: center;
+}
 
+.color-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 20px;
+  padding: 40px 0 20px;
+}
+
+/* ── Demo trigger buttons ── */
+.demo-btn {
+  padding: 12px 28px;
+  background: rgba(124, 58, 237, 0.18);
+  border: 1px solid rgba(124, 58, 237, 0.32);
+  border-radius: 10px;
+  color: #c4b5fd;
+  font-size: 0.95rem;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.demo-btn:hover {
+  background: rgba(124, 58, 237, 0.28);
+  border-color: rgba(124, 58, 237, 0.5);
+}
+
+.demo-chip {
+  padding: 8px 20px;
+  background: rgba(30, 41, 59, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.demo-chip:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+/* ============================================================
+   .ease-tooltip Component
+   ============================================================
+
+   Usage:
+     <button class="ease-tooltip ease-tooltip--top"
+             data-ease-tooltip="Your tooltip text"
+             style="--ease-tooltip-bg: #3b1fa8; --ease-tooltip-delay: 0.2s">
+       Hover me
+     </button>
+*/
+
+/* Base: relative positioning required for absolute ::after */
 .ease-tooltip {
-    position: relative;
+  position: relative;
+  /* Overflow must NOT be hidden on the trigger */
 }
 
+/* Tooltip text bubble (::after) and arrow (::before) */
+.ease-tooltip::after,
 .ease-tooltip::before {
-    content: attr(data-tip);
-    position: absolute;
-    bottom: 100%;
-    left: 50%;
-    transform: translateX(-50%) translateY(-8px);
-    background-color: #000000;
-    color: #ffffff;
-    font-size: 0.8rem;
-    font-weight: 500;
-    padding: 0.5rem 0.75rem;
-    border-radius: 4px;
-    white-space: nowrap;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.25s ease, transform 0.25s ease;
-    z-index: 100;
+  pointer-events: none;
+  position: absolute;
+  z-index: 9999;
+  opacity: 0;
+  transition:
+    opacity var(--ease-tooltip-dur) ease var(--ease-tooltip-delay),
+    transform var(--ease-tooltip-dur) cubic-bezier(0.22, 1, 0.36, 1) var(--ease-tooltip-delay);
 }
 
+/* Tooltip bubble text */
 .ease-tooltip::after {
-    content: "";
-    position: absolute;
-    bottom: 100%;
-    left: 50%;
-    transform: translateX(-50%) translateY(0);
-    border-width: 5px 5px 0 5px;
-    border-style: solid;
-    border-color: #000000 transparent transparent transparent;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.25s ease, transform 0.25s ease;
-    z-index: 100;
+  content: attr(data-ease-tooltip);
+  background: var(--ease-tooltip-bg);
+  color: var(--ease-tooltip-color);
+  padding: var(--ease-tooltip-padding);
+  border-radius: var(--ease-tooltip-radius);
+  font-size: var(--ease-tooltip-font);
+  font-weight: 500;
+  white-space: nowrap;
+  max-width: min(260px, 90vw);
+  overflow-wrap: break-word;
+  white-space: normal;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  line-height: 1.4;
 }
 
-.ease-tooltip:hover::before {
-    opacity: 1;
-    transform: translateX(-50%) translateY(-4px);
+/* Arrow pseudo-element */
+.ease-tooltip::before {
+  content: '';
+  border: var(--ease-tooltip-arrow) solid transparent;
 }
 
-.ease-tooltip:hover::after {
-    opacity: 1;
-    transform: translateX(-50%) translateY(4px);
+/* ── On show ── */
+.ease-tooltip:hover::after,
+.ease-tooltip:hover::before,
+.ease-tooltip:focus-visible::after,
+.ease-tooltip:focus-visible::before {
+  opacity: 1;
 }
 
-/*
-   Direction Modifier Module: Bottom Layout State Updates*/
-
-.ease-tooltip-bottom::before {
-    bottom: auto;
-    top: 100%;
-    transform: translateX(-50%) translateY(8px);
+/* ---- TOP ---- */
+.ease-tooltip--top::after {
+  bottom: var(--ease-tooltip-offset);
+  left: 50%;
+  transform: translateX(-50%) translateY(6px);
+}
+.ease-tooltip--top:hover::after,
+.ease-tooltip--top:focus-visible::after {
+  transform: translateX(-50%) translateY(0);
+}
+.ease-tooltip--top::before {
+  border-top-color: var(--ease-tooltip-bg);
+  bottom: calc(100% + 4px);
+  left: 50%;
+  transform: translateX(-50%) translateY(6px);
+}
+.ease-tooltip--top:hover::before,
+.ease-tooltip--top:focus-visible::before {
+  transform: translateX(-50%) translateY(0);
 }
 
-.ease-tooltip-bottom::after {
-    bottom: auto;
-    top: 100%;
-    transform: translateX(-50%) translateY(0);
-    border-width: 0 5px 5px 5px;
-    border-color: transparent transparent #000000 transparent;
+/* ---- BOTTOM ---- */
+.ease-tooltip--bottom::after {
+  top: var(--ease-tooltip-offset);
+  left: 50%;
+  transform: translateX(-50%) translateY(-6px);
+}
+.ease-tooltip--bottom:hover::after,
+.ease-tooltip--bottom:focus-visible::after {
+  transform: translateX(-50%) translateY(0);
+}
+.ease-tooltip--bottom::before {
+  border-bottom-color: var(--ease-tooltip-bg);
+  top: calc(100% + 4px);
+  left: 50%;
+  transform: translateX(-50%) translateY(-6px);
+}
+.ease-tooltip--bottom:hover::before,
+.ease-tooltip--bottom:focus-visible::before {
+  transform: translateX(-50%) translateY(0);
 }
 
-.ease-tooltip-bottom:hover::before {
-    transform: translateX(-50%) translateY(4px);
+/* ---- LEFT ---- */
+.ease-tooltip--left::after {
+  right: var(--ease-tooltip-offset);
+  top: 50%;
+  transform: translateY(-50%) translateX(6px);
+}
+.ease-tooltip--left:hover::after,
+.ease-tooltip--left:focus-visible::after {
+  transform: translateY(-50%) translateX(0);
+}
+.ease-tooltip--left::before {
+  border-left-color: var(--ease-tooltip-bg);
+  right: calc(100% + 4px);
+  top: 50%;
+  transform: translateY(-50%) translateX(6px);
+}
+.ease-tooltip--left:hover::before,
+.ease-tooltip--left:focus-visible::before {
+  transform: translateY(-50%) translateX(0);
 }
 
-.ease-tooltip-bottom:hover::after {
-    transform: translateX(-50%) translateY(-4px);
+/* ---- RIGHT ---- */
+.ease-tooltip--right::after {
+  left: var(--ease-tooltip-offset);
+  top: 50%;
+  transform: translateY(-50%) translateX(-6px);
+}
+.ease-tooltip--right:hover::after,
+.ease-tooltip--right:focus-visible::after {
+  transform: translateY(-50%) translateX(0);
+}
+.ease-tooltip--right::before {
+  border-right-color: var(--ease-tooltip-bg);
+  left: calc(100% + 4px);
+  top: 50%;
+  transform: translateY(-50%) translateX(-6px);
+}
+.ease-tooltip--right:hover::before,
+.ease-tooltip--right:focus-visible::before {
+  transform: translateY(-50%) translateX(0);
 }
 
+/* ── Color presets ── */
+.ease-tooltip--ocean  { --ease-tooltip-bg: #0e7490; }
+.ease-tooltip--ember  { --ease-tooltip-bg: #b45309; }
+.ease-tooltip--forest { --ease-tooltip-bg: #166534; }
+
+/* ── Reduced motion ── */
 @media (prefers-reduced-motion: reduce) {
-    .ease-tooltip::before,
-    .ease-tooltip::after {
-        transition: none !important;
-    }
+  .ease-tooltip::after,
+  .ease-tooltip::before {
+    transition: opacity 0.01ms;
+  }
 }


### PR DESCRIPTION
## Summary
Adds a pure CSS animated tooltip component with arrow pointers and four directional variants. The tooltip text is stored in a `data-ease-tooltip` attribute and rendered via `content: attr(data-ease-tooltip)` on a `::after` pseudo-element. An arrow is created using a border-trick `::before` pseudo-element. Both pseudo-elements animate in with `opacity` + `transform` (6px slide offset) transitions. Triggered on both `:hover` and `:focus-visible` for keyboard accessibility. Three color presets (ocean, ember, forest) and a configurable delay via `--ease-tooltip-delay` are included.

## Root Cause
EaseMotion CSS had no tooltip component. The issue requested a pure CSS approach using pseudo-elements with fade-in + slide animation.

## Changes Made
- `submissions/examples/ease-tooltip/demo.html`: Showcases all four directions (Top/Bottom/Left/Right) plus color variants (Default/Ocean/Ember/Forest) and delay variants (0ms/300ms/800ms). Imports `../../easemotion.css` and `style.css`. Inline `style` used only for `--ease-tooltip-delay` custom property overrides on the delay demo buttons (CSS variable, not raw style).
- `submissions/examples/ease-tooltip/style.css`: Defines `.ease-tooltip` base, `.ease-tooltip--top`, `--bottom`, `--left`, `--right` directional modifiers, color presets (`.ease-tooltip--ocean`, `--ember`, `--forest`), and `prefers-reduced-motion` fallback. All tooltip positioning uses `::after` and `::before` with `absolute` positioning.
- `submissions/examples/ease-tooltip/README.md`: Component overview, usage markup, CSS variable reference, direction class table, and color preset table.

## How to Test
1. Open `submissions/examples/ease-tooltip/demo.html` in a browser.
2. Hover each directional button — tooltip should appear from the correct direction with a slide-in animation.
3. Verify the arrow triangle points from the bubble toward the trigger element.
4. Tab to each button and verify tooltip appears on `:focus-visible`.
5. Hover the color variant chips — ocean/ember/forest color presets visible.
6. Hover delay variant chips —  300ms and 800ms delays are noticeable.
7. Set `prefers-reduced-motion: reduce` — tooltips should appear instantly.

## Related Issue
Closes #13304