### PR TITLE
[Feat] #5945 — Add cards text dark token demo (unique folder)

### DIFF
--- a/submissions/examples/cards-text-dark-token-5945-ag/README.md
+++ b/submissions/examples/cards-text-dark-token-5945-ag/README.md
@@ -1,0 +1,31 @@
+# Undefined Card Dark Token
+
+This submission demonstrates the CSS issue where cards reference an undefined token (`--ease-color-text-dark`), and showcases the clean remediation by defining it properly.
+
+---
+
+## The Issue
+
+In `components/cards.css`, cards reference `var(--ease-color-text-dark, #f8fafc)`. However, the token `--ease-color-text-dark` is never initialized in `core/variables.css`.
+
+This causes themes attempting to override the text color in dark cards to fail, since there is no centralized root property to target.
+
+## The Solution
+
+To resolve this issue, the token needs to be declared inside the global stylesheet:
+
+```css
+:root {
+  --ease-color-text-dark: #f8fafc;
+}
+```
+
+This ensures full customizability of dark card text values across the application.
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Observe the "Before" card where `var(--ease-color-text-dark)` fails to resolve custom overrides.
+3. Observe the "After" card where the token has been successfully resolved and styled.

--- a/submissions/examples/cards-text-dark-token-5945-ag/demo.html
+++ b/submissions/examples/cards-text-dark-token-5945-ag/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Card Dark Token Fix — EaseMotion CSS</title>
+  <meta name="description" content="Demo showing the missing --ease-color-text-dark token issue in cards and its clean resolution.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Bug Triage Demo</span>
+      <h1>Undefined Card Dark Token</h1>
+      <p class="description">
+        Demonstrates the issue where cards reference the undefined <code>--ease-color-text-dark</code> variable, 
+        and showcases the clean remediation by defining the token.
+      </p>
+    </header>
+
+    <main class="showcase">
+
+      <!-- Case 1: Broken State (Simulation) -->
+      <section class="demo-section">
+        <h2 class="section-label">Before: Undefined Token Issue</h2>
+        <div class="demo-card-state broken-state">
+          <div class="ease-card-dark-demo">
+            <h3>System Status</h3>
+            <p class="desc">This card is using the default style. When custom themes try to override light/dark text colors, it fails because the variable is undefined.</p>
+            <div class="status-indicator">Offline</div>
+          </div>
+        </div>
+        <p class="status-note text-danger">⚠️ Text contrast fails to adapt to theme overrides because the token does not exist in root variables.</p>
+      </section>
+
+      <!-- Case 2: Fixed State -->
+      <section class="demo-section">
+        <h2 class="section-label">After: Token Remediated</h2>
+        <div class="demo-card-state fixed-state">
+          <div class="ease-card-dark-demo fixed-card">
+            <h3>System Status</h3>
+            <p class="desc">This card defines the missing token cleanly. Any custom color themes are now successfully applied to the dark card text.</p>
+            <div class="status-indicator status-indicator--active">Active</div>
+          </div>
+        </div>
+        <p class="status-note text-success">✅ Text contrast adapts perfectly when <code>--ease-color-text-dark</code> is declared.</p>
+      </section>
+
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/cards-text-dark-token-5945-ag/style.css
+++ b/submissions/examples/cards-text-dark-token-5945-ag/style.css
@@ -1,0 +1,170 @@
+/* ============================================================
+   Card Dark Token Fix — style.css
+   Submission for EaseMotion CSS Issue #5945
+   Showing undefined --ease-color-text-dark token fix
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 800px;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ── Showcase ── */
+.showcase {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 28px;
+}
+
+.demo-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 24px;
+  background: rgba(31, 41, 55, 0.2);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+}
+
+.section-label {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+.demo-card-state {
+  display: flex;
+  justify-content: center;
+  padding: 24px;
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.25);
+}
+
+/* ── Card Styles ── */
+.ease-card-dark-demo {
+  background: #1e293b;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 20px;
+  border-radius: 12px;
+  width: 100%;
+  max-width: 280px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/* Simulation of undefined token behavior vs defined token */
+.broken-state .ease-card-dark-demo h3,
+.broken-state .ease-card-dark-demo .desc {
+  /* Under custom dark text config overrides, colors fail to render cleanly */
+  color: var(--ease-color-text-dark); /* Undefined, falls back to browser default (usually transparent or black on dark card!) */
+}
+
+/* Fix applied: declare the token locally for the fixed demo card */
+.fixed-state .fixed-card {
+  --ease-color-text-dark: #f8fafc; /* Safe token definition fallback */
+}
+
+.fixed-state .fixed-card h3 {
+  color: var(--ease-color-text-dark);
+  font-size: 1.15rem;
+  font-weight: 700;
+}
+
+.fixed-state .fixed-card .desc {
+  color: var(--ease-color-text-dark);
+  opacity: 0.8;
+  font-size: 0.88rem;
+  line-height: 1.5;
+}
+
+/* Helper Indicator UI */
+.status-indicator {
+  display: inline-block;
+  align-self: flex-start;
+  padding: 4px 10px;
+  background: rgba(239, 68, 68, 0.2);
+  border: 1px solid rgba(239, 68, 68, 0.4);
+  color: #fca5a5;
+  border-radius: 6px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.status-indicator--active {
+  background: rgba(16, 185, 129, 0.2);
+  border-color: rgba(16, 185, 129, 0.4);
+  color: #a7f3d0;
+}
+
+.status-note {
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.text-danger { color: #f87171; }
+.text-success { color: #34d399; }


### PR DESCRIPTION
## Summary
Adds a demonstration showcase of the undefined `--ease-color-text-dark` token issue in cards and its remediation. In the core library, cards reference `var(--ease-color-text-dark, #f8fafc)` which is never initialized, causing custom theme overrides to break. Defining the variable cleanly fixes this issue.

## Root Cause
In `components/cards.css`, cards reference `var(--ease-color-text-dark, #f8fafc)`, but `--ease-color-text-dark` is never initialized in `core/variables.css`.

## Changes Made
- `submissions/examples/cards-text-dark-token-5945-ag/demo.html`: Two cards displaying the contrast issues before the fix, and the successful application of the color token after declaring it.
- `submissions/examples/cards-text-dark-token-5945-ag/style.css`: Layout styles, broken card state simulation, and the resolved state style declaration.
- `submissions/examples/cards-text-dark-token-5945-ag/README.md`: Explains the missing token bug, local declaration fix, and testing guidelines.

## How to Test
1. Open `demo.html` in a browser.
2. Verify that the "After" card resolves the text color perfectly while the "Before" card fails to apply overrides due to the undefined token.

## Related Issue
Closes #5945