### PR TITLE
Add CSS outline hover button component

### DIFF
--- a/submissions/examples/outline-hover-button-ij/README.md
+++ b/submissions/examples/outline-hover-button-ij/README.md
@@ -1,0 +1,7 @@
+# CSS outline-hover-button
+
+Outline buttons with background fill on hover, scale-in entrance, and color variants for primary, success, danger.
+
+## Files
+- `demo.html`
+- `style.css`

--- a/submissions/examples/outline-hover-button-ij/demo.html
+++ b/submissions/examples/outline-hover-button-ij/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS outline-hover-button</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo">
+    <h1>Outline Hover Buttons</h1>
+    <div class="oh-group">
+      <button class="oh-btn primary">Primary</button>
+      <button class="oh-btn success">Success</button>
+      <button class="oh-btn danger">Danger</button>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/outline-hover-button-ij/style.css
+++ b/submissions/examples/outline-hover-button-ij/style.css
@@ -1,0 +1,23 @@
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { min-height: 100vh; display: flex; justify-content: center; align-items: center; background: #0e0e1a; font-family: "Outfit", sans-serif; color: #fff; }
+@media (prefers-reduced-motion: reduce) { * { animation: none !important; } }
+.demo { text-align: center; }
+h1 { font-size: 16px; margin-bottom: 32px; color: #e94560; letter-spacing: 2px; text-transform: uppercase; }
+.oh-group { display: flex; gap: 16px; justify-content: center; flex-wrap: wrap; }
+
+.oh-btn { font-size: 12px; font-weight: 600; letter-spacing: 0.5px; padding: 10px 24px; border-radius: 6px; cursor: pointer; transition: all 0.3s ease; background: transparent; position: relative; overflow: hidden; text-transform: uppercase; }
+.oh-btn.primary { border: 1.5px solid rgba(233,69,96,0.3); color: #e94560; }
+.oh-btn.success { border: 1.5px solid rgba(46,204,113,0.3); color: #2ecc71; }
+.oh-btn.danger { border: 1.5px solid rgba(231,76,60,0.3); color: #e74c3c; }
+.oh-btn::after { content: ""; position: absolute; bottom: 0; left: 0; width: 100%; height: 0; transition: height 0.3s ease; z-index: -1; }
+.oh-btn.primary::after { background: rgba(233,69,96,0.1); }
+.oh-btn.success::after { background: rgba(46,204,113,0.1); }
+.oh-btn.danger::after { background: rgba(231,76,60,0.1); }
+.oh-btn:hover { color: #fff; transform: translateY(-2px); }
+.oh-btn.primary:hover { background: rgba(233,69,96,0.15); border-color: #e94560; box-shadow: 0 4px 16px rgba(233,69,96,0.15); }
+.oh-btn.success:hover { background: rgba(46,204,113,0.15); border-color: #2ecc71; box-shadow: 0 4px 16px rgba(46,204,113,0.15); }
+.oh-btn.danger:hover { background: rgba(231,76,60,0.15); border-color: #e74c3c; box-shadow: 0 4px 16px rgba(231,76,60,0.15); }
+.oh-btn { animation: oh-in 0.4s ease-out forwards; opacity: 0; }
+.oh-btn:nth-child(1) { animation-delay: 0s; } .oh-btn:nth-child(2) { animation-delay: 0.1s; } .oh-btn:nth-child(3) { animation-delay: 0.2s; }
+
+@keyframes oh-in { 0% { opacity: 0; transform: scale(0.85); } 100% { opacity: 1; transform: scale(1); } }


### PR DESCRIPTION
## Component: outline-hover-button — outline buttons with fill-on-hover

### What this adds
Outline buttons with background fill on hover, scale-in entrance, and color variants for primary, success, danger.

### Acceptance Criteria covered
- Outline border style
- Background fill on hover
- Scale-in entrance
- Three color variants
- Hover lift with shadow

### Files
- `submissions/examples/outline-hover-button-ij/demo.html`
- `submissions/examples/outline-hover-button-ij/style.css`
- `submissions/examples/outline-hover-button-ij/README.md`

### How to review
Open `demo.html` to see buttons scale in. Hover each to see background fill and lift effect.

**Closes #29016**
