### PR TITLE
fix: add missing @keyframes ease-kf-hover-pulse-glow (Issue #10072)

### DIFF
--- a/submissions/examples/fix-hover-pulse-glow-keyframe-uj/README.md
+++ b/submissions/examples/fix-hover-pulse-glow-keyframe-uj/README.md
@@ -1,0 +1,54 @@
+# Fix: Missing `@keyframes ease-kf-hover-pulse-glow`
+
+## What does this do?
+
+Adds the missing `@keyframes ease-kf-hover-pulse-glow` definition that the existing `.ease-hover-pulse-glow:hover` class references but never had — so the hover animation actually runs instead of silently doing nothing.
+
+## How is it used?
+
+Apply the class to any element and hover over it:
+
+```html
+<!-- On a card -->
+<div class="ease-card ease-hover-pulse-glow">
+  Hover me
+</div>
+
+<!-- On a button -->
+<button class="ease-btn ease-btn-primary ease-hover-pulse-glow">
+  Click Me
+</button>
+```
+
+The hover effect combines:
+- A gentle **scale pulse** (1 → 1.06 → 1)
+- A layered **drop-shadow glow** tied to `--ease-color-primary`
+
+The glow uses `filter: drop-shadow()` (not `box-shadow`), so it is **not clipped** by parent `overflow: hidden` containers.
+
+## Why is it useful?
+
+Issue #10072 added the `.ease-hover-pulse-glow` utility class but omitted the corresponding `@keyframes` block. As a result, every element using this class has a silent no-op animation — the browser finds no keyframe named `ease-kf-hover-pulse-glow` and skips the animation entirely.
+
+This fix:
+
+1. **Defines the missing keyframe** with an rgba() fallback for broad browser support, and a `@supports (color: color-mix(...))` block that upgrades the glow to use `--ease-color-primary` dynamically for users with modern browsers.
+
+2. **Removes the conflicting `transition`** on the base class. The original code had both `transition: transform, filter` on `.ease-hover-pulse-glow` and `animation` on `.ease-hover-pulse-glow:hover`. These fight on hover-out — animation fills the end state, but transition tries to animate back from it, causing a visual jump. Removing the transition lets the `animation: forwards` fill behave correctly.
+
+3. **Adds `prefers-reduced-motion` support** so the animation is disabled for users who have requested reduced motion, keeping the component WCAG-compliant.
+
+This fits EaseMotion's philosophy of composable, zero-dependency animation utilities that respect user preferences.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `style.css` | The keyframe definition + fixed base class |
+| `demo.html` | Side-by-side: broken (before) vs fixed (after) |
+| `README.md` | This document |
+
+## Related
+
+- Issue #10072 — original `.ease-hover-pulse-glow` addition (missing keyframe)
+- `core/animations.css` line 1547–1558 — where the fix should be integrated

--- a/submissions/examples/fix-hover-pulse-glow-keyframe-uj/demo.html
+++ b/submissions/examples/fix-hover-pulse-glow-keyframe-uj/demo.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: Missing ease-kf-hover-pulse-glow Keyframe Demo</title>
+
+  <!--
+    Self-contained demo. No server required, no CDN, no external frameworks.
+    All styles are inlined or loaded from style.css in the same folder.
+  -->
+
+  <style>
+    /* ── Design tokens (standalone — no easemotion.css dependency) ── */
+    :root {
+      --ease-color-primary:        #6c63ff;
+      --ease-color-primary-dark:   #4b44cc;
+      --ease-color-bg:             #f8fafc;
+      --ease-color-surface:        #ffffff;
+      --ease-color-text:           #1e293b;
+      --ease-color-muted:          #64748b;
+      --ease-color-neutral-200:    #e2e8f0;
+      --ease-color-neutral-900:    #0f172a;
+      --ease-radius-md:            0.5rem;
+      --ease-radius-lg:            1rem;
+      --ease-font-sans:            system-ui, -apple-system, 'Segoe UI', sans-serif;
+      --ease-shadow-md:            0 4px 6px -1px rgba(0,0,0,0.10), 0 2px 4px -1px rgba(0,0,0,0.06);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --ease-color-bg:       #0b1121;
+        --ease-color-surface:  #141e33;
+        --ease-color-text:     #e2e8f0;
+        --ease-color-muted:    #94a3b8;
+        --ease-color-neutral-200: #334155;
+      }
+    }
+
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: var(--ease-font-sans);
+      background: var(--ease-color-bg);
+      color: var(--ease-color-text);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 2.5rem;
+      padding: 2rem 1rem;
+    }
+
+    .page-header { text-align: center; max-width: 560px; }
+    .page-header h1 { font-size: 1.6rem; font-weight: 700; margin-bottom: 0.5rem; }
+    .page-header p { color: var(--ease-color-muted); font-size: 0.95rem; line-height: 1.6; }
+
+    code {
+      background: rgba(108, 99, 255, 0.1);
+      color: var(--ease-color-primary);
+      padding: 0.1em 0.4em;
+      border-radius: 4px;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85em;
+    }
+
+    .section {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1rem;
+      width: 100%;
+      max-width: 700px;
+    }
+
+    .section-label {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--ease-color-muted);
+    }
+
+    .demo-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 1.25rem;
+      width: 100%;
+    }
+
+    .demo-card {
+      padding: 2rem 1.5rem;
+      text-align: center;
+      border-radius: var(--ease-radius-lg);
+      background: var(--ease-color-surface);
+      border: 1px solid var(--ease-color-neutral-200);
+      box-shadow: var(--ease-shadow-md);
+      font-weight: 600;
+      font-size: 0.95rem;
+      cursor: pointer;
+      user-select: none;
+    }
+
+    .demo-card span {
+      display: block;
+      font-size: 0.75rem;
+      font-weight: 400;
+      color: var(--ease-color-muted);
+      margin-top: 0.4rem;
+    }
+
+    .broken-demo .demo-card:hover {
+      animation: ease-kf-hover-pulse-glow 300ms cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+    }
+
+    .badge {
+      display: inline-block;
+      padding: 0.2rem 0.65rem;
+      border-radius: 9999px;
+      font-size: 0.72rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+    .badge-broken { background: rgba(185,28,28,0.12); color: #b91c1c; }
+    .badge-fixed  { background: rgba(21,128,61,0.12);  color: #15803d; }
+  </style>
+
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>Bug Fix: Missing <code>@keyframes ease-kf-hover-pulse-glow</code></h1>
+    <p>
+      The <code>.ease-hover-pulse-glow:hover</code> class references a keyframe that
+      was never defined. This demo shows the broken state vs the fixed state side by side.
+    </p>
+  </header>
+
+  <section class="section broken-demo">
+    <div style="display:flex;align-items:center;gap:0.5rem;">
+      <span class="badge badge-broken">Before — Broken</span>
+      <span class="section-label">Hover has no effect (keyframe missing)</span>
+    </div>
+    <div class="demo-grid">
+      <div class="demo-card" aria-label="Broken card">Card A<span>No pulse, no glow</span></div>
+      <div class="demo-card" aria-label="Broken card">Card B<span>No pulse, no glow</span></div>
+      <div class="demo-card" aria-label="Broken card">Card C<span>No pulse, no glow</span></div>
+    </div>
+  </section>
+
+  <section class="section">
+    <div style="display:flex;align-items:center;gap:0.5rem;">
+      <span class="badge badge-fixed">After — Fixed</span>
+      <span class="section-label">Hover triggers pulse + glow animation</span>
+    </div>
+    <div class="demo-grid">
+      <div class="demo-card hover-pulse-glow" aria-label="Fixed card">Card A<span>Pulse + glow on hover ✓</span></div>
+      <div class="demo-card hover-pulse-glow" aria-label="Fixed card">Card B<span>Pulse + glow on hover ✓</span></div>
+      <div class="demo-card hover-pulse-glow" aria-label="Fixed card">Card C<span>Pulse + glow on hover ✓</span></div>
+    </div>
+  </section>
+
+  <section class="section">
+    <span class="section-label">Works on any element — here on buttons</span>
+    <div style="display:flex;flex-wrap:wrap;gap:1rem;justify-content:center;">
+      <button class="hover-pulse-glow" style="padding:0.75rem 2rem;border:2px solid var(--ease-color-primary);border-radius:var(--ease-radius-md);background:var(--ease-color-primary);color:#fff;font-weight:600;font-size:0.9rem;cursor:pointer;">Primary Button</button>
+      <button class="hover-pulse-glow" style="padding:0.75rem 2rem;border:2px solid var(--ease-color-primary);border-radius:var(--ease-radius-md);background:transparent;color:var(--ease-color-primary);font-weight:600;font-size:0.9rem;cursor:pointer;">Outline Button</button>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/fix-hover-pulse-glow-keyframe-uj/style.css
+++ b/submissions/examples/fix-hover-pulse-glow-keyframe-uj/style.css
@@ -1,0 +1,93 @@
+/* =============================================================
+   Submission: fix-hover-pulse-glow-keyframe-uj
+   Bug Fix: Missing @keyframes ease-kf-hover-pulse-glow
+
+   The class .ease-hover-pulse-glow:hover (core/animations.css, Issue #10072)
+   references this keyframe, but it was never defined anywhere in the codebase.
+   The browser silently treats the animation as a no-op.
+
+   This submission adds the missing definition. The effect combines:
+     - A gentle scale pulse (1 → 1.06 → 1)
+     - A layered filter glow using drop-shadow (not box-shadow, so it
+       is not clipped by overflow: hidden parent containers)
+
+   The rgba() fallback ensures the effect works in all browsers.
+   The @supports block upgrades to color-mix() where available so the
+   glow automatically follows --ease-color-primary theme changes.
+
+   Also removes the conflicting `transition` from the base class — having
+   both transition and animation on the same properties (transform, filter)
+   causes them to fight on hover-out, leaving a visual jump.
+   ============================================================= */
+
+/* ── Step 1: Define the missing keyframe ─────────────────────── */
+
+@keyframes ease-kf-hover-pulse-glow {
+  0% {
+    transform: scale(1);
+    filter: drop-shadow(0 0 0px rgba(108, 99, 255, 0));
+  }
+
+  50% {
+    transform: scale(1.06);
+    /* Layer 1: tight inner glow   Layer 2: wide ambient glow */
+    filter:
+      drop-shadow(0 0 8px  rgba(108, 99, 255, 0.55))
+      drop-shadow(0 0 20px rgba(108, 99, 255, 0.30));
+  }
+
+  100% {
+    transform: scale(1);
+    filter: drop-shadow(0 0 0px rgba(108, 99, 255, 0));
+  }
+}
+
+/* Progressive enhancement: use color-mix() to tie glow to the theme token */
+@supports (color: color-mix(in srgb, red 50%, transparent)) {
+  @keyframes ease-kf-hover-pulse-glow {
+    0% {
+      transform: scale(1);
+      filter: drop-shadow(0 0 0px transparent);
+    }
+
+    50% {
+      transform: scale(1.06);
+      filter:
+        drop-shadow(0 0 8px  color-mix(in srgb, var(--ease-color-primary, #6c63ff) 55%, transparent))
+        drop-shadow(0 0 20px color-mix(in srgb, var(--ease-color-primary, #6c63ff) 30%, transparent));
+    }
+
+    100% {
+      transform: scale(1);
+      filter: drop-shadow(0 0 0px transparent);
+    }
+  }
+}
+
+/* ── Step 2: Fix the base class ──────────────────────────────── */
+
+/*
+  Remove the conflicting `transition` property.
+  The original class had both `transition: transform, filter` on the base
+  and `animation` on :hover. These fight each other: animation wins on
+  hover-in, but transition fires on hover-out, causing a visual jump.
+  Removing the transition lets `animation: forwards` fill correctly.
+*/
+.hover-pulse-glow {
+  position: relative;
+  z-index: 1;
+  transform-origin: center;
+  /* No transition here — animation handles both in and out states */
+}
+
+.hover-pulse-glow:hover {
+  animation: ease-kf-hover-pulse-glow 300ms cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+/* ── Step 3: Respect prefers-reduced-motion ───────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .hover-pulse-glow:hover {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Summary

This submission fixes **Issue #10072** — the `.ease-hover-pulse-glow:hover` class references `ease-kf-hover-pulse-glow` but the `@keyframes` block was **never defined anywhere** in the codebase. The browser silently skips the animation, making the class a complete no-op.

## Files Added

```
submissions/examples/fix-hover-pulse-glow-keyframe-uj/
├── style.css    ← The missing @keyframes definition
├── demo.html    ← Self-contained before/after demo (no server/CDN required)
└── README.md    ← What / How / Why
```

## What the fix does

1. **Defines `@keyframes ease-kf-hover-pulse-glow`** — a scale pulse (1 → 1.06 → 1) combined with a layered `filter: drop-shadow()` glow. Uses `rgba()` fallback for broad browser support, with a `@supports (color: color-mix(...))` progressive enhancement that ties the glow color to `--ease-color-primary`.

2. **Removes the conflicting `transition`** on the base `.ease-hover-pulse-glow` class — the original had both `transition: transform, filter` and `animation` on `:hover`. These fight on hover-out: animation fills the end state but transition tries to animate back, causing a visual jump. Removing the transition lets `animation: forwards` fill cleanly.

3. **Adds `prefers-reduced-motion` guard** — disables the animation for users who have requested reduced motion (WCAG compliance).

## Demo

Open `demo.html` directly in a browser — no server or build step needed. It shows the broken state (no animation) side-by-side with the fixed state.

## PR Checklist

- [x] Files added only inside `submissions/examples/`
- [x] Includes all three required files: `demo.html`, `style.css`, `README.md`
- [x] `demo.html` works by opening directly in a browser (no server, no CDN)
- [x] One PR focused on one fix
- [x] Unique identifier `-uj` appended to folder name
- [x] No changes to `core/` or `components/`