### PR TITLE
feat: add pointer-events-default-tm CSS utility (#23510)

### DIFF
--- a/submissions/examples/pointer-events-default-tm/README.md
+++ b/submissions/examples/pointer-events-default-tm/README.md
@@ -1,0 +1,11 @@
+# Pointer-Events Control Utilities
+
+This playground showcases event targeting capabilities using variants of the CSS native `pointer-events` properties under a dark-theme presentation canvas.
+
+## Core Utility Mappings
+- **`.em-pointer-auto`**: Restores typical hardware cursor capture sequences, processing event target states natively.
+- **`.em-pointer-none`**: Makes the element abstractly invisible to mouse events, allowing click actions to hit whatever sits directly behind it.
+
+## Common Production Use Cases
+- **Bypassing Decorative Elements**: Allowing users to click buttons that sit underneath translucent overlays or floating icons.
+- **Form State Handling**: Combining `pointer-events: none` with a desaturated visual state to securely lock interactive anchor tags or custom UI components.

--- a/submissions/examples/pointer-events-default-tm/demo.html
+++ b/submissions/examples/pointer-events-default-tm/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion - Pointer Events Utility Showcase</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="showcase-container">
+    <header style="margin-bottom: 2.5rem;">
+      <h1 style="margin: 0; font-size: 1.75rem;">Pointer-Events Utilities</h1>
+      <p style="color: var(--em-text-muted); margin-top: 0.5rem;">Demonstrating pointer targeting, structural glassmorphism pass-throughs, and action-state termination.</p>
+    </header>
+
+    <main>
+      <div class="interactive-card">
+        <h3>Standard Interaction (<code>.em-pointer-auto</code>)</h3>
+        <p>The system cursor captures mouse clicks, hover transitions, and cursor pointers normally.</p>
+        <a href="#" class="em-interactive-element em-pointer-auto" onclick="alert('Action Triggered Successful!')">Active Action Trigger</a>
+      </div>
+
+      <div class="interactive-card">
+        <h3>Disabled Element Pattern (<code>.em-pointer-none</code>)</h3>
+        <p>Applying the class stops hover states and prevents clicking. The underlying anchor script cannot execute.</p>
+        <a href="#" class="em-interactive-element em-state-disabled em-pointer-none" onclick="alert('This shouldn\'t fire!')">Disabled Action Trigger</a>
+      </div>
+
+      <div class="interactive-card" style="height: 140px;">
+        <h3>Pass-Through Layering (<code>.em-pointer-none</code>)</h3>
+        <p style="margin-bottom: 1rem;">Click the button below. Even though an accent box covers the card completely, mouse actions pass straight through it to hit the button underneath.</p>
+        
+        <a href="#" class="em-interactive-element" onclick="alert('Button Clicked Through the Layer!')">Target Button</a>
+        
+        <div class="click-through-overlay em-pointer-none">
+          Overlay Layer (.em-pointer-none)
+        </div>
+      </div>
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/pointer-events-default-tm/style.css
+++ b/submissions/examples/pointer-events-default-tm/style.css
@@ -1,0 +1,97 @@
+/* EaseMotion Dark Mode Variables */
+:root {
+  --em-bg-dark: #0f172a;
+  --em-panel-bg: #1e293b;
+  --em-text-primary: #f8fafc;
+  --em-text-muted: #94a3b8;
+  --em-color-accent: #3b82f6;
+  --em-color-disabled: #475569;
+  --em-border-color: #334155;
+  --em-radius: 8px;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background-color: var(--em-bg-dark);
+  color: var(--em-text-primary);
+  padding: 2rem;
+  margin: 0;
+}
+
+.showcase-container {
+  max-width: 750px;
+  margin: 0 auto;
+}
+
+.interactive-card {
+  background: var(--em-panel-bg);
+  border: 1px solid var(--em-border-color);
+  border-radius: var(--em-radius);
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  position: relative;
+}
+
+.interactive-card h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  font-size: 1.1rem;
+}
+
+.interactive-card p {
+  color: var(--em-text-muted);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+/* UI Interactive Indicators */
+.em-interactive-element {
+  display: inline-block;
+  padding: 0.6rem 1.2rem;
+  background: var(--em-color-accent);
+  color: #ffffff;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: 500;
+  transition: opacity 0.2s, background-color 0.2s;
+}
+
+.em-interactive-element:hover {
+  background: #2563eb;
+}
+
+/* Simulated Overlay Block */
+.click-through-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(59, 130, 246, 0.15);
+  border: 2px dashed var(--em-color-accent);
+  border-radius: var(--em-radius);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+/* ==========================================================================
+   Pointer Events Utility Options
+   ========================================================================== */
+
+/* Restores default pointing hardware event bubbling (auto) */
+.em-pointer-auto {
+  pointer-events: auto;
+}
+
+/* Disables cursor click, hover, and toggle selection targeting completely */
+.em-pointer-none {
+  pointer-events: none;
+}
+
+/* Disabled UI Component Styling Bundle */
+.em-state-disabled {
+  background-color: var(--em-color-disabled) !important;
+  color: #64748b !important;
+  opacity: 0.6;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
## Description
This PR addresses issue #23510 by adding an operational pointer-events tracking demo within the `submissions/` space. It covers click-through handling, layout pass-through architectures, and real-world component termination states across a dark mode canvas.

### Changes Made
- Created new directory: `submissions/examples/pointer-events-default-tm/`
- Added `demo.html` setting up actionable items, simulated overlays, and active event blockers.
- Added `style.css` configuring core target event properties alongside project theme blocks.
- Added an operational `README.md` containing behavioral descriptions and production pattern instructions.

## Checklist
- [x] My files are added exclusively inside the `submissions/` directory.
- [x] I have included all three required files: `demo.html`, `style.css`, and `README.md`.
- [x] All interaction nodes are explicitly testable via standard pointer hardware.
- [x] No existing active item conflicts with this patch.

Closes #23510