### PR TITLE
feat: add card-stack-deck component (#30238)

### DIFF
--- a/submissions/examples/ease-card-stack-deck-ij/README.md
+++ b/submissions/examples/ease-card-stack-deck-ij/README.md
@@ -1,0 +1,15 @@
+# Card Stack Deck
+
+Stacked card deck that fans out on hover. Cards spread with rotation and translation offsets via `--cs-i` index and `--cs-fan` state variable.
+
+## Features
+
+- Cards stack by default
+- Fan out on hover with rotation
+- Staggered Y offsets per card via `--cs-i`
+- Color per card via `--cs-bg`
+- Smooth cubic-bezier transitions
+
+## Usage
+
+Set `--cs-i` (index) and `--cs-bg` (color) on each `.cs-card`. Hover `.cs-deck` to trigger the fan transform.

--- a/submissions/examples/ease-card-stack-deck-ij/demo.html
+++ b/submissions/examples/ease-card-stack-deck-ij/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Card Stack Deck - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Card Deck</h1>
+    <p class="desc">Hover to fan out the card stack</p>
+    <div class="cs-deck" id="csDeck">
+      <div class="cs-card" style="--cs-i: 0; --cs-bg: #e94560;">1</div>
+      <div class="cs-card" style="--cs-i: 1; --cs-bg: #fbbf24;">2</div>
+      <div class="cs-card" style="--cs-i: 2; --cs-bg: #34d399;">3</div>
+      <div class="cs-card" style="--cs-i: 3; --cs-bg: #60a5fa;">4</div>
+      <div class="cs-card" style="--cs-i: 4; --cs-bg: #a78bfa;">5</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-card-stack-deck-ij/style.css
+++ b/submissions/examples/ease-card-stack-deck-ij/style.css
@@ -1,0 +1,73 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 0.5rem;
+  color: #94a3b8;
+}
+
+.desc {
+  font-size: 0.875rem;
+  color: #64748b;
+  margin-bottom: 2rem;
+}
+
+.cs-deck {
+  --cs-fan: 0;
+  position: relative;
+  width: 120px;
+  height: 170px;
+  margin: 0 auto;
+  cursor: pointer;
+}
+
+.cs-deck:hover {
+  --cs-fan: 1;
+}
+
+.cs-card {
+  --cs-i: 0;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 120px;
+  height: 170px;
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #0f172a;
+  background: var(--cs-bg, #e94560);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  transform: translateY(calc(var(--cs-i) * 4px)) rotate(0deg);
+  transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+  z-index: calc(10 - var(--cs-i));
+}
+
+.cs-deck:hover .cs-card {
+  transform:
+    translateY(calc(var(--cs-i) * 30px - 40px))
+    rotate(calc((var(--cs-i) - 2) * 8deg));
+}


### PR DESCRIPTION
## Component: ease-card-stack-deck ? stacked cards that fan out on hover via --cs-i and --cs-fan

### What this adds
Stacked card deck that fans out on hover. Cards spread with rotation and translation offsets via --cs-i index and --cs-fan state variable.

### Acceptance Criteria covered
- Cards stack by default
- Fan out on hover with rotation
- Staggered Y offsets per card via --cs-i
- Color per card via --cs-bg
- Smooth cubic-bezier transitions

### Files
- submissions/examples/ease-card-stack-deck-ij/demo.html
- submissions/examples/ease-card-stack-deck-ij/style.css
- submissions/examples/ease-card-stack-deck-ij/README.md

### How to review
Open demo.html and hover over the card stack to see it fan out.

**Closes #30238**
