### PR TITLE
Add counter-reset CSS utilities (counter-reset-tm)

### DIFF
--- a/submissions/examples/counter-reset-1-ij/README.md
+++ b/submissions/examples/counter-reset-1-ij/README.md
@@ -1,0 +1,7 @@
+# CSS counter-reset — Section Counter
+
+Auto-numbered document sections using CSS counters with decimal and roman numeral numbering, hover slide effect.
+
+## Files
+- `demo.html`
+- `style.css`

--- a/submissions/examples/counter-reset-1-ij/demo.html
+++ b/submissions/examples/counter-reset-1-ij/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS counter-reset — Section Counter</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo">
+    <h1>Section Counter</h1>
+    <div class="cr-demo">
+      <div class="cr-section">
+        <h2 class="cr-heading">Introduction</h2>
+        <p class="cr-text">CSS counters let you number elements automatically.</p>
+      </div>
+      <div class="cr-section">
+        <h2 class="cr-heading">Setup</h2>
+        <p class="cr-text">Use <code>counter-reset</code> on the parent container.</p>
+      </div>
+      <div class="cr-section">
+        <h2 class="cr-heading">Usage</h2>
+        <p class="cr-text">Increment with <code>counter-increment</code> on child elements.</p>
+      </div>
+      <div class="cr-section">
+        <h2 class="cr-heading">Styling</h2>
+        <p class="cr-text">Style counters with <code>::before</code> and <code>content: counter()</code>.</p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/counter-reset-1-ij/style.css
+++ b/submissions/examples/counter-reset-1-ij/style.css
@@ -1,0 +1,21 @@
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { min-height: 100vh; display: flex; justify-content: center; align-items: center; background: #0e0e1a; font-family: "Outfit", sans-serif; color: #fff; }
+@media (prefers-reduced-motion: reduce) { * { animation: none !important; } }
+.demo { text-align: center; max-width: 420px; width: 100%; padding: 20px; }
+h1 { font-size: 16px; margin-bottom: 28px; color: #e94560; letter-spacing: 2px; text-transform: uppercase; }
+
+.cr-demo { counter-reset: section-counter; text-align: left; }
+.cr-section { margin-bottom: 16px; padding: 12px 16px; background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.06); border-radius: 6px; transition: all 0.3s; counter-increment: section-counter; }
+.cr-section:hover { background: rgba(255,255,255,0.06); border-color: rgba(233,69,96,0.15); transform: translateX(4px); }
+.cr-heading { font-size: 14px; color: rgba(255,255,255,0.7); margin-bottom: 4px; font-weight: 600; letter-spacing: 0.3px; }
+.cr-heading::before { content: counter(section-counter, decimal-leading-zero) ". "; color: #e94560; font-weight: 700; }
+.cr-text { font-size: 12px; color: rgba(255,255,255,0.4); line-height: 1.6; }
+.cr-text code { font-family: "Outfit", sans-serif; font-size: 11px; padding: 1px 6px; background: rgba(255,255,255,0.06); border-radius: 3px; color: rgba(255,255,255,0.6); }
+.cr-section { animation: cr-slide 0.4s ease-out forwards; opacity: 0; }
+.cr-section:nth-child(1) { animation-delay: 0s; } .cr-section:nth-child(2) { animation-delay: 0.1s; }
+.cr-section:nth-child(3) { animation-delay: 0.2s; } .cr-section:nth-child(4) { animation-delay: 0.3s; }
+
+@keyframes cr-slide { 0% { opacity: 0; transform: translateX(-12px); } 100% { opacity: 1; transform: translateX(0); } }
+
+.cr-section::after { content: "§" counter(section-counter, upper-roman); position: absolute; right: 12px; font-size: 10px; color: rgba(233,69,96,0.15); font-weight: 700; }
+.cr-section { position: relative; }


### PR DESCRIPTION
## Component: counter-reset — Section Counter with auto-numbering

### What this adds
Auto-numbered document sections using CSS counters with decimal and roman numeral numbering, hover slide effect.

### Acceptance Criteria covered
- counter-reset on parent container
- counter-increment on children
- Decimal-leading-zero numbering
- Roman numeral decoration via ::after pseudo-element
- Staggered slide-in entrance
- Hover slide with accent border highlight

### Files
- `submissions/examples/counter-reset-1-ij/demo.html`
- `submissions/examples/counter-reset-1-ij/style.css`
- `submissions/examples/counter-reset-1-ij/README.md`

### How to review
Open `demo.html` to see numbered sections slide in. Each section auto-numbers via CSS counter.

**Closes #28773**
