### PR TITLE
feat(alert): add ease-alert notification banner with color variants, dismiss, and animation (GSSoC 2026)

### DIFF
--- a/submissions/core_changes-issue-23903/README.md
+++ b/submissions/core_changes-issue-23903/README.md
@@ -1,0 +1,88 @@
+# ease-alert
+
+A CSS-only notification banner component with color variants, styles, sizes, dismiss button, icon support, accent borders, and animated transitions.
+
+## What
+
+Alert/notification banner built with flexbox layout, CSS custom properties, and semantic class variants. No JavaScript required for styling or animation.
+
+## How
+
+1. Include `style.css`.
+2. Use `<div class="ease-alert ease-alert--{variant}">` with optional icon, title, message, and close button.
+3. Add modifier classes for style, size, dismiss, animation, and accent border.
+
+## Why
+
+Provides a lightweight, reusable, accessible (focus-visible close button, role="alert" ready) alert banner system without JavaScript dependencies.
+
+## Variants
+
+### Colors
+| Class | Context |
+|---|---|
+| `ease-alert--info` | Blue info |
+| `ease-alert--success` | Green success |
+| `ease-alert--warning` | Amber warning |
+| `ease-alert--danger` | Red error/danger |
+| `ease-alert--neutral` | Gray neutral |
+| `ease-alert--accent` | Purple accent |
+
+### Styles
+| Class | Description |
+|---|---|
+| _(default)_ | Filled background + border |
+| `ease-alert--outline` | Transparent background, 2px border |
+| `ease-alert--subtle` | No border, lighter background |
+| `ease-alert--elevated` | Box shadow lift |
+
+### Accent Borders
+| Class | Description |
+|---|---|
+| `ease-alert--bordered-left` | 4px left accent border |
+| `ease-alert--bordered-top` | 4px top accent border |
+
+### Sizes
+| Class | Description |
+|---|---|
+| `ease-alert--sm` | Small padding + font |
+| _(default)_ | Medium |
+| `ease-alert--lg` | Large padding + font |
+
+### Modifiers
+| Class | Description |
+|---|---|
+| `ease-alert--dismissible` | Adds right padding for close button |
+| `ease-alert--no-icon` | Hides icon slot |
+| `ease-alert--centered` | Centers text and stacks vertically |
+| `ease-alert--animated` | Slide-in animation on mount |
+| `ease-alert--sticky` | Sticky positioning at top |
+| `ease-alert--full` | Full width (block) |
+| `ease-alert--inline` | Inline-flex display |
+| `ease-alert--with-progress` | Auto-dismiss progress bar (5s) |
+
+### Roundedness
+| Class | Description |
+|---|---|
+| `ease-alert--rounded-none` | Square |
+| `ease-alert--rounded-sm` | 0.25rem |
+| _(default)_ | 0.5rem |
+| `ease-alert--rounded-lg` | 0.75rem |
+| `ease-alert--rounded-xl` | 1rem |
+| `ease-alert--rounded-full` | 9999px |
+
+## Sub-components
+
+- `.ease-alert__icon` — Icon container
+- `.ease-alert__content` — Title + message wrapper
+- `.ease-alert__title` — Optional bold title
+- `.ease-alert__message` — Alert body text
+- `.ease-alert__close` — Dismiss button (requires JavaScript to remove)
+- `.ease-alert__action` — Action link/button
+- `.ease-alert__progress` — Auto-dismiss progress indicator
+
+## Accessibility
+
+- Close button has `:focus-visible` outline.
+- Use `role="alert"` or `role="status"` on the alert element.
+- Close button should have `aria-label`.

--- a/submissions/core_changes-issue-23903/demo.html
+++ b/submissions/core_changes-issue-23903/demo.html
@@ -1,0 +1,386 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-alert demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #f8fafc;
+      color: #1e293b;
+      padding: 2rem;
+      line-height: 1.6;
+    }
+    .container { max-width: 900px; margin: 0 auto; }
+    h1 { font-size: 2rem; margin-bottom: 0.5rem; }
+    h2 {
+      font-size: 1.25rem;
+      margin: 2rem 0 1rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 2px solid #e2e8f0;
+    }
+    .section {
+      background: #fff;
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+    .section > .ease-alert { margin-bottom: 0.75rem; }
+    .section > .ease-alert:last-child { margin-bottom: 0; }
+    .section > p { margin-bottom: 0.75rem; color: #64748b; }
+    .row { display: flex; flex-wrap: wrap; gap: 0.75rem; }
+    .col { display: flex; flex-direction: column; gap: 0.5rem; flex:1; min-width:200px; }
+    .badge {
+      display: inline-block;
+      font-size: 0.75rem;
+      padding: 0.125rem 0.5rem;
+      border-radius: 999px;
+      background: #e2e8f0;
+      color: #475569;
+      align-self: flex-start;
+      margin-bottom: 0.25rem;
+    }
+    pre {
+      background: #1e293b;
+      color: #e2e8f0;
+      padding: 1rem;
+      border-radius: 6px;
+      overflow-x: auto;
+      font-size: 0.875rem;
+      margin-top: 0.75rem;
+    }
+    code { font-family: "SF Mono", Consolas, monospace; }
+    .feature-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1rem;
+    }
+    .feature-card {
+      background: #fff;
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      padding: 1.25rem;
+    }
+    .feature-card h3 { font-size: 1rem; margin-bottom: 0.5rem; }
+    .feature-card p { font-size: 0.875rem; color: #64748b; }
+    .icon-placeholder {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 1.25rem;
+      height: 1.25rem;
+      font-weight: bold;
+      font-size: 0.75rem;
+    }
+    .btn-demo {
+      background: none;
+      border: 1px solid #d1d5db;
+      padding: 0.375rem 0.75rem;
+      border-radius: 0.375rem;
+      cursor: pointer;
+      font-size: 0.875rem;
+    }
+    .btn-demo:hover { background: #f3f4f6; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>ease-alert</h1>
+    <p>CSS-only notification banner component with color variants, sizes, styles, dismiss, icon, and animated transitions.</p>
+
+    <h2>Features</h2>
+    <div class="feature-grid">
+      <div class="feature-card">
+        <h3>6 Color Variants</h3>
+        <p>Info, success, warning, danger, neutral, accent.</p>
+      </div>
+      <div class="feature-card">
+        <h3>3 Styles</h3>
+        <p>Filled (default), outline, subtle (no border).</p>
+      </div>
+      <div class="feature-card">
+        <h3>4 Accent Borders</h3>
+        <p>Left, top accent border + bordered edges.</p>
+      </div>
+      <div class="feature-card">
+        <h3>2 Sizes</h3>
+        <p>Default, sm, lg. Custom via CSS properties.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Dismissible</h3>
+        <p>Close button with absolute positioning.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Animated</h3>
+        <p>Slide-in/out, progress bar, auto-dismiss ready.</p>
+      </div>
+    </div>
+
+    <h2>Color Variants</h2>
+    <div class="section">
+      <p>Six semantic color themes for different notification contexts.</p>
+      <div class="ease-alert ease-alert--info">
+        <span class="ease-alert__icon icon-placeholder">i</span>
+        <div class="ease-alert__content">
+          <div class="ease-alert__title">Info</div>
+          <div class="ease-alert__message">This is an informational alert.</div>
+        </div>
+      </div>
+      <div class="ease-alert ease-alert--success">
+        <span class="ease-alert__icon icon-placeholder">&#10003;</span>
+        <div class="ease-alert__content">
+          <div class="ease-alert__title">Success</div>
+          <div class="ease-alert__message">Your changes have been saved successfully.</div>
+        </div>
+      </div>
+      <div class="ease-alert ease-alert--warning">
+        <span class="ease-alert__icon icon-placeholder">!</span>
+        <div class="ease-alert__content">
+          <div class="ease-alert__title">Warning</div>
+          <div class="ease-alert__message">Your session will expire in 5 minutes.</div>
+        </div>
+      </div>
+      <div class="ease-alert ease-alert--danger">
+        <span class="ease-alert__icon icon-placeholder">&#10007;</span>
+        <div class="ease-alert__content">
+          <div class="ease-alert__title">Danger</div>
+          <div class="ease-alert__message">There was an error processing your request.</div>
+        </div>
+      </div>
+      <div class="ease-alert ease-alert--neutral">
+        <span class="ease-alert__icon icon-placeholder">&#8226;</span>
+        <div class="ease-alert__content">
+          <div class="ease-alert__message">A neutral notification with no title.</div>
+        </div>
+      </div>
+      <div class="ease-alert ease-alert--accent">
+        <span class="ease-alert__icon icon-placeholder">&#9829;</span>
+        <div class="ease-alert__content">
+          <div class="ease-alert__title">Accent</div>
+          <div class="ease-alert__message">A purple accented alert for special messages.</div>
+        </div>
+      </div>
+    </div>
+
+    <h2>Styles</h2>
+    <div class="section">
+      <div class="row">
+        <div class="col">
+          <span class="badge">filled (default)</span>
+          <div class="ease-alert ease-alert--info">
+            <span class="ease-alert__icon icon-placeholder">i</span>
+            <div class="ease-alert__content">
+              <div class="ease-alert__message">Filled alert with background.</div>
+            </div>
+          </div>
+        </div>
+        <div class="col">
+          <span class="badge">outline</span>
+          <div class="ease-alert ease-alert--info ease-alert--outline">
+            <span class="ease-alert__icon icon-placeholder">i</span>
+            <div class="ease-alert__content">
+              <div class="ease-alert__message">Outline alert with 2px border.</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="row" style="margin-top:0.75rem;">
+        <div class="col">
+          <span class="badge">subtle</span>
+          <div class="ease-alert ease-alert--info ease-alert--subtle">
+            <span class="ease-alert__icon icon-placeholder">i</span>
+            <div class="ease-alert__content">
+              <div class="ease-alert__message">Subtle alert with no visible border.</div>
+            </div>
+          </div>
+        </div>
+        <div class="col">
+          <span class="badge">elevated</span>
+          <div class="ease-alert ease-alert--info ease-alert--elevated">
+            <span class="ease-alert__icon icon-placeholder">i</span>
+            <div class="ease-alert__content">
+              <div class="ease-alert__message">Elevated alert with shadow.</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <h2>Accent Borders</h2>
+    <div class="section">
+      <div class="row">
+        <div class="col">
+          <span class="badge">bordered-left</span>
+          <div class="ease-alert ease-alert--warning ease-alert--bordered-left">
+            <span class="ease-alert__icon icon-placeholder">!</span>
+            <div class="ease-alert__content">
+              <div class="ease-alert__message">Alert with left accent border.</div>
+            </div>
+          </div>
+        </div>
+        <div class="col">
+          <span class="badge">bordered-top</span>
+          <div class="ease-alert ease-alert--danger ease-alert--bordered-top">
+            <span class="ease-alert__icon icon-placeholder">&#10007;</span>
+            <div class="ease-alert__content">
+              <div class="ease-alert__message">Alert with top accent border.</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <h2>Sizes</h2>
+    <div class="section">
+      <div class="ease-alert ease-alert--success ease-alert--sm">
+        <span class="ease-alert__icon icon-placeholder">&#10003;</span>
+        <div class="ease-alert__content">
+          <div class="ease-alert__message">Small alert (sm).</div>
+        </div>
+      </div>
+      <div class="ease-alert ease-alert--success">
+        <span class="ease-alert__icon icon-placeholder">&#10003;</span>
+        <div class="ease-alert__content">
+          <div class="ease-alert__message">Default size alert.</div>
+        </div>
+      </div>
+      <div class="ease-alert ease-alert--success ease-alert--lg">
+        <span class="ease-alert__icon icon-placeholder">&#10003;</span>
+        <div class="ease-alert__content">
+          <div class="ease-alert__title">Large Alert</div>
+          <div class="ease-alert__message">Large size alert with bigger padding and font.</div>
+        </div>
+      </div>
+    </div>
+
+    <h2>Dismissible</h2>
+    <div class="section">
+      <div class="ease-alert ease-alert--info ease-alert--dismissible">
+        <span class="ease-alert__icon icon-placeholder">i</span>
+        <div class="ease-alert__content">
+          <div class="ease-alert__title">Dismissible Alert</div>
+          <div class="ease-alert__message">Click the close button to dismiss. Add JavaScript to remove the element.</div>
+        </div>
+        <button class="ease-alert__close" aria-label="Close">&times;</button>
+      </div>
+    </div>
+
+    <h2>With Action</h2>
+    <div class="section">
+      <div class="ease-alert ease-alert--warning">
+        <span class="ease-alert__icon icon-placeholder">!</span>
+        <div class="ease-alert__content">
+          <div class="ease-alert__message">Your password will expire in 7 days.</div>
+          <button class="ease-alert__action">Change password</button>
+        </div>
+      </div>
+    </div>
+
+    <h2>Centered & No Icon</h2>
+    <div class="section">
+      <div class="row">
+        <div class="col">
+          <span class="badge">centered</span>
+          <div class="ease-alert ease-alert--success ease-alert--centered">
+            <span class="ease-alert__icon icon-placeholder">&#10003;</span>
+            <div class="ease-alert__content">
+              <div class="ease-alert__title">Payment Successful</div>
+              <div class="ease-alert__message">Your transaction has been processed.</div>
+            </div>
+          </div>
+        </div>
+        <div class="col">
+          <span class="badge">no icon</span>
+          <div class="ease-alert ease-alert--danger ease-alert--no-icon">
+            <div class="ease-alert__content">
+              <div class="ease-alert__title">Error</div>
+              <div class="ease-alert__message">An error occurred without an icon.</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <h2>Animated</h2>
+    <div class="section">
+      <p>Slide-in animation on mount. Click the action button to preview the animation.</p>
+      <div class="ease-alert ease-alert--success ease-alert--animated" id="demo-animated">
+        <span class="ease-alert__icon icon-placeholder">&#10003;</span>
+        <div class="ease-alert__content">
+          <div class="ease-alert__message">This alert slides in with animation.</div>
+        </div>
+      </div>
+    </div>
+
+    <h2>With Progress Bar</h2>
+    <div class="section">
+      <div class="ease-alert ease-alert--warning ease-alert--with-progress" style="overflow:hidden;">
+        <span class="ease-alert__icon icon-placeholder">!</span>
+        <div class="ease-alert__content">
+          <div class="ease-alert__message">This alert will auto-dismiss after 5 seconds (visual indicator).</div>
+        </div>
+        <div class="ease-alert__progress"></div>
+      </div>
+    </div>
+
+    <h2>Rounded Variants</h2>
+    <div class="section">
+      <div class="ease-alert ease-alert--info ease-alert--rounded-none">
+        <span class="ease-alert__icon icon-placeholder">i</span>
+        <div class="ease-alert__content"><div class="ease-alert__message">Rounded none</div></div>
+      </div>
+      <div class="ease-alert ease-alert--info ease-alert--rounded-sm">
+        <span class="ease-alert__icon icon-placeholder">i</span>
+        <div class="ease-alert__content"><div class="ease-alert__message">Rounded sm</div></div>
+      </div>
+      <div class="ease-alert ease-alert--info">
+        <span class="ease-alert__icon icon-placeholder">i</span>
+        <div class="ease-alert__content"><div class="ease-alert__message">Rounded md (default)</div></div>
+      </div>
+      <div class="ease-alert ease-alert--info ease-alert--rounded-lg">
+        <span class="ease-alert__icon icon-placeholder">i</span>
+        <div class="ease-alert__content"><div class="ease-alert__message">Rounded lg</div></div>
+      </div>
+      <div class="ease-alert ease-alert--info ease-alert--rounded-full">
+        <span class="ease-alert__icon icon-placeholder">i</span>
+        <div class="ease-alert__content"><div class="ease-alert__message">Rounded full (pill)</div></div>
+      </div>
+    </div>
+
+    <h2>Usage</h2>
+    <div class="section">
+      <pre>&lt;!-- Basic alert --&gt;
+&lt;div class="ease-alert ease-alert--info"&gt;
+  &lt;span class="ease-alert__icon"&gt;&amp;#9432;&lt;/span&gt;
+  &lt;div class="ease-alert__content"&gt;
+    &lt;div class="ease-alert__title"&gt;Title&lt;/div&gt;
+    &lt;div class="ease-alert__message"&gt;Message text.&lt;/div&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+
+&lt;!-- Color variants --&gt;
+&lt;div class="ease-alert ease-alert--success"&gt;...&lt;/div&gt;
+&lt;div class="ease-alert ease-alert--warning"&gt;...&lt;/div&gt;
+&lt;div class="ease-alert ease-alert--danger"&gt;...&lt;/div&gt;
+
+&lt;!-- Styles --&gt;
+&lt;div class="ease-alert ease-alert--info ease-alert--outline"&gt;...&lt;/div&gt;
+&lt;div class="ease-alert ease-alert--info ease-alert--subtle"&gt;...&lt;/div&gt;
+
+&lt;!-- Sizes --&gt;
+&lt;div class="ease-alert ease-alert--sm"&gt;...&lt;/div&gt;
+&lt;div class="ease-alert ease-alert--lg"&gt;...&lt;/div&gt;
+
+&lt;!-- Dismissible --&gt;
+&lt;div class="ease-alert ease-alert--dismissible"&gt;
+  ...
+  &lt;button class="ease-alert__close"&gt;&amp;times;&lt;/button&gt;
+&lt;/div&gt;</pre>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/core_changes-issue-23903/style.css
+++ b/submissions/core_changes-issue-23903/style.css
@@ -1,0 +1,352 @@
+@layer easemotion-components {
+  .ease-alert {
+    --ease-alert-padding: 1rem;
+    --ease-alert-radius: 0.5rem;
+    --ease-alert-font-size: 0.875rem;
+    --ease-alert-bg: #eff6ff;
+    --ease-alert-border: #bfdbfe;
+    --ease-alert-color: #1e40af;
+    --ease-alert-icon-color: #3b82f6;
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: var(--ease-alert-padding);
+    border-radius: var(--ease-alert-radius);
+    background: var(--ease-alert-bg);
+    border: 1px solid var(--ease-alert-border);
+    color: var(--ease-alert-color);
+    font-size: var(--ease-alert-font-size);
+    line-height: 1.5;
+    position: relative;
+  }
+
+  .ease-alert__icon {
+    flex-shrink: 0;
+    width: 1.25rem;
+    height: 1.25rem;
+    color: var(--ease-alert-icon-color);
+    margin-top: 0.125rem;
+  }
+
+  .ease-alert__content {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .ease-alert__title {
+    font-weight: 600;
+    font-size: 1em;
+    margin-bottom: 0.25rem;
+  }
+
+  .ease-alert__message {
+    opacity: 0.9;
+  }
+
+  .ease-alert__close {
+    flex-shrink: 0;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: inherit;
+    opacity: 0.5;
+    padding: 0.25rem;
+    line-height: 1;
+    font-size: 1.125rem;
+    border-radius: 0.25rem;
+    transition: opacity 0.15s ease;
+  }
+
+  .ease-alert__close:hover {
+    opacity: 1;
+  }
+
+  .ease-alert__close:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+  }
+
+  .ease-alert--info {
+    --ease-alert-bg: #eff6ff;
+    --ease-alert-border: #bfdbfe;
+    --ease-alert-color: #1e40af;
+    --ease-alert-icon-color: #3b82f6;
+  }
+
+  .ease-alert--success {
+    --ease-alert-bg: #f0fdf4;
+    --ease-alert-border: #bbf7d0;
+    --ease-alert-color: #166534;
+    --ease-alert-icon-color: #22c55e;
+  }
+
+  .ease-alert--warning {
+    --ease-alert-bg: #fffbeb;
+    --ease-alert-border: #fde68a;
+    --ease-alert-color: #92400e;
+    --ease-alert-icon-color: #f59e0b;
+  }
+
+  .ease-alert--danger {
+    --ease-alert-bg: #fef2f2;
+    --ease-alert-border: #fecaca;
+    --ease-alert-color: #991b1b;
+    --ease-alert-icon-color: #ef4444;
+  }
+
+  .ease-alert--neutral {
+    --ease-alert-bg: #f8fafc;
+    --ease-alert-border: #e2e8f0;
+    --ease-alert-color: #475569;
+    --ease-alert-icon-color: #64748b;
+  }
+
+  .ease-alert--accent {
+    --ease-alert-bg: #faf5ff;
+    --ease-alert-border: #e9d5ff;
+    --ease-alert-color: #6b21a8;
+    --ease-alert-icon-color: #a855f7;
+  }
+
+  .ease-alert--outline {
+    background: transparent;
+    border-width: 2px;
+  }
+
+  .ease-alert--outline.ease-alert--info {
+    background: transparent;
+  }
+
+  .ease-alert--outline.ease-alert--success {
+    background: transparent;
+  }
+
+  .ease-alert--outline.ease-alert--warning {
+    background: transparent;
+  }
+
+  .ease-alert--outline.ease-alert--danger {
+    background: transparent;
+  }
+
+  .ease-alert--outline.ease-alert--neutral {
+    background: transparent;
+  }
+
+  .ease-alert--outline.ease-alert--accent {
+    background: transparent;
+  }
+
+  .ease-alert--subtle {
+    border: none;
+    box-shadow: none;
+  }
+
+  .ease-alert--subtle.ease-alert--info {
+    background: #f0f9ff;
+  }
+
+  .ease-alert--subtle.ease-alert--success {
+    background: #f0fdf4;
+  }
+
+  .ease-alert--subtle.ease-alert--warning {
+    background: #fff7ed;
+  }
+
+  .ease-alert--subtle.ease-alert--danger {
+    background: #fef2f2;
+  }
+
+  .ease-alert--bordered-left {
+    border-left: 4px solid var(--ease-alert-border);
+  }
+
+  .ease-alert--bordered-top {
+    border-top: 4px solid var(--ease-alert-border);
+  }
+
+  .ease-alert--dismissible {
+    padding-right: 2.75rem;
+  }
+
+  .ease-alert--dismissible .ease-alert__close {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+  }
+
+  .ease-alert--no-icon .ease-alert__icon {
+    display: none;
+  }
+
+  .ease-alert--centered {
+    text-align: center;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .ease-alert--centered .ease-alert__icon {
+    margin-bottom: 0.25rem;
+  }
+
+  .ease-alert--sm {
+    --ease-alert-padding: 0.5rem 0.75rem;
+    --ease-alert-font-size: 0.75rem;
+    --ease-alert-radius: 0.375rem;
+  }
+
+  .ease-alert--sm .ease-alert__icon {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  .ease-alert--lg {
+    --ease-alert-padding: 1.25rem 1.5rem;
+    --ease-alert-font-size: 1rem;
+    --ease-alert-radius: 0.75rem;
+  }
+
+  .ease-alert--lg .ease-alert__icon {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+
+  .ease-alert--elevated {
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+  }
+
+  .ease-alert--sticky {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+  }
+
+  .ease-alert--rounded-sm {
+    border-radius: 0.25rem;
+  }
+
+  .ease-alert--rounded-md {
+    border-radius: 0.5rem;
+  }
+
+  .ease-alert--rounded-lg {
+    border-radius: 0.75rem;
+  }
+
+  .ease-alert--rounded-xl {
+    border-radius: 1rem;
+  }
+
+  .ease-alert--rounded-full {
+    border-radius: 9999px;
+  }
+
+  .ease-alert--rounded-none {
+    border-radius: 0;
+  }
+
+  .ease-alert--full {
+    width: 100%;
+  }
+
+  .ease-alert--inline {
+    display: inline-flex;
+  }
+
+  .ease-alert--animated {
+    animation: ease-alert-slideIn 0.3s ease;
+  }
+
+  @keyframes ease-alert-slideIn {
+    0% {
+      opacity: 0;
+      transform: translateY(-0.5rem);
+    }
+    100% {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  .ease-alert--animated-out {
+    animation: ease-alert-slideOut 0.25s ease forwards;
+  }
+
+  @keyframes ease-alert-slideOut {
+    0% {
+      opacity: 1;
+      transform: translateY(0);
+    }
+    100% {
+      opacity: 0;
+      transform: translateY(-0.5rem);
+    }
+  }
+
+  .ease-alert__action {
+    display: inline-block;
+    margin-top: 0.5rem;
+    font-weight: 500;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    color: inherit;
+    opacity: 0.85;
+    cursor: pointer;
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: inherit;
+  }
+
+  .ease-alert__action:hover {
+    opacity: 1;
+  }
+
+  .ease-alert__list {
+    margin: 0.5rem 0 0;
+    padding-left: 1.25rem;
+  }
+
+  .ease-alert__list li {
+    margin-bottom: 0.25rem;
+  }
+
+  .ease-alert--with-progress .ease-alert__progress {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    height: 3px;
+    background: var(--ease-alert-icon-color);
+    opacity: 0.3;
+    border-radius: 0 0 var(--ease-alert-radius) var(--ease-alert-radius);
+    animation: ease-alert-progress 5s linear forwards;
+  }
+
+  @keyframes ease-alert-progress {
+    0% { width: 100%; }
+    100% { width: 0%; }
+  }
+
+  .ease-alert--multiline {
+    flex-direction: column;
+  }
+
+  .ease-alert--multiline .ease-alert__icon {
+    margin-bottom: 0.25rem;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ease-alert--animated {
+      animation: none;
+    }
+
+    .ease-alert--animated-out {
+      animation: none;
+    }
+
+    .ease-alert--with-progress .ease-alert__progress {
+      animation: none;
+    }
+  }
+}


### PR DESCRIPTION
## Description
Adds a CSS-only notification banner component. Features: 6 color variants (info, success, warning, danger, neutral, accent), 4 styles (filled, outline, subtle, elevated), 3 sizes (sm, default, lg), accent borders (left/top), dismissible close button, centered mode, no-icon mode, action button, progress bar auto-dismiss indicator, slide-in/out animation, 6 roundedness levels, sticky positioning, and prefers-reduced-motion support.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

## Checklist
- [x] `style.css` — All component styles under `@layer easemotion-components`
- [x] `demo.html` — Interactive demo covering colors, styles, sizes, borders, dismiss, actions, centered, animations, progress, roundedness, and code usage
- [x] `README.md` — What, how, why documentation with full modifier tables

## Maintainer Actions
1. Review `submissions/core_changes-issue-23903/style.css`
2. Copy contents into the main CSS bundle (e.g., `components/alert.css`)
3. Reference/demo the component in the documentation site

**Closes #23903**