### PR TITLE
Add chip/tag input component with enter-to-add and removable chips (#25631)

### DIFF
--- a/submissions/examples/core_changes-issue-25631/README.md
+++ b/submissions/examples/core_changes-issue-25631/README.md
@@ -1,0 +1,3 @@
+1. What does this do? Creates a tag/chip input where users type and press Enter to create removable chips with an entrance animation, duplicate detection, and Backspace-to-remove-last.
+2. How is it used? Use `.chip-input` container with `.chip` elements and `.chip-input-field`. The JS handles add, remove, duplicate detection, and chip count display.
+3. Why is it useful? Chip inputs are standard for skills, emails, and keyword filters — this implementation provides smooth scale+fade chip entrance animation, a compact inline-flex layout, and keyboard-friendly interactions.

--- a/submissions/examples/core_changes-issue-25631/demo.html
+++ b/submissions/examples/core_changes-issue-25631/demo.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chip Tags — Demo</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: #0f172a;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+      font-family: system-ui, sans-serif;
+    }
+    .card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 1rem;
+      padding: 1.5rem;
+      width: 100%;
+      max-width: 450px;
+    }
+    .card h2 {
+      color: #e2e8f0;
+      margin: 0 0 0.25rem;
+      font-size: 1.1rem;
+    }
+    .card p {
+      color: #64748b;
+      font-size: 0.85rem;
+      margin: 0 0 1rem;
+    }
+    .chip-count {
+      margin-top: 0.75rem;
+      font-size: 0.8rem;
+      color: #475569;
+    }
+    .chip-count span {
+      color: #94a3b8;
+      font-weight: 600;
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h2>Skills</h2>
+    <p>Type a skill and press Enter or comma to add</p>
+    <div class="chip-input" id="chipContainer">
+      <div class="chip" data-value="HTML">
+        HTML
+        <button class="chip-remove" aria-label="Remove">×</button>
+      </div>
+      <div class="chip" data-value="CSS">
+        CSS
+        <button class="chip-remove" aria-label="Remove">×</button>
+      </div>
+      <input class="chip-input-field" id="chipField" placeholder="Type and press Enter..." autofocus>
+    </div>
+    <div class="chip-count">Chips: <span id="chipCount">2</span></div>
+  </div>
+
+  <script>
+    (function() {
+      var container = document.getElementById('chipContainer');
+      var field = document.getElementById('chipField');
+      var count = document.getElementById('chipCount');
+
+      function updateCount() {
+        var chips = container.querySelectorAll('.chip');
+        count.textContent = chips.length;
+      }
+
+      function addChip(value) {
+        value = value.trim();
+        if (!value) return;
+        var existing = container.querySelectorAll('.chip');
+        for (var i = 0; i < existing.length; i++) {
+          if (existing[i].getAttribute('data-value').toLowerCase() === value.toLowerCase()) {
+            return;
+          }
+        }
+        var chip = document.createElement('div');
+        chip.className = 'chip';
+        chip.setAttribute('data-value', value);
+        chip.innerHTML = value + '<button class="chip-remove" aria-label="Remove">×</button>';
+        chip.querySelector('.chip-remove').addEventListener('click', function() {
+          chip.remove();
+          updateCount();
+        });
+        container.insertBefore(chip, field);
+        updateCount();
+      }
+
+      field.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter' || e.key === ',') {
+          e.preventDefault();
+          addChip(field.value);
+          field.value = '';
+        }
+        if (e.key === 'Backspace' && field.value === '') {
+          var chips = container.querySelectorAll('.chip');
+          if (chips.length > 0) {
+            chips[chips.length - 1].remove();
+            updateCount();
+          }
+        }
+      });
+
+      container.querySelectorAll('.chip-remove').forEach(function(btn) {
+        btn.addEventListener('click', function() {
+          btn.closest('.chip').remove();
+          updateCount();
+        });
+      });
+
+      updateCount();
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/core_changes-issue-25631/style.css
+++ b/submissions/examples/core_changes-issue-25631/style.css
@@ -1,0 +1,79 @@
+.chip-input {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border: 1px solid #334155;
+  border-radius: 0.75rem;
+  background: #1e293b;
+  min-height: 2.75rem;
+  align-items: center;
+}
+
+.chip-input-field {
+  border: none;
+  outline: none;
+  background: transparent;
+  color: #e2e8f0;
+  font-size: 0.9rem;
+  padding: 0.25rem;
+  min-width: 120px;
+  flex: 1;
+  font-family: inherit;
+}
+
+.chip-input-field::placeholder {
+  color: #475569;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.75rem;
+  background: #334155;
+  color: #e2e8f0;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  animation: chip-enter 0.2s ease both;
+}
+
+@keyframes chip-enter {
+  from {
+    transform: scale(0);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.chip-remove {
+  cursor: pointer;
+  opacity: 0.5;
+  font-size: 1rem;
+  line-height: 1;
+  transition: opacity 0.15s, transform 0.15s;
+  background: none;
+  border: none;
+  color: #e2e8f0;
+  padding: 0;
+}
+
+.chip-remove:hover {
+  opacity: 1;
+  transform: scale(1.2);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chip {
+    animation: none;
+  }
+  .chip-remove {
+    transition: none;
+  }
+  .chip-remove:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
### Description

Adds a tag/chip input component where users type and press Enter to create removable chips with a scale+fade entrance animation, duplicate detection, and keyboard navigation.

### Changes

- `submissions/examples/core_changes-issue-25631/style.css` — chip input container, chip badges with enter animation, remove button hover effects
- `submissions/examples/core_changes-issue-25631/demo.html` — interactive demo with Enter/add, click-to-remove, Backspace-to-remove-last
- `submissions/examples/core_changes-issue-25631/README.md` — what/how/why

### Features

- Enter or comma to add chips
- Scale+fade entrance animation via @keyframes
- Duplicate detection (case-insensitive)
- Backspace removes last chip when field is empty
- Hover scale on remove button
- Respects prefers-reduced-motion

Closes #25631