### PR TITLE
add before-after-comparison-qn to submissions/examples

### DIFF
--- a/submissions/examples/before-after-comparison-qn/README.md
+++ b/submissions/examples/before-after-comparison-qn/README.md
@@ -1,0 +1,49 @@
+# Animated Before/After Image Comparison
+
+## Description
+A modern, interactive image comparison component that reveals the "after" image with a smooth wipe effect on hover. It features an animated slider handle that moves across the image, "Before" and "After" labels with glassmorphism styling, and a smooth `clip-path` animation. Perfect for showcasing transformations, photo edits, design changes, and product comparisons. Built entirely with pure CSS, requiring absolutely zero JavaScript.
+
+## Files
+- `demo.html`: Contains the HTML structure with two stacked images, labels, and a slider handle.
+- `style.css`: Contains the clip-path animation, slider movement, and hover effects.
+
+## How to use
+1. Open `demo.html` in your browser and hover over the image to see the comparison effect.
+2. Copy the HTML and CSS into your project.
+3. **Structure:**
+   - Wrap everything in a `.comparison-container-qn` div
+   - Add the "before" image in `.comparison-before-qn`
+   - Add the "after" image in `.comparison-after-qn`
+   - Include the `.comparison-slider-qn` with the handle
+   - Add labels with `.comparison-label-qn`
+4. **Customization:**
+   - **Images:** Replace the `src` attributes in the `<img>` tags with your own images.
+   - **Animation Speed:** Adjust the `0.6s` transition duration in `.comparison-after-qn` and `.comparison-slider-qn`.
+   - **Slider Position:** The slider moves from left to right on hover. To change the direction, modify the `clip-path` values and `transform` properties.
+   - **Label Style:** Change the `background`, `color`, and `padding` in `.comparison-label-qn`.
+   - **Handle Size:** Modify the `width` and `height` in `.slider-handle-qn`.
+
+## Features
+- **Smooth Wipe Effect:** Uses `clip-path: inset()` for a hardware-accelerated reveal animation
+- **Animated Slider Handle:** Moves across the image in sync with the reveal
+- **Glassmorphism Labels:** Semi-transparent labels with backdrop blur
+- **Hover Interaction:** Cursor changes to `ew-resize` to indicate interactivity
+- **Responsive Design:** Adapts to mobile screens
+- **Accessibility:** Respects `prefers-reduced-motion` user preference
+
+## Technical Details
+- The "after" image uses `clip-path: inset(0 100% 0 0)` to start fully hidden
+- On hover, it transitions to `clip-path: inset(0 0 0 0)` to reveal the image
+- The slider handle uses `transform: translateX()` to move across the container
+- Both animations use the same timing function for perfect synchronization
+- `clip-path` is hardware-accelerated for smooth performance
+
+## Use Cases
+- Photo editing before/after comparisons
+- Design mockup presentations
+- Product transformation showcases
+- Real estate property renovations
+- Fitness progress photos
+- Art restoration displays
+- Filter/effect demonstrations
+- Website redesign comparisons

--- a/submissions/examples/before-after-comparison-qn/demo.html
+++ b/submissions/examples/before-after-comparison-qn/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Before/After Image Comparison - EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="demo-container-qn">
+        <h2>Image Transformation</h2>
+        <p>Hover over the image to see the comparison</p>
+        
+        <!-- Before/After Comparison Container -->
+        <div class="comparison-container-qn">
+            <!-- Before Image (Base Layer) -->
+            <div class="comparison-before-qn">
+                <img src="https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=800&q=80" alt="Before">
+                <span class="comparison-label-qn label-before-qn">Before</span>
+            </div>
+            
+            <!-- After Image (Overlay Layer) -->
+            <div class="comparison-after-qn">
+                <img src="https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=800&q=80&sat=-100&con=20" alt="After">
+                <span class="comparison-label-qn label-after-qn">After</span>
+            </div>
+            
+            <!-- Slider Handle -->
+            <div class="comparison-slider-qn">
+                <div class="slider-handle-qn">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                        <polyline points="15 18 9 12 15 6"></polyline>
+                        <polyline points="9 18 15 12 9 6"></polyline>
+                    </svg>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/before-after-comparison-qn/style.css
+++ b/submissions/examples/before-after-comparison-qn/style.css
@@ -1,0 +1,205 @@
+/* Basic Reset and Layout */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    padding: 40px 20px;
+}
+
+.demo-container-qn {
+    background: rgba(255, 255, 255, 0.95);
+    padding: 50px;
+    border-radius: 24px;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    text-align: center;
+    max-width: 700px;
+    width: 100%;
+}
+
+.demo-container-qn h2 {
+    color: #2c3e50;
+    font-size: 2rem;
+    margin-bottom: 10px;
+    font-weight: 700;
+}
+
+.demo-container-qn p {
+    color: #7f8c8d;
+    font-size: 1rem;
+    margin-bottom: 40px;
+}
+
+/* Comparison Container */
+.comparison-container-qn {
+    position: relative;
+    width: 100%;
+    max-width: 600px;
+    height: 400px;
+    margin: 0 auto;
+    border-radius: 16px;
+    overflow: hidden;
+    box-shadow: 0 15px 40px rgba(0, 0, 0, 0.2);
+    cursor: ew-resize;
+}
+
+/* Before Image (Base Layer) */
+.comparison-before-qn {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1;
+}
+
+.comparison-before-qn img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+/* After Image (Overlay Layer) */
+.comparison-after-qn {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 2;
+    /* Start fully hidden (clipped from the right) */
+    clip-path: inset(0 100% 0 0);
+    transition: clip-path 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.comparison-after-qn img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+/* Reveal the after image on hover */
+.comparison-container-qn:hover .comparison-after-qn {
+    clip-path: inset(0 0 0 0);
+}
+
+/* Labels */
+.comparison-label-qn {
+    position: absolute;
+    bottom: 20px;
+    padding: 8px 16px;
+    background: rgba(0, 0, 0, 0.7);
+    color: #ffffff;
+    font-size: 0.9rem;
+    font-weight: 600;
+    border-radius: 20px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    z-index: 5;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+}
+
+.label-before-qn {
+    left: 20px;
+}
+
+.label-after-qn {
+    right: 20px;
+}
+
+/* Slider Handle */
+.comparison-slider-qn {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 4px;
+    height: 100%;
+    background: #ffffff;
+    z-index: 10;
+    box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
+    transform: translateX(0);
+    transition: transform 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Move the slider to the right on hover */
+.comparison-container-qn:hover .comparison-slider-qn {
+    transform: translateX(calc(100% - 4px));
+}
+
+/* Slider Handle Circle */
+.slider-handle-qn {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 48px;
+    height: 48px;
+    background: #ffffff;
+    border-radius: 50%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.slider-handle-qn svg {
+    width: 24px;
+    height: 24px;
+    color: #667eea;
+}
+
+/* Handle hover effect */
+.comparison-container-qn:hover .slider-handle-qn {
+    transform: translate(-50%, -50%) scale(1.15);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+    .demo-container-qn {
+        padding: 30px 20px;
+    }
+    
+    .demo-container-qn h2 {
+        font-size: 1.6rem;
+    }
+    
+    .comparison-container-qn {
+        height: 300px;
+    }
+    
+    .slider-handle-qn {
+        width: 40px;
+        height: 40px;
+    }
+    
+    .slider-handle-qn svg {
+        width: 20px;
+        height: 20px;
+    }
+    
+    .comparison-label-qn {
+        font-size: 0.8rem;
+        padding: 6px 12px;
+    }
+}
+
+/* Respect user preference for reduced motion */
+@media (prefers-reduced-motion: reduce) {
+    .comparison-after-qn,
+    .comparison-slider-qn {
+        transition: none;
+    }
+}


### PR DESCRIPTION

## Description
This PR adds a new "Before/After Image Comparison" component to the repository. It creates an interactive image reveal effect with a smooth wipe animation, animated slider handle, and glassmorphism labels, all built with pure CSS `clip-path` animations.

## Changes
- Added `submissions/examples/before-after-comparison-qn/` folder.
- Added `demo.html` with the HTML structure for two stacked images, labels, and slider handle.
- Added `style.css` with clip-path animation, slider movement, and hover effects.
- Added `README.md` with usage instructions and customization tips.

## Related Issue
Closes #29654

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] I have placed my files in the `submissions/examples/before-after-comparison-qn/` directory.
- [x] I have not modified any files in `core/` or `components/`.
- [x] My submission includes `demo.html`, `style.css`, and `README.md`.
- [x] I have appended a unique identifier (`-qn`) to the feature name to avoid conflicts.
- [x] My commits are squashed into a single meaningful commit with a clear message.