### PR TITLE
feat(utility): add text overflow utilities for issue #28013

### DIFF
--- a/submissions/docs/core_changes-issue-28013/README.md
+++ b/submissions/docs/core_changes-issue-28013/README.md
@@ -1,0 +1,28 @@
+# ease-text-overflow — Text Overflow Utility Classes
+
+## What does this do?
+
+Controls how text behaves when it overflows its container — truncation, ellipsis, clip, and word-break utilities.
+
+## How is it used?
+
+```html
+<p class="ease-truncate">Long text gets ellipsis…</p>
+<p class="ease-text-clip">Overflow is clipped</p>
+<p class="ease-break-all">LongWordThatBreaks</p>
+```
+
+### Classes
+
+| Class | Property | Use Case |
+|---|---|---|
+| `.ease-truncate` | `text-overflow: ellipsis` + `overflow: hidden` + `nowrap` | Single-line truncation |
+| `.ease-text-clip` | `text-overflow: clip` + `overflow: hidden` | Hard clip |
+| `.ease-break-normal` | `word-break: normal` | Default |
+| `.ease-break-all` | `word-break: break-all` | Break any character |
+| `.ease-break-keep` | `word-break: keep-all` | No CJK breaks |
+| `.ease-break-word` | `overflow-wrap: break-word` | Break long words |
+| `.ease-whitespace-normal` | `white-space: normal` | Default wrapping |
+| `.ease-whitespace-nowrap` | `white-space: nowrap` | No wrapping |
+| `.ease-whitespace-pre` | `white-space: pre` | Preserve whitespace |
+| `.ease-whitespace-pre-wrap` | `white-space: pre-wrap` | Preserve + wrap |

--- a/submissions/docs/core_changes-issue-28013/demo.html
+++ b/submissions/docs/core_changes-issue-28013/demo.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-text-overflow — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #f8fafc; color: #1e293b; padding: 3rem 1.5rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      body { background: #0f172a; color: #f1f5f9; }
+    }
+    .demo-header { text-align: center; margin-bottom: 3rem; }
+    .demo-header h1 { font-size: clamp(2rem, 5vw, 3rem); }
+    .demo-header p { color: #64748b; margin-top: 0.5rem; }
+    .demo-section { max-width: 720px; margin: 0 auto 2.5rem; }
+    .demo-section h2 {
+      font-size: 0.75rem; font-weight: 600; text-transform: uppercase;
+      letter-spacing: 0.1em; color: #6c63ff; margin-bottom: 0.75rem;
+    }
+    .class-tag {
+      display: inline-block; font-size: 0.65rem; font-family: monospace;
+      background: #f1f5f9; border: 1px solid #e2e8f0;
+      border-radius: 999px; padding: 0.3em 0.75em; color: #6c63ff; margin-bottom: 1rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      .class-tag { background: #1e293b; border-color: #334155; }
+    }
+    .card {
+      background: white; border: 1px solid #e2e8f0; border-radius: 0.5rem;
+      padding: 1rem; margin-bottom: 1rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      .card { background: #1e293b; border-color: #334155; }
+    }
+    .card .label { font-size: 0.7rem; font-weight: 600; color: #6c63ff; margin-bottom: 0.3rem; }
+    .demo-box {
+      max-width: 280px; padding: 0.5rem; border: 1px dashed #cbd5e1;
+      border-radius: 0.25rem; font-size: 0.875rem;
+    }
+    .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+  </style>
+</head>
+<body>
+<header class="demo-header">
+  <h1>ease-text-overflow</h1>
+  <p>Text overflow, break, and whitespace utilities</p>
+</header>
+
+<section class="demo-section">
+  <h2>Truncation</h2>
+  <div class="grid">
+    <div class="card">
+      <div class="label">.ease-truncate</div>
+      <div class="demo-box ease-truncate">This is a very long text that should be truncated with an ellipsis because it overflows the container.</div>
+    </div>
+    <div class="card">
+      <div class="label">.ease-text-clip</div>
+      <div class="demo-box ease-text-clip">This is a very long text that will be clipped abruptly with no ellipsis when it overflows.</div>
+    </div>
+  </div>
+</section>
+
+<section class="demo-section">
+  <h2>Word Break</h2>
+  <div class="grid">
+    <div class="card">
+      <div class="label">.ease-break-word</div>
+      <div class="demo-box ease-break-word" style="max-width:180px;">Supercalifragilisticexpialidocious breaks gracefully.</div>
+    </div>
+    <div class="card">
+      <div class="label">.ease-break-all</div>
+      <div class="demo-box ease-break-all" style="max-width:180px;">Supercalifragilisticexpialidocious breaks at any character.</div>
+    </div>
+  </div>
+</section>
+
+<section class="demo-section">
+  <h2>Whitespace</h2>
+  <div class="grid">
+    <div class="card">
+      <div class="label">.ease-whitespace-nowrap</div>
+      <div class="demo-box ease-whitespace-nowrap">Never breaks to a new line no matter how long</div>
+    </div>
+    <div class="card">
+      <div class="label">.ease-whitespace-pre</div>
+      <div class="demo-box ease-whitespace-pre" style="max-width:280px;">Preserves   spaces
+and line
+breaks.</div>
+    </div>
+    <div class="card">
+      <div class="label">.ease-whitespace-pre-wrap</div>
+      <div class="demo-box ease-whitespace-pre-wrap" style="max-width:200px;">Preserves   spaces
+and wraps when needed.</div>
+    </div>
+    <div class="card">
+      <div class="label">.ease-whitespace-normal</div>
+      <div class="demo-box ease-whitespace-normal" style="max-width:200px;">Collapses   spaces and wraps   normally.</div>
+    </div>
+  </div>
+</section>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-28013/style.css
+++ b/submissions/docs/core_changes-issue-28013/style.css
@@ -1,0 +1,31 @@
+/* ============================================================
+   ease-text-overflow — Text Overflow Utility Classes
+   Submission for EaseMotion CSS · Issue #28013
+   ============================================================ */
+
+@layer easemotion-utilities {
+
+.ease-truncate {
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+  white-space: nowrap !important;
+}
+
+.ease-text-clip {
+  overflow: hidden !important;
+  text-overflow: clip !important;
+  white-space: nowrap !important;
+}
+
+.ease-break-normal { word-break: normal !important; }
+.ease-break-all    { word-break: break-all !important; }
+.ease-break-keep   { word-break: keep-all !important; }
+.ease-break-word   { overflow-wrap: break-word !important; }
+
+.ease-whitespace-normal   { white-space: normal !important; }
+.ease-whitespace-nowrap   { white-space: nowrap !important; }
+.ease-whitespace-pre      { white-space: pre !important; }
+.ease-whitespace-pre-wrap { white-space: pre-wrap !important; }
+.ease-whitespace-pre-line { white-space: pre-line !important; }
+
+}


### PR DESCRIPTION
## ✦ Description
Adds text-overflow/break/whitespace utility classes: truncate, text-clip, break-{normal,all,keep,word}, whitespace-{normal,nowrap,pre,pre-wrap,pre-line}.

Fixes #28013
---
## ✦ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
---
## Changes
- `submissions/docs/core_changes-issue-28013/` with `style.css`, `README.md`, `demo.html`
## New Classes
11 text overflow/break/whitespace classes
## Testing
- All changes additive only