### PR TITLE
feat(utility): add CSS mask-image and clip-path utilities for issue #28634

### DIFF
--- a/submissions/docs/core_changes-issue-28634/README.md
+++ b/submissions/docs/core_changes-issue-28634/README.md
@@ -1,0 +1,36 @@
+# ease-mask — CSS Mask & Clip-Path Utility Classes
+
+## What does this do?
+
+Provides CSS `mask-image` and `clip-path` utility classes for creating common visual effects: circular crops, polygon shapes, gradient fades, and image masks.
+
+## How is it used?
+
+```html
+<img src="photo.jpg" class="ease-clip-circle" alt="Round photo" />
+<img src="photo.jpg" class="ease-clip-hexagon" alt="Hex crop" />
+<div class="ease-mask-fade-top">Fades out at the top</div>
+```
+
+### Clip-Path Classes
+
+| Class | Shape |
+|---|---|
+| `.ease-clip-circle` | `circle(50%)` — perfect circle |
+| `.ease-clip-ellipse` | `ellipse(50% 35%)` — oval |
+| `.ease-clip-hexagon` | Hexagon polygon |
+| `.ease-clip-triangle` | Equilateral triangle |
+| `.ease-clip-diamond` | Rotated square |
+| `.ease-clip-chevron` | Chevron/banner shape |
+| `.ease-clip-blob` | Organic blob (approx) |
+
+### Mask Classes
+
+| Class | Effect |
+|---|---|
+| `.ease-mask-fade-top` | Fades to transparent at top |
+| `.ease-mask-fade-bottom` | Fades at bottom |
+| `.ease-mask-fade-left` | Fades at left |
+| `.ease-mask-fade-right` | Fades at right |
+| `.ease-mask-fade-all` | Fades on all edges |
+| `.ease-mask-circle` | Circular mask via radial gradient |

--- a/submissions/docs/core_changes-issue-28634/demo.html
+++ b/submissions/docs/core_changes-issue-28634/demo.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-mask — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #f8fafc; color: #1e293b; padding: 3rem 1.5rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      body { background: #0f172a; color: #f1f5f9; }
+    }
+    .demo-header { text-align: center; margin-bottom: 3rem; }
+    .demo-header h1 { font-size: clamp(2rem, 5vw, 3rem); }
+    .demo-header p { color: #64748b; margin-top: 0.5rem; }
+    .demo-section { max-width: 960px; margin: 0 auto 2.5rem; }
+    .demo-section h2 {
+      font-size: 0.75rem; font-weight: 600; text-transform: uppercase;
+      letter-spacing: 0.1em; color: #6c63ff; margin-bottom: 1rem;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+      gap: 1.5rem;
+    }
+    .item {
+      text-align: center;
+    }
+    .item .shape {
+      width: 100%; aspect-ratio: 1;
+      background: linear-gradient(135deg, #6c63ff, #ec4899);
+      margin-bottom: 0.5rem;
+    }
+    .item .label {
+      font-size: 0.65rem; font-family: monospace; color: #6c63ff;
+    }
+    .demo-image {
+      width: 200px; height: 200px; margin: 0 auto;
+      background: linear-gradient(135deg, #f59e0b, #ef4444, #ec4899, #6c63ff, #3b82f6, #10b981);
+      border-radius: 0.5rem;
+    }
+    .mask-demo {
+      max-width: 720px; margin: 0 auto;
+    }
+    .mask-item {
+      margin-bottom: 2rem;
+    }
+    .mask-item .label { margin-bottom: 0.5rem; }
+    .mask-image-box {
+      width: 100%; height: 250px;
+      background: linear-gradient(135deg, #6c63ff 0%, #8b5cf6 25%, #ec4899 50%, #f59e0b 75%, #10b981 100%);
+      background-size: cover;
+    }
+    .flex-row {
+      display: flex; gap: 1.5rem; flex-wrap: wrap;
+    }
+  </style>
+</head>
+<body>
+<header class="demo-header">
+  <h1>ease-mask</h1>
+  <p>CSS clip-path &amp; mask-image utility classes</p>
+</header>
+
+<section class="demo-section">
+  <h2>Clip-Path Shapes</h2>
+  <div class="grid">
+    <div class="item">
+      <div class="shape ease-clip-circle"></div>
+      <div class="label">ease-clip-circle</div>
+    </div>
+    <div class="item">
+      <div class="shape ease-clip-ellipse"></div>
+      <div class="label">ease-clip-ellipse</div>
+    </div>
+    <div class="item">
+      <div class="shape ease-clip-hexagon"></div>
+      <div class="label">ease-clip-hexagon</div>
+    </div>
+    <div class="item">
+      <div class="shape ease-clip-triangle"></div>
+      <div class="label">ease-clip-triangle</div>
+    </div>
+    <div class="item">
+      <div class="shape ease-clip-diamond"></div>
+      <div class="label">ease-clip-diamond</div>
+    </div>
+    <div class="item">
+      <div class="shape ease-clip-chevron"></div>
+      <div class="label">ease-clip-chevron</div>
+    </div>
+    <div class="item">
+      <div class="shape ease-clip-blob"></div>
+      <div class="label">ease-clip-blob</div>
+    </div>
+  </div>
+</section>
+
+<section class="demo-section mask-demo">
+  <h2>Mask Gradients</h2>
+  <div class="flex-row">
+    <div class="mask-item">
+      <div class="label">ease-mask-fade-top</div>
+      <div class="mask-image-box ease-mask-fade-top"></div>
+    </div>
+    <div class="mask-item">
+      <div class="label">ease-mask-fade-bottom</div>
+      <div class="mask-image-box ease-mask-fade-bottom"></div>
+    </div>
+    <div class="mask-item">
+      <div class="label">ease-mask-fade-left</div>
+      <div class="mask-image-box ease-mask-fade-left"></div>
+    </div>
+    <div class="mask-item">
+      <div class="label">ease-mask-fade-right</div>
+      <div class="mask-image-box ease-mask-fade-right"></div>
+    </div>
+    <div class="mask-item">
+      <div class="label">ease-mask-fade-all</div>
+      <div class="mask-image-box ease-mask-fade-all"></div>
+    </div>
+    <div class="mask-item">
+      <div class="label">ease-mask-circle</div>
+      <div class="mask-image-box ease-mask-circle"></div>
+    </div>
+  </div>
+</section>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-28634/style.css
+++ b/submissions/docs/core_changes-issue-28634/style.css
@@ -1,0 +1,74 @@
+/* ============================================================
+   ease-mask — CSS Mask & Clip-Path Utility Classes
+   Submission for EaseMotion CSS · Issue #28634
+   ============================================================ */
+
+@layer easemotion-utilities {
+
+/* ══════════════════════════════════════════════════════════
+   CLIP-PATH SHAPES
+   ══════════════════════════════════════════════════════════ */
+
+.ease-clip-circle {
+  clip-path: circle(50%) !important;
+}
+
+.ease-clip-ellipse {
+  clip-path: ellipse(50% 35%) !important;
+}
+
+.ease-clip-hexagon {
+  clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%) !important;
+}
+
+.ease-clip-triangle {
+  clip-path: polygon(50% 0%, 100% 100%, 0% 100%) !important;
+}
+
+.ease-clip-diamond {
+  clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%) !important;
+}
+
+.ease-clip-chevron {
+  clip-path: polygon(0% 0%, 100% 0%, 100% 75%, 50% 100%, 0% 75%) !important;
+}
+
+.ease-clip-blob {
+  clip-path: polygon(25% 0%, 75% 0%, 100% 25%, 100% 70%, 80% 100%, 20% 100%, 0% 70%, 0% 25%) !important;
+}
+
+/* ══════════════════════════════════════════════════════════
+   MASK GRADIENTS
+   ══════════════════════════════════════════════════════════ */
+
+.ease-mask-fade-top {
+  mask-image: linear-gradient(to top, black 0%, transparent 100%) !important;
+  -webkit-mask-image: linear-gradient(to top, black 0%, transparent 100%) !important;
+}
+
+.ease-mask-fade-bottom {
+  mask-image: linear-gradient(to bottom, black 0%, transparent 100%) !important;
+  -webkit-mask-image: linear-gradient(to bottom, black 0%, transparent 100%) !important;
+}
+
+.ease-mask-fade-left {
+  mask-image: linear-gradient(to right, black 0%, transparent 100%) !important;
+  -webkit-mask-image: linear-gradient(to right, black 0%, transparent 100%) !important;
+}
+
+.ease-mask-fade-right {
+  mask-image: linear-gradient(to left, black 0%, transparent 100%) !important;
+  -webkit-mask-image: linear-gradient(to left, black 0%, transparent 100%) !important;
+}
+
+.ease-mask-fade-all {
+  mask-image: radial-gradient(ellipse 75% 75% at center, black 50%, transparent 100%) !important;
+  -webkit-mask-image: radial-gradient(ellipse 75% 75% at center, black 50%, transparent 100%) !important;
+}
+
+.ease-mask-circle {
+  mask-image: radial-gradient(circle at center, black 0%, transparent 100%) !important;
+  -webkit-mask-image: radial-gradient(circle at center, black 0%, transparent 100%) !important;
+}
+
+}


### PR DESCRIPTION
## ✦ Description
Adds CSS `clip-path` and `mask-image` utility classes for common shapes and gradient fade effects.

Fixes #28634
---
## ✦ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
---
## Changes
- `submissions/docs/core_changes-issue-28634/` with `style.css`, `README.md`, `demo.html`
## New Classes
**Clip-path:** circle, ellipse, hexagon, triangle, diamond, chevron, blob
**Mask:** fade-top, fade-bottom, fade-left, fade-right, fade-all, circle
## Testing
- All changes additive only