### PR TITLE
feat: add Dependabot config for weekly updates (#20498)

### DIFF
--- a/submissions/examples/dependabot-config-ax/README.md
+++ b/submissions/examples/dependabot-config-ax/README.md
@@ -1,0 +1,32 @@
+﻿# Dependabot Configuration for Weekly Dependency Updates
+
+A pre‑configured Dependabot setup that automatically creates pull requests for outdated npm dependencies on a weekly basis.
+
+## Files
+- `dependabot.yml` – the Dependabot configuration file
+- `demo.html` – explains how the tool works
+- `style.css` – demo page styling
+- `README.md` – this file
+
+## How to Set Up
+1. Copy `dependabot.yml` into your repository's `.github/` folder.
+2. Ensure Dependabot is enabled in your repository settings.
+3. Dependabot will automatically run on the schedule defined in the config.
+
+## Configuration Details
+| Setting | Value |
+|---------|-------|
+| Ecosystem | npm |
+| Schedule | Weekly (Monday 9:00 AM) |
+| Open PR Limit | 5 |
+| Target Branch | main |
+| Auto‑label | `dependencies` |
+
+## EaseMotion classes used in demo
+- **Layout:** `ease-container`, `ease-flex`, `ease-items-center`, `ease-justify-center`, `ease-min-h-screen`, `ease-py-16`
+- **Background:** `ease-bg-gray-50`, `ease-bg-white`
+- **Typography:** `ease-text-4xl`, `ease-font-bold`, `ease-text-gray-500`, `ease-text-sm`, `ease-text-gray-400`, `ease-text-lg`, `ease-font-semibold`, `ease-text-gray-600`
+- **Spacing:** `ease-mb-2`, `ease-mb-4`, `ease-mb-8`, `ease-mt-4`, `ease-mt-6`, `ease-mt-8`, `ease-p-6`, `ease-pl-5`
+- **Components:** `ease-card`
+- **Animation:** `ease-fade-in`, `ease-delay-200`, `ease-delay-500`
+- **Utilities:** `ease-list-disc`, `ease-space-y-2`

--- a/submissions/examples/dependabot-config-ax/demo.html
+++ b/submissions/examples/dependabot-config-ax/demo.html
@@ -1,0 +1,44 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dependabot Configuration</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-50 ease-min-h-screen ease-flex ease-items-center ease-justify-center">
+
+  <div class="ease-container ease-text-center ease-py-16">
+    <h1 class="ease-text-4xl ease-font-bold ease-mb-4 ease-fade-in">
+      Dependabot Setup
+    </h1>
+    <p class="ease-text-gray-500 ease-mb-8 ease-fade-in ease-delay-200">
+      Automatically keep your npm dependencies up to date with weekly pull requests.
+    </p>
+
+    <div class="ease-card ease-p-6 ease-max-w-lg ease-mx-auto ease-bg-white ease-text-left">
+      <h2 class="ease-text-lg ease-font-semibold ease-mb-2">Configuration Details</h2>
+      <ul class="ease-text-sm ease-text-gray-600 ease-list-disc ease-pl-5 ease-space-y-2 ease-mb-4">
+        <li>Runs <strong>weekly</strong> on Monday at 9:00 AM</li>
+        <li>Limits to <strong>5 open PRs</strong> at once</li>
+        <li>Targets the <code>main</code> branch</li>
+        <li>Auto‑labels PRs with <code>dependencies</code></li>
+        <li>Uses the <code>npm</code> ecosystem</li>
+      </ul>
+
+      <h2 class="ease-text-lg ease-font-semibold ease-mt-6 ease-mb-2">How to use</h2>
+      <pre class="code-block"><code># Copy the config file to your repo:
+.github/dependabot.yml</code></pre>
+      <p class="ease-text-sm ease-text-gray-500 ease-mt-4">
+        Once placed in the correct directory, Dependabot will automatically open PRs for outdated dependencies.
+      </p>
+    </div>
+
+    <p class="ease-text-sm ease-text-gray-400 ease-mt-8 ease-fade-in ease-delay-500">
+      Built for EaseMotion CSS — never fall behind on dependency updates.
+    </p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/dependabot-config-ax/dependabot.yml
+++ b/submissions/examples/dependabot-config-ax/dependabot.yml
@@ -1,0 +1,12 @@
+﻿version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    target-branch: "main"
+    labels:
+      - "dependencies"

--- a/submissions/examples/dependabot-config-ax/style.css
+++ b/submissions/examples/dependabot-config-ax/style.css
@@ -1,0 +1,22 @@
+﻿.code-block {
+  background: #f1f5f9;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  font-size: 0.875rem;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+body {
+  font-family: system-ui, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
Closes #20498

Dependabot Configuration for Weekly Dependency Updates
A pre-configured Dependabot setup that automatically creates PRs for outdated npm dependencies on a weekly schedule.

Files added
- submissions/examples/dependabot-config-ax/dependabot.yml – the configuration file
- submissions/examples/dependabot-config-ax/demo.html – demo page
- submissions/examples/dependabot-config-ax/style.css – demo styles
- submissions/examples/dependabot-config-ax/README.md – instructions

How it works
- Runs weekly on Monday at 9:00 AM
- Limits open PRs to 5
- Targets the main branch and auto‑labels PRs as `dependencies`
- Copy dependabot.yml to .github/ to activate