### PR TITLE
submission: fix validator whitelist allowing top-level file changes (issue #11994)

### DIFF
--- a/submissions/core_changes-issue-11994/README.md
+++ b/submissions/core_changes-issue-11994/README.md
@@ -1,0 +1,52 @@
+# Submission Validator: Reject top-level docs, README, LICENSE, package.json, and bundle files
+
+## What does this fix?
+
+The PR submission validator at `.github/workflows/submission-validator.yml` has a whitelist that exempts `README.md`, `LICENSE`, `package.json`, `easemotion.css`, and `easemotion.min.css` from the "Core Framework Protection" check. This allows contributor PRs to modify these top-level files without triggering a validation failure, which contradicts the documented submission-only policy.
+
+## Root Cause
+
+In the validator script (lines 127–133), the following condition skips the core-files check for five top-level files:
+
+```javascript
+if (
+  filename !== 'README.md' &&
+  filename !== 'LICENSE' &&
+  filename !== 'package.json' &&
+  filename !== 'easemotion.css' &&
+  filename !== 'easemotion.min.css'
+) {
+  coreFiles.push(filename);
+}
+```
+
+This means PRs that modify `README.md`, `LICENSE`, `package.json`, `easemotion.css`, or `easemotion.min.css` at the repository root are **not** flagged as core framework violations.
+
+## Proposed Fix
+
+Remove the whitelist so that **every** file outside `submissions/` is treated as a core framework file by default. For maintainer-led changes, the `main` branch or privileged workflows can bypass this check — but for contributor PRs (`pull_request_target`), the validator should reject any non-submission change.
+
+### Modified code (in `.github/workflows/submission-validator.yml`)
+
+Replace lines 127–133 with:
+
+```javascript
+} else {
+  // ALL files outside submissions/ are treated as core files
+  coreFiles.push(filename);
+}
+```
+
+This tightens the validator to match the documented policy: contributors may only modify files inside `submissions/`.
+
+## Alternative Approach Considered
+
+An alternative would be to update CONTRIBUTING.md to document which non-submission files are explicitly allowed. However, this weakens the policy and creates confusion. **Option A** (removing the whitelist) is the recommended fix.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `.github/workflows/submission-validator.yml` | Remove 5-line whitelist on lines 127–133, making `coreFiles.push(filename)` unconditional for non-submission files |
+
+Fixes #11994

--- a/submissions/core_changes-issue-11994/demo.html
+++ b/submissions/core_changes-issue-11994/demo.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Validator Whitelist Fix — Demo #11994</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #0f172a;
+      color: #f1f5f9;
+      min-height: 100vh;
+      padding: 3rem 1.5rem;
+    }
+    .container { max-width: 900px; margin: 0 auto; }
+    h1 {
+      font-size: clamp(1.75rem, 4vw, 2.75rem);
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      margin-bottom: 0.75rem;
+    }
+    .subtitle {
+      color: #94a3b8;
+      font-size: 1rem;
+      margin-bottom: 2.5rem;
+    }
+    .issue-badge {
+      display: inline-block;
+      background: #6c63ff;
+      color: #fff;
+      font-size: 0.75rem;
+      font-weight: 600;
+      padding: 0.35em 0.9em;
+      border-radius: 999px;
+      margin-bottom: 1rem;
+    }
+    section {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 0.75rem;
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+    section h2 {
+      font-size: 1.1rem;
+      font-weight: 600;
+      margin-bottom: 1rem;
+      color: #6c63ff;
+    }
+    .bad {
+      background: rgba(239, 68, 68, 0.1);
+      border-color: #ef4444;
+    }
+    .bad h2 { color: #ef4444; }
+    .good {
+      background: rgba(34, 197, 94, 0.1);
+      border-color: #22c55e;
+    }
+    .good h2 { color: #22c55e; }
+    code {
+      background: #0f172a;
+      padding: 0.2em 0.5em;
+      border-radius: 0.375rem;
+      font-size: 0.85em;
+      color: #e2e8f0;
+    }
+    pre {
+      background: #0f172a;
+      padding: 1rem;
+      border-radius: 0.5rem;
+      overflow-x: auto;
+      font-size: 0.8rem;
+      line-height: 1.6;
+      margin-top: 0.75rem;
+    }
+    .file-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 0.75rem;
+    }
+    .file-table th, .file-table td {
+      text-align: left;
+      padding: 0.5rem 0.75rem;
+      border-bottom: 1px solid #334155;
+      font-size: 0.85rem;
+    }
+    .file-table th {
+      color: #94a3b8;
+      font-weight: 600;
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    .allowed { color: #22c55e; }
+    .blocked { color: #ef4444; }
+    .whitelisted-bug { color: #f59e0b; }
+    .footer {
+      text-align: center;
+      margin-top: 3rem;
+      color: #64748b;
+      font-size: 0.8rem;
+    }
+    .footer a { color: #6c63ff; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <span class="issue-badge">Issue #11994</span>
+    <h1>Submission Validator Whitelist Bug</h1>
+    <p class="subtitle">
+      The validator currently allows top-level file changes despite the submission-only policy.
+      This demo shows which files are wrongly permitted and how the fix resolves it.
+    </p>
+
+    <section>
+      <h2>Current Behavior (Broken)</h2>
+      <p>
+        The validator explicitly whitelists these 5 files — changes to them are
+        <strong class="whitelisted-bug">not rejected</strong>, violating the policy:
+      </p>
+      <table class="file-table">
+        <thead>
+          <tr><th>File</th><th>Currently</th><th>Should Be</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>README.md</code></td><td class="whitelisted-bug"> Allowed (bug)</td><td class="blocked">Blocked</td></tr>
+          <tr><td><code>LICENSE</code></td><td class="whitelisted-bug"> Allowed (bug)</td><td class="blocked">Blocked</td></tr>
+          <tr><td><code>package.json</code></td><td class="whitelisted-bug"> Allowed (bug)</td><td class="blocked">Blocked</td></tr>
+          <tr><td><code>easemotion.css</code></td><td class="whitelisted-bug"> Allowed (bug)</td><td class="blocked">Blocked</td></tr>
+          <tr><td><code>easemotion.min.css</code></td><td class="whitelisted-bug"> Allowed (bug)</td><td class="blocked">Blocked</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Root Cause (validator lines 127–133)</h2>
+      <pre>} else {
+  if (
+    filename !== 'README.md' &amp;&amp;
+    filename !== 'LICENSE' &amp;&amp;
+    filename !== 'package.json' &amp;&amp;
+    filename !== 'easemotion.css' &amp;&amp;
+    filename !== 'easemotion.min.css'
+  ) {
+    coreFiles.push(filename);  // only these are rejected
+  }
+  // the 5 whitelisted files fall through silently
+}</pre>
+      <p>These 5 files <strong>skip</strong> the <code>coreFiles</code> check entirely.</p>
+    </section>
+
+    <section class="good">
+      <h2>Proposed Fix</h2>
+      <p>Remove the whitelist condition — reject ALL non-submission files:</p>
+      <pre>} else {
+  // ALL files outside submissions/ are core violations
+  coreFiles.push(filename);
+}</pre>
+      <table class="file-table">
+        <thead>
+          <tr><th>File</th><th>After Fix</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>submissions/examples/my-feature/demo.html</code></td><td class="allowed"> Allowed</td></tr>
+          <tr><td><code>submissions/examples/my-feature/style.css</code></td><td class="allowed"> Allowed</td></tr>
+          <tr><td><code>submissions/examples/my-feature/README.md</code></td><td class="allowed"> Allowed</td></tr>
+          <tr><td><code>README.md</code> (root)</td><td class="blocked"> Rejected</td></tr>
+          <tr><td><code>LICENSE</code></td><td class="blocked"> Rejected</td></tr>
+          <tr><td><code>package.json</code></td><td class="blocked"> Rejected</td></tr>
+          <tr><td><code>easemotion.css</code></td><td class="blocked"> Rejected</td></tr>
+          <tr><td><code>easemotion.min.css</code></td><td class="blocked"> Rejected</td></tr>
+          <tr><td><code>docs/anything.md</code> (root)</td><td class="blocked"> Rejected</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>What stays the same</h2>
+      <ul style="list-style: none; display: flex; flex-direction: column; gap: 0.5rem;">
+        <li> PRs with only <code>submissions/</code> changes still pass normally</li>
+        <li> Existing file modification and deletion checks remain unchanged</li>
+        <li> All per-folder quality checks (demo.html, style.css, README.md) remain unchanged</li>
+        <li> Maintainers can still push directly to <code>main</code> — this only affects PRs</li>
+      </ul>
+    </section>
+
+    <div class="footer">
+      Submission for <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/11994">#11994</a>
+      — EaseMotion CSS
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/core_changes-issue-11994/style.css
+++ b/submissions/core_changes-issue-11994/style.css
@@ -1,0 +1,51 @@
+/* ============================================================
+   Submission Validator Whitelist Fix
+   Proposed change for .github/workflows/submission-validator.yml
+   Issue #11994 — removes top-level file exemptions
+   ============================================================
+
+   ## Problem (current code in validator, lines 127–133)
+
+   The following whitelist allows README.md, LICENSE, package.json,
+   easemotion.css, and easemotion.min.css to bypass the core-files
+   protection check:
+
+   } else {
+     if (
+       filename !== 'README.md' &&
+       filename !== 'LICENSE' &&
+       filename !== 'package.json' &&
+       filename !== 'easemotion.css' &&
+       filename !== 'easemotion.min.css'
+     ) {
+       coreFiles.push(filename);
+     }
+   }
+
+   ## Fix (proposed replacement)
+
+   Remove the whitelist so ALL files outside submissions/ are rejected:
+
+   } else {
+     // Reject ALL non-submission files for contributor PRs
+     coreFiles.push(filename);
+   }
+
+   ## Why this matters
+
+   Without this fix, a contributor PR can:
+   - Modify the root README.md to insert unrelated content
+   - Change LICENSE, package.json, easemotion.css, or easemotion.min.css
+   - Edit top-level docs/ files without being flagged
+
+   This violates the repository policy documented in CONTRIBUTING.md
+   which states that only submissions/ changes are permitted.
+*/
+
+/* This file serves as a patch document for the validator workflow.
+   The actual change is to .github/workflows/submission-validator.yml
+   — remove the 5-line whitelist condition on lines 127–133.
+
+   No CSS changes are needed; this file is submitted to satisfy the
+   required file structure for core_changes submissions.
+ */


### PR DESCRIPTION
## ✦ Description

The submission validator at `.github/workflows/submission-validator.yml` allows contributor PRs to modify top-level files (`README.md`, `LICENSE`, `package.json`, `easemotion.css`, `easemotion.min.css`) without triggering validation failures. The validator currently has a whitelist that exempts these 5 files from the "Core Framework Protection" check, contradicting the repository submission-only policy documented in CONTRIBUTING.md.

The fix removes this whitelist so that **ALL files outside `submissions/`** are treated as core framework violations for contributor PRs.

Fixes #11994

---

## ⟡ Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (non-breaking change to docs)

---

## ✦ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have verified that my changes work correctly

---

## ⟡ Root Cause

In `.github/workflows/submission-validator.yml` (lines 127–133), the validator exempts 5 top-level files:

```javascript
if (
  filename !== 'README.md' &&
  filename !== 'LICENSE' &&
  filename !== 'package.json' &&
  filename !== 'easemotion.css' &&
  filename !== 'easemotion.min.css'
) {
  coreFiles.push(filename);
}
```

This allows PRs to modify these files without being flagged.

## Changes Made

- Added `submissions/core_changes-issue-11994/README.md` — documents issue, root cause, and proposed fix
- Added `submissions/core_changes-issue-11994/style.css` — contains the proposed modified validator code
- Added `submissions/core_changes-issue-11994/demo.html` — visual comparison of current vs fixed behavior

**Proposed fix for maintainer**: Remove the 5-line whitelist condition, making `coreFiles.push(filename)` unconditional for all non-submission files.

---

## Additional Notes
- Branch: `core_changes-issue-11994`
- Only touches files inside `submissions/` — no core files modified