### PR TITLE
feat(ui): add image swipe wipe reveal component submission (#27266)

### DIFF
--- a/submissions/examples/image-swipe-reveal-ps/README.md
+++ b/submissions/examples/image-swipe-reveal-ps/README.md
@@ -1,0 +1,5 @@
+# Image Swipe Wipe Reveal
+
+1. What does this do? Creates a cinematic reveal animation where a solid block of color sweeps across the container to reveal an image hiding underneath.
+2. How is it used? Wrap an `<img>` tag in a container with the `.image-swipe-reveal-ps` class. The CSS utilizes an `::after` pseudo-element to create the sweeping color block, synchronized perfectly with the image fading in halfway through the animation.
+3. Why is it useful? This effect is a staple of high-end, award-winning portfolio websites and landing pages (often referred to as an awwwards-style reveal), implemented here natively in CSS without relying on heavy JS timeline libraries like GSAP.

--- a/submissions/examples/image-swipe-reveal-ps/demo.html
+++ b/submissions/examples/image-swipe-reveal-ps/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Image Swipe Reveal Demo</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      background-color: #f8fafc;
+      font-family: sans-serif;
+      margin: 0;
+      padding: 2rem;
+    }
+    .gallery {
+      display: flex;
+      gap: 2rem;
+    }
+    
+    /* Optional stagger delays for multiple images */
+    .delay-1::after { animation-delay: 0.2s; }
+    .delay-1 img { animation-delay: 0.8s; }
+    .delay-1 { animation-delay: 1.4s; }
+
+    .delay-2::after { animation-delay: 0.4s; }
+    .delay-2 img { animation-delay: 1.0s; }
+    .delay-2 { animation-delay: 1.6s; }
+  </style>
+</head>
+<body>
+  
+  <div class="gallery">
+    <!-- Image 1 -->
+    <div class="image-swipe-reveal-ps">
+      <!-- Using a placeholder image for the demo -->
+      <img src="https://images.unsplash.com/photo-1550684848-fac1c5b4e853?auto=format&fit=crop&w=300&h=400&q=80" alt="Architecture">
+    </div>
+
+    <!-- Image 2 (Staggered Delay) -->
+    <div class="image-swipe-reveal-ps delay-1">
+      <img src="https://images.unsplash.com/photo-1534447677768-be436bb09401?auto=format&fit=crop&w=300&h=400&q=80" alt="Nature">
+    </div>
+
+    <!-- Image 3 (Staggered Delay) -->
+    <div class="image-swipe-reveal-ps delay-2">
+      <img src="https://images.unsplash.com/photo-1542314831-c6a4d14abac2?auto=format&fit=crop&w=300&h=400&q=80" alt="Cityscape">
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/image-swipe-reveal-ps/style.css
+++ b/submissions/examples/image-swipe-reveal-ps/style.css
@@ -1,0 +1,82 @@
+.image-swipe-reveal-ps {
+  position: relative;
+  display: inline-block;
+  overflow: hidden;
+  border-radius: 8px; /* Optional: smooth corners */
+  /* Prevent interaction during animation */
+  pointer-events: none;
+}
+
+/* The actual image starts hidden */
+.image-swipe-reveal-ps img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  opacity: 0;
+  /* Fade the image in instantly at exactly the halfway point of the swipe animation */
+  animation: kf-reveal-content 0.1s 0.6s forwards;
+}
+
+/* The solid color block that swipes across */
+.image-swipe-reveal-ps::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #3b82f6; /* Customizable wipe color */
+  
+  /* Start completely off-screen to the left */
+  transform: translateX(-100%);
+  
+  /* Animate across the image using a smooth cubic-bezier */
+  animation: kf-swipe-wipe 1.2s cubic-bezier(0.77, 0, 0.175, 1) forwards;
+}
+
+/* The swipe animation */
+@keyframes kf-swipe-wipe {
+  0% {
+    transform: translateX(-100%);
+  }
+  45%, 55% {
+    /* Pause slightly in the middle to fully cover the element */
+    transform: translateX(0);
+  }
+  100% {
+    /* Exit off-screen to the right */
+    transform: translateX(100%);
+  }
+}
+
+/* The content reveal animation */
+@keyframes kf-reveal-content {
+  to {
+    opacity: 1;
+  }
+}
+
+/* Re-enable pointer events after animation finishes */
+.image-swipe-reveal-ps {
+  animation: kf-enable-pointer 0.1s 1.2s forwards;
+}
+
+@keyframes kf-enable-pointer {
+  to {
+    pointer-events: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .image-swipe-reveal-ps::after {
+    display: none;
+  }
+  .image-swipe-reveal-ps img {
+    animation: none;
+    opacity: 1;
+  }
+  .image-swipe-reveal-ps {
+    pointer-events: auto;
+    animation: none;
+  }
+}


### PR DESCRIPTION
## PR Title
`feat(ui): add image swipe wipe reveal component submission (#27266)`

## PR Description

### Description
This PR addresses **Issue #27266** by introducing the Image Swipe Wipe Reveal component to the community examples track.

This provides a premium, cinematic reveal animation often seen on high-end portfolio websites (an awwwards-style sweep reveal). A solid block of primary color sweeps across the container, revealing the image seamlessly as it passes.

### Changes Made
- Created a new submission folder `submissions/examples/image-swipe-reveal-ps/`.
- Added `demo.html` showcasing three images utilizing the reveal class. Staggered CSS animation delays were applied to demonstrate how the component can be used in a gallery/grid staggered entrance.
- Added `style.css` containing the core logic:
  - An `::after` pseudo-element acts as the solid color block. It animates from `translateX(-100%)` to `translateX(100%)` using a dramatic `cubic-bezier(0.77, 0, 0.175, 1)` easing.
  - The actual `<img>` tag opacity is delayed precisely so that it fades in instantly (`0.1s`) at the exact moment the color block fully covers the container (`0.6s`).
  - Pointer events are disabled on the container during the animation to prevent dragging/hover bugs, and re-enabled automatically at the end of the timeline.
- Added a `prefers-reduced-motion` media query to instantly show the image and hide the sweeping block for accessibility.
- Added a `README.md` explaining the implementation and usage.

### Testing/Verification
- Opened `demo.html` locally in a browser.
- Verified that the blue sweep completely covers the bounding box before the image reveals itself.
- Verified that staggered delays (applied via external helper classes in the demo) work flawlessly without breaking the internal timeline coordination of the pseudo-element and the image.

### Related Issue
Closes #27266

---
*Note: I am a GSSoC (GirlScript Summer of Code) contributor.*
