### PR TITLE
feat(select-none): add ease-select-none text selection and drag utility classes (GSSoC 2026)

### DIFF
--- a/submissions/core_changes-issue-23895/README.md
+++ b/submissions/core_changes-issue-23895/README.md
@@ -1,0 +1,26 @@
+# ease-select-none
+
+Utility classes for `user-select` and `-webkit-user-drag` properties. Controls text selection, copy behavior, and element dragging.
+
+## What
+
+Single-purpose CSS utilities:
+- **user-select**: none, text, all, auto, contain (with webkit prefixes)
+- **Children scoped**: `ease-select-none-children` applies to all descendants
+- **Drag**: `ease-drag-none`, `ease-drag-auto`, `ease-drag-element`
+- **Aliases**: `ease-no-select`, `ease-no-copy`, `ease-copy-none`, `ease-copy-all`
+- **Touch variants**: `ease-touch-select-none/auto` (applied on touch devices)
+
+## How
+
+1. Include `style.css`.
+2. Apply `.ease-select-{value}` to any element.
+
+## Why
+
+Prevents accidental text selection on UI elements (buttons, drag handles, icons, sliders). The `all` value is useful for code blocks to enable quick copying. `contain` limits selection scope within a single element.
+
+## Accessibility
+
+- Avoid using `user-select: none` on content text — it prevents users from selecting/copying information.
+- Appropriate use cases: drag handles, button text, slider thumbs, icon labels, decorative elements.

--- a/submissions/core_changes-issue-23895/demo.html
+++ b/submissions/core_changes-issue-23895/demo.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-select-none demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #f8fafc;
+      color: #1e293b;
+      padding: 2rem;
+      line-height: 1.6;
+    }
+    .container { max-width: 900px; margin: 0 auto; }
+    h1 { font-size: 2rem; margin-bottom: 0.5rem; }
+    h2 {
+      font-size: 1.25rem;
+      margin: 2rem 0 1rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 2px solid #e2e8f0;
+    }
+    .section {
+      background: #fff;
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+    .section > p { margin-bottom: 0.75rem; color: #64748b; }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+      gap: 0.75rem;
+    }
+    .demo-box {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.375rem;
+      padding: 1rem 0.75rem;
+      border: 1px solid #e2e8f0;
+      border-radius: 6px;
+      background: #fff;
+      text-align: center;
+    }
+    .demo-box code { font-size: 0.75rem; color: #475569; }
+    .demo-text {
+      padding: 0.75rem;
+      background: #f1f5f9;
+      border-radius: 4px;
+      font-size: 0.875rem;
+      margin-top: 0.25rem;
+      width: 100%;
+    }
+    .interactive-test {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      margin-top: 0.75rem;
+    }
+    .test-card {
+      flex: 1;
+      min-width: 200px;
+      padding: 1rem;
+      border: 1px solid #e2e8f0;
+      border-radius: 6px;
+      background: #f8fafc;
+    }
+    .test-card h4 { font-size: 0.875rem; margin-bottom: 0.375rem; }
+    .test-card p { font-size: 0.8125rem; color: #64748b; }
+    pre {
+      background: #1e293b;
+      color: #e2e8f0;
+      padding: 1rem;
+      border-radius: 6px;
+      overflow-x: auto;
+      font-size: 0.875rem;
+      margin-top: 0.75rem;
+    }
+    code { font-family: "SF Mono", Consolas, monospace; }
+    .feature-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1rem;
+    }
+    .feature-card {
+      background: #fff;
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      padding: 1.25rem;
+    }
+    .feature-card h3 { font-size: 1rem; margin-bottom: 0.5rem; }
+    .feature-card p { font-size: 0.875rem; color: #64748b; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>ease-select-none</h1>
+    <p>CSS user-select and user-drag utility classes for controlling text selection, copy behavior, and element dragging.</p>
+
+    <h2>Features</h2>
+    <div class="feature-grid">
+      <div class="feature-card">
+        <h3>5 User-Select Values</h3>
+        <p>none, text, all, auto, contain with webkit prefixes for Safari.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Inheritance Control</h3>
+        <p>Child-targeting variants (select-none-children, select-text-children) for scoped selection on containers.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Drag Control</h3>
+        <p>ease-drag-none, ease-drag-auto, ease-drag-element for native drag behavior.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Aliases</h3>
+        <p>ease-no-select, ease-no-copy, ease-copy-none, ease-copy-all for intuitive naming.</p>
+      </div>
+    </div>
+
+    <h2>User Select Classes</h2>
+    <div class="section">
+      <p>Try selecting the text in each box to see the effect.</p>
+      <div class="grid">
+        <div class="demo-box">
+          <code>ease-select-none</code>
+          <div class="demo-text ease-select-none">You cannot select this text.</div>
+        </div>
+        <div class="demo-box">
+          <code>ease-select-text</code>
+          <div class="demo-text ease-select-text">You can select this text.</div>
+        </div>
+        <div class="demo-box">
+          <code>ease-select-all</code>
+          <div class="demo-text ease-select-all">Click once to select all.</div>
+        </div>
+        <div class="demo-box">
+          <code>ease-select-auto</code>
+          <div class="demo-text ease-select-auto">Browser default selection.</div>
+        </div>
+        <div class="demo-box">
+          <code>ease-select-contain</code>
+          <div class="demo-text ease-select-contain">Selection contained here.</div>
+        </div>
+      </div>
+    </div>
+
+    <h2>Aliases & Combined</h2>
+    <div class="section">
+      <div class="grid">
+        <div class="demo-box">
+          <code>ease-no-select</code>
+          <div class="demo-text ease-no-select">Cannot select</div>
+        </div>
+        <div class="demo-box">
+          <code>ease-no-copy</code>
+          <div class="demo-text ease-no-copy">Cannot copy</div>
+        </div>
+        <div class="demo-box">
+          <code>ease-copy-none</code>
+          <div class="demo-text ease-copy-none">Copy disabled</div>
+        </div>
+        <div class="demo-box">
+          <code>ease-copy-all</code>
+          <div class="demo-text ease-copy-all">Select all at once</div>
+        </div>
+      </div>
+    </div>
+
+    <h2>Drag Classes</h2>
+    <div class="section">
+      <div class="grid">
+        <div class="demo-box">
+          <code>ease-drag-none</code>
+          <div class="demo-text ease-drag-none" draggable="true">Try to drag me</div>
+        </div>
+        <div class="demo-box">
+          <code>ease-drag-auto</code>
+          <div class="demo-text ease-drag-auto" draggable="true">Drag auto</div>
+        </div>
+        <div class="demo-box">
+          <code>ease-drag-element</code>
+          <div class="demo-text ease-drag-element" draggable="true">Drag element</div>
+        </div>
+      </div>
+    </div>
+
+    <h2>Interactive Test</h2>
+    <div class="section">
+      <div class="interactive-test">
+        <div class="test-card ease-select-none">
+          <h4>ease-select-none</h4>
+          <p>This entire card has selection disabled. Try selecting this text — it won't work.</p>
+        </div>
+        <div class="test-card ease-select-all">
+          <h4>ease-select-all</h4>
+          <p>Single click anywhere in this card selects all text at once.</p>
+        </div>
+      </div>
+    </div>
+
+    <h2>Usage</h2>
+    <div class="section">
+      <pre>&lt;!-- Prevent text selection on UI elements --&gt;
+&lt;button class="ease-select-none"&gt;Click me&lt;/button&gt;
+
+&lt;!-- Allow copying code blocks --&gt;
+&lt;pre class="ease-select-all"&gt;Select all code easily&lt;/pre&gt;
+
+&lt;!-- Disable selection on drag handles --&gt;
+&lt;div class="ease-drag-none" draggable="true"&gt;
+  Drag handle (no text selection)
+&lt;/div&gt;
+
+&lt;!-- Disable children selection from container --&gt;
+&lt;div class="ease-select-none-children"&gt;
+  &lt;p&gt;Can't select this&lt;/p&gt;
+  &lt;span&gt;Or this&lt;/span&gt;
+&lt;/div&gt;</pre>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/core_changes-issue-23895/style.css
+++ b/submissions/core_changes-issue-23895/style.css
@@ -1,0 +1,43 @@
+@layer easemotion-utilities {
+  .ease-select-none { user-select: none; -webkit-user-select: none; }
+  .ease-select-text { user-select: text; -webkit-user-select: text; }
+  .ease-select-all { user-select: all; -webkit-user-select: all; }
+  .ease-select-auto { user-select: auto; -webkit-user-select: auto; }
+  .ease-select-contain { user-select: contain; -webkit-user-select: contain; }
+
+  .ease-select-none-children * { user-select: none; -webkit-user-select: none; }
+  .ease-select-text-children * { user-select: text; -webkit-user-select: text; }
+
+  .ease-copy-none { user-select: none; -webkit-user-select: none; }
+  .ease-copy-all { user-select: all; -webkit-user-select: all; }
+
+  .ease-no-select { user-select: none; -webkit-user-select: none; }
+  .ease-no-copy { user-select: none; -webkit-user-select: none; }
+
+  .ease-drag-none { -webkit-user-drag: none; user-drag: none; }
+  .ease-drag-auto { -webkit-user-drag: auto; user-drag: auto; }
+  .ease-drag-element { -webkit-user-drag: element; user-drag: element; }
+
+  .ease-select-none-important { user-select: none !important; -webkit-user-select: none !important; }
+
+  @media (hover: none) {
+    .ease-touch-select-none { user-select: none; -webkit-user-select: none; }
+    .ease-touch-select-auto { user-select: auto; -webkit-user-select: auto; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ease-reduced-select-none { user-select: none; -webkit-user-select: none; }
+  }
+
+  .ease-select-none-sm { user-select: none; -webkit-user-select: none; }
+  .ease-select-none-md { user-select: none; -webkit-user-select: none; }
+  .ease-select-none-lg { user-select: none; -webkit-user-select: none; }
+
+  .ease-select-none-print { user-select: none; -webkit-user-select: none; }
+
+  .ease-user-select-none { user-select: none; -webkit-user-select: none; }
+  .ease-user-select-text { user-select: text; -webkit-user-select: text; }
+  .ease-user-select-all { user-select: all; -webkit-user-select: all; }
+  .ease-user-select-auto { user-select: auto; -webkit-user-select: auto; }
+  .ease-user-select-contain { user-select: contain; -webkit-user-select: contain; }
+}


### PR DESCRIPTION
## Description
Adds user-select utility classes: 5 user-select values (none, text, all, auto, contain) with webkit prefixes, children-scoped variants, drag control (none, auto, element), intuitive aliases (no-select, no-copy, copy-none, copy-all), and touch-device media query variants.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

## Checklist
- [x] `style.css` — All utilities under `@layer easemotion-utilities`
- [x] `demo.html` — Interactive demo with user-select grid, aliases, drag classes, interactive test cards, and code usage
- [x] `README.md` — What, how, why documentation

## Maintainer Actions
1. Review `submissions/core_changes-issue-23895/style.css`
2. Copy contents into the main CSS bundle (e.g., `utilities/select.css`)
3. Reference in the documentation site

**Closes #23895**