### PR TITLE
feat: add ripple-water-effect component (#29717)

### DIFF
--- a/submissions/examples/ease-ripple-water-effect-ij/README.md
+++ b/submissions/examples/ease-ripple-water-effect-ij/README.md
@@ -1,0 +1,15 @@
+# Ripple Water Effect
+
+A clickable pond surface that creates expanding ripple circles at the click position. JS creates ripple elements with `--rp-x`, `--rp-y`, and `--rp-size` CSS variables. CSS handles the scale and opacity animation.
+
+## Features
+
+- Expanding ripple circle on click
+- Position via `--rp-x` and `--rp-y` CSS variables
+- Size via `--rp-size` CSS variable
+- Auto-removes animation after completion
+- Gradient water surface background
+
+## Usage
+
+Click the pond. JS creates a `.ripple-circle` div with position and size set as CSS variables. The `@keyframes rippleGrow` animation scales from 0 to 1 with opacity fade-out.

--- a/submissions/examples/ease-ripple-water-effect-ij/demo.html
+++ b/submissions/examples/ease-ripple-water-effect-ij/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ripple Water Effect - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Water Ripple</h1>
+    <p class="desc">Click the surface to create expanding ripples</p>
+    <div class="ripple-pond" id="ripplePond">
+      <span class="ripple-label">Click anywhere</span>
+    </div>
+  </div>
+  <script>
+    const pond = document.getElementById('ripplePond');
+
+    pond.addEventListener('click', (e) => {
+      const rect = pond.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const ripple = document.createElement('div');
+      ripple.className = 'ripple-circle';
+      ripple.style.setProperty('--rp-x', x);
+      ripple.style.setProperty('--rp-y', y);
+      ripple.style.setProperty('--rp-size', Math.max(rect.width, rect.height) * 1.2);
+      pond.appendChild(ripple);
+      ripple.addEventListener('animationend', () => ripple.remove());
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-ripple-water-effect-ij/style.css
+++ b/submissions/examples/ease-ripple-water-effect-ij/style.css
@@ -1,0 +1,78 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 0.5rem;
+  color: #94a3b8;
+}
+
+.desc {
+  font-size: 0.875rem;
+  color: #64748b;
+  margin-bottom: 2rem;
+}
+
+.ripple-pond {
+  position: relative;
+  width: 340px;
+  height: 300px;
+  background: linear-gradient(180deg, #0c4a6e, #082f49);
+  border-radius: 20px;
+  overflow: hidden;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto;
+}
+
+.ripple-label {
+  position: relative;
+  z-index: 1;
+  color: rgba(255,255,255,0.4);
+  font-size: 0.9rem;
+  pointer-events: none;
+}
+
+.ripple-circle {
+  position: absolute;
+  left: calc(var(--rp-x, 0) * 1px - var(--rp-size, 100px) / 2);
+  top: calc(var(--rp-y, 0) * 1px - var(--rp-size, 100px) / 2);
+  width: var(--rp-size, 100px);
+  height: var(--rp-size, 100px);
+  border-radius: 50%;
+  border: 2px solid rgba(255,255,255,0.3);
+  animation: rippleGrow 0.8s ease-out forwards;
+  pointer-events: none;
+}
+
+@keyframes rippleGrow {
+  0% {
+    transform: scale(0);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Component: ease-ripple-water-effect ? expanding ripple circles on click, position via --rp-x and --rp-y

### What this adds
A clickable pond surface that creates expanding ripple circles at the click position. JS creates ripple elements with --rp-x, --rp-y, and --rp-size. CSS handles the scale/opacity keyframe animation.

### Acceptance Criteria covered
- Expanding ripple circle on click
- Position via --rp-x and --rp-y CSS variables
- Size via --rp-size CSS variable
- Auto-removes after animation ends
- Gradient water surface background

### Files
- submissions/examples/ease-ripple-water-effect-ij/demo.html
- submissions/examples/ease-ripple-water-effect-ij/style.css
- submissions/examples/ease-ripple-water-effect-ij/README.md

### How to review
Open demo.html and click the blue pond surface to see ripple circles expand outward.

**Closes #29717**
