### PR TITLE
feat(typing-text): add CSS-only typewriter animation with cursor blink (GSSoC 2026)

### DIFF
--- a/submissions/examples/ease-typing-text-23908/README.md
+++ b/submissions/examples/ease-typing-text-23908/README.md
@@ -1,0 +1,34 @@
+# CSS-Only Typewriter Text
+
+## What does this do?
+
+A pure CSS typewriter animation that types out text character-by-character using `@keyframes` with `steps()`, then stops. Includes a blinking caret cursor. No JavaScript needed.
+
+## How is it used?
+
+```html
+<span class="ease-typing-text">Your text here</span>
+```
+
+| Modifier | Effect |
+|----------|--------|
+| `ease-typing-fast` | 1s duration |
+| `ease-typing-slow` | 4s duration |
+| `ease-typing-cursor-blue` | Blue cursor |
+| `ease-typing-cursor-green` | Green cursor |
+| `ease-typing-cursor-red` | Red cursor |
+| `ease-typing-cursor-none` | No cursor |
+
+Multi-line:
+```html
+<span class="ease-typing-multiline">
+  <span class="ease-typing-line">Line one</span>
+  <span class="ease-typing-line" style="--ease-typing-line-index: 1">Line two</span>
+</span>
+```
+
+Customize via CSS variables: `--ease-typing-speed`, `--ease-typing-cursor-color`, `--ease-typing-steps`.
+
+## Why is it useful?
+
+Provides a lightweight typewriter effect for hero sections and landing pages without JavaScript. Respects `prefers-reduced-motion` and integrates with EaseMotion CSS design tokens.

--- a/submissions/examples/ease-typing-text-23908/demo.html
+++ b/submissions/examples/ease-typing-text-23908/demo.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Typing Text Component - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="typing-demo">
+    <div class="typing-header">
+      <h1>ease-typing-text</h1>
+      <p>CSS-only typewriter animation with no JavaScript required.</p>
+    </div>
+
+    <div class="typing-card">
+      <h2>Single Line</h2>
+      <p class="desc">Basic typewriter that types one line and stops. Uses <code>steps()</code> for character-by-character effect.</p>
+      <div style="font-size: 1.5rem; font-weight: 700;">
+        <span class="ease-typing-text typing-1" style="--ease-typing-steps: 28;">Hello, I'm a typewriter! 🖋️</span>
+      </div>
+      <pre><span class="tag">&lt;span</span> <span class="keyword">class</span>=<span class="string">"ease-typing-text"</span><span class="tag">&gt;</span>Hello, I'm a typewriter!<span class="tag">&lt;/span&gt;</span></pre>
+    </div>
+
+    <div class="typing-card">
+      <h2>Multi-Line</h2>
+      <p class="desc">Each line types sequentially with staggered delays.</p>
+      <div style="font-size: 1.125rem; line-height: 2;">
+        <span class="ease-typing-multiline">
+          <span class="ease-typing-line" style="--ease-typing-steps: 22;">Line one appears first.</span>
+          <span class="ease-typing-line" style="--ease-typing-line-index: 1; --ease-typing-steps: 23;">Line two follows after a delay.</span>
+          <span class="ease-typing-line" style="--ease-typing-line-index: 2; --ease-typing-steps: 24;">And line three finishes the set.</span>
+        </span>
+      </div>
+      <pre><span class="tag">&lt;span</span> <span class="keyword">class</span>=<span class="string">"ease-typing-multiline"</span><span class="tag">&gt;</span><br>  <span class="tag">&lt;span</span> <span class="keyword">class</span>=<span class="string">"ease-typing-line"</span><span class="tag">&gt;</span>Line one<span class="tag">&lt;/span&gt;</span><br>  <span class="tag">&lt;span</span> <span class="keyword">class</span>=<span class="string">"ease-typing-line"</span> <span class="keyword">style</span>=<span class="string">"--ease-typing-line-index: 1"</span><span class="tag">&gt;</span>Line two<span class="tag">&lt;/span&gt;</span><br>  <span class="tag">&lt;span</span> <span class="keyword">class</span>=<span class="string">"ease-typing-line"</span> <span class="keyword">style</span>=<span class="string">"--ease-typing-line-index: 2"</span><span class="tag">&gt;</span>Line three<span class="tag">&lt;/span&gt;</span><br><span class="tag">&lt;/span&gt;</span></pre>
+    </div>
+
+    <div class="typing-card">
+      <h2>Speed Variants</h2>
+      <p class="desc">Use <code>ease-typing-fast</code> (1s) and <code>ease-typing-slow</code> (4s) modifiers.</p>
+      <div style="display: flex; flex-direction: column; gap: 1.25rem;">
+        <div><span class="ease-typing-text ease-typing-fast typing-2" style="--ease-typing-steps: 20;">Fast typing speed!</span></div>
+        <div><span class="ease-typing-text typing-2" style="--ease-typing-steps: 20; --ease-typing-speed: 2s;">Default speed</span></div>
+        <div><span class="ease-typing-text ease-typing-slow typing-3" style="--ease-typing-steps: 18;">Slow typing speed...</span></div>
+      </div>
+      <pre><span class="keyword">class</span>=<span class="string">"ease-typing-text ease-typing-fast"</span>  <span class="comment">/* 1s */</span><br><span class="keyword">class</span>=<span class="string">"ease-typing-text"</span>                <span class="comment">/* 2s (default) */</span><br><span class="keyword">class</span>=<span class="string">"ease-typing-text ease-typing-slow"</span>  <span class="comment">/* 4s */</span></pre>
+    </div>
+
+    <div class="typing-card">
+      <h2>Cursor Colors</h2>
+      <p class="desc">Custom cursor colors via modifier classes or <code>--ease-typing-cursor-color</code> variable.</p>
+      <div style="display: flex; flex-direction: column; gap: 1.25rem;">
+        <div><span class="ease-typing-text ease-typing-cursor-blue typing-4" style="--ease-typing-steps: 28;">Blue cursor (default accent)</span></div>
+        <div><span class="ease-typing-text ease-typing-cursor-green typing-5" style="--ease-typing-steps: 28;" style="--ease-typing-steps: 29;">Green cursor variant</span></div>
+        <div><span class="ease-typing-text ease-typing-cursor-red typing-6" style="--ease-typing-steps: 26;">Red cursor variant</span></div>
+        <div><span class="ease-typing-text ease-typing-cursor-none typing-7" style="--ease-typing-steps: 26;">No cursor at all</span></div>
+      </div>
+      <pre><span class="keyword">class</span>=<span class="string">"ease-typing-text ease-typing-cursor-blue"</span><br><span class="keyword">class</span>=<span class="string">"ease-typing-text ease-typing-cursor-none"</span><br><span class="keyword">style</span>=<span class="string">"--ease-typing-cursor-color: #ff6b6b"</span></pre>
+    </div>
+
+    <div class="typing-card" style="text-align: center; border-color: #6c63ff;">
+      <p style="color: #94a3b8; font-size: 0.85rem;">
+        All variants respect <code>prefers-reduced-motion</code> and show full text immediately.
+      </p>
+    </div>
+  </div>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      document.querySelectorAll('.ease-typing-text, .ease-typing-line').forEach(el => {
+        el.style.width = '0';
+        void el.offsetWidth;
+        el.style.animation = 'none';
+        void el.offsetWidth;
+        el.style.animation = '';
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-typing-text-23908/style.css
+++ b/submissions/examples/ease-typing-text-23908/style.css
@@ -1,0 +1,169 @@
+:root {
+  --ease-typing-speed: 2s;
+  --ease-typing-cursor-color: var(--ease-color-primary, #6c63ff);
+  --ease-typing-steps: 20;
+}
+
+.ease-typing-text {
+  display: inline-block;
+  overflow: hidden;
+  white-space: nowrap;
+  border-right: 3px solid var(--ease-typing-cursor-color);
+  width: 0;
+  animation: ease-typing var(--ease-typing-speed) steps(var(--ease-typing-steps)) forwards,
+             ease-cursor-blink 0.75s step-end infinite;
+}
+
+.ease-typing-text[data-text]::after {
+  content: attr(data-text);
+  visibility: hidden;
+  display: block;
+  height: 0;
+  overflow: hidden;
+}
+
+.ease-typing-fast {
+  --ease-typing-speed: 1s;
+}
+
+.ease-typing-slow {
+  --ease-typing-speed: 4s;
+}
+
+.ease-typing-cursor-blue {
+  --ease-typing-cursor-color: #3b82f6;
+}
+
+.ease-typing-cursor-green {
+  --ease-typing-cursor-color: #10b981;
+}
+
+.ease-typing-cursor-red {
+  --ease-typing-cursor-color: #ef4444;
+}
+
+.ease-typing-cursor-white {
+  --ease-typing-cursor-color: #ffffff;
+}
+
+.ease-typing-cursor-none {
+  border-right: none;
+}
+
+.ease-typing-multiline {
+  white-space: normal;
+  overflow: visible;
+  border-right: none;
+  display: block;
+}
+
+.ease-typing-multiline .ease-typing-line {
+  display: block;
+  overflow: hidden;
+  white-space: nowrap;
+  width: 0;
+  border-right: 3px solid var(--ease-typing-cursor-color);
+  animation: ease-typing var(--ease-typing-speed) steps(var(--ease-typing-steps)) forwards,
+             ease-cursor-blink 0.75s step-end infinite;
+  animation-delay: calc(var(--ease-typing-line-index, 0) * 0.5s);
+}
+
+.ease-typing-multiline .ease-typing-line:last-child {
+  border-right: 3px solid var(--ease-typing-cursor-color);
+}
+
+@keyframes ease-typing {
+  from { width: 0; }
+  to { width: 100%; }
+}
+
+@keyframes ease-cursor-blink {
+  0%, 100% { border-color: var(--ease-typing-cursor-color); }
+  50% { border-color: transparent; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-typing-text,
+  .ease-typing-multiline .ease-typing-line {
+    width: 100%;
+    border-right: none;
+    animation: none;
+  }
+  .ease-typing-text {
+    white-space: normal;
+    border-right: none;
+  }
+}
+
+body {
+  font-family: 'Courier New', Courier, monospace;
+  background: #0f172a;
+  color: #e2e8f0;
+  margin: 0;
+  padding: 2rem;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.typing-demo {
+  max-width: 800px;
+  width: 100%;
+}
+
+.typing-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.typing-header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, #6c63ff, #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.typing-header p {
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
+.typing-card {
+  background: #1e293b;
+  border-radius: 1rem;
+  padding: 2rem;
+  margin-bottom: 2rem;
+  border: 1px solid #334155;
+}
+
+.typing-card h2 {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #64748b;
+  margin: 0 0 0.25rem;
+}
+
+.typing-card .desc {
+  color: #94a3b8;
+  font-size: 0.8rem;
+  margin: 0 0 1.5rem;
+}
+
+.typing-card pre {
+  background: #0f172a;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  font-size: 0.75rem;
+  color: #7dd3fc;
+  margin-top: 1.5rem;
+  overflow-x: auto;
+  line-height: 1.5;
+}
+
+.typing-card pre .comment { color: #64748b; }
+.typing-card pre .keyword { color: #fbbf24; }
+.typing-card pre .string { color: #34d399; }
+.typing-card pre .tag { color: #f472b6; }


### PR DESCRIPTION
## Description
Pure CSS typewriter animation using `@keyframes` with `steps()` for character-by-character typing and a blinking caret cursor. No JavaScript required. Supports single-line, multi-line (staggered), speed variants, and cursor color customization.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

## Checklist
- [x] `style.css` — Pure CSS with `@keyframes ease-typing`, `ease-cursor-blink`, `--ease-typing-speed` variable, `ease-typing-fast/slow` modifiers, `ease-typing-cursor-*` color variants, `ease-typing-multiline` staggered lines, `prefers-reduced-motion` fallback
- [x] `demo.html` — 5 demos: single-line, multi-line, speed variants, cursor colors, no-cursor variant
- [x] `README.md` — What, how, why with modifier table

## Maintainer Actions
1. Review `submissions/examples/ease-typing-text-23908/style.css`
2. Integrate into core animation library
3. Reference in documentation site

**Closes #21305**