### PR TITLE
[Feat] #13395 — Add CSS scroll-driven animation showcase (unique folder)

### DIFF
--- a/submissions/examples/ease-scroll-driven-13395-ag/README.md
+++ b/submissions/examples/ease-scroll-driven-13395-ag/README.md
@@ -1,0 +1,42 @@
+# CSS Scroll-Driven Animations
+
+This submission implements a pure CSS-only Scroll-Driven Animation showcase to demonstrate modern scroll-linked interactive visual behaviors.
+
+---
+
+## Technical Overview
+
+Native CSS scroll-driven animations bind standard keyframe animations directly to scroll containers (using `scroll()`) or element-in-viewport boundaries (using `view()`), completely removing the requirement for heavy JS scroll listener code.
+
+### 1. Reading Progress Bar
+A full-width top progress bar is bound to the document's scrolling root:
+```css
+.ease-scroll-progress {
+  transform-origin: left;
+  transform: scaleX(0);
+  animation: growProgress linear;
+  animation-timeline: scroll(root);
+}
+```
+
+### 2. View-Linked Entrances
+Content cards automatically transition, scaling up and sliding forward into view as they cross the viewport:
+```css
+.entrance-trigger {
+  animation: slideUpView linear;
+  animation-timeline: view();
+  animation-range: entry 10% cover 40%;
+}
+```
+
+### 3. Parallax Background Scaling
+The hero image shifts and scales down gracefully as its parent moves through view, producing parallax depth.
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser supporting Scroll-Driven animations (e.g. Chrome, Edge, Opera, or Safari 17+).
+2. Scroll down slowly — observe the progress bar fill purple and cyan across the top.
+3. Observe Section 3's elements scaling up and fading in as they move into view.
+4. Enable `prefers-reduced-motion` in your system preferences — verify all animations stop and elements load in static states.

--- a/submissions/examples/ease-scroll-driven-13395-ag/demo.html
+++ b/submissions/examples/ease-scroll-driven-13395-ag/demo.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scroll-Driven Animations — EaseMotion CSS</title>
+  <meta name="description" content="Modern pure-CSS Scroll-Driven animations including a reading progress bar, fade-in-on-scroll sections, and image parallax scale effects.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Top Reading Progress Bar -->
+  <div class="ease-scroll-progress" aria-hidden="true"></div>
+
+  <div class="container">
+    <header class="hero">
+      <span class="demo-badge">EaseMotion CSS — Scroll Driven</span>
+      <h1>CSS Scroll-Driven Animations</h1>
+      <p class="description">
+        Leverage modern browser capabilities with <code>animation-timeline: scroll()</code> and <code>view()</code>.
+        Scroll down to see the reading progress bar fill, content cards slide in, and images scale dynamically.
+      </p>
+      <div class="scroll-indicator">
+        <span class="mouse-wheel"></span>
+        <span class="scroll-text">Scroll Down</span>
+      </div>
+    </header>
+
+    <main class="content-stream">
+
+      <!-- Feature Section 1: Progress Indicator -->
+      <section class="scroll-section">
+        <div class="section-content">
+          <span class="section-num">01</span>
+          <h2>Reading Progress Bar</h2>
+          <p>Look at the very top of your viewport. A thin purple progress indicator expands horizontally from 0% to 100% as you scroll through this document. No JS event listeners, passive handlers, or paint calculations are used.</p>
+        </div>
+      </section>
+
+      <!-- Feature Section 2: Parallax Card -->
+      <section class="scroll-section">
+        <div class="parallax-card">
+          <div class="parallax-image-wrapper">
+            <div class="parallax-bg" style="background: linear-gradient(135deg, #7c3aed, #22d3ee);"></div>
+          </div>
+          <div class="parallax-body">
+            <span class="section-num">02</span>
+            <h2>Parallax Image Scaling</h2>
+            <p>The card background above scales dynamically relative to its intersection with the viewport. By linking the scale transformation to the scroll progress, we create a beautiful, smooth parallax depth effect.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- Feature Section 3: View-Driven Entrance -->
+      <section class="scroll-section">
+        <div class="section-content entrance-trigger">
+          <span class="section-num">03</span>
+          <h2>View-Linked Entrance</h2>
+          <p>These elements slide upward, rotate, and fade in automatically as they cross the bottom edge of the screen, and fade back out when they exit the top edge, utilizing CSS <code>view()</code> timelines.</p>
+        </div>
+      </section>
+
+      <!-- Feature Section 4: Grid Stagger -->
+      <section class="scroll-section">
+        <div class="grid-container">
+          <div class="grid-card stagger-1">
+            <h3>Responsive</h3>
+            <p>Adapts fluidly to screen dimensions.</p>
+          </div>
+          <div class="grid-card stagger-2">
+            <h3>Zero Dependency</h3>
+            <p>100% HTML and CSS with zero JavaScript.</p>
+          </div>
+          <div class="grid-card stagger-3">
+            <h3>Performant</h3>
+            <p>Hardware accelerated on the compositor thread.</p>
+          </div>
+        </div>
+      </section>
+
+    </main>
+
+    <footer class="demo-footer">
+      <p>EaseMotion CSS Examples — Scroll-Driven Animations</p>
+    </footer>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-scroll-driven-13395-ag/style.css
+++ b/submissions/examples/ease-scroll-driven-13395-ag/style.css
@@ -1,0 +1,323 @@
+/* ============================================================
+   Scroll-Driven Animations — style.css
+   Submission for EaseMotion CSS Issue #13395
+   Reading progress, scroll-triggered entrances, image parallax
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 200vh; /* Make sure we have plenty of scroll space */
+  padding: 0;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+}
+
+.container {
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 24px;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── Hero / Header ── */
+.hero {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  position: relative;
+  padding-bottom: 80px;
+}
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 24px;
+}
+
+.hero h1 {
+  font-size: clamp(2.2rem, 8vw, 3.6rem);
+  font-weight: 800;
+  line-height: 1.15;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 16px;
+}
+
+.hero .description {
+  color: var(--text-secondary);
+  font-size: 1.1rem;
+  max-width: 580px;
+  line-height: 1.7;
+}
+
+/* Scroll indicator animation */
+.scroll-indicator {
+  position: absolute;
+  bottom: 40px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.mouse-wheel {
+  width: 24px;
+  height: 40px;
+  border: 2px solid var(--text-muted);
+  border-radius: 12px;
+  position: relative;
+}
+
+.mouse-wheel::before {
+  content: '';
+  width: 4px;
+  height: 8px;
+  background: var(--primary-color);
+  border-radius: 2px;
+  position: absolute;
+  top: 6px;
+  left: 50%;
+  transform: translateX(-50%);
+  animation: mouseScroll 1.6s ease-out infinite;
+}
+
+@keyframes mouseScroll {
+  0%   { opacity: 1; transform: translate(-50%, 0); }
+  100% { opacity: 0; transform: translate(-50%, 14px); }
+}
+
+.scroll-text {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+/* ── Content Sections ── */
+.content-stream {
+  display: flex;
+  flex-direction: column;
+  gap: 120px;
+  padding: 80px 0;
+}
+
+.scroll-section {
+  width: 100%;
+}
+
+.section-content {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  padding: 40px;
+  border-radius: 20px;
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.section-num {
+  font-size: 0.85rem;
+  font-weight: 800;
+  color: #c4b5fd;
+  letter-spacing: 0.05em;
+}
+
+h2 {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+p {
+  color: var(--text-secondary);
+  line-height: 1.65;
+  font-size: 0.95rem;
+}
+
+/* ============================================================
+   1. Reading Progress Bar
+   Linked to overall viewport scroll
+   ============================================================ */
+
+.ease-scroll-progress {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 4px;
+  background: linear-gradient(90deg, #7c3aed, #22d3ee);
+  z-index: 1000;
+  transform-origin: left;
+  transform: scaleX(0);
+}
+
+@supports (animation-timeline: scroll()) {
+  .ease-scroll-progress {
+    animation: growProgress linear;
+    animation-timeline: scroll(root);
+  }
+}
+
+@keyframes growProgress {
+  to { transform: scaleX(1); }
+}
+
+/* ============================================================
+   2. Parallax Image Scaling
+   Linked to intersection view progress
+   ============================================================ */
+
+.parallax-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 20px;
+  overflow: hidden;
+  backdrop-filter: blur(8px);
+}
+
+.parallax-image-wrapper {
+  height: 240px;
+  overflow: hidden;
+  position: relative;
+}
+
+.parallax-bg {
+  width: 100%;
+  height: 100%;
+  transform: scale(1.3);
+}
+
+@supports (animation-timeline: view()) {
+  .parallax-bg {
+    animation: zoomParallax linear;
+    animation-timeline: view();
+    animation-range: entry 0% exit 100%;
+  }
+}
+
+@keyframes zoomParallax {
+  from { transform: scale(1.35) translateY(-8%); }
+  to   { transform: scale(1.0) translateY(8%); }
+}
+
+.parallax-body {
+  padding: 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* ============================================================
+   3. View-Driven Entrance & Grid Stagger
+   ============================================================ */
+
+@supports (animation-timeline: view()) {
+  .entrance-trigger {
+    animation: slideUpView linear;
+    animation-timeline: view();
+    animation-range: entry 10% cover 40%;
+  }
+
+  .grid-container .grid-card {
+    animation: slideUpView linear;
+    animation-timeline: view();
+    animation-range: entry 10% cover 35%;
+  }
+}
+
+@keyframes slideUpView {
+  from {
+    opacity: 0;
+    transform: translateY(60px) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* Grid Container */
+.grid-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.grid-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  padding: 28px;
+  border-radius: 16px;
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.grid-card h3 {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #22d3ee;
+}
+
+/* Fallback for browsers that don't support view() timelines */
+@supports not (animation-timeline: view()) {
+  .entrance-trigger,
+  .grid-card {
+    opacity: 0.9;
+    transform: none;
+  }
+  .ease-scroll-progress {
+    transform: scaleX(0.5); /* fallback value, showing mid scroll */
+  }
+}
+
+.demo-footer {
+  text-align: center;
+  padding: 60px 0;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  border-top: 1px solid rgba(255,255,255,0.05);
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-scroll-progress,
+  .parallax-bg,
+  .entrance-trigger,
+  .grid-card,
+  .mouse-wheel::before {
+    animation: none !important;
+    transform: none !important;
+    opacity: 1 !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-scroll-driven` showcase showcasing pure-CSS scroll-driven animations. It demonstrates:
- A viewport reading progress bar using `animation-timeline: scroll(root)`.
- Image zoom/parallax scaling using `animation-timeline: view()` and `animation-range`.
- Fade/scale section entrances using viewport triggers.
Includes clean fallback states for older browsers and full `prefers-reduced-motion` compliance.

## Root Cause
No scroll-driven or scroll-linked animation utilities/examples existed in EaseMotion CSS to show how to build modern scroll effects without massive JavaScript dependencies.

## Changes Made
- `submissions/examples/ease-scroll-driven-13395-ag/demo.html`: Layout with high scroll space, reading indicator, parallax image card, and view-linked content.
- `submissions/examples/ease-scroll-driven-13395-ag/style.css`: Scroll & view timeline animations, entry ranges, fallbacks using `@supports not`, and accessibility rules.
- `submissions/examples/ease-scroll-driven-13395-ag/README.md`: Explains CSS `scroll()` vs `view()`, `animation-range` mapping, and verification procedures.

## How to Test
1. Open `demo.html` in a supported browser.
2. Scroll to verify progress bar behavior, background parallax scaling, and card entrances.

## Related Issue
Closes #13395