### PR TITLE
feat: add data refresh panel demo

### DIFF
--- a/submissions/examples/data-refresh-panel/README.md
+++ b/submissions/examples/data-refresh-panel/README.md
@@ -1,0 +1,15 @@
+# Data Refresh Panel
+
+A CSS-only data refresh panel with sync metadata, an animated progress rail, and compact metric cells.
+
+## Features
+
+- Responsive card layout
+- Sync status indicator
+- Hover-driven progress rail
+- Structured metadata using `dl`, `dt`, and `dd`
+
+## Files
+
+- `demo.html`
+- `style.css`

--- a/submissions/examples/data-refresh-panel/demo.html
+++ b/submissions/examples/data-refresh-panel/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Data Refresh Panel</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="refresh-board" aria-label="Data refresh status">
+    <section class="refresh-card">
+      <div class="refresh-topline">
+        <span class="status-dot"></span>
+        <p>Live sync</p>
+      </div>
+      <h1>Data refresh panel</h1>
+      <p class="summary">Workspace metrics updated 4 minutes ago. Next refresh starts automatically.</p>
+      <div class="sync-rail" aria-hidden="true">
+        <span></span>
+      </div>
+      <dl>
+        <div><dt>Source</dt><dd>Analytics API</dd></div>
+        <div><dt>Rows</dt><dd>12,840</dd></div>
+        <div><dt>Status</dt><dd>Healthy</dd></div>
+      </dl>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/data-refresh-panel/style.css
+++ b/submissions/examples/data-refresh-panel/style.css
@@ -1,0 +1,103 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #eef7f6;
+  color: #122422;
+  font-family: Arial, sans-serif;
+}
+
+.refresh-board {
+  width: min(92vw, 450px);
+}
+
+.refresh-card {
+  padding: 30px;
+  border: 1px solid #c8dedb;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 22px 52px rgba(18, 36, 34, 0.13);
+}
+
+.refresh-topline {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-bottom: 10px;
+}
+
+.refresh-topline p {
+  margin: 0;
+  color: #087568;
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.status-dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: #10b981;
+  box-shadow: 0 0 0 7px rgba(16, 185, 129, 0.14);
+}
+
+h1 {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
+.summary {
+  margin: 12px 0 20px;
+  color: #536865;
+  line-height: 1.55;
+}
+
+.sync-rail {
+  height: 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e2efed;
+}
+
+.sync-rail span {
+  display: block;
+  width: 68%;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #0f766e, #22c55e);
+  transition: width 0.25s ease;
+}
+
+.refresh-card:hover .sync-rail span {
+  width: 86%;
+}
+
+dl {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  margin: 22px 0 0;
+}
+
+dl div {
+  padding: 12px;
+  border: 1px solid #d7e8e5;
+  border-radius: 7px;
+  background: #f8fcfb;
+}
+
+dt {
+  color: #6b7d7a;
+  font-size: 0.72rem;
+}
+
+dd {
+  margin: 5px 0 0;
+  font-weight: 800;
+}


### PR DESCRIPTION
## Description
Adds a data refresh panel with sync metadata, status copy, and an animated progress rail.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have tested the animation/demo locally
- [x] I have added/updated documentation where necessary
- [x] This PR adds a new example under `submissions/examples/data-refresh-panel`