### PR TITLE
Add CSS tag chip component

### DIFF
--- a/submissions/examples/ease-tag-chip-za/README.md
+++ b/submissions/examples/ease-tag-chip-za/README.md
@@ -1,0 +1,12 @@
+# CSS Tags & Chips
+
+## What does this do?
+Tag and chip components with color variants, outline style, close button, sizes, and input area.
+
+## How is it used?
+```html
+<span class="tc-tag tc-primary">Label <button class="tc-close">&times;</button></span>
+```
+
+## Why is it useful?
+Flexible tag UI. Pill-shaped badges, filled/outline variants, dismissible chips, input chip area. Pure CSS.

--- a/submissions/examples/ease-tag-chip-za/demo.html
+++ b/submissions/examples/ease-tag-chip-za/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Tag Chip - EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<header class="tc-hd"><h1>CSS Tags & Chips</h1><p>Tag and chip components</p></header>
+<section class="tc-sc"><h2>Color Variants</h2>
+<div class="tc-row"><span class="tc-tag tc-primary">Primary</span><span class="tc-tag tc-success">Success</span><span class="tc-tag tc-warning">Warning</span><span class="tc-tag tc-danger">Danger</span><span class="tc-tag tc-info">Info</span><span class="tc-tag tc-dark">Dark</span></div>
+</section>
+<section class="tc-sc"><h2>Outline Tags</h2>
+<div class="tc-row"><span class="tc-tag tc-outline tc-o-primary">Primary</span><span class="tc-tag tc-outline tc-o-success">Success</span><span class="tc-tag tc-outline tc-o-warning">Warning</span><span class="tc-tag tc-outline tc-o-danger">Danger</span><span class="tc-tag tc-outline tc-o-info">Info</span></div>
+</section>
+<section class="tc-sc"><h2>With Close Button</h2>
+<div class="tc-row"><span class="tc-tag tc-primary">React <button class="tc-close">&times;</button></span><span class="tc-tag tc-success">Vue <button class="tc-close">&times;</button></span><span class="tc-tag tc-info">Angular <button class="tc-close">&times;</button></span><span class="tc-tag tc-dark">Svelte <button class="tc-close">&times;</button></span></div>
+</section>
+<section class="tc-sc"><h2>Sizes</h2>
+<div class="tc-row"><span class="tc-tag tc-primary tc-sm">Small</span><span class="tc-tag tc-primary">Default</span><span class="tc-tag tc-primary tc-lg">Large</span></div>
+</section>
+<section class="tc-sc"><h2>Chip Input Area</h2>
+<div class="tc-chip-area"><div class="tc-chips"><span class="tc-tag tc-primary">JavaScript <button class="tc-close">&times;</button></span><span class="tc-tag tc-success">CSS <button class="tc-close">&times;</button></span><span class="tc-tag tc-info">HTML <button class="tc-close">&times;</button></span><input type="text" class="tc-input" placeholder="Add tag..."></div></div>
+</section>
+<footer class="ftr"><p>EaseMotion - Tags & Chips | GSSoC 2026</p></footer>
+</body>
+</html>

--- a/submissions/examples/ease-tag-chip-za/style.css
+++ b/submissions/examples/ease-tag-chip-za/style.css
@@ -1,0 +1,12 @@
+/* Tag Chip - ease-tag-chip-za */
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{--tc-bg:#0b0b1c;--tc-crd:#1c1c42;--tc-txt:#e2e2f0;--tc-mut:#7a7ab2;--tc-brd:#2c2c5c;--tc-pri:#6366f1;--tc-suc:#22c55e;--tc-wrn:#f59e0b;--tc-dng:#ef4444;--tc-inf:#3b82f6;--tc-drk:#334155;--tc-rad:20px;--tc-fnt:"Inter","Segoe UI",sans-serif}
+body{font-family:var(--tc-fnt);background:var(--tc-bg);color:var(--tc-txt);padding:20px;min-height:100vh}.tc-hd{text-align:center;padding:40px 20px 20px}.tc-hd h1{font-size:2.2rem;font-weight:700;margin-bottom:6px}.tc-hd p{color:var(--tc-mut)}
+.tc-sc{max-width:760px;margin:28px auto;padding:22px;background:var(--tc-crd);border:1px solid var(--tc-brd);border-radius:12px}.tc-sc h2{margin-bottom:16px;padding-bottom:8px;border-bottom:1px solid var(--tc-brd);font-size:1.15rem}
+.tc-row{display:flex;gap:10px;flex-wrap:wrap;padding:8px 0}
+.tc-tag{display:inline-flex;align-items:center;gap:6px;padding:6px 14px;font-size:0.85rem;font-weight:500;border-radius:var(--tc-rad);color:#fff;white-space:nowrap}.tc-primary{background:var(--tc-pri)}.tc-success{background:var(--tc-suc)}.tc-warning{background:var(--tc-wrn)}.tc-danger{background:var(--tc-dng)}.tc-info{background:var(--tc-inf)}.tc-dark{background:var(--tc-drk)}
+.tc-outline{background:transparent;border:1.5px solid}.tc-o-primary{color:var(--tc-pri);border-color:var(--tc-pri)}.tc-o-success{color:var(--tc-suc);border-color:var(--tc-suc)}.tc-o-warning{color:var(--tc-wrn);border-color:var(--tc-wrn)}.tc-o-danger{color:var(--tc-dng);border-color:var(--tc-dng)}.tc-o-info{color:var(--tc-inf);border-color:var(--tc-inf)}
+.tc-close{background:none;border:none;color:inherit;font-size:1rem;cursor:pointer;padding:0;line-height:1;opacity:0.7}.tc-close:hover{opacity:1}
+.tc-sm{font-size:0.75rem;padding:3px 10px}.tc-lg{font-size:1rem;padding:8px 18px}
+.tc-chip-area{background:rgba(255,255,255,0.02);border:1px solid var(--tc-brd);border-radius:10px;padding:8px}.tc-chips{display:flex;flex-wrap:wrap;gap:6px;align-items:center}.tc-input{flex:1;min-width:100px;padding:6px 8px;border:none;background:none;color:var(--tc-txt);font-family:var(--tc-fnt);font-size:0.85rem;outline:none}.tc-input::placeholder{color:var(--tc-mut)}
+.ftr{text-align:center;padding:24px;color:var(--tc-mut);font-size:0.8rem;border-top:1px solid var(--tc-brd);max-width:760px;margin:28px auto 0}


### PR DESCRIPTION
## Summary
Adds add css tag chip component.

## Files
- submissions/examples/ease-tag-chip-za/demo.html
- submissions/examples/ease-tag-chip-za/style.css
- submissions/examples/ease-tag-chip-za/README.md

## GSSOC26
This contribution is part of GSSoC 2026.

Fixes #25807