### PR TITLE
[Feat] #15131 — Add text-overflow-ellipsis utility (unique folder)

### DIFF
--- a/submissions/examples/ease-text-ellipsis-15131-ag/README.md
+++ b/submissions/examples/ease-text-ellipsis-15131-ag/README.md
@@ -1,0 +1,28 @@
+# Text Overflow Ellipsis Utility
+
+This submission demonstrates and implements the `.ease-text-overflow-ellipsis` typography utility class designed to truncate long heading strings to a single line with trailing `...` text.
+
+---
+
+## Technical Overview
+
+Text wrapping inside structured card components can break visual alignments. The truncation utility is declared using:
+
+```css
+.ease-text-overflow-ellipsis {
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+```
+
+This prevents text from wrapping to multiple lines while indicating to users that additional hidden copy exists.
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. In the **Without Truncation** card, observe how the long heading wraps to 3 lines, shifting card body paragraphs downwards.
+3. In the **With Ellipsis Truncation** card, verify that the heading is truncated cleanly to a single line with `...` at the end, maintaining card layout alignment.

--- a/submissions/examples/ease-text-ellipsis-15131-ag/demo.html
+++ b/submissions/examples/ease-text-ellipsis-15131-ag/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Text Overflow Ellipsis — EaseMotion CSS</title>
+  <meta name="description" content="Demo of text truncation using the ease-text-overflow-ellipsis utility class in card components.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Typography Utilities</span>
+      <h1>Text Overflow Ellipsis</h1>
+      <p class="description">
+        Demonstrates the utility class <code>ease-text-overflow-ellipsis</code>. 
+        Compare how long headings break layouts versus how truncation with ellipsis preserves alignment.
+      </p>
+    </header>
+
+    <main class="showcase">
+
+      <!-- Case 1: Without Truncation (Wraps & Breaks Heights) -->
+      <article class="demo-card">
+        <span class="status-badge badge-warning">Without Truncation</span>
+        <div class="card-content">
+          <h2 class="long-title">Extremely Long Card Heading That Wraps and Breaks Grid Layout Alignments</h2>
+          <p>The long heading wraps to multiple lines, pushing the content down and breaking vertical grid alignment relative to sibling cards.</p>
+        </div>
+      </article>
+
+      <!-- Case 2: With Truncation (Ellipsis) -->
+      <article class="demo-card">
+        <span class="status-badge badge-success">With Ellipsis Truncation</span>
+        <div class="card-content">
+          <h2 class="long-title ease-text-overflow-ellipsis">Extremely Long Card Heading That Wraps and Breaks Grid Layout Alignments</h2>
+          <p>The heading is truncated gracefully to a single line with an trailing ellipsis. Sibling card heights remain perfectly aligned.</p>
+        </div>
+      </article>
+
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-text-ellipsis-15131-ag/style.css
+++ b/submissions/examples/ease-text-ellipsis-15131-ag/style.css
@@ -1,0 +1,140 @@
+/* ============================================================
+   Text Overflow Ellipsis — style.css
+   Submission for EaseMotion CSS Issue #15131
+   Grids showcasing layout impact of single-line text truncation
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --success-color: #10b981;
+  --warning-color: #f59e0b;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 820px;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ── Showcase ── */
+.showcase {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 28px;
+}
+
+.demo-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 20px;
+  padding: 32px 24px;
+  backdrop-filter: blur(8px);
+  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.status-badge {
+  align-self: flex-start;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+.badge-warning {
+  background: rgba(245, 158, 11, 0.15);
+  color: #fcd34d;
+}
+
+.badge-success {
+  background: rgba(16, 185, 129, 0.15);
+  color: #a7f3d0;
+}
+
+.card-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.long-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.card-content p {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+/* ============================================================
+   Text Overflow Ellipsis Class (Core implementation under test)
+   ============================================================ */
+
+.ease-text-overflow-ellipsis {
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}


### PR DESCRIPTION
## Summary
Adds the `ease-text-ellipsis` showcase. It demonstrates the utility class `.ease-text-overflow-ellipsis` which handles single-line truncation using `white-space: nowrap`, `overflow: hidden`, and `text-overflow: ellipsis` rules to preserve heights and alignments in card grid systems.

## Root Cause
No truncation or text-overflow ellipsis helper demonstrations existed in EaseMotion CSS to show how to handle overflow copy in card headers.

## Changes Made
- `submissions/examples/ease-text-ellipsis-15131-ag/demo.html`: Two cards displaying the visual difference between wrapped and truncated card headers.
- `submissions/examples/ease-text-ellipsis-15131-ag/style.css`: Truncation rules, card dimensions, and layout configurations.
- `submissions/examples/ease-text-ellipsis-15131-ag/README.md`: Explains truncation logic and verification.

## How to Test
1. Open `demo.html` in a browser.
2. Observe how the truncated card preserves single-line boundaries.

## Related Issue
Closes #15131