### PR TITLE
feat(utility): add static noise grain texture utility for issue #28630

### DIFF
--- a/submissions/docs/core_changes-issue-28630/README.md
+++ b/submissions/docs/core_changes-issue-28630/README.md
@@ -1,0 +1,32 @@
+# ease-noise — Static Grain/Noise Texture Overlay Utility
+
+## What does this do?
+
+Adds a subtle film-grain / static noise texture overlay using a CSS-only `mask` with a repeating conic-gradient or SVG data-URI. Gives surfaces a tactile, analog feel without JavaScript or external assets.
+
+## How is it used?
+
+```html
+<div class="ease-noise">
+  <!-- Content with subtle grain texture -->
+</div>
+```
+
+### Variants
+
+| Class | Opacity | Description |
+|---|---|---|
+| `.ease-noise` | ~0.5 | Default subtle grain |
+| `.ease-noise-light` | ~0.25 | Very subtle grain |
+| `.ease-noise-heavy` | ~0.8 | Pronounced grain |
+
+## Custom Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `--ease-noise-opacity` | `0.5` | Grain overlay opacity |
+| `--ease-noise-size` | `256px` | Pattern tile size |
+
+## Why?
+
+Adds visual texture to hero sections, cards, and backgrounds. No external images or JS required.

--- a/submissions/docs/core_changes-issue-28630/demo.html
+++ b/submissions/docs/core_changes-issue-28630/demo.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-noise — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #f8fafc; color: #1e293b; padding: 3rem 1.5rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      body { background: #0f172a; color: #f1f5f9; }
+    }
+    .demo-header { text-align: center; margin-bottom: 3rem; }
+    .demo-header h1 { font-size: clamp(2rem, 5vw, 3rem); }
+    .demo-header p { color: #64748b; margin-top: 0.5rem; }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+      gap: 1.5rem; max-width: 960px; margin: 0 auto;
+    }
+    .card {
+      border-radius: 0.75rem; padding: 3rem 2rem; text-align: center;
+      overflow: hidden; position: relative;
+    }
+    .card h3 { font-size: 1.25rem; font-weight: 700; position: relative; z-index: 2; }
+    .card p { font-size: 0.875rem; margin-top: 0.5rem; opacity: 0.7; position: relative; z-index: 2; }
+    .class-tag {
+      display: inline-block; font-size: 0.65rem; font-family: monospace;
+      background: rgba(255,255,255,0.15); border: 1px solid rgba(255,255,255,0.2);
+      border-radius: 999px; padding: 0.3em 0.75em; color: #e2e8f0;
+      position: relative; z-index: 2; margin-top: 1rem;
+    }
+    .card-bg1 { background: linear-gradient(135deg, #6c63ff, #8b5cf6); color: white; }
+    .card-bg2 { background: linear-gradient(135deg, #1e293b, #0f172a); color: white; }
+    .card-bg3 { background: linear-gradient(135deg, #f59e0b, #ec4899); color: white; }
+    .card-bg4 { background: linear-gradient(135deg, #10b981, #34d399); color: white; }
+    .card-bg5 { background: linear-gradient(135deg, #3b82f6, #06b6d4); color: white; }
+    .note {
+      max-width: 720px; margin: 2.5rem auto 0; text-align: center;
+      font-size: 0.875rem; color: #64748b;
+    }
+  </style>
+</head>
+<body>
+<header class="demo-header">
+  <h1>ease-noise</h1>
+  <p>Static grain/noise texture overlay — pure CSS, no JS</p>
+</header>
+
+<div class="grid">
+  <div class="card card-bg1 ease-noise">
+    <h3>Default Grain</h3>
+    <p>Subtle film texture</p>
+    <div class="class-tag">.ease-noise</div>
+  </div>
+  <div class="card card-bg2 ease-noise-light">
+    <h3>Light Grain</h3>
+    <p>Very subtle</p>
+    <div class="class-tag">.ease-noise-light</div>
+  </div>
+  <div class="card card-bg3 ease-noise-heavy">
+    <h3>Heavy Grain</h3>
+    <p>Pronounced texture</p>
+    <div class="class-tag">.ease-noise-heavy</div>
+  </div>
+  <div class="card card-bg4 ease-noise">
+    <h3>On Green</h3>
+    <p>Works on any background</p>
+    <div class="class-tag">.ease-noise</div>
+  </div>
+  <div class="card card-bg5 ease-noise">
+    <h3>On Blue</h3>
+    <p>Film grain aesthetic</p>
+    <div class="class-tag">.ease-noise</div>
+  </div>
+  <div class="card card-bg2 ease-noise-pure ease-noise">
+    <h3>Pure CSS Mode</h3>
+    <p>Conic-gradient fallback</p>
+    <div class="class-tag">.ease-noise-pure</div>
+  </div>
+</div>
+
+<p class="note">Uses SVG <code>feTurbulence</code> via data-URI with <code>mix-blend-mode: overlay</code> and <code>pointer-events: none</code>. The SVG is generated inline — no external assets needed.</p>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-28630/style.css
+++ b/submissions/docs/core_changes-issue-28630/style.css
@@ -1,0 +1,54 @@
+/* ============================================================
+   ease-noise — Static Grain/Noise Texture Overlay Utility
+   Submission for EaseMotion CSS · Issue #28630
+   ============================================================ */
+
+@layer easemotion-utilities {
+
+/* ── Noise overlay using SVG filter via data-URI ───────── */
+
+.ease-noise,
+.ease-noise-light,
+.ease-noise-heavy {
+  position: relative;
+}
+
+.ease-noise::after,
+.ease-noise-light::after,
+.ease-noise-heavy::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+  mix-blend-mode: overlay;
+  /* SVG noise texture as data-URI */
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.5'/%3E%3C/svg%3E");
+  background-repeat: repeat;
+  background-size: var(--ease-noise-size, 256px) var(--ease-noise-size, 256px);
+}
+
+.ease-noise::after {
+  opacity: 0.5;
+}
+
+.ease-noise-light::after {
+  opacity: 0.25;
+}
+
+.ease-noise-heavy::after {
+  opacity: 0.8;
+}
+
+/* ── Alternative: conic-gradient noise (pure CSS fallback) ─ */
+
+.ease-noise-pure::after {
+  background-image: none !important;
+  background: repeating-conic-gradient(
+    rgba(0,0,0,0.03) 0% 25%,
+    rgba(0,0,0,0.06) 0% 50%
+  ) !important;
+  background-size: 4px 4px !important;
+}
+
+}


### PR DESCRIPTION
## ✦ Description
Adds `.ease-noise` — static film-grain texture overlay using inline SVG `feTurbulence` via data-URI. Light and heavy variants included.

Fixes #28630
---
## ✦ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
---
## Changes
- `submissions/docs/core_changes-issue-28630/` with `style.css`, `README.md`, `demo.html`
## New Classes
`.ease-noise`, `.ease-noise-light`, `.ease-noise-heavy`, `.ease-noise-pure`
## Testing
- All changes additive only