### PR TITLE
Add container query utility with inline-size breakpoints (#25640)

### DIFF
--- a/submissions/examples/core_changes-issue-25640/README.md
+++ b/submissions/examples/core_changes-issue-25640/README.md
@@ -1,0 +1,3 @@
+1. What does this do? Provides container query utility classes using `container-type: inline-size` and `@container` breakpoints at 400px, 640px, and 800px, so components respond to their own container width rather than the viewport.
+2. How is it used? Add `container-type: inline-size` to a parent element, then use `@container` rules to style children at each breakpoint. The demo includes a card layout that switches column/row and a grid that adjusts column count.
+3. Why is it useful? Container queries are more modular than media queries — components adapt to wherever they are placed, making them truly reusable across different layout contexts without viewport dependencies.

--- a/submissions/examples/core_changes-issue-25640/demo.html
+++ b/submissions/examples/core_changes-issue-25640/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Container Queries Utility — Demo</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      margin: 0;
+      background: #0f172a;
+      font-family: system-ui, sans-serif;
+    }
+  </style>
+</head>
+<body>
+  <div class="cq-wrapper">
+    <h1>Container Queries Utility</h1>
+    <p class="subtitle">Resize the container below to see components respond to their own width, not the viewport.</p>
+
+    <div class="cq-controls">
+      <button onclick="setWidth(300)" data-w="300">300px</button>
+      <button onclick="setWidth(400)" data-w="400">400px</button>
+      <button onclick="setWidth(500)" data-w="500">500px</button>
+      <button onclick="setWidth(640)" data-w="640" class="active">640px</button>
+      <button onclick="setWidth(800)" data-w="800">800px</button>
+      <button onclick="setWidth(900)" data-w="900">Full</button>
+    </div>
+
+    <div class="cq-container" id="demo-container" style="max-width: 640px;">
+      <div class="cq-card">
+        <div class="cq-card-icon">&#9733;</div>
+        <div class="cq-card-body">
+          <h3>Container Queries</h3>
+          <p>This card changes layout based on its container width — not the viewport. At 400px+ it switches from column to row. At 640px+ the icon and text grow. At 800px+ everything scales up further.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="cq-container" id="grid-container" style="max-width: 640px; margin-top: 2rem;">
+      <div class="cq-grid" id="demo-grid">
+        <div class="cq-grid-item"><strong>Feature</strong>Responds to container width</div>
+        <div class="cq-grid-item"><strong>Benefit</strong>More modular than media queries</div>
+        <div class="cq-grid-item"><strong>Usage</strong>Set container-type: inline-size</div>
+        <div class="cq-grid-item"><strong>Breakpoints</strong>@container min-width rules</div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    function setWidth(w) {
+      document.getElementById('demo-container').style.maxWidth = w + 'px';
+      document.getElementById('grid-container').style.maxWidth = w + 'px';
+      document.querySelectorAll('.cq-controls button').forEach(function(btn) {
+        btn.classList.toggle('active', btn.dataset.w === '' + w);
+      });
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/core_changes-issue-25640/style.css
+++ b/submissions/examples/core_changes-issue-25640/style.css
@@ -1,0 +1,181 @@
+.cq-wrapper {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem;
+  font-family: system-ui, sans-serif;
+}
+
+.cq-wrapper h1 {
+  color: #e2e8f0;
+  font-size: 1.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.cq-wrapper .subtitle {
+  color: #64748b;
+  font-size: 0.85rem;
+  margin-bottom: 2rem;
+}
+
+.cq-controls {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.cq-controls button {
+  padding: 0.4rem 0.9rem;
+  border-radius: 0.5rem;
+  border: 1px solid #334155;
+  background: #1e293b;
+  color: #e2e8f0;
+  cursor: pointer;
+  font-size: 0.8rem;
+  transition: background 0.2s;
+}
+
+.cq-controls button:hover {
+  background: #334155;
+}
+
+.cq-controls button.active {
+  background: #818cf8;
+  color: #0f172a;
+  border-color: #818cf8;
+  font-weight: 600;
+}
+
+.cq-container {
+  container-type: inline-size;
+  container-name: card;
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  transition: max-width 0.4s ease;
+  overflow: hidden;
+}
+
+.cq-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+}
+
+.cq-card-icon {
+  width: 48px;
+  height: 48px;
+  background: #818cf8;
+  border-radius: 0.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #0f172a;
+  font-size: 1.25rem;
+  flex-shrink: 0;
+}
+
+.cq-card-body {
+  text-align: center;
+}
+
+.cq-card-body h3 {
+  color: #e2e8f0;
+  margin: 0 0 0.25rem;
+  font-size: 1rem;
+}
+
+.cq-card-body p {
+  color: #94a3b8;
+  font-size: 0.8rem;
+  margin: 0;
+  line-height: 1.5;
+}
+
+@container card (min-width: 400px) {
+  .cq-card {
+    flex-direction: row;
+    text-align: left;
+  }
+  .cq-card-body {
+    text-align: left;
+  }
+}
+
+@container card (min-width: 640px) {
+  .cq-card {
+    gap: 1.5rem;
+    padding: 0.5rem 0;
+  }
+  .cq-card-icon {
+    width: 56px;
+    height: 56px;
+    font-size: 1.5rem;
+  }
+  .cq-card-body h3 {
+    font-size: 1.1rem;
+  }
+  .cq-card-body p {
+    font-size: 0.85rem;
+  }
+}
+
+@container card (min-width: 800px) {
+  .cq-card {
+    gap: 2rem;
+    padding: 1rem 0;
+  }
+  .cq-card-icon {
+    width: 64px;
+    height: 64px;
+    font-size: 1.75rem;
+  }
+  .cq-card-body h3 {
+    font-size: 1.25rem;
+  }
+}
+
+.cq-grid {
+  display: grid;
+  container-type: inline-size;
+  container-name: grid;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.cq-grid-item {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  color: #94a3b8;
+  font-size: 0.8rem;
+  text-align: center;
+}
+
+.cq-grid-item strong {
+  display: block;
+  color: #e2e8f0;
+  font-size: 0.95rem;
+  margin-bottom: 0.25rem;
+}
+
+@container grid (min-width: 400px) {
+  .cq-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@container grid (min-width: 640px) {
+  .cq-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cq-container {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
Adds container query utility with `container-type: inline-size`, `@container` breakpoints at 400px/640px/800px, a responsive card layout demo, and an auto-adjusting grid demo. Closes #25640