### PR TITLE
fix: Stylelint font quote violation in Vite example

### DIFF
--- a/submissions/fix-stylelint-font-quotes/README.md
+++ b/submissions/fix-stylelint-font-quotes/README.md
@@ -1,0 +1,21 @@
+# Fix: Stylelint Font Quote Violation in Vite Example
+
+## Issue
+
+Running the workspace linter command `npm run lint` fails with a font-family name quote violation in `examples/react-vite/src/App.css`.
+
+## Root Cause
+
+On line 20 of `examples/react-vite/src/App.css`, the `font-family` property includes quotes around the single-word font name `"Inter"`. Under standard Stylelint rule checks (`font-family-name-quotes`), single-word font family names that do not require escaping must not be wrapped in quotes.
+
+## Fix
+
+Remove single quotes around `'Inter'` in the `font-family` property inside `examples/react-vite/src/App.css` (line 20).
+
+## Files Changed
+
+- `examples/react-vite/src/App.css` — Remove quotes from font-family declaration
+
+## Demo
+
+Open `demo.html` to verify that the Vite dashboard fonts render correctly with `font-family: Inter` without quotes.

--- a/submissions/fix-stylelint-font-quotes/demo.html
+++ b/submissions/fix-stylelint-font-quotes/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: Stylelint Font Quote Violation in Vite Example</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 2rem;
+      font-family: var(--ease-font-sans);
+      background: var(--ease-color-bg);
+      color: var(--ease-color-text);
+      margin: 0;
+      padding: 1rem;
+    }
+    h1 { font-size: 1.5rem; text-align: center; }
+    p { color: var(--ease-color-muted); max-width: 520px; text-align: center; }
+  </style>
+</head>
+<body>
+  <h1>Fix: Stylelint Font Quote Violation in Vite Example</h1>
+  <p>The linter throws an error if single-word font family names are quoted. Below is a text rendering showcasing the Inter font family defined without quotes.</p>
+
+  <div class="demo-container">
+    <div class="demo-font-display">
+      Inter Font Family
+    </div>
+    <p>Using: <code>font-family: Inter, system-ui, -apple-system, sans-serif;</code></p>
+  </div>
+</body>
+</html>

--- a/submissions/fix-stylelint-font-quotes/style.css
+++ b/submissions/fix-stylelint-font-quotes/style.css
@@ -1,0 +1,31 @@
+/* =============================================================
+   Fix: Stylelint Font Quote Violation in Vite Example
+   
+   Vite example project's App.css file contains a Stylelint
+   rule violation (font-family-name-quotes error) due to
+   unnecessary quotes around 'Inter' font family name.
+   
+   BEFORE (in examples/react-vite/src/App.css, line 20):
+   ─────────────────────────────────────────────────────
+   font-family: 'Inter', system-ui, -apple-system, sans-serif;
+   
+   AFTER:
+   ──────
+   font-family: Inter, system-ui, -apple-system, sans-serif;
+   ============================================================= */
+
+.demo-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--ease-space-4, 1rem);
+  font-family: Inter, system-ui, -apple-system, sans-serif;
+  max-width: 600px;
+  width: 100%;
+}
+
+.demo-font-display {
+  font-size: var(--ease-text-4xl, 2.25rem);
+  font-weight: 700;
+  color: var(--ease-color-primary, #6c63ff);
+}


### PR DESCRIPTION
## Pull Request Description

This PR proposes a fix for the Stylelint quote violation on single-word font family names in the React Vite example. 

In accordance with EaseMotion CSS contribution guidelines (temporary freeze policy on core/example edits), the fix has been submitted inside the `submissions/` directory under `submissions/fix-stylelint-font-quotes/` so the maintainer can review and safely integrate the change.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Proposes a Stylelint rule fix for the Vite example `App.css` file where the single-word font family `"Inter"` was unnecessarily quoted.

**How does a developer use it?**

N/A (Linter code quality fix).

**Why does it fit EaseMotion CSS?**

Unblocks `npm run lint` from failing globally on repository environments.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---

## Notes for Maintainer

The submission resides entirely in `submissions/fix-stylelint-font-quotes/`. It documents that `examples/react-vite/src/App.css` on line 20 needs `'Inter'` changed to `Inter` without quotes to satisfy the linter rule.
