### PR TITLE
[Feat] #15909 — Add animation delay sequences CSS demo (unique folder)

### DIFF
--- a/submissions/examples/ease-animation-delay-seq-15909-ag/README.md
+++ b/submissions/examples/ease-animation-delay-seq-15909-ag/README.md
@@ -1,0 +1,38 @@
+# Animation Delay Sequences Demo
+
+This submission demonstrates four practical patterns for CSS animation stagger sequences using incremental `animation-delay` values. All delays are driven via the `--stagger-delay` CSS custom property set directly on each element.
+
+---
+
+## Patterns Demonstrated
+
+| Pattern | Keyframe | Effect |
+|---------|----------|--------|
+| Card Stagger | `staggerFadeUp` | Cards fade in and rise from below |
+| List Slide-In | `staggerSlideRight` | Items slide in from the left |
+| Grid Wave | `staggerScale` | Cells pop in with elastic scale |
+| Word-by-Word | `staggerFadeUp` | Words animate in sequentially |
+
+## Core Pattern
+
+```css
+/* Each item gets an incremental --stagger-delay */
+.item:nth-child(1) { --stagger-delay: 0s; }
+.item:nth-child(2) { --stagger-delay: 0.1s; }
+/* ... */
+
+/* Parent triggers animation via a class toggle */
+.container.is-played .item {
+  animation: staggerFadeUp 0.45s ease both;
+  animation-delay: var(--stagger-delay, 0s);
+}
+```
+
+The `is-played` class is toggled by JavaScript, allowing the sequence to be replayed by removing and re-adding the class (after forcing a reflow with `element.offsetWidth`).
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Verify all four demos animate on page load with distinct stagger timing.
+3. Click **Replay** on any demo to re-trigger its sequence.
+4. Enable `prefers-reduced-motion` — verify all elements appear immediately without animation.

--- a/submissions/examples/ease-animation-delay-seq-15909-ag/demo.html
+++ b/submissions/examples/ease-animation-delay-seq-15909-ag/demo.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Animation Delay Sequences — EaseMotion CSS</title>
+  <meta name="description" content="Interactive demo of CSS animation-delay stagger sequences: cards, list items, grid cells, and text word-by-word.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Animation Technique</span>
+      <h1>Animation Delay Sequences</h1>
+      <p class="description">
+        Four stagger patterns using incremental <code>animation-delay</code> values.
+        Click <strong>Replay</strong> on any demo to re-trigger the sequence.
+      </p>
+    </header>
+
+    <main class="demos">
+
+      <!-- Demo 1: Stagger cards -->
+      <section class="demo-section">
+        <div class="demo-header">
+          <h2 class="demo-title">Card Stagger</h2>
+          <button class="replay-btn" data-target="cards" type="button">Replay</button>
+        </div>
+        <div class="stagger-cards" id="cards">
+          <div class="stagger-card" style="--stagger-delay: 0s;">01</div>
+          <div class="stagger-card" style="--stagger-delay: 0.1s;">02</div>
+          <div class="stagger-card" style="--stagger-delay: 0.2s;">03</div>
+          <div class="stagger-card" style="--stagger-delay: 0.3s;">04</div>
+          <div class="stagger-card" style="--stagger-delay: 0.4s;">05</div>
+        </div>
+      </section>
+
+      <!-- Demo 2: List items -->
+      <section class="demo-section">
+        <div class="demo-header">
+          <h2 class="demo-title">List Slide-In</h2>
+          <button class="replay-btn" data-target="list" type="button">Replay</button>
+        </div>
+        <ul class="stagger-list" id="list">
+          <li class="stagger-list-item" style="--stagger-delay: 0s;">Design tokens and variables</li>
+          <li class="stagger-list-item" style="--stagger-delay: 0.12s;">Keyframe animation library</li>
+          <li class="stagger-list-item" style="--stagger-delay: 0.24s;">Scroll-driven utilities</li>
+          <li class="stagger-list-item" style="--stagger-delay: 0.36s;">Motion accessibility support</li>
+          <li class="stagger-list-item" style="--stagger-delay: 0.48s;">Zero-JS interactions</li>
+        </ul>
+      </section>
+
+      <!-- Demo 3: Grid cells -->
+      <section class="demo-section">
+        <div class="demo-header">
+          <h2 class="demo-title">Grid Wave</h2>
+          <button class="replay-btn" data-target="grid" type="button">Replay</button>
+        </div>
+        <div class="stagger-grid" id="grid">
+          <div class="stagger-cell" style="--stagger-delay: 0s;"></div>
+          <div class="stagger-cell" style="--stagger-delay: 0.07s;"></div>
+          <div class="stagger-cell" style="--stagger-delay: 0.14s;"></div>
+          <div class="stagger-cell" style="--stagger-delay: 0.21s;"></div>
+          <div class="stagger-cell" style="--stagger-delay: 0.28s;"></div>
+          <div class="stagger-cell" style="--stagger-delay: 0.35s;"></div>
+          <div class="stagger-cell" style="--stagger-delay: 0.42s;"></div>
+          <div class="stagger-cell" style="--stagger-delay: 0.49s;"></div>
+          <div class="stagger-cell" style="--stagger-delay: 0.56s;"></div>
+        </div>
+      </section>
+
+      <!-- Demo 4: Word-by-word text -->
+      <section class="demo-section">
+        <div class="demo-header">
+          <h2 class="demo-title">Word-by-Word</h2>
+          <button class="replay-btn" data-target="words" type="button">Replay</button>
+        </div>
+        <p class="stagger-words" id="words" aria-label="The future is motion">
+          <span class="word" style="--stagger-delay: 0s;">The</span>
+          <span class="word" style="--stagger-delay: 0.15s;">future</span>
+          <span class="word" style="--stagger-delay: 0.3s;">is</span>
+          <span class="word" style="--stagger-delay: 0.45s;">motion.</span>
+        </p>
+      </section>
+
+    </main>
+  </div>
+
+  <script>
+    // Replay: remove and re-add animation class via a brief void reflow
+    document.querySelectorAll('.replay-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const id = btn.dataset.target;
+        const el = document.getElementById(id);
+        el.classList.add('paused');
+        // Force reflow to reset animation
+        void el.offsetWidth;
+        el.classList.remove('paused');
+        el.classList.remove('is-played');
+        void el.offsetWidth;
+        el.classList.add('is-played');
+      });
+    });
+    // Trigger initial play
+    document.querySelectorAll('.stagger-cards, .stagger-list, .stagger-grid, .stagger-words').forEach(el => {
+      el.classList.add('is-played');
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-animation-delay-seq-15909-ag/style.css
+++ b/submissions/examples/ease-animation-delay-seq-15909-ag/style.css
@@ -1,0 +1,267 @@
+/* ============================================================
+   Animation Delay Sequences — style.css
+   Submission for EaseMotion CSS Issue #15909
+   Four stagger demos: cards, list, grid wave, word-by-word
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.5);
+  --card-border: rgba(255, 255, 255, 0.07);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 820px;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ── Demo Sections ── */
+.demos {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+}
+
+@media (max-width: 640px) { .demos { grid-template-columns: 1fr; } }
+
+.demo-section {
+  padding: 28px;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.demo-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.demo-title {
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+.replay-btn {
+  background: rgba(124, 58, 237, 0.15);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 5px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background-color 0.15s ease;
+}
+
+.replay-btn:hover { background: rgba(124, 58, 237, 0.28); }
+
+/* ============================================================
+   Shared stagger animation keyframe
+   ============================================================ */
+
+@keyframes staggerFadeUp {
+  from { opacity: 0; transform: translateY(16px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes staggerSlideRight {
+  from { opacity: 0; transform: translateX(-20px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes staggerScale {
+  from { opacity: 0; transform: scale(0.6); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+/* ============================================================
+   Demo 1 — Card Stagger
+   ============================================================ */
+
+.stagger-cards {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.stagger-card {
+  flex: 1 0 48px;
+  height: 72px;
+  border-radius: 10px;
+  background: linear-gradient(135deg, #7c3aed, #22d3ee);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: #fff;
+  opacity: 0;
+}
+
+/* Trigger animation by is-played class */
+.stagger-cards.is-played .stagger-card {
+  animation: staggerFadeUp 0.45s cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: var(--stagger-delay, 0s);
+}
+
+/* ============================================================
+   Demo 2 — List Slide-In
+   ============================================================ */
+
+.stagger-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.stagger-list-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+  opacity: 0;
+}
+
+.stagger-list-item::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #7c3aed;
+  flex-shrink: 0;
+}
+
+.stagger-list.is-played .stagger-list-item {
+  animation: staggerSlideRight 0.4s cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: var(--stagger-delay, 0s);
+}
+
+/* ============================================================
+   Demo 3 — Grid Wave
+   ============================================================ */
+
+.stagger-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+
+.stagger-cell {
+  height: 48px;
+  border-radius: 8px;
+  background: linear-gradient(135deg, rgba(124,58,237,0.4), rgba(34,211,238,0.4));
+  border: 1px solid rgba(167, 139, 250, 0.2);
+  opacity: 0;
+}
+
+.stagger-grid.is-played .stagger-cell {
+  animation: staggerScale 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  animation-delay: var(--stagger-delay, 0s);
+}
+
+/* ============================================================
+   Demo 4 — Word-by-Word
+   ============================================================ */
+
+.stagger-words {
+  font-size: 2rem;
+  font-weight: 800;
+  line-height: 1.3;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3em;
+}
+
+.word {
+  display: inline-block;
+  opacity: 0;
+  background: linear-gradient(90deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.stagger-words.is-played .word {
+  animation: staggerFadeUp 0.5s cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: var(--stagger-delay, 0s);
+}
+
+/* ============================================================
+   Reduced Motion
+   ============================================================ */
+
+@media (prefers-reduced-motion: reduce) {
+  .stagger-card,
+  .stagger-list-item,
+  .stagger-cell,
+  .word {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds a comprehensive educational demo showcase of `animation-delay` stagger sequences. It demonstrates four distinct CSS stagger patterns (card rise, list slide-in, grid scale pop, and word-by-word fade) using inline custom properties to drive the delays cleanly. It includes a JS replay helper and full `prefers-reduced-motion` support.

## Root Cause
No interactive sequence stagger demo or guide existed to help contributors understand how to create complex orchestrations using EaseMotion CSS delay utilities.

## Changes Made
- `submissions/examples/ease-animation-delay-seq-15909-ag/demo.html`: Responsive cards, list, grid, and text containers with custom delays and a replay trigger.
- `submissions/examples/ease-animation-delay-seq-15909-ag/style.css`: Keyframes for each type of animation, layout styles, and animation classes triggered via `.is-played`.
- `submissions/examples/ease-animation-delay-seq-15909-ag/README.md`: Breakdown of the stagger pattern, inline delay configuration API, and verification guide.

## How to Test
1. Open `demo.html` in a browser.
2. Observe all four containers playing staggered animations on load.
3. Click "Replay" on any card/list/grid/text to re-run the animation.

## Related Issue
Closes #15909