### PR TITLE
fix(tooltip): prevent viewport overflow on right/left edges (#23641)

### DIFF
--- a/submissions/core_changes-issue-23641/README.md
+++ b/submissions/core_changes-issue-23641/README.md
@@ -1,0 +1,33 @@
+# Tooltip Viewport Overflow Fix
+
+## 1. What does this do?
+
+Fixes the tooltip component (`components/tooltips.css`) to prevent overflow when tooltips appear near viewport edges. Previously, tooltips near the right edge would extend beyond the viewport causing horizontal scrollbars.
+
+**CSS changes:**
+- Added `max-width: min(300px, 90vw)` to all tooltips
+- Added `overflow-wrap: break-word` and `word-break: break-word` for long text
+- Right-positioned tooltips (`data-position="right"`) near right edge: constrained to `calc(100vw - 100% - 2rem)`
+- Left-positioned tooltips (`data-position="left"`) near left edge: constrained to `calc(100% - 2rem)`
+- Mobile override: `max-width: calc(100vw - 2rem)` on small viewports
+- All fixes wrapped in `@layer easemotion-components`
+
+## 2. How is it used?
+
+No markup changes required. Existing tooltip usage is unaffected:
+
+```html
+<span class="ease-tooltip" data-tooltip="Tooltip text" data-position="right">
+  Hover me
+</span>
+```
+
+The fix is purely CSS — tooltips now automatically respect viewport boundaries.
+
+## 3. Why is this useful?
+
+- Eliminates horizontal scrollbar caused by overflowing tooltips
+- Long tooltip text wraps instead of overflowing
+- Works on all four positions (top, bottom, left, right)
+- Mobile-friendly with viewport-aware constraints
+- Backward compatible — no markup or API changes

--- a/submissions/core_changes-issue-23641/demo.html
+++ b/submissions/core_changes-issue-23641/demo.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tooltip Viewport Fix — Demo · Issue #23641</title>
+  <link rel="stylesheet" href="../../core/variables.css" />
+  <link rel="stylesheet" href="../../components/tooltips.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+      background: #0f172a;
+      color: #f1f5f9;
+      min-height: 100vh;
+      overflow-x: hidden;
+    }
+    .demo-header {
+      text-align: center;
+      padding: 3rem 1rem 2rem;
+      border-bottom: 1px solid #1e293b;
+    }
+    .demo-header h1 {
+      font-size: clamp(1.75rem, 4vw, 2.75rem);
+      font-weight: 700;
+      background: linear-gradient(135deg, #6c63ff, #e040fb);
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+    .demo-header p {
+      color: #94a3b8;
+      margin-top: 0.75rem;
+      font-size: 0.95rem;
+      max-width: 620px;
+      margin-inline: auto;
+      line-height: 1.6;
+    }
+    .demo-content {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 2rem 1rem 3rem;
+    }
+    .demo-content h2 {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: #6c63ff;
+      margin-bottom: 1rem;
+    }
+    .test-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 2rem;
+      margin-bottom: 1.5rem;
+      min-height: 140px;
+    }
+    .test-row.center {
+      justify-content: center;
+      gap: 2rem;
+    }
+    .badge {
+      display: inline-block;
+      background: #0f172a;
+      border: 1px solid #334155;
+      border-radius: 6px;
+      padding: 0.25rem 0.6rem;
+      font-size: 0.65rem;
+      color: #64748b;
+      margin-left: 0.5rem;
+    }
+    .trigger {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.6rem 1rem;
+      background: #6c63ff;
+      color: #fff;
+      border-radius: 8px;
+      font-size: 0.85rem;
+      font-weight: 600;
+      cursor: pointer;
+      border: none;
+    }
+    .trigger-sm {
+      padding: 0.4rem 0.75rem;
+      font-size: 0.75rem;
+    }
+    .edge-label {
+      font-size: 0.65rem;
+      color: #ef4444;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    .info {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+    .info h3 {
+      font-size: 0.85rem;
+      color: #f1f5f9;
+      margin-bottom: 0.75rem;
+    }
+    .info ul {
+      list-style: none;
+      padding: 0;
+    }
+    .info li {
+      color: #94a3b8;
+      font-size: 0.8rem;
+      line-height: 1.8;
+      padding-left: 1.25rem;
+      position: relative;
+    }
+    .info li::before {
+      content: ">";
+      position: absolute;
+      left: 0;
+      color: #6c63ff;
+      font-weight: 700;
+    }
+    .demo-footer {
+      text-align: center;
+      padding: 2rem;
+      color: #475569;
+      font-size: 0.75rem;
+      border-top: 1px solid #1e293b;
+    }
+  </style>
+</head>
+<body>
+  <header class="demo-header">
+    <h1>Tooltip Viewport Overflow Fix</h1>
+    <p>Tooltips no longer overflow the viewport on any edge. <code>max-width</code>, <code>overflow-wrap</code>, and edge-aware positioning keep tooltips visible even on the far right or left.</p>
+  </header>
+
+  <div class="demo-content">
+    <h2>Edge Cases</h2>
+
+    <div class="test-row">
+      <span class="edge-label">Left edge</span>
+      <span class="trigger ease-tooltip" data-tooltip="This tooltip is near the left edge — it should not overflow or get cropped" data-position="right">Hover me (left)</span>
+      <span></span>
+    </div>
+
+    <div class="test-row" style="justify-content:flex-end;">
+      <span></span>
+      <span class="trigger ease-tooltip" data-tooltip="This tooltip is near the right edge — it should stay within the viewport and not cause horizontal scrolling" data-position="left">Hover me (right)</span>
+      <span class="edge-label">Right edge</span>
+    </div>
+
+    <h2>All Positions</h2>
+    <div class="test-row center">
+      <span class="trigger ease-tooltip" data-tooltip="Top tooltip — default position" data-position="top">Top</span>
+      <span class="trigger ease-tooltip" data-tooltip="Bottom tooltip with a much longer description that would have overflowed before the fix" data-position="bottom">Bottom</span>
+      <span class="trigger ease-tooltip" data-tooltip="Left tooltip" data-position="left">Left</span>
+      <span class="trigger ease-tooltip" data-tooltip="Right tooltip" data-position="right">Right</span>
+    </div>
+
+    <h2>Long Content</h2>
+    <div class="test-row center">
+      <span class="trigger ease-tooltip" data-tooltip="This is an exceptionally long tooltip message that would previously cause horizontal overflow and break the layout. Now it wraps properly within viewport bounds using max-width: min(300px, 90vw) and overflow-wrap: break-word." data-position="top">Long text (top)</span>
+      <span class="trigger ease-tooltip" data-tooltip="This is an exceptionally long tooltip message that would previously cause horizontal overflow and break the layout. Now it wraps properly within viewport bounds using max-width: min(300px, 90vw) and overflow-wrap: break-word." data-position="bottom">Long text (bottom)</span>
+    </div>
+
+    <h2>Width Variants</h2>
+    <div class="test-row center">
+      <span class="trigger ease-tooltip" data-tooltip="Standard width (default) — single line" data-position="top">Default</span>
+      <span class="trigger ease-tooltip" data-tooltip="Wide variant with multi-line text that wraps at 250px max-width" data-width="wide" data-position="top">Wide</span>
+      <span class="trigger ease-tooltip" data-tooltip="Full variant with multi-line text that wraps at 320px max-width" data-width="full" data-position="top">Full</span>
+    </div>
+
+    <h2>Mobile Viewport</h2>
+    <div class="test-row center">
+      <span class="trigger trigger-sm ease-tooltip" data-tooltip="On mobile, max-width shrinks to calc(100vw - 2rem)" data-position="top">Hover (mobile)</span>
+      <span class="trigger trigger-sm ease-tooltip" data-tooltip="Right tooltip on mobile" data-position="right">Right (mobile)</span>
+    </div>
+
+    <div class="info">
+      <h3>What was fixed</h3>
+      <ul>
+        <li>Added <code>max-width: min(300px, 90vw)</code> to prevent overflow beyond viewport</li>
+        <li>Added <code>overflow-wrap: break-word</code> + <code>word-break: break-word</code> for long text</li>
+        <li>Right-positioned tooltips near right edge constrain to <code>calc(100vw - 100% - 2rem)</code></li>
+        <li>Left-positioned tooltips near left edge constrain to <code>calc(100% - 2rem)</code></li>
+        <li>Mobile viewport uses <code>calc(100vw - 2rem)</code> for maximum space</li>
+      </ul>
+    </div>
+  </div>
+
+  <footer class="demo-footer">
+    Issue #23641 &middot; Tooltip Viewport Overflow Fix &middot; EaseMotion CSS
+  </footer>
+</body>
+</html>

--- a/submissions/core_changes-issue-23641/style.css
+++ b/submissions/core_changes-issue-23641/style.css
@@ -1,0 +1,51 @@
+/* ============================================================
+   Tooltip Viewport Overflow Fix — Issue #23641
+   Prevents tooltips from overflowing the viewport on any edge.
+   ============================================================ */
+
+@layer easemotion-components {
+  .ease-tooltip::after {
+    max-width: min(300px, 90vw) !important;
+    overflow-wrap: break-word !important;
+    word-break: break-word !important;
+    white-space: normal !important;
+  }
+
+  .ease-tooltip[data-position="right"]::after {
+    left: calc(100% + var(--ease-tooltip-gap, 0.5rem)) !important;
+    right: auto !important;
+    max-width: calc(100vw - 100% - 2rem) !important;
+  }
+
+  .ease-tooltip[data-position="left"]::after {
+    right: calc(100% + var(--ease-tooltip-gap, 0.5rem)) !important;
+    left: auto !important;
+    max-width: calc(100% - 2rem) !important;
+  }
+
+  .ease-tooltip[data-position="top"]::after,
+  .ease-tooltip:not([data-position])::after {
+    max-width: min(300px, 90vw) !important;
+  }
+
+  .ease-tooltip[data-position="bottom"]::after {
+    max-width: min(300px, 90vw) !important;
+  }
+
+  @media (max-width: 640px) {
+    .ease-tooltip::after {
+      max-width: calc(100vw - 2rem) !important;
+      font-size: 0.72rem;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ease-tooltip::after,
+    .ease-tooltip::before {
+      transition: none !important;
+    }
+    .ease-tooltip::after {
+      transform: none !important;
+    }
+  }
+}


### PR DESCRIPTION
## Description

The tooltip component (`components/tooltips.css`) used fixed `transform` offsets to position tooltips above, below, left, or right of the trigger element. When a trigger was near the **right edge of the viewport**, the tooltip overflowed horizontally causing a horizontal scrollbar. There was no viewport boundary detection or fallback positioning.

Fixes #23641

## Type of Change
- [x] Bug fix (non-breaking change which fixes a layout issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have added demo.html, style.css, and README.md

## Maintainer Actions
1. Merge the CSS additions from `style.css` into `components/tooltips.css`

## Changes
- Added `max-width: min(300px, 90vw)` to prevent overflow
- Added `overflow-wrap: break-word; word-break: break-word` for long text
- Right-positioned tooltips: `max-width: calc(100vw - 100% - 2rem)` to stay within viewport right edge
- Left-positioned tooltips: `max-width: calc(100% - 2rem)` to stay within viewport left edge
- Mobile: `max-width: calc(100vw - 2rem)` on narrow viewports
- All inside `@layer easemotion-components` with `!important` to override existing styles