### PR TITLE
[Feat] #15067 — Add appearance-none utility (unique folder)

### DIFF
--- a/submissions/examples/appearance-none-15067-ag/README.md
+++ b/submissions/examples/appearance-none-15067-ag/README.md
@@ -1,0 +1,27 @@
+# Appearance None Utility
+
+This submission implements a form component customization sandbox demonstrating the visual behavior of the `ease-appearance-none` resets class.
+
+---
+
+## Technical Overview
+
+Browser native styling defaults limit visual flexibility on key form components (like selectors, inputs, and toggles). The utility class resets these styles:
+
+```css
+.ease-appearance-none {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+```
+
+This clears default arrows, border-shadows, and background layouts, allowing developers to build custom overlays and arrows.
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Observe the **Default Browser Input** — notice the native layout, system colors, and system arrow indicators.
+3. Observe the **Custom Styling** input — verify that all native indicators have been cleared, presenting a clean border with a custom chevron indicator.

--- a/submissions/examples/appearance-none-15067-ag/demo.html
+++ b/submissions/examples/appearance-none-15067-ag/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Appearance None Utility — EaseMotion CSS</title>
+  <meta name="description" content="Visual form customization demo comparing native browser inputs against custom styling built with the appearance-none class.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Reset Utilities</span>
+      <h1>Appearance Reset Utility</h1>
+      <p class="description">
+        Demonstrates the utility class <code>ease-appearance-none</code>. 
+        Compare how standard browser inputs render versus how reset inputs allow fully custom designs.
+      </p>
+    </header>
+
+    <main class="showcase">
+
+      <!-- Case 1: Browser Default Selector -->
+      <section class="demo-card">
+        <h2 class="section-title">Default Browser Input</h2>
+        <p class="card-desc">Standard select dropdown using native browser styling and disclosure arrows.</p>
+        
+        <div class="input-wrapper">
+          <select class="native-select">
+            <option>Option Alpha</option>
+            <option>Option Beta</option>
+            <option>Option Gamma</option>
+          </select>
+        </div>
+      </section>
+
+      <!-- Case 2: Custom Selector (appearance: none) -->
+      <section class="demo-card">
+        <h2 class="section-title">Custom Styling (Appearance None)</h2>
+        <p class="card-desc">Resets native browser overrides using <code>appearance-none</code>, allowing custom colors and custom arrows.</p>
+
+        <div class="input-wrapper">
+          <select class="custom-select ease-appearance-none">
+            <option>Option Alpha</option>
+            <option>Option Beta</option>
+            <option>Option Gamma</option>
+          </select>
+          <span class="custom-arrow">▼</span>
+        </div>
+      </section>
+
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/appearance-none-15067-ag/style.css
+++ b/submissions/examples/appearance-none-15067-ag/style.css
@@ -1,0 +1,168 @@
+/* ============================================================
+   Appearance None Utility — style.css
+   Submission for EaseMotion CSS Issue #15067
+   Form input customizations removing native OS styles
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 820px;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ── Showcase ── */
+.showcase {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 28px;
+}
+
+.demo-card {
+  padding: 28px;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 20px;
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.section-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+.card-desc {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.input-wrapper {
+  position: relative;
+  width: 100%;
+}
+
+/* Default Selector */
+.native-select {
+  width: 100%;
+  padding: 12px;
+  font-family: inherit;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+  background: #fff;
+  color: #333;
+}
+
+/* Custom Selector using appearance-none */
+.custom-select {
+  width: 100%;
+  padding: 12px 40px 12px 16px;
+  font-family: inherit;
+  border-radius: 8px;
+  border: 1px solid var(--card-border);
+  background: rgba(0, 0, 0, 0.2);
+  color: var(--text-primary);
+  cursor: pointer;
+  outline: none;
+  font-weight: 600;
+  transition: all 0.2s ease;
+}
+
+.custom-select:hover {
+  background: rgba(0, 0, 0, 0.35);
+  border-color: rgba(124, 58, 237, 0.4);
+}
+
+.custom-select:focus {
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.25);
+}
+
+.custom-select option {
+  background: #1f2937;
+  color: var(--text-primary);
+}
+
+.custom-arrow {
+  position: absolute;
+  right: 16px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  pointer-events: none;
+}
+
+/* ============================================================
+   Appearance None Class (Core utility under test)
+   ============================================================ */
+
+.ease-appearance-none {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}


### PR DESCRIPTION
## Summary
Adds the `ease-appearance-none` showcase demonstrating visual resets on form inputs. It compares native select controls against custom styled dropdown layouts built using `.ease-appearance-none` resets, verifying custom chevron attachments and border configurations.

## Root Cause
No input reset or appearance reset utility demonstrations or guides existed in EaseMotion CSS to show how to build custom inputs.

## Changes Made
- `submissions/examples/appearance-none-15067-ag/demo.html`: Two selector cards contrasting system default dropdowns with custom input containers.
- `submissions/examples/appearance-none-15067-ag/style.css`: Input resets, focus shadows, hover highlights, and custom arrow placements.
- `submissions/examples/appearance-none-15067-ag/README.md`: Explains browser-native styling overrides and manual inspection.

## How to Test
1. Open `demo.html` in a browser.
2. Confirm the custom dropdown renders cleanly without native system arrows.

## Related Issue
Closes #15067