### PR TITLE
[Feat] #5874 — Add CSS chip states visual feedback demo (unique folder)

### DIFF
--- a/submissions/examples/chip-states-bug-demo-5874-ag/README.md
+++ b/submissions/examples/chip-states-bug-demo-5874-ag/README.md
@@ -1,0 +1,36 @@
+# CSS Chip States Visual Feedback
+
+This demo details accessibility and visual enhancements for the selected and disabled states of `.ease-chip` controls.
+
+---
+
+## The Visual Gap
+
+In basic stylesheet settings, selected chips have minimal contrast variations, making them difficult to distinguish from standard state chips. 
+
+Disabled chips also lack clear signals—they have fixed color profiles, keep default pointer cursors, and trigger interactive states, which leads to layout confusion.
+
+---
+
+## Enhanced State Solutions
+
+This submission enhances state indicators:
+
+1. **Selected State (`.selected`)**:
+   - Applies an active checkmark icon (`✓`) using CSS `::before` pseudo-elements.
+   - Boosts border colors to purple (`#a78bfa`) and adds a soft background glow.
+
+2. **Disabled State (`.disabled`)**:
+   - Reduces opacity to `0.45` to make it appear dimmed.
+   - Applies `filter: grayscale(1)` to strip colored indicators.
+   - Sets `cursor: not-allowed` and blocks mouse interactions via `pointer-events: none`.
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a web browser.
+2. In the **Enhanced Chip States** card:
+   - Click on the standard chips under "Standard Tags". Verify they switch to `selected` status with a checkmark and glowing border.
+   - Hover over the chips under "Disabled States". Verify the cursor updates to `not-allowed` and clicking has no effect.
+3. Compare the visual layout side-by-side with the "Traditional Chip States" column.

--- a/submissions/examples/chip-states-bug-demo-5874-ag/demo.html
+++ b/submissions/examples/chip-states-bug-demo-5874-ag/demo.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Chip States Visual Feedback — EaseMotion CSS</title>
+  <meta name="description" content="An interactive comparison showing visual accessibility improvements for selected and disabled chip states.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Interactive States</span>
+      <h1>Chip States Visual Feedback</h1>
+      <p class="description">
+        Observe the current vs enhanced design of <code>.selected</code> and <code>.disabled</code> chip elements,
+        focused on optimizing high-contrast readability and focus indicators.
+      </p>
+    </header>
+
+    <!-- Comparison grids -->
+    <main class="grid-wrapper">
+
+      <!-- Column 1: Current/Default Chips -->
+      <section class="card" aria-label="Traditional chip states">
+        <h2 class="card-title">Traditional Chip States</h2>
+        <p class="card-subtitle">Selected chips have minimal contrast differences, and disabled chips lack cursor hints or strong grayscale cues.</p>
+
+        <div class="chip-showcase">
+          <div class="chip-group">
+            <span class="group-label">Standard Tags</span>
+            <div class="chip-row">
+              <span class="traditional-chip">Design</span>
+              <span class="traditional-chip">Coding</span>
+              <span class="traditional-chip">Art</span>
+            </div>
+          </div>
+
+          <div class="chip-group">
+            <span class="group-label">Selected States</span>
+            <div class="chip-row">
+              <span class="traditional-chip traditional-chip--selected">Design</span>
+              <span class="traditional-chip traditional-chip--selected">Coding</span>
+              <span class="traditional-chip">Art</span>
+            </div>
+          </div>
+
+          <div class="chip-group">
+            <span class="group-label">Disabled States</span>
+            <div class="chip-row">
+              <span class="traditional-chip traditional-chip--disabled">Design</span>
+              <span class="traditional-chip traditional-chip--disabled">Coding</span>
+              <span class="traditional-chip">Art</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Column 2: Enhanced Chips -->
+      <section class="card card--glow" aria-label="Enhanced chip states">
+        <h2 class="card-title">Enhanced Chip States</h2>
+        <p class="card-subtitle">Active check indicators on selected states, grayscale filters + not-allowed cursor guides on disabled states.</p>
+
+        <div class="chip-showcase">
+          <div class="chip-group">
+            <span class="group-label">Standard Tags</span>
+            <div class="chip-row">
+              <button class="ease-chip" type="button">Design</button>
+              <button class="ease-chip" type="button">Coding</button>
+              <button class="ease-chip" type="button">Art</button>
+            </div>
+          </div>
+
+          <div class="chip-group">
+            <span class="group-label">Selected States</span>
+            <div class="chip-row">
+              <button class="ease-chip selected" type="button" aria-pressed="true">Design</button>
+              <button class="ease-chip selected" type="button" aria-pressed="true">Coding</button>
+              <button class="ease-chip" type="button" aria-pressed="false">Art</button>
+            </div>
+          </div>
+
+          <div class="chip-group">
+            <span class="group-label">Disabled States</span>
+            <div class="chip-row">
+              <button class="ease-chip disabled" disabled type="button">Design</button>
+              <button class="ease-chip disabled" disabled type="button">Coding</button>
+              <button class="ease-chip" type="button">Art</button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+    </main>
+
+    <!-- Technical Guide -->
+    <section class="syntax-section" aria-label="Technical Details">
+      <h2 class="section-title">Visual Spec Sheet</h2>
+      <div class="syntax-card">
+        <table class="spec-table">
+          <thead>
+            <tr>
+              <th>State</th>
+              <th>Traditional Styling</th>
+              <th>Enhanced Styling</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>Selected</strong></td>
+              <td>Subtle opacity change</td>
+              <td>Explicit purple border, active tag indicator, and shadow glow.</td>
+            </tr>
+            <tr>
+              <td><strong>Disabled</strong></td>
+              <td>Fixed colors only</td>
+              <td>Grayscale filter, 50% opacity, pointer-events disable, and not-allowed cursor.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+  </div>
+
+  <!-- Interactive script to let users toggle enhanced chip selection -->
+  <script>
+    const chips = document.querySelectorAll('.ease-chip:not(.disabled)');
+    chips.forEach(c => {
+      c.addEventListener('click', () => {
+        c.classList.toggle('selected');
+        c.setAttribute('aria-pressed', c.classList.contains('selected'));
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/chip-states-bug-demo-5874-ag/style.css
+++ b/submissions/examples/chip-states-bug-demo-5874-ag/style.css
@@ -1,0 +1,254 @@
+/* ============================================================
+   CSS Chip States Visual Feedback — style.css
+   Submission for EaseMotion CSS Issue #5874
+   Optimizes chip accessibility (selected, disabled guides)
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.6);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+
+  /* Accent presets */
+  --chip-bg: rgba(255, 255, 255, 0.06);
+  --chip-selected-bg: rgba(124, 58, 237, 0.16);
+  --chip-selected-border: #a78bfa;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 900px;
+  display: flex;
+  flex-direction: column;
+  gap: 56px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.4rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1.05rem;
+  max-width: 580px;
+  margin: 0 auto;
+  line-height: 1.7;
+}
+
+/* ── Grid Layout Showcase ── */
+.grid-wrapper {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(380px, 1fr));
+  gap: 32px;
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  padding: 36px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  backdrop-filter: blur(8px);
+}
+
+.card--glow {
+  border-color: rgba(167, 139, 250, 0.25);
+  box-shadow: 0 0 32px rgba(167, 139, 250, 0.05);
+}
+
+.card-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.card-subtitle {
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin-bottom: 16px;
+}
+
+/* Chip Showcase Layouts */
+.chip-showcase {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  padding-top: 16px;
+}
+
+.chip-group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.group-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+/* ============================================================
+   1. Traditional Chips (Minimal visual markers)
+   ============================================================ */
+
+.traditional-chip {
+  display: inline-block;
+  padding: 6px 16px;
+  border-radius: 99px;
+  background: var(--chip-bg);
+  font-size: 0.88rem;
+  font-weight: 500;
+  border: 1px solid transparent;
+}
+
+.traditional-chip--selected {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+.traditional-chip--disabled {
+  opacity: 0.8;
+}
+
+/* ============================================================
+   2. Enhanced Chips (Accessible & Clear)
+   ============================================================ */
+
+.ease-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 16px;
+  border-radius: 99px;
+  background: var(--chip-bg);
+  color: var(--text-primary);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  font-family: inherit;
+  font-size: 0.88rem;
+  font-weight: 600;
+  cursor: pointer;
+  outline: none;
+  transition: all 0.2s ease;
+  user-select: none;
+}
+
+.ease-chip:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.ease-chip:focus-visible {
+  box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.35);
+  border-color: var(--chip-selected-border);
+}
+
+/* Selected state overrides */
+.ease-chip.selected {
+  background: var(--chip-selected-bg);
+  border-color: var(--chip-selected-border);
+  color: #c4b5fd;
+  box-shadow: 0 0 10px rgba(124, 58, 237, 0.1);
+}
+
+.ease-chip.selected::before {
+  content: "✓";
+  font-size: 0.85em;
+  font-weight: 800;
+}
+
+/* Disabled state overrides */
+.ease-chip.disabled,
+.ease-chip[disabled] {
+  opacity: 0.45;
+  filter: grayscale(1);
+  cursor: not-allowed;
+  pointer-events: none; /* Block click handlers */
+}
+
+/* ── Technical Guide Table ── */
+.syntax-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 12px;
+  padding: 32px;
+  overflow-x: auto;
+}
+
+.spec-table {
+  width: 100%;
+  border-collapse: collapse;
+  text-align: left;
+}
+
+.spec-table th,
+.spec-table td {
+  padding: 12px 16px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  font-size: 0.9rem;
+}
+
+.spec-table th {
+  font-weight: 700;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+}
+
+.spec-table tbody tr:last-child td {
+  border-bottom: none;
+}


### PR DESCRIPTION
## Summary
Adds an interactive chip states showcase demonstrating high-contrast selection borders, active checkmark prefixes, and grayscale dimmed overlays to indicate disabled states. Includes side-by-side comparisons of standard tag groups, selected tag options, and disabled options to verify accessibility cues. Submitted under a unique suffix-protected folder to avoid path conflicts.

## Root Cause
Selected chips lacked high-contrast outline borders and active indicators, and disabled chips lacked cursors or grayscale filters, resulting in poor accessibility.

## Changes Made
- `submissions/examples/chip-states-bug-demo-5874-ag/demo.html`: Grid comparing standard and enhanced tag buttons, with interactive clicking scripts to test selection.
- `submissions/examples/chip-states-bug-demo-5874-ag/style.css`: Coordinates visual styles including checkmark pseudo-elements, grayscale filters, and pointer-events controls.
- `submissions/examples/chip-states-bug-demo-5874-ag/README.md`: Shortcoming analysis, enhanced classes definition, and manual testing instructions.

## How to Test
1. Open `submissions/examples/chip-states-bug-demo-5874-ag/demo.html` in a web browser.
2. In the "Enhanced Chip States" column, click chips to select/deselect them. Verify that a checkmark and purple outline glow appear.
3. Hover over disabled chips and verify that clicking is blocked and a "not-allowed" cursor appears.

## Related Issue
Closes #5874