### PR TITLE
feat: add source map generation to build script for #23650

### DIFF
--- a/submissions/core_changes-issue-23650/README.md
+++ b/submissions/core_changes-issue-23650/README.md
@@ -1,0 +1,128 @@
+# Source Maps Generation — Issue #23650
+
+## What does this do?
+
+This submission proposes generating source maps (`.map` files) for the minified production stylesheet `easemotion.min.css` by upgrading the build script using the standard `clean-css` compiler.
+
+## How is it used?
+
+Run the build script in the terminal:
+
+```bash
+npm run build
+```
+
+This compiles the stylesheet and outputs both `easemotion.min.css` and its corresponding source map file `easemotion.min.css.map`. When inspected in browser DevTools, rules will map directly back to their original CSS partial files in `core/` and `components/`.
+
+## Why is it useful?
+
+It enables developers using EaseMotion CSS in production to easily debug and trace CSS style issues directly back to original source files and line numbers, instead of having all rules map to a single unreadable, minified line.
+
+---
+
+## Proposed Changes in Core Code
+
+The following changes are proposed to integrate source maps:
+
+### 1. File: `package.json`
+
+Add `clean-css` under `devDependencies`:
+
+```json
+"devDependencies": {
+  "clean-css": "^5.3.3",
+  ...
+}
+```
+
+### 2. File: `core/layers.css` (New File)
+
+Extract cascade layers declaration to a separate file so that `@import` rules remain at the very top of `easemotion.css` (required for CSS spec compliance with clean-css):
+
+```css
+@layer easemotion-base, easemotion-components, easemotion-utilities;
+```
+
+### 3. File: `easemotion.css`
+
+Replace the `@layer` declaration with the new layers stylesheet import:
+
+```css
+- @layer easemotion-base, easemotion-components, easemotion-utilities;
++ @import "./core/layers.css";
+```
+
+### 4. File: `scripts/build-minified-css.mjs`
+
+Rewrite the build script to use `clean-css` and generate relative-path source maps:
+
+```javascript
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import CleanCSS from "clean-css";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, "..");
+const entryFile = path.join(rootDir, "easemotion.css");
+const outputFile = path.join(rootDir, "easemotion.min.css");
+const mapFile = path.join(rootDir, "easemotion.min.css.map");
+
+async function build() {
+  const options = {
+    inline: ["local"],
+    sourceMap: true,
+    rebase: false,
+  };
+
+  const output = await new Promise((resolve, reject) => {
+    new CleanCSS(options).minify([entryFile], (error, result) => {
+      if (error) return reject(error);
+      if (result.errors.length > 0)
+        return reject(new Error(result.errors.join("\n")));
+      resolve(result);
+    });
+  });
+
+  let minifiedCss = output.styles;
+  // Append sourceMappingURL
+  minifiedCss += `\n/*# sourceMappingURL=${path.basename(outputFile)}.map */\n`;
+
+  // Make source paths relative to rootDir
+  const sourceMap = JSON.parse(output.sourceMap.toString());
+  sourceMap.sources = sourceMap.sources.map((source) => {
+    if (path.isAbsolute(source)) {
+      return path.relative(rootDir, source);
+    }
+    return source;
+  });
+
+  await mkdir(path.dirname(outputFile), { recursive: true });
+  await writeFile(outputFile, minifiedCss, "utf8");
+  await writeFile(mapFile, JSON.stringify(sourceMap), "utf8");
+
+  // Write docs
+  const docsDir = path.join(rootDir, "docs");
+  await mkdir(docsDir, { recursive: true });
+  const docsOutputFile = path.join(docsDir, "easemotion.min.css");
+  const docsMapFile = path.join(docsDir, "easemotion.min.css.map");
+  await writeFile(docsOutputFile, minifiedCss, "utf8");
+  await writeFile(docsMapFile, JSON.stringify(sourceMap), "utf8");
+
+  const summary = {
+    entry: path.relative(rootDir, entryFile),
+    output: path.relative(rootDir, outputFile),
+    bytes: Buffer.byteLength(minifiedCss, "utf8"),
+  };
+
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+build().catch((error) => {
+  console.error("Build failed:", error);
+  process.exitCode = 1;
+});
+```
+
+Fixes #23650

--- a/submissions/core_changes-issue-23650/demo.html
+++ b/submissions/core_changes-issue-23650/demo.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EaseMotion CSS — Source Maps Compilation Proposal</title>
+    <!-- Link EaseMotion Framework relative to submissions directory -->
+    <link rel="stylesheet" href="../../easemotion.css" />
+    <!-- Custom Proposal Styles -->
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Source Maps Generation</h1>
+      <p>
+        Proposed build infrastructure using <code>clean-css</code> to generate
+        source maps for production debugging.
+      </p>
+    </header>
+
+    <main class="demo-container">
+      <div class="demo-title">Proposed Architecture & Setup</div>
+
+      <!-- Step 1 -->
+      <div class="step-card">
+        <div class="step-header">
+          <span class="step-number">1</span>
+          <span class="step-title"
+            >Modularize Cascade Layers (core/layers.css)</span
+          >
+        </div>
+        <p>
+          Moving the cascade layers declaration to its own file allows all
+          <code>@import</code> statements to sit at the absolute top of
+          <code>easemotion.css</code>. This enables compiler compliance for
+          standards-based minifiers.
+        </p>
+        <div class="code-block">
+          <span class="code-comment">/* core/layers.css */</span><br />
+          <span class="code-keyword">@layer</span> easemotion-base,
+          easemotion-components, easemotion-utilities;
+        </div>
+      </div>
+
+      <!-- Step 2 -->
+      <div class="step-card">
+        <div class="step-header">
+          <span class="step-number">2</span>
+          <span class="step-title"
+            >CleanCSS Compiling (scripts/build-minified-css.mjs)</span
+          >
+        </div>
+        <p>
+          Integrating <code>clean-css</code> handles local CSS import inlining,
+          compression, and outputs standard-compliant source map files with
+          relative paths.
+        </p>
+        <pre
+          class="code-block"
+        ><code><span class="code-keyword">import</span> CleanCSS <span class="code-keyword">from</span> <span class="code-string">"clean-css"</span>;
+
+<span class="code-keyword">const</span> options = {
+  inline: [<span class="code-string">"local"</span>],
+  sourceMap: <span class="code-keyword">true</span>,
+  rebase: <span class="code-keyword">false</span>
+};
+
+<span class="code-comment">// Outputs: easemotion.min.css.map alongside minified file</span></code></pre>
+      </div>
+
+      <!-- Step 3 -->
+      <div class="step-card">
+        <div class="step-header">
+          <span class="step-number">3</span>
+          <span class="step-title">Production Mapping Comment</span>
+        </div>
+        <p>
+          A reference mapping comment is dynamically appended to the end of
+          <code>easemotion.min.css</code> to allow browser developer tools to
+          fetch and load the original partial layouts.
+        </p>
+        <div class="code-block">
+          <span class="code-comment"
+            >/*# sourceMappingURL=easemotion.min.css.map */</span
+          >
+        </div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/submissions/core_changes-issue-23650/style.css
+++ b/submissions/core_changes-issue-23650/style.css
@@ -1,0 +1,135 @@
+/* ============================================================
+   EaseMotion CSS Source Maps Proposal — style.css
+   ============================================================ */
+
+@import url("https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap");
+
+:root {
+  --font-sans: "Outfit", -apple-system, BlinkMacSystemFont, sans-serif;
+  --bg-primary: #09090b;
+  --bg-secondary: #121217;
+  --text-primary: #f4f4f5;
+  --text-secondary: #a1a1aa;
+  --border-color: rgba(255, 255, 255, 0.08);
+  --accent-gradient: linear-gradient(
+    135deg,
+    #3b82f6 0%,
+    #6366f1 50%,
+    #8b5cf6 100%
+  );
+}
+
+body {
+  font-family: var(--font-sans);
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  margin: 0;
+  padding: 3rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-height: 100vh;
+}
+
+header {
+  text-align: center;
+  max-width: 600px;
+  margin-bottom: 3.5rem;
+}
+
+h1 {
+  font-size: 2.25rem;
+  font-weight: 700;
+  background: var(--accent-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 0.5rem;
+}
+
+p {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+/* Demo container */
+.demo-container {
+  width: 100%;
+  max-width: 650px;
+  background: rgba(18, 18, 23, 0.6);
+  backdrop-filter: blur(12px);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  padding: 2rem;
+  box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.3);
+}
+
+.demo-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 1.5rem;
+  color: #818cf8;
+}
+
+/* Visual step card */
+.step-card {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.step-card:last-child {
+  margin-bottom: 0;
+}
+
+.step-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.step-number {
+  background: var(--accent-gradient);
+  color: #ffffff;
+  font-weight: 700;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.8rem;
+}
+
+.step-title {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.code-block {
+  background: #000000;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  padding: 1rem;
+  font-family: monospace;
+  font-size: 0.85rem;
+  color: #cbd5e1;
+  overflow-x: auto;
+  line-height: 1.4;
+}
+
+.code-keyword {
+  color: #f472b6;
+}
+.code-string {
+  color: #34d399;
+}
+.code-comment {
+  color: #64748b;
+}
+.code-function {
+  color: #60a5fa;
+}


### PR DESCRIPTION
## ✦ Description
Upgrade the build process to generate source maps (`easemotion.min.css.map`) for the production minified stylesheet `easemotion.min.css`. This enables developer tools in the browser to map compiled rules directly back to their original CSS partial files in `core/` and `components/` for easier debugging.

Fixes #23650

---

## ⟡ Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (non-breaking change to docs)
- [x] Code styling/formatting (prettier, eslint, spacing)

---

## ✦ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [ ] I have verified that my changes work correctly on both desktop and mobile viewports.
- [x] (If applicable) I have run npm run lint and npm run format locally before pushing.

---

## ⟡ Screenshots / Screen Recordings (Required for UI changes)

N/A — Source map build script integration proposal submitted under submissions directory.

---

## Description

### Root Cause
The existing regex-based build script (`scripts/build-minified-css.mjs`) minifies and concatenates stylesheets but does not support generating a standard source map, which makes debugging production styles challenging.

### Changes Made
- Created `submissions/core_changes-issue-23650/demo.html` displaying visual documentation of the proposed build scripts refactoring steps.
- Created `submissions/core_changes-issue-23650/style.css` styling the step cards and code highlights.
- Created `submissions/core_changes-issue-23650/README.md` answering the contribution questions and detailing the exact code patch guidelines for `package.json`, `core/layers.css` (new file), `easemotion.css`, and `scripts/build-minified-css.mjs` using `clean-css` compiler.

### Testing Performed

- Validated compilation sizes, map generation, and relative paths resolution locally.
- Formatted with prettier.

### Result

Build outputs valid minified stylesheet and mapping configurations successfully.

---

## Additional Notes
- Branch pushed: submissions/core_changes-issue-23650
- Compare URL: https://github.com/Pcmhacker-piro/EaseMotion-css/compare/main...submissions/core_changes-issue-23650