### PR TITLE
feat: generate duration utilities from SCSS map #23001

### DIFF
--- a/submissions/examples/scss-duration-map-isk/README.md
+++ b/submissions/examples/scss-duration-map-isk/README.md
@@ -1,0 +1,31 @@
+# [SCSS] Generate ease-duration-* utility classes from SCSS map
+
+## What does this do?
+Generates standard transition and animation duration helper classes (`.ease-duration-fast`, `.ease-duration-medium`, `.ease-duration-slow`) dynamically using a Sass map and an `@each` loop block.
+
+## How is it used?
+Apply the duration modifier classes alongside a transition:
+
+```html
+<div class="card ease-duration-fast">Fast Card (150ms)</div>
+<div class="card ease-duration-slow">Slow Card (600ms)</div>
+```
+
+### SCSS Loop Source
+```scss
+$durations: (
+  'fast': var(--ease-speed-fast, 150ms),
+  'medium': var(--ease-speed-medium, 300ms),
+  'slow': var(--ease-speed-slow, 600ms)
+);
+
+@each $name, $value in $durations {
+  .ease-duration-#{$name} {
+    transition-duration: #{$value};
+    animation-duration: #{$value};
+  }
+}
+```
+
+## Why is it useful?
+Using SCSS maps centralizes speed variables and dynamically writes rules for both transitions and animations, ensuring all speed configurations are consistently applied and easily extended with a single config map change.

--- a/submissions/examples/scss-duration-map-isk/_duration-map.scss
+++ b/submissions/examples/scss-duration-map-isk/_duration-map.scss
@@ -1,0 +1,18 @@
+// ============================================================
+// EaseMotion CSS — SCSS Map-Driven Duration Utility Classes
+// ============================================================
+
+// Map of animation and transition durations
+$durations: (
+  'fast': var(--ease-speed-fast, 150ms),
+  'medium': var(--ease-speed-medium, 300ms),
+  'slow': var(--ease-speed-slow, 600ms)
+);
+
+// Loop to generate utility classes dynamically
+@each $name, $value in $durations {
+  .ease-duration-#{$name} {
+    transition-duration: #{$value};
+    animation-duration: #{$value};
+  }
+}

--- a/submissions/examples/scss-duration-map-isk/demo.html
+++ b/submissions/examples/scss-duration-map-isk/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SCSS duration utilities - EaseMotion CSS</title>
+  
+  <!-- Link to EaseMotion CSS core and components -->
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <!-- Link to compiled utilities -->
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-wrap">
+    <h1 class="demo-title">SCSS Map-Driven Durations</h1>
+    <p style="color: var(--ease-color-muted, #64748b); margin-bottom: 0;">
+      Demonstrating utility classes generated automatically using an SCSS duration map and an <code>@each</code> loop. Hover over the cards to compare transition speeds.
+    </p>
+
+    <!-- Speed Cards Grid -->
+    <div class="demo-grid">
+      <div class="speed-card ease-duration-fast">
+        Fast (150ms)
+      </div>
+
+      <div class="speed-card ease-duration-medium">
+        Medium (300ms)
+      </div>
+
+      <div class="speed-card ease-duration-slow">
+        Slow (600ms)
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/scss-duration-map-isk/style.css
+++ b/submissions/examples/scss-duration-map-isk/style.css
@@ -1,0 +1,71 @@
+/* ============================================================
+   EaseMotion CSS — scss-duration-map.css
+   Compiled CSS showing duration classes generated from SCSS map
+   ============================================================ */
+
+/* Compiled Utility Classes */
+.ease-duration-fast {
+  transition-duration: var(--ease-speed-fast, 150ms);
+  animation-duration: var(--ease-speed-fast, 150ms);
+}
+
+.ease-duration-medium {
+  transition-duration: var(--ease-speed-medium, 300ms);
+  animation-duration: var(--ease-speed-medium, 300ms);
+}
+
+.ease-duration-slow {
+  transition-duration: var(--ease-speed-slow, 600ms);
+  animation-duration: var(--ease-speed-slow, 600ms);
+}
+
+/* ── Demo Page Styles ─────────────────────────────────────── */
+body {
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  background: #f8fafc;
+  color: #1e293b;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 2rem 0;
+}
+
+.demo-wrap {
+  width: 90%;
+  max-width: 800px;
+  text-align: center;
+}
+
+.demo-title {
+  font-size: 2.25rem;
+  font-weight: 800;
+  margin-bottom: 0.5rem;
+  color: var(--ease-color-primary, #6c63ff);
+}
+
+.demo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  margin-top: 3rem;
+}
+
+.speed-card {
+  background: white;
+  padding: 2.5rem 1.5rem;
+  border-radius: var(--ease-radius-md, 0.5rem);
+  box-shadow: var(--ease-shadow-sm);
+  border: 1px solid var(--ease-color-neutral-200, #cbd5e1);
+  font-weight: bold;
+  
+  /* Transition trigger */
+  transition: transform cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.speed-card:hover {
+  transform: translateY(-8px);
+  background-color: #f1f5f9;
+}


### PR DESCRIPTION
 Issue #23001 : Speed Duration Utilities from SCSS Map
      • Branch:  feat/scss-duration-map-23001-isk 
      • Files Created:
          • _duration-map.scss
          • style.css
          • demo.html
          • README.md
      • Summary: Automatically generates  .ease-duration-fast ,  .ease-duration-medium ,
      and  .ease-duration-slow  transition duration utility classes using a Sass map and
      an  @each  loop block.