### PR TITLE
feat: add breadcrumb-arrow component (#29728)

### DIFF
--- a/submissions/examples/ease-breadcrumb-arrow-ij/README.md
+++ b/submissions/examples/ease-breadcrumb-arrow-ij/README.md
@@ -1,0 +1,15 @@
+# Breadcrumb Arrow
+
+Navigation breadcrumbs with arrow separators. Active step via `--bc-current`. Previous steps are highlighted, current step is gold, future steps are muted.
+
+## Features
+
+- Arrow separators between breadcrumb items
+- Active step via --bc-current CSS variable
+- Current step highlighted in gold
+- Previous steps dimly lit
+- Previous/Next navigation
+
+## Usage
+
+Set `--bc-current` on `.bc-trail` to indicate the current step index. CSS colors items before the current index as active, the current as gold, and future items as muted.

--- a/submissions/examples/ease-breadcrumb-arrow-ij/demo.html
+++ b/submissions/examples/ease-breadcrumb-arrow-ij/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Breadcrumb Arrow - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Breadcrumb</h1>
+    <p class="desc">Navigation breadcrumbs with arrow separators driven by --bc-current</p>
+    <div class="bc-card">
+      <nav class="bc-trail" style="--bc-current: 2; --bc-total: 4;">
+        <a href="#" class="bc-item" data-idx="0">Home</a>
+        <a href="#" class="bc-item" data-idx="1">Products</a>
+        <span class="bc-item bc-current" data-idx="2">Category</span>
+        <span class="bc-item" data-idx="3">Subcategory</span>
+      </nav>
+      <p class="bc-hint">Current: Category</p>
+      <div class="bc-controls">
+        <button id="bcPrev">← Prev</button>
+        <button id="bcNext">Next →</button>
+      </div>
+    </div>
+  </div>
+  <script>
+    const trail = document.querySelector('.bc-trail');
+    const hint = document.querySelector('.bc-hint');
+    const items = document.querySelectorAll('.bc-item');
+    const labels = ['Home', 'Products', 'Category', 'Subcategory'];
+
+    function updateBreadcrumb(cur) {
+      trail.style.setProperty('--bc-current', cur);
+      items.forEach((item, i) => {
+        item.classList.toggle('active', i < cur);
+        item.classList.toggle('bc-current', i === cur - 1);
+      });
+      hint.textContent = `Current: ${labels[cur - 1]}`;
+    }
+
+    document.getElementById('bcPrev').addEventListener('click', () => {
+      let cur = parseInt(trail.style.getPropertyValue('--bc-current')) || 1;
+      if (cur > 1) updateBreadcrumb(cur - 1);
+    });
+
+    document.getElementById('bcNext').addEventListener('click', () => {
+      let cur = parseInt(trail.style.getPropertyValue('--bc-current')) || 1;
+      if (cur < 4) updateBreadcrumb(cur + 1);
+    });
+
+    updateBreadcrumb(2);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-breadcrumb-arrow-ij/style.css
+++ b/submissions/examples/ease-breadcrumb-arrow-ij/style.css
@@ -1,0 +1,105 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 0.5rem;
+  color: #94a3b8;
+}
+
+.desc {
+  font-size: 0.875rem;
+  color: #64748b;
+  margin-bottom: 2rem;
+  max-width: 340px;
+}
+
+.bc-card {
+  background: #1e293b;
+  border-radius: 20px;
+  padding: 2rem;
+  width: 460px;
+  margin: 0 auto;
+}
+
+.bc-trail {
+  --bc-current: 1;
+  display: flex;
+  align-items: center;
+  gap: 0;
+  flex-wrap: wrap;
+}
+
+.bc-item {
+  position: relative;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.85rem;
+  text-decoration: none;
+  color: #64748b;
+  transition: color 0.2s ease;
+}
+
+.bc-item + .bc-item::before {
+  content: '›';
+  margin-right: 0.75rem;
+  color: #334155;
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+
+.bc-item.active {
+  color: #e2e8f0;
+}
+
+.bc-item.bc-current {
+  color: #fbbf24;
+  font-weight: 600;
+}
+
+.bc-hint {
+  margin-top: 1rem;
+  font-size: 0.85rem;
+  color: #94a3b8;
+}
+
+.bc-controls {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  margin-top: 1rem;
+}
+
+.bc-controls button {
+  padding: 8px 20px;
+  background: #334155;
+  border: none;
+  border-radius: 8px;
+  color: #e2e8f0;
+  font-family: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.bc-controls button:hover {
+  background: #475569;
+}


### PR DESCRIPTION
## Component: ease-breadcrumb-arrow ? navigation breadcrumbs with arrow separators, active step via --bc-current

### What this adds
Navigation breadcrumbs with arrow separators. Active step via --bc-current (1-based). JS toggles .active and .bc-current classes for visual highlighting. Previous steps are lit, current is gold.

### Acceptance Criteria covered
- Arrow separators between breadcrumb items
- Active step via --bc-current CSS variable
- Current step highlighted in gold
- Previous steps dimly lit
- Previous/Next navigation

### Files
- submissions/examples/ease-breadcrumb-arrow-ij/demo.html
- submissions/examples/ease-breadcrumb-arrow-ij/style.css
- submissions/examples/ease-breadcrumb-arrow-ij/README.md

### How to review
Open demo.html and click Previous/Next to navigate breadcrumb steps.

**Closes #29728**
