### PR TITLE
feat: add toast notification component with auto-dismiss

### DIFF
--- a/submissions/examples/toast-rb/README.md
+++ b/submissions/examples/toast-rb/README.md
@@ -1,0 +1,45 @@
+# Toast Notification Component
+
+A pure CSS toast notification system with auto-dismiss, entrance animations, and a visual progress bar. No JavaScript required.
+
+## Files
+
+- `demo.html` — Live preview with slide-right, slide-up, and dark mode variants
+- `style.css` — All toast styles, keyframes, and layout helpers
+
+## How Auto-Dismiss Works
+
+The entire toast lifecycle is handled by a single CSS keyframe animation:
+
+1. **0% – 8%** : Toast slides into view (entrance)
+2. **8% – 92%** : Toast stays fully visible (dwell)
+3. **92% – 100%** : Toast slides out and fades (exit)
+
+`animation-fill-mode: forwards` keeps the toast in the hidden exit state after the animation completes. No JS timers needed.
+
+## Classes
+
+| Class | Description |
+|-------|-------------|
+| `.toast-container` | Fixed-position wrapper (top-right by default) |
+| `.toast` | Base toast banner |
+| `.toast-success` | Green accent variant |
+| `.toast-error` | Red accent variant |
+| `.toast-info` | Blue accent variant |
+| `.toast-slide-right` | Slides in from right edge |
+| `.toast-slide-up` | Slides in from bottom |
+| `.toast-static` | Disables auto-dismiss (persistent) |
+| `.toast-dark` | Dark mode palette swap |
+
+## CSS Custom Properties
+
+Override these on `.toast` or via inline styles:
+
+```css
+.toast {
+  --toast-duration: 4s;        /* Total lifecycle time */
+  --toast-delay: 0s;             /* Entrance delay (staggering) */
+  --toast-bg: #ffffff;           /* Background color */
+  --toast-text: #111827;         /* Text color */
+  --toast-accent: #3b82f6;     /* Border + progress bar color */
+}

--- a/submissions/examples/toast-rb/demo.html
+++ b/submissions/examples/toast-rb/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Toast Notification Demo — EaseMotion CSS</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <!-- ===== SLIDE-RIGHT TOASTS (top-right) ===== -->
+  <div class="toast-container">
+    <div class="toast toast-info toast-slide-right" style="--toast-delay: 0.5s;">
+      Welcome back! You have 3 new notifications.
+    </div>
+
+    <div class="toast toast-success toast-slide-right" style="--toast-delay: 2.5s;">
+      Profile updated successfully.
+    </div>
+
+    <div class="toast toast-error toast-slide-right" style="--toast-delay: 4.5s;">
+      Unable to connect. Retrying in 5s...
+    </div>
+  </div>
+
+  <!-- ===== SLIDE-UP TOASTS (bottom-center) ===== -->
+  <div class="toast-container" style="top: auto; bottom: 1rem; right: 50%; transform: translateX(50%); align-items: center;">
+    <div class="toast toast-success toast-slide-up" style="--toast-delay: 6.5s; --toast-duration: 3.5s;">
+      Changes saved!
+    </div>
+  </div>
+
+  <!-- ===== PAGE CONTENT ===== -->
+  <section class="demo-section">
+    <h2 class="demo-title">Toast Notification Component</h2>
+    <p class="demo-desc">
+      Pure CSS auto-dismissing toasts. No JavaScript timers. The animation lifecycle handles entrance, dwell, and exit automatically using CSS keyframes. Staggered delays simulate a realistic notification stream.
+    </p>
+
+    <h3 class="demo-title" style="font-size: 1rem;">Key Features</h3>
+    <ul style="color: #374151; line-height: 1.8; padding-left: 1.25rem;">
+      <li><strong>Auto-dismiss</strong> — Entire lifecycle (in → stay → out) controlled by one CSS animation</li>
+      <li><strong>Progress bar</strong> — Visual countdown via ::after pseudo-element</li>
+      <li><strong>Zero JavaScript</strong> — No timers, no state management</li>
+      <li><strong>Direction variants</strong> — Slide from right or slide from bottom</li>
+      <li><strong>Color variants</strong> — Success, error, info with accessible contrast</li>
+      <li><strong>Dark mode</strong> — .toast-dark class swaps the palette instantly</li>
+    </ul>
+  </section>
+
+  <!-- ===== DARK MODE DEMO ===== -->
+  <div class="demo-dark-bg">
+    <section class="demo-section">
+      <h2 class="demo-title">Dark Mode Toasts</h2>
+      <p class="demo-desc">
+        Add <code>.toast-dark</code> alongside any color variant for an automatic dark palette swap.
+      </p>
+    </section>
+
+    <div class="toast-container">
+      <div class="toast toast-dark toast-info toast-slide-right" style="--toast-delay: 1s;">
+        Dark mode is now enabled.
+      </div>
+      <div class="toast toast-dark toast-success toast-slide-right" style="--toast-delay: 3s;">
+        Backup completed successfully.
+      </div>
+      <div class="toast toast-dark toast-error toast-slide-right" style="--toast-delay: 5s;">
+        Session expired. Please log in again.
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/toast-rb/style.css
+++ b/submissions/examples/toast-rb/style.css
@@ -1,0 +1,220 @@
+/* ============================================
+   Toast Notification Component — submissions/examples/toast-rb
+   Pure CSS auto-dismissing toast banners
+   ============================================ */
+
+/* ---- Toast Container ---- */
+.toast-container {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  max-width: 100%;
+  padding: 0 1rem;
+  pointer-events: none;
+}
+
+/* ---- Base Toast ---- */
+.toast {
+  --toast-duration: 4s;
+  --toast-delay: 0s;
+  --toast-bg: #ffffff;
+  --toast-text: #111827;
+  --toast-accent: #3b82f6;
+  --toast-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+
+  position: relative;
+  background: var(--toast-bg);
+  color: var(--toast-text);
+  padding: 1rem 1.25rem;
+  padding-right: 2.5rem;
+  border-radius: 0.75rem;
+  border-left: 4px solid var(--toast-accent);
+  box-shadow: var(--toast-shadow);
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  max-width: 24rem;
+  width: 100%;
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: auto;
+  margin-bottom: 0.75rem;
+
+  animation-fill-mode: forwards;
+  animation-delay: var(--toast-delay);
+}
+
+/* ---- Progress Bar (visual timer) ---- */
+.toast::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 3px;
+  background: var(--toast-accent);
+  opacity: 0.5;
+  width: 100%;
+  animation: toast-progress var(--toast-duration) linear forwards;
+  animation-delay: var(--toast-delay);
+}
+
+@keyframes toast-progress {
+  from { width: 100%; }
+  to { width: 0%; }
+}
+
+/* ---- Color Variants ---- */
+.toast-success {
+  --toast-bg: #ecfdf5;
+  --toast-text: #065f46;
+  --toast-accent: #10b981;
+}
+
+.toast-error {
+  --toast-bg: #fef2f2;
+  --toast-text: #991b1b;
+  --toast-accent: #ef4444;
+}
+
+.toast-info {
+  --toast-bg: #eff6ff;
+  --toast-text: #1e40af;
+  --toast-accent: #3b82f6;
+}
+
+/* ---- Dark Variants ---- */
+.toast-dark {
+  --toast-bg: #1f2937;
+  --toast-text: #f9fafb;
+  --toast-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.4);
+}
+
+.toast-dark.toast-success {
+  --toast-bg: #064e3b;
+  --toast-text: #d1fae5;
+  --toast-accent: #34d399;
+}
+
+.toast-dark.toast-error {
+  --toast-bg: #7f1d1d;
+  --toast-text: #fee2e2;
+  --toast-accent: #f87171;
+}
+
+.toast-dark.toast-info {
+  --toast-bg: #1e3a8a;
+  --toast-text: #dbeafe;
+  --toast-accent: #60a5fa;
+}
+
+/* ---- Slide Right (from right edge) ---- */
+.toast-slide-right {
+  transform: translateX(120%);
+  animation-name: toast-slide-right;
+  animation-duration: var(--toast-duration);
+  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@keyframes toast-slide-right {
+  0% {
+    transform: translateX(120%);
+    opacity: 0;
+  }
+  8% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  92% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(120%);
+    opacity: 0;
+  }
+}
+
+/* ---- Slide Up (from bottom) ---- */
+.toast-slide-up {
+  transform: translateY(120%);
+  animation-name: toast-slide-up;
+  animation-duration: var(--toast-duration);
+  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@keyframes toast-slide-up {
+  0% {
+    transform: translateY(120%);
+    opacity: 0;
+  }
+  8% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  92% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(120%);
+    opacity: 0;
+  }
+}
+
+/* ---- Static Toast (no auto-dismiss) ---- */
+.toast-static {
+  animation: none;
+  opacity: 1;
+  transform: none;
+}
+
+.toast-static::after {
+  animation: none;
+  width: 100%;
+}
+
+/* ---- Demo Layout ---- */
+body {
+  font-family: 'Inter', system-ui, sans-serif;
+  background: #f3f4f6;
+  padding: 2rem 1rem;
+  margin: 0;
+  color: #111827;
+  min-height: 100vh;
+}
+
+.demo-section {
+  max-width: 800px;
+  margin: 0 auto 3rem;
+}
+
+.demo-title {
+  font-weight: 600;
+  font-size: 1.25rem;
+  margin-bottom: 1.5rem;
+}
+
+.demo-desc {
+  color: #6b7280;
+  margin-bottom: 2rem;
+  line-height: 1.6;
+}
+
+.demo-dark-bg {
+  background: #111827;
+  margin: 2rem -1rem -2rem;
+  padding: 2rem 1rem;
+  min-height: 60vh;
+}
+
+.demo-dark-bg .demo-title {
+  color: #f9fafb;
+}
+
+.demo-dark-bg .demo-desc {
+  color: #9ca3af;
+}


### PR DESCRIPTION
## Summary
Adds a pure CSS toast notification system submitted inside `submissions/examples/toast-rb/` as per the current contribution freeze policy.

## What's Included
- `demo.html` — Live preview with slide-right, slide-up, and dark mode demos
- `style.css` — All toast styles, keyframes, and layout helpers
- `README.md` — Usage docs and customization guide

## Key Features
- **Zero JavaScript** — Full lifecycle (entrance → dwell → exit) controlled by a single CSS keyframe animation
- **Auto-dismiss** — `animation-fill-mode: forwards` hides the toast after `--toast-duration` expires
- **Visual progress bar** — `::after` pseudo-element shows a shrinking accent bar as the timer counts down
- **Direction variants** — `.toast-slide-right` (from right edge) and `.toast-slide-up` (from bottom)
- **Color variants** — `.toast-success`, `.toast-error`, `.toast-info` with WCAG-friendly contrast
- **Dark mode** — `.toast-dark` class instantly swaps to a dark palette
- **Staggered delays** — `--toast-delay` custom property sequences multiple toasts
- **Static mode** — `.toast-static` disables auto-dismiss for persistent notifications
- **Responsive** — Max-width 24rem with mobile-safe padding

## Classes
| Class | Description |
|-------|-------------|
| `.toast-container` | Fixed-position wrapper |
| `.toast` | Base banner |
| `.toast-success` / `.toast-error` / `.toast-info` | Color variants |
| `.toast-slide-right` / `.toast-slide-up` | Entrance directions |
| `.toast-static` | Persistent (no auto-dismiss) |
| `.toast-dark` | Dark palette |

## CSS Variables
| Variable | Default | Purpose |
|----------|---------|---------|
| `--toast-duration` | `4s` | Total lifecycle time |
| `--toast-delay` | `0s` | Entrance stagger delay |
| `--toast-bg` | `#ffffff` | Background |
| `--toast-text` | `#111827` | Text color |
| `--toast-accent` | `#3b82f6` | Border + progress bar |

## Checklist
- [x] Submitted inside `submissions/examples/` only
- [x] Does not modify `core/`, `components/`, or workflow files
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] One feature per PR
- [x] Commit message follows Conventional Commits format
- [x] Feature does not duplicate existing EaseMotion classes
- [x] I have read the [Contributing Guide](https://github.com/SAPTARSHI-coder/EaseMotion-css/blob/main/CONTRIBUTING.md)

## Related Issue
Closes #25290

---

**Note to maintainer:** This is a raw submission. I understand the naming will be standardized to the `ease-*` prefix during the curation pipeline if approved.