### PR TITLE
[Feat] #15123 — Add scroll-snap-align-start utility (unique folder)

### DIFF
--- a/submissions/examples/ease-scroll-snap-align-15123-ag/README.md
+++ b/submissions/examples/ease-scroll-snap-align-15123-ag/README.md
@@ -1,0 +1,25 @@
+# Scroll Snap Align Start Utility
+
+This submission implements a horizontal gallery carousel demonstrating the visual behavior of the `ease-scroll-snap-align-start` utility class.
+
+---
+
+## Technical Overview
+
+While the container defines the snap type framework, child items must declare snap alignment rules to lock the layout onto viewport bounds:
+
+```css
+.ease-scroll-snap-align-start {
+  scroll-snap-align: start;
+}
+```
+
+This locks the slide's left boundary flush against the viewport's left edge upon scrolling release.
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Swipe or scroll horizontally inside the **With snap-align-start** container — verify cards snap flush against the left boundary.
+3. Scroll inside the **Without snap-align-start** container — verify that cards scroll freely without locking.

--- a/submissions/examples/ease-scroll-snap-align-15123-ag/demo.html
+++ b/submissions/examples/ease-scroll-snap-align-15123-ag/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scroll Snap Align Start — EaseMotion CSS</title>
+  <meta name="description" content="Comparison of horizontal scroll snapping with and without scroll-snap-align-start child properties.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Layout Utilities</span>
+      <h1>Scroll Snap Align Start</h1>
+      <p class="description">
+        Demonstrates the utility class <code>ease-scroll-snap-align-start</code> on child elements.
+        Compare snapping alignment on the left versus continuous unaligned scrolling.
+      </p>
+    </header>
+
+    <main class="showcase">
+
+      <!-- Case 1: Aligned Start -->
+      <section class="demo-section">
+        <h2 class="section-title">With snap-align-start (Snaps to left boundary)</h2>
+        <div class="snap-viewport snap-x-mandatory">
+          <div class="snap-slide ease-scroll-snap-align-start slide-1"><span>Card 01</span></div>
+          <div class="snap-slide ease-scroll-snap-align-start slide-2"><span>Card 02</span></div>
+          <div class="snap-slide ease-scroll-snap-align-start slide-3"><span>Card 03</span></div>
+          <div class="snap-slide ease-scroll-snap-align-start slide-4"><span>Card 04</span></div>
+        </div>
+      </section>
+
+      <!-- Case 2: No Alignment (Free Scroll) -->
+      <section class="demo-section">
+        <h2 class="section-title">Without snap-align-start (Continuous scroll, no snapping)</h2>
+        <div class="snap-viewport snap-x-mandatory">
+          <div class="snap-slide slide-1"><span>Card 01</span></div>
+          <div class="snap-slide slide-2"><span>Card 02</span></div>
+          <div class="snap-slide slide-3"><span>Card 03</span></div>
+          <div class="snap-slide slide-4"><span>Card 04</span></div>
+        </div>
+      </section>
+
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-scroll-snap-align-15123-ag/style.css
+++ b/submissions/examples/ease-scroll-snap-align-15123-ag/style.css
@@ -1,0 +1,145 @@
+/* ============================================================
+   Scroll Snap Align Start — style.css
+   Submission for EaseMotion CSS Issue #15123
+   Carousels demonstrating snap alignment constraints
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 820px;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ── Showcase ── */
+.showcase {
+  display: flex;
+  flex-direction: column;
+  gap: 36px;
+}
+
+.demo-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.section-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+/* ── Viewport ── */
+.snap-viewport {
+  display: flex;
+  overflow-x: auto;
+  gap: 16px;
+  padding: 12px;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  scrollbar-width: none;
+}
+
+.snap-viewport::-webkit-scrollbar {
+  display: none;
+}
+
+.snap-slide {
+  flex: 0 0 280px;
+  height: 160px;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  font-weight: 800;
+  color: #fff;
+  box-shadow: 0 8px 20px rgba(0,0,0,0.15);
+}
+
+/* Background Gradients */
+.slide-1 { background: linear-gradient(135deg, #7c3aed, #6366f1); }
+.slide-2 { background: linear-gradient(135deg, #06b6d4, #0ea5e9); }
+.slide-3 { background: linear-gradient(135deg, #10b981, #14b8a6); }
+.slide-4 { background: linear-gradient(135deg, #f59e0b, #ef4444); }
+
+.snap-x-mandatory {
+  scroll-snap-type: x mandatory;
+}
+
+/* ============================================================
+   Scroll Snap Align Class (Core utility under test)
+   ============================================================ */
+
+.ease-scroll-snap-align-start {
+  scroll-snap-align: start;
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-scroll-snap-align-start {
+    scroll-snap-align: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-scroll-snap-align-15123` showcase demonstrating the `ease-scroll-snap-align-start` child item property. It compares a snapped grid carousel against a free-scrolling container to show alignment constraints.

## Root Cause
No scroll-snap item alignment demonstrations or guides existed in EaseMotion CSS to show how to configure child slide alignments.

## Changes Made
- `submissions/examples/ease-scroll-snap-align-15123-ag/demo.html`: Two horizontal carousel layouts showing snap alignment start vs no alignment.
- `submissions/examples/ease-scroll-snap-align-15123-ag/style.css`: Carousel flex bounds, slide sizes, scroll-snap-align settings, and gradient formatting.
- `submissions/examples/ease-scroll-snap-align-15123-ag/README.md`: Explains snap alignments, slide offsets, and testing steps.

## How to Test
1. Open `demo.html` in a browser.
2. Scroll horizontally to verify slide alignment bounds on snapping.

## Related Issue
Closes #15123