### PR TITLE
submission: add ease-dropdown dropdown/select menu component (issue #25554)

### DIFF
--- a/submissions/examples/ease-dropdown/README.md
+++ b/submissions/examples/ease-dropdown/README.md
@@ -1,0 +1,76 @@
+# ease-dropdown
+
+## What does this do?
+
+CSS dropdown/select menu component with **click** and **hover** trigger modes, nested submenus, and smooth fade+slide animation.
+
+## How is it used?
+
+```html
+<div class="ease-dropdown">
+  <button class="ease-dropdown-trigger">Trigger</button>
+  <ul class="ease-dropdown-menu">
+    <li><button class="ease-dropdown-item">Item</button></li>
+  </ul>
+</div>
+```
+
+### Trigger modes
+
+| Mode | Class | Behavior |
+|------|-------|----------|
+| Click | `.ease-dropdown` (default) | Toggle via JS `.ease-open` class |
+| Hover | `.ease-dropdown.ease-dropdown--hover` | Pure CSS hover + focus-within |
+
+### Available Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-dropdown` | Wrapper (position: relative) |
+| `.ease-dropdown-trigger` | Button/link that opens the menu |
+| `.ease-dropdown-menu` | The dropdown list (absolute positioned) |
+| `.ease-dropdown-menu--right` | Right-aligned variant |
+| `.ease-dropdown-menu--top` | Opens upward |
+| `.ease-dropdown-menu.ease-open` | Visible state (JS toggle) |
+| `.ease-dropdown-item` | Individual menu item |
+| `.ease-dropdown-item--active` | Highlighted selected item |
+| `.ease-dropdown-item--disabled` | Non-interactive item |
+| `.ease-dropdown-divider` | Horizontal separator |
+| `.ease-dropdown-header` | Section label (uppercase, muted) |
+| `.ease-dropdown-submenu` | Nested submenu wrapper |
+| `.ease-dropdown-submenu--hover` | Submenu opens on hover (CSS only) |
+| `.ease-dropdown-submenu-trigger` | Button with chevron arrow |
+
+### Responsive
+
+- No specific breakpoint overrides (menus work at all widths)
+- For mobile, use click mode (hover has no effect on touch)
+
+### Animation
+
+- Open: fade in `opacity: 0 → 1` + slide `translateY(-6px) → 0`
+- Close: reverse
+- Duration: `var(--ease-speed-fast, 150ms)`
+- Timing: `var(--ease-ease)`
+- `prefers-reduced-motion: reduce` disables transitions
+
+### Design Tokens Used
+
+| Token | Fallback | Purpose |
+|-------|----------|---------|
+| `--ease-color-surface` | `#fff` / `#141e33` | Menu background |
+| `--ease-color-text` | `#1e293b` / `#e2e8f0` | Item text |
+| `--ease-color-neutral-100` | `#f1f5f9` | Item hover bg |
+| `--ease-color-neutral-200` | `#e2e8f0` | Border, divider |
+| `--ease-color-neutral-400` | `#94a3b8` | Header text |
+| `--ease-color-neutral-500` | `#64748b` | Dark header text |
+| `--ease-color-neutral-700` | `#334155` | Dark border |
+| `--ease-color-neutral-800` | `#1e293b` | Dark item hover bg |
+| `--ease-color-primary` | `#6c63ff` | Active bg |
+| `--ease-radius-md` | `0.75rem` | Menu/item border radius |
+| `--ease-shadow-lg` | `0 10px 30px...` | Menu shadow |
+| `--ease-speed-fast` | `150ms` | Transition duration |
+| `--ease-ease` | cubic-bezier | Transition timing |
+| `--ease-font-sans` | sans-serif | Item font |
+
+Fixes #25554

--- a/submissions/examples/ease-dropdown/demo.html
+++ b/submissions/examples/ease-dropdown/demo.html
@@ -1,0 +1,536 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-dropdown — EaseMotion CSS</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../easemotion.min.css">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: 'Inter', system-ui, -apple-system, sans-serif;
+      background: #f8fafc;
+      color: #1e293b;
+      min-height: 100vh;
+    }
+    @media (prefers-color-scheme: dark) {
+      body { background: #0f172a; color: #e2e8f0; }
+    }
+    .page-header {
+      text-align: center;
+      padding: 4rem 1.5rem 2rem;
+    }
+    .page-header h1 {
+      font-size: clamp(2rem, 5vw, 3rem);
+      font-weight: 700;
+      letter-spacing: -0.02em;
+    }
+    .page-header p {
+      margin-top: 0.75rem;
+      color: #64748b;
+      max-width: 600px;
+      margin-inline: auto;
+    }
+    .nav-bar {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 2rem;
+      padding: 1rem 1.5rem;
+      background: var(--ease-color-surface, #fff);
+      border-bottom: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+    }
+    @media (prefers-color-scheme: dark) {
+      .nav-bar { background: #141e33; border-color: #334155; }
+    }
+    .nav-bar .logo {
+      font-weight: 700;
+      font-size: 1.125rem;
+      color: var(--ease-color-primary, #6c63ff);
+    }
+    .nav-link {
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: var(--ease-color-neutral-500, #64748b);
+      text-decoration: none;
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.5rem;
+      transition: color 0.15s, background 0.15s;
+    }
+    .nav-link:hover { color: var(--ease-color-text, #1e293b); background: var(--ease-color-neutral-100, #f1f5f9); }
+    .demo-area {
+      max-width: 900px;
+      margin: 2rem auto;
+      padding: 0 1.5rem;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 1rem;
+    }
+    .demo-card {
+      background: var(--ease-color-surface, #fff);
+      border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+      border-radius: var(--ease-radius-lg, 1rem);
+      padding: 2rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      min-height: 200px;
+    }
+    @media (prefers-color-scheme: dark) {
+      .demo-card { background: #141e33; border-color: #334155; }
+    }
+    .demo-card h3 {
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: var(--ease-color-neutral-400, #94a3b8);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+    .demo-card .preview {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .demo-card .desc {
+      font-size: 0.8rem;
+      color: var(--ease-color-neutral-400, #94a3b8);
+      line-height: 1.5;
+    }
+    .section-label {
+      text-align: center;
+      padding: 2rem 1.5rem 1rem;
+    }
+    .section-label h2 {
+      font-size: 0.75rem; font-weight: 600; text-transform: uppercase;
+      letter-spacing: 0.1em; color: var(--ease-color-primary, #6c63ff);
+    }
+    .badge {
+      display: inline-block;
+      font-size: 0.6rem;
+      font-weight: 700;
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+      border-radius: 999px;
+      padding: 0.25em 0.6em;
+      color: var(--ease-color-neutral-500, #64748b);
+      margin-left: 0.5rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      .badge { background: #1e293b; border-color: #334155; }
+    }
+    .trigger-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.625rem 1.25rem;
+      font-family: inherit;
+      font-size: 0.875rem;
+      font-weight: 500;
+      background: var(--ease-color-primary, #6c63ff);
+      color: #fff;
+      border: none;
+      border-radius: var(--ease-radius-md, 0.75rem);
+      cursor: pointer;
+      transition: opacity 0.15s;
+    }
+    .trigger-btn:hover { opacity: 0.9; }
+    .trigger-btn--secondary {
+      background: transparent;
+      color: var(--ease-color-text, #1e293b);
+      border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+    }
+    .trigger-btn--secondary:hover { background: var(--ease-color-neutral-100, #f1f5f9); }
+    .chevron { width: 10px; height: 10px; flex-shrink: 0; }
+    .log-console {
+      max-width: 900px;
+      margin: 2rem auto;
+      padding: 0 1.5rem;
+    }
+    .log-console .log-title {
+      font-size: 0.65rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--ease-color-neutral-400, #94a3b8);
+      margin-bottom: 0.5rem;
+    }
+    .log-console .log-box {
+      background: #030712;
+      border: 1px solid rgba(255,255,255,0.08);
+      border-radius: var(--ease-radius-md, 0.75rem);
+      padding: 1rem;
+      max-height: 120px;
+      overflow-y: auto;
+      font-family: monospace;
+      font-size: 0.75rem;
+    }
+    .log-console .log-line {
+      display: flex;
+      gap: 0.75rem;
+      padding: 2px 0;
+    }
+    .log-console .log-time { color: var(--ease-color-primary, #6c63ff); }
+    .log-console .log-msg { color: #e2e8f0; }
+    .divider {
+      max-width: 900px; margin: 0 auto;
+      border: none; border-top: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+    }
+    @media (prefers-color-scheme: dark) { .divider { border-color: #334155; } }
+    @media (max-width: 640px) {
+      .nav-bar { gap: 1rem; flex-wrap: wrap; }
+    }
+  </style>
+</head>
+<body>
+
+  <nav class="nav-bar">
+    <span class="logo">EaseMotion</span>
+    <div class="ease-dropdown ease-dropdown--hover">
+      <button class="nav-link ease-dropdown-trigger">
+        Products
+        <svg class="chevron" viewBox="0 0 10 6" fill="none"><path d="M1 1L5 5L9 1" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </button>
+      <ul class="ease-dropdown-menu">
+        <li><a href="#" class="ease-dropdown-item">Analytics</a></li>
+        <li><a href="#" class="ease-dropdown-item">Dashboard</a></li>
+        <li><a href="#" class="ease-dropdown-item">Reports</a></li>
+        <li><a href="#" class="ease-dropdown-item">Integrations</a></li>
+      </ul>
+    </div>
+    <div class="ease-dropdown ease-dropdown--hover">
+      <button class="nav-link ease-dropdown-trigger">
+        Resources
+        <svg class="chevron" viewBox="0 0 10 6" fill="none"><path d="M1 1L5 5L9 1" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </button>
+      <ul class="ease-dropdown-menu ease-dropdown-menu--right">
+        <li class="ease-dropdown-header">Learn</li>
+        <li><a href="#" class="ease-dropdown-item">Documentation</a></li>
+        <li><a href="#" class="ease-dropdown-item">API Reference</a></li>
+        <li class="ease-dropdown-divider"></li>
+        <li class="ease-dropdown-header">Community</li>
+        <li><a href="#" class="ease-dropdown-item">GitHub</a></li>
+        <li><a href="#" class="ease-dropdown-item">Discord</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <header class="page-header">
+    <h1>ease-dropdown</h1>
+    <p>Dropdown and select menu component with click and hover triggers, nested submenus, and smooth animation.</p>
+  </header>
+
+  <hr class="divider">
+  <div class="section-label">
+    <h2>Click-triggered dropdowns</h2>
+  </div>
+
+  <div class="demo-area">
+    <div class="demo-card">
+      <h3>Sort Select <span class="badge">click</span></h3>
+      <div class="preview">
+        <div class="ease-dropdown">
+          <button class="trigger-btn trigger-btn--secondary ease-dropdown-trigger">
+            Sort: Newest
+            <svg class="chevron" viewBox="0 0 10 6" fill="none"><path d="M1 1L5 5L9 1" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          </button>
+          <ul class="ease-dropdown-menu">
+            <li><button class="ease-dropdown-item ease-dropdown-item--active" data-sort="Newest">Newest First</button></li>
+            <li><button class="ease-dropdown-item" data-sort="Oldest">Oldest First</button></li>
+            <li><button class="ease-dropdown-item" data-sort="Popular">Most Popular</button></li>
+            <li><button class="ease-dropdown-item" data-sort="Name">Alphabetical</button></li>
+          </ul>
+        </div>
+      </div>
+      <p class="desc">Click to open and select an option. Active item is highlighted.</p>
+    </div>
+
+    <div class="demo-card">
+      <h3>Action Menu <span class="badge">click</span></h3>
+      <div class="preview">
+        <div class="ease-dropdown">
+          <button class="trigger-btn ease-dropdown-trigger">
+            Actions
+            <svg class="chevron" viewBox="0 0 10 6" fill="none"><path d="M1 1L5 5L9 1" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          </button>
+          <ul class="ease-dropdown-menu">
+            <li><button class="ease-dropdown-item">Edit</button></li>
+            <li><button class="ease-dropdown-item">Duplicate</button></li>
+            <li><button class="ease-dropdown-item ease-dropdown-item--disabled">Archive</button></li>
+            <li class="ease-dropdown-divider"></li>
+            <li><button class="ease-dropdown-item" style="color: #ef4444;">Delete</button></li>
+          </ul>
+        </div>
+      </div>
+      <p class="desc">Standard action menu with divider, disabled item, and danger action.</p>
+    </div>
+
+    <div class="demo-card">
+      <h3>Nested Submenus <span class="badge">nested</span></h3>
+      <div class="preview">
+        <div class="ease-dropdown">
+          <button class="trigger-btn trigger-btn--secondary ease-dropdown-trigger">
+            Share
+            <svg class="chevron" viewBox="0 0 10 6" fill="none"><path d="M1 1L5 5L9 1" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          </button>
+          <ul class="ease-dropdown-menu">
+            <li><button class="ease-dropdown-item">Copy Link</button></li>
+            <li class="ease-dropdown-submenu">
+              <button class="ease-dropdown-item ease-dropdown-submenu-trigger">Send to</button>
+              <ul class="ease-dropdown-menu">
+                <li><button class="ease-dropdown-item">Slack</button></li>
+                <li><button class="ease-dropdown-item">Discord</button></li>
+                <li><button class="ease-dropdown-item">Email</button></li>
+              </ul>
+            </li>
+            <li class="ease-dropdown-submenu">
+              <button class="ease-dropdown-item ease-dropdown-submenu-trigger">Export</button>
+              <ul class="ease-dropdown-menu">
+                <li><button class="ease-dropdown-item">PDF</button></li>
+                <li><button class="ease-dropdown-item">Markdown</button></li>
+                <li><button class="ease-dropdown-item">HTML</button></li>
+              </ul>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <p class="desc">Multi-level nested menus opening to the side on hover.</p>
+    </div>
+
+    <div class="demo-card">
+      <h3>Right-aligned <span class="badge">position</span></h3>
+      <div class="preview" style="justify-content: flex-end;">
+        <div class="ease-dropdown">
+          <button class="trigger-btn trigger-btn--secondary ease-dropdown-trigger">
+            Profile
+            <svg class="chevron" viewBox="0 0 10 6" fill="none"><path d="M1 1L5 5L9 1" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          </button>
+          <ul class="ease-dropdown-menu ease-dropdown-menu--right">
+            <li class="ease-dropdown-header">john@example.com</li>
+            <li><button class="ease-dropdown-item">Settings</button></li>
+            <li><button class="ease-dropdown-item">Billing</button></li>
+            <li class="ease-dropdown-divider"></li>
+            <li><button class="ease-dropdown-item">Sign Out</button></li>
+          </ul>
+        </div>
+      </div>
+      <p class="desc">Right-aligned menu for avatar or user-menus positioned at the edge.</p>
+    </div>
+  </div>
+
+  <hr class="divider">
+  <div class="section-label">
+    <h2>Hover-triggered</h2>
+  </div>
+
+  <div class="demo-area">
+    <div class="demo-card">
+      <h3>Top Nav Hover <span class="badge">hover</span></h3>
+      <div class="preview">
+        <div class="ease-dropdown ease-dropdown--hover">
+          <button class="trigger-btn trigger-btn--secondary ease-dropdown-trigger">
+            Hover me
+            <svg class="chevron" viewBox="0 0 10 6" fill="none"><path d="M1 1L5 5L9 1" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          </button>
+          <ul class="ease-dropdown-menu">
+            <li><button class="ease-dropdown-item">Item One</button></li>
+            <li><button class="ease-dropdown-item">Item Two</button></li>
+            <li><button class="ease-dropdown-item">Item Three</button></li>
+          </ul>
+        </div>
+      </div>
+      <p class="desc">Open on hover, close on leave. Pure CSS, no JS required.</p>
+    </div>
+    <div class="demo-card">
+      <h3>Nested on Hover <span class="badge">hover</span></h3>
+      <div class="preview">
+        <div class="ease-dropdown ease-dropdown--hover">
+          <button class="trigger-btn ease-dropdown-trigger">
+            More
+            <svg class="chevron" viewBox="0 0 10 6" fill="none"><path d="M1 1L5 5L9 1" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          </button>
+          <ul class="ease-dropdown-menu">
+            <li><button class="ease-dropdown-item">Dashboard</button></li>
+            <li class="ease-dropdown-submenu ease-dropdown-submenu--hover">
+              <button class="ease-dropdown-item ease-dropdown-submenu-trigger">Admin</button>
+              <ul class="ease-dropdown-menu">
+                <li><button class="ease-dropdown-item">Users</button></li>
+                <li><button class="ease-dropdown-item">Roles</button></li>
+                <li><button class="ease-dropdown-item">Logs</button></li>
+              </ul>
+            </li>
+            <li><button class="ease-dropdown-item">Settings</button></li>
+          </ul>
+        </div>
+      </div>
+      <p class="desc">Nested submenus triggered on hover with CSS only (`.ease-dropdown-submenu--hover`).</p>
+    </div>
+  </div>
+
+  <div class="section-label">
+    <h2>Event log</h2>
+  </div>
+  <div class="log-console">
+    <div class="log-box" id="logBox">
+      <div class="log-line"><span class="log-time">[init]</span><span class="log-msg">Dropdown demo ready.</span></div>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var logBox = document.getElementById('logBox');
+
+      function log(msg) {
+        var time = new Date().toTimeString().slice(0, 8);
+        var line = document.createElement('div');
+        line.className = 'log-line';
+        line.innerHTML = '<span class="log-time">[' + time + ']</span><span class="log-msg">' + msg + '</span>';
+        logBox.appendChild(line);
+        logBox.scrollTop = logBox.scrollHeight;
+      }
+
+      function closeAll(except) {
+        document.querySelectorAll('.ease-dropdown').forEach(function (dd) {
+          if (dd === except || dd.classList.contains('ease-dropdown--hover')) return;
+          dd.classList.remove('is-open');
+          var menu = dd.querySelector('.ease-dropdown-menu');
+          if (menu) menu.classList.remove('ease-open');
+          var trigger = dd.querySelector('.ease-dropdown-trigger');
+          if (trigger) trigger.setAttribute('aria-expanded', 'false');
+          dd.querySelectorAll('.ease-dropdown-submenu').forEach(function (sub) {
+            sub.classList.remove('is-open');
+            var subMenu = sub.querySelector('.ease-dropdown-menu');
+            if (subMenu) subMenu.classList.remove('ease-open');
+          });
+        });
+      }
+
+      // Click-triggered dropdowns
+      document.querySelectorAll('.ease-dropdown:not(.ease-dropdown--hover)').forEach(function (dd) {
+        var trigger = dd.querySelector('.ease-dropdown-trigger');
+        var menu = dd.querySelector('.ease-dropdown-menu');
+        if (!trigger || !menu) return;
+
+        trigger.setAttribute('aria-haspopup', 'true');
+        trigger.setAttribute('aria-expanded', 'false');
+
+        trigger.addEventListener('click', function (e) {
+          e.stopPropagation();
+          var wasOpen = menu.classList.contains('ease-open');
+          closeAll(dd);
+          if (!wasOpen) {
+            menu.classList.add('ease-open');
+            dd.classList.add('is-open');
+            trigger.setAttribute('aria-expanded', 'true');
+            log('Opened: ' + (trigger.textContent || '').trim());
+          } else {
+            log('Closed: ' + (trigger.textContent || '').trim());
+          }
+        });
+      });
+
+      // Click nested submenus
+      document.querySelectorAll('.ease-dropdown-submenu:not(.ease-dropdown-submenu--hover)').forEach(function (sub) {
+        var subTrigger = sub.querySelector('.ease-dropdown-submenu-trigger');
+        var subMenu = sub.querySelector('.ease-dropdown-menu');
+        if (!subTrigger || !subMenu) return;
+
+        subTrigger.addEventListener('click', function (e) {
+          e.stopPropagation();
+          e.preventDefault();
+          var wasOpen = subMenu.classList.contains('ease-open');
+          var parent = sub.closest('.ease-dropdown-menu');
+          parent.querySelectorAll(':scope > li.ease-dropdown-submenu').forEach(function (s) {
+            if (s !== sub) {
+              s.classList.remove('is-open');
+              var sm = s.querySelector('.ease-dropdown-menu');
+              if (sm) sm.classList.remove('ease-open');
+            }
+          });
+          if (!wasOpen) {
+            subMenu.classList.add('ease-open');
+            sub.classList.add('is-open');
+            log('Opened submenu: ' + (subTrigger.textContent || '').trim());
+          } else {
+            log('Closed submenu: ' + (subTrigger.textContent || '').trim());
+          }
+        });
+      });
+
+      // Select items in sort dropdown
+      document.querySelectorAll('.ease-dropdown-item[data-sort]').forEach(function (item) {
+        item.addEventListener('click', function (e) {
+          e.stopPropagation();
+          var dd = item.closest('.ease-dropdown');
+          var trigger = dd.querySelector('.ease-dropdown-trigger');
+          var value = item.getAttribute('data-sort');
+          dd.querySelectorAll('.ease-dropdown-item[data-sort]').forEach(function (i) {
+            i.classList.remove('ease-dropdown-item--active');
+          });
+          item.classList.add('ease-dropdown-item--active');
+          trigger.innerHTML = 'Sort: ' + value +
+            '<svg class="chevron" viewBox="0 0 10 6" fill="none"><path d="M1 1L5 5L9 1" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+          var menu = dd.querySelector('.ease-dropdown-menu');
+          menu.classList.remove('ease-open');
+          dd.classList.remove('is-open');
+          trigger.setAttribute('aria-expanded', 'false');
+          trigger.focus();
+          log('Sort: ' + value);
+        });
+      });
+
+      // Action items
+      document.querySelectorAll('.ease-dropdown-item:not([data-sort])').forEach(function (item) {
+        if (item.closest('.ease-dropdown-submenu')) return;
+        item.addEventListener('click', function (e) {
+          if (item.classList.contains('ease-dropdown-item--disabled')) return;
+          e.stopPropagation();
+          var label = item.textContent.trim();
+          log('Action: ' + label);
+          var dd = item.closest('.ease-dropdown');
+          if (dd) {
+            var menu = dd.querySelector('.ease-dropdown-menu');
+            if (menu) menu.classList.remove('ease-open');
+            dd.classList.remove('is-open');
+          }
+        });
+      });
+
+      // Keyboard navigation
+      document.addEventListener('keydown', function (e) {
+        var open = document.querySelector('.ease-dropdown-menu.ease-open');
+        if (!open) return;
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          var dd = open.closest('.ease-dropdown');
+          open.classList.remove('ease-open');
+          if (dd) {
+            dd.classList.remove('is-open');
+            var trig = dd.querySelector('.ease-dropdown-trigger');
+            if (trig) { trig.setAttribute('aria-expanded', 'false'); trig.focus(); }
+          }
+          log('Closed via Escape');
+        }
+        if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+          e.preventDefault();
+          var items = open.querySelectorAll('.ease-dropdown-item:not(.ease-dropdown-item--disabled)');
+          if (!items.length) return;
+          var idx = Array.from(items).indexOf(document.activeElement);
+          if (e.key === 'ArrowDown') idx = (idx + 1) % items.length;
+          else idx = (idx - 1 + items.length) % items.length;
+          items[idx].focus();
+        }
+      });
+
+      // Click outside
+      document.addEventListener('click', function (e) {
+        if (!e.target.closest('.ease-dropdown')) closeAll();
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-dropdown/style.css
+++ b/submissions/examples/ease-dropdown/style.css
@@ -1,0 +1,191 @@
+.ease-dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+.ease-dropdown-trigger {
+  cursor: pointer;
+  user-select: none;
+}
+
+.ease-dropdown-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 100;
+  min-width: 200px;
+  margin-top: 6px;
+  padding: 6px;
+  background: var(--ease-color-surface, #fff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-md, 0.75rem);
+  box-shadow: var(--ease-shadow-lg, 0 10px 30px rgba(0,0,0,0.12));
+  list-style: none;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-6px);
+  pointer-events: none;
+  transition:
+    opacity var(--ease-speed-fast, 150ms) var(--ease-ease),
+    transform var(--ease-speed-fast, 150ms) var(--ease-ease),
+    visibility var(--ease-speed-fast, 150ms) var(--ease-ease);
+}
+
+.ease-dropdown-menu--right {
+  left: auto;
+  right: 0;
+}
+
+.ease-dropdown-menu--top {
+  top: auto;
+  bottom: 100%;
+  margin-top: 0;
+  margin-bottom: 6px;
+  transform: translateY(6px);
+}
+
+.ease-dropdown-menu.ease-open,
+.ease-dropdown--hover:hover > .ease-dropdown-menu,
+.ease-dropdown--hover:focus-within > .ease-dropdown-menu {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.ease-dropdown-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-family: var(--ease-font-sans, sans-serif);
+  color: var(--ease-color-text, #1e293b);
+  background: transparent;
+  border: none;
+  border-radius: calc(var(--ease-radius-md, 0.75rem) - 2px);
+  cursor: pointer;
+  text-align: left;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: background var(--ease-speed-fast, 150ms) var(--ease-ease);
+}
+
+.ease-dropdown-item:hover,
+.ease-dropdown-item:focus-visible {
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  outline: none;
+}
+
+.ease-dropdown-item:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: -2px;
+}
+
+.ease-dropdown-item--active {
+  background: var(--ease-color-primary, #6c63ff);
+  color: #fff;
+}
+
+.ease-dropdown-item--disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.ease-dropdown-divider {
+  height: 1px;
+  margin: 4px 6px;
+  background: var(--ease-color-neutral-200, #e2e8f0);
+  border: none;
+}
+
+.ease-dropdown-header {
+  padding: 0.375rem 0.75rem;
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 700;
+  color: var(--ease-color-neutral-400, #94a3b8);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  pointer-events: none;
+}
+
+.ease-dropdown-submenu {
+  position: relative;
+}
+
+.ease-dropdown-submenu > .ease-dropdown-menu {
+  top: -6px;
+  left: 100%;
+  margin-top: 0;
+  margin-left: 4px;
+  transform: translateX(-4px);
+}
+
+.ease-dropdown-submenu > .ease-dropdown-menu--left {
+  left: auto;
+  right: 100%;
+  margin-left: 0;
+  margin-right: 4px;
+  transform: translateX(4px);
+}
+
+.ease-dropdown-submenu.ease-open > .ease-dropdown-menu,
+.ease-dropdown-submenu--hover:hover > .ease-dropdown-menu {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(0);
+  pointer-events: auto;
+}
+
+.ease-dropdown-submenu-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.ease-dropdown-submenu-trigger::after {
+  content: '';
+  display: inline-block;
+  width: 5px;
+  height: 5px;
+  border-right: 1.5px solid currentColor;
+  border-top: 1.5px solid currentColor;
+  transform: rotate(45deg);
+  margin-left: auto;
+  opacity: 0.5;
+  flex-shrink: 0;
+}
+
+.ease-dropdown-submenu--hover:hover > .ease-dropdown-submenu-trigger::after,
+.ease-dropdown-submenu.ease-open > .ease-dropdown-submenu-trigger::after {
+  opacity: 1;
+}
+
+@media (prefers-color-scheme: dark) {
+  .ease-dropdown-menu {
+    background: var(--ease-color-surface, #141e33);
+    border-color: var(--ease-color-neutral-700, #334155);
+    box-shadow: 0 10px 30px rgba(0,0,0,0.4);
+  }
+  .ease-dropdown-item {
+    color: var(--ease-color-text, #e2e8f0);
+  }
+  .ease-dropdown-item:hover,
+  .ease-dropdown-item:focus-visible {
+    background: var(--ease-color-neutral-800, #1e293b);
+  }
+  .ease-dropdown-divider {
+    background: var(--ease-color-neutral-700, #334155);
+  }
+  .ease-dropdown-header {
+    color: var(--ease-color-neutral-500, #64748b);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-dropdown-menu {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## ✦ Description

Adds a dropdown/select menu component with click and hover trigger modes, nested submenus, and smooth fade+slide animation.

Fixes #25554

---

## ⟡ Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

---

## ✦ Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] My changes generate no new warnings or errors

---

## Changes Made

- `submissions/examples/ease-dropdown/style.css` — positioning (absolute, top 100%), fade+slide animation, click/hover modes, nested submenus, right-aligned/top variants, dividers/headers, active/disabled states, dark mode
- `submissions/examples/ease-dropdown/demo.html` — nav bar with hover dropdowns, click-triggered sort select, action menu, nested submenus, right-aligned profile menu; inline JS for toggle, keyboard nav (Escape/Arrow), click-outside-to-close, live event log
- `submissions/examples/ease-dropdown/README.md` — full documentation

### Trigger Modes

| Mode | Class | Behavior |
|------|-------|----------|
| Click | `.ease-dropdown` (default) | Toggle via JS `.ease-open` class |
| Hover | `.ease-dropdown--hover` | Pure CSS hover + focus-within |

---

## Additional Notes
- Branch: `feat/ease-dropdown-25554`
- 3 new files only — no modifications or deletions