### PR TITLE
Include newer components in modular bundle

### DIFF
--- a/easemotion/all.css
+++ b/easemotion/all.css
@@ -18,6 +18,22 @@
 @import "../components/loaders.css";
 @import "../components/tooltips.css";
 @import "../components/modals.css";
-
-
-
+@import "../components/command-palette.css";
+@import "../components/announce-bar.css";
+@import "../components/avatar.css";
+@import "../components/breadcrumb.css";
+@import "../components/btn-magnetic.css";
+@import "../components/compare-table.css";
+@import "../components/connection-status.css";
+@import "../components/fab.css";
+@import "../components/kbd.css";
+@import "../components/pagination.css";
+@import "../components/password-strength.css";
+@import "../components/progress.css";
+@import "../components/read-more.css";
+@import "../components/scroll-gallery.css";
+@import "../components/skeleton.css";
+@import "../components/tag.css";
+@import "../components/toast.css";
+@import "../components/view-transitions.css";
+@import "../components/forms.css";


### PR DESCRIPTION
## Summary
- Adds the missing newer component imports to easemotion/all.css so the modular full bundle matches the main entry coverage.

Fixes #27879

## Tests
- npm run validate:pack
