### PR TITLE
feat(pagination): add ease-pagination component with page navigation, sizes, colors, and layouts (GSSoC 2026)

### DIFF
--- a/submissions/core_changes-issue-23902/README.md
+++ b/submissions/core_changes-issue-23902/README.md
@@ -1,0 +1,90 @@
+# ease-pagination
+
+A CSS-only pagination component with page numbers, active/disabled/ellipsis states, alignment, sizes, color themes, layout variants, responsive visibility, and dark mode.
+
+## What
+
+Flexible pagination navigation built with flexbox, CSS custom properties, and semantic class modifiers. Uses `<nav>` with `<a>` elements for page links.
+
+## How
+
+1. Include `style.css`.
+2. Use `<nav class="ease-pagination">` as the wrapper.
+3. Add `.ease-pagination__item` to each page link/button.
+4. Apply `.ease-pagination__item--active`, `.ease-pagination__item--disabled`, or `.ease-pagination__item--ellipsis` as needed.
+5. Add modifier classes to the `<nav>` for size, color, alignment, layout.
+
+## Why
+
+Provides a lightweight, reusable, accessible pagination system that works with any JavaScript framework (pairs with client-side or server-side state management).
+
+## Modifiers
+
+### Sizes
+| Class | Description |
+|---|---|
+| `ease-pagination--sm` | Small (1.75rem) |
+| _(default)_ | Medium (2.25rem) |
+| `ease-pagination--lg` | Large (2.75rem) |
+
+### Color Themes
+| Class | Description |
+|---|---|
+| `ease-pagination--primary` | Blue (default) |
+| `ease-pagination--secondary` | Gray |
+| `ease-pagination--success` | Green |
+| `ease-pagination--danger` | Red |
+| `ease-pagination--warning` | Amber |
+| `ease-pagination--dark` | Dark background scheme |
+
+### Alignment
+| Class | Description |
+|---|---|
+| _(default)_ | Flex-start |
+| `ease-pagination--centered` | Center |
+| `ease-pagination--end` | Flex-end |
+| `ease-pagination--between` | Space-between |
+
+### Layout Variants
+| Class | Description |
+|---|---|
+| `ease-pagination--no-border` | Removes borders from all items |
+| `ease-pagination--outline` | Active item has outline style (transparent bg) |
+| `ease-pagination--compact` | Zero gap, segmented button group style |
+| `ease-pagination--stretched` | Equal-width items |
+| `ease-pagination--with-icons` | Larger font for prev/next icons |
+
+### Rounded
+| Class | Description |
+|---|---|
+| `ease-pagination--rounded-none` | Square |
+| _(default)_ | 0.375rem |
+| `ease-pagination--rounded-sm` | 0.25rem |
+| `ease-pagination--rounded-lg` | 0.5rem |
+| `ease-pagination--rounded-xl` | 0.75rem |
+| `ease-pagination--rounded-full` | Pill shape |
+
+### Behavior
+| Class | Description |
+|---|---|
+| `ease-pagination--responsive` | Hides middle page items on small screens |
+| `ease-pagination--animated` | Adds transition and click scale effect |
+| `ease-pagination--sticky` | Sticky bottom positioning |
+
+## Sub-components
+
+- `.ease-pagination__item` — Page link/button
+- `.ease-pagination__item--active` — Current page state
+- `.ease-pagination__item--disabled` — Non-interactive state
+- `.ease-pagination__item--ellipsis` — Separator span
+- `.ease-pagination__item--prev` — Previous button
+- `.ease-pagination__item--next` — Next button
+- `.ease-pagination__item--page` — Numbered page
+- `.ease-pagination__info` — Page count label
+
+## Accessibility
+
+- Wrapped in `<nav>` with `aria-label`.
+- `:focus-visible` ring on all interactive items.
+- Use `aria-current="page"` on the active item.
+- Disabled items use `pointer-events: none` and reduced opacity.

--- a/submissions/core_changes-issue-23902/demo.html
+++ b/submissions/core_changes-issue-23902/demo.html
@@ -1,0 +1,315 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-pagination demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #f8fafc;
+      color: #1e293b;
+      padding: 2rem;
+      line-height: 1.6;
+    }
+    .container { max-width: 900px; margin: 0 auto; }
+    h1 { font-size: 2rem; margin-bottom: 0.5rem; }
+    h2 {
+      font-size: 1.25rem;
+      margin: 2rem 0 1rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 2px solid #e2e8f0;
+    }
+    .section {
+      background: #fff;
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+    .section > p { margin-bottom: 0.75rem; color: #64748b; }
+    .section > .ease-pagination { margin-bottom: 0.5rem; }
+    .section > .ease-pagination:last-child { margin-bottom: 0; }
+    .row { display: flex; flex-wrap: wrap; gap: 1.5rem; align-items: flex-start; }
+    .col { display: flex; flex-direction: column; gap: 0.5rem; flex:1; min-width:200px; }
+    .badge {
+      display: inline-block;
+      font-size: 0.75rem;
+      padding: 0.125rem 0.5rem;
+      border-radius: 999px;
+      background: #e2e8f0;
+      color: #475569;
+      align-self: flex-start;
+    }
+    pre {
+      background: #1e293b;
+      color: #e2e8f0;
+      padding: 1rem;
+      border-radius: 6px;
+      overflow-x: auto;
+      font-size: 0.875rem;
+      margin-top: 0.75rem;
+    }
+    code { font-family: "SF Mono", Consolas, monospace; }
+    .feature-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1rem;
+    }
+    .feature-card {
+      background: #fff;
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      padding: 1.25rem;
+    }
+    .feature-card h3 { font-size: 1rem; margin-bottom: 0.5rem; }
+    .feature-card p { font-size: 0.875rem; color: #64748b; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>ease-pagination</h1>
+    <p>CSS-only pagination component with page numbers, active/disabled states, ellipsis, sizes, colors, alignment, layout variations, and responsive visibility.</p>
+
+    <h2>Features</h2>
+    <div class="feature-grid">
+      <div class="feature-card">
+        <h3>6 Color Themes</h3>
+        <p>Primary, secondary, success, danger, warning, dark mode.</p>
+      </div>
+      <div class="feature-card">
+        <h3>3 Sizes</h3>
+        <p>sm, default, lg.</p>
+      </div>
+      <div class="feature-card">
+        <h3>4 Alignments</h3>
+        <p>Start (default), centered, end, space-between.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Layout Variants</h3>
+        <p>Default, compact (segmented), stretched (equal width), no-border, outline active.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Responsive</h3>
+        <p>Responsive mode hides inner pages on small screens.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Accessible</h3>
+        <p>Focus-visible ring, aria-label ready, nav landmark.</p>
+      </div>
+    </div>
+
+    <h2>Basic</h2>
+    <div class="section">
+      <p>Default pagination with page numbers, prev/next, and ellipsis.</p>
+      <nav class="ease-pagination" aria-label="Page navigation">
+        <a class="ease-pagination__item ease-pagination__item--disabled" href="#">&laquo; Prev</a>
+        <a class="ease-pagination__item ease-pagination__item--active" href="#">1</a>
+        <a class="ease-pagination__item ease-pagination__item--page" href="#">2</a>
+        <a class="ease-pagination__item ease-pagination__item--page" href="#">3</a>
+        <a class="ease-pagination__item ease-pagination__item--page" href="#">4</a>
+        <span class="ease-pagination__item ease-pagination__item--ellipsis">&hellip;</span>
+        <a class="ease-pagination__item ease-pagination__item--page" href="#">10</a>
+        <a class="ease-pagination__item" href="#">Next &raquo;</a>
+      </nav>
+    </div>
+
+    <h2>Alignments</h2>
+    <div class="section">
+      <p>Three alignment options for different layout contexts.</p>
+      <nav class="ease-pagination" aria-label="Left">
+        <a class="ease-pagination__item ease-pagination__item--disabled" href="#">Prev</a>
+        <a class="ease-pagination__item ease-pagination__item--active" href="#">1</a>
+        <a class="ease-pagination__item" href="#">2</a>
+        <a class="ease-pagination__item" href="#">3</a>
+        <a class="ease-pagination__item" href="#">Next</a>
+      </nav>
+      <nav class="ease-pagination ease-pagination--centered" aria-label="Centered">
+        <a class="ease-pagination__item ease-pagination__item--disabled" href="#">Prev</a>
+        <a class="ease-pagination__item ease-pagination__item--active" href="#">1</a>
+        <a class="ease-pagination__item" href="#">2</a>
+        <a class="ease-pagination__item" href="#">3</a>
+        <a class="ease-pagination__item" href="#">Next</a>
+      </nav>
+      <nav class="ease-pagination ease-pagination--end" aria-label="Right">
+        <a class="ease-pagination__item ease-pagination__item--disabled" href="#">Prev</a>
+        <a class="ease-pagination__item ease-pagination__item--active" href="#">1</a>
+        <a class="ease-pagination__item" href="#">2</a>
+        <a class="ease-pagination__item" href="#">3</a>
+        <a class="ease-pagination__item" href="#">Next</a>
+      </nav>
+    </div>
+
+    <h2>Sizes</h2>
+    <div class="section">
+      <nav class="ease-pagination ease-pagination--sm" aria-label="Small">
+        <a class="ease-pagination__item ease-pagination__item--disabled" href="#">Prev</a>
+        <a class="ease-pagination__item ease-pagination__item--active" href="#">1</a>
+        <a class="ease-pagination__item" href="#">2</a>
+        <a class="ease-pagination__item" href="#">3</a>
+        <a class="ease-pagination__item" href="#">Next</a>
+      </nav>
+      <nav class="ease-pagination" aria-label="Default">
+        <a class="ease-pagination__item ease-pagination__item--disabled" href="#">Prev</a>
+        <a class="ease-pagination__item ease-pagination__item--active" href="#">1</a>
+        <a class="ease-pagination__item" href="#">2</a>
+        <a class="ease-pagination__item" href="#">3</a>
+        <a class="ease-pagination__item" href="#">Next</a>
+      </nav>
+      <nav class="ease-pagination ease-pagination--lg" aria-label="Large">
+        <a class="ease-pagination__item ease-pagination__item--disabled" href="#">Prev</a>
+        <a class="ease-pagination__item ease-pagination__item--active" href="#">1</a>
+        <a class="ease-pagination__item" href="#">2</a>
+        <a class="ease-pagination__item" href="#">3</a>
+        <a class="ease-pagination__item" href="#">Next</a>
+      </nav>
+    </div>
+
+    <h2>Color Themes</h2>
+    <div class="section">
+      <nav class="ease-pagination ease-pagination--primary" aria-label="Primary">
+        <a class="ease-pagination__item" href="#">1</a>
+        <a class="ease-pagination__item ease-pagination__item--active" href="#">2</a>
+        <a class="ease-pagination__item" href="#">3</a>
+      </nav>
+      <nav class="ease-pagination ease-pagination--secondary" aria-label="Secondary">
+        <a class="ease-pagination__item" href="#">1</a>
+        <a class="ease-pagination__item ease-pagination__item--active" href="#">2</a>
+        <a class="ease-pagination__item" href="#">3</a>
+      </nav>
+      <nav class="ease-pagination ease-pagination--success" aria-label="Success">
+        <a class="ease-pagination__item" href="#">1</a>
+        <a class="ease-pagination__item ease-pagination__item--active" href="#">2</a>
+        <a class="ease-pagination__item" href="#">3</a>
+      </nav>
+      <nav class="ease-pagination ease-pagination--danger" aria-label="Danger">
+        <a class="ease-pagination__item" href="#">1</a>
+        <a class="ease-pagination__item ease-pagination__item--active" href="#">2</a>
+        <a class="ease-pagination__item" href="#">3</a>
+      </nav>
+      <nav class="ease-pagination ease-pagination--warning" aria-label="Warning">
+        <a class="ease-pagination__item" href="#">1</a>
+        <a class="ease-pagination__item ease-pagination__item--active" href="#">2</a>
+        <a class="ease-pagination__item" href="#">3</a>
+      </nav>
+    </div>
+
+    <h2>Dark Mode</h2>
+    <div class="section" style="background:#111827;">
+      <nav class="ease-pagination ease-pagination--dark" aria-label="Dark">
+        <a class="ease-pagination__item ease-pagination__item--disabled" href="#">Prev</a>
+        <a class="ease-pagination__item ease-pagination__item--active" href="#">1</a>
+        <a class="ease-pagination__item" href="#">2</a>
+        <a class="ease-pagination__item" href="#">3</a>
+        <a class="ease-pagination__item" href="#">Next</a>
+      </nav>
+    </div>
+
+    <h2>Layout Variants</h2>
+    <div class="section">
+      <p><span class="badge">no-border</span></p>
+      <nav class="ease-pagination ease-pagination--no-border" aria-label="No border">
+        <a class="ease-pagination__item ease-pagination__item--disabled" href="#">Prev</a>
+        <a class="ease-pagination__item ease-pagination__item--active" href="#">1</a>
+        <a class="ease-pagination__item" href="#">2</a>
+        <a class="ease-pagination__item" href="#">3</a>
+        <a class="ease-pagination__item" href="#">Next</a>
+      </nav>
+      <p><span class="badge">outline active</span></p>
+      <nav class="ease-pagination ease-pagination--outline" aria-label="Outline">
+        <a class="ease-pagination__item" href="#">1</a>
+        <a class="ease-pagination__item ease-pagination__item--active" href="#">2</a>
+        <a class="ease-pagination__item" href="#">3</a>
+      </nav>
+      <p><span class="badge">compact (segmented)</span></p>
+      <nav class="ease-pagination ease-pagination--compact" aria-label="Compact">
+        <a class="ease-pagination__item ease-pagination__item--disabled" href="#">Prev</a>
+        <a class="ease-pagination__item" href="#">1</a>
+        <a class="ease-pagination__item ease-pagination__item--active" href="#">2</a>
+        <a class="ease-pagination__item" href="#">3</a>
+        <a class="ease-pagination__item" href="#">Next</a>
+      </nav>
+      <p><span class="badge">stretched (equal width)</span></p>
+      <nav class="ease-pagination ease-pagination--stretched" aria-label="Stretched">
+        <a class="ease-pagination__item ease-pagination__item--disabled" href="#">Prev</a>
+        <a class="ease-pagination__item" href="#">1</a>
+        <a class="ease-pagination__item ease-pagination__item--active" href="#">2</a>
+        <a class="ease-pagination__item" href="#">3</a>
+        <a class="ease-pagination__item" href="#">Next</a>
+      </nav>
+    </div>
+
+    <h2>With Info</h2>
+    <div class="section">
+      <nav class="ease-pagination ease-pagination--between" aria-label="With info">
+        <a class="ease-pagination__item ease-pagination__item--disabled" href="#">&laquo; Prev</a>
+        <a class="ease-pagination__item ease-pagination__item--active" href="#">1</a>
+        <a class="ease-pagination__item" href="#">2</a>
+        <a class="ease-pagination__item" href="#">3</a>
+        <span class="ease-pagination__info">Page 1 of 10</span>
+        <a class="ease-pagination__item" href="#">Next &raquo;</a>
+      </nav>
+    </div>
+
+    <h2>Rounded Variants</h2>
+    <div class="section">
+      <nav class="ease-pagination ease-pagination--rounded-none" aria-label="None">
+        <a class="ease-pagination__item ease-pagination__item--active" href="#">1</a>
+        <a class="ease-pagination__item" href="#">2</a>
+        <a class="ease-pagination__item" href="#">3</a>
+      </nav>
+      <nav class="ease-pagination ease-pagination--rounded-sm" aria-label="Sm">
+        <a class="ease-pagination__item ease-pagination__item--active" href="#">1</a>
+        <a class="ease-pagination__item" href="#">2</a>
+        <a class="ease-pagination__item" href="#">3</a>
+      </nav>
+      <nav class="ease-pagination ease-pagination--rounded-lg" aria-label="Lg">
+        <a class="ease-pagination__item ease-pagination__item--active" href="#">1</a>
+        <a class="ease-pagination__item" href="#">2</a>
+        <a class="ease-pagination__item" href="#">3</a>
+      </nav>
+      <nav class="ease-pagination ease-pagination--rounded-xl" aria-label="Xl">
+        <a class="ease-pagination__item ease-pagination__item--active" href="#">1</a>
+        <a class="ease-pagination__item" href="#">2</a>
+        <a class="ease-pagination__item" href="#">3</a>
+      </nav>
+      <nav class="ease-pagination ease-pagination--rounded-full" aria-label="Full">
+        <a class="ease-pagination__item ease-pagination__item--active" href="#">1</a>
+        <a class="ease-pagination__item" href="#">2</a>
+        <a class="ease-pagination__item" href="#">3</a>
+      </nav>
+    </div>
+
+    <h2>Usage</h2>
+    <div class="section">
+      <pre>&lt;nav class="ease-pagination" aria-label="Page navigation"&gt;
+  &lt;a class="ease-pagination__item ease-pagination__item--disabled" href="#"&gt;&amp;laquo; Prev&lt;/a&gt;
+  &lt;a class="ease-pagination__item ease-pagination__item--active" href="#"&gt;1&lt;/a&gt;
+  &lt;a class="ease-pagination__item" href="#"&gt;2&lt;/a&gt;
+  &lt;a class="ease-pagination__item" href="#"&gt;3&lt;/a&gt;
+  &lt;span class="ease-pagination__item ease-pagination__item--ellipsis"&gt;&amp;hellip;&lt;/span&gt;
+  &lt;a class="ease-pagination__item" href="#"&gt;10&lt;/a&gt;
+  &lt;a class="ease-pagination__item" href="#"&gt;Next &amp;raquo;&lt;/a&gt;
+&lt;/nav&gt;
+
+&lt;!-- Alignments --&gt;
+&lt;nav class="ease-pagination ease-pagination--centered"&gt;...&lt;/nav&gt;
+&lt;nav class="ease-pagination ease-pagination--end"&gt;...&lt;/nav&gt;
+
+&lt;!-- Sizes --&gt;
+&lt;nav class="ease-pagination ease-pagination--sm"&gt;...&lt;/nav&gt;
+&lt;nav class="ease-pagination ease-pagination--lg"&gt;...&lt;/nav&gt;
+
+&lt;!-- Colors --&gt;
+&lt;nav class="ease-pagination ease-pagination--success"&gt;...&lt;/nav&gt;
+
+&lt;!-- Layouts --&gt;
+&lt;nav class="ease-pagination ease-pagination--compact"&gt;...&lt;/nav&gt;
+&lt;nav class="ease-pagination ease-pagination--stretched"&gt;...&lt;/nav&gt;
+&lt;nav class="ease-pagination ease-pagination--no-border"&gt;...&lt;/nav&gt;</pre>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/core_changes-issue-23902/style.css
+++ b/submissions/core_changes-issue-23902/style.css
@@ -1,0 +1,268 @@
+@layer easemotion-components {
+  .ease-pagination {
+    --ease-pagination-gap: 0.25rem;
+    --ease-pagination-size: 2.25rem;
+    --ease-pagination-radius: 0.375rem;
+    --ease-pagination-font-size: 0.875rem;
+    --ease-pagination-color: #374151;
+    --ease-pagination-bg: #fff;
+    --ease-pagination-border: #d1d5db;
+    --ease-pagination-active-bg: #3b82f6;
+    --ease-pagination-active-color: #fff;
+    --ease-pagination-hover-bg: #f3f4f6;
+    --ease-pagination-disabled-opacity: 0.4;
+    display: flex;
+    align-items: center;
+    gap: var(--ease-pagination-gap);
+    flex-wrap: wrap;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .ease-pagination__item {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: var(--ease-pagination-size);
+    height: var(--ease-pagination-size);
+    padding: 0 0.5rem;
+    border-radius: var(--ease-pagination-radius);
+    border: 1px solid var(--ease-pagination-border);
+    background: var(--ease-pagination-bg);
+    color: var(--ease-pagination-color);
+    font-size: var(--ease-pagination-font-size);
+    text-decoration: none;
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+    user-select: none;
+    line-height: 1;
+    white-space: nowrap;
+  }
+
+  .ease-pagination__item:hover {
+    background: var(--ease-pagination-hover-bg);
+    border-color: #9ca3af;
+  }
+
+  .ease-pagination__item:focus-visible {
+    outline: 2px solid var(--ease-pagination-active-bg);
+    outline-offset: 2px;
+  }
+
+  .ease-pagination__item--active {
+    background: var(--ease-pagination-active-bg);
+    color: var(--ease-pagination-active-color);
+    border-color: var(--ease-pagination-active-bg);
+    cursor: default;
+    pointer-events: none;
+  }
+
+  .ease-pagination__item--disabled {
+    opacity: var(--ease-pagination-disabled-opacity);
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
+  .ease-pagination__item--prev,
+  .ease-pagination__item--next {
+    font-weight: 600;
+  }
+
+  .ease-pagination__item--ellipsis {
+    border: none;
+    background: none;
+    cursor: default;
+    pointer-events: none;
+    min-width: auto;
+    padding: 0 0.25rem;
+  }
+
+  .ease-pagination__item--ellipsis:hover {
+    background: none;
+  }
+
+  .ease-pagination__info {
+    font-size: 0.875rem;
+    color: #6b7280;
+    margin-left: 0.5rem;
+    white-space: nowrap;
+  }
+
+  .ease-pagination--centered {
+    justify-content: center;
+  }
+
+  .ease-pagination--end {
+    justify-content: flex-end;
+  }
+
+  .ease-pagination--between {
+    justify-content: space-between;
+  }
+
+  .ease-pagination--sm {
+    --ease-pagination-size: 1.75rem;
+    --ease-pagination-gap: 0.125rem;
+    --ease-pagination-font-size: 0.75rem;
+    --ease-pagination-radius: 0.25rem;
+  }
+
+  .ease-pagination--lg {
+    --ease-pagination-size: 2.75rem;
+    --ease-pagination-gap: 0.375rem;
+    --ease-pagination-font-size: 1rem;
+    --ease-pagination-radius: 0.5rem;
+  }
+
+  .ease-pagination--rounded-none {
+    --ease-pagination-radius: 0;
+  }
+
+  .ease-pagination--rounded-sm {
+    --ease-pagination-radius: 0.25rem;
+  }
+
+  .ease-pagination--rounded-lg {
+    --ease-pagination-radius: 0.5rem;
+  }
+
+  .ease-pagination--rounded-xl {
+    --ease-pagination-radius: 0.75rem;
+  }
+
+  .ease-pagination--rounded-full {
+    --ease-pagination-radius: 9999px;
+  }
+
+  .ease-pagination--no-border .ease-pagination__item {
+    border: none;
+  }
+
+  .ease-pagination--no-border .ease-pagination__item--active {
+    border: none;
+  }
+
+  .ease-pagination--outline .ease-pagination__item--active {
+    background: transparent;
+    color: var(--ease-pagination-active-bg);
+    border-color: var(--ease-pagination-active-bg);
+    box-shadow: inset 0 0 0 1px var(--ease-pagination-active-bg);
+  }
+
+  .ease-pagination--primary {
+    --ease-pagination-active-bg: #3b82f6;
+  }
+
+  .ease-pagination--secondary {
+    --ease-pagination-active-bg: #6b7280;
+  }
+
+  .ease-pagination--success {
+    --ease-pagination-active-bg: #22c55e;
+  }
+
+  .ease-pagination--danger {
+    --ease-pagination-active-bg: #ef4444;
+  }
+
+  .ease-pagination--warning {
+    --ease-pagination-active-bg: #f59e0b;
+    --ease-pagination-active-color: #1e293b;
+  }
+
+  .ease-pagination--dark {
+    --ease-pagination-color: #e5e7eb;
+    --ease-pagination-bg: #1f2937;
+    --ease-pagination-border: #374151;
+    --ease-pagination-hover-bg: #374151;
+    --ease-pagination-active-bg: #3b82f6;
+    --ease-pagination-active-color: #fff;
+  }
+
+  .ease-pagination--dark .ease-pagination__item--ellipsis {
+    color: #6b7280;
+  }
+
+  .ease-pagination--dark .ease-pagination__info {
+    color: #9ca3af;
+  }
+
+  .ease-pagination--with-icons .ease-pagination__item--prev,
+  .ease-pagination--with-icons .ease-pagination__item--next {
+    font-size: 1.125rem;
+    line-height: 1;
+  }
+
+  .ease-pagination--sticky {
+    position: sticky;
+    bottom: 0;
+    background: #fff;
+    padding: 0.75rem 0;
+    z-index: 10;
+  }
+
+  .ease-pagination--responsive .ease-pagination__item--page {
+    display: none;
+  }
+
+  @media (min-width: 480px) {
+    .ease-pagination--responsive .ease-pagination__item--page:nth-last-child(-n+5),
+    .ease-pagination--responsive .ease-pagination__item--page:nth-child(-n+5) {
+      display: inline-flex;
+    }
+  }
+
+  @media (min-width: 640px) {
+    .ease-pagination--responsive .ease-pagination__item--page {
+      display: inline-flex;
+    }
+  }
+
+  .ease-pagination--animated .ease-pagination__item {
+    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.15s ease;
+  }
+
+  .ease-pagination--animated .ease-pagination__item:active {
+    transform: scale(0.95);
+  }
+
+  .ease-pagination--compact {
+    --ease-pagination-gap: 0;
+  }
+
+  .ease-pagination--compact .ease-pagination__item {
+    border-radius: 0;
+  }
+
+  .ease-pagination--compact .ease-pagination__item:first-child {
+    border-radius: var(--ease-pagination-radius) 0 0 var(--ease-pagination-radius);
+  }
+
+  .ease-pagination--compact .ease-pagination__item:last-child {
+    border-radius: 0 var(--ease-pagination-radius) var(--ease-pagination-radius) 0;
+  }
+
+  .ease-pagination--compact .ease-pagination__item + .ease-pagination__item {
+    margin-left: -1px;
+  }
+
+  .ease-pagination--stretched {
+    width: 100%;
+  }
+
+  .ease-pagination--stretched .ease-pagination__item {
+    flex: 1;
+    text-align: center;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ease-pagination--animated .ease-pagination__item {
+      transition: none;
+    }
+
+    .ease-pagination--animated .ease-pagination__item:active {
+      transform: none;
+    }
+  }
+}


### PR DESCRIPTION
## Description
Adds a CSS-only pagination component. Features: page numbers with active/disabled/ellipsis states, 3 sizes (sm, default, lg), 6 color themes (primary, secondary, success, danger, warning, dark), 4 alignments (start, centered, end, between), layout variants (no-border, outline active, compact segmented, stretched equal-width, with-icons), 6 roundedness levels, responsive mode (hides inner pages on mobile), dark mode, sticky positioning, animation, and page info label.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

## Checklist
- [x] `style.css` — All component styles under `@layer easemotion-components`
- [x] `demo.html` — Interactive demo with basic, alignments, sizes, colors, dark mode, layout variants, info, roundedness, and code usage
- [x] `README.md` — What, how, why documentation with full modifier tables

## Maintainer Actions
1. Review `submissions/core_changes-issue-23902/style.css`
2. Copy contents into the main CSS bundle (e.g., `components/pagination.css`)
3. Reference/demo the component in the documentation site

**Closes #23902**