### PR TITLE
[Feat] #15542 — Add CSS accent-color Form Styling Example (unique folder)

### DIFF
--- a/submissions/examples/accent-color-forms-15542-ag/README.md
+++ b/submissions/examples/accent-color-forms-15542-ag/README.md
@@ -1,0 +1,40 @@
+# CSS accent-color Form Styling Example
+
+This submission demonstrates the use of the CSS `accent-color` property to style native interactive form control elements dynamically.
+
+---
+
+## Overview
+
+Historically, customizing checkboxes, radio buttons, range inputs, and progress bars required rebuilding them completely using custom elements, leading to accessibility issues.
+
+The `accent-color` property solves this by allowing developers to set a custom theme color for the colored components of native form elements, retaining their built-in accessibility benefits.
+
+---
+
+## Target Elements
+
+`accent-color` affects the following elements in modern browsers:
+- `<input type="checkbox">`
+- `<input type="radio">`
+- `<input type="range">`
+- `<progress>`
+
+---
+
+## Usage
+
+```css
+.accented-control {
+  accent-color: #7c3aed; /* Set your custom theme color */
+}
+```
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a web browser.
+2. Observe Checkboxes, Radios, Range Sliders, and Progress Bars rendered in purple.
+3. Choose any color theme in the selector panel (e.g. Emerald, Rose, Amber).
+4. Verify that all native form controls change color immediately to match the selection.

--- a/submissions/examples/accent-color-forms-15542-ag/demo.html
+++ b/submissions/examples/accent-color-forms-15542-ag/demo.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS accent-color Form Styling — EaseMotion CSS</title>
+  <meta name="description" content="A premium showcase of native form controls customized dynamically using the CSS accent-color property.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Form Controls</span>
+      <h1>CSS <code>accent-color</code> Customization</h1>
+      <p class="description">
+        Styling native interactive form elements has historically required replacing them with custom divs.
+        The <code>accent-color</code> property solves this by recoloring native controls elegantly.
+      </p>
+    </header>
+
+    <!-- Interactive Customizer Panel -->
+    <main class="grid-wrapper">
+
+      <!-- Form Inputs Column -->
+      <section class="card" aria-label="Interactive Form Controls">
+        <h2 class="card-title">Native Form Controls</h2>
+        <p class="card-subtitle">Recolored using the CSS <code>accent-color</code> property.</p>
+
+        <form class="demo-form" onsubmit="return false;">
+          <!-- Checkbox Section -->
+          <div class="form-group">
+            <label class="group-label">Checkboxes</label>
+            <div class="control-row">
+              <label class="native-control-wrapper">
+                <input type="checkbox" checked class="accented-control">
+                <span>Receive updates</span>
+              </label>
+              <label class="native-control-wrapper">
+                <input type="checkbox" checked class="accented-control">
+                <span>Accept policies</span>
+              </label>
+            </div>
+          </div>
+
+          <!-- Radio Buttons Section -->
+          <div class="form-group">
+            <label class="group-label">Radio Buttons</label>
+            <div class="control-row">
+              <label class="native-control-wrapper">
+                <input type="radio" name="options" checked class="accented-control">
+                <span>Standard delivery</span>
+              </label>
+              <label class="native-control-wrapper">
+                <input type="radio" name="options" class="accented-control">
+                <span>Express delivery</span>
+              </label>
+            </div>
+          </div>
+
+          <!-- Range Slider Section -->
+          <div class="form-group">
+            <label class="group-label" id="volume-label">Range Slider (Volume: 70%)</label>
+            <input type="range" min="0" max="100" value="70" class="accented-control range-input" id="volume-range" aria-labelledby="volume-label">
+          </div>
+
+          <!-- Progress Bar Section -->
+          <div class="form-group">
+            <label class="group-label">Progress Bar</label>
+            <progress value="75" max="100" class="accented-control progress-bar"></progress>
+          </div>
+        </form>
+      </section>
+
+      <!-- Theme Controls Column -->
+      <section class="card card--glow" aria-label="Accent Customizer">
+        <h2 class="card-title">Color Theme Selector</h2>
+        <p class="card-subtitle">Choose a theme color to dynamically override the CSS variable controlling <code>accent-color</code>.</p>
+
+        <div class="theme-picker-grid">
+          <button class="theme-btn theme-btn--purple active" data-color="#7c3aed" aria-label="Purple theme"></button>
+          <button class="theme-btn theme-btn--cyan" data-color="#06b6d4" aria-label="Cyan theme"></button>
+          <button class="theme-btn theme-btn--emerald" data-color="#10b981" aria-label="Emerald theme"></button>
+          <button class="theme-btn theme-btn--amber" data-color="#f59e0b" aria-label="Amber theme"></button>
+          <button class="theme-btn theme-btn--rose" data-color="#f43f5e" aria-label="Rose theme"></button>
+          <button class="theme-btn theme-btn--indigo" data-color="#4f46e5" aria-label="Indigo theme"></button>
+        </div>
+
+        <div class="code-box">
+          <pre><code>.accented-control {
+  accent-color: <span id="code-val">#7c3aed</span>;
+}</code></pre>
+        </div>
+      </section>
+
+    </main>
+  </div>
+
+  <!-- Interactive script to update CSS variables dynamically -->
+  <script>
+    const themeButtons = document.querySelectorAll('.theme-btn');
+    const codeValEl = document.getElementById('code-val');
+    const rangeEl = document.getElementById('volume-range');
+    const labelEl = document.getElementById('volume-label');
+
+    // Handle range updates
+    rangeEl.addEventListener('input', (e) => {
+      labelEl.textContent = `Range Slider (Volume: ${e.target.value}%)`;
+    });
+
+    // Handle theme pickers
+    themeButtons.forEach(btn => {
+      btn.addEventListener('click', () => {
+        // Toggle active status
+        themeButtons.forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+
+        // Extract color and update custom property on body
+        const color = btn.getAttribute('data-color');
+        document.documentElement.style.setProperty('--user-accent-color', color);
+        codeValEl.textContent = color;
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/accent-color-forms-15542-ag/style.css
+++ b/submissions/examples/accent-color-forms-15542-ag/style.css
@@ -1,0 +1,240 @@
+/* ============================================================
+   CSS accent-color Form Styling — style.css
+   Submission for EaseMotion CSS Issue #15542
+   Recolors native HTML form elements using accent-color
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.6);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+
+  /* Default theme color variable, overridable by inline JS */
+  --user-accent-color: #7c3aed;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 860px;
+  display: flex;
+  flex-direction: column;
+  gap: 56px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.4rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1.05rem;
+  max-width: 580px;
+  margin: 0 auto;
+  line-height: 1.7;
+}
+
+.description code {
+  font-family: monospace;
+  background: rgba(124, 58, 237, 0.14);
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 0.88em;
+  color: #c4b5fd;
+}
+
+/* ── Customizer Panel ── */
+.grid-wrapper {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  gap: 32px;
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  padding: 36px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  backdrop-filter: blur(8px);
+}
+
+.card--glow {
+  border-color: rgba(167, 139, 250, 0.2);
+  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.2);
+}
+
+.card-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.card-subtitle {
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin-bottom: 12px;
+}
+
+/* ── Accented Form Controls ── */
+.demo-form {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.group-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.control-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+}
+
+.native-control-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+}
+
+/* Range input layout */
+.range-input {
+  width: 100%;
+  cursor: pointer;
+}
+
+/* Progress bar layout */
+.progress-bar {
+  width: 100%;
+  height: 10px;
+  border-radius: 99px;
+  overflow: hidden;
+  border: none;
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+/* Webkit progress fill customization */
+.progress-bar::-webkit-progress-value {
+  background-color: var(--user-accent-color);
+  transition: background-color 0.3s ease;
+}
+
+/* Firefox progress fill customization */
+.progress-bar::-moz-progress-bar {
+  background-color: var(--user-accent-color);
+}
+
+/* Apply accent-color to native form controls */
+.accented-control {
+  accent-color: var(--user-accent-color);
+}
+
+/* ── Theme buttons ── */
+.theme-picker-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.theme-btn {
+  height: 48px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.theme-btn:hover {
+  transform: translateY(-2px);
+  border-color: rgba(255, 255, 255, 0.3);
+}
+
+.theme-btn.active {
+  border: 2px solid #fff !important;
+  transform: scale(1.05);
+}
+
+.theme-btn--purple  { background: #7c3aed; }
+.theme-btn--cyan    { background: #06b6d4; }
+.theme-btn--emerald { background: #10b981; }
+.theme-btn--amber   { background: #f59e0b; }
+.theme-btn--rose    { background: #f43f5e; }
+.theme-btn--indigo  { background: #4f46e5; }
+
+/* ── Code display box ── */
+.code-box {
+  margin-top: 10px;
+}
+
+pre {
+  background: rgba(0, 0, 0, 0.3);
+  padding: 16px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  font-size: 0.88rem;
+  overflow-x: auto;
+}
+
+code {
+  font-family: 'Courier New', Courier, monospace;
+  color: #c4b5fd;
+}


### PR DESCRIPTION
## Summary
Adds an interactive CSS showcase showing how to use `accent-color` to customize checkboxes, radio buttons, range sliders, and progress bars. Features an interactive panel letting developers choose different theme colors and watch the native controls transition dynamically using CSS custom properties. Submitted under a unique suffix-protected folder to avoid path conflicts.

## Root Cause
Native form controls are historically difficult to style, forcing developers to build custom elements that often lack native accessibility characteristics.

## Changes Made
- `submissions/examples/accent-color-forms-15542-ag/demo.html`: Forms containing native checkboxes, radios, ranges, and progress bars, combined with an interactive theme switcher.
- `submissions/examples/accent-color-forms-15542-ag/style.css`: Links native elements to the custom property `--user-accent-color` via the `accent-color` attribute.
- `submissions/examples/accent-color-forms-15542-ag/README.md`: Explains the usage, target elements, and verification instructions.

## How to Test
1. Open `submissions/examples/accent-color-forms-15542-ag/demo.html` in a web browser.
2. Select any color button in the "Color Theme Selector" panel.
3. Verify that native checkboxes, radio options, the volume slider, and the progress bar change color immediately.

## Related Issue
Closes #15542