### PR TITLE
[Feat] #19880 — Add chat input with send button animation (unique folder)

### DIFF
--- a/submissions/examples/ease-chat-input-19880-ag/README.md
+++ b/submissions/examples/ease-chat-input-19880-ag/README.md
@@ -1,0 +1,25 @@
+# Chat Message Input Component
+
+This submission implements the `ease-chat-input` component — a chat-style message input with a fading character counter, an animated send button (scale + rotate), and a success flash after sending.
+
+---
+
+## Features
+
+- **Character Counter**: Fades in from `opacity: 0` to `opacity: 1` the moment the user starts typing, and turns amber when approaching the 280-character limit.
+- **Send Button Animation**: On click, the arrow icon rotates 45° and scales to 0.8 (a subtle loading indicator). After the message is appended the button flashes green with an elastic bounce via `@keyframes successFlash`.
+- **Message Bubble Entrance**: Newly appended bubbles animate in with `bubbleIn` (fade + slight upward slide + scale).
+- **Keyboard Submit**: Pressing `Enter` (without `Shift`) sends the message; `Shift+Enter` creates a newline.
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Click in the textarea and type — verify the character counter fades in.
+3. Type 241+ characters — verify the counter turns amber.
+4. Press **Send** or hit `Enter` — verify:
+   - The send icon briefly rotates.
+   - A new bubble appears with a slide-in animation.
+   - The button flashes green.
+5. Enable `prefers-reduced-motion` — verify all animations are suppressed and counter is immediately visible.

--- a/submissions/examples/ease-chat-input-19880-ag/demo.html
+++ b/submissions/examples/ease-chat-input-19880-ag/demo.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chat Input — EaseMotion CSS</title>
+  <meta name="description" content="Chat message input with character counter, animated send button, and success flash state.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Input Component</span>
+      <h1>Chat Message Input</h1>
+      <p class="description">
+        A chat-style input with a fading character counter, an animated send button that
+        spins and scales on submit, and a success flash state after sending.
+      </p>
+    </header>
+
+    <!-- Chat Window Preview -->
+    <main class="chat-window">
+
+      <!-- Message history -->
+      <div class="chat-messages" id="chat-messages">
+        <div class="chat-bubble chat-bubble--received">
+          <span class="bubble-avatar">S</span>
+          <p class="bubble-text">Hey! Love the new animation presets. What are you working on?</p>
+        </div>
+        <div class="chat-bubble chat-bubble--sent">
+          <p class="bubble-text">Thanks! Building the chat input component right now 😄</p>
+          <span class="bubble-avatar bubble-avatar--sent">A</span>
+        </div>
+      </div>
+
+      <!-- Chat Input Row -->
+      <div class="ease-chat-input" id="chat-input-wrapper">
+        <textarea
+          id="chat-textarea"
+          class="chat-textarea"
+          placeholder="Type a message…"
+          rows="1"
+          maxlength="280"
+          aria-label="Chat message input"
+        ></textarea>
+
+        <div class="input-footer">
+          <span class="char-counter" id="char-counter" aria-live="polite">0 / 280</span>
+          <button class="send-btn" id="send-btn" type="button" aria-label="Send message">
+            <svg class="send-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+              <path d="M22 2L11 13" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M22 2L15 22L11 13L2 9L22 2Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </button>
+        </div>
+      </div>
+
+    </main>
+  </div>
+
+  <script>
+    const textarea = document.getElementById('chat-textarea');
+    const counter = document.getElementById('char-counter');
+    const sendBtn = document.getElementById('send-btn');
+    const messages = document.getElementById('chat-messages');
+
+    // Character counter
+    textarea.addEventListener('input', () => {
+      const len = textarea.value.length;
+      counter.textContent = `${len} / 280`;
+      counter.classList.toggle('counter--visible', len > 0);
+      counter.classList.toggle('counter--warning', len > 240);
+    });
+
+    // Send button action
+    sendBtn.addEventListener('click', sendMessage);
+    textarea.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        sendMessage();
+      }
+    });
+
+    function sendMessage() {
+      const text = textarea.value.trim();
+      if (!text) return;
+
+      // Animate send button
+      sendBtn.classList.add('send-btn--sending');
+
+      setTimeout(() => {
+        // Add message bubble
+        const bubble = document.createElement('div');
+        bubble.className = 'chat-bubble chat-bubble--sent chat-bubble--new';
+        bubble.innerHTML = `<p class="bubble-text">${text}</p><span class="bubble-avatar bubble-avatar--sent">A</span>`;
+        messages.appendChild(bubble);
+        messages.scrollTop = messages.scrollHeight;
+
+        // Reset
+        textarea.value = '';
+        counter.textContent = '0 / 280';
+        counter.classList.remove('counter--visible', 'counter--warning');
+        sendBtn.classList.remove('send-btn--sending');
+        sendBtn.classList.add('send-btn--success');
+
+        setTimeout(() => sendBtn.classList.remove('send-btn--success'), 1000);
+      }, 400);
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-chat-input-19880-ag/style.css
+++ b/submissions/examples/ease-chat-input-19880-ag/style.css
@@ -1,0 +1,273 @@
+/* ============================================================
+   Chat Input — style.css
+   Submission for EaseMotion CSS Issue #19880
+   Chat input with fading counter, animated send button, success flash
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.65);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+  --accent-cyan: #22d3ee;
+  --success-color: #10b981;
+  --warning-color: #f59e0b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 640px;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Chat Window
+   ============================================================ */
+
+.chat-window {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  background: rgba(9, 13, 22, 0.6);
+  border: 1px solid var(--card-border);
+  border-radius: 20px;
+  overflow: hidden;
+  backdrop-filter: blur(8px);
+}
+
+/* ── Message History ── */
+.chat-messages {
+  padding: 24px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-height: 240px;
+  max-height: 320px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255,255,255,0.1) transparent;
+}
+
+.chat-bubble {
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+  max-width: 80%;
+}
+
+.chat-bubble--received {
+  align-self: flex-start;
+}
+
+.chat-bubble--sent {
+  align-self: flex-end;
+  flex-direction: row;
+}
+
+.bubble-text {
+  padding: 10px 14px;
+  border-radius: 16px;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.chat-bubble--received .bubble-text {
+  background: rgba(255, 255, 255, 0.07);
+  border-bottom-left-radius: 4px;
+}
+
+.chat-bubble--sent .bubble-text {
+  background: var(--primary-color);
+  color: #fff;
+  border-bottom-right-radius: 4px;
+}
+
+.bubble-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: rgba(255,255,255,0.1);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.bubble-avatar--sent {
+  background: rgba(167, 139, 250, 0.25);
+}
+
+/* New bubble entrance */
+.chat-bubble--new {
+  animation: bubbleIn 0.3s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@keyframes bubbleIn {
+  from { opacity: 0; transform: translateY(12px) scale(0.95); }
+  to   { opacity: 1; transform: none; }
+}
+
+/* ============================================================
+   Chat Input Component
+   ============================================================ */
+
+.ease-chat-input {
+  border-top: 1px solid var(--card-border);
+  padding: 14px 16px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: rgba(17, 24, 39, 0.5);
+}
+
+.chat-textarea {
+  width: 100%;
+  background: transparent;
+  border: none;
+  outline: none;
+  font-family: inherit;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+  resize: none;
+  line-height: 1.5;
+  max-height: 120px;
+  overflow-y: auto;
+}
+
+.chat-textarea::placeholder {
+  color: var(--text-muted);
+}
+
+/* ── Input Footer: counter + send button ── */
+.input-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+/* Character counter: fades in when typing begins */
+.char-counter {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  opacity: 0;
+  transition: opacity 0.2s ease, color 0.2s ease;
+}
+
+.char-counter.counter--visible {
+  opacity: 1;
+}
+
+.char-counter.counter--warning {
+  color: var(--warning-color);
+}
+
+/* ── Send Button ── */
+.send-btn {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: none;
+  background: var(--primary-color);
+  color: #fff;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.send-btn:hover {
+  background: #6d28d9;
+  transform: scale(1.05);
+}
+
+.send-icon {
+  width: 16px;
+  height: 16px;
+  transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* Sending state: rotate + scale the icon */
+.send-btn--sending .send-icon {
+  transform: rotate(45deg) scale(0.8);
+}
+
+/* Success state: flash green */
+.send-btn--success {
+  background: var(--success-color) !important;
+  animation: successFlash 0.6s ease;
+}
+
+@keyframes successFlash {
+  0%   { transform: scale(1); }
+  30%  { transform: scale(1.15); }
+  60%  { transform: scale(0.95); }
+  100% { transform: scale(1); }
+}
+
+/* ── Reduced motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .send-icon,
+  .send-btn,
+  .chat-bubble--new {
+    transition: none !important;
+    animation: none !important;
+    transform: none !important;
+  }
+  .char-counter { opacity: 1; }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-chat-input` component: a chat-style message textarea with a character counter that fades in on typing (turning amber near the limit), an animated send button (icon rotates + scales during send, flashes green on success), and new message bubbles that animate in. Keyboard `Enter` to send is supported.

## Root Cause
No chat input component existed in EaseMotion CSS with the animated states users expect from modern messaging interfaces.

## Changes Made
- `submissions/examples/ease-chat-input-19880-ag/demo.html`: Chat window with message history and the input component; vanilla JS handles counter, send animation, and bubble appending.
- `submissions/examples/ease-chat-input-19880-ag/style.css`: Opacity-fade counter, SVG icon rotation + scale keyframe, success flash keyframe, bubble entrance animation.
- `submissions/examples/ease-chat-input-19880-ag/README.md`: Feature breakdown and verification steps.

## How to Test
1. Open `demo.html`, type a message, watch counter fade in.
2. Press Send or Enter — verify icon animation and green success flash.

## Related Issue
Closes #19880