### PR TITLE
feat: add slide-toggle-switch component (#29550)

### DIFF
--- a/submissions/examples/ease-slide-toggle-switch-ij/README.md
+++ b/submissions/examples/ease-slide-toggle-switch-ij/README.md
@@ -1,0 +1,15 @@
+# Slide Toggle Switch
+
+A CSS-only toggle switch component with smooth sliding thumb animation and active press state.
+
+## Features
+
+- Smooth sliding thumb with cubic-bezier bounce transition
+- Background color change on toggle
+- Active press state with thumb scale down
+- Clean dark theme settings layout
+- Pure CSS with hidden checkbox input
+
+## Usage
+
+Include `style.css` and structure each toggle with a hidden checkbox `.toggle-input`, `.toggle-track`, and `.toggle-thumb`. The checked state controls the thumb position and track color.

--- a/submissions/examples/ease-slide-toggle-switch-ij/demo.html
+++ b/submissions/examples/ease-slide-toggle-switch-ij/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Slide Toggle Switch</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h2 class="title">Preferences</h2>
+    <div class="toggle-group">
+      <div class="toggle-row">
+        <span class="toggle-label">Dark Mode</span>
+        <label class="toggle">
+          <input type="checkbox" class="toggle-input" checked>
+          <span class="toggle-track">
+            <span class="toggle-thumb"></span>
+          </span>
+        </label>
+      </div>
+      <div class="toggle-row">
+        <span class="toggle-label">Notifications</span>
+        <label class="toggle">
+          <input type="checkbox" class="toggle-input">
+          <span class="toggle-track">
+            <span class="toggle-thumb"></span>
+          </span>
+        </label>
+      </div>
+      <div class="toggle-row">
+        <span class="toggle-label">Auto-save</span>
+        <label class="toggle">
+          <input type="checkbox" class="toggle-input" checked>
+          <span class="toggle-track">
+            <span class="toggle-thumb"></span>
+          </span>
+        </label>
+      </div>
+      <div class="toggle-row">
+        <span class="toggle-label">Sound Effects</span>
+        <label class="toggle">
+          <input type="checkbox" class="toggle-input">
+          <span class="toggle-track">
+            <span class="toggle-thumb"></span>
+          </span>
+        </label>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-slide-toggle-switch-ij/style.css
+++ b/submissions/examples/ease-slide-toggle-switch-ij/style.css
@@ -1,0 +1,100 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #1a1a2e;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  padding: 20px;
+}
+
+.container {
+  width: 420px;
+  background: #16213e;
+  border-radius: 16px;
+  padding: 30px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+}
+
+.title {
+  color: #fff;
+  font-size: 20px;
+  margin-bottom: 24px;
+}
+
+.toggle-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-radius: 12px;
+  transition: background 0.3s ease;
+}
+
+.toggle-row:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.toggle-label {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 15px;
+  font-weight: 500;
+}
+
+.toggle {
+  cursor: pointer;
+  display: inline-flex;
+}
+
+.toggle-input {
+  display: none;
+}
+
+.toggle-track {
+  width: 48px;
+  height: 26px;
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 13px;
+  position: relative;
+  transition: background 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.toggle-input:checked + .toggle-track {
+  background: #e94560;
+}
+
+.toggle-thumb {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 20px;
+  height: 20px;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+.toggle-input:checked + .toggle-track .toggle-thumb {
+  transform: translateX(22px);
+}
+
+.toggle-track:active .toggle-thumb {
+  transform: scale(0.9);
+}
+
+.toggle-input:checked + .toggle-track:active .toggle-thumb {
+  transform: translateX(22px) scale(0.9);
+}


### PR DESCRIPTION
## Component: ease-slide-toggle-switch ? CSS-only toggle switch with bounce thumb animation

### What this adds
- Toggle switches with sliding thumb animation using cubic-bezier bounce
- Background color change on checked state
- Active press state with thumb scale-down
- Multiple toggle rows in a settings layout
- Pure CSS using hidden checkbox

### Acceptance Criteria covered
- Thumb slides with bounce transition on toggle
- Track color changes when checked
- Active press scales thumb down
- Multiple toggles in a vertical list
- Dark theme settings panel

### Files
- submissions/examples/ease-slide-toggle-switch-ij/demo.html
- submissions/examples/ease-slide-toggle-switch-ij/style.css
- submissions/examples/ease-slide-toggle-switch-ij/README.md

### How to review
Open demo.html and click each toggle switch to see the slide animation.

**Closes #29550**
