### PR TITLE
[Feat] #17949 — Add modal hash jump prevention demo (unique folder)

### DIFF
--- a/submissions/examples/modal-hash-jump-17949-ag/README.md
+++ b/submissions/examples/modal-hash-jump-17949-ag/README.md
@@ -1,0 +1,31 @@
+# Modal Hash Viewport Jump Prevention
+
+This submission demonstrates and resolves viewport jumping issues in pure CSS anchor-based modals when clearing URL hash indicators.
+
+---
+
+## Technical Details
+
+Pure CSS modals utilize the URL hash anchor format:
+```html
+<a href="#modal-id">Open</a>
+<div id="modal-id">...</div>
+```
+
+Naively clearing the hash selector via `window.location.hash = ''` causes browsers to search for an empty target, scroll-shifting the viewport automatically back to the top coordinates.
+
+### The Remediation
+Instead of changing the hash directly, we update the navigation history state utilizing:
+```javascript
+history.replaceState(null, null, window.location.pathname + window.location.search);
+```
+This updates the browser URL, removes the hash reference, and keeps page scroll coordinates intact.
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Scroll down until the trigger cards are centered in view.
+3. Click **Open Naive Modal**, then click **Close and Jump** — verify the viewport jumps back to the top.
+4. Scroll down again, click **Open Smooth Modal**, and click **Close Smoothly** — verify the modal closes with zero jumping.

--- a/submissions/examples/modal-hash-jump-17949-ag/demo.html
+++ b/submissions/examples/modal-hash-jump-17949-ag/demo.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Modal Hash Jump Remediation — EaseMotion CSS</title>
+  <meta name="description" content="Interactive demo showing how clearing modal URL hash jumps the viewport to the top, and the History API remediation.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Tall Spacer to allow scrolling -->
+  <div class="tall-header">
+    <span>Scroll down to find the modal triggers...</span>
+    <div class="scroll-arrow">↓</div>
+  </div>
+
+  <div class="container" id="interactive-zone">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Navigation Specs</span>
+      <h1>Modal Hash Jump Prevention</h1>
+      <p class="description">
+        Pure CSS modals use hash anchors (e.g. <code>#modal</code>) which scroll the page to top when cleared naively.
+        Test the naive close vs the smooth close below.
+      </p>
+    </header>
+
+    <main class="showcase">
+
+      <!-- Case 1: Naive Close Modal -->
+      <section class="demo-card">
+        <h2 class="section-title">Naive Close Modal</h2>
+        <p class="card-desc">Clears hash using <code>window.location.hash = ''</code>. Watch the page jump violently back to the top of the viewport.</p>
+        <button class="ease-btn open-btn" id="btn-trigger-naive" type="button">Open Naive Modal</button>
+      </section>
+
+      <!-- Case 2: Smooth Close Modal -->
+      <section class="demo-card">
+        <h2 class="section-title">Smooth Close Modal (Remediated)</h2>
+        <p class="card-desc">Clears hash using <code>history.replaceState()</code>. The modal closes while maintaining your scroll offset.</p>
+        <button class="ease-btn open-btn ease-btn-success" id="btn-trigger-smooth" type="button">Open Smooth Modal</button>
+      </section>
+
+    </main>
+  </div>
+
+  <div class="tall-footer">
+    <span>Tall spacer below...</span>
+  </div>
+
+  <!-- Modal 1: Naive -->
+  <div class="modal-overlay" id="modal-naive">
+    <div class="modal-content">
+      <h3>Naive Close Modal</h3>
+      <p>Clicking close will set <code>window.location.hash = ''</code>, triggering a page jump.</p>
+      <button class="close-btn" id="btn-close-naive" type="button">Close and Jump</button>
+    </div>
+  </div>
+
+  <!-- Modal 2: Smooth -->
+  <div class="modal-overlay" id="modal-smooth">
+    <div class="modal-content">
+      <h3>Smooth Close Modal</h3>
+      <p>Clicking close will run history overrides, keeping the viewport position intact.</p>
+      <button class="close-btn close-btn-success" id="btn-close-smooth" type="button">Close Smoothly</button>
+    </div>
+  </div>
+
+  <script>
+    const modalNaive = document.getElementById('modal-naive');
+    const modalSmooth = document.getElementById('modal-smooth');
+
+    // Trigger Openings
+    document.getElementById('btn-trigger-naive').addEventListener('click', () => {
+      modalNaive.classList.add('active');
+    });
+
+    document.getElementById('btn-trigger-smooth').addEventListener('click', () => {
+      modalSmooth.classList.add('active');
+    });
+
+    // Close Naive (location.hash manipulation)
+    document.getElementById('btn-close-naive').addEventListener('click', () => {
+      modalNaive.classList.remove('active');
+      window.location.hash = ''; // Page jumps to top
+    });
+
+    // Close Smooth (History API replacement)
+    document.getElementById('btn-close-smooth').addEventListener('click', () => {
+      modalSmooth.classList.remove('active');
+      // Replace hash smoothly without resetting scroll position
+      history.replaceState(null, null, window.location.pathname + window.location.search);
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/modal-hash-jump-17949-ag/style.css
+++ b/submissions/examples/modal-hash-jump-17949-ag/style.css
@@ -1,0 +1,233 @@
+/* ============================================================
+   Modal Hash Jump Remediation — style.css
+   Submission for EaseMotion CSS Issue #17949
+   Modals with viewport position maintenance parameters
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --success-color: #10b981;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  min-height: 250vh; /* Extremely tall to allow testing scroll offsets */
+}
+
+/* Spacer headers/footers */
+.tall-header,
+.tall-footer {
+  height: 60vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.85rem;
+}
+
+.scroll-arrow {
+  font-size: 2rem;
+  margin-top: 12px;
+  animation: pulseArrow 1.5s infinite alternate ease-in-out;
+}
+
+@keyframes pulseArrow {
+  0% { transform: translateY(0); }
+  100% { transform: translateY(10px); }
+}
+
+.container {
+  max-width: 820px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+  padding: 0 20px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ── Showcase ── */
+.showcase {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 28px;
+}
+
+.demo-card {
+  padding: 28px;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 20px;
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  justify-content: space-between;
+}
+
+.section-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+.card-desc {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.ease-btn {
+  background: var(--primary-color);
+  border: none;
+  color: #fff;
+  padding: 12px;
+  border-radius: 8px;
+  font-family: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(124,58,237,0.25);
+  transition: all 0.2s ease;
+  text-align: center;
+}
+
+.ease-btn:hover {
+  filter: brightness(1.1);
+  transform: translateY(-1px);
+}
+
+.ease-btn-success {
+  background: var(--success-color);
+  box-shadow: 0 4px 12px rgba(16,185,129,0.25);
+}
+
+/* ============================================================
+   Modals
+   ============================================================ */
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(4px);
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+}
+
+.modal-overlay.active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.modal-content {
+  background: #1f2937;
+  border: 1px solid var(--card-border);
+  padding: 32px;
+  border-radius: 16px;
+  max-width: 400px;
+  width: 90%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  transform: scale(0.9);
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.modal-overlay.active .modal-content {
+  transform: scale(1);
+}
+
+.modal-content h3 {
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.modal-content p {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.close-btn {
+  background: var(--primary-color);
+  border: none;
+  color: #fff;
+  padding: 10px;
+  border-radius: 8px;
+  font-family: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  transition: filter 0.2s ease;
+}
+
+.close-btn:hover {
+  filter: brightness(1.1);
+}
+
+.close-btn-success {
+  background: var(--success-color);
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .modal-overlay,
+  .modal-content,
+  .scroll-arrow {
+    transition: none !important;
+    animation: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-modal-hash-jump` showcase demonstrating viewport jump behaviors in pure CSS hash modals. It contrasts standard hash clearing methods (which push page coordinates back to 0) with History API implementations that update URLs smoothly while preserving current scroll bounds.

## Root Cause
CSS hash modal close selectors reset hash parameters via empty strings, causing browsers to scroll back to the top anchor points.

## Changes Made
- `submissions/examples/modal-hash-jump-17949-ag/demo.html`: Two cards displaying trigger mechanics on a tall, scrollable page layout.
- `submissions/examples/modal-hash-jump-17949-ag/style.css`: Overlay parameters, height metrics, transition boundaries, and responsive boxes.
- `submissions/examples/modal-hash-jump-17949-ag/README.md`: Explains hash redirects, history API implementations, and testing guides.

## How to Test
1. Open `demo.html` in a browser.
2. Scroll to the buttons, click them, and verify that the smooth-close modal preserves scroll positions.

## Related Issue
Closes #17949