### PR TITLE
Add 3D flip card component with front/back faces on hover (#25638)

### DIFF
--- a/submissions/examples/core_changes-issue-25638/README.md
+++ b/submissions/examples/core_changes-issue-25638/README.md
@@ -1,0 +1,3 @@
+1. What does this do? Creates a 3D flip card with front and back faces — rotates on hover using CSS 3D transforms with perspective and backface-visibility.
+2. How is it used? Wrap `.flip-card-front` and `.flip-card-back` inside `.flip-card > .flip-card-inner`. Add `.flip-card--vertical` for rotateX instead of rotateY.
+3. Why is it useful? A classic UI pattern for portfolios, flashcards, product cards, and interactive content — implemented purely in CSS with no JS required, including a reduced-motion fallback.

--- a/submissions/examples/core_changes-issue-25638/demo.html
+++ b/submissions/examples/core_changes-issue-25638/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>3D Flip Card — Demo</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: #0f172a;
+      display: flex;
+      gap: 2rem;
+      align-items: center;
+      justify-content: center;
+      flex-wrap: wrap;
+      padding: 2rem;
+      font-family: system-ui, sans-serif;
+    }
+    .note {
+      position: fixed;
+      bottom: 1rem;
+      left: 50%;
+      transform: translateX(-50%);
+      color: #475569;
+      font-size: 0.75rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="flip-card">
+    <div class="flip-card-inner">
+      <div class="flip-card-front">
+        <div class="flip-card-icon">🚀</div>
+        <h2>Hover to Flip</h2>
+        <p>Default horizontal flip</p>
+      </div>
+      <div class="flip-card-back">
+        <h2>Back Side</h2>
+        <p>This content is revealed with a 3D rotateY transform.</p>
+        <p style="margin-top:1rem"><a href="#">Learn more →</a></p>
+      </div>
+    </div>
+  </div>
+
+  <div class="flip-card flip-card--vertical">
+    <div class="flip-card-inner">
+      <div class="flip-card-front">
+        <div class="flip-card-icon">🔄</div>
+        <h2>Vertical Flip</h2>
+        <p>Hover for rotateX</p>
+      </div>
+      <div class="flip-card-back">
+        <h2>Vertical Back</h2>
+        <p>Uses rotateX instead of rotateY for a vertical axis flip effect.</p>
+        <p style="margin-top:1rem"><a href="#">Explore →</a></p>
+      </div>
+    </div>
+  </div>
+
+  <div class="note">Hover over cards · Respects prefers-reduced-motion</div>
+</body>
+</html>

--- a/submissions/examples/core_changes-issue-25638/style.css
+++ b/submissions/examples/core_changes-issue-25638/style.css
@@ -1,0 +1,83 @@
+.flip-card {
+  perspective: 800px;
+  width: 280px;
+  height: 380px;
+}
+
+.flip-card-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.6s ease;
+  transform-style: preserve-3d;
+}
+
+.flip-card:hover .flip-card-inner {
+  transform: rotateY(180deg);
+}
+
+.flip-card-front,
+.flip-card-back {
+  position: absolute;
+  inset: 0;
+  backface-visibility: hidden;
+  border-radius: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  text-align: center;
+}
+
+.flip-card-front {
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: #fff;
+}
+
+.flip-card-back {
+  background: #1e293b;
+  color: #e2e8f0;
+  transform: rotateY(180deg);
+  border: 1px solid #334155;
+}
+
+.flip-card-back a {
+  color: #818cf8;
+  text-decoration: none;
+}
+
+.flip-card-back a:hover {
+  text-decoration: underline;
+}
+
+.flip-card-icon {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+}
+
+.flip-card h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.25rem;
+}
+
+.flip-card p {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.8;
+  line-height: 1.5;
+}
+
+.flip-card--vertical:hover .flip-card-inner {
+  transform: rotateX(180deg);
+}
+
+.flip-card--vertical .flip-card-back {
+  transform: rotateX(180deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .flip-card-inner {
+    transition: none;
+  }
+}


### PR DESCRIPTION
### Description

Adds a 3D flip card component that rotates on hover to reveal back content, with horizontal (rotateY) and vertical (rotateX) variants.

### Changes

- `submissions/examples/core_changes-issue-25638/style.css` — 3D perspective, preserve-3d, backface-visibility, reduced-motion
- `submissions/examples/core_changes-issue-25638/demo.html` — two demo cards (horizontal + vertical flip)
- `submissions/examples/core_changes-issue-25638/README.md` — what/how/why

### Features

- 3D perspective with `preserve-3d` and `backface-visibility: hidden`
- Horizontal flip via `rotateY(180deg)` on hover
- Vertical flip via `.flip-card--vertical` modifier (`rotateX`)
- Zero JS required
- Respects `prefers-reduced-motion: reduce`

Closes #25638