### PR TITLE
feat(aspect-ratio): add ease-aspect-ratio utility with 16 ratios and legacy fallback (GSSoC 2026)

### DIFF
--- a/submissions/core_changes-issue-23891/README.md
+++ b/submissions/core_changes-issue-23891/README.md
@@ -1,0 +1,43 @@
+# ease-aspect-ratio — Aspect Ratio Utility
+
+## 1. What does this do?
+
+Adds aspect ratio utility classes using the native CSS `aspect-ratio` property. Supports common ratios (square, video, 4:3, 3:2, 21:9, 9:16, 2:3, 3:4, 2:1, 4:1), semantic aliases (golden, portrait, landscape, cinema, instagram, iphone, a4), legacy padding-box fallback (`.ease-aspect-box`), and responsive breakpoint variants.
+
+**Classes:**
+- `.ease-aspect-auto` — Default browser behavior
+- `.ease-aspect-square` — 1:1
+- `.ease-aspect-video` — 16:9
+- `.ease-aspect-{4/3|3/2|8/5|21/9|9/16|2/3|3/4|1/2|2/1|4/1}` — Numeric ratios
+- `.ease-aspect-{golden|portrait|landscape|cinema|instagram|iphone|a4}` — Named aliases
+- `.ease-aspect-box` — Legacy padding-bottom: 100% fallback
+- `.ease-aspect-box-{video|wide|square}` — Legacy fallbacks for common ratios
+- `.ease-{sm|md|lg|xl}:aspect-{square|video|auto|4/3|3/2|21/9}` — Responsive
+
+## 2. How is it used?
+
+```html
+<!-- Modern -->
+<img class="ease-aspect-square" src="photo.jpg" alt="Square" />
+<div class="ease-aspect-video">
+  <iframe src="..."></iframe>
+</div>
+
+<!-- Legacy fallback -->
+<div class="ease-aspect-box">
+  <div>Child content (absolutely positioned)</div>
+</div>
+
+<!-- Responsive -->
+<div class="ease-aspect-square ease-lg:aspect-video">
+  Square on mobile, 16:9 on desktop
+</div>
+```
+
+## 3. Why is this useful?
+
+- **16 ratios** — Covering most common use cases
+- **Named aliases** — Semantic (golden, portrait, cinema)
+- **Legacy fallback** — Padding-box technique for older browsers
+- **Responsive** — Breakpoint-prefixed variants
+- **Modern** — Uses native `aspect-ratio` where supported

--- a/submissions/core_changes-issue-23891/demo.html
+++ b/submissions/core_changes-issue-23891/demo.html
@@ -1,0 +1,315 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-aspect-ratio — Demo · Issue #23891</title>
+  <link rel="stylesheet" href="../../core/variables.css" />
+  <link rel="stylesheet" href="../../core/base.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+      background: #0f172a;
+      color: #f1f5f9;
+      min-height: 100vh;
+    }
+    .demo-header {
+      text-align: center;
+      padding: 3rem 1rem 2rem;
+      border-bottom: 1px solid #1e293b;
+    }
+    .demo-header h1 {
+      font-size: clamp(1.75rem, 4vw, 2.75rem);
+      font-weight: 700;
+      background: linear-gradient(135deg, #6c63ff, #e040fb);
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+    .demo-header p {
+      color: #94a3b8;
+      margin-top: 0.75rem;
+      font-size: 0.95rem;
+      max-width: 620px;
+      margin-inline: auto;
+      line-height: 1.6;
+    }
+    .demo-content {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 2rem 1rem 3rem;
+    }
+    .demo-content h2 {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: #6c63ff;
+      margin-bottom: 0.75rem;
+      margin-top: 2rem;
+    }
+    .section-desc {
+      color: #64748b;
+      font-size: 0.8rem;
+      margin-bottom: 0.75rem;
+      line-height: 1.5;
+    }
+    .feature-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+      gap: 0.75rem;
+      margin-bottom: 1.5rem;
+    }
+    .feature {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 8px;
+      padding: 0.75rem;
+      text-align: center;
+    }
+    .feature .icon { font-size: 1.25rem; margin-bottom: 0.3rem; }
+    .feature .label { font-size: 0.7rem; color: #94a3b8; }
+    .demo-card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 1rem;
+      margin-bottom: 1rem;
+    }
+    .demo-card .title {
+      font-size: 0.7rem;
+      color: #64748b;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.5rem;
+    }
+    .demo-card .class-name {
+      font-family: monospace;
+      font-size: 0.8rem;
+      color: #22c55e;
+      margin-bottom: 0.5rem;
+    }
+    .aspect-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+      gap: 1rem;
+      margin-bottom: 1rem;
+    }
+    .aspect-item {
+      background: linear-gradient(135deg, #6c63ff, #3b82f6);
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: #fff;
+      width: 100%;
+    }
+    .aspect-item.gold { background: linear-gradient(135deg, #f59e0b, #d97706); }
+    .aspect-item.rose { background: linear-gradient(135deg, #e040fb, #ec4899); }
+    .aspect-item.teal { background: linear-gradient(135deg, #14b8a6, #0d9488); }
+    .aspect-item.orange { background: linear-gradient(135deg, #f97316, #ea580c); }
+    .aspect-box-item {
+      background: #334155;
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.75rem;
+      color: #94a3b8;
+      width: 100%;
+    }
+    .aspect-box-item > * {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 100%;
+      height: 100%;
+    }
+    .code-block {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 1.5rem;
+    }
+    .code-block pre {
+      color: #e2e8f0;
+      font-size: 0.8rem;
+      overflow-x: auto;
+      line-height: 1.7;
+    }
+    .demo-footer {
+      text-align: center;
+      padding: 2rem;
+      color: #475569;
+      font-size: 0.75rem;
+      border-top: 1px solid #1e293b;
+    }
+  </style>
+</head>
+<body>
+  <header class="demo-header">
+    <h1>ease-aspect-ratio</h1>
+    <p>Aspect ratio utility classes using the native <code>aspect-ratio</code> CSS property. Includes common ratios, semantic aliases (square, video, portrait, landscape), golden ratio, cinema, and legacy padding-box fallback for older browsers.</p>
+  </header>
+
+  <div class="demo-content">
+    <h2>Features</h2>
+    <div class="feature-grid">
+      <div class="feature"><div class="icon">⬜</div><div class="label">Square 1:1</div></div>
+      <div class="feature"><div class="icon">🎬</div><div class="label">Video 16:9</div></div>
+      <div class="feature"><div class="icon">🖥️</div><div class="label">4:3</div></div>
+      <div class="feature"><div class="icon">📱</div><div class="label">9:16</div></div>
+      <div class="feature"><div class="icon">🎥</div><div class="label">21:9</div></div>
+      <div class="feature"><div class="icon">🥇</div><div class="label">Golden 1.618</div></div>
+      <div class="feature"><div class="icon">🖼️</div><div class="label">Portrait</div></div>
+      <div class="feature"><div class="icon">📐</div><div class="label">Padding Box</div></div>
+    </div>
+
+    <h2>Square (1:1)</h2>
+    <p class="section-desc">Perfect square ratio, ideal for avatars and thumbnails.</p>
+    <div class="demo-card">
+      <div class="class-name">.ease-aspect-square</div>
+      <div style="width:150px;">
+        <div class="aspect-item ease-aspect-square">1:1</div>
+      </div>
+    </div>
+
+    <h2>Standard Ratios</h2>
+    <p class="section-desc">Commonly used aspect ratios for images, embeds, and media.</p>
+    <div class="demo-card">
+      <div class="aspect-grid">
+        <div>
+          <div class="class-name">.ease-aspect-video</div>
+          <div class="aspect-item rose ease-aspect-video" style="width:100%;">16:9</div>
+        </div>
+        <div>
+          <div class="class-name">.ease-aspect-4\/3</div>
+          <div class="aspect-item gold ease-aspect-4\/3" style="width:100%;">4:3</div>
+        </div>
+        <div>
+          <div class="class-name">.ease-aspect-3\/2</div>
+          <div class="aspect-item teal ease-aspect-3\/2" style="width:100%;">3:2</div>
+        </div>
+        <div>
+          <div class="class-name">.ease-aspect-8\/5</div>
+          <div class="aspect-item orange ease-aspect-8\/5" style="width:100%;">8:5</div>
+        </div>
+      </div>
+    </div>
+
+    <h2>Portrait &amp; Tall Ratios</h2>
+    <p class="section-desc">For vertical content like mobile screens and portraits.</p>
+    <div class="demo-card">
+      <div class="aspect-grid">
+        <div>
+          <div class="class-name">.ease-aspect-9\/16</div>
+          <div class="aspect-item gold ease-aspect-9\/16" style="width:120px;margin:auto;">9:16</div>
+        </div>
+        <div>
+          <div class="class-name">.ease-aspect-2\/3</div>
+          <div class="aspect-item rose ease-aspect-2\/3" style="width:120px;margin:auto;">2:3</div>
+        </div>
+        <div>
+          <div class="class-name">.ease-aspect-3\/4</div>
+          <div class="aspect-item teal ease-aspect-3\/4" style="width:120px;margin:auto;">3:4</div>
+        </div>
+      </div>
+    </div>
+
+    <h2>Wide &amp; Panoramic</h2>
+    <p class="section-desc">Ultra-wide and cinema ratios for hero sections and banners.</p>
+    <div class="demo-card">
+      <div class="aspect-grid">
+        <div>
+          <div class="class-name">.ease-aspect-21\/9</div>
+          <div class="aspect-item orange ease-aspect-21\/9" style="width:100%;">21:9</div>
+        </div>
+        <div>
+          <div class="class-name">.ease-aspect-2\/1</div>
+          <div class="aspect-item ease-aspect-2\/1" style="width:100%;">2:1</div>
+        </div>
+        <div>
+          <div class="class-name">.ease-aspect-4\/1</div>
+          <div class="aspect-item gold ease-aspect-4\/1" style="width:100%;">4:1</div>
+        </div>
+      </div>
+    </div>
+
+    <h2>Special Ratios</h2>
+    <p class="section-desc">Named semantic ratios for specific use cases.</p>
+    <div class="demo-card">
+      <div class="aspect-grid">
+        <div>
+          <div class="class-name">.ease-aspect-golden</div>
+          <div class="aspect-item gold ease-aspect-golden" style="width:100%;">1.618:1</div>
+        </div>
+        <div>
+          <div class="class-name">.ease-aspect-iphone</div>
+          <div class="aspect-item rose ease-aspect-iphone" style="width:100px;margin:auto;">9:19.5</div>
+        </div>
+        <div>
+          <div class="class-name">.ease-aspect-a4</div>
+          <div class="aspect-item teal ease-aspect-a4" style="width:100px;margin:auto;">A4</div>
+        </div>
+      </div>
+    </div>
+
+    <h2>Legacy Padding-Box Fallback</h2>
+    <p class="section-desc">For browsers without native aspect-ratio support. Wraps child content in an absolutely positioned container.</p>
+    <div class="demo-card">
+      <div class="aspect-grid">
+        <div>
+          <div class="class-name">.ease-aspect-box</div>
+          <div class="ease-aspect-box" style="width:100%;">
+            <div class="aspect-box-item" style="background:#334155;">Padding 1:1</div>
+          </div>
+        </div>
+        <div>
+          <div class="class-name">.ease-aspect-box-video</div>
+          <div class="ease-aspect-box-video" style="width:100%;">
+            <div class="aspect-box-item" style="background:#334155;">Padding 16:9</div>
+          </div>
+        </div>
+        <div>
+          <div class="class-name">.ease-aspect-box-wide</div>
+          <div class="ease-aspect-box-wide" style="width:100%;">
+            <div class="aspect-box-item" style="background:#334155;">Padding 4:3</div>
+          </div>
+        </div>
+        <div>
+          <div class="class-name">.ease-aspect-box-square</div>
+          <div class="ease-aspect-box-square" style="width:100%;">
+            <div class="aspect-box-item" style="background:#334155;">Padding 1:1</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <h2>Usage</h2>
+    <div class="code-block">
+      <pre>
+<span style="color:#64748b;">&lt;!-- Modern (CSS aspect-ratio) --&gt;</span>
+&lt;img class="ease-aspect-square" src="photo.jpg" alt="Square photo" /&gt;
+&lt;div class="ease-aspect-video"&gt;&lt;iframe src="..."&gt;&lt;/iframe&gt;&lt;/div&gt;
+
+<span style="color:#64748b;">&lt;!-- Legacy padding-box fallback --&gt;</span>
+&lt;div class="ease-aspect-box"&gt;
+  &lt;div&gt;Content inside absolutely positioned wrapper&lt;/div&gt;
+&lt;/div&gt;
+
+<span style="color:#64748b;">&lt;!-- Responsive --&gt;</span>
+&lt;div class="ease-aspect-square ease-lg:aspect-video"&gt;
+  Square on mobile, 16:9 on desktop.
+&lt;/div&gt;</pre>
+    </div>
+  </div>
+
+  <footer class="demo-footer">
+    Issue #23891 &middot; ease-aspect-ratio &middot; EaseMotion CSS
+  </footer>
+</body>
+</html>

--- a/submissions/core_changes-issue-23891/style.css
+++ b/submissions/core_changes-issue-23891/style.css
@@ -1,0 +1,146 @@
+/* ============================================================
+   ease-aspect-ratio — Aspect Ratio Utility
+   Submission for EaseMotion CSS · Issue #23891
+   ============================================================ */
+
+@layer easemotion-utilities {
+  .ease-aspect-auto {
+    aspect-ratio: auto;
+  }
+
+  .ease-aspect-square {
+    aspect-ratio: 1 / 1;
+  }
+
+  .ease-aspect-video {
+    aspect-ratio: 16 / 9;
+  }
+
+  .ease-aspect-4\/3 {
+    aspect-ratio: 4 / 3;
+  }
+
+  .ease-aspect-3\/2 {
+    aspect-ratio: 3 / 2;
+  }
+
+  .ease-aspect-8\/5 {
+    aspect-ratio: 8 / 5;
+  }
+
+  .ease-aspect-21\/9 {
+    aspect-ratio: 21 / 9;
+  }
+
+  .ease-aspect-9\/16 {
+    aspect-ratio: 9 / 16;
+  }
+
+  .ease-aspect-2\/3 {
+    aspect-ratio: 2 / 3;
+  }
+
+  .ease-aspect-3\/4 {
+    aspect-ratio: 3 / 4;
+  }
+
+  .ease-aspect-1\/2 {
+    aspect-ratio: 1 / 2;
+  }
+
+  .ease-aspect-2\/1 {
+    aspect-ratio: 2 / 1;
+  }
+
+  .ease-aspect-4\/1 {
+    aspect-ratio: 4 / 1;
+  }
+
+  .ease-aspect-golden {
+    aspect-ratio: 1.618 / 1;
+  }
+
+  .ease-aspect-portrait {
+    aspect-ratio: 3 / 4;
+  }
+
+  .ease-aspect-landscape {
+    aspect-ratio: 4 / 3;
+  }
+
+  .ease-aspect-cinema {
+    aspect-ratio: 21 / 9;
+  }
+
+  .ease-aspect-instagram {
+    aspect-ratio: 1 / 1;
+  }
+
+  .ease-aspect-iphone {
+    aspect-ratio: 9 / 19.5;
+  }
+
+  .ease-aspect-a4 {
+    aspect-ratio: 1 / 1.414;
+  }
+
+  .ease-aspect-box {
+    position: relative;
+  }
+
+  .ease-aspect-box::before {
+    content: '';
+    display: block;
+    padding-bottom: 100%;
+  }
+
+  .ease-aspect-box > * {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  .ease-aspect-box-video::before {
+    padding-bottom: 56.25%;
+  }
+
+  .ease-aspect-box-wide::before {
+    padding-bottom: 75%;
+  }
+
+  .ease-aspect-box-square::before {
+    padding-bottom: 100%;
+  }
+
+  @media (min-width: 640px) {
+    .ease-sm\:aspect-square { aspect-ratio: 1 / 1; }
+    .ease-sm\:aspect-video { aspect-ratio: 16 / 9; }
+    .ease-sm\:aspect-auto { aspect-ratio: auto; }
+    .ease-sm\:aspect-4\/3 { aspect-ratio: 4 / 3; }
+  }
+
+  @media (min-width: 768px) {
+    .ease-md\:aspect-square { aspect-ratio: 1 / 1; }
+    .ease-md\:aspect-video { aspect-ratio: 16 / 9; }
+    .ease-md\:aspect-auto { aspect-ratio: auto; }
+    .ease-md\:aspect-4\/3 { aspect-ratio: 4 / 3; }
+    .ease-md\:aspect-3\/2 { aspect-ratio: 3 / 2; }
+  }
+
+  @media (min-width: 1024px) {
+    .ease-lg\:aspect-square { aspect-ratio: 1 / 1; }
+    .ease-lg\:aspect-video { aspect-ratio: 16 / 9; }
+    .ease-lg\:aspect-auto { aspect-ratio: auto; }
+    .ease-lg\:aspect-4\/3 { aspect-ratio: 4 / 3; }
+    .ease-lg\:aspect-21\/9 { aspect-ratio: 21 / 9; }
+  }
+
+  @media (min-width: 1280px) {
+    .ease-xl\:aspect-square { aspect-ratio: 1 / 1; }
+    .ease-xl\:aspect-video { aspect-ratio: 16 / 9; }
+    .ease-xl\:aspect-auto { aspect-ratio: auto; }
+    .ease-xl\:aspect-4\/3 { aspect-ratio: 4 / 3; }
+  }
+}


### PR DESCRIPTION
## Description
Adds aspect ratio utility classes using native CSS aspect-ratio. Supports 16 common ratios (square, video, 4:3, 3:2, 8:5, 21:9, 9:16, 2:3, 3:4, 1:2, 2:1, 4:1), semantic aliases (golden 1.618, portrait, landscape, cinema, instagram, iphone, a4), legacy padding-box fallback for older browsers, and responsive breakpoint variants.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

## Checklist
- [x] `style.css` — All utility styles under `@layer easemotion-utilities`
- [x] `demo.html` — Interactive demo with feature grid, square, standard ratios, portrait/tall, wide/panoramic, special ratios, legacy padding-box, and code usage block
- [x] `README.md` — What, how, why documentation

## Maintainer Actions
1. Review `submissions/core_changes-issue-23891/style.css`
2. Copy contents into the main CSS bundle (e.g., `utilities/aspect-ratio.css`)
3. Reference/demo the utility in the documentation site

**Closes #23891**