### PR TITLE
Add star rating component — interactive 1-5 stars with hover preview (#25630)

### DIFF
--- a/submissions/examples/core_changes-issue-25630/README.md
+++ b/submissions/examples/core_changes-issue-25630/README.md
@@ -1,0 +1,3 @@
+1. What does this do? Creates an interactive 1-5 star rating with hover preview (stars highlight up to the hovered position), click-to-rate, and a read-only display mode.
+2. How is it used? Use radio inputs and labels inside `.star-rating` with `direction: rtl` for the CSS-only hover chain effect. Add `.star-rating--readonly` for display-only mode.
+3. Why is it useful? A star rating is a standard UI pattern for reviews and feedback — this implementation uses pure CSS for hover highlighting (no JS dependency for the core interaction) and is fully keyboard accessible via native radio inputs.

--- a/submissions/examples/core_changes-issue-25630/demo.html
+++ b/submissions/examples/core_changes-issue-25630/demo.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Star Rating — Demo</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: #0f172a;
+      display: flex;
+      flex-direction: column;
+      gap: 2.5rem;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+      font-family: system-ui, sans-serif;
+    }
+    .card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 1rem;
+      padding: 2rem;
+      text-align: center;
+      max-width: 350px;
+    }
+    .card h2 {
+      color: #e2e8f0;
+      margin: 0 0 0.25rem;
+      font-size: 1.1rem;
+    }
+    .card p {
+      color: #64748b;
+      font-size: 0.85rem;
+      margin: 0 0 1rem;
+    }
+    .card .rating-value {
+      margin-top: 0.75rem;
+      font-size: 0.8rem;
+      color: #94a3b8;
+    }
+    .card .rating-value span {
+      color: #f59e0b;
+      font-weight: 600;
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h2>Rate your experience</h2>
+    <p>Click a star to rate</p>
+    <div class="star-rating" id="rating1">
+      <input type="radio" name="stars" id="star5" value="5"><label for="star5" title="5 stars">★</label>
+      <input type="radio" name="stars" id="star4" value="4"><label for="star4" title="4 stars">★</label>
+      <input type="radio" name="stars" id="star3" value="3"><label for="star3" title="3 stars">★</label>
+      <input type="radio" name="stars" id="star2" value="2"><label for="star2" title="2 stars">★</label>
+      <input type="radio" name="stars" id="star1" value="1"><label for="star1" title="1 star">★</label>
+    </div>
+    <div class="rating-value">Rating: <span id="display1">0</span> / 5</div>
+  </div>
+
+  <div class="card">
+    <h2>Read-only display</h2>
+    <p>Pre-selected 4 stars</p>
+    <div class="star-rating star-rating--readonly" id="rating2">
+      <input type="radio" name="stars2" id="r5" value="5"><label for="r5">★</label>
+      <input type="radio" name="stars2" id="r4" value="4" checked><label for="r4">★</label>
+      <input type="radio" name="stars2" id="r3" value="3"><label for="r3">★</label>
+      <input type="radio" name="stars2" id="r2" value="2"><label for="r2">★</label>
+      <input type="radio" name="stars2" id="r1" value="1"><label for="r1">★</label>
+    </div>
+    <div class="rating-value">Rating: <span id="display2">4</span> / 5</div>
+  </div>
+
+  <script>
+    document.querySelectorAll('.star-rating:not(.star-rating--readonly)').forEach(function(container) {
+      var display = container.parentElement.querySelector('.rating-value span');
+      container.addEventListener('change', function(e) {
+        if (display) display.textContent = e.target.value;
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/core_changes-issue-25630/style.css
+++ b/submissions/examples/core_changes-issue-25630/style.css
@@ -1,0 +1,53 @@
+.star-rating {
+  display: flex;
+  gap: 0.25rem;
+  direction: rtl;
+}
+
+.star-rating input {
+  display: none;
+}
+
+.star-rating label {
+  cursor: pointer;
+  font-size: 1.75rem;
+  color: #475569;
+  transition: color 0.15s, transform 0.15s;
+  user-select: none;
+}
+
+.star-rating label:hover,
+.star-rating label:hover ~ label,
+.star-rating input:checked ~ label {
+  color: #f59e0b;
+}
+
+.star-rating label:hover {
+  transform: scale(1.2);
+}
+
+.star-rating--readonly label {
+  cursor: default;
+}
+
+.star-rating--readonly label:hover {
+  transform: none;
+}
+
+.star-rating--readonly label:hover,
+.star-rating--readonly label:hover ~ label {
+  color: #475569;
+}
+
+.star-rating--readonly input:checked ~ label {
+  color: #f59e0b;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .star-rating label {
+    transition: none;
+  }
+  .star-rating label:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
### Description

Adds an interactive star rating component with hover highlight preview, click-to-rate, and a read-only display mode.

### Changes

- `submissions/examples/core_changes-issue-25630/style.css` — radio-based stars with RTL direction for CSS hover chain, size/color transitions, readonly variant
- `submissions/examples/core_changes-issue-25630/demo.html` — interactive and readonly demo cards, JS for display update
- `submissions/examples/core_changes-issue-25630/README.md` — what/how/why

### Features

- Pure CSS hover highlighting via `direction: rtl` and sibling selectors
- Keyboard accessible via native radio inputs
- Read-only mode via `.star-rating--readonly`
- Hover scale animation with reduced-motion support

Closes #25630