### PR TITLE
feat: add white-space-prewrap-tm CSS utility (#23511)

### DIFF
--- a/submissions/examples/white-space-prewrap-tm/README.md
+++ b/submissions/examples/white-space-prewrap-tm/README.md
@@ -1,0 +1,15 @@
+# White-Space Control Utilities
+
+This playground showcases text layout and token structure behaviors using the native CSS `white-space` property variations within **EaseMotion**.
+
+## Behavior Comparison Model
+- **`.em-ws-normal`**: Collapses whitespace sequences, handles carriage returns as single breaks, and wraps content natively.
+- **`.em-ws-nowrap`**: Standard collapse engine, but eliminates line-breaks across the entire inline layout boundary.
+- **`.em-ws-pre`**: Retains whitespace and structural line-breaks exactly as formatted, without wrapping content.
+- **`.em-ws-pre-wrap`**: Retains whitespaces and explicit line-breaks while enabling responsive wrapping at container boundaries.
+- **`.em-ws-pre-line`**: Collapses multi-character spaces into single strings, but respects explicit user line-breaks.
+
+## Folder Mapping
+- `demo.html` - Visual showcase layout cards.
+- `style.css` - Structural wrapper attributes.
+- `README.md` - Technical behavior index.

--- a/submissions/examples/white-space-prewrap-tm/demo.html
+++ b/submissions/examples/white-space-prewrap-tm/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion - White Space Property Utilities</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="showcase-container">
+    <header style="margin-bottom: 2rem;">
+      <h1 style="margin: 0; font-size: 1.75rem;">White-Space Formatting Utilities</h1>
+      <p style="color: var(--em-text-secondary); margin-top: 0.5rem;">Visualizing text formatting, sequence compression, and line-break wrappers inside modern component bounds.</p>
+    </header>
+
+    <main>
+      <div class="text-box-card">
+        <h3>Standard Behavior (<code>.em-ws-normal</code>)</h3>
+        <div class="text-preview-container em-ws-normal">
+          This layout collapses   multiple sequential white spaces and
+          interprets carriage returns as a single blank space, wrapping natively when required.
+        </div>
+      </div>
+
+      <div class="text-box-card">
+        <h3>No Wrapping Allowed (<code>.em-ws-nowrap</code>)</h3>
+        <div class="text-preview-container em-ws-nowrap">
+          This text path completely ignores container boundaries and forces the text block onto a single inline strip without wrapping.
+        </div>
+      </div>
+
+      <div class="text-box-card">
+        <h3>Preserve Everything Natively (<code>.em-ws-pre</code>)</h3>
+        <div class="text-preview-container em-ws-pre">
+  Line 1: Multiple spaces     are safely preserved here.
+  Line 2: Explicit line breaks are maintained without wrapping behaviors.
+        </div>
+      </div>
+
+      <div class="text-box-card">
+        <h3>Preserve Spaces & Wrap Safely (<code>.em-ws-pre-wrap</code>)</h3>
+        <div class="text-preview-container em-ws-pre-wrap">
+  Line 1: Multiple spaces     are safely preserved here.
+  Line 2: Explicit line breaks are maintained, AND text will wrap gracefully when it intersects the border edge constraints of this card box.
+        </div>
+      </div>
+
+      <div class="text-box-card">
+        <h3>Collapse Spaces & Keep Breaks (<code>.em-ws-pre-line</code>)</h3>
+        <div class="text-preview-container em-ws-pre-line">
+  Line 1: Multiple spaces     collapse into single spacing sequences.
+  Line 2: Explicit line breaks are safely maintained, and text wraps naturally when boundary constraints require it.
+        </div>
+      </div>
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/white-space-prewrap-tm/style.css
+++ b/submissions/examples/white-space-prewrap-tm/style.css
@@ -1,0 +1,71 @@
+/* EaseMotion Theme Tokens */
+:root {
+  --em-bg-slate: #f8fafc;
+  --em-bg-box: #ffffff;
+  --em-border-color: #cbd5e1;
+  --em-text-dark: #0f172a;
+  --em-text-secondary: #475569;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background-color: var(--em-bg-slate);
+  color: var(--em-text-dark);
+  padding: 2rem;
+  margin: 0;
+}
+
+.showcase-container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.text-box-card {
+  background-color: var(--em-bg-box);
+  border: 1px solid var(--em-border-color);
+  border-radius: 8px;
+  padding: 1.25rem;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.text-box-card h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  font-size: 1.1rem;
+}
+
+/* Sample Text Display Container */
+.text-preview-container {
+  background-color: #f1f5f9;
+  border-left: 4px solid #6366f1;
+  padding: 1rem;
+  font-family: monospace;
+  font-size: 0.95rem;
+  overflow-x: auto; /* Gracefully catches overflowing content */
+  max-width: 100%;
+}
+
+/* ==========================================================================
+   White Space Handling Utility Variants
+   ========================================================================== */
+
+.em-ws-normal {
+  white-space: normal;
+}
+
+.em-ws-nowrap {
+  white-space: nowrap;
+}
+
+.em-ws-pre {
+  white-space: pre;
+}
+
+.em-ws-pre-wrap {
+  white-space: pre-wrap;
+}
+
+.em-ws-pre-line {
+  white-space: pre-line;
+}


### PR DESCRIPTION
## Description
This PR addresses issue #23511 by adding an implementation demonstration for the CSS `white-space` structural formatting properties under the `submissions/` space. It explicitly breaks down sequence mapping variations (`normal`, `nowrap`, `pre`, `pre-wrap`, `pre-line`) through clean comparison containers.

### Changes Made
- Created new directory: `submissions/examples/white-space-prewrap-tm/`
- Added `demo.html` staging multi-format strings to test sequence compression.
- Added `style.css` implementing explicit layout selectors and containment fields.
- Added a structural `README.md` containing behavior comparison definitions.

## Checklist
- [x] My files are added exclusively inside the `submissions/` directory.
- [x] I have included all three required files: `demo.html`, `style.css`, and `README.md`.
- [x] Containers utilize overflow safeguards safely.
- [x] No existing active item conflicts with this patch.

Closes #23511