### PR TITLE
feat: add text-select-prevent-tm CSS utility (#23517)

### DIFF
--- a/submissions/examples/text-select-prevent-tm/README.md
+++ b/submissions/examples/text-select-prevent-tm/README.md
@@ -1,0 +1,11 @@
+# Text Selection Control Utilities
+
+This utility directory showcases behavior control mechanics using variants of the CSS native `user-select` rules.
+
+## Core Classes
+- `.em-select-none`: Disables structural text highlighting entirely within the bounds of a target element.
+- `.em-select-all`: Selects the entire content block seamlessly on a single cursor engagement or pointer event click.
+- `.em-select-text`: Enforces standardized structural highlighting and standard manual manipulation behaviors.
+
+## UX & Accessibility Guardrails
+While `.em-select-none` prevents accidental highlights on system UI components like buttons, interactive menus, and switches, it should never be applied indiscriminately to informative text layouts, as this can degrade overall layout accessibility for typical users.

--- a/submissions/examples/text-select-prevent-tm/demo.html
+++ b/submissions/examples/text-select-prevent-tm/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion - User Select Property Utilities</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="showcase-container">
+    <header style="margin-bottom: 2rem;">
+      <h1 style="margin: 0; font-size: 1.75rem;">Text Selection Control Utility</h1>
+      <p style="color: var(--em-color-muted); margin-top: 0.5rem;">Interactive variations of the <code>user-select</code> property across practical component paradigms.</p>
+    </header>
+
+    <main>
+      <div class="demo-card">
+        <h3>Prevent Highlight (<code>.em-select-none</code>)</h3>
+        <p>Useful for structural UI elements where accidental click-dragging triggers ugly text highlighting overlays (e.g., button collections).</p>
+        <a href="#" class="em-btn em-select-none">Double Click Me Safely</a>
+      </div>
+
+      <div class="demo-card">
+        <h3>Whole Block Selection (<code>.em-select-all</code>)</h3>
+        <p>Click anywhere inside the code box below. A single click will automatically highlight the entire query snippet instantly for fast clipboard utility.</p>
+        <div class="em-code-box em-select-all">npm install @easemotion/css --save-dev</div>
+      </div>
+
+      <div class="demo-card">
+        <h3>Standard Behavior (<code>.em-select-text</code>)</h3>
+        <p class="em-select-text">
+          This container enforces traditional structural text behavior. Users can precisely click, sweep, drag, and copy single character arrays or line breaks natively without multi-select interference blocks.
+        </p>
+      </div>
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/text-select-prevent-tm/style.css
+++ b/submissions/examples/text-select-prevent-tm/style.css
@@ -1,0 +1,94 @@
+/* Design Tokens Mock */
+:root {
+  --em-color-bg: #f8fafc;
+  --em-color-surface: #ffffff;
+  --em-color-primary: #6366f1;
+  --em-color-text: #0f172a;
+  --em-color-muted: #475569;
+  --em-border-light: #e2e8f0;
+  --em-radius-md: 8px;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background-color: var(--em-color-bg);
+  color: var(--em-color-text);
+  padding: 2rem;
+  margin: 0;
+}
+
+.showcase-container {
+  max-width: 750px;
+  margin: 0 auto;
+}
+
+.demo-card {
+  background: var(--em-color-surface);
+  border: 1px solid var(--em-border-light);
+  border-radius: var(--em-radius-md);
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.demo-card h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  font-size: 1.1rem;
+}
+
+.demo-card p {
+  color: var(--em-color-muted);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+/* UI Interactive Components */
+.em-btn {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  background: var(--em-color-primary);
+  color: white;
+  border-radius: 6px;
+  font-weight: 500;
+  text-decoration: none;
+  margin-top: 0.5rem;
+}
+
+.em-code-box {
+  background: #1e293b;
+  color: #38bdf8;
+  padding: 1rem;
+  border-radius: 6px;
+  font-family: monospace;
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
+}
+
+/* ==========================================================================
+   User Select Functional Utilities
+   ========================================================================== */
+
+/* Prevents selection (Perfect for UI controls, drag zones, buttons) */
+.em-select-none {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+/* Forces standard selection bounds */
+.em-select-text {
+  -webkit-user-select: text;
+  -moz-user-select: text;
+  -ms-user-select: text;
+  user-select: text;
+}
+
+/* One-click selects the entire block element (Ideal for code, tokens, keys) */
+.em-select-all {
+  -webkit-user-select: all;
+  -moz-user-select: all;
+  -ms-user-select: all;
+  user-select: all;
+}


### PR DESCRIPTION
## Description
This PR addresses issue #23517 by implementing a user selection utility showcase inside the `submissions/` directory. It demonstrates the structural applications of `user-select` values (`none`, `text`, `all`) through real-world components like copyable code cells and protected button interfaces.

### Changes Made
- Created new directory: `submissions/examples/text-select-prevent-tm/`
- Added `demo.html` with concrete component instances for user interaction.
- Added `style.css` containing cross-browser `-webkit-`, `-moz-`, and `-ms-` vendor prefixes for consistent behavior.
- Added a structural `README.md` featuring layout explanations and accessibility parameters.

## Checklist
- [x] My files are added exclusively inside the `submissions/` directory.
- [x] I have included all three required files: `demo.html`, `style.css`, and `README.md`.
- [x] Vendor-specific syntax prefixes are appended accurately.
- [x] No existing items or active PR branches conflict with this patch.

Closes #23517