### PR TITLE
feat(animation): add ease-basilisk-stare animation submission (#26907)

### DIFF
--- a/submissions/examples/ease-basilisk-ps/README.md
+++ b/submissions/examples/ease-basilisk-ps/README.md
@@ -1,0 +1,5 @@
+# Ease Basilisk Stare Animation
+
+1. What does this do? Creates a "petrification" animation where an element emits a brief eerie green glow before hardening into high-contrast grayscale stone and shrinking slightly under its new weight.
+2. How is it used? Apply `.ease-basilisk-ps` for an immediate one-time petrification, or `.ease-basilisk-hover-ps` to trigger the transformation when the user hovers over the element. 
+3. Why is it useful? It's a fantastic thematic animation for game UIs, creative disabled states (e.g. turning a button to "stone" when it becomes inactive), or storytelling elements. It utilizes pure CSS filters (`grayscale`, `contrast`, `sepia`, `drop-shadow`) leaving the main thread unblocked.

--- a/submissions/examples/ease-basilisk-ps/demo.html
+++ b/submissions/examples/ease-basilisk-ps/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Ease Basilisk Stare Demo</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      gap: 3rem;
+      min-height: 100vh;
+      background-color: #111827;
+      font-family: sans-serif;
+      margin: 0;
+      padding: 2rem;
+    }
+    
+    .demo-card {
+      width: 250px;
+      padding: 2rem;
+      background: linear-gradient(135deg, #f59e0b, #ef4444);
+      border-radius: 12px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      color: white;
+      text-align: center;
+      box-shadow: 0 10px 25px rgba(0,0,0,0.5);
+      cursor: pointer;
+    }
+    
+    .demo-emoji {
+      font-size: 4rem;
+      margin-bottom: 1rem;
+    }
+    
+    .instruction {
+      color: #9ca3af;
+      font-size: 1.125rem;
+    }
+  </style>
+</head>
+<body>
+  
+  <p class="instruction">Hover over the card to look the Basilisk in the eyes...</p>
+
+  <!-- We use the hover variant here to make the demo interactive -->
+  <div class="ease-basilisk-hover-ps demo-card">
+    <div class="demo-emoji">🦁</div>
+    <h3>Brave Knight</h3>
+    <p>Hover me to turn to stone.</p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-basilisk-ps/style.css
+++ b/submissions/examples/ease-basilisk-ps/style.css
@@ -1,0 +1,42 @@
+.ease-basilisk-ps {
+  display: inline-block;
+  /* Use forwards so the element stays "petrified" (turned to stone) after the animation ends */
+  animation: kf-basilisk-stare 2s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+  will-change: filter, transform;
+}
+
+@keyframes kf-basilisk-stare {
+  0% {
+    filter: grayscale(0) contrast(1) drop-shadow(0 0 0 transparent);
+    transform: scale(1);
+    opacity: 1;
+  }
+  15% {
+    /* The eerie glow of the Basilisk's stare */
+    filter: drop-shadow(0 0 20px rgba(34, 197, 94, 0.9)) grayscale(0.2) contrast(1.2);
+    transform: scale(1.02);
+  }
+  40% {
+    /* Petrification process begins */
+    filter: drop-shadow(0 0 10px rgba(34, 197, 94, 0.5)) grayscale(0.6) contrast(1.3);
+    transform: scale(0.98);
+  }
+  100% {
+    /* Fully turned to cold, hard stone */
+    filter: drop-shadow(0 0 0 transparent) grayscale(1) contrast(1.5) sepia(0.1) hue-rotate(-10deg);
+    transform: scale(0.95);
+    opacity: 0.85;
+  }
+}
+
+/* Optional hover interaction to trigger it on hover instead of immediately */
+.ease-basilisk-hover-ps:hover {
+  animation: kf-basilisk-stare 1.5s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-basilisk-ps,
+  .ease-basilisk-hover-ps:hover {
+    animation-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## PR Title
`feat(animation): add ease-basilisk-stare animation submission (#26907)`

## PR Description

### Description
This PR addresses **Issue #26907** by introducing the `ease-basilisk-stare` animation to the community examples track.

Inspired by the mythical Basilisk that turns its victims to stone with a single glance, this animation "petrifies" the target element. It emits a brief, eerie green glow before hardening the element into a high-contrast, desaturated "stone" block that scales down slightly under its new weight.

### Changes Made
- Created a new submission folder `submissions/examples/ease-basilisk-ps/`.
- Added `demo.html` with an interactive card. The demo utilizes the `hover` variant so users can manually trigger the petrification effect by hovering over the card.
- Added `style.css` containing the core logic:
  - `@keyframes kf-basilisk-stare` interpolates through a sequence of CSS `filter` states (starting with a green `drop-shadow` and ending in `grayscale(1) contrast(1.5) sepia(0.1)`).
  - Uses `animation-fill-mode: forwards` so the element remains permanently "turned to stone" once the animation concludes.
  - Implements `will-change: filter, transform` for smooth hardware-accelerated transitions.
- Added a `prefers-reduced-motion` media query to instantly snap the element to the final stone state without the flashing glow for accessibility compliance.
- Added `README.md` explaining the implementation and usage.

### Testing/Verification
- Opened `demo.html` locally in a browser.
- Verified that hovering over the card smoothly executes the petrification effect.
- Verified that the final "stone" state looks heavy, desaturated, and distinct from the initial vibrant state.

### Related Issue
Closes #26907

---
*Note: I am a GSSoC (GirlScript Summer of Code) contributor.*
