### PR TITLE
submission: add ease-star-rating star rating component (issue #25558)

### DIFF
--- a/submissions/examples/ease-star-rating/README.md
+++ b/submissions/examples/ease-star-rating/README.md
@@ -1,0 +1,84 @@
+# ease-star-rating
+
+## What does this do?
+
+Provides a **star rating** component for displaying and collecting ratings. Supports 1-5 star display, half-stars, interactive click-to-rate, size variants, color themes, and animated entrance (bounce/zoom).
+
+## How is it used?
+
+```html
+<div class="ease-rating">
+  <span class="ease-star ease-star-filled"></span>
+  <span class="ease-star ease-star-filled"></span>
+  <span class="ease-star ease-star-filled"></span>
+  <span class="ease-star ease-star-filled"></span>
+  <span class="ease-star"></span>
+</div>
+```
+
+### Available Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-rating` | Star rating container (inline-flex) |
+| `.ease-star` | Individual star (CSS clip-path) |
+| `.ease-star-filled` | Filled star (amber) |
+| `.ease-star-half` | Half-filled star (via `::before`) |
+| `.ease-rating-interactive` | Clickable rating with cursor pointer |
+| `.ease-rating-sm` | Small size (1em) |
+| `.ease-rating-lg` | Large size (1.75em) |
+| `.ease-rating-xl` | Extra large size (2.25em) |
+| `.ease-rating-color-blue` | Blue star color |
+| `.ease-rating-color-green` | Green star color |
+| `.ease-rating-color-red` | Red star color |
+| `.ease-rating-color-purple` | Purple star color |
+| `.ease-rating-animate-bounce` | Bounce-in entrance animation |
+| `.ease-rating-animate-zoom` | Zoom-in entrance animation |
+| `.ease-rating-score` | Text score label |
+| `.ease-rating-label` | Text label beside rating |
+
+### Size Variants
+
+| Class | Star Size | Best for |
+|-------|-----------|----------|
+| `.ease-rating-sm` | 1em | Compact lists, product cards |
+| (default) | 1.25em | Standard ratings |
+| `.ease-rating-lg` | 1.75em | Reviews, testimonials |
+| `.ease-rating-xl` | 2.25em | Hero sections, featured content |
+
+### Color Themes
+
+| Class | Color |
+|-------|-------|
+| (default) | Amber `#f59e0b` |
+| `.ease-rating-color-blue` | Blue `#3b82f6` |
+| `.ease-rating-color-green` | Green `#16a34a` |
+| `.ease-rating-color-red` | Red `#dc2626` |
+| `.ease-rating-color-purple` | Purple `#8b5cf6` |
+
+### Animation
+
+| Class | Keyframes | Delay |
+|-------|-----------|-------|
+| `ease-rating-animate-bounce` | `ease-star-bounce-in` | 0.05s stagger per star |
+| `ease-rating-animate-zoom` | `ease-star-zoom-in` | 0.05s stagger per star |
+
+### Interactive (JavaScript)
+
+The demo includes JS that handles hover preview and click-to-rate. Data attributes (`data-value`) on each star track the position (1-5).
+
+### Design Tokens Used
+
+| Token | Fallback | Purpose |
+|-------|----------|---------|
+| `--ease-rating-color` | `#f59e0b` | Filled star color |
+| `--ease-rating-empty` | `#e2e8f0` / `#475569` | Empty star color |
+| `--ease-color-neutral-200` | `#e2e8f0` | Empty star (light) |
+| `--ease-color-neutral-400` | `#94a3b8` | Label text |
+| `--ease-color-neutral-500` | `#64748b` | Score text |
+| `--ease-color-neutral-600` | `#475569` | Empty star (dark) |
+| `--ease-text-sm` | `0.875rem` | Score font size |
+| `--ease-text-xs` | `0.75rem` | Label font size |
+| `--ease-speed-fast` | `150ms` | Star transition |
+
+Fixes #25558

--- a/submissions/examples/ease-star-rating/demo.html
+++ b/submissions/examples/ease-star-rating/demo.html
@@ -1,0 +1,300 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-star-rating — Star Rating Component</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="../../easemotion.min.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: 'Inter', system-ui, -apple-system, sans-serif;
+      background: #f8fafc;
+      color: #1e293b;
+      min-height: 100vh;
+    }
+    @media (prefers-color-scheme: dark) {
+      body { background: #0f172a; color: #e2e8f0; }
+    }
+    .page-header {
+      text-align: center;
+      padding: 4rem 1.5rem 2rem;
+    }
+    .page-header h1 { font-size: clamp(2rem,5vw,3rem); font-weight: 700; letter-spacing: -0.02em; }
+    .page-header p { margin-top: 0.75rem; color: #64748b; max-width: 600px; margin-inline: auto; }
+    .demo-section { max-width: 800px; margin: 0 auto; padding: 0 1.5rem 3rem; }
+    .demo-card {
+      background: var(--ease-color-surface, #fff);
+      border: 1px solid #e2e8f0;
+      border-radius: 1rem;
+      padding: 2rem;
+      margin-bottom: 1.5rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      .demo-card { background: #141e33; border-color: #334155; }
+    }
+    .demo-card h3 {
+      font-size: 0.75rem; font-weight: 600; text-transform: uppercase;
+      letter-spacing: 0.1em; color: #6c63ff; margin-bottom: 1rem;
+    }
+    .tag {
+      display: inline-block;
+      font-size: 0.65rem; font-family: monospace;
+      background: #f1f5f9; border: 1px solid #e2e8f0;
+      border-radius: 999px; padding: 0.3em 0.75em;
+      color: #6c63ff; margin-bottom: 1rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      .tag { background: #1e293b; border-color: #334155; }
+    }
+    .row { display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; margin: 0.75rem 0; }
+    .label { font-size: 0.8rem; color: #64748b; min-width: 80px; }
+    .divider {
+      max-width: 800px; margin: 0 auto;
+      border: none; border-top: 1px solid #e2e8f0;
+    }
+    @media (prefers-color-scheme: dark) {
+      .divider { border-color: #334155; }
+    }
+  </style>
+</head>
+<body>
+  <header class="page-header">
+    <h1>ease-star-rating</h1>
+    <p>Star rating component with display and interactive modes, half-stars, size variants, color themes, and animated entrance.</p>
+  </header>
+
+  <hr class="divider" />
+
+  <div class="demo-section">
+    <div class="demo-card">
+      <h3>Display Ratings</h3>
+      <span class="tag">.ease-rating</span>
+      <div class="row">
+        <span class="label">5 stars</span>
+        <div class="ease-rating">
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+        </div>
+      </div>
+      <div class="row">
+        <span class="label">4 stars</span>
+        <div class="ease-rating">
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star"></span>
+        </div>
+      </div>
+      <div class="row">
+        <span class="label">3.5 stars</span>
+        <div class="ease-rating">
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-half"></span>
+          <span class="ease-star"></span>
+        </div>
+      </div>
+      <div class="row">
+        <span class="label">2 stars</span>
+        <div class="ease-rating">
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star"></span>
+          <span class="ease-star"></span>
+          <span class="ease-star"></span>
+        </div>
+      </div>
+    </div>
+
+    <div class="demo-card">
+      <h3>Size Variants</h3>
+      <span class="tag">.ease-rating-sm / .ease-rating-lg / .ease-rating-xl</span>
+      <div class="row">
+        <span class="label">Small (sm)</span>
+        <div class="ease-rating ease-rating-sm">
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star"></span>
+        </div>
+      </div>
+      <div class="row">
+        <span class="label">Default</span>
+        <div class="ease-rating">
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star"></span>
+        </div>
+      </div>
+      <div class="row">
+        <span class="label">Large (lg)</span>
+        <div class="ease-rating ease-rating-lg">
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star"></span>
+        </div>
+      </div>
+      <div class="row">
+        <span class="label">Extra large (xl)</span>
+        <div class="ease-rating ease-rating-xl">
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star"></span>
+        </div>
+      </div>
+    </div>
+
+    <div class="demo-card">
+      <h3>Color Themes</h3>
+      <span class="tag">.ease-rating-color-blue / .ease-rating-color-green / .ease-rating-color-red / .ease-rating-color-purple</span>
+      <div class="row">
+        <span class="label">Default (amber)</span>
+        <div class="ease-rating">
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+        </div>
+      </div>
+      <div class="row">
+        <span class="label">Blue</span>
+        <div class="ease-rating ease-rating-color-blue">
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+        </div>
+      </div>
+      <div class="row">
+        <span class="label">Green</span>
+        <div class="ease-rating ease-rating-color-green">
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+        </div>
+      </div>
+      <div class="row">
+        <span class="label">Red</span>
+        <div class="ease-rating ease-rating-color-red">
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+        </div>
+      </div>
+      <div class="row">
+        <span class="label">Purple</span>
+        <div class="ease-rating ease-rating-color-purple">
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+        </div>
+      </div>
+    </div>
+
+    <div class="demo-card">
+      <h3>Interactive Rating (click to rate)</h3>
+      <span class="tag">.ease-rating-interactive</span>
+      <div class="row">
+        <span class="label">Click a star</span>
+        <div class="ease-rating ease-rating-interactive ease-rating-lg" id="interactiveRating">
+          <span class="ease-star" data-value="1"></span>
+          <span class="ease-star" data-value="2"></span>
+          <span class="ease-star" data-value="3"></span>
+          <span class="ease-star" data-value="4"></span>
+          <span class="ease-star" data-value="5"></span>
+        </div>
+        <span id="ratingDisplay" style="font-size:0.875rem;color:#64748b;">Not rated</span>
+      </div>
+    </div>
+
+    <div class="demo-card">
+      <h3>Animated Entrance</h3>
+      <span class="tag">.ease-rating-animate-bounce / .ease-rating-animate-zoom</span>
+      <div class="row">
+        <span class="label">Bounce in</span>
+        <div class="ease-rating ease-rating-animate-bounce">
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+        </div>
+      </div>
+      <div class="row">
+        <span class="label">Zoom in</span>
+        <div class="ease-rating ease-rating-animate-zoom">
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+          <span class="ease-star ease-star-filled"></span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var interactive = document.getElementById('interactiveRating');
+      var display = document.getElementById('ratingDisplay');
+      var stars = interactive.querySelectorAll('.ease-star');
+      var currentValue = 0;
+
+      function setRating(value) {
+        currentValue = value;
+        stars.forEach(function (s, i) {
+          s.classList.toggle('ease-star-filled', i < value);
+        });
+        display.textContent = value > 0 ? value + ' / 5' : 'Not rated';
+      }
+
+      stars.forEach(function (star) {
+        star.addEventListener('mouseenter', function () {
+          var val = parseInt(this.getAttribute('data-value'));
+          stars.forEach(function (s, i) {
+            s.classList.toggle('ease-star-filled', i < val);
+            s.classList.toggle('ease-star-hover', s === star);
+          });
+        });
+
+        star.addEventListener('mouseleave', function () {
+          stars.forEach(function (s, i) {
+            s.classList.toggle('ease-star-filled', i < currentValue);
+            s.classList.remove('ease-star-hover');
+          });
+        });
+
+        star.addEventListener('click', function () {
+          var val = parseInt(this.getAttribute('data-value'));
+          setRating(val === currentValue ? val : val);
+        });
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-star-rating/style.css
+++ b/submissions/examples/ease-star-rating/style.css
@@ -1,0 +1,127 @@
+@layer easemotion-components {
+
+  .ease-rating {
+    display: inline-flex;
+    gap: 2px;
+    --ease-rating-color: #f59e0b;
+    --ease-rating-empty: var(--ease-color-neutral-200, #e2e8f0);
+    align-items: center;
+  }
+
+  .ease-star {
+    width: 1.25em;
+    height: 1.25em;
+    background: var(--ease-rating-empty);
+    clip-path: polygon(50% 0%, 61% 35%, 98% 35%, 68% 57%, 79% 91%, 50% 70%, 21% 91%, 32% 57%, 2% 35%, 39% 35%);
+    transition: background var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+                transform var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+    flex-shrink: 0;
+  }
+
+  .ease-star-filled {
+    background: var(--ease-rating-color);
+  }
+
+  .ease-star-half {
+    position: relative;
+    background: var(--ease-rating-empty);
+  }
+
+  .ease-star-half::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: var(--ease-rating-color);
+    clip-path: polygon(0% 0%, 50% 0%, 50% 100%, 0% 100%);
+  }
+
+  .ease-rating-sm .ease-star {
+    width: 1em;
+    height: 1em;
+  }
+
+  .ease-rating-lg .ease-star {
+    width: 1.75em;
+    height: 1.75em;
+  }
+
+  .ease-rating-xl .ease-star {
+    width: 2.25em;
+    height: 2.25em;
+  }
+
+  .ease-rating-interactive .ease-star {
+    cursor: pointer;
+  }
+
+  .ease-rating-interactive .ease-star-hover {
+    transform: scale(1.2);
+  }
+
+  .ease-rating-score {
+    font-size: var(--ease-text-sm, 0.875rem);
+    color: var(--ease-color-neutral-500, #64748b);
+    margin-left: var(--ease-space-2, 0.5rem);
+    align-self: center;
+  }
+
+  .ease-rating-label {
+    font-size: var(--ease-text-xs, 0.75rem);
+    color: var(--ease-color-neutral-400, #94a3b8);
+    margin-left: var(--ease-space-1, 0.25rem);
+    align-self: center;
+  }
+
+  .ease-rating-color-blue { --ease-rating-color: #3b82f6; }
+  .ease-rating-color-green { --ease-rating-color: #16a34a; }
+  .ease-rating-color-red { --ease-rating-color: #dc2626; }
+  .ease-rating-color-purple { --ease-rating-color: #8b5cf6; }
+
+}
+
+@keyframes ease-star-bounce-in {
+  0% { transform: scale(0); }
+  50% { transform: scale(1.15); }
+  100% { transform: scale(1); }
+}
+
+@keyframes ease-star-zoom-in {
+  0% { transform: scale(0.3); opacity: 0; }
+  100% { transform: scale(1); opacity: 1; }
+}
+
+.ease-rating-animate-bounce .ease-star-filled {
+  animation: ease-star-bounce-in 0.4s var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)) both;
+}
+
+.ease-rating-animate-zoom .ease-star-filled {
+  animation: ease-star-zoom-in 0.3s var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)) both;
+}
+
+.ease-rating-animate-bounce .ease-star-filled:nth-child(2) { animation-delay: 0.05s; }
+.ease-rating-animate-bounce .ease-star-filled:nth-child(3) { animation-delay: 0.1s; }
+.ease-rating-animate-bounce .ease-star-filled:nth-child(4) { animation-delay: 0.15s; }
+.ease-rating-animate-bounce .ease-star-filled:nth-child(5) { animation-delay: 0.2s; }
+
+.ease-rating-animate-zoom .ease-star-filled:nth-child(2) { animation-delay: 0.05s; }
+.ease-rating-animate-zoom .ease-star-filled:nth-child(3) { animation-delay: 0.1s; }
+.ease-rating-animate-zoom .ease-star-filled:nth-child(4) { animation-delay: 0.15s; }
+.ease-rating-animate-zoom .ease-star-filled:nth-child(5) { animation-delay: 0.2s; }
+
+@media (prefers-color-scheme: dark) {
+  @layer easemotion-components {
+    .ease-rating {
+      --ease-rating-empty: var(--ease-color-neutral-600, #475569);
+    }
+    .ease-rating-score {
+      color: var(--ease-color-neutral-400, #94a3b8);
+    }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-rating-animate-bounce .ease-star-filled,
+  .ease-rating-animate-zoom .ease-star-filled {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## ✦ Description

Adds a star rating component using CSS clip-path stars. Supports display mode, half-stars, interactive click-to-rate with JS, size variants, color themes, and animated entrance.

Fixes #25558

---

## ⟡ Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

---

## ✦ Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] My changes generate no new warnings or errors

---

## Changes Made

- Added `submissions/examples/ease-star-rating/style.css` — clip-path stars, display/half/interactive modes, 4 sizes, 5 color themes, bounce/zoom animations, dark mode
- Added `submissions/examples/ease-star-rating/demo.html` — 5 demo cards covering all variants + interactive with JS
- Added `submissions/examples/ease-star-rating/README.md` — documentation

---

## Additional Notes
- Branch: `feat/ease-star-rating-25558`
- 3 new files only — no modifications or deletions