### PR TITLE
feat(cursor): add ease-cursor-* utility classes for all CSS cursor values (GSSoC 2026)

### DIFF
--- a/submissions/core_changes-issue-23894/README.md
+++ b/submissions/core_changes-issue-23894/README.md
@@ -1,0 +1,27 @@
+# ease-cursor
+
+Cursor utility classes covering all standard CSS keyword cursor values plus media-query-aware variants for hover, touch, and mouse input.
+
+## What
+
+Single-purpose CSS utility classes for the `cursor` property. Each class maps directly to a CSS cursor keyword value, with additional responsive variants:
+
+- **Basic**: auto, default, pointer, wait, text, move, help, not-allowed, none, context-menu, progress, cell, crosshair, vertical-text, alias, copy, no-drop, grab, grabbing, all-scroll, zoom-in, zoom-out
+- **Resize**: col-resize, row-resize, n-resize, e-resize, s-resize, w-resize, ne-resize, nw-resize, se-resize, sw-resize, ew-resize, ns-resize, nesw-resize, nwse-resize
+- **Hover-aware**: `ease-cursor-hover-pointer`, `ease-cursor-hover-grab`, `ease-cursor-hover-grabbing`, `ease-cursor-hover-zoom-in`, `ease-cursor-hover-zoom-out` (only apply when `@media (hover: hover)` matches)
+- **Touch-aware**: `ease-cursor-touch-auto`, `ease-cursor-touch-default` (applied on coarse pointer devices)
+- **Mouse-aware**: `ease-cursor-mouse-pointer`, `ease-cursor-mouse-grab` (applied on fine pointer devices)
+
+## How
+
+1. Include `style.css`.
+2. Apply `.ease-cursor-{value}` to any element.
+
+## Why
+
+Provides a consistent, discoverable naming scheme for cursor values. Media query variants allow cursor to adapt to input device capabilities without JavaScript.
+
+## Accessibility
+
+- Custom cursors can affect usability. Avoid overly complex cursor changes.
+- The `none` cursor should be used sparingly and only when hiding the cursor serves a clear purpose (e.g., video fullscreen, drawing canvas).

--- a/submissions/core_changes-issue-23894/demo.html
+++ b/submissions/core_changes-issue-23894/demo.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-cursor demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #f8fafc;
+      color: #1e293b;
+      padding: 2rem;
+      line-height: 1.6;
+    }
+    .container { max-width: 1000px; margin: 0 auto; }
+    h1 { font-size: 2rem; margin-bottom: 0.5rem; }
+    h2 {
+      font-size: 1.25rem;
+      margin: 2rem 0 1rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 2px solid #e2e8f0;
+    }
+    .section {
+      background: #fff;
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+    .section > p { margin-bottom: 0.75rem; color: #64748b; }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+      gap: 0.75rem;
+    }
+    .cursor-box {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 0.375rem;
+      padding: 1rem 0.5rem;
+      border: 1px solid #e2e8f0;
+      border-radius: 6px;
+      background: #fff;
+      min-height: 70px;
+    }
+    .cursor-box span {
+      font-size: 0.6875rem;
+      color: #475569;
+      text-align: center;
+      word-break: break-word;
+      max-width: 100%;
+    }
+    .cursor-label {
+      font-size: 0.75rem;
+      color: #64748b;
+      margin-top: 0.25rem;
+    }
+    pre {
+      background: #1e293b;
+      color: #e2e8f0;
+      padding: 1rem;
+      border-radius: 6px;
+      overflow-x: auto;
+      font-size: 0.875rem;
+      margin-top: 0.75rem;
+    }
+    code { font-family: "SF Mono", Consolas, monospace; }
+    .feature-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1rem;
+    }
+    .feature-card {
+      background: #fff;
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      padding: 1.25rem;
+    }
+    .feature-card h3 { font-size: 1rem; margin-bottom: 0.5rem; }
+    .feature-card p { font-size: 0.875rem; color: #64748b; }
+    .badge {
+      display: inline-block;
+      font-size: 0.75rem;
+      padding: 0.125rem 0.5rem;
+      border-radius: 999px;
+      background: #e2e8f0;
+      color: #475569;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>ease-cursor</h1>
+    <p>Cursor utility classes covering all standard CSS cursor values plus hover, touch, and mouse media query variants.</p>
+
+    <h2>Features</h2>
+    <div class="feature-grid">
+      <div class="feature-card">
+        <h3>36 Cursor Values</h3>
+        <p>All CSS cursor keywords including directional resize cursors, zoom, grab, and aliases.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Hover Variants</h3>
+        <p>Cursor changes only when hover is supported via <code>@media (hover: hover)</code>.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Pointer Variants</h3>
+        <p>Separate classes for coarse (touch) and fine (mouse) pointer devices.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Reduced Motion</h3>
+        <p>Smooth cursor transition only when user hasn't requested reduced motion.</p>
+      </div>
+    </div>
+
+    <h2>Basic Cursors</h2>
+    <div class="section">
+      <p>Standard cursor values for common interaction states.</p>
+      <div class="grid">
+        <div class="cursor-box ease-cursor-auto"><span>auto</span></div>
+        <div class="cursor-box ease-cursor-default"><span>default</span></div>
+        <div class="cursor-box ease-cursor-pointer"><span>pointer</span></div>
+        <div class="cursor-box ease-cursor-wait"><span>wait</span></div>
+        <div class="cursor-box ease-cursor-text"><span>text</span></div>
+        <div class="cursor-box ease-cursor-move"><span>move</span></div>
+        <div class="cursor-box ease-cursor-help"><span>help</span></div>
+        <div class="cursor-box ease-cursor-not-allowed"><span>not-allowed</span></div>
+        <div class="cursor-box ease-cursor-none"><span>none</span></div>
+        <div class="cursor-box ease-cursor-context-menu"><span>context-menu</span></div>
+        <div class="cursor-box ease-cursor-progress"><span>progress</span></div>
+        <div class="cursor-box ease-cursor-cell"><span>cell</span></div>
+        <div class="cursor-box ease-cursor-crosshair"><span>crosshair</span></div>
+        <div class="cursor-box ease-cursor-vertical-text"><span>vertical-text</span></div>
+        <div class="cursor-box ease-cursor-alias"><span>alias</span></div>
+        <div class="cursor-box ease-cursor-copy"><span>copy</span></div>
+        <div class="cursor-box ease-cursor-no-drop"><span>no-drop</span></div>
+        <div class="cursor-box ease-cursor-grab"><span>grab</span></div>
+        <div class="cursor-box ease-cursor-grabbing"><span>grabbing</span></div>
+        <div class="cursor-box ease-cursor-all-scroll"><span>all-scroll</span></div>
+        <div class="cursor-box ease-cursor-zoom-in"><span>zoom-in</span></div>
+        <div class="cursor-box ease-cursor-zoom-out"><span>zoom-out</span></div>
+      </div>
+    </div>
+
+    <h2>Resize Cursors</h2>
+    <div class="section">
+      <p>Directional resize cursors for draggable edges and corners.</p>
+      <div class="grid">
+        <div class="cursor-box ease-cursor-col-resize"><span>col-resize</span></div>
+        <div class="cursor-box ease-cursor-row-resize"><span>row-resize</span></div>
+        <div class="cursor-box ease-cursor-n-resize"><span>n-resize</span></div>
+        <div class="cursor-box ease-cursor-e-resize"><span>e-resize</span></div>
+        <div class="cursor-box ease-cursor-s-resize"><span>s-resize</span></div>
+        <div class="cursor-box ease-cursor-w-resize"><span>w-resize</span></div>
+        <div class="cursor-box ease-cursor-ne-resize"><span>ne-resize</span></div>
+        <div class="cursor-box ease-cursor-nw-resize"><span>nw-resize</span></div>
+        <div class="cursor-box ease-cursor-se-resize"><span>se-resize</span></div>
+        <div class="cursor-box ease-cursor-sw-resize"><span>sw-resize</span></div>
+        <div class="cursor-box ease-cursor-ew-resize"><span>ew-resize</span></div>
+        <div class="cursor-box ease-cursor-ns-resize"><span>ns-resize</span></div>
+        <div class="cursor-box ease-cursor-nesw-resize"><span>nesw-resize</span></div>
+        <div class="cursor-box ease-cursor-nwse-resize"><span>nwse-resize</span></div>
+      </div>
+    </div>
+
+    <h2>Media Query Variants</h2>
+    <div class="section">
+      <p>These classes only apply when the device supports hover (desktop), coarse pointer (touch), or fine pointer (mouse).</p>
+      <div class="grid">
+        <div class="cursor-box ease-cursor-hover-pointer"><span>hover-pointer</span></div>
+        <div class="cursor-box ease-cursor-hover-grab"><span>hover-grab</span></div>
+        <div class="cursor-box ease-cursor-hover-grabbing"><span>hover-grabbing</span></div>
+        <div class="cursor-box ease-cursor-hover-zoom-in"><span>hover-zoom-in</span></div>
+        <div class="cursor-box ease-cursor-hover-zoom-out"><span>hover-zoom-out</span></div>
+        <div class="cursor-box ease-cursor-touch-auto"><span>touch-auto</span></div>
+        <div class="cursor-box ease-cursor-touch-default"><span>touch-default</span></div>
+        <div class="cursor-box ease-cursor-mouse-pointer"><span>mouse-pointer</span></div>
+        <div class="cursor-box ease-cursor-mouse-grab"><span>mouse-grab</span></div>
+      </div>
+    </div>
+
+    <h2>Usage</h2>
+    <div class="section">
+      <pre>&lt;!-- Basic cursor --&gt;
+&lt;button class="ease-cursor-pointer"&gt;Click me&lt;/button&gt;
+&lt;div class="ease-cursor-grab"&gt;Drag me&lt;/div&gt;
+&lt;input class="ease-cursor-text" readonly value="Read only"&gt;
+
+&lt;!-- Disabled states --&gt;
+&lt;button class="ease-cursor-not-allowed" disabled&gt;Disabled&lt;/button&gt;
+
+&lt;!-- Resize handles --&gt;
+&lt;div class="ease-cursor-ew-resize" style="width:200px;height:20px;background:#e2e8f0;"&gt;&lt;/div&gt;
+&lt;div class="ease-cursor-ns-resize" style="width:20px;height:100px;background:#e2e8f0;"&gt;&lt;/div&gt;
+
+&lt;!-- Interactive --&gt;
+&lt;div class="ease-cursor-zoom-in" onclick="zoom()"&gt;Zoom area&lt;/div&gt;
+&lt;div class="ease-cursor-move"&gt;Draggable element&lt;/div&gt;
+
+&lt;!-- Hide cursor --&gt;
+&lt;div class="ease-cursor-none"&gt;No cursor here&lt;/div&gt;</pre>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/core_changes-issue-23894/style.css
+++ b/submissions/core_changes-issue-23894/style.css
@@ -1,0 +1,62 @@
+@layer easemotion-utilities {
+  .ease-cursor-auto { cursor: auto; }
+  .ease-cursor-default { cursor: default; }
+  .ease-cursor-pointer { cursor: pointer; }
+  .ease-cursor-wait { cursor: wait; }
+  .ease-cursor-text { cursor: text; }
+  .ease-cursor-move { cursor: move; }
+  .ease-cursor-help { cursor: help; }
+  .ease-cursor-not-allowed { cursor: not-allowed; }
+  .ease-cursor-none { cursor: none; }
+  .ease-cursor-context-menu { cursor: context-menu; }
+  .ease-cursor-progress { cursor: progress; }
+  .ease-cursor-cell { cursor: cell; }
+  .ease-cursor-crosshair { cursor: crosshair; }
+  .ease-cursor-vertical-text { cursor: vertical-text; }
+  .ease-cursor-alias { cursor: alias; }
+  .ease-cursor-copy { cursor: copy; }
+  .ease-cursor-no-drop { cursor: no-drop; }
+  .ease-cursor-grab { cursor: grab; }
+  .ease-cursor-grabbing { cursor: grabbing; }
+  .ease-cursor-all-scroll { cursor: all-scroll; }
+  .ease-cursor-col-resize { cursor: col-resize; }
+  .ease-cursor-row-resize { cursor: row-resize; }
+  .ease-cursor-n-resize { cursor: n-resize; }
+  .ease-cursor-e-resize { cursor: e-resize; }
+  .ease-cursor-s-resize { cursor: s-resize; }
+  .ease-cursor-w-resize { cursor: w-resize; }
+  .ease-cursor-ne-resize { cursor: ne-resize; }
+  .ease-cursor-nw-resize { cursor: nw-resize; }
+  .ease-cursor-se-resize { cursor: se-resize; }
+  .ease-cursor-sw-resize { cursor: sw-resize; }
+  .ease-cursor-ew-resize { cursor: ew-resize; }
+  .ease-cursor-ns-resize { cursor: ns-resize; }
+  .ease-cursor-nesw-resize { cursor: nesw-resize; }
+  .ease-cursor-nwse-resize { cursor: nwse-resize; }
+  .ease-cursor-zoom-in { cursor: zoom-in; }
+  .ease-cursor-zoom-out { cursor: zoom-out; }
+
+  @media (hover: hover) {
+    .ease-cursor-hover-pointer { cursor: pointer; }
+    .ease-cursor-hover-grab { cursor: grab; }
+    .ease-cursor-hover-grabbing { cursor: grabbing; }
+    .ease-cursor-hover-zoom-in { cursor: zoom-in; }
+    .ease-cursor-hover-zoom-out { cursor: zoom-out; }
+  }
+
+  @media (pointer: coarse) {
+    .ease-cursor-touch-auto { cursor: auto; }
+    .ease-cursor-touch-default { cursor: default; }
+  }
+
+  @media (pointer: fine) {
+    .ease-cursor-mouse-pointer { cursor: pointer; }
+    .ease-cursor-mouse-grab { cursor: grab; }
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .ease-cursor-smooth {
+      transition: cursor 0.15s ease;
+    }
+  }
+}


### PR DESCRIPTION
## Description
Adds cursor utility classes: 36 CSS keyword cursor values (auto, pointer, grab, zoom-in, not-allowed, all directional resize cursors, etc.), plus media-query-aware variants for hover-capable devices, coarse pointer (touch), and fine pointer (mouse).

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

## Checklist
- [x] `style.css` — All utilities under `@layer easemotion-utilities`
- [x] `demo.html` — Interactive demo with basic cursors grid, resize cursors grid, media query variants, and code usage block
- [x] `README.md` — What, how, why documentation

## Maintainer Actions
1. Review `submissions/core_changes-issue-23894/style.css`
2. Copy contents into the main CSS bundle (e.g., `utilities/cursor.css`)
3. Reference in the documentation site

**Closes #23894**