### PR TITLE
feat: add nth-child-patterns CSS utility (#24056)

### DIFF
--- a/submissions/examples/nth-child-patterns/README.md
+++ b/submissions/examples/nth-child-patterns/README.md
@@ -1,0 +1,13 @@
+# nth-child Structural Selector Patterns
+
+This utility directory showcases common structural selection patterns leveraging the standard CSS `:nth-child()` functional argument options inside **EaseMotion**.
+
+## Implemented Patterns
+- **Even/Odd Zebra Striping**: Standard alternating structures (`even` and `odd`) targeting dynamic row lists.
+- **Mathematical Steps (`3n`)**: Multi-step targeting sequences for custom component grids or multi-column spacing indicators.
+- **Mathematical Offsets (`3n+1`)**: Grid elements with target modifications starting precisely from an explicitly managed point.
+
+## File Map
+- `demo.html` - Container configurations showcasing real-world list states.
+- `style.css` - Custom structural selections integrated with token variables.
+- `README.md` - Documentation overview.

--- a/submissions/examples/nth-child-patterns/demo.html
+++ b/submissions/examples/nth-child-patterns/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion - nth-child Selector Patterns Utility</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header class="header">
+      <h1>EaseMotion <code>nth-child</code> Utility Patterns</h1>
+      <p>A structured visualization of complex item iteration utilizing mathematical structural pseudo-classes combined with EaseMotion background and border design tokens.</p>
+    </header>
+
+    <main>
+      <section class="demo-section">
+        <h2>Alternating Rows: <code>:nth-child(even)</code></h2>
+        <p>Applies a subtle secondary background to all even-indexed rows.</p>
+        <ul class="item-list pattern-even">
+          <li class="item">Row 1</li>
+          <li class="item">Row 2 (Even)</li>
+          <li class="item">Row 3</li>
+          <li class="item">Row 4 (Even)</li>
+          <li class="item">Row 5</li>
+        </ul>
+      </section>
+
+      <section class="demo-section">
+        <h2>Alternating Rows: <code>:nth-child(odd)</code></h2>
+        <p>Applies an accent highlight style to all odd-indexed rows.</p>
+        <ul class="item-list pattern-odd">
+          <li class="item">Row 1 (Odd)</li>
+          <li class="item">Row 2</li>
+          <li class="item">Row 3 (Odd)</li>
+          <li class="item">Row 4</li>
+          <li class="item">Row 5 (Odd)</li>
+        </ul>
+      </section>
+
+      <section class="demo-section">
+        <h2>Step Pattern: <code>:nth-child(3n)</code></h2>
+        <p>Targets every third item in the sequence (3rd, 6th, etc.).</p>
+        <ul class="item-list pattern-3n">
+          <li class="item">Row 1</li>
+          <li class="item">Row 2</li>
+          <li class="item">Row 3 (3n)</li>
+          <li class="item">Row 4</li>
+          <li class="item">Row 5</li>
+          <li class="item">Row 6 (3n)</li>
+        </ul>
+      </section>
+
+      <section class="demo-section">
+        <h2>Offset Pattern: <code>:nth-child(3n+1)</code></h2>
+        <p>Targets every third element starting from an offset of the 1st element (1st, 4th, 7th, etc.).</p>
+        <ul class="item-list pattern-3n-plus-1">
+          <li class="item">Row 1 (3n+1)</li>
+          <li class="item">Row 2</li>
+          <li class="item">Row 3</li>
+          <li class="item">Row 4 (3n+1)</li>
+          <li class="item">Row 5</li>
+          <li class="item">Row 6</li>
+          <li class="item">Row 7 (3n+1)</li>
+        </ul>
+      </section>
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/nth-child-patterns/style.css
+++ b/submissions/examples/nth-child-patterns/style.css
@@ -1,0 +1,93 @@
+/* EaseMotion Design Tokens */
+:root {
+  --easemotion-bg-main: #f8fafc;
+  --easemotion-bg-card: #ffffff;
+  --easemotion-bg-stripe-even: #f1f5f9;
+  --easemotion-bg-stripe-accent: #e0f2fe;
+  --easemotion-border-light: #e2e8f0;
+  --easemotion-border-accent: #38bdf8;
+  --easemotion-text-main: #0f172a;
+  --easemotion-text-muted: #64748b;
+  --easemotion-radius-sm: 6px;
+  --easemotion-radius-md: 12px;
+}
+
+/* Base Demo Styling */
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background-color: var(--easemotion-bg-main);
+  color: var(--easemotion-text-main);
+  padding: 2rem;
+  margin: 0;
+}
+
+.container {
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+.header {
+  margin-bottom: 2.5rem;
+}
+
+.demo-section {
+  background: var(--easemotion-bg-card);
+  border: 1px solid var(--easemotion-border-light);
+  border-radius: var(--easemotion-radius-md);
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.demo-section h2 {
+  margin-top: 0;
+  font-size: 1.25rem;
+  color: var(--easemotion-text-main);
+}
+
+.demo-section p {
+  color: var(--easemotion-text-muted);
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+}
+
+/* Base List Structure */
+.item-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.item {
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--easemotion-border-light);
+  border-radius: var(--easemotion-radius-sm);
+  background-color: var(--easemotion-bg-card);
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+/* --- Pattern 1: Alternating Rows (even) --- */
+.pattern-even .item:nth-child(even) {
+  background-color: var(--easemotion-bg-stripe-even);
+}
+
+/* --- Pattern 2: Alternating Rows (odd) --- */
+.pattern-odd .item:nth-child(odd) {
+  background-color: var(--easemotion-bg-stripe-accent);
+  border-color: var(--easemotion-border-accent);
+}
+
+/* --- Pattern 3: Every 3rd Item (3n) --- */
+.pattern-3n .item:nth-child(3n) {
+  background-color: #fef08a; /* Soft warning/highlight color */
+  border-color: #facc15;
+}
+
+/* --- Pattern 4: Offset Grid Pattern (3n+1) --- */
+.pattern-3n-plus-1 .item:nth-child(3n+1) {
+  background-color: #bbf7d0; /* Soft green success/highlight color */
+  border-color: #4ade80;
+}


### PR DESCRIPTION
## Description
This PR addresses issue #24056 by introducing a comprehensive `nth-child` functional selector pattern demo inside the `submissions/` directory. It demonstrates structural pseudo-class selection styles utilizing mathematical patterns combined with EaseMotion's background and border tokens.

### Changes Made
- Created a new directory: `submissions/examples/nth-child-patterns/`
- Added `demo.html` to clearly visualize and document different iteration patterns (`even`, `odd`, `3n`, `3n+1`).
- Added `style.css` implementing alternating zebra striping and complex row steps tied to EaseMotion design tokens.
- Added an explanatory `README.md` detailing the structural layout utility and structural patterns used.

## Checklist
- [x] My files are added exclusively inside the `submissions/` directory.
- [x] I have included all three required files: `demo.html`, `style.css`, and `README.md`.
- [x] The markup and CSS rules utilize project background and border tokens.
- [x] No existing issues or PRs conflict with this implementation.

## Screenshots / Previews
*(Optional: Feel free to drag and drop a screenshot of your local test rendering here to speed up the maintainer's review process!)*

Closes #24056