### PR TITLE
feat(utility): add direction-aware slide animations for issue #16996

### DIFF
--- a/submissions/docs/core_changes-issue-16996/README.md
+++ b/submissions/docs/core_changes-issue-16996/README.md
@@ -1,0 +1,36 @@
+# ease-slide-direction — Direction-Aware Slide Animations
+
+## What does this do?
+
+Adds slide-in/out animations from 8 directions: top, bottom, left, right, top-left, top-right, bottom-left, bottom-right. Useful for entrance animations, panels, modals, and tooltips.
+
+## How is it used?
+
+```html
+<div class="ease-slide-in-top">Slides in from top</div>
+<div class="ease-slide-in-bottom-left">Slides in from bottom-left</div>
+```
+
+### Classes
+
+| Class | Direction | Transform |
+|---|---|---|
+| `.ease-slide-in-top` | From top | `translateY(-100%)` |
+| `.ease-slide-in-bottom` | From bottom | `translateY(100%)` |
+| `.ease-slide-in-left` | From left | `translateX(-100%)` |
+| `.ease-slide-in-right` | From right | `translateX(100%)` |
+| `.ease-slide-in-top-left` | From top-left | `translate(-100%, -100%)` |
+| `.ease-slide-in-top-right` | From top-right | `translate(100%, -100%)` |
+| `.ease-slide-in-bottom-left` | From bottom-left | `translate(-100%, 100%)` |
+| `.ease-slide-in-bottom-right` | From bottom-right | `translate(100%, 100%)` |
+
+## Custom Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `--ease-slide-duration` | `0.4s` | Animation duration |
+| `--ease-slide-timing` | `cubic-bezier(0.16, 1, 0.3, 1)` | Easing curve |
+
+## Accessibility
+
+Respected via `prefers-reduced-motion`.

--- a/submissions/docs/core_changes-issue-16996/demo.html
+++ b/submissions/docs/core_changes-issue-16996/demo.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-slide-direction — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #f8fafc; color: #1e293b; padding: 3rem 1.5rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      body { background: #0f172a; color: #f1f5f9; }
+    }
+    .demo-header { text-align: center; margin-bottom: 3rem; }
+    .demo-header h1 { font-size: clamp(2rem, 5vw, 3rem); }
+    .demo-header p { color: #64748b; margin-top: 0.5rem; }
+    .demo-section { max-width: 800px; margin: 0 auto 2.5rem; }
+    .demo-section > h2 {
+      font-size: 0.75rem; font-weight: 600; text-transform: uppercase;
+      letter-spacing: 0.1em; color: #6c63ff; margin-bottom: 0.75rem;
+    }
+    .class-tag {
+      display: inline-block; font-size: 0.65rem; font-family: monospace;
+      background: #f1f5f9; border: 1px solid #e2e8f0;
+      border-radius: 999px; padding: 0.3em 0.75em; color: #6c63ff; margin-bottom: 1rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      .class-tag { background: #1e293b; border-color: #334155; }
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+      gap: 1rem;
+    }
+    .card {
+      padding: 1.5rem 1rem; border-radius: 0.5rem;
+      background: white; border: 1px solid #e2e8f0;
+      text-align: center; font-size: 0.8rem; font-weight: 500;
+    }
+    @media (prefers-color-scheme: dark) {
+      .card { background: #1e293b; border-color: #334155; }
+    }
+    .card .tag { font-size: 0.6rem; color: #6c63ff; font-family: monospace; margin-top: 0.3rem; }
+
+    .controls {
+      text-align: center; margin: 1.5rem 0;
+    }
+    .btn {
+      padding: 0.65rem 1.25rem; background: #6c63ff; color: white;
+      border: none; border-radius: 0.5rem; font-size: 0.875rem; font-weight: 600;
+      cursor: pointer;
+    }
+    .btn:active { transform: scale(0.97); }
+
+    .demo-panel {
+      overflow: hidden; border-radius: 0.75rem;
+    }
+    .panel-inner {
+      min-height: 200px; display: grid; place-items: center;
+      font-size: 1.25rem; font-weight: 600;
+      color: white; background: linear-gradient(135deg, #6c63ff, #8b5cf6);
+    }
+
+    .note { text-align: center; font-size: 0.8rem; color: #64748b; margin-top: 2rem; }
+  </style>
+</head>
+<body>
+<header class="demo-header">
+  <h1>ease-slide-direction</h1>
+  <p>Direction-aware slide animations — 8 directions</p>
+</header>
+
+<section class="demo-section demo-panel" id="demoPanel">
+  <h2>Live Demo</h2>
+  <div class="controls">
+    <button class="btn" onclick="replay()">Replay Animation</button>
+  </div>
+  <div id="panel" class="panel-inner ease-slide-in-left">Slides from the left</div>
+</section>
+
+<section class="demo-section">
+  <h2>All Directions</h2>
+  <div class="class-tag">Animations play on page load</div>
+  <div class="grid">
+    <div class="card ease-slide-in-top" style="--ease-slide-duration:0.6s;">
+      ease-slide-in-top
+    </div>
+    <div class="card ease-slide-in-bottom" style="animation-delay:0.1s;">
+      ease-slide-in-bottom
+    </div>
+    <div class="card ease-slide-in-left" style="animation-delay:0.2s;">
+      ease-slide-in-left
+    </div>
+    <div class="card ease-slide-in-right" style="animation-delay:0.3s;">
+      ease-slide-in-right
+    </div>
+    <div class="card ease-slide-in-top-left" style="animation-delay:0.4s;">
+      ease-slide-in-top-left
+    </div>
+    <div class="card ease-slide-in-top-right" style="animation-delay:0.5s;">
+      ease-slide-in-top-right
+    </div>
+    <div class="card ease-slide-in-bottom-left" style="animation-delay:0.6s;">
+      ease-slide-in-bottom-left
+    </div>
+    <div class="card ease-slide-in-bottom-right" style="animation-delay:0.7s;">
+      ease-slide-in-bottom-right
+    </div>
+  </div>
+</section>
+
+<script>
+function replay() {
+  var p = document.getElementById('panel');
+  var dirs = ['top', 'bottom', 'left', 'right', 'top-left', 'top-right', 'bottom-left', 'bottom-right'];
+  var next = dirs[Math.floor(Math.random() * dirs.length)];
+  p.className = 'panel-inner';
+  void p.offsetWidth;
+  p.classList.add('ease-slide-in-' + next);
+  p.textContent = 'Slides from ' + next;
+}
+</script>
+<p class="note">Customize via <code>--ease-slide-duration</code> (default 0.4s) and <code>--ease-slide-timing</code>. Respects <code>prefers-reduced-motion</code>.</p>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-16996/style.css
+++ b/submissions/docs/core_changes-issue-16996/style.css
@@ -1,0 +1,100 @@
+/* ============================================================
+   ease-slide-direction — Direction-Aware Slide Animations
+   Submission for EaseMotion CSS · Issue #16996
+   ============================================================ */
+
+@layer easemotion-utilities {
+
+/* ── Keyframes ─────────────────────────────────────────── */
+
+@keyframes ease-slide-from-top {
+  from { transform: translateY(-100%); opacity: 0; }
+  to   { transform: translateY(0); opacity: 1; }
+}
+
+@keyframes ease-slide-from-bottom {
+  from { transform: translateY(100%); opacity: 0; }
+  to   { transform: translateY(0); opacity: 1; }
+}
+
+@keyframes ease-slide-from-left {
+  from { transform: translateX(-100%); opacity: 0; }
+  to   { transform: translateX(0); opacity: 1; }
+}
+
+@keyframes ease-slide-from-right {
+  from { transform: translateX(100%); opacity: 0; }
+  to   { transform: translateX(0); opacity: 1; }
+}
+
+@keyframes ease-slide-from-top-left {
+  from { transform: translate(-100%, -100%); opacity: 0; }
+  to   { transform: translate(0, 0); opacity: 1; }
+}
+
+@keyframes ease-slide-from-top-right {
+  from { transform: translate(100%, -100%); opacity: 0; }
+  to   { transform: translate(0, 0); opacity: 1; }
+}
+
+@keyframes ease-slide-from-bottom-left {
+  from { transform: translate(-100%, 100%); opacity: 0; }
+  to   { transform: translate(0, 0); opacity: 1; }
+}
+
+@keyframes ease-slide-from-bottom-right {
+  from { transform: translate(100%, 100%); opacity: 0; }
+  to   { transform: translate(0, 0); opacity: 1; }
+}
+
+/* ── Utility classes ───────────────────────────────────── */
+
+[class*="ease-slide-in-"] {
+  --ease-slide-duration: 0.4s;
+  --ease-slide-timing: cubic-bezier(0.16, 1, 0.3, 1);
+
+  animation: var(--ease-slide-duration) var(--ease-slide-timing) forwards;
+}
+
+.ease-slide-in-top {
+  animation-name: ease-slide-from-top;
+}
+
+.ease-slide-in-bottom {
+  animation-name: ease-slide-from-bottom;
+}
+
+.ease-slide-in-left {
+  animation-name: ease-slide-from-left;
+}
+
+.ease-slide-in-right {
+  animation-name: ease-slide-from-right;
+}
+
+.ease-slide-in-top-left {
+  animation-name: ease-slide-from-top-left;
+}
+
+.ease-slide-in-top-right {
+  animation-name: ease-slide-from-top-right;
+}
+
+.ease-slide-in-bottom-left {
+  animation-name: ease-slide-from-bottom-left;
+}
+
+.ease-slide-in-bottom-right {
+  animation-name: ease-slide-from-bottom-right;
+}
+
+/* ── Reduced motion ────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  [class*="ease-slide-in-"] {
+    animation: none !important;
+    opacity: 1 !important;
+  }
+}
+
+}


### PR DESCRIPTION
## ✦ Description
Adds 8 direction-aware slide-in animations (top, bottom, left, right, top-left, top-right, bottom-left, bottom-right). Each uses translate + opacity for smooth entrances.

Fixes #16996
---
## ✦ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
---
## Changes
- `submissions/docs/core_changes-issue-16996/` with `style.css`, `README.md`, `demo.html`
## New Classes
`.ease-slide-in-top`, `.ease-slide-in-bottom`, `.ease-slide-in-left`, `.ease-slide-in-right`, `.ease-slide-in-top-left`, `.ease-slide-in-top-right`, `.ease-slide-in-bottom-left`, `.ease-slide-in-bottom-right`
## Testing
- All changes additive only