### PR TITLE
[Feat] #15911 — Add perspective-3d CSS demo (unique folder)

### DIFF
--- a/submissions/examples/ease-perspective-3d-15911-ag/README.md
+++ b/submissions/examples/ease-perspective-3d-15911-ag/README.md
@@ -1,0 +1,20 @@
+# 3D Perspective Gallery
+
+This submission implements a 3D Perspective Gallery showcasing CSS 3D capabilities (`perspective`, `transform-style: preserve-3d`, and `translateZ` spatial layout parameters).
+
+---
+
+## Technical Details
+
+- **Perspective Scene**: The outer container establishes a viewport depth. Adjusting the perspective range dynamically changes vanishing point distance (smaller = greater distortion).
+- **preserve-3d**: Keeps cards aligned relative to parent axes rotations.
+- **translateZ**: Places elements at distinct depths, creating parallax spatial depth.
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Drag the **Perspective** slider — verify the 3D depth distortion changes dynamically.
+3. Drag the **Rotate Y** slider — observe how the three cards rotate around a central axis while preserving depth.
+4. Enable `prefers-reduced-motion` — verify all Y-rotations are disabled.

--- a/submissions/examples/ease-perspective-3d-15911-ag/demo.html
+++ b/submissions/examples/ease-perspective-3d-15911-ag/demo.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>3D Perspective Gallery — EaseMotion CSS</title>
+  <meta name="description" content="Showcase of CSS perspective-3d utility features showing how varying perspective depths affect layout distortion.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — 3D Utilities</span>
+      <h1>3D Perspective Gallery</h1>
+      <p class="description">
+        Demonstrates the impact of <code>perspective</code> on 3D elements. 
+        Adjust the slider to change perspective values and rotate the gallery.
+      </p>
+    </header>
+
+    <!-- Interactive Sliders -->
+    <div class="controls-panel">
+      <div class="control-group">
+        <label for="perspective-range">Perspective: <span id="perspective-val">600px</span></label>
+        <input type="range" id="perspective-range" min="200" max="1500" value="600">
+      </div>
+      <div class="control-group">
+        <label for="rotate-range">Rotate Y: <span id="rotate-val">-20deg</span></label>
+        <input type="range" id="rotate-range" min="-180" max="180" value="-20">
+      </div>
+    </div>
+
+    <main class="showcase">
+      
+      <!-- Perspective Scene -->
+      <div class="perspective-scene" id="scene" style="perspective: 600px;">
+        <div class="gallery-3d" id="gallery" style="transform: rotateY(-20deg);">
+          
+          <div class="gallery-card card-left">
+            <span class="card-num">01</span>
+            <h3>Deep View</h3>
+            <p>Rotated left to emphasize perspective depth.</p>
+          </div>
+
+          <div class="gallery-card card-center">
+            <span class="card-num">02</span>
+            <h3>Frontal View</h3>
+            <p>Centered card showing baseline parameters.</p>
+          </div>
+
+          <div class="gallery-card card-right">
+            <span class="card-num">03</span>
+            <h3>Wide Angle</h3>
+            <p>Rotated right to demonstrate side vanishing points.</p>
+          </div>
+
+        </div>
+      </div>
+
+    </main>
+  </div>
+
+  <script>
+    const perspectiveSlider = document.getElementById('perspective-range');
+    const rotateSlider = document.getElementById('rotate-range');
+    
+    const pVal = document.getElementById('perspective-val');
+    const rVal = document.getElementById('rotate-val');
+    
+    const scene = document.getElementById('scene');
+    const gallery = document.getElementById('gallery');
+
+    perspectiveSlider.addEventListener('input', () => {
+      const p = `${perspectiveSlider.value}px`;
+      pVal.textContent = p;
+      scene.style.perspective = p;
+    });
+
+    rotateSlider.addEventListener('input', () => {
+      const r = `${rotateSlider.value}deg`;
+      rVal.textContent = r;
+      gallery.style.transform = `rotateY(${r})`;
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-perspective-3d-15911-ag/style.css
+++ b/submissions/examples/ease-perspective-3d-15911-ag/style.css
@@ -1,0 +1,193 @@
+/* ============================================================
+   3D Perspective Gallery — style.css
+   Submission for EaseMotion CSS Issue #15911
+   CSS 3D perspective scenes with interactive rotation
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.55);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 900px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+  align-items: center;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ── Controls Panel ── */
+.controls-panel {
+  display: flex;
+  gap: 28px;
+  flex-wrap: wrap;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--card-border);
+  padding: 16px 28px;
+  border-radius: 16px;
+  justify-content: center;
+}
+
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 180px;
+}
+
+.control-group label {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+}
+
+.control-group input[type="range"] {
+  accent-color: var(--primary-color);
+  cursor: pointer;
+}
+
+/* ── Showcase Scene ── */
+.showcase {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 40px 0;
+}
+
+.perspective-scene {
+  width: 100%;
+  max-width: 760px;
+  height: 340px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.gallery-3d {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  transform-style: preserve-3d;
+  transition: transform 0.1s ease;
+}
+
+/* ── Gallery Cards ── */
+.gallery-card {
+  position: absolute;
+  width: 200px;
+  height: 280px;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 20px;
+  padding: 24px;
+  backdrop-filter: blur(8px);
+  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  backface-visibility: visible;
+  transition: transform 0.3s ease;
+}
+
+.card-num {
+  font-size: 0.75rem;
+  font-weight: 800;
+  color: #22d3ee;
+}
+
+.gallery-card h3 {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin-top: 12px;
+}
+
+.gallery-card p {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+/* 3D Placement mappings */
+.card-left {
+  transform: rotateY(45deg) translateZ(160px);
+  background: linear-gradient(135deg, rgba(30, 41, 59, 0.8), rgba(124, 58, 237, 0.2));
+}
+
+.card-center {
+  transform: translateZ(260px);
+  border-color: rgba(124, 58, 237, 0.3);
+}
+
+.card-right {
+  transform: rotateY(-45deg) translateZ(160px);
+  background: linear-gradient(135deg, rgba(30, 41, 59, 0.8), rgba(6, 182, 212, 0.2));
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .gallery-3d,
+  .gallery-card {
+    transform: none !important;
+    transition: none !important;
+  }
+  .controls-panel {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-perspective-3d` showcase. It features three-dimensional layout cards rotated in virtual space, using `perspective` and `transform-style: preserve-3d` properties. It includes sliders to dynamically adjust viewport depth and rotation, with fallbacks for motion sensitivities.

## Root Cause
No interactive perspective or 3D coordinate mapping demonstration existed in EaseMotion CSS to show how to combine layout components with 3D translation rules.

## Changes Made
- `submissions/examples/ease-perspective-3d-15911-ag/demo.html`: Container elements showing perspective depths with active sliders.
- `submissions/examples/ease-perspective-3d-15911-ag/style.css`: 3D gallery cards rotated using `translateZ` offsets, slider inputs styling, and accessibility adjustments.
- `submissions/examples/ease-perspective-3d-15911-ag/README.md`: Breakdown of vanishing points, 3D rotations, and testing instructions.

## How to Test
1. Open `demo.html` in a browser.
2. Drag depth and rotation ranges to observe visual adjustments.

## Related Issue
Closes #15911