### PR TITLE
Add CSS breadcrumb navigation component

### DIFF
--- a/submissions/examples/ease-breadcrumb-za/README.md
+++ b/submissions/examples/ease-breadcrumb-za/README.md
@@ -1,0 +1,12 @@
+# CSS Breadcrumb Navigation
+
+## What does this do?
+CSS breadcrumb trails with multiple separator styles (slash, arrow, bullet, line, custom) and collapsed variant.
+
+## How is it used?
+```html
+<nav class="br-breadcrumb" aria-label="Breadcrumb"><ol><li><a href="#">Home</a></li><li aria-current="page">Page</li></ol></nav>
+```
+
+## Why is it useful?
+Provides clear navigation hierarchy without JavaScript. Multiple separator styles. ARIA-compliant. Collapsible for deep paths. CSS-only hover states.

--- a/submissions/examples/ease-breadcrumb-za/demo.html
+++ b/submissions/examples/ease-breadcrumb-za/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Breadcrumb - EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<header class="br-header"><h1>CSS Breadcrumb Navigation</h1><p>CSS-only breadcrumb trails with multiple separators and hierarchy indicators</p></header>
+<section class="br-section"><h2>Default Slash</h2><nav class="br-breadcrumb" aria-label="Breadcrumb"><ol><li><a href="#">Home</a></li><li><a href="#">Products</a></li><li><a href="#">Electronics</a></li><li aria-current="page">Laptops</li></ol></nav></section>
+<section class="br-section"><h2>Arrow Separator</h2><nav class="br-breadcrumb br-arrow" aria-label="Breadcrumb"><ol><li><a href="#">Dashboard</a></li><li><a href="#">Analytics</a></li><li aria-current="page">Reports</li></ol></nav></section>
+<section class="br-section"><h2>Bullet Separator</h2><nav class="br-breadcrumb br-bullet" aria-label="Breadcrumb"><ol><li><a href="#">Store</a></li><li><a href="#">Men</a></li><li><a href="#">Shoes</a></li><li aria-current="page">Running</li></ol></nav></section>
+<section class="br-section"><h2>Line Separator</h2><nav class="br-breadcrumb br-line" aria-label="Breadcrumb"><ol><li><a href="#">Docs</a></li><li><a href="#">Components</a></li><li><a href="#">Navigation</a></li><li aria-current="page">Breadcrumb</li></ol></nav></section>
+<section class="br-section"><h2>Custom Icon</h2><nav class="br-breadcrumb br-custom" aria-label="Breadcrumb"><ol><li><a href="#">&#127968; Home</a></li><li><a href="#">&#128193; Projects</a></li><li><a href="#">&#9881; Settings</a></li><li aria-current="page">&#128200; Reports</li></ol></nav></section>
+<section class="br-section"><h2>Collapsed Breadcrumb</h2><nav class="br-breadcrumb br-collapsed" aria-label="Breadcrumb"><ol><li><a href="#">Root</a></li><li><span class="br-ellipsis" title="3 hidden levels">&#8230;</span></li><li><a href="#">Nested</a></li><li><a href="#">Deep</a></li><li aria-current="page">Current</li></ol></nav></section>
+<footer class="ftr"><p>EaseMotion CSS - Breadcrumb | GSSoC 2026</p></footer>
+</body>
+</html>

--- a/submissions/examples/ease-breadcrumb-za/style.css
+++ b/submissions/examples/ease-breadcrumb-za/style.css
@@ -1,0 +1,15 @@
+/* Breadcrumb - ease-breadcrumb-za */
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{--br-bg:#0a0a1a;--br-card:#16163a;--br-txt:#e0e0ff;--br-txt2:#9090bb;--br-brd:#2a2a5a;--br-accent:#667eea;--br-rad:8px;--br-font:"Segoe UI",system-ui,sans-serif}
+body{font-family:var(--br-font);background:var(--br-bg);color:var(--br-txt);padding:20px;min-height:100vh}
+.br-header{text-align:center;padding:40px 20px 20px}.br-header h1{font-size:2.2rem;font-weight:700;margin-bottom:8px}.br-header p{color:var(--br-txt2);font-size:1.05rem}
+.br-section{max-width:800px;margin:30px auto;padding:24px;background:var(--br-card);border:1px solid var(--br-brd);border-radius:12px}.br-section h2{font-size:1.3rem;margin-bottom:20px;padding-bottom:8px;border-bottom:1px solid var(--br-brd)}
+.br-breadcrumb ol{list-style:none;display:flex;flex-wrap:wrap;align-items:center;gap:4px;padding:12px 16px;background:rgba(255,255,255,0.02);border-radius:var(--br-rad);border:1px solid var(--br-brd)}
+.br-breadcrumb li{display:flex;align-items:center;gap:4px;color:var(--br-txt2);font-size:0.9rem}
+.br-breadcrumb li+li::before{content:"/";color:var(--br-txt2);margin-right:4px;opacity:0.4}
+.br-breadcrumb a{color:var(--br-accent);text-decoration:none;transition:color 0.2s}.br-breadcrumb a:hover{color:var(--br-txt);text-decoration:underline}
+.br-breadcrumb li[aria-current]{color:var(--br-txt);font-weight:600}
+.br-arrow li+li::before{content:"\2192"}.br-bullet li+li::before{content:"\2022";font-size:1.2rem}.br-line li+li::before{content:"\007C";font-weight:300}
+.br-custom li+li::before{content:"\276F";font-size:0.7rem;color:var(--br-accent);opacity:0.7}
+.br-ellipsis{color:var(--br-txt2);cursor:default;padding:0 4px;letter-spacing:2px}
+.ftr{text-align:center;padding:30px;color:var(--br-txt2);font-size:0.85rem;border-top:1px solid var(--br-brd);margin-top:30px}


### PR DESCRIPTION
## Summary
Adds add css breadcrumb navigation component.

## Files
- submissions/examples/ease-breadcrumb-za/demo.html
- submissions/examples/ease-breadcrumb-za/style.css
- submissions/examples/ease-breadcrumb-za/README.md

## GSSOC26
This contribution is part of GSSoC 2026.

Fixes #25768