### PR TITLE
feat: add CSS button-underline component

### DIFF
--- a/submissions/examples/button-underline-ij/README.md
+++ b/submissions/examples/button-underline-ij/README.md
@@ -1,0 +1,7 @@
+# CSS button-underline
+
+Text buttons with animated underline effects: slide from left, center, right, and grow variants.
+
+## Files
+- `demo.html`
+- `style.css`

--- a/submissions/examples/button-underline-ij/demo.html
+++ b/submissions/examples/button-underline-ij/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS button-underline</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo">
+    <h1>Underline Buttons</h1>
+    <div class="button-grid">
+      <button class="btn-underline left">Slide Left</button>
+      <button class="btn-underline center">Slide Center</button>
+      <button class="btn-underline right">Slide Right</button>
+      <button class="btn-underline grow">Grow</button>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/button-underline-ij/style.css
+++ b/submissions/examples/button-underline-ij/style.css
@@ -1,0 +1,21 @@
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { min-height: 100vh; display: flex; justify-content: center; align-items: center; background: #0e0e1a; font-family: "Outfit", sans-serif; color: #fff; }
+@media (prefers-reduced-motion: reduce) { * { animation: none !important; } }
+.demo { text-align: center; }
+h1 { font-size: 16px; margin-bottom: 32px; color: #e94560; letter-spacing: 2px; text-transform: uppercase; }
+.button-grid { display: flex; gap: 20px; justify-content: center; flex-wrap: wrap; }
+
+.btn-underline { background: none; border: none; color: rgba(255,255,255,0.7); font-size: 15px; font-family: "Outfit", sans-serif; cursor: pointer; padding: 8px 4px; position: relative; letter-spacing: 1px; transition: color 0.3s; }
+.btn-underline:hover { color: #e94560; }
+.btn-underline::after { content: ""; position: absolute; bottom: 0; height: 2px; background: #e94560; border-radius: 1px; transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1); }
+.btn-underline.left::after { left: 50%; width: 0; }
+.btn-underline.left:hover::after { left: 0; width: 100%; }
+.btn-underline.center::after { left: 50%; width: 0; transform: translateX(-50%); }
+.btn-underline.center:hover::after { width: 100%; }
+.btn-underline.right::after { right: 50%; width: 0; }
+.btn-underline.right:hover::after { right: 0; width: 100%; }
+.btn-underline.grow::after { left: 0; width: 0; }
+.btn-underline.grow:hover::after { width: 100%; }
+.btn-underline.grow { animation: shimmer 2s ease-in-out infinite; }
+
+@keyframes shimmer { 0%, 100% { opacity: 0.7; } 50% { opacity: 1; text-shadow: 0 0 8px rgba(233,69,96,0.3); } }


### PR DESCRIPTION
## Component: CSS button-underline — Text button with animated underline

### What this adds
A CSS-only text button component with four underline animation variants: slide from left, slide from center, slide from right, and grow from left. Includes text shimmer animation on one variant.

### Acceptance Criteria covered
- [x] Real CSS animation with @keyframes
- [x] Unique visual styling
- [x] Multiple animated elements

### Files
- submissions/examples/button-underline-ij/demo.html
- submissions/examples/button-underline-ij/style.css
- submissions/examples/button-underline-ij/README.md

### How to review
Open demo.html directly in a browser. Hover over each button to see the underline animate from different directions.

**Closes #29176**
