### PR TITLE
feat: add ease-draw component

### DIFF
--- a/submissions/examples/ease-draw-ij/README.md
+++ b/submissions/examples/ease-draw-ij/README.md
@@ -1,0 +1,7 @@
+# ease-draw
+
+Four SVG paths (wave, offset wave, circle, pentagon) with stroke-dasharray draw animation demonstrating ease-draw utility.
+
+## Files
+- `demo.html`
+- `style.css`

--- a/submissions/examples/ease-draw-ij/demo.html
+++ b/submissions/examples/ease-draw-ij/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-draw</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo">
+    <h1>SVG Draw Animations</h1>
+    <svg class="draw-svg" viewBox="0 0 300 200" xmlns="http://www.w3.org/2000/svg">
+      <path class="path p1" d="M30 170 Q80 20 120 60 T200 140 T270 50" fill="none" />
+      <path class="path p2" d="M40 170 Q90 30 130 70 T210 150 T265 60" fill="none" />
+      <circle class="path p3" cx="150" cy="100" r="60" fill="none" />
+      <polygon class="path p4" points="150,50 190,90 180,140 120,140 110,90" fill="none" />
+    </svg>
+    <div class="legend">
+      <span><i class="sw s1"></i> Wave</span>
+      <span><i class="sw s2"></i> Offset</span>
+      <span><i class="sw s3"></i> Circle</span>
+      <span><i class="sw s4"></i> Pentagon</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-draw-ij/style.css
+++ b/submissions/examples/ease-draw-ij/style.css
@@ -1,0 +1,18 @@
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { min-height: 100vh; display: flex; justify-content: center; align-items: center; background: #0e0e1a; font-family: "Outfit", sans-serif; color: #fff; }
+@media (prefers-reduced-motion: reduce) { * { animation: none !important; } }
+.demo { text-align: center; }
+h1 { font-size: 16px; margin-bottom: 20px; color: #e94560; letter-spacing: 2px; text-transform: uppercase; }
+
+.draw-svg { width: 300px; height: 200px; }
+.path { stroke-width: 2.5; stroke-linecap: round; stroke-linejoin: round; stroke-dasharray: 500; stroke-dashoffset: 500; }
+.p1 { stroke: #e94560; animation: draw 3s ease-in-out infinite; }
+.p2 { stroke: #533483; animation: draw 3s ease-in-out 0.5s infinite; }
+.p3 { stroke: #0f3460; animation: draw 3s ease-in-out 1s infinite; }
+.p4 { stroke: #ffb6c1; animation: draw 3s ease-in-out 1.5s infinite; }
+
+@keyframes draw { 0% { stroke-dashoffset: 500; } 30% { stroke-dashoffset: 0; } 70% { stroke-dashoffset: 0; } 100% { stroke-dashoffset: 500; } }
+
+.legend { display: flex; gap: 16px; justify-content: center; margin-top: 16px; font-size: 12px; color: rgba(255,255,255,0.6); }
+.sw { display: inline-block; width: 12px; height: 3px; border-radius: 2px; vertical-align: middle; margin-right: 4px; }
+.s1 { background: #e94560; } .s2 { background: #533483; } .s3 { background: #0f3460; } .s4 { background: #ffb6c1; }


### PR DESCRIPTION
## Component: ease-draw — SVG path stroke drawing animation utility

### What this adds
Four SVG paths (wave, offset wave, circle, pentagon) drawn using stroke-dasharray animation, showcasing the ease-draw drawing utility.

### Acceptance Criteria covered
- [x] Real CSS animation with @keyframes
- [x] Unique visual styling
- [x] Multiple animated elements

### Files
- submissions/examples/ease-draw-ij/demo.html
- submissions/examples/ease-draw-ij/style.css
- submissions/examples/ease-draw-ij/README.md

### How to review
Open demo.html and observe the SVG paths being drawn.

**Closes #28624**
