### PR TITLE
feat(component): add image comparison slider for issue #28614

### DIFF
--- a/submissions/docs/core_changes-issue-28614/README.md
+++ b/submissions/docs/core_changes-issue-28614/README.md
@@ -1,0 +1,34 @@
+# ease-image-compare — Before/After Image Comparison Slider
+
+## What does this do?
+
+Creates an interactive before/after image comparison slider using a clip-based approach. Drag or click to reveal the underlying image. Requires minimal JS for mouse/touch interaction.
+
+## How is it used?
+
+```html
+<div class="ease-image-compare">
+  <div class="ease-image-compare-after">
+    <img src="after.jpg" alt="After" />
+  </div>
+  <div class="ease-image-compare-before" style="clip-path: inset(0 50% 0 0);">
+    <img src="before.jpg" alt="Before" />
+  </div>
+  <div class="ease-image-compare-handle"></div>
+</div>
+```
+
+### Classes
+
+| Class | Description |
+|---|---|
+| `.ease-image-compare` | Container |
+| `.ease-image-compare-before` | Before image (clipped) |
+| `.ease-image-compare-after` | After image (full) |
+| `.ease-image-compare-handle` | Draggable divider handle |
+
+## Custom Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `--ease-compare-pos` | `50%` | Initial split position |

--- a/submissions/docs/core_changes-issue-28614/compare.js
+++ b/submissions/docs/core_changes-issue-28614/compare.js
@@ -1,0 +1,55 @@
+/* ============================================================
+   ease-image-compare — JavaScript
+   Handles mouse/touch drag to reposition the compare slider.
+   ============================================================ */
+
+(function () {
+  "use strict";
+
+  function init() {
+    var comparers = document.querySelectorAll(".ease-image-compare");
+    comparers.forEach(function (cmp) {
+      var before = cmp.querySelector(".ease-image-compare-before");
+      var root = cmp;
+
+      function setPos(pct) {
+        var p = Math.max(0, Math.min(100, pct));
+        root.style.setProperty("--ease-compare-pos", p + "%");
+      }
+
+      function onMove(clientX) {
+        var rect = root.getBoundingClientRect();
+        var pct = ((clientX - rect.left) / rect.width) * 100;
+        setPos(pct);
+      }
+
+      function onDown(e) {
+        root.classList.add("ease-image-compare-dragging");
+        onMove(e.clientX || e.touches[0].clientX);
+      }
+
+      function onUp() {
+        root.classList.remove("ease-image-compare-dragging");
+      }
+
+      function onDrag(e) {
+        if (!root.classList.contains("ease-image-compare-dragging")) return;
+        e.preventDefault();
+        onMove(e.clientX || e.touches[0].clientX);
+      }
+
+      root.addEventListener("mousedown", onDown);
+      root.addEventListener("touchstart", onDown, { passive: true });
+      document.addEventListener("mousemove", onDrag);
+      document.addEventListener("touchmove", onDrag, { passive: false });
+      document.addEventListener("mouseup", onUp);
+      document.addEventListener("touchend", onUp);
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/submissions/docs/core_changes-issue-28614/demo.html
+++ b/submissions/docs/core_changes-issue-28614/demo.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-image-compare — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #f8fafc; color: #1e293b; padding: 3rem 1.5rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      body { background: #0f172a; color: #f1f5f9; }
+    }
+    .demo-header { text-align: center; margin-bottom: 3rem; }
+    .demo-header h1 { font-size: clamp(2rem, 5vw, 3rem); }
+    .demo-header p { color: #64748b; margin-top: 0.5rem; }
+    .demo-section { max-width: 720px; margin: 0 auto; }
+    .demo-section h2 {
+      font-size: 0.75rem; font-weight: 600; text-transform: uppercase;
+      letter-spacing: 0.1em; color: #6c63ff; margin-bottom: 0.75rem;
+    }
+    .class-tag {
+      display: inline-block; font-size: 0.65rem; font-family: monospace;
+      background: #f1f5f9; border: 1px solid #e2e8f0;
+      border-radius: 999px; padding: 0.3em 0.75em; color: #6c63ff; margin-bottom: 1rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      .class-tag { background: #1e293b; border-color: #334155; }
+    }
+
+    /* Fake images using gradients */
+    .fake-img-before {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      display: flex; align-items: center; justify-content: center;
+      color: rgba(255,255,255,0.6); font-size: 1.2rem; font-weight: 600;
+      min-height: 400px;
+    }
+    .fake-img-after {
+      background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+      display: flex; align-items: center; justify-content: center;
+      color: rgba(255,255,255,0.6); font-size: 1.2rem; font-weight: 600;
+      min-height: 400px;
+    }
+    .fake-img-before.portrait, .fake-img-after.portrait {
+      min-height: 500px;
+    }
+
+    .note { text-align: center; font-size: 0.8rem; color: #64748b; margin-top: 1.5rem; }
+  </style>
+</head>
+<body>
+<header class="demo-header">
+  <h1>ease-image-compare</h1>
+  <p>Before/after image comparison slider — drag the handle</p>
+</header>
+
+<section class="demo-section">
+  <h2>Side-by-Side Comparison</h2>
+  <div class="class-tag">.ease-image-compare</div>
+
+  <div class="ease-image-compare" style="border-radius:0.75rem;overflow:hidden;">
+    <div class="ease-image-compare-after">
+      <div class="fake-img-after">After</div>
+    </div>
+    <div class="ease-image-compare-before">
+      <div class="fake-img-before">Before</div>
+    </div>
+    <div class="ease-image-compare-handle"></div>
+    <div class="ease-image-compare-label ease-image-compare-label-before">Before</div>
+    <div class="ease-image-compare-label ease-image-compare-label-after">After</div>
+  </div>
+</section>
+
+<section class="demo-section" style="margin-top:2rem;">
+  <h2>Tall / Portrait</h2>
+  <div class="class-tag">.ease-image-compare</div>
+
+  <div class="ease-image-compare" style="border-radius:0.75rem;overflow:hidden;max-height:500px;">
+    <div class="ease-image-compare-after">
+      <div class="fake-img-after portrait">After</div>
+    </div>
+    <div class="ease-image-compare-before">
+      <div class="fake-img-before portrait">Before</div>
+    </div>
+    <div class="ease-image-compare-handle"></div>
+  </div>
+</section>
+
+<p class="note">Drag the white handle left/right to compare. Works with mouse and touch.</p>
+
+<script src="compare.js"></script>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-28614/style.css
+++ b/submissions/docs/core_changes-issue-28614/style.css
@@ -1,0 +1,112 @@
+/* ============================================================
+   ease-image-compare — Before/After Image Comparison Slider
+   Submission for EaseMotion CSS · Issue #28614
+   ============================================================ */
+
+@layer easemotion-components {
+
+.ease-image-compare {
+  --ease-compare-pos: 50%;
+
+  position: relative;
+  overflow: hidden;
+  cursor: col-resize;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.ease-image-compare img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  pointer-events: none;
+}
+
+/* ── After image (full width, behind) ──────────────────── */
+
+.ease-image-compare-after {
+  width: 100%;
+}
+
+/* ── Before image (clipped overlay) ────────────────────── */
+
+.ease-image-compare-before {
+  position: absolute;
+  inset: 0;
+  clip-path: inset(0 calc(100% - var(--ease-compare-pos)) 0 0);
+  -webkit-clip-path: inset(0 calc(100% - var(--ease-compare-pos)) 0 0);
+}
+
+.ease-image-compare-before img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* ── Drag handle ───────────────────────────────────────── */
+
+.ease-image-compare-handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: var(--ease-compare-pos);
+  width: 4px;
+  background: white;
+  transform: translateX(-50%);
+  box-shadow: 0 0 8px rgba(0,0,0,0.3);
+  pointer-events: none;
+  z-index: 2;
+}
+
+.ease-image-compare-handle::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+  border: 2px solid white;
+}
+
+.ease-image-compare-handle::after {
+  content: "⟷";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 0.85rem;
+  color: #1e293b;
+  z-index: 1;
+  line-height: 1;
+}
+
+/* ── Labels (optional) ─────────────────────────────────── */
+
+.ease-image-compare-label {
+  position: absolute;
+  top: 1rem;
+  padding: 0.25rem 0.75rem;
+  background: rgba(0,0,0,0.6);
+  color: white;
+  font-size: 0.75rem;
+  border-radius: 0.25rem;
+  pointer-events: none;
+  z-index: 3;
+}
+
+.ease-image-compare-label-before {
+  left: 1rem;
+}
+
+.ease-image-compare-label-after {
+  right: 1rem;
+}
+
+}


### PR DESCRIPTION
Fixes #28614

Adds `.ease-image-compare` — before/after image comparison slider using CSS clip-path with mouse/touch drag support.