### PR TITLE
feat(breadcrumb): add auto-separator, separator variants, and responsive collapse (#23909)

### DIFF
--- a/submissions/core_changes-issue-23909/README.md
+++ b/submissions/core_changes-issue-23909/README.md
@@ -1,0 +1,45 @@
+# ease-breadcrumb — Responsive Breadcrumb Component
+
+## 1. What does this do?
+
+Enhances the existing `components/breadcrumb.css` with auto-separator via `::before` pseudo-element (no manual separator elements needed), four separator styles, responsive mobile collapse, and dark mode support.
+
+**New CSS additions:**
+- **Auto-separator**: `.ease-breadcrumb-item + .ease-breadcrumb-item::before` inserts separator automatically
+- **Separator variants**: `.ease-breadcrumb-chevron` (❯), `.ease-breadcrumb-arrow` (→), `.ease-breadcrumb-dot` (·)
+- **Current page**: `.ease-breadcrumb-current` replaces `.ease-breadcrumb-active` with bold text weight
+- **Responsive collapse**: `.ease-breadcrumb-collapsible` hides intermediate items on mobile, shows "..." 
+- **Dark mode**: `.ease-breadcrumb-current` uses `--ease-color-text` for theme-aware coloring
+- **Reduced motion**: Transitions disabled
+
+## 2. How is it used?
+
+```html
+<!-- Default slash separator -->
+<nav aria-label="Breadcrumb">
+  <ol class="ease-breadcrumb-list">
+    <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Home</a></li>
+    <li class="ease-breadcrumb-item"><span class="ease-breadcrumb-current">Page</span></li>
+  </ol>
+</nav>
+
+<!-- Chevron + collapse -->
+<nav class="ease-breadcrumb-chevron ease-breadcrumb-collapsible" aria-label="Breadcrumb">
+  <ol class="ease-breadcrumb-list">
+    <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Home</a></li>
+    <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Category</a></li>
+    <li class="ease-breadcrumb-item"><span class="ease-breadcrumb-current">Item</span></li>
+  </ol>
+</nav>
+
+<!-- Size variant -->
+<nav class="ease-breadcrumb-sm" aria-label="Breadcrumb">...</nav>
+```
+
+## 3. Why is this useful?
+
+- **Cleaner HTML** — No manual separator elements needed
+- **Four separator styles** — Choose slash, chevron, arrow, or dot
+- **Responsive** — Collapses to "..." on mobile automatically
+- **Theme-aware** — Uses `--ease-color-*` tokens for light/dark mode
+- **Accessible** — Uses `<nav aria-label="Breadcrumb">` and `<ol>` semantics

--- a/submissions/core_changes-issue-23909/demo.html
+++ b/submissions/core_changes-issue-23909/demo.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-breadcrumb — Demo · Issue #23909</title>
+  <link rel="stylesheet" href="../../core/variables.css" />
+  <link rel="stylesheet" href="../../core/base.css" />
+  <link rel="stylesheet" href="../../components/breadcrumb.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+      background: #0f172a;
+      color: #f1f5f9;
+      min-height: 100vh;
+    }
+    .demo-header {
+      text-align: center;
+      padding: 3rem 1rem 2rem;
+      border-bottom: 1px solid #1e293b;
+    }
+    .demo-header h1 {
+      font-size: clamp(1.75rem, 4vw, 2.75rem);
+      font-weight: 700;
+      background: linear-gradient(135deg, #6c63ff, #e040fb);
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+    .demo-header p {
+      color: #94a3b8;
+      margin-top: 0.75rem;
+      font-size: 0.95rem;
+      max-width: 620px;
+      margin-inline: auto;
+      line-height: 1.6;
+    }
+    .demo-content {
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 2rem 1rem 3rem;
+    }
+    .demo-content h2 {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: #6c63ff;
+      margin-bottom: 0.75rem;
+      margin-top: 2rem;
+    }
+    .section-desc {
+      color: #64748b;
+      font-size: 0.8rem;
+      margin-bottom: 0.75rem;
+      line-height: 1.5;
+    }
+    .demo-box {
+      background: var(--ease-color-surface, #1e293b);
+      border: 1px solid var(--ease-color-border, #334155);
+      border-radius: 12px;
+      padding: 1.5rem;
+      margin-bottom: 1rem;
+    }
+    .demo-box label {
+      font-size: 0.7rem;
+      color: #64748b;
+      display: block;
+      margin-bottom: 0.5rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    .demo-footer {
+      text-align: center;
+      padding: 2rem;
+      color: #475569;
+      font-size: 0.75rem;
+      border-top: 1px solid #1e293b;
+    }
+  </style>
+</head>
+<body>
+  <header class="demo-header">
+    <h1>ease-breadcrumb</h1>
+    <p>Responsive breadcrumb component with auto-separator, four separator styles, and mobile collapse. Built on the existing <code>ease-breadcrumb</code> base.</p>
+  </header>
+
+  <div class="demo-content">
+    <h2>Default (slash separator)</h2>
+    <p class="section-desc">Auto-separator via <code>::before</code> pseudo-element — no need to manually insert separators.</p>
+    <div class="demo-box">
+      <nav aria-label="Breadcrumb">
+        <ol class="ease-breadcrumb-list">
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Home</a></li>
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Products</a></li>
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Electronics</a></li>
+          <li class="ease-breadcrumb-item"><span class="ease-breadcrumb-current">Smartphones</span></li>
+        </ol>
+      </nav>
+    </div>
+
+    <h2>Separator Variants</h2>
+    <p class="section-desc">Add a modifier class to change the separator symbol.</p>
+
+    <div class="demo-box">
+      <label>Chevron — .ease-breadcrumb-chevron</label>
+      <nav aria-label="Breadcrumb" class="ease-breadcrumb-chevron">
+        <ol class="ease-breadcrumb-list">
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Dashboard</a></li>
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Analytics</a></li>
+          <li class="ease-breadcrumb-item"><span class="ease-breadcrumb-current">Reports</span></li>
+        </ol>
+      </nav>
+    </div>
+
+    <div class="demo-box">
+      <label>Arrow — .ease-breadcrumb-arrow</label>
+      <nav aria-label="Breadcrumb" class="ease-breadcrumb-arrow">
+        <ol class="ease-breadcrumb-list">
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Settings</a></li>
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Account</a></li>
+          <li class="ease-breadcrumb-item"><span class="ease-breadcrumb-current">Security</span></li>
+        </ol>
+      </nav>
+    </div>
+
+    <div class="demo-box">
+      <label>Dot — .ease-breadcrumb-dot</label>
+      <nav aria-label="Breadcrumb" class="ease-breadcrumb-dot">
+        <ol class="ease-breadcrumb-list">
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Docs</a></li>
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Components</a></li>
+          <li class="ease-breadcrumb-item"><span class="ease-breadcrumb-current">Breadcrumb</span></li>
+        </ol>
+      </nav>
+    </div>
+
+    <h2>Size Variants</h2>
+    <div class="demo-box">
+      <label>Small — .ease-breadcrumb-sm</label>
+      <nav aria-label="Breadcrumb" class="ease-breadcrumb-sm">
+        <ol class="ease-breadcrumb-list">
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Home</a></li>
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Blog</a></li>
+          <li class="ease-breadcrumb-item"><span class="ease-breadcrumb-current">Post Title</span></li>
+        </ol>
+      </nav>
+    </div>
+
+    <div class="demo-box">
+      <label>Large — .ease-breadcrumb-lg</label>
+      <nav aria-label="Breadcrumb" class="ease-breadcrumb-lg">
+        <ol class="ease-breadcrumb-list">
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Home</a></li>
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Blog</a></li>
+          <li class="ease-breadcrumb-item"><span class="ease-breadcrumb-current">Post Title</span></li>
+        </ol>
+      </nav>
+    </div>
+
+    <h2>Responsive Collapse</h2>
+    <p class="section-desc">Add <code>.ease-breadcrumb-collapsible</code> — on mobile (&lt;640px), intermediate items collapse to "...". Resize the browser to see it in action.</p>
+    <div class="demo-box">
+      <nav aria-label="Breadcrumb" class="ease-breadcrumb-collapsible">
+        <ol class="ease-breadcrumb-list">
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Home</a></li>
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Products</a></li>
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Electronics</a></li>
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Phones</a></li>
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Accessories</a></li>
+          <li class="ease-breadcrumb-item"><span class="ease-breadcrumb-current">Cases</span></li>
+        </ol>
+      </nav>
+    </div>
+
+    <h2>Usage</h2>
+    <div class="demo-box">
+      <pre style="color:#e2e8f0;font-size:0.8rem;overflow-x:auto;line-height:1.7;">
+<span style="color:#64748b;">&lt;!-- Default with auto-separator --&gt;</span>
+&lt;nav aria-label="Breadcrumb"&gt;
+  &lt;ol class="ease-breadcrumb-list"&gt;
+    &lt;li class="ease-breadcrumb-item"&gt;
+      &lt;a href="#" class="ease-breadcrumb-link"&gt;Home&lt;/a&gt;
+    &lt;/li&gt;
+    &lt;li class="ease-breadcrumb-item"&gt;
+      &lt;span class="ease-breadcrumb-current"&gt;Current&lt;/span&gt;
+    &lt;/li&gt;
+  &lt;/ol&gt;
+&lt;/nav&gt;
+
+<span style="color:#64748b;">&lt;!-- With chevron separator + collapse --&gt;</span>
+&lt;nav class="ease-breadcrumb-chevron ease-breadcrumb-collapsible"
+     aria-label="Breadcrumb"&gt;
+  ...
+&lt;/nav&gt;</pre>
+    </div>
+  </div>
+
+  <footer class="demo-footer">
+    Issue #23909 &middot; ease-breadcrumb &middot; EaseMotion CSS
+  </footer>
+</body>
+</html>

--- a/submissions/core_changes-issue-23909/style.css
+++ b/submissions/core_changes-issue-23909/style.css
@@ -1,0 +1,61 @@
+/* ============================================================
+   ease-breadcrumb — Responsive Breadcrumb Component
+   Submission for EaseMotion CSS · Issue #23909
+   Adds auto-separator and responsive collapse to existing
+   breadcrumb component.
+   ============================================================ */
+
+@layer easemotion-components {
+  .ease-breadcrumb-item + .ease-breadcrumb-item::before {
+    content: "/";
+    color: var(--ease-color-neutral-400, #94a3b8);
+    margin-right: var(--ease-space-1, 0.25rem);
+  }
+
+  .ease-breadcrumb-current {
+    color: var(--ease-color-text, #1f2937);
+    font-weight: 600;
+  }
+
+  .ease-breadcrumb-chevron .ease-breadcrumb-item + .ease-breadcrumb-item::before {
+    content: "\276F";
+  }
+
+  .ease-breadcrumb-arrow .ease-breadcrumb-item + .ease-breadcrumb-item::before {
+    content: "\2192";
+  }
+
+  .ease-breadcrumb-dot .ease-breadcrumb-item + .ease-breadcrumb-item::before {
+    content: "\B7";
+    font-weight: 700;
+  }
+
+  @media (max-width: 640px) {
+    .ease-breadcrumb-collapsible .ease-breadcrumb-item ~ .ease-breadcrumb-item {
+      display: none;
+    }
+
+    .ease-breadcrumb-collapsible .ease-breadcrumb-item:last-child,
+    .ease-breadcrumb-collapsible .ease-breadcrumb-item:nth-last-child(2) {
+      display: inline-flex;
+    }
+
+    .ease-breadcrumb-collapsible .ease-breadcrumb-item:nth-last-child(2)::before {
+      content: "...";
+      color: var(--ease-color-text-muted, #4b5563);
+      margin-right: var(--ease-space-1, 0.25rem);
+    }
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .ease-breadcrumb-current {
+      color: var(--ease-color-text, #e2e8f0);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ease-breadcrumb-link {
+      transition: none !important;
+    }
+  }
+}


### PR DESCRIPTION
## Description

Enhances the existing breadcrumb component with auto-separator via `::before` pseudo-element, four separator styles (slash, chevron, arrow, dot), responsive mobile collapse with "...", dark mode support, and `prefers-reduced-motion`.

Fixes #23909

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have added demo.html, style.css, and README.md

## Maintainer Actions
1. Merge additions from `style.css` into `components/breadcrumb.css`

## New Features
- **Auto-separator**: `.ease-breadcrumb-item + .ease-breadcrumb-item::before { content: "/" }`
- **Separator variants**: `.ease-breadcrumb-chevron` (❯), `.ease-breadcrumb-arrow` (→), `.ease-breadcrumb-dot` (·)
- **Current page**: `.ease-breadcrumb-current` with bold + `--ease-color-text` token
- **Responsive collapse**: `.ease-breadcrumb-collapsible` hides intermediate items at ≤640px, shows "..."
- **Dark mode**: Uses `--ease-color-text` for theming
- **Reduced motion**: Transitions disabled