### PR TITLE
Add warehouse reorder threshold monitor

### DIFF
--- a/submissions/examples/warehouse-reorder-threshold-monitor-ts/README.md
+++ b/submissions/examples/warehouse-reorder-threshold-monitor-ts/README.md
@@ -1,0 +1,21 @@
+# Warehouse Reorder Threshold Monitor
+
+## What does this do?
+
+Watch reorder thresholds by on-hand stock, lead time, supplier, and stockout risk.
+
+## How is it used?
+
+Link `style.css` and use the supplied card markup with tone modifiers:
+
+```html
+<article class="item-card item-card--warn">
+  <span class="status status--warn">Pending</span>
+</article>
+```
+
+Available tone modifiers are `good`, `info`, `warn`, and `bad`.
+
+## Why is it useful?
+
+This adds a responsive CSS-only operational example for issue #25070, with semantic HTML, visible focus states, non-color status labels, animated progress meters, and reduced-motion support.

--- a/submissions/examples/warehouse-reorder-threshold-monitor-ts/demo.html
+++ b/submissions/examples/warehouse-reorder-threshold-monitor-ts/demo.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Warehouse Reorder Threshold Monitor</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="shell">
+    <header class="page-header">
+      <div>
+        <p class="eyebrow">Inventory planning</p>
+        <h1>Warehouse Reorder Threshold Monitor</h1>
+        <p class="intro">Watch reorder thresholds by on-hand stock, lead time, supplier, and stockout risk.</p>
+      </div>
+      <a class="jump-link" href="#workspace">View details</a>
+    </header>
+
+    <section class="metrics" aria-label="Summary metrics">
+      <div class="metric"><span>SKUs watched</span><strong>156</strong></div><div class="metric"><span>Below threshold</span><strong>13</strong></div><div class="metric"><span>Orders placed</span><strong>9</strong></div>
+    </section>
+
+    <section class="workspace" id="workspace" aria-labelledby="workspace-title">
+      <div class="section-heading">
+        <div>
+          <p class="eyebrow">Current view</p>
+          <h2 id="workspace-title">Operational status</h2>
+        </div>
+        <span>Warehouse replenishment</span>
+      </div>
+      <div class="lane-labels" aria-label="Column guide">
+        <span>SKU</span><span>On hand</span><span>Lead time</span><span>Action</span>
+      </div>
+      <div class="card-grid">
+        <article class="item-card item-card--bad">
+          <div class="item-heading">
+            <h2>Thermal labels</h2>
+            <span class="status status--bad">18%</span>
+          </div>
+          <dl class="item-meta">
+            <div><dt>Owner</dt><dd>4 days</dd></div>
+            <div><dt>Update</dt><dd>Reorder now</dd></div>
+          </dl>
+          <div class="meter" role="img" aria-label="Thermal labels progress 18%">
+            <span class="meter-fill meter-fill--18"></span>
+          </div>
+        </article>
+<article class="item-card item-card--warn">
+          <div class="item-heading">
+            <h2>Mailer boxes</h2>
+            <span class="status status--warn">36%</span>
+          </div>
+          <dl class="item-meta">
+            <div><dt>Owner</dt><dd>8 days</dd></div>
+            <div><dt>Update</dt><dd>Supplier quote</dd></div>
+          </dl>
+          <div class="meter" role="img" aria-label="Mailer boxes progress 36%">
+            <span class="meter-fill meter-fill--36"></span>
+          </div>
+        </article>
+<article class="item-card item-card--info">
+          <div class="item-heading">
+            <h2>Tape rolls</h2>
+            <span class="status status--info">58%</span>
+          </div>
+          <dl class="item-meta">
+            <div><dt>Owner</dt><dd>3 days</dd></div>
+            <div><dt>Update</dt><dd>Monitor</dd></div>
+          </dl>
+          <div class="meter" role="img" aria-label="Tape rolls progress 58%">
+            <span class="meter-fill meter-fill--58"></span>
+          </div>
+        </article>
+<article class="item-card item-card--good">
+          <div class="item-heading">
+            <h2>Pallet wrap</h2>
+            <span class="status status--good">82%</span>
+          </div>
+          <dl class="item-meta">
+            <div><dt>Owner</dt><dd>5 days</dd></div>
+            <div><dt>Update</dt><dd>Healthy stock</dd></div>
+          </dl>
+          <div class="meter" role="img" aria-label="Pallet wrap progress 82%">
+            <span class="meter-fill meter-fill--82"></span>
+          </div>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/warehouse-reorder-threshold-monitor-ts/style.css
+++ b/submissions/examples/warehouse-reorder-threshold-monitor-ts/style.css
@@ -1,0 +1,365 @@
+:root {
+  color-scheme: light;
+  --bg: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #667085;
+  --line: #d9e2ef;
+  --good: #15803d;
+  --good-bg: #dcfce7;
+  --info: #2563eb;
+  --info-bg: #dbeafe;
+  --warn: #b45309;
+  --warn-bg: #fef3c7;
+  --bad: #b91c1c;
+  --bad-bg: #fee2e2;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    linear-gradient(140deg, rgba(37, 99, 235, 0.08), transparent 34%),
+    linear-gradient(320deg, rgba(21, 128, 61, 0.08), transparent 36%),
+    var(--bg);
+  color: var(--ink);
+}
+
+.shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 40px 0;
+}
+
+.page-header,
+.workspace,
+.metric,
+.item-card {
+  background: rgba(255, 255, 255, 0.94);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+
+.page-header,
+.workspace {
+  box-shadow: 0 20px 48px rgba(23, 32, 51, 0.08);
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  align-items: center;
+  padding: 28px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--info);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 760px;
+  margin-bottom: 10px;
+  font-size: clamp(2rem, 4vw, 3.4rem);
+  line-height: 1;
+}
+
+.intro {
+  max-width: 700px;
+  margin-bottom: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.jump-link {
+  flex: 0 0 auto;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 10px 16px;
+  color: var(--ink);
+  font-weight: 800;
+  text-decoration: none;
+  transition: transform 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+
+.jump-link:hover,
+.jump-link:focus-visible {
+  background: var(--ink);
+  border-color: var(--ink);
+  color: var(--surface);
+  transform: translateY(-2px);
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin: 18px 0;
+}
+
+.metric {
+  min-height: 104px;
+  padding: 18px;
+}
+
+.metric span,
+.section-heading span,
+.lane-labels span,
+.item-meta dt {
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.metric strong {
+  display: block;
+  margin-top: 8px;
+  font-size: 2rem;
+}
+
+.workspace {
+  padding: 24px;
+}
+
+.section-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: end;
+  margin-bottom: 18px;
+}
+
+.section-heading h2 {
+  margin-bottom: 0;
+  font-size: 1.35rem;
+}
+
+.lane-labels,
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.lane-labels {
+  margin-bottom: 12px;
+}
+
+.lane-labels span {
+  padding: 0 4px;
+}
+
+.item-card {
+  position: relative;
+  overflow: hidden;
+  min-height: 248px;
+  padding: 18px;
+  border-top-width: 5px;
+  transition: transform 220ms ease, border-color 220ms ease, box-shadow 220ms ease;
+}
+
+.item-card::after {
+  position: absolute;
+  inset: auto 16px 16px auto;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  background: currentColor;
+  content: "";
+  opacity: 0.08;
+  transform: scale(0.84);
+  transition: transform 220ms ease, opacity 220ms ease;
+}
+
+.item-card:hover,
+.item-card:focus-within {
+  box-shadow: 0 18px 36px rgba(23, 32, 51, 0.12);
+  transform: translateY(-4px);
+}
+
+.item-card:hover::after,
+.item-card:focus-within::after {
+  opacity: 0.14;
+  transform: scale(1);
+}
+
+.item-card--good {
+  border-top-color: var(--good);
+  color: var(--good);
+}
+
+.item-card--info {
+  border-top-color: var(--info);
+  color: var(--info);
+}
+
+.item-card--warn {
+  border-top-color: var(--warn);
+  color: var(--warn);
+}
+
+.item-card--bad {
+  border-top-color: var(--bad);
+  color: var(--bad);
+}
+
+.item-heading {
+  display: grid;
+  gap: 10px;
+}
+
+.item-heading h2 {
+  margin-bottom: 0;
+  color: var(--ink);
+  font-size: 1.08rem;
+}
+
+.status {
+  width: fit-content;
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.status--good {
+  background: var(--good-bg);
+  color: var(--good);
+}
+
+.status--info {
+  background: var(--info-bg);
+  color: var(--info);
+}
+
+.status--warn {
+  background: var(--warn-bg);
+  color: var(--warn);
+}
+
+.status--bad {
+  background: var(--bad-bg);
+  color: var(--bad);
+}
+
+.item-meta {
+  display: grid;
+  gap: 12px;
+  margin: 22px 0 18px;
+  color: var(--ink);
+}
+
+.item-meta dd {
+  margin: 4px 0 0;
+  color: var(--ink);
+  font-weight: 800;
+}
+
+.meter {
+  height: 10px;
+  overflow: hidden;
+  background: #e8edf5;
+  border-radius: 999px;
+}
+
+.meter span {
+  display: block;
+  height: 100%;
+  background: currentColor;
+  border-radius: inherit;
+  animation: fill-meter 900ms ease both;
+}
+
+.meter-fill--16 { width: 16%; }
+.meter-fill--18 { width: 18%; }
+.meter-fill--19 { width: 19%; }
+.meter-fill--22 { width: 22%; }
+.meter-fill--24 { width: 24%; }
+.meter-fill--28 { width: 28%; }
+.meter-fill--29 { width: 29%; }
+.meter-fill--31 { width: 31%; }
+.meter-fill--36 { width: 36%; }
+.meter-fill--43 { width: 43%; }
+.meter-fill--44 { width: 44%; }
+.meter-fill--45 { width: 45%; }
+.meter-fill--47 { width: 47%; }
+.meter-fill--48 { width: 48%; }
+.meter-fill--52 { width: 52%; }
+.meter-fill--54 { width: 54%; }
+.meter-fill--56 { width: 56%; }
+.meter-fill--58 { width: 58%; }
+.meter-fill--62 { width: 62%; }
+.meter-fill--63 { width: 63%; }
+.meter-fill--64 { width: 64%; }
+.meter-fill--67 { width: 67%; }
+.meter-fill--72 { width: 72%; }
+.meter-fill--74 { width: 74%; }
+.meter-fill--78 { width: 78%; }
+.meter-fill--82 { width: 82%; }
+.meter-fill--84 { width: 84%; }
+.meter-fill--86 { width: 86%; }
+.meter-fill--88 { width: 88%; }
+.meter-fill--91 { width: 91%; }
+.meter-fill--100 { width: 100%; }
+
+@keyframes fill-meter {
+  from {
+    width: 0;
+  }
+}
+
+@media (max-width: 900px) {
+  .lane-labels {
+    display: none;
+  }
+
+  .card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 700px) {
+  .shell {
+    width: min(100% - 20px, 1120px);
+    padding: 20px 0;
+  }
+
+  .page-header,
+  .section-heading {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .metrics,
+  .card-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .jump-link {
+    width: fit-content;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::after {
+    animation-duration: 1ms !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a responsive CSS-only inventory monitor for reorder thresholds, lead times, suppliers, and stockout risk.

Closes #25070

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside submissions/examples/warehouse-reorder-threshold-monitor-ts/
- [x] Includes demo.html, style.css, and README.md
- [x] No changes to core/ or components/
- [x] One feature per PR
- [x] Includes responsive styling and reduced-motion handling

## Validation

- [x] Repository Stylelint configuration passes
- [x] Repository HTMLHint configuration passes
- [x] git diff --check passes
- [x] No JavaScript or external assets