### PR TITLE
feat: add SCSS regression test tool (#23094)

### DIFF
--- a/submissions/examples/scss-regression-test-v2/README.md
+++ b/submissions/examples/scss-regression-test-v2/README.md
@@ -1,0 +1,37 @@
+﻿# SCSS Regression Test Tool
+
+A Node.js script that compiles a SCSS snippet and compares the output
+with the expected raw CSS. Useful for catching regressions when updating
+SCSS variables or mixins in EaseMotion CSS.
+
+## Files
+- `test-scss-regression.js` – the test script
+- `demo.html` – explains how to run the tool
+- `style.css` – demo page styling
+- `README.md` – this file
+
+## How to use
+
+1. Install dependencies:
+   ```bash
+   npm install sass
+Run the script:
+
+bash
+node test-scss-regression.js
+The script compiles a sample SCSS snippet and compares it with the
+expected raw CSS. If they match, it prints ✅ PASS; otherwise it shows
+the differences and exits with an error code.
+
+EaseMotion classes used in demo
+Layout: ease-container, ease-flex, ease-items-center, ease-justify-center, ease-min-h-screen, ease-py-16
+
+Background: ease-bg-gray-50, ease-bg-white
+
+Typography: ease-text-3xl, ease-font-bold, ease-text-gray-500, ease-text-sm, ease-text-gray-400, ease-text-lg, ease-font-semibold
+
+Spacing: ease-mb-2, ease-mb-4, ease-mb-8, ease-mt-4, ease-mt-8, ease-p-6
+
+Components: ease-card
+
+Animation: ease-fade-in, ease-delay-200, ease-delay-500

--- a/submissions/examples/scss-regression-test-v2/demo.html
+++ b/submissions/examples/scss-regression-test-v2/demo.html
@@ -1,0 +1,39 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SCSS Regression Test Tool</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-50 ease-min-h-screen ease-flex ease-items-center ease-justify-center">
+
+  <div class="ease-container ease-text-center ease-py-16">
+    <h1 class="ease-text-3xl ease-font-bold ease-mb-4 ease-fade-in">
+      SCSS Regression Test
+    </h1>
+    <p class="ease-text-gray-500 ease-mb-8 ease-fade-in ease-delay-200">
+      A script that tests SCSS compilation output against raw CSS to catch drift or regressions.
+    </p>
+
+    <div class="ease-card ease-p-6 ease-max-w-lg ease-mx-auto ease-bg-white ease-text-left">
+      <h2 class="ease-text-lg ease-font-semibold ease-mb-2">How to run</h2>
+      <pre class="code-block"><code># Install dependencies
+npm install sass
+
+# Run the regression test
+node test-scss-regression.js</code></pre>
+      <p class="ease-text-sm ease-text-gray-500 ease-mt-4">
+        The script compiles a sample SCSS snippet and compares it with the expected CSS.
+        It reports whether the output matches or shows the differences.
+      </p>
+    </div>
+
+    <p class="ease-text-sm ease-text-gray-400 ease-mt-8 ease-fade-in ease-delay-500">
+      Built for EaseMotion CSS — ensure SCSS changes don't break the framework.
+    </p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/scss-regression-test-v2/style.css
+++ b/submissions/examples/scss-regression-test-v2/style.css
@@ -1,0 +1,24 @@
+﻿.code-block {
+  background: #f1f5f9;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  font-size: 0.875rem;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.ease-max-w-lg { max-width: 32rem; }
+
+body {
+  font-family: system-ui, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/submissions/examples/scss-regression-test-v2/test-scss-regression.js
+++ b/submissions/examples/scss-regression-test-v2/test-scss-regression.js
@@ -1,0 +1,37 @@
+﻿const sass = require('sass');
+
+const scssInput = `
+$primary: #3b82f6;
+$radius: 0.5rem;
+
+.ease-btn-primary {
+  background: $primary;
+  border-radius: $radius;
+  &:hover {
+    background: darken($primary, 10%);
+  }
+}
+`;
+
+const expectedCSS = `\
+.ease-btn-primary {
+  background: #3b82f6;
+  border-radius: 0.5rem;
+}
+.ease-btn-primary:hover {
+  background: rgb(11.1512195122, 99.1219512195, 242.8487804878);
+}
+`;
+
+const compiled = sass.compileString(scssInput, { style: 'expanded' }).css;
+
+if (compiled.trim() === expectedCSS.trim()) {
+  console.log('✅ PASS: SCSS compilation matches expected CSS.');
+} else {
+  console.log('❌ FAIL: Output differs.');
+  console.log('--- EXPECTED ---');
+  console.log(expectedCSS);
+  console.log('--- ACTUAL ---');
+  console.log(compiled);
+  process.exit(1);
+}


### PR DESCRIPTION
Closes #23094

SCSS Regression Test Tool
A Node.js script that compiles a SCSS snippet and compares the output with the expected raw CSS to catch regressions.

Files added
- submissions/examples/scss-regression-test-v2/demo.html
- submissions/examples/scss-regression-test-v2/style.css
- submissions/examples/scss-regression-test-v2/README.md
- submissions/examples/scss-regression-test-v2/test-scss-regression.js

How it works
- Uses the sass npm package to compile a SCSS input.
- Compares the compiled output with a reference raw CSS string.
- Prints PASS/FAIL and shows diffs on failure.