### PR TITLE
Add error handling to claim handler

### DIFF
--- a/.github/scripts/autoClaimHandle.js
+++ b/.github/scripts/autoClaimHandle.js
@@ -1,120 +1,112 @@
-// will handle /claim
-async function findExistingAssignments(
-  github,
-  owner,
-  repo,
-  username,
-  currentIssueNumber
-) {
-  const { data: issues } = await github.rest.issues.listForRepo({
-    owner,
-    repo,
-    assignee: username,
-    state: "open",
-    per_page: 100,
-  });
-  return issues.filter(
-    (issue) => !issue.pull_request && issue.number !== currentIssueNumber
-  );
-}
-
-// change to increase/decrease the cap
-const MAX_ASSIGNED_ISSUES = 25;
-
 async function handleClaim({ github, context }) {
   const { owner, repo } = context.repo;
   const issueNumber = context.payload.issue.number;
   const commenter = context.payload.comment.user.login;
 
-  // Fetch the latest issue state to prevent race conditions on closed issues
-  const { data: issue } = await github.rest.issues.get({
-    owner,
-    repo,
-    issue_number: issueNumber,
-  });
+  try {
+    const { data: issue } = await github.rest.issues.get({
+      owner,
+      repo,
+      issue_number: issueNumber,
+    });
 
-  if (issue.state === "closed") {
+    if (issue.state === "closed") {
+      await github.rest.issues.createComment({
+        owner,
+        repo,
+        issue_number: issueNumber,
+        body: `🔒 **Oops!** This issue is closed. Commands can only be used on open issues.`,
+      });
+      return;
+    }
+
+    const currentAssignees = context.payload.issue.assignees.map((a) =>
+      a.login.toLowerCase()
+    );
+    const issueLabels = context.payload.issue.labels.map((l) =>
+      l.name.toLowerCase()
+    );
+    const issueTitle = (context.payload.issue.title || "").toLowerCase();
+    const issueBody = (context.payload.issue.body || "").toLowerCase();
+
+    const isSubmissionIssue =
+      issueLabels.some(
+        (label) => label.includes("submission") || label.includes("gssoc")
+      ) ||
+      issueTitle.includes("submission") ||
+      issueBody.includes("submission");
+
+    if (currentAssignees.includes(commenter.toLowerCase())) {
+      await github.rest.issues.createComment({
+        owner,
+        repo,
+        issue_number: issueNumber,
+        body: `✅ **You're all set!** You are already assigned to this issue, @${commenter}.`,
+      });
+      return;
+    }
+
+    if (currentAssignees.length > 0 && !isSubmissionIssue) {
+      const assigneeList = currentAssignees.map((a) => `@${a}`).join(", ");
+      await github.rest.issues.createComment({
+        owner,
+        repo,
+        issue_number: issueNumber,
+        body: `🤝 **Already taken!** This issue is currently assigned to ${assigneeList}. Please look for another open issue to contribute to! 🔍`,
+      });
+      return;
+    }
+
+    const existingIssues = await findExistingAssignments(
+      github,
+      owner,
+      repo,
+      commenter,
+      issueNumber
+    );
+
+    if (existingIssues.length >= MAX_ASSIGNED_ISSUES) {
+      const issueList = existingIssues
+        .map((i) => `> 📋 [#${i.number} — ${i.title}](${i.html_url})`)
+        .join("\n");
+
+      await github.rest.issues.createComment({
+        owner,
+        repo,
+        issue_number: issueNumber,
+        body: `⚠️ **Limit reached, @${commenter}!** You already have **${existingIssues.length}/${MAX_ASSIGNED_ISSUES}** active assigned issues.\n\nPlease complete or \`/unclaim\` your current issue before claiming a new one:\n\n${issueList}`,
+      });
+      return;
+    }
+
+    await github.rest.issues.addAssignees({
+      owner,
+      repo,
+      issue_number: issueNumber,
+      assignees: [commenter],
+    });
+
+    const contributingUrl = `https://github.com/${owner}/${repo}/blob/main/CONTRIBUTING.md`;
+
     await github.rest.issues.createComment({
       owner,
       repo,
       issue_number: issueNumber,
-      body: `🔒 **Oops!** This issue is closed. Commands can only be used on open issues.`,
+      body: `🎉 **Assigned!** Welcome aboard, @${commenter}! 🌟\n\n⏳ **Timeframe:** You have **1 day (24 hours)** to submit a Pull Request before it becomes open for others to claim.\n\n> 💡 **Tip:** Be sure to check out our [CONTRIBUTING.md](${contributingUrl}) to get off to a great start.\n\nHappy coding! 🚀✨`,
     });
-    return;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("Failed to handle /claim command:", err);
+
+    try {
+      await github.rest.issues.createComment({
+        owner,
+        repo,
+        issue_number: issueNumber,
+        body: `⚠️ **Claim failed for @${commenter}.**\n\nThe bot hit an error while processing this command:\n\n\`\`\`\n${message}\n\`\`\`\n\nPlease retry later or ask a maintainer to check the workflow logs.`,
+      });
+    } catch (commentError) {
+      console.error("Failed to post /claim error comment:", commentError);
+    }
   }
-
-  const currentAssignees = context.payload.issue.assignees.map((a) =>
-    a.login.toLowerCase()
-  );
-  const issueLabels = context.payload.issue.labels.map((l) =>
-    l.name.toLowerCase()
-  );
-  const issueTitle = (context.payload.issue.title || "").toLowerCase();
-  const issueBody = (context.payload.issue.body || "").toLowerCase();
-
-  const isSubmissionIssue =
-    issueLabels.some(
-      (label) => label.includes("submission") || label.includes("gssoc")
-    ) ||
-    issueTitle.includes("submission") ||
-    issueBody.includes("submission");
-
-  if (currentAssignees.includes(commenter.toLowerCase())) {
-    await github.rest.issues.createComment({
-      owner,
-      repo,
-      issue_number: issueNumber,
-      body: `✅ **You're all set!** You are already assigned to this issue, @${commenter}.`,
-    });
-    return;
-  }
-
-  if (currentAssignees.length > 0 && !isSubmissionIssue) {
-    const assigneeList = currentAssignees.map((a) => `@${a}`).join(", ");
-    await github.rest.issues.createComment({
-      owner,
-      repo,
-      issue_number: issueNumber,
-      body: `🤝 **Already taken!** This issue is currently assigned to ${assigneeList}. Please look for another open issue to contribute to! 🔍`,
-    });
-    return;
-  }
-
-  const existingIssues = await findExistingAssignments(
-    github,
-    owner,
-    repo,
-    commenter,
-    issueNumber
-  );
-  if (existingIssues.length >= MAX_ASSIGNED_ISSUES) {
-    const issueList = existingIssues
-      .map((i) => `> 📋 [#${i.number} — ${i.title}](${i.html_url})`)
-      .join("\n");
-    await github.rest.issues.createComment({
-      owner,
-      repo,
-      issue_number: issueNumber,
-      body: `⚠️ **Limit reached, @${commenter}!** You already have **${existingIssues.length}/${MAX_ASSIGNED_ISSUES}** active assigned issues.\n\nPlease complete or \`/unclaim\` your current issue before claiming a new one:\n\n${issueList}`,
-    });
-    return;
-  }
-
-  await github.rest.issues.addAssignees({
-    owner,
-    repo,
-    issue_number: issueNumber,
-    assignees: [commenter],
-  });
-
-  // comment message
-  const contributingUrl = `https://github.com/${owner}/${repo}/blob/main/CONTRIBUTING.md`;
-  await github.rest.issues.createComment({
-    owner,
-    repo,
-    issue_number: issueNumber,
-    body: `🎉 **Assigned!** Welcome aboard, @${commenter}! 🌟\n\n⏳ **Timeframe:** You have **1 day (24 hours)** to submit a Pull Request before it becomes open for others to claim.\n\n> 💡 **Tip:** Be sure to check out our [CONTRIBUTING.md](${contributingUrl}) to get off to a great start.\n\nHappy coding! 🚀✨`,
-  });
 }
-
-module.exports = { handleClaim };


### PR DESCRIPTION
## Pull Request Description

Fixes #4623

Added error handling around `handleClaim()` so GitHub API failures are caught instead of causing silent workflow failures.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (describe below)

Error handling improvement for GitHub Actions claim workflow.

---

## Submission Checklist

- [ ] All changes are inside `submissions/`
- [ ] Includes `demo.html`
- [ ] Includes `style.css`
- [ ] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A `try/catch` boundary around the `/claim` handler so errors are logged and reported back on the issue.

**How does a developer use it?**

No UI usage is required. The GitHub Actions bot automatically uses this when processing `/claim` comments.

**Why does it fit EaseMotion CSS?**

It improves contributor experience by making bot failures visible instead of silently failing during issue claiming.

---

## Demo

- [ ] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This PR updates `.github/scripts/autoClaimHandle.js` only. It catches failures in `handleClaim()` and attempts to post a helpful error comment on the issue.
