### PR TITLE
fix: replace hardcoded colors and fix transparent background in .ease…

### DIFF
--- a/submissions/examples/avatar-group-theme-fix/README.md
+++ b/submissions/examples/avatar-group-theme-fix/README.md
@@ -1,0 +1,52 @@
+# Fix: Overlapping Avatar Group Initials Background & Dark Mode Borders
+
+**Fixes:** [#26276](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/26276)
+
+---
+
+## 🐛 Bug Description
+
+In `components/avatar.css`, the `.ease-avatar-group-item` class is missing a `background-color` definition. When developers create text-based or initials-only avatars (e.g. `<div class="ease-avatar-group-item">JD</div>`), the text has `color: #fff` but the background is transparent. On a standard light page, this white text is completely invisible.
+
+Additionally, the avatar group uses several hardcoded color values:
+- `border: 2px solid white` on `.ease-avatar-group .ease-avatar`
+- `border: 2px solid white` on `.ease-avatar-group-count`
+- `background: #e2e8f0; color: #475569;` on `.ease-avatar-group-count`
+- `border: 2px solid #fff` on `.ease-avatar-group-item`
+
+In dark mode, these borders remain bright white (creating harsh, un-themed lines against dark backgrounds) and the count badge retains its light-gray background.
+
+---
+
+## ✅ Fix
+
+Replace the hardcoded colors with the framework's existing design tokens and specify a default background color for the group items:
+
+```css
+/* ✅ Fixed — uses design tokens and adds default background */
+.ease-avatar-group .ease-avatar {
+  border: 2px solid var(--ease-color-surface, #ffffff);
+}
+
+.ease-avatar-group-count {
+  background: var(--ease-color-neutral-200, #e2e8f0);
+  color: var(--ease-color-text, #475569);
+  border: 2px solid var(--ease-color-surface, #ffffff);
+}
+
+.ease-avatar-group-item {
+  background: var(--ease-color-neutral-200, #e2e8f0);
+  color: var(--ease-color-text, #1e293b);
+  border: 2px solid var(--ease-color-surface, #ffffff);
+}
+```
+
+---
+
+## 📁 Submission Contents
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Interactive side-by-side demonstration of the bug vs. the fix in light & dark modes |
+| `style.css` | Raw CSS showing the proposed fix and demo page layout |
+| `README.md` | This documentation file |

--- a/submissions/examples/avatar-group-theme-fix/demo.html
+++ b/submissions/examples/avatar-group-theme-fix/demo.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix #26276 — Avatar Group Theme Adaptability | EaseMotion CSS</title>
+  <meta name="description" content="Demonstrates the fix for transparent initials background and hardcoded borders in the overlapping avatar group component." />
+
+  <!-- EaseMotion CSS -->
+  <link rel="stylesheet" href="../../../easemotion.css" />
+
+  <!-- Google Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Fira+Code&display=swap" rel="stylesheet" />
+
+  <!-- Demo styles -->
+  <link rel="stylesheet" href="style.css" />
+</head>
+
+<body>
+
+  <header>
+    <div>
+      <h1>Fix #26276 — Avatar Group Theme Adaptability</h1>
+      <p>Toggle dark mode to observe the contrast and border adaptivity issues</p>
+    </div>
+    <button class="toggle-btn" id="theme-toggle" type="button" aria-label="Toggle dark mode">
+      🌙 Dark Mode
+    </button>
+  </header>
+
+  <main>
+
+    <!-- ── LEFT: Buggy Behaviour (Before) ────────────────────── -->
+    <section class="panel" aria-label="Buggy Behaviour">
+      <span class="panel-label bug">❌ Before (Bug)</span>
+      
+      <div class="demo-box demo-buggy">
+        <p style="font-size: 0.85rem; font-weight: 600; margin-bottom: 0.5rem;">Overlapping Text/Initials Avatars:</p>
+        
+        <div class="ease-avatar-group">
+          <div class="ease-avatar-group-item">AB</div>
+          <div class="ease-avatar-group-item">CD</div>
+          <div class="ease-avatar-group-count">+3</div>
+        </div>
+      </div>
+
+      <div class="code-block" aria-label="Buggy CSS snippet">
+        <span class="del">/* Initials are invisible (white text on transparent) */</span><br />
+        <span class="del">.ease-avatar-group-item {</span><br />
+        <span class="del">&nbsp;&nbsp;border: 2px solid #fff;</span><br />
+        <span class="del">&nbsp;&nbsp;color: #fff;</span><br />
+        <span class="del">&nbsp;&nbsp;/* No background-color defined */</span><br />
+        <span class="del">}</span>
+      </div>
+
+      <p style="font-size: 0.8rem; line-height: 1.4;">
+        <strong>Issues:</strong><br />
+        1. The initials "AB" and "CD" are completely invisible in light mode.<br />
+        2. In dark mode, the white border and light count badge background fail to adapt.
+      </p>
+    </section>
+
+    <!-- ── RIGHT: Fixed Behaviour (After) ────────────────────── -->
+    <section class="panel" aria-label="Fixed Behaviour">
+      <span class="panel-label fix">✅ After (Fix)</span>
+      
+      <div class="demo-box demo-fixed">
+        <p style="font-size: 0.85rem; font-weight: 600; margin-bottom: 0.5rem;">Overlapping Text/Initials Avatars:</p>
+        
+        <div class="ease-avatar-group">
+          <div class="ease-avatar-group-item">AB</div>
+          <div class="ease-avatar-group-item">CD</div>
+          <div class="ease-avatar-group-count">+3</div>
+        </div>
+      </div>
+
+      <div class="code-block" aria-label="Fixed CSS snippet">
+        <span class="ins">/* Initials visible and borders adapt to theme */</span><br />
+        <span class="ins">.ease-avatar-group-item {</span><br />
+        <span class="ins">&nbsp;&nbsp;background: var(--ease-color-neutral-200, #e2e8f0);</span><br />
+        <span class="ins">&nbsp;&nbsp;color: var(--ease-color-text, #1e293b);</span><br />
+        <span class="ins">&nbsp;&nbsp;border: 2px solid var(--ease-color-surface, #ffffff);</span><br />
+        <span class="ins">}</span>
+      </div>
+
+      <p style="font-size: 0.8rem; line-height: 1.4;">
+        <strong>Improvements:</strong><br />
+        1. Initials have a default neutral background and dark text color, making them visible.<br />
+        2. Borders and count badges use design tokens to seamlessly blend in both light and dark mode.
+      </p>
+    </section>
+
+  </main>
+
+  <script>
+    const btn = document.getElementById('theme-toggle');
+    const html = document.documentElement;
+
+    btn.addEventListener('click', function () {
+      const isDark = html.getAttribute('data-theme') === 'dark';
+      if (isDark) {
+        html.removeAttribute('data-theme');
+        btn.textContent = '🌙 Dark Mode';
+      } else {
+        html.setAttribute('data-theme', 'dark');
+        btn.textContent = '☀️ Light Mode';
+      }
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/avatar-group-theme-fix/style.css
+++ b/submissions/examples/avatar-group-theme-fix/style.css
@@ -1,0 +1,167 @@
+/*
+ * EaseMotion CSS — Fix: Avatar Group Theme Adaptability
+ * Issue: https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/26276
+ */
+
+/* ── Demo Page Layout ────────────────────────────────────────── */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', system-ui, sans-serif;
+  min-height: 100vh;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  background: var(--ease-color-bg, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+header {
+  padding: 1.5rem 2rem;
+  border-bottom: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+header h1 {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+header p {
+  font-size: 0.8rem;
+  color: var(--ease-color-muted, #64748b);
+}
+
+.toggle-btn {
+  padding: 0.4rem 1rem;
+  border-radius: 9999px;
+  border: 1.5px solid var(--ease-color-primary, #6c63ff);
+  background: transparent;
+  color: var(--ease-color-primary, #6c63ff);
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+}
+
+.toggle-btn:hover {
+  background: var(--ease-color-primary, #6c63ff);
+  color: #fff;
+}
+
+main {
+  padding: 2rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  max-width: 960px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+@media (max-width: 768px) {
+  main { grid-template-columns: 1fr; }
+}
+
+.panel {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: 1rem;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.panel-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  display: inline-flex;
+  width: fit-content;
+}
+
+.panel-label.bug {
+  background: color-mix(in srgb, #ef4444 12%, transparent);
+  color: #ef4444;
+}
+
+.panel-label.fix {
+  background: color-mix(in srgb, #22c55e 12%, transparent);
+  color: #22c55e;
+}
+
+.demo-box {
+  padding: 1.5rem;
+  background: var(--ease-color-bg, #f8fafc);
+  border-radius: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* ── Buggy Simulation (Hardcoded values) ─────────────────────── */
+
+.demo-buggy .ease-avatar-group .ease-avatar {
+  border: 2px solid white !important;
+}
+
+.demo-buggy .ease-avatar-group-count {
+  background: #e2e8f0 !important;
+  color: #475569 !important;
+  border: 2px solid white !important;
+}
+
+.demo-buggy .ease-avatar-group-item {
+  border: 2px solid #fff !important;
+  color: #fff !important;
+  background: transparent !important; /* missing background */
+}
+
+/* ── Fixed Implementation (Using design tokens) ───────────────── */
+
+.demo-fixed .ease-avatar-group .ease-avatar {
+  border: 2px solid var(--ease-color-surface, #ffffff);
+}
+
+.demo-fixed .ease-avatar-group-count {
+  background: var(--ease-color-neutral-200, #e2e8f0);
+  color: var(--ease-color-text, #475569);
+  border: 2px solid var(--ease-color-surface, #ffffff);
+}
+
+.demo-fixed .ease-avatar-group-item {
+  background: var(--ease-color-neutral-200, #e2e8f0);
+  color: var(--ease-color-text, #1e293b);
+  border: 2px solid var(--ease-color-surface, #ffffff);
+}
+
+/* ── Code display ─────────────────────────────────────────────── */
+
+.code-block {
+  background: var(--ease-color-neutral-900, #0f172a);
+  color: #e2e8f0;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  font-family: 'Fira Code', monospace;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  overflow-x: auto;
+}
+
+.code-block .del { color: #f87171; }
+.code-block .ins { color: #4ade80; }


### PR DESCRIPTION
## Pull Request Description

Fixes #26276

Replaces hardcoded color values and fixes the missing `background-color` in `.ease-toast-body`'s sister component class `.ease-avatar-group-item` in `components/avatar.css`. In light mode, initials/text-based avatars are currently invisible because they render as white text on a transparent background. Additionally, the white/light-gray borders and count badges do not adapt to dark mode. 

This PR introduces a submission demo showing a side-by-side comparison of the bug vs. the fix in both light and dark modes with an interactive theme toggle.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/avatar-group-theme-fix/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — documents the required CSS changes
- [x] Includes `README.md` — explains the bug, root cause, and fix
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A submission demo documenting and fixing the transparent background on `.ease-avatar-group-item` and replacing hardcoded border/badge colors with design tokens.

**How does a developer use it?**

```html
<!-- Current broken behaviour (initials are invisible, borders don't adapt to dark mode) -->
<div class="ease-avatar-group">
  <div class="ease-avatar-group-item">JD</div>
  <div class="ease-avatar-group-count">+3</div>
</div>

<!-- Fix: Change components/avatar.css to use: -->
<!-- background: var(--ease-color-neutral-200) -->
<!-- color: var(--ease-color-text) -->
<!-- border: 2px solid var(--ease-color-surface) -->
