### PR TITLE
feat: add color-picker-swatch component (#29724)

### DIFF
--- a/submissions/examples/ease-color-picker-swatch-ij/README.md
+++ b/submissions/examples/ease-color-picker-swatch-ij/README.md
@@ -1,0 +1,15 @@
+# Color Picker Swatch
+
+A grid of color swatches with animated active state. Active index via `--cp-active`. CSS highlights the selected swatch with scale, border ring, and shadow.
+
+## Features
+
+- Clickable color swatches with animated active state
+- Active index via `--cp-active` CSS variable
+- Scale and ring highlight on selected swatch
+- Hover scale effect on all swatches
+- Selected color label display
+
+## Usage
+
+Set `--cp-active` (0-based index) on `.swatch-grid`. Each `.cp-swatch` uses `--cp-color` for its background. JS toggles `.active` class on the selected swatch for visual highlight.

--- a/submissions/examples/ease-color-picker-swatch-ij/demo.html
+++ b/submissions/examples/ease-color-picker-swatch-ij/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Color Picker Swatch - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Color Swatches</h1>
+    <p class="desc">Click a swatch to select — active state via --cp-active</p>
+    <div class="swatch-grid" id="swatchGrid" style="--cp-active: 0;">
+      <div class="cp-swatch" style="--cp-color: #e94560;" data-idx="0"></div>
+      <div class="cp-swatch" style="--cp-color: #fbbf24;" data-idx="1"></div>
+      <div class="cp-swatch" style="--cp-color: #34d399;" data-idx="2"></div>
+      <div class="cp-swatch" style="--cp-color: #60a5fa;" data-idx="3"></div>
+      <div class="cp-swatch" style="--cp-color: #a78bfa;" data-idx="4"></div>
+      <div class="cp-swatch" style="--cp-color: #fb923c;" data-idx="5"></div>
+    </div>
+    <p class="selected-label" id="selectedLabel">Selected: <span style="color: #e94560;">#e94560</span></p>
+  </div>
+  <script>
+    const grid = document.getElementById('swatchGrid');
+    const label = document.getElementById('selectedLabel');
+    const swatches = document.querySelectorAll('.cp-swatch');
+    const colors = ['#e94560', '#fbbf24', '#34d399', '#60a5fa', '#a78bfa', '#fb923c'];
+
+    swatches.forEach((swatch, i) => {
+      swatch.addEventListener('click', () => {
+        grid.style.setProperty('--cp-active', i);
+        swatches.forEach(s => s.classList.remove('active'));
+        swatch.classList.add('active');
+        label.innerHTML = `Selected: <span style="color: ${colors[i]};">${colors[i]}</span>`;
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-color-picker-swatch-ij/style.css
+++ b/submissions/examples/ease-color-picker-swatch-ij/style.css
@@ -1,0 +1,74 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 0.5rem;
+  color: #94a3b8;
+}
+
+.desc {
+  font-size: 0.875rem;
+  color: #64748b;
+  margin-bottom: 2rem;
+  max-width: 320px;
+}
+
+.swatch-grid {
+  --cp-active: 0;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  max-width: 300px;
+  margin: 0 auto;
+}
+
+.cp-swatch {
+  --cp-color: #e94560;
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  background: var(--cp-color);
+  cursor: pointer;
+  transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.2s ease;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+}
+
+.cp-swatch:hover {
+  transform: scale(1.1);
+}
+
+.cp-swatch.active {
+  transform: scale(1.15);
+  box-shadow: 0 0 0 3px #e2e8f0, 0 4px 16px rgba(0,0,0,0.3);
+}
+
+.selected-label {
+  margin-top: 1.5rem;
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+.selected-label span {
+  font-weight: 600;
+}


### PR DESCRIPTION
## Component: ease-color-picker-swatch ? color swatch grid with animated active state, color via --cp-color, active via --cp-active

### What this adds
A grid of clickable color swatches with an animated active state. Each swatch's color via --cp-color. Active index via --cp-active. CSS handles the scale and ring highlight on the active swatch with a bounce transition.

### Acceptance Criteria covered
- Clickable color swatches with animated active state
- Active index via --cp-active CSS variable
- Scale and ring highlight on selected swatch
- Hover scale effect on all swatches
- Selected color label display

### Files
- submissions/examples/ease-color-picker-swatch-ij/demo.html
- submissions/examples/ease-color-picker-swatch-ij/style.css
- submissions/examples/ease-color-picker-swatch-ij/README.md

### How to review
Open demo.html and click different swatches to see the active state animate.

**Closes #29724**
