### PR TITLE
[Feat] #15903 — Add backdrop-filter-saturate CSS demo (unique folder)

### DIFF
--- a/submissions/examples/ease-backdrop-filter-saturate-15903-ag/README.md
+++ b/submissions/examples/ease-backdrop-filter-saturate-15903-ag/README.md
@@ -1,0 +1,23 @@
+# Backdrop Filter Saturate
+
+This submission implements a frosted glass UI panel showcase demonstrating the visual capabilities of CSS `backdrop-filter: saturate()`.
+
+---
+
+## Technical Details
+
+- **Frosted Glass Integration**: Leverages `backdrop-filter` combining `blur()` and `saturate()` parameters.
+- **Dynamic Backgrounds**: Uses absolute positioned color blobs that slide behind the elements to highlight the saturation values.
+- **Modifiers**:
+  - Normal Glass: `backdrop-filter: blur(12px)`
+  - Double Saturation: `backdrop-filter: saturate(200%) blur(12px)`
+  - Triple Saturation: `backdrop-filter: saturate(300%) blur(12px)`
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Watch the background blobs move behind the glass panels.
+3. Observe how the cyan and purple blobs become intensely colored and vibrant when passing behind the 200% and 300% saturated glass cards.
+4. Enable `prefers-reduced-motion` — verify background blob movement stops.

--- a/submissions/examples/ease-backdrop-filter-saturate-15903-ag/demo.html
+++ b/submissions/examples/ease-backdrop-filter-saturate-15903-ag/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Backdrop Filter Saturate — EaseMotion CSS</title>
+  <meta name="description" content="Frosted glass UI panels showcasing CSS backdrop-filter saturate effects over moving background color blobs.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Animated Color Blobs in Background -->
+  <div class="blob blob-1" aria-hidden="true"></div>
+  <div class="blob blob-2" aria-hidden="true"></div>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Filter Utilities</span>
+      <h1>Backdrop Filter Saturate</h1>
+      <p class="description">
+        Observe how the glass cards saturate the moving color blobs underneath.
+        Compare standard glass, double saturation, and triple saturation.
+      </p>
+    </header>
+
+    <main class="showcase">
+
+      <!-- Case 1: Standard Glass (Saturate 100%) -->
+      <section class="glass-card glass-normal">
+        <span class="glass-tag">Normal</span>
+        <h2>Baseline Glass</h2>
+        <p>Standard frosted glass using <code>backdrop-filter: blur(12px)</code>. Background colors pass through unchanged.</p>
+      </section>
+
+      <!-- Case 2: Saturated Glass (Saturate 200%) -->
+      <section class="glass-card glass-saturate-200">
+        <span class="glass-tag tag-cyan">Saturate 200%</span>
+        <h2>Enhanced Colors</h2>
+        <p>Uses <code>backdrop-filter: saturate(200%) blur(12px)</code>. Background elements become twice as vibrant.</p>
+      </section>
+
+      <!-- Case 3: Saturated Glass (Saturate 300%) -->
+      <section class="glass-card glass-saturate-300">
+        <span class="glass-tag tag-purple">Saturate 300%</span>
+        <h2>Vivid Spectrum</h2>
+        <p>Uses <code>backdrop-filter: saturate(300%) blur(12px)</code>. Background colors pop intensely under the frosted layer.</p>
+      </section>
+
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-backdrop-filter-saturate-15903-ag/style.css
+++ b/submissions/examples/ease-backdrop-filter-saturate-15903-ag/style.css
@@ -1,0 +1,199 @@
+/* ============================================================
+   Backdrop Filter Saturate — style.css
+   Submission for EaseMotion CSS Issue #15903
+   Frosted glass overlays with background saturation modifiers
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #070913 0%, #0d111d 100%);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  overflow-x: hidden;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 960px;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+  position: relative;
+  z-index: 10;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Background Animated Color Blobs
+   ============================================================ */
+
+.blob {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(80px);
+  opacity: 0.45;
+  z-index: 1;
+}
+
+.blob-1 {
+  width: 320px;
+  height: 320px;
+  background: #7c3aed;
+  top: 15%;
+  left: 20%;
+  animation: moveBlob1 12s infinite alternate ease-in-out;
+}
+
+.blob-2 {
+  width: 280px;
+  height: 280px;
+  background: #06b6d4;
+  bottom: 15%;
+  right: 20%;
+  animation: moveBlob2 10s infinite alternate ease-in-out;
+}
+
+@keyframes moveBlob1 {
+  0%   { transform: translate(0, 0) scale(1); }
+  100% { transform: translate(120px, 80px) scale(1.2); }
+}
+
+@keyframes moveBlob2 {
+  0%   { transform: translate(0, 0) scale(1); }
+  100% { transform: translate(-100px, -60px) scale(0.85); }
+}
+
+/* ============================================================
+   Glass Cards & Backdrop Filters
+   ============================================================ */
+
+.showcase {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 28px;
+}
+
+.glass-card {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--card-border);
+  border-radius: 24px;
+  padding: 36px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+  transition: transform 0.25s ease;
+}
+
+.glass-card:hover {
+  transform: translateY(-4px);
+}
+
+.glass-tag {
+  align-self: flex-start;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 4px 8px;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-secondary);
+  border-radius: 4px;
+}
+
+.tag-cyan {
+  background: rgba(6, 182, 212, 0.15);
+  color: #67e8f9;
+}
+
+.tag-purple {
+  background: rgba(124, 58, 237, 0.15);
+  color: #c4b5fd;
+}
+
+.glass-card h2 {
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.glass-card p {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+/* ── Backdrop Filter Variations ── */
+
+.glass-normal {
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.glass-saturate-200 {
+  backdrop-filter: saturate(200%) blur(12px);
+  -webkit-backdrop-filter: saturate(200%) blur(12px);
+}
+
+.glass-saturate-300 {
+  backdrop-filter: saturate(300%) blur(12px);
+  -webkit-backdrop-filter: saturate(300%) blur(12px);
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .blob {
+    animation: none !important;
+  }
+  .glass-card {
+    transition: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-backdrop-filter-saturate` showcase. It demonstrates frosted-glass card panels utilizing `backdrop-filter: saturate()` parameters (normal, 200%, and 300% saturation) over moving animated background blobs to show color saturation changes.

## Root Cause
No backdrop filter or color saturation utility demonstrations existed in EaseMotion CSS to show how to build frosted glass elements.

## Changes Made
- `submissions/examples/ease-backdrop-filter-saturate-15903-ag/demo.html`: Card panels showing different saturation levels over absolute color nodes.
- `submissions/examples/ease-backdrop-filter-saturate-15903-ag/style.css`: Background blobs, keyframe translations, backdrop filter properties, and responsive grid parameters.
- `submissions/examples/ease-backdrop-filter-saturate-15903-ag/README.md`: Explains saturation levels, frosted glass styling, and manual inspection.

## How to Test
1. Open `demo.html` in a browser.
2. Watch the moving color spheres to observe how colors saturate as they pass underneath each card.

## Related Issue
Closes #15903