### PR TITLE
feat: add pop-over-tooltip component (#29714)

### DIFF
--- a/submissions/examples/ease-pop-over-tooltip-ij/README.md
+++ b/submissions/examples/ease-pop-over-tooltip-ij/README.md
@@ -1,0 +1,15 @@
+# Pop Over Tooltip
+
+Tooltips that appear on hover with a scale + opacity animation. Position and animation origin controlled via `--tip-from`, `--tip-top`, `--tip-left`, etc. CSS variables. Supports top, bottom, left, right positions.
+
+## Features
+
+- Appear on hover with scale and opacity animation
+- Position via --tip-top, --tip-bottom, --tip-left, --tip-right
+- Animation origin via --tip-from (translate + scale)
+- Smooth bounce cubic-bezier transition
+- Four-direction support (top, bottom, left, right)
+
+## Usage
+
+Wrap a trigger element and `.tooltip-box` in a `.tooltip-wrap`. Set position and `--tip-from` based on direction. Hovering the trigger shows the tooltip with animation.

--- a/submissions/examples/ease-pop-over-tooltip-ij/demo.html
+++ b/submissions/examples/ease-pop-over-tooltip-ij/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pop Over Tooltip - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Pop Over Tooltip</h1>
+    <p class="desc">Hover the buttons to see tooltips with scale + opacity animation</p>
+    <div class="tooltip-demo">
+      <div class="tooltip-wrap">
+        <button class="tooltip-trigger">Top</button>
+        <div class="tooltip-box" style="--tip-from: translateY(8px) scale(0.85); --tip-bottom: auto; --tip-top: -8px; --tip-left: 50%; --tip-x: -50%;">
+          <span>Top Tooltip</span>
+        </div>
+      </div>
+      <div class="tooltip-wrap">
+        <button class="tooltip-trigger">Bottom</button>
+        <div class="tooltip-box" style="--tip-from: translateY(-8px) scale(0.85); --tip-top: calc(100% + 8px); --tip-bottom: auto; --tip-left: 50%; --tip-x: -50%;">
+          <span>Bottom Tooltip</span>
+        </div>
+      </div>
+      <div class="tooltip-wrap">
+        <button class="tooltip-trigger">Left</button>
+        <div class="tooltip-box" style="--tip-from: translateX(8px) scale(0.85); --tip-top: 50%; --tip-bottom: auto; --tip-right: calc(100% + 8px); --tip-left: auto; --tip-x: 0; --tip-y: -50%;">
+          <span>Left Tooltip</span>
+        </div>
+      </div>
+      <div class="tooltip-wrap">
+        <button class="tooltip-trigger">Right</button>
+        <div class="tooltip-box" style="--tip-from: translateX(-8px) scale(0.85); --tip-top: 50%; --tip-bottom: auto; --tip-left: calc(100% + 8px); --tip-right: auto; --tip-x: 0; --tip-y: -50%;">
+          <span>Right Tooltip</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-pop-over-tooltip-ij/style.css
+++ b/submissions/examples/ease-pop-over-tooltip-ij/style.css
@@ -1,0 +1,99 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 0.5rem;
+  color: #94a3b8;
+}
+
+.desc {
+  font-size: 0.875rem;
+  color: #64748b;
+  margin-bottom: 2.5rem;
+  max-width: 340px;
+}
+
+.tooltip-demo {
+  display: flex;
+  gap: 1.5rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+.tooltip-wrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.tooltip-trigger {
+  padding: 10px 24px;
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 10px;
+  color: #e2e8f0;
+  font-family: inherit;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.tooltip-trigger:hover {
+  background: #334155;
+}
+
+.tooltip-box {
+  position: absolute;
+  top: var(--tip-top, auto);
+  bottom: var(--tip-bottom, auto);
+  left: var(--tip-left, auto);
+  right: var(--tip-right, auto);
+  transform: translate(var(--tip-x, 0), var(--tip-y, 0));
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease, transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+  z-index: 10;
+}
+
+.tooltip-box span {
+  display: block;
+  padding: 6px 14px;
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  font-size: 0.8rem;
+  color: #94a3b8;
+  white-space: nowrap;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+  transform: var(--tip-from, none);
+  transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.tooltip-wrap:hover .tooltip-box {
+  opacity: 1;
+}
+
+.tooltip-wrap:hover .tooltip-box span {
+  transform: none;
+}


### PR DESCRIPTION
## Component: ease-pop-over-tooltip ? tooltip with scale + opacity animation on hover, position via CSS variables

### What this adds
Tooltips that appear on hover with a scale and opacity animation. Position is controlled via --tip-top, --tip-bottom, --tip-left, --tip-right, and animation origin via --tip-from. Supports top, bottom, left, and right positions.

### Acceptance Criteria covered
- Tooltip appears on hover with scale + opacity animation
- Position via --tip-top, --tip-bottom, --tip-left, --tip-right CSS variables
- Animation origin via --tip-from
- Smooth bounce cubic-bezier transition
- Four-direction support (top, bottom, left, right)

### Files
- submissions/examples/ease-pop-over-tooltip-ij/demo.html
- submissions/examples/ease-pop-over-tooltip-ij/style.css
- submissions/examples/ease-pop-over-tooltip-ij/README.md

### How to review
Open demo.html and hover over each button to see tooltips appear with animation.

**Closes #29714**
