### PR TITLE
feat(scss): add accordion expand/collapse max-height utilities (#28467)

### DIFF
--- a/submissions/scss/scss-accordion-expand-collapse-max-height-utilities/README.md
+++ b/submissions/scss/scss-accordion-expand-collapse-max-height-utilities/README.md
@@ -1,0 +1,28 @@
+# Accordion Expand/Collapse Max-Height Utilities
+
+SCSS utility module for smooth accordion expand/collapse transitions using `max-height`.
+
+## Files
+
+- `_accordion-expand-collapse-max-height-utilities.scss`
+
+## Mixins
+
+### `accordion-panel($max-height-open, $duration, $easing, $overflow)`
+
+Generates base accordion panel styles. Collapsed by default; expands when `.is-open`, `[open]`, or `.ease-accordion-open` is present.
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `$max-height-open` | `20rem` | Target max-height when expanded |
+| `$duration` | `var(--ease-speed-medium, 0.3s)` | Transition duration |
+| `$easing` | `var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1))` | Timing function |
+| `$overflow` | `hidden` | Overflow when collapsed |
+
+**SCSS:**
+```scss
+@use 'accordion-expand-collapse-max-height-utilities' as accordion;
+
+.my-panel {
+  @include accordion.accordion-panel($max-height-open: 30rem);
+}

--- a/submissions/scss/scss-accordion-expand-collapse-max-height-utilities/_accordion-expand-collapse-max-height-utilities.scss
+++ b/submissions/scss/scss-accordion-expand-collapse-max-height-utilities/_accordion-expand-collapse-max-height-utilities.scss
@@ -1,0 +1,102 @@
+// ==========================================
+// Accordion Expand/Collapse Max-Height Utilities
+// EaseMotion CSS
+// Issues: #28467 #27841
+// ==========================================
+
+@use 'sass:map';
+
+// --- Configuration ---
+$ease-accordion-heights: (
+  'xs': 6rem,
+  'sm': 10rem,
+  'md': 20rem,
+  'lg': 30rem,
+  'xl': 40rem,
+  '2xl': 60rem,
+  '3xl': 80rem,
+  'screen': 100vh,
+  'none': 0
+) !default;
+
+$ease-accordion-duration: var(--ease-speed-medium, 0.3s) !default;
+$ease-accordion-easing: var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)) !default;
+
+// --- Core Mixins ---
+
+@mixin accordion-panel(
+  $max-height-open: map.get($ease-accordion-heights, 'md'),
+  $duration: $ease-accordion-duration,
+  $easing: $ease-accordion-easing,
+  $overflow: hidden
+) {
+  max-height: 0;
+  overflow: $overflow;
+  transition: max-height $duration $easing;
+
+  &.is-open,
+  &[open],
+  &.ease-accordion-open {
+    max-height: $max-height-open;
+  }
+}
+
+@mixin accordion-state-open($max-height-open: map.get($ease-accordion-heights, 'md')) {
+  max-height: $max-height-open;
+}
+
+@mixin accordion-state-collapsed {
+  max-height: 0;
+  overflow: hidden;
+}
+
+@mixin generate-accordion-utilities(
+  $prefix: 'ease-accordion',
+  $heights: $ease-accordion-heights,
+  $duration: $ease-accordion-duration,
+  $easing: $ease-accordion-easing
+) {
+  .#{$prefix}-collapse {
+    max-height: 0 !important;
+    overflow: hidden !important;
+    transition: max-height $duration $easing !important;
+  }
+
+  .#{$prefix}-open {
+    max-height: map.get($heights, 'md') !important;
+    overflow: hidden !important;
+    transition: max-height $duration $easing !important;
+  }
+
+  @each $key, $value in $heights {
+    @if $key != 'none' {
+      .#{$prefix}-open-#{$key} {
+        max-height: $value !important;
+        overflow: hidden !important;
+        transition: max-height $duration $easing !important;
+      }
+    }
+  }
+
+  @each $key, $value in $heights {
+    @if $key != 'none' {
+      .#{$prefix}-expand-#{$key} {
+        max-height: $value !important;
+        overflow: hidden !important;
+      }
+    }
+  }
+
+  .#{$prefix}-collapsed {
+    max-height: 0 !important;
+    overflow: hidden !important;
+  }
+}
+
+@include generate-accordion-utilities();
+
+@media (prefers-reduced-motion: reduce) {
+  [class*='ease-accordion-'] {
+    transition: max-height 0.01ms !important;
+  }
+}


### PR DESCRIPTION
Closes #28467
Closes #27841

## Changes

| File | Description |
|------|-------------|
| `submissions/scss/scss-accordion-expand-collapse-max-height-utilities/_accordion-expand-collapse-max-height-utilities.scss` | SCSS partial with `accordion-panel`, `accordion-state-open`, `accordion-state-collapsed`, `generate-accordion-utilities` mixins and generated `.ease-accordion-*` utility classes |
| `submissions/scss/scss-accordion-expand-collapse-max-height-utilities/README.md` | Documentation: mixin parameters, usage examples, compiled CSS output |

## Technical Notes

- Uses `max-height` transition (CSS cannot interpolate `height: auto`).
- `.ease-` prefix and `!important` match existing utility conventions in `core/utilities.css`.
- Timing falls back to EaseMotion CSS custom properties (`--ease-speed-medium`, `--ease-ease`).
- Includes `prefers-reduced-motion` support.