### PR TITLE
feat(utility): add neon hover effect utility classes for issue #28024

### DIFF
--- a/submissions/docs/core_changes-issue-28024/README.md
+++ b/submissions/docs/core_changes-issue-28024/README.md
@@ -1,0 +1,36 @@
+# ease-neon — Neon Hover Effect Utility Classes
+
+## What does this do?
+
+Adds neon glow hover effects to buttons, cards, and interactive elements. Uses `text-shadow` and `box-shadow` animations for a pulsing neon sign aesthetic — pure CSS, no JS required.
+
+## How is it used?
+
+```html
+<button class="ease-neon-pink">Neon Pink</button>
+<a class="ease-neon-blue" href="#">Neon Blue</a>
+<div class="ease-neon-purple">Glow Card</div>
+```
+
+### Classes
+
+| Class | Glow Color |
+|---|---|
+| `.ease-neon-blue` | Cyan/blue glow (#00d4ff) |
+| `.ease-neon-pink` | Hot pink glow (#ff00ff) |
+| `.ease-neon-green` | Lime green glow (#39ff14) |
+| `.ease-neon-purple` | Purple glow (#b026ff) |
+| `.ease-neon-rainbow` | Cycling rainbow glow |
+
+## Custom Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `--ease-neon-color` | *(per class)* | Glow color |
+| `--ease-neon-blur` | `8px` | Blur radius |
+| `--ease-neon-intensity` | `1` | Multiplier for glow spread |
+| `--ease-neon-duration` | `1.5s` | Pulse animation speed |
+
+## Accessibility
+
+Respected via `prefers-reduced-motion: reduce` — disables the pulse animation.

--- a/submissions/docs/core_changes-issue-28024/demo.html
+++ b/submissions/docs/core_changes-issue-28024/demo.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-neon — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #0a0a0f; color: #f1f5f9; padding: 3rem 1.5rem;
+    }
+    .demo-header { text-align: center; margin-bottom: 3rem; }
+    .demo-header h1 { font-size: clamp(2rem, 5vw, 3rem); }
+    .demo-header p { color: #64748b; margin-top: 0.5rem; }
+    .demo-section { max-width: 800px; margin: 0 auto 2.5rem; }
+    .demo-section h2 {
+      font-size: 0.75rem; font-weight: 600; text-transform: uppercase;
+      letter-spacing: 0.1em; color: #6c63ff; margin-bottom: 0.75rem;
+    }
+    .class-tag {
+      display: inline-block; font-size: 0.65rem; font-family: monospace;
+      background: #1e293b; border: 1px solid #334155;
+      border-radius: 999px; padding: 0.3em 0.75em; color: #a5b4fc; margin-bottom: 1rem;
+    }
+    .btn-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+      gap: 1rem;
+    }
+    .btn {
+      padding: 0.75rem 1.25rem; border: 2px solid;
+      border-radius: 0.5rem; font-size: 0.875rem; font-weight: 600;
+      cursor: pointer; background: transparent; color: #f1f5f9;
+      text-align: center; text-decoration: none;
+      outline-offset: 2px;
+    }
+    .btn-blue { border-color: #00d4ff; }
+    .btn-pink { border-color: #ff00ff; }
+    .btn-green { border-color: #39ff14; }
+    .btn-purple { border-color: #b026ff; }
+    .btn-rainbow { border-color: #ff0000; }
+
+    .card-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+      gap: 1rem;
+    }
+    .card {
+      padding: 2rem 1rem; border-radius: 0.75rem;
+      border: 1px solid #1e293b; text-align: center;
+      cursor: pointer; background: rgba(255,255,255,0.02);
+    }
+    .card h3 { font-size: 1rem; margin-bottom: 0.25rem; }
+    .card p { font-size: 0.75rem; color: #64748b; }
+
+    .note { text-align: center; font-size: 0.8rem; color: #64748b; margin-top: 2rem; }
+  </style>
+</head>
+<body>
+<header class="demo-header">
+  <h1 class="ease-neon-pink" style="--ease-neon-duration:2s;">ease-neon</h1>
+  <p>Neon glow hover effects — hover over any element below</p>
+</header>
+
+<section class="demo-section">
+  <h2>Buttons</h2>
+  <div class="class-tag">.ease-neon-*</div>
+  <div class="btn-grid">
+    <button class="btn btn-blue ease-neon-blue">Neon Blue</button>
+    <button class="btn btn-pink ease-neon-pink">Neon Pink</button>
+    <button class="btn btn-green ease-neon-green">Neon Green</button>
+    <button class="btn btn-purple ease-neon-purple">Neon Purple</button>
+    <button class="btn btn-rainbow ease-neon-rainbow">Neon Rainbow</button>
+  </div>
+</section>
+
+<section class="demo-section">
+  <h2>Cards</h2>
+  <div class="card-grid">
+    <div class="card ease-neon-blue">
+      <h3>Blue</h3>
+      <p>Cyan neon glow</p>
+      <div class="class-tag" style="margin-top:0.5rem;">ease-neon-blue</div>
+    </div>
+    <div class="card ease-neon-pink">
+      <h3>Pink</h3>
+      <p>Hot pink glow</p>
+      <div class="class-tag" style="margin-top:0.5rem;">ease-neon-pink</div>
+    </div>
+    <div class="card ease-neon-green">
+      <h3>Green</h3>
+      <p>Lime glow</p>
+      <div class="class-tag" style="margin-top:0.5rem;">ease-neon-green</div>
+    </div>
+    <div class="card ease-neon-purple">
+      <h3>Purple</h3>
+      <p>Violet glow</p>
+      <div class="class-tag" style="margin-top:0.5rem;">ease-neon-purple</div>
+    </div>
+    <div class="card ease-neon-rainbow">
+      <h3>Rainbow</h3>
+      <p>Cycling hues</p>
+      <div class="class-tag" style="margin-top:0.5rem;">ease-neon-rainbow</div>
+    </div>
+  </div>
+</section>
+
+<section class="demo-section">
+  <h2>Inline Text</h2>
+  <p style="font-size:1.25rem;text-align:center;">
+    Hover <span class="ease-neon-blue">this text</span>,
+    <span class="ease-neon-pink">this text</span>, or
+    <span class="ease-neon-green">this text</span>.
+  </p>
+</section>
+
+<p class="note"><code>prefers-reduced-motion</code> disables the pulse animation. Customize via <code>--ease-neon-color</code>, <code>--ease-neon-blur</code>, <code>--ease-neon-duration</code>.</p>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-28024/style.css
+++ b/submissions/docs/core_changes-issue-28024/style.css
@@ -1,0 +1,98 @@
+/* ============================================================
+   ease-neon — Neon Hover Effect Utility Classes
+   Submission for EaseMotion CSS · Issue #28024
+   ============================================================ */
+
+@layer easemotion-utilities {
+
+/* ── Base ──────────────────────────────────────────────── */
+
+[class*="ease-neon"] {
+  --ease-neon-blur: 8px;
+  --ease-neon-intensity: 1;
+  --ease-neon-duration: 1.5s;
+
+  transition:
+    box-shadow var(--ease-neon-duration) ease-in-out,
+    text-shadow var(--ease-neon-duration) ease-in-out;
+}
+
+[class*="ease-neon"]:hover,
+[class*="ease-neon"]:focus-visible {
+  animation: ease-neon-pulse var(--ease-neon-duration) ease-in-out infinite alternate;
+}
+
+@keyframes ease-neon-pulse {
+  from {
+    filter: brightness(1);
+    box-shadow: 0 0 calc(var(--ease-neon-blur) * var(--ease-neon-intensity))
+                calc(var(--ease-neon-blur) * 0.5 * var(--ease-neon-intensity))
+                var(--ease-neon-color);
+    text-shadow: 0 0 calc(var(--ease-neon-blur) * 0.5)
+                 var(--ease-neon-color);
+  }
+  to {
+    filter: brightness(1.2);
+    box-shadow: 0 0 calc(var(--ease-neon-blur) * 2 * var(--ease-neon-intensity))
+                calc(var(--ease-neon-blur) * var(--ease-neon-intensity))
+                var(--ease-neon-color),
+                0 0 calc(var(--ease-neon-blur) * 3 * var(--ease-neon-intensity))
+                calc(var(--ease-neon-blur) * 0.5 * var(--ease-neon-intensity))
+                var(--ease-neon-color);
+    text-shadow: 0 0 calc(var(--ease-neon-blur))
+                 var(--ease-neon-color),
+                 0 0 calc(var(--ease-neon-blur) * 2)
+                 var(--ease-neon-color);
+  }
+}
+
+/* ── Color presets ────────────────────────────────────── */
+
+.ease-neon-blue {
+  --ease-neon-color: #00d4ff;
+}
+
+.ease-neon-pink {
+  --ease-neon-color: #ff00ff;
+}
+
+.ease-neon-green {
+  --ease-neon-color: #39ff14;
+}
+
+.ease-neon-purple {
+  --ease-neon-color: #b026ff;
+}
+
+/* ── Rainbow (cycles through hues) ─────────────────────── */
+
+.ease-neon-rainbow {
+  --ease-neon-color: #ff0000;
+}
+
+.ease-neon-rainbow:hover,
+.ease-neon-rainbow:focus-visible {
+  animation:
+    ease-neon-pulse var(--ease-neon-duration) ease-in-out infinite alternate,
+    ease-neon-hue-rotate 3s linear infinite;
+}
+
+@keyframes ease-neon-hue-rotate {
+  to {
+    filter: hue-rotate(360deg);
+  }
+}
+
+/* ── Reduced motion ────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  [class*="ease-neon"]:hover,
+  [class*="ease-neon"]:focus-visible {
+    animation: none !important;
+  }
+  [class*="ease-neon"] {
+    transition: none !important;
+  }
+}
+
+}


### PR DESCRIPTION
## ✦ Description
Adds neon glow hover effect utility classes (`.ease-neon-blue`, `.ease-neon-pink`, `.ease-neon-green`, `.ease-neon-purple`, `.ease-neon-rainbow`). Hover triggers a pulsing box-shadow/text-shadow animation.

Fixes #28024

---

## ✦ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings or console errors.

---

## Description

### Changes Made
- Added `submissions/docs/core_changes-issue-28024/` with `style.css`, `README.md`, `demo.html`

### New Classes
| Class | Glow Color |
|---|---|
| `.ease-neon-blue` | Cyan/blue (#00d4ff) |
| `.ease-neon-pink` | Hot pink (#ff00ff) |
| `.ease-neon-green` | Lime (#39ff14) |
| `.ease-neon-purple` | Purple (#b026ff) |
| `.ease-neon-rainbow` | Cycling hue rotate |

### Testing
- Works in Chrome, Firefox, Safari
- `prefers-reduced-motion` respected
- All changes additive only