### PR TITLE
[Feat] #19872 — Add animated tag cloud with size weighting (unique folder)

### DIFF
--- a/submissions/examples/ease-tag-cloud-19872-ag/README.md
+++ b/submissions/examples/ease-tag-cloud-19872-ag/README.md
@@ -1,0 +1,38 @@
+# Animated Tag Cloud Component
+
+This submission implements the `ease-tag-cloud` component — a flexible, animated tag cloud where each tag's visual weight (size and opacity) is driven by the `--ease-tag-weight` CSS custom property (1–5), with staggered entrance animations and an elastic hover interaction.
+
+---
+
+## How Weight Sizing Works
+
+The `--ease-tag-weight` variable (1–5) is set directly on each `.ease-tag` element via inline `style`. The CSS maps it to font size and opacity:
+
+```css
+.ease-tag {
+  --_w: var(--ease-tag-weight, 3);
+  /* Linear interpolation: weight 1-5 → 0.75rem to 1.6rem */
+  font-size: calc(0.75rem + (var(--_w) - 1) * 0.2125rem);
+}
+```
+
+Opacity levels per weight are defined via CSS custom property fallbacks and attribute selectors, ensuring the animation can target the correct final opacity for each tag.
+
+## Usage
+
+```html
+<div class="ease-tag-cloud">
+  <a href="#" class="ease-tag" style="--ease-tag-weight: 5;">CSS Animation</a>
+  <a href="#" class="ease-tag" style="--ease-tag-weight: 2;">Performance</a>
+</div>
+```
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Verify tags animate in one by one with an upward scale-fade entrance.
+3. Verify heavier tags (weight 5) are larger and fully opaque; lighter tags (weight 1) are smaller and more transparent.
+4. Hover any tag — verify it scales up elastically and highlights purple.
+5. Enable `prefers-reduced-motion` — verify all animations are suppressed.

--- a/submissions/examples/ease-tag-cloud-19872-ag/demo.html
+++ b/submissions/examples/ease-tag-cloud-19872-ag/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tag Cloud — EaseMotion CSS</title>
+  <meta name="description" content="Animated tag cloud with size-weighted tags using CSS custom properties, stagger entrance, and hover scale + color effects.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Tag Component</span>
+      <h1>Animated Tag Cloud</h1>
+      <p class="description">
+        Tags sized by a weight variable (1–5) animate in with a staggered entrance
+        and respond to hover with a scale and color accent shift.
+      </p>
+    </header>
+
+    <main>
+      <div class="ease-tag-cloud" aria-label="Topics tag cloud">
+        <a href="#" class="ease-tag" style="--ease-tag-weight: 5;">CSS Animation</a>
+        <a href="#" class="ease-tag" style="--ease-tag-weight: 4;">Web Design</a>
+        <a href="#" class="ease-tag" style="--ease-tag-weight: 5;">JavaScript</a>
+        <a href="#" class="ease-tag" style="--ease-tag-weight: 3;">Typography</a>
+        <a href="#" class="ease-tag" style="--ease-tag-weight: 2;">Grid Layout</a>
+        <a href="#" class="ease-tag" style="--ease-tag-weight: 4;">Motion Design</a>
+        <a href="#" class="ease-tag" style="--ease-tag-weight: 1;">Accessibility</a>
+        <a href="#" class="ease-tag" style="--ease-tag-weight: 3;">Custom Properties</a>
+        <a href="#" class="ease-tag" style="--ease-tag-weight: 5;">UI Components</a>
+        <a href="#" class="ease-tag" style="--ease-tag-weight: 2;">Dark Mode</a>
+        <a href="#" class="ease-tag" style="--ease-tag-weight: 4;">Flexbox</a>
+        <a href="#" class="ease-tag" style="--ease-tag-weight: 1;">Performance</a>
+        <a href="#" class="ease-tag" style="--ease-tag-weight: 3;">Keyframes</a>
+        <a href="#" class="ease-tag" style="--ease-tag-weight: 2;">Responsive</a>
+        <a href="#" class="ease-tag" style="--ease-tag-weight: 4;">Open Source</a>
+      </div>
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-tag-cloud-19872-ag/style.css
+++ b/submissions/examples/ease-tag-cloud-19872-ag/style.css
@@ -1,0 +1,190 @@
+/* ============================================================
+   Tag Cloud — style.css
+   Submission for EaseMotion CSS Issue #19872
+   Size-weighted tags with staggered entrance and hover animations
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+
+  /* Tag weight sizes: maps weight 1-5 to font-size values */
+  --tag-size-1: 0.78rem;
+  --tag-size-2: 0.92rem;
+  --tag-size-3: 1.08rem;
+  --tag-size-4: 1.28rem;
+  --tag-size-5: 1.55rem;
+
+  /* Tag weight opacity: heavier = more opaque */
+  --tag-opacity-1: 0.45;
+  --tag-opacity-2: 0.60;
+  --tag-opacity-3: 0.75;
+  --tag-opacity-4: 0.88;
+  --tag-opacity-5: 1.00;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 760px;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Tag Cloud Container
+   ============================================================ */
+
+.ease-tag-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px 16px;
+  justify-content: center;
+  align-items: center;
+  padding: 40px 32px;
+  background: rgba(31, 41, 55, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 20px;
+  backdrop-filter: blur(8px);
+}
+
+/* ============================================================
+   Tag Element
+   Font size and opacity driven by --ease-tag-weight (1–5)
+   ============================================================ */
+
+.ease-tag {
+  text-decoration: none;
+  font-weight: 600;
+  color: var(--text-primary);
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.04);
+  cursor: pointer;
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1),
+              background-color 0.2s ease,
+              border-color 0.2s ease,
+              color 0.2s ease;
+
+  /* Stagger entrance */
+  opacity: 0;
+  animation: tagFadeIn 0.5s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+
+  /*
+    Weight-based sizing via CSS clamp mapping.
+    We compute font-size and opacity from --ease-tag-weight.
+    Weight 1 = smallest/most transparent; 5 = largest/fully opaque.
+    CSS can't directly switch on a custom property value, so we use
+    calc() with a linear interpolation from weight 1–5 across a range.
+  */
+  --_w: var(--ease-tag-weight, 3);
+  /* Map weight 1-5 to font-size 0.75rem - 1.6rem */
+  font-size: calc(0.75rem + (var(--_w) - 1) * 0.2125rem);
+  /* Map weight 1-5 to opacity 0.4 - 1.0 */
+  opacity: 0; /* reset to 0 for animation; animation sets final opacity indirectly */
+}
+
+/* Apply weight-based opacity per weight level */
+.ease-tag[style*="--ease-tag-weight: 1"] { --_final-opacity: var(--tag-opacity-1); }
+.ease-tag[style*="--ease-tag-weight: 2"] { --_final-opacity: var(--tag-opacity-2); }
+.ease-tag[style*="--ease-tag-weight: 3"] { --_final-opacity: var(--tag-opacity-3); }
+.ease-tag[style*="--ease-tag-weight: 4"] { --_final-opacity: var(--tag-opacity-4); }
+.ease-tag[style*="--ease-tag-weight: 5"] { --_final-opacity: var(--tag-opacity-5); }
+
+@keyframes tagFadeIn {
+  from {
+    opacity: 0;
+    transform: scale(0.85) translateY(8px);
+  }
+  to {
+    opacity: var(--_final-opacity, 0.75);
+    transform: scale(1) translateY(0);
+  }
+}
+
+/* Stagger delays */
+.ease-tag:nth-child(1)  { animation-delay: 0.04s; }
+.ease-tag:nth-child(2)  { animation-delay: 0.08s; }
+.ease-tag:nth-child(3)  { animation-delay: 0.12s; }
+.ease-tag:nth-child(4)  { animation-delay: 0.16s; }
+.ease-tag:nth-child(5)  { animation-delay: 0.20s; }
+.ease-tag:nth-child(6)  { animation-delay: 0.24s; }
+.ease-tag:nth-child(7)  { animation-delay: 0.28s; }
+.ease-tag:nth-child(8)  { animation-delay: 0.32s; }
+.ease-tag:nth-child(9)  { animation-delay: 0.36s; }
+.ease-tag:nth-child(10) { animation-delay: 0.40s; }
+.ease-tag:nth-child(11) { animation-delay: 0.44s; }
+.ease-tag:nth-child(12) { animation-delay: 0.48s; }
+.ease-tag:nth-child(13) { animation-delay: 0.52s; }
+.ease-tag:nth-child(14) { animation-delay: 0.56s; }
+.ease-tag:nth-child(15) { animation-delay: 0.60s; }
+
+/* Hover: elastic scale + accent color */
+.ease-tag:hover {
+  transform: scale(1.12);
+  background: rgba(167, 139, 250, 0.15);
+  border-color: rgba(167, 139, 250, 0.4);
+  color: #c4b5fd;
+  opacity: 1 !important;
+}
+
+/* ── Reduced motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-tag {
+    animation: none !important;
+    opacity: var(--_final-opacity, 0.75) !important;
+    transform: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-tag-cloud` component: tags whose font size and opacity scale linearly with a `--ease-tag-weight` CSS custom property (1–5). Tags animate in with a staggered scale-fade entrance and respond to hover with an elastic scale-up and purple accent highlight.

## Root Cause
No tag cloud component existed in EaseMotion CSS for blog category pages, content dashboards, or topic exploration UIs.

## Changes Made
- `submissions/examples/ease-tag-cloud-19872-ag/demo.html`: 15 tags with varying weights (1–5) arranged in a flex-wrap cloud container.
- `submissions/examples/ease-tag-cloud-19872-ag/style.css`: `calc()`-based weight-to-font-size mapping, opacity levels via CSS variables, staggered `nth-child` delays, elastic hover transform.
- `submissions/examples/ease-tag-cloud-19872-ag/README.md`: Explains the weight mapping technique, usage API, and verification steps.

## How to Test
1. Open `demo.html` in a browser.
2. Verify larger/more opaque tags have `--ease-tag-weight: 5` and smaller/lighter have `--ease-tag-weight: 1`.
3. Hover any tag — verify elastic scale + purple highlight.

## Related Issue
Closes #19872