### PR TITLE
docs: add interactive CSS custom property theming guide

### DIFF
--- a/submissions/examples/custom-property-theming-ap/README.md
+++ b/submissions/examples/custom-property-theming-ap/README.md
@@ -1,0 +1,143 @@
+# CSS Custom Property Theming Guide
+
+Welcome to the **CSS Custom Property Theming Guide**! This comprehensive tutorial explains how to customize, extend, and override EaseMotion CSS components dynamically using native CSS custom properties (CSS variables).
+
+---
+
+## 📋 Table of Contents
+1. [Benefits of CSS Variables over SASS/LESS](#1-benefits-of-css-variables-over-sassless)
+2. [EaseMotion Variables Registry](#2-easemotion-variables-registry)
+3. [Global Theme Overrides](#3-global-theme-overrides)
+4. [Element-Level Scoped Overrides](#4-element-level-scoped-overrides)
+5. [Avoiding the `!important` Anti-Pattern](#5-avoiding-the-important-anti-pattern)
+6. [Dynamic Control via JavaScript](#6-dynamic-control-via-javascript)
+
+---
+
+## 1. Benefits of CSS Variables over SASS/LESS
+
+Preprocessors like SASS compile variables into static values at build time. Conversely, CSS Custom Properties:
+1. **Compute in the Browser**: They can change dynamically in response to user actions (e.g. settings sliders, color pickers).
+2. **Follow the Cascade**: Custom properties inherit values from parent containers, allowing you to scope changes without changing component class declarations.
+3. **Read and Write via JavaScript**: You can read or overwrite property variables directly in JS, bridging the gap between design tokens and dynamic application state.
+
+---
+
+## 2. EaseMotion Variables Registry
+
+EaseMotion components inherit values from the following design variables:
+
+| Variable Name | Default Value | Description |
+| :--- | :--- | :--- |
+| `--ease-brand` | `#8b5cf6` | Primary color accent used for buttons, links, and borders |
+| `--ease-bg-base` | `#030712` | Bottom viewport backdrop color |
+| `--ease-bg-surface` | `#0b0f19` | Content card, popup, or element backgrounds |
+| `--ease-bg-surface-hover` | `#111827` | Content card background when hovered |
+| `--ease-border` | `#1f2937` | Subtle border and divider lines |
+| `--ease-border-hover` | `#374151` | Divider line colors on element hover |
+| `--ease-border-radius` | `12px` | Corner rounding curvature metric |
+| `--ease-padding-card` | `1.5rem` | Inner element content padding spacing |
+| `--ease-anim-duration` | `0.6s` | Base duration timing for transitions and animations |
+
+---
+
+## 3. Global Theme Overrides
+
+To redefine variables globally across your entire project, declare your overrides inside the `:root` pseudo-class (or `body` selector).
+
+```css
+/* Custom Global Dark Theme override */
+:root {
+  --ease-brand: #10b981; /* Emerald green accent */
+  --ease-bg-base: #064e3b; /* Dark forest backdrop */
+  --ease-bg-surface: #022c22; /* Card surfaces */
+  --ease-border: #047857;
+  --ease-border-radius: 8px;
+}
+```
+
+Any EaseMotion element on the page will automatically compute its styles using these updated values.
+
+---
+
+## 4. Element-Level Scoped Overrides
+
+Because CSS Custom Properties follow the cascade, you can scope an override to a specific component or section. Sibling components outside of this container remain unaffected.
+
+```css
+/* Global setup */
+:root {
+  --ease-brand: #8b5cf6;
+}
+
+/* Local override applied to warning cards only */
+.warning-accent-card {
+  --ease-brand: #f97316; /* Orange accent override */
+  --ease-border: #ea580c;
+}
+```
+
+### HTML Implementation
+```html
+<!-- Card 1: Inherits the global violet (--ease-brand: #8b5cf6) -->
+<div class="theme-card">...</div>
+
+<!-- Card 2: Uses the scoped orange override (--ease-brand: #f97316) -->
+<div class="theme-card warning-accent-card">...</div>
+```
+
+---
+
+## 5. Avoiding the `!important` Anti-Pattern
+
+In legacy CSS frameworks, customizing components often results in "specificity battles." If the framework declares a class like:
+
+```css
+/* Framework baseline code */
+.alert-box {
+  background-color: #f3f4f6 !important;
+}
+```
+
+Developers are forced to append `!important` to their own overrides to bypass this block, which clutters the stylesheet.
+
+### How CSS Variables Solve This
+
+By referencing a variable inside the baseline style, the framework gives you a clean API to hook into without needing high-specificity selectors:
+
+```css
+/* Framework baseline code */
+.alert-box {
+  background-color: var(--ease-bg-surface); /* No !important needed! */
+}
+```
+
+You can now customize the backdrop simply by changing the variable's value:
+
+```css
+/* Custom application stylesheet */
+.alert-box {
+  --ease-bg-surface: #ffffff; /* Smooth, override without specificity clashes */
+}
+```
+
+---
+
+## 6. Dynamic Control via JavaScript
+
+To create highly interactive themes (such as letting users custom-select accent colors or configure card spacing via dashboard sliders), manipulate custom variables dynamically:
+
+```javascript
+// Get target element container
+const container = document.querySelector('.playground-canvas');
+
+// Dynamically set CSS variables based on inputs
+function updateAccent(colorHex) {
+  container.style.setProperty('--ease-brand', colorHex);
+  container.style.setProperty('--ease-brand-glow', `${colorHex}55`); // 55 adds opacity channel
+}
+
+function updateRadius(radiusValue) {
+  container.style.setProperty('--ease-border-radius', `${radiusValue}px`);
+}
+```

--- a/submissions/examples/custom-property-theming-ap/demo.html
+++ b/submissions/examples/custom-property-theming-ap/demo.html
@@ -1,0 +1,333 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EaseMotion CSS — CSS Custom Property Theming Guide</title>
+    <!-- Outfit & Fira Code Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;600&family=Outfit:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div id="container-root" class="app-container">
+      <!-- Header -->
+      <header class="app-header">
+        <h1>EaseMotion Theming Engine</h1>
+        <p>
+          Explore EaseMotion's CSS Custom Property architecture. Learn how to customize global components,
+          scope overrides locally to specific elements, and avoid the <code>!important</code> anti-pattern.
+        </p>
+      </header>
+
+      <!-- Playground Sandbox -->
+      <h2 class="section-heading">Live Theming Playground Sandbox</h2>
+      <div class="playground-grid">
+        <!-- Controls Sidebar -->
+        <aside class="playground-sidebar">
+          <!-- Preset Themes Selector -->
+          <div class="option-group">
+            <label class="option-label" for="preset-select">Global Preset Theme</label>
+            <select id="preset-select" class="option-select">
+              <option value="default" selected>Default Neon Violet</option>
+              <option value="emerald">Emerald Forest</option>
+              <option value="cyberpunk">Cyberpunk Orange</option>
+              <option value="slate">Slate Minimal Light</option>
+            </select>
+          </div>
+
+          <!-- Variable Sliders -->
+          <div class="option-group">
+            <label class="option-label">Brand Accent Color</label>
+            <div class="color-picker-row">
+              <input type="color" id="brand-color" class="color-input" value="#8b5cf6" />
+              <code id="brand-hex" style="font-size:0.85rem;">#8b5cf6</code>
+            </div>
+          </div>
+
+          <div class="option-group">
+            <label class="option-label">Card Border Radius</label>
+            <div class="slider-row">
+              <input type="range" id="radius-slider" class="slider-input" min="0" max="30" value="12" />
+              <span id="radius-val" class="slider-val">12px</span>
+            </div>
+          </div>
+
+          <div class="option-group">
+            <label class="option-label">Card Padding</label>
+            <div class="slider-row">
+              <input type="range" id="padding-slider" class="slider-input" min="8" max="40" value="24" />
+              <span id="padding-val" class="slider-val">1.5rem</span>
+            </div>
+          </div>
+
+          <div class="option-group">
+            <label class="option-label">Animation Duration</label>
+            <div class="slider-row">
+              <input type="range" id="duration-slider" class="slider-input" min="1" max="20" value="6" />
+              <span id="duration-val" class="slider-val">0.6s</span>
+            </div>
+          </div>
+
+          <!-- Scoped Overrides -->
+          <div class="option-group">
+            <label class="option-label">Element-Scoped Overrides</label>
+            <label class="toggle-row">
+              <input type="checkbox" id="scoped-card-2" class="toggle-checkbox" />
+              <span>Override Card #2 to Orange accent</span>
+            </label>
+            <label class="toggle-row">
+              <input type="checkbox" id="scoped-card-3" class="toggle-checkbox" />
+              <span>Override Card #3 to Pink accent</span>
+            </label>
+          </div>
+
+          <button id="replay-transitions" class="theme-card-btn">Replay Transition</button>
+        </aside>
+
+        <!-- Display Canvas -->
+        <main id="display-canvas" class="playground-canvas">
+          <div class="cards-container">
+            <!-- Card 1 -->
+            <div class="theme-card" id="demo-card-1">
+              <div class="theme-card-icon">⚡</div>
+              <h3 class="theme-card-title">Responsive Flow</h3>
+              <p class="theme-card-desc">
+                Adapts seamlessly using variables. Inherits all global changes from the parent container.
+              </p>
+              <button class="theme-card-btn">Action 1</button>
+            </div>
+
+            <!-- Card 2 -->
+            <div class="theme-card" id="demo-card-2">
+              <div class="theme-card-icon">⚙️</div>
+              <h3 class="theme-card-title">Dynamic Control</h3>
+              <p class="theme-card-desc">
+                Can be locally overridden to orange without affecting sibling components or global scopes.
+              </p>
+              <button class="theme-card-btn">Action 2</button>
+            </div>
+
+            <!-- Card 3 -->
+            <div class="theme-card" id="demo-card-3">
+              <div class="theme-card-icon">🎨</div>
+              <h3 class="theme-card-title">Creative Space</h3>
+              <p class="theme-card-desc">
+                Supports scoped adjustments. Can override styling metrics cleanly with zero !important hooks.
+              </p>
+              <button class="theme-card-btn">Action 3</button>
+            </div>
+          </div>
+        </main>
+
+        <!-- Code Block -->
+        <div class="code-panel">
+          <h4>Current Variable Mappings Code</h4>
+          <pre id="code-view" class="code-view"></pre>
+        </div>
+      </div>
+
+      <!-- Variables Reference Table -->
+      <section class="registry-panel">
+        <h2 class="section-heading" style="margin-top: 0;">EaseMotion CSS Variable Registry</h2>
+        <div class="registry-table-wrapper">
+          <table class="registry-table">
+            <thead>
+              <tr>
+                <th>Variable Name</th>
+                <th>Default Value</th>
+                <th>Description</th>
+                <th>Usage Example</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>--ease-brand</code></td>
+                <td><span class="swatch" style="background-color: #8b5cf6;"></span>#8b5cf6</td>
+                <td>Primary brand colors used for CTAs, active focus borders, and highlights.</td>
+                <td><code>color: var(--ease-brand);</code></td>
+              </tr>
+              <tr>
+                <td><code>--ease-bg-base</code></td>
+                <td><span class="swatch" style="background-color: #030712;"></span>#030712</td>
+                <td>Root application viewport background color.</td>
+                <td><code>background-color: var(--ease-bg-base);</code></td>
+              </tr>
+              <tr>
+                <td><code>--ease-bg-surface</code></td>
+                <td><span class="swatch" style="background-color: #0b0f19;"></span>#0b0f19</td>
+                <td>Surface components background (cards, dashboards, drawers).</td>
+                <td><code>background-color: var(--ease-bg-surface);</code></td>
+              </tr>
+              <tr>
+                <td><code>--ease-border-radius</code></td>
+                <td><code>12px</code></td>
+                <td>Outer border radius rounding metrics.</td>
+                <td><code>border-radius: var(--ease-border-radius);</code></td>
+              </tr>
+              <tr>
+                <td><code>--ease-padding-card</code></td>
+                <td><code>1.5rem</code></td>
+                <td>Inner spacing metrics for cards and containers.</td>
+                <td><code>padding: var(--ease-padding-card);</code></td>
+              </tr>
+              <tr>
+                <td><code>--ease-anim-duration</code></td>
+                <td><code>0.6s</code></td>
+                <td>Standard time duration metric for interface transitions.</td>
+                <td><code>transition-duration: var(--ease-anim-duration);</code></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <!-- Footer -->
+      <footer class="footer">
+        <p>
+          EaseMotion CSS — Created for GSSOC 2026. View issue on
+          <a
+            href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/20468"
+            target="_blank"
+            rel="noopener noreferrer"
+            >GitHub #20468</a
+          >.
+        </p>
+      </footer>
+    </div>
+
+    <!-- Interactive Logic -->
+    <script>
+      (function () {
+        const root = document.getElementById("container-root");
+        const canvas = document.getElementById("display-canvas");
+        const presetSelect = document.getElementById("preset-select");
+        
+        const brandColorInput = document.getElementById("brand-color");
+        const brandHex = document.getElementById("brand-hex");
+        const radiusSlider = document.getElementById("radius-slider");
+        const radiusVal = document.getElementById("radius-val");
+        const paddingSlider = document.getElementById("padding-slider");
+        const paddingVal = document.getElementById("padding-val");
+        const durationSlider = document.getElementById("duration-slider");
+        const durationVal = document.getElementById("duration-val");
+
+        const scopedCard2 = document.getElementById("scoped-card-2");
+        const scopedCard3 = document.getElementById("scoped-card-3");
+        const replayBtn = document.getElementById("replay-transitions");
+
+        const card1 = document.getElementById("demo-card-1");
+        const card2 = document.getElementById("demo-card-2");
+        const card3 = document.getElementById("demo-card-3");
+        
+        const codeView = document.getElementById("code-view");
+
+        function updateTheming() {
+          // Reset theme classes
+          canvas.className = "playground-canvas";
+          const preset = presetSelect.value;
+          if (preset !== "default") {
+            canvas.classList.add(`theme-${preset}`);
+          }
+
+          // Apply Sliders/Pickers directly on container inline style to trigger variable override
+          const brandValue = brandColorInput.value;
+          brandHex.textContent = brandValue;
+          canvas.style.setProperty("--ease-brand", brandValue);
+          canvas.style.setProperty("--ease-brand-glow", `${brandValue}55`); // add opacity
+
+          const radiusValue = radiusSlider.value;
+          radiusVal.textContent = `${radiusValue}px`;
+          canvas.style.setProperty("--ease-border-radius", `${radiusValue}px`);
+
+          const paddingValue = paddingSlider.value;
+          paddingVal.textContent = `${(paddingValue / 16).toFixed(2)}rem`;
+          canvas.style.setProperty("--ease-padding-card", `${(paddingValue / 16).toFixed(2)}rem`);
+
+          const durationValue = durationSlider.value;
+          durationVal.textContent = `${(durationValue / 10).toFixed(1)}s`;
+          canvas.style.setProperty("--ease-anim-duration", `${(durationValue / 10).toFixed(1)}s`);
+
+          // Handles scoped element overrides
+          if (scopedCard2.checked) {
+            card2.classList.add("scoped-override-orange");
+          } else {
+            card2.classList.remove("scoped-override-orange");
+          }
+
+          if (scopedCard3.checked) {
+            card3.classList.add("scoped-override-pink");
+          } else {
+            card3.classList.remove("scoped-override-pink");
+          }
+
+          updateCodeOutput(preset, brandValue, radiusValue, paddingValue, durationValue);
+        }
+
+        function updateCodeOutput(preset, brand, radius, padding, duration) {
+          let presetText = "";
+          if (preset !== "default") {
+            presetText = `/* Global Preset Configuration */\n.playground-canvas {\n  /* Applied ${preset} preset variables */\n}\n\n`;
+          }
+
+          const dynamicText = `/* Dynamic CSS Custom Property Overrides on Container */\n.playground-canvas {\n  --ease-brand: ${brand};\n  --ease-border-radius: ${radius}px;\n  --ease-padding-card: ${(padding / 16).toFixed(2)}rem;\n  --ease-anim-duration: ${(duration / 10).toFixed(1)}s;\n}\n\n/* Element-Scoped overrides without using !important */\n${scopedCard2.checked ? '.scoped-override-orange {\n  --ease-brand: #f97316;\n  --ease-border: #ea580c;\n}\n' : ''}${scopedCard3.checked ? '.scoped-override-pink {\n  --ease-brand: #ec4899;\n  --ease-border: #db2777;\n}\n' : ''}`;
+
+          codeView.textContent = `${presetText}${dynamicText}`;
+        }
+
+        function replayAnimation() {
+          const cards = [card1, card2, card3];
+          cards.forEach((card) => {
+            card.style.animation = "none";
+            void card.offsetWidth; // trigger reflow
+            card.style.animation = "";
+          });
+        }
+
+        // Listeners
+        presetSelect.addEventListener("change", () => {
+          // Sync default colors based on preset selection
+          if (presetSelect.value === "emerald") {
+            brandColorInput.value = "#10b981";
+            radiusSlider.value = 12;
+            paddingSlider.value = 24;
+            durationSlider.value = 6;
+          } else if (presetSelect.value === "cyberpunk") {
+            brandColorInput.value = "#ff007f";
+            radiusSlider.value = 0;
+            paddingSlider.value = 20;
+            durationSlider.value = 3;
+          } else if (presetSelect.value === "slate") {
+            brandColorInput.value = "#475569";
+            radiusSlider.value = 8;
+            paddingSlider.value = 28;
+            durationSlider.value = 8;
+          } else {
+            brandColorInput.value = "#8b5cf6";
+            radiusSlider.value = 12;
+            paddingSlider.value = 24;
+            durationSlider.value = 6;
+          }
+          updateTheming();
+        });
+
+        brandColorInput.addEventListener("input", updateTheming);
+        radiusSlider.addEventListener("input", updateTheming);
+        paddingSlider.addEventListener("input", updateTheming);
+        durationSlider.addEventListener("input", updateTheming);
+        
+        scopedCard2.addEventListener("change", updateTheming);
+        scopedCard3.addEventListener("change", updateTheming);
+        
+        replayBtn.addEventListener("click", replayAnimation);
+
+        // Init
+        updateTheming();
+      })();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/custom-property-theming-ap/style.css
+++ b/submissions/examples/custom-property-theming-ap/style.css
@@ -1,0 +1,433 @@
+/* ============================================================
+   EaseMotion CSS — CSS Custom Property Theming Guide
+   Defines global variables, scoped overrides, preset themes,
+   and interactive playground layouts.
+   ============================================================ */
+
+/* ------------------------------------------------------------
+   1. GLOBAL SYSTEM VARIABLES (DEFAULT VALUES)
+   ------------------------------------------------------------ */
+:root {
+  /* Brand accents */
+  --ease-brand: #8b5cf6;
+  --ease-brand-glow: rgba(139, 92, 246, 0.35);
+
+  /* Surfaces & Backdrops */
+  --ease-bg-base: #030712;
+  --ease-bg-surface: #0b0f19;
+  --ease-bg-surface-hover: #111827;
+  --ease-border: #1f2937;
+  --ease-border-hover: #374151;
+
+  /* Typography */
+  --ease-text-primary: #f9fafb;
+  --ease-text-secondary: #9ca3af;
+  --ease-text-muted: #6b7280;
+
+  /* Layout tokens */
+  --ease-border-radius: 12px;
+  --ease-padding-card: 1.5rem;
+
+  /* Motion parameters */
+  --ease-anim-duration: 0.6s;
+  --ease-anim-timing: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-anim-delay: 0s;
+}
+
+/* ------------------------------------------------------------
+   2. PRESET THEME DECLARATIONS (GLOBAL VALUES APPLIED ON CONTAINER)
+   ------------------------------------------------------------ */
+
+/* Emerald Forest Theme */
+.theme-emerald {
+  --ease-brand: #10b981;
+  --ease-brand-glow: rgba(16, 185, 129, 0.35);
+  --ease-bg-base: #022c22;
+  --ease-bg-surface: #064e3b;
+  --ease-bg-surface-hover: #0f766e;
+  --ease-border: #047857;
+  --ease-border-hover: #059669;
+  --ease-text-primary: #ecfdf5;
+  --ease-text-secondary: #a7f3d0;
+  --ease-text-muted: #34d399;
+}
+
+/* Cyberpunk Neon Orange Theme */
+.theme-cyberpunk {
+  --ease-brand: #ff007f;
+  --ease-brand-glow: rgba(255, 0, 127, 0.45);
+  --ease-bg-base: #0f001c;
+  --ease-bg-surface: #1a0033;
+  --ease-bg-surface-hover: #2d004d;
+  --ease-border: #ffaa00;
+  --ease-border-hover: #ffcc00;
+  --ease-text-primary: #00ffff;
+  --ease-text-secondary: #ff00ff;
+  --ease-text-muted: #ffaa00;
+  --ease-border-radius: 0px; /* Blocks display style */
+}
+
+/* Slate Minimal Theme */
+.theme-slate {
+  --ease-brand: #475569;
+  --ease-brand-glow: rgba(71, 85, 105, 0.15);
+  --ease-bg-base: #f8fafc;
+  --ease-bg-surface: #ffffff;
+  --ease-bg-surface-hover: #f1f5f9;
+  --ease-border: #e2e8f0;
+  --ease-border-hover: #cbd5e1;
+  --ease-text-primary: #0f172a;
+  --ease-text-secondary: #475569;
+  --ease-text-muted: #64748b;
+}
+
+/* ------------------------------------------------------------
+   3. SCOPED (ELEMENT-LEVEL) OVERRIDES DEMO
+   ------------------------------------------------------------ */
+
+/* Target card element overrides accent color locally without !important */
+.scoped-override-orange {
+  --ease-brand: #f97316;
+  --ease-brand-glow: rgba(249, 115, 22, 0.35);
+  --ease-border: #ea580c;
+}
+
+.scoped-override-pink {
+  --ease-brand: #ec4899;
+  --ease-brand-glow: rgba(236, 72, 153, 0.35);
+  --ease-border: #db2777;
+}
+
+/* ------------------------------------------------------------
+   4. LAYOUT & PRESENTATION STYLING
+   ------------------------------------------------------------ */
+body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--ease-bg-base);
+  color: var(--ease-text-primary);
+  font-family: "Outfit", sans-serif;
+  line-height: 1.5;
+  transition: background-color 0.4s ease, color 0.4s ease;
+}
+
+.app-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem;
+}
+
+/* Header */
+.app-header {
+  border-bottom: 1px solid var(--ease-border);
+  padding-bottom: 2rem;
+  margin-bottom: 3rem;
+  transition: border-color 0.4s ease;
+}
+
+.app-header h1 {
+  font-size: 2.5rem;
+  font-weight: 800;
+  margin: 0 0 0.5rem 0;
+  color: var(--ease-brand);
+  letter-spacing: -0.02em;
+  transition: color 0.4s ease;
+}
+
+.app-header p {
+  font-size: 1.05rem;
+  color: var(--ease-text-secondary);
+  max-width: 800px;
+  margin: 0;
+  transition: color 0.4s ease;
+}
+
+.section-heading {
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin: 3.5rem 0 1.5rem 0;
+  border-left: 4px solid var(--ease-brand);
+  padding-left: 0.75rem;
+  transition: border-color 0.4s ease;
+}
+
+/* ------------------------------------------------------------
+   PLAYGROUND LAB LAYOUT
+   ------------------------------------------------------------ */
+.playground-grid {
+  display: grid;
+  grid-template-columns: 350px 1fr;
+  gap: 2rem;
+  margin-bottom: 3.5rem;
+}
+
+.playground-sidebar {
+  background-color: var(--ease-bg-surface);
+  border: 1px solid var(--ease-border);
+  border-radius: 12px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  transition: background-color 0.4s ease, border-color 0.4s ease;
+}
+
+.option-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.option-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--ease-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.option-select {
+  background-color: var(--ease-bg-base);
+  border: 1px solid var(--ease-border);
+  color: var(--ease-text-primary);
+  padding: 0.6rem;
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: 0.9rem;
+  outline: none;
+  transition: all 0.2s ease;
+}
+
+.option-select:focus {
+  border-color: var(--ease-brand);
+}
+
+.slider-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.slider-input {
+  flex: 1;
+  accent-color: var(--ease-brand);
+}
+
+.slider-val {
+  font-size: 0.85rem;
+  color: var(--ease-text-secondary);
+  min-width: 45px;
+  text-align: right;
+}
+
+/* Color picker row */
+.color-picker-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.color-input {
+  border: none;
+  background: none;
+  width: 45px;
+  height: 45px;
+  cursor: pointer;
+}
+
+/* Checkbox toggle */
+.toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.toggle-checkbox {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--ease-brand);
+}
+
+/* Playground Display Canvas */
+.playground-canvas {
+  background-color: var(--ease-bg-base);
+  border: 1px solid var(--ease-border);
+  border-radius: 12px;
+  padding: 2rem;
+  min-height: 400px;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  justify-content: center;
+  transition: background-color 0.4s ease, border-color 0.4s ease;
+}
+
+.cards-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+}
+
+.theme-card {
+  background-color: var(--ease-bg-surface);
+  border: 1px solid var(--ease-border);
+  border-radius: var(--ease-border-radius);
+  padding: var(--ease-padding-card);
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+  transition: all var(--ease-anim-duration) var(--ease-anim-timing);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  opacity: 0;
+  animation: cardFadeIn var(--ease-anim-duration) var(--ease-anim-timing) var(--ease-anim-delay) forwards;
+}
+
+.theme-card:hover {
+  border-color: var(--ease-brand);
+  transform: translateY(-4px);
+  box-shadow: 0 0 15px var(--ease-brand-glow);
+}
+
+.theme-card-icon {
+  font-size: 2rem;
+  color: var(--ease-brand);
+  transition: color 0.3s ease;
+}
+
+.theme-card-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.theme-card-desc {
+  font-size: 0.85rem;
+  color: var(--ease-text-secondary);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.theme-card-btn {
+  background-color: var(--ease-brand);
+  color: #fff;
+  border: none;
+  padding: 0.5rem;
+  border-radius: 6px;
+  font-weight: 600;
+  cursor: pointer;
+  font-size: 0.8rem;
+  transition: opacity 0.2s ease;
+}
+
+.theme-card-btn:hover {
+  opacity: 0.9;
+}
+
+@keyframes cardFadeIn {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* Code Preview panel */
+.code-panel {
+  grid-column: 1 / -1;
+  background-color: #010409;
+  border: 1px solid var(--ease-border);
+  border-radius: 8px;
+  padding: 1.25rem;
+}
+
+.code-panel h4 {
+  margin: 0 0 0.5rem 0;
+  font-size: 0.8rem;
+  color: var(--ease-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.code-view {
+  font-family: "Fira Code", monospace;
+  color: var(--ease-brand);
+  margin: 0;
+  font-size: 0.85rem;
+  white-space: pre-wrap;
+  word-break: break-all;
+  transition: color 0.4s ease;
+}
+
+/* ------------------------------------------------------------
+   REGISTRY TABLE STYLING
+   ------------------------------------------------------------ */
+.registry-panel {
+  background-color: var(--ease-bg-surface);
+  border: 1px solid var(--ease-border);
+  border-radius: 12px;
+  padding: 1.75rem;
+  margin-bottom: 3.5rem;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+}
+
+.registry-table-wrapper {
+  overflow-x: auto;
+}
+
+.registry-table {
+  width: 100%;
+  border-collapse: collapse;
+  text-align: left;
+  font-size: 0.9rem;
+}
+
+.registry-table th, .registry-table td {
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid var(--ease-border);
+}
+
+.registry-table th {
+  font-weight: 700;
+  color: var(--ease-text-secondary);
+  background-color: var(--ease-bg-surface-hover);
+}
+
+.registry-table code {
+  font-family: "Fira Code", monospace;
+  color: var(--ease-brand);
+  transition: color 0.3s ease;
+}
+
+.swatch {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  vertical-align: middle;
+  margin-right: 0.5rem;
+  border: 1px solid var(--ease-border);
+}
+
+.footer {
+  text-align: center;
+  border-top: 1px solid var(--ease-border);
+  padding: 2rem 0;
+  margin-top: 4.5rem;
+  color: var(--ease-text-muted);
+  font-size: 0.85rem;
+}
+
+.footer a {
+  color: var(--ease-brand);
+  text-decoration: none;
+  transition: color 0.3s ease;
+}
+
+.footer a:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 900px) {
+  .playground-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
### Description
This PR addresses and implements the CSS Custom Property Theming Guide. It introduces a comprehensive guide, preset overrides, and an interactive properties customizer playground to demonstrate global vs. local scoping, real-time property bindings, and the elimination of !important anti-patterns.

This submission has **909 lines of changes**, which satisfies the line count requirement (500+ lines) for the level:advanced badge.

### Checklist
- [x] Folder added inside `submissions/examples/` with name `custom-property-theming-ap`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`

Closes #20468