### PR TITLE
submission: fix validator whitelist allowing top-level file changes (issue #11994)

### DIFF
--- a/submissions/examples/validator-whitelist-fix/README.md
+++ b/submissions/examples/validator-whitelist-fix/README.md
@@ -1,0 +1,43 @@
+# Submission Validator: Remove top-level file whitelist
+
+## What does this fix?
+
+The PR submission validator at `.github/workflows/submission-validator.yml` has a whitelist that exempts `README.md`, `LICENSE`, `package.json`, `easemotion.css`, and `easemotion.min.css` from the "Core Framework Protection" check. This allows contributor PRs to modify these top-level files without triggering a validation failure, which contradicts the documented submission-only policy.
+
+## Root Cause
+
+In the validator script (lines 160–166), the following condition skips the core-files check for five top-level files:
+
+```javascript
+} else {
+  if (
+    filename !== 'README.md' &&
+    filename !== 'LICENSE' &&
+    filename !== 'package.json' &&
+    filename !== 'easemotion.css' &&
+    filename !== 'easemotion.min.css'
+  ) {
+    coreFiles.push(filename);
+  }
+}
+```
+
+This means PRs that modify `README.md`, `LICENSE`, `package.json`, `easemotion.css`, or `easemotion.min.css` at the repository root are **not** flagged as core framework violations.
+
+## Proposed Fix
+
+Remove the whitelist so that **every** file outside `submissions/` is treated as a core framework file. Replace lines 160–168 with:
+
+```javascript
+} else {
+  coreFiles.push(filename);
+}
+```
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.github/workflows/submission-validator.yml:160-168` | Remove the 5-line whitelist condition, making `coreFiles.push(filename)` unconditional for all non-submission files |
+
+Fixes #11994

--- a/submissions/examples/validator-whitelist-fix/demo.html
+++ b/submissions/examples/validator-whitelist-fix/demo.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Validator Whitelist Fix — #11994</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #0f172a;
+      color: #f1f5f9;
+      min-height: 100vh;
+      padding: 3rem 1.5rem;
+    }
+    .container { max-width: 900px; margin: 0 auto; }
+    h1 { font-size: clamp(1.75rem, 4vw, 2.75rem); font-weight: 700; margin-bottom: 0.75rem; }
+    .subtitle { color: #94a3b8; font-size: 1rem; margin-bottom: 2.5rem; }
+    .issue-badge { display: inline-block; background: #6c63ff; color: #fff; font-size: 0.75rem; font-weight: 600; padding: 0.35em 0.9em; border-radius: 999px; margin-bottom: 1rem; }
+    section { background: #1e293b; border: 1px solid #334155; border-radius: 0.75rem; padding: 1.5rem; margin-bottom: 1.5rem; }
+    section h2 { font-size: 1.1rem; font-weight: 600; margin-bottom: 1rem; color: #6c63ff; }
+    .bad { background: rgba(239,68,68,0.1); border-color: #ef4444; }
+    .bad h2 { color: #ef4444; }
+    .good { background: rgba(34,197,94,0.1); border-color: #22c55e; }
+    .good h2 { color: #22c55e; }
+    code { background: #0f172a; padding: 0.2em 0.5em; border-radius: 0.375rem; font-size: 0.85em; color: #e2e8f0; }
+    pre { background: #0f172a; padding: 1rem; border-radius: 0.5rem; overflow-x: auto; font-size: 0.8rem; line-height: 1.6; margin-top: 0.75rem; }
+    .file-table { width: 100%; border-collapse: collapse; margin-top: 0.75rem; }
+    .file-table th, .file-table td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #334155; font-size: 0.85rem; }
+    .file-table th { color: #94a3b8; font-weight: 600; font-size: 0.75rem; text-transform: uppercase; }
+    .allowed { color: #22c55e; }
+    .blocked { color: #ef4444; }
+    .bug { color: #f59e0b; }
+    .footer { text-align: center; margin-top: 3rem; color: #64748b; font-size: 0.8rem; }
+    .footer a { color: #6c63ff; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <span class="issue-badge">Issue #11994</span>
+    <h1>Submission Validator Whitelist Bug</h1>
+    <p class="subtitle">The validator whitelists 5 top-level files — they bypass the core-files check.</p>
+
+    <section class="bad">
+      <h2>Current Behavior (Bug)</h2>
+      <table class="file-table">
+        <thead><tr><th>File</th><th>Status</th></tr></thead>
+        <tbody>
+          <tr><td><code>README.md</code> (root)</td><td class="bug"> Allowed (bug)</td></tr>
+          <tr><td><code>LICENSE</code></td><td class="bug"> Allowed (bug)</td></tr>
+          <tr><td><code>package.json</code></td><td class="bug"> Allowed (bug)</td></tr>
+          <tr><td><code>easemotion.css</code></td><td class="bug"> Allowed (bug)</td></tr>
+          <tr><td><code>easemotion.min.css</code></td><td class="bug"> Allowed (bug)</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Root Cause (lines 160–166)</h2>
+      <pre>} else {
+  if (
+    filename !== 'README.md' &amp;&amp;
+    filename !== 'LICENSE' &amp;&amp;
+    filename !== 'package.json' &amp;&amp;
+    filename !== 'easemotion.css' &amp;&amp;
+    filename !== 'easemotion.min.css'
+  ) {
+    coreFiles.push(filename);
+  }
+}</pre>
+    </section>
+
+    <section class="good">
+      <h2>Proposed Fix</h2>
+      <pre>} else {
+  coreFiles.push(filename);
+}</pre>
+      <table class="file-table">
+        <thead><tr><th>Scope</th><th>After Fix</th></tr></thead>
+        <tbody>
+          <tr><td><code>submissions/examples/*</code></td><td class="allowed"> Allowed</td></tr>
+          <tr><td><code>README.md</code> (root)</td><td class="blocked"> Blocked</td></tr>
+          <tr><td><code>LICENSE</code></td><td class="blocked"> Blocked</td></tr>
+          <tr><td><code>package.json</code></td><td class="blocked"> Blocked</td></tr>
+          <tr><td><code>easemotion.css</code></td><td class="blocked"> Blocked</td></tr>
+          <tr><td><code>easemotion.min.css</code></td><td class="blocked"> Blocked</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <div class="footer">
+      Submission for <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/11994">#11994</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/validator-whitelist-fix/style.css
+++ b/submissions/examples/validator-whitelist-fix/style.css
@@ -1,0 +1,33 @@
+/* ============================================================
+   Submission Validator Whitelist Fix
+   Proposed change for .github/workflows/submission-validator.yml
+   Issue #11994 — removes top-level file exemptions
+   ============================================================
+
+   ## Problem (current code in validator, lines 160-166)
+
+   } else {
+     if (
+       filename !== 'README.md' &&
+       filename !== 'LICENSE' &&
+       filename !== 'package.json' &&
+       filename !== 'easemotion.css' &&
+       filename !== 'easemotion.min.css'
+     ) {
+       coreFiles.push(filename);
+     }
+   }
+
+   ## Fix (proposed replacement)
+
+   } else {
+     coreFiles.push(filename);
+   }
+
+   ## Why this matters
+
+   Without this fix, a contributor PR can modify README.md, LICENSE,
+   package.json, easemotion.css, or easemotion.min.css at the root
+   level without triggering validation failure, violating the
+   submission-only policy stated in CONTRIBUTING.md.
+*/


### PR DESCRIPTION
## ✦ Description

The submission validator at `.github/workflows/submission-validator.yml` allows contributor PRs to modify top-level files (`README.md`, `LICENSE`, `package.json`, `easemotion.css`, `easemotion.min.css`) without triggering validation failures. The validator currently has a whitelist that exempts these 5 files from the "Core Framework Protection" check, contradicting the repository submission-only policy documented in CONTRIBUTING.md.

The fix removes this whitelist so that **ALL files outside `submissions/`** are treated as core framework violations for contributor PRs.

Fixes #11994

---

## ⟡ Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (non-breaking change to docs)

---

## ✦ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have verified that my changes work correctly

---

## ⟡ Root Cause

In `.github/workflows/submission-validator.yml` (lines 160–166), the validator exempts 5 top-level files:

```javascript
if (
  filename !== 'README.md' &&
  filename !== 'LICENSE' &&
  filename !== 'package.json' &&
  filename !== 'easemotion.css' &&
  filename !== 'easemotion.min.css'
) {
  coreFiles.push(filename);
}
```

## Changes Made

- Added `submissions/examples/validator-whitelist-fix/README.md` — documents issue, root cause, and proposed fix
- Added `submissions/examples/validator-whitelist-fix/style.css` — contains the proposed modified validator code
- Added `submissions/examples/validator-whitelist-fix/demo.html` — visual comparison of current vs fixed behavior

**Proposed fix for maintainer**: Remove the 5-line whitelist condition, making `coreFiles.push(filename)` unconditional for all non-submission files.

---

## Additional Notes
- Branch: `fix/validator-whitelist-11994`
- Only touches files inside `submissions/examples/` — no core files modified