### PR TITLE
feat(utility): add text wrapping utility classes for issue #28608

### DIFF
--- a/submissions/docs/core_changes-issue-28608/README.md
+++ b/submissions/docs/core_changes-issue-28608/README.md
@@ -1,0 +1,34 @@
+# ease-text-balance — Text Wrapping Utility Classes
+
+## What does this do?
+
+Provides CSS text-wrapping utilities for better typographic control: balanced headlines, orphan-free paragraphs, truncation, and multi-line clamping.
+
+## How is it used?
+
+```html
+<h2 class="ease-text-balance">A perfectly balanced heading across all screen sizes</h2>
+<p class="ease-text-pretty">No orphaned words at the end of my paragraphs.</p>
+<p class="ease-text-truncate">Long text gets cut off with ellipsis…</p>
+<p class="ease-text-clamp-2">This text will be clamped to exactly two lines.</p>
+```
+
+### Classes
+
+| Class | Property | Use case |
+|---|---|---|
+| `.ease-text-balance` | `text-wrap: balance` | Center-aligned headings |
+| `.ease-text-pretty` | `text-wrap: pretty` | Body text (orphan prevention) |
+| `.ease-text-nowrap` | `white-space: nowrap` | Labels, badges, inline items |
+| `.ease-text-truncate` | `overflow: hidden` + `text-overflow: ellipsis` | Single-line truncation |
+| `.ease-text-clamp-2` | `-webkit-line-clamp: 2` | Two-line clamp |
+| `.ease-text-clamp-3` | `-webkit-line-clamp: 3` | Three-line clamp |
+| `.ease-text-clamp-4` | `-webkit-line-clamp: 4` | Four-line clamp |
+| `.ease-text-clamp-5` | `-webkit-line-clamp: 5` | Five-line clamp |
+| `.ease-text-hyphens` | `hyphens: auto` | Automatic hyphenation |
+
+## Browser Support
+
+- `text-wrap: balance` / `pretty`: Chrome 114+, Safari 17+, Firefox 121+
+- `-webkit-line-clamp`: All modern browsers
+- `hyphens: auto`: All modern browsers (requires `lang` attribute)

--- a/submissions/docs/core_changes-issue-28608/demo.html
+++ b/submissions/docs/core_changes-issue-28608/demo.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-text-balance — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: Georgia, "Times New Roman", serif;
+      background: #f8fafc; color: #1e293b; padding: 3rem 1.5rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      body { background: #0f172a; color: #f1f5f9; }
+    }
+    .demo-header { text-align: center; margin-bottom: 3rem; }
+    .demo-header h1 { font-size: clamp(2rem, 5vw, 3rem); }
+    .demo-header p { color: #64748b; margin-top: 0.5rem; }
+    .demo-section { max-width: 720px; margin: 0 auto 2.5rem; }
+    .demo-section h2 {
+      font-size: 0.75rem; font-weight: 600; text-transform: uppercase;
+      letter-spacing: 0.1em; color: #6c63ff; margin-bottom: 0.75rem;
+    }
+    .class-tag {
+      display: inline-block; font-size: 0.65rem; font-family: monospace;
+      background: #f1f5f9; border: 1px solid #e2e8f0;
+      border-radius: 999px; padding: 0.3em 0.75em; color: #6c63ff; margin-bottom: 0.75rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      .class-tag { background: #1e293b; border-color: #334155; }
+    }
+    .demo-section h3 { font-size: 1rem; margin-bottom: 0.5rem; }
+    .demo-section p { line-height: 1.7; color: #475569; margin-bottom: 1.5rem; }
+    @media (prefers-color-scheme: dark) {
+      .demo-section p { color: #94a3b8; }
+    }
+    .card {
+      background: white; border: 1px solid #e2e8f0; border-radius: 0.75rem;
+      padding: 1.5rem; margin-bottom: 1.5rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      .card { background: #1e293b; border-color: #334155; }
+    }
+    .truncate-box {
+      max-width: 300px; border: 1px dashed #cbd5e1; padding: 0.5rem;
+    }
+    .clamp-box {
+      max-width: 320px; border: 1px dashed #cbd5e1; padding: 0.5rem;
+    }
+    .hyphen-box {
+      max-width: 200px; border: 1px dashed #cbd5e1; padding: 0.5rem;
+    }
+  </style>
+</head>
+<body>
+<header class="demo-header">
+  <h1 class="ease-text-balance">ease-text-balance Text Wrapping Utilities</h1>
+  <p>Balanced headings, orphan-free paragraphs, truncation &amp; clamping</p>
+</header>
+
+<section class="demo-section">
+  <h2>Text Balancing</h2>
+  <div class="class-tag">.ease-text-balance</div>
+  <div class="card">
+    <h3 style="text-align:center;max-width:500px;margin:0 auto;font-size:1.5rem;line-height:1.3;" class="ease-text-balance">
+      This heading uses text-wrap: balance to distribute text evenly across every single line on all viewports
+    </h3>
+  </div>
+  <p>Compare with the same text without balance:</p>
+  <div class="card">
+    <h3 style="text-align:center;max-width:500px;margin:0 auto;font-size:1.5rem;line-height:1.3;">
+      This heading does NOT use text-wrap: balance so lines may be very uneven naturally
+    </h3>
+  </div>
+</section>
+
+<section class="demo-section">
+  <h2>Pretty (Orphan Prevention)</h2>
+  <div class="class-tag">.ease-text-pretty</div>
+  <div class="card">
+    <p class="ease-text-pretty" style="max-width:480px;">
+      The quick brown fox jumps over the lazy dog near the bank of the river. A wonderful serenity has taken possession of my entire soul, like these sweet mornings of spring which I enjoy with my whole heart.
+    </p>
+  </div>
+</section>
+
+<section class="demo-section">
+  <h2>No-Wrap</h2>
+  <div class="class-tag">.ease-text-nowrap</div>
+  <div class="card">
+    <span class="ease-text-nowrap" style="background:#6c63ff;color:white;padding:0.25em 0.75em;border-radius:999px;font-family:monospace;font-size:0.875rem;">
+      User ID: 42 • Never Breaks
+    </span>
+  </div>
+</section>
+
+<section class="demo-section">
+  <h2>Truncation</h2>
+  <div class="class-tag">.ease-text-truncate</div>
+  <div class="card truncate-box">
+    <p class="ease-text-truncate" style="font-family:monospace;font-size:0.875rem;">
+      This is a very long piece of text that should be truncated with an ellipsis because it exceeds the available container width and there is no room for it to continue on the same line.
+    </p>
+  </div>
+</section>
+
+<section class="demo-section">
+  <h2>Line Clamping</h2>
+  <div class="class-tag">.ease-text-clamp-2</div>
+  <div class="card clamp-box">
+    <p class="ease-text-clamp-2" style="font-size:0.875rem;line-height:1.6;">
+      This paragraph will be clamped to exactly two lines of text. Any content beyond the second line will be gracefully truncated with an ellipsis by the browser's native line clamping mechanism. This is useful for card descriptions and preview snippets where space is constrained.
+    </p>
+  </div>
+  <div class="class-tag">.ease-text-clamp-3</div>
+  <div class="card clamp-box">
+    <p class="ease-text-clamp-3" style="font-size:0.875rem;line-height:1.6;">
+      This paragraph will be clamped to exactly three lines of text. Any content beyond the third line will be truncated with an ellipsis. This is useful for card descriptions, article previews, and anywhere you need to show a consistent number of lines. The browser automatically handles the ellipsis placement.
+    </p>
+  </div>
+</section>
+
+<section class="demo-section">
+  <h2>Hyphenation</h2>
+  <div class="class-tag">.ease-text-hyphens</div>
+  <div class="card hyphen-box">
+    <p class="ease-text-hyphens" style="font-size:0.875rem;line-height:1.6;text-align:justify;">
+      Antidisestablishmentarianism is a political philosophy that opposes the withdrawal of state support from an established church. This extraordinarily long word demonstrates automatic hyphenation beautifully.
+    </p>
+  </div>
+  <p>Note: Requires a <code>lang</code> attribute on the document or parent for correct hyphenation rules.</p>
+</section>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-28608/style.css
+++ b/submissions/docs/core_changes-issue-28608/style.css
@@ -1,0 +1,67 @@
+/* ============================================================
+   ease-text-balance — Text Wrapping Utility Classes
+   Submission for EaseMotion CSS · Issue #28608
+   ============================================================ */
+
+@layer easemotion-utilities {
+
+/* ── Text wrapping ─────────────────────────────────────── */
+
+.ease-text-balance {
+  text-wrap: balance !important;
+}
+
+.ease-text-pretty {
+  text-wrap: pretty !important;
+}
+
+.ease-text-nowrap {
+  white-space: nowrap !important;
+}
+
+/* ── Single-line truncation ────────────────────────────── */
+
+.ease-text-truncate {
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+  white-space: nowrap !important;
+}
+
+/* ── Multi-line clamping ───────────────────────────────── */
+
+.ease-text-clamp-2 {
+  display: -webkit-box !important;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+}
+
+.ease-text-clamp-3 {
+  display: -webkit-box !important;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+}
+
+.ease-text-clamp-4 {
+  display: -webkit-box !important;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
+  overflow: hidden;
+}
+
+.ease-text-clamp-5 {
+  display: -webkit-box !important;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 5;
+  overflow: hidden;
+}
+
+/* ── Hyphenation ───────────────────────────────────────── */
+
+.ease-text-hyphens {
+  hyphens: auto !important;
+  -webkit-hyphens: auto;
+}
+
+}


### PR DESCRIPTION
## ✦ Description
Adds text wrapping and balancing utility classes: `.ease-text-balance`, `.ease-text-pretty`, `.ease-text-truncate`, `.ease-text-clamp-{2,3,4,5}`, `.ease-text-nowrap`, and `.ease-text-hyphens`.

Fixes #28608

---

## ⟡ Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

---

## ✦ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings or console errors.

---

## Description

### Changes Made
- Added `submissions/docs/core_changes-issue-28608/`:
  - `style.css` — text-wrap balance/pretty, truncation, clamping, hyphens
  - `README.md` — class reference table and usage examples
  - `demo.html` — interactive demo for each utility

### New Classes
| Class | Description |
|---|---|
| `.ease-text-balance` | `text-wrap: balance` |
| `.ease-text-pretty` | `text-wrap: pretty` (orphan prevention) |
| `.ease-text-nowrap` | `white-space: nowrap` |
| `.ease-text-truncate` | Single-line ellipsis truncation |
| `.ease-text-clamp-2` through `-5` | Multi-line line clamp |
| `.ease-text-hyphens` | `hyphens: auto` |

### Testing
- All changes additive only