### PR TITLE
fix(submission): ease-page-transition-fade — full page fade #20549

### DIFF
--- a/submissions/examples/fix-20549-ease-page-transition-fade-rs/README.md
+++ b/submissions/examples/fix-20549-ease-page-transition-fade-rs/README.md
@@ -1,0 +1,31 @@
+# ease-page-transition-fade
+
+## Issue
+**Issue #20549**: Animation: ease-page-transition-fade — page fades out and next page fades in
+
+## Bug
+No CSS utility existed for fade-based page transitions. Pages appeared and disappeared instantly on navigation, providing a jarring user experience with no visual continuity.
+
+## Fix
+Implemented a full-page fade transition system using CSS `@keyframes` that directly mirrors the View Transitions API specification:
+
+```css
+/* Production implementation */
+@view-transition { navigation: auto; }
+
+::view-transition-old(root) { animation: fadeOut 0.35s ease-in-out; }
+::view-transition-new(root) { animation: fadeIn 0.35s ease-in-out; }
+```
+
+## CSS Classes Provided
+| Class | Effect |
+|---|---|
+| `.fade-out` | Active page fades to `opacity: 0` in 0.35s |
+| `.fade-in` | New page fades from `opacity: 0` to `1` in 0.35s |
+| `.active-page` | Page is visible and interactive |
+
+## Why It Works
+The `@keyframes fadeOut` and `fadeIn` operate on `opacity` only, which is a compositor-only property — it triggers no layout or paint, keeping the transition hardware-accelerated and smooth. The 0.35s duration is aligned with human perceptual comfort for page-level transitions.
+
+## Verification
+Open `demo.html`. Click "Navigate → Products" — the current page gently fades to invisible, then the products page fades in. Click "← Back to Home" for the reverse. The CSS implementation block at the bottom shows the production-ready View Transitions API code.

--- a/submissions/examples/fix-20549-ease-page-transition-fade-rs/demo.html
+++ b/submissions/examples/fix-20549-ease-page-transition-fade-rs/demo.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ease-page-transition-fade Demo</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="page-layout">
+        <header class="demo-header">
+            <h1>ease-page-transition-fade</h1>
+            <p>Full page fades out, then new page fades in using the View Transitions API pattern.</p>
+        </header>
+
+        <!-- Bug Demo -->
+        <div class="demo-section">
+            <h2>Bug: Instant Page Switch</h2>
+            <div class="browser-mock">
+                <div class="browser-chrome">
+                    <span class="chrome-dot r"></span><span class="chrome-dot y"></span><span class="chrome-dot g"></span>
+                    <span class="chrome-url">myapp.com/products</span>
+                </div>
+                <div class="bug-area">
+                    <p class="bug-label">Page appears instantly — no fade transition.</p>
+                </div>
+            </div>
+        </div>
+
+        <!-- Fix Demo -->
+        <div class="demo-section">
+            <h2>Fix: Fade Page Transition</h2>
+            <p class="fix-caption">Click "Navigate" to trigger the full-page fade-out → fade-in transition.</p>
+
+            <div class="browser-mock">
+                <div class="browser-chrome">
+                    <span class="chrome-dot r"></span><span class="chrome-dot y"></span><span class="chrome-dot g"></span>
+                    <span class="chrome-url" id="urlBar">myapp.com/home</span>
+                </div>
+
+                <div class="fade-viewport">
+                    <div class="fade-page active-page" id="pageHome">
+                        <div class="page-inner page-home">
+                            <h3>🏠 Home Page</h3>
+                            <p>This page fades out when you navigate away.</p>
+                        </div>
+                    </div>
+                    <div class="fade-page" id="pageProducts">
+                        <div class="page-inner page-products">
+                            <h3>🛍️ Products Page</h3>
+                            <p>This page fades in from invisible after the transition.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="nav-controls">
+                    <button class="nav-btn" id="navBtn" onclick="triggerFade()">Navigate → Products</button>
+                    <button class="nav-btn secondary" id="backBtn" onclick="fadeBack()" style="display:none">← Back to Home</button>
+                </div>
+            </div>
+        </div>
+
+        <!-- CSS Implementation Reference -->
+        <div class="demo-section">
+            <h2>CSS Implementation Reference</h2>
+            <div class="code-box">
+                <pre><code>/* ease-page-transition-fade */
+@view-transition {
+    navigation: auto;
+}
+
+::view-transition-old(root) {
+    animation: fadeOut 0.35s ease-in-out;
+}
+
+::view-transition-new(root) {
+    animation: fadeIn 0.35s ease-in-out;
+}
+
+@keyframes fadeOut {
+    from { opacity: 1; }
+    to   { opacity: 0; }
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}</code></pre>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        function triggerFade() {
+            const home = document.getElementById('pageHome');
+            const products = document.getElementById('pageProducts');
+            const urlBar = document.getElementById('urlBar');
+            const navBtn = document.getElementById('navBtn');
+            const backBtn = document.getElementById('backBtn');
+
+            home.classList.add('fade-out');
+            setTimeout(() => {
+                home.classList.remove('active-page', 'fade-out');
+                products.classList.add('active-page', 'fade-in');
+                products.addEventListener('animationend', () => products.classList.remove('fade-in'), { once: true });
+                urlBar.textContent = 'myapp.com/products';
+                navBtn.style.display = 'none';
+                backBtn.style.display = 'inline-flex';
+            }, 370);
+        }
+
+        function fadeBack() {
+            const home = document.getElementById('pageHome');
+            const products = document.getElementById('pageProducts');
+            const urlBar = document.getElementById('urlBar');
+            const navBtn = document.getElementById('navBtn');
+            const backBtn = document.getElementById('backBtn');
+
+            products.classList.add('fade-out');
+            setTimeout(() => {
+                products.classList.remove('active-page', 'fade-out');
+                home.classList.add('active-page', 'fade-in');
+                home.addEventListener('animationend', () => home.classList.remove('fade-in'), { once: true });
+                urlBar.textContent = 'myapp.com/home';
+                navBtn.style.display = 'inline-flex';
+                backBtn.style.display = 'none';
+            }, 370);
+        }
+    </script>
+</body>
+</html>

--- a/submissions/examples/fix-20549-ease-page-transition-fade-rs/style.css
+++ b/submissions/examples/fix-20549-ease-page-transition-fade-rs/style.css
@@ -1,0 +1,193 @@
+:root {
+    --bg: #0f172a;
+    --card-bg: #1e293b;
+    --border: #334155;
+    --text: #f1f5f9;
+    --muted: #94a3b8;
+    --accent: #a78bfa;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+    font-family: 'Plus Jakarta Sans', sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    min-height: 100vh;
+    padding: 2rem;
+}
+
+.page-layout {
+    max-width: 800px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 3rem;
+}
+
+.demo-header { text-align: center; padding: 1rem 0; }
+.demo-header h1 { font-size: 2rem; font-weight: 700; color: var(--accent); margin-bottom: 0.5rem; }
+.demo-header p { color: var(--muted); }
+
+.demo-section { display: flex; flex-direction: column; gap: 1rem; }
+.demo-section h2 { font-size: 1.2rem; font-weight: 600; }
+.fix-caption { color: var(--muted); font-size: 0.9rem; }
+
+/* Browser Mock */
+.browser-mock {
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.3);
+}
+
+.browser-chrome {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+    background: #0f172a;
+    border-bottom: 1px solid var(--border);
+}
+
+.chrome-dot { width: 12px; height: 12px; border-radius: 50%; }
+.chrome-dot.r { background: #ef4444; }
+.chrome-dot.y { background: #f59e0b; }
+.chrome-dot.g { background: #22c55e; }
+
+.chrome-url {
+    font-family: monospace;
+    font-size: 0.8rem;
+    color: var(--muted);
+    margin-left: 0.75rem;
+    background: rgba(255,255,255,0.05);
+    padding: 0.25rem 0.75rem;
+    border-radius: 4px;
+    border: 1px solid var(--border);
+}
+
+/* Bug Area */
+.bug-area {
+    padding: 3rem 2rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.bug-label {
+    color: var(--muted);
+    font-style: italic;
+    font-size: 0.9rem;
+    border: 1px dashed var(--border);
+    padding: 1.5rem 3rem;
+    border-radius: 8px;
+    text-align: center;
+}
+
+/* Fade Viewport */
+.fade-viewport {
+    position: relative;
+    height: 200px;
+    overflow: hidden;
+}
+
+/* ============================================================
+   ease-page-transition-fade — core CSS implementation
+   Old page fades to opacity 0; new page fades in from opacity 0.
+   Maps directly to @view-transition API:
+     ::view-transition-old → fadeOut
+     ::view-transition-new → fadeIn
+   ============================================================ */
+
+.fade-page {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    pointer-events: none;
+    visibility: hidden;
+}
+
+.fade-page.active-page {
+    opacity: 1;
+    pointer-events: auto;
+    visibility: visible;
+}
+
+/* View Transition Keyframes */
+@keyframes fadeOut {
+    from { opacity: 1; }
+    to   { opacity: 0; }
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+.fade-out {
+    animation: fadeOut 0.35s ease-in-out forwards;
+    pointer-events: none;
+}
+
+.fade-in {
+    animation: fadeIn 0.35s ease-in-out forwards;
+}
+
+/* Page Inners */
+.page-inner {
+    width: 85%;
+    padding: 2rem;
+    border-radius: 10px;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.page-inner h3 { font-size: 1.25rem; }
+.page-inner p { color: var(--muted); font-size: 0.9rem; }
+
+.page-home { background: rgba(167,139,250,0.1); border: 1px solid rgba(167,139,250,0.2); }
+.page-products { background: rgba(251,191,36,0.08); border: 1px solid rgba(251,191,36,0.18); }
+
+/* Nav Controls */
+.nav-controls {
+    padding: 1rem;
+    display: flex;
+    gap: 0.75rem;
+    justify-content: center;
+    border-top: 1px solid var(--border);
+}
+
+.nav-btn {
+    display: inline-flex;
+    align-items: center;
+    background: var(--accent);
+    color: #0f172a;
+    border: none;
+    padding: 0.65rem 1.5rem;
+    border-radius: 8px;
+    font-family: inherit;
+    font-weight: 600;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: filter 0.2s, transform 0.2s;
+}
+
+.nav-btn:hover { filter: brightness(1.15); transform: translateY(-1px); }
+.nav-btn.secondary { background: transparent; color: var(--text); border: 1px solid var(--border); }
+
+/* Code Reference */
+.code-box {
+    background: #0d1117;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1.5rem;
+    overflow-x: auto;
+}
+
+.code-box pre { font-family: 'SFMono-Regular', Consolas, monospace; font-size: 0.85rem; line-height: 1.6; }
+.code-box code { color: #c9d1d9; }


### PR DESCRIPTION
**fix(submission): ease-page-transition-fade — full page fade #20549**

## Related Issue  
Closes #20549

---
## Description
Implemented a full-page opacity fade transition using `@keyframes fadeOut` and `fadeIn`. The CSS operates on `opacity` only (compositor-only, no layout reflow). Directly mirrors the `@view-transition { navigation: auto }` + `::view-transition-old/new` API pattern.

## How to Verify Locally
Click "Navigate → Products" — current page fades out, products page fades in. Click back for the reverse.

**Labels:** `type:bug` · `component` · `GSSoC-26` · `level:intermediate`
