### PR TITLE
[Feat] #25811 — Add CSS bottom navigation component (unique folder)

### DIFF
--- a/submissions/examples/ease-bottom-nav-25811-ag/README.md
+++ b/submissions/examples/ease-bottom-nav-25811-ag/README.md
@@ -1,0 +1,19 @@
+# Mobile Bottom Navigation Component
+
+This submission implements a premium glassmorphic bottom navigation tab bar commonly used in mobile application viewports.
+
+---
+
+## Technical Details
+
+- **Mobile Viewport Simulator**: Renders tab alignments inside a custom mock phone frame.
+- **Micro-Animations**: Clicking tabs triggers icon translateY translations and reveals neon active indicator dots.
+- **Glassmorphic Blurs**: Uses `backdrop-filter: blur(20px)` and alpha border boundaries.
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Click through the bottom tabs (Home, Search, Library, Profile).
+3. Verify that active tabs shift colors and reveal bottom indicator dots smoothly.

--- a/submissions/examples/ease-bottom-nav-25811-ag/demo.html
+++ b/submissions/examples/ease-bottom-nav-25811-ag/demo.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mobile Bottom Navigation — EaseMotion CSS</title>
+  <meta name="description" content="Premium responsive mobile bottom navigation bar with active indicators, micro-animations, and glassmorphism layouts.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Nav Components</span>
+      <h1>Bottom Navigation Bar</h1>
+      <p class="description">
+        Commonly utilized in mobile application layouts. 
+        Click the tabs below inside the simulator frame to verify active transition states.
+      </p>
+    </header>
+
+    <main class="showcase">
+
+      <!-- Simulated Mobile Device Frame -->
+      <div class="mobile-frame">
+        <div class="status-bar">
+          <span>9:41</span>
+          <span>📶 🔋</span>
+        </div>
+        
+        <div class="mobile-content" id="screen-content">
+          <h2>Home Feed</h2>
+          <p>Tap items in the bottom tab bar to switch views.</p>
+        </div>
+
+        <!-- Glassmorphism Bottom Tab Bar -->
+        <nav class="ease-bottom-nav">
+          
+          <button class="nav-tab active" data-view="Home" type="button">
+            <span class="tab-icon">🏠</span>
+            <span class="tab-label">Home</span>
+            <span class="active-dot"></span>
+          </button>
+
+          <button class="nav-tab" data-view="Search" type="button">
+            <span class="tab-icon">🔍</span>
+            <span class="tab-label">Search</span>
+            <span class="active-dot"></span>
+          </button>
+
+          <button class="nav-tab" data-view="Library" type="button">
+            <span class="tab-icon">📚</span>
+            <span class="tab-label">Library</span>
+            <span class="active-dot"></span>
+          </button>
+
+          <button class="nav-tab" data-view="Profile" type="button">
+            <span class="tab-icon">👤</span>
+            <span class="tab-label">Profile</span>
+            <span class="active-dot"></span>
+          </button>
+
+        </nav>
+      </div>
+
+    </main>
+  </div>
+
+  <script>
+    const tabs = document.querySelectorAll('.nav-tab');
+    const content = document.getElementById('screen-content');
+
+    tabs.forEach(tab => {
+      tab.addEventListener('click', () => {
+        tabs.forEach(t => t.classList.remove('active'));
+        tab.classList.add('active');
+
+        const view = tab.dataset.view;
+        content.innerHTML = `
+          <h2>${view} View</h2>
+          <p>Showing user content for the ${view.toLowerCase()} module.</p>
+        `;
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-bottom-nav-25811-ag/style.css
+++ b/submissions/examples/ease-bottom-nav-25811-ag/style.css
@@ -1,0 +1,201 @@
+/* ============================================================
+   Mobile Bottom Navigation — style.css
+   Submission for EaseMotion CSS Issue #25811
+   Glassmorphic bottom tab bars with active dot highlights
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --bar-bg: rgba(31, 41, 55, 0.65);
+  --bar-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 800px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+  align-items: center;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+  max-width: 500px;
+}
+
+/* ============================================================
+   Mobile Simulator Frame
+   ============================================================ */
+
+.mobile-frame {
+  width: 320px;
+  height: 580px;
+  background: #0f172a;
+  border: 10px solid #1e293b;
+  border-radius: 40px;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+}
+
+/* Status Bar Mock */
+.status-bar {
+  padding: 12px 24px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+  display: flex;
+  justify-content: space-between;
+}
+
+/* Main Display Area */
+.mobile-content {
+  flex: 1;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+
+.mobile-content h2 {
+  font-size: 1.5rem;
+  font-weight: 800;
+}
+
+.mobile-content p {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+/* ============================================================
+   Bottom Navigation Component
+   ============================================================ */
+
+.ease-bottom-nav {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background: var(--bar-bg);
+  border-top: 1px solid var(--bar-border);
+  padding: 12px 18px 20px; /* Extra padding bottom for home indicator spacing */
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  display: flex;
+  justify-content: space-around;
+  box-shadow: 0 -10px 25px rgba(0,0,0,0.15);
+}
+
+.nav-tab {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  width: 52px;
+  position: relative;
+  transition: color 0.25s ease;
+}
+
+.tab-icon {
+  font-size: 1.15rem;
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.tab-label {
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+/* Active Highlight Dot */
+.active-dot {
+  position: absolute;
+  bottom: -6px;
+  width: 4px;
+  height: 4px;
+  background: var(--primary-color);
+  border-radius: 50%;
+  transform: scale(0);
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* ── Active Tab Styling ── */
+.nav-tab.active {
+  color: var(--text-primary);
+}
+
+.nav-tab.active .tab-icon {
+  transform: translateY(-4px) scale(1.1);
+}
+
+.nav-tab.active .active-dot {
+  transform: scale(1);
+  box-shadow: 0 0 8px var(--primary-color);
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .tab-icon,
+  .active-dot {
+    transition: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-bottom-nav` component. Designed for mobile layouts, it features a glassmorphic bottom tab bar containing icons and labels that slide and reveal neon indicator dots upon selection using client tab clicks.

## Root Cause
No bottom navigation components or mobile-viewport-centered navigation bars existed in the library.

## Changes Made
- `submissions/examples/ease-bottom-nav-25811-ag/demo.html`: Mobile screen frame housing tab buttons, labels, and indicators.
- `submissions/examples/ease-bottom-nav-25811-ag/style.css`: Simulator phone parameters, navigation bar blur layers, tab transitions, and dot indicators.
- `submissions/examples/ease-bottom-nav-25811-ag/README.md`: Explains CSS properties, mobile styling, and manual inspection.

## How to Test
1. Open `demo.html` in a browser.
2. Click tabs inside the mobile frame to verify selection highlights.

## Related Issue
Closes #25811