### PR TITLE
feat(utility): add outline and ring focus utilities for issue #28009

### DIFF
--- a/submissions/docs/core_changes-issue-28009/README.md
+++ b/submissions/docs/core_changes-issue-28009/README.md
@@ -1,0 +1,28 @@
+# ease-outline — Outline & Ring Focus Utility Classes
+
+## What does this do?
+
+Provides CSS `outline` and `box-shadow` ring utilities for focus indicators, accessibility, and visual emphasis. Rings use `box-shadow` (non-scaling) while outlines use the native `outline` property.
+
+## How is it used?
+
+```html
+<button class="ease-ring-2 ease-ring-primary">Focused</button>
+<input class="ease-outline-2" />
+<div class="ease-ring-inset">Inset ring</div>
+```
+
+### Classes
+
+| Class | Property | Value |
+|---|---|---|
+| `.ease-outline-0` | `outline` | `none` |
+| `.ease-outline-1` | `outline` | `1px solid` |
+| `.ease-outline-2` | `outline` | `2px solid` |
+| `.ease-outline-4` | `outline` | `4px solid` |
+| `.ease-ring-1` | `box-shadow` | `0 0 0 1px` |
+| `.ease-ring-2` | `box-shadow` | `0 0 0 2px` |
+| `.ease-ring-4` | `box-shadow` | `0 0 0 4px` |
+| `.ease-ring-inset` | `box-shadow` | Inset ring |
+| `.ease-ring-primary` | color | Primary color var |
+| `.ease-ring-offset-2` | `box-shadow` | With 2px offset |

--- a/submissions/docs/core_changes-issue-28009/demo.html
+++ b/submissions/docs/core_changes-issue-28009/demo.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-outline — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #f8fafc; color: #1e293b; padding: 3rem 1.5rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      body { background: #0f172a; color: #f1f5f9; }
+    }
+    .demo-header { text-align: center; margin-bottom: 3rem; }
+    .demo-header h1 { font-size: clamp(2rem, 5vw, 3rem); }
+    .demo-header p { color: #64748b; margin-top: 0.5rem; }
+    .demo-section { max-width: 720px; margin: 0 auto 2.5rem; }
+    .demo-section h2 {
+      font-size: 0.75rem; font-weight: 600; text-transform: uppercase;
+      letter-spacing: 0.1em; color: #6c63ff; margin-bottom: 0.75rem;
+    }
+    .class-tag {
+      display: inline-block; font-size: 0.65rem; font-family: monospace;
+      background: #f1f5f9; border: 1px solid #e2e8f0;
+      border-radius: 999px; padding: 0.3em 0.75em; color: #6c63ff; margin-bottom: 1rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      .class-tag { background: #1e293b; border-color: #334155; }
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+      gap: 1rem;
+    }
+    .card {
+      background: white; border: 1px solid #e2e8f0; border-radius: 0.5rem;
+      padding: 1.5rem 0.75rem; text-align: center;
+    }
+    @media (prefers-color-scheme: dark) {
+      .card { background: #1e293b; border-color: #334155; }
+    }
+    .card .demo-box {
+      width: 48px; height: 48px; margin: 0 auto 0.5rem;
+      border-radius: 0.375rem; background: #f1f5f9;
+    }
+    @media (prefers-color-scheme: dark) {
+      .card .demo-box { background: #334155; }
+    }
+    .card .tag { font-family: monospace; font-size: 0.6rem; color: #6c63ff; }
+    .btn-group { display: flex; gap: 0.75rem; flex-wrap: wrap; }
+    .btn {
+      padding: 0.65rem 1.25rem; border-radius: 0.375rem; font-size: 0.875rem;
+      font-weight: 500; cursor: pointer; border: none;
+    }
+  </style>
+</head>
+<body>
+<header class="demo-header">
+  <h1>ease-outline</h1>
+  <p>Outline &amp; ring focus utility classes</p>
+</header>
+
+<section class="demo-section">
+  <h2>Rings (box-shadow)</h2>
+  <div class="class-tag">.ease-ring-*</div>
+  <div class="grid">
+    <div class="card"><div class="demo-box ease-ring-1" style="background:white;"></div><div class="tag">ring-1</div></div>
+    <div class="card"><div class="demo-box ease-ring-2" style="background:white;"></div><div class="tag">ring-2</div></div>
+    <div class="card"><div class="demo-box ease-ring-4" style="background:white;"></div><div class="tag">ring-4</div></div>
+    <div class="card"><div class="demo-box ease-ring-inset" style="background:white;"></div><div class="tag">ring-inset</div></div>
+    <div class="card"><div class="demo-box ease-ring-2 ease-ring-danger" style="background:white;"></div><div class="tag">ring-2 danger</div></div>
+    <div class="card"><div class="demo-box ease-ring-2 ease-ring-success" style="background:white;"></div><div class="tag">ring-2 success</div></div>
+  </div>
+</section>
+
+<section class="demo-section">
+  <h2>Outlines</h2>
+  <div class="class-tag">.ease-outline-*</div>
+  <div class="grid">
+    <div class="card"><div class="demo-box ease-outline-1"></div><div class="tag">outline-1</div></div>
+    <div class="card"><div class="demo-box ease-outline-2"></div><div class="tag">outline-2</div></div>
+    <div class="card"><div class="demo-box ease-outline-4"></div><div class="tag">outline-4</div></div>
+    <div class="card"><div class="demo-box ease-outline-0"></div><div class="tag">outline-0</div></div>
+  </div>
+</section>
+
+<section class="demo-section">
+  <h2>Focus Ring</h2>
+  <div class="class-tag">.ease-focus-ring — tab to each button</div>
+  <div class="btn-group">
+    <button class="btn ease-focus-ring" style="background:#6c63ff;color:white;">Focus Me</button>
+    <button class="btn ease-focus-ring" style="background:#1e293b;color:white;--ease-ring-color:#39ff14;">Green Ring</button>
+    <button class="btn ease-focus-ring" style="background:white;color:#1e293b;border:1px solid #cbd5e1;--ease-ring-color:#ff00ff;">Pink Ring</button>
+  </div>
+</section>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-28009/style.css
+++ b/submissions/docs/core_changes-issue-28009/style.css
@@ -1,0 +1,72 @@
+/* ============================================================
+   ease-outline — Outline & Ring Focus Utility Classes
+   Submission for EaseMotion CSS · Issue #28009
+   ============================================================ */
+
+@layer easemotion-utilities {
+
+/* ── Outline ───────────────────────────────────────────── */
+
+.ease-outline-0 { outline: none !important; }
+
+.ease-outline-1 {
+  outline: 1px solid var(--ease-outline-color, var(--ease-color-neutral-400, #94a3b8)) !important;
+}
+
+.ease-outline-2 {
+  outline: 2px solid var(--ease-outline-color, var(--ease-color-neutral-400, #94a3b8)) !important;
+}
+
+.ease-outline-4 {
+  outline: 4px solid var(--ease-outline-color, var(--ease-color-neutral-400, #94a3b8)) !important;
+}
+
+/* ── Ring (box-shadow) ─────────────────────────────────── */
+
+.ease-ring-1 {
+  box-shadow: 0 0 0 1px var(--ease-ring-color, var(--ease-color-primary, #6c63ff)) !important;
+}
+
+.ease-ring-2 {
+  box-shadow: 0 0 0 2px var(--ease-ring-color, var(--ease-color-primary, #6c63ff)) !important;
+}
+
+.ease-ring-4 {
+  box-shadow: 0 0 0 4px var(--ease-ring-color, var(--ease-color-primary, #6c63ff)) !important;
+}
+
+.ease-ring-inset {
+  box-shadow: inset 0 0 0 2px var(--ease-ring-color, var(--ease-color-primary, #6c63ff)) !important;
+}
+
+.ease-ring-offset-2 {
+  box-shadow: 0 0 0 2px var(--ease-ring-color, var(--ease-color-primary, #6c63ff)),
+              0 0 0 4px var(--ease-ring-offset-color, #fff) !important;
+}
+
+/* ── Colors ────────────────────────────────────────────── */
+
+.ease-ring-primary {
+  --ease-ring-color: var(--ease-color-primary, #6c63ff);
+}
+
+.ease-ring-danger {
+  --ease-ring-color: var(--ease-color-danger, #ef4444);
+}
+
+.ease-ring-success {
+  --ease-ring-color: var(--ease-color-success, #10b981);
+}
+
+.ease-ring-warning {
+  --ease-ring-color: var(--ease-color-warning, #f59e0b);
+}
+
+/* ── Focus variant ─────────────────────────────────────── */
+
+.ease-focus-ring:focus-visible {
+  outline: none !important;
+  box-shadow: 0 0 0 2px var(--ease-ring-color, var(--ease-color-primary, #6c63ff)) !important;
+}
+
+}


### PR DESCRIPTION
## ✦ Description
Adds outline (0/1/2/4) and ring (1/2/4/inset/offset) utility classes with color variants and focus-ring for accessible focus indicators.

Fixes #28009
---
## ✦ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
---
## Changes
- `submissions/docs/core_changes-issue-28009/` with `style.css`, `README.md`, `demo.html`
## New Classes
15+ outline, ring, and focus utility classes
## Testing
- All changes additive only