### PR TITLE
[Feat] #15572 — Add CSS scroll-padding Anchor Navigation Example (unique folder)

### DIFF
--- a/submissions/examples/scroll-padding-nav-15572-ag/README.md
+++ b/submissions/examples/scroll-padding-nav-15572-ag/README.md
@@ -1,0 +1,37 @@
+# CSS Scroll-Padding Anchor Navigation Example
+
+This interactive example showcases how to resolve the common bug where sticky navigation headers overlay target section headings when anchor links are clicked.
+
+---
+
+## The Overlay Bug
+
+When a sticky navigation header is active:
+- Clicking a link to `#section-1` scrolls the top of `#section-1` directly to the top of the viewport.
+- The sticky header (e.g. `80px` tall) sits on top, overlaying the first few lines of text or the heading of that section.
+
+---
+
+## The Scroll-Padding Solution
+
+By applying `scroll-padding-top` to the `html` element or scroll container, you tell the browser to offset landing position by the height of the sticky nav.
+
+```css
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: 80px; /* Offset matching header height */
+}
+```
+
+This avoids the need for:
+- Complex Javascript calculations on click handlers.
+- Empty filler elements or huge padding/negative margin hacks inside sections.
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a web browser.
+2. Click any of the section links in the sticky navigation header at the top (e.g. **Syntax**).
+3. The page will smoothly scroll to the chosen section.
+4. Verify that the section's title lands exactly below the frosted-glass navigation bar without being covered.

--- a/submissions/examples/scroll-padding-nav-15572-ag/demo.html
+++ b/submissions/examples/scroll-padding-nav-15572-ag/demo.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Scroll-Padding Anchor Navigation — EaseMotion CSS</title>
+  <meta name="description" content="Interactive demo showing how CSS scroll-padding prevents sticky navigation bars from covering content headings.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Sticky Header Navigation -->
+  <header class="sticky-header">
+    <div class="header-container">
+      <span class="logo">EaseMotion CSS</span>
+      <nav aria-label="Page Sections">
+        <ul class="nav-links">
+          <li><a href="#introduction" class="nav-link">Introduction</a></li>
+          <li><a href="#features" class="nav-link">Features</a></li>
+          <li><a href="#syntax" class="nav-link">Syntax</a></li>
+          <li><a href="#demo" class="nav-link">Live Comparison</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="content-wrapper">
+    <!-- Header Hero -->
+    <section class="hero-section">
+      <span class="demo-badge">EaseMotion CSS — Showcase</span>
+      <h1>Scroll-Padding Anchor Navigation</h1>
+      <p class="description">
+        Learn how the <code>scroll-padding</code> CSS property creates elegant, accessible
+        offset scrolling for pages with fixed/sticky headers.
+      </p>
+      <div class="scroll-prompt">Scroll down or click links above to see it in action</div>
+    </section>
+
+    <!-- Section 1: Introduction -->
+    <section id="introduction" class="content-section">
+      <div class="section-card">
+        <h2>1. The Overlay Problem</h2>
+        <p>
+          When you implement a sticky navigation header, clicking anchor links (like <code>#section</code>)
+          tells the browser to scroll the top of that section to the top of the viewport.
+        </p>
+        <p class="problem-text">
+          <strong>The Bug:</strong> The fixed header overlays the first few lines of the target section,
+          blocking headings, subtitles, and introductory paragraphs.
+        </p>
+      </div>
+    </section>
+
+    <!-- Section 2: Features -->
+    <section id="features" class="content-section">
+      <div class="section-card">
+        <h2>2. Scroll-Padding Solution</h2>
+        <p>
+          By applying <code>scroll-padding-top</code> to the scroll container (usually the <code>html</code> element),
+          you define an inset scroll offset. The browser offsets the landing position by exactly the height
+          of your navigation bar.
+        </p>
+        <ul class="benefit-list">
+          <li>No complex JavaScript calculation required</li>
+          <li>Smooth, native scrolling preserved</li>
+          <li>Works with all keyboard navigation and screen-readers</li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- Section 3: Syntax -->
+    <section id="syntax" class="content-section">
+      <div class="section-card">
+        <h2>3. Clean CSS Implementation</h2>
+        <p>Implementing scroll offsets requires only two CSS declarations on your HTML element:</p>
+        <pre><code>html {
+  scroll-behavior: smooth;
+  scroll-padding-top: 80px; /* Matching sticky header height */
+}</code></pre>
+      </div>
+    </section>
+
+    <!-- Section 4: Live Comparison -->
+    <section id="demo" class="content-section">
+      <div class="section-card">
+        <h2>4. Live Comparison</h2>
+        <p>Try clicking the navigation links at the top. Notice how each section lands precisely 80px below the viewport top, leaving the section heading fully visible beneath the frosted-glass navbar.</p>
+        <div class="comparison-indicator">✓ Scroll-padding active: Headings are fully visible!</div>
+      </div>
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/scroll-padding-nav-15572-ag/style.css
+++ b/submissions/examples/scroll-padding-nav-15572-ag/style.css
@@ -1,0 +1,227 @@
+/* ============================================================
+   Scroll-Padding Anchor Navigation — style.css
+   Submission for EaseMotion CSS Issue #15572
+   Solves sticky header heading-overlay bugs using pure CSS
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.6);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-accent: #a78bfa;
+
+  --header-height: 80px;
+}
+
+/* Apply scroll behavior and padding to html element */
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: var(--header-height);
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 250vh; /* Extremely tall page to showcase scrolling */
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+}
+
+/* ── Sticky Navigation Header ── */
+.sticky-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: var(--header-height);
+  background: rgba(17, 24, 39, 0.7);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--card-border);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+}
+
+.header-container {
+  width: 100%;
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 0 24px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.logo {
+  font-size: 1.15rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 28px;
+}
+
+.nav-link {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 600;
+  transition: color 0.2s ease;
+}
+
+.nav-link:hover,
+.nav-link:focus-visible {
+  color: var(--text-accent);
+  outline: none;
+}
+
+/* ── Content layouts ── */
+.content-wrapper {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: calc(var(--header-height) + 40px) 24px 100px;
+  display: flex;
+  flex-direction: column;
+  gap: 120px;
+}
+
+/* Hero */
+.hero-section {
+  text-align: center;
+  padding: 60px 0;
+}
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 20px;
+}
+
+h1 {
+  font-size: 2.6rem;
+  font-weight: 800;
+  margin-bottom: 16px;
+  line-height: 1.25;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1.1rem;
+  line-height: 1.7;
+  max-width: 600px;
+  margin: 0 auto 32px;
+}
+
+.scroll-prompt {
+  color: var(--text-accent);
+  font-size: 0.88rem;
+  font-weight: 500;
+  animation: bounce 2s infinite;
+}
+
+@keyframes bounce {
+  0%, 20%, 50%, 80%, 100% { transform: translateY(0); }
+  40% { transform: translateY(-6px); }
+  60% { transform: translateY(-3px); }
+}
+
+/* Section Card */
+.content-section {
+  scroll-margin-top: 10px; /* Extra margin spacing if needed */
+}
+
+.section-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  padding: 40px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+}
+
+.section-card h2 {
+  font-size: 1.6rem;
+  font-weight: 700;
+  margin-bottom: 16px;
+  color: var(--text-accent);
+}
+
+.section-card p {
+  color: var(--text-secondary);
+  line-height: 1.8;
+  margin-bottom: 16px;
+}
+
+.problem-text {
+  border-left: 4px solid #ef4444;
+  padding-left: 16px;
+  color: #fca5a5 !important;
+}
+
+.benefit-list {
+  list-style-type: none;
+  padding-left: 4px;
+}
+
+.benefit-list li {
+  color: var(--text-secondary);
+  margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.benefit-list li::before {
+  content: "✦";
+  color: var(--text-accent);
+}
+
+.comparison-indicator {
+  background: rgba(16, 185, 129, 0.12);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+  padding: 12px 18px;
+  border-radius: 8px;
+  color: #34d399;
+  font-weight: 600;
+  font-size: 0.9rem;
+  margin-top: 20px;
+}
+
+pre {
+  background: rgba(0, 0, 0, 0.3);
+  padding: 18px;
+  border-radius: 8px;
+  overflow-x: auto;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+code {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 0.9rem;
+  color: #c4b5fd;
+}
+
+/* ── Reduced motion ── */
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}


### PR DESCRIPTION
## Summary
Adds a pure CSS anchor navigation example showing how to use `scroll-padding-top` to prevent sticky headers from overlaying target section headings. The example features a sticky navigation bar with a frosted glass background, smooth scroll transitions, and a clear comparison explanation. Submitted under a unique suffix-protected folder to avoid path integrity conflicts.

## Root Cause
When anchor links are clicked, the browser aligns the top of the element to the viewport top, which covers the section title under sticky headers.

## Changes Made
- `submissions/examples/scroll-padding-nav-15572-ag/demo.html`: Sticky top header navigation and section structure linked to anchor links.
- `submissions/examples/scroll-padding-nav-15572-ag/style.css`: Implements `scroll-padding-top` offset styling, smooth-scrolling behavior, and responsive header aesthetics.
- `submissions/examples/scroll-padding-nav-15572-ag/README.md`: Explains the bug, solution syntax, and instructions for verification.

## How to Test
1. Open `submissions/examples/scroll-padding-nav-15572-ag/demo.html` in a web browser.
2. Click on the section links in the sticky navigation header (e.g. "Syntax").
3. Verify that the page scrolls smoothly and target headings land cleanly below the sticky nav.

## Related Issue
Closes #15572