### PR TITLE
feat(neon-glass-navbar): add CSS-only glassmorphism navbar with neon glow effects (GSSoC 2026)

### DIFF
--- a/submissions/examples/neon-glass-navbar-23908/README.md
+++ b/submissions/examples/neon-glass-navbar-23908/README.md
@@ -1,0 +1,30 @@
+# Neon Glass Navigation Bar
+
+## What does this do?
+
+A CSS-only navigation bar combining glassmorphism (`backdrop-filter: blur()`) and neon glow effects. Features frosted glass background, glowing link hover states, animated underline indicators, and gradient CTA button.
+
+## How is it used?
+
+```html
+<nav class="neon-glass-navbar">
+  <div class="logo">Brand</div>
+  <ul class="nav-links">
+    <li><a href="#" class="active">Home</a></li>
+    <li><a href="#">Link</a></li>
+  </ul>
+  <button class="cta-btn">Action</button>
+</nav>
+```
+
+| Variant | Effect |
+|---------|--------|
+| `neon-glass-navbar` | Cyan/magenta neon |
+| `neon-glass-navbar-green` | Green/blue neon |
+| `neon-glass-navbar-dark` | Denser glass overlay |
+
+Customize colors via CSS variables: `--neon-cyan`, `--neon-magenta`, `--neon-green`, `--glass-bg`.
+
+## Why is it useful?
+
+Demonstrates real-world component combining glassmorphism, neon glow, animated indicators, and responsive behavior — all CSS-only. Respects `prefers-reduced-motion`.

--- a/submissions/examples/neon-glass-navbar-23908/demo.html
+++ b/submissions/examples/neon-glass-navbar-23908/demo.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Neon Glass Navbar - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-sections">
+    <div class="demo-header">
+      <h1>Neon Glass Navbar</h1>
+      <p>Glassmorphism + neon glow — pure CSS, zero JavaScript</p>
+      <span class="badge">CSS-only component</span>
+    </div>
+
+    <div class="demo-section">
+      <h2>Default (Cyan/Magenta)</h2>
+      <p class="desc">Frosted glass background with cyan neon underlines and gradient CTA button.</p>
+
+      <nav class="neon-glass-navbar">
+        <div class="logo">EaseMotion</div>
+        <ul class="nav-links">
+          <li><a href="#" class="active">Home</a></li>
+          <li><a href="#">Features</a></li>
+          <li><a href="#">Examples</a></li>
+          <li><a href="#">Docs</a></li>
+          <li><a href="#">Contact</a></li>
+        </ul>
+        <button class="cta-btn">Get Started</button>
+      </nav>
+
+      <pre><span class="tag">&lt;nav</span> <span class="keyword">class</span>=<span class="string">"neon-glass-navbar"</span><span class="tag">&gt;</span><br>  <span class="tag">&lt;div</span> <span class="keyword">class</span>=<span class="string">"logo"</span><span class="tag">&gt;</span>EaseMotion<span class="tag">&lt;/div&gt;</span><br>  <span class="tag">&lt;ul</span> <span class="keyword">class</span>=<span class="string">"nav-links"</span><span class="tag">&gt;</span><br>    <span class="tag">&lt;li&gt;&lt;a</span> <span class="keyword">href</span>=<span class="string">"#"</span> <span class="keyword">class</span>=<span class="string">"active"</span><span class="tag">&gt;</span>Home<span class="tag">&lt;/a&gt;&lt;/li&gt;</span><br>    ...<br>  <span class="tag">&lt;/ul&gt;</span><br>  <span class="tag">&lt;button</span> <span class="keyword">class</span>=<span class="string">"cta-btn"</span><span class="tag">&gt;</span>Get Started<span class="tag">&lt;/button&gt;</span><br><span class="tag">&lt;/nav&gt;</span></pre>
+    </div>
+
+    <div class="demo-section">
+      <h2>Green Neon Variant</h2>
+      <p class="desc">Same glass structure with green neon accents and blue-green gradient CTA.</p>
+
+      <nav class="neon-glass-navbar neon-glass-navbar-green">
+        <div class="logo">EaseMotion</div>
+        <ul class="nav-links">
+          <li><a href="#" class="active">Home</a></li>
+          <li><a href="#">Features</a></li>
+          <li><a href="#">Examples</a></li>
+          <li><a href="#">Docs</a></li>
+          <li><a href="#">Contact</a></li>
+        </ul>
+        <button class="cta-btn">Get Started</button>
+      </nav>
+
+      <pre><span class="keyword">class</span>=<span class="string">"neon-glass-navbar neon-glass-navbar-green"</span></pre>
+    </div>
+
+    <div class="demo-section">
+      <h2>Dark Glass Variant</h2>
+      <p class="desc">Denser glass overlay for higher contrast backgrounds.</p>
+
+      <nav class="neon-glass-navbar neon-glass-navbar-dark">
+        <div class="logo">EaseMotion</div>
+        <ul class="nav-links">
+          <li><a href="#" class="active">Home</a></li>
+          <li><a href="#">Features</a></li>
+          <li><a href="#">Examples</a></li>
+          <li><a href="#">Docs</a></li>
+          <li><a href="#">Contact</a></li>
+        </ul>
+        <button class="cta-btn">Get Started</button>
+      </nav>
+
+      <pre><span class="keyword">class</span>=<span class="string">"neon-glass-navbar neon-glass-navbar-dark"</span></pre>
+    </div>
+
+    <div class="demo-section" style="text-align: center; border-color: rgba(0, 255, 255, 0.2);">
+      <p style="color: rgba(255,255,255,0.4); font-size: 0.8rem;">
+        Features: <code>backdrop-filter: blur()</code>, <code>text-shadow</code> neon glow, animated underline indicator, gradient CTA, responsive mobile layout, <code>prefers-reduced-motion</code> support.
+      </p>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/neon-glass-navbar-23908/style.css
+++ b/submissions/examples/neon-glass-navbar-23908/style.css
@@ -1,0 +1,264 @@
+:root {
+  --glass-bg: rgba(255, 255, 255, 0.06);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-blur: 16px;
+  --neon-cyan: #00ffff;
+  --neon-magenta: #ff00ff;
+  --neon-green: #00ff88;
+  --text-primary: rgba(255, 255, 255, 0.9);
+  --text-muted: rgba(255, 255, 255, 0.5);
+}
+
+.neon-glass-navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.85rem 2rem;
+  background: var(--glass-bg);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  border: 1px solid var(--glass-border);
+  border-radius: 1rem;
+  position: relative;
+  z-index: 10;
+}
+
+.neon-glass-navbar .logo {
+  font-size: 1.25rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, var(--neon-cyan), var(--neon-magenta));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  letter-spacing: -0.02em;
+}
+
+.neon-glass-navbar .nav-links {
+  display: flex;
+  gap: 1.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.neon-glass-navbar .nav-links a {
+  text-decoration: none;
+  color: var(--text-muted);
+  position: relative;
+  transition: color 0.3s ease, text-shadow 0.3s ease;
+  font-size: 0.9rem;
+  font-weight: 500;
+  padding: 0.25rem 0;
+}
+
+.neon-glass-navbar .nav-links a:hover,
+.neon-glass-navbar .nav-links a.active {
+  color: var(--text-primary);
+}
+
+.neon-glass-navbar .nav-links a:hover {
+  text-shadow:
+    0 0 8px var(--neon-cyan),
+    0 0 20px var(--neon-cyan),
+    0 0 40px rgba(0, 255, 255, 0.3);
+}
+
+.neon-glass-navbar .nav-links a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -4px;
+  width: 0;
+  height: 2px;
+  background: var(--neon-cyan);
+  border-radius: 1px;
+  transition: width 0.3s ease;
+  box-shadow: 0 0 8px var(--neon-cyan);
+}
+
+.neon-glass-navbar .nav-links a:hover::after,
+.neon-glass-navbar .nav-links a.active::after {
+  width: 100%;
+}
+
+.neon-glass-navbar .cta-btn {
+  padding: 0.6rem 1.4rem;
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.85rem;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  background: linear-gradient(135deg, var(--neon-cyan), var(--neon-magenta));
+  color: #0f172a;
+  box-shadow: 0 0 20px rgba(0, 255, 255, 0.2);
+}
+
+.neon-glass-navbar .cta-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 0 30px rgba(0, 255, 255, 0.4), 0 0 60px rgba(255, 0, 255, 0.2);
+}
+
+.neon-glass-navbar .cta-btn:active {
+  transform: translateY(0);
+}
+
+.neon-glass-navbar-green .nav-links a:hover {
+  text-shadow:
+    0 0 8px var(--neon-green),
+    0 0 20px var(--neon-green),
+    0 0 40px rgba(0, 255, 136, 0.3);
+}
+
+.neon-glass-navbar-green .nav-links a::after {
+  background: var(--neon-green);
+  box-shadow: 0 0 8px var(--neon-green);
+}
+
+.neon-glass-navbar-green .cta-btn {
+  background: linear-gradient(135deg, var(--neon-green), #00b8ff);
+  box-shadow: 0 0 20px rgba(0, 255, 136, 0.2);
+}
+
+.neon-glass-navbar-green .cta-btn:hover {
+  box-shadow: 0 0 30px rgba(0, 255, 136, 0.4), 0 0 60px rgba(0, 184, 255, 0.2);
+}
+
+.neon-glass-navbar-dark {
+  --glass-bg: rgba(0, 0, 0, 0.4);
+  --glass-border: rgba(255, 255, 255, 0.08);
+}
+
+@media (max-width: 640px) {
+  .neon-glass-navbar {
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1rem;
+  }
+  .neon-glass-navbar .nav-links {
+    gap: 1rem;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+  .neon-glass-navbar .nav-links a {
+    font-size: 0.8rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .neon-glass-navbar .nav-links a,
+  .neon-glass-navbar .nav-links a::after,
+  .neon-glass-navbar .cta-btn {
+    transition: none;
+  }
+  .neon-glass-navbar .nav-links a:hover::after,
+  .neon-glass-navbar .nav-links a.active::after {
+    width: 100%;
+  }
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: #0f172a;
+  overflow-x: hidden;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background:
+    radial-gradient(ellipse at 20% 50%, rgba(0, 255, 255, 0.08) 0%, transparent 50%),
+    radial-gradient(ellipse at 80% 50%, rgba(255, 0, 255, 0.08) 0%, transparent 50%),
+    radial-gradient(ellipse at 50% 0%, rgba(0, 255, 136, 0.05) 0%, transparent 50%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.demo-sections {
+  position: relative;
+  z-index: 1;
+  max-width: 800px;
+  width: 90%;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 2rem;
+}
+
+.demo-section {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1rem;
+  padding: 2rem;
+}
+
+.demo-section h2 {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: rgba(255, 255, 255, 0.4);
+  margin: 0 0 0.25rem;
+}
+
+.demo-section .desc {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.8rem;
+  margin: 0 0 1.5rem;
+}
+
+.demo-section pre {
+  background: #0f172a;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  font-size: 0.75rem;
+  color: #7dd3fc;
+  margin-top: 1.5rem;
+  overflow-x: auto;
+  line-height: 1.5;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.demo-section pre .comment { color: #64748b; }
+.demo-section pre .keyword { color: #fbbf24; }
+.demo-section pre .string { color: #34d399; }
+.demo-section pre .tag { color: #f472b6; }
+
+.demo-header {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.demo-header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, var(--neon-cyan), var(--neon-magenta));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin: 0 0 0.5rem;
+}
+
+.demo-header p {
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.demo-header .badge {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  background: rgba(0, 255, 255, 0.1);
+  color: var(--neon-cyan);
+  border: 1px solid rgba(0, 255, 255, 0.2);
+  margin-top: 0.75rem;
+}


### PR DESCRIPTION
## Description
CSS-only navigation bar combining glassmorphism (`backdrop-filter: blur()`) with neon glow hover effects. Features frosted glass background, glowing link text-shadow, animated underline indicators, gradient CTA button, and responsive mobile layout.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

## Checklist
- [x] `style.css` — Glass navbar with `backdrop-filter`, neon `text-shadow`, animated `::after` underline, gradient CTA with hover lift, 3 variants (default cyan/magenta, green, dark), responsive breakpoints, `prefers-reduced-motion` fallback
- [x] `demo.html` — 3 demos: default, green neon variant, dark glass variant
- [x] `README.md` — What, how, why with variant table

## Maintainer Actions
1. Review `submissions/examples/neon-glass-navbar-23908/style.css`
2. Integrate into components/
3. Reference in documentation

**Closes #21295**