### PR TITLE
feat(scss): add per-category SCSS animation partials (#23653)

### DIFF
--- a/submissions/core_changes-issue-23653/README.md
+++ b/submissions/core_changes-issue-23653/README.md
@@ -1,0 +1,39 @@
+# SCSS Modular Animation Partials
+
+1. **What does this do?**
+   Adds per-category SCSS partials (`_fade.scss`, `_slide.scss`, `_bounce.scss`, `_zoom.scss`, `_rotate.scss`, `_hover.scss`) that mirror the modular CSS architecture. Each partial contains only the mixins relevant to its animation category, allowing SCSS users to import selectively instead of importing the entire mixin set.
+
+2. **How is it used?**
+
+   ```scss
+   // Selective import — only what you need
+   @use "easemotion-css/scss/fade";
+   @use "easemotion-css/scss/zoom";
+
+   .my-element {
+     @include fade.fade-in();
+     @include zoom.zoom-out();
+   }
+
+   // Or import everything via the index
+   @use "easemotion-css/scss" as ease;
+
+   .hero {
+     @include ease.fade-in();
+   }
+   ```
+
+3. **Files added/updated:**
+
+   | File | Description |
+   |---|---|
+   | `scss/_fade.scss` (new) | `fade-in`, `fade-out`, `fade-in-up`, `fade-in-down` |
+   | `scss/_slide.scss` (new) | `slide-up`, `slide-down`, `slide-left`, `slide-right` |
+   | `scss/_bounce.scss` (new) | `bounce-in`, `bounce-out`, `bounce-up` |
+   | `scss/_zoom.scss` (new) | `zoom-in`, `zoom-out`, `zoom-in-up`, `zoom-out-down` |
+   | `scss/_rotate.scss` (new) | `rotate-in`, `rotate-out`, `rotate-in-down-left`, `rotate-in-up-left`, `rotate-out-down-right` |
+   | `scss/_hover.scss` (new) | `hover-lift`, `hover-glow`, `hover-scale` |
+   | `scss/_index.scss` (updated) | Now forwards all 6 new partials |
+
+4. **Why is it useful?**
+   Previously, SCSS users who only needed fade animations had to import the entire mixin set. These modular partials match the CSS-side `easemotion/fade.css` architecture, reduce import overhead, and make the SCSS layer as composable as the CSS layer.

--- a/submissions/core_changes-issue-23653/scss/_bounce.scss
+++ b/submissions/core_changes-issue-23653/scss/_bounce.scss
@@ -1,0 +1,16 @@
+// ============================================
+// EaseMotion CSS — SCSS Bounce Animation Partial
+// ============================================
+@use "variables" as *;
+
+@mixin bounce-in($duration: $speed-medium, $delay: 0s, $easing: $ease-ease) {
+  @include animate(ease-kf-bounce-in, $duration, $easing, $delay);
+}
+
+@mixin bounce-out($duration: $speed-medium, $delay: 0s, $easing: $ease-ease) {
+  @include animate(ease-kf-bounce-out, $duration, $easing, $delay);
+}
+
+@mixin bounce-up($duration: $speed-medium, $delay: 0s, $easing: $ease-ease) {
+  @include animate(ease-kf-bounce-up, $duration, $easing, $delay);
+}

--- a/submissions/core_changes-issue-23653/scss/_fade.scss
+++ b/submissions/core_changes-issue-23653/scss/_fade.scss
@@ -1,0 +1,20 @@
+// ============================================
+// EaseMotion CSS — SCSS Fade Animation Partial
+// ============================================
+@use "variables" as *;
+
+@mixin fade-in($duration: $speed-medium, $delay: 0s, $easing: $ease-ease) {
+  @include animate(ease-kf-fade-in, $duration, $easing, $delay);
+}
+
+@mixin fade-out($duration: $speed-medium, $delay: 0s, $easing: $ease-ease) {
+  @include animate(ease-kf-fade-out, $duration, $easing, $delay);
+}
+
+@mixin fade-in-up($duration: $speed-medium, $delay: 0s, $easing: $ease-ease) {
+  @include animate(ease-kf-fade-in-up, $duration, $easing, $delay);
+}
+
+@mixin fade-in-down($duration: $speed-medium, $delay: 0s, $easing: $ease-ease) {
+  @include animate(ease-kf-fade-in-down, $duration, $easing, $delay);
+}

--- a/submissions/core_changes-issue-23653/scss/_hover.scss
+++ b/submissions/core_changes-issue-23653/scss/_hover.scss
@@ -1,0 +1,25 @@
+// ============================================
+// EaseMotion CSS — SCSS Hover Animation Partial
+// ============================================
+@use "variables" as *;
+
+@mixin hover-lift($duration: $speed-fast, $easing: $ease-ease) {
+  @include transition(transform, $duration, $easing);
+  &:hover {
+    transform: translateY(-3px);
+  }
+}
+
+@mixin hover-glow($duration: $speed-fast, $easing: $ease-ease) {
+  @include transition(box-shadow, $duration, $easing);
+  &:hover {
+    box-shadow: 0 0 16px rgba(108, 99, 255, 0.45);
+  }
+}
+
+@mixin hover-scale($duration: $speed-fast, $easing: $ease-ease) {
+  @include transition(transform, $duration, $easing);
+  &:hover {
+    transform: scale(1.05);
+  }
+}

--- a/submissions/core_changes-issue-23653/scss/_index.scss
+++ b/submissions/core_changes-issue-23653/scss/_index.scss
@@ -1,0 +1,13 @@
+// ============================================
+// EaseMotion CSS — SCSS Entry Point
+// Forwards all modular animation partials.
+// ============================================
+
+@forward 'variables';
+@forward 'mixins';
+@forward 'fade';
+@forward 'slide';
+@forward 'bounce';
+@forward 'zoom';
+@forward 'rotate';
+@forward 'hover';

--- a/submissions/core_changes-issue-23653/scss/_rotate.scss
+++ b/submissions/core_changes-issue-23653/scss/_rotate.scss
@@ -1,0 +1,24 @@
+// ============================================
+// EaseMotion CSS — SCSS Rotate Animation Partial
+// ============================================
+@use "variables" as *;
+
+@mixin rotate-in($duration: $speed-medium, $delay: 0s, $easing: $ease-ease) {
+  @include animate(ease-kf-rotate-in, $duration, $easing, $delay);
+}
+
+@mixin rotate-out($duration: $speed-medium, $delay: 0s, $easing: $ease-ease) {
+  @include animate(ease-kf-rotate-out, $duration, $easing, $delay);
+}
+
+@mixin rotate-in-down-left($duration: $speed-medium, $delay: 0s, $easing: $ease-ease) {
+  @include animate(ease-kf-rotate-in-down-left, $duration, $easing, $delay);
+}
+
+@mixin rotate-in-up-left($duration: $speed-medium, $delay: 0s, $easing: $ease-ease) {
+  @include animate(ease-kf-rotate-in-up-left, $duration, $easing, $delay);
+}
+
+@mixin rotate-out-down-right($duration: $speed-medium, $delay: 0s, $easing: $ease-ease) {
+  @include animate(ease-kf-rotate-out-down-right, $duration, $easing, $delay);
+}

--- a/submissions/core_changes-issue-23653/scss/_slide.scss
+++ b/submissions/core_changes-issue-23653/scss/_slide.scss
@@ -1,0 +1,20 @@
+// ============================================
+// EaseMotion CSS — SCSS Slide Animation Partial
+// ============================================
+@use "variables" as *;
+
+@mixin slide-up($duration: $speed-medium, $delay: 0s, $easing: $ease-ease) {
+  @include animate(ease-kf-slide-up, $duration, $easing, $delay);
+}
+
+@mixin slide-down($duration: $speed-medium, $delay: 0s, $easing: $ease-ease) {
+  @include animate(ease-kf-slide-down, $duration, $easing, $delay);
+}
+
+@mixin slide-left($duration: $speed-medium, $delay: 0s, $easing: $ease-ease) {
+  @include animate(ease-kf-slide-left, $duration, $easing, $delay);
+}
+
+@mixin slide-right($duration: $speed-medium, $delay: 0s, $easing: $ease-ease) {
+  @include animate(ease-kf-slide-right, $duration, $easing, $delay);
+}

--- a/submissions/core_changes-issue-23653/scss/_zoom.scss
+++ b/submissions/core_changes-issue-23653/scss/_zoom.scss
@@ -1,0 +1,20 @@
+// ============================================
+// EaseMotion CSS — SCSS Zoom Animation Partial
+// ============================================
+@use "variables" as *;
+
+@mixin zoom-in($duration: $speed-medium, $delay: 0s, $easing: $ease-ease) {
+  @include animate(ease-kf-zoom-in, $duration, $easing, $delay);
+}
+
+@mixin zoom-out($duration: $speed-medium, $delay: 0s, $easing: $ease-ease) {
+  @include animate(ease-kf-zoom-out, $duration, $easing, $delay);
+}
+
+@mixin zoom-in-up($duration: $speed-medium, $delay: 0s, $easing: $ease-ease) {
+  @include animate(ease-kf-zoom-in-up, $duration, $easing, $delay);
+}
+
+@mixin zoom-out-down($duration: $speed-medium, $delay: 0s, $easing: $ease-ease) {
+  @include animate(ease-kf-zoom-out-down, $duration, $easing, $delay);
+}


### PR DESCRIPTION
## ✦ Description
Adds per-category SCSS partials (`_fade.scss`, `_slide.scss`, `_bounce.scss`, `_zoom.scss`, `_rotate.scss`, `_hover.scss`) that mirror the modular CSS architecture. Each partial contains mixins relevant to its animation category, allowing SCSS users to import selectively.

Fixes #23653

---

## ⟡ Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (non-breaking change to docs)
- [ ] Code styling/formatting (prettier, eslint, spacing)

---

## ✦ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [ ] (If applicable) I have run npm run lint and npm run format locally before pushing.

---

## Description

### Root Cause
The SCSS layer only had `_index.scss`, `_mixins.scss`, and `_variables.scss`. There were no per-animation SCSS partials matching the `easemotion/` modular CSS files. SCSS users who only needed fade animations had to import the entire mixin set.

### Changes Made
- Added `scss/_fade.scss` — fade-in, fade-out, fade-in-up, fade-in-down
- Added `scss/_slide.scss` — slide-up, slide-down, slide-left, slide-right
- Added `scss/_bounce.scss` — bounce-in, bounce-out, bounce-up
- Added `scss/_zoom.scss` — zoom-in, zoom-out, zoom-in-up, zoom-out-down
- Added `scss/_rotate.scss` — rotate-in, rotate-out, rotate-in-down-left, rotate-in-up-left, rotate-out-down-right
- Added `scss/_hover.scss` — hover-lift, hover-glow, hover-scale
- Updated `scss/_index.scss` to forward all 6 new partials
- Each partial uses `@use "variables" as *` for token access
- Existing `_mixins.scss` remains untouched for backward compatibility

### Usage
```scss
@use "easemotion-css/scss/fade";
@use "easemotion-css/scss/zoom";

.my-element {
  @include fade.fade-in();
  @include zoom.zoom-out();
}
```

---

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

---

## Additional Notes
- No breaking changes — existing `_mixins.scss` is unchanged.
- The submission lives at `submissions/core_changes-issue-23653/` per project guidelines.
- Partial files should be copied to `scss/` directory by the maintainer.