### PR TITLE
add animated-tabs-qn to submissions/examples

### DIFF
--- a/submissions/examples/animated-tabs-qn/README.md
+++ b/submissions/examples/animated-tabs-qn/README.md
@@ -1,0 +1,32 @@
+# CSS-Only Animated Tabs Component
+
+## Description
+A clean, modern, and fully interactive tabs component built entirely with pure CSS. It features smooth content transitions with fade and slide effects, an animated sliding underline indicator that moves between tabs, and active state highlighting. Uses the radio button hack for state management, requiring absolutely zero JavaScript.
+
+## Files
+- `demo.html`: Contains the HTML structure using hidden radio inputs, tab labels, a sliding indicator, and content panels.
+- `style.css`: Contains the layout, the sliding indicator animation, content fade/slide transitions, and active state styling.
+
+## How to use
+1. Open `demo.html` in your browser and click the tabs to see the smooth transitions.
+2. Copy the HTML and CSS into your project.
+3. **Structure:**
+   - Add hidden radio inputs with unique IDs (e.g., `tab-1-qn`, `tab-2-qn`)
+   - Create labels with `for` attributes matching the radio IDs
+   - Add a `.tab-indicator-qn` div inside the labels container
+   - Create content panels with classes like `.tab-panel-1-qn`, `.tab-panel-2-qn`
+4. **Customization:**
+   - **Number of Tabs:** To add more tabs, adjust the `width` of `.tab-indicator-qn` (e.g., for 4 tabs: `width: 25%`). Update the `translateX` values in the CSS (0%, 100%, 200%, 300%).
+   - **Colors:** Change the active tab color and indicator color by modifying `#3498db` in the CSS.
+   - **Animation Speed:** Adjust the `0.4s` transition durations to make the sliding and fading faster or slower.
+   - **Content Height:** Modify the `min-height: 250px` in `.tab-content-wrapper-qn` to accommodate more or less content.
+
+## Adding More Tabs
+To add a 4th tab:
+1. Add a new radio input: `<input type="radio" name="tabs-qn" id="tab-4-qn" class="tab-radio-qn">`
+2. Add a new label: `<label for="tab-4-qn" class="tab-label-qn"><span>Support</span></label>`
+3. Add a new content panel: `<div class="tab-content-qn tab-panel-4-qn">...</div>`
+4. Update CSS:
+   - Change `.tab-indicator-qn` width to `25%`
+   - Add: `#tab-4-qn:checked ~ .tab-labels-qn .tab-indicator-qn { transform: translateX(300%); }`
+   - Add: `#tab-4-qn:checked ~ .tab-content-wrapper-qn .tab-panel-4-qn { opacity: 1; visibility: visible; transform: translateY(0); }`

--- a/submissions/examples/animated-tabs-qn/demo.html
+++ b/submissions/examples/animated-tabs-qn/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Animated Tabs - EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="tabs-container-qn">
+        <h2>Product Features</h2>
+        
+        <!-- Hidden Radio Inputs for State Management -->
+        <input type="radio" name="tabs-qn" id="tab-1-qn" class="tab-radio-qn" checked>
+        <input type="radio" name="tabs-qn" id="tab-2-qn" class="tab-radio-qn">
+        <input type="radio" name="tabs-qn" id="tab-3-qn" class="tab-radio-qn">
+        
+        <!-- Tab Labels -->
+        <div class="tab-labels-qn">
+            <label for="tab-1-qn" class="tab-label-qn">
+                <span>Design</span>
+            </label>
+            <label for="tab-2-qn" class="tab-label-qn">
+                <span>Development</span>
+            </label>
+            <label for="tab-3-qn" class="tab-label-qn">
+                <span>Marketing</span>
+            </label>
+            
+            <!-- The Sliding Indicator -->
+            <div class="tab-indicator-qn"></div>
+        </div>
+        
+        <!-- Tab Content Panels -->
+        <div class="tab-content-wrapper-qn">
+            <div class="tab-content-qn tab-panel-1-qn">
+                <h3>Beautiful Design</h3>
+                <p>Our design system provides pixel-perfect components that are both beautiful and functional. Every element is crafted with attention to detail, ensuring a consistent and polished user experience across your entire application.</p>
+                <ul>
+                    <li>Responsive layouts</li>
+                    <li>Modern color palettes</li>
+                    <li>Accessible components</li>
+                </ul>
+            </div>
+            
+            <div class="tab-content-qn tab-panel-2-qn">
+                <h3>Robust Development</h3>
+                <p>Built with modern web standards and best practices. Our components are lightweight, performant, and easy to integrate into any project. No dependencies, just pure HTML and CSS.</p>
+                <ul>
+                    <li>Zero JavaScript required</li>
+                    <li>Hardware-accelerated animations</li>
+                    <li>Cross-browser compatible</li>
+                </ul>
+            </div>
+            
+            <div class="tab-content-qn tab-panel-3-qn">
+                <h3>Effective Marketing</h3>
+                <p>Engage your audience with stunning animations and interactive elements. Our components are designed to capture attention and improve user engagement, helping you convert visitors into customers.</p>
+                <ul>
+                    <li>Eye-catching animations</li>
+                    <li>Interactive hover effects</li>
+                    <li>Conversion-optimized</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/animated-tabs-qn/style.css
+++ b/submissions/examples/animated-tabs-qn/style.css
@@ -1,0 +1,155 @@
+/* Basic Reset and Layout */
+body {
+    background-color: #f8f9fa;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    margin: 0;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+.tabs-container-qn {
+    background: #ffffff;
+    padding: 40px;
+    border-radius: 16px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+    width: 100%;
+    max-width: 600px;
+}
+
+.tabs-container-qn h2 {
+    margin-top: 0;
+    margin-bottom: 30px;
+    color: #2c3e50;
+    text-align: center;
+    font-size: 1.8rem;
+}
+
+/* Hide the radio inputs */
+.tab-radio-qn {
+    display: none;
+}
+
+/* Tab Labels Container */
+.tab-labels-qn {
+    display: flex;
+    position: relative;
+    border-bottom: 2px solid #e9ecef;
+    margin-bottom: 30px;
+}
+
+/* Individual Tab Label */
+.tab-label-qn {
+    flex: 1;
+    text-align: center;
+    padding: 15px 20px;
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #7f8c8d;
+    transition: color 0.3s ease;
+    position: relative;
+    z-index: 2;
+}
+
+.tab-label-qn:hover {
+    color: #3498db;
+}
+
+/* The Sliding Indicator */
+.tab-indicator-qn {
+    position: absolute;
+    bottom: -2px;
+    left: 0;
+    width: 33.333%; /* 100% / 3 tabs */
+    height: 3px;
+    background: #3498db;
+    border-radius: 3px 3px 0 0;
+    transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+    z-index: 1;
+}
+
+/* --- Active Tab States --- */
+/* Tab 1 Active */
+#tab-1-qn:checked ~ .tab-labels-qn .tab-label-qn:nth-child(1) {
+    color: #3498db;
+}
+
+#tab-1-qn:checked ~ .tab-labels-qn .tab-indicator-qn {
+    transform: translateX(0);
+}
+
+/* Tab 2 Active */
+#tab-2-qn:checked ~ .tab-labels-qn .tab-label-qn:nth-child(2) {
+    color: #3498db;
+}
+
+#tab-2-qn:checked ~ .tab-labels-qn .tab-indicator-qn {
+    transform: translateX(100%);
+}
+
+/* Tab 3 Active */
+#tab-3-qn:checked ~ .tab-labels-qn .tab-label-qn:nth-child(3) {
+    color: #3498db;
+}
+
+#tab-3-qn:checked ~ .tab-labels-qn .tab-indicator-qn {
+    transform: translateX(200%);
+}
+
+/* Tab Content Wrapper */
+.tab-content-wrapper-qn {
+    position: relative;
+    min-height: 250px;
+}
+
+/* Tab Content Panel Base */
+.tab-content-qn {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(10px);
+    transition: opacity 0.4s ease, visibility 0.4s ease, transform 0.4s ease;
+}
+
+/* Show Active Panel */
+#tab-1-qn:checked ~ .tab-content-wrapper-qn .tab-panel-1-qn,
+#tab-2-qn:checked ~ .tab-content-wrapper-qn .tab-panel-2-qn,
+#tab-3-qn:checked ~ .tab-content-wrapper-qn .tab-panel-3-qn {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+}
+
+/* Content Styling */
+.tab-content-qn h3 {
+    margin-top: 0;
+    margin-bottom: 15px;
+    color: #2c3e50;
+    font-size: 1.4rem;
+}
+
+.tab-content-qn p {
+    color: #555;
+    line-height: 1.7;
+    margin-bottom: 20px;
+}
+
+.tab-content-qn ul {
+    margin: 0;
+    padding-left: 20px;
+    color: #666;
+}
+
+.tab-content-qn li {
+    margin-bottom: 8px;
+    line-height: 1.6;
+}
+
+.tab-content-qn li::marker {
+    color: #3498db;
+}


### PR DESCRIPTION

## Description
This PR adds a new "CSS-Only Animated Tabs" component to the repository. It creates a smooth, interactive tabbed interface with content fade/slide transitions and an animated sliding underline indicator, all built with pure CSS using the radio button hack.

## Changes
- Added `submissions/examples/animated-tabs-qn/` folder.
- Added `demo.html` with the HTML structure using radio inputs, labels, and content panels.
- Added `style.css` with the sliding indicator animation, content transitions, and active state styling.
- Added `README.md` with usage instructions and detailed tips for adding more tabs.

## Related Issue
Closes #27149

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] I have placed my files in the `submissions/examples/animated-tabs-qn/` directory.
- [x] I have not modified any files in `core/` or `components/`.
- [x] My submission includes `demo.html`, `style.css`, and `README.md`.
- [x] I have appended a unique identifier (`-qn`) to the feature name to avoid conflicts.
- [x] My commits are squashed into a single meaningful commit with a clear message.