### PR TITLE
Add drag-and-drop file upload component with preview chips (#25632)

### DIFF
--- a/submissions/examples/core_changes-issue-25632/README.md
+++ b/submissions/examples/core_changes-issue-25632/README.md
@@ -1,0 +1,3 @@
+1. What does this do? Creates a drag-and-drop file upload zone with visual drag-over feedback (scale, border color, background tint) and displays selected files as removable chips with an entrance animation.
+2. How is it used? Use `.file-upload` as the drop zone container; the JS handles drag events, file selection, and file chip rendering with remove buttons.
+3. Why is it useful? A styled file upload with animated feedback improves the UX of forms and dashboards — this implementation provides drag-and-drop, click-to-browse, file chips with scale+fade entrance, and reduced-motion support.

--- a/submissions/examples/core_changes-issue-25632/demo.html
+++ b/submissions/examples/core_changes-issue-25632/demo.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>File Upload — Demo</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: #0f172a;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+      font-family: system-ui, sans-serif;
+    }
+    .card {
+      width: 100%;
+      max-width: 480px;
+    }
+    .card h2 {
+      color: #e2e8f0;
+      margin: 0 0 0.25rem;
+      font-size: 1.1rem;
+    }
+    .card p {
+      color: #64748b;
+      font-size: 0.85rem;
+      margin: 0 0 1rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h2>Upload Files</h2>
+    <p>Drag & drop files or click to browse</p>
+    <div class="file-upload" id="dropZone">
+      <div class="file-upload-icon">📁</div>
+      <p class="file-upload-text"><strong>Click to upload</strong> or drag and drop</p>
+      <p class="file-upload-hint">Supports images, PDFs, and documents (max 5MB each)</p>
+      <div class="file-upload-files" id="fileList"></div>
+    </div>
+  </div>
+
+  <script>
+    (function() {
+      var zone = document.getElementById('dropZone');
+      var list = document.getElementById('fileList');
+      var input = document.createElement('input');
+      input.type = 'file';
+      input.multiple = true;
+
+      function addFiles(files) {
+        for (var i = 0; i < files.length; i++) {
+          var file = files[i];
+          var chip = document.createElement('span');
+          chip.className = 'file-upload-file';
+          chip.innerHTML = '📄 ' + file.name + ' <button class="file-upload-remove" aria-label="Remove">×</button>';
+          chip.querySelector('.file-upload-remove').addEventListener('click', function() {
+            chip.remove();
+          });
+          list.appendChild(chip);
+        }
+      }
+
+      zone.addEventListener('click', function() {
+        input.click();
+      });
+
+      input.addEventListener('change', function() {
+        addFiles(input.files);
+        input.value = '';
+      });
+
+      zone.addEventListener('dragover', function(e) {
+        e.preventDefault();
+        zone.classList.add('file-upload--dragover');
+      });
+
+      zone.addEventListener('dragleave', function(e) {
+        e.preventDefault();
+        zone.classList.remove('file-upload--dragover');
+      });
+
+      zone.addEventListener('drop', function(e) {
+        e.preventDefault();
+        zone.classList.remove('file-upload--dragover');
+        addFiles(e.dataTransfer.files);
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/core_changes-issue-25632/style.css
+++ b/submissions/examples/core_changes-issue-25632/style.css
@@ -1,0 +1,107 @@
+.file-upload {
+  border: 2px dashed #334155;
+  border-radius: 1rem;
+  padding: 3rem 2rem;
+  text-align: center;
+  cursor: pointer;
+  transition: border-color 0.2s, background 0.2s, transform 0.2s;
+  background: #1e293b;
+}
+
+.file-upload:hover {
+  border-color: #6366f1;
+  background: #1a2235;
+}
+
+.file-upload--dragover {
+  border-color: #6366f1;
+  background: rgba(99, 102, 241, 0.08);
+  transform: scale(1.02);
+}
+
+.file-upload-icon {
+  font-size: 2.5rem;
+  margin-bottom: 0.75rem;
+  opacity: 0.6;
+}
+
+.file-upload-text {
+  color: #94a3b8;
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.file-upload-text strong {
+  color: #818cf8;
+}
+
+.file-upload-hint {
+  color: #475569;
+  font-size: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.file-upload-files {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.file-upload-file {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.75rem;
+  background: #334155;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  color: #e2e8f0;
+  animation: file-enter 0.2s ease both;
+}
+
+@keyframes file-enter {
+  from {
+    transform: scale(0);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.file-upload-remove {
+  cursor: pointer;
+  opacity: 0.5;
+  background: none;
+  border: none;
+  color: #e2e8f0;
+  font-size: 1rem;
+  padding: 0;
+  line-height: 1;
+  transition: opacity 0.15s, transform 0.15s;
+}
+
+.file-upload-remove:hover {
+  opacity: 1;
+  transform: scale(1.2);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .file-upload {
+    transition: none;
+  }
+  .file-upload--dragover {
+    transform: none;
+  }
+  .file-upload-file {
+    animation: none;
+  }
+  .file-upload-remove {
+    transition: none;
+  }
+  .file-upload-remove:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
### Description

Adds a drag-and-drop file upload zone with animated drag-over feedback and file preview chips.

### Changes

- `submissions/examples/core_changes-issue-25632/style.css` — dashed drop zone, dragover scale/border/background transitions, file chips with enter animation
- `submissions/examples/core_changes-issue-25632/demo.html` — interactive demo with drag-and-drop, click-to-browse, file chip rendering
- `submissions/examples/core_changes-issue-25632/README.md` — what/how/why

### Features

- Drag-and-drop with visual hover/dragover states
- Click to open file browser
- File chips with scale+fade entrance animation
- Individual file removal
- Respects prefers-reduced-motion

Closes #25632