### PR TITLE
fix(chip): add support for data-theme dark mode

### DIFF
--- a/components/chip.css
+++ b/components/chip.css
@@ -118,6 +118,25 @@
   }
 }
 
+/* ── Manual Dark Theme Support ──────────────────────────────── */
+[data-theme="dark"] .ease-chip {
+  background: var(--ease-color-neutral-700, #374151);
+  border-color: var(--ease-color-neutral-600, #4b5563);
+  color: var(--ease-color-neutral-100, #f3f4f6);
+}
+
+[data-theme="dark"] .ease-chip:hover {
+  background: var(--ease-color-neutral-600, #4b5563);
+  border-color: var(--ease-color-primary, #6366f1);
+}
+
+[data-theme="dark"] .ease-chip-group input[type="checkbox"]:checked + .ease-chip {
+  background: var(--ease-color-primary, #6366f1);
+  border-color: var(--ease-color-primary, #6366f1);
+  color: #ffffff;
+  box-shadow: 0 2px 8px rgba(99, 102, 241, 0.5);
+}
+
 /* ── Reduced Motion ─────────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
   .ease-chip {


### PR DESCRIPTION
## Summary

This PR adds support for the `[data-theme="dark"]` selector for the Chip component, allowing it to respond correctly when the theme is switched programmatically using the `data-theme` attribute.

## Changes Made

* Added `[data-theme="dark"]` styles for `.ease-chip`
* Added dark theme hover styles
* Added dark theme styles for selected chips
* Preserved existing `@media (prefers-color-scheme: dark)` behavior

## Testing

* Verified that chips render correctly when `data-theme="dark"` is applied to the `<html>` element.
* Confirmed that the existing system dark mode behavior remains unchanged.

