### PR TITLE
Exclude chip demo HTML from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "easemotion.min.css",
     "core/",
     "components/",
+    "!components/*.html",
     "easemotion/",
     "scss/",
     "dist/",


### PR DESCRIPTION
## Summary
- Adds a package files exclusion for component demo HTML so dry-run package contents do not include the chip demo artifact.

Fixes #27876

## Tests
- npm run validate:pack
