### PR TITLE
[Feat] #13371 — Add filter brightness and contrast utility classes (unique folder)

### DIFF
--- a/submissions/examples/filter-brightness-contrast-13371-ag/README.md
+++ b/submissions/examples/filter-brightness-contrast-13371-ag/README.md
@@ -1,0 +1,26 @@
+# Filter Brightness & Contrast Utilities
+
+This submission implements a visual preview dashboard demonstrating the combined utility of CSS `filter: brightness()` and `filter: contrast()` utility combinations.
+
+---
+
+## Technical Design
+
+CSS filters allow modifying contrast and brightness exposures dynamically:
+- **Brightness**: Adjusts light levels. `filter: brightness(0.5)` dims, while `1.5` boosts brightness.
+- **Contrast**: Adjusts difference between light and dark pixels. `filter: contrast(0.5)` flattens shadows, while `1.5` creates highly defined shapes.
+
+These properties are combined within a single `filter` directive:
+```css
+.image-sandbox {
+  filter: brightness(var(--brightness, 1)) contrast(var(--contrast, 1));
+}
+```
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Drag the **Brightness** and **Contrast** sliders — verify the image vector adjusts exposure and colors dynamically.
+3. Click the preset buttons (e.g. "Vivid Intense") — verify the preview shifts to match the preset's target settings.

--- a/submissions/examples/filter-brightness-contrast-13371-ag/demo.html
+++ b/submissions/examples/filter-brightness-contrast-13371-ag/demo.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Filter Brightness & Contrast — EaseMotion CSS</title>
+  <meta name="description" content="Visual image adjustment sandbox demonstrating the combined utility effects of CSS brightness and contrast filters.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Visual Filters</span>
+      <h1>Filter Brightness & Contrast</h1>
+      <p class="description">
+        Playground demonstrating brightness and contrast utility classes. 
+        Adjust the sliders below or select a preset to apply combinations.
+      </p>
+    </header>
+
+    <main class="dashboard">
+
+      <!-- Left Panel: Live Preview Card -->
+      <section class="preview-panel">
+        <div class="image-sandbox" id="preview-image" style="--brightness: 1; --contrast: 1;">
+          <svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+              <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" style="stop-color:#8b5cf6;stop-opacity:1" />
+                <stop offset="100%" style="stop-color:#ec4899;stop-opacity:1" />
+              </linearGradient>
+            </defs>
+            <rect width="200" height="200" fill="url(#grad)" />
+            <!-- Colorful shapes to show contrast contrast -->
+            <circle cx="60" cy="140" r="30" fill="#06b6d4" />
+            <polygon points="150,50 180,110 120,110" fill="#10b981" />
+            <text x="100" y="105" fill="#ffffff" font-family="Outfit, sans-serif" font-weight="900" font-size="28" text-anchor="middle">PREVIEW</text>
+          </svg>
+        </div>
+      </section>
+
+      <!-- Right Panel: Sliders & Presets -->
+      <section class="controls-panel">
+        <h2 class="section-title">Adjust Filters</h2>
+        
+        <div class="control-group">
+          <label for="brightness-range">Brightness: <span id="brightness-val">100%</span></label>
+          <input type="range" id="brightness-range" min="50" max="200" value="100">
+        </div>
+
+        <div class="control-group">
+          <label for="contrast-range">Contrast: <span id="contrast-val">100%</span></label>
+          <input type="range" id="contrast-range" min="50" max="200" value="100">
+        </div>
+
+        <h2 class="section-title">Presets</h2>
+        <div class="preset-grid">
+          <button class="preset-btn" data-b="50" data-c="150" type="button">High Contrast Dim</button>
+          <button class="preset-btn" data-b="150" data-c="50" type="button">Low Contrast Bright</button>
+          <button class="preset-btn" data-b="130" data-c="130" type="button">Vivid Intense</button>
+          <button class="preset-btn" data-b="100" data-c="100" type="button">Reset Baseline</button>
+        </div>
+      </section>
+
+    </main>
+  </div>
+
+  <script>
+    const preview = document.getElementById('preview-image');
+    
+    const bSlider = document.getElementById('brightness-range');
+    const cSlider = document.getElementById('contrast-range');
+    
+    const bVal = document.getElementById('brightness-val');
+    const cVal = document.getElementById('contrast-val');
+
+    const updateFilters = () => {
+      const b = bSlider.value;
+      const c = cSlider.value;
+      
+      bVal.textContent = `${b}%`;
+      cVal.textContent = `${c}%`;
+      
+      preview.style.setProperty('--brightness', b / 100);
+      preview.style.setProperty('--contrast', c / 100);
+    };
+
+    bSlider.addEventListener('input', updateFilters);
+    cSlider.addEventListener('input', updateFilters);
+
+    // Presets
+    document.querySelectorAll('.preset-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        bSlider.value = btn.dataset.b;
+        cSlider.value = btn.dataset.c;
+        updateFilters();
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/filter-brightness-contrast-13371-ag/style.css
+++ b/submissions/examples/filter-brightness-contrast-13371-ag/style.css
@@ -1,0 +1,173 @@
+/* ============================================================
+   Filter Brightness & Contrast — style.css
+   Submission for EaseMotion CSS Issue #13371
+   Sliders and combined presets for brightness/contrast filters
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 900px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Dashboard Layout
+   ============================================================ */
+
+.dashboard {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 28px;
+}
+
+@media (max-width: 768px) {
+  .dashboard { grid-template-columns: 1fr; }
+}
+
+.preview-panel,
+.controls-panel {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  padding: 28px;
+  border-radius: 20px;
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.section-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+
+/* ── Left: Image Sandbox ── */
+.image-sandbox {
+  width: 100%;
+  aspect-ratio: 1;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(255,255,255,0.06);
+  
+  /* Filter rules bound to JS custom variables */
+  filter: brightness(var(--brightness, 1)) contrast(var(--contrast, 1));
+}
+
+.image-sandbox svg {
+  width: 100%;
+  height: 100%;
+}
+
+/* ── Right: Controls ── */
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.control-group label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.control-group input[type="range"] {
+  accent-color: var(--primary-color);
+  cursor: pointer;
+}
+
+/* Preset Buttons Grid */
+.preset-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.preset-btn {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--card-border);
+  color: var(--text-secondary);
+  padding: 10px;
+  border-radius: 8px;
+  font-family: inherit;
+  font-size: 0.78rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.preset-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-primary);
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .image-sandbox {
+    filter: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-filter-brightness-contrast` showcase demonstrating the combination of visual exposure filters. It includes brightness (50% to 200%) and contrast (50% to 200%) control sliders alongside quick presets (Vivid Intense, Low Contrast Bright) to preview image adjustments.

## Root Cause
No utility guides or showcases existed in EaseMotion CSS to demonstrate combining multiple filter attributes together on elements.

## Changes Made
- `submissions/examples/filter-brightness-contrast-13371-ag/demo.html`: SVG element with sliders and presets mapping custom properties.
- `submissions/examples/filter-brightness-contrast-13371-ag/style.css`: Dashboard styling, filter parameters, and preset selectors.
- `submissions/examples/filter-brightness-contrast-13371-ag/README.md`: Technical breakdown of filter values, combinations, and testing steps.

## How to Test
1. Open `demo.html` in a browser.
2. Drag filter sliders and click presets to verify visual adjustments.

## Related Issue
Closes #13371