### PR TITLE
[Feat] #15127 — Add scroll-snap-type-x utility (unique folder)

### DIFF
--- a/submissions/examples/ease-scroll-snap-15127-ag/README.md
+++ b/submissions/examples/ease-scroll-snap-15127-ag/README.md
@@ -1,0 +1,21 @@
+# Scroll Snap Type X Utility
+
+This submission implements a horizontal gallery carousel demonstrating the visual behaviors of `ease-scroll-snap-x-mandatory` and `ease-scroll-snap-x-proximity` utility classes.
+
+---
+
+## Technical Overview
+
+Horizontal scroll snapping coordinates scroll boundaries for mobile sliders, galleries, and carousel layouts without heavy scroll velocity calculation scripts.
+
+The utility definitions are:
+- Mandatory Snap (`ease-scroll-snap-x-mandatory`): `scroll-snap-type: x mandatory;` — forces the viewport to snap to a slide boundary immediately upon release.
+- Proximity Snap (`ease-scroll-snap-x-proximity`): `scroll-snap-type: x proximity;` — snaps to boundaries only if the scroll release position is close to the threshold.
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Swipe or scroll horizontally inside the **Mandatory Snap** container — verify it locks perfectly onto a slide boundary when released.
+3. Scroll inside the **Proximity Snap** container — observe that it only snaps if you release near a slide boundary.

--- a/submissions/examples/ease-scroll-snap-15127-ag/demo.html
+++ b/submissions/examples/ease-scroll-snap-15127-ag/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scroll Snap Type X — EaseMotion CSS</title>
+  <meta name="description" content="Horizontal carousel slider showing CSS scroll-snap-type-x mandatory and proximity behaviors.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Navigation Utilities</span>
+      <h1>Scroll Snap Type X</h1>
+      <p class="description">
+        Demonstrates the utility classes <code>ease-scroll-snap-x-mandatory</code> and <code>ease-scroll-snap-x-proximity</code>.
+        Swipe horizontally across the slides below to test snap constraints.
+      </p>
+    </header>
+
+    <main class="showcase">
+
+      <!-- Case 1: Mandatory Snap -->
+      <section class="demo-section">
+        <h2 class="section-title">Mandatory Snap (Locks to slide boundary)</h2>
+        <div class="snap-viewport ease-scroll-snap-x-mandatory">
+          <div class="snap-slide slide-1"><span>Slide 01</span></div>
+          <div class="snap-slide slide-2"><span>Slide 02</span></div>
+          <div class="snap-slide slide-3"><span>Slide 03</span></div>
+          <div class="snap-slide slide-4"><span>Slide 04</span></div>
+        </div>
+      </section>
+
+      <!-- Case 2: Proximity Snap -->
+      <section class="demo-section">
+        <h2 class="section-title">Proximity Snap (Snaps only when close)</h2>
+        <div class="snap-viewport ease-scroll-snap-x-proximity">
+          <div class="snap-slide slide-1"><span>Slide 01</span></div>
+          <div class="snap-slide slide-2"><span>Slide 02</span></div>
+          <div class="snap-slide slide-3"><span>Slide 03</span></div>
+          <div class="snap-slide slide-4"><span>Slide 04</span></div>
+        </div>
+      </section>
+
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-scroll-snap-15127-ag/style.css
+++ b/submissions/examples/ease-scroll-snap-15127-ag/style.css
@@ -1,0 +1,149 @@
+/* ============================================================
+   Scroll Snap Type X — style.css
+   Submission for EaseMotion CSS Issue #15127
+   Horizontal carousels with mandatory and proximity snap types
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 820px;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ── Showcase ── */
+.showcase {
+  display: flex;
+  flex-direction: column;
+  gap: 36px;
+}
+
+.demo-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.section-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+/* ============================================================
+   Scroll Snap Core Viewport
+   ============================================================ */
+
+.snap-viewport {
+  display: flex;
+  overflow-x: auto;
+  gap: 16px;
+  padding: 12px;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  scrollbar-width: none; /* Hide scrollbar for clean UI (Firefox) */
+}
+
+.snap-viewport::-webkit-scrollbar {
+  display: none; /* Hide scrollbar (Chrome/Safari) */
+}
+
+.snap-slide {
+  flex: 0 0 280px;
+  height: 160px;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  font-weight: 800;
+  color: #fff;
+  scroll-snap-align: start; /* Standard item behavior */
+  box-shadow: 0 8px 20px rgba(0,0,0,0.15);
+}
+
+/* Background Gradients */
+.slide-1 { background: linear-gradient(135deg, #7c3aed, #6366f1); }
+.slide-2 { background: linear-gradient(135deg, #06b6d4, #0ea5e9); }
+.slide-3 { background: linear-gradient(135deg, #10b981, #14b8a6); }
+.slide-4 { background: linear-gradient(135deg, #f59e0b, #ef4444); }
+
+/* ============================================================
+   Scroll Snap Type Utilities (Core classes under test)
+   ============================================================ */
+
+.ease-scroll-snap-x-mandatory {
+  scroll-snap-type: x mandatory;
+}
+
+.ease-scroll-snap-x-proximity {
+  scroll-snap-type: x proximity;
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .snap-viewport {
+    scroll-snap-type: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-scroll-snap-15127` showcase demonstrating `ease-scroll-snap-x-mandatory` and `ease-scroll-snap-x-proximity` container properties. Users can swipe or scroll horizontally to test snapping behaviors.

## Root Cause
No scroll-snap container utility demonstrations or guides existed in EaseMotion CSS to show how to build CSS-only carousels and galleries.

## Changes Made
- `submissions/examples/ease-scroll-snap-15127-ag/demo.html`: Two horizontal slider viewports presenting mandatory and proximity scroll snapping.
- `submissions/examples/ease-scroll-snap-15127-ag/style.css`: Viewport constraints, flex slide items, scroll-snap-type classes, and color formatting.
- `submissions/examples/ease-scroll-snap-15127-ag/README.md`: Explains snap types, carousel structures, and manual validation.

## How to Test
1. Open `demo.html` in a browser.
2. Scroll horizontally to verify snapping behaviors.

## Related Issue
Closes #15127