### PR TITLE
Add theme toggle component — dark/light mode switcher with smooth transition (#25633)

### DIFF
--- a/submissions/examples/core_changes-issue-25633/README.md
+++ b/submissions/examples/core_changes-issue-25633/README.md
@@ -1,0 +1,3 @@
+1. What does this do? Toggles between light and dark mode with smooth CSS transitions, persisting preference in localStorage and respecting the user's system `prefers-color-scheme`.
+2. How is it used? Add the `.theme-toggle` button and the CSS defines `data-theme="dark"` on `<html>` — the JS handles the toggle and persistence.
+3. Why is it useful? A theme toggle is a standard UI pattern that improves user experience; this lightweight implementation uses CSS custom properties for clean theming and takes 0 external dependencies.

--- a/submissions/examples/core_changes-issue-25633/demo.html
+++ b/submissions/examples/core_changes-issue-25633/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Theme Toggle — Demo</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <div class="card">
+    <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
+      <span class="sun">☀️</span>
+      <span class="moon">🌙</span>
+    </button>
+    <h1>Theme Toggle</h1>
+    <p>Click the button to toggle between light and dark mode. Your preference is saved in localStorage and respected on reload.</p>
+  </div>
+
+  <script>
+    (function() {
+      var stored = localStorage.getItem('theme');
+      var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      if (stored === 'dark' || (!stored && prefersDark)) {
+        document.documentElement.setAttribute('data-theme', 'dark');
+      }
+      document.getElementById('themeToggle').addEventListener('click', function() {
+        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+        if (isDark) {
+          document.documentElement.removeAttribute('data-theme');
+          localStorage.setItem('theme', 'light');
+        } else {
+          document.documentElement.setAttribute('data-theme', 'dark');
+          localStorage.setItem('theme', 'dark');
+        }
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/core_changes-issue-25633/style.css
+++ b/submissions/examples/core_changes-issue-25633/style.css
@@ -1,0 +1,79 @@
+* {
+  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+:root {
+  color-scheme: light;
+  --bg: #ffffff;
+  --text: #0f172a;
+  --surface: #f1f5f9;
+  --border: #e2e8f0;
+  --toggle-bg: #e2e8f0;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --bg: #0f172a;
+  --text: #e2e8f0;
+  --surface: #1e293b;
+  --border: #334155;
+  --toggle-bg: #334155;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  font-family: system-ui, sans-serif;
+}
+
+.theme-toggle {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  cursor: pointer;
+  background: var(--toggle-bg);
+  display: grid;
+  place-items: center;
+  font-size: 1.25rem;
+  transition: background 0.2s, transform 0.2s, border-color 0.2s;
+}
+
+.theme-toggle:hover {
+  transform: scale(1.1);
+}
+
+.theme-toggle .sun { display: block; }
+.theme-toggle .moon { display: none; }
+[data-theme="dark"] .theme-toggle .sun { display: none; }
+[data-theme="dark"] .theme-toggle .moon { display: block; }
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 2.5rem;
+  text-align: center;
+  box-shadow: 0 4px 24px rgba(0,0,0,0.06);
+  max-width: 400px;
+}
+
+.card h1 {
+  margin: 1rem 0 0.5rem;
+  font-size: 1.5rem;
+}
+
+.card p {
+  color: var(--text);
+  opacity: 0.7;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * { transition: none !important; }
+}


### PR DESCRIPTION
### Description

Adds a dark/light mode theme toggle button with smooth CSS transitions, localStorage persistence, and system preference detection.

### Changes

- `submissions/examples/core_changes-issue-25633/style.css` — CSS custom properties for light/dark themes, toggle button styles, reduced-motion support
- `submissions/examples/core_changes-issue-25633/demo.html` — demo card with sun/moon icon toggle, JS inlined
- `submissions/examples/core_changes-issue-25633/README.md` — what/how/why

### Features

- Toggles `data-theme="dark"` on `<html>` element
- Persists preference in localStorage
- Respects system `prefers-color-scheme` as default
- Smooth transitions on background, text, border, and shadow
- Respects `prefers-reduced-motion: reduce` (disables all transitions)

Closes #25633