### PR TITLE
feat: add scroll reveal animations (#27078)

### DIFF
--- a/submissions/examples/scroll-reveal-ax/README.md
+++ b/submissions/examples/scroll-reveal-ax/README.md
@@ -1,0 +1,32 @@
+﻿# Scroll Reveal Animations
+
+A collection of scroll‑based reveal effects that trigger when elements enter the viewport. Uses `IntersectionObserver` (a tiny JS snippet) to add a `show` class, while CSS handles the animations without custom keyframes.
+
+## Effects
+- **Fade Up** – slides up and fades in
+- **Fade Down** – slides down and fades in
+- **Slide from Left** – slides in from the left
+- **Slide from Right** – slides in from the right
+- **Zoom Reveal** – scales up from a smaller size
+
+## EaseMotion Classes Used in Demo
+- **Layout:** `ease-container`, `ease-py-16`
+- **Background:** `ease-bg-gray-50`, `ease-bg-white`
+- **Typography:** `ease-text-4xl`, `ease-font-bold`, `ease-text-center`, `ease-text-gray-500`, `ease-text-sm`, `ease-text-gray-400`, `ease-text-3xl`, `ease-text-gray-600`
+- **Spacing:** `ease-mb-4`, `ease-mb-8`, `ease-mb-16`, `ease-mt-8`, `ease-p-8`
+- **Components:** `ease-card`
+- **Animation:** `ease-fade-in`, `ease-delay-200`
+- **Utilities:** `ease-shadow-md`
+
+## How It Works
+- Each section has the class `reveal` plus a specific direction class (`fade-up`, `fade-down`, `slide-left`, `slide-right`, `zoom-reveal`).
+- The `IntersectionObserver` adds the class `show` when the element enters the viewport.
+- CSS transitions then move the element to its natural position and change opacity from 0 to 1.
+- No custom keyframes are used — only CSS transitions and EaseMotion utility classes for the initial entrance.
+- The animation respects `prefers-reduced-motion`.
+
+## How to Use
+1. Copy the HTML structure and CSS into your project.
+2. Add the `reveal` and direction class to any element you want to animate on scroll.
+3. Include the JavaScript snippet (IntersectionObserver) in your page.
+4. Ensure the path to `easemotion.css` is correct.

--- a/submissions/examples/scroll-reveal-ax/demo.html
+++ b/submissions/examples/scroll-reveal-ax/demo.html
@@ -1,0 +1,69 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scroll Reveal Animations</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-50 ease-font-sans">
+
+  <div class="ease-container ease-py-16">
+
+    <h1 class="ease-text-4xl ease-font-bold ease-text-center ease-mb-4 ease-fade-in">
+      Scroll Reveal Animations
+    </h1>
+    <p class="ease-text-gray-500 ease-text-center ease-mb-16 ease-fade-in ease-delay-200">
+      Each section appears with a different animation when scrolled into view.
+    </p>
+
+    <!-- Fade Up -->
+    <section class="reveal fade-up ease-bg-white ease-card ease-p-8 ease-mb-8 ease-shadow-md">
+      <h2 class="ease-text-3xl ease-font-bold ease-mb-4">⬆️ Fade Up Reveal</h2>
+      <p class="ease-text-gray-600">This card slides up and fades in when it enters the viewport.</p>
+    </section>
+
+    <!-- Fade Down -->
+    <section class="reveal fade-down ease-bg-white ease-card ease-p-8 ease-mb-8 ease-shadow-md">
+      <h2 class="ease-text-3xl ease-font-bold ease-mb-4">⬇️ Fade Down Reveal</h2>
+      <p class="ease-text-gray-600">This card slides down and fades in when scrolled into view.</p>
+    </section>
+
+    <!-- Slide from Left -->
+    <section class="reveal slide-left ease-bg-white ease-card ease-p-8 ease-mb-8 ease-shadow-md">
+      <h2 class="ease-text-3xl ease-font-bold ease-mb-4">⬅️ Slide from Left</h2>
+      <p class="ease-text-gray-600">This card slides in from the left with a fade effect.</p>
+    </section>
+
+    <!-- Slide from Right -->
+    <section class="reveal slide-right ease-bg-white ease-card ease-p-8 ease-mb-8 ease-shadow-md">
+      <h2 class="ease-text-3xl ease-font-bold ease-mb-4">➡️ Slide from Right</h2>
+      <p class="ease-text-gray-600">This card slides in from the right and fades in.</p>
+    </section>
+
+    <!-- Zoom Reveal -->
+    <section class="reveal zoom-reveal ease-bg-white ease-card ease-p-8 ease-mb-8 ease-shadow-md">
+      <h2 class="ease-text-3xl ease-font-bold ease-mb-4">🔍 Zoom Reveal</h2>
+      <p class="ease-text-gray-600">This card scales up from a smaller size and fades in.</p>
+    </section>
+
+    <p class="ease-text-sm ease-text-gray-400 ease-text-center ease-mt-8">
+      Uses <code>IntersectionObserver</code> + EaseMotion classes. No custom keyframes.
+    </p>
+  </div>
+
+  <script>
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('show');
+        }
+      });
+    }, { threshold: 0.15 });
+
+    document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/scroll-reveal-ax/style.css
+++ b/submissions/examples/scroll-reveal-ax/style.css
@@ -1,0 +1,38 @@
+﻿/* Scroll Reveal – Custom Styling */
+
+/* Initially hidden and positioned off-screen / scaled down */
+.reveal {
+  opacity: 0;
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.fade-up {
+  transform: translateY(40px);
+}
+.fade-down {
+  transform: translateY(-40px);
+}
+.slide-left {
+  transform: translateX(-40px);
+}
+.slide-right {
+  transform: translateX(40px);
+}
+.zoom-reveal {
+  transform: scale(0.9);
+}
+
+/* When the element becomes visible, show it in its final position */
+.reveal.show {
+  opacity: 1;
+  transform: translateY(0) translateX(0) scale(1);
+}
+
+/* Respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .reveal {
+    transition: none;
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
Closes #27078

Scroll Reveal Animations
A collection of scroll‑triggered reveal effects (fade up, fade down, slide left/right, zoom) using IntersectionObserver and CSS transitions — no custom keyframes.

Files added
- submissions/examples/scroll-reveal-ax/demo.html
- submissions/examples/scroll-reveal-ax/style.css
- submissions/examples/scroll-reveal-ax/README.md

How it works
- IntersectionObserver adds a .show class when an element enters the viewport.
- CSS transitions handle the reveal (opacity + transform).
- Five animation variants included.
- Respects prefers-reduced-motion.