### PR TITLE
feat: add drawer-slide-panel component (#30236)

### DIFF
--- a/submissions/examples/ease-drawer-slide-panel-ij/README.md
+++ b/submissions/examples/ease-drawer-slide-panel-ij/README.md
@@ -1,0 +1,15 @@
+# Drawer Slide Panel
+
+Sliding drawer panel that opens from the right edge. Content slides in with smooth cubic-bezier transition, overlay darkens behind via `--dp-open` custom property.
+
+## Features
+
+- Panel slides in from right edge via `--dp-open`
+- Overlay darkens behind with opacity transition
+- Close button inside panel
+- Smooth cubic-bezier transition
+- Toggle switches inside drawer
+
+## Usage
+
+Set `--dp-open` (0 or 1) on `.dp-overlay` and `.dp-drawer`. CSS controls the transform translation and overlay opacity.

--- a/submissions/examples/ease-drawer-slide-panel-ij/demo.html
+++ b/submissions/examples/ease-drawer-slide-panel-ij/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Drawer Slide Panel - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Drawer Panel</h1>
+    <p class="desc">Sliding drawer panel from the right edge</p>
+    <button class="dp-btn" id="dpOpen">Open Drawer</button>
+    <div class="dp-overlay" id="dpOverlay" style="--dp-open: 0;"></div>
+    <div class="dp-drawer" id="dpDrawer" style="--dp-open: 0;">
+      <div class="dp-header">
+        <h2>Settings</h2>
+        <button class="dp-close" id="dpClose">&times;</button>
+      </div>
+      <div class="dp-body">
+        <div class="dp-row"><span>Notifications</span><span class="dp-toggle"></span></div>
+        <div class="dp-row"><span>Dark Mode</span><span class="dp-toggle dp-on"></span></div>
+        <div class="dp-row"><span>Sound</span><span class="dp-toggle"></span></div>
+        <div class="dp-row"><span>Auto-save</span><span class="dp-toggle dp-on"></span></div>
+      </div>
+    </div>
+  </div>
+  <script>
+    const overlay = document.getElementById('dpOverlay');
+    const drawer = document.getElementById('dpDrawer');
+    const openBtn = document.getElementById('dpOpen');
+    const closeBtn = document.getElementById('dpClose');
+
+    function openDrawer() {
+      overlay.style.setProperty('--dp-open', 1);
+      drawer.style.setProperty('--dp-open', 1);
+    }
+
+    function closeDrawer() {
+      overlay.style.setProperty('--dp-open', 0);
+      drawer.style.setProperty('--dp-open', 0);
+    }
+
+    openBtn.addEventListener('click', openDrawer);
+    closeBtn.addEventListener('click', closeDrawer);
+    overlay.addEventListener('click', closeDrawer);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-drawer-slide-panel-ij/style.css
+++ b/submissions/examples/ease-drawer-slide-panel-ij/style.css
@@ -1,0 +1,156 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  text-align: center;
+  width: 100%;
+  max-width: 380px;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 0.5rem;
+  color: #94a3b8;
+}
+
+.desc {
+  font-size: 0.875rem;
+  color: #64748b;
+  margin-bottom: 2rem;
+}
+
+.dp-btn {
+  padding: 0.75rem 2rem;
+  border: none;
+  border-radius: 12px;
+  background: #e94560;
+  color: #fff;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.dp-btn:hover {
+  background: #d63850;
+}
+
+.dp-overlay {
+  --dp-open: 0;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, calc(0.5 * var(--dp-open)));
+  pointer-events: none;
+  opacity: var(--dp-open);
+  transition: opacity 0.3s ease, background 0.3s ease;
+  z-index: 90;
+}
+
+.dp-drawer {
+  --dp-open: 0;
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 300px;
+  background: #1e293b;
+  border-left: 1px solid #334155;
+  z-index: 100;
+  transform: translateX(calc((1 - var(--dp-open)) * 100%));
+  transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+  display: flex;
+  flex-direction: column;
+}
+
+.dp-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.25rem;
+  border-bottom: 1px solid #334155;
+}
+
+.dp-header h2 {
+  font-size: 1.1rem;
+  font-weight: 500;
+}
+
+.dp-close {
+  background: none;
+  border: none;
+  color: #94a3b8;
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 4px;
+  line-height: 1;
+  transition: color 0.2s ease;
+}
+
+.dp-close:hover {
+  color: #e94560;
+}
+
+.dp-body {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  flex: 1;
+}
+
+.dp-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  background: #0f172a;
+  border-radius: 10px;
+  font-size: 0.85rem;
+  color: #cbd5e1;
+}
+
+.dp-toggle {
+  width: 40px;
+  height: 22px;
+  background: #334155;
+  border-radius: 11px;
+  position: relative;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.dp-toggle::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #64748b;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.dp-toggle.dp-on {
+  background: #e94560;
+}
+
+.dp-toggle.dp-on::after {
+  transform: translateX(18px);
+  background: #fff;
+}


### PR DESCRIPTION
## Component: ease-drawer-slide-panel ? sliding drawer panel from right edge via --dp-open

### What this adds
Sliding drawer panel that opens from the right edge. Content slides in with smooth cubic-bezier transition, overlay darkens behind via --dp-open custom property.

### Acceptance Criteria covered
- Panel slides in from right edge via --dp-open
- Overlay darkens behind with opacity transition
- Close button inside panel
- Smooth cubic-bezier transition

### Files
- submissions/examples/ease-drawer-slide-panel-ij/demo.html
- submissions/examples/ease-drawer-slide-panel-ij/style.css
- submissions/examples/ease-drawer-slide-panel-ij/README.md

### How to review
Open demo.html and click "Open Drawer" to see the panel slide in from the right.

**Closes #30236**
