### PR TITLE
Fix broken GitHub Raw CDN installation snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ EaseMotion CSS can also be loaded using alternative CDN providers.
 ```html
 <link
   rel="stylesheet"
-  href="https://raw.githubusercontent.com/SAPTARSHI-coder/EaseMotion-css/main/easemotion.min.css"
+  href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
 />
 ```
 


### PR DESCRIPTION
## Description

This PR fixes the broken GitHub Raw CDN installation snippet in the documentation.

### Changes Made

- Removed the unsupported `raw.githubusercontent.com` stylesheet URL.
- Replaced it with the supported jsDelivr CDN URL.
- Prevented browser MIME-type issues when users follow the installation guide.

## Why

GitHub Raw serves CSS files with a `text/plain` MIME type, which can prevent browsers from loading the stylesheet correctly. Using jsDelivr provides a proper CDN endpoint for CSS files.

## Checklist

- [x] Updated README documentation
- [x] Replaced unsupported GitHub Raw CDN
- [x] Verified installation snippet