### PR TITLE
[Feat] #15901 — Add filter-brightness-utilities CSS demo (unique folder)

### DIFF
--- a/submissions/examples/ease-filter-brightness-15901-ag/README.md
+++ b/submissions/examples/ease-filter-brightness-15901-ag/README.md
@@ -1,0 +1,22 @@
+# Filter Brightness Utilities
+
+This submission implements a visual demonstration of CSS `filter: brightness()` utilities.
+
+---
+
+## Technical Details
+
+CSS brightness filters dynamically adjust element exposure values without requiring image pre-processing.
+
+The classes are configured as:
+- Dim State: `filter: brightness(0.55)` (increases to `1.0` on hover)
+- Baseline State: `filter: brightness(1.0)`
+- Bright State: `filter: brightness(1.45)` (decreases to `1.0` on hover)
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Inspect the three cards: notice that the image backgrounds display dim, normal, and bright color schemes respectively.
+3. Hover over the **Dim** and **Bright** cards — verify their background exposure values return to the default baseline 100% state.

--- a/submissions/examples/ease-filter-brightness-15901-ag/demo.html
+++ b/submissions/examples/ease-filter-brightness-15901-ag/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Filter Brightness Utilities — EaseMotion CSS</title>
+  <meta name="description" content="Showcase of CSS filter brightness utilities demonstrating dim, normal, and bright image card states.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Filter Utilities</span>
+      <h1>Filter Brightness Utilities</h1>
+      <p class="description">
+        Demonstrates the visual effect of brightness filters. Hover over each card to toggle between modified and baseline states.
+      </p>
+    </header>
+
+    <main class="showcase">
+
+      <!-- Case 1: Dim State (50% Brightness) -->
+      <section class="demo-card brightness-dim">
+        <div class="card-image-bg" style="background: linear-gradient(135deg, #f59e0b, #ef4444);"></div>
+        <div class="card-content">
+          <span class="brightness-tag">Dim (50%)</span>
+          <h2>Atmospheric Glow</h2>
+          <p>This card is dimmed to 50% brightness. Hovering increases brightness back to 100%.</p>
+        </div>
+      </section>
+
+      <!-- Case 2: Normal State (100% Brightness) -->
+      <section class="demo-card brightness-normal">
+        <div class="card-image-bg" style="background: linear-gradient(135deg, #7c3aed, #22d3ee);"></div>
+        <div class="card-content">
+          <span class="brightness-tag">Normal (100%)</span>
+          <h2>Baseline Balance</h2>
+          <p>This card maintains baseline 100% brightness. Hovering has no modification.</p>
+        </div>
+      </section>
+
+      <!-- Case 3: Bright State (150% Brightness) -->
+      <section class="demo-card brightness-bright">
+        <div class="card-image-bg" style="background: linear-gradient(135deg, #10b981, #3b82f6);"></div>
+        <div class="card-content">
+          <span class="brightness-tag">Bright (150%)</span>
+          <h2>High Contrast</h2>
+          <p>This card is boosted to 150% brightness. Hovering dims it back down to 100%.</p>
+        </div>
+      </section>
+
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-filter-brightness-15901-ag/style.css
+++ b/submissions/examples/ease-filter-brightness-15901-ag/style.css
@@ -1,0 +1,164 @@
+/* ============================================================
+   Filter Brightness Utilities — style.css
+   Submission for EaseMotion CSS Issue #15901
+   Varying brightness filter configurations (dim, normal, bright)
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 900px;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ── Showcase ── */
+.showcase {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 28px;
+}
+
+.demo-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 20px;
+  overflow: hidden;
+  backdrop-filter: blur(8px);
+  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.25s ease, filter 0.25s ease;
+}
+
+.demo-card:hover {
+  transform: translateY(-4px);
+}
+
+.card-image-bg {
+  height: 140px;
+  width: 100%;
+  transition: filter 0.25s ease;
+}
+
+.card-content {
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.brightness-tag {
+  align-self: flex-start;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 4px 8px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 4px;
+  color: var(--text-secondary);
+}
+
+.demo-card h2 {
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.demo-card p {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+/* ============================================================
+   Brightness Filter Configurations
+   ============================================================ */
+
+/* Dim State */
+.brightness-dim .card-image-bg {
+  filter: brightness(0.55);
+}
+.brightness-dim:hover .card-image-bg {
+  filter: brightness(1.0);
+}
+
+/* Normal State */
+.brightness-normal .card-image-bg {
+  filter: brightness(1.0);
+}
+
+/* Bright State */
+.brightness-bright .card-image-bg {
+  filter: brightness(1.45);
+}
+.brightness-bright:hover .card-image-bg {
+  filter: brightness(1.0);
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .demo-card,
+  .card-image-bg {
+    transition: none !important;
+    transform: none !important;
+    filter: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-filter-brightness` showcase. It demonstrates how CSS `filter: brightness()` changes visual components under three baseline configurations (dim at 55%, normal at 100%, and bright at 145%). Transitions occur smoothly on mouse hover events.

## Root Cause
No filter brightness utility examples or guides existed in EaseMotion CSS to show how to adjust element exposure values.

## Changes Made
- `submissions/examples/ease-filter-brightness-15901-ag/demo.html`: Three card layouts showcasing dim, default, and bright image backgrounds.
- `submissions/examples/ease-filter-brightness-15901-ag/style.css`: Exposure parameters, hover transitions, tag labeling, and column sizes.
- `submissions/examples/ease-filter-brightness-15901-ag/README.md`: Explains CSS brightness logic, parameters, and manual inspection.

## How to Test
1. Open `demo.html` in a browser.
2. Hover over the cards to verify that brightness transitions work as expected.

## Related Issue
Closes #15901