### PR TITLE
feat: add removable-tag component (#29544)

### DIFF
--- a/submissions/examples/ease-removable-tag-ij/README.md
+++ b/submissions/examples/ease-removable-tag-ij/README.md
@@ -1,0 +1,15 @@
+# Removable Tag
+
+Tag/chip component with a shrink-and-fade removal animation using the CSS checkbox hack.
+
+## Features
+
+- Tags appear with a scale-in animation
+- Removal triggers a shrink-and-fade animation
+- Hover effect on the close button with color transition
+- Pure CSS implementation (checkbox hack for removal state)
+- Responsive flex-wrap layout
+
+## Usage
+
+Include `style.css` and structure tags with `.tag`, `.tag-text`, `.tag-remove`, and a hidden checkbox `.tag-toggle` paired with a `.tag-shim` element for the removal animation.

--- a/submissions/examples/ease-removable-tag-ij/demo.html
+++ b/submissions/examples/ease-removable-tag-ij/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Removable Tag</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h2 class="title">Tags</h2>
+    <div class="tags-wrapper">
+      <div class="tag">
+        <span class="tag-text">JavaScript</span>
+        <label class="tag-remove" for="close1">×</label>
+        <input type="checkbox" id="close1" class="tag-toggle" hidden>
+        <div class="tag-shim"></div>
+      </div>
+      <div class="tag">
+        <span class="tag-text">React</span>
+        <label class="tag-remove" for="close2">×</label>
+        <input type="checkbox" id="close2" class="tag-toggle" hidden>
+        <div class="tag-shim"></div>
+      </div>
+      <div class="tag">
+        <span class="tag-text">CSS</span>
+        <label class="tag-remove" for="close3">×</label>
+        <input type="checkbox" id="close3" class="tag-toggle" hidden>
+        <div class="tag-shim"></div>
+      </div>
+      <div class="tag">
+        <span class="tag-text">HTML</span>
+        <label class="tag-remove" for="close4">×</label>
+        <input type="checkbox" id="close4" class="tag-toggle" hidden>
+        <div class="tag-shim"></div>
+      </div>
+      <div class="tag">
+        <span class="tag-text">TypeScript</span>
+        <label class="tag-remove" for="close5">×</label>
+        <input type="checkbox" id="close5" class="tag-toggle" hidden>
+        <div class="tag-shim"></div>
+      </div>
+    </div>
+    <p class="hint">Click the × to remove a tag</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-removable-tag-ij/style.css
+++ b/submissions/examples/ease-removable-tag-ij/style.css
@@ -1,0 +1,123 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #1a1a2e;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  padding: 20px;
+}
+
+.container {
+  width: 500px;
+  background: #16213e;
+  border-radius: 16px;
+  padding: 30px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+}
+
+.title {
+  color: #fff;
+  font-size: 20px;
+  margin-bottom: 20px;
+}
+
+.tags-wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px 6px 14px;
+  background: #0f3460;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  position: relative;
+  overflow: hidden;
+  animation: tagAppear 0.3s ease-out;
+}
+
+@keyframes tagAppear {
+  from {
+    opacity: 0;
+    transform: scale(0.8);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.tag-text {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.85);
+  font-weight: 500;
+}
+
+.tag-remove {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.4);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  line-height: 1;
+}
+
+.tag-remove:hover {
+  background: rgba(233, 69, 96, 0.3);
+  color: #e94560;
+}
+
+.tag-toggle:checked ~ .tag-shim {
+  animation: tagRemoval 0.4s ease-in forwards;
+}
+
+@keyframes tagRemoval {
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(0);
+    opacity: 0;
+  }
+}
+
+.tag-toggle:checked ~ .tag-text,
+.tag-toggle:checked ~ .tag-remove {
+  animation: tagFadeOut 0.4s ease-in forwards;
+}
+
+@keyframes tagFadeOut {
+  to {
+    opacity: 0;
+  }
+}
+
+.tag-shim {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.hint {
+  color: rgba(255, 255, 255, 0.3);
+  font-size: 12px;
+  margin-top: 16px;
+  text-align: center;
+}


### PR DESCRIPTION
## Component: ease-removable-tag ? Tag/chip with animated removal using checkbox hack

### What this adds
- Tags with scale-in appear animation
- Close button with hover color transition
- Removal triggers shrink-and-fade animation
- Pure CSS using checkbox hack for state
- Responsive flex-wrap tag layout

### Acceptance Criteria covered
- Tags display as rounded chips with text
- Close ? button has hover styling
- Clicking ? triggers removal animation (scale + fade)
- Tags wrap naturally on smaller widths
- All CSS animation driven

### Files
- submissions/examples/ease-removable-tag-ij/demo.html
- submissions/examples/ease-removable-tag-ij/style.css
- submissions/examples/ease-removable-tag-ij/README.md

### How to review
Open demo.html and click the ? on any tag to see the removal animation.

**Closes #29544**
