### PR TITLE
feat(morphing-shape): add CSS-only shape morphing with border-radius and clip-path (GSSoC 2026)

### DIFF
--- a/submissions/examples/ease-morphing-shape-23908/README.md
+++ b/submissions/examples/ease-morphing-shape-23908/README.md
@@ -1,0 +1,30 @@
+# CSS Shape Morphing
+
+## What does this do?
+
+CSS-only shape morphing animations using `border-radius` percentage manipulation (organic blob) and `clip-path: polygon()` transitions (geometric morphs). Three animation classes with infinite looping.
+
+## How is it used?
+
+```html
+<!-- Organic blob morphing (circle ↔ blob ↔ rounded square) -->
+<div class="ease-morph-blob"></div>
+
+<!-- Geometric morphing (diamond ↔ triangle ↔ hexagon) -->
+<div class="ease-morph-geometric"></div>
+
+<!-- Combined morphing loader with gradient -->
+<div class="ease-morph-loader"></div>
+```
+
+| Modifier | Effect |
+|----------|--------|
+| `ease-morph-blob-fast` | 1.5s duration |
+| `ease-morph-blob-slow` | 6s duration |
+| `ease-morph-loader-fast` | 1.5s loader |
+
+Customize via CSS variables: `--ease-morph-duration`, `--ease-morph-color`, `--ease-morph-size`.
+
+## Why is it useful?
+
+Provides loading states and micro-interactions without SVG, JS, or external dependencies. GPU-friendly (only composited properties). Respects `prefers-reduced-motion`.

--- a/submissions/examples/ease-morphing-shape-23908/demo.html
+++ b/submissions/examples/ease-morphing-shape-23908/demo.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Shape Morphing - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="morph-demo">
+    <div class="morph-header">
+      <h1>ease-morph</h1>
+      <p>CSS-only shape morphing using border-radius and clip-path transitions. No SVG or JS.</p>
+    </div>
+
+    <div class="morph-card">
+      <h2>Blob Morphing</h2>
+      <p class="desc">Organic blob effect using border-radius percentage manipulation. Smooth infinite loop.</p>
+      <div class="morph-grid">
+        <div class="morph-item">
+          <div class="morph-container">
+            <div class="ease-morph-blob" style="--ease-morph-color: #6c63ff;"></div>
+          </div>
+          <span class="label">Default</span>
+        </div>
+        <div class="morph-item">
+          <div class="morph-container">
+            <div class="ease-morph-blob ease-morph-blob-fast" style="--ease-morph-color: #f59e0b;"></div>
+          </div>
+          <span class="label">Fast (1.5s)</span>
+        </div>
+        <div class="morph-item">
+          <div class="morph-container">
+            <div class="ease-morph-blob ease-morph-blob-slow" style="--ease-morph-color: #10b981;"></div>
+          </div>
+          <span class="label">Slow (6s)</span>
+        </div>
+        <div class="morph-item">
+          <div class="morph-container">
+            <div class="ease-morph-blob" style="--ease-morph-color: #ec4899;"></div>
+          </div>
+          <span class="label">Custom color</span>
+        </div>
+      </div>
+      <pre><span class="keyword">class</span>=<span class="string">"ease-morph-blob"</span><br><span class="keyword">class</span>=<span class="string">"ease-morph-blob ease-morph-blob-fast"</span><br><span class="keyword">style</span>=<span class="string">"--ease-morph-color: #f59e0b; --ease-morph-duration: 2s"</span></pre>
+    </div>
+
+    <div class="morph-card">
+      <h2>Geometric Morphing</h2>
+      <p class="desc">Diamond → Triangle → Hexagon using clip-path polygon() transitions.</p>
+      <div class="morph-grid">
+        <div class="morph-item">
+          <div class="morph-container">
+            <div class="ease-morph-geometric" style="--ease-morph-color: #8b5cf6;"></div>
+          </div>
+          <span class="label">Diamond morph</span>
+        </div>
+        <div class="morph-item">
+          <div class="morph-container">
+            <div class="ease-morph-geometric ease-morph-blob-fast" style="--ease-morph-color: #f97316;"></div>
+          </div>
+          <span class="label">Fast variant</span>
+        </div>
+        <div class="morph-item">
+          <div class="morph-container">
+            <div class="ease-morph-geometric ease-morph-blob-slow" style="--ease-morph-color: #14b8a6;"></div>
+          </div>
+          <span class="label">Slow variant</span>
+        </div>
+      </div>
+      <pre><span class="keyword">class</span>=<span class="string">"ease-morph-geometric"</span><br><span class="comment">/* Morphs: diamond → rotated diamond → triangle → hexagon */</span></pre>
+    </div>
+
+    <div class="morph-card">
+      <h2>Morphing Loader</h2>
+      <p class="desc">Circle → Square → Diamond → Blob with gradient background and glow shadow.</p>
+      <div class="morph-grid">
+        <div class="morph-item">
+          <div class="morph-container">
+            <div class="ease-morph-loader"></div>
+          </div>
+          <span class="label">Default</span>
+        </div>
+        <div class="morph-item">
+          <div class="morph-container">
+            <div class="ease-morph-loader ease-morph-loader-fast" style="--ease-morph-color: #f59e0b; --ease-color-secondary: #f97316;"></div>
+          </div>
+          <span class="label">Fast loader</span>
+        </div>
+      </div>
+      <pre><span class="keyword">class</span>=<span class="string">"ease-morph-loader"</span><br><span class="comment">/* Morphs: circle → rounded square → diamond → blob */</span></pre>
+    </div>
+
+    <div class="morph-card">
+      <h2>All Sizes</h2>
+      <p class="desc">Customize size via <code>--ease-morph-size</code> variable.</p>
+      <div class="morph-columns">
+        <div class="morph-item">
+          <div class="ease-morph-blob" style="--ease-morph-color: #6c63ff; --ease-morph-size: 60px;"></div>
+          <span class="label">60px</span>
+        </div>
+        <div class="morph-item">
+          <div class="ease-morph-blob" style="--ease-morph-color: #8b5cf6; --ease-morph-size: 100px;"></div>
+          <span class="label">100px</span>
+        </div>
+        <div class="morph-item">
+          <div class="ease-morph-blob" style="--ease-morph-color: #a78bfa; --ease-morph-size: 140px;"></div>
+          <span class="label">140px</span>
+        </div>
+      </div>
+      <pre><span class="keyword">style</span>=<span class="string">"--ease-morph-size: 80px"</span></pre>
+    </div>
+
+    <div class="morph-card" style="text-align: center; border-color: #6c63ff;">
+      <p style="color: #94a3b8; font-size: 0.85rem;">
+        Uses only <code>border-radius</code> and <code>clip-path</code>. No layout thrashing. Respects <code>prefers-reduced-motion</code>.
+      </p>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-morphing-shape-23908/style.css
+++ b/submissions/examples/ease-morphing-shape-23908/style.css
@@ -1,0 +1,228 @@
+:root {
+  --ease-morph-duration: 3s;
+  --ease-morph-color: var(--ease-color-primary, #6c63ff);
+  --ease-morph-size: 120px;
+}
+
+.ease-morph-blob {
+  width: var(--ease-morph-size);
+  height: var(--ease-morph-size);
+  background: var(--ease-morph-color);
+  animation: ease-morph-blob var(--ease-morph-duration) ease-in-out infinite;
+}
+
+.ease-morph-blob-fast {
+  --ease-morph-duration: 1.5s;
+}
+
+.ease-morph-blob-slow {
+  --ease-morph-duration: 6s;
+}
+
+.ease-morph-geometric {
+  width: var(--ease-morph-size);
+  height: var(--ease-morph-size);
+  background: var(--ease-morph-color);
+  animation: ease-morph-geometric var(--ease-morph-duration) ease-in-out infinite;
+}
+
+.ease-morph-loader {
+  width: var(--ease-morph-size);
+  height: var(--ease-morph-size);
+  background: linear-gradient(135deg, var(--ease-morph-color), var(--ease-color-secondary, #a78bfa));
+  animation: ease-morph-loader var(--ease-morph-duration) ease-in-out infinite;
+  box-shadow: 0 0 30px rgba(108, 99, 255, 0.3);
+}
+
+.ease-morph-loader-fast {
+  --ease-morph-duration: 1.5s;
+}
+
+@keyframes ease-morph-blob {
+  0%, 100% {
+    border-radius: 50%;
+    transform: scale(1) rotate(0deg);
+  }
+  25% {
+    border-radius: 40% 60% 60% 40% / 60% 40% 60% 40%;
+    transform: scale(1.05) rotate(10deg);
+  }
+  50% {
+    border-radius: 30% 70% 40% 60% / 50% 50% 50% 50%;
+    transform: scale(0.95) rotate(-5deg);
+  }
+  75% {
+    border-radius: 60% 40% 50% 50% / 40% 60% 40% 60%;
+    transform: scale(1.05) rotate(15deg);
+  }
+}
+
+@keyframes ease-morph-geometric {
+  0%, 100% {
+    border-radius: 0;
+    clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+    transform: rotate(0deg);
+  }
+  25% {
+    border-radius: 50%;
+    clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+    transform: rotate(45deg);
+  }
+  50% {
+    border-radius: 0;
+    clip-path: polygon(50% 0%, 100% 100%, 0% 100%);
+    transform: rotate(0deg);
+  }
+  75% {
+    border-radius: 0;
+    clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
+    transform: rotate(180deg);
+  }
+}
+
+@keyframes ease-morph-loader {
+  0%, 100% {
+    border-radius: 50%;
+    clip-path: none;
+    transform: scale(1) rotate(0deg);
+  }
+  25% {
+    border-radius: 20%;
+    clip-path: none;
+    transform: scale(0.85) rotate(90deg);
+  }
+  50% {
+    border-radius: 50%;
+    clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+    transform: scale(1.15) rotate(180deg);
+  }
+  75% {
+    border-radius: 30% 70% 50% 50% / 50% 40% 60% 50%;
+    clip-path: none;
+    transform: scale(0.9) rotate(270deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-morph-blob,
+  .ease-morph-geometric,
+  .ease-morph-loader {
+    animation: none;
+    border-radius: 50%;
+    transform: none;
+    clip-path: none;
+  }
+  .ease-morph-geometric {
+    clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+  }
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  margin: 0;
+  padding: 2rem;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.morph-demo {
+  max-width: 900px;
+  width: 100%;
+}
+
+.morph-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.morph-header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, #6c63ff, #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin: 0 0 0.5rem;
+}
+
+.morph-header p {
+  color: #64748b;
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.morph-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 2rem;
+  place-items: center;
+  margin-bottom: 2rem;
+}
+
+.morph-card {
+  background: #1e293b;
+  border-radius: 1rem;
+  padding: 2rem;
+  margin-bottom: 2rem;
+  border: 1px solid #334155;
+}
+
+.morph-card h2 {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #64748b;
+  margin: 0 0 0.25rem;
+}
+
+.morph-card .desc {
+  color: #94a3b8;
+  font-size: 0.8rem;
+  margin: 0 0 1.5rem;
+}
+
+.morph-card pre {
+  background: #0f172a;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  font-size: 0.75rem;
+  color: #7dd3fc;
+  margin-top: 1.5rem;
+  overflow-x: auto;
+  line-height: 1.5;
+}
+
+.morph-card pre .comment { color: #64748b; }
+.morph-card pre .keyword { color: #fbbf24; }
+.morph-card pre .string { color: #34d399; }
+.morph-card pre .tag { color: #f472b6; }
+
+.morph-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.morph-item .label {
+  font-size: 0.8rem;
+  color: #94a3b8;
+  text-align: center;
+}
+
+.morph-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 160px;
+}
+
+.morph-columns {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}


### PR DESCRIPTION
## Description
CSS-only shape morphing animations. Organic blob effect via `border-radius` percentage manipulation, geometric morphing via `clip-path: polygon()` transitions, and a combined morphing loader with gradient background.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

## Checklist
- [x] `style.css` — `@keyframes ease-morph-blob` (border-radius), `ease-morph-geometric` (clip-path), `ease-morph-loader` (combined); speed modifiers, custom properties (`--ease-morph-duration`, `--ease-morph-color`, `--ease-morph-size`), `prefers-reduced-motion` fallback
- [x] `demo.html` — 4 demos: blob morphing (4 variants), geometric morphing (3 variants), morphing loader (2 variants), size customization
- [x] `README.md` — What, how, why

## Maintainer Actions
1. Review `submissions/examples/ease-morphing-shape-23908/style.css`
2. Integrate into core animation library
3. Reference in documentation

**Closes #21309**