### PR TITLE
Add CSS readonly input component

### DIFF
--- a/submissions/examples/ease-input-readonly-zz/README.md
+++ b/submissions/examples/ease-input-readonly-zz/README.md
@@ -1,0 +1,12 @@
+# Readonly Input
+
+## What does this do?
+Readonly Input component with primary, secondary, and outline variants. Dark theme with CSS custom properties.
+
+## How is it used?
+```html
+<div class=\"roi-primary\">Readonly Input Primary</div>
+```
+
+## Why is it useful?
+Reusable readonly input UI element. Dark theme with CSS custom properties.

--- a/submissions/examples/ease-input-readonly-zz/demo.html
+++ b/submissions/examples/ease-input-readonly-zz/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Readonly Input - EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<header class="roi-header"><h1>CSS Readonly Input</h1><p>Readonly Input with primary, secondary, outline variants</p></header>
+<section class="roi-section"><h2>Variations</h2>
+<div class="roi-example"><label>Primary</label><div class="roi-primary">roi primary</div></div>
+<div class="roi-example"><label>Secondary</label><div class="roi-secondary">roi secondary</div></div>
+<div class="roi-example"><label>Outline</label><div class="roi-outline">roi outline</div></div>
+</section>
+<section class="roi-section"><h2>Usage</h2><pre>&lt;div class="roi-primary"&gt;Readonly Input Primary&lt;/div&gt;</pre></section>
+</body>
+</html>

--- a/submissions/examples/ease-input-readonly-zz/style.css
+++ b/submissions/examples/ease-input-readonly-zz/style.css
@@ -1,0 +1,10 @@
+/* ease-input-readonly-zz */
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{--roi-bg:#0f0f23;--roi-card:#1a1a3e;--roi-txt:#e0e0ff;--roi-txt2:#8888bb;--roi-brd:#2a2a5a;--roi-accent:#667eea;--roi-rad:12px;--roi-font:"Segoe UI",system-ui,sans-serif}
+body{font-family:var(--roi-font);background:var(--roi-bg);color:var(--roi-txt);padding:20px}
+.roi-header{text-align:center;padding:40px 20px}.roi-header h1{font-size:2.2rem;font-weight:700;margin-bottom:8px}.roi-header p{color:var(--roi-txt2);font-size:1.05rem}
+.roi-section{max-width:700px;margin:30px auto;padding:24px;background:var(--roi-card);border:1px solid var(--roi-brd);border-radius:12px}.roi-section h2{font-size:1.3rem;margin-bottom:20px;padding-bottom:8px;border-bottom:1px solid var(--roi-brd)}.roi-section pre{background:rgba(0,0,0,0.3);padding:16px;border-radius:8px;font-size:0.85rem;color:var(--roi-txt2);overflow-x:auto;white-space:pre-wrap}
+.roi-example{margin-bottom:24px}.roi-example:last-child{margin-bottom:0}.roi-example>label{display:block;font-size:0.85rem;color:var(--roi-txt2);margin-bottom:10px;font-weight:600}
+.roi-primary{display:inline-flex;align-items:center;gap:8px;padding:12px 20px;background:var(--roi-accent);color:#fff;border-radius:var(--roi-rad);font-size:0.95rem;font-family:var(--roi-font)}
+.roi-secondary{display:inline-flex;align-items:center;gap:8px;padding:12px 20px;background:rgba(255,255,255,0.05);color:var(--roi-txt);border:1px solid var(--roi-brd);border-radius:var(--roi-rad);font-size:0.95rem;font-family:var(--roi-font)}
+.roi-outline{display:inline-flex;align-items:center;gap:8px;padding:12px 20px;background:transparent;color:var(--roi-accent);border:2px solid var(--roi-accent);border-radius:var(--roi-rad);font-size:0.95rem;font-family:var(--roi-font);transition:all 0.3s}.roi-outline:hover{background:var(--roi-accent);color:#fff}


### PR DESCRIPTION
## Summary
Adds add css readonly input component.

## Files
- submissions/examples/ease-input-readonly-zz/demo.html
- submissions/examples/ease-input-readonly-zz/style.css
- submissions/examples/ease-input-readonly-zz/README.md

## GSSOC26
This contribution is part of GSSoC 2026.

Fixes #29055