### PR TITLE
feat: add ease-seed-sprout animation entry utility (Issue #26884)

### DIFF
--- a/submissions/examples/ease-seed-sprout/README.md
+++ b/submissions/examples/ease-seed-sprout/README.md
@@ -1,0 +1,14 @@
+# Ease Seed Sprout Animation
+
+An elastic entry animation designed to replicate natural biological cell expansion. It springs outward from an absolute zero footprint into full maturity with an expressive organic overshoot.
+
+## Features
+- **Rooted Expansion Bounds**: Implements a dedicated `transform-origin: bottom center` to keep the base fixed on the ground while scaling upward.
+- **Inertial Settling Curves**: Leverages custom keyframes to create a soft, bouncy wobble at the peak of growth.
+- **Three Core Configuration Speeds**: Includes `default`, `fast`, and `slow` bloom modulators.
+
+## Core Utility Usage
+```html
+<div class="element ease-seed-sprout">🌱</div>
+<div class="element ease-seed-sprout-fast">🌱</div>
+<div class="element ease-seed-sprout-slow">🌱</div>

--- a/submissions/examples/ease-seed-sprout/demo.html
+++ b/submissions/examples/ease-seed-sprout/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ease Seed Sprout Animation Demo</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <div class="garden-container">
+        <div class="header-info">
+            <h2>Animation: <span class="accent">ease-seed-sprout</span></h2>
+            <p>An elastic, scaling entry utility animation that replicates the organic bursting growth of a plant seedling.</p>
+        </div>
+
+        <div class="garden-patch">
+            
+            <div class="patch-card">
+                <div class="soil-line">
+                    <div id="sprout1" class="sprout-element ease-seed-sprout">🌱</div>
+                </div>
+                <span class="badge">Default Sprout</span>
+            </div>
+
+            <div class="patch-card">
+                <div class="soil-line">
+                    <div id="sprout2" class="sprout-element ease-seed-sprout-fast">🌱</div>
+                </div>
+                <span class="badge">Fast Burst</span>
+            </div>
+
+            <div class="patch-card">
+                <div class="soil-line">
+                    <div id="sprout3" class="sprout-element ease-seed-sprout-slow">🌱</div>
+                </div>
+                <span class="badge">Slow Bloom</span>
+            </div>
+
+        </div>
+
+        <button class="replay-btn" onclick="triggerReplay()">🧑‍🌾 Replant & Re-sprout</button>
+    </div>
+
+    <script>
+        function triggerReplay() {
+            const elements = [
+                { id: 'sprout1', class: 'ease-seed-sprout' },
+                { id: 'sprout2', class: 'ease-seed-sprout-fast' },
+                { id: 'sprout3', class: 'ease-seed-sprout-slow' }
+            ];
+            
+            elements.forEach(item => {
+                const el = document.getElementById(item.id);
+                // Remove class to reset animation state
+                el.classList.remove(item.class);
+                // Trigger reflow to restart CSS sequence
+                void el.offsetWidth; 
+                // Re-add target animation profile
+                el.classList.add(item.class);
+            });
+        }
+    </script>
+</body>
+</html>

--- a/submissions/examples/ease-seed-sprout/style.css
+++ b/submissions/examples/ease-seed-sprout/style.css
@@ -1,0 +1,143 @@
+/* Base Layout Reset */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-family: 'Plus Jakarta Sans', sans-serif;
+}
+
+body {
+    min-height: 100vh;
+    background: linear-gradient(135deg, #111827 0%, #064e3b 100%);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow: hidden;
+    padding: 2rem;
+}
+
+.garden-container {
+    text-align: center;
+    width: 100%;
+    max-width: 900px;
+}
+
+.header-info h2 {
+    color: #ffffff;
+    font-size: 1.8rem;
+    margin-bottom: 0.5rem;
+}
+
+.header-info .accent {
+    color: #34d399;
+    text-shadow: 0 0 15px rgba(52, 211, 153, 0.3);
+}
+
+.header-info p {
+    color: #9ca3af;
+    font-size: 0.95rem;
+    margin-bottom: 4rem;
+}
+
+/* Garden Patch Grid */
+.garden-patch {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 2rem;
+    margin-bottom: 3rem;
+}
+
+.patch-card {
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid rgba(255, 255, 255, 0.07);
+    backdrop-filter: blur(12px);
+    border-radius: 24px;
+    padding: 3rem 1.5rem 1.5rem 1.5rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    box-shadow: 0 20px 45px rgba(0,0,0,0.4);
+}
+
+/* Soil / Base Anchor Layer */
+.soil-line {
+    height: 120px;
+    width: 100%;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    border-bottom: 4px solid #78350f; /* Rich soil tone baseline */
+    padding-bottom: 2px;
+    position: relative;
+}
+
+.sprout-element {
+    font-size: 4rem;
+    line-height: 1;
+    display: inline-block;
+    user-select: none;
+    
+    /* CRITICAL: Anchor transformation strictly to the base soil line */
+    transform-origin: bottom center;
+}
+
+.badge {
+    color: #cbd5e1;
+    font-size: 0.8rem;
+    font-weight: 600;
+    background: rgba(52, 211, 153, 0.12);
+    border: 1px solid rgba(52, 211, 153, 0.2);
+    padding: 0.4rem 0.9rem;
+    border-radius: 30px;
+    margin-top: 1.5rem;
+}
+
+.replay-btn {
+    background: #10b981;
+    color: white;
+    font-weight: 600;
+    border: none;
+    padding: 0.75rem 1.75rem;
+    border-radius: 14px;
+    cursor: pointer;
+    box-shadow: 0 4px 14px rgba(16, 185, 129, 0.3);
+    transition: background 0.2s, transform 0.1s;
+}
+
+.replay-btn:hover { background: #059669; }
+.replay-btn:active { transform: scale(0.97); }
+
+/* ==========================================================================
+   Ease Motion CSS Core Animation Keyframes & Utility Classes
+   ========================================================================== */
+
+@keyframes ease-seed-sprout {
+    0% {
+        transform: scale(0) translateY(10px) rotate(-5deg);
+        opacity: 0;
+    }
+    50% {
+        opacity: 1;
+        transform: scale(1.12) translateY(-4px) rotate(3deg); /* Elastic overshooting burst */
+    }
+    70% {
+        transform: scale(0.95) translateY(1px) rotate(-1deg);  /* Settling recoil */
+    }
+    100% {
+        transform: scale(1) translateY(0) rotate(0deg);
+        opacity: 1;
+    }
+}
+
+/* Modifiers */
+.ease-seed-sprout {
+    animation: ease-seed-sprout 1.2s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+.ease-seed-sprout-fast {
+    animation: ease-seed-sprout 0.7s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+.ease-seed-sprout-slow {
+    animation: ease-seed-sprout 2.2s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}


### PR DESCRIPTION
## Description
This PR addresses and resolves Issue #26884 by introducing the **`ease-seed-sprout`** animation entry utility. It features an elastic, spring-loaded keyframe sequence engineered to replicate the organic bursting growth of a plant seedling emerging from the ground.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Implemented
- Developed a garden-themed sandbox interface in `submissions/examples/ease-seed-sprout/demo.html` featuring interactive script triggers to replay the sprouting animation on-demand.
- Built progressive structural keyframe segments inside `style.css` using custom timing mechanics to smoothly combine scaling thresholds (`scale(0)` to `scale(1.12)`) alongside subtle rotation variations.
- Bound structural properties using `transform-origin: bottom center` to hold baseline coordinates steady against a dark, styled baseline.
- Exported three custom utility speeds: `ease-seed-sprout` (default), `ease-seed-sprout-fast`, and `ease-seed-sprout-slow`.
- Included usage documentation inside `README.md`.

## Screenshots / Visual Reference
| Interactive Garden Patch Stage |
| --- |
| _A stylized testing environment showing seedling elements sprouting with realistic inertial overshooting physics._ |

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or console errors
- [x] All file submissions are strictly placed inside the `submissions/` directory
- [x] This feature does not duplicate existing components within the core setup

Closes #26884