### PR TITLE
feat(scss): add per-category SCSS animation partials (#23653)

### DIFF
--- a/submissions/core_changes-issue-23653/README.md
+++ b/submissions/core_changes-issue-23653/README.md
@@ -1,0 +1,53 @@
+# SCSS Animation Partials — Modular Imports for EaseMotion CSS
+
+## 1. What does this do?
+
+Adds per-category SCSS partial files (`_fade.scss`, `_slide.scss`, `_bounce.scss`, `_zoom.scss`, `_rotate.scss`, `_hover.scss`) that mirror the modular CSS architecture of EaseMotion. Each partial contains mixins relevant only to its animation category, allowing SCSS users to import selectively instead of importing the entire mixin set.
+
+**New files in `scss/`:**
+
+| File | Mixins |
+|------|--------|
+| `_fade.scss` | `fade-in`, `fade-out`, `fade-icon-exit`, `pulse-fade`, `blur-to-focus` |
+| `_slide.scss` | `slide-up`, `slide-down`, `slide-in-from-*` (8 directional variants), `slide-image-exit` |
+| `_bounce.scss` | `bounce`, `bounce-in`, `bounce-text`, `bounce-button-exit` |
+| `_zoom.scss` | `zoom-in`, `zoom-out`, `reveal-scale`, `morph-card` |
+| `_rotate.scss` | `rotate`, `rotate-image-exit`, `flip`, `gradient-rotation` |
+| `_hover.scss` | `pulse`, `ping`, `shimmer`, `shimmer-sweep`, `shimmer-text`, `shake`, `wave`, `hover-pulse-glow`, `cursor-blink`, `typewriter-loop`, `count-up` |
+| `_index.scss` | Forwards all partials and existing `variables`/`mixins` |
+
+## 2. How is it used?
+
+```scss
+// Selective import — only the fade category
+@use "easemotion-css/scss/fade" as fade;
+
+.hero {
+  @include fade.fade-in(0.6s, 0.2s);
+}
+
+// Import everything
+@use "easemotion-css/scss" as ease;
+
+.card {
+  @include ease.zoom-in(0.4s);
+}
+
+// Namespace import for multiple categories
+@use "easemotion-css/scss/slide" as slide;
+@use "easemotion-css/scss/bounce" as *;
+
+.drawer {
+  @include slide.slide-in-from-right;
+}
+.badge {
+  @include bounce-in;
+}
+```
+
+## 3. Why is it useful?
+
+- **Tree-shakeable** — only `@use` the categories you need
+- **Matches CSS architecture** — mirrors `easemotion/fade.css`, `easemotion/slide.css`, etc.
+- **Smaller bundles** — no need to import all 60+ keyframes when you only need fade
+- **Backward compatible** — `_index.scss` still forwards all mixins via the old `_mixins.scss`

--- a/submissions/core_changes-issue-23653/demo.html
+++ b/submissions/core_changes-issue-23653/demo.html
@@ -1,0 +1,227 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SCSS Animation Partials — Demo · Issue #23653</title>
+  <link rel="stylesheet" href="../../core/variables.css" />
+  <link rel="stylesheet" href="../../core/animations.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+      background: #0f172a;
+      color: #f1f5f9;
+      min-height: 100vh;
+    }
+    .demo-header {
+      text-align: center;
+      padding: 3rem 1rem 2rem;
+      border-bottom: 1px solid #1e293b;
+    }
+    .demo-header h1 {
+      font-size: clamp(1.75rem, 4vw, 2.75rem);
+      font-weight: 700;
+      background: linear-gradient(135deg, #6c63ff, #e040fb);
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+    .demo-header p {
+      color: #94a3b8;
+      margin-top: 0.75rem;
+      font-size: 0.95rem;
+      max-width: 700px;
+      margin-inline: auto;
+      line-height: 1.6;
+    }
+    .category {
+      max-width: 1100px;
+      margin: 2rem auto;
+      padding: 0 1rem;
+    }
+    .category h2 {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: #6c63ff;
+      margin-bottom: 1rem;
+      padding-left: 0.5rem;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+      gap: 0.75rem;
+    }
+    .card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 1.25rem 0.75rem;
+      text-align: center;
+      cursor: pointer;
+      transition: border-color 0.2s, box-shadow 0.2s;
+      user-select: none;
+    }
+    .card:hover {
+      border-color: #6c63ff;
+      box-shadow: 0 0 20px rgba(108,99,255,0.15);
+    }
+    .card .preview {
+      width: 56px;
+      height: 56px;
+      margin: 0 auto 0.75rem;
+      background: linear-gradient(135deg, #6c63ff, #e040fb);
+      border-radius: 12px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.25rem;
+    }
+    .card .label {
+      font-size: 0.75rem;
+      font-family: monospace;
+      color: #94a3b8;
+      word-break: break-all;
+    }
+    .card .class-tag {
+      display: inline-block;
+      font-size: 0.6rem;
+      font-family: monospace;
+      background: #0f172a;
+      border: 1px solid #334155;
+      border-radius: 999px;
+      padding: 0.2em 0.5em;
+      color: #a78bfa;
+      margin-top: 0.4rem;
+    }
+    .code-section {
+      max-width: 1100px;
+      margin: 2rem auto;
+      padding: 0 1rem;
+    }
+    .code-section h2 {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: #6c63ff;
+      margin-bottom: 1rem;
+    }
+    pre {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 1.5rem;
+      overflow-x: auto;
+      font-size: 0.8rem;
+      line-height: 1.6;
+      color: #e2e8f0;
+    }
+    .hl { color: #a78bfa; }
+    .cm { color: #64748b; }
+  </style>
+</head>
+<body>
+  <header class="demo-header">
+    <h1>SCSS Animation Partials</h1>
+    <p>Modular per-category SCSS partials for EaseMotion CSS. Click any card to replay its animation. Each category maps to a dedicated <code>_category.scss</code> partial that users can import selectively.</p>
+  </header>
+
+  <section class="category">
+    <h2>Fade &mdash; scss/_fade.scss</h2>
+    <div class="grid">
+      <div class="card" onclick="this.querySelector('.preview').classList.remove('ease-fade-in');void this.offsetWidth;this.querySelector('.preview').classList.add('ease-fade-in')"><div class="preview ease-fade-in">F</div><div class="label">fade-in</div><span class="class-tag">.ease-fade-in</span></div>
+      <div class="card" onclick="this.querySelector('.preview').classList.remove('ease-fade-out');void this.offsetWidth;this.querySelector('.preview').classList.add('ease-fade-out')"><div class="preview ease-fade-out">F</div><div class="label">fade-out</div><span class="class-tag">.ease-fade-out</span></div>
+      <div class="card" onclick="this.querySelector('.preview').classList.remove('ease-pulse-fade');void this.offsetWidth;this.querySelector('.preview').classList.add('ease-pulse-fade')"><div class="preview ease-pulse-fade">F</div><div class="label">pulse-fade</div><span class="class-tag">.ease-pulse-fade</span></div>
+      <div class="card" onclick="this.querySelector('.preview').classList.remove('ease-blur-to-focus');void this.offsetWidth;this.querySelector('.preview').classList.add('ease-blur-to-focus')"><div class="preview ease-blur-to-focus">F</div><div class="label">blur-to-focus</div><span class="class-tag">.ease-blur-to-focus</span></div>
+    </div>
+  </section>
+
+  <section class="category">
+    <h2>Slide &mdash; scss/_slide.scss</h2>
+    <div class="grid">
+      <div class="card" onclick="this.querySelector('.preview').classList.remove('ease-slide-up');void this.offsetWidth;this.querySelector('.preview').classList.add('ease-slide-up')"><div class="preview ease-slide-up">S</div><div class="label">slide-up</div><span class="class-tag">.ease-slide-up</span></div>
+      <div class="card" onclick="this.querySelector('.preview').classList.remove('ease-slide-down');void this.offsetWidth;this.querySelector('.preview').classList.add('ease-slide-down')"><div class="preview ease-slide-down">S</div><div class="label">slide-down</div><span class="class-tag">.ease-slide-down</span></div>
+      <div class="card" onclick="this.querySelector('.preview').classList.remove('ease-slide-in-from-left');void this.offsetWidth;this.querySelector('.preview').classList.add('ease-slide-in-from-left')"><div class="preview ease-slide-in-from-left">S</div><div class="label">slide-in-from-left</div><span class="class-tag">.ease-slide-in-from-left</span></div>
+      <div class="card" onclick="this.querySelector('.preview').classList.remove('ease-slide-in-from-right');void this.offsetWidth;this.querySelector('.preview').classList.add('ease-slide-in-from-right')"><div class="preview ease-slide-in-from-right">S</div><div class="label">slide-in-from-right</div><span class="class-tag">.ease-slide-in-from-right</span></div>
+      <div class="card" onclick="this.querySelector('.preview').classList.remove('ease-slide-in-from-top');void this.offsetWidth;this.querySelector('.preview').classList.add('ease-slide-in-from-top')"><div class="preview ease-slide-in-from-top">S</div><div class="label">slide-in-from-top</div><span class="class-tag">.ease-slide-in-from-top</span></div>
+      <div class="card" onclick="this.querySelector('.preview').classList.remove('ease-slide-in-from-bottom');void this.offsetWidth;this.querySelector('.preview').classList.add('ease-slide-in-from-bottom')"><div class="preview ease-slide-in-from-bottom">S</div><div class="label">slide-in-from-bottom</div><span class="class-tag">.ease-slide-in-from-bottom</span></div>
+    </div>
+  </section>
+
+  <section class="category">
+    <h2>Bounce &mdash; scss/_bounce.scss</h2>
+    <div class="grid">
+      <div class="card" onclick="this.querySelector('.preview').classList.remove('ease-bounce');void this.offsetWidth;this.querySelector('.preview').classList.add('ease-bounce')"><div class="preview ease-bounce">B</div><div class="label">bounce</div><span class="class-tag">.ease-bounce</span></div>
+      <div class="card" onclick="this.querySelector('.preview').classList.remove('ease-bounce-in');void this.offsetWidth;this.querySelector('.preview').classList.add('ease-bounce-in')"><div class="preview ease-bounce-in">B</div><div class="label">bounce-in</div><span class="class-tag">.ease-bounce-in</span></div>
+      <div class="card" onclick="this.querySelector('.preview').classList.remove('ease-bounce-text');void this.offsetWidth;this.querySelector('.preview').classList.add('ease-bounce-text')"><div class="preview ease-bounce-text">B</div><div class="label">bounce-text</div><span class="class-tag">.ease-bounce-text</span></div>
+    </div>
+  </section>
+
+  <section class="category">
+    <h2>Zoom &mdash; scss/_zoom.scss</h2>
+    <div class="grid">
+      <div class="card" onclick="this.querySelector('.preview').classList.remove('ease-zoom-in');void this.offsetWidth;this.querySelector('.preview').classList.add('ease-zoom-in')"><div class="preview ease-zoom-in">Z</div><div class="label">zoom-in</div><span class="class-tag">.ease-zoom-in</span></div>
+      <div class="card" onclick="this.querySelector('.preview').classList.remove('ease-zoom-out');void this.offsetWidth;this.querySelector('.preview').classList.add('ease-zoom-out')"><div class="preview ease-zoom-out">Z</div><div class="label">zoom-out</div><span class="class-tag">.ease-zoom-out</span></div>
+      <div class="card" onclick="this.querySelector('.preview').classList.remove('ease-reveal-scale');void this.offsetWidth;this.querySelector('.preview').classList.add('ease-reveal-scale')"><div class="preview ease-reveal-scale">Z</div><div class="label">reveal-scale</div><span class="class-tag">.ease-reveal-scale</span></div>
+    </div>
+  </section>
+
+  <section class="category">
+    <h2>Rotate &mdash; scss/_rotate.scss</h2>
+    <div class="grid">
+      <div class="card" onclick="this.querySelector('.preview').classList.remove('ease-rotate');void this.offsetWidth;this.querySelector('.preview').classList.add('ease-rotate')"><div class="preview ease-rotate">R</div><div class="label">rotate</div><span class="class-tag">.ease-rotate</span></div>
+      <div class="card" onclick="this.querySelector('.preview').classList.remove('ease-flip');void this.offsetWidth;this.querySelector('.preview').classList.add('ease-flip')"><div class="preview ease-flip">R</div><div class="label">flip</div><span class="class-tag">.ease-flip</span></div>
+      <div class="card" onclick="this.querySelector('.preview').classList.remove('ease-gradient-rotation');void this.offsetWidth;this.querySelector('.preview').classList.add('ease-gradient-rotation')"><div class="preview ease-gradient-rotation">R</div><div class="label">gradient-rotation</div><span class="class-tag">.ease-gradient-rotation</span></div>
+    </div>
+  </section>
+
+  <section class="category">
+    <h2>Hover / Interactive &mdash; scss/_hover.scss</h2>
+    <div class="grid">
+      <div class="card" onclick="this.querySelector('.preview').classList.remove('ease-pulse');void this.offsetWidth;this.querySelector('.preview').classList.add('ease-pulse')"><div class="preview ease-pulse">H</div><div class="label">pulse</div><span class="class-tag">.ease-pulse</span></div>
+      <div class="card" onclick="this.querySelector('.preview').classList.remove('ease-ping');void this.offsetWidth;this.querySelector('.preview').classList.add('ease-ping')"><div class="preview ease-ping">H</div><div class="label">ping</div><span class="class-tag">.ease-ping</span></div>
+      <div class="card" onclick="this.querySelector('.preview').classList.remove('ease-shimmer');void this.offsetWidth;this.querySelector('.preview').classList.add('ease-shimmer')"><div class="preview ease-shimmer">H</div><div class="label">shimmer</div><span class="class-tag">.ease-shimmer</span></div>
+      <div class="card" onclick="this.querySelector('.preview').classList.remove('ease-shake');void this.offsetWidth;this.querySelector('.preview').classList.add('ease-shake')"><div class="preview ease-shake">H</div><div class="label">shake</div><span class="class-tag">.ease-shake</span></div>
+      <div class="card" onclick="this.querySelector('.preview').classList.remove('ease-wave');void this.offsetWidth;this.querySelector('.preview').classList.add('ease-wave')"><div class="preview ease-wave">H</div><div class="label">wave</div><span class="class-tag">.ease-wave</span></div>
+      <div class="card" onclick="this.querySelector('.preview').classList.remove('ease-hover-pulse-glow');void this.offsetWidth;this.querySelector('.preview').classList.add('ease-hover-pulse-glow')"><div class="preview ease-hover-pulse-glow">H</div><div class="label">hover-pulse-glow</div><span class="class-tag">.ease-hover-pulse-glow</span></div>
+    </div>
+  </section>
+
+  <section class="code-section">
+    <h2>SCSS Usage Examples</h2>
+    <pre>
+<span class="cm">// Import only what you need</span>
+@use "easemotion-css/scss/fade" as fade;
+@use "easemotion-css/scss/slide" as slide;
+@use "easemotion-css/scss/bounce" as *;
+
+<span class="cm">// Use mixins with optional overrides</span>
+.my-hero {
+  @include fade.fade-in(0.6s);
+}
+
+.my-modal {
+  @include slide.slide-in-from-top(0.4s, 0s, var(--ease-ease-bounce));
+}
+
+.my-badge {
+  @include bounce(0.5s);
+}
+
+<span class="cm">// Or import everything</span>
+@use "easemotion-css/scss" as ease;
+
+.my-card {
+  @include ease.zoom-in;
+}</pre>
+  </section>
+
+  <footer style="text-align:center;padding:2rem 1rem;color:#475569;font-size:0.75rem;border-top:1px solid #1e293b;">
+    Issue #23653 &middot; SCSS Animation Partials &middot; EaseMotion CSS
+  </footer>
+</body>
+</html>

--- a/submissions/core_changes-issue-23653/scss/_bounce.scss
+++ b/submissions/core_changes-issue-23653/scss/_bounce.scss
@@ -1,0 +1,17 @@
+@use "variables" as *;
+
+@mixin bounce($duration: $speed-medium, $delay: $delay-none, $easing: $ease-bounce, $fill: $fill-both) {
+  @include animate(ease-kf-bounce, $duration, $easing, $delay, $fill);
+}
+
+@mixin bounce-in($duration: $speed-medium, $delay: $delay-none, $easing: $ease-bounce, $fill: $fill-both) {
+  @include animate(ease-kf-bounce-in, $duration, $easing, $delay, $fill);
+}
+
+@mixin bounce-text($duration: $speed-medium, $delay: $delay-none, $easing: $ease-bounce, $fill: $fill-both) {
+  @include animate(ease-kf-bounce-text, $duration, $easing, $delay, $fill);
+}
+
+@mixin bounce-button-exit($duration: $speed-fast, $delay: $delay-none, $easing: $ease-bounce, $fill: $fill-both) {
+  @include animate(ease-kf-bounce-button-exit, $duration, $easing, $delay, $fill);
+}

--- a/submissions/core_changes-issue-23653/scss/_fade.scss
+++ b/submissions/core_changes-issue-23653/scss/_fade.scss
@@ -1,0 +1,29 @@
+@use "variables" as *;
+
+@mixin fade-in($duration: $speed-medium, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-fade-in, $duration, $easing, $delay, $fill);
+}
+
+@mixin fade-out($duration: $speed-medium, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-fade-out, $duration, $easing, $delay, $fill);
+}
+
+@mixin fade-in-up($duration: $speed-medium, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-fade-in, $duration, $easing, $delay, $fill);
+}
+
+@mixin fade-in-down($duration: $speed-medium, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-fade-in, $duration, $easing, $delay, $fill);
+}
+
+@mixin fade-icon-exit($duration: $speed-fast, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-fade-icon-exit, $duration, $easing, $delay, $fill);
+}
+
+@mixin pulse-fade($duration: $speed-slow, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-pulse-fade, $duration, $easing, $delay, $fill);
+}
+
+@mixin blur-to-focus($duration: $speed-medium, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-blur-to-focus, $duration, $easing, $delay, $fill);
+}

--- a/submissions/core_changes-issue-23653/scss/_hover.scss
+++ b/submissions/core_changes-issue-23653/scss/_hover.scss
@@ -1,0 +1,45 @@
+@use "variables" as *;
+
+@mixin pulse($duration: $speed-slow, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-pulse, $duration, $easing, $delay, $fill);
+}
+
+@mixin ping($duration: $speed-slow, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-ping, $duration, $easing, $delay, $fill);
+}
+
+@mixin shimmer($duration: $speed-slow, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-shimmer, $duration, $easing, $delay, $fill);
+}
+
+@mixin shimmer-sweep($duration: $speed-slow, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-shimmer-sweep, $duration, $easing, $delay, $fill);
+}
+
+@mixin shimmer-text($duration: $speed-slow, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-shimmer-text, $duration, $easing, $delay, $fill);
+}
+
+@mixin shake($duration: $speed-medium, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-shake, $duration, $easing, $delay, $fill);
+}
+
+@mixin wave($duration: $speed-medium, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-wave, $duration, $easing, $delay, $fill);
+}
+
+@mixin hover-pulse-glow($duration: $speed-medium, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-hover-pulse-glow, $duration, $easing, $delay, $fill);
+}
+
+@mixin cursor-blink($duration: 1s, $delay: $delay-none, $easing: step-end, $fill: $fill-both) {
+  @include animate(ease-kf-cursor-blink, $duration, $easing, $delay, $fill);
+}
+
+@mixin typewriter-loop($duration: $speed-slow, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-typewriter-loop, $duration, $easing, $delay, $fill);
+}
+
+@mixin count-up($duration: $speed-medium, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-count-up, $duration, $easing, $delay, $fill);
+}

--- a/submissions/core_changes-issue-23653/scss/_index.scss
+++ b/submissions/core_changes-issue-23653/scss/_index.scss
@@ -1,0 +1,8 @@
+@forward "variables";
+@forward "mixins";
+@forward "fade";
+@forward "slide";
+@forward "bounce";
+@forward "zoom";
+@forward "rotate";
+@forward "hover";

--- a/submissions/core_changes-issue-23653/scss/_mixins.scss
+++ b/submissions/core_changes-issue-23653/scss/_mixins.scss
@@ -1,0 +1,26 @@
+@use "variables" as *;
+
+@mixin animate(
+  $name,
+  $duration: $speed-medium,
+  $easing: $ease-ease,
+  $delay: $delay-none,
+  $fill: $fill-both,
+  $iteration: 1
+) {
+  animation-name:            $name;
+  animation-duration:        $duration;
+  animation-timing-function: $easing;
+  animation-delay:           $delay;
+  animation-fill-mode:       $fill;
+  animation-iteration-count: $iteration;
+}
+
+@mixin transition(
+  $property: all,
+  $duration: $duration-fast,
+  $easing: $ease-out-cubic,
+  $delay: $delay-none
+) {
+  transition: $property $duration $easing $delay;
+}

--- a/submissions/core_changes-issue-23653/scss/_rotate.scss
+++ b/submissions/core_changes-issue-23653/scss/_rotate.scss
@@ -1,0 +1,17 @@
+@use "variables" as *;
+
+@mixin rotate($duration: $speed-slow, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-rotate, $duration, $easing, $delay, $fill);
+}
+
+@mixin rotate-image-exit($duration: $speed-fast, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-rotate-image-exit, $duration, $easing, $delay, $fill);
+}
+
+@mixin flip($duration: $speed-medium, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-flip, $duration, $easing, $delay, $fill);
+}
+
+@mixin gradient-rotation($duration: $speed-slow, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-gradient-rotation, $duration, $easing, $delay, $fill);
+}

--- a/submissions/core_changes-issue-23653/scss/_slide.scss
+++ b/submissions/core_changes-issue-23653/scss/_slide.scss
@@ -1,0 +1,53 @@
+@use "variables" as *;
+
+@mixin slide-up($duration: $speed-medium, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-slide-up, $duration, $easing, $delay, $fill);
+}
+
+@mixin slide-down($duration: $speed-medium, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-slide-down, $duration, $easing, $delay, $fill);
+}
+
+@mixin slide-in-from-top($duration: $speed-medium, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-slide-in-from-top, $duration, $easing, $delay, $fill);
+}
+
+@mixin slide-in-from-bottom($duration: $speed-medium, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-slide-in-from-bottom, $duration, $easing, $delay, $fill);
+}
+
+@mixin slide-in-from-left($duration: $speed-medium, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-slide-in-from-left, $duration, $easing, $delay, $fill);
+}
+
+@mixin slide-in-from-right($duration: $speed-medium, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-slide-in-from-right, $duration, $easing, $delay, $fill);
+}
+
+@mixin slide-in-from-top-left($duration: $speed-medium, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-slide-in-from-top-left, $duration, $easing, $delay, $fill);
+}
+
+@mixin slide-in-from-top-right($duration: $speed-medium, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-slide-in-from-top-right, $duration, $easing, $delay, $fill);
+}
+
+@mixin slide-in-from-bottom-left($duration: $speed-medium, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-slide-in-from-bottom-left, $duration, $easing, $delay, $fill);
+}
+
+@mixin slide-in-from-bottom-right($duration: $speed-medium, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-slide-in-from-bottom-right, $duration, $easing, $delay, $fill);
+}
+
+@mixin slide-in-left($duration: $speed-medium, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-slide-in-left, $duration, $easing, $delay, $fill);
+}
+
+@mixin slide-in-right($duration: $speed-medium, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-slide-in-right, $duration, $easing, $delay, $fill);
+}
+
+@mixin slide-image-exit($duration: $speed-fast, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-slide-image-exit, $duration, $easing, $delay, $fill);
+}

--- a/submissions/core_changes-issue-23653/scss/_variables.scss
+++ b/submissions/core_changes-issue-23653/scss/_variables.scss
@@ -1,0 +1,20 @@
+$speed-fast:        200ms;
+$speed-medium:      400ms;
+$speed-slow:        800ms;
+
+$duration-fast:     $speed-fast;
+$duration-normal:   $speed-medium;
+$duration-slow:     $speed-slow;
+
+$ease-ease:         cubic-bezier(0.4, 0, 0.2, 1);
+$ease-bounce:       cubic-bezier(0.34, 1.56, 0.64, 1);
+$ease-in-out:       cubic-bezier(0, 0, 0.2, 1);
+$ease-ping:         cubic-bezier(0, 0, 0.2, 1);
+
+$ease-in-out-cubic: $ease-ease;
+$ease-out-cubic:    $ease-ease;
+$ease-in-cubic:     $ease-ease;
+$ease-elastic:      $ease-bounce;
+
+$delay-none: 0s;
+$fill-both: both;

--- a/submissions/core_changes-issue-23653/scss/_zoom.scss
+++ b/submissions/core_changes-issue-23653/scss/_zoom.scss
@@ -1,0 +1,17 @@
+@use "variables" as *;
+
+@mixin zoom-in($duration: $speed-medium, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-zoom-in, $duration, $easing, $delay, $fill);
+}
+
+@mixin zoom-out($duration: $speed-medium, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-zoom-out, $duration, $easing, $delay, $fill);
+}
+
+@mixin reveal-scale($duration: $speed-medium, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-reveal-scale, $duration, $easing, $delay, $fill);
+}
+
+@mixin morph-card($duration: $speed-medium, $delay: $delay-none, $easing: $ease-ease, $fill: $fill-both) {
+  @include animate(ease-kf-morph-card, $duration, $easing, $delay, $fill);
+}

--- a/submissions/core_changes-issue-23653/style.css
+++ b/submissions/core_changes-issue-23653/style.css
@@ -1,0 +1,73 @@
+/* ============================================================
+   Compiled CSS Output from SCSS Animation Partials
+   Submission for EaseMotion CSS · Issue #23653
+   Demonstrates the CSS that each SCSS mixin generates.
+   ============================================================ */
+
+@layer easemotion-animations {
+  /* ── Fade ──────────────────────────────────────────────────── */
+  .ease-fade-in              { animation: ease-kf-fade-in        var(--ease-speed-medium) cubic-bezier(0.4,0,0.2,1) 0s both; }
+  .ease-fade-out             { animation: ease-kf-fade-out       var(--ease-speed-medium) cubic-bezier(0.4,0,0.2,1) 0s both; }
+  .ease-fade-icon-exit       { animation: ease-kf-fade-icon-exit var(--ease-speed-fast)   cubic-bezier(0.4,0,0.2,1) 0s both; }
+  .ease-pulse-fade           { animation: ease-kf-pulse-fade     var(--ease-speed-slow)   cubic-bezier(0.4,0,0.2,1) 0s both; }
+  .ease-blur-to-focus        { animation: ease-kf-blur-to-focus  var(--ease-speed-medium) cubic-bezier(0.4,0,0.2,1) 0s both; }
+
+  /* ── Slide ─────────────────────────────────────────────────── */
+  .ease-slide-up             { animation: ease-kf-slide-up               var(--ease-speed-medium) cubic-bezier(0.4,0,0.2,1) 0s both; }
+  .ease-slide-down           { animation: ease-kf-slide-down             var(--ease-speed-medium) cubic-bezier(0.4,0,0.2,1) 0s both; }
+  .ease-slide-in-from-top    { animation: ease-kf-slide-in-from-top      var(--ease-speed-medium) cubic-bezier(0.4,0,0.2,1) 0s both; }
+  .ease-slide-in-from-bottom { animation: ease-kf-slide-in-from-bottom   var(--ease-speed-medium) cubic-bezier(0.4,0,0.2,1) 0s both; }
+  .ease-slide-in-from-left   { animation: ease-kf-slide-in-from-left     var(--ease-speed-medium) cubic-bezier(0.4,0,0.2,1) 0s both; }
+  .ease-slide-in-from-right  { animation: ease-kf-slide-in-from-right    var(--ease-speed-medium) cubic-bezier(0.4,0,0.2,1) 0s both; }
+  .ease-slide-in-left        { animation: ease-kf-slide-in-left          var(--ease-speed-medium) cubic-bezier(0.4,0,0.2,1) 0s both; }
+  .ease-slide-in-right       { animation: ease-kf-slide-in-right         var(--ease-speed-medium) cubic-bezier(0.4,0,0.2,1) 0s both; }
+  .ease-slide-image-exit     { animation: ease-kf-slide-image-exit       var(--ease-speed-fast)   cubic-bezier(0.4,0,0.2,1) 0s both; }
+
+  /* ── Bounce ────────────────────────────────────────────────── */
+  .ease-bounce               { animation: ease-kf-bounce           var(--ease-speed-medium) cubic-bezier(0.34,1.56,0.64,1) 0s both; }
+  .ease-bounce-in            { animation: ease-kf-bounce-in        var(--ease-speed-medium) cubic-bezier(0.34,1.56,0.64,1) 0s both; }
+  .ease-bounce-text          { animation: ease-kf-bounce-text      var(--ease-speed-medium) cubic-bezier(0.34,1.56,0.64,1) 0s both; }
+  .ease-bounce-button-exit   { animation: ease-kf-bounce-button-exit var(--ease-speed-fast) cubic-bezier(0.34,1.56,0.64,1) 0s both; }
+
+  /* ── Zoom ──────────────────────────────────────────────────── */
+  .ease-zoom-in              { animation: ease-kf-zoom-in    var(--ease-speed-medium) cubic-bezier(0.4,0,0.2,1) 0s both; }
+  .ease-zoom-out             { animation: ease-kf-zoom-out   var(--ease-speed-medium) cubic-bezier(0.4,0,0.2,1) 0s both; }
+  .ease-reveal-scale         { animation: ease-kf-reveal-scale var(--ease-speed-medium) cubic-bezier(0.4,0,0.2,1) 0s both; }
+  .ease-morph-card           { animation: ease-kf-morph-card   var(--ease-speed-medium) cubic-bezier(0.4,0,0.2,1) 0s both; }
+
+  /* ── Rotate ────────────────────────────────────────────────── */
+  .ease-rotate               { animation: ease-kf-rotate           var(--ease-speed-slow) cubic-bezier(0.4,0,0.2,1) 0s both; }
+  .ease-rotate-image-exit    { animation: ease-kf-rotate-image-exit var(--ease-speed-fast) cubic-bezier(0.4,0,0.2,1) 0s both; }
+  .ease-flip                 { animation: ease-kf-flip              var(--ease-speed-medium) cubic-bezier(0.4,0,0.2,1) 0s both; }
+  .ease-gradient-rotation    { animation: ease-kf-gradient-rotation  var(--ease-speed-slow) cubic-bezier(0.4,0,0.2,1) 0s both; }
+
+  /* ── Hover / Interactive ───────────────────────────────────── */
+  .ease-pulse                { animation: ease-kf-pulse           var(--ease-speed-slow) cubic-bezier(0.4,0,0.2,1) 0s both; }
+  .ease-ping                 { animation: ease-kf-ping            var(--ease-speed-slow) cubic-bezier(0.4,0,0.2,1) 0s both; }
+  .ease-shimmer              { animation: ease-kf-shimmer         var(--ease-speed-slow) cubic-bezier(0.4,0,0.2,1) 0s both; }
+  .ease-shimmer-sweep        { animation: ease-kf-shimmer-sweep   var(--ease-speed-slow) cubic-bezier(0.4,0,0.2,1) 0s both; }
+  .ease-shimmer-text         { animation: ease-kf-shimmer-text    var(--ease-speed-slow) cubic-bezier(0.4,0,0.2,1) 0s both; }
+  .ease-shake                { animation: ease-kf-shake           var(--ease-speed-medium) cubic-bezier(0.4,0,0.2,1) 0s both; }
+  .ease-wave                 { animation: ease-kf-wave            var(--ease-speed-medium) cubic-bezier(0.4,0,0.2,1) 0s both; }
+  .ease-hover-pulse-glow     { animation: ease-kf-hover-pulse-glow var(--ease-speed-medium) cubic-bezier(0.4,0,0.2,1) 0s both; }
+  .ease-cursor-blink         { animation: ease-kf-cursor-blink    1s step-end 0s both; }
+  .ease-typewriter-loop      { animation: ease-kf-typewriter-loop var(--ease-speed-slow) cubic-bezier(0.4,0,0.2,1) 0s both; }
+  .ease-count-up             { animation: ease-kf-count-up        var(--ease-speed-medium) cubic-bezier(0.4,0,0.2,1) 0s both; }
+
+  /* ── Reduced Motion ────────────────────────────────────────── */
+  @media (prefers-reduced-motion: reduce) {
+    .ease-fade-in, .ease-fade-out, .ease-fade-icon-exit, .ease-pulse-fade,
+    .ease-blur-to-focus, .ease-slide-up, .ease-slide-down,
+    .ease-slide-in-from-top, .ease-slide-in-from-bottom,
+    .ease-slide-in-from-left, .ease-slide-in-from-right,
+    .ease-slide-in-left, .ease-slide-in-right, .ease-slide-image-exit,
+    .ease-bounce, .ease-bounce-in, .ease-bounce-text, .ease-bounce-button-exit,
+    .ease-zoom-in, .ease-zoom-out, .ease-reveal-scale, .ease-morph-card,
+    .ease-rotate, .ease-rotate-image-exit, .ease-flip, .ease-gradient-rotation,
+    .ease-pulse, .ease-ping, .ease-shimmer, .ease-shimmer-sweep, .ease-shimmer-text,
+    .ease-shake, .ease-wave, .ease-hover-pulse-glow, .ease-cursor-blink,
+    .ease-typewriter-loop, .ease-count-up {
+      animation: none !important;
+    }
+  }
+}


### PR DESCRIPTION
## Description
Adds per-category SCSS partials (`_fade.scss`, `_slide.scss`, `_bounce.scss`, `_zoom.scss`, `_rotate.scss`, `_hover.scss`) that mirror the modular CSS architecture. Each partial contains mixins relevant to its animation category, allowing SCSS users to import selectively via `@use "easemotion-css/scss/fade" as fade;`.

Fixes #23653

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have added demo.html, style.css, and README.md

## Maintainer Actions
1. Copy `scss/*.scss` → `scss/` directory (overwrite `_index.scss` to forward new partials)
2. The partials import `_variables.scss` and `_mixins.scss` from the same directory

## Files Changed
- `submissions/core_changes-issue-23653/README.md` — Documentation
- `submissions/core_changes-issue-23653/style.css` — Compiled CSS demo output
- `submissions/core_changes-issue-23653/demo.html` — Interactive demo
- `submissions/core_changes-issue-23653/scss/_fade.scss` — 5 fade mixins
- `submissions/core_changes-issue-23653/scss/_slide.scss` — 12 slide/reveal mixins
- `submissions/core_changes-issue-23653/scss/_bounce.scss` — 4 bounce mixins
- `submissions/core_changes-issue-23653/scss/_zoom.scss` — 4 zoom/scale mixins
- `submissions/core_changes-issue-23653/scss/_rotate.scss` — 4 rotate/flip mixins
- `submissions/core_changes-issue-23653/scss/_hover.scss` — 11 hover/interactive mixins
- `submissions/core_changes-issue-23653/scss/_index.scss` — Forwards all partials
- `submissions/core_changes-issue-23653/scss/_mixins.scss` — Base animate/transition mixins
- `submissions/core_changes-issue-23653/scss/_variables.scss` — Token definitions