### PR TITLE
fix: add pagination to fallback PR list fetch

### DIFF
--- a/.github/workflows/pr-rate-limiter.yml
+++ b/.github/workflows/pr-rate-limiter.yml
@@ -43,14 +43,39 @@ jobs:
               const searchResult = await github.rest.search.issuesAndPullRequests({ q });
               totalCount = searchResult.data.total_count;
               console.log(`Found ${totalCount} PRs submitted by @${prAuthor} in the last 24 hours.`);
-            } catch (err) {
+                       } catch (err) {
               console.log(`Error calling search API: ${err.message}`);
-              // Fallback: list pulls and filter
-              const pulls = await github.rest.pulls.list({ owner, repo, state: 'all', per_page: 100 });
+
               const limitMs = Date.now() - 24 * 60 * 60 * 1000;
-              const matchingPulls = pulls.data.filter(p => p.user.login === prAuthor && new Date(p.created_at).getTime() >= limitMs);
+              let page = 1;
+              let matchingPulls = [];
+
+              while (true) {
+                const pulls = await github.rest.pulls.list({
+                  owner,
+                  repo,
+                  state: "all",
+                  per_page: 100,
+                  page
+                });
+
+                if (pulls.data.length === 0) break;
+
+                matchingPulls.push(
+                  ...pulls.data.filter(
+                    p =>
+                      p.user.login === prAuthor &&
+                      new Date(p.created_at).getTime() >= limitMs
+                  )
+                );
+
+                if (pulls.data.length < 100) break;
+
+                page++;
+              }
+
               totalCount = matchingPulls.length;
-              console.log(`Fallback: Found ${totalCount} PRs in last 100 items.`);
+              console.log(`Fallback: Found ${totalCount} PRs across ${page} page(s).`);
             }
             
             if (totalCount > DAILY_LIMIT) {


### PR DESCRIPTION
## Pull Request Description

This PR fixes the fallback logic in the contribution rate limiter workflow by adding pagination when fetching pull requests. Previously, the fallback checked only the first 100 PRs, which could result in an incorrect count for contributors with more than 100 pull requests.

### Type of Change

* [x] Other (Workflow bug fix)

### Feature Description

**What does this add?**

Adds pagination to the fallback `github.rest.pulls.list()` API calls so all pull requests are checked instead of only the first page.

**Why is this needed?**

This ensures the rate limiter calculates the contributor's PR count accurately even when the repository contains more than 100 pull requests.

### Browser Testing

Not applicable (GitHub Actions workflow change).

### Notes for Maintainer

This change only updates the fallback logic used when the Search API fails. No behavior changes occur when the Search API succeeds.
