### PR TITLE
fix(submission): ease-mouse-parallax-layers — 3 depth layers #20554

### DIFF
--- a/submissions/examples/fix-20554-ease-mouse-parallax-layers-rs/README.md
+++ b/submissions/examples/fix-20554-ease-mouse-parallax-layers-rs/README.md
@@ -1,0 +1,19 @@
+# ease-mouse-parallax-layers
+
+## Issue
+**Issue #20554**: Animation: ease-mouse-parallax-layers — multiple layers at different parallax speeds
+
+## Bug
+There was no mechanism in EaseMotion CSS to create multi-layer parallax depth. Existing layers all move at the same rate on mouse interaction, losing the 3D depth illusion.
+
+## Fix
+Implemented a CSS variable-driven parallax system with 3 depth layers each responding at different translation speeds:
+- **Layer 1** (furthest): `0.5x` speed — `translateX(calc(var(--mouse-x) * -15px))`
+- **Layer 2** (midground): `1x` speed — `translateX(calc(var(--mouse-x) * -30px))`
+- **Layer 3** (closest): `1.5x` speed — `translateX(calc(var(--mouse-x) * -45px))`
+
+## Why It Works
+The CSS `calc()` function multiplies the normalized mouse position (−1 to 1) by a layer-specific constant. Faster-moving layers appear closer to the viewer per the parallax principle. The JavaScript only reads and writes the `--mouse-x` / `--mouse-y` CSS variables — all animation is handled by CSS `transform` transitions.
+
+## Verification
+Open `demo.html` and hover over the parallax scene box. Move your mouse to all corners to see the three layers shift at distinctly different speeds, creating a convincing 3D depth illusion.

--- a/submissions/examples/fix-20554-ease-mouse-parallax-layers-rs/demo.html
+++ b/submissions/examples/fix-20554-ease-mouse-parallax-layers-rs/demo.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ease-mouse-parallax-layers Demo</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="page-layout">
+        <header class="demo-header">
+            <h1>ease-mouse-parallax-layers</h1>
+            <p>Three stacked layers moving at different speeds on mouse interaction, creating CSS 3D depth.</p>
+        </header>
+
+        <div class="demo-section">
+            <h2>Bug: No Depth Effect</h2>
+            <div class="bug-box">
+                <div class="scene-flat">
+                    <div class="flat-layer layer-back">🌌 Background</div>
+                    <div class="flat-layer layer-mid">⭐ Midground</div>
+                    <div class="flat-layer layer-front">🚀 Foreground</div>
+                </div>
+                <p class="caption">All layers move at the same rate — no parallax depth.</p>
+            </div>
+        </div>
+
+        <div class="demo-section">
+            <h2>Fix: CSS var-driven Parallax Layers</h2>
+            <p class="fix-caption">Hover over the scene below to see all 3 layers respond at different speeds.</p>
+            <div class="parallax-scene" id="parallaxScene">
+                <!-- Layer 1: Slowest (0.5x speed) — furthest back -->
+                <div class="parallax-layer layer-depth-1">
+                    <div class="layer-content">
+                        <span class="layer-emoji">🌌</span>
+                        <p>Layer 1 — Speed: 0.5x</p>
+                        <p class="layer-sub">(Furthest — slowest)</p>
+                    </div>
+                </div>
+                <!-- Layer 2: Normal (1x speed) — middle -->
+                <div class="parallax-layer layer-depth-2">
+                    <div class="layer-content">
+                        <span class="layer-emoji">⭐</span>
+                        <p>Layer 2 — Speed: 1x</p>
+                        <p class="layer-sub">(Midground)</p>
+                    </div>
+                </div>
+                <!-- Layer 3: Fastest (1.5x speed) — closest -->
+                <div class="parallax-layer layer-depth-3">
+                    <div class="layer-content">
+                        <span class="layer-emoji">🚀</span>
+                        <p>Layer 3 — Speed: 1.5x</p>
+                        <p class="layer-sub">(Closest — fastest)</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        // Minimal JS only for reading mouse position — the animation is pure CSS transform via CSS vars
+        const scene = document.getElementById('parallaxScene');
+        scene.addEventListener('mousemove', (e) => {
+            const rect = scene.getBoundingClientRect();
+            const cx = rect.width / 2;
+            const cy = rect.height / 2;
+            const dx = (e.clientX - rect.left - cx) / cx; // -1 to 1
+            const dy = (e.clientY - rect.top - cy) / cy;  // -1 to 1
+            scene.style.setProperty('--mouse-x', dx);
+            scene.style.setProperty('--mouse-y', dy);
+        });
+        scene.addEventListener('mouseleave', () => {
+            scene.style.setProperty('--mouse-x', 0);
+            scene.style.setProperty('--mouse-y', 0);
+        });
+    </script>
+</body>
+</html>

--- a/submissions/examples/fix-20554-ease-mouse-parallax-layers-rs/style.css
+++ b/submissions/examples/fix-20554-ease-mouse-parallax-layers-rs/style.css
@@ -1,0 +1,158 @@
+:root {
+    --bg: #0a0a1a;
+    --card-bg: #12122a;
+    --border: #2a2a4a;
+    --text: #e2e8f0;
+    --muted: #94a3b8;
+    --accent: #818cf8;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+    font-family: 'Plus Jakarta Sans', sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    min-height: 100vh;
+    padding: 2rem;
+}
+
+.page-layout {
+    max-width: 900px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 3rem;
+}
+
+.demo-header {
+    text-align: center;
+    padding: 2rem;
+}
+
+.demo-header h1 {
+    font-size: 2rem;
+    font-weight: 700;
+    color: var(--accent);
+    margin-bottom: 0.5rem;
+}
+
+.demo-header p { color: var(--muted); font-size: 1rem; }
+
+.demo-section { display: flex; flex-direction: column; gap: 1rem; }
+.demo-section h2 { font-size: 1.25rem; font-weight: 600; }
+
+/* Bug Demo */
+.bug-box {
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 2rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.5rem;
+}
+
+.scene-flat {
+    display: flex;
+    gap: 1rem;
+}
+
+.flat-layer {
+    padding: 0.75rem 1.25rem;
+    border-radius: 8px;
+    font-weight: 600;
+    font-size: 0.9rem;
+    border: 1px solid var(--border);
+    background: rgba(255,255,255,0.05);
+    /* All at same transform — no depth */
+    transition: transform 0.2s;
+}
+
+.flat-layer:hover { transform: translateY(-4px); }
+
+.caption {
+    font-size: 0.85rem;
+    color: var(--muted);
+    font-style: italic;
+}
+
+/* Fix Demo */
+.fix-caption { color: var(--muted); font-size: 0.95rem; }
+
+/* ============================================================
+   ease-mouse-parallax-layers — the actual CSS implementation
+   Each layer reads --mouse-x and --mouse-y (set by JS from
+   the mousemove event) and applies them at different multipliers
+   via CSS calc(), creating the depth illusion purely in CSS.
+   ============================================================ */
+
+.parallax-scene {
+    --mouse-x: 0;
+    --mouse-y: 0;
+
+    position: relative;
+    width: 100%;
+    height: 380px;
+    border-radius: 16px;
+    overflow: hidden;
+    background: radial-gradient(ellipse at center, #1a1a3e 0%, #0a0a1a 80%);
+    border: 1px solid var(--border);
+    cursor: crosshair;
+    perspective: 800px;
+}
+
+/* Base layer styles */
+.parallax-layer {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    will-change: transform;
+    /* CSS var-driven translateX/Y at different speed multipliers */
+    transition: transform 0.08s linear;
+}
+
+/* Layer 1: 0.5x speed — furthest back, subtlest movement */
+.layer-depth-1 {
+    transform: translateX(calc(var(--mouse-x) * -15px))
+               translateY(calc(var(--mouse-y) * -10px));
+}
+
+/* Layer 2: 1x speed — mid depth */
+.layer-depth-2 {
+    transform: translateX(calc(var(--mouse-x) * -30px))
+               translateY(calc(var(--mouse-y) * -20px));
+}
+
+/* Layer 3: 1.5x speed — closest, most dramatic movement */
+.layer-depth-3 {
+    transform: translateX(calc(var(--mouse-x) * -45px))
+               translateY(calc(var(--mouse-y) * -30px));
+}
+
+.layer-content {
+    text-align: center;
+    padding: 1.5rem 2rem;
+    border-radius: 12px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.layer-depth-1 .layer-content { background: rgba(129,140,248,0.08); border: 1px solid rgba(129,140,248,0.15); }
+.layer-depth-2 .layer-content { background: rgba(167,139,250,0.12); border: 1px solid rgba(167,139,250,0.2); }
+.layer-depth-3 .layer-content { background: rgba(196,181,253,0.16); border: 1px solid rgba(196,181,253,0.25); }
+
+.layer-emoji { font-size: 2.5rem; }
+
+.layer-content p {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--text);
+}
+
+.layer-sub { font-size: 0.78rem; color: var(--muted); font-weight: 400; }


### PR DESCRIPTION
**fix(submission): ease-mouse-parallax-layers — 3 depth layers #20554**

## Related Issue  
Closes #20554

---
## Description
Implemented a CSS variable-driven multi-layer parallax system. Three stacked layers each respond to mouse movement at different speeds (0.5x, 1x, 1.5x), creating a convincing 3D depth illusion. JavaScript only reads mouse position and writes `--mouse-x` / `--mouse-y` CSS vars; all movement is handled by CSS `calc()` and `transform`.

## How to Verify Locally
Hover over the parallax scene — layers visibly move at different rates depending on their simulated depth.

**Labels:** `type:bug` · `component` · `GSSoC-26` · `level:intermediate`
