### PR TITLE
feat(resize): add ease-resize element resize utility (GSSoC 2026)

### DIFF
--- a/submissions/core_changes-issue-23897/README.md
+++ b/submissions/core_changes-issue-23897/README.md
@@ -1,0 +1,40 @@
+# ease-resize — Element Resize Utility
+
+## 1. What does this do?
+
+Adds element resize utility classes. Control whether users can resize elements, and in which direction.
+
+**Classes:**
+- `.ease-resize` — Resize both directions (`resize: both`)
+- `.ease-resize-x` — Resize horizontally only (`resize: horizontal`)
+- `.ease-resize-y` — Resize vertically only (`resize: vertical`)
+- `.ease-resize-both` — Explicit both (alias)
+- `.ease-resize-inline` — Logical inline direction
+- `.ease-resize-block` — Logical block direction
+- `.ease-resize-none` — Disable resize (`resize: none`)
+- `.ease-resize-handle` — Custom `::-webkit-resizer` styling
+- `.ease-resize-handle-custom` — Pseudo-element `::after` handle
+- `.ease-{sm|md|lg|xl}:resize` / `:resize-x` / `:resize-y` / `:resize-none` — Responsive variants
+
+## 2. How is it used?
+
+```html
+<!-- Both directions -->
+<div class="ease-resize" style="width:200px;height:100px;">Content...</div>
+
+<!-- Horizontal only -->
+<div class="ease-resize-x" style="width:200px;">Width adjustable...</div>
+
+<!-- Disable -->
+<div class="ease-resize-none">Fixed size...</div>
+
+<!-- Custom handle -->
+<div class="ease-resize-handle-custom">Styled resizer...</div>
+```
+
+## 3. Why is this useful?
+
+- **Fine control** — Both, horizontal, vertical, or no resize
+- **Custom handles** — Styled resizer indicators
+- **Responsive** — Breakpoint-prefixed variants
+- **Override** — Apply `ease-resize-none` to disable inherited resize

--- a/submissions/core_changes-issue-23897/demo.html
+++ b/submissions/core_changes-issue-23897/demo.html
@@ -1,0 +1,270 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-resize — Demo · Issue #23897</title>
+  <link rel="stylesheet" href="../../core/variables.css" />
+  <link rel="stylesheet" href="../../core/base.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+      background: #0f172a;
+      color: #f1f5f9;
+      min-height: 100vh;
+    }
+    .demo-header {
+      text-align: center;
+      padding: 3rem 1rem 2rem;
+      border-bottom: 1px solid #1e293b;
+    }
+    .demo-header h1 {
+      font-size: clamp(1.75rem, 4vw, 2.75rem);
+      font-weight: 700;
+      background: linear-gradient(135deg, #6c63ff, #e040fb);
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+    .demo-header p {
+      color: #94a3b8;
+      margin-top: 0.75rem;
+      font-size: 0.95rem;
+      max-width: 620px;
+      margin-inline: auto;
+      line-height: 1.6;
+    }
+    .demo-content {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 2rem 1rem 3rem;
+    }
+    .demo-content h2 {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: #6c63ff;
+      margin-bottom: 0.75rem;
+      margin-top: 2rem;
+    }
+    .section-desc {
+      color: #64748b;
+      font-size: 0.8rem;
+      margin-bottom: 0.75rem;
+      line-height: 1.5;
+    }
+    .feature-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+      gap: 0.75rem;
+      margin-bottom: 1.5rem;
+    }
+    .feature {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 8px;
+      padding: 0.75rem;
+      text-align: center;
+    }
+    .feature .icon { font-size: 1.25rem; margin-bottom: 0.3rem; }
+    .feature .label { font-size: 0.7rem; color: #94a3b8; }
+    .demo-card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 1rem;
+      margin-bottom: 1rem;
+    }
+    .demo-card .title {
+      font-size: 0.7rem;
+      color: #64748b;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.5rem;
+    }
+    .demo-card .class-name {
+      font-family: monospace;
+      font-size: 0.8rem;
+      color: #22c55e;
+      margin-bottom: 0.5rem;
+    }
+    .resize-box {
+      background: linear-gradient(135deg, #1e293b, #334155);
+      border: 1px solid #475569;
+      border-radius: 8px;
+      padding: 1rem;
+      font-size: 0.85rem;
+      line-height: 1.6;
+      color: #cbd5e1;
+      min-width: 200px;
+      min-height: 100px;
+      max-width: 400px;
+      max-height: 300px;
+      width: 250px;
+    }
+    .resize-box-x {
+      min-width: 200px;
+      max-width: 500px;
+      width: 300px;
+      height: 80px;
+    }
+    .resize-box-y {
+      min-height: 80px;
+      max-height: 300px;
+      height: 100px;
+      width: 300px;
+    }
+    .row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+    }
+    .code-block {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 1.5rem;
+    }
+    .code-block pre {
+      color: #e2e8f0;
+      font-size: 0.8rem;
+      overflow-x: auto;
+      line-height: 1.7;
+    }
+    .demo-footer {
+      text-align: center;
+      padding: 2rem;
+      color: #475569;
+      font-size: 0.75rem;
+      border-top: 1px solid #1e293b;
+    }
+  </style>
+</head>
+<body>
+  <header class="demo-header">
+    <h1>ease-resize</h1>
+    <p>Element resize utility classes. Control how elements can be resized by users with both, horizontal, vertical, and none variants. Includes custom resize handle styling and responsive breakpoints.</p>
+  </header>
+
+  <div class="demo-content">
+    <h2>Features</h2>
+    <div class="feature-grid">
+      <div class="feature"><div class="icon">↔️</div><div class="label">Both</div></div>
+      <div class="feature"><div class="icon">↔️</div><div class="label">Horizontal</div></div>
+      <div class="feature"><div class="icon">↕️</div><div class="label">Vertical</div></div>
+      <div class="feature"><div class="icon">🚫</div><div class="label">None</div></div>
+      <div class="feature"><div class="icon">🎨</div><div class="label">Custom Handle</div></div>
+      <div class="feature"><div class="icon">📱</div><div class="label">Responsive</div></div>
+    </div>
+
+    <h2>Both Directions</h2>
+    <p class="section-desc">Drag the bottom-right corner to resize in any direction.</p>
+    <div class="demo-card">
+      <div class="title">.ease-resize</div>
+      <div class="resize-box ease-resize">
+        This element can be resized in both directions. Grab the handle at the bottom-right corner and drag.
+      </div>
+    </div>
+
+    <h2>Horizontal Only</h2>
+    <p class="section-desc">Resize width only. Height stays fixed.</p>
+    <div class="demo-card">
+      <div class="title">.ease-resize-x</div>
+      <div class="resize-box resize-box-x ease-resize-x">
+        Drag horizontally to change the width of this element. The height remains fixed.
+      </div>
+    </div>
+
+    <h2>Vertical Only</h2>
+    <p class="section-desc">Resize height only. Width stays fixed.</p>
+    <div class="demo-card">
+      <div class="title">.ease-resize-y</div>
+      <div class="resize-box resize-box-y ease-resize-y">
+        Drag vertically to change the height of this element. The width remains fixed.
+      </div>
+    </div>
+
+    <h2>All Variants</h2>
+    <p class="section-desc">Explicit both and logical property variants.</p>
+    <div class="demo-card">
+      <div class="row">
+        <div>
+          <div class="title">.ease-resize-both</div>
+          <div class="resize-box ease-resize-both">
+            Explicit resize: both. Same as .ease-resize.
+          </div>
+        </div>
+        <div>
+          <div class="title">.ease-resize-inline</div>
+          <div class="resize-box ease-resize-inline">
+            Logical inline direction resize.
+          </div>
+        </div>
+        <div>
+          <div class="title">.ease-resize-block</div>
+          <div class="resize-box ease-resize-block">
+            Logical block direction resize.
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <h2>None (No Resize)</h2>
+    <p class="section-desc">Resize is disabled. Useful to override a parent resize class.</p>
+    <div class="demo-card">
+      <div class="title">.ease-resize-none</div>
+      <div class="resize-box ease-resize-none" style="width:250px;height:80px;">
+        This element cannot be resized. The handle is hidden.
+      </div>
+    </div>
+
+    <h2>Custom Handle</h2>
+    <p class="section-desc">Styled resizer handle with ::-webkit-resizer or a CSS ::after pseudo-element.</p>
+    <div class="row">
+      <div class="demo-card" style="flex:1;">
+        <div class="title">.ease-resize-handle</div>
+        <div class="resize-box ease-resize-handle">
+          Custom styled resizer via ::-webkit-resizer with neutral colors.
+        </div>
+      </div>
+      <div class="demo-card" style="flex:1;">
+        <div class="title">.ease-resize-handle-custom</div>
+        <div class="resize-box ease-resize-handle-custom">
+          Pseudo-element handle with a corner bracket indicator using ::after.
+        </div>
+      </div>
+    </div>
+
+    <h2>Usage</h2>
+    <div class="code-block">
+      <pre>
+<span style="color:#64748b;">&lt;!-- Resize both directions --&gt;</span>
+&lt;div class="ease-resize" style="width:200px;height:100px;"&gt;
+  Resizable content...
+&lt;/div&gt;
+
+<span style="color:#64748b;">&lt;!-- Resize horizontal only --&gt;</span>
+&lt;div class="ease-resize-x" style="width:200px;height:100px;"&gt;
+  Width adjustable...
+&lt;/div&gt;
+
+<span style="color:#64748b;">&lt;!-- Disable resize --&gt;</span>
+&lt;div class="ease-resize-none"&gt;
+  Fixed size...
+&lt;/div&gt;
+
+<span style="color:#64748b;">&lt;!-- Custom handle --&gt;</span>
+&lt;div class="ease-resize-handle-custom" style="width:200px;height:100px;"&gt;
+  Custom styled resizer...
+&lt;/div&gt;</pre>
+    </div>
+  </div>
+
+  <footer class="demo-footer">
+    Issue #23897 &middot; ease-resize &middot; EaseMotion CSS
+  </footer>
+</body>
+</html>

--- a/submissions/core_changes-issue-23897/style.css
+++ b/submissions/core_changes-issue-23897/style.css
@@ -1,0 +1,148 @@
+/* ============================================================
+   ease-resize — Element Resize Utility
+   Submission for EaseMotion CSS · Issue #23897
+   ============================================================ */
+
+@layer easemotion-utilities {
+  .ease-resize {
+    resize: both;
+    overflow: auto;
+  }
+
+  .ease-resize-x {
+    resize: horizontal;
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+
+  .ease-resize-y {
+    resize: vertical;
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+
+  .ease-resize-both {
+    resize: both;
+    overflow: auto;
+  }
+
+  .ease-resize-none {
+    resize: none;
+    overflow: visible;
+  }
+
+  .ease-resize-inline {
+    resize: inline;
+    overflow: auto;
+  }
+
+  .ease-resize-block {
+    resize: block;
+    overflow: auto;
+  }
+
+  .ease-resize-handle {
+    resize: both;
+    overflow: auto;
+  }
+
+  .ease-resize-handle::-webkit-resizer {
+    background: var(--ease-color-neutral-300, #cbd5e1);
+    border: 2px solid var(--ease-color-neutral-400, #94a3b8);
+    border-radius: 2px;
+    width: 12px;
+    height: 12px;
+  }
+
+  .ease-resize-handle-custom {
+    resize: both;
+    overflow: auto;
+    position: relative;
+  }
+
+  .ease-resize-handle-custom::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    width: 12px;
+    height: 12px;
+    border-style: solid;
+    border-width: 0 3px 3px 0;
+    border-color: var(--ease-color-neutral-500, #64748b);
+    pointer-events: none;
+    opacity: 0.5;
+  }
+
+  @media (min-width: 640px) {
+    .ease-sm\:resize {
+      resize: both;
+      overflow: auto;
+    }
+    .ease-sm\:resize-x {
+      resize: horizontal;
+      overflow-x: auto;
+    }
+    .ease-sm\:resize-y {
+      resize: vertical;
+      overflow-y: auto;
+    }
+    .ease-sm\:resize-none {
+      resize: none;
+    }
+  }
+
+  @media (min-width: 768px) {
+    .ease-md\:resize {
+      resize: both;
+      overflow: auto;
+    }
+    .ease-md\:resize-x {
+      resize: horizontal;
+      overflow-x: auto;
+    }
+    .ease-md\:resize-y {
+      resize: vertical;
+      overflow-y: auto;
+    }
+    .ease-md\:resize-none {
+      resize: none;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .ease-lg\:resize {
+      resize: both;
+      overflow: auto;
+    }
+    .ease-lg\:resize-x {
+      resize: horizontal;
+      overflow-x: auto;
+    }
+    .ease-lg\:resize-y {
+      resize: vertical;
+      overflow-y: auto;
+    }
+    .ease-lg\:resize-none {
+      resize: none;
+    }
+  }
+
+  @media (min-width: 1280px) {
+    .ease-xl\:resize {
+      resize: both;
+      overflow: auto;
+    }
+    .ease-xl\:resize-x {
+      resize: horizontal;
+      overflow-x: auto;
+    }
+    .ease-xl\:resize-y {
+      resize: vertical;
+      overflow-y: auto;
+    }
+    .ease-xl\:resize-none {
+      resize: none;
+    }
+  }
+}


### PR DESCRIPTION
## Description
Adds element resize utility classes. Control whether users can resize elements in both, horizontal, vertical, or no direction. Includes custom resize handle styling via ::-webkit-resizer and ::after pseudo-element, logical property support, and responsive breakpoint variants.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

## Checklist
- [x] `style.css` — All utility styles under `@layer easemotion-utilities`
- [x] `demo.html` — Interactive demo with feature grid, both, x, y, variants, none, custom handles, and code usage block
- [x] `README.md` — What, how, why documentation

## Maintainer Actions
1. Review `submissions/core_changes-issue-23897/style.css`
2. Copy contents into the main CSS bundle (e.g., `utilities/resize.css`)
3. Reference/demo the utility in the documentation site

**Closes #23897**