### PR TITLE
feat: add slide-cart-panel component (#29700)

### DIFF
--- a/submissions/examples/ease-slide-cart-panel-ij/README.md
+++ b/submissions/examples/ease-slide-cart-panel-ij/README.md
@@ -1,0 +1,15 @@
+# Slide Cart Panel
+
+A shopping cart panel that slides in from the right using a CSS custom property `--panel-open` to control the slide transition.
+
+## Features
+
+- Slide-in cart panel with bounce cubic-bezier transition
+- Overlay backdrop with opacity transition
+- Cart count badge indicator
+- Product listing with hover effects
+- JS toggles the `--panel-open` CSS variable
+
+## Usage
+
+Include `style.css` and structure the HTML with a `.cart-panel` element whose `transform: translateX()` is controlled by `--panel-open` (0 = closed, 1 = open). Toggle the variable with JavaScript.

--- a/submissions/examples/ease-slide-cart-panel-ij/demo.html
+++ b/submissions/examples/ease-slide-cart-panel-ij/demo.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Slide Cart Panel - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Slide Cart Panel</h1>
+    <div class="page-layout">
+      <header class="topbar">
+        <span class="logo">Store</span>
+        <button class="cart-btn" id="cartBtn" aria-label="Open cart">
+          <span class="cart-icon">🛒</span>
+          <span class="cart-count" id="cartCount">3</span>
+        </button>
+      </header>
+      <main class="products">
+        <div class="product-card">
+          <div class="product-img" style="background: #533483">🎧</div>
+          <div class="product-info">
+            <h3>Wireless Headphones</h3>
+            <span class="price">$79.99</span>
+          </div>
+        </div>
+        <div class="product-card">
+          <div class="product-img" style="background: #0f3460">⌚</div>
+          <div class="product-info">
+            <h3>Smart Watch</h3>
+            <span class="price">$199.99</span>
+          </div>
+        </div>
+        <div class="product-card">
+          <div class="product-img" style="background: #e94560">📱</div>
+          <div class="product-info">
+            <h3>Phone Case</h3>
+            <span class="price">$24.99</span>
+          </div>
+        </div>
+      </main>
+    </div>
+    <div class="cart-overlay" id="cartOverlay"></div>
+    <div class="cart-panel" id="cartPanel" style="--panel-open: 0;">
+      <div class="cart-header">
+        <h2>Shopping Cart</h2>
+        <button class="close-btn" id="closeBtn">✕</button>
+      </div>
+      <div class="cart-items">
+        <div class="cart-item">
+          <span class="item-name">Wireless Headphones</span>
+          <span class="item-qty">×1</span>
+          <span class="item-price">$79.99</span>
+        </div>
+        <div class="cart-item">
+          <span class="item-name">Smart Watch</span>
+          <span class="item-qty">×1</span>
+          <span class="item-price">$199.99</span>
+        </div>
+        <div class="cart-item">
+          <span class="item-name">Phone Case</span>
+          <span class="item-qty">×1</span>
+          <span class="item-price">$24.99</span>
+        </div>
+      </div>
+      <div class="cart-footer">
+        <div class="cart-total">
+          <span>Total</span>
+          <span class="total-price">$304.97</span>
+        </div>
+        <button class="checkout-btn">Checkout</button>
+      </div>
+    </div>
+    <p class="description">Click the cart icon to slide the panel in from the right. CSS handles the slide animation via <code>--panel-open</code> variable.</p>
+  </div>
+  <script>
+    const cartBtn = document.getElementById('cartBtn');
+    const cartPanel = document.getElementById('cartPanel');
+    const cartOverlay = document.getElementById('cartOverlay');
+    const closeBtn = document.getElementById('closeBtn');
+    function openCart() {
+      cartPanel.style.setProperty('--panel-open', '1');
+      cartOverlay.classList.add('visible');
+    }
+    function closeCart() {
+      cartPanel.style.setProperty('--panel-open', '0');
+      cartOverlay.classList.remove('visible');
+    }
+    cartBtn.addEventListener('click', openCart);
+    closeBtn.addEventListener('click', closeCart);
+    cartOverlay.addEventListener('click', closeCart);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-slide-cart-panel-ij/style.css
+++ b/submissions/examples/ease-slide-cart-panel-ij/style.css
@@ -1,0 +1,273 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 1.5rem;
+  color: #94a3b8;
+}
+
+.description {
+  margin-top: 1.5rem;
+  font-size: 0.875rem;
+  color: #64748b;
+  max-width: 340px;
+}
+
+.description code {
+  background: #1e293b;
+  padding: 0.1rem 0.3rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  color: #fbbf24;
+}
+
+.page-layout {
+  width: 340px;
+  background: #1e293b;
+  border-radius: 20px;
+  overflow: hidden;
+  margin: 0 auto;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid #334155;
+}
+
+.logo {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #f1f5f9;
+}
+
+.cart-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  position: relative;
+  padding: 4px;
+}
+
+.cart-icon {
+  font-size: 1.3rem;
+  display: block;
+}
+
+.cart-count {
+  position: absolute;
+  top: -4px;
+  right: -6px;
+  background: #e94560;
+  color: #fff;
+  font-size: 0.65rem;
+  font-weight: 700;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.products {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.product-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  background: #0f172a;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.product-card:hover {
+  background: #1a2332;
+}
+
+.product-img {
+  width: 48px;
+  height: 48px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.3rem;
+  flex-shrink: 0;
+}
+
+.product-info {
+  text-align: left;
+  flex: 1;
+}
+
+.product-info h3 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.price {
+  font-size: 0.8rem;
+  color: #94a3b8;
+}
+
+.cart-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 9;
+}
+
+.cart-overlay.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.cart-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 320px;
+  height: 100vh;
+  background: #1e293b;
+  box-shadow: -4px 0 24px rgba(0, 0, 0, 0.4);
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  transform: translateX(calc(var(--panel-open, 0) * 100%));
+  transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.cart-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem;
+  border-bottom: 1px solid #334155;
+}
+
+.cart-header h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #f1f5f9;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  color: #94a3b8;
+  font-size: 1.1rem;
+  cursor: pointer;
+  padding: 4px;
+  transition: color 0.2s ease;
+}
+
+.close-btn:hover {
+  color: #e94560;
+}
+
+.cart-items {
+  flex: 1;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  overflow-y: auto;
+}
+
+.cart-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 0;
+  border-bottom: 1px solid #334155;
+  font-size: 0.85rem;
+}
+
+.cart-item:last-child {
+  border-bottom: none;
+}
+
+.item-name {
+  flex: 1;
+  color: #e2e8f0;
+}
+
+.item-qty {
+  color: #64748b;
+}
+
+.item-price {
+  color: #fbbf24;
+  font-weight: 600;
+  min-width: 56px;
+  text-align: right;
+}
+
+.cart-footer {
+  padding: 1.25rem;
+  border-top: 1px solid #334155;
+}
+
+.cart-total {
+  display: flex;
+  justify-content: space-between;
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 12px;
+  color: #f1f5f9;
+}
+
+.total-price {
+  color: #fbbf24;
+}
+
+.checkout-btn {
+  width: 100%;
+  padding: 12px;
+  background: #e94560;
+  border: none;
+  border-radius: 10px;
+  color: #fff;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.checkout-btn:hover {
+  background: #d63851;
+}


### PR DESCRIPTION
## Component: ease-slide-cart-panel ? sliding cart panel with bounce transition tied to --panel-open

### What this adds
A shopping cart panel that slides in from the right. The panel translates via a CSS custom property --panel-open. JS sets the variable from button clicks. The overlay backdrop fades in with the panel.

### Acceptance Criteria covered
- Cart panel slides in from right using --panel-open CSS variable
- CSS handles the slide transition via cubic-bezier
- Overlay backdrop fades in when panel opens
- Cart icon shows item count badge

### Files
- submissions/examples/ease-slide-cart-panel-ij/demo.html
- submissions/examples/ease-slide-cart-panel-ij/style.css
- submissions/examples/ease-slide-cart-panel-ij/README.md

### How to review
Open demo.html in a browser. Click the cart icon; the panel slides in from the right. Click the overlay or close button to dismiss.

**Closes #29700**
