### PR TITLE
[Feat] #5953 — Add utilities gap fallbacks demo (unique folder)

### DIFF
--- a/submissions/examples/utilities-gap-fallbacks-5953-ag/README.md
+++ b/submissions/examples/utilities-gap-fallbacks-5953-ag/README.md
@@ -1,0 +1,43 @@
+# Spacing Gap Utility Fallbacks
+
+This submission demonstrates and fixes the issue where some space/gap utility classes lack fallback definitions, leading to grid collapsed states in environments where `--ease-space-*` variables aren't globally defined.
+
+---
+
+## The Issue
+
+In `core/utilities.css`, utilities like `.ease-gap-1`, `.ease-gap-3`, and `.ease-gap-10` reference variables without standard fallback fallbacks:
+- `gap: var(--ease-space-1)` (missing `, 0.25rem`)
+- `gap: var(--ease-space-3)` (missing `, 0.75rem`)
+- `gap: var(--ease-space-10)` (missing `, 2.5rem`)
+
+If the space variables are not resolved or missing from the stylesheet, browser spacing collapses entirely.
+
+## The Fix
+
+Provide explicit fallback parameters inside `var()` properties:
+
+```css
+/* Gap-1 Fix */
+.ease-gap-1 {
+  gap: var(--ease-space-1, 0.25rem);
+}
+
+/* Gap-3 Fix */
+.ease-gap-3 {
+  gap: var(--ease-space-3, 0.75rem);
+}
+
+/* Gap-10 Fix */
+.ease-gap-10 {
+  gap: var(--ease-space-10, 2.5rem);
+}
+```
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. In the "Before" section, observe that the three grids have collapsed gap borders (0px spacing).
+3. In the "After" section, verify that standard spacing gaps (4px, 12px, 40px) are successfully applied.

--- a/submissions/examples/utilities-gap-fallbacks-5953-ag/demo.html
+++ b/submissions/examples/utilities-gap-fallbacks-5953-ag/demo.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gap Utility Fallbacks — EaseMotion CSS</title>
+  <meta name="description" content="Demo showing the missing var() fallback issue in gap utilities and its clean resolution.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Spacing Bug Demo</span>
+      <h1>Gap Utility Fallbacks</h1>
+      <p class="description">
+        Demonstrates how the absence of fallback values in <code>.ease-gap-1</code>, 
+        <code>.ease-gap-3</code>, and <code>.ease-gap-10</code> breaks grid layout gaps when 
+        design tokens are missing, and shows how adding fallbacks resolves this.
+      </p>
+    </header>
+
+    <main class="showcase">
+
+      <!-- Case 1: Broken state - No variables and no fallbacks -->
+      <section class="demo-section">
+        <h2 class="section-label">Before: Missing Fallbacks (Gaps Collapsed)</h2>
+        <div class="demo-grid-wrapper broken-gaps">
+          
+          <div class="test-grid test-gap-1-broken">
+            <div class="grid-box">1</div>
+            <div class="grid-box">2</div>
+            <div class="grid-box">3</div>
+          </div>
+          <span class="status-note text-danger">⚠️ gap-1 (0.25rem / 4px) collapsed</span>
+
+          <div class="test-grid test-gap-3-broken">
+            <div class="grid-box">1</div>
+            <div class="grid-box">2</div>
+            <div class="grid-box">3</div>
+          </div>
+          <span class="status-note text-danger">⚠️ gap-3 (0.75rem / 12px) collapsed</span>
+
+          <div class="test-grid test-gap-10-broken">
+            <div class="grid-box">1</div>
+            <div class="grid-box">2</div>
+            <div class="grid-box">3</div>
+          </div>
+          <span class="status-note text-danger">⚠️ gap-10 (2.5rem / 40px) collapsed</span>
+
+        </div>
+      </section>
+
+      <!-- Case 2: Fixed state - Fallbacks applied -->
+      <section class="demo-section">
+        <h2 class="section-label">After: Fallbacks Implemented (Correct Gaps)</h2>
+        <div class="demo-grid-wrapper fixed-gaps">
+          
+          <div class="test-grid test-gap-1-fixed">
+            <div class="grid-box">1</div>
+            <div class="grid-box">2</div>
+            <div class="grid-box">3</div>
+          </div>
+          <span class="status-note text-success">✅ gap-1 fallback (4px) active</span>
+
+          <div class="test-grid test-gap-3-fixed">
+            <div class="grid-box">1</div>
+            <div class="grid-box">2</div>
+            <div class="grid-box">3</div>
+          </div>
+          <span class="status-note text-success">✅ gap-3 fallback (12px) active</span>
+
+          <div class="test-grid test-gap-10-fixed">
+            <div class="grid-box">1</div>
+            <div class="grid-box">2</div>
+            <div class="grid-box">3</div>
+          </div>
+          <span class="status-note text-success">✅ gap-10 fallback (40px) active</span>
+
+        </div>
+      </section>
+
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/utilities-gap-fallbacks-5953-ag/style.css
+++ b/submissions/examples/utilities-gap-fallbacks-5953-ag/style.css
@@ -1,0 +1,168 @@
+/* ============================================================
+   Gap Utility Fallbacks — style.css
+   Submission for EaseMotion CSS Issue #5953
+   Add fallbacks to ease-gap-1, ease-gap-3, and ease-gap-10
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 820px;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ── Showcase ── */
+.showcase {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+  gap: 28px;
+}
+
+.demo-section {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 24px;
+  background: rgba(31, 41, 55, 0.2);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+}
+
+.section-label {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+.demo-grid-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  background: rgba(0, 0, 0, 0.2);
+  padding: 20px;
+  border-radius: 12px;
+}
+
+/* ── Grid Boxes ── */
+.test-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px dashed rgba(255, 255, 255, 0.1);
+  padding: 8px;
+  border-radius: 8px;
+}
+
+.grid-box {
+  background: linear-gradient(135deg, #7c3aed, #22d3ee);
+  color: #fff;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  border-radius: 4px;
+  font-size: 0.85rem;
+}
+
+/* ============================================================
+   Broken State (Without fallback variables)
+   ============================================================ */
+
+.broken-gaps .test-gap-1-broken {
+  gap: var(--ease-space-1); /* Undefined, browser collapses gap to 0 */
+}
+
+.broken-gaps .test-gap-3-broken {
+  gap: var(--ease-space-3); /* Undefined, browser collapses gap to 0 */
+}
+
+.broken-gaps .test-gap-10-broken {
+  gap: var(--ease-space-10); /* Undefined, browser collapses gap to 0 */
+}
+
+/* ============================================================
+   Fixed State (With CSS fallbacks)
+   ============================================================ */
+
+.fixed-gaps .test-gap-1-fixed {
+  gap: var(--ease-space-1, 0.25rem); /* Resolves to 0.25rem / 4px */
+}
+
+.fixed-gaps .test-gap-3-fixed {
+  gap: var(--ease-space-3, 0.75rem); /* Resolves to 0.75rem / 12px */
+}
+
+.fixed-gaps .test-gap-10-fixed {
+  gap: var(--ease-space-10, 2.5rem); /* Resolves to 2.5rem / 40px */
+}
+
+/* Spacing Status Helpers */
+.status-note {
+  font-size: 0.75rem;
+  font-weight: 600;
+  margin-top: -12px;
+}
+
+.text-danger { color: #f87171; }
+.text-success { color: #34d399; }


### PR DESCRIPTION
## Summary
Adds the spacing gap fallback demonstration. In `utilities.css`, `.ease-gap-1`, `.ease-gap-3`, and `.ease-gap-10` use `var(--ease-space-*)` variables without fallback pixel parameters, unlike other gap utilities. If spacing variables are missing or custom theme overrides are unset, browser gaps collapse to zero.

## Root Cause
In `core/utilities.css`, several gap values lack safe fallback definitions inside `var()`.

## Changes Made
- `submissions/examples/utilities-gap-fallbacks-5953-ag/demo.html`: Two-column comparison layout showing the broken collapsed boxes before, and the correctly spaced boxes after applying the fallback values.
- `submissions/examples/utilities-gap-fallbacks-5953-ag/style.css`: Grid boxes styling, spacing comparison classes, and fallback value overrides.
- `submissions/examples/utilities-gap-fallbacks-5953-ag/README.md`: Explains variables, fallbacks, and manual inspection details.

## How to Test
1. Open `demo.html` in a browser.
2. Verify that the "After" grids display gaps (4px, 12px, 40px) correctly while the "Before" grids are collapsed.

## Related Issue
Closes #5953