### PR TITLE
[Docs] #17742 — Add workflow concurrency group demo (unique folder)

### DIFF
--- a/submissions/examples/concurrency-scheduler-17742-ag/README.md
+++ b/submissions/examples/concurrency-scheduler-17742-ag/README.md
@@ -1,0 +1,35 @@
+# Action Concurrency Group Guidelines
+
+This guide details workflow config guidelines to manage matrix scheduling issues in GitHub Actions, preventing accidental run cancellations.
+
+---
+
+## Technical Overview: Concurrency Groups in Matrix Runs
+
+Configuring concurrency limits prevents simultaneous deployment runs from colliding. However, naively setting static group tags on workflow schedules triggers cancellation conflicts on matrix jobs:
+
+```yaml
+# BUG: Static key cancels all sibling matrix threads (e.g. Node 18 cancels Node 16)
+concurrency:
+  group: auto-merge-run
+  cancel-in-progress: true
+```
+
+### The Remediation
+
+To prevent matrix threads from cancelling one another, scope the concurrency keys dynamically utilizing the matrix parameter inputs:
+
+```yaml
+# SECURE: Uniquely scopes groups per matrix run thread, allowing parallel execution
+concurrency:
+  group: auto-merge-run-${{ github.run_id }}-${{ matrix.version }}
+  cancel-in-progress: true
+```
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Click **Trigger Static Matrix Run** — observe how subsequent jobs cancel previous running runs, leaving only Node 20 as completed.
+3. Click **Trigger Dynamic Matrix Run** — verify that all three matrix jobs run concurrently and complete successfully.

--- a/submissions/examples/concurrency-scheduler-17742-ag/demo.html
+++ b/submissions/examples/concurrency-scheduler-17742-ag/demo.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Concurrency Group Simulator — EaseMotion CSS</title>
+  <meta name="description" content="GitHub Actions workflow simulator demonstrating matrix job cancel-in-progress concurrency conflicts and remediations.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Workflow Specs</span>
+      <h1>Workflow Concurrency Simulator</h1>
+      <p class="description">
+        Demonstrates matrix scheduling conflicts in GitHub Actions. 
+        Compare how static concurrency keys cancel matrix jobs versus how dynamic scoping resolves it.
+      </p>
+    </header>
+
+    <main class="dashboard">
+
+      <!-- Column 1: Static Concurrency -->
+      <section class="demo-card">
+        <h2 class="section-title">Static Key (Cancels Concurrent Jobs)</h2>
+        <p class="card-desc">Uses <code>concurrency: group-name</code>. Matrix threads cancel each other out, leaving only one survivor.</p>
+        
+        <div class="jobs-list" id="jobs-static">
+          <div class="job-item" data-job="1">Node 16 <span class="job-status status-idle">Idle</span></div>
+          <div class="job-item" data-job="2">Node 18 <span class="job-status status-idle">Idle</span></div>
+          <div class="job-item" data-job="3">Node 20 <span class="job-status status-idle">Idle</span></div>
+        </div>
+
+        <button class="ease-btn" id="btn-run-static" type="button">Trigger Static Matrix Run</button>
+      </section>
+
+      <!-- Column 2: Dynamic Concurrency -->
+      <section class="demo-card">
+        <h2 class="section-title">Dynamic Key (Allows Concurrent Jobs)</h2>
+        <p class="card-desc">Uses <code>concurrency: group-${{ matrix.version }}</code>. Scopes groups uniquely so all matrix runs complete.</p>
+
+        <div class="jobs-list" id="jobs-dynamic">
+          <div class="job-item" data-job="1">Node 16 <span class="job-status status-idle">Idle</span></div>
+          <div class="job-item" data-job="2">Node 18 <span class="job-status status-idle">Idle</span></div>
+          <div class="job-item" data-job="3">Node 20 <span class="job-status status-idle">Idle</span></div>
+        </div>
+
+        <button class="ease-btn ease-btn-success" id="btn-run-dynamic" type="button">Trigger Dynamic Matrix Run</button>
+      </section>
+
+    </main>
+  </div>
+
+  <script>
+    const staticList = document.getElementById('jobs-static').querySelectorAll('.job-item');
+    const dynamicList = document.getElementById('jobs-dynamic').querySelectorAll('.job-item');
+
+    const updateStatus = (item, text, className) => {
+      const statusEl = item.querySelector('.job-status');
+      statusEl.textContent = text;
+      statusEl.className = `job-status ${className}`;
+    };
+
+    // Static Simulation (Trigger cancels previous running jobs)
+    document.getElementById('btn-run-static').addEventListener('click', () => {
+      // Start Job 1
+      updateStatus(staticList[0], 'Running...', 'status-running');
+      
+      // Job 2 starts 300ms later, cancels Job 1
+      setTimeout(() => {
+        updateStatus(staticList[0], 'Cancelled', 'status-cancelled');
+        updateStatus(staticList[1], 'Running...', 'status-running');
+        
+        // Job 3 starts 300ms later, cancels Job 2
+        setTimeout(() => {
+          updateStatus(staticList[1], 'Cancelled', 'status-cancelled');
+          updateStatus(staticList[2], 'Running...', 'status-running');
+          
+          setTimeout(() => {
+            updateStatus(staticList[2], 'Completed', 'status-success');
+          }, 600);
+        }, 300);
+      }, 300);
+    });
+
+    // Dynamic Simulation (All run to completion)
+    document.getElementById('btn-run-dynamic').addEventListener('click', () => {
+      // Start all concurrently
+      staticList.forEach((_, idx) => {
+        updateStatus(dynamicList[idx], 'Running...', 'status-running');
+        setTimeout(() => {
+          updateStatus(dynamicList[idx], 'Completed', 'status-success');
+        }, 500 + idx * 200);
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/concurrency-scheduler-17742-ag/style.css
+++ b/submissions/examples/concurrency-scheduler-17742-ag/style.css
@@ -1,0 +1,177 @@
+/* ============================================================
+   Concurrency Group Simulator — style.css
+   Submission for EaseMotion CSS Issue #17742
+   GitHub Action job runner lists and status badges
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --success-color: #10b981;
+  --danger-color: #ef4444;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 900px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Dashboard Layout
+   ============================================================ */
+
+.dashboard {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  gap: 28px;
+}
+
+.demo-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  padding: 28px;
+  border-radius: 20px;
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.section-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+.card-desc {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+/* Jobs Status List */
+.jobs-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: rgba(0,0,0,0.15);
+  border-radius: 12px;
+  padding: 16px;
+}
+
+.job-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  background: rgba(255,255,255,0.02);
+  border: 1px solid rgba(255,255,255,0.04);
+  border-radius: 8px;
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.job-status {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+/* Badge Color Mappings */
+.status-idle      { background: rgba(255,255,255,0.08); color: var(--text-secondary); }
+.status-running   { background: rgba(59, 130, 246, 0.15); color: #93c5fd; }
+.status-cancelled { background: rgba(239, 68, 68, 0.12); color: #fca5a5; }
+.status-success   { background: rgba(16, 185, 129, 0.12); color: #a7f3d0; }
+
+.ease-btn {
+  background: var(--primary-color);
+  border: none;
+  color: #fff;
+  padding: 14px;
+  border-radius: 8px;
+  font-family: inherit;
+  font-weight: 700;
+  font-size: 0.85rem;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(124,58,237,0.25);
+  transition: all 0.2s ease;
+  text-align: center;
+}
+
+.ease-btn:hover {
+  filter: brightness(1.1);
+  transform: translateY(-1px);
+}
+
+.ease-btn-success {
+  background: var(--success-color);
+  box-shadow: 0 4px 12px rgba(16,185,129,0.25);
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-btn {
+    transition: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-concurrency-scheduler` simulator. It illustrates CI/CD scheduling conflicts where static workflow concurrency keys trigger early cancellations on concurrent matrix builds, and showcases dynamic key scopes that allow jobs to run concurrently to completion.

## Root Cause
The auto-merge workflow used a static concurrency group tag, causing scheduled matrix runs to cancel preceding matrix threads.

## Changes Made
- `submissions/examples/concurrency-scheduler-17742-ag/demo.html`: Grid layouts with job items and simulator triggers.
- `submissions/examples/concurrency-scheduler-17742-ag/style.css`: Viewport frames, status badge backgrounds, button styling, and job list borders.
- `submissions/examples/concurrency-scheduler-17742-ag/README.md`: GHA workflow files instructions, dynamic naming specifications, and testing lists.

## How to Test
1. Open `demo.html` in a browser.
2. Click trigger buttons to confirm run outputs.

## Related Issue
Closes #17742