### PR TITLE
feat: add SCSS regression test tool (#23094)

### DIFF
--- a/submissions/examples/scss-regression-test-ax/test-scss-regression.js
+++ b/submissions/examples/scss-regression-test-ax/test-scss-regression.js
@@ -1,0 +1,38 @@
+﻿const sass = require('sass');
+const { ok, deepEqual } = require('assert');
+
+const scssInput = `
+$primary: #3b82f6;
+$radius: 0.5rem;
+
+.ease-btn-primary {
+  background: $primary;
+  border-radius: $radius;
+  &:hover {
+    background: darken($primary, 10%);
+  }
+}
+`;
+
+const expectedCSS = `\
+.ease-btn-primary {
+  background: #3b82f6;
+  border-radius: 0.5rem;
+}
+.ease-btn-primary:hover {
+  background: rgb(11.1512195122, 99.1219512195, 242.8487804878);
+}
+`;
+
+const compiled = sass.compileString(scssInput, { style: 'expanded' }).css;
+
+if (compiled.trim() === expectedCSS.trim()) {
+  console.log('✅ PASS: SCSS compilation matches expected CSS.');
+} else {
+  console.log('❌ FAIL: Output differs.');
+  console.log('--- EXPECTED ---');
+  console.log(expectedCSS);
+  console.log('--- ACTUAL ---');
+  console.log(compiled);
+  process.exit(1);
+}


### PR DESCRIPTION
Closes #23094

SCSS Regression Test Tool
A Node.js script that compiles a SCSS snippet and compares the output with the expected raw CSS to catch regressions.

Files added
- submissions/examples/scss-regression-test-ax/test-scss-regression.js – the test script
- submissions/examples/scss-regression-test-ax/demo.html – usage demo page
- submissions/examples/scss-regression-test-ax/style.css – demo styles
- submissions/examples/scss-regression-test-ax/README.md – instructions

How it works
- Uses the `sass` npm package to compile a SCSS input.
- Compares the compiled output with a reference raw CSS string.
- Prints PASS/FAIL and shows diffs on failure.