### PR TITLE
[Feat] #25879 — Add macOS-style navigation component (unique folder)

### DIFF
--- a/submissions/examples/ease-macos-dock-25879-ag/demo.html
+++ b/submissions/examples/ease-macos-dock-25879-ag/demo.html
@@ -28,27 +28,27 @@
     <div class="dock-container">
       <nav class="ease-dock">
         
-        <div class="dock-item" data-title="Finder">
+        <div class="dock-item" id="dock-finder" data-title="Finder">
           <div class="icon Finder"><span>Finder</span></div>
           <span class="tooltip">Finder</span>
         </div>
 
-        <div class="dock-item" data-title="Terminal">
+        <div class="dock-item" id="dock-terminal" data-title="Terminal">
           <div class="icon Terminal"><span>Terminal</span></div>
           <span class="tooltip">Terminal</span>
         </div>
 
-        <div class="dock-item" data-title="Browser">
+        <div class="dock-item" id="dock-browser" data-title="Browser">
           <div class="icon Browser"><span>Browser</span></div>
           <span class="tooltip">Browser</span>
         </div>
 
-        <div class="dock-item" data-title="Mail">
+        <div class="dock-item" id="dock-mail" data-title="Mail">
           <div class="icon Mail"><span>Mail</span></div>
           <span class="tooltip">Mail</span>
         </div>
 
-        <div class="dock-item" data-title="Settings">
+        <div class="dock-item" id="dock-settings" data-title="Settings">
           <div class="icon Settings"><span>Settings</span></div>
           <span class="tooltip">Settings</span>
         </div>


### PR DESCRIPTION
## Summary
Adds the `ease-macos-dock` component. It provides a glassmorphism navigation bar containing circular icons that magnify smoothly on mouse hover, implementing adjacent sibling selectors (`+`) to scale neighboring icons slightly to replicate the macOS dock magnification effect.

## Root Cause
No interactive docks or magnification-based layouts existed in the EaseMotion CSS component library.

## Changes Made
- `submissions/examples/ease-macos-dock-25879-ag/demo.html`: Nav container housing dock nodes, SVGs, and tooltip parameters.
- `submissions/examples/ease-macos-dock-25879-ag/style.css`: Glassmorphism panel configurations, tooltip animations, hover transitions, and adjacent sibling targets.
- `submissions/examples/ease-macos-dock-25879-ag/README.md`: Explains adjacent selector structures, transition guidelines, and manual testing.

## How to Test
1. Open `demo.html` in a browser.
2. Hover over icons to verify the magnification transitions.

## Related Issue
Closes #25879