### PR TITLE
fix: remove unsupported GitHub Raw CDN stylesheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,14 +260,6 @@ EaseMotion CSS can also be loaded using alternative CDN providers.
 />
 ```
 
-### GitHub Raw CDN
-
-```html
-<link
-  rel="stylesheet"
-  href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
-/>```
-
 > jsDelivr is recommended for production usage because it provides global caching and better reliability.
 
 ### Option 2 — npm

--- a/README.md
+++ b/README.md
@@ -265,9 +265,8 @@ EaseMotion CSS can also be loaded using alternative CDN providers.
 ```html
 <link
   rel="stylesheet"
-  href="https://raw.githubusercontent.com/SAPTARSHI-coder/EaseMotion-css/main/easemotion.min.css"
-/>
-```
+  href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+/>```
 
 > jsDelivr is recommended for production usage because it provides global caching and better reliability.
 


### PR DESCRIPTION
## Pull Request Description

Fixes #20525

This PR removes the unsupported GitHub Raw CDN stylesheet snippet from the README. Browsers may reject `raw.githubusercontent.com` stylesheets because they can be served with a non-CSS MIME type, so the documentation should only recommend browser-safe CDN options.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [ ] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

This updates the installation documentation by removing the broken GitHub Raw CDN stylesheet option.

**How does a developer use it?**

```html
<link
  rel="stylesheet"
  href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css"
/>