### PR TITLE
feat: add northstar risk snapshot panel demo

### DIFF
--- a/submissions/examples/northstar-risk-snapshot-panel/README.md
+++ b/submissions/examples/northstar-risk-snapshot-panel/README.md
@@ -1,0 +1,15 @@
+# northstar risk snapshot panel
+
+Adds a risk snapshot panel with weighted signal chips and a compact confidence meter.
+
+## Features
+
+- Responsive CSS-only component
+- Original layout and interaction treatment
+- Accessible semantic HTML structure
+- Compact visual design for product interfaces
+
+## Files
+
+- `demo.html`
+- `style.css`

--- a/submissions/examples/northstar-risk-snapshot-panel/demo.html
+++ b/submissions/examples/northstar-risk-snapshot-panel/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Northstar Risk Snapshot</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="risk-shell" aria-label="Risk snapshot panel">
+    <section class="risk-panel">
+      <p class="eyebrow">Northstar</p>
+      <h1>Risk snapshot</h1>
+      <div class="score-row">
+        <strong>72</strong>
+        <span>Moderate exposure</span>
+      </div>
+      <div class="meter" aria-hidden="true"><i></i></div>
+      <ul>
+        <li><b>Billing drift</b><em>+8%</em></li>
+        <li><b>Access review</b><em>due</em></li>
+        <li><b>Policy coverage</b><em>91%</em></li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/northstar-risk-snapshot-panel/style.css
+++ b/submissions/examples/northstar-risk-snapshot-panel/style.css
@@ -1,0 +1,94 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #f4f7fb;
+  color: #172033;
+  font-family: Arial, sans-serif;
+}
+
+.risk-shell {
+  width: min(92vw, 430px);
+}
+
+.risk-panel {
+  padding: 30px;
+  border: 1px solid #d8e2ef;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 20px 48px rgba(25, 40, 68, 0.13);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #315ddc;
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 18px;
+  font-size: 1.75rem;
+}
+
+.score-row {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.score-row strong {
+  font-size: 3rem;
+  line-height: 1;
+}
+
+.score-row span {
+  color: #5e6e84;
+  font-weight: 700;
+}
+
+.meter {
+  height: 12px;
+  margin: 18px 0 20px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e7edf7;
+}
+
+.meter i {
+  display: block;
+  width: 72%;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #315ddc, #14b8a6);
+  transition: width 0.24s ease;
+}
+
+.risk-panel:hover .meter i {
+  width: 82%;
+}
+
+ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+li {
+  display: flex;
+  justify-content: space-between;
+  padding: 12px 0;
+  border-top: 1px solid #e7edf7;
+}
+
+em {
+  color: #315ddc;
+  font-style: normal;
+  font-weight: 800;
+}


### PR DESCRIPTION
## Description
Adds a risk snapshot panel with weighted signal chips and a compact confidence meter.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have tested the animation/demo locally
- [x] I have added/updated documentation where necessary
- [x] This PR adds a new example under `submissions/examples/northstar-risk-snapshot-panel`