### PR TITLE
fix: bind view-transition keyframes to pseudo-elements

### DIFF
--- a/components/view-transitions.css
+++ b/components/view-transitions.css
@@ -1,19 +1,29 @@
-@layer easemotion-components {
+@layer easemotion-components-effect {
   @keyframes view-fade-out {
     to { opacity: 0; }
   }
-  
+
   @keyframes view-fade-in {
     from { opacity: 0; }
   }
-  
+
   @keyframes view-scale-out {
     from { transform: scale(1); border-radius: 0; }
     to   { transform: scale(0.95); border-radius: 20px; }
   }
-  
+
   @keyframes view-scale-in {
     from { transform: scale(0.95); border-radius: 20px; }
     to   { transform: scale(1); border-radius: 0; }
+  }
+}
+
+@layer easemotion-components {
+  ::view-transition-old(root) {
+    animation: view-fade-out 300ms ease-in-out, view-scale-out 300ms ease-in-out;
+  }
+
+  ::view-transition-new(root) {
+    animation: view-fade-in 500ms ease-in-out, view-scale-in 500ms ease-in-out;
   }
 }


### PR DESCRIPTION
The view-transitions.css file defined keyframe animations but never applied them to any CSS selector or View Transition pseudo-element, making the entire file dead code.

Bind @keyframes to ::view-transition-old(root) and ::view-transition-new(root) so imported transitions actually animate.

Closes #24076