### PR TITLE
fix: add dark mode support to glass navbar backdrop-filter fallback (…

### DIFF
--- a/submissions/examples/navbar-fallback-fix/README.md
+++ b/submissions/examples/navbar-fallback-fix/README.md
@@ -1,0 +1,42 @@
+# Fix: Glass Navbar Fallback in Dark Mode
+
+**Fixes:** [#26463](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/26463)
+
+---
+
+## 🐛 Bug Description
+
+In `components/navbar.css`, the `@supports not (backdrop-filter: blur(0))` fallback (lines 98-104) is hardcoded to a solid white background (`rgba(255, 255, 255, 0.92)`). On browsers or devices that do not support `backdrop-filter` (or have it disabled), the navbar renders as a solid bright white block in dark mode, completely breaking the dark theme.
+
+---
+
+## ✅ Fix
+
+Introduce dark mode overrides (for both `@media (prefers-color-scheme: dark)` and `[data-theme="dark"]`) inside the `@supports` fallback block:
+
+```css
+@supports not (backdrop-filter: blur(0)) {
+  @media (prefers-color-scheme: dark) {
+    .ease-navbar-glass,
+    .ease-navbar-glass-blur {
+      background: var(--ease-color-surface, #141e33) !important;
+      border-color: var(--ease-color-neutral-700, #334155) !important;
+    }
+  }
+  [data-theme="dark"] .ease-navbar-glass,
+  [data-theme="dark"] .ease-navbar-glass-blur {
+    background: #141e33 !important;
+    border-color: #334155 !important;
+  }
+}
+```
+
+---
+
+## 📁 Submission Contents
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Live demonstration of the navbar fallback in light & dark modes |
+| `style.css` | Raw CSS showing the proposed fix and demo page layout |
+| `README.md` | This documentation file |

--- a/submissions/examples/navbar-fallback-fix/demo.html
+++ b/submissions/examples/navbar-fallback-fix/demo.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix #26463 — Glass Navbar Fallback | EaseMotion CSS</title>
+  <meta name="description" content="Demonstrates the fix for the glass navbar fallback lacking dark mode support on browsers without backdrop-filter support." />
+
+  <!-- EaseMotion CSS -->
+  <link rel="stylesheet" href="../../../easemotion.css" />
+
+  <!-- Google Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+
+  <!-- Demo styles -->
+  <link rel="stylesheet" href="style.css" />
+</head>
+
+<body>
+
+  <header>
+    <div>
+      <h1>Fix #26463 — Glass Navbar Fallback</h1>
+      <p>Toggle dark mode to see if the fallback (with simulated no-backdrop-filter support) adapts correctly</p>
+    </div>
+    <button class="toggle-btn" id="theme-toggle" type="button" aria-label="Toggle dark mode">
+      🌙 Dark Mode
+    </button>
+  </header>
+
+  <main style="display: grid; grid-template-columns: 1fr 1fr; gap: 2rem;">
+
+    <!-- ── LEFT: Buggy Behaviour (Before) ────────────────────── -->
+    <section class="panel" aria-label="Buggy Behaviour">
+      <span class="panel-label bug">❌ Before (Bug)</span>
+      
+      <div class="demo-box demo-buggy simulated-no-blur">
+        <nav class="ease-navbar-glass">
+          <div class="ease-navbar-brand">Brand</div>
+        </nav>
+      </div>
+
+      <p style="font-size: 0.8rem; line-height: 1.4;">
+        <strong>Issue:</strong> In dark mode, the glass navbar fallback remains bright white (<code>rgba(255, 255, 255, 0.92)</code>) on browsers that do not support backdrop-filter.
+      </p>
+    </section>
+
+    <!-- ── RIGHT: Fixed Behaviour (After) ────────────────────── -->
+    <section class="panel" aria-label="Fixed Behaviour">
+      <span class="panel-label fix">✅ After (Fix)</span>
+      
+      <div class="demo-box demo-fixed simulated-no-blur">
+        <nav class="ease-navbar-glass">
+          <div class="ease-navbar-brand">Brand</div>
+        </nav>
+      </div>
+
+      <p style="font-size: 0.8rem; line-height: 1.4;">
+        <strong>Fix:</strong> Adding media query and data-theme overrides inside the <code>@supports not (backdrop-filter)</code> block ensures the navbar fallback is dark (<code>#141e33</code>) in dark mode.
+      </p>
+    </section>
+
+  </main>
+
+  <script>
+    const btn = document.getElementById('theme-toggle');
+    const html = document.documentElement;
+
+    btn.addEventListener('click', function () {
+      const isDark = html.getAttribute('data-theme') === 'dark';
+      if (isDark) {
+        html.removeAttribute('data-theme');
+        btn.textContent = '🌙 Dark Mode';
+      } else {
+        html.setAttribute('data-theme', 'dark');
+        btn.textContent = '☀️ Light Mode';
+      }
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/navbar-fallback-fix/style.css
+++ b/submissions/examples/navbar-fallback-fix/style.css
@@ -1,0 +1,138 @@
+/*
+ * EaseMotion CSS — Fix: Glass Navbar Fallback in Dark Mode
+ * Issue: https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/26463
+ */
+
+/* ── Demo Page Layout ────────────────────────────────────────── */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', system-ui, sans-serif;
+  min-height: 100vh;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  background: var(--ease-color-bg, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+header {
+  padding: 1.5rem 2rem;
+  border-bottom: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+header h1 {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+header p {
+  font-size: 0.8rem;
+  color: var(--ease-color-muted, #64748b);
+}
+
+.toggle-btn {
+  padding: 0.4rem 1rem;
+  border-radius: 9999px;
+  border: 1.5px solid var(--ease-color-primary, #6c63ff);
+  background: transparent;
+  color: var(--ease-color-primary, #6c63ff);
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+}
+
+.toggle-btn:hover {
+  background: var(--ease-color-primary, #6c63ff);
+  color: #fff;
+}
+
+main {
+  padding: 2rem;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+  max-width: 960px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.panel {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: 1rem;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.panel-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  display: inline-flex;
+  width: fit-content;
+}
+
+.panel-label.bug {
+  background: color-mix(in srgb, #ef4444 12%, transparent);
+  color: #ef4444;
+}
+
+.panel-label.fix {
+  background: color-mix(in srgb, #22c55e 12%, transparent);
+  color: #22c55e;
+}
+
+.demo-box {
+  padding: 1.5rem;
+  background: var(--ease-color-bg, #f8fafc);
+  border-radius: 0.5rem;
+  min-height: 100px;
+}
+
+/* ── Simulating no backdrop-filter support ─────────────────── */
+.simulated-no-blur {
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+
+/* ── Buggy Simulation (Fails to adapt fallback in dark mode) ── */
+
+.demo-buggy.simulated-no-blur .ease-navbar-glass {
+  background: rgba(255, 255, 255, 0.92) !important;
+  border-color: rgba(15, 23, 42, 0.12) !important;
+  color: #0f172a !important;
+}
+
+/* ── Fixed Implementation (Fallback adapts in dark mode) ────── */
+
+[data-theme="dark"] .demo-fixed.simulated-no-blur .ease-navbar-glass {
+  background: #141e33 !important;
+  border-color: #334155 !important;
+  color: #f1f5f9 !important;
+}
+@media (prefers-color-scheme: dark) {
+  .demo-fixed.simulated-no-blur .ease-navbar-glass {
+    background: #141e33 !important;
+    border-color: #334155 !important;
+    color: #f1f5f9 !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Fixes #26463

Adds dark mode overrides inside the `@supports not (backdrop-filter: blur(0))` fallback block in `components/navbar.css`. Currently, the fallback is hardcoded to a solid white background (`rgba(255, 255, 255, 0.92)`). On browsers or devices without `backdrop-filter` support, the navbar renders as a solid white block in dark mode. The fix adds overrides to use a dark background instead.

This PR introduces a submission demo showing a side-by-side comparison of the bug vs. the fix with an interactive theme toggle.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/navbar-fallback-fix/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — documents the required CSS changes
- [x] Includes `README.md` — explains the bug, root cause, and fix
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A submission demo documenting and fixing the lack of dark mode support in the glass navbar backdrop-filter fallback.

**How does a developer use it?**

```html
<nav class="ease-navbar-glass">
  <div class="ease-navbar-brand">Brand</div>
</nav>
```

**Why does it fit EaseMotion CSS?**

Browsers that do not support backdrop-filters must still render components in the correct theme. Providing a dark fallback background prevents jarring layout breaks.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The actual core fix required in `components/navbar.css` is adding these overrides:

```css
@supports not (backdrop-filter: blur(0)) {
  @media (prefers-color-scheme: dark) {
    .ease-navbar-glass,
    .ease-navbar-glass-blur {
      background: var(--ease-color-surface, #141e33) !important;
      border-color: var(--ease-color-neutral-700, #334155) !important;
    }
  }
  [data-theme="dark"] .ease-navbar-glass,
  [data-theme="dark"] .ease-navbar-glass-blur {
    background: #141e33 !important;
    border-color: #334155 !important;
  }
}
```
