### PR TITLE
feat: add bundle size tracking with bundlewatch (#20508)

### DIFF
--- a/submissions/examples/bundlewatch-tracking-ax/README.md
+++ b/submissions/examples/bundlewatch-tracking-ax/README.md
@@ -1,0 +1,54 @@
+﻿# Bundle Size Tracking with Bundlewatch
+
+A complete setup guide for tracking CSS bundle sizes on every pull request using Bundlewatch. Prevents accidental bundle bloat by failing CI if the size exceeds defined limits.
+
+## Files
+- `bundlewatch.config.json` – configuration file with file paths and max sizes
+- `demo.html` – explains how the tool works
+- `style.css` – demo page styling
+- `README.md` – this file
+
+## How to Set Up
+
+1. **Install Bundlewatch** as a dev dependency:
+   ```bash
+   npm install --save-dev bundlewatch
+Add the configuration file bundlewatch.config.json to your repository root with the contents provided.
+
+Add a GitHub Actions workflow (example below) to run Bundlewatch on every PR:
+
+yaml
+name: Bundle Size Check
+on: [pull_request]
+jobs:
+  bundlewatch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Bundlewatch
+        run: npx bundlewatch
+        env:
+          BUNDLEWATCH_GITHUB_TOKEN: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}
+Create a GitHub Personal Access Token with repo scope and add it as a secret named BUNDLEWATCH_GITHUB_TOKEN in your repository settings.
+
+How It Works
+Bundlewatch compares the sizes of easemotion.css and easemotion.min.css against the main branch.
+
+If any file exceeds its max size by more than 5KB, the PR check fails and the PR is blocked.
+
+A comment is posted on the PR with the exact size delta for each file.
+
+EaseMotion classes used in demo
+Layout: ease-container, ease-flex, ease-items-center, ease-justify-center, ease-min-h-screen, ease-py-16
+
+Background: ease-bg-gray-50, ease-bg-white
+
+Typography: ease-text-4xl, ease-font-bold, ease-text-gray-500, ease-text-sm, ease-text-gray-400, ease-text-lg, ease-font-semibold, ease-text-gray-600
+
+Spacing: ease-mb-2, ease-mb-4, ease-mb-8, ease-mt-4, ease-mt-6, ease-mt-8, ease-p-6, ease-pl-5
+
+Components: ease-card
+
+Animation: ease-fade-in, ease-delay-200, ease-delay-500
+
+Utilities: ease-list-disc, ease-space-y-2

--- a/submissions/examples/bundlewatch-tracking-ax/bundlewatch.config.json
+++ b/submissions/examples/bundlewatch-tracking-ax/bundlewatch.config.json
@@ -1,0 +1,17 @@
+﻿{
+  "files": [
+    {
+      "path": "./easemotion.css",
+      "maxSize": "170 kB"
+    },
+    {
+      "path": "./easemotion.min.css",
+      "maxSize": "30 kB"
+    }
+  ],
+  "ci": {
+    "trackBranches": ["main"],
+    "defaultCompression": "gzip",
+    "maxSize": "5 kB"
+  }
+}

--- a/submissions/examples/bundlewatch-tracking-ax/demo.html
+++ b/submissions/examples/bundlewatch-tracking-ax/demo.html
@@ -1,0 +1,57 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bundle Size Tracking with Bundlewatch</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-50 ease-min-h-screen ease-flex ease-items-center ease-justify-center">
+
+  <div class="ease-container ease-text-center ease-py-16">
+    <h1 class="ease-text-4xl ease-font-bold ease-mb-4 ease-fade-in">
+      Bundle Size Tracking
+    </h1>
+    <p class="ease-text-gray-500 ease-mb-8 ease-fade-in ease-delay-200">
+      Monitor your CSS bundle sizes and catch unexpected growth before it reaches production.
+    </p>
+
+    <div class="ease-card ease-p-6 ease-max-w-lg ease-mx-auto ease-bg-white ease-text-left">
+      <h2 class="ease-text-lg ease-font-semibold ease-mb-2">How it works</h2>
+      <ul class="ease-text-sm ease-text-gray-600 ease-list-disc ease-pl-5 ease-space-y-2 ease-mb-4">
+        <li>Installs <code>bundlewatch</code> as a dev dependency</li>
+        <li>Defines size limits for <code>easemotion.css</code> and <code>easemotion.min.css</code></li>
+        <li>Runs on every PR and fails CI if any bundle exceeds its max size by more than 5KB</li>
+        <li>Comments the bundle size delta directly on the PR</li>
+      </ul>
+
+      <h2 class="ease-text-lg ease-font-semibold ease-mt-6 ease-mb-2">Configuration</h2>
+      <pre class="code-block"><code>{
+  "files": [
+    {
+      "path": "./easemotion.css",
+      "maxSize": "170 kB"
+    },
+    {
+      "path": "./easemotion.min.css",
+      "maxSize": "30 kB"
+    }
+  ],
+  "ci": {
+    "trackBranches": ["main"],
+    "defaultCompression": "gzip"
+  }
+}</code></pre>
+      <p class="ease-text-sm ease-text-gray-500 ease-mt-4">
+        The workflow fails if any tracked file exceeds its max size by more than 5KB compared to the main branch.
+      </p>
+    </div>
+
+    <p class="ease-text-sm ease-text-gray-400 ease-mt-8 ease-fade-in ease-delay-500">
+      Built for EaseMotion CSS — keep the framework lightweight.
+    </p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/bundlewatch-tracking-ax/style.css
+++ b/submissions/examples/bundlewatch-tracking-ax/style.css
@@ -1,0 +1,22 @@
+﻿.code-block {
+  background: #f1f5f9;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  font-size: 0.875rem;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+body {
+  font-family: system-ui, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
Closes #20508

Bundle Size Tracking with Bundlewatch
A complete setup guide and configuration for tracking CSS bundle sizes on every PR, preventing unexpected bloat.

Files added
- submissions/examples/bundlewatch-tracking-ax/bundlewatch.config.json – configuration file
- submissions/examples/bundlewatch-tracking-ax/demo.html – demo page
- submissions/examples/bundlewatch-tracking-ax/style.css – demo styles
- submissions/examples/bundlewatch-tracking-ax/README.md – instructions

How it works
- Defines max sizes for easemotion.css (170 kB) and easemotion.min.css (30 kB).
- Fails CI if any bundle grows more than 5KB unexpectedly.
- Includes GitHub Actions workflow example and secret setup instructions.