### PR TITLE
feat(components): add css-only hover tooltip (#28818)

### DIFF
--- a/submissions/examples/ease-hover-tooltip/README.md
+++ b/submissions/examples/ease-hover-tooltip/README.md
@@ -1,0 +1,15 @@
+# CSS-Only Hover Tooltip Card
+
+A lightweight tooltip card component that appears on hover using only CSS. It utilizes hover states, `absolute` positioning, and pseudo-elements to create a useful UI pattern without relying on any JavaScript.
+
+## Files
+- `demo.html` - Contains the demo structure.
+- `style.css` - Contains the core utility classes.
+
+## Usage
+Add the nested structure to any text element:
+```html
+<span class="em-tooltip">
+  Hover me
+  <span class="em-tooltip-text">Simple tooltip info</span>
+</span>

--- a/submissions/examples/ease-hover-tooltip/demo.html
+++ b/submissions/examples/ease-hover-tooltip/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hover Tooltip Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body
+    style="display: flex; justify-content: center; align-items: center; height: 100vh; background-color: #f8fafc; margin: 0; font-family: sans-serif;">
+
+    <span class="em-tooltip">
+        Hover over me!
+        <span class="em-tooltip-text">I am a CSS-only tooltip</span>
+    </span>
+</body>
+
+</html>

--- a/submissions/examples/ease-hover-tooltip/style.css
+++ b/submissions/examples/ease-hover-tooltip/style.css
@@ -1,0 +1,38 @@
+.em-tooltip {
+    position: relative;
+    display: inline-flex;
+    cursor: help;
+    border-bottom: 1px dashed #64748b;
+}
+
+.em-tooltip-text {
+    position: absolute;
+    bottom: calc(100% + 10px);
+    left: 50%;
+    transform: translateX(-50%) scale(0.95);
+    padding: 0.65rem 0.9rem;
+    background: #0f172a;
+    color: white;
+    border-radius: 0.5rem;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    font-size: 0.9rem;
+}
+
+.em-tooltip:hover .em-tooltip-text,
+.em-tooltip:focus-within .em-tooltip-text {
+    opacity: 1;
+    transform: translateX(-50%) scale(1);
+}
+
+.em-tooltip-text::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 6px solid transparent;
+    border-top-color: #0f172a;
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a CSS-only hover tooltip card component. It uses `position: absolute`, pseudo-elements, and hover states to show a clean, accessible tooltip without any JavaScript dependencies.
Resolves #28818.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A reusable CSS utility (`.em-tooltip` and `.em-tooltip-text`) for a lightweight, animated tooltip that appears on hover.

**How does a developer use it?**

```html
<span class="em-tooltip">
  Hover me
  <span class="em-tooltip-text">Tooltip info</span>
</span>