### PR TITLE
feat(rating): add ease-rating star rating component with CSS-only interactivity (GSSoC 2026)

### DIFF
--- a/submissions/core_changes-issue-23906/README.md
+++ b/submissions/core_changes-issue-23906/README.md
@@ -1,0 +1,49 @@
+# ease-rating
+
+A CSS-only star rating component with interactive hover, keyboard accessibility, color variants, sizes, symbol styles, animations, and read-only/disabled modes.
+
+## What
+
+CSS-only interactive star rating using hidden radio inputs with `<label>` elements styled as star characters. Supports 8 color themes, 4 sizes, outline/heart/star symbols, pop-in/bounce/scale/rotate/glow animations, RTL, dark mode, tooltips, and inline value display.
+
+## How
+
+1. Include `style.css`.
+2. Create a `.ease-rating` container with `<input type="radio">` and `<label>` pairs in descending order (highest value first).
+3. Apply modifier classes for customisation (`--red`, `--lg`, `--outline`, `--animated`, etc.).
+
+## Why
+
+Provides a lightweight, dependency-free, accessible rating input that works with any form and can be styled purely with CSS. No JavaScript required for core interactivity.
+
+## Modifiers
+
+| Class | Effect |
+|---|---|
+| `ease-rating--sm` | Small size |
+| `ease-rating--lg` | Large size |
+| `ease-rating--xl` | Extra large size |
+| `ease-rating--red/blue/green/purple/pink/orange/teal` | Color variants |
+| `ease-rating--disabled` | Grayed out, no interaction |
+| `ease-rating--readonly` | No interaction, full color |
+| `ease-rating--animated` | Pop-in stagger animation on mount |
+| `ease-rating--bounce` | Bounce easing on hover |
+| `ease-rating--scale` | Scale up on hover |
+| `ease-rating--rotate` | Rotate + scale on hover |
+| `ease-rating--glow` | Drop-shadow glow on checked/hover |
+| `ease-rating--outline` | Empty stars, fill on check |
+| `ease-rating--heart` | Heart symbols |
+| `ease-rating--dark` | Dark background color scheme |
+| `ease-rating--no-animation` | Disable transitions |
+| `ease-rating--responsive` | Fluid size via `clamp()` |
+| `ease-rating--with-text` | Show numeric labels below stars |
+| `ease-rating--tooltip` | Show tooltip on hover |
+| `ease-rating--shadow` | Drop shadow filter |
+| `ease-rating--stagger` | Staggered animation delay per star |
+
+## Accessibility
+
+- Uses native `<input type="radio">` for keyboard navigation and screen reader support.
+- Focus visible ring via `:focus-within`.
+- `title` attribute on labels for descriptive text.
+- Supports `aria-label` and `fieldset/legend` patterns.

--- a/submissions/core_changes-issue-23906/demo.html
+++ b/submissions/core_changes-issue-23906/demo.html
@@ -1,0 +1,416 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-rating demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #f8fafc;
+      color: #1e293b;
+      padding: 2rem;
+      line-height: 1.6;
+    }
+    .container { max-width: 900px; margin: 0 auto; }
+    h1 { font-size: 2rem; margin-bottom: 0.5rem; }
+    h2 {
+      font-size: 1.25rem;
+      margin: 2rem 0 1rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 2px solid #e2e8f0;
+    }
+    .section {
+      background: #fff;
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+    .section p { margin-bottom: 0.75rem; color: #64748b; }
+    .row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1.5rem;
+      align-items: center;
+    }
+    .col { display: flex; flex-direction: column; gap: 0.5rem; }
+    .badge {
+      display: inline-block;
+      font-size: 0.75rem;
+      padding: 0.125rem 0.5rem;
+      border-radius: 999px;
+      background: #e2e8f0;
+      color: #475569;
+    }
+    pre {
+      background: #1e293b;
+      color: #e2e8f0;
+      padding: 1rem;
+      border-radius: 6px;
+      overflow-x: auto;
+      font-size: 0.875rem;
+      margin-top: 0.75rem;
+    }
+    code { font-family: "SF Mono", Consolas, monospace; }
+    hr { margin: 2rem 0; border: none; border-top: 1px solid #e2e8f0; }
+    .feature-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 1rem;
+    }
+    .feature-card {
+      background: #fff;
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      padding: 1.25rem;
+    }
+    .feature-card h3 { font-size: 1rem; margin-bottom: 0.5rem; }
+    .feature-card p { font-size: 0.875rem; color: #64748b; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>&#9733; ease-rating</h1>
+    <p>CSS-only star rating component with interactive hover, color variants, sizes, symbols, animations, and accessibility.</p>
+
+    <h2>Features</h2>
+    <div class="feature-grid">
+      <div class="feature-card">
+        <h3>6 Color Variants</h3>
+        <p>Default amber, red, blue, green, purple, pink, orange, teal.</p>
+      </div>
+      <div class="feature-card">
+        <h3>4 Sizes</h3>
+        <p>sm, default, lg, xl with CSS custom properties.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Symbol Styles</h3>
+        <p>Star (filled/outline), heart, custom icons via data attributes.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Animations</h3>
+        <p>Pop-in, bounce, stagger, scale, rotate hover effects.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Interactive</h3>
+        <p>Keyboard accessible, focus ring, tooltip on hover, inline value display.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Modes</h3>
+        <p>Disabled, readonly, dark mode, RTL, reduced-motion support.</p>
+      </div>
+    </div>
+
+    <h2>Default (5 stars)</h2>
+    <div class="section">
+      <p>Basic interactive star rating using radio inputs.</p>
+      <div class="ease-rating">
+        <input type="radio" id="s1-5" name="default" value="5">
+        <label for="s1-5" title="5 stars"></label>
+        <input type="radio" id="s1-4" name="default" value="4">
+        <label for="s1-4" title="4 stars"></label>
+        <input type="radio" id="s1-3" name="default" value="3" checked>
+        <label for="s1-3" title="3 stars"></label>
+        <input type="radio" id="s1-2" name="default" value="2">
+        <label for="s1-2" title="2 stars"></label>
+        <input type="radio" id="s1-1" name="default" value="1">
+        <label for="s1-1" title="1 star"></label>
+      </div>
+    </div>
+
+    <h2>Sizes</h2>
+    <div class="section">
+      <div class="row">
+        <div class="col">
+          <span class="badge">sm</span>
+          <div class="ease-rating ease-rating--sm">
+            <input type="radio" id="sz-sm-5" name="size-sm" value="5"><label for="sz-sm-5"></label>
+            <input type="radio" id="sz-sm-4" name="size-sm" value="4" checked><label for="sz-sm-4"></label>
+            <input type="radio" id="sz-sm-3" name="size-sm" value="3"><label for="sz-sm-3"></label>
+            <input type="radio" id="sz-sm-2" name="size-sm" value="2"><label for="sz-sm-2"></label>
+            <input type="radio" id="sz-sm-1" name="size-sm" value="1"><label for="sz-sm-1"></label>
+          </div>
+        </div>
+        <div class="col">
+          <span class="badge">default</span>
+          <div class="ease-rating">
+            <input type="radio" id="sz-d-5" name="size-d" value="5"><label for="sz-d-5"></label>
+            <input type="radio" id="sz-d-4" name="size-d" value="4" checked><label for="sz-d-4"></label>
+            <input type="radio" id="sz-d-3" name="size-d" value="3"><label for="sz-d-3"></label>
+            <input type="radio" id="sz-d-2" name="size-d" value="2"><label for="sz-d-2"></label>
+            <input type="radio" id="sz-d-1" name="size-d" value="1"><label for="sz-d-1"></label>
+          </div>
+        </div>
+        <div class="col">
+          <span class="badge">lg</span>
+          <div class="ease-rating ease-rating--lg">
+            <input type="radio" id="sz-lg-5" name="size-lg" value="5"><label for="sz-lg-5"></label>
+            <input type="radio" id="sz-lg-4" name="size-lg" value="4" checked><label for="sz-lg-4"></label>
+            <input type="radio" id="sz-lg-3" name="size-lg" value="3"><label for="sz-lg-3"></label>
+            <input type="radio" id="sz-lg-2" name="size-lg" value="2"><label for="sz-lg-2"></label>
+            <input type="radio" id="sz-lg-1" name="size-lg" value="1"><label for="sz-lg-1"></label>
+          </div>
+        </div>
+        <div class="col">
+          <span class="badge">xl</span>
+          <div class="ease-rating ease-rating--xl">
+            <input type="radio" id="sz-xl-5" name="size-xl" value="5"><label for="sz-xl-5"></label>
+            <input type="radio" id="sz-xl-4" name="size-xl" value="4" checked><label for="sz-xl-4"></label>
+            <input type="radio" id="sz-xl-3" name="size-xl" value="3"><label for="sz-xl-3"></label>
+            <input type="radio" id="sz-xl-2" name="size-xl" value="2"><label for="sz-xl-2"></label>
+            <input type="radio" id="sz-xl-1" name="size-xl" value="1"><label for="sz-xl-1"></label>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <h2>Color Variants</h2>
+    <div class="section">
+      <div class="row">
+        <div class="col">
+          <span class="badge">amber (default)</span>
+          <div class="ease-rating">
+            <input type="radio" id="c-am-5" name="c-am" value="5"><label for="c-am-5"></label>
+            <input type="radio" id="c-am-4" name="c-am" value="4"><label for="c-am-4"></label>
+            <input type="radio" id="c-am-3" name="c-am" value="3" checked><label for="c-am-3"></label>
+            <input type="radio" id="c-am-2" name="c-am" value="2"><label for="c-am-2"></label>
+            <input type="radio" id="c-am-1" name="c-am" value="1"><label for="c-am-1"></label>
+          </div>
+        </div>
+        <div class="col">
+          <span class="badge">red</span>
+          <div class="ease-rating ease-rating--red">
+            <input type="radio" id="c-re-5" name="c-re" value="5"><label for="c-re-5"></label>
+            <input type="radio" id="c-re-4" name="c-re" value="4"><label for="c-re-4"></label>
+            <input type="radio" id="c-re-3" name="c-re" value="3" checked><label for="c-re-3"></label>
+            <input type="radio" id="c-re-2" name="c-re" value="2"><label for="c-re-2"></label>
+            <input type="radio" id="c-re-1" name="c-re" value="1"><label for="c-re-1"></label>
+          </div>
+        </div>
+        <div class="col">
+          <span class="badge">blue</span>
+          <div class="ease-rating ease-rating--blue">
+            <input type="radio" id="c-bl-5" name="c-bl" value="5"><label for="c-bl-5"></label>
+            <input type="radio" id="c-bl-4" name="c-bl" value="4"><label for="c-bl-4"></label>
+            <input type="radio" id="c-bl-3" name="c-bl" value="3" checked><label for="c-bl-3"></label>
+            <input type="radio" id="c-bl-2" name="c-bl" value="2"><label for="c-bl-2"></label>
+            <input type="radio" id="c-bl-1" name="c-bl" value="1"><label for="c-bl-1"></label>
+          </div>
+        </div>
+        <div class="col">
+          <span class="badge">green</span>
+          <div class="ease-rating ease-rating--green">
+            <input type="radio" id="c-gr-5" name="c-gr" value="5"><label for="c-gr-5"></label>
+            <input type="radio" id="c-gr-4" name="c-gr" value="4"><label for="c-gr-4"></label>
+            <input type="radio" id="c-gr-3" name="c-gr" value="3" checked><label for="c-gr-3"></label>
+            <input type="radio" id="c-gr-2" name="c-gr" value="2"><label for="c-gr-2"></label>
+            <input type="radio" id="c-gr-1" name="c-gr" value="1"><label for="c-gr-1"></label>
+          </div>
+        </div>
+        <div class="col">
+          <span class="badge">purple</span>
+          <div class="ease-rating ease-rating--purple">
+            <input type="radio" id="c-pu-5" name="c-pu" value="5"><label for="c-pu-5"></label>
+            <input type="radio" id="c-pu-4" name="c-pu" value="4"><label for="c-pu-4"></label>
+            <input type="radio" id="c-pu-3" name="c-pu" value="3" checked><label for="c-pu-3"></label>
+            <input type="radio" id="c-pu-2" name="c-pu" value="2"><label for="c-pu-2"></label>
+            <input type="radio" id="c-pu-1" name="c-pu" value="1"><label for="c-pu-1"></label>
+          </div>
+        </div>
+        <div class="col">
+          <span class="badge">pink</span>
+          <div class="ease-rating ease-rating--pink">
+            <input type="radio" id="c-pi-5" name="c-pi" value="5"><label for="c-pi-5"></label>
+            <input type="radio" id="c-pi-4" name="c-pi" value="4"><label for="c-pi-4"></label>
+            <input type="radio" id="c-pi-3" name="c-pi" value="3" checked><label for="c-pi-3"></label>
+            <input type="radio" id="c-pi-2" name="c-pi" value="2"><label for="c-pi-2"></label>
+            <input type="radio" id="c-pi-1" name="c-pi" value="1"><label for="c-pi-1"></label>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <h2>Symbol Styles</h2>
+    <div class="section">
+      <div class="row">
+        <div class="col">
+          <span class="badge">filled stars (default)</span>
+          <div class="ease-rating">
+            <input type="radio" id="sy-fi-5" name="sy-fi" value="5"><label for="sy-fi-5"></label>
+            <input type="radio" id="sy-fi-4" name="sy-fi" value="4"><label for="sy-fi-4"></label>
+            <input type="radio" id="sy-fi-3" name="sy-fi" value="3" checked><label for="sy-fi-3"></label>
+            <input type="radio" id="sy-fi-2" name="sy-fi" value="2"><label for="sy-fi-2"></label>
+            <input type="radio" id="sy-fi-1" name="sy-fi" value="1"><label for="sy-fi-1"></label>
+          </div>
+        </div>
+        <div class="col">
+          <span class="badge">outline (empty/fill)</span>
+          <div class="ease-rating ease-rating--outline">
+            <input type="radio" id="sy-ou-5" name="sy-ou" value="5"><label for="sy-ou-5"></label>
+            <input type="radio" id="sy-ou-4" name="sy-ou" value="4"><label for="sy-ou-4"></label>
+            <input type="radio" id="sy-ou-3" name="sy-ou" value="3" checked><label for="sy-ou-3"></label>
+            <input type="radio" id="sy-ou-2" name="sy-ou" value="2"><label for="sy-ou-2"></label>
+            <input type="radio" id="sy-ou-1" name="sy-ou" value="1"><label for="sy-ou-1"></label>
+          </div>
+        </div>
+        <div class="col">
+          <span class="badge">hearts</span>
+          <div class="ease-rating ease-rating--heart">
+            <input type="radio" id="sy-he-5" name="sy-he" value="5"><label for="sy-he-5"></label>
+            <input type="radio" id="sy-he-4" name="sy-he" value="4"><label for="sy-he-4"></label>
+            <input type="radio" id="sy-he-3" name="sy-he" value="3" checked><label for="sy-he-3"></label>
+            <input type="radio" id="sy-he-2" name="sy-he" value="2"><label for="sy-he-2"></label>
+            <input type="radio" id="sy-he-1" name="sy-he" value="1"><label for="sy-he-1"></label>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <h2>Animations & Effects</h2>
+    <div class="section">
+      <div class="row">
+        <div class="col">
+          <span class="badge">pop-in animated</span>
+          <div class="ease-rating ease-rating--animated">
+            <input type="radio" id="an-po-5" name="an-po" value="5"><label for="an-po-5"></label>
+            <input type="radio" id="an-po-4" name="an-po" value="4"><label for="an-po-4"></label>
+            <input type="radio" id="an-po-3" name="an-po" value="3" checked><label for="an-po-3"></label>
+            <input type="radio" id="an-po-2" name="an-po" value="2"><label for="an-po-2"></label>
+            <input type="radio" id="an-po-1" name="an-po" value="1"><label for="an-po-1"></label>
+          </div>
+        </div>
+        <div class="col">
+          <span class="badge">bounce hover</span>
+          <div class="ease-rating ease-rating--bounce">
+            <input type="radio" id="an-bo-5" name="an-bo" value="5"><label for="an-bo-5"></label>
+            <input type="radio" id="an-bo-4" name="an-bo" value="4"><label for="an-bo-4"></label>
+            <input type="radio" id="an-bo-3" name="an-bo" value="3" checked><label for="an-bo-3"></label>
+            <input type="radio" id="an-bo-2" name="an-bo" value="2"><label for="an-bo-2"></label>
+            <input type="radio" id="an-bo-1" name="an-bo" value="1"><label for="an-bo-1"></label>
+          </div>
+        </div>
+        <div class="col">
+          <span class="badge">scale hover</span>
+          <div class="ease-rating ease-rating--scale">
+            <input type="radio" id="an-sc-5" name="an-sc" value="5"><label for="an-sc-5"></label>
+            <input type="radio" id="an-sc-4" name="an-sc" value="4"><label for="an-sc-4"></label>
+            <input type="radio" id="an-sc-3" name="an-sc" value="3" checked><label for="an-sc-3"></label>
+            <input type="radio" id="an-sc-2" name="an-sc" value="2"><label for="an-sc-2"></label>
+            <input type="radio" id="an-sc-1" name="an-sc" value="1"><label for="an-sc-1"></label>
+          </div>
+        </div>
+        <div class="col">
+          <span class="badge">rotate hover</span>
+          <div class="ease-rating ease-rating--rotate">
+            <input type="radio" id="an-ro-5" name="an-ro" value="5"><label for="an-ro-5"></label>
+            <input type="radio" id="an-ro-4" name="an-ro" value="4"><label for="an-ro-4"></label>
+            <input type="radio" id="an-ro-3" name="an-ro" value="3" checked><label for="an-ro-3"></label>
+            <input type="radio" id="an-ro-2" name="an-ro" value="2"><label for="an-ro-2"></label>
+            <input type="radio" id="an-ro-1" name="an-ro" value="1"><label for="an-ro-1"></label>
+          </div>
+        </div>
+        <div class="col">
+          <span class="badge">glow checked</span>
+          <div class="ease-rating ease-rating--glow ease-rating--purple">
+            <input type="radio" id="an-gl-5" name="an-gl" value="5"><label for="an-gl-5"></label>
+            <input type="radio" id="an-gl-4" name="an-gl" value="4"><label for="an-gl-4"></label>
+            <input type="radio" id="an-gl-3" name="an-gl" value="3" checked><label for="an-gl-3"></label>
+            <input type="radio" id="an-gl-2" name="an-gl" value="2"><label for="an-gl-2"></label>
+            <input type="radio" id="an-gl-1" name="an-gl" value="1"><label for="an-gl-1"></label>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <h2>Modes</h2>
+    <div class="section">
+      <div class="row">
+        <div class="col">
+          <span class="badge">readonly</span>
+          <div class="ease-rating ease-rating--readonly">
+            <input type="radio" id="mo-ro-5" name="mo-ro" value="5"><label for="mo-ro-5"></label>
+            <input type="radio" id="mo-ro-4" name="mo-ro" value="4" checked><label for="mo-ro-4"></label>
+            <input type="radio" id="mo-ro-3" name="mo-ro" value="3"><label for="mo-ro-3"></label>
+            <input type="radio" id="mo-ro-2" name="mo-ro" value="2"><label for="mo-ro-2"></label>
+            <input type="radio" id="mo-ro-1" name="mo-ro" value="1"><label for="mo-ro-1"></label>
+          </div>
+        </div>
+        <div class="col">
+          <span class="badge">disabled</span>
+          <div class="ease-rating ease-rating--disabled">
+            <input type="radio" id="mo-di-5" name="mo-di" value="5"><label for="mo-di-5"></label>
+            <input type="radio" id="mo-di-4" name="mo-di" value="4"><label for="mo-di-4"></label>
+            <input type="radio" id="mo-di-3" name="mo-di" value="3" checked><label for="mo-di-3"></label>
+            <input type="radio" id="mo-di-2" name="mo-di" value="2"><label for="mo-di-2"></label>
+            <input type="radio" id="mo-di-1" name="mo-di" value="1"><label for="mo-di-1"></label>
+          </div>
+        </div>
+        <div class="col">
+          <span class="badge">dark mode</span>
+          <div style="background:#1e293b;padding:0.75rem;border-radius:6px;">
+            <div class="ease-rating ease-rating--dark">
+              <input type="radio" id="mo-dk-5" name="mo-dk" value="5"><label for="mo-dk-5"></label>
+              <input type="radio" id="mo-dk-4" name="mo-dk" value="4"><label for="mo-dk-4"></label>
+              <input type="radio" id="mo-dk-3" name="mo-dk" value="3" checked><label for="mo-dk-3"></label>
+              <input type="radio" id="mo-dk-2" name="mo-dk" value="2"><label for="mo-dk-2"></label>
+              <input type="radio" id="mo-dk-1" name="mo-dk" value="1"><label for="mo-dk-1"></label>
+            </div>
+          </div>
+        </div>
+        <div class="col">
+          <span class="badge">RTL</span>
+          <div class="ease-rating" dir="rtl">
+            <input type="radio" id="mo-rt-5" name="mo-rt" value="5"><label for="mo-rt-5"></label>
+            <input type="radio" id="mo-rt-4" name="mo-rt" value="4"><label for="mo-rt-4"></label>
+            <input type="radio" id="mo-rt-3" name="mo-rt" value="3" checked><label for="mo-rt-3"></label>
+            <input type="radio" id="mo-rt-2" name="mo-rt" value="2"><label for="mo-rt-2"></label>
+            <input type="radio" id="mo-rt-1" name="mo-rt" value="1"><label for="mo-rt-1"></label>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <h2>Usage</h2>
+    <div class="section">
+      <pre><code>&lt;!-- Basic rating --&gt;
+&lt;div class="ease-rating"&gt;
+  &lt;input type="radio" id="star-5" name="rating" value="5"&gt;
+  &lt;label for="star-5"&gt;&lt;/label&gt;
+  &lt;input type="radio" id="star-4" name="rating" value="4"&gt;
+  &lt;label for="star-4"&gt;&lt;/label&gt;
+  &lt;input type="radio" id="star-3" name="rating" value="3" checked&gt;
+  &lt;label for="star-3"&gt;&lt;/label&gt;
+  &lt;input type="radio" id="star-2" name="rating" value="2"&gt;
+  &lt;label for="star-2"&gt;&lt;/label&gt;
+  &lt;input type="radio" id="star-1" name="rating" value="1"&gt;
+  &lt;label for="star-1"&gt;&lt;/label&gt;
+&lt;/div&gt;
+
+&lt;!-- Color variants --&gt;
+&lt;div class="ease-rating ease-rating--red"&gt;...&lt;/div&gt;
+&lt;div class="ease-rating ease-rating--blue"&gt;...&lt;/div&gt;
+
+&lt;!-- Sizes --&gt;
+&lt;div class="ease-rating ease-rating--sm"&gt;...&lt;/div&gt;
+&lt;div class="ease-rating ease-rating--lg"&gt;...&lt;/div&gt;
+
+&lt;!-- Symbol styles --&gt;
+&lt;div class="ease-rating ease-rating--outline"&gt;...&lt;/div&gt;
+&lt;div class="ease-rating ease-rating--heart"&gt;...&lt;/div&gt;
+
+&lt;!-- Animations --&gt;
+&lt;div class="ease-rating ease-rating--animated"&gt;...&lt;/div&gt;
+&lt;div class="ease-rating ease-rating--bounce"&gt;...&lt;/div&gt;
+
+&lt;!-- Modes --&gt;
+&lt;div class="ease-rating ease-rating--readonly"&gt;...&lt;/div&gt;
+&lt;div class="ease-rating ease-rating--disabled"&gt;...&lt;/div&gt;
+&lt;div class="ease-rating ease-rating--dark"&gt;...&lt;/div&gt;
+&lt;div class="ease-rating" dir="rtl"&gt;...&lt;/div&gt;</code></pre>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/core_changes-issue-23906/style.css
+++ b/submissions/core_changes-issue-23906/style.css
@@ -1,0 +1,383 @@
+@layer easemotion-components {
+  .ease-rating {
+    --ease-rating-size: 1.5rem;
+    --ease-rating-gap: 0.25rem;
+    --ease-rating-color: #f59e0b;
+    --ease-rating-color-empty: #d1d5db;
+    --ease-rating-color-hover: #fbbf24;
+    --ease-rating-color-active: #d97706;
+    --ease-rating-transition: 0.2s ease;
+    display: inline-flex;
+    gap: var(--ease-rating-gap);
+    direction: ltr;
+    unicode-bidi: bidi-override;
+  }
+
+  .ease-rating input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .ease-rating label {
+    cursor: pointer;
+    font-size: var(--ease-rating-size);
+    color: var(--ease-rating-color-empty);
+    transition: color var(--ease-rating-transition), transform var(--ease-rating-transition);
+    line-height: 1;
+  }
+
+  .ease-rating label::before {
+    content: "\2605";
+  }
+
+  .ease-rating label:hover,
+  .ease-rating label:hover ~ label {
+    color: var(--ease-rating-color-hover);
+  }
+
+  .ease-rating input:checked ~ label {
+    color: var(--ease-rating-color);
+  }
+
+  .ease-rating input:checked + label {
+    color: var(--ease-rating-color-active);
+  }
+
+  .ease-rating label:active {
+    transform: scale(1.3);
+  }
+
+  .ease-rating:focus-within {
+    outline: 2px solid var(--ease-rating-color);
+    outline-offset: 4px;
+    border-radius: 4px;
+  }
+
+  .ease-rating[dir="rtl"] {
+    direction: rtl;
+  }
+
+  .ease-rating[dir="rtl"] label:hover,
+  .ease-rating[dir="rtl"] label:hover ~ label {
+    color: var(--ease-rating-color-hover);
+  }
+
+  .ease-rating--sm {
+    --ease-rating-size: 1rem;
+    --ease-rating-gap: 0.125rem;
+  }
+
+  .ease-rating--lg {
+    --ease-rating-size: 2.25rem;
+    --ease-rating-gap: 0.375rem;
+  }
+
+  .ease-rating--xl {
+    --ease-rating-size: 3rem;
+    --ease-rating-gap: 0.5rem;
+  }
+
+  .ease-rating--red {
+    --ease-rating-color: #ef4444;
+    --ease-rating-color-hover: #f87171;
+    --ease-rating-color-active: #dc2626;
+  }
+
+  .ease-rating--blue {
+    --ease-rating-color: #3b82f6;
+    --ease-rating-color-hover: #60a5fa;
+    --ease-rating-color-active: #2563eb;
+  }
+
+  .ease-rating--green {
+    --ease-rating-color: #22c55e;
+    --ease-rating-color-hover: #4ade80;
+    --ease-rating-color-active: #16a34a;
+  }
+
+  .ease-rating--purple {
+    --ease-rating-color: #a855f7;
+    --ease-rating-color-hover: #c084fc;
+    --ease-rating-color-active: #9333ea;
+  }
+
+  .ease-rating--pink {
+    --ease-rating-color: #ec4899;
+    --ease-rating-color-hover: #f472b6;
+    --ease-rating-color-active: #db2777;
+  }
+
+  .ease-rating--orange {
+    --ease-rating-color: #f97316;
+    --ease-rating-color-hover: #fb923c;
+    --ease-rating-color-active: #ea580c;
+  }
+
+  .ease-rating--teal {
+    --ease-rating-color: #14b8a6;
+    --ease-rating-color-hover: #2dd4bf;
+    --ease-rating-color-active: #0d9488;
+  }
+
+  .ease-rating--disabled {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+
+  .ease-rating--readonly {
+    pointer-events: none;
+  }
+
+  .ease-rating--readonly label {
+    cursor: default;
+  }
+
+  .ease-rating--animated label {
+    animation: ease-rating-pop 0.3s ease calc(var(--i, 0) * 0.05s) both;
+  }
+
+  @keyframes ease-rating-pop {
+    0% {
+      transform: scale(0);
+      opacity: 0;
+    }
+    60% {
+      transform: scale(1.2);
+    }
+    100% {
+      transform: scale(1);
+      opacity: 1;
+    }
+  }
+
+  .ease-rating--outline label::before {
+    content: "\2606";
+  }
+
+  .ease-rating--outline input:checked ~ label {
+    color: var(--ease-rating-color);
+  }
+
+  .ease-rating--outline input:checked ~ label::before {
+    content: "\2605";
+  }
+
+  .ease-rating--outline input:checked + label {
+    color: var(--ease-rating-color-active);
+  }
+
+  .ease-rating--heart label::before {
+    content: "\2661";
+  }
+
+  .ease-rating--heart input:checked ~ label::before,
+  .ease-rating--heart label:hover::before,
+  .ease-rating--heart label:hover ~ label::before {
+    content: "\2665";
+  }
+
+  .ease-rating--heart input:checked + label::before {
+    content: "\2665";
+  }
+
+  .ease-rating--star-2 label::before {
+    content: "\2605";
+  }
+
+  .ease-rating--star-3 label::before {
+    content: "\2605";
+  }
+
+  .ease-rating--star-4 label::before {
+    content: "\2605";
+  }
+
+  .ease-rating--star-5 label::before {
+    content: "\2605";
+  }
+
+  .ease-rating--star-6 label::before {
+    content: "\2605";
+  }
+
+  .ease-rating--star-7 label::before {
+    content: "\2605";
+  }
+
+  .ease-rating--star-8 label::before {
+    content: "\2605";
+  }
+
+  .ease-rating--star-9 label::before {
+    content: "\2605";
+  }
+
+  .ease-rating--star-10 label::before {
+    content: "\2605";
+  }
+
+  .ease-rating--inline {
+    display: inline-flex;
+    vertical-align: middle;
+  }
+
+  .ease-rating--block {
+    display: flex;
+    justify-content: center;
+  }
+
+  .ease-rating__value {
+    display: inline-block;
+    margin-left: 0.5rem;
+    font-size: 0.875rem;
+    color: #6b7280;
+    vertical-align: middle;
+  }
+
+  .ease-rating + .ease-rating__value {
+    margin-left: 0.5rem;
+  }
+
+  .ease-rating--tooltip {
+    position: relative;
+  }
+
+  .ease-rating--tooltip label::after {
+    content: attr(data-tip);
+    position: absolute;
+    bottom: calc(100% + 6px);
+    left: 50%;
+    transform: translateX(-50%) scale(0);
+    background: #1f2937;
+    color: #fff;
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    white-space: nowrap;
+    opacity: 0;
+    transition: transform 0.15s ease, opacity 0.15s ease;
+    pointer-events: none;
+  }
+
+  .ease-rating--tooltip label:hover::after {
+    transform: translateX(-50%) scale(1);
+    opacity: 1;
+  }
+
+  .ease-rating--inline-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .ease-rating--inline-label .ease-rating__label-text {
+    font-size: 0.875rem;
+    color: #374151;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ease-rating--animated label {
+      animation: none;
+    }
+
+    .ease-rating label:active {
+      transform: none;
+    }
+
+    .ease-rating--tooltip label::after {
+      transition: none;
+    }
+  }
+
+  .ease-rating--dark label {
+    color: #4b5563;
+  }
+
+  .ease-rating--dark input:checked ~ label {
+    color: #fbbf24;
+  }
+
+  .ease-rating--dark label:hover,
+  .ease-rating--dark label:hover ~ label {
+    color: #f59e0b;
+  }
+
+  .ease-rating--no-animation label {
+    transition: none;
+  }
+
+  .ease-rating--bounce label {
+    transition: color var(--ease-rating-transition), transform 0.15s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+  }
+
+  .ease-rating--stagger label:nth-child(1) { --i: 1; }
+  .ease-rating--stagger label:nth-child(2) { --i: 2; }
+  .ease-rating--stagger label:nth-child(3) { --i: 3; }
+  .ease-rating--stagger label:nth-child(4) { --i: 4; }
+  .ease-rating--stagger label:nth-child(5) { --i: 5; }
+  .ease-rating--stagger label:nth-child(6) { --i: 6; }
+  .ease-rating--stagger label:nth-child(7) { --i: 7; }
+  .ease-rating--stagger label:nth-child(8) { --i: 8; }
+  .ease-rating--stagger label:nth-child(9) { --i: 9; }
+  .ease-rating--stagger label:nth-child(10) { --i: 10; }
+
+  .ease-rating--custom-icon label::before {
+    content: attr(data-icon);
+  }
+
+  .ease-rating--responsive {
+    --ease-rating-size: clamp(1rem, 4vw, 2.5rem);
+  }
+
+  .ease-rating--with-text label {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.125rem;
+  }
+
+  .ease-rating--with-text label::after {
+    content: attr(data-rating-text);
+    font-size: 0.625rem;
+    color: #9ca3af;
+    display: block;
+  }
+
+  .ease-rating--scale label:hover {
+    transform: scale(1.4);
+  }
+
+  .ease-rating--rotate label:hover {
+    transform: rotate(15deg) scale(1.2);
+  }
+
+  .ease-rating--shadow label {
+    filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.1));
+  }
+
+  .ease-rating--glow input:checked ~ label {
+    filter: drop-shadow(0 0 6px var(--ease-rating-color));
+  }
+
+  .ease-rating--glow label:hover,
+  .ease-rating--glow label:hover ~ label {
+    filter: drop-shadow(0 0 8px var(--ease-rating-color-hover));
+  }
+
+  .ease-rating--inline-value {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .ease-rating--inline-value .ease-rating__value {
+    font-weight: 600;
+    color: var(--ease-rating-color);
+  }
+}


### PR DESCRIPTION
## Description
Adds a CSS-only star rating component. Features: 8 color variants (amber, red, blue, green, purple, pink, orange, teal), 4 sizes (sm, default, lg, xl), symbol styles (filled stars, outline fill/unfill, hearts), animations (pop-in, bounce, scale, rotate, stagger, glow), accessibility (keyboard nav via radio inputs, focus ring, screen reader support), and modes (readonly, disabled, dark, RTL).

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

## Checklist
- [x] `style.css` — All component styles under `@layer easemotion-components`
- [x] `demo.html` — Interactive demo with feature grid, sizes, colors, symbols, effects, modes sections and code usage block
- [x] `README.md` — What, how, why documentation with modifier table

## Maintainer Actions
1. Review `submissions/core_changes-issue-23906/style.css`
2. Copy contents into the main CSS bundle (e.g., `components/rating.css`)
3. Reference/demo the component in the documentation site

**Closes #23906**