### PR TITLE
[Docs] #17746 — Add API error resilience demo (unique folder)

### DIFF
--- a/submissions/examples/api-error-resilience-17746-ag/README.md
+++ b/submissions/examples/api-error-resilience-17746-ag/README.md
@@ -1,0 +1,36 @@
+# API Error Resilience Guidelines
+
+This guide details code resilience guidelines for scripting integrations, demonstrating caught rate-limit exception handlers.
+
+---
+
+## Technical Overview: The Guardless Request
+
+Script integrations querying GitHub APIs (like assignment logs or comment updates) can crash if rate-limiting blocks requests or credentials expire:
+
+```javascript
+// VULNERABLE: A request failure throws an unhandled exception, crashing Node
+await octokit.rest.issues.removeAssignees({ ... });
+```
+
+### The Remediation
+Wrap all network queries inside `try-catch` structures. This allows logging failure metrics and scheduling backoff retries without terminating the process thread:
+
+```javascript
+// SECURE: Exceptions are caught, allowing recovery loops
+try {
+  await octokit.rest.issues.removeAssignees({ ... });
+} catch (error) {
+  console.error("API error encountered:", error.message);
+  // Schedule backoff retry
+  setTimeout(retryCall, 5000);
+}
+```
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Click **Trigger Guardless API** — observe the unhandled exception error crash simulation.
+3. Click **Trigger Resilient API** — verify that the try-catch handler intercepts the error, schedules a retry, and resolves the call successfully on the second pass.

--- a/submissions/examples/api-error-resilience-17746-ag/demo.html
+++ b/submissions/examples/api-error-resilience-17746-ag/demo.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>API Error Resilience Sandbox — EaseMotion CSS</title>
+  <meta name="description" content="Dashboard simulating REST API error-handling patterns, try-catch guards, and rate-limiting recovery.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — API Resilience Specs</span>
+      <h1>API Error Resilience</h1>
+      <p class="description">
+        Demonstrates script crashes caused by missing try-catch error guards on API queries.
+        Simulate requests below to test crash prevention and retry wrappers.
+      </p>
+    </header>
+
+    <main class="dashboard">
+
+      <!-- Left Panel: Trigger Sandbox -->
+      <section class="demo-card state-card">
+        <h2 class="section-title">API Simulators</h2>
+        
+        <div class="simulator-buttons">
+          <button class="ease-btn" id="btn-trigger-vuln" type="button">Trigger Guardless API (Crashes)</button>
+          <button class="ease-btn ease-btn-success" id="btn-trigger-resilient" type="button">Trigger Resilient API (Recovers)</button>
+        </div>
+      </section>
+
+      <!-- Right Panel: Visual Logs -->
+      <section class="demo-card logs-card">
+        <h2 class="section-title">API Output Logs</h2>
+        
+        <div class="logs-console" id="logs-console">
+          <div class="log-line text-muted">[System] Sandbox active. Waiting for API triggers...</div>
+        </div>
+      </section>
+
+    </main>
+  </div>
+
+  <script>
+    const logsConsole = document.getElementById('logs-console');
+
+    const logMsg = (text, type = 'normal') => {
+      const line = document.createElement('div');
+      line.className = `log-line ${type === 'muted' ? 'text-muted' : ''} ${type === 'danger' ? 'text-danger' : ''} ${type === 'success' ? 'text-success' : ''}`;
+      line.innerHTML = text;
+      logsConsole.appendChild(line);
+      logsConsole.scrollTop = logsConsole.scrollHeight;
+    };
+
+    // Simulated Guardless Call (Crashes thread on error)
+    document.getElementById('btn-trigger-vuln').addEventListener('click', () => {
+      logMsg('🚀 Dispatching API request to <code>/issues/unclaim</code>...', 'normal');
+      
+      // Simulate crash by throwing unhandled exception
+      setTimeout(() => {
+        logMsg('❌ API Error: Rate limit exceeded (403 Forbidden)', 'danger');
+        logMsg('💥 ERROR: Uncaught Exception! Node process terminated.', 'danger');
+      }, 600);
+    });
+
+    // Simulated Resilient Call (Caught and retried)
+    document.getElementById('btn-trigger-resilient').addEventListener('click', () => {
+      logMsg('🚀 Dispatching API request to <code>/issues/unclaim</code>...', 'normal');
+      
+      setTimeout(() => {
+        logMsg('⚠️ API Error: Rate limit exceeded (403 Forbidden) - Caught by try-catch!', 'danger');
+        logMsg('🔄 Scheduling exponential backoff retry in 1000ms...', 'muted');
+        
+        setTimeout(() => {
+          logMsg('🚀 Retrying API request to <code>/issues/unclaim</code>...', 'normal');
+          setTimeout(() => {
+            logMsg('✅ API Success: Issue successfully unclaimed! (200 OK)', 'success');
+          }, 600);
+        }, 1000);
+      }, 600);
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/api-error-resilience-17746-ag/style.css
+++ b/submissions/examples/api-error-resilience-17746-ag/style.css
@@ -1,0 +1,170 @@
+/* ============================================================
+   API Error Resilience Sandbox — style.css
+   Submission for EaseMotion CSS Issue #17746
+   Resilient dashboard layout and API console log formats
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --success-color: #10b981;
+  --danger-color: #ef4444;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 820px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Dashboard Layout
+   ============================================================ */
+
+.dashboard {
+  display: grid;
+  grid-template-columns: 1fr 1.3fr;
+  gap: 28px;
+}
+
+@media (max-width: 768px) {
+  .dashboard { grid-template-columns: 1fr; }
+}
+
+.demo-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  padding: 28px;
+  border-radius: 20px;
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.section-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+.simulator-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  justify-content: center;
+  height: 100%;
+}
+
+.ease-btn {
+  background: var(--primary-color);
+  border: none;
+  color: #fff;
+  padding: 14px;
+  border-radius: 8px;
+  font-family: inherit;
+  font-weight: 700;
+  font-size: 0.85rem;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(124,58,237,0.25);
+  transition: all 0.2s ease;
+  text-align: center;
+}
+
+.ease-btn:hover {
+  filter: brightness(1.1);
+  transform: translateY(-1px);
+}
+
+.ease-btn-success {
+  background: var(--success-color);
+  box-shadow: 0 4px 12px rgba(16,185,129,0.25);
+}
+
+/* Console Logs */
+.logs-console {
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255,255,255,0.04);
+  border-radius: 12px;
+  padding: 16px;
+  font-family: monospace;
+  font-size: 0.82rem;
+  height: 220px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.log-line {
+  line-height: 1.45;
+  word-break: break-all;
+}
+
+.text-muted { color: var(--text-muted); }
+.text-danger { color: var(--danger-color); }
+.text-success { color: var(--success-color); }
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-btn {
+    transition: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-api-error-resilience` sandbox. It illustrates how unhandled REST API request exceptions (like rate-limiting or network issues) crash integration scripts, and demonstrates try-catch recovery wrappers that log error metrics and schedule backoffs.

## Root Cause
Issue unclaiming scripts had no error-handling logic around assignment API requests, causing script crashes under rate-limiting.

## Changes Made
- `submissions/examples/api-error-resilience-17746-ag/demo.html`: Simulator action nodes linked to an event logging console.
- `submissions/examples/api-error-resilience-17746-ag/style.css`: Dashboard grids, terminal layouts, alert colors, and text states.
- `submissions/examples/api-error-resilience-17746-ag/README.md`: Explains REST try-catch boundaries, retry loops, and validation steps.

## How to Test
1. Open `demo.html` in a browser.
2. Trigger both API simulations to confirm that only the resilient workflow recovers.

## Related Issue
Closes #17746