### PR TITLE
feat: add ease-moss-spread surface expansion utility (Issue #26880)

### DIFF
--- a/submissions/examples/ease-moss-spread/README.md
+++ b/submissions/examples/ease-moss-spread/README.md
@@ -1,0 +1,14 @@
+# Ease Moss Spread Animation
+
+A low-profile surface-creeping transition utility designed to simulate directional cell expansion across localized surface coordinates.
+
+## Features
+- **Asymmetric Aspect Creep**: Runs independent horizontal and vertical scale ratios (`scaleX`/`scaleY`) to emulate climbing plant layers.
+- **Surface Anchor Profiling**: Configured with a dedicated `transform-origin: bottom center` value to maintain surface line contact during growth.
+- **Three Structural Speeds**: Built with `default`, `fast` burst, and slow ambient `slow` options.
+
+## Core Utility Usage
+```html
+<div class="element ease-moss-spread">🌿</div>
+<div class="element ease-moss-spread-fast">🌿</div>
+<div class="element ease-moss-spread-slow">🌿</div>

--- a/submissions/examples/ease-moss-spread/demo.html
+++ b/submissions/examples/ease-moss-spread/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ease Moss Spread Animation Demo</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <div class="forest-container">
+        <div class="header-info">
+            <h2>Animation: <span class="accent">ease-moss-spread</span></h2>
+            <p>A creeping, low-profile directional scaling utility that simulates organic surface covering and growth spreading.</p>
+        </div>
+
+        <div class="forest-grid">
+            
+            <div class="terrain-card">
+                <div class="stone-surface">
+                    <div id="moss1" class="moss-element ease-moss-spread">🟢🌿</div>
+                </div>
+                <span class="badge">Standard Spread</span>
+            </div>
+
+            <div class="terrain-card">
+                <div class="stone-surface">
+                    <div id="moss2" class="moss-element ease-moss-spread-fast">🟢🌿</div>
+                </div>
+                <span class="badge">Rapid / Fast</span>
+            </div>
+
+            <div class="terrain-card">
+                <div class="stone-surface">
+                    <div id="moss3" class="moss-element ease-moss-spread-slow">🟢🌿</div>
+                </div>
+                <span class="badge">Patient / Slow</span>
+            </div>
+
+        </div>
+
+        <button class="action-btn" onclick="triggerSpread()">🌧️ Trigger Rainfall & Spread</button>
+    </div>
+
+    <script>
+        function triggerSpread() {
+            const elements = [
+                { id: 'moss1', class: 'ease-moss-spread' },
+                { id: 'moss2', class: 'ease-moss-spread-fast' },
+                { id: 'moss3', class: 'ease-moss-spread-slow' }
+            ];
+            
+            elements.forEach(item => {
+                const el = document.getElementById(item.id);
+                el.classList.remove(item.class);
+                void el.offsetWidth; // Force CSS reflow
+                el.classList.add(item.class);
+            });
+        }
+    </script>
+</body>
+</html>

--- a/submissions/examples/ease-moss-spread/style.css
+++ b/submissions/examples/ease-moss-spread/style.css
@@ -1,0 +1,146 @@
+/* Base Layout Reset */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-family: 'Plus Jakarta Sans', sans-serif;
+}
+
+body {
+    min-height: 100vh;
+    background: linear-gradient(135deg, #1c1917 0%, #0c0a09 100%);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow: hidden;
+    padding: 2rem;
+}
+
+.forest-container {
+    text-align: center;
+    width: 100%;
+    max-width: 900px;
+}
+
+.header-info h2 {
+    color: #ffffff;
+    font-size: 1.8rem;
+    margin-bottom: 0.5rem;
+}
+
+.header-info .accent {
+    color: #4ade80;
+    text-shadow: 0 0 15px rgba(74, 222, 128, 0.3);
+}
+
+.header-info p {
+    color: #a8a29e;
+    font-size: 0.95rem;
+    margin-bottom: 4rem;
+}
+
+/* Layout Grid Setup */
+.forest-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 2rem;
+    margin-bottom: 3rem;
+}
+
+.terrain-card {
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    backdrop-filter: blur(12px);
+    border-radius: 24px;
+    padding: 3rem 1.5rem 1.5rem 1.5rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    box-shadow: 0 20px 45px rgba(0,0,0,0.5);
+}
+
+/* Simulated Stone Anchor Base */
+.stone-surface {
+    height: 100px;
+    width: 100%;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    border-bottom: 8px solid #44403c; /* Stone texture baseline */
+    position: relative;
+    background: rgba(0, 0, 0, 0.2);
+    border-radius: 4px;
+}
+
+.moss-element {
+    font-size: 3rem;
+    line-height: 1;
+    display: inline-block;
+    user-select: none;
+    
+    /* Anchor to bottom center so it flattens and creeps outward across the surface */
+    transform-origin: bottom center;
+}
+
+.badge {
+    color: #cbd5e1;
+    font-size: 0.8rem;
+    font-weight: 600;
+    background: rgba(74, 222, 128, 0.12);
+    border: 1px solid rgba(74, 222, 128, 0.2);
+    padding: 0.4rem 0.9rem;
+    border-radius: 30px;
+    margin-top: 1.5rem;
+}
+
+.action-btn {
+    background: #1c1917;
+    color: #f5f5f4;
+    font-weight: 600;
+    border: 1px solid #44403c;
+    padding: 0.75rem 1.75rem;
+    border-radius: 14px;
+    cursor: pointer;
+    transition: background 0.2s, transform 0.1s;
+}
+
+.action-btn:hover { background: #292524; #44403c; }
+.action-btn:active { transform: scale(0.97); }
+
+/* ==========================================================================
+   Ease Motion CSS Core Animation Keyframes & Utility Classes
+   ========================================================================== */
+
+@keyframes ease-moss-spread {
+    0% {
+        transform: scaleX(0) scaleY(0);
+        opacity: 0;
+        filter: saturate(0.6) brightness(0.8);
+    }
+    45% {
+        transform: scaleX(0.7) scaleY(0.3); /* Creeps wide and flat first */
+        opacity: 0.8;
+    }
+    80% {
+        transform: scaleX(1.05) scaleY(0.9); /* Asymmetric stretch overshoot */
+        filter: saturate(1.1) brightness(1);
+    }
+    100% {
+        transform: scaleX(1) scaleY(1);
+        opacity: 1;
+        filter: saturate(1.2) brightness(1.05);
+    }
+}
+
+/* Modifiers */
+.ease-moss-spread {
+    animation: ease-moss-spread 2s cubic-bezier(0.215, 0.610, 0.355, 1) forwards;
+}
+
+.ease-moss-spread-fast {
+    animation: ease-moss-spread 0.9s cubic-bezier(0.215, 0.610, 0.355, 1) forwards;
+}
+
+.ease-moss-spread-slow {
+    animation: ease-moss-spread 4.5s cubic-bezier(0.215, 0.610, 0.355, 1) forwards;
+}


### PR DESCRIPTION
## Description
This PR addresses and resolves Issue #26880 by introducing the **`ease-moss-spread`** animation utility. It features an asymmetric, surface-creeping expansion keyframe timeline engineered to replicate low-profile vegetation creeping, stretching, and blanketing flat or curved UI surfaces.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Implemented
- Developed a terrain-themed sandbox testing board in `submissions/examples/ease-moss-spread/demo.html` featuring interactive control logic to replay the moss growth cycle on-demand.
- Built progressive expansion intervals inside `style.css` that isolate horizontal growth curves (`scaleX`) before unfolding vertically (`scaleY`) to create a fluid, crawling effect rather than a mechanical zoom.
- Anchored structural baseline transformation zones via `transform-origin: bottom center` to keep the elements rooted to their contact surfaces.
- Exported three distinct utility timing profiles: `ease-moss-spread` (default), `ease-moss-spread-fast`, and `ease-moss-spread-slow`.
- Documented implementation mechanics inside `README.md`.

## Screenshots / Visual Reference
| Interactive Terrain Spread Showcase Stage |
| --- |
| _A stylized sandbox stage illustrating elements crawling and stretching asymmetrically over a stone textured baseline context._ |

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or console errors
- [x] All file submissions are strictly placed inside the `submissions/` directory
- [x] This feature does not duplicate existing components within the core setup

Closes #26880