### PR TITLE
[Feat] #15110 — Add object-scale-down utility (unique folder)

### DIFF
--- a/submissions/examples/ease-object-scale-down-15110-ag/README.md
+++ b/submissions/examples/ease-object-scale-down-15110-ag/README.md
@@ -1,0 +1,19 @@
+# Object Scale Down Utility
+
+This submission implements a media fit comparison showcase demonstrating the visual output of the `ease-object-scale-down` utility class.
+
+---
+
+## Technical Details
+
+The `object-fit` parameters determine how replaceable elements (like `<img>`, `<video>`, `<svg>`) fill their structural boxes:
+- **Cover**: Resizes to fill parent box, cropping as needed.
+- **Contain**: Fits entire asset inside parent box, maintaining aspect ratio.
+- **Scale-Down**: Dynamically acts as `none` (smaller natural size) or `contain` (larger natural size), preventing pixelation of small assets.
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Observe the three panels: verify that the center circle in the **Scale-Down** card is correctly contained and not stretched or cropped.

--- a/submissions/examples/ease-object-scale-down-15110-ag/demo.html
+++ b/submissions/examples/ease-object-scale-down-15110-ag/demo.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Object Scale Down Utility — EaseMotion CSS</title>
+  <meta name="description" content="Comparison showcase of CSS object-fit cover, contain, and scale-down utilities using responsive grids.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Media Utilities</span>
+      <h1>Object Scale Down</h1>
+      <p class="description">
+        Demonstrates the utility class <code>ease-object-scale-down</code>. 
+        Compare how layout elements containing images scale, crop, or preserve natural proportions.
+      </p>
+    </header>
+
+    <main class="showcase">
+
+      <!-- Case 1: Object Fit Cover -->
+      <section class="demo-card">
+        <span class="fit-tag tag-purple">Object-Fit: Cover</span>
+        <div class="img-wrapper">
+          <!-- Inline SVG acting as an oversized image -->
+          <svg class="demo-img ease-object-cover" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+            <rect width="100" height="100" fill="#7c3aed"/>
+            <circle cx="50" cy="50" r="40" fill="#22d3ee"/>
+          </svg>
+        </div>
+        <p class="desc-text">Crops the image to completely fill the bounds, causing circle distortion at the edges.</p>
+      </section>
+
+      <!-- Case 2: Object Fit Contain -->
+      <section class="demo-card">
+        <span class="fit-tag tag-cyan">Object-Fit: Contain</span>
+        <div class="img-wrapper">
+          <svg class="demo-img ease-object-contain" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+            <rect width="100" height="100" fill="#7c3aed"/>
+            <circle cx="50" cy="50" r="40" fill="#22d3ee"/>
+          </svg>
+        </div>
+        <p class="desc-text">Scales the image to fit within the box. Preserves aspect ratio, but leaves empty side gaps.</p>
+      </section>
+
+      <!-- Case 3: Object Fit Scale Down -->
+      <section class="demo-card">
+        <span class="fit-tag tag-success">Object-Fit: Scale-Down</span>
+        <div class="img-wrapper">
+          <svg class="demo-img ease-object-scale-down" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+            <rect width="100" height="100" fill="#7c3aed"/>
+            <circle cx="50" cy="50" r="40" fill="#22d3ee"/>
+          </svg>
+        </div>
+        <p class="desc-text">Dynamically chooses the smaller of <code>none</code> or <code>contain</code>, preventing pixelation on smaller assets.</p>
+      </section>
+
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-object-scale-down-15110-ag/style.css
+++ b/submissions/examples/ease-object-scale-down-15110-ag/style.css
@@ -1,0 +1,139 @@
+/* ============================================================
+   Object Scale Down Utility — style.css
+   Submission for EaseMotion CSS Issue #15110
+   Varying object-fit parameters (cover, contain, scale-down)
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 900px;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ── Showcase Grid ── */
+.showcase {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 28px;
+}
+
+.demo-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 24px;
+  padding: 24px;
+  backdrop-filter: blur(8px);
+  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.fit-tag {
+  align-self: flex-start;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+.tag-purple { background: rgba(124, 58, 237, 0.15); color: #c4b5fd; }
+.tag-cyan   { background: rgba(6, 182, 212, 0.15); color: #67e8f9; }
+.tag-success { background: rgba(16, 185, 129, 0.15); color: #a7f3d0; }
+
+.img-wrapper {
+  width: 100%;
+  height: 160px;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid rgba(255,255,255,0.05);
+}
+
+.demo-img {
+  width: 100%;
+  height: 100%;
+}
+
+.desc-text {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+/* ============================================================
+   Object Fit Utility Classes (Core classes under test)
+   ============================================================ */
+
+.ease-object-cover {
+  object-fit: cover;
+}
+
+.ease-object-contain {
+  object-fit: contain;
+}
+
+.ease-object-scale-down {
+  object-fit: scale-down;
+}


### PR DESCRIPTION
## Summary
Adds the `ease-object-scale-down-15110` showcase. It compares image sizing utilities (`cover`, `contain`, `scale-down`) to demonstrate how `.ease-object-scale-down` prevents pixelation of small media assets.

## Root Cause
No media size layout or object-fit utility demonstrations existed in EaseMotion CSS to show how to contain media nodes.

## Changes Made
- `submissions/examples/ease-object-scale-down-15110-ag/demo.html`: Three card sections containing inline vector graphics.
- `submissions/examples/ease-object-scale-down-15110-ag/style.css`: Image fit rules, wrapper dimensions, and column grids.
- `submissions/examples/ease-object-scale-down-15110-ag/README.md`: Explains sizing differences and testing steps.

## How to Test
1. Open `demo.html` in a browser.
2. Verify visual centering and proportional aspect-ratios of contained SVG circles.

## Related Issue
Closes #15110