### PR TITLE
fix(submission): ease-page-transition-slide — slide left on nav #20550

### DIFF
--- a/submissions/examples/fix-20550-ease-page-transition-slide-rs/README.md
+++ b/submissions/examples/fix-20550-ease-page-transition-slide-rs/README.md
@@ -1,0 +1,27 @@
+# ease-page-transition-slide
+
+## Issue
+**Issue #20550**: Animation: ease-page-transition-slide — page slides left on navigation
+
+## Bug
+No CSS utility existed for sliding page transitions. Navigation between routes caused instant content replacement with no animation, breaking the sense of spatial context for the user.
+
+## Fix
+Implemented a slide-left/slide-right page transition system using CSS `@keyframes`. The fix maps directly to the View Transitions API pattern where:
+
+- `::view-transition-old(root)` → `slideOutLeft` — current page exits to the left
+- `::view-transition-new(root)` → `slideInRight` — incoming page enters from the right
+
+## CSS Classes Provided
+| Class | Effect |
+|---|---|
+| `.slide-out-left` | Current page exits left (0 → -100%) |
+| `.slide-in-right` | New page enters from right (100% → 0) |
+| `.slide-out-right` | Reverse: page exits right |
+| `.slide-in-from-left` | Reverse: page enters from left |
+
+## Why It Works
+The `overflow: hidden` on the viewport container clips both pages as they move. Using `position: absolute` on page containers and `translateX` keyframes creates a clean, hardware-accelerated sliding effect with no layout reflow.
+
+## Verification
+Open `demo.html`. Click "Navigate → About" to see the home page slide left as the about page slides in from the right. Click "← Back to Home" for the reverse transition.

--- a/submissions/examples/fix-20550-ease-page-transition-slide-rs/demo.html
+++ b/submissions/examples/fix-20550-ease-page-transition-slide-rs/demo.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ease-page-transition-slide Demo</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="page-layout">
+        <header class="demo-header">
+            <h1>ease-page-transition-slide</h1>
+            <p>Current page slides left while new page slides in from the right on navigation.</p>
+        </header>
+
+        <!-- Bug Demo -->
+        <div class="demo-section">
+            <h2>Bug: No Slide Transition</h2>
+            <div class="browser-mock">
+                <div class="browser-chrome">
+                    <span class="chrome-dot r"></span><span class="chrome-dot y"></span><span class="chrome-dot g"></span>
+                    <span class="chrome-url">myapp.com/about</span>
+                </div>
+                <div class="bug-pages">
+                    <div class="bug-page">Page A — appears instantly, no animation.</div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Fix Demo -->
+        <div class="demo-section">
+            <h2>Fix: Slide Page Transition</h2>
+            <p class="fix-caption">Click "Navigate →" to trigger the slide transition between pages.</p>
+            
+            <div class="browser-mock">
+                <div class="browser-chrome">
+                    <span class="chrome-dot r"></span><span class="chrome-dot y"></span><span class="chrome-dot g"></span>
+                    <span class="chrome-url" id="urlBar">myapp.com/home</span>
+                </div>
+                <!-- Viewport that clips the pages -->
+                <div class="viewport-clip">
+                    <!-- Page A (current) -->
+                    <div class="page-slide" id="pageA">
+                        <div class="page-inner page-a">
+                            <h3>🏠 Home Page</h3>
+                            <p>Welcome! You are on the home page.</p>
+                        </div>
+                    </div>
+                    <!-- Page B (incoming) — starts off to the right -->
+                    <div class="page-slide page-slide-offscreen" id="pageB">
+                        <div class="page-inner page-b">
+                            <h3>📋 About Page</h3>
+                            <p>This is the about page, slid in from the right.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="nav-controls">
+                    <button class="nav-btn" id="navBtn" onclick="triggerSlide()">Navigate → About</button>
+                    <button class="nav-btn secondary" id="backBtn" onclick="slideBack()" style="display:none">← Back to Home</button>
+                </div>
+            </div>
+        </div>
+
+        <!-- CSS Implementation Reference -->
+        <div class="demo-section">
+            <h2>CSS Implementation Reference</h2>
+            <div class="code-box">
+                <pre><code>/* ease-page-transition-slide */
+@view-transition {
+    navigation: auto;
+}
+
+::view-transition-old(root) {
+    animation: slideOutLeft 0.4s ease-in-out;
+}
+
+::view-transition-new(root) {
+    animation: slideInRight 0.4s ease-in-out;
+}
+
+@keyframes slideOutLeft {
+    from { transform: translateX(0); }
+    to   { transform: translateX(-100%); }
+}
+
+@keyframes slideInRight {
+    from { transform: translateX(100%); }
+    to   { transform: translateX(0); }
+}</code></pre>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        let isOnB = false;
+
+        function triggerSlide() {
+            const pageA = document.getElementById('pageA');
+            const pageB = document.getElementById('pageB');
+            const urlBar = document.getElementById('urlBar');
+            const navBtn = document.getElementById('navBtn');
+            const backBtn = document.getElementById('backBtn');
+
+            pageA.classList.add('slide-out-left');
+            pageB.classList.remove('page-slide-offscreen');
+            pageB.classList.add('slide-in-right');
+
+            urlBar.textContent = 'myapp.com/about';
+            navBtn.style.display = 'none';
+            backBtn.style.display = 'inline-flex';
+        }
+
+        function slideBack() {
+            const pageA = document.getElementById('pageA');
+            const pageB = document.getElementById('pageB');
+            const urlBar = document.getElementById('urlBar');
+            const navBtn = document.getElementById('navBtn');
+            const backBtn = document.getElementById('backBtn');
+
+            pageA.classList.remove('slide-out-left');
+            pageA.classList.add('slide-in-from-left');
+            pageB.classList.remove('slide-in-right');
+            pageB.classList.add('slide-out-right');
+
+            urlBar.textContent = 'myapp.com/home';
+            navBtn.style.display = 'inline-flex';
+            backBtn.style.display = 'none';
+
+            setTimeout(() => {
+                pageA.classList.remove('slide-in-from-left');
+                pageB.classList.remove('slide-out-right');
+                pageB.classList.add('page-slide-offscreen');
+            }, 420);
+        }
+    </script>
+</body>
+</html>

--- a/submissions/examples/fix-20550-ease-page-transition-slide-rs/style.css
+++ b/submissions/examples/fix-20550-ease-page-transition-slide-rs/style.css
@@ -1,0 +1,207 @@
+:root {
+    --bg: #0f172a;
+    --card-bg: #1e293b;
+    --border: #334155;
+    --text: #f1f5f9;
+    --muted: #94a3b8;
+    --accent: #38bdf8;
+    --page-a: #1e3a5f;
+    --page-b: #1e3a3a;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+    font-family: 'Plus Jakarta Sans', sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    min-height: 100vh;
+    padding: 2rem;
+}
+
+.page-layout {
+    max-width: 800px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 3rem;
+}
+
+.demo-header { text-align: center; padding: 1rem 0; }
+.demo-header h1 { font-size: 2rem; font-weight: 700; color: var(--accent); margin-bottom: 0.5rem; }
+.demo-header p { color: var(--muted); }
+
+.demo-section { display: flex; flex-direction: column; gap: 1rem; }
+.demo-section h2 { font-size: 1.2rem; font-weight: 600; }
+.fix-caption { color: var(--muted); font-size: 0.9rem; }
+
+/* Browser Mock */
+.browser-mock {
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.3);
+}
+
+.browser-chrome {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+    background: #0f172a;
+    border-bottom: 1px solid var(--border);
+}
+
+.chrome-dot {
+    width: 12px; height: 12px; border-radius: 50%;
+}
+.chrome-dot.r { background: #ef4444; }
+.chrome-dot.y { background: #f59e0b; }
+.chrome-dot.g { background: #22c55e; }
+
+.chrome-url {
+    font-family: monospace;
+    font-size: 0.8rem;
+    color: var(--muted);
+    margin-left: 0.75rem;
+    background: rgba(255,255,255,0.05);
+    padding: 0.25rem 0.75rem;
+    border-radius: 4px;
+    border: 1px solid var(--border);
+}
+
+/* Bug Demo */
+.bug-pages {
+    padding: 2rem;
+}
+
+.bug-page {
+    padding: 2rem;
+    background: rgba(255,255,255,0.04);
+    border: 1px dashed var(--border);
+    border-radius: 8px;
+    color: var(--muted);
+    font-style: italic;
+    text-align: center;
+}
+
+/* Fix Demo — Viewport Clip */
+.viewport-clip {
+    position: relative;
+    width: 100%;
+    height: 200px;
+    overflow: hidden;
+}
+
+/* ============================================================
+   ease-page-transition-slide — core CSS implementation
+   Old page slides out to the left; new page slides in from right.
+   Uses CSS @keyframes for the animation, matching what the
+   View Transitions API would do with ::view-transition-old/new.
+   ============================================================ */
+
+.page-slide {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.page-slide-offscreen {
+    transform: translateX(100%);
+}
+
+.page-inner {
+    width: 90%;
+    padding: 2rem;
+    border-radius: 10px;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.page-inner h3 { font-size: 1.25rem; }
+.page-inner p { color: var(--muted); font-size: 0.9rem; }
+
+.page-a { background: rgba(56,189,248,0.1); border: 1px solid rgba(56,189,248,0.2); }
+.page-b { background: rgba(52,211,153,0.1); border: 1px solid rgba(52,211,153,0.2); }
+
+/* Slide Transition Keyframes */
+@keyframes slideOutLeft {
+    from { transform: translateX(0); }
+    to   { transform: translateX(-100%); }
+}
+
+@keyframes slideInRight {
+    from { transform: translateX(100%); }
+    to   { transform: translateX(0); }
+}
+
+@keyframes slideOutRight {
+    from { transform: translateX(0); }
+    to   { transform: translateX(100%); }
+}
+
+@keyframes slideInFromLeft {
+    from { transform: translateX(-100%); }
+    to   { transform: translateX(0); }
+}
+
+.slide-out-left {
+    animation: slideOutLeft 0.4s ease-in-out forwards;
+}
+
+.slide-in-right {
+    animation: slideInRight 0.4s ease-in-out forwards;
+}
+
+.slide-out-right {
+    animation: slideOutRight 0.4s ease-in-out forwards;
+}
+
+.slide-in-from-left {
+    animation: slideInFromLeft 0.4s ease-in-out forwards;
+}
+
+/* Nav Controls */
+.nav-controls {
+    padding: 1rem;
+    display: flex;
+    gap: 0.75rem;
+    justify-content: center;
+    border-top: 1px solid var(--border);
+}
+
+.nav-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: var(--accent);
+    color: #0f172a;
+    border: none;
+    padding: 0.65rem 1.5rem;
+    border-radius: 8px;
+    font-family: inherit;
+    font-weight: 600;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: filter 0.2s, transform 0.2s;
+}
+
+.nav-btn:hover { filter: brightness(1.15); transform: translateY(-1px); }
+.nav-btn.secondary { background: transparent; color: var(--text); border: 1px solid var(--border); }
+
+/* Code Reference Box */
+.code-box {
+    background: #0d1117;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1.5rem;
+    overflow-x: auto;
+}
+
+.code-box pre { font-family: 'SFMono-Regular', Consolas, monospace; font-size: 0.85rem; line-height: 1.6; }
+.code-box code { color: #79c0ff; }


### PR DESCRIPTION
**fix(submission): ease-page-transition-slide — page slides left on nav #20550**

## Related Issue  
Closes #20550

---
## Description
Implemented a slide-based page transition using CSS `@keyframes slideOutLeft` and `slideInRight`, directly mirroring what `::view-transition-old/new(root)` would do with the View Transitions API. Both directions (forward/back) are supported.

## How to Verify Locally
Click "Navigate → About" — the home page slides left, about page slides in from right. Click back for the reverse.

**Labels:** `type:bug` · `component` · `GSSoC-26` · `level:intermediate`
