### PR TITLE
fix: add dark mode support to tag component and variants (#26461)

### DIFF
--- a/submissions/examples/tag-theme-fix/README.md
+++ b/submissions/examples/tag-theme-fix/README.md
@@ -1,0 +1,41 @@
+# Fix: Tag Component Dark Mode Support
+
+**Fixes:** [#26461](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/26461)
+
+---
+
+## 🐛 Bug Description
+
+The Tag component (`components/tag.css`) has no dark mode support. The base `.ease-tag` uses hardcoded background and text colors (`background: #e0e7ff; color: #4338ca;`) and the semantic classes (`.ease-tag-success`, `.ease-tag-danger`, `.ease-tag-warning`, `.ease-tag-info`) also use hardcoded light-theme colors. In dark mode, these tags remain extremely bright, causing poor contrast and breaking the dark mode design.
+
+---
+
+## ✅ Fix
+
+Introduce dark mode overrides (for both `@media (prefers-color-scheme: dark)` and `[data-theme="dark"]`) using darker backgrounds and lighter text colors:
+
+```css
+@media (prefers-color-scheme: dark) {
+  .ease-tag { background: var(--ease-color-neutral-800, #1e293b); color: var(--ease-color-neutral-200, #e2e8f0); }
+  .ease-tag-success { background: rgba(21, 128, 61, 0.2); color: var(--ease-color-success-light, #86efac); }
+  .ease-tag-danger { background: rgba(185, 28, 28, 0.2); color: var(--ease-color-danger-light, #fca5a5); }
+  .ease-tag-warning { background: rgba(180, 83, 9, 0.2); color: var(--ease-color-warning-light, #fcd34d); }
+  .ease-tag-info { background: rgba(59, 130, 246, 0.2); color: var(--ease-color-info-light, #93c5fd); }
+}
+
+[data-theme="dark"] .ease-tag { background: #1e293b; color: #e2e8f0; }
+[data-theme="dark"] .ease-tag-success { background: rgba(21, 128, 61, 0.2); color: #86efac; }
+[data-theme="dark"] .ease-tag-danger { background: rgba(185, 28, 28, 0.2); color: #fca5a5; }
+[data-theme="dark"] .ease-tag-warning { background: rgba(180, 83, 9, 0.2); color: #fcd34d; }
+[data-theme="dark"] .ease-tag-info { background: rgba(59, 130, 246, 0.2); color: #93c5fd; }
+```
+
+---
+
+## 📁 Submission Contents
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Live demonstration of the tag component in light & dark modes |
+| `style.css` | Raw CSS showing the proposed fix and demo page layout |
+| `README.md` | This documentation file |

--- a/submissions/examples/tag-theme-fix/demo.html
+++ b/submissions/examples/tag-theme-fix/demo.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix #26461 — Tag Dark Mode Support | EaseMotion CSS</title>
+  <meta name="description" content="Demonstrates the fix for the Tag component lacking dark mode support." />
+
+  <!-- EaseMotion CSS -->
+  <link rel="stylesheet" href="../../../easemotion.css" />
+
+  <!-- Google Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+
+  <!-- Demo styles -->
+  <link rel="stylesheet" href="style.css" />
+</head>
+
+<body>
+
+  <header>
+    <div>
+      <h1>Fix #26461 — Tag Dark Mode Support</h1>
+      <p>Toggle dark mode to see if the tags adapt correctly</p>
+    </div>
+    <button class="toggle-btn" id="theme-toggle" type="button" aria-label="Toggle dark mode">
+      🌙 Dark Mode
+    </button>
+  </header>
+
+  <main>
+
+    <!-- ── LEFT: Buggy Behaviour (Before) ────────────────────── -->
+    <section class="panel" aria-label="Buggy Behaviour">
+      <span class="panel-label bug">❌ Before (Bug)</span>
+      
+      <div class="demo-box demo-buggy">
+        <span class="ease-tag">Standard</span>
+        <span class="ease-tag ease-tag-success">Success</span>
+        <span class="ease-tag ease-tag-danger">Danger</span>
+      </div>
+
+      <p style="font-size: 0.8rem; line-height: 1.4;">
+        <strong>Issue:</strong> In dark mode, the tags remain bright pastel-colored with high-contrast text, looking completely un-themed and jarring.
+      </p>
+    </section>
+
+    <!-- ── RIGHT: Fixed Behaviour (After) ────────────────────── -->
+    <section class="panel" aria-label="Fixed Behaviour">
+      <span class="panel-label fix">✅ After (Fix)</span>
+      
+      <div class="demo-box demo-fixed">
+        <span class="ease-tag">Standard</span>
+        <span class="ease-tag ease-tag-success">Success</span>
+        <span class="ease-tag ease-tag-danger">Danger</span>
+      </div>
+
+      <p style="font-size: 0.8rem; line-height: 1.4;">
+        <strong>Fix:</strong> Adding theme-appropriate dark mode overrides allows the tags to render with dark backgrounds and soft, readable text.
+      </p>
+    </section>
+
+  </main>
+
+  <script>
+    const btn = document.getElementById('theme-toggle');
+    const html = document.documentElement;
+
+    btn.addEventListener('click', function () {
+      const isDark = html.getAttribute('data-theme') === 'dark';
+      if (isDark) {
+        html.removeAttribute('data-theme');
+        btn.textContent = '🌙 Dark Mode';
+      } else {
+        html.setAttribute('data-theme', 'dark');
+        btn.textContent = '☀️ Light Mode';
+      }
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/tag-theme-fix/style.css
+++ b/submissions/examples/tag-theme-fix/style.css
@@ -1,0 +1,127 @@
+/*
+ * EaseMotion CSS — Fix: Tag Component Dark Mode Support
+ * Issue: https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/26461
+ */
+
+/* ── Demo Page Layout ────────────────────────────────────────── */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', system-ui, sans-serif;
+  min-height: 100vh;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  background: var(--ease-color-bg, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+header {
+  padding: 1.5rem 2rem;
+  border-bottom: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+header h1 {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+header p {
+  font-size: 0.8rem;
+  color: var(--ease-color-muted, #64748b);
+}
+
+.toggle-btn {
+  padding: 0.4rem 1rem;
+  border-radius: 9999px;
+  border: 1.5px solid var(--ease-color-primary, #6c63ff);
+  background: transparent;
+  color: var(--ease-color-primary, #6c63ff);
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+}
+
+.toggle-btn:hover {
+  background: var(--ease-color-primary, #6c63ff);
+  color: #fff;
+}
+
+main {
+  padding: 2rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  max-width: 960px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+@media (max-width: 768px) {
+  main { grid-template-columns: 1fr; }
+}
+
+.panel {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: 1rem;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.panel-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  display: inline-flex;
+  width: fit-content;
+}
+
+.panel-label.bug {
+  background: color-mix(in srgb, #ef4444 12%, transparent);
+  color: #ef4444;
+}
+
+.panel-label.fix {
+  background: color-mix(in srgb, #22c55e 12%, transparent);
+  color: #22c55e;
+}
+
+.demo-box {
+  padding: 1.5rem;
+  background: var(--ease-color-bg, #f8fafc);
+  border-radius: 0.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+/* ── Buggy Simulation (Fails to adapt to [data-theme="dark"]) ── */
+
+.demo-buggy [data-theme="dark"] .ease-tag { background: #e0e7ff !important; color: #4338ca !important; }
+.demo-buggy [data-theme="dark"] .ease-tag-success { background: #dcfce7 !important; color: #15803d !important; }
+.demo-buggy [data-theme="dark"] .ease-tag-danger { background: #fee2e2 !important; color: #b91c1c !important; }
+
+/* ── Fixed Implementation (Adding [data-theme="dark"] support) ── */
+
+[data-theme="dark"] .demo-fixed .ease-tag { background: #1e293b; color: #e2e8f0; }
+[data-theme="dark"] .demo-fixed .ease-tag-success { background: rgba(21, 128, 61, 0.2); color: #86efac; }
+[data-theme="dark"] .demo-fixed .ease-tag-danger { background: rgba(185, 28, 28, 0.2); color: #fca5a5; }


### PR DESCRIPTION
## Pull Request Description

Fixes #26461

Adds dark mode overrides for the Tag component and its semantic variants (`ease-tag-success`, `ease-tag-danger`, etc.). The colors in `components/tag.css` were hardcoded to light-theme pastels, causing them to remain extremely bright in dark mode. The fix implements theme-appropriate dark mode overrides.

This PR introduces a submission demo showing a side-by-side comparison of the bug vs. the fix with an interactive theme toggle.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/tag-theme-fix/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — documents the required CSS changes
- [x] Includes `README.md` — explains the bug, root cause, and fix
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A submission demo documenting and fixing the lack of dark mode support in the Tag component and variants.

**How does a developer use it?**

```html
<span class="ease-tag ease-tag-success">Success</span>
```

**Why does it fit EaseMotion CSS?**

Pastel colors designed for light mode create readability and contrast issues on dark backgrounds. Implementing dark mode variants with appropriate contrast ratios satisfies WCAG guidelines and maintains design harmony.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The actual core fix required in `components/tag.css` is adding these overrides:

```css
@media (prefers-color-scheme: dark) {
  .ease-tag { background: var(--ease-color-neutral-800, #1e293b); color: var(--ease-color-neutral-200, #e2e8f0); }
  .ease-tag-success { background: rgba(21, 128, 61, 0.2); color: var(--ease-color-success-light, #86efac); }
  .ease-tag-danger { background: rgba(185, 28, 28, 0.2); color: var(--ease-color-danger-light, #fca5a5); }
  .ease-tag-warning { background: rgba(180, 83, 9, 0.2); color: var(--ease-color-warning-light, #fcd34d); }
  .ease-tag-info { background: rgba(59, 130, 246, 0.2); color: var(--ease-color-info-light, #93c5fd); }
}

[data-theme="dark"] .ease-tag { background: #1e293b; color: #e2e8f0; }
[data-theme="dark"] .ease-tag-success { background: rgba(21, 128, 61, 0.2); color: #86efac; }
[data-theme="dark"] .ease-tag-danger { background: rgba(185, 28, 28, 0.2); color: #fca5a5; }
[data-theme="dark"] .ease-tag-warning { background: rgba(180, 83, 9, 0.2); color: #fcd34d; }
[data-theme="dark"] .ease-tag-info { background: rgba(59, 130, 246, 0.2); color: #93c5fd; }
```
