### PR TITLE
Add CSS dashboard layout component

### DIFF
--- a/submissions/examples/ease-dashboard-za/README.md
+++ b/submissions/examples/ease-dashboard-za/README.md
@@ -1,0 +1,15 @@
+# CSS Dashboard Layout Component
+
+## What does this do?
+A complete CSS dashboard layout with sidebar navigation, header, stats cards, bar chart, activity feed, and data table in a responsive grid layout.
+
+## How is it used?
+```html
+<div class="dsh-layout">
+  <aside class="dsh-sidebar">Sidebar</aside>
+  <main class="dsh-main">Content</main>
+</div>
+```
+
+## Why is it useful?
+Provides a full-featured dashboard interface for admin panels and analytics applications. Responsive grid layout, dark theme, and reusable card/table/stat components. Customizable via CSS variables.

--- a/submissions/examples/ease-dashboard-za/demo.html
+++ b/submissions/examples/ease-dashboard-za/demo.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Dashboard - EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="dsh-layout">
+<aside class="dsh-sidebar">
+<div class="dsh-brand">
+<div class="dsh-logo">E</div>
+<h2>EaseMotion</h2>
+</div>
+<nav class="dsh-nav">
+<a href="#" class="dsh-nav-item dsh-active"><span class="dsh-nav-icon">&#9750;</span><span class="dsh-nav-text">Dashboard</span></a>
+<a href="#" class="dsh-nav-item"><span class="dsh-nav-icon">&#9783;</span><span class="dsh-nav-text">Analytics</span></a>
+<a href="#" class="dsh-nav-item"><span class="dsh-nav-icon">&#9993;</span><span class="dsh-nav-text">Messages</span><span class="dsh-badge">12</span></a>
+<a href="#" class="dsh-nav-item"><span class="dsh-nav-icon">&#9881;</span><span class="dsh-nav-text">Settings</span></a>
+<a href="#" class="dsh-nav-item"><span class="dsh-nav-icon">&#9733;</span><span class="dsh-nav-text">Favorites</span></a>
+<a href="#" class="dsh-nav-item"><span class="dsh-nav-icon">&#9776;</span><span class="dsh-nav-text">Files</span></a>
+<a href="#" class="dsh-nav-item"><span class="dsh-nav-icon">&#9742;</span><span class="dsh-nav-text">Support</span></a>
+</nav>
+<div class="dsh-user">
+<div class="dsh-avatar">JD</div>
+<div class="dsh-user-info">
+<strong>John Doe</strong>
+<span>Administrator</span>
+</div>
+</div>
+</aside>
+<main class="dsh-main">
+<header class="dsh-header">
+<div class="dsh-search">
+<span class="dsh-search-icon">&#9740;</span>
+<input type="text" placeholder="Search anything...">
+</div>
+<div class="dsh-header-right">
+<div class="dsh-notif">
+<span class="dsh-notif-icon">&#9766;</span>
+<span class="dsh-notif-dot"></span>
+</div>
+<div class="dsh-notif">
+<span class="dsh-notif-icon">&#9888;</span>
+<span class="dsh-notif-dot dsh-notif-dot-red"></span>
+</div>
+<div class="dsh-avatar-sm">JD</div>
+</div>
+</header>
+<div class="dsh-content">
+<div class="dsh-page-header">
+<h1>Dashboard Overview</h1>
+<div class="dsh-actions">
+<button class="dsh-btn dsh-btn-primary">+ New Report</button>
+<button class="dsh-btn dsh-btn-outline">Export</button>
+</div>
+</div>
+<div class="dsh-stats">
+<div class="dsh-stat-card">
+<div class="dsh-stat-icon dsh-stat-icon-blue">&#9733;</div>
+<div class="dsh-stat-info">
+<span class="dsh-stat-label">Total Revenue</span>
+<span class="dsh-stat-value">$48,295</span>
+<span class="dsh-stat-change dsh-stat-up">&#9650; 12.5%</span>
+</div>
+</div>
+<div class="dsh-stat-card">
+<div class="dsh-stat-icon dsh-stat-icon-green">&#9783;</div>
+<div class="dsh-stat-info">
+<span class="dsh-stat-label">Active Users</span>
+<span class="dsh-stat-value">2,847</span>
+<span class="dsh-stat-change dsh-stat-up">&#9650; 8.2%</span>
+</div>
+</div>
+<div class="dsh-stat-card">
+<div class="dsh-stat-icon dsh-stat-icon-purple">&#9881;</div>
+<div class="dsh-stat-info">
+<span class="dsh-stat-label">Orders</span>
+<span class="dsh-stat-value">1,423</span>
+<span class="dsh-stat-change dsh-stat-up">&#9650; 3.7%</span>
+</div>
+</div>
+<div class="dsh-stat-card">
+<div class="dsh-stat-icon dsh-stat-icon-orange">&#9888;</div>
+<div class="dsh-stat-info">
+<span class="dsh-stat-label">Bounce Rate</span>
+<span class="dsh-stat-value">24.8%</span>
+<span class="dsh-stat-change dsh-stat-down">&#9660; 2.1%</span>
+</div>
+</div>
+</div>
+<div class="dsh-grid-2col">
+<div class="dsh-card">
+<div class="dsh-card-header">
+<h3>Weekly Revenue</h3>
+<select class="dsh-select"><option>This Week</option><option>This Month</option></select>
+</div>
+<div class="dsh-chart">
+<div class="dsh-bar" style="height:60%"><span>Mon</span></div>
+<div class="dsh-bar" style="height:85%"><span>Tue</span></div>
+<div class="dsh-bar" style="height:45%"><span>Wed</span></div>
+<div class="dsh-bar" style="height:90%"><span>Thu</span></div>
+<div class="dsh-bar" style="height:70%"><span>Fri</span></div>
+<div class="dsh-bar" style="height:55%"><span>Sat</span></div>
+<div class="dsh-bar" style="height:80%"><span>Sun</span></div>
+</div>
+</div>
+<div class="dsh-card">
+<div class="dsh-card-header">
+<h3>Recent Activity</h3>
+<a href="#" class="dsh-link">View All</a>
+</div>
+<div class="dsh-activity">
+<div class="dsh-activity-item">
+<div class="dsh-activity-dot dsh-dot-blue"></div>
+<div class="dsh-activity-info"><p>New user registered</p><span>2 min ago</span></div>
+</div>
+<div class="dsh-activity-item">
+<div class="dsh-activity-dot dsh-dot-green"></div>
+<div class="dsh-activity-info"><p>Order #1284 completed</p><span>15 min ago</span></div>
+</div>
+<div class="dsh-activity-item">
+<div class="dsh-activity-dot dsh-dot-purple"></div>
+<div class="dsh-activity-info"><p>Server backup finished</p><span>32 min ago</span></div>
+</div>
+<div class="dsh-activity-item">
+<div class="dsh-activity-dot dsh-dot-orange"></div>
+<div class="dsh-activity-info"><p>Payment received $2,400</p><span>1 hr ago</span></div>
+</div>
+<div class="dsh-activity-item">
+<div class="dsh-activity-dot dsh-dot-red"></div>
+<div class="dsh-activity-info"><p>SSL certificate renewed</p><span>2 hr ago</span></div>
+</div>
+</div>
+</div>
+</div>
+<div class="dsh-card dsh-table-card">
+<div class="dsh-card-header">
+<h3>Recent Orders</h3>
+<div class="dsh-card-actions">
+<button class="dsh-btn dsh-btn-sm">View All</button>
+</div>
+</div>
+<table class="dsh-table">
+<thead><tr><th>Order ID</th><th>Customer</th><th>Product</th><th>Status</th><th>Amount</th><th>Action</th></tr></thead>
+<tbody>
+<tr><td>#2841</td><td>Alice Johnson</td><td>Pro Plan Annual</td><td><span class="dsh-status dsh-status-paid">Paid</span></td><td>$299</td><td><button class="dsh-btn dsh-btn-xs">View</button></td></tr>
+<tr><td>#2842</td><td>Bob Martinez</td><td>Starter Monthly</td><td><span class="dsh-status dsh-status-pending">Pending</span></td><td>$29</td><td><button class="dsh-btn dsh-btn-xs">View</button></td></tr>
+<tr><td>#2843</td><td>Carol Chen</td><td>Enterprise Suite</td><td><span class="dsh-status dsh-status-paid">Paid</span></td><td>$999</td><td><button class="dsh-btn dsh-btn-xs">View</button></td></tr>
+<tr><td>#2844</td><td>David Kim</td><td>Pro Plan Monthly</td><td><span class="dsh-status dsh-status-canceled">Canceled</span></td><td>$49</td><td><button class="dsh-btn dsh-btn-xs">View</button></td></tr>
+<tr><td>#2845</td><td>Eve Williams</td><td>Starter Annual</td><td><span class="dsh-status dsh-status-paid">Paid</span></td><td>$199</td><td><button class="dsh-btn dsh-btn-xs">View</button></td></tr>
+</tbody>
+</table>
+</div>
+</div>
+</main>
+</div>
+</body>
+</html>

--- a/submissions/examples/ease-dashboard-za/style.css
+++ b/submissions/examples/ease-dashboard-za/style.css
@@ -1,0 +1,91 @@
+/* Dashboard Layout - ease-dashboard-za */
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{--dsh-bg:#0a0a1a;--dsh-sidebar:#12122a;--dsh-card:#1a1a3a;--dsh-txt:#e0e0ff;--dsh-txt2:#9090bb;--dsh-border:#2a2a5a;--dsh-accent:#667eea;--dsh-green:#48bb78;--dsh-purple:#a855f7;--dsh-orange:#f6ad55;--dsh-red:#f56565;--dsh-blue:#3b82f6;--dsh-radius:10px;--dsh-font:"Segoe UI",system-ui,sans-serif;--dsh-sidebar-w:240px;--dsh-header-h:64px}
+html,body{height:100%}body{font-family:var(--dsh-font);background:var(--dsh-bg);color:var(--dsh-txt);overflow:hidden}
+.dsh-layout{display:grid;grid-template-columns:var(--dsh-sidebar-w) 1fr;height:100vh}
+/* Sidebar */
+.dsh-sidebar{background:var(--dsh-sidebar);border-right:1px solid var(--dsh-border);display:flex;flex-direction:column;overflow-y:auto}
+.dsh-brand{display:flex;align-items:center;gap:12px;padding:18px 20px;border-bottom:1px solid var(--dsh-border)}
+.dsh-logo{width:36px;height:36px;border-radius:8px;background:linear-gradient(135deg,var(--dsh-accent),#764ba2);display:flex;align-items:center;justify-content:center;color:#fff;font-weight:800;font-size:1.2rem}
+.dsh-brand h2{font-size:1.1rem;font-weight:700}
+.dsh-nav{flex:1;padding:12px 10px;display:flex;flex-direction:column;gap:2px}
+.dsh-nav-item{display:flex;align-items:center;gap:12px;padding:10px 14px;border-radius:8px;color:var(--dsh-txt2);text-decoration:none;font-size:0.9rem;font-weight:500;transition:all 0.2s;position:relative}
+.dsh-nav-item:hover{background:rgba(102,126,234,0.08);color:var(--dsh-txt)}
+.dsh-nav-item.dsh-active{background:rgba(102,126,234,0.15);color:var(--dsh-accent)}
+.dsh-nav-icon{font-size:1.1rem;width:22px;text-align:center}
+.dsh-nav-text{flex:1}
+.dsh-badge{padding:2px 8px;border-radius:10px;background:var(--dsh-accent);color:#fff;font-size:0.7rem;font-weight:700}
+.dsh-user{display:flex;align-items:center;gap:10px;padding:14px 18px;border-top:1px solid var(--dsh-border);margin-top:auto}
+.dsh-avatar{width:40px;height:40px;border-radius:50%;background:linear-gradient(135deg,var(--dsh-accent),var(--dsh-purple));display:flex;align-items:center;justify-content:center;color:#fff;font-weight:700;font-size:0.85rem;flex-shrink:0}
+.dsh-user-info strong{display:block;font-size:0.85rem;line-height:1.3}
+.dsh-user-info span{font-size:0.75rem;color:var(--dsh-txt2)}
+/* Header */
+.dsh-main{display:flex;flex-direction:column;overflow:hidden}
+.dsh-header{display:flex;align-items:center;justify-content:space-between;padding:0 24px;height:var(--dsh-header-h);border-bottom:1px solid var(--dsh-border);background:var(--dsh-card);flex-shrink:0}
+.dsh-search{display:flex;align-items:center;gap:10px;background:rgba(255,255,255,0.04);border:1px solid var(--dsh-border);border-radius:8px;padding:8px 14px;width:300px}
+.dsh-search input{background:none;border:none;outline:none;color:var(--dsh-txt);font-size:0.88rem;width:100%;font-family:var(--dsh-font)}
+.dsh-search input::placeholder{color:var(--dsh-txt2)}
+.dsh-search-icon{color:var(--dsh-txt2);font-size:0.9rem}
+.dsh-header-right{display:flex;align-items:center;gap:16px}
+.dsh-notif{position:relative;cursor:pointer;width:36px;height:36px;border-radius:8px;background:rgba(255,255,255,0.04);display:flex;align-items:center;justify-content:center;transition:background 0.2s}
+.dsh-notif:hover{background:rgba(255,255,255,0.08)}
+.dsh-notif-icon{font-size:1.1rem;color:var(--dsh-txt2)}
+.dsh-notif-dot{position:absolute;top:6px;right:6px;width:8px;height:8px;border-radius:50%;background:var(--dsh-green);border:2px solid var(--dsh-card)}
+.dsh-notif-dot-red{background:var(--dsh-red)}
+.dsh-avatar-sm{width:34px;height:34px;border-radius:50%;background:linear-gradient(135deg,var(--dsh-accent),var(--dsh-purple));display:flex;align-items:center;justify-content:center;color:#fff;font-size:0.7rem;font-weight:700;cursor:pointer}
+/* Content */
+.dsh-content{padding:24px;overflow-y:auto;flex:1}
+.dsh-page-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:24px}
+.dsh-page-header h1{font-size:1.5rem;font-weight:700}
+.dsh-actions{display:flex;gap:10px}
+.dsh-btn{padding:10px 20px;border:none;border-radius:8px;font-family:var(--dsh-font);font-size:0.88rem;font-weight:600;cursor:pointer;transition:all 0.2s}
+.dsh-btn-primary{background:var(--dsh-accent);color:#fff}.dsh-btn-primary:hover{background:#5a6fd6;box-shadow:0 4px 15px rgba(102,126,234,0.3)}
+.dsh-btn-outline{background:transparent;border:1px solid var(--dsh-border);color:var(--dsh-txt2)}.dsh-btn-outline:hover{border-color:var(--dsh-accent);color:var(--dsh-accent)}
+.dsh-btn-sm{padding:6px 14px;font-size:0.82rem}
+.dsh-btn-xs{padding:4px 10px;font-size:0.75rem;border-radius:6px;background:rgba(102,126,234,0.1);color:var(--dsh-accent);border:1px solid rgba(102,126,234,0.2)}.dsh-btn-xs:hover{background:rgba(102,126,234,0.2)}
+/* Stats */
+.dsh-stats{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:16px;margin-bottom:24px}
+.dsh-stat-card{background:var(--dsh-card);border:1px solid var(--dsh-border);border-radius:var(--dsh-radius);padding:20px;display:flex;align-items:center;gap:16px;transition:border-color 0.3s}
+.dsh-stat-card:hover{border-color:var(--dsh-accent)}
+.dsh-stat-icon{width:48px;height:48px;border-radius:12px;display:flex;align-items:center;justify-content:center;font-size:1.3rem;flex-shrink:0}
+.dsh-stat-icon-blue{background:rgba(59,130,246,0.15);color:var(--dsh-blue)}
+.dsh-stat-icon-green{background:rgba(72,187,120,0.15);color:var(--dsh-green)}
+.dsh-stat-icon-purple{background:rgba(168,85,247,0.15);color:var(--dsh-purple)}
+.dsh-stat-icon-orange{background:rgba(246,173,85,0.15);color:var(--dsh-orange)}
+.dsh-stat-info{display:flex;flex-direction:column;gap:2px}
+.dsh-stat-label{font-size:0.8rem;color:var(--dsh-txt2);text-transform:uppercase;letter-spacing:0.5px}
+.dsh-stat-value{font-size:1.5rem;font-weight:700;line-height:1.2}
+.dsh-stat-change{font-size:0.78rem;font-weight:600}
+.dsh-stat-up{color:var(--dsh-green)}.dsh-stat-down{color:var(--dsh-red)}
+/* Grid cards */
+.dsh-grid-2col{display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-bottom:24px}
+.dsh-card{background:var(--dsh-card);border:1px solid var(--dsh-border);border-radius:var(--dsh-radius);padding:20px}
+.dsh-card-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:16px;padding-bottom:12px;border-bottom:1px solid var(--dsh-border)}
+.dsh-card-header h3{font-size:1rem;font-weight:600}
+.dsh-link{color:var(--dsh-accent);text-decoration:none;font-size:0.85rem;font-weight:500}.dsh-link:hover{text-decoration:underline}
+.dsh-select{padding:6px 10px;border-radius:6px;background:rgba(255,255,255,0.04);border:1px solid var(--dsh-border);color:var(--dsh-txt);font-size:0.82rem;font-family:var(--dsh-font);outline:none;cursor:pointer}
+/* Chart bars */
+.dsh-chart{display:flex;align-items:flex-end;gap:8px;height:180px;padding:20px 0 0}
+.dsh-bar{flex:1;background:linear-gradient(to top,var(--dsh-accent),rgba(102,126,234,0.3));border-radius:6px 6px 0 0;display:flex;align-items:flex-end;justify-content:center;padding-bottom:6px;font-size:0.7rem;color:var(--dsh-txt2);transition:height 0.5s,opacity 0.3s;min-height:8px;position:relative}
+.dsh-bar:hover{opacity:0.8}.dsh-bar span{position:absolute;bottom:-20px;font-size:0.7rem}
+.dsh-table-card{padding:0}.dsh-table-card .dsh-card-header{padding:16px 20px;margin-bottom:0}
+.dsh-card-actions{padding:0 20px 16px}
+/* Activity */
+.dsh-activity{display:flex;flex-direction:column;gap:14px}
+.dsh-activity-item{display:flex;align-items:flex-start;gap:12px}
+.dsh-activity-dot{width:10px;height:10px;border-radius:50%;margin-top:5px;flex-shrink:0}
+.dsh-dot-blue{background:var(--dsh-blue)}.dsh-dot-green{background:var(--dsh-green)}.dsh-dot-purple{background:var(--dsh-purple)}.dsh-dot-orange{background:var(--dsh-orange)}.dsh-dot-red{background:var(--dsh-red)}
+.dsh-activity-info p{font-size:0.88rem;line-height:1.4}.dsh-activity-info span{font-size:0.75rem;color:var(--dsh-txt2)}
+/* Table */
+.dsh-table{width:100%;border-collapse:collapse;font-size:0.88rem}
+.dsh-table th{padding:12px 16px;text-align:left;font-size:0.78rem;text-transform:uppercase;letter-spacing:0.5px;color:var(--dsh-txt2);border-bottom:1px solid var(--dsh-border);font-weight:600}
+.dsh-table td{padding:12px 16px;border-bottom:1px solid rgba(42,42,90,0.5);color:var(--dsh-txt2)}
+.dsh-table tr:hover td{background:rgba(255,255,255,0.02)}
+.dsh-table tr:last-child td{border-bottom:none}
+.dsh-status{padding:3px 10px;border-radius:12px;font-size:0.75rem;font-weight:600}
+.dsh-status-paid{background:rgba(72,187,120,0.12);color:var(--dsh-green)}
+.dsh-status-pending{background:rgba(246,173,85,0.12);color:var(--dsh-orange)}
+.dsh-status-canceled{background:rgba(245,101,101,0.12);color:var(--dsh-red)}
+/* Responsive */
+@media(max-width:1024px){.dsh-stats{grid-template-columns:repeat(2,1fr)}.dsh-grid-2col{grid-template-columns:1fr}}
+@media(max-width:768px){.dsh-layout{grid-template-columns:1fr}.dsh-sidebar{display:none}.dsh-search{width:180px}.dsh-stats{grid-template-columns:1fr}.dsh-table{font-size:0.8rem}.dsh-table th,.dsh-table td{padding:8px 10px}}


### PR DESCRIPTION
## Summary
Adds add css dashboard layout component.

## Files
- submissions/examples/ease-dashboard-za/demo.html
- submissions/examples/ease-dashboard-za/style.css
- submissions/examples/ease-dashboard-za/README.md

## GSSOC26
This contribution is part of GSSoC 2026.

Fixes #26042