### PR TITLE
Add support queue aging snapshot

### DIFF
--- a/submissions/examples/support-queue-aging-snapshot-ts/README.md
+++ b/submissions/examples/support-queue-aging-snapshot-ts/README.md
@@ -1,0 +1,21 @@
+# Support Queue Aging Snapshot
+
+## What does this do?
+
+Group open support tickets by age band, customer tier, SLA risk, priority, and owner coverage.
+
+## How is it used?
+
+Link `style.css` and use the supplied semantic card markup. Status colors are controlled with item and status modifier classes:
+
+```html
+<article class="item-card item-card--warn">
+  <span class="status status--warn">Needs review</span>
+</article>
+```
+
+Available tone modifiers are `good`, `info`, `warn`, and `bad`.
+
+## Why is it useful?
+
+This adds a responsive CSS-only operational example for issue #25821, with semantic HTML, visible focus states, non-color status labels, animated progress meters, and reduced-motion support.

--- a/submissions/examples/support-queue-aging-snapshot-ts/demo.html
+++ b/submissions/examples/support-queue-aging-snapshot-ts/demo.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Support Queue Aging Snapshot</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="shell">
+    <header class="page-header">
+      <div>
+        <p class="eyebrow">Support operations</p>
+        <h1>Support Queue Aging Snapshot</h1>
+        <p class="intro">Group open support tickets by age band, customer tier, SLA risk, priority, and owner coverage.</p>
+      </div>
+      <a class="jump-link" href="#workspace">View details</a>
+    </header>
+
+    <section class="metrics" aria-label="Summary metrics">
+      <div class="metric"><span>Open tickets</span><strong>186</strong></div><div class="metric"><span>SLA risk</span><strong>14</strong></div><div class="metric"><span>Aged 72h+</span><strong>9</strong></div>
+    </section>
+
+    <section class="workspace" id="workspace" aria-labelledby="workspace-title">
+      <div class="section-heading">
+        <div>
+          <p class="eyebrow">Current view</p>
+          <h2 id="workspace-title">Operational status</h2>
+        </div>
+        <span>Updated 10 minutes ago</span>
+      </div>
+      <div class="card-grid">
+        <article class="item-card item-card--good">
+        <div class="item-heading">
+          <h2>0-8 hours</h2>
+          <span class="status status--good">Healthy</span>
+        </div>
+        <dl class="item-meta">
+          <div><dt>Owner</dt><dd>Tier 2</dd></div>
+          <div><dt>Detail</dt><dd>68 tickets in rotation</dd></div>
+        </dl>
+        <p>Owners balanced</p>
+        <div class="meter" role="img" aria-label="0-8 hours progress 86%">
+          <span class="meter-fill meter-fill--86"></span>
+        </div>
+      </article>
+<article class="item-card item-card--info">
+        <div class="item-heading">
+          <h2>8-24 hours</h2>
+          <span class="status status--info">Watching</span>
+        </div>
+        <dl class="item-meta">
+          <div><dt>Owner</dt><dd>Enterprise</dd></div>
+          <div><dt>Detail</dt><dd>42 tickets waiting</dd></div>
+        </dl>
+        <p>Escalation review</p>
+        <div class="meter" role="img" aria-label="8-24 hours progress 64%">
+          <span class="meter-fill meter-fill--64"></span>
+        </div>
+      </article>
+<article class="item-card item-card--warn">
+        <div class="item-heading">
+          <h2>24-48 hours</h2>
+          <span class="status status--warn">At risk</span>
+        </div>
+        <dl class="item-meta">
+          <div><dt>Owner</dt><dd>Strategic</dd></div>
+          <div><dt>Detail</dt><dd>18 tickets near SLA</dd></div>
+        </dl>
+        <p>Lead review</p>
+        <div class="meter" role="img" aria-label="24-48 hours progress 42%">
+          <span class="meter-fill meter-fill--42"></span>
+        </div>
+      </article>
+<article class="item-card item-card--bad">
+        <div class="item-heading">
+          <h2>72h+</h2>
+          <span class="status status--bad">Breached</span>
+        </div>
+        <dl class="item-meta">
+          <div><dt>Owner</dt><dd>Mixed</dd></div>
+          <div><dt>Detail</dt><dd>9 tickets need recovery</dd></div>
+        </dl>
+        <p>Manager assigned</p>
+        <div class="meter" role="img" aria-label="72h+ progress 18%">
+          <span class="meter-fill meter-fill--18"></span>
+        </div>
+      </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/support-queue-aging-snapshot-ts/style.css
+++ b/submissions/examples/support-queue-aging-snapshot-ts/style.css
@@ -1,0 +1,357 @@
+:root {
+  color-scheme: light;
+  --bg: #f6f8fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #667085;
+  --line: #d9e2ef;
+  --good: #15803d;
+  --good-bg: #dcfce7;
+  --info: #2563eb;
+  --info-bg: #dbeafe;
+  --warn: #b45309;
+  --warn-bg: #fef3c7;
+  --bad: #b91c1c;
+  --bad-bg: #fee2e2;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.08), transparent 34%),
+    linear-gradient(315deg, rgba(21, 128, 61, 0.08), transparent 36%),
+    var(--bg);
+  color: var(--ink);
+}
+
+.shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 40px 0;
+}
+
+.page-header,
+.workspace,
+.metric,
+.item-card {
+  background: rgba(255, 255, 255, 0.94);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+
+.page-header,
+.workspace {
+  box-shadow: 0 20px 48px rgba(23, 32, 51, 0.08);
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  align-items: center;
+  padding: 28px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--info);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 760px;
+  margin-bottom: 10px;
+  font-size: clamp(2rem, 4vw, 3.4rem);
+  line-height: 1;
+}
+
+.intro {
+  max-width: 700px;
+  margin-bottom: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.jump-link {
+  flex: 0 0 auto;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 10px 16px;
+  color: var(--ink);
+  font-weight: 800;
+  text-decoration: none;
+  transition: transform 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+
+.jump-link:hover,
+.jump-link:focus-visible {
+  background: var(--ink);
+  border-color: var(--ink);
+  color: var(--surface);
+  transform: translateY(-2px);
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin: 18px 0;
+}
+
+.metric {
+  min-height: 104px;
+  padding: 18px;
+}
+
+.metric span,
+.section-heading span,
+.item-meta dt {
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.metric strong {
+  display: block;
+  margin-top: 8px;
+  font-size: 2rem;
+}
+
+.workspace {
+  padding: 24px;
+}
+
+.section-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: end;
+  margin-bottom: 18px;
+}
+
+.section-heading h2 {
+  margin-bottom: 0;
+  font-size: 1.35rem;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.item-card {
+  position: relative;
+  overflow: hidden;
+  min-height: 246px;
+  padding: 20px;
+  border-left-width: 5px;
+  transition: transform 220ms ease, border-color 220ms ease, box-shadow 220ms ease;
+}
+
+.item-card::after {
+  position: absolute;
+  inset: auto 18px 18px auto;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: currentColor;
+  content: "";
+  opacity: 0.08;
+  transform: scale(0.84);
+  transition: transform 220ms ease, opacity 220ms ease;
+}
+
+.item-card:hover,
+.item-card:focus-within {
+  box-shadow: 0 18px 36px rgba(23, 32, 51, 0.12);
+  transform: translateY(-4px);
+}
+
+.item-card:hover::after,
+.item-card:focus-within::after {
+  opacity: 0.14;
+  transform: scale(1);
+}
+
+.item-card--good {
+  border-left-color: var(--good);
+  color: var(--good);
+}
+
+.item-card--info {
+  border-left-color: var(--info);
+  color: var(--info);
+}
+
+.item-card--warn {
+  border-left-color: var(--warn);
+  color: var(--warn);
+}
+
+.item-card--bad {
+  border-left-color: var(--bad);
+  color: var(--bad);
+}
+
+.item-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: start;
+}
+
+.item-heading h2 {
+  margin-bottom: 0;
+  color: var(--ink);
+  font-size: 1.12rem;
+}
+
+.status {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 0.78rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.status--good {
+  background: var(--good-bg);
+  color: var(--good);
+}
+
+.status--info {
+  background: var(--info-bg);
+  color: var(--info);
+}
+
+.status--warn {
+  background: var(--warn-bg);
+  color: var(--warn);
+}
+
+.status--bad {
+  background: var(--bad-bg);
+  color: var(--bad);
+}
+
+.item-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin: 22px 0 16px;
+  color: var(--ink);
+}
+
+.item-meta dd {
+  margin: 4px 0 0;
+  color: var(--ink);
+  font-weight: 800;
+}
+
+.item-card p {
+  margin-bottom: 18px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.meter {
+  height: 10px;
+  overflow: hidden;
+  background: #e8edf5;
+  border-radius: 999px;
+}
+
+.meter span {
+  display: block;
+  height: 100%;
+  background: currentColor;
+  border-radius: inherit;
+  animation: fill-meter 900ms ease both;
+}
+
+.meter-fill--17 { width: 17%; }
+.meter-fill--18 { width: 18%; }
+.meter-fill--19 { width: 19%; }
+.meter-fill--21 { width: 21%; }
+.meter-fill--22 { width: 22%; }
+.meter-fill--24 { width: 24%; }
+.meter-fill--28 { width: 28%; }
+.meter-fill--42 { width: 42%; }
+.meter-fill--44 { width: 44%; }
+.meter-fill--46 { width: 46%; }
+.meter-fill--48 { width: 48%; }
+.meter-fill--52 { width: 52%; }
+.meter-fill--54 { width: 54%; }
+.meter-fill--56 { width: 56%; }
+.meter-fill--61 { width: 61%; }
+.meter-fill--62 { width: 62%; }
+.meter-fill--63 { width: 63%; }
+.meter-fill--64 { width: 64%; }
+.meter-fill--68 { width: 68%; }
+.meter-fill--70 { width: 70%; }
+.meter-fill--76 { width: 76%; }
+.meter-fill--82 { width: 82%; }
+.meter-fill--86 { width: 86%; }
+.meter-fill--88 { width: 88%; }
+.meter-fill--91 { width: 91%; }
+.meter-fill--92 { width: 92%; }
+.meter-fill--94 { width: 94%; }
+.meter-fill--95 { width: 95%; }
+.meter-fill--96 { width: 96%; }
+.meter-fill--100 { width: 100%; }
+
+@keyframes fill-meter {
+  from {
+    width: 0;
+  }
+}
+
+@media (max-width: 760px) {
+  .shell {
+    width: min(100% - 20px, 1120px);
+    padding: 20px 0;
+  }
+
+  .page-header,
+  .section-heading,
+  .item-heading {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .metrics,
+  .card-grid,
+  .item-meta {
+    grid-template-columns: 1fr;
+  }
+
+  .jump-link,
+  .status {
+    width: fit-content;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::after {
+    animation-duration: 1ms !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a responsive CSS-only support queue snapshot for ticket age bands, customer tier, SLA risk, and ownership.

Closes #25821

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside submissions/examples/support-queue-aging-snapshot-ts/
- [x] Includes demo.html, style.css, and README.md
- [x] No changes to core/ or components/
- [x] One feature per PR
- [x] Includes responsive styling and reduced-motion handling

## Validation

- [x] Repository Stylelint configuration passes
- [x] Repository HTMLHint configuration passes
- [x] git diff --check passes
- [x] No JavaScript or external assets