### PR TITLE
feat: add ease-drop-cap styling utility (#23961)

### DIFF
--- a/submissions/examples/drop-cap-utility/README.md
+++ b/submissions/examples/drop-cap-utility/README.md
@@ -1,0 +1,15 @@
+# Typography Drop-Cap Utilities
+
+This component utility collection provides classic editorial structural modifications leveraging the native CSS `::first-letter` pseudo-element syntax inside **EaseMotion**.
+
+## Implemented Variant Tokens
+- `.ease-drop-cap`: Floats a bolded, large-scale serif character into the structural paragraph layout body.
+- `.ease-drop-cap-circle`: Wraps the targeted leading element with a high-contrast circular solid background badge.
+- `.ease-drop-cap-outlined`: Borders the leading structural character with an inline container border box.
+
+## Variable Ecosystem Hook Architecture
+Users can pass parameters locally to scale elements dynamically:
+- `--ease-drop-cap-size`
+- `--ease-drop-cap-color`
+- `--ease-drop-cap-font`
+- `--ease-drop-cap-weight`

--- a/submissions/examples/drop-cap-utility/demo.html
+++ b/submissions/examples/drop-cap-utility/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion - Drop Cap Typography Utilities</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-container">
+    <header style="margin-bottom: 2rem;">
+      <h1 style="margin: 0; font-size: 2rem; color: #1e293b;">Typography Drop-Cap Utility</h1>
+      <p style="color: #64748b; margin-top: 0.5rem;">Demonstrating editorial typographic structures utilizing CSS <code>::first-letter</code> selectors wrapped inside custom EaseMotion utility layers.</p>
+    </header>
+
+    <main>
+      <section class="section-block">
+        <h2>Standard Drop-Cap (<code>.ease-drop-cap</code>)</h2>
+        <p class="ease-drop-cap">
+          EaseMotion simplifies classic editorial elements natively. This paragraph demonstrates the baseline look of a traditional floated drop-cap. The letter scales elegantly relative to its container while retaining line alignment seamlessly across multiple lines of text.
+        </p>
+      </section>
+
+      <section class="section-block">
+        <h2>Circular Drop-Cap (<code>.ease-drop-cap-circle</code>)</h2>
+        <p class="ease-drop-cap-circle">
+          Modern UI layouts often demand high contrast emphasis layouts. By utilizing a circular background fallback alongside explicit padding tokens, the first letter converts instantly into an eye-catching, self-contained layout badge component.
+        </p>
+      </section>
+
+      <section class="section-block">
+        <h2>Outlined Drop-Cap (<code>.ease-drop-cap-outlined</code>)</h2>
+        <p class="ease-drop-cap-outlined">
+          Framed borders present clean geometric stability for contemporary editorial columns. This style appends a solid perimeter framing element to isolate and call attention directly to the start of complex text layouts.
+        </p>
+      </section>
+
+      <section class="section-block">
+        <h2>Token Variable Overrides</h2>
+        <p class="ease-drop-cap custom-token-override">
+          Flexible layout control is crucial for production frameworks. By altering local layout parameters via <code>--ease-drop-cap-*</code> variables, developers can redefine the sizing constraints, inline font-family stacks, and target text colors completely on demand.
+        </p>
+      </section>
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/drop-cap-utility/style.css
+++ b/submissions/examples/drop-cap-utility/style.css
@@ -1,0 +1,101 @@
+/* EaseMotion Design Tokens Setup */
+:root {
+  --ease-color-primary: #6c63ff;
+  --ease-color-secondary: #2c3e50;
+  --ease-text-color: #333333;
+  --ease-bg-color: #ffffff;
+  --ease-border-color: #e2e8f0;
+}
+
+/* Base Document Styles */
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  line-height: 1.6;
+  color: var(--ease-text-color);
+  background-color: #f8fafc;
+  padding: 2rem;
+  margin: 0;
+}
+
+.demo-container {
+  max-width: 800px;
+  margin: 0 auto;
+  background: var(--ease-bg-color);
+  padding: 2.5rem;
+  border-radius: 12px;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03);
+}
+
+.section-block {
+  margin-bottom: 3rem;
+  border-bottom: 1px solid var(--ease-border-color);
+  padding-bottom: 1.5rem;
+}
+
+.section-block:last-child {
+  margin-bottom: 0;
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.section-block h2 {
+  font-size: 1.25rem;
+  color: var(--ease-color-secondary);
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+/* ==========================================================================
+   @layer easemotion-utilities
+   ========================================================================== */
+@layer easemotion-utilities {
+  
+  /* Standard Classic Drop-Cap */
+  .ease-drop-cap::first-letter {
+    font-size: var(--ease-drop-cap-size, 3em);
+    font-weight: var(--ease-drop-cap-weight, 700);
+    float: left;
+    line-height: 1;
+    margin-right: 0.5rem;
+    margin-top: 0.15rem;
+    color: var(--ease-drop-cap-color, var(--ease-color-primary, #6c63ff));
+    font-family: var(--ease-drop-cap-font, serif);
+  }
+
+  /* Circular Badge Drop-Cap */
+  .ease-drop-cap-circle::first-letter {
+    font-size: var(--ease-drop-cap-size, 1.75em);
+    font-weight: var(--ease-drop-cap-weight, 700);
+    background: var(--ease-drop-cap-bg, var(--ease-color-primary, #6c63ff));
+    color: #ffffff;
+    padding: 0.4rem 0.6rem;
+    margin-right: 0.6rem;
+    margin-top: 0.2rem;
+    border-radius: 50%;
+    float: left;
+    line-height: 1;
+    font-family: var(--ease-drop-cap-font, sans-serif);
+  }
+
+  /* Outlined Frame Drop-Cap */
+  .ease-drop-cap-outlined::first-letter {
+    font-size: var(--ease-drop-cap-size, 3em);
+    font-weight: var(--ease-drop-cap-weight, 700);
+    float: left;
+    line-height: 1;
+    margin-right: 0.6rem;
+    margin-top: 0.15rem;
+    padding: 0.25rem 0.4rem;
+    border: 2px solid var(--ease-drop-cap-border, var(--ease-color-primary, #6c63ff));
+    color: var(--ease-drop-cap-color, var(--ease-color-primary, #6c63ff));
+    font-family: var(--ease-drop-cap-font, serif);
+  }
+}
+
+/* Custom Overrides Demonstration Block */
+.custom-token-override {
+  --ease-drop-cap-size: 4em;
+  --ease-drop-cap-color: #e11d48; /* Deep Rose */
+  --ease-drop-cap-font: 'Georgia', serif;
+  --ease-drop-cap-weight: 900;
+}


### PR DESCRIPTION
## Description
This PR addresses issue #23961 by introducing the typographic `ease-drop-cap` utility inside the `submissions/` space. It provides comprehensive configurations (`ease-drop-cap`, `ease-drop-cap-circle`, `ease-drop-cap-outlined`) utilizing `::first-letter` rendering targets mapped cleanly to custom CSS runtime variables.

### Changes Made
- Created new folder path: `submissions/examples/drop-cap-utility/`
- Added `demo.html` showcasing baseline, circular, bordered, and custom-variable text variations.
- Added `style.css` containing the `@layer easemotion-utilities` declarations and parametric styling tokens.
- Added `README.md` documenting layout options.

## Checklist
- [x] My files are added exclusively inside the `submissions/` directory.
- [x] I have included all three required files: `demo.html`, `style.css`, and `README.md`.
- [x] Style layouts adapt natively to utility variable overrides.
- [x] No existing items or active PR branches conflict with this patch.

Closes #23961