### PR TITLE
feat(examples): add Reveal Focus Card on Hover (CSS Animation)

### DIFF
--- a/submissions/examples/reveal-focus-card/README.md
+++ b/submissions/examples/reveal-focus-card/README.md
@@ -1,0 +1,22 @@
+# Reveal Focus Card
+
+A hover-reveal card with clip-path gradient animation — pure CSS.
+
+## Features
+- Gradient cover retracts upward on hover
+- Content reveals with smooth clip-path animation
+- Reusable card component pattern
+
+## Usage
+```html
+<div class="focus-card">
+  <div class="card-content">...</div>
+  <div class="card-cover"></div>
+</div>
+```
+
+## Browser Support
+- Chrome 1+, Firefox 3.5+, Safari 3.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript

--- a/submissions/examples/reveal-focus-card/demo.html
+++ b/submissions/examples/reveal-focus-card/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reveal Focus Card — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Reveal Focus Card</h1>
+  <p class="subtitle">A hover-reveal card that lifts a gradient cover using CSS clip-path animation — pure CSS.</p>
+  <section><h2>Demo</h2><p class="sec-desc">Hover the card to reveal content underneath</p><div class="focus-card"><div class="card-content"><h3>Discover More</h3><p>Hover to reveal what lies beneath the gradient cover.</p><span class="card-cta">Learn More →</span></div><div class="card-cover"></div></div></section>
+  <section><h2>How It Works</h2><p>The cover layer animates <code>clip-path</code> from <code>inset(0)</code> to <code>inset(0 0 100% 0)</code>, sliding the gradient upward on hover to reveal card content.</p></section>
+</body>
+</html>

--- a/submissions/examples/reveal-focus-card/style.css
+++ b/submissions/examples/reveal-focus-card/style.css
@@ -1,0 +1,16 @@
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+body { background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; padding: 4rem 1rem; text-align: center; }
+h1 { color: #fff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+.subtitle { color: #9ca3af; margin-bottom: 2rem; }
+section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; max-width: 500px; margin-left: auto; margin-right: auto; text-align: left; }
+h2 { color: #fff; font-size: 1.1rem; margin-bottom: 0.75rem; }
+.sec-desc { font-size: 0.85rem; color: #9ca3af; margin-bottom: 1rem; }
+p { color: #9ca3af; line-height: 1.8; margin-top: 1rem; }
+code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+.focus-card { position: relative; width: 100%; height: 220px; border-radius: 14px; overflow: hidden; cursor: pointer; }
+.card-content { position: absolute; inset: 0; padding: 2rem; display: flex; flex-direction: column; justify-content: flex-end; background: linear-gradient(135deg, #1a1a2e, #16213e); z-index: 0; }
+.card-content h3 { color: #fff; font-size: 1.2rem; margin-bottom: 0.5rem; }
+.card-content p { color: #9ca3af; font-size: 0.85rem; margin: 0; }
+.card-cta { display: inline-block; margin-top: 1rem; color: #818cf8; font-weight: 600; font-size: 0.9rem; }
+.card-cover { position: absolute; inset: 0; background: linear-gradient(135deg, #6366f1, #8b5cf6, #ec4899); clip-path: inset(0); transition: clip-path 0.5s ease; z-index: 1; }
+.focus-card:hover .card-cover { clip-path: inset(0 0 100% 0); }


### PR DESCRIPTION
Closes #29664 — A hover-reveal card with clip-path gradient cover animation.