### PR TITLE
feat(scss): easemotion-scss standalone npm package with tokens, mixins, keyframes and utilities (#23088)

### DIFF
--- a/submissions/docs/easemotion-scss-package/README.md
+++ b/submissions/docs/easemotion-scss-package/README.md
@@ -1,0 +1,501 @@
+﻿# easemotion-scss — Standalone SCSS Package
+
+Closes #23088 — Proposal and implementation guide for publishing the
+EaseMotion CSS SCSS partials as a standalone npm package `easemotion-scss`.
+
+---
+
+## Overview
+
+`easemotion-scss` is a standalone npm package that exposes all EaseMotion
+CSS animation tokens, mixins, and utilities as SCSS partials. Developers
+can import only what they need — no compiled CSS shipped, no runtime
+overhead, full tree-shaking by default.
+
+```bash
+npm install easemotion-scss
+```
+
+---
+
+## Package Structure
+easemotion-scss/
+
+├── package.json
+
+├── README.md
+
+├── index.scss                  # Main entry — forwards everything
+
+├── scss/
+
+│   ├── _index.scss             # Barrel file for @forward
+
+│   ├── _variables.scss         # Duration, easing, colour tokens
+
+│   ├── _mixins.scss            # Animation mixins
+
+│   ├── _utilities.scss         # Utility classes (ease-fade-up etc.)
+
+│   ├── _keyframes.scss         # @keyframes declarations
+
+│   └── _reset.scss             # Optional motion-safe reset
+
+└── dist/
+
+└── easemotion.css          # Pre-compiled full CSS (optional CDN use)
+---
+
+## package.json
+
+```json
+{
+  "name": "easemotion-scss",
+  "version": "1.0.0",
+  "description": "SCSS partials for EaseMotion CSS — tokens, mixins, and utilities",
+  "main": "index.scss",
+  "style": "dist/easemotion.css",
+  "exports": {
+    ".": "./index.scss",
+    "./variables": "./scss/_variables.scss",
+    "./mixins": "./scss/_mixins.scss",
+    "./utilities": "./scss/_utilities.scss",
+    "./keyframes": "./scss/_keyframes.scss",
+    "./reset": "./scss/_reset.scss",
+    "./dist/css": "./dist/easemotion.css"
+  },
+  "files": [
+    "scss/",
+    "dist/",
+    "index.scss",
+    "README.md"
+  ],
+  "keywords": [
+    "css", "scss", "sass", "animation", "easemotion",
+    "transitions", "utilities", "motion", "keyframes"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SAPTARSHI-coder/EaseMotion-css"
+  },
+  "peerDependencies": {
+    "sass": ">=1.50.0"
+  }
+}
+```
+
+---
+
+## SCSS Partials
+
+### scss/_variables.scss
+
+```scss
+// ── Duration ─────────────────────────────────────────────────────
+$ease-duration-instant: 100ms  !default;
+$ease-duration-fast:    150ms  !default;
+$ease-duration-base:    300ms  !default;
+$ease-duration-slow:    600ms  !default;
+$ease-duration-xslow:   1000ms !default;
+
+// ── Easing ───────────────────────────────────────────────────────
+$ease-linear:           linear                          !default;
+$ease-in:               cubic-bezier(0.4, 0, 1, 1)     !default;
+$ease-out:              cubic-bezier(0, 0, 0.2, 1)     !default;
+$ease-in-out:           cubic-bezier(0.4, 0, 0.2, 1)   !default;
+$ease-spring:           cubic-bezier(0.34, 1.56, 0.64, 1) !default;
+$ease-snap:             cubic-bezier(0.25, 0.46, 0.45, 0.94) !default;
+$ease-bounce:           cubic-bezier(0.68, -0.55, 0.27, 1.55) !default;
+
+// ── Motion scale ─────────────────────────────────────────────────
+$ease-slide-sm:         12px  !default;
+$ease-slide-base:       24px  !default;
+$ease-slide-lg:         48px  !default;
+$ease-skew-base:        3deg  !default;
+$ease-skew-strong:      6deg  !default;
+$ease-scale-sm:         0.95  !default;
+$ease-scale-base:       0.9   !default;
+
+// ── Colour ───────────────────────────────────────────────────────
+$ease-primary:          #6366f1 !default;
+$ease-primary-dark:     #4f46e5 !default;
+$ease-surface:          #1e293b !default;
+$ease-border:           rgba(255,255,255,0.08) !default;
+$ease-text:             #e2e8f0 !default;
+$ease-muted:            #64748b !default;
+```
+
+### scss/_keyframes.scss
+
+```scss
+@keyframes ease-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes ease-fade-up {
+  from { opacity: 0; transform: translateY(var(--ease-slide, 24px)); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes ease-fade-down {
+  from { opacity: 0; transform: translateY(calc(var(--ease-slide, 24px) * -1)); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes ease-fade-left {
+  from { opacity: 0; transform: translateX(var(--ease-slide, 24px)); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes ease-fade-right {
+  from { opacity: 0; transform: translateX(calc(var(--ease-slide, 24px) * -1)); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes ease-zoom-in {
+  from { opacity: 0; transform: scale(0.9); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+@keyframes ease-zoom-out {
+  from { opacity: 0; transform: scale(1.1); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+@keyframes ease-spin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes ease-pulse {
+  0%,100% { opacity: 1; }
+  50%      { opacity: 0.4; }
+}
+
+@keyframes ease-bounce-in {
+  0%   { opacity: 0; transform: scale(0.3); }
+  50%  { opacity: 1; transform: scale(1.1); }
+  70%  { transform: scale(0.95); }
+  100% { transform: scale(1); }
+}
+
+@keyframes ease-shake {
+  0%,100% { transform: translateX(0); }
+  20%,60% { transform: translateX(-8px); }
+  40%,80% { transform: translateX(8px); }
+}
+```
+
+### scss/_mixins.scss
+
+```scss
+@use 'variables' as v;
+
+// ── Core animate mixin ────────────────────────────────────────────
+@mixin ease-animate(
+  $name,
+  $duration: v.$ease-duration-base,
+  $easing:   v.$ease-in-out,
+  $delay:    0ms,
+  $fill:     both,
+  $count:    1
+) {
+  animation-name:            $name;
+  animation-duration:        $duration;
+  animation-timing-function: $easing;
+  animation-delay:           $delay;
+  animation-fill-mode:       $fill;
+  animation-iteration-count: $count;
+}
+
+// ── Directional fade mixins ───────────────────────────────────────
+@mixin ease-fade-in($duration: v.$ease-duration-base, $delay: 0ms) {
+  @include ease-animate(ease-fade-in, $duration, v.$ease-in-out, $delay);
+}
+
+@mixin ease-fade-up($duration: v.$ease-duration-base, $delay: 0ms, $distance: v.$ease-slide-base) {
+  --ease-slide: #{$distance};
+  opacity: 0;
+  transform: translateY($distance);
+  @include ease-animate(ease-fade-up, $duration, v.$ease-spring, $delay);
+}
+
+@mixin ease-fade-down($duration: v.$ease-duration-base, $delay: 0ms) {
+  @include ease-animate(ease-fade-down, $duration, v.$ease-spring, $delay);
+}
+
+@mixin ease-fade-left($duration: v.$ease-duration-base, $delay: 0ms) {
+  @include ease-animate(ease-fade-left, $duration, v.$ease-spring, $delay);
+}
+
+@mixin ease-fade-right($duration: v.$ease-duration-base, $delay: 0ms) {
+  @include ease-animate(ease-fade-right, $duration, v.$ease-spring, $delay);
+}
+
+@mixin ease-zoom-in($duration: v.$ease-duration-base, $delay: 0ms) {
+  @include ease-animate(ease-zoom-in, $duration, v.$ease-spring, $delay);
+}
+
+// ── Stagger nth-child ─────────────────────────────────────────────
+@mixin ease-stagger($base-delay: 100ms, $count: 6) {
+  @for $i from 1 through $count {
+    &:nth-child(#{$i}) { animation-delay: #{($i - 1) * $base-delay}; }
+  }
+}
+
+// ── Hover interactions ────────────────────────────────────────────
+@mixin ease-hover-lift($distance: 6px, $shadow: 0 20px 40px rgba(0,0,0,0.25)) {
+  transition: transform v.$ease-duration-base v.$ease-snap,
+              box-shadow v.$ease-duration-base v.$ease-snap;
+  &:hover {
+    transform:  translateY(-$distance);
+    box-shadow: $shadow;
+  }
+}
+
+@mixin ease-hover-scale($scale: 1.04) {
+  transition: transform v.$ease-duration-base v.$ease-snap;
+  &:hover { transform: scale($scale); }
+}
+
+@mixin ease-hover-glow($color: v.$ease-primary, $spread: 24px) {
+  transition: box-shadow v.$ease-duration-base v.$ease-snap;
+  &:hover { box-shadow: 0 0 $spread #{$color}60; }
+}
+
+// ── Transition shorthand ──────────────────────────────────────────
+@mixin ease-transition(
+  $props:    all,
+  $duration: v.$ease-duration-base,
+  $easing:   v.$ease-snap
+) {
+  transition: $props $duration $easing;
+}
+
+// ── Safe motion wrapper ───────────────────────────────────────────
+@mixin ease-safe-motion {
+  @media (prefers-reduced-motion: no-preference) { @content; }
+}
+
+// ── Reduced motion reset ──────────────────────────────────────────
+@mixin ease-reduced-motion-reset {
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+      animation-duration:        0.01ms !important;
+      animation-iteration-count: 1      !default;
+      transition-duration:       0.01ms !important;
+    }
+  }
+}
+```
+
+### scss/_utilities.scss
+
+```scss
+@use 'variables' as v;
+@use 'keyframes';
+
+// Utility classes that mirror the mixin output
+.ease-fade-in   { animation: ease-fade-in  v.$ease-duration-base v.$ease-in-out  both; }
+.ease-fade-up   { animation: ease-fade-up  v.$ease-duration-base v.$ease-spring  both; opacity: 0; transform: translateY(v.$ease-slide-base); }
+.ease-fade-down { animation: ease-fade-down v.$ease-duration-base v.$ease-spring both; }
+.ease-zoom-in   { animation: ease-zoom-in  v.$ease-duration-base v.$ease-spring  both; }
+.ease-spin      { animation: ease-spin     1s                     linear infinite; }
+.ease-pulse     { animation: ease-pulse    2s                     ease-in-out infinite; }
+.ease-bounce-in { animation: ease-bounce-in v.$ease-duration-slow v.$ease-out   both; }
+.ease-shake     { animation: ease-shake    500ms                  v.$ease-snap   both; }
+
+// Duration modifiers
+.ease-fast  { animation-duration: v.$ease-duration-fast  !important; }
+.ease-slow  { animation-duration: v.$ease-duration-slow  !important; }
+.ease-xslow { animation-duration: v.$ease-duration-xslow !important; }
+
+// Delay modifiers
+.ease-delay-100 { animation-delay: 100ms; }
+.ease-delay-200 { animation-delay: 200ms; }
+.ease-delay-300 { animation-delay: 300ms; }
+.ease-delay-400 { animation-delay: 400ms; }
+.ease-delay-500 { animation-delay: 500ms; }
+.ease-delay-700 { animation-delay: 700ms; }
+
+// Hover utilities
+.ease-hover-lift  { transition: transform v.$ease-duration-base v.$ease-snap, box-shadow v.$ease-duration-base v.$ease-snap; }
+.ease-hover-lift:hover  { transform: translateY(-6px); box-shadow: 0 20px 40px rgba(0,0,0,0.25); }
+.ease-hover-scale { transition: transform v.$ease-duration-base v.$ease-snap; }
+.ease-hover-scale:hover { transform: scale(1.04); }
+```
+
+### scss/_reset.scss
+
+```scss
+// Optional motion-safe reset — import separately if needed
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration:        0.01ms !important;
+    animation-iteration-count: 1      !important;
+    transition-duration:       0.01ms !important;
+    scroll-behavior:           auto   !important;
+  }
+}
+```
+
+### scss/_index.scss (barrel file)
+
+```scss
+@forward 'variables';
+@forward 'keyframes';
+@forward 'mixins';
+@forward 'utilities';
+```
+
+### index.scss (main entry)
+
+```scss
+// easemotion-scss — main entry point
+// @use 'easemotion-scss' to get everything
+// @use 'easemotion-scss/variables' for tokens only
+@forward 'scss/index';
+```
+
+---
+
+## Usage After Installing
+
+### Get everything
+
+```scss
+@use 'easemotion-scss' as em;
+
+.hero {
+  @include em.ease-fade-up($delay: 200ms);
+  @include em.ease-hover-lift;
+}
+```
+
+### Get only what you need (tree-shakeable)
+
+```scss
+// Only tokens — zero CSS output
+@use 'easemotion-scss/variables' as v;
+
+.btn {
+  transition: background v.$ease-duration-base v.$ease-snap;
+}
+```
+
+### Only mixins
+
+```scss
+@use 'easemotion-scss/mixins' as m;
+
+.card {
+  @include m.ease-fade-up;
+  @include m.ease-safe-motion {
+    @include m.ease-hover-lift(8px);
+  }
+}
+```
+
+### Only utility classes
+
+```scss
+// Generates .ease-fade-up, .ease-zoom-in, .ease-hover-scale etc.
+@use 'easemotion-scss/utilities';
+```
+
+---
+
+## Framework Examples
+
+### React + CSS Modules
+
+```scss
+// Button.module.scss
+@use 'easemotion-scss/mixins' as m;
+@use 'easemotion-scss/variables' as v;
+
+.button {
+  background: v.$ease-primary;
+  @include m.ease-hover-scale(1.05);
+  @include m.ease-transition(background);
+}
+```
+
+### Vue 3 SFC
+
+```vue
+<style lang="scss" scoped>
+@use 'easemotion-scss/mixins' as m;
+
+.hero-title {
+  @include m.ease-safe-motion {
+    @include m.ease-fade-up($duration: 600ms);
+  }
+}
+</style>
+```
+
+### Astro Component
+
+```astro
+<style lang="scss">
+@use 'easemotion-scss' as em;
+
+.card {
+  @include em.ease-fade-up($delay: var(--delay, 0ms));
+  @include em.ease-hover-lift;
+}
+</style>
+```
+
+### SvelteKit Component
+
+```svelte
+<style lang="scss">
+@use 'easemotion-scss/mixins' as m;
+
+.section > * {
+  @include m.ease-safe-motion { @include m.ease-fade-up; }
+  @include m.ease-stagger(120ms, 4);
+}
+</style>
+```
+
+### Plain SCSS (Webpack / Vite)
+
+```scss
+// main.scss
+@use 'easemotion-scss/reset';      // motion-safe reset
+@use 'easemotion-scss/utilities';  // utility classes
+```
+
+---
+
+## Publishing to npm
+
+```bash
+# Authenticate
+npm login
+
+# Dry run — check what gets published
+npm pack --dry-run
+
+# Publish
+npm publish --access public
+```
+
+Versioning follows semantic versioning (semver):
+- Patch `1.0.x` — bug fixes, typo corrections
+- Minor `1.x.0` — new mixins or tokens (backward compatible)
+- Major `x.0.0` — breaking changes to existing mixin signatures
+
+---
+
+## Files in This Submission
+
+| File | Purpose |
+|------|---------|
+| README.md | This package guide and API reference |
+| demo.html | Visual preview of all mixins and utilities |
+| style.css | Compiled output showing what the SCSS produces |

--- a/submissions/docs/easemotion-scss-package/demo.html
+++ b/submissions/docs/easemotion-scss-package/demo.html
@@ -1,0 +1,107 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>easemotion-scss npm Package Demo</title>
+  <link rel="stylesheet" href="style.css"/>
+</head>
+<body>
+<div class="page">
+
+  <div class="hero stagger">
+    <h1 class="ease-fade-up"><span>easemotion-scss</span><br/>npm Package</h1>
+    <p class="ease-fade-up ease-delay-100">
+      Standalone SCSS partials for EaseMotion CSS — tokens, mixins,
+      keyframes, and utilities. Import only what you need.
+    </p>
+    <div class="ease-fade-up ease-delay-200">
+      <a class="btn" href="#">npm install easemotion-scss</a>
+      <a class="btn btn-outline" href="#">View on GitHub</a>
+    </div>
+  </div>
+
+  <!-- Utility classes demo -->
+  <div class="section">
+    <h2>Animation Utilities</h2>
+    <p class="section-sub">Compiled from scss/_utilities.scss — use as classes directly</p>
+    <div class="grid stagger">
+      <div class="card ease-fade-up">
+        <span class="badge">.ease-fade-up</span>
+        <h3>Fade Up</h3>
+        <p>Spring-eased entrance from below. The most used utility.</p>
+      </div>
+      <div class="card ease-zoom-in ease-delay-100">
+        <span class="badge">.ease-zoom-in</span>
+        <h3>Zoom In</h3>
+        <p>Scale from 90% to 100% with spring easing on entrance.</p>
+      </div>
+      <div class="card ease-bounce-in ease-delay-200">
+        <span class="badge">.ease-bounce-in</span>
+        <h3>Bounce In</h3>
+        <p>Playful overshoot entrance for icons and badges.</p>
+      </div>
+      <div class="card ease-fade-in ease-delay-300">
+        <span class="badge">.ease-fade-in</span>
+        <h3>Fade In</h3>
+        <p>Simple opacity fade. Pairs well with slide transforms.</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- Hover utilities -->
+  <div class="section">
+    <h2>Hover Utilities</h2>
+    <p class="section-sub">Compiled from ease-hover-lift and ease-hover-scale mixins</p>
+    <div class="demo-row">
+      <div class="demo-box ease-hover-lift">&#9650;</div>
+      <div class="demo-box ease-hover-scale">&#9654;</div>
+      <div class="demo-box ease-hover-lift" style="background:linear-gradient(135deg,#6366f1,#8b5cf6);">&#9733;</div>
+      <div class="demo-box ease-hover-scale" style="background:linear-gradient(135deg,#0891b2,#06b6d4);">&#9670;</div>
+    </div>
+  </div>
+
+  <!-- Modifier classes -->
+  <div class="section">
+    <h2>Duration &amp; Delay Modifiers</h2>
+    <p class="section-sub">.ease-fast .ease-slow .ease-xslow .ease-delay-100 to .ease-delay-500</p>
+    <div class="grid stagger">
+      <div class="card ease-fade-up ease-fast">
+        <span class="badge">.ease-fast — 150ms</span>
+        <h3>Fast</h3>
+        <p>Micro-interactions and hover responses.</p>
+      </div>
+      <div class="card ease-fade-up ease-delay-200">
+        <span class="badge">.ease-slow — 600ms</span>
+        <h3>Slow</h3>
+        <p>Hero entrances and page-level transitions.</p>
+      </div>
+      <div class="card ease-fade-up ease-delay-400">
+        <span class="badge">.ease-xslow — 1000ms</span>
+        <h3>Extra Slow</h3>
+        <p>Ambient loops and background decorations.</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- Usage code -->
+  <div class="section">
+    <h2>Quick Install &amp; Usage</h2>
+    <p class="section-sub">Three import styles — full, partial, or utilities-only</p>
+    <div class="code-block">
+      <span style="color:#f472b6;">// 1. Full package</span><br/>
+      <span style="color:#60a5fa;">@use</span> <span style="color:#fbbf24;">'easemotion-scss'</span> <span style="color:#60a5fa;">as</span> em;<br/>
+      .hero { <span style="color:#34d399;">@include</span> em.ease-fade-up($delay: 200ms); }<br/>
+      <br/>
+      <span style="color:#f472b6;">// 2. Tokens only (zero CSS output)</span><br/>
+      <span style="color:#60a5fa;">@use</span> <span style="color:#fbbf24;">'easemotion-scss/variables'</span> <span style="color:#60a5fa;">as</span> v;<br/>
+      .btn { transition: background v.$ease-duration-base v.$ease-snap; }<br/>
+      <br/>
+      <span style="color:#f472b6;">// 3. Utility classes only</span><br/>
+      <span style="color:#60a5fa;">@use</span> <span style="color:#fbbf24;">'easemotion-scss/utilities'</span>;
+    </div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/submissions/docs/easemotion-scss-package/style.css
+++ b/submissions/docs/easemotion-scss-package/style.css
@@ -1,0 +1,79 @@
+﻿*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: system-ui, sans-serif;
+  background: #0d0d14;
+  color: #e2e8f0;
+  min-height: 100vh;
+  padding: 2rem 1rem;
+}
+
+/* Compiled keyframes from scss/_keyframes.scss */
+@keyframes ease-fade-in  { from{opacity:0} to{opacity:1} }
+@keyframes ease-fade-up  { from{opacity:0;transform:translateY(24px)} to{opacity:1;transform:translateY(0)} }
+@keyframes ease-zoom-in  { from{opacity:0;transform:scale(0.9)} to{opacity:1;transform:scale(1)} }
+@keyframes ease-bounce-in{ 0%{opacity:0;transform:scale(0.3)} 50%{opacity:1;transform:scale(1.1)} 70%{transform:scale(0.95)} 100%{transform:scale(1)} }
+@keyframes ease-pulse    { 0%,100%{opacity:1} 50%{opacity:0.4} }
+@keyframes ease-spin     { to{transform:rotate(360deg)} }
+@keyframes ease-shake    { 0%,100%{transform:translateX(0)} 20%,60%{transform:translateX(-8px)} 40%,80%{transform:translateX(8px)} }
+
+/* Compiled utilities from scss/_utilities.scss */
+.ease-fade-in   { animation: ease-fade-in   300ms cubic-bezier(0.4,0,0.2,1) both; }
+.ease-fade-up   { animation: ease-fade-up   300ms cubic-bezier(0.34,1.56,0.64,1) both; }
+.ease-zoom-in   { animation: ease-zoom-in   300ms cubic-bezier(0.34,1.56,0.64,1) both; }
+.ease-bounce-in { animation: ease-bounce-in 600ms cubic-bezier(0,0,0.2,1) both; }
+.ease-pulse     { animation: ease-pulse     2s ease-in-out infinite; }
+.ease-spin      { animation: ease-spin      1s linear infinite; }
+.ease-shake     { animation: ease-shake     500ms cubic-bezier(0.25,0.46,0.45,0.94) both; }
+
+.ease-fast  { animation-duration: 150ms  !important; }
+.ease-slow  { animation-duration: 600ms  !important; }
+.ease-xslow { animation-duration: 1000ms !important; }
+
+.ease-delay-100 { animation-delay: 100ms; }
+.ease-delay-200 { animation-delay: 200ms; }
+.ease-delay-300 { animation-delay: 300ms; }
+.ease-delay-400 { animation-delay: 400ms; }
+
+.ease-hover-lift { transition: transform 300ms cubic-bezier(0.25,0.46,0.45,0.94), box-shadow 300ms cubic-bezier(0.25,0.46,0.45,0.94); }
+.ease-hover-lift:hover { transform: translateY(-6px); box-shadow: 0 20px 40px rgba(0,0,0,0.25); }
+.ease-hover-scale { transition: transform 300ms cubic-bezier(0.25,0.46,0.45,0.94); }
+.ease-hover-scale:hover { transform: scale(1.04); }
+
+/* Stagger helpers */
+.stagger > *:nth-child(1) { animation-delay:   0ms; }
+.stagger > *:nth-child(2) { animation-delay: 100ms; }
+.stagger > *:nth-child(3) { animation-delay: 200ms; }
+.stagger > *:nth-child(4) { animation-delay: 300ms; }
+.stagger > *:nth-child(5) { animation-delay: 400ms; }
+.stagger > *:nth-child(6) { animation-delay: 500ms; }
+
+/* Demo page */
+.page { max-width: 960px; margin: 0 auto; }
+.hero { text-align:center; padding:4rem 2rem; background:radial-gradient(ellipse 700px 400px at 50% 40%,#6366f115,transparent); border-radius:16px; margin-bottom:3rem; }
+.hero h1 { font-size:clamp(2rem,5vw,3.5rem); font-weight:900; margin-bottom:1rem; }
+.hero h1 span { color:#6366f1; }
+.hero p { color:#64748b; max-width:500px; margin:0 auto 2rem; line-height:1.7; }
+.btn { display:inline-block; background:#6366f1; color:#fff; padding:0.85rem 2rem; border-radius:8px; font-weight:700; text-decoration:none; margin:0.3rem; transition:background 300ms ease,transform 300ms ease; }
+.btn:hover { background:#4f46e5; transform:scale(1.04); }
+.btn-outline { background:transparent; border:1.5px solid rgba(255,255,255,0.2); }
+.btn-outline:hover { border-color:#6366f1; color:#a5b4fc; }
+
+.section { padding:2rem 0; margin-bottom:1rem; }
+.section h2 { font-size:1.2rem; font-weight:800; margin-bottom:0.4rem; }
+.section-sub { color:#475569; font-size:0.8rem; font-family:monospace; margin-bottom:1.4rem; }
+
+.grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(200px,1fr)); gap:1rem; }
+.card { background:#1e293b; border:1px solid rgba(255,255,255,0.07); border-radius:12px; padding:1.4rem; }
+.card .badge { display:inline-block; background:rgba(99,102,241,0.15); color:#a5b4fc; font-size:0.7rem; padding:0.18rem 0.55rem; border-radius:4px; margin-bottom:0.7rem; font-family:monospace; }
+.card h3 { font-size:0.95rem; font-weight:700; margin-bottom:0.3rem; }
+.card p { color:#64748b; font-size:0.82rem; line-height:1.6; }
+
+.demo-row { display:flex; flex-wrap:wrap; gap:1rem; align-items:center; margin-top:1rem; }
+.demo-box { width:80px; height:80px; border-radius:10px; background:#1e293b; border:1px solid rgba(255,255,255,0.07); display:flex; align-items:center; justify-content:center; font-size:1.5rem; }
+
+.code-block { background:#0f172a; border:1px solid rgba(255,255,255,0.06); border-radius:10px; padding:1rem 1.3rem; font-family:monospace; font-size:0.8rem; color:#a5b4fc; line-height:1.9; overflow-x:auto; margin-top:0.8rem; }
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-fade-in,.ease-fade-up,.ease-zoom-in,.ease-bounce-in,.ease-shake { animation:none; opacity:1; transform:none; }
+}


### PR DESCRIPTION
Closes #23088

## What
Proposal and full implementation spec for publishing EaseMotion CSS
SCSS partials as a standalone npm package `easemotion-scss`.

## Package Contents
- _variables.scss — duration, easing, motion scale, colour tokens
- _keyframes.scss — 9 named @keyframes (fade, zoom, bounce, spin, shake)
- _mixins.scss — ease-fade-up/down/left/right, ease-zoom-in,
  ease-stagger, ease-hover-lift/scale/glow, ease-transition, ease-safe-motion
- _utilities.scss — compiled utility classes with duration/delay modifiers
- _reset.scss — prefers-reduced-motion reset (optional import)
- index.scss — main entry with @forward barrel

## Import Styles
- Full: @use 'easemotion-scss' as em
- Tokens only (zero CSS): @use 'easemotion-scss/variables' as v
- Mixins only: @use 'easemotion-scss/mixins' as m
- Utilities only: @use 'easemotion-scss/utilities'

## Framework examples included
React CSS Modules, Vue 3 SFC, Astro, SvelteKit, plain SCSS