### PR TITLE
[Feat] #15435 — Add CSS field-sizing Auto-Growing Input Example (unique folder)

### DIFF
--- a/submissions/examples/field-sizing-15435-ag/README.md
+++ b/submissions/examples/field-sizing-15435-ag/README.md
@@ -1,0 +1,31 @@
+# CSS field-sizing Auto-Growing Input Example
+
+This submission demonstrates the implementation of content-aware auto-growing text inputs and textareas using the new CSS `field-sizing` property.
+
+---
+
+## Technical Overview
+
+Traditionally, making text inputs or textareas grow to fit their typed content required attaching JavaScript listeners to monitor character length and recalculate element heights/widths on the fly.
+
+The CSS `field-sizing` property solves this natively:
+
+```css
+.auto-grow-textarea {
+  field-sizing: content; /* Dynamically adjusts width/height to contents */
+  min-height: 48px;
+  max-height: 250px;
+}
+```
+
+Applying `field-sizing: content` ensures that elements expand as lines wrap, and shrink when lines are deleted, providing native responsiveness.
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in Chrome or Edge.
+2. In the **Auto-Growing Sizing** column:
+   - Type additional words into the text input. Verify the input box extends horizontally to fit the text.
+   - Type multiple paragraphs into the textarea. Verify it expands vertically instead of displaying scrollbars.
+   - Delete text inside the controls. Verify they shrink back to their minimum size.

--- a/submissions/examples/field-sizing-15435-ag/demo.html
+++ b/submissions/examples/field-sizing-15435-ag/demo.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS field-sizing Auto-Growing Inputs — EaseMotion CSS</title>
+  <meta name="description" content="An interactive showcase of the new CSS field-sizing property for auto-growing form controls.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Form Elements</span>
+      <h1>CSS <code>field-sizing</code> Auto-Growing Inputs</h1>
+      <p class="description">
+        Say goodbye to scrollbars inside small textareas and complex JavaScript size calculators.
+        The new <code>field-sizing</code> property allows form fields to adapt directly to their content.
+      </p>
+    </header>
+
+    <!-- Side-by-Side Comparison -->
+    <main class="grid-wrapper">
+
+      <!-- Column 1: Traditional Fixed Controls -->
+      <section class="card" aria-label="Standard form inputs">
+        <h2 class="card-title">Traditional Sizing</h2>
+        <p class="card-subtitle">Default inputs have fixed widths/heights, forcing scrollbars or hidden content when values overflow.</p>
+
+        <form class="demo-form" onsubmit="return false;">
+          <div class="form-group">
+            <label class="group-label">Standard Text Input</label>
+            <input type="text" placeholder="Type a long text..." value="This text will overflow the viewport boundary of the input box" class="standard-input">
+          </div>
+
+          <div class="form-group">
+            <label class="group-label">Standard Textarea</label>
+            <textarea class="standard-textarea" placeholder="Start typing...">This textarea has a fixed height. If you type several lines of paragraph content, a scrollbar will appear on the right side instead of the box expanding to show it all.</textarea>
+          </div>
+        </form>
+      </section>
+
+      <!-- Column 2: Auto-Growing Controls -->
+      <section class="card card--glow" aria-label="Auto growing form inputs">
+        <h2 class="card-title">Auto-Growing Sizing</h2>
+        <p class="card-subtitle">With <code>field-sizing: content</code> active, the elements expand horizontally and vertically to fit what's typed.</p>
+
+        <form class="demo-form" onsubmit="return false;">
+          <div class="form-group">
+            <label class="group-label">Auto-Growing Text Input</label>
+            <input type="text" placeholder="Type a long text..." value="This input expands to fit my content" class="auto-grow-input">
+          </div>
+
+          <div class="form-group">
+            <label class="group-label">Auto-Growing Textarea</label>
+            <textarea class="auto-grow-textarea" placeholder="Start typing...">This textarea expands to fit my content automatically. Try typing a few more lines here or deleting some sentences to see it resize in real time.</textarea>
+          </div>
+        </form>
+      </section>
+
+    </main>
+
+    <!-- CSS Syntax Card -->
+    <section class="syntax-section" aria-label="Syntax detail">
+      <h2 class="section-title">CSS Implementation</h2>
+      <div class="syntax-card">
+        <p>To enable content-aware auto-sizing, apply <code>field-sizing: content</code> and set appropriate bounds using <code>min-width</code>/<code>max-width</code> or <code>min-height</code>/<code>max-height</code>:</p>
+        <pre><code>.auto-grow-textarea {
+  field-sizing: content;
+  min-height: 48px;
+  max-height: 300px;
+  width: 100%;
+}</code></pre>
+        <div class="support-info">
+          <strong>Browser Support Notice:</strong> Natively supported in Chrome, Edge, and Opera. Fallback fixed styling automatically handles older engines.
+        </div>
+      </div>
+    </section>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/field-sizing-15435-ag/style.css
+++ b/submissions/examples/field-sizing-15435-ag/style.css
@@ -1,0 +1,233 @@
+/* ============================================================
+   CSS field-sizing Auto-Growing Inputs — style.css
+   Submission for EaseMotion CSS Issue #15435
+   Demonstrates content-based auto-sizing for form elements
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.6);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 900px;
+  display: flex;
+  flex-direction: column;
+  gap: 56px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.4rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1.05rem;
+  max-width: 580px;
+  margin: 0 auto;
+  line-height: 1.7;
+}
+
+/* ── Grid Layout Showcase ── */
+.grid-wrapper {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(380px, 1fr));
+  gap: 32px;
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  padding: 36px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  backdrop-filter: blur(8px);
+}
+
+.card--glow {
+  border-color: rgba(167, 139, 250, 0.25);
+  box-shadow: 0 0 32px rgba(167, 139, 250, 0.05);
+}
+
+.card-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.card-subtitle {
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin-bottom: 12px;
+}
+
+/* ── Forms and Inputs ── */
+.demo-form {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.group-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+/* Base Form Control Styles */
+input[type="text"],
+textarea {
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid var(--card-border);
+  border-radius: 8px;
+  padding: 12px 16px;
+  font-family: inherit;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input[type="text"]:focus,
+textarea:focus {
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.25);
+}
+
+/* 1. Traditional controls */
+.standard-input {
+  width: 100%;
+}
+
+.standard-textarea {
+  width: 100%;
+  height: 96px;
+  resize: none;
+}
+
+/* ============================================================
+   2. Auto-Growing Controls (field-sizing: content)
+   ============================================================ */
+
+.auto-grow-input {
+  field-sizing: content;
+  min-width: 150px;
+  max-width: 100%;
+  align-self: flex-start; /* Prevent default stretching to full container */
+}
+
+.auto-grow-textarea {
+  field-sizing: content;
+  width: 100%;
+  min-height: 48px;
+  max-height: 250px;
+  resize: none; /* Resize handle is redundant with field-sizing */
+}
+
+/* ── Syntax Details ── */
+.syntax-section {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  text-align: center;
+}
+
+.syntax-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 12px;
+  padding: 32px;
+}
+
+.syntax-card p {
+  color: var(--text-secondary);
+  margin-bottom: 16px;
+  font-size: 0.95rem;
+}
+
+pre {
+  background: rgba(0, 0, 0, 0.3);
+  padding: 18px;
+  border-radius: 8px;
+  overflow-x: auto;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  margin-bottom: 20px;
+}
+
+code {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 0.9rem;
+  color: #c4b5fd;
+}
+
+.support-info {
+  background: rgba(167, 139, 250, 0.08);
+  border-left: 4px solid #7c3aed;
+  padding: 12px 18px;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}


### PR DESCRIPTION
## Summary
Adds a CSS showcase showing how to use the modern `field-sizing: content` property to create auto-growing text inputs and textareas that adapt dynamically to typed text without JavaScript event listeners. Includes a side-by-side comparison with traditional fixed-size input elements. Submitted under a unique suffix-protected folder to avoid path conflicts.

## Root Cause
Native text inputs and textareas historically have fixed dimensions, requiring heavy JavaScript resize calculations to handle wrapping or long single-line inputs.

## Changes Made
- `submissions/examples/field-sizing-15435-ag/demo.html`: Comparison forms demonstrating traditional fixed styling versus modern auto-growing controls.
- `submissions/examples/field-sizing-15435-ag/style.css`: Uses `field-sizing: content` with custom `min-width`/`max-height` constraints.
- `submissions/examples/field-sizing-15435-ag/README.md`: Explains the new CSS feature, usage, and validation steps.

## How to Test
1. Open `submissions/examples/field-sizing-15435-ag/demo.html` in Chrome or Edge.
2. In the "Auto-Growing Sizing" column, type or delete text in the input and textarea fields.
3. Verify the fields expand and shrink dynamically.

## Related Issue
Closes #15435