### PR TITLE
feat(modal): add keyboard focus trapping and ARIA attributes (#23643)

### DIFF
--- a/submissions/core_changes-issue-23643/README.md
+++ b/submissions/core_changes-issue-23643/README.md
@@ -1,0 +1,56 @@
+# Modal Focus Trap — Keyboard Accessibility for EaseMotion CSS
+
+## 1. What does this do?
+
+Fixes the modal component (`core/modal.js` + `components/modals.css`) to implement proper keyboard focus trapping and ARIA attributes for WCAG 2.4.3 compliance.
+
+**Changes in `modal.js`:**
+- Adds `aria-modal="true"` and `role="dialog"` to the modal element on open
+- Removes ARIA attributes when the modal closes
+- Implements robust focus trapping — Tab/Shift+Tab cycle only through focusable elements inside the overlay
+- Catches focus escaping to elements behind the overlay and redirects it back inside
+- Cleanup function removes keydown listeners when modal closes
+- Sets `aria-hidden="true"` / `"false"` on the overlay based on state
+- Auto-links `aria-labelledby` to the modal header heading id
+
+**Changes in CSS:**
+- Added `focus-visible` ring styles for all focusable elements inside the modal
+- Added `aria-hidden="false"` state styling for the overlay
+
+## 2. How is it used?
+
+```html
+<!-- Modal overlay with ARIA state -->
+<div class="ease-modal-overlay" id="my-modal" aria-hidden="true">
+  <div class="ease-modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+    <div class="ease-modal-header">
+      <h2 id="modal-title">My Modal</h2>
+      <a href="#" class="ease-modal-close" aria-label="Close">&times;</a>
+    </div>
+    <div class="ease-modal-body">
+      <p>Tab through elements — focus never escapes the modal.</p>
+      <button>Action</button>
+    </div>
+    <div class="ease-modal-footer">
+      <a href="#" class="btn">Cancel</a>
+      <a href="#" class="btn">Confirm</a>
+    </div>
+  </div>
+</div>
+
+<!-- Trigger -->
+<a href="#my-modal" class="btn">Open Modal</a>
+```
+
+Keyboard behavior:
+- **Tab**: Moves focus to the next focusable element inside the modal
+- **Shift+Tab**: Moves focus to the previous focusable element inside the modal
+- **Escape**: Closes the modal and returns focus to the trigger element
+- **Click backdrop**: Closes the modal
+
+## 3. Why is this useful?
+
+- **WCAG 2.4.3 compliance** — Focus order is preserved within the modal
+- **WCAG 4.1.2 compliance** — ARIA attributes convey modal state to screen readers
+- **Better UX** — Users cannot accidentally interact with content behind the modal
+- **Focus restoration** — Keyboard focus returns to the triggering element after close

--- a/submissions/core_changes-issue-23643/demo.html
+++ b/submissions/core_changes-issue-23643/demo.html
@@ -1,0 +1,295 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Modal Focus Trap — Demo · Issue #23643</title>
+  <link rel="stylesheet" href="../../core/variables.css" />
+  <link rel="stylesheet" href="../../components/modals.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+      background: #0f172a;
+      color: #f1f5f9;
+      min-height: 100vh;
+    }
+    .demo-header {
+      text-align: center;
+      padding: 3rem 1rem 2rem;
+    }
+    .demo-header h1 {
+      font-size: clamp(1.75rem, 4vw, 2.75rem);
+      font-weight: 700;
+      background: linear-gradient(135deg, #6c63ff, #e040fb);
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+    .demo-header p {
+      color: #94a3b8;
+      margin-top: 0.75rem;
+      font-size: 0.95rem;
+      max-width: 620px;
+      margin-inline: auto;
+      line-height: 1.6;
+    }
+    .demo-content {
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 0 1rem 3rem;
+    }
+    .demo-content h2 {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: #6c63ff;
+      margin-bottom: 1rem;
+    }
+    .card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 2rem;
+      margin-bottom: 1.5rem;
+    }
+    .card p {
+      color: #94a3b8;
+      line-height: 1.6;
+      margin-bottom: 1rem;
+    }
+    .btn {
+      display: inline-block;
+      padding: 0.6rem 1.25rem;
+      border-radius: 8px;
+      text-decoration: none;
+      font-weight: 600;
+      font-size: 0.875rem;
+      transition: background 0.2s, transform 0.2s;
+      cursor: pointer;
+      border: none;
+    }
+    .btn-primary {
+      background: #6c63ff;
+      color: #fff;
+    }
+    .btn-primary:hover {
+      background: #5b52e0;
+    }
+    .btn-outline {
+      background: transparent;
+      color: #94a3b8;
+      border: 1px solid #334155;
+    }
+    .btn-outline:hover {
+      border-color: #6c63ff;
+      color: #fff;
+    }
+    .a11y-features {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+      gap: 0.75rem;
+      margin-bottom: 1.5rem;
+    }
+    .feature {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 8px;
+      padding: 1rem;
+      text-align: center;
+    }
+    .feature .icon {
+      font-size: 1.5rem;
+      margin-bottom: 0.5rem;
+    }
+    .feature .label {
+      font-size: 0.75rem;
+      color: #94a3b8;
+    }
+    .feature .status {
+      font-size: 0.65rem;
+      color: #22c55e;
+      margin-top: 0.25rem;
+    }
+    .demo-footer {
+      text-align: center;
+      padding: 2rem;
+      color: #475569;
+      font-size: 0.75rem;
+      border-top: 1px solid #1e293b;
+    }
+
+    /* Tab-trap visible demo styles */
+    .focus-trap-demo {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 1.5rem;
+      margin-top: 1.5rem;
+    }
+    .focus-trap-demo h3 {
+      font-size: 0.85rem;
+      color: #f1f5f9;
+      margin-bottom: 0.75rem;
+    }
+    .focus-trap-demo kbd {
+      display: inline-block;
+      background: #0f172a;
+      border: 1px solid #334155;
+      border-radius: 4px;
+      padding: 0.15em 0.5em;
+      font-size: 0.75rem;
+      color: #a78bfa;
+    }
+    .focus-trap-demo p {
+      color: #64748b;
+      font-size: 0.8rem;
+      line-height: 1.6;
+    }
+  </style>
+</head>
+<body>
+  <header class="demo-header">
+    <h1>Modal Focus Trap</h1>
+    <p>Accessibility enhancements for the EaseMotion modal component — keyboard focus trapping, <code>aria-modal</code>, <code>role="dialog"</code>, and Escape-to-close.</p>
+  </header>
+
+  <div class="demo-content">
+    <h2>Accessibility Features</h2>
+    <div class="a11y-features">
+      <div class="feature">
+        <div class="icon">🎯</div>
+        <div class="label">Focus Trap</div>
+        <div class="status">Tab/Shift+Tab cycles inside modal</div>
+      </div>
+      <div class="feature">
+        <div class="icon">⌨️</div>
+        <div class="label">Escape Key</div>
+        <div class="status">Closes modal, returns focus</div>
+      </div>
+      <div class="feature">
+        <div class="icon">🏷️</div>
+        <div class="label">ARIA Attributes</div>
+        <div class="status"><code>aria-modal="true"</code> + <code>role="dialog"</code></div>
+      </div>
+      <div class="feature">
+        <div class="icon">🔙</div>
+        <div class="label">Focus Return</div>
+        <div class="status">Returns to trigger element on close</div>
+      </div>
+    </div>
+
+    <h2>Demo</h2>
+    <div class="card">
+      <p>Click the buttons below to open modals. While a modal is open, <strong>Tab</strong> and <strong>Shift+Tab</strong> cycle through focusable elements inside the modal only — focus never escapes behind the overlay. Press <strong>Escape</strong> or click the backdrop to close.</p>
+      <p>
+        <a href="#modal-demo-1" class="btn btn-primary">Open Modal 1</a>
+        <a href="#modal-demo-2" class="btn btn-outline" style="margin-left:0.5rem;">Open Modal 2</a>
+        <a href="#modal-demo-3" class="btn btn-outline" style="margin-left:0.5rem;">Modal with Form</a>
+      </p>
+    </div>
+
+    <div class="focus-trap-demo">
+      <h3>How to test</h3>
+      <p>
+        Open a modal above, then press <kbd>Tab</kbd> repeatedly. Focus will wrap through all focusable elements inside the modal. Press <kbd>Shift</kbd> + <kbd>Tab</kbd> to go backwards. Press <kbd>Escape</kbd> to close. After closing, focus returns to the button that opened the modal.
+      </p>
+    </div>
+
+    <div class="card" style="margin-top:1.5rem;">
+      <p style="font-size:0.85rem;color:#f1f5f9;font-weight:600;">Focusable background elements</p>
+      <p>These inputs are behind the modal — they should NOT receive focus while the modal is open:</p>
+      <p>
+        <input type="text" placeholder="Try tabbing here while modal is open" style="background:#0f172a;border:1px solid #334155;border-radius:6px;padding:0.5rem;color:#94a3b8;width:100%;max-width:300px;" />
+      </p>
+      <p>
+        <button class="btn btn-outline" onclick="alert('This should be unreachable when a modal is open')">Background Button</button>
+      </p>
+    </div>
+  </div>
+
+  <!-- Modal 1 -->
+  <div class="ease-modal-overlay" id="modal-demo-1" aria-hidden="true">
+    <div class="ease-modal">
+      <div class="ease-modal-header">
+        <h2 id="modal-1-title">Getting Started</h2>
+        <a href="#" class="ease-modal-close" aria-label="Close modal">&times;</a>
+      </div>
+      <div class="ease-modal-body">
+        <p>Welcome to the EaseMotion modal component with full keyboard accessibility support.</p>
+        <p>Tab through the elements inside this modal to verify focus trapping works correctly.</p>
+        <p><a href="#">Example Link 1</a></p>
+        <p><button class="btn btn-primary" onclick="alert('Action triggered')">Action Button</button></p>
+      </div>
+      <div class="ease-modal-footer">
+        <a href="#" class="btn btn-outline">Cancel</a>
+        <a href="#" class="btn btn-primary">Confirm</a>
+      </div>
+    </div>
+  </div>
+
+  <!-- Modal 2 -->
+  <div class="ease-modal-overlay" id="modal-demo-2" aria-hidden="true">
+    <div class="ease-modal ease-modal-lg">
+      <div class="ease-modal-header">
+        <h2 id="modal-2-title">Keyboard Shortcuts</h2>
+        <a href="#" class="ease-modal-close" aria-label="Close modal">&times;</a>
+      </div>
+      <div class="ease-modal-body">
+        <p>The following keyboard shortcuts are available when a modal is open:</p>
+        <ul style="color:#94a3b8;line-height:2;padding-left:1.25rem;">
+          <li><kbd>Tab</kbd> — Move to next focusable element</li>
+          <li><kbd>Shift</kbd> + <kbd>Tab</kbd> — Move to previous focusable element</li>
+          <li><kbd>Escape</kbd> — Close the modal</li>
+        </ul>
+        <p style="margin-top:1rem;"><a href="#">Learn more about accessibility</a></p>
+        <p><button class="btn btn-primary" onclick="alert('Shortcuts work!')">Test Focus</button></p>
+      </div>
+      <div class="ease-modal-footer">
+        <a href="#" class="btn btn-outline">Close</a>
+      </div>
+    </div>
+  </div>
+
+  <!-- Modal 3 (with form fields) -->
+  <div class="ease-modal-overlay" id="modal-demo-3" aria-hidden="true">
+    <div class="ease-modal">
+      <div class="ease-modal-header">
+        <h2 id="modal-3-title">Contact Form</h2>
+        <a href="#" class="ease-modal-close" aria-label="Close modal">&times;</a>
+      </div>
+      <div class="ease-modal-body">
+        <p>Fill out this form to test focus trapping with input elements.</p>
+        <p>
+          <label style="display:block;color:#94a3b8;font-size:0.8rem;margin-bottom:0.25rem;">Name</label>
+          <input type="text" placeholder="Enter your name" style="width:100%;background:#0f172a;border:1px solid #334155;border-radius:6px;padding:0.5rem;color:#f1f5f9;margin-bottom:0.75rem;" />
+        </p>
+        <p>
+          <label style="display:block;color:#94a3b8;font-size:0.8rem;margin-bottom:0.25rem;">Role</label>
+          <select style="width:100%;background:#0f172a;border:1px solid #334155;border-radius:6px;padding:0.5rem;color:#f1f5f9;margin-bottom:0.75rem;">
+            <option>Developer</option>
+            <option>Designer</option>
+            <option>Product Manager</option>
+          </select>
+        </p>
+        <p>
+          <label style="display:block;color:#94a3b8;font-size:0.8rem;margin-bottom:0.25rem;">Message</label>
+          <textarea rows="3" placeholder="Type your message" style="width:100%;background:#0f172a;border:1px solid #334155;border-radius:6px;padding:0.5rem;color:#f1f5f9;margin-bottom:0.75rem;"></textarea>
+        </p>
+        <p><button class="btn btn-primary" onclick="alert('Form submitted!')">Submit</button></p>
+      </div>
+      <div class="ease-modal-footer">
+        <a href="#" class="btn btn-outline">Cancel</a>
+        <a href="#" class="btn btn-primary">Send</a>
+      </div>
+    </div>
+  </div>
+
+  <script src="modal.js"></script>
+  <footer class="demo-footer">
+    Issue #23643 &middot; Modal Focus Trap &middot; EaseMotion CSS
+  </footer>
+</body>
+</html>

--- a/submissions/core_changes-issue-23643/modal.js
+++ b/submissions/core_changes-issue-23643/modal.js
@@ -1,0 +1,176 @@
+(function () {
+  'use strict';
+
+  let previousFocusedElement = null;
+
+  function getFocusableElements(container) {
+    return container.querySelectorAll(
+      'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled])'
+    );
+  }
+
+  function trapFocus(overlay, modal) {
+    const focusableElements = getFocusableElements(overlay);
+
+    if (focusableElements.length > 0) {
+      focusableElements[0].focus();
+    } else {
+      modal.focus();
+    }
+
+    function handleKeydown(e) {
+      if (e.key === 'Escape') {
+        window.location.hash = '';
+        return;
+      }
+
+      if (e.key !== 'Tab') return;
+
+      const elements = getFocusableElements(overlay);
+      if (elements.length === 0) {
+        e.preventDefault();
+        return;
+      }
+
+      const first = elements[0];
+      const last = elements[elements.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === first || !overlay.contains(document.activeElement)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last || !overlay.contains(document.activeElement)) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    overlay.addEventListener('keydown', handleKeydown);
+    return function cleanup() {
+      overlay.removeEventListener('keydown', handleKeydown);
+    };
+  }
+
+  function setModalAttributes(modal) {
+    modal.setAttribute('role', 'dialog');
+    modal.setAttribute('aria-modal', 'true');
+    if (!modal.hasAttribute('aria-label') && !modal.hasAttribute('aria-labelledby')) {
+      const header = modal.querySelector('.ease-modal-header');
+      if (header) {
+        const heading = header.querySelector('h2, h3, h4');
+        if (heading && heading.id) {
+          modal.setAttribute('aria-labelledby', heading.id);
+        }
+      }
+    }
+  }
+
+  function removeModalAttributes(modal) {
+    modal.removeAttribute('role');
+    modal.removeAttribute('aria-modal');
+  }
+
+  function checkModal() {
+    const hash = window.location.hash;
+    const body = document.body;
+
+    const overlays = document.querySelectorAll('.ease-modal-overlay');
+    overlays.forEach(function (overlay) {
+      overlay.classList.remove('is-active');
+      overlay.setAttribute('aria-hidden', 'true');
+      const modal = overlay.querySelector('.ease-modal');
+      if (modal) {
+        removeModalAttributes(modal);
+      }
+    });
+
+    if (hash) {
+      try {
+        const escapedHashSelector = '#' + CSS.escape(hash.substring(1));
+        const overlay = document.querySelector(escapedHashSelector + '.ease-modal-overlay');
+        if (overlay) {
+          body.style.overflow = 'hidden';
+          previousFocusedElement = document.activeElement;
+
+          overlay.classList.add('is-active');
+          overlay.setAttribute('aria-hidden', 'false');
+
+          const modal = overlay.querySelector('.ease-modal');
+          if (modal) {
+            setModalAttributes(modal);
+            modal.setAttribute('tabindex', '-1');
+            var cleanup = trapFocus(overlay, modal);
+            overlay._cleanupFocusTrap = cleanup;
+          }
+          return;
+        }
+      } catch (e) {
+        window.location.hash = '';
+      }
+    }
+
+    body.style.overflow = '';
+
+    overlays.forEach(function (overlay) {
+      if (typeof overlay._cleanupFocusTrap === 'function') {
+        overlay._cleanupFocusTrap();
+        delete overlay._cleanupFocusTrap;
+      }
+    });
+
+    if (previousFocusedElement && typeof previousFocusedElement.focus === 'function') {
+      previousFocusedElement.focus();
+      previousFocusedElement = null;
+    }
+  }
+
+  window.addEventListener('hashchange', checkModal);
+
+  document.addEventListener('click', function (e) {
+    const hash = window.location.hash;
+    if (!hash) return;
+
+    try {
+      const escapedHashSelector = '#' + CSS.escape(hash.substring(1));
+      const overlay = document.querySelector(escapedHashSelector + '.ease-modal-overlay');
+      if (!overlay || !overlay.classList.contains('is-active')) return;
+
+      if (e.target === overlay) {
+        window.location.hash = '';
+        e.preventDefault();
+      }
+    } catch (e) {
+      // Invalid selector, ignore
+    }
+  }, true);
+
+  document.addEventListener('keydown', function () {
+    if (!window.location.hash) return;
+    try {
+      const escapedHashSelector = '#' + CSS.escape(window.location.hash.substring(1));
+      const overlay = document.querySelector(escapedHashSelector + '.ease-modal-overlay');
+      if (!overlay) return;
+
+      const modal = overlay.querySelector('.ease-modal');
+      if (modal && document.activeElement && !overlay.contains(document.activeElement)) {
+        const focusable = getFocusableElements(overlay);
+        if (focusable.length > 0) {
+          focusable[0].focus();
+        } else {
+          modal.focus();
+        }
+      }
+    } catch (e) {
+      // Invalid selector, ignore
+    }
+  }, true);
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', checkModal);
+  } else {
+    checkModal();
+  }
+})();

--- a/submissions/core_changes-issue-23643/style.css
+++ b/submissions/core_changes-issue-23643/style.css
@@ -1,0 +1,39 @@
+/* ============================================================
+   Modal Accessibility Enhancements — Issue #23643
+   Adds focus-visible outlines, aria-modal support styling
+   ============================================================ */
+
+@layer easemotion-components {
+  .ease-modal[aria-modal="true"] {
+    outline: none;
+  }
+
+  .ease-modal[aria-modal="true"]:focus {
+    outline: none;
+  }
+
+  .ease-modal-close:focus-visible,
+  .ease-modal a:focus-visible,
+  .ease-modal button:focus-visible,
+  .ease-modal input:focus-visible,
+  .ease-modal select:focus-visible,
+  .ease-modal textarea:focus-visible {
+    outline: 2px solid var(--ease-color-primary, #6c63ff);
+    outline-offset: 2px;
+    border-radius: var(--ease-radius-sm, 0.25rem);
+  }
+
+  .ease-modal-overlay[aria-hidden="false"] {
+    visibility: visible;
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ease-modal-overlay,
+    .ease-modal,
+    .ease-modal-close {
+      transition: none !important;
+    }
+  }
+}


### PR DESCRIPTION
## Description

The modal component (`core/modal.js` + `components/modals.css`) showed and hid modals but did not implement proper keyboard focus trapping. When a modal was open, pressing Tab allowed focus to escape to elements behind the overlay, violating WCAG 2.4.3 (Focus Order). Screen reader users and keyboard-only users could accidentally interact with content behind the modal.

Fixes #23643

## Type of Change
- [x] Bug fix (non-breaking change which fixes an accessibility issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have added demo.html, style.css, README.md, and updated modal.js

## Maintainer Actions
1. Copy `modal.js` → `core/modal.js` (replaces existing file)
2. Copy `style.css` additions or merge them into `components/modals.css`

## What Changed

### JavaScript (`modal.js`)
- **Focus trapping**: Dedicated handler wraps Tab/Shift+Tab within focusable elements; focus escaping the overlay is redirected back inside
- **ARIA attributes**: Sets `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` on open; removes them on close
- **Overlay state**: Sets `aria-hidden="true"` / `"false"` based on visibility
- **Cleanup**: Removes keydown listeners when modal closes
- **Edge cases**: Handles empty focusable lists, non-overlay focus escape, missing heading IDs

### CSS (`style.css`)
- Added `focus-visible` outline ring for all focusable elements inside modal
- Added `aria-hidden="false"` state selector for overlay visibility