### PR TITLE
[Docs] #17745 — Add API stale state sandbox (unique folder)

### DIFF
--- a/submissions/examples/api-stale-state-17745-ag/README.md
+++ b/submissions/examples/api-stale-state-17745-ag/README.md
@@ -1,0 +1,40 @@
+# Webhook Payload Stale State Guidelines
+
+This guide details code integrity guidelines for managing webhook race conditions, demonstrating how to prevent stale state validations.
+
+---
+
+## Technical Overview: The Stale Context Bug
+
+Webhook event triggers (like GitHub Action triggers) supply a snapshot JSON payload detailing state configurations at the moment of trigger firing:
+```javascript
+// BUG: Uses payload parameters snapshot which might be stale by execution time
+const assignees = context.payload.issue.assignees;
+```
+
+If another workflow or admin updates assignment parameters in the seconds between the webhook firing and the script executing, the payload snapshot becomes stale, creating race conditions.
+
+---
+
+## Best Practices for Webhook Query Checks
+
+1. **Explicit API Refetches**:
+   Instead of checking payload snapshots directly, query the database or REST API to fetch the most recent status:
+   ```javascript
+   const freshIssue = await octokit.rest.issues.get({
+     owner: context.repo.owner,
+     repo: context.repo.repo,
+     issue_number: context.issue.number
+   });
+   const assignees = freshIssue.data.assignees;
+   ```
+2. **Conditional Assertions**:
+   Include state validation gates prior to writing modifications to the database.
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Click **Check Stale Webhook Payload** — observe the warning indicating stale assignments checks occurred.
+3. Click **Query Fresh API Status** — verify the simulator fetches the latest database status, showing that the unassignment was captured correctly.

--- a/submissions/examples/api-stale-state-17745-ag/demo.html
+++ b/submissions/examples/api-stale-state-17745-ag/demo.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>API Stale State Sandbox — EaseMotion CSS</title>
+  <meta name="description" content="State resolution sandbox simulating webhook race conditions, stale payload checks, and fresh API query resolutions.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Script Resilience</span>
+      <h1>API Stale State Resolver</h1>
+      <p class="description">
+        Demonstrates webhook race conditions where scripts rely on stale context payloads (e.g. <code>context.payload.issue</code>) 
+        instead of querying fresh database status.
+      </p>
+    </header>
+
+    <main class="dashboard">
+
+      <!-- Left Panel: Trigger Sandbox -->
+      <section class="demo-card state-card">
+        <h2 class="section-title">State Query Simulators</h2>
+        
+        <div class="simulator-buttons">
+          <button class="ease-btn" id="btn-run-stale" type="button">Check Stale Webhook Payload</button>
+          <button class="ease-btn ease-btn-success" id="btn-run-fresh" type="button">Query Fresh API Status</button>
+        </div>
+      </section>
+
+      <!-- Right Panel: Visual Logs -->
+      <section class="demo-card logs-card">
+        <h2 class="section-title">Query Console Logs</h2>
+        
+        <div class="logs-console" id="logs-console">
+          <div class="log-line text-muted">[System] Sandbox active. Webhook payload initialized (Assignees: "john_doe").</div>
+        </div>
+      </section>
+
+    </main>
+  </div>
+
+  <script>
+    const logsConsole = document.getElementById('logs-console');
+
+    const logMsg = (text, type = 'normal') => {
+      const line = document.createElement('div');
+      line.className = `log-line ${type === 'muted' ? 'text-muted' : ''} ${type === 'danger' ? 'text-danger' : ''} ${type === 'success' ? 'text-success' : ''}`;
+      line.innerHTML = text;
+      logsConsole.appendChild(line);
+      logsConsole.scrollTop = logsConsole.scrollHeight;
+    };
+
+    // Stale check (uses context.payload)
+    document.getElementById('btn-run-stale').addEventListener('click', () => {
+      logMsg('🚀 Checking assignees list from incoming Webhook payload...', 'normal');
+      setTimeout(() => {
+        logMsg('🔍 Read: <code>context.payload.issue.assignees</code> -> ["john_doe"]', 'muted');
+        logMsg('⚠️ WARNING: Checked stale cache! Skip unclaim logic because john_doe is still listed.', 'danger');
+      }, 500);
+    });
+
+    // Fresh check (queries API)
+    document.getElementById('btn-run-fresh').addEventListener('click', () => {
+      logMsg('🚀 Refetching latest database state via API...', 'normal');
+      setTimeout(() => {
+        logMsg('🔄 API GET /repos/.../issues/123 -> Status: Refetched', 'muted');
+        logMsg('🔍 Read: <code>response.data.assignees</code> -> [] (john_doe was unassigned 2s ago)', 'success');
+        logMsg('✅ SUCCESS: Fresh data utilized. Triggering auto-claim routine successfully!', 'success');
+      }, 600);
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/api-stale-state-17745-ag/style.css
+++ b/submissions/examples/api-stale-state-17745-ag/style.css
@@ -1,0 +1,170 @@
+/* ============================================================
+   API Stale State Sandbox — style.css
+   Submission for EaseMotion CSS Issue #17745
+   Visual logs console and state query buttons
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --success-color: #10b981;
+  --danger-color: #ef4444;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 820px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Dashboard Layout
+   ============================================================ */
+
+.dashboard {
+  display: grid;
+  grid-template-columns: 1fr 1.3fr;
+  gap: 28px;
+}
+
+@media (max-width: 768px) {
+  .dashboard { grid-template-columns: 1fr; }
+}
+
+.demo-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  padding: 28px;
+  border-radius: 20px;
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.section-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+.simulator-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  justify-content: center;
+  height: 100%;
+}
+
+.ease-btn {
+  background: var(--primary-color);
+  border: none;
+  color: #fff;
+  padding: 14px;
+  border-radius: 8px;
+  font-family: inherit;
+  font-weight: 700;
+  font-size: 0.85rem;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(124,58,237,0.25);
+  transition: all 0.2s ease;
+  text-align: center;
+}
+
+.ease-btn:hover {
+  filter: brightness(1.1);
+  transform: translateY(-1px);
+}
+
+.ease-btn-success {
+  background: var(--success-color);
+  box-shadow: 0 4px 12px rgba(16,185,129,0.25);
+}
+
+/* Console Logs */
+.logs-console {
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255,255,255,0.04);
+  border-radius: 12px;
+  padding: 16px;
+  font-family: monospace;
+  font-size: 0.82rem;
+  height: 220px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.log-line {
+  line-height: 1.45;
+  word-break: break-all;
+}
+
+.text-muted { color: var(--text-muted); }
+.text-danger { color: var(--danger-color); }
+.text-success { color: var(--success-color); }
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-btn {
+    transition: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-api-stale-state` sandbox. It illustrates how relying on stale context payload data inside GitHub action workflows introduces race conditions, and demonstrates refetching latest states via API GET requests to guarantee query reliability.

## Root Cause
Issue auto-claiming scripts checked assignment flags from the webhook snapshot instead of refetching the latest states via the issues API.

## Changes Made
- `submissions/examples/api-stale-state-17745-ag/demo.html`: Simulator action nodes linked to an event logging console.
- `submissions/examples/api-stale-state-17745-ag/style.css`: Dashboard layouts, console logs styling, warning flags, and success colors.
- `submissions/examples/api-stale-state-17745-ag/README.md`: Explains stale payloads, race conditions, refetch overrides, and testing tips.

## How to Test
1. Open `demo.html` in a browser.
2. Trigger both simulations to confirm stale warnings vs fresh successes.

## Related Issue
Closes #17745