### PR TITLE
feat: add range-dual-thumb component (#29706)

### DIFF
--- a/submissions/examples/ease-range-dual-thumb-ij/README.md
+++ b/submissions/examples/ease-range-dual-thumb-ij/README.md
@@ -1,0 +1,15 @@
+# Range Dual Thumb
+
+A dual-thumb range slider for selecting a min/max value range. CSS handles the fill position and thumb positions via `--range-min` and `--range-max` custom properties.
+
+## Features
+
+- Two draggable thumbs for min and max selection
+- Fill highlight between the thumbs
+- Positions driven by `--range-min` and `--range-max` CSS variables
+- Labels update with current values
+- Horizontal track with grab interaction
+
+## Usage
+
+Include `style.css` and structure with `.range-track`, `.range-fill`, and two `.range-thumb` elements. JS sets `--range-min` and `--range-max` on drag.

--- a/submissions/examples/ease-range-dual-thumb-ij/demo.html
+++ b/submissions/examples/ease-range-dual-thumb-ij/demo.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Range Dual Thumb - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Dual Thumb Range</h1>
+    <div class="range-card">
+      <h2 class="range-title">Price Range</h2>
+      <div class="range-track" id="rangeTrack">
+        <div class="range-fill" id="rangeFill" style="--range-min: 0.25; --range-max: 0.75;"></div>
+        <div class="range-thumb range-thumb-min" id="thumbMin" style="--range-min: 0.25;">◀</div>
+        <div class="range-thumb range-thumb-max" id="thumbMax" style="--range-max: 0.75;">▶</div>
+      </div>
+      <div class="range-labels">
+        <span id="minLabel">$25</span>
+        <span id="maxLabel">$75</span>
+      </div>
+    </div>
+    <p class="description">Drag either thumb. CSS controls positions via <code>--range-min</code> and <code>--range-max</code>.</p>
+  </div>
+  <script>
+    const track = document.getElementById('rangeTrack');
+    const fill = document.getElementById('rangeFill');
+    const thumbMin = document.getElementById('thumbMin');
+    const thumbMax = document.getElementById('thumbMax');
+    const minLabel = document.getElementById('minLabel');
+    const maxLabel = document.getElementById('maxLabel');
+    let activeThumb = null;
+
+    function getVal(clientX) {
+      const rect = track.getBoundingClientRect();
+      return Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+    }
+
+    function update() {
+      const min = parseFloat(thumbMin.style.getPropertyValue('--range-min')) || 0;
+      const max = parseFloat(thumbMax.style.getPropertyValue('--range-max')) || 1;
+      fill.style.setProperty('--range-min', min);
+      fill.style.setProperty('--range-max', max);
+      minLabel.textContent = '$' + Math.round(min * 100);
+      maxLabel.textContent = '$' + Math.round(max * 100);
+    }
+
+    track.addEventListener('mousedown', (e) => {
+      const val = getVal(e.clientX);
+      const min = parseFloat(thumbMin.style.getPropertyValue('--range-min')) || 0;
+      const max = parseFloat(thumbMax.style.getPropertyValue('--range-max')) || 1;
+      activeThumb = Math.abs(val - min) < Math.abs(val - max) ? thumbMin : thumbMax;
+      const v = getVal(e.clientX);
+      if (activeThumb === thumbMin) {
+        activeThumb.style.setProperty('--range-min', Math.min(v, parseFloat(thumbMax.style.getPropertyValue('--range-max')) || 1));
+      } else {
+        activeThumb.style.setProperty('--range-max', Math.max(v, parseFloat(thumbMin.style.getPropertyValue('--range-min')) || 0));
+      }
+      update();
+    });
+
+    document.addEventListener('mousemove', (e) => {
+      if (!activeThumb) return;
+      const v = getVal(e.clientX);
+      if (activeThumb === thumbMin) {
+        const max = parseFloat(thumbMax.style.getPropertyValue('--range-max')) || 1;
+        activeThumb.style.setProperty('--range-min', Math.min(v, max - 0.05));
+      } else {
+        const min = parseFloat(thumbMin.style.getPropertyValue('--range-min')) || 0;
+        activeThumb.style.setProperty('--range-max', Math.max(v, min + 0.05));
+      }
+      update();
+    });
+
+    document.addEventListener('mouseup', () => { activeThumb = null; });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-range-dual-thumb-ij/style.css
+++ b/submissions/examples/ease-range-dual-thumb-ij/style.css
@@ -1,0 +1,119 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 1.5rem;
+  color: #94a3b8;
+}
+
+.description {
+  margin-top: 1.5rem;
+  font-size: 0.875rem;
+  color: #64748b;
+  max-width: 380px;
+}
+
+.description code {
+  background: #1e293b;
+  padding: 0.1rem 0.3rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  color: #fbbf24;
+}
+
+.range-card {
+  background: #1e293b;
+  border-radius: 20px;
+  padding: 2rem;
+  width: 380px;
+  margin: 0 auto;
+}
+
+.range-title {
+  font-size: 1rem;
+  font-weight: 500;
+  color: #94a3b8;
+  margin-bottom: 1.5rem;
+}
+
+.range-track {
+  height: 6px;
+  background: #334155;
+  border-radius: 3px;
+  position: relative;
+  cursor: pointer;
+  touch-action: none;
+}
+
+.range-fill {
+  position: absolute;
+  top: 0;
+  left: calc(var(--range-min, 0) * 100%);
+  width: calc((var(--range-max, 1) - var(--range-min, 0)) * 100%);
+  height: 100%;
+  background: linear-gradient(90deg, #e94560, #fbbf24);
+  border-radius: 3px;
+  transition: left 0.05s linear, width 0.05s linear;
+}
+
+.range-thumb {
+  position: absolute;
+  top: 50%;
+  width: 28px;
+  height: 28px;
+  background: #f1f5f9;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.5rem;
+  color: #1e293b;
+  cursor: grab;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  user-select: none;
+  transition: left 0.05s linear;
+  z-index: 1;
+}
+
+.range-thumb:active {
+  cursor: grabbing;
+}
+
+.range-thumb-min {
+  left: calc(var(--range-min, 0) * 100%);
+  transform: translate(-50%, -50%);
+}
+
+.range-thumb-max {
+  left: calc(var(--range-max, 1) * 100%);
+  transform: translate(-50%, -50%);
+}
+
+.range-labels {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 1.25rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #f1f5f9;
+}


### PR DESCRIPTION
## Component: ease-range-dual-thumb ? dual-thumb range slider with fill and positions tied to --range-min and --range-max

### What this adds
A dual-thumb range slider for selecting a min/max value range. JS sets --range-min and --range-max CSS variables on drag. CSS handles the fill highlight position and thumb positions.

### Acceptance Criteria covered
- Two draggable thumbs for min and max
- Fill highlight between thumbs
- Positions driven by --range-min and --range-max
- Labels update with current values
- Grab cursor interaction

### Files
- submissions/examples/ease-range-dual-thumb-ij/demo.html
- submissions/examples/ease-range-dual-thumb-ij/style.css
- submissions/examples/ease-range-dual-thumb-ij/README.md

### How to review
Open demo.html in a browser. Drag either thumb to adjust the price range.

**Closes #29706**
