### PR TITLE
feat(theme): add .ease-dark class for dark mode toggle (#23639)

### DIFF
--- a/submissions/core_changes-issue-23639/README.md
+++ b/submissions/core_changes-issue-23639/README.md
@@ -1,0 +1,40 @@
+# Dark Mode CSS Variables and `.ease-dark` Theme Toggle
+
+## 1. What does this do?
+
+Adds the missing `.ease-dark` class selector to the framework's theming system. The existing `core/variables.css` already supports:
+- `prefers-color-scheme: dark` media query (auto dark mode)
+- `[data-theme="dark"]` attribute selector
+- `[data-theme="light"]` attribute selector
+
+**Missing:** `.ease-dark` class selector — the only one mentioned by name in the issue.
+
+This submission adds `.ease-dark` as a class alias with the same dark-mode variable overrides, so both `<html class="ease-dark">` and `<html data-theme="dark">` work equivalently.
+
+**Variables overridden in dark mode:**
+- `--ease-color-bg`, `--ease-color-surface`, `--ease-color-text`, `--ease-color-muted`, `--ease-color-border`
+- `--ease-shadow-sm` through `--ease-shadow-xl` (adjusted for dark backgrounds)
+- `--ease-glass-bg`, `--ease-glass-border`
+- `--ease-glow-*` tokens for each semantic color
+
+## 2. How is it used?
+
+```html
+<!-- Via class -->
+<html class="ease-dark">
+
+<!-- Via data attribute (already supported) -->
+<html data-theme="dark">
+
+<!-- Toggle via JS -->
+document.documentElement.classList.toggle('ease-dark');
+```
+
+All existing components (buttons, cards, modals, toasts, tabs, badges, etc.) automatically inherit the dark palette because they use `--ease-color-*` variables.
+
+## 3. Why is this useful?
+
+- Complete the theming API: class, attribute, and media query all work
+- Framework convention uses `.ease-*` class names — `.ease-dark` fits the pattern
+- Zero migration for existing components — they already use design tokens
+- Three activation methods for different use cases

--- a/submissions/core_changes-issue-23639/demo.html
+++ b/submissions/core_changes-issue-23639/demo.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dark Mode Theme Toggle — Demo · Issue #23639</title>
+  <link rel="stylesheet" href="../../core/variables.css" />
+  <link rel="stylesheet" href="../../core/base.css" />
+  <link rel="stylesheet" href="../../components/buttons.css" />
+  <link rel="stylesheet" href="../../components/cards.css" />
+  <link rel="stylesheet" href="../../components/modals.css" />
+  <link rel="stylesheet" href="../../components/tabs.css" />
+  <link rel="stylesheet" href="../../components/badges.css" />
+  <link rel="stylesheet" href="../../components/toast.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+      background: var(--ease-color-bg);
+      color: var(--ease-color-text);
+      min-height: 100vh;
+      transition: background var(--ease-speed-medium, 0.3s) var(--ease-ease, ease),
+                  color var(--ease-speed-medium, 0.3s) var(--ease-ease, ease);
+    }
+    .demo-header {
+      text-align: center;
+      padding: 3rem 1rem 2rem;
+      border-bottom: 1px solid var(--ease-color-border, #e2e8f0);
+    }
+    .demo-header h1 {
+      font-size: clamp(1.75rem, 4vw, 2.75rem);
+      font-weight: 700;
+      background: linear-gradient(135deg, #6c63ff, #e040fb);
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+    .demo-header p {
+      color: var(--ease-color-muted);
+      margin-top: 0.75rem;
+      font-size: 0.95rem;
+      max-width: 620px;
+      margin-inline: auto;
+      line-height: 1.6;
+    }
+    .demo-content {
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 2rem 1rem 3rem;
+    }
+    .demo-content h2 {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: #6c63ff;
+      margin-bottom: 1rem;
+      margin-top: 2rem;
+    }
+    .toggle-bar {
+      display: flex;
+      justify-content: center;
+      gap: 1rem;
+      padding: 1.5rem 1rem;
+      background: var(--ease-color-surface);
+      border-bottom: 1px solid var(--ease-color-border, #e2e8f0);
+    }
+    .component-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+      gap: 1rem;
+    }
+    .demo-card {
+      background: var(--ease-color-surface);
+      border: 1px solid var(--ease-color-border, #e2e8f0);
+      border-radius: var(--ease-radius-lg, 1rem);
+      padding: 1.5rem;
+      box-shadow: var(--ease-shadow-sm);
+    }
+    .demo-card h3 {
+      font-size: var(--ease-text-sm, 0.875rem);
+      margin-bottom: 0.75rem;
+    }
+    .color-swatch {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin-bottom: 0.4rem;
+      font-size: 0.75rem;
+    }
+    .color-swatch .swatch {
+      width: 20px;
+      height: 20px;
+      border-radius: 4px;
+      border: 1px solid var(--ease-color-border, #e2e8f0);
+    }
+    .demo-footer {
+      text-align: center;
+      padding: 2rem;
+      color: #475569;
+      font-size: 0.75rem;
+      border-top: 1px solid var(--ease-color-border, #e2e8f0);
+      transition: border-color var(--ease-speed-medium, 0.3s);
+    }
+  </style>
+</head>
+<body>
+  <div class="toggle-bar">
+    <button class="btn btn-primary" onclick="document.documentElement.classList.toggle('ease-dark')">
+      Toggle .ease-dark
+    </button>
+    <button class="btn btn-outline" onclick="document.documentElement.removeAttribute('data-theme'); document.documentElement.classList.remove('ease-dark')">
+      Reset
+    </button>
+  </div>
+
+  <header class="demo-header">
+    <h1>Dark Mode Theme Toggle</h1>
+    <p>Add <code>.ease-dark</code> to <code>&lt;html&gt;</code> to enable dark mode. All components inherit the dark palette automatically via CSS custom properties. Uses <code>--ease-color-*</code> design tokens for seamless theming.</p>
+  </header>
+
+  <div class="demo-content">
+    <h2>Design Tokens</h2>
+    <div class="component-grid">
+      <div class="demo-card">
+        <h3>Background</h3>
+        <div class="color-swatch"><div class="swatch" style="background:var(--ease-color-bg)"></div> --ease-color-bg</div>
+        <div class="color-swatch"><div class="swatch" style="background:var(--ease-color-surface)"></div> --ease-color-surface</div>
+      </div>
+      <div class="demo-card">
+        <h3>Text</h3>
+        <div class="color-swatch"><div class="swatch" style="background:var(--ease-color-text)"></div> --ease-color-text</div>
+        <div class="color-swatch"><div class="swatch" style="background:var(--ease-color-muted)"></div> --ease-color-muted</div>
+      </div>
+      <div class="demo-card">
+        <h3>Border</h3>
+        <div class="color-swatch"><div class="swatch" style="background:var(--ease-color-border, #e2e8f0)"></div> --ease-color-border</div>
+      </div>
+    </div>
+
+    <h2>Component Preview</h2>
+    <div class="component-grid">
+      <div class="demo-card">
+        <h3>Buttons</h3>
+        <p><button class="btn btn-primary">Primary</button></p>
+        <p><button class="btn btn-outline">Outline</button></p>
+        <p><button class="btn btn-ghost">Ghost</button></p>
+      </div>
+      <div class="demo-card">
+        <h3>Badges</h3>
+        <p><span class="badge badge-primary">Primary</span></p>
+        <p><span class="badge badge-success">Success</span></p>
+        <p><span class="badge badge-danger">Danger</span></p>
+      </div>
+      <div class="demo-card">
+        <h3>Navigation</h3>
+        <p style="display:flex;gap:0.5rem;flex-wrap:wrap;">
+          <span class="tab active">Active</span>
+          <span class="tab">Default</span>
+        </p>
+      </div>
+    </div>
+
+    <h2>Usage</h2>
+    <div style="background:var(--ease-color-surface);border:1px solid var(--ease-color-border, #e2e8f0);border-radius:12px;padding:1rem;">
+      <pre style="color:var(--ease-color-text);font-size:0.8rem;overflow-x:auto;">
+<span style="color:#64748b;">&lt;!-- Toggle via class --&gt;</span>
+&lt;html class="ease-dark"&gt;
+
+<span style="color:#64748b;">&lt;!-- Toggle via JavaScript --&gt;</span>
+document.documentElement.classList.toggle('ease-dark');
+
+<span style="color:#64748b;">&lt;!-- Auto dark mode via OS preference (already built into core/variables.css) --&gt;</span>
+@media (prefers-color-scheme: dark) { ... }</pre>
+    </div>
+  </div>
+
+  <footer class="demo-footer">
+    Issue #23639 &middot; Dark Mode Theme Toggle &middot; EaseMotion CSS
+  </footer>
+</body>
+</html>

--- a/submissions/core_changes-issue-23639/style.css
+++ b/submissions/core_changes-issue-23639/style.css
@@ -1,0 +1,40 @@
+/* ============================================================
+   Dark Mode Theme Toggle — Issue #23639
+   Adds .ease-dark class alias for [data-theme="dark"]
+   ============================================================ */
+
+@layer easemotion-base {
+  .ease-dark {
+    color-scheme: dark;
+
+    --ease-color-bg:      #0b1121;
+    --ease-color-surface: #141e33;
+    --ease-color-text:    #e2e8f0;
+    --ease-color-muted:   #94a3b8;
+    --ease-color-border:  #1e293b;
+    --ease-shadow-sm:  0 1px 3px rgba(0, 0, 0, 0.30),
+                       0 1px 2px rgba(0, 0, 0, 0.20);
+    --ease-shadow-md:  0 4px 6px -1px rgba(0, 0, 0, 0.35),
+                       0 2px 4px -1px rgba(0, 0, 0, 0.25);
+    --ease-shadow-lg:  0 10px 15px -3px rgba(0, 0, 0, 0.40),
+                       0 4px 6px -2px rgba(0, 0, 0, 0.25);
+    --ease-shadow-xl:  0 20px 25px -5px rgba(0, 0, 0, 0.45),
+                       0 10px 10px -5px rgba(0, 0, 0, 0.30);
+    --ease-glass-bg: rgba(15, 23, 42, 0.30);
+    --ease-glass-border: rgba(255, 255, 255, 0.08);
+    --ease-glow-primary:   0 0 16px rgba(108, 99, 255, 0.45);
+    --ease-glow-secondary: 0 0 16px rgba(139, 92, 246, 0.45);
+    --ease-glow-success:   0 0 16px rgba(34, 197, 94, 0.45);
+    --ease-glow-danger:    0 0 16px rgba(239, 68, 68, 0.45);
+    --ease-glow-info:      0 0 16px rgba(59, 130, 246, 0.45);
+  }
+
+  @supports (color: color-mix(in srgb, red 50%, transparent)) {
+    .ease-dark {
+      --ease-glass-bg:
+        color-mix(in srgb, var(--ease-color-surface) 30%, transparent);
+      --ease-glass-border:
+        color-mix(in srgb, var(--ease-color-surface) 8%, transparent);
+    }
+  }
+}


### PR DESCRIPTION
## Description

The framework had `[data-theme="dark"]` attribute support and `prefers-color-scheme: dark` media query in `core/variables.css`, but was missing the `.ease-dark` class selector. Applying `class="ease-dark"` to `<html>` did nothing.

This adds `.ease-dark` as a class alias with the same dark-mode token overrides, so all three activation methods work.

Fixes #23639

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have added demo.html, style.css, and README.md

## Maintainer Actions
1. Merge the `.ease-dark` block from `style.css` into `core/variables.css` inside the `@layer easemotion-base` block

## Variables Overridden
- `--ease-color-bg`, `--ease-color-surface`, `--ease-color-text`, `--ease-color-muted`, `--ease-color-border`
- `--ease-shadow-sm` through `--ease-shadow-xl`
- `--ease-glass-bg`, `--ease-glass-border`
- `--ease-glow-primary`, `--ease-glow-secondary`, `--ease-glow-success`, `--ease-glow-danger`, `--ease-glow-info`
- `@supports (color: color-mix(...))` version for glass tokens