### PR TITLE
feat: add ease-neon-outline-chip-z1

### DIFF
--- a/submissions/examples/ease-neon-outline-chip-z1/README.md
+++ b/submissions/examples/ease-neon-outline-chip-z1/README.md
@@ -1,0 +1,37 @@
+# Ease Neon Outline Chip
+
+## Overview
+
+This example demonstrates a reusable CSS-only neon outline chip component with glowing hover interactions and animated borders.
+
+## Features
+
+- Pure HTML and CSS
+- Neon outline effect
+- Animated glow
+- Responsive layout
+- Multiple color variants
+- No JavaScript
+
+## Folder Structure
+
+```text
+ease-neon-outline-chip-z1/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+## Installation
+
+1. Open the example folder.
+2. Launch `demo.html`.
+3. Customize labels and colors.
+
+## Browser Support
+
+Compatible with all modern browsers supporting CSS animations and transitions.
+
+## Why This Example
+
+Neon chips provide attractive labels for technologies, categories, tags, filters, and status indicators while remaining lightweight and reusable.

--- a/submissions/examples/ease-neon-outline-chip-z1/demo.html
+++ b/submissions/examples/ease-neon-outline-chip-z1/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Ease Neon Outline Chip</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<main class="wrapper">
+
+<header>
+<h1>Ease Neon Outline Chip</h1>
+<p>Animated glowing chips built with modern CSS.</p>
+</header>
+
+<section class="chip-group">
+
+<span class="chip cyan">HTML</span>
+<span class="chip blue">CSS</span>
+<span class="chip purple">JavaScript</span>
+<span class="chip green">React</span>
+<span class="chip orange">Node.js</span>
+<span class="chip pink">MongoDB</span>
+
+</section>
+
+<section class="info">
+
+<h2>Reusable Component</h2>
+
+<p>
+Perfect for category labels, skill tags,
+technology stacks, filters, and dashboard
+status indicators.
+</p>
+
+</section>
+
+</main>
+
+</body>
+</html>

--- a/submissions/examples/ease-neon-outline-chip-z1/style.css
+++ b/submissions/examples/ease-neon-outline-chip-z1/style.css
@@ -1,0 +1,86 @@
+:root{
+--bg:#0f172a;
+--text:#f8fafc;
+--radius:999px;
+}
+
+*{
+margin:0;
+padding:0;
+box-sizing:border-box;
+}
+
+body{
+font-family:system-ui,sans-serif;
+background:var(--bg);
+color:var(--text);
+display:grid;
+place-items:center;
+min-height:100vh;
+padding:2rem;
+}
+
+.wrapper{
+width:min(900px,100%);
+text-align:center;
+}
+
+header{
+margin-bottom:2rem;
+}
+
+header p{
+margin-top:.75rem;
+color:#cbd5e1;
+}
+
+.chip-group{
+display:flex;
+justify-content:center;
+flex-wrap:wrap;
+gap:1rem;
+margin-bottom:2rem;
+}
+
+.chip{
+padding:.8rem 1.5rem;
+border:2px solid currentColor;
+border-radius:var(--radius);
+font-weight:600;
+letter-spacing:.03em;
+animation:pulse 2.5s ease-in-out infinite;
+transition:.3s;
+}
+
+.chip:hover{
+background:currentColor;
+color:#0f172a;
+box-shadow:0 0 18px currentColor;
+transform:translateY(-4px);
+}
+
+.cyan{color:#22d3ee;}
+.blue{color:#3b82f6;}
+.purple{color:#a855f7;}
+.green{color:#22c55e;}
+.orange{color:#f97316;}
+.pink{color:#ec4899;}
+
+.info{
+max-width:620px;
+margin:auto;
+line-height:1.7;
+color:#cbd5e1;
+}
+
+@keyframes pulse{
+50%{
+box-shadow:0 0 14px currentColor;
+}
+}
+
+@media(max-width:640px){
+body{
+padding:1rem;
+}
+}


### PR DESCRIPTION
## Summary

Add a reusable CSS-only neon outline chip component with glowing borders, hover effects, and multiple color variants.

## Features

- Neon outline styling
- Animated glow effect
- Responsive chip layout
- Multiple color themes
- Pure HTML and CSS

## Files Added

```text
submissions/examples/ease-neon-outline-chip-z1/
├── demo.html
├── style.css
└── README.md
```

## Testing

- Opened `demo.html` in modern browsers
- Verified glow animation
- Tested hover interactions
- Confirmed responsive layout
- Checked all color variants

## Why This Feature

Neon outline chips are useful for displaying technologies, categories, labels, filters, and status badges in dashboards, developer portfolios, documentation sites, and SaaS interfaces.

## Checklist

- [x] Added a new example folder only
- [x] Included `demo.html`
- [x] Included `style.css`
- [x] Included `README.md`
- [x] No existing files modified
- [x] No JavaScript used
- [x] Responsive layout verified