### PR TITLE
feat(sr-only): add ease-sr-only screen reader only utility (GSSoC 2026)

### DIFF
--- a/submissions/core_changes-issue-23892/README.md
+++ b/submissions/core_changes-issue-23892/README.md
@@ -1,0 +1,42 @@
+# ease-sr-only — Screen Reader Only Utility
+
+## 1. What does this do?
+
+Adds screen reader only utility classes that visually hide content while keeping it accessible to assistive technology (screen readers). Includes focusable variant for skip links, semantic aliases, and responsive breakpoint variants.
+
+**Classes:**
+- `.ease-sr-only` — Visually hide, keep accessible to screen readers
+- `.ease-not-sr-only` — Restore visibility (undo sr-only)
+- `.ease-sr-only-focusable` — Hidden until focused (for skip links)
+- `.ease-sr-only-label` — Semantic alias for ARIA labels
+- `.ease-sr-only-description` — Semantic alias for ARIA descriptions
+- `.ease-sr-inline` — Inline sr-only variant
+- `.ease-{sm|md|lg|xl}:sr-only` — Responsive hide
+- `.ease-{sm|md|lg|xl}:not-sr-only` — Responsive show
+
+## 2. How is it used?
+
+```html
+<!-- Icon button label -->
+<button>
+  <svg><!-- icon --></svg>
+  <span class="ease-sr-only">Search</span>
+</button>
+
+<!-- Skip link -->
+<a href="#main" class="ease-sr-only-focusable">
+  Skip to main content
+</a>
+
+<!-- Responsive -->
+<span class="ease-lg:sr-only">Mobile only text</span>
+<span class="ease-sr-only ease-md:not-sr-only">Visible md+</span>
+```
+
+## 3. Why is this useful?
+
+- **Accessibility** — WCAG compliant visually hidden pattern
+- **Skip links** — Focusable variant for keyboard navigation
+- **Icon buttons** — Label icon-only controls
+- **Responsive** — Show/hide content at breakpoints
+- **Reset** — `ease-not-sr-only` to override

--- a/submissions/core_changes-issue-23892/demo.html
+++ b/submissions/core_changes-issue-23892/demo.html
@@ -1,0 +1,259 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-sr-only — Demo · Issue #23892</title>
+  <link rel="stylesheet" href="../../core/variables.css" />
+  <link rel="stylesheet" href="../../core/base.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+      background: #0f172a;
+      color: #f1f5f9;
+      min-height: 100vh;
+    }
+    .demo-header {
+      text-align: center;
+      padding: 3rem 1rem 2rem;
+      border-bottom: 1px solid #1e293b;
+    }
+    .demo-header h1 {
+      font-size: clamp(1.75rem, 4vw, 2.75rem);
+      font-weight: 700;
+      background: linear-gradient(135deg, #6c63ff, #e040fb);
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+    .demo-header p {
+      color: #94a3b8;
+      margin-top: 0.75rem;
+      font-size: 0.95rem;
+      max-width: 620px;
+      margin-inline: auto;
+      line-height: 1.6;
+    }
+    .demo-content {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 2rem 1rem 3rem;
+    }
+    .demo-content h2 {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: #6c63ff;
+      margin-bottom: 0.75rem;
+      margin-top: 2rem;
+    }
+    .section-desc {
+      color: #64748b;
+      font-size: 0.8rem;
+      margin-bottom: 0.75rem;
+      line-height: 1.5;
+    }
+    .feature-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+      gap: 0.75rem;
+      margin-bottom: 1.5rem;
+    }
+    .feature {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 8px;
+      padding: 0.75rem;
+      text-align: center;
+    }
+    .feature .icon { font-size: 1.25rem; margin-bottom: 0.3rem; }
+    .feature .label { font-size: 0.7rem; color: #94a3b8; }
+    .demo-card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 1rem;
+      margin-bottom: 1rem;
+    }
+    .demo-card .title {
+      font-size: 0.7rem;
+      color: #64748b;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.5rem;
+    }
+    .demo-card .class-name {
+      font-family: monospace;
+      font-size: 0.8rem;
+      color: #22c55e;
+      margin-bottom: 0.5rem;
+    }
+    .sr-demo {
+      background: #334155;
+      border-radius: 8px;
+      padding: 1rem;
+      font-size: 0.9rem;
+    }
+    .sr-demo .icon-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 2.5rem;
+      height: 2.5rem;
+      background: #475569;
+      border: none;
+      border-radius: 8px;
+      color: #e2e8f0;
+      cursor: pointer;
+      font-size: 1.2rem;
+    }
+    .sr-demo .icon-btn:hover {
+      background: #6c63ff;
+    }
+    .skip-link {
+      display: inline-block;
+      background: #6c63ff;
+      color: #fff;
+      padding: 0.5rem 1rem;
+      border-radius: 6px;
+      text-decoration: none;
+      font-size: 0.85rem;
+    }
+    .code-block {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 1.5rem;
+    }
+    .code-block pre {
+      color: #e2e8f0;
+      font-size: 0.8rem;
+      overflow-x: auto;
+      line-height: 1.7;
+    }
+    .demo-footer {
+      text-align: center;
+      padding: 2rem;
+      color: #475569;
+      font-size: 0.75rem;
+      border-top: 1px solid #1e293b;
+    }
+  </style>
+</head>
+<body>
+  <header class="demo-header">
+    <h1>ease-sr-only</h1>
+    <p>Screen reader only utility classes. Visually hide content while keeping it accessible to assistive technology. Includes focusable variants for skip links, semantic aliases, and responsive breakpoints.</p>
+  </header>
+
+  <div class="demo-content">
+    <h2>Features</h2>
+    <div class="feature-grid">
+      <div class="feature"><div class="icon">👁️</div><div class="label">Visually Hidden</div></div>
+      <div class="feature"><div class="icon">📢</div><div class="label">Screen Reader</div></div>
+      <div class="feature"><div class="icon">🔁</div><div class="label">Focusable</div></div>
+      <div class="feature"><div class="icon">🏷️</div><div class="label">Label</div></div>
+      <div class="feature"><div class="icon">📝</div><div class="label">Description</div></div>
+      <div class="feature"><div class="icon">🔄</div><div class="label">Reset</div></div>
+      <div class="feature"><div class="icon">📱</div><div class="label">Responsive</div></div>
+    </div>
+
+    <h2>Basic sr-only</h2>
+    <p class="section-desc">Content is visually hidden but announced by screen readers.</p>
+    <div class="demo-card">
+      <div class="title">Buttons with icon-only labels</div>
+      <div class="sr-demo">
+        <button class="icon-btn" aria-label="Search">
+          🔍
+          <span class="ease-sr-only">Search</span>
+        </button>
+        <button class="icon-btn" aria-label="Notifications">
+          🔔
+          <span class="ease-sr-only">Notifications</span>
+        </button>
+        <button class="icon-btn" aria-label="Settings">
+          ⚙️
+          <span class="ease-sr-only">Settings</span>
+        </button>
+        <p style="margin-top:0.75rem;color:#94a3b8;font-size:0.8rem;">
+          Each button has an <code>aria-label</code> and an inner <code>.ease-sr-only</code> span for screen readers. The text is invisible on screen.
+        </p>
+      </div>
+    </div>
+
+    <h2>Skip Link (Focusable)</h2>
+    <p class="section-desc">Hidden until focused. Perfect for skip-to-content links.</p>
+    <div class="demo-card">
+      <div class="title">.ease-sr-only-focusable</div>
+      <div class="sr-demo">
+        <a href="#main-content" class="ease-sr-only-focusable skip-link">
+          Skip to main content
+        </a>
+        <p style="margin-top:0.75rem;color:#94a3b8;font-size:0.8rem;">
+          Tab to focus the link above. It becomes visible when focused via keyboard navigation.
+        </p>
+      </div>
+    </div>
+
+    <h2>Reset (not-sr-only)</h2>
+    <p class="section-desc">Restore visibility to a previously hidden element. Useful for responsive toggling.</p>
+    <div class="demo-card">
+      <div class="title">.ease-not-sr-only</div>
+      <div class="sr-demo">
+        <span class="ease-sr-only ease-not-sr-only">
+          This text is visible because .ease-not-sr-only overrides .ease-sr-only.
+        </span>
+      </div>
+    </div>
+
+    <h2>Responsive sr-only</h2>
+    <p class="section-desc">Hide content only on certain breakpoints.</p>
+    <div class="demo-card">
+      <div class="title">.ease-lg:sr-only</div>
+      <div class="sr-demo">
+        <span class="ease-lg:sr-only">
+          This text is visible on mobile/tablet but hidden on desktop (lg+).
+        </span>
+      </div>
+    </div>
+    <div class="demo-card">
+      <div class="title">.ease-md:not-sr-only</div>
+      <div class="sr-demo">
+        <span class="ease-sr-only ease-md:not-sr-only">
+          This text is hidden on mobile but visible on md+ screens.
+        </span>
+      </div>
+    </div>
+
+    <h2>Usage</h2>
+    <div class="code-block">
+      <pre>
+<span style="color:#64748b;">&lt;!-- Icon button with accessible label --&gt;</span>
+&lt;button&gt;
+  &lt;svg&gt;...&lt;/svg&gt;
+  &lt;span class="ease-sr-only"&gt;Search&lt;/span&gt;
+&lt;/button&gt;
+
+<span style="color:#64748b;">&lt;!-- Skip navigation link --&gt;</span>
+&lt;a href="#main" class="ease-sr-only-focusable"&gt;
+  Skip to main content
+&lt;/a&gt;
+
+<span style="color:#64748b;">&lt;!-- Responsive: hide on desktop --&gt;</span>
+&lt;span class="ease-lg:sr-only"&gt;Mobile only text&lt;/span&gt;
+
+<span style="color:#64748b;">&lt;!-- Show on md+, hidden on smaller screens --&gt;</span>
+&lt;span class="ease-sr-only ease-md:not-sr-only"&gt;
+  Visible on tablet and up
+&lt;/span&gt;</pre>
+    </div>
+  </div>
+
+  <footer class="demo-footer">
+    Issue #23892 &middot; ease-sr-only &middot; EaseMotion CSS
+  </footer>
+</body>
+</html>

--- a/submissions/core_changes-issue-23892/style.css
+++ b/submissions/core_changes-issue-23892/style.css
@@ -1,0 +1,188 @@
+/* ============================================================
+   ease-sr-only — Screen Reader Only Utility
+   Submission for EaseMotion CSS · Issue #23892
+   ============================================================ */
+
+@layer easemotion-utilities {
+  .ease-sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .ease-not-sr-only {
+    position: static;
+    width: auto;
+    height: auto;
+    padding: 0;
+    margin: 0;
+    overflow: visible;
+    clip: auto;
+    white-space: normal;
+    border: none;
+  }
+
+  .ease-sr-only-focusable {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .ease-sr-only-focusable:focus,
+  .ease-sr-only-focusable:focus-visible,
+  .ease-sr-only-focusable:focus-within {
+    position: static;
+    width: auto;
+    height: auto;
+    padding: inherit;
+    margin: 0;
+    overflow: visible;
+    clip: auto;
+    white-space: normal;
+    border: none;
+  }
+
+  .ease-sr-only-focusable:focus-visible {
+    outline: 2px solid var(--ease-color-primary, #6c63ff);
+    outline-offset: 2px;
+  }
+
+  .ease-sr-only-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .ease-sr-only-description {
+    position: absolute;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+  }
+
+  .ease-sr-inline {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+  }
+
+  @media (min-width: 640px) {
+    .ease-sm\:sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+    .ease-sm\:not-sr-only {
+      position: static;
+      width: auto;
+      height: auto;
+      overflow: visible;
+      clip: auto;
+      white-space: normal;
+    }
+  }
+
+  @media (min-width: 768px) {
+    .ease-md\:sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+    .ease-md\:not-sr-only {
+      position: static;
+      width: auto;
+      height: auto;
+      overflow: visible;
+      clip: auto;
+      white-space: normal;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .ease-lg\:sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+    .ease-lg\:not-sr-only {
+      position: static;
+      width: auto;
+      height: auto;
+      overflow: visible;
+      clip: auto;
+      white-space: normal;
+    }
+  }
+
+  @media (min-width: 1280px) {
+    .ease-xl\:sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+    .ease-xl\:not-sr-only {
+      position: static;
+      width: auto;
+      height: auto;
+      overflow: visible;
+      clip: auto;
+      white-space: normal;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ease-sr-only-focusable {
+      transition: none !important;
+    }
+  }
+}


### PR DESCRIPTION
## Description
Adds screen reader only utility classes that visually hide content while keeping it accessible to assistive technology. Includes focusable variant for skip links, semantic aliases (label, description), inline variant, responsive breakpoint variants (sm/md/lg/xl), and not-sr-only reset.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

## Checklist
- [x] `style.css` — All utility styles under `@layer easemotion-utilities`
- [x] `demo.html` — Interactive demo with feature grid, icon buttons, skip link, responsive, reset, and code usage block
- [x] `README.md` — What, how, why documentation

## Maintainer Actions
1. Review `submissions/core_changes-issue-23892/style.css`
2. Copy contents into the main CSS bundle (e.g., `utilities/sr-only.css`)
3. Reference/demo the utility in the documentation site

**Closes #23892**