### PR TITLE
feat(scss): add staggered entrance delay utility classes (#28468)

### DIFF
--- a/submissions/scss/scss-staggered-entrance-delay-utility-classes/README.md
+++ b/submissions/scss/scss-staggered-entrance-delay-utility-classes/README.md
@@ -1,0 +1,22 @@
+# Staggered Entrance Delay Utility Classes
+
+A reusable SCSS utility module providing staggered animation and transition delay mixins for cascading entrance effects in EaseMotion CSS.
+
+---
+
+## Features
+
+- Reusable staggered entrance delay mixins
+- Container-based child staggering via nth-child
+- Individual delay utility classes
+- Transition delay utilities for hover/state changes
+- Reduced motion support
+
+---
+
+## Installation
+
+Copy the `_staggered-entrance-delay-utility-classes.scss` file into your SCSS project and import it:
+
+```scss
+@import "staggered-entrance-delay-utility-classes";

--- a/submissions/scss/scss-staggered-entrance-delay-utility-classes/_staggered-entrance-delay-utility-classes.scss
+++ b/submissions/scss/scss-staggered-entrance-delay-utility-classes/_staggered-entrance-delay-utility-classes.scss
@@ -1,0 +1,161 @@
+// ==========================================
+// Staggered Entrance Delay Utility Classes
+// EaseMotion CSS
+// Issues: #28468 #27842
+// ==========================================
+
+@use 'sass:map';
+
+// --- Configuration ---
+// Delay scale matching EaseMotion animation timing tokens.
+$ease-stagger-delays: (
+  'none': 0ms,
+  '75': 75ms,
+  '100': 100ms,
+  '150': 150ms,
+  '200': 200ms,
+  '300': 300ms,
+  '400': 400ms,
+  '500': 500ms,
+  '600': 600ms,
+  '700': 700ms,
+  '800': 800ms,
+  '1000': 1000ms
+) !default;
+
+$ease-stagger-duration: var(--ease-speed-medium, 0.7s) !default;
+$ease-stagger-easing: var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)) !default;
+
+// --- Core Mixins ---
+
+// Generates staggered entrance delay styles for a container and its children.
+// Each child gets an incremental animation delay based on its index.
+//
+// @param $delay-step      Base delay increment per child (ms)
+// @param $duration        Animation duration
+// @param $easing          Animation timing function
+// @param $initial-delay   Starting delay before first child
+// @param $property        CSS property to transition (default: animation-delay)
+@mixin stagger-entrance(
+  $delay-step: 100ms,
+  $duration: $ease-stagger-duration,
+  $easing: $ease-stagger-easing,
+  $initial-delay: 0ms,
+  $property: animation-delay
+) {
+  > * {
+    #{$property}: $initial-delay;
+    animation-duration: $duration;
+    animation-timing-function: $easing;
+    animation-fill-mode: both;
+
+    @for $i from 2 through 20 {
+      &:nth-child(#{$i}) {
+        #{$property}: calc(#{$initial-delay} + #{$delay-step} * #{$i - 1});
+      }
+    }
+  }
+}
+
+// Generates staggered transition-delay styles for hover or state changes.
+// Useful for cascading fade-ins on hover.
+//
+// @param $delay-step      Base delay increment per child (ms)
+// @param $initial-delay   Starting delay before first child
+@mixin stagger-transition(
+  $delay-step: 100ms,
+  $initial-delay: 0ms
+) {
+  > * {
+    transition-delay: $initial-delay;
+
+    @for $i from 2 through 20 {
+      &:nth-child(#{$i}) {
+        transition-delay: calc(#{$initial-delay} + #{$delay-step} * #{$i - 1});
+      }
+    }
+  }
+}
+
+// --- Utility Generator ---
+
+// Emits the full set of .ease-stagger-* utility classes.
+// @param $prefix            CSS class prefix
+// @param $delays            Map of delay keys to millisecond values
+// @param $duration          Default animation duration
+// @param $easing            Default animation easing
+@mixin generate-stagger-utilities(
+  $prefix: 'ease-stagger',
+  $delays: $ease-stagger-delays,
+  $duration: $ease-stagger-duration,
+  $easing: $ease-stagger-easing
+) {
+  // Container utilities: apply stagger to all direct children
+  @each $key, $value in $delays {
+    @if $key != 'none' {
+      .#{$prefix}-#{$key} {
+        > * {
+          animation-duration: $duration;
+          animation-timing-function: $easing;
+          animation-fill-mode: both;
+
+          @for $i from 1 through 12 {
+            &:nth-child(#{$i}) {
+              animation-delay: calc(#{$value} * #{$i - 1});
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Individual delay utilities (for manual staggering)
+  @each $key, $value in $delays {
+    .#{$prefix}-delay-#{$key} {
+      animation-delay: $value !important;
+    }
+  }
+
+  // Transition delay utilities
+  @each $key, $value in $delays {
+    .#{$prefix}-transition-delay-#{$key} {
+      transition-delay: $value !important;
+    }
+  }
+
+  // Staggered hover transition container
+  .#{$prefix}-hover {
+    > * {
+      transition-property: opacity, transform;
+      transition-duration: $duration;
+      transition-timing-function: $easing;
+
+      @for $i from 1 through 12 {
+        &:nth-child(#{$i}) {
+          transition-delay: calc(100ms * #{$i - 1});
+        }
+      }
+    }
+
+    &:hover > * {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    > * {
+      opacity: 0;
+      transform: translateY(12px);
+    }
+  }
+}
+
+// --- Emit default EaseMotion utility classes ---
+@include generate-stagger-utilities();
+
+// --- Respect reduced-motion preferences ---
+@media (prefers-reduced-motion: reduce) {
+  [class*='ease-stagger-'] {
+    animation-delay: 0ms !important;
+    transition-delay: 0ms !important;
+  }
+}


### PR DESCRIPTION
Closes #28468
Closes #27842

## Changes

| File | Description |
|------|-------------|
| `submissions/scss/scss-staggered-entrance-delay-utility-classes/_staggered-entrance-delay-utility-classes.scss` | SCSS partial with `stagger-entrance`, `stagger-transition`, `generate-stagger-utilities` mixins and generated `.ease-stagger-*` utility classes |
| `submissions/scss/scss-staggered-entrance-delay-utility-classes/README.md` | Documentation: mixin parameters, usage examples, compiled CSS output |

## Technical Notes

- Container-based nth-child staggering for automatic cascade delays.
- Individual `.ease-stagger-delay-*` and `.ease-stagger-transition-delay-*` utilities for manual control.
- `.ease-stagger-hover` utility for hover-triggered staggered fade-ins.
- Includes `prefers-reduced-motion` support.