### PR TITLE
feat: add input-float-label component (#29736)

### DIFF
--- a/submissions/examples/ease-input-float-label-ij/README.md
+++ b/submissions/examples/ease-input-float-label-ij/README.md
@@ -1,0 +1,15 @@
+# Input Float Label
+
+An input with a label that floats up when focused or filled. Float state via `--fl-filled` (0 or 1). CSS handles label translateY, scale, and color transitions. An underline bar animates on focus.
+
+## Features
+
+- Label floats up on focus/fill
+- Float state via `--fl-filled` CSS variable
+- Animated underline bar on focus
+- Scale and color transition on label
+- Bounce cubic-bezier for label motion
+
+## Usage
+
+Set `--fl-filled` (0 or 1) on `.fl-field`. CSS floats the label up when focused or filled. The underline bar expands on focus.

--- a/submissions/examples/ease-input-float-label-ij/demo.html
+++ b/submissions/examples/ease-input-float-label-ij/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Input Float Label - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Float Label</h1>
+    <p class="desc">Label floats up when input is focused or filled</p>
+    <div class="fl-card">
+      <div class="fl-field" style="--fl-filled: 0;">
+        <input type="text" class="fl-input" id="flInput" placeholder=" ">
+        <label class="fl-label" for="flInput">Full Name</label>
+        <span class="fl-bar"></span>
+      </div>
+      <div class="fl-field" style="--fl-filled: 0;">
+        <input type="email" class="fl-input" id="flEmail" placeholder=" ">
+        <label class="fl-label" for="flEmail">Email Address</label>
+        <span class="fl-bar"></span>
+      </div>
+      <div class="fl-field" style="--fl-filled: 0;">
+        <input type="password" class="fl-input" id="flPass" placeholder=" ">
+        <label class="fl-label" for="flPass">Password</label>
+        <span class="fl-bar"></span>
+      </div>
+    </div>
+  </div>
+  <script>
+    document.querySelectorAll('.fl-input').forEach(input => {
+      const field = input.closest('.fl-field');
+
+      function update() {
+        const filled = input.value.length > 0 ? 1 : 0;
+        field.style.setProperty('--fl-filled', filled);
+      }
+
+      input.addEventListener('input', update);
+      input.addEventListener('focus', () => field.style.setProperty('--fl-filled', 1));
+      input.addEventListener('blur', update);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-input-float-label-ij/style.css
+++ b/submissions/examples/ease-input-float-label-ij/style.css
@@ -1,0 +1,102 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 0.5rem;
+  color: #94a3b8;
+}
+
+.desc {
+  font-size: 0.875rem;
+  color: #64748b;
+  margin-bottom: 2rem;
+  max-width: 320px;
+}
+
+.fl-card {
+  background: #1e293b;
+  border-radius: 20px;
+  padding: 2rem 1.5rem;
+  width: 340px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  text-align: left;
+}
+
+.fl-field {
+  --fl-filled: 0;
+  position: relative;
+}
+
+.fl-input {
+  width: 100%;
+  padding: 1rem 0.75rem 0.5rem;
+  background: #0f172a;
+  border: 1px solid #334155;
+  border-radius: 10px;
+  color: #e2e8f0;
+  font-family: inherit;
+  font-size: 0.95rem;
+  outline: none;
+  transition: border-color 0.2s ease;
+}
+
+.fl-input:focus {
+  border-color: #e94560;
+}
+
+.fl-label {
+  position: absolute;
+  left: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 0.9rem;
+  color: #64748b;
+  pointer-events: none;
+  transition: all 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+  transform-origin: left center;
+}
+
+.fl-input:focus ~ .fl-label,
+.fl-field[style*="--fl-filled: 1"] .fl-label {
+  top: 0.4rem;
+  transform: translateY(0) scale(0.75);
+  color: #e94560;
+}
+
+.fl-bar {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 0;
+  height: 2px;
+  background: #e94560;
+  transition: width 0.3s ease, left 0.3s ease;
+}
+
+.fl-input:focus ~ .fl-bar {
+  width: 100%;
+  left: 0;
+}


### PR DESCRIPTION
## Component: ease-input-float-label ? input with floating label animation, state via --fl-filled

### What this adds
A text input where the label floats up on focus or when filled. --fl-filled (0 or 1) controls the float state. CSS handles label translateY, scale, and color transitions with a bounce cubic-bezier. An underline bar animates on focus.

### Acceptance Criteria covered
- Label floats up on focus/fill
- Float state via --fl-filled CSS variable
- Animated underline bar on focus
- Scale and color transition on label
- Bounce cubic-bezier for label motion

### Files
- submissions/examples/ease-input-float-label-ij/demo.html
- submissions/examples/ease-input-float-label-ij/style.css
- submissions/examples/ease-input-float-label-ij/README.md

### How to review
Open demo.html and click each input. The label should float up.

**Closes #29736**
