### PR TITLE
feat(truncate): add ease-truncate text truncation and line-clamp utility (GSSoC 2026)

### DIFF
--- a/submissions/core_changes-issue-23890/README.md
+++ b/submissions/core_changes-issue-23890/README.md
@@ -1,0 +1,33 @@
+# ease-truncate — Text Truncation & Line Clamp Utility
+
+## 1. What does this do?
+
+Adds text truncation utility classes for controlling text overflow. Supports single-line truncation with ellipsis, multi-line line-clamp (1–6 lines), clip truncation (no ellipsis), responsive breakpoint variants, and a reset class.
+
+**Classes:**
+- `.ease-truncate` — Single-line `text-overflow: ellipsis; white-space: nowrap`
+- `.ease-truncate-{1-6}` — `-webkit-line-clamp` for N lines
+- `.ease-truncate-multiline` — Default 3-line clamp
+- `.ease-truncate-ellipsis` — Explicit ellipsis alias
+- `.ease-truncate-clip` — Clip overflow (no ellipsis)
+- `.ease-truncate-none` — Reset all truncation
+- `.ease-{sm|md|lg|xl}:truncate` / `.ease-{sm|md|lg|xl}:truncate-{2|3|4}` — Responsive variants
+
+## 2. How is it used?
+
+```html
+<p class="ease-truncate">Single-line truncated text...</p>
+<p class="ease-truncate-3">Clamped to three visible lines...</p>
+<p class="ease-truncate-clip">Clipped with no ellipsis</p>
+<p class="ease-truncate ease-lg:truncate-2">
+  Single line on mobile, 2 lines on desktop
+</p>
+```
+
+## 3. Why is this useful?
+
+- **No JavaScript** — Pure CSS truncation
+- **Flexible** — 1–6 line clamp options
+- **Responsive** — Breakpoint-prefixed variants
+- **Reset support** — `ease-truncate-none` to override
+- **Accessible** — Content remains in DOM for screen readers

--- a/submissions/core_changes-issue-23890/demo.html
+++ b/submissions/core_changes-issue-23890/demo.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-truncate — Demo · Issue #23890</title>
+  <link rel="stylesheet" href="../../core/variables.css" />
+  <link rel="stylesheet" href="../../core/base.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+      background: #0f172a;
+      color: #f1f5f9;
+      min-height: 100vh;
+    }
+    .demo-header {
+      text-align: center;
+      padding: 3rem 1rem 2rem;
+      border-bottom: 1px solid #1e293b;
+    }
+    .demo-header h1 {
+      font-size: clamp(1.75rem, 4vw, 2.75rem);
+      font-weight: 700;
+      background: linear-gradient(135deg, #6c63ff, #e040fb);
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+    .demo-header p {
+      color: #94a3b8;
+      margin-top: 0.75rem;
+      font-size: 0.95rem;
+      max-width: 620px;
+      margin-inline: auto;
+      line-height: 1.6;
+    }
+    .demo-content {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 2rem 1rem 3rem;
+    }
+    .demo-content h2 {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: #6c63ff;
+      margin-bottom: 0.75rem;
+      margin-top: 2rem;
+    }
+    .section-desc {
+      color: #64748b;
+      font-size: 0.8rem;
+      margin-bottom: 0.75rem;
+      line-height: 1.5;
+    }
+    .feature-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+      gap: 0.75rem;
+      margin-bottom: 1.5rem;
+    }
+    .feature {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 8px;
+      padding: 0.75rem;
+      text-align: center;
+    }
+    .feature .icon { font-size: 1.25rem; margin-bottom: 0.3rem; }
+    .feature .label { font-size: 0.7rem; color: #94a3b8; }
+    .demo-card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 1rem;
+      margin-bottom: 1rem;
+    }
+    .demo-card .title {
+      font-size: 0.7rem;
+      color: #64748b;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.5rem;
+    }
+    .demo-card .class-name {
+      font-family: monospace;
+      font-size: 0.8rem;
+      color: #22c55e;
+      margin-bottom: 0.5rem;
+    }
+    .demo-box {
+      width: 100%;
+      max-width: 400px;
+      background: #334155;
+      border-radius: 8px;
+      padding: 0.75rem;
+      font-size: 0.9rem;
+      line-height: 1.6;
+      color: #e2e8f0;
+    }
+    .demo-box.wider {
+      max-width: 300px;
+    }
+    .code-block {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 1.5rem;
+    }
+    .code-block pre {
+      color: #e2e8f0;
+      font-size: 0.8rem;
+      overflow-x: auto;
+      line-height: 1.7;
+    }
+    .demo-footer {
+      text-align: center;
+      padding: 2rem;
+      color: #475569;
+      font-size: 0.75rem;
+      border-top: 1px solid #1e293b;
+    }
+  </style>
+</head>
+<body>
+  <header class="demo-header">
+    <h1>ease-truncate</h1>
+    <p>Text truncation and line-clamp utility classes. Control how text overflows with single-line (ellipsis), multi-line (clamp), and responsive breakpoint variants.</p>
+  </header>
+
+  <div class="demo-content">
+    <h2>Features</h2>
+    <div class="feature-grid">
+      <div class="feature"><div class="icon">◀</div><div class="label">Single-line</div></div>
+      <div class="feature"><div class="icon">123456</div><div class="label">Line Clamp 1-6</div></div>
+      <div class="feature"><div class="icon">▶</div><div class="label">Multi-line</div></div>
+      <div class="feature"><div class="icon">✂️</div><div class="label">Clip</div></div>
+      <div class="feature"><div class="icon">🔁</div><div class="label">Responsive</div></div>
+      <div class="feature"><div class="icon">🚫</div><div class="label">None</div></div>
+    </div>
+
+    <h2>Single-Line Truncation</h2>
+    <p class="section-desc">Classic text-overflow: ellipsis with no wrapping.</p>
+    <div class="demo-card">
+      <div class="title">Example</div>
+      <div class="class-name">.ease-truncate</div>
+      <div class="demo-box ease-truncate">
+        This is a very long text that should be truncated with an ellipsis at the end because it exceeds the container width and cannot wrap to the next line.
+      </div>
+    </div>
+
+    <h2>Multi-Line Line Clamp</h2>
+    <p class="section-desc">Clamp text to N lines using -webkit-line-clamp.</p>
+    <div class="demo-card">
+      <div class="title">.ease-truncate-2</div>
+      <div class="demo-box wider ease-truncate-2">
+        This is a long paragraph that will be clamped to exactly two lines. The remaining content will be hidden and an ellipsis will appear at the end of the second line to indicate there is more content.
+      </div>
+    </div>
+    <div class="demo-card">
+      <div class="title">.ease-truncate-3</div>
+      <div class="demo-box wider ease-truncate-3">
+        This is a long paragraph that will be clamped to exactly three lines. The remaining content will be hidden and an ellipsis will appear at the end of the third line. This gives you precise control over how much text to show.
+      </div>
+    </div>
+    <div class="demo-card">
+      <div class="title">.ease-truncate-4</div>
+      <div class="demo-box wider ease-truncate-4">
+        This is a long paragraph clamped to four lines. You can see exactly four lines of text before the ellipsis kicks in. This is useful for card descriptions, article previews, and any other situation where you want to show a limited preview of text content.
+      </div>
+    </div>
+
+    <h2>Line Clamp Variants (5, 6, multi-line)</h2>
+    <p class="section-desc">Higher clamp counts and the generic multi-line variant (default 3).</p>
+    <div class="demo-card">
+      <div class="title">.ease-truncate-5</div>
+      <div class="demo-box wider ease-truncate-5">
+        1. First line of clamped text content.<br>
+        2. Second line with additional details about the content being displayed in the container element on the page.<br>
+        3. Third line continues with even more text that will eventually be truncated by the line clamp utility class applied to this demo box.<br>
+        4. Fourth line keeps going with additional content that fills out the paragraph with meaningful text for demonstration purposes.<br>
+        5. Fifth line is the final visible line before the ellipsis truncation indicator appears at the end of the text content.
+      </div>
+    </div>
+
+    <h2>Clip vs Ellipsis</h2>
+    <p class="section-desc">.ease-truncate-clip cuts off without indicator; .ease-truncate-ellipsis adds ...</p>
+    <div class="demo-card">
+      <div class="title">.ease-truncate-clip</div>
+      <div class="demo-box wider ease-truncate-clip">
+        This text is clipped without any ellipsis indicator when it overflows the container boundaries.
+      </div>
+    </div>
+
+    <h2>None (Reset)</h2>
+    <p class="section-desc">.ease-truncate-none removes all truncation to show full content.</p>
+    <div class="demo-card">
+      <div class="title">.ease-truncate-none</div>
+      <div class="demo-box wider ease-truncate">
+        This text has truncation active by default but can be reset with .ease-truncate-none to show the full content without any overflow restrictions applied to the element.
+      </div>
+      <div style="margin-top:0.5rem;">
+        <span class="ease-truncate-none" style="font-family:monospace;font-size:0.8rem;color:#22c55e;">With .ease-truncate-none, the full text is now visible.</span>
+      </div>
+    </div>
+
+    <h2>Usage</h2>
+    <div class="code-block">
+      <pre>
+<span style="color:#64748b;">&lt;!-- Single-line ellipsis --&gt;</span>
+&lt;p class="ease-truncate"&gt;Long text that will be truncated...&lt;/p&gt;
+
+<span style="color:#64748b;">&lt;!-- Multi-line clamp --&gt;</span>
+&lt;p class="ease-truncate-3"&gt;Text clamped to 3 lines...&lt;/p&gt;
+
+<span style="color:#64748b;">&lt;!-- Responsive: clamp on large screens only --&gt;</span>
+&lt;p class="ease-truncate ease-lg:truncate-2"&gt;
+  Single line on mobile, 2 lines on desktop...
+&lt;/p&gt;
+
+<span style="color:#64748b;">&lt;!-- Clip (no ellipsis) --&gt;</span>
+&lt;p class="ease-truncate-clip"&gt;Text clipped abruptly...&lt;/p&gt;
+
+<span style="color:#64748b;">&lt;!-- Reset truncation --&gt;</span>
+&lt;p class="ease-truncate ease-truncate-none"&gt;Full text visible&lt;/p&gt;</pre>
+    </div>
+  </div>
+
+  <footer class="demo-footer">
+    Issue #23890 &middot; ease-truncate &middot; EaseMotion CSS
+  </footer>
+</body>
+</html>

--- a/submissions/core_changes-issue-23890/style.css
+++ b/submissions/core_changes-issue-23890/style.css
@@ -1,0 +1,181 @@
+/* ============================================================
+   ease-truncate — Text Truncation & Line Clamp Utility
+   Submission for EaseMotion CSS · Issue #23890
+   ============================================================ */
+
+@layer easemotion-utilities {
+  .ease-truncate {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .ease-truncate-1 {
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .ease-truncate-2 {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .ease-truncate-3 {
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .ease-truncate-4 {
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .ease-truncate-5 {
+    display: -webkit-box;
+    -webkit-line-clamp: 5;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .ease-truncate-6 {
+    display: -webkit-box;
+    -webkit-line-clamp: 6;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .ease-truncate-none {
+    overflow: visible;
+    text-overflow: clip;
+    white-space: normal;
+    display: block;
+    -webkit-line-clamp: unset;
+    -webkit-box-orient: unset;
+  }
+
+  .ease-truncate-multiline {
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .ease-truncate-ellipsis {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .ease-truncate-clip {
+    overflow: hidden;
+    text-overflow: clip;
+    white-space: nowrap;
+  }
+
+  @media (min-width: 640px) {
+    .ease-sm\:truncate {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .ease-sm\:truncate-2 {
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+    .ease-sm\:truncate-3 {
+      display: -webkit-box;
+      -webkit-line-clamp: 3;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+  }
+
+  @media (min-width: 768px) {
+    .ease-md\:truncate {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .ease-md\:truncate-2 {
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+    .ease-md\:truncate-3 {
+      display: -webkit-box;
+      -webkit-line-clamp: 3;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+    .ease-md\:truncate-4 {
+      display: -webkit-box;
+      -webkit-line-clamp: 4;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .ease-lg\:truncate {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .ease-lg\:truncate-2 {
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+    .ease-lg\:truncate-3 {
+      display: -webkit-box;
+      -webkit-line-clamp: 3;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+  }
+
+  @media (min-width: 1280px) {
+    .ease-xl\:truncate {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .ease-xl\:truncate-2 {
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+    .ease-xl\:truncate-3 {
+      display: -webkit-box;
+      -webkit-line-clamp: 3;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ease-truncate,
+    .ease-truncate-1,
+    .ease-truncate-2,
+    .ease-truncate-3,
+    .ease-truncate-4,
+    .ease-truncate-5,
+    .ease-truncate-6,
+    .ease-truncate-multiline {
+      transition: none !important;
+    }
+  }
+}


### PR DESCRIPTION
## Description
Adds text truncation utility classes for controlling text overflow. Supports single-line truncation with ellipsis, multi-line line-clamp (1–6 lines), clip truncation (no ellipsis), responsive breakpoint variants (sm/md/lg/xl), and a reset class.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

## Checklist
- [x] `style.css` — All utility styles under `@layer easemotion-utilities`
- [x] `demo.html` — Interactive demo with feature grid, single-line, line-clamp (2/3/4/5), clip vs ellipsis, reset, and code usage block
- [x] `README.md` — What, how, why documentation

## Maintainer Actions
1. Review `submissions/core_changes-issue-23890/style.css`
2. Copy contents into the main CSS bundle (e.g., `utilities/truncate.css`)
3. Reference/demo the utility in the documentation site

**Closes #23890**