### PR TITLE
feat: add CSS-only star rating component with half-star support

### DIFF
--- a/submissions/examples/rating-rb/README.md
+++ b/submissions/examples/rating-rb/README.md
@@ -1,0 +1,20 @@
+# Star Rating Component
+
+A pure CSS star rating system with interactive selection and read-only display modes. No JavaScript required.
+
+## Files
+
+- `demo.html` — Live preview with interactive, display, size, and dark mode variants
+- `style.css` — All rating styles, animations, and layout helpers
+
+## How It Works
+
+### Interactive Rating
+Uses hidden radio buttons inside a `flex-direction: row-reverse` container. The `~` general sibling selector highlights the hovered/checked star and all stars to its left visually.
+
+```html
+&lt;fieldset class="rating"&gt;
+  &lt;input type="radio" id="star5" name="rating" value="5" /&gt;
+  &lt;label for="star5"&gt;&lt;div class="star"&gt;&lt;/div&gt;&lt;/label&gt;
+  &lt;!-- ... repeat for 4, 3, 2, 1 --&gt;
+&lt;/fieldset&gt;

--- a/submissions/examples/rating-rb/demo.html
+++ b/submissions/examples/rating-rb/demo.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Star Rating Demo — EaseMotion CSS</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <!-- ===== INTERACTIVE RATING ===== -->
+  <section class="demo-section">
+    <h2 class="demo-title">Interactive Star Rating</h2>
+    <p class="demo-desc">Click a star to set a rating. Hover to preview. Keyboard accessible (Tab + arrow keys). Zero JavaScript.</p>
+
+    <div class="demo-row">
+      <span class="demo-label">Default</span>
+      <fieldset class="rating">
+        <input type="radio" id="star5" name="rating" value="5" />
+        <label for="star5"><div class="star"></div></label>
+
+        <input type="radio" id="star4" name="rating" value="4" />
+        <label for="star4"><div class="star"></div></label>
+
+        <input type="radio" id="star3" name="rating" value="3" checked />
+        <label for="star3"><div class="star"></div></label>
+
+        <input type="radio" id="star2" name="rating" value="2" />
+        <label for="star2"><div class="star"></div></label>
+
+        <input type="radio" id="star1" name="rating" value="1" />
+        <label for="star1"><div class="star"></div></label>
+      </fieldset>
+    </div>
+
+    <div class="demo-row">
+      <span class="demo-label">Small</span>
+      <fieldset class="rating rating-sm">
+        <input type="radio" id="star5s" name="rating-sm" value="5" />
+        <label for="star5s"><div class="star"></div></label>
+
+        <input type="radio" id="star4s" name="rating-sm" value="4" checked />
+        <label for="star4s"><div class="star"></div></label>
+
+        <input type="radio" id="star3s" name="rating-sm" value="3" />
+        <label for="star3s"><div class="star"></div></label>
+
+        <input type="radio" id="star2s" name="rating-sm" value="2" />
+        <label for="star2s"><div class="star"></div></label>
+
+        <input type="radio" id="star1s" name="rating-sm" value="1" />
+        <label for="star1s"><div class="star"></div></label>
+      </fieldset>
+    </div>
+
+    <div class="demo-row">
+      <span class="demo-label">Large</span>
+      <fieldset class="rating rating-lg">
+        <input type="radio" id="star5l" name="rating-lg" value="5" />
+        <label for="star5l"><div class="star"></div></label>
+
+        <input type="radio" id="star4l" name="rating-lg" value="4" />
+        <label for="star4l"><div class="star"></div></label>
+
+        <input type="radio" id="star3l" name="rating-lg" value="3" />
+        <label for="star3l"><div class="star"></div></label>
+
+        <input type="radio" id="star2l" name="rating-lg" value="2" checked />
+        <label for="star2l"><div class="star"></div></label>
+
+        <input type="radio" id="star1l" name="rating-lg" value="1" />
+        <label for="star1l"><div class="star"></div></label>
+      </fieldset>
+    </div>
+  </section>
+
+  <!-- ===== READ-ONLY DISPLAY RATING ===== -->
+  <section class="demo-section">
+    <h2 class="demo-title">Read-Only Display Rating</h2>
+    <p class="demo-desc">Use .star-full, .star-half, and plain .star to compose any rating value. Perfect for showing average review scores.</p>
+
+    <div class="demo-row">
+      <span class="demo-label">5.0</span>
+      <div class="rating-display">
+        <div class="star star-full"></div>
+        <div class="star star-full"></div>
+        <div class="star star-full"></div>
+        <div class="star star-full"></div>
+        <div class="star star-full"></div>
+        <span class="rating-value">5.0</span>
+      </div>
+    </div>
+
+    <div class="demo-row">
+      <span class="demo-label">4.5</span>
+      <div class="rating-display">
+        <div class="star star-full"></div>
+        <div class="star star-full"></div>
+        <div class="star star-full"></div>
+        <div class="star star-full"></div>
+        <div class="star star-half"></div>
+        <span class="rating-value">4.5</span>
+      </div>
+    </div>
+
+    <div class="demo-row">
+      <span class="demo-label">3.5</span>
+      <div class="rating-display">
+        <div class="star star-full"></div>
+        <div class="star star-full"></div>
+        <div class="star star-full"></div>
+        <div class="star star-half"></div>
+        <div class="star"></div>
+        <span class="rating-value">3.5</span>
+      </div>
+    </div>
+
+    <div class="demo-row">
+      <span class="demo-label">2.0</span>
+      <div class="rating-display">
+        <div class="star star-full"></div>
+        <div class="star star-full"></div>
+        <div class="star"></div>
+        <div class="star"></div>
+        <div class="star"></div>
+        <span class="rating-value">2.0</span>
+      </div>
+    </div>
+
+    <div class="demo-row">
+      <span class="demo-label">0.0</span>
+      <div class="rating-display">
+        <div class="star"></div>
+        <div class="star"></div>
+        <div class="star"></div>
+        <div class="star"></div>
+        <div class="star"></div>
+        <span class="rating-value">0.0</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===== DARK MODE ===== -->
+  <div class="demo-dark-bg">
+    <section class="demo-section">
+      <h2 class="demo-title">Dark Mode Rating</h2>
+      <p class="demo-desc">Wrap in .rating-dark for an instant dark palette swap.</p>
+
+      <div class="demo-row">
+        <span class="demo-label">Interactive</span>
+        <fieldset class="rating rating-dark">
+          <input type="radio" id="star5d" name="rating-dark" value="5" checked />
+          <label for="star5d"><div class="star"></div></label>
+
+          <input type="radio" id="star4d" name="rating-dark" value="4" />
+          <label for="star4d"><div class="star"></div></label>
+
+          <input type="radio" id="star3d" name="rating-dark" value="3" />
+          <label for="star3d"><div class="star"></div></label>
+
+          <input type="radio" id="star2d" name="rating-dark" value="2" />
+          <label for="star2d"><div class="star"></div></label>
+
+          <input type="radio" id="star1d" name="rating-dark" value="1" />
+          <label for="star1d"><div class="star"></div></label>
+        </fieldset>
+      </div>
+
+      <div class="demo-row">
+        <span class="demo-label">Display</span>
+        <div class="rating-display rating-dark">
+          <div class="star star-full"></div>
+          <div class="star star-full"></div>
+          <div class="star star-full"></div>
+          <div class="star star-half"></div>
+          <div class="star"></div>
+          <span class="rating-value">3.5</span>
+        </div>
+      </div>
+    </section>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/rating-rb/style.css
+++ b/submissions/examples/rating-rb/style.css
@@ -1,0 +1,201 @@
+/* ============================================
+   Star Rating Component — submissions/examples/rating-rb
+   Pure CSS interactive + read-only star rating
+   ============================================ */
+
+/* ---- Star Shape (clip-path) ---- */
+.star {
+  width: 2rem;
+  height: 2rem;
+  background: #e5e7eb;
+  clip-path: polygon(50% 0%, 61% 35%, 98% 35%, 68% 57%, 79% 91%, 50% 70%, 21% 91%, 32% 57%, 2% 35%, 39% 35%);
+  -webkit-clip-path: polygon(50% 0%, 61% 35%, 98% 35%, 68% 57%, 79% 91%, 50% 70%, 21% 91%, 32% 57%, 2% 35%, 39% 35%);
+  transition: background 0.2s ease, transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+  flex-shrink: 0;
+}
+
+/* ---- Full & Half Fill States ---- */
+.star-full {
+  background: #fbbf24;
+}
+
+.star-half {
+  background: linear-gradient(90deg, #fbbf24 50%, #e5e7eb 50%);
+}
+
+/* ============================================
+   INTERACTIVE RATING (radio buttons)
+   ============================================ */
+
+.rating {
+  display: inline-flex;
+  flex-direction: row-reverse;
+  align-items: center;
+  gap: 0.25rem;
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+/* Hide radio inputs but keep them keyboard accessible */
+.rating input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  margin: 0;
+}
+
+.rating label {
+  cursor: pointer;
+  display: block;
+  padding: 0.125rem;
+  line-height: 0;
+  transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* Default empty star */
+.rating label .star {
+  background: #e5e7eb;
+}
+
+/* Hover: highlight hovered star + all stars to the left (visually) */
+.rating label:hover .star,
+.rating label:hover ~ label .star {
+  background: #fbbf24;
+}
+
+.rating label:hover {
+  transform: scale(1.2);
+}
+
+/* Checked: highlight selected star + all stars to the left (visually) */
+.rating input:checked ~ label .star {
+  background: #fbbf24;
+}
+
+/* Focus ring for keyboard navigation */
+.rating input:focus-visible + label .star {
+  outline: 2px solid #3b82f6;
+  outline-offset: 3px;
+  border-radius: 2px;
+}
+
+/* ============================================
+   READ-ONLY DISPLAY RATING
+   ============================================ */
+
+.rating-display {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.rating-value {
+  margin-left: 0.5rem;
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #6b7280;
+}
+
+/* ============================================
+   SIZE VARIANTS
+   ============================================ */
+
+.rating-sm .star,
+.rating-sm label .star {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.rating-lg .star,
+.rating-lg label .star {
+  width: 2.75rem;
+  height: 2.75rem;
+}
+
+/* ============================================
+   DARK MODE VARIANT
+   ============================================ */
+
+.rating-dark .star {
+  background: #374151;
+}
+
+.rating-dark .star-full {
+  background: #fbbf24;
+}
+
+.rating-dark .star-half {
+  background: linear-gradient(90deg, #fbbf24 50%, #374151 50%);
+}
+
+.rating-dark .rating-value {
+  color: #9ca3af;
+}
+
+/* ============================================
+   DEMO LAYOUT
+   ============================================ */
+
+body {
+  font-family: 'Inter', system-ui, sans-serif;
+  background: #f9fafb;
+  padding: 2rem 1rem;
+  margin: 0;
+  color: #111827;
+  min-height: 100vh;
+}
+
+.demo-section {
+  max-width: 700px;
+  margin: 0 auto 2.5rem;
+}
+
+.demo-title {
+  font-weight: 600;
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.demo-desc {
+  color: #6b7280;
+  font-size: 0.875rem;
+  margin-bottom: 1.25rem;
+  line-height: 1.5;
+}
+
+.demo-row {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.demo-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+  min-width: 6rem;
+}
+
+.demo-dark-bg {
+  background: #111827;
+  margin: 2rem -1rem -2rem;
+  padding: 2rem 1rem;
+  min-height: 50vh;
+}
+
+.demo-dark-bg .demo-title {
+  color: #f9fafb;
+}
+
+.demo-dark-bg .demo-desc {
+  color: #9ca3af;
+}
+
+.demo-dark-bg .demo-label {
+  color: #d1d5db;
+}


### PR DESCRIPTION
## Summary
Adds a pure CSS star rating system submitted inside `submissions/examples/rating-rb/` as per the current contribution freeze policy.

## What's Included
- `demo.html` — Live preview with interactive, display, size, and dark mode variants
- `style.css` — All rating styles, clip-path shapes, and animations
- `README.md` — Usage docs and customization guide

## Key Features
- **Zero JavaScript** — Native radio buttons handle all state
- **Interactive** — Click to rate, hover to preview, keyboard arrow keys to navigate
- **Half-star display** — `.star-half` uses `linear-gradient(90deg, ...)` clipped to a star `polygon()` shape
- **Read-only mode** — Compose any score by mixing `.star`, `.star-full`, and `.star-half`
- **Hover bounce** — Stars scale with `cubic-bezier(0.34, 1.56, 0.64, 1)` easing
- **Size variants** — `.rating-sm` (1.25rem) and `.rating-lg` (2.75rem)
- **Dark mode** — `.rating-dark` swaps empty-star and text colors instantly
- **Accessible** — `&lt;fieldset&gt;` + radio buttons provide native screen-reader and keyboard support

## Classes
| Class | Description |
|-------|-------------|
| `.rating` | Interactive radio-button wrapper |
| `.rating-display` | Read-only static stars |
| `.star` | Base empty star shape |
| `.star-full` | Filled star |
| `.star-half` | Half-filled star (gradient) |
| `.rating-sm` / `.rating-lg` | Size modifiers |
| `.rating-dark` | Dark palette |
| `.rating-value` | Numeric score label |

## How the CSS Trick Works
`flex-direction: row-reverse` places DOM order as 5-4-3-2-1. The `~` general sibling selector then highlights the hovered/checked star and all stars to its **left** visually — exactly the behavior users expect from a 5-star rating.

## Checklist
- [x] Submitted inside `submissions/examples/` only
- [x] Does not modify `core/`, `components/`, or workflow files
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] One feature per PR
- [x] Commit message follows Conventional Commits format
- [x] Feature does not duplicate existing EaseMotion classes
- [x] I have read the [Contributing Guide](https://github.com/SAPTARSHI-coder/EaseMotion-css/blob/main/CONTRIBUTING.md)

---

**Note to maintainer:** This is a raw submission. I understand the naming will be standardized to the `ease-*` prefix during the curation pipeline if approved.