### PR TITLE
Add CSS marquee ticker component

### DIFF
--- a/submissions/examples/ease-marquee-za/README.md
+++ b/submissions/examples/ease-marquee-za/README.md
@@ -1,0 +1,16 @@
+# CSS Marquee Ticker Component
+
+## What does this do?
+A pure CSS horizontal scrolling text ticker and news bar with multiple speed and direction variants, plus fade-edge support.
+
+## How is it used?
+```html
+<div class="mrq-bar">
+  <div class="mrq-track mrq-left">
+    <span class="mrq-item">Scrolling text here &bull;</span>
+  </div>
+</div>
+```
+
+## Why is it useful?
+Creates scrolling news tickers, logo carousels, and announcement bars without JavaScript. Pause on hover, multiple speeds and directions. GPU-accelerated for smooth performance.

--- a/submissions/examples/ease-marquee-za/demo.html
+++ b/submissions/examples/ease-marquee-za/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Marquee Ticker - EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<header class="mrq-header"><h1>CSS Marquee Ticker</h1><p>Horizontal scrolling text ticker and news bar</p></header>
+<section class="mrq-section"><h2>News Ticker</h2><div class="mrq-bar"><div class="mrq-track mrq-left"><span class="mrq-item">Breaking: CSS-only marquee component now available &bull; Pure CSS scrolling text with pause on hover &bull; Zero JavaScript overhead &bull; Smooth 60fps GPU-accelerated animation &bull;</span></div></div></section>
+<section class="mrq-section"><h2>Speed Variants</h2><div class="mrq-strip"><div class="mrq-track mrq-fast"><span class="mrq-item">Fast scrolling &bull; 8s duration &bull; </span></div></div><div class="mrq-strip"><div class="mrq-track mrq-normal"><span class="mrq-item">Normal scrolling &bull; 15s duration &bull; </span></div></div><div class="mrq-strip"><div class="mrq-track mrq-slow"><span class="mrq-item">Slow scrolling &bull; 30s duration &bull; </span></div></div></section>
+<section class="mrq-section"><h2>Direction Variants</h2><div class="mrq-strip"><div class="mrq-track mrq-left"><span class="mrq-item">Left scrolling &bull; right to left &bull; </span></div></div><div class="mrq-strip"><div class="mrq-track mrq-right"><span class="mrq-item">Right scrolling &bull; left to right &bull; </span></div></div></section>
+<section class="mrq-section"><h2>Fade Edges</h2><div class="mrq-bar mrq-fade"><div class="mrq-track mrq-left"><span class="mrq-item">This marquee has gradient fade edges to blend smoothly with the background &bull; CSS mask-image creates the fade effect &bull; </span></div></div></section>
+<section class="mrq-section"><h2>Logo Ticker</h2><div class="mrq-bar mrq-fade"><div class="mrq-track mrq-right"><span class="mrq-item mrq-logo">✦ BrandOne ✦ BrandTwo ✦ BrandThree ✦ BrandFour ✦ BrandFive ✦ </span></div></div></section>
+</body>
+</html>

--- a/submissions/examples/ease-marquee-za/style.css
+++ b/submissions/examples/ease-marquee-za/style.css
@@ -1,0 +1,20 @@
+/* Marquee Ticker - ease-marquee-za */
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{--mrq-bg:#0a0a1a;--mrq-card:#16163a;--mrq-txt:#e0e0ff;--mrq-txt2:#9090bb;--mrq-border:#2a2a5a;--mrq-accent:#667eea;--mrq-radius:12px;--mrq-font:"Segoe UI",system-ui,sans-serif}
+body{font-family:var(--mrq-font);background:var(--mrq-bg);color:var(--mrq-txt);min-height:100vh;padding:20px}
+.mrq-header{text-align:center;padding:40px 20px 20px}.mrq-header h1{font-size:2.2rem;font-weight:700;margin-bottom:8px}.mrq-header p{color:var(--mrq-txt2);font-size:1.05rem}
+.mrq-section{max-width:960px;margin:30px auto;padding:24px;background:var(--mrq-card);border:1px solid var(--mrq-border);border-radius:var(--mrq-radius)}.mrq-section h2{font-size:1.3rem;margin-bottom:20px;padding-bottom:8px;border-bottom:1px solid var(--mrq-border)}
+.mrq-bar{width:100%;overflow:hidden;background:rgba(255,255,255,0.03);border-radius:8px;padding:12px 0}
+.mrq-strip{overflow:hidden;margin-bottom:12px;background:rgba(255,255,255,0.02);border-radius:6px;padding:8px 0}
+.mrq-strip:last-child{margin-bottom:0}
+.mrq-track{display:flex;white-space:nowrap;width:fit-content}
+.mrq-item{padding:0 8px;font-size:0.95rem;color:var(--mrq-txt2);display:inline-block}
+.mrq-left{animation:mrq-scroll-left 15s linear infinite}
+.mrq-right{animation:mrq-scroll-right 15s linear infinite}
+.mrq-fast{animation-duration:8s}.mrq-normal{animation-duration:15s}.mrq-slow{animation-duration:30s}
+.mrq-track:hover{animation-play-state:paused}
+@keyframes mrq-scroll-left{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
+@keyframes mrq-scroll-right{0%{transform:translateX(-50%)}100%{transform:translateX(0)}}
+.mrq-fade{mask-image:linear-gradient(to right,transparent 2%,black 15%,black 85%,transparent 98%);-webkit-mask-image:linear-gradient(to right,transparent 2%,black 15%,black 85%,transparent 98%)}
+.mrq-logo{font-weight:700;color:var(--mrq-accent);letter-spacing:2px;font-size:1.1rem}
+@media(max-width:600px){.mrq-item{font-size:0.85rem}}


### PR DESCRIPTION
## Summary
Adds add css marquee ticker component.

## Files
- submissions/examples/ease-marquee-za/demo.html
- submissions/examples/ease-marquee-za/style.css
- submissions/examples/ease-marquee-za/README.md

## GSSOC26
This contribution is part of GSSoC 2026.

Fixes #25929