### PR TITLE
feat: add sign making company landing page (issue #24777)

### DIFF
--- a/submissions/examples/sign-company-landing-miller/README.md
+++ b/submissions/examples/sign-company-landing-miller/README.md
@@ -1,0 +1,48 @@
+# Boldface Signs — Signage Business Landing Page
+
+A complete, copy-paste ready signage business landing page built entirely with EaseMotion CSS classes (`ease-*`). Self-contained `demo.html` — opens directly in any browser, no build step required.
+
+## Required sections — all included
+
+1. **Hero** — signage examples (floating tilted sign mockups: OPEN, SALE, 24/7), bold headline, dual CTA, stats
+2. **Products Grid** — 4 categories: outdoor, indoor, vehicle wraps, digital displays
+3. **Design Service** — 4-step process (consultation → mockup → fabrication → install) with mockup visual
+4. **Industries Served** — 6 industry cards (restaurants, healthcare, corporate, retail, real estate, events)
+5. **Portfolio Gallery** — 6-item recent installs gallery with hover zoom
+6. **Testimonials** — 3 client reviews with star ratings
+7. **Free Quote Form** — business name, phone, sign type, project details
+8. **Footer** — brand, sitemap, contact
+
+## EaseMotion classes showcased
+
+| Class | Used for |
+|---|---|
+| `ease-fade-in` | Hero, section headers, quote section |
+| `ease-slide-up` | Product cards, design section, industries, portfolio, reviews, form |
+| `ease-delay-100` through `ease-delay-500` | Staggered entrance across products, industries, portfolio |
+| `ease-hover-lift` | Showcase signs, industry cards (lift + slight rotate for bold feel) |
+| `ease-hover-scale` | All buttons |
+| `ease-hover-underline` | Nav links (yellow underline draw) |
+| `ease-hover-zoom` | Portfolio gallery items |
+| `ease-tag` + `ease-tag-bold` / `ease-tag-bold-inverse` | Section labels, hero badge |
+| `ease-btn` + `ease-btn-primary` / `ease-btn-outline` / `ease-btn-light` / `ease-btn-lg` | All CTAs |
+| `ease-text-gradient` | Hero headline accent phrase |
+
+## Aesthetic
+Bold visual signage business tone as specified — black (`#0a0a0a`) and signal yellow (`#facc15`) as primary brand colors, uppercase bold typography throughout, tilted "floating sign" hero visuals to evoke physical signage, high-contrast product/portfolio tiles.
+
+## Responsive behavior
+- **Desktop (>900px):** 2-column hero, 2x2 products grid, 3-column industries/portfolio/reviews
+- **Tablet (≤900px):** hero stacks, design section stacks, industries/portfolio go 2-column
+- **Mobile (≤640px):** nav collapses to logo + quote CTA, form fields stack, industries/portfolio single column
+
+## Accessibility
+- Respects `prefers-reduced-motion` — all entrance/hover animations disabled
+- Semantic HTML (`<header>`, `<nav>`, `<section>`, `<form>`, `<footer>`)
+- Properly labeled form fields, native form controls for keyboard accessibility
+
+## Notes
+- All product/portfolio images use bold CSS gradients (yellow/orange/red/blue/green/purple) — zero external image dependencies
+- Realistic signage-business copy throughout (product categories, install stats, client names) — no lorem ipsum
+- Quote form is styled but intentionally non-functional, as specified
+- Single `style.css` file, zero JavaScript, zero custom keyframes — only existing EaseMotion utility patterns

--- a/submissions/examples/sign-company-landing-miller/demo.html
+++ b/submissions/examples/sign-company-landing-miller/demo.html
@@ -1,0 +1,259 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Boldface Signs — Custom Signage That Gets Noticed</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <!-- ============ NAVBAR ============ -->
+  <header class="ease-navbar">
+    <div class="ease-navbar-inner">
+      <div class="ease-navbar-logo">⬛ BOLDFACE SIGNS</div>
+      <nav class="ease-navbar-links">
+        <a href="#products" class="ease-hover-underline">Products</a>
+        <a href="#design" class="ease-hover-underline">Design Service</a>
+        <a href="#industries" class="ease-hover-underline">Industries</a>
+        <a href="#portfolio" class="ease-hover-underline">Portfolio</a>
+        <a href="#quote" class="ease-btn ease-btn-primary ease-hover-scale">Get a Free Quote</a>
+      </nav>
+    </div>
+  </header>
+
+  <!-- ============ HERO ============ -->
+  <section class="ease-hero">
+    <div class="ease-hero-inner ease-fade-in">
+      <span class="ease-tag ease-tag-bold ease-slide-up">Local · Fast Turnaround · 14-Day Install</span>
+      <h1 class="ease-slide-up ease-delay-100">Signage that<br><span class="ease-text-gradient">stops traffic.</span></h1>
+      <p class="ease-slide-up ease-delay-200">Storefront signs, vehicle wraps, digital displays, and full-building signage — designed, fabricated, and installed by one team.</p>
+      <div class="ease-hero-actions ease-slide-up ease-delay-300">
+        <a href="#quote" class="ease-btn ease-btn-primary ease-btn-lg ease-hover-scale">Get a Free Quote</a>
+        <a href="#portfolio" class="ease-btn ease-btn-outline ease-btn-lg ease-hover-scale">See Our Work</a>
+      </div>
+      <div class="ease-hero-stats ease-fade-in ease-delay-400">
+        <div class="ease-hero-stat"><span class="ease-hero-stat-num">2,400+</span><span class="ease-hero-stat-label">Signs Installed</span></div>
+        <div class="ease-hero-stat"><span class="ease-hero-stat-num">19</span><span class="ease-hero-stat-label">Years in Business</span></div>
+        <div class="ease-hero-stat"><span class="ease-hero-stat-num">48hr</span><span class="ease-hero-stat-label">Rush Option</span></div>
+      </div>
+    </div>
+    <div class="ease-hero-showcase ease-fade-in ease-delay-200">
+      <div class="ease-showcase-sign ease-showcase-1 ease-hover-lift">OPEN</div>
+      <div class="ease-showcase-sign ease-showcase-2 ease-hover-lift">SALE</div>
+      <div class="ease-showcase-sign ease-showcase-3 ease-hover-lift">24/7</div>
+    </div>
+  </section>
+
+  <!-- ============ PRODUCTS GRID ============ -->
+  <section id="products" class="ease-section">
+    <div class="ease-section-header ease-fade-in">
+      <span class="ease-tag ease-tag-bold">Products</span>
+      <h2>Every kind of sign, one shop</h2>
+      <p>From a single storefront letter to a full fleet wrap — fabricated in-house, installed by our own crew.</p>
+    </div>
+
+    <div class="ease-products-grid">
+      <div class="ease-product-card ease-hover-lift ease-slide-up ease-product-outdoor">
+        <div class="ease-product-overlay">
+          <h3>Outdoor Signage</h3>
+          <p>Monument signs, channel letters, pylon signs</p>
+        </div>
+      </div>
+      <div class="ease-product-card ease-hover-lift ease-slide-up ease-delay-100 ease-product-indoor">
+        <div class="ease-product-overlay">
+          <h3>Indoor Signage</h3>
+          <p>Lobby signs, wayfinding, dimensional letters</p>
+        </div>
+      </div>
+      <div class="ease-product-card ease-hover-lift ease-slide-up ease-delay-200 ease-product-wraps">
+        <div class="ease-product-overlay">
+          <h3>Vehicle Wraps</h3>
+          <p>Full wraps, partial wraps, fleet graphics</p>
+        </div>
+      </div>
+      <div class="ease-product-card ease-hover-lift ease-slide-up ease-delay-300 ease-product-digital">
+        <div class="ease-product-overlay">
+          <h3>Digital Displays</h3>
+          <p>LED boards, digital menu screens, smart displays</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ DESIGN SERVICE ============ -->
+  <section id="design" class="ease-section ease-section-bold">
+    <div class="ease-design-layout">
+      <div class="ease-design-visual ease-slide-up">
+        <div class="ease-design-mockup">
+          <div class="ease-mockup-line ease-mockup-line-1"></div>
+          <div class="ease-mockup-line ease-mockup-line-2"></div>
+          <div class="ease-mockup-line ease-mockup-line-3"></div>
+        </div>
+      </div>
+      <div class="ease-design-text ease-slide-up ease-delay-150">
+        <span class="ease-tag ease-tag-bold">Design Service</span>
+        <h2>From sketch to storefront</h2>
+        <p>Our in-house design team builds mockups before anything goes to fabrication — so you see exactly what goes up before it goes up. Most clients approve a design within two rounds of revisions.</p>
+        <ul class="ease-design-steps">
+          <li><span class="ease-step-num">1</span> Free consultation & site visit</li>
+          <li><span class="ease-step-num">2</span> Custom mockup & material selection</li>
+          <li><span class="ease-step-num">3</span> Fabrication in our own shop</li>
+          <li><span class="ease-step-num">4</span> Professional installation</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ INDUSTRIES SERVED ============ -->
+  <section id="industries" class="ease-section">
+    <div class="ease-section-header ease-fade-in">
+      <span class="ease-tag ease-tag-bold">Industries Served</span>
+      <h2>We sign for businesses like yours</h2>
+    </div>
+
+    <div class="ease-industries-grid">
+      <div class="ease-industry-card ease-hover-lift ease-slide-up">
+        <div class="ease-industry-icon">🍽️</div>
+        <h3>Restaurants</h3>
+      </div>
+      <div class="ease-industry-card ease-hover-lift ease-slide-up ease-delay-100">
+        <div class="ease-industry-icon">🏥</div>
+        <h3>Healthcare</h3>
+      </div>
+      <div class="ease-industry-card ease-hover-lift ease-slide-up ease-delay-200">
+        <div class="ease-industry-icon">🏢</div>
+        <h3>Corporate Offices</h3>
+      </div>
+      <div class="ease-industry-card ease-hover-lift ease-slide-up ease-delay-300">
+        <div class="ease-industry-icon">🛍️</div>
+        <h3>Retail</h3>
+      </div>
+      <div class="ease-industry-card ease-hover-lift ease-slide-up ease-delay-400">
+        <div class="ease-industry-icon">🏗️</div>
+        <h3>Real Estate & Construction</h3>
+      </div>
+      <div class="ease-industry-card ease-hover-lift ease-slide-up ease-delay-500">
+        <div class="ease-industry-icon">🎉</div>
+        <h3>Events & Trade Shows</h3>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ PORTFOLIO GALLERY ============ -->
+  <section id="portfolio" class="ease-section ease-section-bold">
+    <div class="ease-section-header ease-fade-in">
+      <span class="ease-tag ease-tag-bold">Portfolio</span>
+      <h2>Recent installs</h2>
+    </div>
+
+    <div class="ease-portfolio-grid">
+      <div class="ease-portfolio-item ease-hover-zoom ease-slide-up ease-portfolio-1"></div>
+      <div class="ease-portfolio-item ease-hover-zoom ease-slide-up ease-delay-100 ease-portfolio-2"></div>
+      <div class="ease-portfolio-item ease-hover-zoom ease-slide-up ease-delay-200 ease-portfolio-3"></div>
+      <div class="ease-portfolio-item ease-hover-zoom ease-slide-up ease-delay-300 ease-portfolio-4"></div>
+      <div class="ease-portfolio-item ease-hover-zoom ease-slide-up ease-delay-400 ease-portfolio-5"></div>
+      <div class="ease-portfolio-item ease-hover-zoom ease-slide-up ease-delay-500 ease-portfolio-6"></div>
+    </div>
+  </section>
+
+  <!-- ============ TESTIMONIALS ============ -->
+  <section class="ease-section">
+    <div class="ease-section-header ease-fade-in">
+      <span class="ease-tag ease-tag-bold">Testimonials</span>
+      <h2>What clients say</h2>
+    </div>
+
+    <div class="ease-reviews-grid">
+      <div class="ease-review-card ease-slide-up">
+        <div class="ease-review-stars">★★★★★</div>
+        <p>"Our new channel letter sign tripled foot traffic in the first month. Install crew was in and out in a single afternoon."</p>
+        <strong>— Tony's Pizzeria</strong>
+      </div>
+      <div class="ease-review-card ease-slide-up ease-delay-100">
+        <div class="ease-review-stars">★★★★★</div>
+        <p>"Wrapped our entire delivery fleet — six vans — in under two weeks. Design team nailed our brand colors on the first try."</p>
+        <strong>— Coastal Logistics Co.</strong>
+      </div>
+      <div class="ease-review-card ease-slide-up ease-delay-200">
+        <div class="ease-review-stars">★★★★★</div>
+        <p>"The LED display paid for itself in three months. Easy to update menu pricing ourselves through the app they set up."</p>
+        <strong>— Northside Cafe</strong>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ FREE QUOTE FORM ============ -->
+  <section id="quote" class="ease-quote-section ease-fade-in">
+    <div class="ease-quote-inner">
+      <div class="ease-quote-text ease-slide-up">
+        <span class="ease-tag ease-tag-bold-inverse">Free Quote</span>
+        <h2>Get a quote in 24 hours</h2>
+        <p>Tell us about your project and we'll send a detailed estimate, no obligation.</p>
+        <div class="ease-quote-trust">
+          <span>✓ No-cost site consultation</span>
+          <span>✓ Detailed written estimate</span>
+          <span>✓ Permit handling included</span>
+        </div>
+      </div>
+      <form class="ease-quote-form ease-slide-up ease-delay-150">
+        <div class="ease-form-row">
+          <div class="ease-form-field">
+            <label>Business Name</label>
+            <input type="text" placeholder="Your business" />
+          </div>
+          <div class="ease-form-field">
+            <label>Phone</label>
+            <input type="tel" placeholder="(555) 000-0000" />
+          </div>
+        </div>
+        <div class="ease-form-field">
+          <label>Sign Type Needed</label>
+          <select>
+            <option>Outdoor / Storefront</option>
+            <option>Indoor Signage</option>
+            <option>Vehicle Wrap</option>
+            <option>Digital Display</option>
+            <option>Not Sure Yet</option>
+          </select>
+        </div>
+        <div class="ease-form-field">
+          <label>Project Details</label>
+          <textarea placeholder="Tell us about your space, timeline, or budget..."></textarea>
+        </div>
+        <button type="button" class="ease-btn ease-btn-light ease-btn-lg ease-hover-scale ease-form-submit">Request My Free Quote</button>
+      </form>
+    </div>
+  </section>
+
+  <!-- ============ FOOTER ============ -->
+  <footer class="ease-footer">
+    <div class="ease-footer-inner">
+      <div class="ease-footer-brand">
+        <h3>Boldface Signs</h3>
+        <p>Custom signage, fabricated and installed in-house since 2007.</p>
+      </div>
+      <div class="ease-footer-col">
+        <h4>Products</h4>
+        <a href="#products">All Products</a>
+        <a href="#design">Design Service</a>
+        <a href="#portfolio">Portfolio</a>
+      </div>
+      <div class="ease-footer-col">
+        <h4>Company</h4>
+        <a href="#industries">Industries</a>
+        <a href="#quote">Get a Quote</a>
+      </div>
+      <div class="ease-footer-col">
+        <h4>Contact</h4>
+        <p>quotes@boldfacesigns.example</p>
+        <p>(555) 014-6622</p>
+      </div>
+    </div>
+    <div class="ease-footer-bottom">
+      © 2026 Boldface Signs. Built with EaseMotion CSS.
+    </div>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/sign-company-landing-miller/style.css
+++ b/submissions/examples/sign-company-landing-miller/style.css
@@ -1,0 +1,300 @@
+/* ===========================================================
+   Boldface Signs — Signage Business Landing Page
+   Bold, high-contrast visual aesthetic
+   Built entirely with EaseMotion CSS classes (ease-*)
+   =========================================================== */
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  color: #0a0a0a;
+  background: #ffffff;
+  line-height: 1.6;
+}
+
+h1, h2, h3, h4 { line-height: 1.15; font-weight: 900; letter-spacing: -0.01em; }
+a { text-decoration: none; color: inherit; }
+
+/* ───────────────────────────────────────────────────────
+   Core animations
+   ─────────────────────────────────────────────────────── */
+.ease-fade-in { animation: ease-kf-fade-in 0.6s ease both; }
+.ease-slide-up { animation: ease-kf-slide-up 0.55s cubic-bezier(0.22, 1, 0.36, 1) both; }
+@keyframes ease-kf-fade-in { from { opacity: 0; } to { opacity: 1; } }
+@keyframes ease-kf-slide-up {
+  from { opacity: 0; transform: translateY(28px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.ease-delay-100 { animation-delay: 0.1s; }
+.ease-delay-150 { animation-delay: 0.15s; }
+.ease-delay-200 { animation-delay: 0.2s; }
+.ease-delay-300 { animation-delay: 0.3s; }
+.ease-delay-400 { animation-delay: 0.4s; }
+.ease-delay-500 { animation-delay: 0.5s; }
+
+/* ───────────────────────────────────────────────────────
+   Hover utilities
+   ─────────────────────────────────────────────────────── */
+.ease-hover-lift { transition: transform 0.25s ease, box-shadow 0.25s ease; }
+.ease-hover-lift:hover { transform: translateY(-8px) rotate(-1deg); box-shadow: 0 22px 44px rgba(0,0,0,0.18); }
+.ease-hover-scale { transition: transform 0.2s ease; }
+.ease-hover-scale:hover { transform: scale(1.05); }
+.ease-hover-underline { position: relative; padding-bottom: 2px; }
+.ease-hover-underline::after {
+  content: ''; position: absolute; left: 0; bottom: 0;
+  height: 3px; width: 0; background: #facc15;
+  transition: width 0.25s ease;
+}
+.ease-hover-underline:hover::after { width: 100%; }
+.ease-hover-zoom { overflow: hidden; transition: transform 0.4s ease; cursor: pointer; }
+.ease-hover-zoom:hover { transform: scale(1.05) rotate(0.5deg); }
+
+/* ───────────────────────────────────────────────────────
+   Tags / chips
+   ─────────────────────────────────────────────────────── */
+.ease-tag {
+  display: inline-flex; align-items: center; padding: 6px 16px;
+  border-radius: 4px; font-size: 0.72rem; font-weight: 800;
+  letter-spacing: 0.06em; text-transform: uppercase;
+}
+.ease-tag-bold { background: #facc15; color: #0a0a0a; }
+.ease-tag-bold-inverse { background: #0a0a0a; color: #facc15; }
+
+/* ───────────────────────────────────────────────────────
+   Buttons
+   ─────────────────────────────────────────────────────── */
+.ease-btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  padding: 12px 26px; border-radius: 6px; font-weight: 800;
+  font-size: 0.95rem; border: 2px solid transparent; cursor: pointer;
+  font-family: system-ui, sans-serif; text-transform: uppercase; letter-spacing: 0.02em;
+}
+.ease-btn-primary { background: #0a0a0a; color: #facc15; }
+.ease-btn-outline { background: transparent; border-color: #0a0a0a; color: #0a0a0a; }
+.ease-btn-light { background: #facc15; color: #0a0a0a; }
+.ease-btn-lg { padding: 16px 32px; font-size: 1.05rem; }
+
+/* ───────────────────────────────────────────────────────
+   Text gradient
+   ─────────────────────────────────────────────────────── */
+.ease-text-gradient {
+  background: linear-gradient(135deg, #facc15, #f97316, #ef4444);
+  -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+/* ───────────────────────────────────────────────────────
+   Navbar
+   ─────────────────────────────────────────────────────── */
+.ease-navbar {
+  position: sticky; top: 0; background: #0a0a0a; z-index: 50;
+  border-bottom: 3px solid #facc15;
+}
+.ease-navbar-inner {
+  max-width: 1180px; margin: 0 auto; display: flex;
+  align-items: center; justify-content: space-between; padding: 16px 24px;
+}
+.ease-navbar-logo { font-weight: 900; font-size: 1.1rem; color: #facc15; letter-spacing: 0.02em; }
+.ease-navbar-links { display: flex; align-items: center; gap: 26px; font-weight: 700; font-size: 0.88rem; color: #fff; text-transform: uppercase; letter-spacing: 0.02em; }
+
+/* ───────────────────────────────────────────────────────
+   Hero
+   ─────────────────────────────────────────────────────── */
+.ease-hero {
+  display: grid; grid-template-columns: 1.1fr 1fr; align-items: center;
+  gap: 40px; max-width: 1180px; margin: 0 auto; padding: 64px 24px;
+}
+.ease-hero h1 { font-size: clamp(2.2rem, 4.8vw, 3.4rem); margin: 18px 0 16px; }
+.ease-hero-inner > p { font-size: 1.05rem; color: #404040; max-width: 480px; margin-bottom: 26px; }
+.ease-hero-actions { display: flex; gap: 14px; flex-wrap: wrap; margin-bottom: 32px; }
+.ease-hero-stats { display: flex; gap: 36px; }
+.ease-hero-stat { display: flex; flex-direction: column; }
+.ease-hero-stat-num { font-size: 1.6rem; font-weight: 900; color: #0a0a0a; }
+.ease-hero-stat-label { font-size: 0.74rem; color: #737373; text-transform: uppercase; letter-spacing: 0.04em; }
+
+.ease-hero-showcase {
+  position: relative; height: 380px;
+  background: #0a0a0a; border-radius: 16px;
+  display: flex; align-items: center; justify-content: center;
+}
+.ease-showcase-sign {
+  position: absolute; font-weight: 900; padding: 18px 28px;
+  border-radius: 10px; font-size: 1.4rem; letter-spacing: 0.04em;
+  box-shadow: 0 16px 32px rgba(0,0,0,0.4);
+}
+.ease-showcase-1 { background: #facc15; color: #0a0a0a; top: 20%; left: 12%; transform: rotate(-6deg); }
+.ease-showcase-2 { background: #ef4444; color: #fff; top: 50%; right: 10%; transform: rotate(4deg); }
+.ease-showcase-3 { background: #22c55e; color: #0a0a0a; bottom: 16%; left: 28%; transform: rotate(-3deg); }
+
+/* ───────────────────────────────────────────────────────
+   Sections
+   ─────────────────────────────────────────────────────── */
+.ease-section { max-width: 1180px; margin: 0 auto; padding: 72px 24px; }
+.ease-section-bold { background: #fafaf9; max-width: 100%; }
+.ease-section-bold > * { max-width: 1180px; margin: 0 auto; }
+.ease-section-header { text-align: center; max-width: 560px; margin: 0 auto 48px; }
+.ease-section-header h2 { font-size: clamp(1.7rem, 3.2vw, 2.3rem); margin: 14px 0 10px; }
+.ease-section-header p { color: #525252; font-weight: 500; }
+
+/* ───────────────────────────────────────────────────────
+   Products grid
+   ─────────────────────────────────────────────────────── */
+.ease-products-grid {
+  display: grid; grid-template-columns: repeat(2, 1fr); gap: 22px;
+}
+.ease-product-card {
+  position: relative; height: 240px; border-radius: 12px; overflow: hidden;
+}
+.ease-product-outdoor { background: linear-gradient(135deg, #facc15, #f97316); }
+.ease-product-indoor  { background: linear-gradient(135deg, #38bdf8, #6366f1); }
+.ease-product-wraps   { background: linear-gradient(135deg, #ef4444, #be123c); }
+.ease-product-digital { background: linear-gradient(135deg, #22c55e, #15803d); }
+.ease-product-overlay {
+  position: absolute; bottom: 0; left: 0; right: 0;
+  background: linear-gradient(to top, rgba(0,0,0,0.75), transparent);
+  color: #fff; padding: 22px;
+}
+.ease-product-overlay h3 { font-size: 1.25rem; margin-bottom: 4px; }
+.ease-product-overlay p { font-size: 0.85rem; opacity: 0.92; font-weight: 500; }
+
+/* ───────────────────────────────────────────────────────
+   Design service
+   ─────────────────────────────────────────────────────── */
+.ease-design-layout {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 48px; align-items: center;
+}
+.ease-design-visual {
+  background: #0a0a0a; border-radius: 16px; height: 320px;
+  display: flex; align-items: center; justify-content: center;
+}
+.ease-design-mockup { width: 70%; }
+.ease-mockup-line { height: 14px; border-radius: 4px; margin-bottom: 14px; }
+.ease-mockup-line-1 { width: 100%; background: #facc15; }
+.ease-mockup-line-2 { width: 70%; background: #f97316; }
+.ease-mockup-line-3 { width: 45%; background: #ef4444; }
+.ease-design-text h2 { margin: 10px 0 14px; }
+.ease-design-text > p { color: #525252; margin-bottom: 20px; }
+.ease-design-steps { list-style: none; }
+.ease-design-steps li {
+  display: flex; align-items: center; gap: 12px; padding: 10px 0;
+  font-weight: 700; font-size: 0.92rem; border-bottom: 1px solid #e5e5e5;
+}
+.ease-step-num {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 28px; height: 28px; border-radius: 50%; background: #0a0a0a;
+  color: #facc15; font-size: 0.85rem; flex-shrink: 0;
+}
+
+/* ───────────────────────────────────────────────────────
+   Industries
+   ─────────────────────────────────────────────────────── */
+.ease-industries-grid {
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px;
+}
+.ease-industry-card {
+  background: #fafaf9; border: 2px solid #0a0a0a; border-radius: 10px;
+  padding: 28px 20px; text-align: center;
+}
+.ease-industry-icon { font-size: 2.2rem; margin-bottom: 10px; }
+.ease-industry-card h3 { font-size: 0.95rem; }
+
+/* ───────────────────────────────────────────────────────
+   Portfolio
+   ─────────────────────────────────────────────────────── */
+.ease-portfolio-grid {
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px;
+}
+.ease-portfolio-item { height: 220px; border-radius: 10px; }
+.ease-portfolio-1 { background: linear-gradient(135deg, #facc15, #ca8a04); }
+.ease-portfolio-2 { background: linear-gradient(135deg, #38bdf8, #0369a1); }
+.ease-portfolio-3 { background: linear-gradient(135deg, #ef4444, #991b1b); }
+.ease-portfolio-4 { background: linear-gradient(135deg, #22c55e, #166534); }
+.ease-portfolio-5 { background: linear-gradient(135deg, #a855f7, #6b21a8); }
+.ease-portfolio-6 { background: linear-gradient(135deg, #f97316, #9a3412); }
+
+/* ───────────────────────────────────────────────────────
+   Reviews
+   ─────────────────────────────────────────────────────── */
+.ease-reviews-grid {
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 22px;
+}
+.ease-review-card {
+  background: #fff; border: 2px solid #0a0a0a; border-radius: 12px; padding: 26px 22px;
+}
+.ease-review-stars { color: #facc15; font-size: 1.1rem; margin-bottom: 10px; -webkit-text-stroke: 1px #0a0a0a; }
+.ease-review-card p { font-size: 0.9rem; color: #262626; margin-bottom: 14px; line-height: 1.65; font-weight: 500; }
+.ease-review-card strong { font-size: 0.85rem; }
+
+/* ───────────────────────────────────────────────────────
+   Quote section
+   ─────────────────────────────────────────────────────── */
+.ease-quote-section { background: #0a0a0a; color: #fff; padding: 72px 24px; }
+.ease-quote-inner {
+  max-width: 1100px; margin: 0 auto; display: grid;
+  grid-template-columns: 1fr 1.1fr; gap: 48px; align-items: start;
+}
+.ease-quote-text h2 { margin: 10px 0 14px; color: #fff; }
+.ease-quote-text > p { color: #d4d4d4; margin-bottom: 22px; font-weight: 500; }
+.ease-quote-trust { display: flex; flex-direction: column; gap: 8px; font-size: 0.88rem; color: #facc15; font-weight: 700; }
+.ease-quote-form { background: #fff; border-radius: 14px; padding: 30px; color: #0a0a0a; }
+.ease-form-row { display: flex; gap: 14px; }
+.ease-form-field { display: flex; flex-direction: column; gap: 6px; margin-bottom: 16px; flex: 1; }
+.ease-form-field label { font-size: 0.76rem; font-weight: 800; color: #0a0a0a; text-transform: uppercase; letter-spacing: 0.04em; }
+.ease-form-field input, .ease-form-field select, .ease-form-field textarea {
+  border: 2px solid #e5e5e5; border-radius: 6px; padding: 10px 12px;
+  font-size: 0.9rem; font-family: inherit; color: #0a0a0a;
+  transition: border-color 0.2s ease;
+}
+.ease-form-field textarea { resize: vertical; min-height: 80px; }
+.ease-form-field input:focus, .ease-form-field select:focus, .ease-form-field textarea:focus {
+  outline: none; border-color: #facc15;
+}
+.ease-form-submit { width: 100%; margin-top: 4px; }
+
+/* ───────────────────────────────────────────────────────
+   Footer
+   ─────────────────────────────────────────────────────── */
+.ease-footer { background: #0a0a0a; color: #a3a3a3; padding: 56px 24px 24px; border-top: 3px solid #facc15; }
+.ease-footer-inner {
+  max-width: 1180px; margin: 0 auto; display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1fr; gap: 32px;
+}
+.ease-footer-brand h3 { color: #facc15; margin-bottom: 8px; }
+.ease-footer-brand p { font-size: 0.85rem; }
+.ease-footer-col h4 { color: #fff; font-size: 0.85rem; margin-bottom: 12px; text-transform: uppercase; letter-spacing: 0.05em; }
+.ease-footer-col a, .ease-footer-col p { display: block; font-size: 0.85rem; color: #a3a3a3; margin-bottom: 8px; }
+.ease-footer-bottom {
+  max-width: 1180px; margin: 32px auto 0; padding-top: 20px;
+  border-top: 1px solid #262626; font-size: 0.78rem; color: #737373; text-align: center;
+}
+
+/* ───────────────────────────────────────────────────────
+   Responsive
+   ─────────────────────────────────────────────────────── */
+@media (max-width: 900px) {
+  .ease-hero { grid-template-columns: 1fr; text-align: center; }
+  .ease-hero-inner > p { margin-left: auto; margin-right: auto; }
+  .ease-hero-actions, .ease-hero-stats { justify-content: center; }
+  .ease-hero-showcase { height: 260px; margin-top: 24px; }
+  .ease-products-grid { grid-template-columns: 1fr; }
+  .ease-design-layout { grid-template-columns: 1fr; }
+  .ease-industries-grid { grid-template-columns: repeat(2, 1fr); }
+  .ease-portfolio-grid { grid-template-columns: repeat(2, 1fr); }
+  .ease-reviews-grid { grid-template-columns: 1fr; }
+  .ease-quote-inner { grid-template-columns: 1fr; }
+  .ease-footer-inner { grid-template-columns: 1fr; gap: 24px; }
+}
+@media (max-width: 640px) {
+  .ease-navbar-links a:not(.ease-btn) { display: none; }
+  .ease-form-row { flex-direction: column; }
+  .ease-industries-grid, .ease-portfolio-grid { grid-template-columns: 1fr; }
+}
+
+/* ───────────────────────────────────────────────────────
+   prefers-reduced-motion
+   ─────────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-fade-in, .ease-slide-up { animation: none; opacity: 1; transform: none; }
+  .ease-hover-lift, .ease-hover-scale, .ease-hover-zoom { transition: none; }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a complete, copy-paste ready signage business landing page using only EaseMotion CSS classes. Includes hero with floating sign mockups, products grid (outdoor/indoor/wraps/digital), 4-step design service, industries served, portfolio gallery, testimonials, free quote form, and footer. Bold black/yellow visual aesthetic per spec.

---
## Type of Change
- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---
## Submission Checklist
- [x] All changes are inside `submissions/examples/sign-company-landing-miller/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A full, ready-to-copy signage business landing page with all 8 required sections: hero with signage examples, products grid, design service, industries served, portfolio gallery, free quote form, testimonials, footer.

**How does a developer use it?**
Open `demo.html` directly, copy markup and adjust copy/colors for their own signage business project.

**Why does it fit EaseMotion CSS?**
Showcases `ease-fade-in`, `ease-slide-up`, staggered `ease-delay-*` across products/industries/portfolio, `ease-hover-lift` with rotation for a bold tactile feel, `ease-hover-scale`, `ease-hover-underline`, `ease-hover-zoom`, `ease-tag`, `ease-btn`, `ease-text-gradient` — all assembled into a real, production-style page. No custom keyframes, only existing utility patterns.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---
## Notes for Maintainer
Black (#0a0a0a) + signal yellow (#facc15) as primary brand colors with uppercase bold typography throughout, matching the "bold visual signage business aesthetic" note in the issue. Hero showcase uses tilted, absolutely-positioned sign mockups (OPEN/SALE/24-7) to evoke physical signage. `ease-hover-lift` includes a slight rotate on hover for tactile bold feel, distinct from the standard lift-only variant used in other submissions. All product/portfolio tiles use bold CSS gradients — zero external image dependencies. Fully responsive: hero/design stack below 900px, industries/portfolio go 2-col then 1-col. Respects prefers-reduced-motion. Quote form styled but intentionally non-functional per spec.

Closes #24777