### PR TITLE
feat: add tab-switcher-underline component (#29722)

### DIFF
--- a/submissions/examples/ease-tab-switcher-underline-ij/README.md
+++ b/submissions/examples/ease-tab-switcher-underline-ij/README.md
@@ -1,0 +1,15 @@
+# Tab Switcher Underline
+
+A tab bar with an animated underline indicator that slides between tabs. Active index via `--ts-active`, total tabs via `--ts-count`. CSS handles the underline translation with a bounce cubic-bezier.
+
+## Features
+
+- Sliding underline indicator between tabs
+- Active index via `--ts-active` CSS variable
+- Tab count via `--ts-count` CSS variable
+- Smooth bounce cubic-bezier transition
+- Dark card layout with tab labels
+
+## Usage
+
+Set `--ts-active` (0-based index) and `--ts-count` (number of tabs) on `.tabs-bar`. CSS translates the `.ts-underline` element accordingly.

--- a/submissions/examples/ease-tab-switcher-underline-ij/demo.html
+++ b/submissions/examples/ease-tab-switcher-underline-ij/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tab Switcher Underline - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Tab Switcher</h1>
+    <p class="desc">Tabs with animated underline indicator</p>
+    <div class="tabs-card">
+      <div class="tabs-bar" style="--ts-active: 0; --ts-count: 4;">
+        <button class="ts-tab" data-index="0">Home</button>
+        <button class="ts-tab" data-index="1">Explore</button>
+        <button class="ts-tab" data-index="2">Settings</button>
+        <button class="ts-tab" data-index="3">Profile</button>
+        <div class="ts-underline"></div>
+      </div>
+      <div class="tab-content">
+        <p id="tabLabel">Home tab active</p>
+      </div>
+    </div>
+  </div>
+  <script>
+    const bar = document.querySelector('.tabs-bar');
+    const tabs = document.querySelectorAll('.ts-tab');
+    const label = document.getElementById('tabLabel');
+    const underline = document.querySelector('.ts-underline');
+
+    tabs.forEach((tab, i) => {
+      tab.addEventListener('click', () => {
+        bar.style.setProperty('--ts-active', i);
+        label.textContent = tab.textContent + ' tab active';
+        tabs.forEach(t => t.classList.remove('active'));
+        tab.classList.add('active');
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-tab-switcher-underline-ij/style.css
+++ b/submissions/examples/ease-tab-switcher-underline-ij/style.css
@@ -1,0 +1,93 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  text-align: center;
+  width: 100%;
+  max-width: 480px;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 0.5rem;
+  color: #94a3b8;
+}
+
+.desc {
+  font-size: 0.875rem;
+  color: #64748b;
+  margin-bottom: 2rem;
+}
+
+.tabs-card {
+  background: #1e293b;
+  border-radius: 16px;
+  padding: 1.5rem;
+}
+
+.tabs-bar {
+  --ts-active: 0;
+  --ts-count: 4;
+  position: relative;
+  display: flex;
+  background: #0f172a;
+  border-radius: 10px;
+  padding: 0.25rem;
+  gap: 0;
+}
+
+.ts-tab {
+  flex: 1;
+  padding: 0.6rem 0.5rem;
+  background: none;
+  border: none;
+  color: #64748b;
+  font-family: inherit;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color 0.2s ease;
+  position: relative;
+  z-index: 1;
+}
+
+.ts-tab.active {
+  color: #e2e8f0;
+}
+
+.ts-underline {
+  position: absolute;
+  bottom: 0.25rem;
+  height: calc(100% - 0.5rem);
+  width: calc(100% / var(--ts-count));
+  background: #334155;
+  border-radius: 8px;
+  transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+  transform: translateX(calc(var(--ts-active) * 100%));
+  pointer-events: none;
+}
+
+.tab-content {
+  margin-top: 1.5rem;
+  text-align: center;
+}
+
+.tab-content p {
+  font-size: 0.9rem;
+  color: #94a3b8;
+}


### PR DESCRIPTION
## Component: ease-tab-switcher-underline ? tab bar with animated sliding underline, index via --ts-active and count via --ts-count

### What this adds
A tab bar with an animated underline indicator that slides between tabs. Active index via --ts-active, total tabs via --ts-count. CSS handles the underline translation with a bounce cubic-bezier transition.

### Acceptance Criteria covered
- Sliding underline indicator between tabs
- Active index via --ts-active CSS variable
- Tab count via --ts-count CSS variable
- Smooth bounce cubic-bezier transition
- Dark card layout with tab labels

### Files
- submissions/examples/ease-tab-switcher-underline-ij/demo.html
- submissions/examples/ease-tab-switcher-underline-ij/style.css
- submissions/examples/ease-tab-switcher-underline-ij/README.md

### How to review
Open demo.html and click each tab to see the underline slide.

**Closes #29722**
