### PR TITLE
feat: add payment method tile demo

### DIFF
--- a/submissions/examples/payment-method-tile/README.md
+++ b/submissions/examples/payment-method-tile/README.md
@@ -1,0 +1,15 @@
+# Payment tile
+
+Adds a payment method tile with selected-state styling and compact card metadata.
+
+## Features
+
+- Responsive centered status card
+- Badge and metadata styling
+- Hover lift interaction
+- Clean semantic HTML and CSS
+
+## Files
+
+- `demo.html`
+- `style.css`

--- a/submissions/examples/payment-method-tile/demo.html
+++ b/submissions/examples/payment-method-tile/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Payment tile</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell" aria-label="Payment tile example">
+    <article class="status-card">
+      <p class="eyebrow">Checkout</p>
+      <header>
+        <h1>Payment tile</h1>
+        <span>Selected</span>
+      </header>
+      <div class="summary-row">
+        <b></b>
+        <div>
+          <strong>Visa ending 4242</strong>
+          <small>Default billing method</small>
+        </div>
+      </div>
+      <button type="button">Review details</button>
+    </article>
+  </main>
+</body>
+</html>

--- a/submissions/examples/payment-method-tile/style.css
+++ b/submissions/examples/payment-method-tile/style.css
@@ -1,0 +1,106 @@
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  --accent: #2563eb;
+  --page: #eff6ff;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: var(--page);
+  color: #172033;
+  font-family: Arial, sans-serif;
+}
+
+.demo-shell {
+  width: min(92vw, 420px);
+}
+
+.status-card {
+  padding: 28px;
+  border: 1px solid rgba(23, 32, 51, 0.12);
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 20px 48px rgba(23, 32, 51, 0.13);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 20px;
+}
+
+h1 {
+  margin: 0;
+  font-size: 1.62rem;
+}
+
+header span {
+  padding: 5px 10px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 14%, white);
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.summary-row {
+  display: grid;
+  grid-template-columns: 44px 1fr;
+  gap: 14px;
+  align-items: center;
+  padding: 16px;
+  border: 1px solid rgba(23, 32, 51, 0.12);
+  border-radius: 8px;
+  background: #fbfdff;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.summary-row:hover {
+  transform: translateY(-2px);
+  border-color: var(--accent);
+}
+
+.summary-row b {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 8px color-mix(in srgb, var(--accent) 16%, white);
+}
+
+strong {
+  display: block;
+  margin-bottom: 4px;
+}
+
+small {
+  color: #5f6f86;
+}
+
+button {
+  width: 100%;
+  margin-top: 20px;
+  padding: 12px 16px;
+  border: 0;
+  border-radius: 6px;
+  background: var(--accent);
+  color: #ffffff;
+  font-weight: 700;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Description
Adds a payment method tile with selected-state styling and compact card metadata.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have tested the animation/demo locally
- [x] I have added/updated documentation where necessary
- [x] This PR adds a new example under `submissions/examples/payment-method-tile`