### PR TITLE
feat: Add unused CSS variable detection script (#20502)

### DIFF
--- a/submissions/examples/unused-css-var-detector-20502/README.md
+++ b/submissions/examples/unused-css-var-detector-20502/README.md
@@ -1,0 +1,129 @@
+# Tooling: CSS Variable Unused Detection Script (#20502)
+
+This directory contains the requested DevOps scripting and an interactive UI visualization for the Dead CSS Variable Detector.
+
+As Node scripts meant to be included in a repository-level `scripts/` folder are currently restricted by the contribution guidelines (which block modifications to core framework and configuration files), this folder provides the script as a copy-paste template, accompanied by an EaseMotion-styled reporting mock.
+
+---
+
+## 🛠 Maintainer Setup Guide
+
+To implement the CSS variable detector, create a file named `scripts/find-unused-vars.js` in the repository root and copy the following script into it:
+
+```javascript
+// scripts/find-unused-vars.js
+const fs = require('fs');
+const path = require('path');
+
+console.log('🔍 Scanning CSS files for custom property usage...\n');
+
+// 1. Find and parse variables.css to get all declared --ease-* vars
+const rootDir = path.join(__dirname, '..');
+const variablesPath = path.join(rootDir, 'core', 'variables.css');
+
+if (!fs.existsSync(variablesPath)) {
+  console.error('❌ Could not find core/variables.css');
+  process.exit(1);
+}
+
+const declaredVars = new Set();
+const varRegex = /(--ease-[a-zA-Z0-9_-]+)\s*:/g;
+
+const varsContent = fs.readFileSync(variablesPath, 'utf8');
+let match;
+while ((match = varRegex.exec(varsContent)) !== null) {
+  declaredVars.add(match[1]);
+}
+
+console.log(`Detected ${declaredVars.size} variable declarations in core/variables.css.`);
+
+// 2. Scan all CSS files for usage: var(--ease-*)
+const usedVarsMap = new Map();
+
+const getCssFiles = (dir, fileList = []) => {
+  if (!fs.existsSync(dir)) return fileList;
+  const files = fs.readdirSync(dir);
+  for (const file of files) {
+    const filePath = path.join(dir, file);
+    if (fs.statSync(filePath).isDirectory()) {
+      if (file !== 'node_modules' && file !== '.git') {
+        getCssFiles(filePath, fileList);
+      }
+    } else if (filePath.endsWith('.css') && file !== 'variables.css') {
+      fileList.push(filePath);
+    }
+  }
+  return fileList;
+};
+
+const cssFiles = getCssFiles(rootDir);
+let usageCount = 0;
+
+for (const file of cssFiles) {
+  const content = fs.readFileSync(file, 'utf8');
+  const usageRegex = /var\s*\(\s*(--ease-[a-zA-Z0-9_-]+)/g;
+  let usageMatch;
+  
+  while ((usageMatch = usageRegex.exec(content)) !== null) {
+    const varName = usageMatch[1];
+    usageCount++;
+    if (!usedVarsMap.has(varName)) {
+      usedVarsMap.set(varName, []);
+    }
+    const relativePath = path.relative(rootDir, file).replace(/\\/g, '/');
+    usedVarsMap.get(varName).push(relativePath);
+  }
+}
+
+console.log(`Found ${usageCount} var(--ease-*) usage instances across ${cssFiles.length} files.\n`);
+
+// 3. Compare and Flag
+let hasErrors = false;
+
+// Flag declared but unused vars
+const unusedVars = Array.from(declaredVars).filter(v => !usedVarsMap.has(v));
+if (unusedVars.length > 0) {
+  console.error('⚠️ UNUSED VARIABLES (Declared but never used):');
+  unusedVars.forEach(v => console.error(`   - ${v}`));
+  hasErrors = true;
+}
+
+// Flag used but undeclared vars
+const undeclaredVars = Array.from(usedVarsMap.keys()).filter(v => !declaredVars.has(v));
+if (undeclaredVars.length > 0) {
+  console.error('\n⚠️ UNDECLARED VARIABLES (Used but missing in variables.css):');
+  undeclaredVars.forEach(v => {
+    console.error(`   - ${v} (found in ${usedVarsMap.get(v)[0]})`);
+  });
+  hasErrors = true;
+}
+
+if (hasErrors) {
+  console.error('\n💥 Error: Variable inconsistencies found! Clean up variables.css.');
+  process.exit(1);
+} else {
+  console.log('✨ All CSS variables are perfectly synced. No dead code found.');
+  process.exit(0);
+}
+```
+
+### Running the tool
+
+You can run this manually via:
+```bash
+node scripts/find-unused-vars.js
+```
+
+You can also integrate it into your GitHub Actions CI by adding it as a linting step before PRs are merged.
+
+---
+
+## 🎨 About the Demo HTML
+
+To fulfill the `submissions/examples` template requirement, `demo.html` and `style.css` visualize a "Dead CSS Variable Detector Dashboard" utilizing EaseMotion classes:
+* `.ease-slide-up-stagger` for the analytical report panels.
+* `.ease-fade-in-up` for smooth text and terminal output reveals.
+* `.ease-pulse` for the live indicator.
+
+## 🔗 Related Issue
+Closes Issue #20502

--- a/submissions/examples/unused-css-var-detector-20502/demo.html
+++ b/submissions/examples/unused-css-var-detector-20502/demo.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Dead CSS Variable Detector</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="./style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+</head>
+<body class="bg-gray-950 text-gray-50 font-sans antialiased min-h-screen display-flex-column">
+
+  <!-- Header -->
+  <header class="border-b border-gray-900 bg-gray-950 sticky-top z-50 ease-slide-down">
+    <div class="container-fluid px-6 py-4 display-flex justify-between align-center max-w-5xl mx-auto">
+      <div class="display-flex align-center gap-3">
+        <div class="w-8 h-8 rounded-md bg-gradient-brand display-flex-center text-gray-900 font-bold text-xs shadow-glow">VAR</div>
+        <span class="font-bold text-lg tracking-tight">CSS Variable Garbage Collector</span>
+      </div>
+      <div class="text-xs font-medium text-amber-400 bg-amber-900 bg-opacity-20 px-3 py-1.5 rounded-full border border-amber-800 border-opacity-50 display-flex align-center gap-2">
+        <span class="w-2 h-2 rounded-full bg-amber-500 ease-pulse"></span>
+        Analysis Complete
+      </div>
+    </div>
+  </header>
+
+  <!-- Main Content -->
+  <main class="flex-grow container-fluid px-6 py-12 max-w-5xl mx-auto w-full">
+    
+    <div class="mb-10 ease-fade-in-up">
+      <h1 class="text-3xl font-bold mb-2">CSS Variable Report</h1>
+      <p class="text-gray-400 text-sm max-w-2xl">This dashboard visualizes the output of the automated dead-code script, identifying CSS custom properties declared in `variables.css` but never used, as well as utilized variables that are missing declarations.</p>
+    </div>
+
+    <div class="grid grid-1 md-grid-2 gap-6 mb-12">
+      
+      <!-- Unused Variables -->
+      <div class="bg-gray-900 border border-gray-800 rounded-xl p-6 ease-slide-up-stagger hover-elevate transition-all">
+        <div class="display-flex align-center justify-between mb-4 pb-4 border-b border-gray-800">
+          <div class="display-flex align-center gap-3">
+            <div class="w-10 h-10 rounded-lg bg-rose-500 bg-opacity-20 text-rose-400 display-flex-center">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"></path><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"></path><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"></path></svg>
+            </div>
+            <div>
+              <h3 class="font-semibold m-0 text-md">Unused Declarations</h3>
+              <div class="text-gray-400 text-xs">Declared but never used</div>
+            </div>
+          </div>
+          <span class="bg-rose-900 text-rose-400 border border-rose-800 px-2 py-1 rounded text-xs font-bold">2 Found</span>
+        </div>
+        
+        <div class="display-flex-column gap-3">
+          <div class="bg-gray-950 p-3 rounded border border-gray-800">
+            <code class="text-rose-400 text-sm font-bold block mb-1">--ease-elastic-out</code>
+            <div class="text-xs text-gray-500 font-mono">Declared in core/variables.css (Line 18)</div>
+          </div>
+          <div class="bg-gray-950 p-3 rounded border border-gray-800">
+            <code class="text-rose-400 text-sm font-bold block mb-1">--ease-bounce-in</code>
+            <div class="text-xs text-gray-500 font-mono">Declared in core/variables.css (Line 24)</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Undeclared Variables -->
+      <div class="bg-gray-900 border border-gray-800 rounded-xl p-6 ease-slide-up-stagger hover-elevate transition-all" style="animation-delay: 0.1s;">
+        <div class="display-flex align-center justify-between mb-4 pb-4 border-b border-gray-800">
+          <div class="display-flex align-center gap-3">
+            <div class="w-10 h-10 rounded-lg bg-amber-500 bg-opacity-20 text-amber-400 display-flex-center">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
+            </div>
+            <div>
+              <h3 class="font-semibold m-0 text-md">Undeclared Variables</h3>
+              <div class="text-gray-400 text-xs">Used but missing definition</div>
+            </div>
+          </div>
+          <span class="bg-amber-900 text-amber-400 border border-amber-800 px-2 py-1 rounded text-xs font-bold">1 Found</span>
+        </div>
+        
+        <div class="display-flex-column gap-3">
+          <div class="bg-gray-950 p-3 rounded border border-gray-800">
+            <div class="display-flex justify-between align-center mb-1">
+              <code class="text-amber-400 text-sm font-bold">--ease-spring-slow</code>
+            </div>
+            <div class="text-xs text-gray-400 font-mono">Used in:</div>
+            <div class="text-xs text-gray-500 font-mono ml-2 mt-1">- submissions/examples/modal/style.css (Line 54)</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    
+    <!-- Code Output -->
+    <div class="bg-black border border-gray-800 rounded-xl overflow-hidden ease-fade-in-up box-shadow-xl" style="animation-delay: 0.3s;">
+      <div class="bg-gray-900 px-4 py-3 border-b border-gray-800 display-flex align-center justify-between">
+        <div class="display-flex align-center gap-2">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-gray-500"><path d="M4 17l6-6-6-6"></path><path d="M12 19h8"></path></svg>
+          <span class="text-xs font-mono text-gray-400">Terminal Output</span>
+        </div>
+        <span class="text-xs font-mono text-rose-400">Exit Code: 1</span>
+      </div>
+      <div class="p-4 overflow-x-auto">
+<pre class="text-sm font-mono text-gray-300 leading-relaxed m-0"><code>> node scripts/find-unused-vars.js
+
+🔍 Scanning CSS files for custom property usage...
+
+Detected 42 variable declarations in core/variables.css.
+Found 114 var(--ease-*) usage instances across 15 files.
+
+⚠️ UNUSED VARIABLES (Declared but never used):
+   - --ease-elastic-out
+   - --ease-bounce-in
+
+⚠️ UNDECLARED VARIABLES (Used but missing in variables.css):
+   - --ease-spring-slow (found in submissions/examples/modal/style.css)
+
+💥 Error: Variable inconsistencies found! Clean up variables.css.
+</code></pre>
+      </div>
+    </div>
+
+  </main>
+</body>
+</html>

--- a/submissions/examples/unused-css-var-detector-20502/style.css
+++ b/submissions/examples/unused-css-var-detector-20502/style.css
@@ -1,0 +1,198 @@
+/* =======================================================
+   Feature: Dead CSS Variable Detector Visualization (20502)
+   Simulates a CI/CD code quality dashboard using EaseMotion
+   ======================================================= */
+
+:root {
+  /* Brand Colors */
+  --brand-cyan: #22d3ee; 
+  --brand-green: #4ade80;
+  
+  /* Dark Theme Gray Scale */
+  --gray-50: #f9fafb;
+  --gray-300: #d1d5db;
+  --gray-400: #9ca3af;
+  --gray-500: #6b7280;
+  --gray-800: #1f2937;
+  --gray-900: #111827;
+  --gray-950: #030712;
+
+  --amber-400: #fbbf24;
+  --amber-500: #f59e0b;
+  --amber-800: #92400e;
+  --amber-900: #78350f;
+
+  --rose-400: #fb7185;
+  --rose-500: #f43f5e;
+  --rose-800: #9f1239;
+  --rose-900: #881337;
+  
+  /* Typography */
+  --font-sans: 'Inter', -apple-system, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  
+  /* Easings */
+  --ease-spring: cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+
+body {
+  margin: 0; padding: 0;
+  font-family: var(--font-sans);
+  background-color: var(--gray-950);
+  color: var(--gray-50);
+  line-height: 1.5;
+}
+
+.antialiased { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+
+h1, h2, h3, h4 { margin-top: 0; }
+p { margin-top: 0; }
+
+/* Utility Classes */
+.font-sans { font-family: var(--font-sans); }
+.font-mono { font-family: var(--font-mono); }
+.font-medium { font-weight: 500; }
+.font-semibold { font-weight: 600; }
+.font-bold { font-weight: 700; }
+.leading-relaxed { line-height: 1.625; }
+.tracking-tight { letter-spacing: -0.025em; }
+
+.text-xs { font-size: 0.75rem; }
+.text-sm { font-size: 0.875rem; }
+.text-md { font-size: 1rem; }
+.text-lg { font-size: 1.125rem; }
+.text-3xl { font-size: 1.875rem; }
+.text-center { text-align: center; }
+
+.m-0 { margin: 0; }
+.ml-2 { margin-left: 0.5rem; }
+.mt-1 { margin-top: 0.25rem; }
+.mb-1 { margin-bottom: 0.25rem; }
+.mb-2 { margin-bottom: 0.5rem; }
+.mb-4 { margin-bottom: 1rem; }
+.mb-10 { margin-bottom: 2.5rem; }
+.mb-12 { margin-bottom: 3rem; }
+.mx-auto { margin-left: auto; margin-right: auto; }
+
+.p-3 { padding: 0.75rem; }
+.p-4 { padding: 1rem; }
+.p-6 { padding: 1.5rem; }
+.pb-4 { padding-bottom: 1rem; }
+.px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+.px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+.px-4 { padding-left: 1rem; padding-right: 1rem; }
+.px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
+.py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+.py-1\.5 { padding-top: 0.375rem; padding-bottom: 0.375rem; }
+.py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
+.py-4 { padding-top: 1rem; padding-bottom: 1rem; }
+.py-12 { padding-top: 3rem; padding-bottom: 3rem; }
+
+.gap-2 { gap: 0.5rem; }
+.gap-3 { gap: 0.75rem; }
+.gap-4 { gap: 1rem; }
+.gap-6 { gap: 1.5rem; }
+
+.max-w-2xl { max-width: 42rem; }
+.max-w-5xl { max-width: 64rem; }
+.w-2 { width: 0.5rem; }
+.h-2 { height: 0.5rem; }
+.w-8 { width: 2rem; }
+.h-8 { height: 2rem; }
+.w-10 { width: 2.5rem; }
+.h-10 { height: 2.5rem; }
+.w-full { width: 100%; }
+.min-h-screen { min-height: 100vh; }
+
+.display-flex { display: flex; }
+.display-flex-center { display: flex; justify-content: center; align-items: center; }
+.display-flex-column { display: flex; flex-direction: column; }
+.align-center { align-items: center; }
+.justify-between { justify-content: space-between; }
+.flex-grow { flex-grow: 1; }
+
+.grid { display: grid; }
+.grid-1 { grid-template-columns: 1fr; }
+@media (min-width: 768px) {
+  .md-grid-2 { grid-template-columns: repeat(2, 1fr); }
+}
+
+.overflow-hidden { overflow: hidden; }
+.overflow-x-auto { overflow-x: auto; }
+.sticky-top { position: sticky; top: 0; }
+.block { display: block; }
+.z-50 { z-index: 50; }
+
+/* Colors */
+.bg-gray-900 { background-color: var(--gray-900); }
+.bg-gray-950 { background-color: var(--gray-950); }
+.bg-black { background-color: #000; }
+
+.bg-amber-500 { background-color: var(--amber-500); }
+.bg-amber-900 { background-color: var(--amber-900); }
+.bg-rose-500 { background-color: var(--rose-500); }
+.bg-rose-900 { background-color: var(--rose-900); }
+.bg-opacity-20 { background-color: color-mix(in srgb, currentColor 20%, transparent); }
+.bg-gradient-brand { background: linear-gradient(135deg, var(--brand-cyan), var(--brand-green)); }
+
+.text-gray-50 { color: var(--gray-50); }
+.text-gray-300 { color: var(--gray-300); }
+.text-gray-400 { color: var(--gray-400); }
+.text-gray-500 { color: var(--gray-500); }
+.text-gray-900 { color: var(--gray-900); }
+
+.text-amber-400 { color: var(--amber-400); }
+.text-rose-400 { color: var(--rose-400); }
+
+/* Borders & Shadows */
+.border { border-width: 1px; border-style: solid; }
+.border-b { border-bottom-width: 1px; border-bottom-style: solid; }
+.border-gray-800 { border-color: var(--gray-800); }
+.border-gray-900 { border-color: var(--gray-900); }
+.border-amber-800 { border-color: var(--amber-800); }
+.border-rose-800 { border-color: var(--rose-800); }
+.border-opacity-50 { border-color: color-mix(in srgb, currentColor 50%, transparent); }
+
+.rounded { border-radius: 0.25rem; }
+.rounded-md { border-radius: 0.375rem; }
+.rounded-lg { border-radius: 0.5rem; }
+.rounded-xl { border-radius: 0.75rem; }
+.rounded-full { border-radius: 9999px; }
+
+.shadow-glow { box-shadow: 0 0 15px 0 rgba(74, 222, 128, 0.4); }
+.box-shadow-xl { box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.5), 0 10px 10px -5px rgba(0, 0, 0, 0.3); }
+
+/* Layout Grid */
+.container-fluid { max-width: 1200px; margin: 0 auto; }
+
+/* Transitions */
+.transition-all { transition: all 0.3s var(--ease-out); }
+.hover-elevate:hover { transform: translateY(-4px); border-color: var(--gray-500); box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.5); }
+
+/* EaseMotion Configuration & Overrides */
+@keyframes ease-slide-up-stagger { 
+  0% { transform: translateY(20px); opacity: 0; } 
+  100% { transform: translateY(0); opacity: 1; } 
+}
+@keyframes ease-slide-down { 
+  from { transform: translateY(-100%); opacity: 0; } 
+  to { transform: translateY(0); opacity: 1; } 
+}
+@keyframes ease-fade-in-up { 
+  0% { transform: translateY(15px); opacity: 0; } 
+  100% { transform: translateY(0); opacity: 1; } 
+}
+@keyframes ease-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.5; transform: scale(0.8); }
+}
+
+/* Class Assignments */
+.ease-slide-up-stagger { animation: ease-slide-up-stagger 0.6s var(--ease-out) forwards; opacity: 0; }
+.ease-slide-down { animation: ease-slide-down 0.6s var(--ease-out) forwards; opacity: 0; }
+.ease-fade-in-up { animation: ease-fade-in-up 0.6s var(--ease-out) forwards; opacity: 0; }
+.ease-pulse { animation: ease-pulse 2s ease-in-out infinite; }


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #20502. Since modifying core repository files or adding root-level scripts currently violates the repository contribution guidelines, this submission provides the complete **Dead CSS Variable Detector Node Script** (`find-unused-vars.js`) as a copy-paste template inside the `README.md`.

To fully adhere to the contribution checklist and CI validator, this PR also includes a beautifully animated **CSS Variable Garbage Collector Dashboard** (`demo.html`) built using standard EaseMotion classes. It visually demonstrates how developers can use EaseMotion to present CI/CD validation steps and dead-code analysis reports.

Closes #20502

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/unused-css-var-detector-20502/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A Node.js script that parses all `.css` files across the project to detect unused `var(--ease-*)` custom properties (declared in `core/variables.css` but never used) as well as undeclared properties (used in a file but missing a declaration). 

**How does a developer use it?**

```bash
# Maintainers copy the script to scripts/find-unused-vars.js and run it:
node scripts/find-unused-vars.js
