### PR TITLE
feat: add theme consistency demo for light/dark mode

### DIFF
--- a/submissions/examples/theme-fix-sg/README.md
+++ b/submissions/examples/theme-fix-sg/README.md
@@ -1,0 +1,10 @@
+# Theme Consistency Fix Demo
+
+## What does this do?
+Fixes theme inconsistencies by ensuring all UI components support light and dark mode properly.
+
+## How is it used?
+Toggle theme using button:
+
+```html
+<body data-theme="light">

--- a/submissions/examples/theme-fix-sg/demo.html
+++ b/submissions/examples/theme-fix-sg/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Theme Fix Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body data-theme="light">
+
+  <div class="container">
+    <h1>Theme Consistency Fix</h1>
+
+    <p>This demo ensures text, buttons, and components work in both themes.</p>
+
+    <button onclick="toggleTheme()">Toggle Theme</button>
+
+    <div class="card">
+      <h2>Card Component</h2>
+      <p>All colors adapt correctly in light/dark mode.</p>
+    </div>
+  </div>
+
+  <script>
+    function toggleTheme() {
+      const body = document.body;
+      body.dataset.theme = body.dataset.theme === "light" ? "dark" : "light";
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/theme-fix-sg/style.css
+++ b/submissions/examples/theme-fix-sg/style.css
@@ -1,0 +1,48 @@
+/* Light Theme */
+body[data-theme="light"] {
+  --bg: #ffffff;
+  --text: #111111;
+  --card: #f5f5f5;
+  --btn: #000000;
+  --btn-text: #ffffff;
+}
+
+/* Dark Theme */
+body[data-theme="dark"] {
+  --bg: #121212;
+  --text: #ffffff;
+  --card: #1e1e1e;
+  --btn: #ffffff;
+  --btn-text: #000000;
+}
+
+body {
+  margin: 0;
+  font-family: Arial;
+  background: var(--bg);
+  color: var(--text);
+  transition: 0.3s ease;
+}
+
+.container {
+  padding: 20px;
+}
+
+button {
+  background: var(--btn);
+  color: var(--btn-text);
+  border: none;
+  padding: 10px 15px;
+  cursor: pointer;
+  margin-bottom: 20px;
+}
+
+button:hover {
+  opacity: 0.8;
+}
+
+.card {
+  background: var(--card);
+  padding: 15px;
+  border-radius: 8px;
+}


### PR DESCRIPTION
## Related Issue - #22535  

## Pull Request Description

This submission adds a **theme consistency demo component** to demonstrate proper light and dark mode behavior across UI elements.

It ensures that text, buttons, and card components correctly adapt to theme changes using CSS variables and a simple theme toggle system.

---

## Type of Change

- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/theme-fix-sargam/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS using theme variables
- [x] Includes `README.md` — explains usage and purpose
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A lightweight demo showing consistent theme behavior across UI components (text, buttons, and cards).

**How does a developer use it?**

```html
<body data-theme="light">