### PR TITLE
feat(carousel): add CSS-only ease-carousel component with scroll-snap (GSSoC 2026)

### DIFF
--- a/submissions/examples/ease-carousel-23908/README.md
+++ b/submissions/examples/ease-carousel-23908/README.md
@@ -1,0 +1,40 @@
+# CSS-Only Carousel Component
+
+## What does this do?
+
+A lightweight CSS carousel component using `scroll-snap-type: x mandatory` with navigation dots, prev/next buttons, and responsive behavior. No JavaScript required for basic scrolling — dots use `:target` anchors, while prev/next buttons are enhanced with optional JS for smooth scroll-by.
+
+## How is it used?
+
+```html
+<div class="ease-carousel" id="my-carousel">
+  <div class="ease-carousel-track">
+    <div class="ease-carousel-slide" id="slide-1">
+      <img src="..." alt="...">
+    </div>
+    <div class="ease-carousel-slide" id="slide-2">
+      <img src="..." alt="...">
+    </div>
+  </div>
+  <div class="ease-carousel-dots">
+    <a href="#slide-1" class="ease-carousel-dot active"></a>
+    <a href="#slide-2" class="ease-carousel-dot"></a>
+  </div>
+</div>
+```
+
+Add prev/next buttons:
+```html
+<button class="ease-carousel-btn ease-carousel-btn-prev">&#8249;</button>
+<button class="ease-carousel-btn ease-carousel-btn-next">&#8250;</button>
+```
+
+Variants:
+- `.ease-carousel-multi` — show 2 slides at once
+- `.ease-carousel-3` — show 3 slides (with `.ease-carousel-multi`)
+- `.ease-carousel-elevated` — add shadow
+- `.ease-carousel-auto` — auto-play
+
+## Why is it useful?
+
+Replaces heavy third-party carousel libraries with a zero-dependency, accessible, scroll-snap-based component. Integrates with EaseMotion CSS tokens (colors, spacing, radius, shadows) and respects `prefers-reduced-motion`.

--- a/submissions/examples/ease-carousel-23908/demo.html
+++ b/submissions/examples/ease-carousel-23908/demo.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Carousel Component - EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="page-header">
+    <h1>EaseMotion Carousel</h1>
+    <p>A CSS-only image carousel using scroll-snap with navigation dots, prev/next buttons, and responsive behavior.</p>
+  </div>
+
+  <div class="demo-grid">
+    <div class="demo-section">
+      <h2>Basic Carousel</h2>
+      <p class="desc">CSS-only carousel with <code>:target</code> dot navigation and hover-reveal buttons.</p>
+
+      <div class="ease-carousel" id="carousel-1">
+        <div class="ease-carousel-track">
+          <div class="ease-carousel-slide" id="slide-1">
+            <div style="background: linear-gradient(135deg, #6c63ff, #a78bfa); height: 350px; display: flex; align-items: center; justify-content: center; color: #fff; font-size: 2rem; font-weight: 700;">Slide 1</div>
+          </div>
+          <div class="ease-carousel-slide" id="slide-2">
+            <div style="background: linear-gradient(135deg, #f59e0b, #f97316); height: 350px; display: flex; align-items: center; justify-content: center; color: #fff; font-size: 2rem; font-weight: 700;">Slide 2</div>
+          </div>
+          <div class="ease-carousel-slide" id="slide-3">
+            <div style="background: linear-gradient(135deg, #10b981, #34d399); height: 350px; display: flex; align-items: center; justify-content: center; color: #fff; font-size: 2rem; font-weight: 700;">Slide 3</div>
+          </div>
+          <div class="ease-carousel-slide" id="slide-4">
+            <div style="background: linear-gradient(135deg, #ef4444, #f472b6); height: 350px; display: flex; align-items: center; justify-content: center; color: #fff; font-size: 2rem; font-weight: 700;">Slide 4</div>
+          </div>
+        </div>
+
+        <button class="ease-carousel-btn ease-carousel-btn-prev" data-carousel-prev="carousel-1">&#8249;</button>
+        <button class="ease-carousel-btn ease-carousel-btn-next" data-carousel-next="carousel-1">&#8250;</button>
+
+        <div class="ease-carousel-dots">
+          <a href="#slide-1" class="ease-carousel-dot active"></a>
+          <a href="#slide-2" class="ease-carousel-dot"></a>
+          <a href="#slide-3" class="ease-carousel-dot"></a>
+          <a href="#slide-4" class="ease-carousel-dot"></a>
+        </div>
+      </div>
+
+      <div class="code-block">
+        <span class="tag">&lt;div</span> <span class="class">class</span>=<span class="string">"ease-carousel"</span><span class="tag">&gt;</span><br>
+        <span class="tag">&nbsp;&nbsp;&lt;div</span> <span class="class">class</span>=<span class="string">"ease-carousel-track"</span><span class="tag">&gt;</span><br>
+        <span class="tag">&nbsp;&nbsp;&nbsp;&nbsp;&lt;div</span> <span class="class">class</span>=<span class="string">"ease-carousel-slide"</span><span class="tag">&gt;</span>...<span class="tag">&lt;/div&gt;</span><br>
+        <span class="tag">&nbsp;&nbsp;&lt;/div&gt;</span><br>
+        <span class="tag">&nbsp;&nbsp;&lt;div</span> <span class="class">class</span>=<span class="string">"ease-carousel-dots"</span><span class="tag">&gt;</span><br>
+        <span class="tag">&nbsp;&nbsp;&nbsp;&nbsp;&lt;a</span> <span class="class">href</span>=<span class="string">"#slide-1"</span> <span class="class">class</span>=<span class="string">"ease-carousel-dot active"</span><span class="tag">&gt;&lt;/a&gt;</span><br>
+        <span class="tag">&nbsp;&nbsp;&lt;/div&gt;</span><br>
+        <span class="tag">&lt;/div&gt;</span>
+      </div>
+    </div>
+
+    <div class="demo-section">
+      <h2>Carousel with Captions</h2>
+      <p class="desc">Image slides with overlaid captions, ideal for hero banners or featured content.</p>
+
+      <div class="ease-carousel ease-carousel-elevated" id="carousel-2">
+        <div class="ease-carousel-track">
+          <div class="ease-carousel-slide" id="cap-1">
+            <div style="background: linear-gradient(135deg, #1e293b, #334155); height: 400px; display: flex; align-items: center; justify-content: center; color: #fff; font-size: 3rem; opacity: 0.3;">🏔️</div>
+            <div class="ease-carousel-caption">
+              <h3>Mountain Retreat</h3>
+              <p>Explore the serene landscapes of the alpine wilderness.</p>
+            </div>
+          </div>
+          <div class="ease-carousel-slide" id="cap-2">
+            <div style="background: linear-gradient(135deg, #0f766e, #14b8a6); height: 400px; display: flex; align-items: center; justify-content: center; color: #fff; font-size: 3rem; opacity: 0.3;">🌊</div>
+            <div class="ease-carousel-caption">
+              <h3>Coastal Getaway</h3>
+              <p>Relax by the ocean with breathtaking seaside views.</p>
+            </div>
+          </div>
+          <div class="ease-carousel-slide" id="cap-3">
+            <div style="background: linear-gradient(135deg, #7c3aed, #a78bfa); height: 400px; display: flex; align-items: center; justify-content: center; color: #fff; font-size: 3rem; opacity: 0.3;">🌆</div>
+            <div class="ease-carousel-caption">
+              <h3>City Lights</h3>
+              <p>Experience the vibrant energy of the urban nightlife.</p>
+            </div>
+          </div>
+        </div>
+
+        <button class="ease-carousel-btn ease-carousel-btn-prev" data-carousel-prev="carousel-2">&#8249;</button>
+        <button class="ease-carousel-btn ease-carousel-btn-next" data-carousel-next="carousel-2">&#8250;</button>
+
+        <div class="ease-carousel-dots">
+          <a href="#cap-1" class="ease-carousel-dot active"></a>
+          <a href="#cap-2" class="ease-carousel-dot"></a>
+          <a href="#cap-3" class="ease-carousel-dot"></a>
+        </div>
+      </div>
+    </div>
+
+    <div class="demo-section">
+      <h2>Multi-Item Carousel</h2>
+      <p class="desc">Shows multiple slides at once using <code>ease-carousel-multi</code> variant.</p>
+
+      <div class="ease-carousel ease-carousel-multi" id="carousel-3">
+        <div class="ease-carousel-track" style="gap: 0.5rem; padding: 0.5rem 0;">
+          <div class="ease-carousel-slide" id="multi-1">
+            <div style="background: linear-gradient(135deg, #6c63ff, #818cf8); border-radius: 0.75rem; height: 200px; display: flex; align-items: center; justify-content: center; color: #fff; font-weight: 700;">Card 1</div>
+          </div>
+          <div class="ease-carousel-slide" id="multi-2">
+            <div style="background: linear-gradient(135deg, #f59e0b, #fbbf24); border-radius: 0.75rem; height: 200px; display: flex; align-items: center; justify-content: center; color: #fff; font-weight: 700;">Card 2</div>
+          </div>
+          <div class="ease-carousel-slide" id="multi-3">
+            <div style="background: linear-gradient(135deg, #10b981, #34d399); border-radius: 0.75rem; height: 200px; display: flex; align-items: center; justify-content: center; color: #fff; font-weight: 700;">Card 3</div>
+          </div>
+          <div class="ease-carousel-slide" id="multi-4">
+            <div style="background: linear-gradient(135deg, #ef4444, #f87171); border-radius: 0.75rem; height: 200px; display: flex; align-items: center; justify-content: center; color: #fff; font-weight: 700;">Card 4</div>
+          </div>
+          <div class="ease-carousel-slide" id="multi-5">
+            <div style="background: linear-gradient(135deg, #8b5cf6, #a78bfa); border-radius: 0.75rem; height: 200px; display: flex; align-items: center; justify-content: center; color: #fff; font-weight: 700;">Card 5</div>
+          </div>
+          <div class="ease-carousel-slide" id="multi-6">
+            <div style="background: linear-gradient(135deg, #ec4899, #f472b6); border-radius: 0.75rem; height: 200px; display: flex; align-items: center; justify-content: center; color: #fff; font-weight: 700;">Card 6</div>
+          </div>
+        </div>
+
+        <button class="ease-carousel-btn ease-carousel-btn-prev" data-carousel-prev="carousel-3">&#8249;</button>
+        <button class="ease-carousel-btn ease-carousel-btn-next" data-carousel-next="carousel-3">&#8250;</button>
+
+        <div class="ease-carousel-dots">
+          <a href="#multi-1" class="ease-carousel-dot active"></a>
+          <a href="#multi-2" class="ease-carousel-dot"></a>
+          <a href="#multi-3" class="ease-carousel-dot"></a>
+          <a href="#multi-4" class="ease-carousel-dot"></a>
+          <a href="#multi-5" class="ease-carousel-dot"></a>
+          <a href="#multi-6" class="ease-carousel-dot"></a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    document.querySelectorAll('[data-carousel-prev], [data-carousel-next]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const carouselId = btn.dataset.carouselPrev || btn.dataset.carouselNext;
+        const carousel = document.getElementById(carouselId);
+        if (!carousel) return;
+        const track = carousel.querySelector('.ease-carousel-track');
+        if (!track) return;
+        const slideWidth = track.querySelector('.ease-carousel-slide')?.offsetWidth || 0;
+        if (!slideWidth) return;
+        const isPrev = btn.dataset.carouselPrev !== undefined;
+        const direction = isPrev ? -1 : 1;
+        track.scrollBy({ left: slideWidth * direction, behavior: 'smooth' });
+      });
+    });
+
+    document.querySelectorAll('.ease-carousel-dot').forEach(dot => {
+      dot.addEventListener('click', (e) => {
+        const dots = dot.closest('.ease-carousel-dots').querySelectorAll('.ease-carousel-dot');
+        dots.forEach(d => d.classList.remove('active'));
+        dot.classList.add('active');
+      });
+    });
+
+    document.querySelectorAll('.ease-carousel-track').forEach(track => {
+      track.addEventListener('scroll', () => {
+        const dots = track.closest('.ease-carousel').querySelector('.ease-carousel-dots');
+        if (!dots) return;
+        const slides = track.querySelectorAll('.ease-carousel-slide');
+        const dotEls = dots.querySelectorAll('.ease-carousel-dot');
+        let activeIdx = 0;
+        const center = track.scrollLeft + track.offsetWidth / 2;
+        slides.forEach((slide, i) => {
+          const rect = slide.getBoundingClientRect();
+          const trackRect = track.getBoundingClientRect();
+          const slideCenter = rect.left + rect.width / 2 - trackRect.left;
+          if (slideCenter <= center) activeIdx = i;
+        });
+        dotEls.forEach((d, i) => d.classList.toggle('active', i === activeIdx));
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-carousel-23908/style.css
+++ b/submissions/examples/ease-carousel-23908/style.css
@@ -1,0 +1,266 @@
+:root {
+  --ease-carousel-radius: var(--ease-radius-lg, 1rem);
+  --ease-carousel-dot-size: 0.5rem;
+  --ease-carousel-dot-active: var(--ease-color-primary, #6c63ff);
+  --ease-carousel-dot-bg: var(--ease-color-neutral-300, #cbd5e1);
+  --ease-carousel-btn-bg: rgba(255, 255, 255, 0.9);
+  --ease-carousel-btn-color: var(--ease-color-text, #1f2937);
+  --ease-carousel-btn-size: 2.5rem;
+}
+
+.ease-carousel {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--ease-carousel-radius);
+}
+
+.ease-carousel-track {
+  display: flex;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+
+.ease-carousel-track::-webkit-scrollbar {
+  display: none;
+}
+
+.ease-carousel-slide {
+  flex: 0 0 100%;
+  scroll-snap-align: start;
+  position: relative;
+}
+
+.ease-carousel-slide img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.ease-carousel-caption {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 2rem 1.5rem 1.5rem;
+  background: linear-gradient(transparent, rgba(0, 0, 0, 0.6));
+  color: #ffffff;
+  text-align: center;
+}
+
+.ease-carousel-caption h3 {
+  margin: 0 0 0.25rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.ease-carousel-caption p {
+  margin: 0;
+  font-size: 0.875rem;
+  opacity: 0.9;
+}
+
+.ease-carousel-dots {
+  display: flex;
+  justify-content: center;
+  gap: var(--ease-space-2, 0.5rem);
+  padding: var(--ease-space-3, 0.75rem);
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 2;
+}
+
+.ease-carousel-dot {
+  width: var(--ease-carousel-dot-size);
+  height: var(--ease-carousel-dot-size);
+  border-radius: var(--ease-radius-full, 9999px);
+  background: var(--ease-carousel-dot-bg);
+  transition: background 0.2s, width 0.2s;
+  cursor: pointer;
+  border: 2px solid rgba(255, 255, 255, 0.4);
+}
+
+.ease-carousel-dot.active,
+.ease-carousel-dot:target {
+  background: var(--ease-carousel-dot-active);
+  width: 1rem;
+  border-color: var(--ease-carousel-dot-active);
+}
+
+.ease-carousel-btn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: var(--ease-carousel-btn-size);
+  height: var(--ease-carousel-btn-size);
+  border-radius: var(--ease-radius-full, 9999px);
+  background: var(--ease-carousel-btn-bg);
+  color: var(--ease-carousel-btn-color);
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  box-shadow: var(--ease-shadow-md, 0 4px 6px -1px rgba(0,0,0,0.1));
+  transition: background 0.2s, transform 0.2s;
+  z-index: 3;
+  opacity: 0;
+  transition: opacity 0.2s, background 0.2s, transform 0.2s;
+}
+
+.ease-carousel:hover .ease-carousel-btn {
+  opacity: 1;
+}
+
+.ease-carousel-btn:hover {
+  background: #ffffff;
+  transform: translateY(-50%) scale(1.1);
+}
+
+.ease-carousel-btn-prev {
+  left: 0.75rem;
+}
+
+.ease-carousel-btn-next {
+  right: 0.75rem;
+}
+
+.ease-carousel-auto {
+  animation: ease-carousel-scroll 15s linear infinite;
+}
+
+@keyframes ease-carousel-scroll {
+  0%, 100% { scroll-behavior: smooth; }
+}
+
+.ease-carousel-auto:hover {
+  animation-play-state: paused;
+}
+
+.ease-carousel-rounded {
+  border-radius: var(--ease-radius-full, 9999px);
+}
+
+.ease-carousel-elevated {
+  box-shadow: var(--ease-shadow-xl, 0 20px 25px -5px rgba(0,0,0,0.1));
+}
+
+.ease-carousel-multi .ease-carousel-slide {
+  flex: 0 0 50%;
+}
+
+.ease-carousel-multi.ease-carousel-3 .ease-carousel-slide {
+  flex: 0 0 33.333%;
+}
+
+.ease-carousel-multi.ease-carousel-4 .ease-carousel-slide {
+  flex: 0 0 25%;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-carousel-track {
+    scroll-behavior: auto;
+  }
+  .ease-carousel-auto {
+    animation: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .ease-carousel-multi .ease-carousel-slide {
+    flex: 0 0 100%;
+  }
+  .ease-carousel-btn {
+    display: none;
+  }
+  .ease-carousel-caption {
+    padding: 1.25rem 1rem 1rem;
+  }
+  .ease-carousel-caption h3 {
+    font-size: 1rem;
+  }
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #f1f5f9;
+  color: #1f2937;
+  margin: 0;
+  padding: 2rem;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.page-header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.page-header h1 {
+  font-size: 2.25rem;
+  font-weight: 800;
+  margin: 0 0 0.5rem;
+  background: linear-gradient(135deg, var(--ease-color-primary, #6c63ff), #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.page-header p {
+  color: #64748b;
+  max-width: 500px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.demo-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+  max-width: 900px;
+  width: 100%;
+}
+
+.demo-section {
+  background: #ffffff;
+  border-radius: 1rem;
+  padding: 2rem;
+  box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
+  border: 1px solid #e2e8f0;
+}
+
+.demo-section h2 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin: 0 0 0.25rem;
+  color: #1e293b;
+}
+
+.demo-section .desc {
+  color: #64748b;
+  margin: 0 0 1.5rem;
+  font-size: 0.9rem;
+}
+
+.code-block {
+  background: #1e293b;
+  color: #e2e8f0;
+  padding: 1rem 1.25rem;
+  border-radius: 0.5rem;
+  font-size: 0.8rem;
+  overflow-x: auto;
+  margin-top: 1.5rem;
+  line-height: 1.5;
+}
+
+.code-block .tag { color: #7dd3fc; }
+.code-block .class { color: #fbbf24; }
+.code-block .string { color: #34d399; }
+.code-block .comment { color: #64748b; }


### PR DESCRIPTION
## Description
Adds a CSS-only image carousel component using `scroll-snap-type: x mandatory`. Features `:target`-based dot navigation, prev/next buttons, overlaid captions, multi-item variants, and `prefers-reduced-motion` support.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

## Checklist
- [x] `style.css` — Carousel component under `@layer easemotion-components` with custom properties, scroll-snap track, dot nav, prev/next buttons, multi-slide variant, reduced-motion support, and responsive breakpoints
- [x] `demo.html` — Three demos: basic carousel, captioned carousel, multi-item carousel
- [x] `README.md` — What, how, why documentation

## Maintainer Actions
1. Review `submissions/examples/ease-carousel-23908/style.css`
2. Copy contents into `components/carousel.css`
3. Add `@import "components/carousel.css";` in `easemotion.css`
4. Reference in the documentation site

**Closes #23908**