### PR TITLE
feat: add weekly Dependabot configuration (#20498)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,29 @@
 version: 2
 updates:
+  # Keep GitHub Actions dependencies up to date
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     assignees:
       - "SAPTARSHI-coder"
+
+  # npm — Node.js / package.json dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"  # check for updates once a week
+      day: "monday"        # run every Monday morning
+      time: "09:00"        # 09:00 UTC
+      timezone: "UTC"
+    # Cap the number of open Dependabot PRs at any one time
+    open-pull-requests-limit: 5
+    # Apply the 'dependencies' label to every Dependabot PR
+    labels:
+      - "dependencies"
+    # Group minor and patch bumps into a single PR to reduce noise
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Pull Request Description

### Overview

This PR adds a GitHub Dependabot configuration to automate weekly npm dependency updates.

**Closes #20498**

---

## Type of Change

* [ ] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix
* [x] Other (DevOps configuration)

---

## Feature Description

### What does this add?

* Weekly npm dependency update checks
* Maximum of 5 open Dependabot pull requests
* Automatic `dependencies` label on generated PRs
* Standard Dependabot v2 configuration

---

## Checklist

* [x] Added `.github/dependabot.yml`
* [x] Uses Dependabot version 2
* [x] Weekly schedule configured
* [x] npm ecosystem configured
* [x] Open PR limit set to 5
* [x] Automatically labels PRs as `dependencies`

---

## Notes for Maintainer

Implements the requested Dependabot configuration according to the issue requirements.
