### PR TITLE
feat: add image-lazy-blur component (#29720)

### DIFF
--- a/submissions/examples/ease-image-lazy-blur-ij/README.md
+++ b/submissions/examples/ease-image-lazy-blur-ij/README.md
@@ -1,0 +1,15 @@
+# Image Lazy Blur
+
+Images that transition from blurry to clear on load. CSS filters use `--img-blur` and `--img-loaded` variables. The `filter: blur()` transitions smoothly using a cubic-bezier curve.
+
+## Features
+
+- Blur-to-clear transition on image load
+- Blur amount via `--img-blur` CSS variable
+- Loaded state via `--img-loaded` (0 or 1)
+- Smooth cubic-bezier transition on filter
+- Card layout with captions
+
+## Usage
+
+Set `--img-loaded` to 0 (blurry) and `--img-blur` to desired blur amount on `.lazy-img`. When the image loads, set `--img-loaded` to 1; CSS transitions `filter: blur()` from the blur amount to 0.

--- a/submissions/examples/ease-image-lazy-blur-ij/demo.html
+++ b/submissions/examples/ease-image-lazy-blur-ij/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Image Lazy Blur - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Lazy Blur</h1>
+    <p class="desc">Images load with a blur-to-clear transition</p>
+    <div class="image-grid">
+      <div class="lazy-card">
+        <div class="lazy-img-wrap">
+          <div class="lazy-img" style="--img-loaded: 0; --img-blur: 20px; --img-src: 'https://picsum.photos/seed/a/400/300';">
+            <img src="https://picsum.photos/seed/a/400/300" alt="Random 1" class="lazy-src" style="--img-loaded: 1;">
+          </div>
+        </div>
+        <span class="lazy-caption">Forest</span>
+      </div>
+      <div class="lazy-card">
+        <div class="lazy-img-wrap">
+          <div class="lazy-img" style="--img-loaded: 0; --img-blur: 20px; --img-src: 'https://picsum.photos/seed/b/400/300';">
+            <img src="https://picsum.photos/seed/b/400/300" alt="Random 2" class="lazy-src" style="--img-loaded: 1;">
+          </div>
+        </div>
+        <span class="lazy-caption">Mountain</span>
+      </div>
+    </div>
+    <p class="description">CSS transitions blur from 20px to 0px using <code>--img-blur</code> when <code>--img-loaded</code> becomes 1.</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-image-lazy-blur-ij/style.css
+++ b/submissions/examples/ease-image-lazy-blur-ij/style.css
@@ -1,0 +1,90 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 0.5rem;
+  color: #94a3b8;
+}
+
+.desc {
+  font-size: 0.875rem;
+  color: #64748b;
+  margin-bottom: 1.5rem;
+}
+
+.description {
+  margin-top: 1.5rem;
+  font-size: 0.875rem;
+  color: #64748b;
+  max-width: 400px;
+}
+
+.description code {
+  background: #1e293b;
+  padding: 0.1rem 0.3rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  color: #fbbf24;
+}
+
+.image-grid {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.lazy-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.lazy-img-wrap {
+  border-radius: 14px;
+  overflow: hidden;
+  width: 200px;
+  height: 150px;
+  background: #1e293b;
+}
+
+.lazy-img {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.lazy-src {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: blur(calc((1 - var(--img-loaded, 0)) * var(--img-blur, 20px)));
+  transition: filter 0.6s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.lazy-caption {
+  font-size: 0.8rem;
+  color: #64748b;
+}


### PR DESCRIPTION
## Component: ease-image-lazy-blur ? blur-to-clear image transition driven by --img-loaded and --img-blur

### What this adds
A lazy image loading effect where images transition from blurry to clear. --img-loaded (0 or 1) controls the blur amount via ilter: blur(calc((1 - var(--img-loaded)) * var(--img-blur))). CSS handles the smooth filter transition.

### Acceptance Criteria covered
- Blur-to-clear transition on image display
- Blur amount via --img-blur CSS variable
- Loaded state via --img-loaded (0 or 1)
- Smooth cubic-bezier transition on filter
- Card layout with captions

### Files
- submissions/examples/ease-image-lazy-blur-ij/demo.html
- submissions/examples/ease-image-lazy-blur-ij/style.css
- submissions/examples/ease-image-lazy-blur-ij/README.md

### How to review
Open demo.html to see images with a blur-to-clear transition effect.

**Closes #29720**
