### PR TITLE
fix(marquee): respect prefers-reduced-motion with static wrapped layout (#23635)

### DIFF
--- a/submissions/core_changes-issue-23635/README.md
+++ b/submissions/core_changes-issue-23635/README.md
@@ -1,0 +1,38 @@
+# Marquee Reduced Motion Fix
+
+## 1. What does this do?
+
+Fixes the marquee component (`components/ease-marquee.css`) to properly respect `prefers-reduced-motion: reduce`. The existing code only set `animation: none`, which stopped the scroll but left the content overflowing as inline-flex. This fix wraps the content into a static centered layout when reduced motion is active.
+
+**CSS change:**
+```css
+@media (prefers-reduced-motion: reduce) {
+  .ease-marquee .ease-marquee-track {
+    animation: none !important;
+    flex-wrap: wrap !important;
+    justify-content: center !important;
+    gap: var(--marquee-gap, 2rem) !important;
+  }
+}
+```
+
+## 2. How is it used?
+
+No markup changes required. The fix is triggered automatically when the user enables "Reduce Motion" in their OS accessibility settings.
+
+```html
+<div class="ease-marquee">
+  <div class="ease-marquee-track">
+    <span>Item 1</span>
+    <span>Item 2</span>
+    <span>Item 3</span>
+  </div>
+</div>
+```
+
+## 3. Why is this useful?
+
+- **WCAG 2.1 SC 2.3.3** — Animation from interactions can be disabled
+- **No overflow** — Content displays as a static wrapped layout instead of clipping
+- **Centered layout** — Items remain visible and readable
+- **Zero JS** — Pure CSS solution

--- a/submissions/core_changes-issue-23635/demo.html
+++ b/submissions/core_changes-issue-23635/demo.html
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Marquee Reduced Motion — Demo · Issue #23635</title>
+  <link rel="stylesheet" href="../../core/variables.css" />
+  <link rel="stylesheet" href="../../core/base.css" />
+  <link rel="stylesheet" href="../../components/ease-marquee.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+      background: #0f172a;
+      color: #f1f5f9;
+      min-height: 100vh;
+    }
+    .demo-header {
+      text-align: center;
+      padding: 3rem 1rem 2rem;
+      border-bottom: 1px solid #1e293b;
+    }
+    .demo-header h1 {
+      font-size: clamp(1.75rem, 4vw, 2.75rem);
+      font-weight: 700;
+      background: linear-gradient(135deg, #6c63ff, #e040fb);
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+    .demo-header p {
+      color: #94a3b8;
+      margin-top: 0.75rem;
+      font-size: 0.95rem;
+      max-width: 620px;
+      margin-inline: auto;
+      line-height: 1.6;
+    }
+    .demo-content {
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 2rem 1rem 3rem;
+    }
+    .demo-content h2 {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: #6c63ff;
+      margin-bottom: 1rem;
+      margin-top: 2rem;
+    }
+    .section-desc {
+      color: #64748b;
+      font-size: 0.8rem;
+      margin-bottom: 1rem;
+      line-height: 1.5;
+    }
+    .marquee-wrapper {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 1.5rem 0;
+    }
+    .demo-badge {
+      display: inline-block;
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 999px;
+      padding: 0.2em 0.6em;
+      font-size: 0.65rem;
+      font-family: monospace;
+      color: #a78bfa;
+      margin-right: 1rem;
+    }
+    .demo-tag {
+      display: inline-block;
+      font-size: 0.75rem;
+      color: #6c63ff;
+      font-weight: 600;
+    }
+    .info-box {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 1.5rem;
+    }
+    .info-box ul {
+      list-style: none;
+      padding: 0;
+      color: #94a3b8;
+      font-size: 0.85rem;
+      line-height: 1.8;
+    }
+    .info-box li {
+      padding-left: 1.25rem;
+      position: relative;
+    }
+    .info-box li::before {
+      content: ">";
+      position: absolute;
+      left: 0;
+      color: #6c63ff;
+      font-weight: 700;
+    }
+    .demo-footer {
+      text-align: center;
+      padding: 2rem;
+      color: #475569;
+      font-size: 0.75rem;
+      border-top: 1px solid #1e293b;
+    }
+  </style>
+</head>
+<body>
+  <header class="demo-header">
+    <h1>Marquee Reduced Motion Fix</h1>
+    <p>When <code>prefers-reduced-motion: reduce</code> is enabled (OS-level accessibility setting), the marquee animation stops and content displays as a static wrapped layout instead of overflowing.</p>
+  </header>
+
+  <div class="demo-content">
+    <h2>Demo</h2>
+    <p class="section-desc">The marquee below scrolls infinitely when motion is allowed. <strong>Enable "Reduce Motion" in your OS settings</strong> to see it switch to a static wrapped layout.</p>
+    <div class="marquee-wrapper">
+      <div class="ease-marquee ease-marquee-slow">
+        <div class="ease-marquee-track">
+          <span style="display:inline-flex;align-items:center;gap:2rem;padding:0 1rem;font-size:1rem;font-weight:600;white-space:nowrap;">
+            <span style="color:#6c63ff;">EaseMotion</span>
+            <span style="color:#64748b;">CSS</span>
+            <span style="color:#22c55e;">Animations</span>
+            <span style="color:#e040fb;">Transitions</span>
+            <span style="color:#f59e0b;">Utilities</span>
+            <span style="color:#3b82f6;">Components</span>
+            <span style="color:#6c63ff;">EaseMotion</span>
+            <span style="color:#64748b;">CSS</span>
+            <span style="color:#22c55e;">Animations</span>
+            <span style="color:#e040fb;">Transitions</span>
+            <span style="color:#f59e0b;">Utilities</span>
+            <span style="color:#3b82f6;">Components</span>
+          </span>
+        </div>
+      </div>
+    </div>
+
+    <div style="margin-top:0.75rem;">
+      <span class="demo-tag">CSS:</span>
+      <span class="demo-badge">.ease-marquee</span>
+      <span class="demo-badge">.ease-marquee-track</span>
+    </div>
+
+    <h2>How to test</h2>
+    <div class="info-box">
+      <ul>
+        <li><strong>macOS:</strong> System Settings → Accessibility → Display → Reduce motion</li>
+        <li><strong>Windows:</strong> Settings → Ease of Access → Display → Show animations</li>
+        <li><strong>Linux:</strong> GNOME Settings → Accessibility → Seeing → Reduced animation</li>
+        <li><strong>DevTools:</strong> Chrome Rendering tab → Emulate prefers-reduced-motion: reduce</li>
+      </ul>
+    </div>
+
+    <h2>What changed</h2>
+    <div class="info-box">
+      <ul>
+        <li>Added <code>flex-wrap: wrap</code> so content wraps into rows instead of inline overflow</li>
+        <li>Added <code>justify-content: center</code> for centered static layout</li>
+        <li>Added <code>gap</code> to maintain spacing between items</li>
+        <li>Used <code>!important</code> to override the existing <code>animation</code> rule</li>
+      </ul>
+    </div>
+
+    <h2>Before vs After</h2>
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem;">
+      <div class="info-box">
+        <p style="color:#ef4444;font-size:0.75rem;font-weight:600;text-transform:uppercase;margin-bottom:0.5rem;">Before</p>
+        <ul>
+          <li><code>animation: none</code> — stops scroll</li>
+          <li>Content still in inline-flex — overflows horizontally</li>
+          <li>Items remain off-screen or clipped</li>
+          <li>Poor user experience for reduced motion users</li>
+        </ul>
+      </div>
+      <div class="info-box">
+        <p style="color:#22c55e;font-size:0.75rem;font-weight:600;text-transform:uppercase;margin-bottom:0.5rem;">After</p>
+        <ul>
+          <li><code>animation: none</code> — stops scroll</li>
+          <li><code>flex-wrap: wrap</code> — items wrap into rows</li>
+          <li><code>justify-content: center</code> — centered static layout</li>
+          <li>All content visible and readable</li>
+        </ul>
+      </div>
+    </div>
+
+    <h2>Marquee Variants</h2>
+    <p class="section-desc">The fix applies to all marquee variants seamlessly.</p>
+    <div style="display:grid;grid-template-columns:1fr;gap:1rem;">
+      <div class="marquee-wrapper">
+        <div class="ease-marquee ease-marquee-fast">
+          <div class="ease-marquee-track">
+            <span style="display:inline-flex;align-items:center;gap:2rem;padding:0 1rem;font-size:0.85rem;white-space:nowrap;">
+              <span>⚡ Fast</span> <span>⚡ Variant</span> <span>⚡ 10s</span>
+              <span>⚡ Fast</span> <span>⚡ Variant</span> <span>⚡ 10s</span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div style="margin-top:0.5rem;">
+      <span class="demo-badge">.ease-marquee-fast</span>
+    </div>
+  </div>
+
+  <footer class="demo-footer">
+    Issue #23635 &middot; Marquee Reduced Motion &middot; EaseMotion CSS
+  </footer>
+</body>
+</html>

--- a/submissions/core_changes-issue-23635/style.css
+++ b/submissions/core_changes-issue-23635/style.css
@@ -1,0 +1,16 @@
+/* ============================================================
+   Marquee Reduced Motion Fix — Issue #23635
+   Respects prefers-reduced-motion by stopping animation
+   AND making content visible via wrapped layout.
+   ============================================================ */
+
+@layer easemotion-components {
+  @media (prefers-reduced-motion: reduce) {
+    .ease-marquee .ease-marquee-track {
+      animation: none !important;
+      flex-wrap: wrap !important;
+      justify-content: center !important;
+      gap: var(--marquee-gap, 2rem) !important;
+    }
+  }
+}


### PR DESCRIPTION
## Description

The marquee component had a `prefers-reduced-motion: reduce` media query that only set `animation: none`, but the inline-flex track still overflowed horizontally. Content remained off-screen and invisible to users who need reduced motion.

This fix adds `flex-wrap: wrap`, `justify-content: center`, and `gap` so the content renders as a static wrapped layout when reduced motion is active.

Fixes #23635

## Type of Change
- [x] Bug fix (non-breaking change which fixes an accessibility issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have added demo.html, style.css, and README.md

## Maintainer Actions
1. Merge the `@media (prefers-reduced-motion: reduce)` block from `style.css` into `components/ease-marquee.css`, replacing the existing reduced-motion block

## Change
- Added `flex-wrap: wrap` + `justify-content: center` + `gap` inside the existing `@media (prefers-reduced-motion: reduce)` block
- Uses `!important` to override inline-flex behavior