### PR TITLE
Add CSS status indicator component

### DIFF
--- a/submissions/examples/ease-status-indicator-za/README.md
+++ b/submissions/examples/ease-status-indicator-za/README.md
@@ -1,0 +1,17 @@
+# CSS Status Indicator Component
+
+## What does this do?
+Status indicator dots and badges for online, offline, busy, away, and idle states with avatar integration, pulse animations, and multiple sizes.
+
+## How is it used?
+```html
+<span class="sti-dot sti-online"></span>
+<div class="sti-avatar-wrap">
+  <div class="sti-avatar">JD</div>
+  <span class="sti-dot sti-online sti-avatar-dot"></span>
+</div>
+<span class="sti-badge sti-badge-online">Online</span>
+```
+
+## Why is it useful?
+Provides clear user presence indicators for chat apps, dashboards, and team interfaces. Multiple visual styles, sizes, and animated pulse variants. Pure CSS, fully customizable.

--- a/submissions/examples/ease-status-indicator-za/demo.html
+++ b/submissions/examples/ease-status-indicator-za/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Status Indicator - EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<header class="sti-header"><h1>CSS Status Indicators</h1><p>Online, offline, busy, and away status dots and badges</p></header>
+<section class="sti-section"><h2>Standard Status Dots</h2><div class="sti-row"><div class="sti-dot-wrap"><span class="sti-dot sti-online"></span><span class="sti-label">Online</span></div><div class="sti-dot-wrap"><span class="sti-dot sti-offline"></span><span class="sti-label">Offline</span></div><div class="sti-dot-wrap"><span class="sti-dot sti-busy"></span><span class="sti-label">Busy</span></div><div class="sti-dot-wrap"><span class="sti-dot sti-away"></span><span class="sti-label">Away</span></div><div class="sti-dot-wrap"><span class="sti-dot sti-idle"></span><span class="sti-label">Idle</span></div></div></section>
+<section class="sti-section"><h2>With Avatar</h2><div class="sti-row"><div class="sti-avatar-wrap"><div class="sti-avatar" style="background:linear-gradient(135deg,#667eea,#764ba2)">JD</div><span class="sti-dot sti-online sti-avatar-dot"></span></div><div class="sti-avatar-wrap"><div class="sti-avatar" style="background:linear-gradient(135deg,#f5576c,#ff6b6b)">SM</div><span class="sti-dot sti-busy sti-avatar-dot"></span></div><div class="sti-avatar-wrap"><div class="sti-avatar" style="background:linear-gradient(135deg,#48bb78,#38a169)">AK</div><span class="sti-dot sti-away sti-avatar-dot"></span></div><div class="sti-avatar-wrap"><div class="sti-avatar" style="background:linear-gradient(135deg,#a855f7,#9333ea)">TL</div><span class="sti-dot sti-offline sti-avatar-dot"></span></div></div></section>
+<section class="sti-section"><h2>Animated Pulse</h2><div class="sti-row"><div class="sti-dot-wrap"><span class="sti-dot sti-online sti-pulse"></span><span class="sti-label">Live</span></div><div class="sti-dot-wrap"><span class="sti-dot sti-busy sti-pulse"></span><span class="sti-label">Recording</span></div><div class="sti-dot-wrap"><span class="sti-dot sti-away sti-pulse-slow"></span><span class="sti-label">Away</span></div></div></section>
+<section class="sti-section"><h2>Badge Style</h2><div class="sti-row"><span class="sti-badge sti-badge-online">Online</span><span class="sti-badge sti-badge-offline">Offline</span><span class="sti-badge sti-badge-busy">Busy</span><span class="sti-badge sti-badge-away">Away</span><span class="sti-badge sti-badge-idle">Idle</span></div></section>
+<section class="sti-section"><h2>Size Variants</h2><div class="sti-row"><div class="sti-dot-wrap"><span class="sti-dot sti-online sti-dot-sm"></span><span class="sti-label">Small</span></div><div class="sti-dot-wrap"><span class="sti-dot sti-online"></span><span class="sti-label">Default</span></div><div class="sti-dot-wrap"><span class="sti-dot sti-online sti-dot-lg"></span><span class="sti-label">Large</span></div><div class="sti-dot-wrap"><span class="sti-dot sti-online sti-dot-xl"></span><span class="sti-label">X-Large</span></div></div></section>
+</body>
+</html>

--- a/submissions/examples/ease-status-indicator-za/style.css
+++ b/submissions/examples/ease-status-indicator-za/style.css
@@ -1,0 +1,26 @@
+/* Status Indicator - ease-status-indicator-za */
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{--sti-bg:#0a0a1a;--sti-card:#16163a;--sti-txt:#e0e0ff;--sti-txt2:#9090bb;--sti-border:#2a2a5a;--sti-online:#48bb78;--sti-offline:#a0aec0;--sti-busy:#f56565;--sti-away:#f6ad55;--sti-idle:#667eea;--sti-radius:12px;--sti-font:"Segoe UI",system-ui,sans-serif}
+body{font-family:var(--sti-font);background:var(--sti-bg);color:var(--sti-txt);min-height:100vh;padding:20px}
+.sti-header{text-align:center;padding:40px 20px 20px}.sti-header h1{font-size:2.2rem;font-weight:700;margin-bottom:8px}.sti-header p{color:var(--sti-txt2);font-size:1.05rem}
+.sti-section{max-width:960px;margin:30px auto;padding:24px;background:var(--sti-card);border:1px solid var(--sti-border);border-radius:var(--sti-radius)}.sti-section h2{font-size:1.3rem;margin-bottom:20px;padding-bottom:8px;border-bottom:1px solid var(--sti-border)}
+.sti-row{display:flex;flex-wrap:wrap;gap:24px;align-items:center;padding:10px 0}
+.sti-dot-wrap{display:flex;flex-direction:column;align-items:center;gap:6px}
+.sti-dot{width:14px;height:14px;border-radius:50%;display:inline-block;background:var(--sti-txt2);transition:transform 0.2s}
+.sti-dot:hover{transform:scale(1.3)}
+.sti-online{background:var(--sti-online);box-shadow:0 0 6px rgba(72,187,120,0.4)}.sti-offline{background:var(--sti-offline)}.sti-busy{background:var(--sti-busy);box-shadow:0 0 6px rgba(245,101,101,0.4)}.sti-away{background:var(--sti-away);box-shadow:0 0 6px rgba(246,173,85,0.4)}.sti-idle{background:var(--sti-idle);box-shadow:0 0 6px rgba(102,126,234,0.4)}
+.sti-label{font-size:0.8rem;color:var(--sti-txt2)}
+.sti-avatar-wrap{position:relative;display:inline-flex}
+.sti-avatar{width:48px;height:48px;border-radius:50%;display:flex;align-items:center;justify-content:center;color:#fff;font-weight:700;font-size:1rem}
+.sti-avatar-dot{position:absolute;bottom:0;right:0;width:16px;height:16px;border:2px solid var(--sti-card)}
+@keyframes sti-pulse{0%,100%{transform:scale(1);opacity:1}50%{transform:scale(1.4);opacity:0.7}}
+.sti-pulse{animation:sti-pulse 2s ease-in-out infinite}
+.sti-pulse-slow{animation:sti-pulse 3s ease-in-out infinite}
+.sti-badge{display:inline-block;padding:4px 14px;border-radius:20px;font-size:0.8rem;font-weight:600;text-transform:uppercase;letter-spacing:0.5px}
+.sti-badge-online{background:rgba(72,187,120,0.15);color:var(--sti-online);border:1px solid rgba(72,187,120,0.3)}
+.sti-badge-offline{background:rgba(160,174,192,0.15);color:var(--sti-offline);border:1px solid rgba(160,174,192,0.3)}
+.sti-badge-busy{background:rgba(245,101,101,0.15);color:var(--sti-busy);border:1px solid rgba(245,101,101,0.3)}
+.sti-badge-away{background:rgba(246,173,85,0.15);color:var(--sti-away);border:1px solid rgba(246,173,85,0.3)}
+.sti-badge-idle{background:rgba(102,126,234,0.15);color:var(--sti-idle);border:1px solid rgba(102,126,234,0.3)}
+.sti-dot-sm{width:10px;height:10px}.sti-dot-lg{width:20px;height:20px}.sti-dot-xl{width:26px;height:26px}
+@media(max-width:600px){.sti-row{gap:16px}}


### PR DESCRIPTION
## Summary
Adds add css status indicator component.

## Files
- submissions/examples/ease-status-indicator-za/demo.html
- submissions/examples/ease-status-indicator-za/style.css
- submissions/examples/ease-status-indicator-za/README.md

## GSSOC26
This contribution is part of GSSoC 2026.

Fixes #25943