### PR TITLE
[Feat] #15545 — Add CSS Sticky Section Headers Example (unique folder)

### DIFF
--- a/submissions/examples/sticky-section-headers-15545-ag/README.md
+++ b/submissions/examples/sticky-section-headers-15545-ag/README.md
@@ -1,0 +1,30 @@
+# CSS Sticky Section Headers Example
+
+This submission demonstrates pure-CSS sticky section headers that stack and shift dynamically as the user scrolls.
+
+---
+
+## Technical Overview
+
+The layout relies entirely on `position: sticky` and the behavior of scroll boundaries:
+
+1. **Scroll Section (`.scroll-section`)**: Set to `position: relative` with a tall height (e.g. `120vh`). This creates a bounding box for the sticky container.
+2. **Sticky Header Bar (`.section-title-bar`)**: Set to `position: sticky; top: 0;`. This pins the bar to the top of the viewport.
+3. **Container Boundary**: When the scroll viewport reaches the bottom of the `.scroll-section` wrapper, the sticky child elements are pushed out of the viewport by their parent container. This creates a natural stacking card deck effect.
+
+---
+
+## Benefits
+
+- **Performance:** Works on the browser's compositor thread for hardware-accelerated 60 FPS transitions.
+- **No JS Event Listeners:** Prevents scroll lag and layout thrashing.
+- **Responsive:** Fits any screen size automatically.
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a web browser.
+2. Scroll down.
+3. Verify that section titles (e.g. **01. Creative Design**, **02. Pure CSS Layout**) stay pinned at the top of the viewport while you scroll through their contents.
+4. Verify that when you cross into a new section, the new heading pushes the old heading out of the viewport.

--- a/submissions/examples/sticky-section-headers-15545-ag/demo.html
+++ b/submissions/examples/sticky-section-headers-15545-ag/demo.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Sticky Section Headers — EaseMotion CSS</title>
+  <meta name="description" content="An interactive demo showing pure CSS sticky section headers that stack or push each other during scroll.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Top Hero Header -->
+  <header class="hero-header">
+    <div class="hero-content">
+      <span class="demo-badge">EaseMotion CSS — Layout Showcase</span>
+      <h1>Sticky Section Headers</h1>
+      <p class="description">
+        Scroll down to observe how section headings stay pinned to the top of the screen
+        within their respective containers, creating a clean stacking layout transition.
+      </p>
+      <div class="scroll-prompt">Scroll Down</div>
+    </div>
+  </header>
+
+  <!-- Section 1: Design -->
+  <section class="scroll-section scroll-section--purple">
+    <header class="section-title-bar">
+      <div class="title-container">
+        <h2>01. Creative Design</h2>
+        <span class="section-badge">Visuals</span>
+      </div>
+    </header>
+    <div class="section-content">
+      <div class="content-card">
+        <h3>Building Premium Aesthetics</h3>
+        <p>Aesthetics are key to modern user interfaces. By blending translucent gradients, frosted glass headers, and high-contrast typography, we create layouts that immediately capture user interest.</p>
+        <p>Using CSS sticky section headers adds a polished, native feel to reading journeys without requiring JavaScript intersection observers.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 2: Layout -->
+  <section class="scroll-section scroll-section--cyan">
+    <header class="section-title-bar">
+      <div class="title-container">
+        <h2>02. Pure CSS Layout</h2>
+        <span class="section-badge">Structure</span>
+      </div>
+    </header>
+    <div class="section-content">
+      <div class="content-card">
+        <h3>How it Works</h3>
+        <p>The <code>position: sticky</code> property keeps an element within the viewport flow until it hits the boundary of its parent container.</p>
+        <p>As you scroll past a section, the next section's sticky title moves up and smoothly pushes the previous title out of the viewport, creating a stacking deck transition.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 3: Performance -->
+  <section class="scroll-section scroll-section--emerald">
+    <header class="section-title-bar">
+      <div class="title-container">
+        <h2>03. Performance Benefits</h2>
+        <span class="section-badge">Metrics</span>
+      </div>
+    </header>
+    <div class="section-content">
+      <div class="content-card">
+        <h3>Hardware Acceleration</h3>
+        <p>Because these transitions are handled natively by the browser's layout engine, they run on the compositor thread. This ensures 60 FPS scrolling even on low-end mobile devices.</p>
+        <p>Avoiding scroll event listeners eliminates scroll lag and layout thrashing, keeping interactions light and responsive.</p>
+      </div>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/sticky-section-headers-15545-ag/style.css
+++ b/submissions/examples/sticky-section-headers-15545-ag/style.css
@@ -1,0 +1,174 @@
+/* ============================================================
+   CSS Sticky Section Headers — style.css
+   Submission for EaseMotion CSS Issue #15545
+   Implements native stacking and shifting headers on scroll
+   ============================================================ */
+
+:root {
+  --bg-dark: #090d16;
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --card-bg: rgba(17, 24, 39, 0.65);
+  --card-border: rgba(255, 255, 255, 0.08);
+
+  --accent-purple: #a78bfa;
+  --accent-cyan: #22d3ee;
+  --accent-emerald: #34d399;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background-color: var(--bg-dark);
+}
+
+/* ── Hero Header ── */
+.hero-header {
+  height: 90vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  padding: 24px;
+  background: radial-gradient(circle at top, rgba(124, 58, 237, 0.12) 0%, transparent 60%);
+}
+
+.hero-content {
+  max-width: 600px;
+}
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 20px;
+}
+
+h1 {
+  font-size: 3rem;
+  font-weight: 800;
+  line-height: 1.2;
+  margin-bottom: 16px;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1.1rem;
+  line-height: 1.7;
+  margin-bottom: 40px;
+}
+
+.scroll-prompt {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--accent-purple);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  animation: bounce 2s infinite;
+}
+
+@keyframes bounce {
+  0%, 20%, 50%, 80%, 100% { transform: translateY(0); }
+  40% { transform: translateY(-6px); }
+  60% { transform: translateY(-3px); }
+}
+
+/* ── Sticky Scroll Sections ── */
+.scroll-section {
+  position: relative; /* REQUIRED: Establishes sticky tracking boundary for children */
+  min-height: 120vh;  /* Height to scroll within the section */
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+/* Color themed section backgrounds */
+.scroll-section--purple  { background: linear-gradient(180deg, #090d16 0%, #15102a 100%); }
+.scroll-section--cyan    { background: linear-gradient(180deg, #090d16 0%, #0d212c 100%); }
+.scroll-section--emerald { background: linear-gradient(180deg, #090d16 0%, #0c2420 100%); }
+
+/* ── Sticky Header Bar ── */
+.section-title-bar {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  width: 100%;
+  padding: 20px 24px;
+  background: rgba(9, 13, 22, 0.75);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--card-border);
+}
+
+.title-container {
+  max-width: 1000px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.section-title-bar h2 {
+  font-size: 1.4rem;
+  font-weight: 800;
+}
+
+/* Apply colors dynamically to headers */
+.scroll-section--purple .section-title-bar h2 { color: var(--accent-purple); }
+.scroll-section--cyan .section-title-bar h2 { color: var(--accent-cyan); }
+.scroll-section--emerald .section-title-bar h2 { color: var(--accent-emerald); }
+
+.section-badge {
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 4px 12px;
+  border-radius: 99px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+/* ── Section Content Cards ── */
+.section-content {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 100px 24px;
+}
+
+.content-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  padding: 40px;
+  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(4px);
+}
+
+.content-card h3 {
+  font-size: 1.6rem;
+  font-weight: 700;
+  margin-bottom: 16px;
+  background: linear-gradient(135deg, #fff, #9ca3af);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.content-card p {
+  font-size: 1.02rem;
+  color: var(--text-secondary);
+  line-height: 1.8;
+  margin-bottom: 18px;
+}
+
+.content-card p:last-child {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
## Summary
Adds a layout showcase demonstrating pure-CSS sticky section headers that stack and shift naturally as the user scrolls. The design features frosted-glass banners, visual color themes (Purple, Cyan, Emerald), and Outfit typography. Submitted under a unique suffix-protected folder to avoid path conflicts.

## Root Cause
Static titles scroll out of view immediately, leaving readers with no context of the current active sub-page or section.

## Changes Made
- `submissions/examples/sticky-section-headers-15545-ag/demo.html`: Layout containing tall sections and sticky titles.
- `submissions/examples/sticky-section-headers-15545-ag/style.css`: Coordinates `position: sticky; top: 0;` inside relative scrolling bounds.
- `submissions/examples/sticky-section-headers-15545-ag/README.md`: Explains layout setup, stacking boundaries, and verification.

## How to Test
1. Open `submissions/examples/sticky-section-headers-15545-ag/demo.html` in a web browser.
2. Scroll through the page and verify headers lock at the top within section boundaries and push each other away.

## Related Issue
Closes #15545