### PR TITLE
feat: add navigation-breadcrumb component (#29741)

### DIFF
--- a/submissions/examples/ease-navigation-breadcrumb-ij/README.md
+++ b/submissions/examples/ease-navigation-breadcrumb-ij/README.md
@@ -1,0 +1,15 @@
+# Navigation Breadcrumb
+
+Animated breadcrumb navigation with hover slide underline on each link. Uses `::after` pseudo-element for the underline width animation. Active state is non-linked.
+
+## Features
+
+- Breadcrumb navigation with separator
+- Link underline slides in on hover via `::after` width transition
+- Bounce cubic-bezier for underline
+- Active state styling for current page
+- Accessible with aria-label and aria-current
+
+## Usage
+
+Standard `<ol>` breadcrumb pattern with `.nb-link` for links and `.nb-active` for current page. The underline animates from 0 to 100% width on hover.

--- a/submissions/examples/ease-navigation-breadcrumb-ij/demo.html
+++ b/submissions/examples/ease-navigation-breadcrumb-ij/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Navigation Breadcrumb - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Breadcrumb</h1>
+    <p class="desc">Animated breadcrumb with hover slide underline</p>
+    <nav class="nb-crumb" aria-label="breadcrumb">
+      <ol class="nb-list">
+        <li class="nb-item"><a href="#" class="nb-link">Home</a></li>
+        <li class="nb-sep" aria-hidden="true">/</li>
+        <li class="nb-item"><a href="#" class="nb-link">Products</a></li>
+        <li class="nb-sep" aria-hidden="true">/</li>
+        <li class="nb-item"><a href="#" class="nb-link">CSS</a></li>
+        <li class="nb-sep" aria-hidden="true">/</li>
+        <li class="nb-item nb-active" aria-current="page">Animations</li>
+      </ol>
+    </nav>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-navigation-breadcrumb-ij/style.css
+++ b/submissions/examples/ease-navigation-breadcrumb-ij/style.css
@@ -1,0 +1,95 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 0.5rem;
+  color: #94a3b8;
+}
+
+.desc {
+  font-size: 0.875rem;
+  color: #64748b;
+  margin-bottom: 2rem;
+  max-width: 300px;
+}
+
+.nb-crumb {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 14px;
+  padding: 0.75rem 1.25rem;
+}
+
+.nb-list {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.nb-item {
+  position: relative;
+}
+
+.nb-link {
+  color: #94a3b8;
+  text-decoration: none;
+  font-size: 0.85rem;
+  padding: 4px 0;
+  position: relative;
+  transition: color 0.25s ease;
+}
+
+.nb-link::after {
+  content: '';
+  position: absolute;
+  bottom: -2px;
+  left: 0;
+  width: 0;
+  height: 2px;
+  background: #e94560;
+  border-radius: 1px;
+  transition: width 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.nb-link:hover {
+  color: #e2e8f0;
+}
+
+.nb-link:hover::after {
+  width: 100%;
+}
+
+.nb-sep {
+  color: #475569;
+  font-size: 0.8rem;
+  user-select: none;
+}
+
+.nb-active {
+  color: #e94560;
+  font-size: 0.85rem;
+  font-weight: 500;
+}


### PR DESCRIPTION
## Component: ease-navigation-breadcrumb ? animated breadcrumb with hover slide underline on links

### What this adds
Breadcrumb navigation with underline that slides in on hover via ::after width transition. Bounce cubic-bezier for underline animation. Active state for current page.

### Acceptance Criteria covered
- Breadcrumb navigation with separator
- Link underline slides in on hover via ::after width transition
- Bounce cubic-bezier for underline
- Active state styling for current page
- Accessible with aria-label and aria-current

### Files
- submissions/examples/ease-navigation-breadcrumb-ij/demo.html
- submissions/examples/ease-navigation-breadcrumb-ij/style.css
- submissions/examples/ease-navigation-breadcrumb-ij/README.md

### How to review
Open demo.html and hover over breadcrumb links to see the underline animate.

**Closes #29741**
