### PR TITLE
feat: add animated loading spinner component (#24198)

### DIFF
--- a/submissions/examples/ease-spinner-cv/README.md
+++ b/submissions/examples/ease-spinner-cv/README.md
@@ -1,0 +1,17 @@
+# Animated Loading Spinner Components (`-cv`)
+
+This module provides reusable, fluid, zero-dependency async feedback spinners inside the **EaseMotion** layout repository workspace.
+
+## Core Styles Available
+- `.ease-spinner-cv`: Smooth boundary circle track spinning infinitely.
+- `.ease-spinner-dots-cv`: Three sequenced, inline micro-dots utilizing staggered negative transition intervals.
+- `.ease-spinner-pulse-cv`: Generates pulsing concentric ripple echoes through composite absolute scale structures.
+- `.ease-spinner-gradient-cv`: Masks and rotates a rich conic layout gradient cleanly across a narrow track thickness.
+
+## Size Helpers
+- `.spinner-sm-cv` (24px)
+- `.spinner-md-cv` (40px)
+- `.spinner-lg-cv` (60px)
+
+## Accessibility Compliance
+Ensure you append `role="status"` and `aria-label="Loading"` parameters straight to the rendering container to preserve screen-reader stability during loading states.

--- a/submissions/examples/ease-spinner-cv/demo.html
+++ b/submissions/examples/ease-spinner-cv/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion - Spinner Animation System</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="cv-container">
+    <header style="margin-bottom: 2.5rem;">
+      <h1 style="margin: 0; font-size: 1.75rem;">Loading Spinner Showcase</h1>
+      <p style="color: var(--cv-text-alt); margin-top: 0.5rem;">Pure-CSS structural feedback indicators built into the <code>-cv</code> utility layout layer.</p>
+    </header>
+
+    <main>
+      <h2 style="font-size: 1.2rem; margin-bottom: 1rem; color: var(--cv-color-primary);">1. Style Profiles</h2>
+      <div class="cv-grid">
+        <div class="cv-card">
+          <div class="ease-spinner-cv spinner-md-cv spinner-primary-cv" role="status" aria-label="Loading"></div>
+          <h3>Classic Circle</h3>
+        </div>
+        <div class="cv-card">
+          <div class="ease-spinner-dots-cv spinner-md-cv spinner-info-cv" role="status" aria-label="Loading">
+            <span></span><span></span><span></span>
+          </div>
+          <h3>Bouncing Dots</h3>
+        </div>
+        <div class="cv-card">
+          <div class="ease-spinner-pulse-cv spinner-md-cv spinner-success-cv" role="status" aria-label="Loading"></div>
+          <h3>Pulse Ripple</h3>
+        </div>
+        <div class="cv-card">
+          <div class="ease-spinner-gradient-cv spinner-md-cv spinner-white-cv" role="status" aria-label="Loading"></div>
+          <h3>Conic Gradient</h3>
+        </div>
+      </div>
+
+      <h2 style="font-size: 1.2rem; margin-bottom: 1rem; color: var(--cv-color-info);">2. Layout Scaling Sizes</h2>
+      <div class="cv-grid">
+        <div class="cv-card">
+          <div class="ease-spinner-cv spinner-sm-cv spinner-info-cv" role="status" aria-label="Loading"></div>
+          <h3>Small (24px)</h3>
+        </div>
+        <div class="cv-card">
+          <div class="ease-spinner-cv spinner-md-cv spinner-info-cv" role="status" aria-label="Loading"></div>
+          <h3>Medium (40px)</h3>
+        </div>
+        <div class="cv-card">
+          <div class="ease-spinner-cv spinner-lg-cv spinner-info-cv" role="status" aria-label="Loading"></div>
+          <h3>Large (60px)</h3>
+        </div>
+      </div>
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-spinner-cv/style.css
+++ b/submissions/examples/ease-spinner-cv/style.css
@@ -1,0 +1,146 @@
+/* EaseMotion Design System Canvas Variables */
+:root {
+  --cv-bg-slate: #0f172a;
+  --cv-panel-bg: #1e293b;
+  --cv-border-muted: #334155;
+  --cv-text-main: #f8fafc;
+  --cv-text-alt: #94a3b8;
+  
+  /* Component Color Palette Tokens */
+  --cv-color-primary: #a855f7;  /* Purple */
+  --cv-color-info: #3b82f6;     /* Blue */
+  --cv-color-success: #22c55e;  /* Green */
+  --cv-color-white: #ffffff;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background-color: var(--cv-bg-slate);
+  color: var(--cv-text-main);
+  padding: 2rem;
+  margin: 0;
+}
+
+.cv-container {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.cv-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.cv-card {
+  background: var(--cv-panel-bg);
+  border: 1px solid var(--cv-border-muted);
+  border-radius: 12px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.25rem;
+  text-align: center;
+}
+
+.cv-card h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--cv-text-alt);
+}
+
+/* ==========================================================================
+   Core Spinner System (.ease-spinner-cv)
+   ========================================================================== */
+
+/* Size System Classes */
+.spinner-sm-cv { --cv-spinner-size: 24px; }
+.spinner-md-cv { --cv-spinner-size: 40px; }
+.spinner-lg-cv { --cv-spinner-size: 60px; }
+
+/* Color Modifier Hook Engine */
+.spinner-primary-cv { --cv-spinner-color: var(--cv-color-primary); }
+.spinner-info-cv { --cv-spinner-color: var(--cv-color-info); }
+.spinner-success-cv { --cv-spinner-color: var(--cv-color-success); }
+.spinner-white-cv { --cv-spinner-color: var(--cv-color-white); }
+
+/* Variant 1: Classic Rotating Border Circle */
+.ease-spinner-cv {
+  width: var(--cv-spinner-size, 40px);
+  height: var(--cv-spinner-size, 40px);
+  border: 4px solid rgba(255, 255, 255, 0.1);
+  border-top-color: var(--cv-spinner-color, var(--cv-color-primary));
+  border-radius: 50%;
+  animation: cv-spin 0.8s linear infinite;
+}
+
+/* Variant 2: Three Bouncing Dots */
+.ease-spinner-dots-cv {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.ease-spinner-dots-cv span {
+  width: calc(var(--cv-spinner-size, 40px) / 4);
+  height: calc(var(--cv-spinner-size, 40px) / 4);
+  background-color: var(--cv-spinner-color, var(--cv-color-primary));
+  border-radius: 50%;
+  animation: cv-bounce 1.2s infinite ease-in-out both;
+}
+
+.ease-spinner-dots-cv span:nth-child(1) { animation-delay: -0.32s; }
+.ease-spinner-dots-cv span:nth-child(2) { animation-delay: -0.16s; }
+
+/* Variant 3: Pulse Ring Ripple */
+.ease-spinner-pulse-cv {
+  position: relative;
+  width: var(--cv-spinner-size, 40px);
+  height: var(--cv-spinner-size, 40px);
+}
+
+.ease-spinner-pulse-cv::before,
+.ease-spinner-pulse-cv::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background-color: var(--cv-spinner-color, var(--cv-color-primary));
+  opacity: 0.6;
+  animation: cv-pulse 2s cubic-bezier(0, 0.5, 0.5, 1) infinite;
+}
+
+.ease-spinner-pulse-cv::after {
+  animation-delay: -1s;
+}
+
+/* Variant 4: Conic Gradient Rotation */
+.ease-spinner-gradient-cv {
+  width: var(--cv-spinner-size, 40px);
+  height: var(--cv-spinner-size, 40px);
+  border-radius: 50%;
+  background: conic-gradient(from 0deg, transparent 30%, var(--cv-spinner-color, var(--cv-color-primary)));
+  -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 5px), #000 100%);
+  mask: radial-gradient(farthest-side, transparent calc(100% - 5px), #000 100%);
+  animation: cv-spin 1s linear infinite;
+}
+
+/* ==========================================================================
+   Animation Keyframe Formula Engine
+   ========================================================================== */
+@keyframes cv-spin {
+  100% { transform: rotate(360deg); }
+}
+
+@keyframes cv-bounce {
+  0%, 80%, 100% { transform: scale(0); }
+  40% { transform: scale(1); }
+}
+
+@keyframes cv-pulse {
+  0% { transform: scale(0); opacity: 1; }
+  100% { transform: scale(1); opacity: 0; }
+}


### PR DESCRIPTION
## Description
This PR addresses issue #24198 by submitting a set of pure-CSS loading spinner interactions within the `submissions/` directory space. It provides structural style variants (`ease-spinner-cv`, `ease-spinner-dots-cv`, `ease-spinner-pulse-cv`, `ease-spinner-gradient-cv`) matching precise sizing, coloring, and semantic accessibility parameters.

### Changes Made
- Created directory: `submissions/examples/ease-spinner-cv/`
- Added `demo.html` staging individual cards mapping distinct sizes and tracking elements.
- Added `style.css` tracking hardware transform scales, negative delays, and gradient masks under localized variables.
- Added a functional `README.md` introducing the layout parameters and fallback configurations.

## Checklist
- [x] My files are added exclusively inside the `submissions/` directory.
- [x] I have included all three required files: `demo.html`, `style.css`, and `README.md`.
- [x] All interactions use the specific `-cv` suffix accurately.
- [x] No existing active item conflicts with this patch.

Closes #24198