### PR TITLE
feat(animation): add ease-minotaur-charge animation submission (#26902)

### DIFF
--- a/submissions/examples/ease-minotaur-ps/README.md
+++ b/submissions/examples/ease-minotaur-ps/README.md
@@ -1,0 +1,5 @@
+# Ease Minotaur Charge Animation
+
+1. What does this do? Creates an aggressive, two-part animation where an element rears back to build tension, and then violently lunges forward.
+2. How is it used? Apply `.ease-minotaur-ps` for an immediate charge, or `.ease-minotaur-hover-ps` to trigger the lunge when hovered. 
+3. Why is it useful? It's highly effective for gamified UIs, aggressive error shakes, or adding distinct personality to interactive elements where a standard linear translation feels too boring. It perfectly mimics the physics of a wind-up and heavy impact.

--- a/submissions/examples/ease-minotaur-ps/demo.html
+++ b/submissions/examples/ease-minotaur-ps/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Ease Minotaur Charge Demo</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: flex-start;
+      padding-left: 20%;
+      min-height: 100vh;
+      background-color: #fce7f3;
+      font-family: sans-serif;
+      margin: 0;
+      overflow-x: hidden;
+    }
+    
+    .demo-bull {
+      font-size: 5rem;
+      cursor: pointer;
+      display: inline-block;
+      filter: drop-shadow(0 10px 10px rgba(0,0,0,0.1));
+    }
+    
+    .instruction {
+      color: #9d174d;
+      font-size: 1.25rem;
+      font-weight: bold;
+      margin-bottom: 3rem;
+    }
+  </style>
+</head>
+<body>
+  
+  <p class="instruction">Hover the bull to trigger the Minotaur Charge!</p>
+
+  <div class="ease-minotaur-hover-ps demo-bull">
+    🐃
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-minotaur-ps/style.css
+++ b/submissions/examples/ease-minotaur-ps/style.css
@@ -1,0 +1,43 @@
+.ease-minotaur-ps {
+  display: inline-block;
+  animation: kf-minotaur-charge 1s cubic-bezier(0.25, 1, 0.5, 1) forwards;
+  will-change: transform;
+}
+
+/* Optional hover trigger for demo purposes */
+.ease-minotaur-hover-ps:hover {
+  animation: kf-minotaur-charge 1s cubic-bezier(0.25, 1, 0.5, 1) forwards;
+}
+
+@keyframes kf-minotaur-charge {
+  0% { 
+    transform: translateX(0) rotate(0) scale(1); 
+  }
+  20% { 
+    /* Wind up / step back */
+    transform: translateX(-15px) rotate(-5deg) scale(0.95); 
+  }
+  35% { 
+    /* Hold briefly to build tension */
+    transform: translateX(-15px) rotate(-5deg) scale(0.95); 
+  }
+  50% { 
+    /* Violent charge forward with head lowered */
+    transform: translateX(80px) rotate(12deg) scale(1.1); 
+  }
+  70% { 
+    /* Rebound/impact recoil */
+    transform: translateX(60px) rotate(5deg) scale(1.05); 
+  }
+  100% { 
+    /* Settle into the new position */
+    transform: translateX(80px) rotate(0) scale(1); 
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-minotaur-ps,
+  .ease-minotaur-hover-ps:hover {
+    animation-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## PR Title
`feat(animation): add ease-minotaur-charge animation submission (#26902)`

## PR Description

### Description
This PR addresses **Issue #26902** by introducing the `ease-minotaur-charge` animation to the community examples track.

Inspired by a bull's charge, this animation provides a powerful, physics-based movement. The element rears back, lowering its "head" (tilting and scaling down slightly) to build tension, and then violently lunges forward before recoiling from the impact.

### Changes Made
- Created a new submission folder `submissions/examples/ease-minotaur-ps/`.
- Added `demo.html` with a fun interactive element. The demo utilizes the `hover` variant so users can manually trigger the charge effect by hovering over the bull emoji.
- Added `style.css` containing the core logic:
  - `@keyframes kf-minotaur-charge` breaks the movement into distinct phases: wind-up (0-20%), tension hold (20-35%), aggressive lunge (50%), recoil (70%), and settle (100%).
  - Utilizes a custom `cubic-bezier(0.25, 1, 0.5, 1)` timing function to make the forward lunge feel explosive while the settle feels grounded.
  - Implements `will-change: transform` to ensure the translations and rotations render cleanly without tearing.
- Added a `prefers-reduced-motion` media query to instantly halt the chaotic animation for accessibility compliance.
- Added `README.md` explaining the implementation and usage.

### Testing/Verification
- Opened `demo.html` locally in a browser.
- Verified that hovering over the element smoothly executes the two-stage wind-up and lunge.
- Verified that the recoil timing feels natural and impactful.

### Related Issue
Closes #26902

---
*Note: I am a GSSoC (GirlScript Summer of Code) contributor.*
