### PR TITLE
Fix manifest repository URL validation

### DIFF
--- a/scripts/validate-package.mjs
+++ b/scripts/validate-package.mjs
@@ -38,7 +38,9 @@ if (manifest.name !== "easemotion-css") {
   fail('expected package name to be "easemotion-css"');
 }
 
-if (!manifest.repository?.url?.includes("SAPTARSHI-coder/EaseMotion-css")) {
+const repositoryUrl = String(manifest.repository?.url ?? "").toLowerCase();
+
+if (!repositoryUrl.includes("saptarshi-coder/easemotion-css")) {
   fail("repository.url must point to SAPTARSHI-coder/EaseMotion-css");
 }
 


### PR DESCRIPTION
## Summary
- Normalizes the package repository URL before checking the expected owner/repo path, so valid casing differences do not fail release validation.

Fixes #27874

## Tests
- npm run validate:manifest
