### PR TITLE
fix: add dark mode support to skeleton component shimmer (#26460)

### DIFF
--- a/submissions/examples/skeleton-shimmer-fix/README.md
+++ b/submissions/examples/skeleton-shimmer-fix/README.md
@@ -1,0 +1,37 @@
+# Fix: Skeleton Loader Dark Mode Support
+
+**Fixes:** [#26460](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/26460)
+
+---
+
+## 🐛 Bug Description
+
+The Skeleton component (`components/skeleton.css`) has no dark mode support. It uses a hardcoded light-theme gradient (`#e2e8f0` and `#f1f5f9`) for the shimmer animation on line 3. In dark mode, the skeleton loader flashes as a very bright white/light-gray block, creating a harsh contrast against dark backgrounds and ruining the dark mode aesthetic.
+
+---
+
+## ✅ Fix
+
+Introduce dark mode overrides (for both `@media (prefers-color-scheme: dark)` and `[data-theme="dark"]`) using darker, theme-appropriate colors:
+
+```css
+@media (prefers-color-scheme: dark) {
+  .ease-skeleton {
+    background: linear-gradient(90deg, var(--ease-color-neutral-800, #1e293b) 25%, var(--ease-color-neutral-700, #334155) 50%, var(--ease-color-neutral-800, #1e293b) 75%);
+  }
+}
+
+[data-theme="dark"] .ease-skeleton {
+  background: linear-gradient(90deg, #1e293b 25%, #334155 50%, #1e293b 75%);
+}
+```
+
+---
+
+## 📁 Submission Contents
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Live demonstration of the skeleton loader in light & dark modes |
+| `style.css` | Raw CSS showing the proposed fix and demo page layout |
+| `README.md` | This documentation file |

--- a/submissions/examples/skeleton-shimmer-fix/demo.html
+++ b/submissions/examples/skeleton-shimmer-fix/demo.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix #26460 — Skeleton Dark Mode Support | EaseMotion CSS</title>
+  <meta name="description" content="Demonstrates the fix for the Skeleton component lacking dark mode support." />
+
+  <!-- EaseMotion CSS -->
+  <link rel="stylesheet" href="../../../easemotion.css" />
+
+  <!-- Google Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+
+  <!-- Demo styles -->
+  <link rel="stylesheet" href="style.css" />
+</head>
+
+<body>
+
+  <header>
+    <div>
+      <h1>Fix #26460 — Skeleton Dark Mode Support</h1>
+      <p>Toggle dark mode to see if the skeleton shimmer adapts correctly</p>
+    </div>
+    <button class="toggle-btn" id="theme-toggle" type="button" aria-label="Toggle dark mode">
+      🌙 Dark Mode
+    </button>
+  </header>
+
+  <main>
+
+    <!-- ── LEFT: Buggy Behaviour (Before) ────────────────────── -->
+    <section class="panel" aria-label="Buggy Behaviour">
+      <span class="panel-label bug">❌ Before (Bug)</span>
+      
+      <div class="demo-box demo-buggy">
+        <div class="ease-skeleton ease-skeleton-avatar"></div>
+        <div class="ease-skeleton ease-skeleton-text"></div>
+        <div class="ease-skeleton ease-skeleton-text" style="width: 60%;"></div>
+      </div>
+
+      <p style="font-size: 0.8rem; line-height: 1.4;">
+        <strong>Issue:</strong> In dark mode, the skeleton remains extremely bright white/light-gray, causing a harsh flash that is un-themed.
+      </p>
+    </section>
+
+    <!-- ── RIGHT: Fixed Behaviour (After) ────────────────────── -->
+    <section class="panel" aria-label="Fixed Behaviour">
+      <span class="panel-label fix">✅ After (Fix)</span>
+      
+      <div class="demo-box demo-fixed">
+        <div class="ease-skeleton ease-skeleton-avatar"></div>
+        <div class="ease-skeleton ease-skeleton-text"></div>
+        <div class="ease-skeleton ease-skeleton-text" style="width: 60%;"></div>
+      </div>
+
+      <p style="font-size: 0.8rem; line-height: 1.4;">
+        <strong>Fix:</strong> Using a dark gradient override allows the skeleton loader to blend softly against dark backgrounds.
+      </p>
+    </section>
+
+  </main>
+
+  <script>
+    const btn = document.getElementById('theme-toggle');
+    const html = document.documentElement;
+
+    btn.addEventListener('click', function () {
+      const isDark = html.getAttribute('data-theme') === 'dark';
+      if (isDark) {
+        html.removeAttribute('data-theme');
+        btn.textContent = '🌙 Dark Mode';
+      } else {
+        html.setAttribute('data-theme', 'dark');
+        btn.textContent = '☀️ Light Mode';
+      }
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/skeleton-shimmer-fix/style.css
+++ b/submissions/examples/skeleton-shimmer-fix/style.css
@@ -1,0 +1,127 @@
+/*
+ * EaseMotion CSS — Fix: Skeleton Loader Dark Mode Support
+ * Issue: https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/26460
+ */
+
+/* ── Demo Page Layout ────────────────────────────────────────── */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', system-ui, sans-serif;
+  min-height: 100vh;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  background: var(--ease-color-bg, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+header {
+  padding: 1.5rem 2rem;
+  border-bottom: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+header h1 {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+header p {
+  font-size: 0.8rem;
+  color: var(--ease-color-muted, #64748b);
+}
+
+.toggle-btn {
+  padding: 0.4rem 1rem;
+  border-radius: 9999px;
+  border: 1.5px solid var(--ease-color-primary, #6c63ff);
+  background: transparent;
+  color: var(--ease-color-primary, #6c63ff);
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+}
+
+.toggle-btn:hover {
+  background: var(--ease-color-primary, #6c63ff);
+  color: #fff;
+}
+
+main {
+  padding: 2rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  max-width: 960px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+@media (max-width: 768px) {
+  main { grid-template-columns: 1fr; }
+}
+
+.panel {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: 1rem;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.panel-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  display: inline-flex;
+  width: fit-content;
+}
+
+.panel-label.bug {
+  background: color-mix(in srgb, #ef4444 12%, transparent);
+  color: #ef4444;
+}
+
+.panel-label.fix {
+  background: color-mix(in srgb, #22c55e 12%, transparent);
+  color: #22c55e;
+}
+
+.demo-box {
+  padding: 1.5rem;
+  background: var(--ease-color-bg, #f8fafc);
+  border-radius: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* ── Buggy Simulation (Fails to adapt to [data-theme="dark"]) ── */
+
+.demo-buggy [data-theme="dark"] .ease-skeleton {
+  background: linear-gradient(90deg, #e2e8f0 25%, #f1f5f9 50%, #e2e8f0 75%) !important;
+}
+
+/* ── Fixed Implementation (Adding [data-theme="dark"] support) ── */
+
+[data-theme="dark"] .demo-fixed .ease-skeleton {
+  background: linear-gradient(90deg, #1e293b 25%, #334155 50%, #1e293b 75%);
+}


### PR DESCRIPTION
## Pull Request Description

Fixes #26460

Adds dark mode overrides for the Skeleton loader shimmer gradient. The gradient background in `components/skeleton.css` was hardcoded to light-theme colors (`#e2e8f0` and `#f1f5f9`), which created a harsh bright flash in dark mode. The fix implements a darker gradient for both `@media (prefers-color-scheme: dark)` and `[data-theme="dark"]`.

This PR introduces a submission demo showing a side-by-side comparison of the bug vs. the fix with an interactive theme toggle.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/skeleton-shimmer-fix/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — documents the required CSS changes
- [x] Includes `README.md` — explains the bug, root cause, and fix
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A submission demo documenting and fixing the lack of dark mode support in the Skeleton component shimmer gradient.

**How does a developer use it?**

```html
<div class="ease-skeleton ease-skeleton-text"></div>
```

**Why does it fit EaseMotion CSS?**

Skeleton loader animations must blend softly with card surfaces. Using a dark gradient in dark mode ensures the component maintains design consistency and avoids jarring bright flashes.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The actual core fix required in `components/skeleton.css` is adding these overrides:

```css
@media (prefers-color-scheme: dark) {
  .ease-skeleton {
    background: linear-gradient(90deg, var(--ease-color-neutral-800, #1e293b) 25%, var(--ease-color-neutral-700, #334155) 50%, var(--ease-color-neutral-800, #1e293b) 75%);
  }
}

[data-theme="dark"] .ease-skeleton {
  background: linear-gradient(90deg, #1e293b 25%, #334155 50%, #1e293b 75%);
}
```
