### PR TITLE
feat: implement dark mode overrides using SCSS maps #23006

### DIFF
--- a/submissions/examples/scss-dark-mode-maps-isk/README.md
+++ b/submissions/examples/scss-dark-mode-maps-isk/README.md
@@ -1,0 +1,51 @@
+# [SCSS] Implement dark mode token overrides using SCSS color maps
+
+## What does this do?
+Implements a clean, map-driven theme override system for light and dark modes in Sass. It generates CSS custom property overrides automatically inside both the `prefers-color-scheme: dark` media query and a manual `.dark-mode` body class.
+
+## How is it used?
+Style elements utilizing the compiled CSS properties:
+
+```css
+.card {
+  background-color: var(--ease-color-surface);
+  color: var(--ease-color-text);
+  border-color: var(--ease-color-muted);
+}
+```
+
+### SCSS Map Implementation
+Define two maps containing identical keys and loop over them to output the property declarations:
+
+```scss
+$light-theme: (
+  'color-bg': #f8fafc,
+  'color-surface': #ffffff,
+  'color-text': #1e293b,
+  'color-muted': #64748b,
+  'color-primary': #6c63ff
+);
+
+$dark-theme: (
+  'color-bg': #0f172a,
+  'color-surface': #1e293b,
+  'color-text': #f8fafc,
+  'color-muted': #94a3b8,
+  'color-primary': #8b5cf6
+);
+
+:root {
+  @each $name, $value in $light-theme {
+    --ease-#{$name}: #{$value};
+  }
+}
+
+body.dark-mode {
+  @each $name, $value in $dark-theme {
+    --ease-#{$name}: #{$value};
+  }
+}
+```
+
+## Why is it useful?
+Using SCSS maps prevents duplicate token keys and manually declared styles for dark mode. If a new color token needs to be added, simply add it to the light and dark maps, and Sass handles writing all CSS overrides automatically.

--- a/submissions/examples/scss-dark-mode-maps-isk/_dark-mode.scss
+++ b/submissions/examples/scss-dark-mode-maps-isk/_dark-mode.scss
@@ -1,0 +1,44 @@
+// ============================================================
+// EaseMotion CSS — SCSS Maps for Dark Mode Token Overrides
+// ============================================================
+
+// Light Theme Tokens Map
+$light-theme: (
+  'color-bg': #f8fafc,
+  'color-surface': #ffffff,
+  'color-text': #1e293b,
+  'color-muted': #64748b,
+  'color-primary': #6c63ff
+);
+
+// Dark Theme Tokens Map
+$dark-theme: (
+  'color-bg': #0f172a,
+  'color-surface': #1e293b,
+  'color-text': #f8fafc,
+  'color-muted': #94a3b8,
+  'color-primary': #8b5cf6
+);
+
+// Generate default variables inside :root selector
+:root {
+  @each $name, $value in $light-theme {
+    --ease-#{$name}: #{$value};
+  }
+}
+
+// Generate overrides under prefers-color-scheme media query
+@media (prefers-color-scheme: dark) {
+  :root {
+    @each $name, $value in $dark-theme {
+      --ease-#{$name}: #{$value};
+    }
+  }
+}
+
+// Support manual dark-mode class overrides
+body.dark-mode {
+  @each $name, $value in $dark-theme {
+    --ease-#{$name}: #{$value};
+  }
+}

--- a/submissions/examples/scss-dark-mode-maps-isk/demo.html
+++ b/submissions/examples/scss-dark-mode-maps-isk/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SCSS Dark Mode maps - EaseMotion CSS</title>
+  
+  <!-- Link to EaseMotion CSS core and components -->
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <!-- Link to compiled theme styles -->
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-wrap">
+    <h1 class="demo-title">SCSS Map-Driven Dark Mode</h1>
+    <p style="color: var(--ease-color-muted); margin-bottom: 2.5rem;">
+      Demonstrating theme override mapping using Sass color maps. This automatically outputs responsive media query variables and supports manual dark-mode toggling.
+    </p>
+
+    <!-- Theme Card -->
+    <div class="theme-card">
+      <h3 style="margin-top: 0; font-size: 1.5rem; font-weight: 800;">Adaptive Card Surface</h3>
+      <p style="color: var(--ease-color-muted); font-size: 0.95rem; line-height: 1.6; margin-bottom: 0;">
+        This card uses color properties generated from our SCSS map definitions. Toggle the theme button below to see the color properties swap values smoothly.
+      </p>
+    </div>
+
+    <!-- Toggle Button -->
+    <button class="btn-toggle" onclick="document.body.classList.toggle('dark-mode');">
+      Toggle Theme
+    </button>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/scss-dark-mode-maps-isk/style.css
+++ b/submissions/examples/scss-dark-mode-maps-isk/style.css
@@ -1,0 +1,85 @@
+/* ============================================================
+   EaseMotion CSS — scss-dark-mode-maps.css
+   Compiled CSS showing dark mode token overrides from SCSS color maps
+   ============================================================ */
+
+/* Light Theme Variables */
+:root {
+  --ease-color-bg: #f8fafc;
+  --ease-color-surface: #ffffff;
+  --ease-color-text: #1e293b;
+  --ease-color-muted: #64748b;
+  --ease-color-primary: #6c63ff;
+}
+
+/* System Dark Theme Override */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ease-color-bg: #0f172a;
+    --ease-color-surface: #1e293b;
+    --ease-color-text: #f8fafc;
+    --ease-color-muted: #94a3b8;
+    --ease-color-primary: #8b5cf6;
+  }
+}
+
+/* Manual Dark Class Override */
+body.dark-mode {
+  --ease-color-bg: #0f172a;
+  --ease-color-surface: #1e293b;
+  --ease-color-text: #f8fafc;
+  --ease-color-muted: #94a3b8;
+  --ease-color-primary: #8b5cf6;
+}
+
+/* ── Demo Page Styles ─────────────────────────────────────── */
+body {
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  background-color: var(--ease-color-bg);
+  color: var(--ease-color-text);
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.demo-wrap {
+  width: 90%;
+  max-width: 500px;
+  text-align: center;
+}
+
+.demo-title {
+  font-size: 2rem;
+  font-weight: 800;
+  margin-top: 0;
+  color: var(--ease-color-primary);
+}
+
+.theme-card {
+  background-color: var(--ease-color-surface);
+  border: 1px solid var(--ease-color-muted);
+  border-radius: var(--ease-radius-lg, 1rem);
+  padding: 2.5rem;
+  box-shadow: var(--ease-shadow-lg);
+  margin-bottom: 2rem;
+}
+
+.btn-toggle {
+  padding: 0.75rem 2rem;
+  background-color: var(--ease-color-primary);
+  color: white;
+  font-weight: bold;
+  border: none;
+  border-radius: var(--ease-radius-full, 9999px);
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(108, 99, 255, 0.3);
+  transition: all 0.2s;
+}
+
+.btn-toggle:hover {
+  transform: translateY(-2px);
+}


### PR DESCRIPTION
Issue #23006 : Dark Mode Token Overrides using SCSS Color Maps
      • Branch:  feat/scss-dark-mode-23006-isk 
      • Files Created:
          • _dark-mode.scss
          • style.css
          • demo.html
          • README.md
      • Summary: Builds a map-driven theme override system inside SCSS, generating
      variables automatically under light/dark configurations.