### PR TITLE
feat(chip): add ease-chip tag component with color variants, sizes, and styles (GSSoC 2026)

### DIFF
--- a/submissions/core_changes-issue-23905/README.md
+++ b/submissions/core_changes-issue-23905/README.md
@@ -1,0 +1,60 @@
+# ease-chip — Chip/Tag Component
+
+## 1. What does this do?
+
+Adds a flexible chip/tag component with multiple color variants, sizes, styles (filled, outline, subtle), pill shape, removable chips, interactive/clickable states, disabled state, and chip groups.
+
+**Classes:**
+- `.ease-chip` — Base chip element
+- `.ease-chip-{primary|secondary|success|warning|danger|info}` — Color variants
+- `.ease-chip-{sm|lg}` — Size variants (default is md)
+- `.ease-chip-outline` — Transparent background with colored border
+- `.ease-chip-subtle` — Light background, no border
+- `.ease-chip-pill` — Fully rounded (9999px)
+- `.ease-chip-remove` — Close/dismiss button inside a chip
+- `.ease-chip-interactive` — Hover/focus/active states for clickable chips
+- `.ease-chip-disabled` — Reduced opacity, no pointer events
+- `.ease-chip-icon` — Icon element inside a chip
+- `.ease-chip-group` — Flex container for chip groups
+- `.ease-chip-group-label` — Optional label for chip groups
+
+## 2. How is it used?
+
+```html
+<!-- Basic filled chip -->
+<span class="ease-chip ease-chip-primary">Primary</span>
+
+<!-- Outline pill chip -->
+<span class="ease-chip ease-chip-outline ease-chip-success ease-chip-pill">
+  Success Outlined
+</span>
+
+<!-- Removable chip -->
+<span class="ease-chip ease-chip-info ease-chip-pill">
+  Label
+  <button class="ease-chip-remove" aria-label="Remove">&times;</button>
+</span>
+
+<!-- Interactive button chip -->
+<button class="ease-chip ease-chip-danger ease-chip-interactive">
+  Delete
+</button>
+
+<!-- Chip group -->
+<div class="ease-chip-group">
+  <span class="ease-chip-group-label">Tags:</span>
+  <span class="ease-chip ease-chip-primary">HTML</span>
+  <span class="ease-chip ease-chip-success">CSS</span>
+</div>
+```
+
+## 3. Why is this useful?
+
+- **6 color variants** — Primary, secondary, success, warning, danger, info
+- **3 styles** — Filled, outline, subtle
+- **3 sizes** — sm, md, lg
+- **Pill shape** — Fully rounded option
+- **Removable** — Built-in close button support
+- **Interactive** — Clickable with focus-visible keyboard support
+- **Groups** — Organized with flex-wrap and optional label
+- **Accessible** — Proper aria-label support on remove buttons

--- a/submissions/core_changes-issue-23905/demo.html
+++ b/submissions/core_changes-issue-23905/demo.html
@@ -1,0 +1,292 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-chip — Demo · Issue #23905</title>
+  <link rel="stylesheet" href="../../core/variables.css" />
+  <link rel="stylesheet" href="../../core/base.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+      background: #0f172a;
+      color: #f1f5f9;
+      min-height: 100vh;
+    }
+    .demo-header {
+      text-align: center;
+      padding: 3rem 1rem 2rem;
+      border-bottom: 1px solid #1e293b;
+    }
+    .demo-header h1 {
+      font-size: clamp(1.75rem, 4vw, 2.75rem);
+      font-weight: 700;
+      background: linear-gradient(135deg, #6c63ff, #e040fb);
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+    .demo-header p {
+      color: #94a3b8;
+      margin-top: 0.75rem;
+      font-size: 0.95rem;
+      max-width: 620px;
+      margin-inline: auto;
+      line-height: 1.6;
+    }
+    .demo-content {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 2rem 1rem 3rem;
+    }
+    .demo-content h2 {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: #6c63ff;
+      margin-bottom: 0.75rem;
+      margin-top: 2rem;
+    }
+    .section-desc {
+      color: #64748b;
+      font-size: 0.8rem;
+      margin-bottom: 0.75rem;
+      line-height: 1.5;
+    }
+    .feature-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+      gap: 0.75rem;
+      margin-bottom: 1.5rem;
+    }
+    .feature {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 8px;
+      padding: 0.75rem;
+      text-align: center;
+    }
+    .feature .icon { font-size: 1.25rem; margin-bottom: 0.3rem; }
+    .feature .label { font-size: 0.7rem; color: #94a3b8; }
+    .demo-card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 1rem;
+      margin-bottom: 1rem;
+    }
+    .demo-card .title {
+      font-size: 0.7rem;
+      color: #64748b;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.5rem;
+    }
+    .demo-card .class-name {
+      font-family: monospace;
+      font-size: 0.8rem;
+      color: #22c55e;
+      margin-bottom: 0.5rem;
+    }
+    .demo-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      align-items: center;
+    }
+    .code-block {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 1.5rem;
+    }
+    .code-block pre {
+      color: #e2e8f0;
+      font-size: 0.8rem;
+      overflow-x: auto;
+      line-height: 1.7;
+    }
+    .demo-footer {
+      text-align: center;
+      padding: 2rem;
+      color: #475569;
+      font-size: 0.75rem;
+      border-top: 1px solid #1e293b;
+    }
+  </style>
+</head>
+<body>
+  <header class="demo-header">
+    <h1>ease-chip</h1>
+    <p>Flexible chip/tag component with color variants, sizes, styles (filled, outline, subtle), removable chips, interactive states, and chip groups.</p>
+  </header>
+
+  <div class="demo-content">
+    <h2>Features</h2>
+    <div class="feature-grid">
+      <div class="feature"><div class="icon">🎨</div><div class="label">6 Colors</div></div>
+      <div class="feature"><div class="icon">📐</div><div class="label">3 Sizes</div></div>
+      <div class="feature"><div class="icon">🖌️</div><div class="label">Filled</div></div>
+      <div class="feature"><div class="icon">○</div><div class="label">Outline</div></div>
+      <div class="feature"><div class="icon">☁️</div><div class="label">Subtle</div></div>
+      <div class="feature"><div class="icon">💊</div><div class="label">Pill</div></div>
+      <div class="feature"><div class="icon">✕</div><div class="label">Removable</div></div>
+      <div class="feature"><div class="icon">👆</div><div class="label">Interactive</div></div>
+    </div>
+
+    <h2>Color Variants (Filled)</h2>
+    <p class="section-desc">Six semantic colors for the default filled style.</p>
+    <div class="demo-card">
+      <div class="demo-row">
+        <span class="ease-chip ease-chip-primary">Primary</span>
+        <span class="ease-chip ease-chip-secondary">Secondary</span>
+        <span class="ease-chip ease-chip-success">Success</span>
+        <span class="ease-chip ease-chip-warning">Warning</span>
+        <span class="ease-chip ease-chip-danger">Danger</span>
+        <span class="ease-chip ease-chip-info">Info</span>
+      </div>
+    </div>
+
+    <h2>Outline Variant</h2>
+    <p class="section-desc">Transparent background with colored border.</p>
+    <div class="demo-card">
+      <div class="demo-row">
+        <span class="ease-chip ease-chip-outline ease-chip-primary">Primary</span>
+        <span class="ease-chip ease-chip-outline ease-chip-secondary">Secondary</span>
+        <span class="ease-chip ease-chip-outline ease-chip-success">Success</span>
+        <span class="ease-chip ease-chip-outline ease-chip-warning">Warning</span>
+        <span class="ease-chip ease-chip-outline ease-chip-danger">Danger</span>
+        <span class="ease-chip ease-chip-outline ease-chip-info">Info</span>
+      </div>
+    </div>
+
+    <h2>Subtle (Ghost) Variant</h2>
+    <p class="section-desc">Light background, no border, muted colors.</p>
+    <div class="demo-card">
+      <div class="demo-row">
+        <span class="ease-chip ease-chip-subtle ease-chip-primary">Primary</span>
+        <span class="ease-chip ease-chip-subtle ease-chip-secondary">Secondary</span>
+        <span class="ease-chip ease-chip-subtle ease-chip-success">Success</span>
+        <span class="ease-chip ease-chip-subtle ease-chip-warning">Warning</span>
+        <span class="ease-chip ease-chip-subtle ease-chip-danger">Danger</span>
+        <span class="ease-chip ease-chip-subtle ease-chip-info">Info</span>
+      </div>
+    </div>
+
+    <h2>Sizes</h2>
+    <p class="section-desc">Small, default (md), and large chips.</p>
+    <div class="demo-card">
+      <div class="demo-row">
+        <span class="ease-chip ease-chip-primary ease-chip-sm">Small</span>
+        <span class="ease-chip ease-chip-primary">Default</span>
+        <span class="ease-chip ease-chip-primary ease-chip-lg">Large</span>
+      </div>
+    </div>
+
+    <h2>Pill Shape</h2>
+    <p class="section-desc">Fully rounded chips using .ease-chip-pill.</p>
+    <div class="demo-card">
+      <div class="demo-row">
+        <span class="ease-chip ease-chip-primary ease-chip-pill">Primary</span>
+        <span class="ease-chip ease-chip-success ease-chip-pill">Success</span>
+        <span class="ease-chip ease-chip-warning ease-chip-pill">Warning</span>
+        <span class="ease-chip ease-chip-outline ease-chip-danger ease-chip-pill">Outline Danger</span>
+        <span class="ease-chip ease-chip-subtle ease-chip-info ease-chip-pill">Subtle Info</span>
+      </div>
+    </div>
+
+    <h2>Removable Chips</h2>
+    <p class="section-desc">Chips with a remove button for dismissible tags.</p>
+    <div class="demo-card">
+      <div class="demo-row">
+        <span class="ease-chip ease-chip-primary ease-chip-pill">
+          JavaScript
+          <button class="ease-chip-remove" onclick="this.parentElement.remove()" aria-label="Remove">✕</button>
+        </span>
+        <span class="ease-chip ease-chip-success ease-chip-pill">
+          React
+          <button class="ease-chip-remove" onclick="this.parentElement.remove()" aria-label="Remove">✕</button>
+        </span>
+        <span class="ease-chip ease-chip-info ease-chip-pill">
+          TypeScript
+          <button class="ease-chip-remove" onclick="this.parentElement.remove()" aria-label="Remove">✕</button>
+        </span>
+        <span class="ease-chip ease-chip-warning ease-chip-pill">
+          CSS
+          <button class="ease-chip-remove" onclick="this.parentElement.remove()" aria-label="Remove">✕</button>
+        </span>
+      </div>
+    </div>
+
+    <h2>Interactive Chips</h2>
+    <p class="section-desc">Clickable chips with hover/focus/active states. Can be links or buttons.</p>
+    <div class="demo-card">
+      <div class="demo-row">
+        <button class="ease-chip ease-chip-primary ease-chip-interactive ease-chip-pill">Click me</button>
+        <a href="#" class="ease-chip ease-chip-success ease-chip-interactive ease-chip-pill">Link chip</a>
+        <button class="ease-chip ease-chip-danger ease-chip-interactive ease-chip-pill">Delete</button>
+      </div>
+    </div>
+
+    <h2>Disabled Chips</h2>
+    <p class="section-desc">Chips can be disabled with reduced opacity and no pointer events.</p>
+    <div class="demo-card">
+      <div class="demo-row">
+        <span class="ease-chip ease-chip-primary disabled">Disabled attr</span>
+        <span class="ease-chip ease-chip-success ease-chip-disabled">Disabled class</span>
+      </div>
+    </div>
+
+    <h2>Chip Group</h2>
+    <p class="section-desc">Organized chip groups with an optional label.</p>
+    <div class="demo-card">
+      <div class="ease-chip-group">
+        <span class="ease-chip-group-label">Tags:</span>
+        <span class="ease-chip ease-chip-primary ease-chip-pill">CSS</span>
+        <span class="ease-chip ease-chip-success ease-chip-pill">HTML</span>
+        <span class="ease-chip ease-chip-info ease-chip-pill">JavaScript</span>
+        <span class="ease-chip ease-chip-warning ease-chip-pill">React</span>
+        <span class="ease-chip ease-chip-danger ease-chip-pill">TypeScript</span>
+      </div>
+    </div>
+
+    <h2>Usage</h2>
+    <div class="code-block">
+      <pre>
+<span style="color:#64748b;">&lt;!-- Basic chip --&gt;</span>
+&lt;span class="ease-chip ease-chip-primary"&gt;Chip&lt;/span&gt;
+
+<span style="color:#64748b;">&lt;!-- Outline pill --&gt;</span>
+&lt;span class="ease-chip ease-chip-outline ease-chip-success ease-chip-pill"&gt;
+  Tag
+&lt;/span&gt;
+
+<span style="color:#64748b;">&lt;!-- Removable --&gt;</span>
+&lt;span class="ease-chip ease-chip-info ease-chip-pill"&gt;
+  Label
+  &lt;button class="ease-chip-remove" onclick="this.parentElement.remove()"
+    aria-label="Remove"&gt;&amp;#10005;&lt;/button&gt;
+&lt;/span&gt;
+
+<span style="color:#64748b;">&lt;!-- Interactive / clickable --&gt;</span>
+&lt;button class="ease-chip ease-chip-primary ease-chip-interactive"&gt;
+  Clickable
+&lt;/button&gt;
+
+<span style="color:#64748b;">&lt;!-- Chip group --&gt;</span>
+&lt;div class="ease-chip-group"&gt;
+  &lt;span class="ease-chip-group-label"&gt;Skills:&lt;/span&gt;
+  &lt;span class="ease-chip ease-chip-primary"&gt;Design&lt;/span&gt;
+  &lt;span class="ease-chip ease-chip-success"&gt;Dev&lt;/span&gt;
+&lt;/div&gt;</pre>
+    </div>
+  </div>
+
+  <footer class="demo-footer">
+    Issue #23905 &middot; ease-chip &middot; EaseMotion CSS
+  </footer>
+</body>
+</html>

--- a/submissions/core_changes-issue-23905/style.css
+++ b/submissions/core_changes-issue-23905/style.css
@@ -1,0 +1,244 @@
+/* ============================================================
+   ease-chip — Chip/Tag Component
+   Submission for EaseMotion CSS · Issue #23905
+   ============================================================ */
+
+@layer easemotion-components {
+  .ease-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--ease-space-1, 0.25rem);
+    padding: 0.125rem 0.625rem;
+    font-size: var(--ease-text-xs, 0.75rem);
+    font-weight: 500;
+    line-height: 1.5;
+    border-radius: var(--ease-radius-md, 0.375rem);
+    border: 1px solid transparent;
+    white-space: nowrap;
+    user-select: none;
+    background: var(--ease-color-neutral-200, #e2e8f0);
+    color: var(--ease-color-neutral-700, #334155);
+  }
+
+  .ease-chip-primary {
+    background: var(--ease-color-primary-100, #ede9fe);
+    color: var(--ease-color-primary-700, #5b21b6);
+    border-color: var(--ease-color-primary-200, #ddd6fe);
+  }
+
+  .ease-chip-secondary {
+    background: var(--ease-color-neutral-200, #e2e8f0);
+    color: var(--ease-color-neutral-700, #334155);
+    border-color: var(--ease-color-neutral-300, #cbd5e1);
+  }
+
+  .ease-chip-success {
+    background: var(--ease-color-success-100, #dcfce7);
+    color: var(--ease-color-success-700, #15803d);
+    border-color: var(--ease-color-success-200, #bbf7d0);
+  }
+
+  .ease-chip-warning {
+    background: var(--ease-color-warning-100, #fef3c7);
+    color: var(--ease-color-warning-700, #a16207);
+    border-color: var(--ease-color-warning-200, #fde68a);
+  }
+
+  .ease-chip-danger {
+    background: var(--ease-color-danger-100, #fee2e2);
+    color: var(--ease-color-danger-700, #b91c1c);
+    border-color: var(--ease-color-danger-200, #fecaca);
+  }
+
+  .ease-chip-info {
+    background: var(--ease-color-info-100, #dbeafe);
+    color: var(--ease-color-info-700, #1d4ed8);
+    border-color: var(--ease-color-info-200, #bfdbfe);
+  }
+
+  .ease-chip-outline {
+    background: transparent;
+  }
+
+  .ease-chip-outline.ease-chip-primary {
+    color: var(--ease-color-primary-600, #7c3aed);
+    border-color: var(--ease-color-primary-400, #a78bfa);
+  }
+
+  .ease-chip-outline.ease-chip-secondary {
+    color: var(--ease-color-neutral-600, #475569);
+    border-color: var(--ease-color-neutral-400, #94a3b8);
+  }
+
+  .ease-chip-outline.ease-chip-success {
+    color: var(--ease-color-success-600, #16a34a);
+    border-color: var(--ease-color-success-400, #4ade80);
+  }
+
+  .ease-chip-outline.ease-chip-warning {
+    color: var(--ease-color-warning-600, #ca8a04);
+    border-color: var(--ease-color-warning-400, #facc15);
+  }
+
+  .ease-chip-outline.ease-chip-danger {
+    color: var(--ease-color-danger-600, #dc2626);
+    border-color: var(--ease-color-danger-400, #f87171);
+  }
+
+  .ease-chip-outline.ease-chip-info {
+    color: var(--ease-color-info-600, #2563eb);
+    border-color: var(--ease-color-info-400, #60a5fa);
+  }
+
+  .ease-chip-subtle {
+    background: var(--ease-color-neutral-100, #f1f5f9);
+    border-color: transparent;
+  }
+
+  .ease-chip-subtle.ease-chip-primary {
+    background: var(--ease-color-primary-50, #f5f3ff);
+    color: var(--ease-color-primary-600, #7c3aed);
+  }
+
+  .ease-chip-subtle.ease-chip-success {
+    background: var(--ease-color-success-50, #f0fdf4);
+    color: var(--ease-color-success-600, #16a34a);
+  }
+
+  .ease-chip-subtle.ease-chip-warning {
+    background: var(--ease-color-warning-50, #fffbeb);
+    color: var(--ease-color-warning-600, #ca8a04);
+  }
+
+  .ease-chip-subtle.ease-chip-danger {
+    background: var(--ease-color-danger-50, #fef2f2);
+    color: var(--ease-color-danger-600, #dc2626);
+  }
+
+  .ease-chip-subtle.ease-chip-info {
+    background: var(--ease-color-info-50, #eff6ff);
+    color: var(--ease-color-info-600, #2563eb);
+  }
+
+  .ease-chip-pill {
+    border-radius: var(--ease-radius-full, 9999px);
+  }
+
+  .ease-chip-sm {
+    padding: 0.0625rem 0.5rem;
+    font-size: var(--ease-text-2xs, 0.625rem);
+  }
+
+  .ease-chip-lg {
+    padding: 0.25rem 0.75rem;
+    font-size: var(--ease-text-sm, 0.875rem);
+  }
+
+  .ease-chip-icon {
+    width: 0.875rem;
+    height: 0.875rem;
+    flex-shrink: 0;
+  }
+
+  .ease-chip-sm .ease-chip-icon {
+    width: 0.75rem;
+    height: 0.75rem;
+  }
+
+  .ease-chip-lg .ease-chip-icon {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  .ease-chip-remove {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1rem;
+    height: 1rem;
+    border: none;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    font-size: 1em;
+    line-height: 1;
+    padding: 0;
+    opacity: 0.6;
+    transition: opacity 0.15s;
+    border-radius: var(--ease-radius-full, 9999px);
+  }
+
+  .ease-chip-remove:hover {
+    opacity: 1;
+    background: rgba(0, 0, 0, 0.1);
+  }
+
+  .ease-chip-interactive {
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s, box-shadow 0.15s;
+  }
+
+  .ease-chip-interactive:hover {
+    filter: brightness(0.95);
+  }
+
+  .ease-chip-interactive:focus-visible {
+    outline: 2px solid var(--ease-color-primary, #6c63ff);
+    outline-offset: 2px;
+  }
+
+  .ease-chip-interactive:active {
+    filter: brightness(0.9);
+  }
+
+  .ease-chip[disabled],
+  .ease-chip-disabled {
+    opacity: 0.5;
+    pointer-events: none;
+    filter: grayscale(0.5);
+  }
+
+  .ease-chip a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .ease-chip a:hover {
+    text-decoration: underline;
+  }
+
+  .ease-chip-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--ease-space-2, 0.5rem);
+    align-items: center;
+  }
+
+  .ease-chip-group-label {
+    font-size: var(--ease-text-xs, 0.75rem);
+    font-weight: 600;
+    color: var(--ease-color-neutral-500, #64748b);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-right: var(--ease-space-1, 0.25rem);
+  }
+
+  @media (min-width: 640px) {
+    .ease-sm\:chip-group {
+      gap: var(--ease-space-3, 0.75rem);
+    }
+  }
+
+  @media (min-width: 768px) {
+    .ease-md\:chip-group {
+      gap: var(--ease-space-3, 0.75rem);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ease-chip-remove,
+    .ease-chip-interactive {
+      transition: none !important;
+    }
+  }
+}


### PR DESCRIPTION
## Description
Adds a flexible chip/tag component with 6 color variants (primary, secondary, success, warning, danger, info), 3 sizes (sm, md, lg), 3 styles (filled, outline, subtle), pill shape, removable chips, interactive/clickable states, disabled state, and chip groups with labels.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

## Checklist
- [x] `style.css` — All component styles under `@layer easemotion-components`
- [x] `demo.html` — Interactive demo with feature grid, colors, outline, subtle, sizes, pills, removable, interactive, disabled, groups, and code usage block
- [x] `README.md` — What, how, why documentation

## Maintainer Actions
1. Review `submissions/core_changes-issue-23905/style.css`
2. Copy contents into the main CSS bundle (e.g., `components/chip.css`)
3. Reference/demo the component in the documentation site

**Closes #23905**