### PR TITLE
[Feat] #15544 — Add CSS object-fit Gallery Example (unique folder)

### DIFF
--- a/submissions/examples/object-fit-cover-15544-ag/README.md
+++ b/submissions/examples/object-fit-cover-15544-ag/README.md
@@ -1,0 +1,46 @@
+# CSS Object-Fit Gallery Example
+
+This submission demonstrates the implementation of responsive gallery grids using the CSS `object-fit` and `object-position` properties.
+
+---
+
+## What is Object-Fit?
+
+The `object-fit` property specifies how an `<img>` or `<video>` element should scale and resize to fit its content box.
+
+- **`cover`** — Fills the container box while preserving the image's aspect ratio, cropping content along edges if ratios do not match. Perfect for uniform card elements.
+- **`contain`** — Fits the entire image within the container box while maintaining the aspect ratio, leaving border pads (letterboxing) if aspect ratios differ.
+- **`fill`** — Resizes the image to occupy all container box space, stretching or squishing content if aspects differ.
+
+---
+
+## Smooth Hover Zoom Animation
+
+A common design pattern is scaling the image slightly on card hover. Combining `object-fit: cover` with an `overflow: hidden` wrapper allows you to scale the image cleanly without expanding its container bounds:
+
+```css
+.zoom-wrapper {
+  overflow: hidden;
+}
+.zoom-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.6s ease;
+}
+.zoom-card:hover .zoom-img {
+  transform: scale(1.08);
+}
+```
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a web browser.
+2. View the comparison grid under "Native Form Controls":
+   - **`object-fit: cover`** — Image should crop cleanly without stretching.
+   - **`object-fit: contain`** — Image fits entirely with dark bars on either side.
+   - **`object-fit: fill`** — Image stretches to fit bounds.
+3. Scroll to "Hover Zoom Integration" and hover over cards.
+4. Verify that images scale up smoothly within their bounding borders.

--- a/submissions/examples/object-fit-cover-15544-ag/demo.html
+++ b/submissions/examples/object-fit-cover-15544-ag/demo.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Object-Fit Gallery — EaseMotion CSS</title>
+  <meta name="description" content="A comparative showcase of CSS object-fit values and hover zoom animations for responsive card layouts.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Layout Utilities</span>
+      <h1>CSS <code>object-fit</code> Image Gallery</h1>
+      <p class="description">
+        Observe how different <code>object-fit</code> values affect image rendering inside
+        fixed aspect-ratio containers, and see how to create smooth hover zoom transitions.
+      </p>
+    </header>
+
+    <!-- Interactive Grid Showcase -->
+    <main class="grid-wrapper">
+
+      <!-- Column 1: object-fit: cover -->
+      <section class="card" aria-label="Object-Fit Cover example">
+        <h2 class="card-title">object-fit: cover</h2>
+        <p class="card-subtitle">Fills the box entirely. Aspect ratio is preserved by cropping the image. Best for cards and galleries.</p>
+        <div class="image-wrapper">
+          <img src="https://images.unsplash.com/photo-1507525428034-b723cf961d3e?w=600&auto=format&fit=crop&q=80" alt="Sandy beach scenery" class="gallery-img gallery-img--cover">
+        </div>
+      </section>
+
+      <!-- Column 2: object-fit: contain -->
+      <section class="card" aria-label="Object-Fit Contain example">
+        <h2 class="card-title">object-fit: contain</h2>
+        <p class="card-subtitle">Fits the full image inside the box, letterboxing or pillarboxing the remaining space if aspects differ.</p>
+        <div class="image-wrapper">
+          <img src="https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=600&auto=format&fit=crop&q=80" alt="Mountain stream landscape" class="gallery-img gallery-img--contain">
+        </div>
+      </section>
+
+      <!-- Column 3: object-fit: fill (distorted) -->
+      <section class="card" aria-label="Object-Fit Fill example">
+        <h2 class="card-title">object-fit: fill</h2>
+        <p class="card-subtitle">Stretches or squishes the image to fit the container dimensions perfectly, distorting the aspect ratio.</p>
+        <div class="image-wrapper">
+          <img src="https://images.unsplash.com/photo-1447752875215-b2761acb3c5d?w=600&auto=format&fit=crop&q=80" alt="Lush green forest bridge" class="gallery-img gallery-img--fill">
+        </div>
+      </section>
+
+    </main>
+
+    <!-- Hover Zoom Component Demo -->
+    <section class="zoom-showcase" aria-label="Gallery hover zoom effect">
+      <h2 class="section-title">Hover Zoom Integration</h2>
+      <div class="zoom-grid">
+        <div class="zoom-card">
+          <div class="zoom-wrapper">
+            <img src="https://images.unsplash.com/photo-1507525428034-b723cf961d3e?w=600&auto=format&fit=crop&q=80" alt="Beach sunset" class="zoom-img">
+          </div>
+          <div class="zoom-info">
+            <h3>Beach Scene</h3>
+            <p>Hover this card to verify smooth scaling.</p>
+          </div>
+        </div>
+        <div class="zoom-card">
+          <div class="zoom-wrapper">
+            <img src="https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=600&auto=format&fit=crop&q=80" alt="Mountain fog" class="zoom-img">
+          </div>
+          <div class="zoom-info">
+            <h3>Mountain Range</h3>
+            <p>Preserves boundaries via overflow hidden.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/object-fit-cover-15544-ag/style.css
+++ b/submissions/examples/object-fit-cover-15544-ag/style.css
@@ -1,0 +1,206 @@
+/* ============================================================
+   CSS Object-Fit Gallery — style.css
+   Submission for EaseMotion CSS Issue #15544
+   Responsive grid showcasing object-fit and zoom animations
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.6);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 960px;
+  display: flex;
+  flex-direction: column;
+  gap: 56px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.4rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1.05rem;
+  max-width: 580px;
+  margin: 0 auto;
+  line-height: 1.7;
+}
+
+/* ── Grid Layout Showcase ── */
+.grid-wrapper {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 32px;
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  backdrop-filter: blur(8px);
+}
+
+.card-title {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.card-subtitle {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  min-height: 48px;
+}
+
+/* ── Image Wrapper Box ── */
+.image-wrapper {
+  width: 100%;
+  height: 200px;
+  border-radius: 10px;
+  overflow: hidden;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.gallery-img {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+/* ── Object Fit Variations ── */
+.gallery-img--cover { object-fit: cover; }
+.gallery-img--contain { object-fit: contain; }
+.gallery-img--fill { object-fit: fill; }
+
+/* ── Zoom Showcase Grid ── */
+.zoom-showcase {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  text-align: center;
+}
+
+.zoom-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  gap: 32px;
+}
+
+.zoom-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+  cursor: pointer;
+}
+
+.zoom-card:hover {
+  border-color: rgba(167, 139, 250, 0.3);
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.3);
+}
+
+.zoom-wrapper {
+  width: 100%;
+  height: 220px;
+  overflow: hidden; /* Mask scaling boundaries */
+}
+
+.zoom-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.6s cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+/* Shorthand hover trigger from parent card */
+.zoom-card:hover .zoom-img {
+  transform: scale(1.08);
+}
+
+.zoom-info {
+  padding: 20px;
+}
+
+.zoom-info h3 {
+  font-size: 1.15rem;
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+
+.zoom-info p {
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+}
+
+/* ── Reduced motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .zoom-img,
+  .zoom-card {
+    transition: none !important;
+  }
+  .zoom-card:hover .zoom-img {
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds an image gallery showcase comparing different `object-fit` values (`cover`, `contain`, `fill`) inside fixed aspect-ratio containers to prevent layout distortion. Also includes a demo of the hover-scaling zoom animation using an `overflow: hidden` mask. Submitted under a unique suffix-protected folder to avoid path conflicts.

## Root Cause
Static image elements stretch and distort unless aspect-ratio handling via `object-fit` is defined explicitly.

## Changes Made
- `submissions/examples/object-fit-cover-15544-ag/demo.html`: Layout showing standard fit differences side-by-side and responsive cards with zoom animations.
- `submissions/examples/object-fit-cover-15544-ag/style.css`: Styles for `.gallery-img--cover`, `--contain`, `--fill`, and zoom transitions.
- `submissions/examples/object-fit-cover-15544-ag/README.md`: Detail explanations of the property values and verification instructions.

## How to Test
1. Open `submissions/examples/object-fit-cover-15544-ag/demo.html` in a web browser.
2. Verify that the image in the `cover` box maintains its ratio and crops cleanly, while the `fill` box stretches.
3. Hover cards in the lower section to verify smooth zooming crops.

## Related Issue
Closes #15544