### PR TITLE
[Feat] #8149 — Add secure contributor wall demo (unique folder)

### DIFF
--- a/submissions/examples/secure-contributor-wall-8149-ag/README.md
+++ b/submissions/examples/secure-contributor-wall-8149-ag/README.md
@@ -1,0 +1,31 @@
+# Secure Contributor Wall
+
+This guide explains how cross-site scripting (XSS) occurs during dynamic wall building processes and provides visual DOM-based sanitization guidelines.
+
+---
+
+## Technical Details
+
+Unsanitized user profile strings (names, bios, profile images) loaded dynamically via scripts can introduce Cross-Site Scripting (XSS) vectors if assigned directly to layout elements:
+
+```javascript
+// VULNERABLE: Direct string mapping allows executing scripts
+element.innerHTML = `<strong>${contributor.name}</strong>`;
+```
+
+### The Remediation
+Avoid rendering inputs with `innerHTML` direct assignments. Instead, build element nodes and assign values using `textContent`, which treats all strings as plain literals:
+
+```javascript
+// SECURE: Browser sanitizes values automatically
+const nameElement = document.createElement('strong');
+nameElement.textContent = contributor.name;
+```
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. In the **Vulnerable Wall** column, click **Render Vulnerable Profiles** — notice that the browser executes the injected script, throwing an alert (if alerts are enabled) or breaking layout parameters.
+3. In the **Secure Wall** column, click **Render Secure Profiles** — verify that the malicious HTML markup is outputted safely as plain text code, preventing script execution.

--- a/submissions/examples/secure-contributor-wall-8149-ag/demo.html
+++ b/submissions/examples/secure-contributor-wall-8149-ag/demo.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Secure Contributor Wall — EaseMotion CSS</title>
+  <meta name="description" content="Visual contributor wall simulation demonstrating input sanitization and XSS mitigation in dynamic profile listings.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Security Specs</span>
+      <h1>Secure Contributor Wall</h1>
+      <p class="description">
+        Demonstrates cross-site scripting (XSS) risks when rendering user-submitted profile names unsanitized,
+        and showcases DOM-based text node sanitization remediations.
+      </p>
+    </header>
+
+    <main class="showcase">
+
+      <!-- Column 1: Vulnerable Rendering -->
+      <section class="demo-card">
+        <h2 class="section-title">Vulnerable Wall (innerHTML)</h2>
+        <p class="card-desc">Renders user data directly using <code>innerHTML</code>, executing embedded scripts or breaking formatting:</p>
+        
+        <div class="wall-grid" id="wall-vulnerable">
+          <!-- Rendered dynamically -->
+        </div>
+
+        <button class="ease-btn" id="btn-render-vuln" type="button">Render Vulnerable Profiles</button>
+      </section>
+
+      <!-- Column 2: Secure Rendering -->
+      <section class="demo-card">
+        <h2 class="section-title">Secure Wall (textContent / node creation)</h2>
+        <p class="card-desc">Safely sanitizes inputs by building text nodes, treating HTML tags as plain copy:</p>
+
+        <div class="wall-grid" id="wall-secure">
+          <!-- Rendered dynamically -->
+        </div>
+
+        <button class="ease-btn ease-btn-success" id="btn-render-secure" type="button">Render Secure Profiles</button>
+      </section>
+
+    </main>
+  </div>
+
+  <script>
+    // Simulated contributor records (one contains malicious markup)
+    const contributors = [
+      { name: "Ada Lovelace", role: "Contributor" },
+      { name: "<strong>Mallory</strong><img src='invalid-img' onerror='alert(\"XSS Triggered!\")'>", role: "Attacker" },
+      { name: "Grace Hopper", role: "Maintainer" }
+    ];
+
+    const wallVuln = document.getElementById('wall-vulnerable');
+    const wallSecure = document.getElementById('wall-secure');
+
+    // Vulnerable Render
+    document.getElementById('btn-render-vuln').addEventListener('click', () => {
+      wallVuln.innerHTML = '';
+      contributors.forEach(c => {
+        const item = document.createElement('div');
+        item.className = 'contributor-item';
+        // VULNERABLE: Direct HTML Injection
+        item.innerHTML = `
+          <div class="avatar">${c.name.charAt(0)}</div>
+          <div class="details">
+            <strong>${c.name}</strong>
+            <span>${c.role}</span>
+          </div>
+        `;
+        wallVuln.appendChild(item);
+      });
+    });
+
+    // Secure Render
+    document.getElementById('btn-render-secure').addEventListener('click', () => {
+      wallSecure.innerHTML = '';
+      contributors.forEach(c => {
+        const item = document.createElement('div');
+        item.className = 'contributor-item';
+
+        const avatar = document.createElement('div');
+        avatar.className = 'avatar';
+        // Use textContent safely
+        avatar.textContent = c.name.replace(/<[^>]*>/g, '').charAt(0);
+
+        const details = document.createElement('div');
+        details.className = 'details';
+
+        const nameEl = document.createElement('strong');
+        // SECURE: Browser handles sanitization when textContent is populated
+        nameEl.textContent = c.name;
+
+        const roleEl = document.createElement('span');
+        roleEl.textContent = c.role;
+
+        details.appendChild(nameEl);
+        details.appendChild(roleEl);
+
+        item.appendChild(avatar);
+        item.appendChild(details);
+        wallSecure.appendChild(item);
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/secure-contributor-wall-8149-ag/style.css
+++ b/submissions/examples/secure-contributor-wall-8149-ag/style.css
@@ -1,0 +1,185 @@
+/* ============================================================
+   Secure Contributor Wall — style.css
+   Submission for EaseMotion CSS Issue #8149
+   Contributor card profiles and dynamic security overlays
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --success-color: #10b981;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 900px;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ── Showcase Grid ── */
+.showcase {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(380px, 1fr));
+  gap: 28px;
+}
+
+.demo-card {
+  padding: 28px;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 20px;
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  justify-content: space-between;
+}
+
+.section-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+.card-desc {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+/* Contributor Grid */
+.wall-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 160px;
+  background: rgba(0,0,0,0.15);
+  border-radius: 12px;
+  padding: 12px;
+}
+
+.contributor-item {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.05);
+  padding: 12px;
+  border-radius: 8px;
+}
+
+.avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--primary-color);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 800;
+  font-size: 0.9rem;
+}
+
+.details {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.details strong {
+  font-size: 0.88rem;
+}
+
+.details span {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+.ease-btn {
+  background: var(--primary-color);
+  border: none;
+  color: #fff;
+  padding: 12px;
+  border-radius: 8px;
+  font-family: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(124,58,237,0.25);
+  transition: all 0.2s ease;
+  text-align: center;
+}
+
+.ease-btn:hover {
+  filter: brightness(1.1);
+  transform: translateY(-1px);
+}
+
+.ease-btn-success {
+  background: var(--success-color);
+  box-shadow: 0 4px 12px rgba(16,185,129,0.25);
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-btn {
+    transition: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-secure-contributor-wall` showcase illustrating cross-site scripting (XSS) vulnerability risks during dynamic rendering. It compares direct `innerHTML` evaluations (allowing malicious elements like `<img onerror="...">` to fire scripts) against DOM text node assignments (`textContent`) which sanitize inputs.

## Root Cause
Dynamic builder scripts rendered input parameters directly via `innerHTML` without sanitization, introducing XSS vulnerability vectors.

## Changes Made
- `submissions/examples/secure-contributor-wall-8149-ag/demo.html`: Two columns demonstrating vulnerable and secure contributor wall lists with simulation buttons.
- `submissions/examples/secure-contributor-wall-8149-ag/style.css`: Profile cards, avatars, layout grids, and buttons.
- `submissions/examples/secure-contributor-wall-8149-ag/README.md`: Explains scripting security, textNode assignments, and validation steps.

## How to Test
1. Open `demo.html` in a browser.
2. Render both lists to verify that only the vulnerable container fires the simulated XSS event, while the secure container sanitizes the input.

## Related Issue
Closes #8149