### PR TITLE
feat: add shape-margin-float-tm CSS utility (#23515)

### DIFF
--- a/submissions/examples/shape-margin-float-tm/README.md
+++ b/submissions/examples/shape-margin-float-tm/README.md
@@ -1,0 +1,13 @@
+# Shape Margin & Float Layout Utilities
+
+This example utility suite demonstrates high-end, responsive magazine-style typographical wrapping configurations leveraging CSS `shape-outside`, `clip-path`, and `shape-margin`.
+
+## Properties Demonstrated
+- **`shape-outside`**: Redefines the coordinate tracking model that inline content flows around.
+- **`shape-margin`**: Allocates an explicit padding vector outside the transformed boundary path to separate text from graphics.
+- **`float`**: Required baseline trigger mechanism to allow text wrappers to engage custom geometric shapes.
+
+## Code Path Mapping
+- `demo.html` - Contains the high-density justified paragraph columns.
+- `style.css` - Custom structural rules assigning circle coordinates and diamond matrix vectors.
+- `README.md` - Documentation summary.

--- a/submissions/examples/shape-margin-float-tm/demo.html
+++ b/submissions/examples/shape-margin-float-tm/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion - Magazine Shape Margin Utilities</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="editorial-container">
+    <header style="margin-bottom: 2.5rem; border-bottom: 2px solid #1c1917; padding-bottom: 1rem;">
+      <h1 style="font-family: Georgia, serif; margin: 0; font-size: 2.5rem;">The Editorial Layout Gazette</h1>
+      <p style="color: #6b6661; font-style: italic; margin-top: 0.25rem;">Showcasing non-rectangular typographic wrapping via <code>shape-margin</code> and <code>shape-outside</code> utilities.</p>
+    </header>
+
+    <main>
+      <article class="magazine-card">
+        <h2>Circular Contour Wrap</h2>
+        <p class="editorial-text">
+          <div class="shape-float-circle">
+            <div class="shape-label">Circle</div>
+          </div>
+          Traditionally, web page elements are bound strictly to rectangular layout bounding boxes. Using the modern CSS <code>shape-outside: circle()</code> property, elements can break past this box grid limitation entirely. Notice how these structural text strings flow dynamically along the curved circumference path instead of stopping flatly on a rigid edge grid line. The companion utility token <code>shape-margin</code> provides precise spatial padding padding vectors, ensuring readability is maintained flawlessly.
+        </p>
+      </article>
+
+      <article class="magazine-card">
+        <h2>Polygon Diamond Multi-Coordinate Wrap</h2>
+        <p class="editorial-text">
+          <div class="shape-float-diamond">
+            <div class="shape-label">Diamond</div>
+          </div>
+          For more intricate geometries, the <code>polygon()</code> function maps arbitrary coordinates natively to match vector layouts. This container creates a complete diamond layout template mapped smoothly down the right-hand column margin layout space. The text flows directly alongside the geometric slopes, stepping inward and expanding outward dynamically tracking the coordinate matrices. This configuration creates rich, high-end editorial experiences similar to printed magazine layouts.
+        </p>
+      </article>
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/shape-margin-float-tm/style.css
+++ b/submissions/examples/shape-margin-float-tm/style.css
@@ -1,0 +1,90 @@
+/* EaseMotion Layout Variables */
+:root {
+  --em-bg-canvas: #fafafa;
+  --em-bg-paper: #ffffff;
+  --em-color-ink: #1c1917;
+  --em-color-accent: #0284c7;
+  --em-border-muted: #e7e5e4;
+  --em-font-serif: Georgia, Cambria, "Times New Roman", Times, serif;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background-color: var(--em-bg-canvas);
+  color: var(--em-color-ink);
+  padding: 2rem;
+  margin: 0;
+}
+
+.editorial-container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.magazine-card {
+  background: var(--em-bg-paper);
+  border: 1px solid var(--em-border-muted);
+  border-radius: 12px;
+  padding: 2.5rem;
+  margin-bottom: 2rem;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.02);
+}
+
+.magazine-card h2 {
+  font-family: var(--em-font-serif);
+  font-size: 1.75rem;
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.editorial-text {
+  font-family: var(--em-font-serif);
+  font-size: 1.05rem;
+  line-height: 1.7;
+  text-align: justify;
+}
+
+/* ==========================================================================
+   Shape Outside & Shape Margin Floating Utilities
+   ========================================================================== */
+
+/* Variant 1: Circular Wrap Utility */
+.shape-float-circle {
+  float: left;
+  width: 140px;
+  height: 140px;
+  background: linear-gradient(135deg, var(--em-color-accent), #0369a1);
+  border-radius: 50%;
+  
+  /* Geometric Wrapping Formula */
+  shape-outside: circle(50%);
+  shape-margin: 20px; /* Forces text path offset away from circle edge */
+}
+
+/* Variant 2: Polygon Diamond Wrap Utility */
+.shape-float-diamond {
+  float: right;
+  width: 130px;
+  height: 130px;
+  background: linear-gradient(135deg, #f43f5e, #be123c);
+  
+  /* Creates physical diamond coordinates */
+  clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+  
+  /* Forces text wrapper tracking path matching the custom coordinates */
+  shape-outside: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+  shape-margin: 15px;
+}
+
+/* Inner graphic indicator labels inside layout bounds */
+.shape-label {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: white;
+  font-weight: bold;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}


### PR DESCRIPTION
## Description
This PR addresses issue #23515 by adding an editorial text-wrapping layout demo utilizing `shape-outside` and `shape-margin` under the `submissions/` directory. It exhibits circle and multi-coordinate polygon tracking parameters for magazine-style typography integration.

### Changes Made
- Created new directory: `submissions/examples/shape-margin-float-tm/`
- Added `demo.html` containing justified article blocks wrapping around non-rectangular elements.
- Added `style.css` managing geometric clip-paths, floating states, and shape-margins.
- Added an operational `README.md` explaining coordinate wrapping principles.

## Checklist
- [x] My files are added exclusively inside the `submissions/` directory.
- [x] I have included all three required files: `demo.html`, `style.css`, and `README.md`.
- [x] Floating elements explicitly use standard required shape constraints.
- [x] No existing active item conflicts with this implementation.

Closes #23515