### PR TITLE
feat: add tooltip viewport overflow and right-edge fixes for #23641

### DIFF
--- a/submissions/core_changes-issue-23641/README.md
+++ b/submissions/core_changes-issue-23641/README.md
@@ -1,0 +1,107 @@
+# Tooltip Viewport Overflow Fixes — Issue #23641
+
+## What does this do?
+
+This submission proposes enhancements to the Tooltip component (`components/tooltips.css`) to prevent text wrapping constraints from causing viewport overflows, and introduces alignment modifiers (`.ease-tooltip-edge-right`) to prevent tooltips from extending past the right edge of the screen.
+
+## How is it used?
+
+By default, long tooltip content now automatically wraps onto multiple lines when it exceeds the maximum size boundary:
+
+```html
+<span
+  class="ease-tooltip"
+  data-tooltip="This is an extremely long tooltip description that wraps automatically."
+>
+  Hover Me
+</span>
+```
+
+For tooltips positioned near the right-hand edge of the viewport, apply the `.ease-tooltip-edge-right` alignment class:
+
+```html
+<span
+  class="ease-tooltip ease-tooltip-edge-right"
+  data-tooltip="Aligned to the right edge."
+>
+  Right Edge Trigger
+</span>
+```
+
+## Why is it useful?
+
+It addresses a critical visual and usability bug in the layout where tooltips positioned near the screen edges cause horizontal overflow scrollbars, maintaining responsive design guidelines without requiring custom JavaScript viewport math.
+
+---
+
+## Proposed Changes in Core Code
+
+To resolve this issue, the following updates are proposed for `components/tooltips.css`:
+
+### File: `components/tooltips.css`
+
+Replace and add these rules inside the `@layer easemotion-components` block:
+
+```css
+  /* Prevent tooltip viewport overflow */
+  .ease-tooltip::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    background: var(--ease-tooltip-bg);
+    color: var(--ease-tooltip-text);
+    font-size: var(--ease-tooltip-font-size);
+    padding: var(--ease-tooltip-padding);
+    border-radius: var(--ease-tooltip-radius);
+
+    /* Constraint dimensions and wrapping properties */
+    width: max-content;
+    max-width: min(300px, 90vw);
+    overflow-wrap: break-word;
+    word-break: break-word;
+    white-space: normal;
+
+    z-index: var(--ease-tooltip-z-index);
+    ...
+  }
+
+  /* Right-Edge Alignment Helper */
+  .ease-tooltip-edge-right[data-position="top"]::after,
+  .ease-tooltip-edge-right:not([data-position])::after {
+    left: auto;
+    right: 0;
+    transform: translateY(4px);
+  }
+
+  .ease-tooltip-edge-right[data-position="top"]:hover::after,
+  .ease-tooltip-edge-right:not([data-position]):hover::after,
+  .ease-tooltip-edge-right[data-position="top"]:focus-within::after,
+  .ease-tooltip-edge-right:not([data-position]):focus-within::after {
+    transform: translateY(0);
+  }
+
+  .ease-tooltip-edge-right[data-position="top"]::before,
+  .ease-tooltip-edge-right:not([data-position])::before {
+    left: auto;
+    right: 12px;
+    margin-left: 0;
+  }
+
+  .ease-tooltip-edge-right[data-position="bottom"]::after {
+    left: auto;
+    right: 0;
+    transform: translateY(-4px);
+  }
+
+  .ease-tooltip-edge-right[data-position="bottom"]:hover::after,
+  .ease-tooltip-edge-right[data-position="bottom"]:focus-within::after {
+    transform: translateY(0);
+  }
+
+  .ease-tooltip-edge-right[data-position="bottom"]::before {
+    left: auto;
+    right: 12px;
+    margin-left: 0;
+  }
+```
+
+Fixes #23641

--- a/submissions/core_changes-issue-23641/demo.html
+++ b/submissions/core_changes-issue-23641/demo.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EaseMotion CSS — Tooltip Overflow Fix Demo</title>
+    <!-- Link EaseMotion Framework relative to submissions directory -->
+    <link rel="stylesheet" href="../../easemotion.css" />
+    <!-- Custom Proposal Styles -->
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Tooltip Viewport Overflow</h1>
+      <p>
+        Pure CSS improvements protecting tooltips from overflowing on long
+        descriptions or near viewport edges.
+      </p>
+    </header>
+
+    <main class="demo-container">
+      <div class="demo-title">Showcase Showcase</div>
+
+      <!-- Long text wrap check -->
+      <div class="showcase-row">
+        <div class="row-info">
+          <span class="row-name">Long Description Wrapping</span>
+          <span class="row-desc"
+            >Using max-width and word-wrap properties to constrain
+            descriptions.</span
+          >
+        </div>
+        <div>
+          <span
+            class="ease-tooltip btn-trigger"
+            data-tooltip="This is an extremely long tooltip description designed to wrap onto multiple lines once it reaches the maximum width boundary."
+          >
+            Hover Me
+          </span>
+        </div>
+      </div>
+
+      <!-- Right edge alignment check -->
+      <div class="showcase-row">
+        <div class="row-info">
+          <span class="row-name"
+            >Right Edge - Default Centered (Overflow Risk)</span
+          >
+          <span class="row-desc"
+            >If this trigger sits on the right-most edge, the tooltip is
+            centered and cuts off or overflows.</span
+          >
+        </div>
+        <div style="display: flex; justify-content: flex-end">
+          <span
+            class="ease-tooltip btn-trigger"
+            data-tooltip="Default centered layout overflows."
+          >
+            Centered
+          </span>
+        </div>
+      </div>
+
+      <!-- Right edge fix check -->
+      <div class="showcase-row">
+        <div class="row-info">
+          <span class="row-name"
+            >Right Edge - Edge Alignment (.ease-tooltip-edge-right)</span
+          >
+          <span class="row-desc"
+            >Aligns the tooltip body flush to the right of the trigger,
+            preventing any right viewport boundary overflow.</span
+          >
+        </div>
+        <div style="display: flex; justify-content: flex-end">
+          <span
+            class="ease-tooltip ease-tooltip-edge-right btn-trigger"
+            data-tooltip="This tooltip body is aligned flush-right to prevent viewport overflow."
+          >
+            Aligned Right
+          </span>
+        </div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/submissions/core_changes-issue-23641/style.css
+++ b/submissions/core_changes-issue-23641/style.css
@@ -1,0 +1,165 @@
+/* ============================================================
+   EaseMotion CSS Tooltip Edge Fix — style.css
+   ============================================================ */
+
+@import url("https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap");
+
+:root {
+  --font-sans: "Outfit", -apple-system, BlinkMacSystemFont, sans-serif;
+  --bg-primary: #09090b;
+  --bg-secondary: #121217;
+  --text-primary: #f4f4f5;
+  --text-secondary: #a1a1aa;
+  --border-color: rgba(255, 255, 255, 0.08);
+  --accent-gradient: linear-gradient(135deg, #10b981 0%, #059669 100%);
+}
+
+body {
+  font-family: var(--font-sans);
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  margin: 0;
+  padding: 3rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-height: 100vh;
+}
+
+header {
+  text-align: center;
+  max-width: 600px;
+  margin-bottom: 3rem;
+}
+
+h1 {
+  font-size: 2.25rem;
+  font-weight: 700;
+  background: var(--accent-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 0.5rem;
+}
+
+p {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+/* Demo container */
+.demo-container {
+  width: 100%;
+  max-width: 650px;
+  background: rgba(18, 18, 23, 0.6);
+  backdrop-filter: blur(12px);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  padding: 2rem;
+  box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.3);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.demo-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #34d399;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.showcase-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.showcase-row:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.row-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  max-width: 70%;
+}
+
+.row-name {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.row-desc {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.btn-trigger {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
+  font-weight: 500;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+/* ── PROPOSED TOOLTIP CSS FIXES ── */
+.ease-tooltip::after {
+  width: max-content;
+  max-width: min(300px, 90vw);
+  overflow-wrap: break-word;
+  word-break: break-word;
+  white-space: normal;
+}
+
+/* Right-Edge Auto Alignment */
+.ease-tooltip-edge-right[data-position="top"]::after,
+.ease-tooltip-edge-right:not([data-position])::after {
+  left: auto;
+  right: 0;
+  transform: translateY(4px);
+}
+
+.ease-tooltip-edge-right[data-position="top"]:hover::after,
+.ease-tooltip-edge-right:not([data-position]):hover::after,
+.ease-tooltip-edge-right[data-position="top"]:focus-within::after,
+.ease-tooltip-edge-right:not([data-position]):focus-within::after {
+  transform: translateY(0);
+}
+
+.ease-tooltip-edge-right[data-position="top"]::before,
+.ease-tooltip-edge-right:not([data-position])::before {
+  left: auto;
+  right: 12px;
+  margin-left: 0;
+}
+
+/* Right-Edge Auto Alignment for Bottom Position */
+.ease-tooltip-edge-right[data-position="bottom"]::after {
+  left: auto;
+  right: 0;
+  transform: translateY(-4px);
+}
+
+.ease-tooltip-edge-right[data-position="bottom"]:hover::after,
+.ease-tooltip-edge-right[data-position="bottom"]:focus-within::after {
+  transform: translateY(0);
+}
+
+.ease-tooltip-edge-right[data-position="bottom"]::before {
+  left: auto;
+  right: 12px;
+  margin-left: 0;
+}


### PR DESCRIPTION
## ✦ Description
Add pure CSS enhancements to the Tooltip component (`components/tooltips.css`) to prevent viewport overflows. Long description tooltips now wrap automatically, and a `.ease-tooltip-edge-right` alignment class is introduced to prevent right-edge viewport cutoff.

Fixes #23641

---

## ⟡ Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (non-breaking change to docs)
- [x] Code styling/formatting (prettier, eslint, spacing)

---

## ✦ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [ ] I have verified that my changes work correctly on both desktop and mobile viewports.
- [x] (If applicable) I have run npm run lint and npm run format locally before pushing.

---

## ⟡ Screenshots / Screen Recordings (Required for UI changes)

N/A — Tooltip viewport overflow and alignment fixes proposal submitted under submissions directory.

---

## Description

### Root Cause
The existing tooltip component uses fixed offsets that cause overflows when trigger elements are near the right viewport edge or have long descriptions.

### Changes Made
- Created `submissions/core_changes-issue-23641/demo.html` showing wrapping long tooltips and the right-edge alignment utility in action.
- Created `submissions/core_changes-issue-23641/style.css` styling the showcase rows and the custom tooltip properties.
- Created `submissions/core_changes-issue-23641/README.md` answering the contribution questions and detailing the proposed rules inside `components/tooltips.css`.

### Testing Performed

- Verified text wrapping limits, word break behaviors, and right-aligned boundary offsets in the browser.
- Formatted with prettier.

### Result

Tooltips are constrained inside the viewport and wrap correctly on overflow.

---

## Additional Notes
- Branch pushed: submissions/core_changes-issue-23641
- Compare URL: https://github.com/Pcmhacker-piro/EaseMotion-css/compare/main...submissions/core_changes-issue-23641