### PR TITLE
Add text reveal animation — character/word split staggered reveal on scroll (#25627)

### DIFF
--- a/submissions/examples/core_changes-issue-25627/README.md
+++ b/submissions/examples/core_changes-issue-25627/README.md
@@ -1,0 +1,3 @@
+1. What does this do? Splits text into individual characters or words wrapped in `<span>` elements and reveals them sequentially with staggered fade+slide animation on scroll.
+2. How is it used? Add `.text-reveal` to a text element. Call `initTextReveal(el, 'chars'|'words')` to split. The JS adds `.text-reveal--visible` when scrolled into view, triggering the staggered transition via CSS custom property `--index`.
+3. Why is it useful? Character/word-level text reveal adds a premium, storytelling feel to hero headlines and section titles — this implementation uses CSS `transition-delay` with `calc()` for staggering, requires no external libraries, and supports up/down/fade directions.

--- a/submissions/examples/core_changes-issue-25627/demo.html
+++ b/submissions/examples/core_changes-issue-25627/demo.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Text Reveal — Demo</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      margin: 0;
+      background: #0f172a;
+      color: #e2e8f0;
+      font-family: system-ui, sans-serif;
+    }
+    .spacer {
+      height: 80vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #475569;
+      font-size: 0.85rem;
+    }
+    .section {
+      max-width: 700px;
+      margin: 0 auto;
+      padding: 2rem;
+    }
+    h1 {
+      font-size: 2.5rem;
+      font-weight: 700;
+      line-height: 1.2;
+      margin-bottom: 1.5rem;
+    }
+    h2 {
+      font-size: 1.75rem;
+      font-weight: 600;
+      margin-top: 4rem;
+      margin-bottom: 1rem;
+    }
+    p {
+      font-size: 1.05rem;
+      line-height: 1.8;
+      color: #94a3b8;
+      margin-bottom: 1.5rem;
+    }
+    .mode-label {
+      display: inline-block;
+      background: #1e293b;
+      padding: 0.25rem 0.75rem;
+      border-radius: 999px;
+      font-size: 0.75rem;
+      color: #6366f1;
+      margin-bottom: 0.5rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="spacer">↓ Scroll down to see text reveal ↓</div>
+
+  <div class="section">
+    <div class="mode-label">Characters — direction: up</div>
+    <h1 class="text-reveal" id="reveal1">Text reveal animation with staggered character entrance</h1>
+  </div>
+
+  <div class="section">
+    <div class="mode-label">Words — direction: down</div>
+    <h2 class="text-reveal text-reveal--down" id="reveal2">Split into individual words and animate sequentially</h2>
+  </div>
+
+  <div class="section">
+    <div class="mode-label">Fade only</div>
+    <p class="text-reveal text-reveal--fade" id="reveal3">Each word fades in with staggered timing. This mode is useful when you want the staggered sequence without the vertical slide. The transition delay is controlled by the --index CSS custom property set on each span element.</p>
+  </div>
+
+  <script>
+    (function() {
+      function initTextReveal(el, type) {
+        var text = el.textContent.trim();
+        var parts = type === 'words' ? text.split(/\s+/) : text.split('');
+        el.textContent = '';
+        parts.forEach(function(part, i) {
+          var span = document.createElement('span');
+          span.textContent = part;
+          span.style.setProperty('--index', i);
+          if (type === 'words' && i < parts.length - 1) {
+            span.textContent = part + ' ';
+          }
+          el.appendChild(span);
+        });
+      }
+
+      var els = [
+        { el: document.getElementById('reveal1'), type: 'chars' },
+        { el: document.getElementById('reveal2'), type: 'words' },
+        { el: document.getElementById('reveal3'), type: 'words' }
+      ];
+
+      els.forEach(function(item) {
+        if (!item.el) return;
+        initTextReveal(item.el, item.type);
+      });
+
+      function checkVisibility() {
+        els.forEach(function(item) {
+          var el = item.el;
+          if (!el) return;
+          var rect = el.getBoundingClientRect();
+          if (rect.top < window.innerHeight - 80) {
+            el.classList.add('text-reveal--visible');
+          }
+        });
+      }
+
+      window.addEventListener('scroll', function() {
+        requestAnimationFrame(checkVisibility);
+      });
+      setTimeout(checkVisibility, 100);
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/core_changes-issue-25627/style.css
+++ b/submissions/examples/core_changes-issue-25627/style.css
@@ -1,0 +1,38 @@
+.text-reveal {
+  overflow: hidden;
+  display: inline-block;
+}
+
+.text-reveal span {
+  display: inline-block;
+  opacity: 0;
+  transform: translateY(40px);
+  transition: opacity 0.4s ease, transform 0.4s ease;
+  transition-delay: calc(var(--index, 0) * 0.04s);
+  white-space: pre;
+}
+
+.text-reveal--visible span {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.text-reveal--down span {
+  transform: translateY(-40px);
+}
+
+.text-reveal--down.text-reveal--visible span {
+  transform: translateY(0);
+}
+
+.text-reveal--fade span {
+  transform: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .text-reveal span {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+}


### PR DESCRIPTION
### Description

Adds a text reveal utility that splits text into characters or words and animates them in sequentially with staggered timing on scroll.

### Changes

- `submissions/examples/core_changes-issue-25627/style.css` — text-reveal base, span transitions with --index delay, up/down/fade direction variants
- `submissions/examples/core_changes-issue-25627/demo.html` — 3 demos (chars-up, words-down, fade), scroll-triggered visibility
- `submissions/examples/core_changes-issue-25627/README.md` — what/how/why

### Features

- Character or word splitting
- Staggered transition via CSS custom property `--index`
- Direction variants: up (default), down, fade
- RAF-scroll-triggered visibility
- Respects prefers-reduced-motion

Closes #25627