### PR TITLE
feat: add modal-dialog-overlay component (#29727)

### DIFF
--- a/submissions/examples/ease-modal-dialog-overlay-ij/README.md
+++ b/submissions/examples/ease-modal-dialog-overlay-ij/README.md
@@ -1,0 +1,15 @@
+# Modal Dialog Overlay
+
+A modal dialog with animated backdrop and panel. Open state via `--md-open` (0 or 1). CSS handles backdrop opacity, panel translateY + scale transitions, and pointer-events.
+
+## Features
+
+- Backdrop fade on open/close
+- Panel slide-up + scale animation
+- Open state via `--md-open` CSS variable
+- Click-outside to close
+- Close button and Cancel button
+
+## Usage
+
+Set `--md-open` to 0 (closed) or 1 (open) on `.modal-overlay`. CSS transitions the backdrop opacity and panel transform.

--- a/submissions/examples/ease-modal-dialog-overlay-ij/demo.html
+++ b/submissions/examples/ease-modal-dialog-overlay-ij/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Modal Dialog Overlay - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Modal Dialog</h1>
+    <p class="desc">Open/close modal with animated backdrop and panel</p>
+    <button class="open-btn" id="openBtn">Open Modal</button>
+  </div>
+
+  <div class="modal-overlay" id="modalOverlay" style="--md-open: 0;">
+    <div class="modal-panel">
+      <div class="modal-header">
+        <h2>Modal Title</h2>
+        <button class="modal-close" id="closeBtn">✕</button>
+      </div>
+      <div class="modal-body">
+        <p>This modal opens with a backdrop fade and panel slide-up animation. CSS handles the transitions via <code>--md-open</code>.</p>
+      </div>
+      <div class="modal-footer">
+        <button class="m-btn secondary" id="cancelBtn">Cancel</button>
+        <button class="m-btn primary">Confirm</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const overlay = document.getElementById('modalOverlay');
+    const openBtn = document.getElementById('openBtn');
+    const closeBtn = document.getElementById('closeBtn');
+    const cancelBtn = document.getElementById('cancelBtn');
+
+    function setOpen(val) {
+      overlay.style.setProperty('--md-open', val);
+      overlay.style.pointerEvents = val === '1' ? 'all' : 'none';
+    }
+
+    openBtn.addEventListener('click', () => setOpen(1));
+    closeBtn.addEventListener('click', () => setOpen(0));
+    cancelBtn.addEventListener('click', () => setOpen(0));
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) setOpen(0);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-modal-dialog-overlay-ij/style.css
+++ b/submissions/examples/ease-modal-dialog-overlay-ij/style.css
@@ -1,0 +1,164 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 0.5rem;
+  color: #94a3b8;
+}
+
+.desc {
+  font-size: 0.875rem;
+  color: #64748b;
+  margin-bottom: 2rem;
+  max-width: 320px;
+}
+
+.open-btn {
+  padding: 14px 36px;
+  background: linear-gradient(135deg, #e94560, #fbbf24);
+  border: none;
+  border-radius: 12px;
+  color: #0f172a;
+  font-family: inherit;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.open-btn:hover {
+  transform: scale(1.05);
+}
+
+.modal-overlay {
+  --md-open: 0;
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background: rgba(0,0,0,calc(var(--md-open) * 0.6));
+  pointer-events: none;
+  opacity: var(--md-open);
+  transition: opacity 0.3s ease, background 0.3s ease;
+}
+
+.modal-panel {
+  background: #1e293b;
+  border-radius: 20px;
+  width: 100%;
+  max-width: 420px;
+  box-shadow: 0 16px 48px rgba(0,0,0,0.4);
+  transform: translateY(calc((1 - var(--md-open)) * 40px)) scale(calc(0.9 + var(--md-open) * 0.1));
+  transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid #334155;
+}
+
+.modal-header h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.modal-close {
+  width: 32px;
+  height: 32px;
+  background: #334155;
+  border: none;
+  border-radius: 50%;
+  color: #94a3b8;
+  font-size: 0.9rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease;
+}
+
+.modal-close:hover {
+  background: #475569;
+}
+
+.modal-body {
+  padding: 1.5rem;
+}
+
+.modal-body p {
+  font-size: 0.9rem;
+  color: #94a3b8;
+  line-height: 1.6;
+}
+
+.modal-body code {
+  background: #0f172a;
+  padding: 0.1rem 0.3rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  color: #fbbf24;
+}
+
+.modal-footer {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  padding: 1rem 1.5rem;
+  border-top: 1px solid #334155;
+}
+
+.m-btn {
+  padding: 10px 24px;
+  border: none;
+  border-radius: 10px;
+  font-family: inherit;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.m-btn.primary {
+  background: #e94560;
+  color: #fff;
+}
+
+.m-btn.primary:hover {
+  background: #d63851;
+}
+
+.m-btn.secondary {
+  background: #334155;
+  color: #94a3b8;
+}
+
+.m-btn.secondary:hover {
+  background: #475569;
+  color: #e2e8f0;
+}


### PR DESCRIPTION
## Component: ease-modal-dialog-overlay ? modal dialog with animated backdrop and panel, open state via --md-open

### What this adds
A modal dialog with an animated backdrop fade and panel slide-up + scale animation. --md-open (0 or 1) controls the open state. CSS transitions handle backdrop opacity, panel transform, and layout.

### Acceptance Criteria covered
- Backdrop fade on open/close
- Panel slide-up + scale animation
- Open state via --md-open CSS variable
- Click-outside to close
- Close button and Cancel button

### Files
- submissions/examples/ease-modal-dialog-overlay-ij/demo.html
- submissions/examples/ease-modal-dialog-overlay-ij/style.css
- submissions/examples/ease-modal-dialog-overlay-ij/README.md

### How to review
Open demo.html and click "Open Modal" to see the animated modal.

**Closes #29727**
