### PR TITLE
feat: add CSS breadcrumb-dot component

### DIFF
--- a/submissions/examples/breadcrumb-dot-ij/README.md
+++ b/submissions/examples/breadcrumb-dot-ij/README.md
@@ -1,0 +1,7 @@
+# CSS breadcrumb-dot
+
+Breadcrumb navigation with animated dot separators that pulse and scale sequentially.
+
+## Files
+- `demo.html`
+- `style.css`

--- a/submissions/examples/breadcrumb-dot-ij/demo.html
+++ b/submissions/examples/breadcrumb-dot-ij/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS breadcrumb-dot</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo">
+    <h1>Dot Breadcrumbs</h1>
+    <nav class="breadcrumb-dot">
+      <span class="crumb">Home</span>
+      <span class="dot"></span>
+      <span class="crumb">Products</span>
+      <span class="dot"></span>
+      <span class="crumb">Electronics</span>
+      <span class="dot"></span>
+      <span class="crumb active">Laptops</span>
+    </nav>
+  </div>
+</body>
+</html>

--- a/submissions/examples/breadcrumb-dot-ij/style.css
+++ b/submissions/examples/breadcrumb-dot-ij/style.css
@@ -1,0 +1,18 @@
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { min-height: 100vh; display: flex; justify-content: center; align-items: center; background: #0e0e1a; font-family: "Outfit", sans-serif; color: #fff; }
+@media (prefers-reduced-motion: reduce) { * { animation: none !important; } }
+.demo { text-align: center; }
+h1 { font-size: 16px; margin-bottom: 32px; color: #e94560; letter-spacing: 2px; text-transform: uppercase; }
+
+.breadcrumb-dot { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; justify-content: center; }
+
+.crumb { font-size: 14px; color: rgba(255,255,255,0.5); letter-spacing: 0.5px; position: relative; cursor: default; transition: color 0.3s; }
+.crumb:hover { color: #e94560; }
+.crumb.active { color: #e94560; font-weight: 600; }
+
+.dot { width: 5px; height: 5px; border-radius: 50%; background: rgba(255,255,255,0.2); display: inline-block; animation: dot-pop 2s ease-in-out infinite; }
+.breadcrumb-dot .dot:nth-child(2) { animation-delay: 0s; }
+.breadcrumb-dot .dot:nth-child(4) { animation-delay: 0.3s; }
+.breadcrumb-dot .dot:nth-child(6) { animation-delay: 0.6s; }
+
+@keyframes dot-pop { 0%, 100% { transform: scale(1); background: rgba(255,255,255,0.2); } 50% { transform: scale(1.5); background: #e94560; } }


### PR DESCRIPTION
## Component: CSS breadcrumb-dot — Dot-separated breadcrumb navigation

### What this adds
A CSS-only breadcrumb navigation component with animated dot separators that pulse and scale sequentially. Active and hover states for breadcrumb items.

### Acceptance Criteria covered
- [x] Real CSS animation with @keyframes
- [x] Unique visual styling
- [x] Multiple animated elements

### Files
- submissions/examples/breadcrumb-dot-ij/demo.html
- submissions/examples/breadcrumb-dot-ij/style.css
- submissions/examples/breadcrumb-dot-ij/README.md

### How to review
Open demo.html directly in a browser to see the dot separator animation.

**Closes #29169**
