### PR TITLE
[Feat] #5877 — Add animated shifting gradient text effect (unique folder)

### DIFF
--- a/submissions/examples/ease-gradient-text-animated-5877-ag/README.md
+++ b/submissions/examples/ease-gradient-text-animated-5877-ag/README.md
@@ -1,0 +1,42 @@
+# Animated Gradient Text
+
+This submission creates the `ease-gradient-text` effect — text where the color is clipped from a shifting gradient background, producing a smooth animated color-sweep through the letters.
+
+---
+
+## What It Does
+
+Combines three CSS techniques:
+1. `background-clip: text` + `-webkit-background-clip: text` — clips the gradient to the text shape
+2. `color: transparent` / `-webkit-text-fill-color: transparent` — makes the element's own color transparent so the background shows through
+3. `@keyframes gradientShift` — animates `background-position` from `0%` to `100%` and back on a `background-size: 200% auto` gradient
+
+## How It's Used
+
+```html
+<!-- Basic usage -->
+<p class="gradient-text gradient-text--ocean">Animated gradient headline</p>
+
+<!-- Large display -->
+<h1 class="gradient-text gradient-text--ember gradient-text--display">Big Impact</h1>
+
+<!-- Slow drift -->
+<p class="gradient-text gradient-text--forest gradient-text--slow">Calm forest flow</p>
+```
+
+## Why It's Useful
+
+- Creates premium, attention-grabbing headings with zero JS
+- Three distinct color presets cover warm, cool, and nature palettes
+- The `--gradient-duration` CSS variable makes speed trivially configurable
+- `prefers-reduced-motion` support ensures the gradient is shown statically for motion-sensitive users
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Verify each of the three preset cards shows a smoothly animating gradient clipped to the text.
+3. Verify the large display card shows the multi-line heading at a larger size.
+4. Verify the slow card animates at roughly half the speed of the default.
+5. Enable `prefers-reduced-motion` in the OS — verify the gradient is static (no animation).

--- a/submissions/examples/ease-gradient-text-animated-5877-ag/demo.html
+++ b/submissions/examples/ease-gradient-text-animated-5877-ag/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Animated Gradient Text — EaseMotion CSS</title>
+  <meta name="description" content="Text clipped to an animated shifting gradient background with multiple color scheme modifiers and reduced-motion support.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Typography Effect</span>
+      <h1>Animated Gradient Text</h1>
+      <p class="description">
+        Text clipped to a shifting gradient background using <code>background-clip: text</code>
+        and <code>@keyframes</code> on <code>background-position</code>.
+        Three color presets — ocean, ember, and forest.
+      </p>
+    </header>
+
+    <main class="showcase">
+
+      <!-- Ocean preset -->
+      <section class="demo-card">
+        <span class="preset-tag">Ocean</span>
+        <p class="gradient-text gradient-text--ocean">Beautiful waves of animated color flow through every letter.</p>
+      </section>
+
+      <!-- Ember preset -->
+      <section class="demo-card">
+        <span class="preset-tag">Ember</span>
+        <p class="gradient-text gradient-text--ember">Warm fire tones shift and dance across this animated headline.</p>
+      </section>
+
+      <!-- Forest preset -->
+      <section class="demo-card">
+        <span class="preset-tag">Forest</span>
+        <p class="gradient-text gradient-text--forest">Deep greens and teal hues sweep through lush typographic motion.</p>
+      </section>
+
+      <!-- Display size -->
+      <section class="demo-card demo-card--wide">
+        <span class="preset-tag">Large display</span>
+        <h2 class="gradient-text gradient-text--ocean gradient-text--display">Shift.
+Flow.
+Animate.</h2>
+      </section>
+
+      <!-- Slow speed modifier -->
+      <section class="demo-card">
+        <span class="preset-tag">Slow speed</span>
+        <p class="gradient-text gradient-text--ember gradient-text--slow">A languid, molten gradient that drifts at half the default speed.</p>
+      </section>
+
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-gradient-text-animated-5877-ag/style.css
+++ b/submissions/examples/ease-gradient-text-animated-5877-ag/style.css
@@ -1,0 +1,199 @@
+/* ============================================================
+   Animated Gradient Text — style.css
+   Submission for EaseMotion CSS Issue #5877
+   background-clip: text + keyframes on background-position
+   ============================================================ */
+
+:root {
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.5);
+  --card-border: rgba(255, 255, 255, 0.07);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+
+  /* Gradient text animation duration */
+  --gradient-duration: 4s;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 760px;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ── Showcase grid ── */
+.showcase {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+}
+
+.demo-card {
+  padding: 32px 28px;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.demo-card--wide {
+  grid-column: 1 / -1;
+}
+
+.preset-tag {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+/* ============================================================
+   Gradient Text Core
+   Technique: background-size: 200%; @keyframes shifts position
+   ============================================================ */
+
+.gradient-text {
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1.35;
+
+  /* Required clip technique */
+  background-size: 200% auto;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  color: transparent; /* Fallback for browsers without background-clip:text */
+
+  animation: gradientShift var(--gradient-duration) linear infinite;
+}
+
+@keyframes gradientShift {
+  0%   { background-position: 0% 50%; }
+  50%  { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+
+/* ============================================================
+   Color Scheme Modifiers
+   ============================================================ */
+
+/* Ocean — violet → cyan → teal */
+.gradient-text--ocean {
+  background-image: linear-gradient(
+    90deg,
+    #7c3aed,
+    #22d3ee,
+    #0ea5e9,
+    #6366f1,
+    #7c3aed
+  );
+}
+
+/* Ember — amber → orange → rose */
+.gradient-text--ember {
+  background-image: linear-gradient(
+    90deg,
+    #f59e0b,
+    #ef4444,
+    #f97316,
+    #ec4899,
+    #f59e0b
+  );
+}
+
+/* Forest — emerald → teal → lime */
+.gradient-text--forest {
+  background-image: linear-gradient(
+    90deg,
+    #10b981,
+    #14b8a6,
+    #84cc16,
+    #22d3ee,
+    #10b981
+  );
+}
+
+/* ============================================================
+   Size Modifier
+   ============================================================ */
+
+.gradient-text--display {
+  font-size: clamp(2.5rem, 8vw, 5rem);
+  font-weight: 900;
+  line-height: 1.1;
+  white-space: pre-line;
+}
+
+/* ============================================================
+   Speed Modifier
+   ============================================================ */
+
+.gradient-text--slow {
+  --gradient-duration: 10s;
+}
+
+/* ============================================================
+   Reduced Motion
+   ============================================================ */
+
+@media (prefers-reduced-motion: reduce) {
+  .gradient-text {
+    animation: none !important;
+    /* Show the start position of the gradient statically */
+    background-position: 0% 50% !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-gradient-text` animated typography effect: text is clipped to a shifting gradient using `background-clip: text` and `@keyframes` animating `background-position` on a `background-size: 200%` gradient. Three color presets (ocean, ember, forest), a display size modifier, and a slow-drift speed modifier are included. Fully respects `prefers-reduced-motion`.

## Root Cause
No animated gradient text effect existed in EaseMotion CSS for creating premium hero headings and display copy without JavaScript.

## Changes Made
- `submissions/examples/ease-gradient-text-animated-5877-ag/demo.html`: Five demo cards covering all presets, display size, and slow speed variants.
- `submissions/examples/ease-gradient-text-animated-5877-ag/style.css`: Core `gradient-text` class with clip technique, `gradientShift` keyframe, three gradient presets, size and speed modifiers, `prefers-reduced-motion` suppression.
- `submissions/examples/ease-gradient-text-animated-5877-ag/README.md`: Explains the three-technique combination, usage API, and verification steps.

## How to Test
1. Open `demo.html` in a browser.
2. Verify gradient shifts continuously through each preset's colors.
3. Enable `prefers-reduced-motion` — verify animation stops, gradient displayed statically.

## Related Issue
Closes #5877