### PR TITLE
feat: add atlas sync window card demo

### DIFF
--- a/submissions/examples/atlas-sync-window-card/README.md
+++ b/submissions/examples/atlas-sync-window-card/README.md
@@ -1,0 +1,15 @@
+# atlas sync window card
+
+Adds a sync window card with schedule metadata and a sliding time rail.
+
+## Features
+
+- Responsive CSS-only component
+- Original layout and interaction treatment
+- Accessible semantic HTML structure
+- Compact visual design for product interfaces
+
+## Files
+
+- `demo.html`
+- `style.css`

--- a/submissions/examples/atlas-sync-window-card/demo.html
+++ b/submissions/examples/atlas-sync-window-card/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Atlas Sync Window</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <article class="sync-card" aria-label="Atlas sync window">
+    <span class="tag">Atlas Sync</span>
+    <h1>02:00 - 02:45</h1>
+    <p>Maintenance window approved for regional data replication.</p>
+    <div class="time-rail" aria-hidden="true">
+      <span></span>
+    </div>
+    <footer>
+      <b>3 regions</b>
+      <b>18 jobs</b>
+      <b>Low risk</b>
+    </footer>
+  </article>
+</body>
+</html>

--- a/submissions/examples/atlas-sync-window-card/style.css
+++ b/submissions/examples/atlas-sync-window-card/style.css
@@ -1,0 +1,80 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #eef8f7;
+  color: #132522;
+  font-family: Arial, sans-serif;
+}
+
+.sync-card {
+  width: min(92vw, 440px);
+  padding: 30px;
+  border: 1px solid #cfe5e1;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 22px 52px rgba(19, 37, 34, 0.13);
+}
+
+.tag {
+  display: inline-flex;
+  padding: 5px 10px;
+  border-radius: 999px;
+  background: #dff5f0;
+  color: #0f766e;
+  font-size: 0.76rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 18px 0 8px;
+  font-size: 2rem;
+}
+
+p {
+  margin: 0;
+  color: #526b67;
+  line-height: 1.55;
+}
+
+.time-rail {
+  height: 38px;
+  margin: 22px 0;
+  padding: 14px;
+  border-radius: 8px;
+  background: #eef8f7;
+}
+
+.time-rail span {
+  display: block;
+  width: 56%;
+  height: 10px;
+  border-radius: 999px;
+  background: #0f766e;
+  transition: transform 0.22s ease, width 0.22s ease;
+}
+
+.sync-card:hover .time-rail span {
+  width: 72%;
+  transform: translateX(18px);
+}
+
+footer {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+
+footer b {
+  padding: 10px;
+  border-radius: 7px;
+  background: #f8fcfb;
+  text-align: center;
+  font-size: 0.82rem;
+}


### PR DESCRIPTION
## Description
Adds a sync window card with schedule metadata and a sliding time rail.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have tested the animation/demo locally
- [x] I have added/updated documentation where necessary
- [x] This PR adds a new example under `submissions/examples/atlas-sync-window-card`