### PR TITLE
feat: add drag-slider-thumb component (#29723)

### DIFF
--- a/submissions/examples/ease-drag-slider-thumb-ij/README.md
+++ b/submissions/examples/ease-drag-slider-thumb-ij/README.md
@@ -1,0 +1,15 @@
+# Drag Slider Thumb
+
+A draggable slider thumb with gradient fill track. Position via `--dt-val` (0 to 1). Thumb scales and glows when dragging. CSS handles the thumb position and fill width.
+
+## Features
+
+- Draggable slider thumb
+- Gradient fill track
+- Thumb scale and glow on drag
+- Position via --dt-val CSS variable
+- Numeric value display
+
+## Usage
+
+Set `--dt-val` (0 to 1) on `.slider-thumb` to control position. CSS translates the thumb via `calc(var(--dt-val) * 100% - 50%)`.

--- a/submissions/examples/ease-drag-slider-thumb-ij/demo.html
+++ b/submissions/examples/ease-drag-slider-thumb-ij/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Drag Slider Thumb - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Drag Thumb</h1>
+    <p class="desc">Draggable slider thumb with glow and scale</p>
+    <div class="slider-wrap">
+      <div class="slider-track" id="sliderTrack">
+        <div class="slider-fill" id="sliderFill"></div>
+        <div class="slider-thumb" id="sliderThumb" style="--dt-val: 0;">
+          <div class="thumb-glow"></div>
+        </div>
+      </div>
+      <div class="slider-value" id="sliderValue">0</div>
+    </div>
+  </div>
+  <script>
+    const track = document.getElementById('sliderTrack');
+    const thumb = document.getElementById('sliderThumb');
+    const fill = document.getElementById('sliderFill');
+    const value = document.getElementById('sliderValue');
+    let dragging = false;
+
+    function updateSlider(clientX) {
+      const rect = track.getBoundingClientRect();
+      let pct = (clientX - rect.left) / rect.width;
+      pct = Math.max(0, Math.min(1, pct));
+      thumb.style.setProperty('--dt-val', pct);
+      fill.style.width = `${pct * 100}%`;
+      value.textContent = Math.round(pct * 100);
+    }
+
+    thumb.addEventListener('mousedown', (e) => {
+      dragging = true;
+      thumb.classList.add('dragging');
+      e.preventDefault();
+    });
+
+    document.addEventListener('mousemove', (e) => {
+      if (dragging) updateSlider(e.clientX);
+    });
+
+    document.addEventListener('mouseup', () => {
+      dragging = false;
+      thumb.classList.remove('dragging');
+    });
+
+    track.addEventListener('click', (e) => {
+      if (e.target === thumb) return;
+      updateSlider(e.clientX);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-drag-slider-thumb-ij/style.css
+++ b/submissions/examples/ease-drag-slider-thumb-ij/style.css
@@ -1,0 +1,105 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  text-align: center;
+  width: 100%;
+  max-width: 400px;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 0.5rem;
+  color: #94a3b8;
+}
+
+.desc {
+  font-size: 0.875rem;
+  color: #64748b;
+  margin-bottom: 2.5rem;
+}
+
+.slider-wrap {
+  background: #1e293b;
+  border-radius: 20px;
+  padding: 3rem 2rem;
+}
+
+.slider-track {
+  position: relative;
+  height: 6px;
+  background: #334155;
+  border-radius: 3px;
+  cursor: pointer;
+  margin: 1.5rem 0;
+}
+
+.slider-fill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  background: linear-gradient(90deg, #e94560, #fbbf24);
+  border-radius: 3px;
+  pointer-events: none;
+  width: 0%;
+}
+
+.slider-thumb {
+  --dt-val: 0;
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 24px;
+  height: 24px;
+  background: #fff;
+  border-radius: 50%;
+  transform: translate(calc(var(--dt-val) * 100% - 50%), -50%);
+  cursor: grab;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.1s ease, box-shadow 0.2s ease;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+}
+
+.slider-thumb.dragging {
+  cursor: grabbing;
+  box-shadow: 0 4px 16px rgba(233, 69, 96, 0.4);
+  transform: translate(calc(var(--dt-val) * 100% - 50%), -50%) scale(1.2);
+}
+
+.thumb-glow {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #e94560;
+  transition: transform 0.2s ease;
+}
+
+.slider-thumb.dragging .thumb-glow {
+  transform: scale(1.3);
+}
+
+.slider-value {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #e94560;
+  font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
## Component: ease-drag-slider-thumb ? draggable slider thumb with gradient fill track and --dt-val position

### What this adds
A draggable slider thumb with a gradient fill track. Position controlled by --dt-val (0 to 1). CSS handles thumb translation via calc(var(--dt-val) * 100% - 50%) and fill width. Thumb scales and glows when dragging.

### Acceptance Criteria covered
- Draggable slider thumb
- Gradient fill track
- Thumb scale and glow on drag
- Position via --dt-val CSS variable
- Numeric value display

### Files
- submissions/examples/ease-drag-slider-thumb-ij/demo.html
- submissions/examples/ease-drag-slider-thumb-ij/style.css
- submissions/examples/ease-drag-slider-thumb-ij/README.md

### How to review
Open demo.html and drag the thumb or click the track.

**Closes #29723**
