### PR TITLE
feat: add CSS breadcrumb-arrow component

### DIFF
--- a/submissions/examples/breadcrumb-arrow-ij/README.md
+++ b/submissions/examples/breadcrumb-arrow-ij/README.md
@@ -1,0 +1,7 @@
+# CSS breadcrumb-arrow
+
+Arrow-separated breadcrumb navigation with hover-highlighted items and sequential arrow blinking.
+
+## Files
+- `demo.html`
+- `style.css`

--- a/submissions/examples/breadcrumb-arrow-ij/demo.html
+++ b/submissions/examples/breadcrumb-arrow-ij/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS breadcrumb-arrow</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo">
+    <h1>Arrow Breadcrumbs</h1>
+    <nav class="breadcrumb-arrow">
+      <span class="cr-item">Dashboard</span>
+      <span class="arrow">&#8250;</span>
+      <span class="cr-item">Settings</span>
+      <span class="arrow">&#8250;</span>
+      <span class="cr-item">Account</span>
+      <span class="arrow">&#8250;</span>
+      <span class="cr-item active">Security</span>
+    </nav>
+  </div>
+</body>
+</html>

--- a/submissions/examples/breadcrumb-arrow-ij/style.css
+++ b/submissions/examples/breadcrumb-arrow-ij/style.css
@@ -1,0 +1,16 @@
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { min-height: 100vh; display: flex; justify-content: center; align-items: center; background: #0e0e1a; font-family: "Outfit", sans-serif; color: #fff; }
+@media (prefers-reduced-motion: reduce) { * { animation: none !important; } }
+.demo { text-align: center; }
+h1 { font-size: 16px; margin-bottom: 32px; color: #e94560; letter-spacing: 2px; text-transform: uppercase; }
+
+.breadcrumb-arrow { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; justify-content: center; }
+.cr-item { font-size: 14px; color: rgba(255,255,255,0.5); letter-spacing: 0.5px; padding: 6px 12px; border-radius: 4px; transition: all 0.3s; cursor: default; }
+.cr-item:hover { color: #e94560; background: rgba(233,69,96,0.08); }
+.cr-item.active { color: #e94560; font-weight: 600; background: rgba(233,69,96,0.12); }
+.arrow { font-size: 16px; color: rgba(255,255,255,0.2); animation: arrow-blink 1.5s ease-in-out infinite; }
+.breadcrumb-arrow .arrow:nth-child(2) { animation-delay: 0s; }
+.breadcrumb-arrow .arrow:nth-child(4) { animation-delay: 0.3s; }
+.breadcrumb-arrow .arrow:nth-child(6) { animation-delay: 0.6s; }
+
+@keyframes arrow-blink { 0%, 100% { opacity: 0.2; } 50% { opacity: 0.7; } }


### PR DESCRIPTION
## Component: CSS breadcrumb-arrow — Arrow-separated breadcrumb navigation

### What this adds
A CSS-only breadcrumb navigation component with arrow separators that blink sequentially, hover-highlighted items with background tint, and active item emphasis.

### Acceptance Criteria covered
- [x] Real CSS animation with @keyframes
- [x] Unique visual styling
- [x] Multiple animated elements

### Files
- submissions/examples/breadcrumb-arrow-ij/demo.html
- submissions/examples/breadcrumb-arrow-ij/style.css
- submissions/examples/breadcrumb-arrow-ij/README.md

### How to review
Open demo.html directly in a browser to see arrow separators blinking in sequence.

**Closes #29167**
