### PR TITLE
feat: add dropdown-select-menu component (#29730)

### DIFF
--- a/submissions/examples/ease-dropdown-select-menu-ij/README.md
+++ b/submissions/examples/ease-dropdown-select-menu-ij/README.md
@@ -1,0 +1,15 @@
+# Dropdown Select Menu
+
+An animated dropdown select menu with scale, opacity, and arrow rotation. Open state via `--dd-open` (0 or 1). CSS handles menu animation and arrow rotation.
+
+## Features
+
+- Animated dropdown with scale and opacity
+- Open state via `--dd-open` CSS variable
+- Arrow rotation when open
+- Click-outside to close
+- Selectable options with highlight
+
+## Usage
+
+Set `--dd-open` (0 or 1) on `.dd-trigger` to control the dropdown state. CSS transitions the menu scale, opacity, and arrow rotation.

--- a/submissions/examples/ease-dropdown-select-menu-ij/demo.html
+++ b/submissions/examples/ease-dropdown-select-menu-ij/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dropdown Select Menu - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Dropdown Select</h1>
+    <p class="desc">Animated dropdown menu with scale/opacity transition</p>
+    <div class="dd-card">
+      <div class="dd-wrap">
+        <button class="dd-trigger" id="ddTrigger" style="--dd-open: 0;">
+          <span id="ddLabel">Choose option</span>
+          <span class="dd-arrow">▾</span>
+        </button>
+        <ul class="dd-menu" id="ddMenu">
+          <li class="dd-option" data-value="option-1">Option One</li>
+          <li class="dd-option" data-value="option-2">Option Two</li>
+          <li class="dd-option" data-value="option-3">Option Three</li>
+          <li class="dd-option" data-value="option-4">Option Four</li>
+        </ul>
+      </div>
+      <p class="dd-result" id="ddResult">Selected: none</p>
+    </div>
+  </diV>
+  <script>
+    const trigger = document.getElementById('ddTrigger');
+    const menu = document.getElementById('ddMenu');
+    const label = document.getElementById('ddLabel');
+    const result = document.getElementById('ddResult');
+    const options = document.querySelectorAll('.dd-option');
+    let open = false;
+
+    function setOpen(val) {
+      trigger.style.setProperty('--dd-open', val ? 1 : 0);
+      menu.style.pointerEvents = val ? 'all' : 'none';
+    }
+
+    trigger.addEventListener('click', () => {
+      open = !open;
+      setOpen(open);
+    });
+
+    document.addEventListener('click', (e) => {
+      if (!e.target.closest('.dd-wrap') && open) {
+        open = false;
+        setOpen(false);
+      }
+    });
+
+    options.forEach(opt => {
+      opt.addEventListener('click', () => {
+        label.textContent = opt.textContent;
+        result.textContent = `Selected: ${opt.textContent}`;
+        open = false;
+        setOpen(false);
+        options.forEach(o => o.classList.remove('selected'));
+        opt.classList.add('selected');
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-dropdown-select-menu-ij/style.css
+++ b/submissions/examples/ease-dropdown-select-menu-ij/style.css
@@ -1,0 +1,120 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 0.5rem;
+  color: #94a3b8;
+}
+
+.desc {
+  font-size: 0.875rem;
+  color: #64748b;
+  margin-bottom: 2rem;
+  max-width: 320px;
+}
+
+.dd-card {
+  background: #1e293b;
+  border-radius: 20px;
+  padding: 2rem;
+  width: 320px;
+  margin: 0 auto;
+}
+
+.dd-wrap {
+  position: relative;
+}
+
+.dd-trigger {
+  --dd-open: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 12px 16px;
+  background: #0f172a;
+  border: 1px solid #334155;
+  border-radius: 12px;
+  color: #e2e8f0;
+  font-family: inherit;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease;
+  text-align: left;
+}
+
+.dd-trigger:hover {
+  border-color: #475569;
+}
+
+.dd-arrow {
+  font-size: 0.8rem;
+  color: #64748b;
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  transform: rotate(calc(var(--dd-open) * 180deg));
+}
+
+.dd-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 12px;
+  list-style: none;
+  overflow: hidden;
+  opacity: var(--dd-open);
+  transform: translateY(calc((1 - var(--dd-open)) * -8px)) scale(calc(0.9 + var(--dd-open) * 0.1));
+  transition: opacity 0.2s ease, transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+  pointer-events: none;
+  z-index: 10;
+}
+
+.dd-option {
+  padding: 10px 16px;
+  font-size: 0.85rem;
+  color: #94a3b8;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.dd-option:hover {
+  background: #334155;
+  color: #e2e8f0;
+}
+
+.dd-option.selected {
+  color: #fbbf24;
+  font-weight: 500;
+}
+
+.dd-option + .dd-option {
+  border-top: 1px solid #0f172a;
+}
+
+.dd-result {
+  margin-top: 1rem;
+  font-size: 0.85rem;
+  color: #64748b;
+}


### PR DESCRIPTION
## Component: ease-dropdown-select-menu ? animated dropdown with scale/opacity, open state via --dd-open

### What this adds
A dropdown select menu with scale and opacity animation. Open state via --dd-open (0 or 1). CSS handles the menu transform, opacity, and arrow rotation with bounce cubic-bezier. Click-outside closes the dropdown.

### Acceptance Criteria covered
- Animated dropdown with scale and opacity
- Open state via --dd-open CSS variable
- Arrow rotation when open
- Click-outside to close
- Selectable options with highlight

### Files
- submissions/examples/ease-dropdown-select-menu-ij/demo.html
- submissions/examples/ease-dropdown-select-menu-ij/style.css
- submissions/examples/ease-dropdown-select-menu-ij/README.md

### How to review
Open demo.html and click the trigger to open the dropdown. Select an option.

**Closes #29730**
