### PR TITLE
fix: add pagination to fallback PR list fetch

### DIFF
--- a/.github/workflows/pr-rate-limiter.yml
+++ b/.github/workflows/pr-rate-limiter.yml
@@ -43,14 +43,44 @@ jobs:
               const searchResult = await github.rest.search.issuesAndPullRequests({ q });
               totalCount = searchResult.data.total_count;
               console.log(`Found ${totalCount} PRs submitted by @${prAuthor} in the last 24 hours.`);
-            } catch (err) {
+                       } catch (err) {
               console.log(`Error calling search API: ${err.message}`);
-              // Fallback: list pulls and filter
-              const pulls = await github.rest.pulls.list({ owner, repo, state: 'all', per_page: 100 });
+
+              // Fallback: list pulls and filter with pagination
               const limitMs = Date.now() - 24 * 60 * 60 * 1000;
-              const matchingPulls = pulls.data.filter(p => p.user.login === prAuthor && new Date(p.created_at).getTime() >= limitMs);
+              let page = 1;
+              let matchingPulls = [];
+
+              while (true) {
+                const pulls = await github.rest.pulls.list({
+                  owner,
+                  repo,
+                  state: 'all',
+                  per_page: 100,
+                  page
+                });
+
+                if (pulls.data.length === 0) {
+                  break;
+                }
+
+                matchingPulls.push(
+                  ...pulls.data.filter(
+                    p =>
+                      p.user.login === prAuthor &&
+                      new Date(p.created_at).getTime() >= limitMs
+                  )
+                );
+
+                if (pulls.data.length < 100) {
+                  break;
+                }
+
+                page++;
+              }
+
               totalCount = matchingPulls.length;
-              console.log(`Fallback: Found ${totalCount} PRs in last 100 items.`);
+              console.log(`Fallback: Found ${totalCount} PRs across ${page} page(s).`);
             }
             
             if (totalCount > DAILY_LIMIT) {


### PR DESCRIPTION
Type of Change

🐛 Bug fix

Summary

This PR improves the fallback logic in the PR rate limiter workflow.

Previously, if the GitHub Search API failed, the workflow only checked the first 100 pull requests. In repositories with many PRs, this could result in an incorrect count.

Changes Made
Added pagination to the fallback pulls.list() API call.
Continued fetching pull requests until all pages are processed.
Kept the existing filtering logic unchanged.

This makes the fallback count more reliable when the Search API is unavailable.

Closes #17743