### PR TITLE
[Feat] #17635 — Add animation restart sandbox (unique folder)

### DIFF
--- a/submissions/examples/animation-restart-17635-ag/README.md
+++ b/submissions/examples/animation-restart-17635-ag/README.md
@@ -1,0 +1,30 @@
+# CSS Animation Restart Sandbox
+
+This sandbox demonstrates style recalculation behavior when re-applying CSS animation classes, comparing naive class swaps against forced DOM reflow solutions.
+
+---
+
+## Technical Details
+
+To optimize rendering, modern browsers batch DOM changes. Removing a class and re-adding it immediately:
+```javascript
+element.classList.remove('my-animation');
+element.classList.add('my-animation');
+```
+occurs in a single style resolution pass. As a result, the browser detects no state change and fails to replay keyframes.
+
+### The Remediation
+A style reflow must be forced between class modification calls. Reading a layout property (like `element.offsetWidth` or `element.clientHeight`) forces style recalculation:
+```javascript
+element.classList.remove('my-animation');
+void element.offsetWidth; // Force Reflow
+element.classList.add('my-animation');
+```
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. In the **Naive Class Swap** card, click **Trigger Naive** repeatedly — verify the pulse animation fails to replay after the initial load.
+3. In the **Forced Reflow** card, click **Trigger Reflow** multiple times — verify the pulse animation restarts cleanly on every click.

--- a/submissions/examples/animation-restart-17635-ag/demo.html
+++ b/submissions/examples/animation-restart-17635-ag/demo.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Animation Restart Sandbox — EaseMotion CSS</title>
+  <meta name="description" content="Visual comparison demonstrating style recalculation issues when re-applying CSS animation classes, and reflow triggers.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Animation Specs</span>
+      <h1>CSS Animation Restart Sandbox</h1>
+      <p class="description">
+        Browsers optimize style changes by grouping them. Removing and adding an animation class 
+        in the same event loop execution fails to trigger a replay. Observe the comparison below.
+      </p>
+    </header>
+
+    <main class="showcase">
+
+      <!-- Case 1: Naive Class Swap -->
+      <section class="demo-card">
+        <h2 class="section-title">Naive Class Swap</h2>
+        <p class="card-desc">Simply removes and adds class in sequence. The animation only plays once on page load.</p>
+        
+        <div class="box-container">
+          <div class="animation-box ease-pulse" id="box-naive">Pulse</div>
+        </div>
+
+        <button class="ease-btn" id="btn-naive" type="button">Trigger Naive</button>
+      </section>
+
+      <!-- Case 2: Forced Reflow Trigger -->
+      <section class="demo-card">
+        <h2 class="section-title">Forced Reflow Restart</h2>
+        <p class="card-desc">Reads <code>offsetWidth</code> to trigger style recalculation before re-applying the class. Restarts perfectly.</p>
+
+        <div class="box-container">
+          <div class="animation-box ease-pulse animation-box--success" id="box-reflow">Pulse</div>
+        </div>
+
+        <button class="ease-btn ease-btn-success" id="btn-reflow" type="button">Trigger Reflow</button>
+      </section>
+
+    </main>
+  </div>
+
+  <script>
+    const boxNaive = document.getElementById('box-naive');
+    const boxReflow = document.getElementById('box-reflow');
+
+    // Naive Trigger
+    document.getElementById('btn-naive').addEventListener('click', () => {
+      boxNaive.classList.remove('ease-pulse');
+      // Immediately adding it back: browser batches the changes, nothing replays
+      boxNaive.classList.add('ease-pulse');
+    });
+
+    // Reflow Trigger
+    document.getElementById('btn-reflow').addEventListener('click', () => {
+      boxReflow.classList.remove('ease-pulse');
+      
+      // Force Reflow / Style Recalculation
+      void boxReflow.offsetWidth;
+      
+      boxReflow.classList.add('ease-pulse');
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/animation-restart-17635-ag/style.css
+++ b/submissions/examples/animation-restart-17635-ag/style.css
@@ -1,0 +1,180 @@
+/* ============================================================
+   CSS Animation Restart Sandbox — style.css
+   Submission for EaseMotion CSS Issue #17635
+   Pulse keyframes and testing containers for animation restart
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --success-color: #10b981;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 820px;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ── Showcase Grid ── */
+.showcase {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 28px;
+}
+
+.demo-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  padding: 28px;
+  border-radius: 20px;
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: center;
+}
+
+.section-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+.card-desc {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  text-align: center;
+}
+
+.box-container {
+  width: 100%;
+  height: 140px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: rgba(0,0,0,0.12);
+  border-radius: 12px;
+  margin: 8px 0;
+}
+
+/* Animated Box */
+.animation-box {
+  width: 70px;
+  height: 70px;
+  border-radius: 16px;
+  background: var(--primary-color);
+  color: #fff;
+  font-size: 0.82rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 15px rgba(124, 58, 237, 0.35);
+}
+
+.animation-box--success {
+  background: var(--success-color);
+  box-shadow: 0 4px 15px rgba(16, 185, 129, 0.35);
+}
+
+.ease-btn {
+  background: var(--primary-color);
+  border: none;
+  color: #fff;
+  padding: 12px 24px;
+  border-radius: 8px;
+  font-family: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(124,58,237,0.25);
+  transition: all 0.2s ease;
+}
+
+.ease-btn:hover {
+  filter: brightness(1.1);
+  transform: translateY(-1px);
+}
+
+.ease-btn-success {
+  background: var(--success-color);
+  box-shadow: 0 4px 12px rgba(16,185,129,0.25);
+}
+
+/* ============================================================
+   Pulse Animation Keyframes
+   ============================================================ */
+
+.ease-pulse {
+  animation: pulseScale 0.6s ease-out;
+}
+
+@keyframes pulseScale {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.22); box-shadow: 0 10px 25px rgba(124, 58, 237, 0.55); }
+  100% { transform: scale(1); }
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-pulse {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-animation-restart` sandbox demonstrating browser style recalculation and DOM reflow characteristics. It compares standard class toggles (which fail to replay animations due to style recalculation batching) with forced reflow operations (`void element.offsetWidth`) that ensure animations replay on every click event.

## Root Cause
When animation classes are removed and re-applied in the same event loop execution, the browser's style optimization engine groups them together, preventing animations from restarting.

## Changes Made
- `submissions/examples/animation-restart-17635-ag/demo.html`: Two visual pulse containers showing trigger buttons for naive and reflow triggers.
- `submissions/examples/animation-restart-17635-ag/style.css`: Pulsing keyframes, display containers, shadow highlights, and hover transitions.
- `submissions/examples/animation-restart-17635-ag/README.md`: Explains DOM reflow triggers, style batching, and manual validation.

## How to Test
1. Open `demo.html` in a browser.
2. Click trigger buttons to confirm that only the reflow version restarts.

## Related Issue
Closes #17635