### PR TITLE
feat(component): add border draw animation on hover for issue #16507

### DIFF
--- a/submissions/docs/core_changes-issue-16507/README.md
+++ b/submissions/docs/core_changes-issue-16507/README.md
@@ -1,0 +1,30 @@
+# ease-border-draw — Border Draw Animation on Hover
+
+## What does this do?
+
+Animates borders to draw around an element on hover. Uses `::before`/`::after` pseudo-elements that slide in from corners, creating a "drawing" border effect. Pure CSS, no JS.
+
+## How is it used?
+
+```html
+<button class="ease-border-draw">Hover me</button>
+<div class="ease-border-draw">Card content</div>
+```
+
+### Variants
+
+| Class | Direction | Description |
+|---|---|---|
+| `.ease-border-draw` | Top → Right → Bottom → Left | Full border draws around the element |
+| `.ease-border-draw-top` | Top only | Line draws from center to edges |
+| `.ease-border-draw-bottom` | Bottom only | Line draws from center to edges |
+| `.ease-border-draw-left` | Bottom → Left | Draws bottom then left |
+| `.ease-border-draw-right` | Top → Right | Draws top then right |
+
+## Custom Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `--ease-border-draw-color` | `currentColor` | Border color |
+| `--ease-border-draw-width` | `2px` | Border thickness |
+| `--ease-border-draw-duration` | `0.4s` | Each segment duration |

--- a/submissions/docs/core_changes-issue-16507/demo.html
+++ b/submissions/docs/core_changes-issue-16507/demo.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-border-draw — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #f8fafc; color: #1e293b; padding: 3rem 1.5rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      body { background: #0f172a; color: #f1f5f9; }
+    }
+    .demo-header { text-align: center; margin-bottom: 3rem; }
+    .demo-header h1 { font-size: clamp(2rem, 5vw, 3rem); }
+    .demo-header p { color: #64748b; margin-top: 0.5rem; }
+    .demo-section { max-width: 720px; margin: 0 auto 2.5rem; }
+    .demo-section h2 {
+      font-size: 0.75rem; font-weight: 600; text-transform: uppercase;
+      letter-spacing: 0.1em; color: #6c63ff; margin-bottom: 0.75rem;
+    }
+    .class-tag {
+      display: inline-block; font-size: 0.65rem; font-family: monospace;
+      background: #f1f5f9; border: 1px solid #e2e8f0;
+      border-radius: 999px; padding: 0.3em 0.75em; color: #6c63ff; margin-bottom: 1rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      .class-tag { background: #1e293b; border-color: #334155; }
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+      gap: 1rem;
+    }
+    .btn {
+      padding: 1rem 1.5rem; border: none; border-radius: 0.5rem;
+      font-size: 0.875rem; font-weight: 600; cursor: pointer;
+      background: #6c63ff; color: white;
+      text-align: center;
+    }
+    .card {
+      padding: 1.5rem; border-radius: 0.5rem;
+      background: white; border: 1px solid #e2e8f0;
+      text-align: center; cursor: pointer;
+    }
+    @media (prefers-color-scheme: dark) {
+      .card { background: #1e293b; border-color: #334155; }
+    }
+    .card h3 { margin-bottom: 0.25rem; }
+    .card p { font-size: 0.8rem; color: #64748b; }
+
+    .demo-row {
+      display: flex; gap: 1rem; flex-wrap: wrap;
+    }
+    .demo-row .card { flex: 1; min-width: 160px; }
+
+    .note { text-align: center; font-size: 0.8rem; color: #64748b; margin-top: 2rem; }
+  </style>
+</head>
+<body>
+<header class="demo-header">
+  <h1>ease-border-draw</h1>
+  <p>Border draw animation on hover</p>
+</header>
+
+<section class="demo-section">
+  <h2>Full Border Draw</h2>
+  <div class="class-tag">.ease-border-draw</div>
+  <div class="grid">
+    <button class="btn ease-border-draw" style="--ease-border-draw-color:white;">
+      Button
+      <span class="ease-border-draw-edge-r"></span>
+      <span class="ease-border-draw-edge-l"></span>
+    </button>
+    <div class="card ease-border-draw" style="--ease-border-draw-color:#6c63ff;">
+      <h3>Card</h3>
+      <p>Draws all 4 sides</p>
+      <span class="ease-border-draw-edge-r"></span>
+      <span class="ease-border-draw-edge-l"></span>
+    </div>
+  </div>
+</section>
+
+<section class="demo-section">
+  <h2>Single-Side Variants</h2>
+  <div class="demo-row">
+    <div class="card ease-border-draw-top" style="--ease-border-draw-color:#6c63ff;">
+      <h3>Top Only</h3>
+      <div class="class-tag" style="margin-top:0.5rem;">ease-border-draw-top</div>
+    </div>
+    <div class="card ease-border-draw-bottom" style="--ease-border-draw-color:#ec4899;">
+      <h3>Bottom Only</h3>
+      <div class="class-tag" style="margin-top:0.5rem;">ease-border-draw-bottom</div>
+    </div>
+    <div class="card ease-border-draw-left" style="--ease-border-draw-color:#10b981;">
+      <h3>Left</h3>
+      <div class="class-tag" style="margin-top:0.5rem;">ease-border-draw-left</div>
+    </div>
+    <div class="card ease-border-draw-right" style="--ease-border-draw-color:#f59e0b;">
+      <h3>Right</h3>
+      <div class="class-tag" style="margin-top:0.5rem;">ease-border-draw-right</div>
+    </div>
+  </div>
+</section>
+
+<section class="demo-section">
+  <h2>Custom Styling</h2>
+  <div class="grid">
+    <div class="btn ease-border-draw" style="background:#1e293b;--ease-border-draw-color:#39ff14;--ease-border-draw-width:3px;--ease-border-draw-duration:0.6s;">
+      Neon Green
+      <span class="ease-border-draw-edge-r"></span>
+      <span class="ease-border-draw-edge-l"></span>
+    </div>
+    <div class="card ease-border-draw-top" style="--ease-border-draw-color:#ff00ff;--ease-border-draw-width:3px;">
+      <h3>Pink Top</h3>
+      <p>Thick pink line</p>
+    </div>
+  </div>
+</section>
+
+<p class="note">Customize via <code>--ease-border-draw-color</code>, <code>--ease-border-draw-width</code>, <code>--ease-border-draw-duration</code>.</p>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-16507/style.css
+++ b/submissions/docs/core_changes-issue-16507/style.css
@@ -1,0 +1,141 @@
+/* ============================================================
+   ease-border-draw — Border Draw Animation on Hover
+   Submission for EaseMotion CSS · Issue #16507
+   ============================================================ */
+
+@layer easemotion-components {
+
+.ease-border-draw,
+.ease-border-draw-top,
+.ease-border-draw-bottom,
+.ease-border-draw-left,
+.ease-border-draw-right {
+  --ease-border-draw-color: currentColor;
+  --ease-border-draw-width: 2px;
+  --ease-border-draw-duration: 0.4s;
+
+  position: relative;
+  overflow: hidden;
+}
+
+/* ── Shared pseudo-element setup ───────────────────────── */
+
+.ease-border-draw::before,
+.ease-border-draw::after,
+.ease-border-draw-top::before,
+.ease-border-draw-bottom::before,
+.ease-border-draw-left::before,
+.ease-border-draw-left::after,
+.ease-border-draw-right::before,
+.ease-border-draw-right::after {
+  content: "";
+  position: absolute;
+  background: var(--ease-border-draw-color);
+  transition: transform var(--ease-border-draw-duration) ease;
+  will-change: transform;
+}
+
+/* ══════════════════════════════════════════════════════════
+   FULL BORDER DRAW (4 sides sequentially)
+   ══════════════════════════════════════════════════════════ */
+
+/* Top: center → right edges */
+.ease-border-draw::before {
+  top: 0; left: 0; right: 0; height: var(--ease-border-draw-width);
+  transform: scaleX(0);
+  transform-origin: left;
+}
+
+/* Bottom: center → edges */
+.ease-border-draw::after {
+  bottom: 0; left: 0; right: 0; height: var(--ease-border-draw-width);
+  transform: scaleX(0);
+  transform-origin: right;
+}
+
+/* Right */
+.ease-border-draw .ease-border-draw-edge-r {
+  position: absolute;
+  top: 0; right: 0; bottom: 0; width: var(--ease-border-draw-width);
+  background: var(--ease-border-draw-color);
+  transform: scaleY(0);
+  transform-origin: bottom;
+  transition: transform var(--ease-border-draw-duration) ease var(--ease-border-draw-duration);
+}
+
+/* Left */
+.ease-border-draw .ease-border-draw-edge-l {
+  position: absolute;
+  top: 0; left: 0; bottom: 0; width: var(--ease-border-draw-width);
+  background: var(--ease-border-draw-color);
+  transform: scaleY(0);
+  transform-origin: top;
+  transition: transform var(--ease-border-draw-duration) ease calc(var(--ease-border-draw-duration) * 2);
+}
+
+.ease-border-draw:hover::before { transform: scaleX(1); }
+.ease-border-draw:hover::after { transform: scaleX(1); }
+.ease-border-draw:hover .ease-border-draw-edge-r { transform: scaleY(1); }
+.ease-border-draw:hover .ease-border-draw-edge-l { transform: scaleY(1); }
+
+/* ══════════════════════════════════════════════════════════
+   SINGLE-SIDE VARIANTS
+   ══════════════════════════════════════════════════════════ */
+
+/* Top: center → edges */
+.ease-border-draw-top::before {
+  top: 0; left: 0; right: 0; height: var(--ease-border-draw-width);
+  transform: scaleX(0);
+  transform-origin: center;
+}
+.ease-border-draw-top:hover::before { transform: scaleX(1); }
+
+/* Bottom: center → edges */
+.ease-border-draw-bottom::before {
+  bottom: 0; left: 0; right: 0; height: var(--ease-border-draw-width);
+  transform: scaleX(0);
+  transform-origin: center;
+}
+.ease-border-draw-bottom:hover::before { transform: scaleX(1); }
+
+/* Left: bottom → top */
+.ease-border-draw-left::before {
+  top: 0; left: 0; bottom: 0; width: var(--ease-border-draw-width);
+  transform: scaleY(0);
+  transform-origin: bottom;
+}
+.ease-border-draw-left::after {
+  bottom: 0; left: 0; right: 0; height: var(--ease-border-draw-width);
+  transform: scaleX(0);
+  transform-origin: right;
+}
+.ease-border-draw-left:hover::before { transform: scaleY(1); }
+.ease-border-draw-left:hover::after { transform: scaleX(1); }
+
+/* Right: top → bottom */
+.ease-border-draw-right::before {
+  top: 0; right: 0; bottom: 0; width: var(--ease-border-draw-width);
+  transform: scaleY(0);
+  transform-origin: top;
+}
+.ease-border-draw-right::after {
+  top: 0; left: 0; right: 0; height: var(--ease-border-draw-width);
+  transform: scaleX(0);
+  transform-origin: left;
+}
+.ease-border-draw-right:hover::before { transform: scaleY(1); }
+.ease-border-draw-right:hover::after { transform: scaleX(1); }
+
+/* ── Reduced motion ────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  [class*="ease-border-draw"]::before,
+  [class*="ease-border-draw"]::after,
+  [class*="ease-border-draw"] .ease-border-draw-edge-r,
+  [class*="ease-border-draw"] .ease-border-draw-edge-l {
+    transition: none !important;
+    transform: none !important;
+  }
+}
+
+}


### PR DESCRIPTION
## ✦ Description
Adds `.ease-border-draw` — animated border draw on hover. Full 4-side variant and single-side variants (top, bottom, left, right). Pure CSS.

Fixes #16507
---
## ✦ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
---
## Changes
- `submissions/docs/core_changes-issue-16507/` with `style.css`, `README.md`, `demo.html`
## New Classes
`.ease-border-draw`, `.ease-border-draw-top`, `.ease-border-draw-bottom`, `.ease-border-draw-left`, `.ease-border-draw-right`
## Testing
- All changes additive only