### PR TITLE
feat: add marquee-infinite component (#29733)

### DIFF
--- a/submissions/examples/ease-marquee-infinite-ij/README.md
+++ b/submissions/examples/ease-marquee-infinite-ij/README.md
@@ -1,0 +1,15 @@
+# Marquee Infinite
+
+An infinite scrolling marquee with colored cards. Speed via `--mi-dur`. Card color via `--mc-hue` (HSL). Pauses on hover. Uses duplicated content for seamless loop with `@keyframes miScroll`.
+
+## Features
+
+- Infinite horizontal scroll with CSS @keyframes
+- Speed via `--mi-dur` CSS variable
+- Card color via `--mc-hue` (HSL hue)
+- Pause on hover via animation-play-state
+- Duplicated groups for seamless loop
+
+## Usage
+
+Set `--mi-dur` on `.mi-track` for speed. Each `.mi-card` uses `--mc-hue` for its HSL background color.

--- a/submissions/examples/ease-marquee-infinite-ij/demo.html
+++ b/submissions/examples/ease-marquee-infinite-ij/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Marquee Infinite - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Marquee Infinite</h1>
+    <p class="desc">Infinite scrolling card marquee with pause on hover</p>
+    <div class="marquee-section">
+      <div class="mi-track" style="--mi-dur: 25s;">
+        <div class="mi-group">
+          <div class="mi-card" style="--mc-hue: 0;">CSS</div>
+          <div class="mi-card" style="--mc-hue: 40;">Animations</div>
+          <div class="mi-card" style="--mc-hue: 80;">Motion</div>
+          <div class="mi-card" style="--mc-hue: 120;">Effects</div>
+          <div class="mi-card" style="--mc-hue: 200;">UI</div>
+        </div>
+        <div class="mi-group" aria-hidden="true">
+          <div class="mi-card" style="--mc-hue: 0;">CSS</div>
+          <div class="mi-card" style="--mc-hue: 40;">Animations</div>
+          <div class="mi-card" style="--mc-hue: 80;">Motion</div>
+          <div class="mi-card" style="--mc-hue: 120;">Effects</div>
+          <div class="mi-card" style="--mc-hue: 200;">UI</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-marquee-infinite-ij/style.css
+++ b/submissions/examples/ease-marquee-infinite-ij/style.css
@@ -1,0 +1,85 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  text-align: center;
+  width: 100%;
+  max-width: 600px;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 0.5rem;
+  color: #94a3b8;
+}
+
+.desc {
+  font-size: 0.875rem;
+  color: #64748b;
+  margin-bottom: 2.5rem;
+}
+
+.marquee-section {
+  overflow: hidden;
+  border-radius: 16px;
+  background: #1e293b;
+  padding: 1.5rem 0;
+}
+
+.mi-track {
+  --mi-dur: 25s;
+  display: flex;
+  gap: 0;
+  width: fit-content;
+  animation: miScroll var(--mi-dur) linear infinite;
+}
+
+.mi-track:hover {
+  animation-play-state: paused;
+}
+
+.mi-group {
+  display: flex;
+  gap: 1rem;
+  padding: 0 0.5rem;
+}
+
+.mi-card {
+  --mc-hue: 0;
+  padding: 0.75rem 1.5rem;
+  background: hsl(var(--mc-hue), 70%, 30%);
+  border-radius: 12px;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #e2e8f0;
+  white-space: nowrap;
+  transition: transform 0.2s ease;
+}
+
+.mi-card:hover {
+  transform: scale(1.05);
+}
+
+@keyframes miScroll {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-50%);
+  }
+}


### PR DESCRIPTION
## Component: ease-marquee-infinite ? infinite scrolling card marquee with speed via --mi-dur, color via --mc-hue

### What this adds
An infinite scrolling marquee with colored cards. Speed via --mi-dur, card color via --mc-hue (HSL). Pauses on hover. Uses duplicated content groups for seamless loop with @keyframes miScroll.

### Acceptance Criteria covered
- Infinite horizontal scroll with CSS @keyframes
- Speed via --mi-dur CSS variable
- Card color via --mc-hue (HSL hue)
- Pause on hover via animation-play-state
- Duplicated groups for seamless loop

### Files
- submissions/examples/ease-marquee-infinite-ij/demo.html
- submissions/examples/ease-marquee-infinite-ij/style.css
- submissions/examples/ease-marquee-infinite-ij/README.md

### How to review
Open demo.html to see the infinite scrolling marquee.

**Closes #29733**
