### PR TITLE
feat: add animated toast notification component (toast-notification-mp)

### DIFF
--- a/submissions/examples/toast-notification-mp/README.md
+++ b/submissions/examples/toast-notification-mp/README.md
@@ -1,0 +1,131 @@
+# Toast Notification Component — `toast-notification-mp`
+
+**EaseMotion CSS Submission** | Issue [#27987](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/27987)  
+**Track:** Standard (HTML/CSS) → `submissions/examples/toast-notification-mp/`
+
+---
+
+## What does this do?
+
+A fully self-contained animated toast notification system with four variants (Success, Error, Warning, Info), smooth slide-and-fade entrance/exit animations, auto-dismiss with a progress bar, manual close, simultaneous stacking, and full light/dark theme support — no external dependencies required.
+
+---
+
+## How is it used?
+
+### 1. Link the stylesheet
+```html
+<link rel="stylesheet" href="style.css" />
+```
+
+### 2. Add the toast container
+Place this once in your page (ideally just before `</body>`). The `aria-live` attribute ensures screen readers announce new toasts automatically.
+
+```html
+<div
+  class="toast-container-mp"
+  id="toastContainer"
+  aria-live="polite"
+  aria-label="Notifications"
+  role="region"
+></div>
+```
+
+### 3. Toast HTML structure
+Each toast follows this structure:
+
+```html
+<div class="toast-mp toast-success-mp" role="alert" aria-live="assertive" aria-atomic="true">
+  <!-- Icon (SVG) -->
+  <svg class="toast-icon-mp" ...></svg>
+
+  <!-- Body -->
+  <div class="toast-body-mp">
+    <p class="toast-title-mp">Changes saved</p>
+    <p class="toast-message-mp">Your profile has been updated successfully.</p>
+  </div>
+
+  <!-- Close button -->
+  <button class="toast-close-mp" aria-label="Dismiss notification">✕</button>
+
+  <!-- Auto-dismiss progress bar -->
+  <div class="toast-progress-mp" aria-hidden="true">
+    <div class="toast-progress-bar-mp" style="animation: toast-progress-mp 4000ms linear forwards;"></div>
+  </div>
+</div>
+```
+
+### 4. Available variant classes
+
+| Variant   | Class to add            |
+|-----------|-------------------------|
+| Success   | `toast-success-mp`      |
+| Error     | `toast-error-mp`        |
+| Warning   | `toast-warning-mp`      |
+| Info      | `toast-info-mp`         |
+
+### 5. Dismiss with exit animation
+Add the `toast-exit-mp` class to trigger the exit animation, then remove the element after the animation ends:
+
+```js
+function dismissToast(id) {
+  const el = document.getElementById(id);
+  if (!el || el.classList.contains('toast-exit-mp')) return;
+  el.classList.add('toast-exit-mp');
+  el.addEventListener('animationend', () => el.remove(), { once: true });
+}
+```
+
+### 6. Dark theme
+Toggle `.dark-theme` on any ancestor element (or `<body>`) to switch to dark mode. All CSS variables update automatically.
+
+```js
+document.body.classList.toggle('dark-theme');
+```
+
+---
+
+## Why is it useful?
+
+Toast notifications are one of the most common feedback patterns in modern web UI, yet EaseMotion CSS had no reusable reference for them. This submission fills that gap with a component that aligns with EaseMotion's animation-first philosophy:
+
+- **Entrance animation** — spring-eased slide-in from the right (bottom on mobile) with a subtle scale bounce, making appearances feel natural rather than abrupt.
+- **Exit animation** — smooth slide-out that collapses height and margin so the remaining toasts reflow gracefully without a jump.
+- **Icon micro-animation** — each icon pops in with a slight overshoot, giving the variant personality without being distracting.
+- **Progress bar** — a thin animated bar communicates exactly how much auto-dismiss time remains, reducing anxiety about losing content.
+- **Accessibility** — `role="alert"`, `aria-live="assertive"`, `aria-atomic="true"` on each toast; `aria-live="polite"` on the container; fully keyboard-navigable close buttons with visible `:focus-visible` rings.
+- **Reduced motion** — all animations are disabled via `@media (prefers-reduced-motion: reduce)`, defaulting to an instant opacity-only fade.
+- **Responsive** — on viewports ≤ 480 px the container moves to the bottom of the screen and animations switch to a vertical slide-up, which feels more native on touch devices.
+- **Zero dependencies** — plain HTML, CSS, and vanilla JS. Works by opening `demo.html` directly in any browser.
+
+---
+
+## File list
+
+| File        | Purpose                                     |
+|-------------|---------------------------------------------|
+| `style.css` | All animations, layout, variants, theming   |
+| `demo.html` | Interactive demo with controls & theme toggle |
+| `README.md` | This documentation                          |
+
+---
+
+## CSS classes reference
+
+| Class                     | Description                                      |
+|---------------------------|--------------------------------------------------|
+| `.toast-container-mp`     | Fixed-position wrapper; stacks toasts vertically |
+| `.toast-mp`               | Base toast element                               |
+| `.toast-success-mp`       | Green success variant                            |
+| `.toast-error-mp`         | Red error variant                                |
+| `.toast-warning-mp`       | Amber warning variant                            |
+| `.toast-info-mp`          | Blue info variant                                |
+| `.toast-exit-mp`          | Triggers exit animation (add via JS)             |
+| `.toast-icon-mp`          | Icon element (SVG)                               |
+| `.toast-body-mp`          | Wraps title + message                            |
+| `.toast-title-mp`         | Bold notification title                          |
+| `.toast-message-mp`       | Supporting description text                      |
+| `.toast-close-mp`         | Dismiss button                                   |
+| `.toast-progress-mp`      | Progress bar track                               |
+| `.toast-progress-bar-mp`  | Animated fill bar                                |
+| `.dark-theme`             | Applied to ancestor to enable dark mode          |

--- a/submissions/examples/toast-notification-mp/demo.html
+++ b/submissions/examples/toast-notification-mp/demo.html
@@ -1,0 +1,397 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Toast Notification — EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    /* ── Demo Page Styles ── */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+      background: #f1f5f9;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+      transition: background 0.3s ease, color 0.3s ease;
+    }
+
+    body.dark-theme {
+      background: #0f0f1a;
+      color: #e2e8f0;
+    }
+
+    .demo-card {
+      background: #ffffff;
+      border-radius: 16px;
+      padding: 36px 32px;
+      max-width: 520px;
+      width: 100%;
+      box-shadow: 0 4px 24px rgba(0,0,0,0.08);
+      transition: background 0.3s ease;
+    }
+
+    body.dark-theme .demo-card {
+      background: #1e1e2e;
+      box-shadow: 0 4px 24px rgba(0,0,0,0.4);
+    }
+
+    .demo-header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 28px;
+    }
+
+    .demo-title {
+      font-size: 22px;
+      font-weight: 700;
+      color: #1a1a2e;
+      line-height: 1.3;
+    }
+
+    body.dark-theme .demo-title { color: #e2e8f0; }
+
+    .demo-subtitle {
+      font-size: 13px;
+      color: #64748b;
+      margin-top: 4px;
+    }
+
+    body.dark-theme .demo-subtitle { color: #94a3b8; }
+
+    /* Theme toggle */
+    .theme-toggle {
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 12px;
+      color: #64748b;
+      cursor: pointer;
+      user-select: none;
+    }
+
+    body.dark-theme .theme-toggle { color: #94a3b8; }
+
+    .toggle-track {
+      width: 40px;
+      height: 22px;
+      background: #cbd5e1;
+      border-radius: 11px;
+      position: relative;
+      transition: background 0.2s ease;
+    }
+
+    .toggle-track.on { background: #3b82f6; }
+
+    .toggle-knob {
+      position: absolute;
+      top: 3px;
+      left: 3px;
+      width: 16px;
+      height: 16px;
+      background: white;
+      border-radius: 50%;
+      transition: transform 0.2s ease;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+    }
+
+    .toggle-track.on .toggle-knob { transform: translateX(18px); }
+
+    /* Buttons grid */
+    .btn-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 10px;
+      margin-bottom: 20px;
+    }
+
+    .btn-toast {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      padding: 11px 16px;
+      border: none;
+      border-radius: 8px;
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: transform 0.1s ease, filter 0.15s ease;
+      font-family: inherit;
+      color: white;
+    }
+
+    .btn-toast:active { transform: scale(0.97); }
+    .btn-toast:hover  { filter: brightness(1.08); }
+    .btn-toast:focus-visible {
+      outline: 3px solid rgba(59,130,246,0.5);
+      outline-offset: 2px;
+    }
+
+    .btn-success { background: #22c55e; }
+    .btn-error   { background: #ef4444; }
+    .btn-warning { background: #f59e0b; }
+    .btn-info    { background: #3b82f6; }
+
+    .btn-clear {
+      grid-column: 1 / -1;
+      padding: 10px;
+      border: 1.5px solid #e2e8f0;
+      border-radius: 8px;
+      font-size: 13px;
+      font-weight: 500;
+      cursor: pointer;
+      background: transparent;
+      color: #64748b;
+      transition: border-color 0.15s, color 0.15s, background 0.15s;
+      font-family: inherit;
+    }
+
+    .btn-clear:hover {
+      border-color: #94a3b8;
+      color: #1a1a2e;
+      background: #f8fafc;
+    }
+
+    body.dark-theme .btn-clear {
+      border-color: rgba(255,255,255,0.12);
+      color: #94a3b8;
+    }
+
+    body.dark-theme .btn-clear:hover {
+      border-color: rgba(255,255,255,0.25);
+      color: #e2e8f0;
+      background: rgba(255,255,255,0.04);
+    }
+
+    /* Duration control */
+    .control-row {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      font-size: 13px;
+      color: #64748b;
+    }
+
+    body.dark-theme .control-row { color: #94a3b8; }
+
+    .control-row label { white-space: nowrap; }
+
+    .control-row input[type="range"] {
+      flex: 1;
+      accent-color: #3b82f6;
+      cursor: pointer;
+    }
+
+    .control-row span {
+      min-width: 36px;
+      text-align: right;
+      font-weight: 600;
+      color: #1a1a2e;
+      font-size: 13px;
+    }
+
+    body.dark-theme .control-row span { color: #e2e8f0; }
+
+    /* Code badge */
+    .code-hint {
+      margin-top: 24px;
+      padding: 12px 14px;
+      background: #f8fafc;
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      font-size: 11.5px;
+      color: #64748b;
+      font-family: 'Cascadia Code', 'Fira Code', monospace;
+      line-height: 1.7;
+    }
+
+    body.dark-theme .code-hint {
+      background: #0f0f1a;
+      border-color: rgba(255,255,255,0.08);
+      color: #94a3b8;
+    }
+
+    .code-hint strong { color: #3b82f6; }
+    .code-hint .tag   { color: #22c55e; }
+  </style>
+</head>
+<body>
+
+  <!-- Toast Container -->
+  <div
+    class="toast-container-mp"
+    id="toastContainer"
+    aria-live="polite"
+    aria-label="Notifications"
+    role="region"
+  ></div>
+
+  <!-- Demo Card -->
+  <div class="demo-card">
+    <div class="demo-header">
+      <div>
+        <div class="demo-title">Toast Notifications</div>
+        <div class="demo-subtitle">Animated · Accessible · Auto-dismiss</div>
+      </div>
+      <label class="theme-toggle" aria-label="Toggle dark mode">
+        <div class="toggle-track" id="toggleTrack">
+          <div class="toggle-knob"></div>
+        </div>
+        Dark
+      </label>
+    </div>
+
+    <div class="btn-grid">
+      <button class="btn-toast btn-success" onclick="showToast('success')">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+        Success
+      </button>
+      <button class="btn-toast btn-error" onclick="showToast('error')">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+        Error
+      </button>
+      <button class="btn-toast btn-warning" onclick="showToast('warning')">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+        Warning
+      </button>
+      <button class="btn-toast btn-info" onclick="showToast('info')">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+        Info
+      </button>
+      <button class="btn-clear" onclick="clearAll()">Clear all toasts</button>
+    </div>
+
+    <div class="control-row">
+      <label for="durationSlider">Auto-dismiss:</label>
+      <input type="range" id="durationSlider" min="2" max="10" value="4" step="1" />
+      <span id="durationLabel">4s</span>
+    </div>
+
+    <div class="code-hint">
+      <span class="tag">&lt;div</span>
+      <strong> class</strong>=<span class="tag">"toast-container-mp"</span>
+      aria-live=<span class="tag">"polite"</span><span class="tag">&gt;</span><br />
+      &nbsp;&nbsp;<span class="tag">&lt;div</span>
+      <strong> class</strong>=<span class="tag">"toast-mp toast-success-mp"</span>
+      role=<span class="tag">"alert"</span><span class="tag">&gt;</span> …
+      <span class="tag">&lt;/div&gt;</span><br />
+      <span class="tag">&lt;/div&gt;</span>
+    </div>
+  </div>
+
+  <script>
+    // ── Toast data ──
+    const TOASTS = {
+      success: {
+        title: 'Changes saved',
+        message: 'Your profile has been updated successfully.',
+        icon: `<svg class="toast-icon-mp" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="9 12 11 14 15 10"/></svg>`
+      },
+      error: {
+        title: 'Upload failed',
+        message: 'Something went wrong. Please check your connection and try again.',
+        icon: `<svg class="toast-icon-mp" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>`
+      },
+      warning: {
+        title: 'Storage almost full',
+        message: 'You\'re using 90% of your available space. Consider upgrading.',
+        icon: `<svg class="toast-icon-mp" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>`
+      },
+      info: {
+        title: 'Update available',
+        message: 'Version 2.4.0 is ready. Refresh to apply the latest changes.',
+        icon: `<svg class="toast-icon-mp" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>`
+      }
+    };
+
+    const CLOSE_ICON = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>`;
+
+    // ── State ──
+    let toastCount = 0;
+    const activeTimers = new Map();
+
+    function getDuration() {
+      return parseInt(document.getElementById('durationSlider').value, 10) * 1000;
+    }
+
+    // ── Create & show a toast ──
+    function showToast(type) {
+      const data = TOASTS[type];
+      const id   = `toast-${++toastCount}`;
+      const ms   = getDuration();
+
+      const el = document.createElement('div');
+      el.className = `toast-mp toast-${type}-mp`;
+      el.id        = id;
+      el.setAttribute('role', 'alert');
+      el.setAttribute('aria-live', 'assertive');
+      el.setAttribute('aria-atomic', 'true');
+
+      el.innerHTML = `
+        ${data.icon}
+        <div class="toast-body-mp">
+          <p class="toast-title-mp">${data.title}</p>
+          <p class="toast-message-mp">${data.message}</p>
+        </div>
+        <button
+          class="toast-close-mp"
+          aria-label="Dismiss notification"
+          onclick="dismissToast('${id}')"
+        >${CLOSE_ICON}</button>
+        <div class="toast-progress-mp" aria-hidden="true">
+          <div
+            class="toast-progress-bar-mp"
+            style="animation: toast-progress-mp ${ms}ms linear forwards;"
+          ></div>
+        </div>
+      `;
+
+      document.getElementById('toastContainer').appendChild(el);
+
+      // Auto-dismiss timer
+      const timer = setTimeout(() => dismissToast(id), ms);
+      activeTimers.set(id, timer);
+    }
+
+    // ── Dismiss with exit animation ──
+    function dismissToast(id) {
+      const el = document.getElementById(id);
+      if (!el || el.classList.contains('toast-exit-mp')) return;
+
+      clearTimeout(activeTimers.get(id));
+      activeTimers.delete(id);
+
+      el.classList.add('toast-exit-mp');
+      el.addEventListener('animationend', () => el.remove(), { once: true });
+    }
+
+    // ── Clear all ──
+    function clearAll() {
+      const container = document.getElementById('toastContainer');
+      [...container.children].forEach(el => dismissToast(el.id));
+    }
+
+    // ── Duration slider ──
+    const slider = document.getElementById('durationSlider');
+    const label  = document.getElementById('durationLabel');
+    slider.addEventListener('input', () => { label.textContent = `${slider.value}s`; });
+
+    // ── Dark mode toggle ──
+    const toggleTrack = document.getElementById('toggleTrack');
+    toggleTrack.parentElement.addEventListener('click', () => {
+      const isDark = document.body.classList.toggle('dark-theme');
+      // Also toggle the toast container's theme
+      document.getElementById('toastContainer').classList.toggle('dark-theme', isDark);
+      toggleTrack.classList.toggle('on', isDark);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/toast-notification-mp/style.css
+++ b/submissions/examples/toast-notification-mp/style.css
@@ -1,0 +1,325 @@
+/* ============================================================
+   Toast Notification Component — toast-notification-mp
+   EaseMotion CSS Submission | Contributor: Mahi Patel
+   ============================================================ */
+
+/* ── CSS Custom Properties ── */
+:root {
+  --toast-font: 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --toast-gap: 12px;
+  --toast-radius: 10px;
+  --toast-min-width: 300px;
+  --toast-max-width: 380px;
+  --toast-padding: 14px 16px;
+  --toast-shadow: 0 8px 24px rgba(0, 0, 0, 0.12), 0 2px 8px rgba(0, 0, 0, 0.08);
+  --toast-z: 9999;
+  --toast-duration: 0.35s;
+  --toast-ease: cubic-bezier(0.34, 1.26, 0.64, 1);
+
+  /* Light theme */
+  --toast-bg: #ffffff;
+  --toast-border: rgba(0, 0, 0, 0.08);
+  --toast-text: #1a1a2e;
+  --toast-subtext: #6b7280;
+  --toast-close-hover: rgba(0, 0, 0, 0.06);
+
+  /* Variant colors */
+  --toast-success-accent: #22c55e;
+  --toast-success-bg: #f0fdf4;
+  --toast-success-border: #bbf7d0;
+
+  --toast-error-accent: #ef4444;
+  --toast-error-bg: #fef2f2;
+  --toast-error-border: #fecaca;
+
+  --toast-warning-accent: #f59e0b;
+  --toast-warning-bg: #fffbeb;
+  --toast-warning-border: #fde68a;
+
+  --toast-info-accent: #3b82f6;
+  --toast-info-bg: #eff6ff;
+  --toast-info-border: #bfdbfe;
+}
+
+/* Dark theme override */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --toast-bg: #1e1e2e;
+    --toast-border: rgba(255, 255, 255, 0.1);
+    --toast-text: #e2e8f0;
+    --toast-subtext: #94a3b8;
+    --toast-close-hover: rgba(255, 255, 255, 0.08);
+    --toast-shadow: 0 8px 24px rgba(0, 0, 0, 0.4), 0 2px 8px rgba(0, 0, 0, 0.3);
+
+    --toast-success-bg: #052e16;
+    --toast-success-border: #166534;
+
+    --toast-error-bg: #2d0707;
+    --toast-error-border: #7f1d1d;
+
+    --toast-warning-bg: #292309;
+    --toast-warning-border: #78350f;
+
+    --toast-info-bg: #0c1c3e;
+    --toast-info-border: #1e3a8a;
+  }
+}
+
+/* Manual dark theme class (for demo toggle) */
+.dark-theme {
+  --toast-bg: #1e1e2e;
+  --toast-border: rgba(255, 255, 255, 0.1);
+  --toast-text: #e2e8f0;
+  --toast-subtext: #94a3b8;
+  --toast-close-hover: rgba(255, 255, 255, 0.08);
+  --toast-shadow: 0 8px 24px rgba(0, 0, 0, 0.4), 0 2px 8px rgba(0, 0, 0, 0.3);
+
+  --toast-success-bg: #052e16;
+  --toast-success-border: #166534;
+
+  --toast-error-bg: #2d0707;
+  --toast-error-border: #7f1d1d;
+
+  --toast-warning-bg: #292309;
+  --toast-warning-border: #78350f;
+
+  --toast-info-bg: #0c1c3e;
+  --toast-info-border: #1e3a8a;
+}
+
+/* ── Keyframes ── */
+@keyframes toast-slide-in-mp {
+  from {
+    opacity: 0;
+    transform: translateX(100%) scale(0.92);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+}
+
+@keyframes toast-slide-out-mp {
+  from {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+    max-height: 120px;
+    margin-bottom: var(--toast-gap);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(110%) scale(0.9);
+    max-height: 0;
+    margin-bottom: 0;
+    padding: 0;
+  }
+}
+
+@keyframes toast-progress-mp {
+  from { width: 100%; }
+  to   { width: 0%; }
+}
+
+@keyframes toast-icon-pop-mp {
+  0%   { transform: scale(0) rotate(-20deg); }
+  70%  { transform: scale(1.2) rotate(5deg); }
+  100% { transform: scale(1) rotate(0deg); }
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .toast-mp,
+  .toast-mp.toast-exit-mp {
+    animation: none !important;
+    transition: opacity 0.15s ease !important;
+  }
+  .toast-progress-bar-mp {
+    animation: none !important;
+  }
+}
+
+/* ── Toast Container ── */
+.toast-container-mp {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--toast-gap);
+  z-index: var(--toast-z);
+  pointer-events: none;
+  max-width: var(--toast-max-width);
+  width: calc(100vw - 40px);
+}
+
+/* ── Individual Toast ── */
+.toast-mp {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: var(--toast-padding);
+  background: var(--toast-bg);
+  border: 1px solid var(--toast-border);
+  border-radius: var(--toast-radius);
+  box-shadow: var(--toast-shadow);
+  min-width: var(--toast-min-width);
+  pointer-events: all;
+  overflow: hidden;
+  font-family: var(--toast-font);
+
+  animation: toast-slide-in-mp var(--toast-duration) var(--toast-ease) forwards;
+  will-change: transform, opacity;
+}
+
+.toast-mp.toast-exit-mp {
+  animation: toast-slide-out-mp 0.3s ease-in forwards;
+  pointer-events: none;
+}
+
+/* ── Variant Left Border Accent ── */
+.toast-mp::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  border-radius: var(--toast-radius) 0 0 var(--toast-radius);
+}
+
+.toast-success-mp { background: var(--toast-success-bg); border-color: var(--toast-success-border); }
+.toast-success-mp::before { background: var(--toast-success-accent); }
+
+.toast-error-mp   { background: var(--toast-error-bg);   border-color: var(--toast-error-border); }
+.toast-error-mp::before   { background: var(--toast-error-accent); }
+
+.toast-warning-mp { background: var(--toast-warning-bg); border-color: var(--toast-warning-border); }
+.toast-warning-mp::before { background: var(--toast-warning-accent); }
+
+.toast-info-mp    { background: var(--toast-info-bg);    border-color: var(--toast-info-border); }
+.toast-info-mp::before    { background: var(--toast-info-accent); }
+
+/* ── Icon ── */
+.toast-icon-mp {
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  margin-top: 1px;
+  animation: toast-icon-pop-mp 0.4s var(--toast-ease) 0.1s both;
+}
+
+.toast-success-mp .toast-icon-mp { color: var(--toast-success-accent); }
+.toast-error-mp   .toast-icon-mp { color: var(--toast-error-accent); }
+.toast-warning-mp .toast-icon-mp { color: var(--toast-warning-accent); }
+.toast-info-mp    .toast-icon-mp { color: var(--toast-info-accent); }
+
+/* ── Body ── */
+.toast-body-mp {
+  flex: 1;
+  min-width: 0;
+}
+
+.toast-title-mp {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--toast-text);
+  line-height: 1.4;
+  margin: 0 0 2px 0;
+}
+
+.toast-message-mp {
+  font-size: 13px;
+  color: var(--toast-subtext);
+  line-height: 1.5;
+  margin: 0;
+  word-break: break-word;
+}
+
+/* ── Close Button ── */
+.toast-close-mp {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--toast-subtext);
+  transition: background 0.15s ease, color 0.15s ease;
+  padding: 0;
+  margin-top: -2px;
+  margin-right: -4px;
+}
+
+.toast-close-mp:hover {
+  background: var(--toast-close-hover);
+  color: var(--toast-text);
+}
+
+.toast-close-mp:focus-visible {
+  outline: 2px solid var(--toast-info-accent);
+  outline-offset: 1px;
+}
+
+/* ── Progress Bar ── */
+.toast-progress-mp {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.toast-progress-bar-mp {
+  height: 100%;
+  border-radius: 0 0 0 var(--toast-radius);
+}
+
+.toast-success-mp .toast-progress-bar-mp { background: var(--toast-success-accent); }
+.toast-error-mp   .toast-progress-bar-mp { background: var(--toast-error-accent); }
+.toast-warning-mp .toast-progress-bar-mp { background: var(--toast-warning-accent); }
+.toast-info-mp    .toast-progress-bar-mp { background: var(--toast-info-accent); }
+
+/* ── Responsive ── */
+@media (max-width: 480px) {
+  .toast-container-mp {
+    top: auto;
+    bottom: 16px;
+    left: 12px;
+    right: 12px;
+    width: auto;
+    max-width: 100%;
+  }
+
+  @keyframes toast-slide-in-mp {
+    from {
+      opacity: 0;
+      transform: translateY(100%) scale(0.95);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+  }
+
+  @keyframes toast-slide-out-mp {
+    from {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+      max-height: 120px;
+      margin-bottom: var(--toast-gap);
+    }
+    to {
+      opacity: 0;
+      transform: translateY(20px) scale(0.95);
+      max-height: 0;
+      margin-bottom: 0;
+      padding: 0;
+    }
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a fully self-contained animated toast notification component with 4 variants
(Success, Error, Warning, Info), smooth entrance/exit animations, auto-dismiss with
a progress bar, manual close, simultaneous stacking, and light/dark theme support.


---
Closes #27987

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/toast-notification-mp/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A reusable animated toast notification component with Success, Error, Warning, and Info
variants featuring smooth slide-in/out animations, auto-dismiss with a progress bar,
manual close, simultaneous stacking, and full light/dark theme support.

**How does a developer use it?**
```html
<!-- 1. Add the container once in your page -->
<div class="toast-container-mp"
     aria-live="polite"
     aria-label="Notifications"
     role="region">

  <!-- 2. Inject toast elements dynamically via JS -->
  <div class="toast-mp toast-success-mp" role="alert" aria-live="assertive" aria-atomic="true">
    <svg class="toast-icon-mp" ...></svg>
    <div class="toast-body-mp">
      <p class="toast-title-mp">Changes saved</p>
      <p class="toast-message-mp">Your profile has been updated successfully.</p>
    </div>
    <button class="toast-close-mp" aria-label="Dismiss notification">✕</button>
    <div class="toast-progress-mp" aria-hidden="true">
      <div class="toast-progress-bar-mp"
           style="animation: toast-progress-mp 4000ms linear forwards;">
      </div>
    </div>
  </div>

</div>

<!-- Variants: toast-success-mp | toast-error-mp | toast-warning-mp | toast-info-mp -->
<!-- Dark mode: add .dark-theme to any ancestor element -->
```

**Why does it fit EaseMotion CSS?**
Toast notifications are one of the most repeated UI patterns in modern web apps, yet
they are rarely done with intentional motion. This submission treats animation as a
first-class concern: a spring-eased slide-in (bottom slide-up on mobile), a
height-collapsing exit so remaining toasts reflow without a jump, and an icon
micro-animation that gives each variant personality. Every timing and easing value
was chosen to feel purposeful rather than decorative, which is exactly EaseMotion's
philosophy of making CSS motion human-readable and meaningful.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

The demo includes a live duration slider (2–10 s auto-dismiss), a dark mode toggle,
a "Clear all" button, and all 4 variant triggers — no server or CDN required.

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
- All CSS class names use the `-mp` suffix to avoid naming conflicts
  (e.g. `toast-mp`, `toast-success-mp`, `toast-container-mp`).
- The `@keyframes` names also carry the `-mp` suffix
  (`toast-slide-in-mp`, `toast-slide-out-mp`, `toast-progress-mp`, `toast-icon-pop-mp`)
  so they won't collide with any existing or future EaseMotion keyframes.
- On mobile (≤ 480 px) the container anchors to the bottom of the screen and the
  entrance/exit animations switch to a vertical slide — feel free to adjust breakpoint.
- `@media (prefers-reduced-motion: reduce)` disables all animations; toasts still
  appear and dismiss, just with a plain opacity fade.
- Dark theme works both via `@media (prefers-color-scheme: dark)` and a manual
  `.dark-theme` class on any ancestor — whichever you prefer to standardize on is fine.
- Happy for you to rename classes to the `ease-*` convention during integration.