### PR TITLE
feat: add hover reveal focus card (SS)

### DIFF
--- a/submissions/examples/29664-hover-reveal-focus-card-SS/README.md
+++ b/submissions/examples/29664-hover-reveal-focus-card-SS/README.md
@@ -1,0 +1,21 @@
+# Hover Reveal Focus Card
+
+## 1. What does this do?
+This is a highly interactive card component that uses a smooth CSS `clip-path` animation to retract a top gradient cover layer on hover, revealing beautifully staggered content beneath it.
+
+## 2. How is it used?
+Apply the core class to the parent container, and separate your content into a hidden layer and a cover layer.
+
+```html
+<article class="ease-reveal-card" tabindex="0">
+  <div class="ease-reveal-content">
+    <h3 class="ease-reveal-title">Hidden Title</h3>
+    <p class="ease-reveal-text">Hidden description text.</p>
+  </div>
+  <div class="ease-reveal-cover">
+    <h2 class="ease-cover-title">Hover Me</h2>
+  </div>
+</article>
+```
+## 3. Why is it useful?
+It fits EaseMotion's animation-first philosophy by delivering a complex, staggered interaction purely through native CSS variables and cubic-bezier transitions. It relies on zero external dependencies (no images or scripts) and handles keyboard focus seamlessly for full accessibility.

--- a/submissions/examples/29664-hover-reveal-focus-card-SS/demo.html
+++ b/submissions/examples/29664-hover-reveal-focus-card-SS/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hover Reveal Focus Card - EaseMotion</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+    <!-- Wrapper to center the component for the demo -->
+    <main class="demo-wrapper">
+
+        <!-- Core Component -->
+        <article class="ease-reveal-card" tabindex="0">
+
+            <!-- Hidden Content Layer -->
+            <div class="ease-reveal-content">
+                <h3 class="ease-reveal-title">Strategic Design</h3>
+                <p class="ease-reveal-text">
+                    Focusing on highly accessible, animation-driven user interfaces that load instantly and perform
+                    flawlessly across all modern browsers.
+                </p>
+                <span class="ease-reveal-action">Explore Metrics &rarr;</span>
+            </div>
+
+            <!-- Top Cover Layer -->
+            <div class="ease-reveal-cover">
+                <span class="ease-cover-icon">✦</span>
+                <h2 class="ease-cover-title">Hover to Reveal</h2>
+            </div>
+
+        </article>
+
+    </main>
+
+</body>
+
+</html>

--- a/submissions/examples/29664-hover-reveal-focus-card-SS/style.css
+++ b/submissions/examples/29664-hover-reveal-focus-card-SS/style.css
@@ -1,0 +1,133 @@
+/* ==========================================================================
+   EaseMotion - Hover Reveal Focus Card
+   ========================================================================== */
+
+:root {
+    --reveal-bg-base: #ffffff;
+    --reveal-bg-cover: linear-gradient(135deg, #6366f1 0%, #a855f7 100%);
+    --reveal-text-dark: #1e293b;
+    --reveal-text-light: #ffffff;
+    --reveal-text-muted: #64748b;
+    --reveal-radius: 20px;
+    --reveal-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* Demo wrapper purely for centering in the browser */
+.demo-wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    background-color: #f8fafc;
+    font-family: system-ui, -apple-system, sans-serif;
+    margin: 0;
+}
+
+/* Base Card Architecture */
+.ease-reveal-card {
+    position: relative;
+    width: 320px;
+    height: 400px;
+    border-radius: var(--reveal-radius);
+    background: var(--reveal-bg-base);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+    overflow: hidden;
+    cursor: pointer;
+    outline: none;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.ease-reveal-card:focus-visible {
+    box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.4);
+}
+
+.ease-reveal-card:hover,
+.ease-reveal-card:focus-visible {
+    transform: translateY(-8px);
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.12);
+}
+
+/* Hidden Content Layer */
+.ease-reveal-content {
+    position: absolute;
+    inset: 0;
+    padding: 2.5rem 2rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    z-index: 1;
+}
+
+.ease-reveal-title {
+    margin: 0 0 0.5rem 0;
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--reveal-text-dark);
+    transform: translateY(20px);
+    opacity: 0;
+    transition: all 0.4s var(--reveal-easing) 0.1s;
+}
+
+.ease-reveal-text {
+    margin: 0 0 1.5rem 0;
+    font-size: 0.95rem;
+    line-height: 1.5;
+    color: var(--reveal-text-muted);
+    transform: translateY(20px);
+    opacity: 0;
+    transition: all 0.4s var(--reveal-easing) 0.15s;
+}
+
+.ease-reveal-action {
+    font-weight: 600;
+    font-size: 0.9rem;
+    color: #6366f1;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    transform: translateY(20px);
+    opacity: 0;
+    transition: all 0.4s var(--reveal-easing) 0.2s;
+}
+
+/* Top Cover Layer */
+.ease-reveal-cover {
+    position: absolute;
+    inset: 0;
+    background: var(--reveal-bg-cover);
+    z-index: 2;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    color: var(--reveal-text-light);
+    clip-path: circle(150% at 50% 50%);
+    transition: clip-path 0.6s var(--reveal-easing);
+}
+
+.ease-cover-icon {
+    font-size: 3rem;
+    margin-bottom: 1rem;
+}
+
+.ease-cover-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 0;
+    letter-spacing: 0.02em;
+}
+
+/* Hover Triggers */
+.ease-reveal-card:hover .ease-reveal-cover,
+.ease-reveal-card:focus-visible .ease-reveal-cover {
+    clip-path: circle(0% at 50% 0%);
+}
+
+.ease-reveal-card:hover .ease-reveal-title,
+.ease-reveal-card:focus-visible .ease-reveal-title,
+.ease-reveal-card:hover .ease-reveal-text,
+.ease-reveal-card:focus-visible .ease-reveal-text,
+.ease-reveal-card:hover .ease-reveal-action,
+.ease-reveal-card:focus-visible .ease-reveal-action {
+    transform: translateY(0);
+    opacity: 1;
+}


### PR DESCRIPTION
## Pull Request Description
Introduces a new interactive UI card (`ease-reveal-card`) #29664, where a gradient cover layer smoothly retracts using CSS `clip-path` to reveal hidden content. Features staggered typography, entrance animations and full keyboard accessibility.

---
## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---
## Submission Checklist
> ⚠️ PRs that fail this checklist will be **closed without review**.
- [x] All changes are inside `submissions/` 
- [x] Includes all required files for my specific track
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A sleek card component with a `clip-path` hover transition that reveals staggered text.

**How does a developer use it?**

```html
<article class="ease-reveal-card">
  <div class="ease-reveal-content">...</div>
  <div class="ease-reveal-cover">...</div>
</article>
```

**Why does it fit EaseMotion CSS?**

It strictly utilizes native CSS capabilities (clip-path and cubic-bezier timings) to create a premium, 60fps interaction without requiring external JavaScript libraries, staying true to the zero-dependency ethos.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Submission is fully isolated inside submissions/examples/hover-reveal-focus-card-SS with my initials appended to prevent merge conflicts. Code strictly utilizes file:/// compatible elements with zero external CDNs.
