### PR TITLE
feat: add CSS class count badge generator (#20500)

### DIFF
--- a/submissions/examples/css-class-count-badge-ax/README.md
+++ b/submissions/examples/css-class-count-badge-ax/README.md
@@ -1,0 +1,41 @@
+﻿# CSS Class Count Badge Generator
+
+A Node.js script that parses the core EaseMotion CSS files, counts classes by category (animation, utility, component), and generates shields.io badge URLs for the README.
+
+## Files
+- `count-classes.js` – the actual script
+- `demo.html` – explains how the tool works
+- `style.css` – demo page styling
+- `README.md` – this file
+
+## Categories
+| Category   | Detection Pattern |
+|------------|-------------------|
+| Animation  | Classes like `ease-fade-in`, `ease-slide-up`, `ease-bounce` |
+| Utility    | Layout, spacing, typography helpers (`ease-container`, `ease-flex`, `ease-text-*`, `ease-p-*`) |
+| Component  | UI components (`ease-btn`, `ease-card`, `ease-input`, `ease-badge`) |
+
+## How to Run
+```bash
+node count-classes.js
+The script reads the CSS files in the core/ directory and prints three shields.io badge URLs in Markdown format.
+
+Example Output
+markdown
+![Animation Classes](https://img.shields.io/badge/animations-25+-blue)
+![Utility Classes](https://img.shields.io/badge/utilities-80+-green)
+![Component Classes](https://img.shields.io/badge/components-15+-orange)
+EaseMotion classes used in demo
+Layout: ease-container, ease-flex, ease-items-center, ease-justify-center, ease-min-h-screen, ease-py-16
+
+Background: ease-bg-gray-50, ease-bg-white
+
+Typography: ease-text-4xl, ease-font-bold, ease-text-gray-500, ease-text-sm, ease-text-gray-400, ease-text-lg, ease-font-semibold, ease-text-gray-600
+
+Spacing: ease-mb-2, ease-mb-4, ease-mb-8, ease-mt-4, ease-mt-6, ease-mt-8, ease-p-6, ease-pl-5
+
+Components: ease-card
+
+Animation: ease-fade-in, ease-delay-200, ease-delay-500
+
+Utilities: ease-list-disc, ease-space-y-2

--- a/submissions/examples/css-class-count-badge-ax/count-classes.js
+++ b/submissions/examples/css-class-count-badge-ax/count-classes.js
@@ -1,0 +1,51 @@
+﻿const fs = require('fs');
+const path = require('path');
+
+// Path to the core CSS directory
+const coreDir = path.join(__dirname, '..', '..', '..', 'core');
+
+// Categories
+const ANIMATION_PATTERNS = /ease-(fade|slide|zoom|bounce|pulse|rotate|flip|ping|spin|shake|wobble|tada|jello|heartBeat|hinge|jackInTheBox|rollIn|rollOut|lightSpeed|swing|flash|headShake)/;
+const UTILITY_PATTERNS = /ease-(container|flex|grid|text-|font-|bg-|p-|m-|gap-|w-|h-|rounded|shadow|opacity|overflow|relative|absolute|fixed|sticky|top-|bottom-|left-|right-|inset-|z-|cursor|select|pointer|hidden|block|inline|inline-block|list-|space-|justify-|items-|self-|order|col-|row-)/;
+const COMPONENT_PATTERNS = /ease-(btn|card|input|badge|chip|tag|modal|tooltip|toast|navbar|sidebar|avatar|spinner|loader|progress|table|form)/;
+
+let animationCount = 0;
+let utilityCount = 0;
+let componentCount = 0;
+
+function countClassesInFile(filePath) {
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const classRegex = /\.(ease-[\w-]+)/g;
+  const classes = new Set();
+  let match;
+  while ((match = classRegex.exec(content)) !== null) {
+    classes.add(match[1]);
+  }
+
+  classes.forEach(cls => {
+    if (ANIMATION_PATTERNS.test(cls)) animationCount++;
+    else if (COMPONENT_PATTERNS.test(cls)) componentCount++;
+    else if (UTILITY_PATTERNS.test(cls)) utilityCount++;
+    // Fallthrough: some classes might not match any category — we skip them
+  });
+}
+
+// Scan core directory
+if (fs.existsSync(coreDir)) {
+  const files = fs.readdirSync(coreDir).filter(f => f.endsWith('.css'));
+  files.forEach(file => {
+    countClassesInFile(path.join(coreDir, file));
+  });
+}
+
+// Generate shields.io badge URLs
+const badges = {
+  animation: `https://img.shields.io/badge/animations-${animationCount}+-blue`,
+  utility: `https://img.shields.io/badge/utilities-${utilityCount}+-green`,
+  component: `https://img.shields.io/badge/components-${componentCount}+-orange`
+};
+
+console.log('## README Badges\n');
+console.log(`![Animation Classes](${badges.animation})`);
+console.log(`![Utility Classes](${badges.utility})`);
+console.log(`![Component Classes](${badges.component})`);

--- a/submissions/examples/css-class-count-badge-ax/demo.html
+++ b/submissions/examples/css-class-count-badge-ax/demo.html
@@ -1,0 +1,46 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Class Count Badge Generator</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-50 ease-min-h-screen ease-flex ease-items-center ease-justify-center">
+
+  <div class="ease-container ease-text-center ease-py-16">
+    <h1 class="ease-text-4xl ease-font-bold ease-mb-4 ease-fade-in">
+      Class Count Badge Generator
+    </h1>
+    <p class="ease-text-gray-500 ease-mb-8 ease-fade-in ease-delay-200">
+      A script that counts CSS classes by category and generates shields.io badge URLs for the README.
+    </p>
+
+    <div class="ease-card ease-p-6 ease-max-w-lg ease-mx-auto ease-bg-white ease-text-left">
+      <h2 class="ease-text-lg ease-font-semibold ease-mb-2">How it works</h2>
+      <ul class="ease-text-sm ease-text-gray-600 ease-list-disc ease-pl-5 ease-space-y-2 ease-mb-4">
+        <li>Parses the core CSS files in the <code>core/</code> directory</li>
+        <li>Counts classes by category: <strong>animation</strong>, <strong>utility</strong>, <strong>component</strong></li>
+        <li>Generates shields.io badge URLs with the current counts</li>
+        <li>Outputs ready‑to‑paste Markdown for the README</li>
+      </ul>
+
+      <h2 class="ease-text-lg ease-font-semibold ease-mt-6 ease-mb-2">How to run</h2>
+      <pre class="code-block"><code># Install dependencies
+npm install fs path
+
+# Run the script
+node count-classes.js</code></pre>
+      <p class="ease-text-sm ease-text-gray-500 ease-mt-4">
+        The script reads <code>core/</code> and prints three shields.io badge URLs (animation, utility, component).
+      </p>
+    </div>
+
+    <p class="ease-text-sm ease-text-gray-400 ease-mt-8 ease-fade-in ease-delay-500">
+      Built for EaseMotion CSS — keep the README badges accurate automatically.
+    </p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-class-count-badge-ax/style.css
+++ b/submissions/examples/css-class-count-badge-ax/style.css
@@ -1,0 +1,22 @@
+﻿.code-block {
+  background: #f1f5f9;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  font-size: 0.875rem;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+body {
+  font-family: system-ui, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
Closes #20500

CSS Class Count Badge Generator
A Node.js script that parses core CSS files, counts classes by category, and generates shields.io badge URLs for the README.

Files added
- submissions/examples/css-class-count-badge-ax/count-classes.js – the badge generator script
- submissions/examples/css-class-count-badge-ax/demo.html – demo page
- submissions/examples/css-class-count-badge-ax/style.css – demo styles
- submissions/examples/css-class-count-badge-ax/README.md – instructions

How it works
- Reads all CSS files in the core/ directory.
- Counts classes by animation, utility, and component categories using regex patterns.
- Outputs three shields.io badge URLs in Markdown format.