### PR TITLE
[Feat] #15570 — Add CSS Hanging Punctuation Example (unique folder)

### DIFF
--- a/submissions/examples/hanging-punctuation-15570-ag/README.md
+++ b/submissions/examples/hanging-punctuation-15570-ag/README.md
@@ -1,0 +1,30 @@
+# CSS Hanging Punctuation Example
+
+This typography showcase demonstrates the use of the CSS `hanging-punctuation` property to achieve professional editorial alignment for quotation marks.
+
+---
+
+## What is Hanging Punctuation?
+
+When a paragraph or blockquote begins with quotation marks (`"`), standard browser rendering aligns the quotation marks to the left border, visually indenting the first line. 
+
+By applying `hanging-punctuation: first last`, quotation marks and other symbols hang outside the text margins. This keeps the vertical reading column perfectly straight and aligned.
+
+---
+
+## Implementation Syntax
+
+```css
+blockquote, p {
+  hanging-punctuation: first last;
+  text-align: justify;
+}
+```
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in Safari or an iOS web view engine.
+2. Observe the comparison between "Standard Alignment" and "Hanging Punctuation".
+3. In the "Hanging Punctuation" column, the quotation marks at the start of blockquotes and paragraphs should hang outside the left/right text boundary box.

--- a/submissions/examples/hanging-punctuation-15570-ag/demo.html
+++ b/submissions/examples/hanging-punctuation-15570-ag/demo.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Hanging Punctuation — EaseMotion CSS</title>
+  <meta name="description" content="A demonstration of the CSS hanging-punctuation property for professional quotation marks and punctuation alignment.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Typography Showcase</span>
+      <h1>CSS Hanging Punctuation</h1>
+      <p class="description">
+        Learn how the <code>hanging-punctuation</code> property improves typographic alignment
+        by pushing quotation marks, brackets, and bullet points outside the text body margin.
+      </p>
+    </header>
+
+    <!-- Visual Showcase -->
+    <main class="grid-wrapper">
+
+      <!-- Column 1: Without Hanging Punctuation -->
+      <section class="card" aria-label="Standard paragraph alignment">
+        <h2 class="card-title">Standard Alignment</h2>
+        <p class="card-subtitle">Default browser behavior wraps punctuation inside the text column, breaking the vertical line of the margin.</p>
+
+        <div class="typography-sample standard-text">
+          <blockquote class="sample-quote">
+            "Design is not just what it looks like and feels like. Design is how it works."
+          </blockquote>
+          <p class="sample-paragraph">
+            "Typography is the craft of endowing a human language with a durable visual form," says Robert Bringhurst. When quotes are placed inside the text block, the left edge of the reading column appears indented, interrupting reading flow.
+          </p>
+        </div>
+      </section>
+
+      <!-- Column 2: With Hanging Punctuation -->
+      <section class="card card--glow" aria-label="Hanging punctuation alignment">
+        <h2 class="card-title">Hanging Punctuation</h2>
+        <p class="card-subtitle">With hanging punctuation active, quotes hang outside the text margins, preserving a perfectly straight vertical reading line.</p>
+
+        <div class="typography-sample hanging-text">
+          <blockquote class="sample-quote">
+            "Design is not just what it looks like and feels like. Design is how it works."
+          </blockquote>
+          <p class="sample-paragraph">
+            "Typography is the craft of endowing a human language with a durable visual form," says Robert Bringhurst. When quotes are placed inside the text block, the left edge of the reading column appears indented, interrupting reading flow.
+          </p>
+        </div>
+      </section>
+
+    </main>
+
+    <!-- CSS Details Section -->
+    <section class="syntax-section" aria-label="CSS syntax reference">
+      <h2 class="section-title">CSS Implementation</h2>
+      <div class="syntax-card">
+        <p>To enable hanging punctuation on blockquotes and paragraphs, use the following rules:</p>
+        <pre><code>blockquote, p {
+  hanging-punctuation: first last;
+  text-align: justify; /* Recommended for full margin alignment */
+}</code></pre>
+        <div class="support-info">
+          <strong>Note on Browser Compatibility:</strong> Supported in Safari and iOS web view engines. For other browsers, standard alignment fallbacks are automatically applied.
+        </div>
+      </div>
+    </section>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/hanging-punctuation-15570-ag/style.css
+++ b/submissions/examples/hanging-punctuation-15570-ag/style.css
@@ -1,0 +1,205 @@
+/* ============================================================
+   CSS Hanging Punctuation — style.css
+   Submission for EaseMotion CSS Issue #15570
+   Demonstrates hanging punctuation for vertical margin alignment
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.6);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-accent: #a78bfa;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 900px;
+  display: flex;
+  flex-direction: column;
+  gap: 56px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.4rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1.05rem;
+  max-width: 580px;
+  margin: 0 auto;
+  line-height: 1.7;
+}
+
+.description code {
+  font-family: monospace;
+  background: rgba(124, 58, 237, 0.14);
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 0.88em;
+  color: #c4b5fd;
+}
+
+/* ── Visual Showcase Cards ── */
+.grid-wrapper {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  gap: 32px;
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  padding: 36px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  backdrop-filter: blur(8px);
+}
+
+.card--glow {
+  border-color: rgba(167, 139, 250, 0.25);
+  box-shadow: 0 0 32px rgba(167, 139, 250, 0.05);
+}
+
+.card-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.card-subtitle {
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+/* Typography Samples */
+.typography-sample {
+  padding: 16px 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  margin-top: 12px;
+}
+
+.sample-quote {
+  font-size: 1.3rem;
+  font-weight: 700;
+  line-height: 1.45;
+  color: var(--text-accent);
+  margin-bottom: 24px;
+  position: relative;
+}
+
+.sample-paragraph {
+  font-size: 0.95rem;
+  line-height: 1.8;
+  color: var(--text-secondary);
+}
+
+/* ── Core Punctuation Alignments ── */
+.standard-text .sample-quote,
+.standard-text .sample-paragraph {
+  hanging-punctuation: none;
+  text-align: justify;
+}
+
+.hanging-text .sample-quote,
+.hanging-text .sample-paragraph {
+  hanging-punctuation: first last;
+  text-align: justify;
+}
+
+/* ── Syntax Details ── */
+.syntax-section {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  text-align: center;
+}
+
+.syntax-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 12px;
+  padding: 32px;
+}
+
+.syntax-card p {
+  color: var(--text-secondary);
+  margin-bottom: 16px;
+  font-size: 0.95rem;
+}
+
+pre {
+  background: rgba(0, 0, 0, 0.3);
+  padding: 18px;
+  border-radius: 8px;
+  overflow-x: auto;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  margin-bottom: 20px;
+}
+
+code {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 0.9rem;
+  color: #c4b5fd;
+}
+
+.support-info {
+  background: rgba(167, 139, 250, 0.08);
+  border-left: 4px solid var(--text-accent);
+  padding: 12px 18px;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}


### PR DESCRIPTION
## Summary
Adds a typography styling showcase demonstrating the use of `hanging-punctuation` to offset blockquotes and quotes outside the margins, keeping text edges vertically straight. Includes side-by-side comparison layouts (with vs without hanging punctuation) and a detail card discussing browser fallback behaviors. Submitted under a unique suffix-protected folder to avoid path conflicts.

## Root Cause
Default rendering positions quotes and brackets inside paragraphs, breaking alignment at column edges.

## Changes Made
- `submissions/examples/hanging-punctuation-15570-ag/demo.html`: Structure for comparing standard typography alignment vs hanging punctuation.
- `submissions/examples/hanging-punctuation-15570-ag/style.css`: Uses `hanging-punctuation: first last` with clean fallback styling.
- `submissions/examples/hanging-punctuation-15570-ag/README.md`: Explains CSS properties and provides implementation instructions.

## How to Test
1. Open `submissions/examples/hanging-punctuation-15570-ag/demo.html` in Safari.
2. Verify quotation marks hang outside text margins in the right column, leaving lines perfectly aligned.

## Related Issue
Closes #15570