### PR TITLE
[Feat] #5947 — Add button icon size variants (unique folder)

### DIFF
--- a/submissions/examples/buttons-icon-size-5947-ag/README.md
+++ b/submissions/examples/buttons-icon-size-5947-ag/README.md
@@ -1,0 +1,27 @@
+# Icon Button Size Variants
+
+This submission implements and demonstrates the missing small (`sm`) and large (`lg`) sizing variants for the `.ease-btn-icon` (icon-only button) component in EaseMotion CSS.
+
+---
+
+## Technical Overview
+
+Icon-only buttons require consistent square dimensions (aspect-ratio 1:1) to prevent distorting circular borders.
+
+The sizing parameters mapped in this demonstration are:
+
+| Class | Button Diameter | Icon (SVG) Size |
+|-------|-----------------|-----------------|
+| `.ease-btn-icon-sm` | `32px` | `14px` |
+| Default | `40px` | `18px` |
+| `.ease-btn-icon-lg` | `48px` | `22px` |
+
+This ensures consistent visual balance alongside standard textual button height scales.
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Inspect the sizing cards: verify that small, medium, and large buttons form perfect circular grids.
+3. Hover to verify interactive scales.

--- a/submissions/examples/buttons-icon-size-5947-ag/demo.html
+++ b/submissions/examples/buttons-icon-size-5947-ag/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Icon Button Size Variants — EaseMotion CSS</title>
+  <meta name="description" content="Showcase of missing ease-btn-icon-sm and ease-btn-icon-lg variants with proper padding, dimensions, and SVG centering.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Button Component</span>
+      <h1>Icon Button Size Variants</h1>
+      <p class="description">
+        EaseMotion CSS defines standard icon buttons but lacks small (sm) and large (lg) variants.
+        This demo implements <code>ease-btn-icon-sm</code> and <code>ease-btn-icon-lg</code> to provide consistent spacing.
+      </p>
+    </header>
+
+    <main class="showcase">
+
+      <!-- Column 1: Small Icon Buttons -->
+      <section class="demo-card">
+        <h2 class="section-title">Small (sm) — 32px</h2>
+        <div class="button-row">
+          <button class="ease-btn-icon-demo ease-btn-icon-sm" aria-label="Search">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
+          </button>
+          <button class="ease-btn-icon-demo ease-btn-icon-sm ease-btn-success" aria-label="Add item">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+          </button>
+          <button class="ease-btn-icon-demo ease-btn-icon-sm ease-btn-danger" aria-label="Delete">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path></svg>
+          </button>
+        </div>
+      </section>
+
+      <!-- Column 2: Default Medium Icon Buttons -->
+      <section class="demo-card">
+        <h2 class="section-title">Medium (default) — 40px</h2>
+        <div class="button-row">
+          <button class="ease-btn-icon-demo" aria-label="Search">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
+          </button>
+          <button class="ease-btn-icon-demo ease-btn-success" aria-label="Add item">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+          </button>
+          <button class="ease-btn-icon-demo ease-btn-danger" aria-label="Delete">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path></svg>
+          </button>
+        </div>
+      </section>
+
+      <!-- Column 3: Large Icon Buttons -->
+      <section class="demo-card">
+        <h2 class="section-title">Large (lg) — 48px</h2>
+        <div class="button-row">
+          <button class="ease-btn-icon-demo ease-btn-icon-lg" aria-label="Search">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
+          </button>
+          <button class="ease-btn-icon-demo ease-btn-icon-lg ease-btn-success" aria-label="Add item">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+          </button>
+          <button class="ease-btn-icon-demo ease-btn-icon-lg ease-btn-danger" aria-label="Delete">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path></svg>
+          </button>
+        </div>
+      </section>
+
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/buttons-icon-size-5947-ag/style.css
+++ b/submissions/examples/buttons-icon-size-5947-ag/style.css
@@ -1,0 +1,192 @@
+/* ============================================================
+   Icon Button Size Variants — style.css
+   Submission for EaseMotion CSS Issue #5947
+   Create small (sm) and large (lg) variants of ease-btn-icon
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --success-color: #10b981;
+  --danger-color: #ef4444;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 900px;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ── Showcase ── */
+.showcase {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 24px;
+}
+
+.demo-card {
+  padding: 24px;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: center;
+}
+
+.section-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+.button-row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ============================================================
+   Icon Button Base Component (Medium Default: 40px)
+   ============================================================ */
+
+.ease-btn-icon-demo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-primary);
+  cursor: pointer;
+  outline: none;
+  transition: background-color 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+}
+
+.ease-btn-icon-demo:hover {
+  background: rgba(255, 255, 255, 0.12);
+  transform: scale(1.05);
+}
+
+.ease-btn-icon-demo svg {
+  width: 18px;
+  height: 18px;
+}
+
+/* Color Overrides */
+.ease-btn-success {
+  background: rgba(16, 185, 129, 0.2);
+  border-color: rgba(16, 185, 129, 0.4);
+  color: #a7f3d0;
+}
+.ease-btn-success:hover {
+  background: rgba(16, 185, 129, 0.35);
+  border-color: rgba(16, 185, 129, 0.6);
+}
+
+.ease-btn-danger {
+  background: rgba(239, 68, 68, 0.2);
+  border-color: rgba(239, 68, 68, 0.4);
+  color: #fca5a5;
+}
+.ease-btn-danger:hover {
+  background: rgba(239, 68, 68, 0.35);
+  border-color: rgba(239, 68, 68, 0.6);
+}
+
+/* ============================================================
+   Small Variant (32px)
+   ============================================================ */
+
+.ease-btn-icon-sm {
+  width: 32px;
+  height: 32px;
+}
+
+.ease-btn-icon-sm svg {
+  width: 14px;
+  height: 14px;
+}
+
+/* ============================================================
+   Large Variant (48px)
+   ============================================================ */
+
+.ease-btn-icon-lg {
+  width: 48px;
+  height: 48px;
+}
+
+.ease-btn-icon-lg svg {
+  width: 22px;
+  height: 22px;
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-btn-icon-demo {
+    transition: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-btn-icon-sm` (32px) and `ease-btn-icon-lg` (48px) size variants for icon-only circular buttons. The core library defines standard `.ease-btn-icon` (40px) but misses matching size variations for layouts needing compact configurations (like inside toolbars or tables) or larger buttons (like hero play buttons).

## Root Cause
In `components/buttons.css`, only the default `.ease-btn-icon` (40px) is styled, leaving a mismatch with general button heights (btn-sm, btn-lg).

## Changes Made
- `submissions/examples/buttons-icon-size-5947-ag/demo.html`: Grid of icon buttons across three sizes (sm, default, lg) and colors (info/default, success, danger).
- `submissions/examples/buttons-icon-size-5947-ag/style.css`: Dimensions, SVG icon scaling ratios, alignments, and spacing configurations.
- `submissions/examples/buttons-icon-size-5947-ag/README.md`: Sizing table and layout validation guide.

## How to Test
1. Open `demo.html` in a browser.
2. Verify visual centering and proportional dimensions of circular icon buttons across sm, md, and lg formats.

## Related Issue
Closes #5947