### PR TITLE
feat: add mix-blend-mode-screen-tm CSS utility (#23513)

### DIFF
--- a/submissions/examples/mix-blend-mode-screen-tm/README.md
+++ b/submissions/examples/mix-blend-mode-screen-tm/README.md
@@ -1,0 +1,15 @@
+# Layer Mix-Blend-Mode Utilities
+
+This utility module presents a showcase playground for CSS layer blending options, explicitly built for complex modern component designs within **EaseMotion**.
+
+## Implemented Blend Utilities
+- `.blend-screen`: Inverts the layer elements, multiplies them, and inverts the result, bleaching out dark pixels completely.
+- `.blend-multiply`: Multiplies the color values of the target element by the underlying canvas background layers.
+- `.blend-overlay`: Combines multiply and screen logic based on the baseline background luminosity profile.
+- `.blend-difference`: Subtracts the darker color from the lighter color to produce high-contrast inversion layouts.
+- `.blend-color-dodge`: Brightens the backdrop color to reflect the overlay color profile.
+
+## Directory Manifest
+- `demo.html` - Staging ground containing full hero typography and structural sample tokens.
+- `style.css` - Custom styling declarations mapping blend equations cleanly.
+- `README.md` - Technical index sheet.

--- a/submissions/examples/mix-blend-mode-screen-tm/demo.html
+++ b/submissions/examples/mix-blend-mode-screen-tm/demo.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion - mix-blend-mode Utility Gallery</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="blend-wrapper">
+    <header>
+      <h1>Layer Mix-Blend-Mode Utilities</h1>
+      <p style="color: var(--em-text-muted); margin-top: 0.5rem;">A functional playground exhibiting compositing utility classes built for creative headers, media intersections, and token-driven elements.</p>
+    </header>
+
+    <section class="hero-blend-stage">
+      <img class="hero-bg-graphic" src="https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe" alt="Abstract fluid wave texture">
+      <h2 class="hero-title-blend">SCREEN</h2>
+    </section>
+
+    <h3 style="margin-bottom: 1rem; font-size: 1.25rem;">Blend Mode Utility Index</h3>
+    <main class="blend-grid">
+      <div class="blend-card">
+        <div class="blend-swatch-box">
+          <div class="blend-circle blend-screen"></div>
+        </div>
+        <p><code>.blend-screen</code></p>
+      </div>
+
+      <div class="blend-card">
+        <div class="blend-swatch-box">
+          <div class="blend-circle blend-multiply"></div>
+        </div>
+        <p><code>.blend-multiply</code></p>
+      </div>
+
+      <div class="blend-card">
+        <div class="blend-swatch-box">
+          <div class="blend-circle blend-overlay"></div>
+        </div>
+        <p><code>.blend-overlay</code></p>
+      </div>
+
+      <div class="blend-card">
+        <div class="blend-swatch-box">
+          <div class="blend-circle blend-difference"></div>
+        </div>
+        <p><code>.blend-difference</code></p>
+      </div>
+
+      <div class="blend-card">
+        <div class="blend-swatch-box">
+          <div class="blend-circle blend-color-dodge"></div>
+        </div>
+        <p><code>.blend-color-dodge</code></p>
+      </div>
+
+      <div class="blend-card">
+        <div class="blend-swatch-box">
+          <div class="blend-circle blend-hard-light"></div>
+        </div>
+        <p><code>.blend-hard-light</code></p>
+      </div>
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/mix-blend-mode-screen-tm/style.css
+++ b/submissions/examples/mix-blend-mode-screen-tm/style.css
@@ -1,0 +1,132 @@
+/* EaseMotion Canvas Variables */
+:root {
+  --em-bg-dark: #0f172a;
+  --em-panel-bg: #1e293b;
+  --em-text-light: #f8fafc;
+  --em-text-muted: #94a3b8;
+  --em-radius-lg: 16px;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background-color: var(--em-bg-dark);
+  color: var(--em-text-light);
+  padding: 2rem;
+  margin: 0;
+}
+
+.blend-wrapper {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+header {
+  margin-bottom: 2.5rem;
+}
+
+/* Hero Blend Canvas Block */
+.hero-blend-stage {
+  position: relative;
+  width: 100%;
+  height: 320px;
+  background: linear-gradient(45deg, #ec4899, #8b5cf6, #3b82f6);
+  border-radius: var(--em-radius-lg);
+  overflow: hidden;
+  margin-bottom: 3rem;
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.3);
+}
+
+.hero-bg-graphic {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0.4;
+}
+
+/* Floating blended text heading array */
+.hero-title-blend {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 4rem;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: -0.02em;
+  margin: 0;
+  color: #ffffff;
+  
+  /* Core Targeting Trigger Rule */
+  mix-blend-mode: screen;
+}
+
+/* Interactive Grid Display */
+.blend-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+}
+
+.blend-card {
+  background: var(--em-panel-bg);
+  border: 1px solid #334155;
+  border-radius: 12px;
+  padding: 1rem;
+  text-align: center;
+  position: relative;
+}
+
+.blend-swatch-box {
+  width: 100%;
+  height: 120px;
+  background: linear-gradient(to right, #34d399, #fbbf24);
+  border-radius: 8px;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Graphic intersecting sphere helper element */
+.blend-circle {
+  position: absolute;
+  width: 70px;
+  height: 70px;
+  background-color: #ef4444;
+  border-radius: 50%;
+}
+
+/* ==========================================================================
+   Mix Blend Mode Utility Variations
+   ========================================================================== */
+.blend-screen {
+  mix-blend-mode: screen;
+}
+
+.blend-multiply {
+  mix-blend-mode: multiply;
+}
+
+.blend-overlay {
+  mix-blend-mode: overlay;
+}
+
+.blend-difference {
+  mix-blend-mode: difference;
+}
+
+.blend-color-dodge {
+  mix-blend-mode: color-dodge;
+}
+
+.blend-hard-light {
+  mix-blend-mode: hard-light;
+}
+
+.blend-color {
+  mix-blend-mode: color;
+}


### PR DESCRIPTION
## Description
This PR addresses issue #23513 by introducing a functional mix-blend-mode utility demonstration inside the `submissions/` directory. It establishes a multi-variant layer showcase (`screen`, `multiply`, `overlay`, `difference`, `color-dodge`, `hard-light`) highlighting text and layout intersections against asset backgrounds.

### Changes Made
- Created new directory: `submissions/examples/mix-blend-mode-screen-tm/`
- Added `demo.html` displaying a high-impact creative hero banner layout and a grid comparison framework.
- Added `style.css` detailing layout rules and layered layer composite blending classes.
- Added a structural `README.md` summarizing the operational parameters.

## Checklist
- [x] My files are added exclusively inside the `submissions/` directory.
- [x] I have included all three required files: `demo.html`, `style.css`, and `README.md`.
- [x] Blend layers render natively on top of dynamic vector structures.
- [x] No existing active item conflicts with this patch.

Closes #23513
