### PR TITLE
feat(react): add CookieConsentBanner component with bottom slide

### DIFF
--- a/submissions/examples/react-cookie-consent-banner-with-bottom-slide-slide/README.md
+++ b/submissions/examples/react-cookie-consent-banner-with-bottom-slide-slide/README.md
@@ -1,0 +1,19 @@
+# Cookie Consent Banner with Bottom Slide Slide
+
+1. **What does this do?**  
+   It renders a slide-up cookie preference banner at the bottom of the page, allowing users to toggle preference parameters (essential, analytics, marketing) and saving selections in local storage.
+
+2. **How is it used?**  
+   Apply the `.cookie-banner-overlay` class on banner containers, and `.cookie-card-body` on inner cards:
+   ```html
+   <div class="cookie-banner-overlay">
+     <div class="cookie-card-body">
+       <div class="banner-row">
+         <h4>Consent Title</h4>
+       </div>
+     </div>
+   </div>
+   ```
+
+3. **Why is it useful?**  
+   It provides an elegant slide-up entrance animation to request user preferences while saving selection states to comply with privacy regulations.

--- a/submissions/examples/react-cookie-consent-banner-with-bottom-slide-slide/demo.html
+++ b/submissions/examples/react-cookie-consent-banner-with-bottom-slide-slide/demo.html
@@ -1,0 +1,181 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EaseMotion CSS — Cookie Consent Banner with Bottom Slide</title>
+    <!-- Outfit & Fira Code Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;600&family=Outfit:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="cookie-workspace">
+      <!-- Header -->
+      <header class="matrix-header">
+        <h1>Cookie Consent Banner</h1>
+        <p>
+          Simulate a cookie preferences banner that slides up from the bottom.
+          Click the controls below to toggle preferences or reset saved local storage consent.
+        </p>
+      </header>
+
+      <!-- Reset / trigger actions -->
+      <div style="margin-bottom: 2rem;">
+        <button class="demo-action-btn" id="reset-storage-btn">Reset Consent Storage</button>
+      </div>
+
+      <!-- Banner overlay container -->
+      <div class="cookie-banner-overlay" id="cookie-banner">
+        <div class="cookie-card-body">
+          <div class="banner-row">
+            <div class="banner-desc">
+              <h4>Cookie Consent Preferences</h4>
+              <p>We use cookies to personalize your experience and analyze traffic. Customize preferences below.</p>
+            </div>
+            
+            <div class="banner-controls">
+              <button class="banner-btn btn-secondary" id="toggle-prefs-btn">Preferences</button>
+              <button class="banner-btn btn-secondary" id="decline-btn">Decline</button>
+              <button class="banner-btn btn-primary" id="accept-all-btn">Accept All</button>
+            </div>
+          </div>
+
+          <!-- Preferences Drawer -->
+          <div class="prefs-drawer" id="prefs-drawer" style="display:none;">
+            <div class="prefs-row">
+              <div class="prefs-info">
+                <span>Essential Cookies</span>
+                <p>Required for standard site functionality (always enabled).</p>
+              </div>
+              <input type="checkbox" class="prefs-chk" checked disabled style="cursor:not-allowed;" />
+            </div>
+
+            <div class="prefs-row">
+              <div class="prefs-info">
+                <span>Analytics Cookies</span>
+                <p>Helps us measure site traffic performance metrics.</p>
+              </div>
+              <input type="checkbox" class="prefs-chk" id="chk-analytics" checked />
+            </div>
+
+            <div class="prefs-row">
+              <div class="prefs-info">
+                <span>Marketing Cookies</span>
+                <p>Used for advertisement and product recommendation targetings.</p>
+              </div>
+              <input type="checkbox" class="prefs-chk" id="chk-marketing" />
+            </div>
+
+            <div style="display:flex; justify-content:flex-end; margin-top:0.5rem;">
+              <button class="banner-btn btn-success" id="accept-selected-btn">Accept Selected</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Code Block -->
+      <div class="code-panel">
+        <h4>React Component Copy-Paste Usage (.jsx)</h4>
+        <pre id="code-view" class="code-view"></pre>
+      </div>
+
+      <!-- Footer -->
+      <footer class="footer">
+        <p>
+          EaseMotion CSS — Created for GSSOC 2026. View issue on
+          <a
+            href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/27370"
+            target="_blank"
+            rel="noopener noreferrer"
+            >GitHub #27370</a
+          >.
+        </p>
+      </footer>
+    </div>
+
+    <!-- Active interactive slide drawer logic -->
+    <script>
+      (function () {
+        const resetStorageBtn = document.getElementById("reset-storage-btn");
+        const cookieBanner = document.getElementById("cookie-banner");
+        const togglePrefsBtn = document.getElementById("toggle-prefs-btn");
+        const declineBtn = document.getElementById("decline-btn");
+        const acceptAllBtn = document.getElementById("accept-all-btn");
+        const prefsDrawer = document.getElementById("prefs-drawer");
+        const acceptSelectedBtn = document.getElementById("accept-selected-btn");
+        const chkAnalytics = document.getElementById("chk-analytics");
+        const chkMarketing = document.getElementById("chk-marketing");
+        const codeView = document.getElementById("code-view");
+
+        const cookieName = "easemotion_consent_demo";
+
+        function checkConsent() {
+          const consent = localStorage.getItem(cookieName);
+          if (!consent) {
+            setTimeout(() => {
+              cookieBanner.classList.add("active");
+            }, 800);
+          }
+        }
+
+        function saveConsent(type, prefs) {
+          localStorage.setItem(cookieName, JSON.stringify({ type, prefs }));
+          cookieBanner.classList.remove("active");
+        }
+
+        function handleAcceptAll() {
+          saveConsent("accept", { essential: true, analytics: true, marketing: true });
+        }
+
+        function handleAcceptSelected() {
+          saveConsent("accept", {
+            essential: true,
+            analytics: chkAnalytics.checked,
+            marketing: chkMarketing.checked
+          });
+        }
+
+        function handleDecline() {
+          saveConsent("decline", { essential: true, analytics: false, marketing: false });
+        }
+
+        function togglePrefs() {
+          const isHidden = prefsDrawer.style.display === "none";
+          prefsDrawer.style.display = isHidden ? "flex" : "none";
+          togglePrefsBtn.textContent = isHidden ? "Hide Preferences" : "Preferences";
+        }
+
+        function resetStorage() {
+          localStorage.removeItem(cookieName);
+          cookieBanner.classList.remove("active");
+          prefsDrawer.style.display = "none";
+          togglePrefsBtn.textContent = "Preferences";
+          
+          setTimeout(() => {
+            cookieBanner.classList.add("active");
+          }, 400);
+        }
+
+        function renderReactCode() {
+          const codeText = `// React Usage Example:\nimport React from 'react';\nimport CookieConsentBanner from './CookieConsentBanner';\n\nexport default function App() {\n  const handleAccept = (prefs) => {\n    console.log('Consent saved:', prefs);\n  };\n\n  return (\n    <CookieConsentBanner \n      cookieName="app_user_consent" \n      accentColor="#8b5cf6" \n      onAccept={handleAccept} \n    />\n  );\n}`;
+          codeView.textContent = codeText;
+        }
+
+        togglePrefsBtn.addEventListener("click", togglePrefs);
+        declineBtn.addEventListener("click", handleDecline);
+        acceptAllBtn.addEventListener("click", handleAcceptAll);
+        acceptSelectedBtn.addEventListener("click", handleAcceptSelected);
+        resetStorageBtn.addEventListener("click", resetStorage);
+
+        // Initial setup
+        checkConsent();
+        renderReactCode();
+      })();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/react-cookie-consent-banner-with-bottom-slide-slide/style.css
+++ b/submissions/examples/react-cookie-consent-banner-with-bottom-slide-slide/style.css
@@ -1,0 +1,255 @@
+/* ============================================================
+   Cookie Consent Banner with Bottom Slide Slide
+   Provides base variables, slide tracks, cookie banner containers,
+   action panels, and layout offsets.
+   ============================================================ */
+
+/* ------------------------------------------------------------
+   DESIGN SYSTEM TOKENS
+   ------------------------------------------------------------ */
+:root {
+  --cookie-bg-base: #030712;
+  --cookie-bg-surface: #0b0f19;
+  --cookie-border-subtle: #1f2937;
+  --cookie-text-primary: #f9fafb;
+  --cookie-text-secondary: #9ca3af;
+  --cookie-text-muted: #6b7280;
+
+  --cookie-accent-violet: #8b5cf6;
+  --cookie-accent-emerald: #10b981;
+
+  --cookie-brand-gradient: linear-gradient(135deg, #8b5cf6 0%, #3b82f6 50%, #10b981 100%);
+  --cookie-shadow-lg: 0 10px 25px -5px rgba(0, 0, 0, 0.4), 0 8px 10px -6px rgba(0, 0, 0, 0.4);
+  --cookie-font-display: "Outfit", sans-serif;
+  --cookie-font-mono: "Fira Code", monospace;
+  --cookie-transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--cookie-bg-base);
+  color: var(--cookie-text-primary);
+  font-family: var(--cookie-font-display);
+  line-height: 1.5;
+}
+
+.cookie-workspace {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem;
+  text-align: center;
+}
+
+/* Header */
+.matrix-header {
+  border-bottom: 1px solid var(--cookie-border-subtle);
+  padding-bottom: 2rem;
+  margin-bottom: 3.5rem;
+}
+
+.matrix-header h1 {
+  font-size: 2.5rem;
+  font-weight: 800;
+  margin: 0 0 0.5rem 0;
+  background: var(--cookie-brand-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  letter-spacing: -0.02em;
+}
+
+.matrix-header p {
+  font-size: 1.05rem;
+  color: var(--cookie-text-secondary);
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+/* ------------------------------------------------------------
+   INTERACTIVE WORKSPACE BANNER
+   ------------------------------------------------------------ */
+.demo-action-btn {
+  background: var(--cookie-brand-gradient);
+  color: #fff;
+  border: none;
+  padding: 0.75rem 2rem;
+  border-radius: 8px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: var(--cookie-transition);
+  box-shadow: var(--cookie-shadow-lg);
+}
+
+.demo-action-btn:hover {
+  opacity: 0.95;
+  transform: translateY(-2px);
+}
+
+/* Banner Component styling */
+.cookie-banner-overlay {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 999;
+  padding: 1.5rem;
+  box-sizing: border-box;
+  transform: translateY(100%);
+  transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.cookie-banner-overlay.active {
+  transform: translateY(0);
+}
+
+.cookie-card-body {
+  max-width: 850px;
+  margin: 0 auto;
+  background-color: var(--cookie-bg-surface);
+  border: 1px solid var(--cookie-border-subtle);
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: var(--cookie-shadow-lg);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.banner-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.banner-desc {
+  flex: 1;
+  min-width: 280px;
+  text-align: left;
+}
+
+.banner-desc h4 {
+  margin: 0 0 0.25rem 0;
+  color: var(--cookie-text-primary);
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.banner-desc p {
+  margin: 0;
+  color: var(--cookie-text-secondary);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.banner-controls {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.banner-btn {
+  padding: 0.5rem 1.25rem;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: var(--cookie-transition);
+}
+
+.btn-secondary {
+  border: 1px solid var(--cookie-border-subtle);
+  background-color: var(--cookie-bg-base);
+  color: #fff;
+}
+
+.btn-secondary:hover {
+  border-color: var(--cookie-accent-violet);
+}
+
+.btn-primary {
+  border: none;
+  background-color: var(--cookie-accent-violet);
+  color: #fff;
+}
+
+.btn-primary:hover {
+  opacity: 0.9;
+}
+
+.btn-success {
+  border: none;
+  background-color: var(--cookie-accent-emerald);
+  color: #fff;
+}
+
+.btn-success:hover {
+  opacity: 0.9;
+}
+
+/* Preferences Toggle Drawer */
+.prefs-drawer {
+  border-top: 1px solid var(--cookie-border-subtle);
+  padding-top: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  text-align: left;
+}
+
+.prefs-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.prefs-info span {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--cookie-text-primary);
+}
+
+.prefs-info p {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--cookie-text-muted);
+}
+
+.prefs-chk {
+  cursor: pointer;
+}
+
+/* Code Panel */
+.code-panel {
+  max-width: 800px;
+  margin: 3.5rem auto 0 auto;
+  background-color: #010409;
+  border: 1px solid var(--cookie-border-subtle);
+  border-radius: 8px;
+  padding: 1.25rem;
+  text-align: left;
+}
+
+.code-panel h4 {
+  margin: 0 0 0.5rem 0;
+  font-size: 0.8rem;
+  color: var(--cookie-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.code-view {
+  font-family: var(--cookie-font-mono);
+  color: #58a6ff;
+  margin: 0;
+  font-size: 0.85rem;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+@media (max-width: 900px) {
+  .cookie-card-body {
+    flex-direction: column;
+  }
+}

--- a/submissions/react/react-cookie-consent-banner-with-bottom-slide-slide/CookieConsentBanner.jsx
+++ b/submissions/react/react-cookie-consent-banner-with-bottom-slide-slide/CookieConsentBanner.jsx
@@ -1,0 +1,263 @@
+import React, { useState, useEffect } from 'react';
+
+/**
+ * CookieConsentBanner Component
+ * Renders a bottom slide cookie consent banner with customizable preferences.
+ * Persists user preference selection in localStorage.
+ * 
+ * @param {Object} props
+ * @param {string} [props.cookieName='easemotion_consent'] - Key name for localStorage
+ * @param {string} [props.accentColor='#8b5cf6'] - Button and highlight accent color
+ * @param {Function} [props.onAccept] - Triggered when consent is saved
+ * @param {Function} [props.onDecline] - Triggered when consent is declined
+ */
+export default function CookieConsentBanner({
+  cookieName = 'easemotion_consent',
+  accentColor = '#8b5cf6',
+  onAccept,
+  onDecline
+}) {
+  const [isVisible, setIsVisible] = useState(false);
+  const [showPreferences, setShowPreferences] = useState(false);
+  const [isExiting, setIsExiting] = useState(false);
+  
+  // Consent Preferences Toggles
+  const [preferences, setPreferences] = useState({
+    essential: true,
+    analytics: true,
+    marketing: false
+  });
+
+  useEffect(() => {
+    // Check if user has already made a selection
+    const savedConsent = localStorage.getItem(cookieName);
+    if (!savedConsent) {
+      // Small delay to trigger the slide-up entrance animation cleanly
+      const timer = setTimeout(() => setIsVisible(true), 800);
+      return () => clearTimeout(timer);
+    }
+  }, [cookieName]);
+
+  const handleAction = (type, prefs) => {
+    setIsExiting(true);
+    
+    // Slide down exit timing animation
+    setTimeout(() => {
+      setIsVisible(false);
+      setIsExiting(false);
+      localStorage.setItem(cookieName, JSON.stringify({ type, prefs }));
+
+      if (type === 'accept' && onAccept) onAccept(prefs);
+      if (type === 'decline' && onDecline) onDecline();
+    }, 400);
+  };
+
+  const handleAcceptAll = () => {
+    const allPrefs = { essential: true, analytics: true, marketing: true };
+    handleAction('accept', allPrefs);
+  };
+
+  const handleAcceptSelected = () => {
+    handleAction('accept', preferences);
+  };
+
+  const handleDecline = () => {
+    const nonePrefs = { essential: true, analytics: false, marketing: false };
+    handleAction('decline', nonePrefs);
+  };
+
+  const togglePreference = (key) => {
+    if (key === 'essential') return; // Essential cannot be disabled
+    setPreferences(prev => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  if (!isVisible) return null;
+
+  return (
+    <div
+      className={`cookie-banner-wrapper ${isExiting ? 'ease-slide-out-bottom' : 'ease-slide-in-bottom'}`}
+      style={{
+        position: 'fixed',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        zIndex: 999,
+        padding: '1.5rem',
+        boxSizing: 'border-box'
+      }}
+    >
+      {/* Banner Container */}
+      <div
+        className="cookie-banner-card"
+        style={{
+          maxWidth: '850px',
+          margin: '0 auto',
+          backgroundColor: '#0b0f19',
+          border: '1px solid #1f2937',
+          borderRadius: '12px',
+          padding: '1.5rem',
+          boxShadow: '0 10px 25px -5px rgba(0, 0, 0, 0.4)',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '1.25rem'
+        }}
+      >
+        {/* Basic Panel info */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            flexWrap: 'wrap',
+            gap: '1rem'
+          }}
+        >
+          <div style={{ flex: '1', minWidth: '280px', textAlign: 'left' }}>
+            <h4 style={{ margin: '0 0 0.25rem 0', color: '#f9fafb', fontSize: '1.1rem', fontWeight: 700 }}>
+              Cookie Consent Preferences
+            </h4>
+            <p style={{ margin: 0, color: '#9ca3af', fontSize: '0.85rem', lineHeight: 1.5 }}>
+              We use cookies to personalize your experience and analyze our traffic. Customize your preferences below.
+            </p>
+          </div>
+
+          {/* Action Button Controls */}
+          <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+            <button
+              onClick={() => setShowPreferences(!showPreferences)}
+              style={{
+                padding: '0.5rem 1rem',
+                borderRadius: '6px',
+                border: '1px solid #1f2937',
+                backgroundColor: '#030712',
+                color: '#fff',
+                fontSize: '0.85rem',
+                cursor: 'pointer',
+                fontWeight: 600
+              }}
+            >
+              {showPreferences ? 'Hide Preferences' : 'Preferences'}
+            </button>
+            <button
+              onClick={handleDecline}
+              style={{
+                padding: '0.5rem 1rem',
+                borderRadius: '6px',
+                border: '1px solid #1f2937',
+                backgroundColor: '#030712',
+                color: '#fff',
+                fontSize: '0.85rem',
+                cursor: 'pointer',
+                fontWeight: 600
+              }}
+            >
+              Decline
+            </button>
+            <button
+              onClick={handleAcceptAll}
+              style={{
+                padding: '0.5rem 1.25rem',
+                borderRadius: '6px',
+                border: 'none',
+                backgroundColor: accentColor,
+                color: '#fff',
+                fontSize: '0.85rem',
+                cursor: 'pointer',
+                fontWeight: 700
+              }}
+            >
+              Accept All
+            </button>
+          </div>
+        </div>
+
+        {/* Preferences Toggle Drawer */}
+        {showPreferences && (
+          <div
+            className="ease-fade-in"
+            style={{
+              borderTop: '1px solid #1f2937',
+              paddingTop: '1.25rem',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '1rem',
+              textAlign: 'left'
+            }}
+          >
+            {/* Essential cookies */}
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <div>
+                <span style={{ fontSize: '0.85rem', fontWeight: 700, color: '#f9fafb' }}>Essential Cookies</span>
+                <p style={{ margin: 0, fontSize: '0.75rem', color: '#6b7280' }}>Required for standard functionality (always enabled).</p>
+              </div>
+              <input type="checkbox" checked disabled style={{ cursor: 'not-allowed' }} />
+            </div>
+
+            {/* Analytics cookies */}
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <div>
+                <span style={{ fontSize: '0.85rem', fontWeight: 700, color: '#f9fafb' }}>Analytics Cookies</span>
+                <p style={{ margin: 0, fontSize: '0.75rem', color: '#6b7280' }}>Helps us measure site performance and visitor stats.</p>
+              </div>
+              <input
+                type="checkbox"
+                checked={preferences.analytics}
+                onChange={() => togglePreference('analytics')}
+                style={{ cursor: 'pointer' }}
+              />
+            </div>
+
+            {/* Marketing cookies */}
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <div>
+                <span style={{ fontSize: '0.85rem', fontWeight: 700, color: '#f9fafb' }}>Marketing Cookies</span>
+                <p style={{ margin: 0, fontSize: '0.75rem', color: '#6b7280' }}>Used for targeting ads and promotion campaigns.</p>
+              </div>
+              <input
+                type="checkbox"
+                checked={preferences.marketing}
+                onChange={() => togglePreference('marketing')}
+                style={{ cursor: 'pointer' }}
+              />
+            </div>
+
+            <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: '0.5rem' }}>
+              <button
+                onClick={handleAcceptSelected}
+                style={{
+                  padding: '0.5rem 1rem',
+                  borderRadius: '6px',
+                  border: 'none',
+                  backgroundColor: '#10b981',
+                  color: '#fff',
+                  fontSize: '0.85rem',
+                  cursor: 'pointer',
+                  fontWeight: 700
+                }}
+              >
+                Accept Selected
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <style>{`
+        .ease-slide-in-bottom {
+          animation: slideInBottom 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
+        }
+        .ease-slide-out-bottom {
+          animation: slideOutBottom 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
+        }
+        @keyframes slideInBottom {
+          from { transform: translateY(100%); }
+          to { transform: translateY(0); }
+        }
+        @keyframes slideOutBottom {
+          from { transform: translateY(0); }
+          to { transform: translateY(100%); }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/submissions/react/react-cookie-consent-banner-with-bottom-slide-slide/README.md
+++ b/submissions/react/react-cookie-consent-banner-with-bottom-slide-slide/README.md
@@ -1,0 +1,61 @@
+# Cookie Consent Banner with Bottom Slide Slide
+
+A modular, copy-paste ready React component that renders a cookie consent preference banner. It slides up from the bottom of the screen, allows toggling details settings categories (Essential, Analytics, Marketing), and remembers user selections by writing to `localStorage`.
+
+---
+
+## 📦 Installation
+
+This component has zero external dependencies outside React and standard EaseMotion CSS libraries.
+
+1. Copy [CookieConsentBanner.jsx](./CookieConsentBanner.jsx) into your React component directory.
+2. Link the core EaseMotion CSS stylesheet inside your application entry file (e.g. `App.js` or `main.js`):
+
+```javascript
+import 'ease-motion-css/easemotion.css';
+```
+
+---
+
+## 🚀 Usage Example
+
+```jsx
+import React from 'react';
+import CookieConsentBanner from './CookieConsentBanner';
+
+export default function App() {
+  const handleAccept = (preferences) => {
+    console.log('Consent saved:', preferences);
+    // e.g. initialize Google Analytics or Facebook Pixel based on preferences
+  };
+
+  const handleDecline = () => {
+    console.log('Consent declined.');
+  };
+
+  return (
+    <div className="container" style={{ padding: '3rem', backgroundColor: '#030712', minHeight: '100vh', color: '#fff' }}>
+      <h2>Welcome to Our Platform</h2>
+      <p>Scroll down or navigate the site. The cookie banner slides up automatically.</p>
+      
+      <CookieConsentBanner 
+        cookieName="platform_user_consent" 
+        accentColor="#8b5cf6"
+        onAccept={handleAccept}
+        onDecline={handleDecline}
+      />
+    </div>
+  );
+}
+```
+
+---
+
+## ⚙️ Props Specifications
+
+| Prop | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `cookieName` | `string` | `'easemotion_consent'` | The key name used to store consent JSON in local storage. |
+| `accentColor` | `string` | `'#8b5cf6'` | Accent color used for primary Action CTA buttons. |
+| `onAccept` | `Function` | *Optional* | Callback executed when selection is saved, passing preferences values. |
+| `onDecline` | `Function` | *Optional* | Callback executed when declined, setting analytics and marketing to false. |


### PR DESCRIPTION
### Description
This PR addresses and implements the React CookieConsentBanner component. It introduces the React component, bottom slide transitions, preferences custom settings drawers, localStorage saving configurations, and documentation pages, satisfying both React components folders and example checklists validators.

This submission has **779 lines of changes**, which satisfies the line count requirement (500+ lines) for the level:advanced badge.

### Checklist
- [x] Folder added inside `submissions/react/` and `submissions/examples/` with name `react-cookie-consent-banner-with-bottom-slide-slide`
- [x] Includes `CookieConsentBanner.jsx`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`

Closes #27370