### PR TITLE
[Feat] #27747 — Add color shading and tinting mixins (unique folder)

### DIFF
--- a/submissions/examples/color-shading-tinting-27747-ag/README.md
+++ b/submissions/examples/color-shading-tinting-27747-ag/README.md
@@ -1,0 +1,37 @@
+# Color Shading & Tinting Mixins
+
+This guide covers SCSS color mixin guidelines used to build tint and shade palette steps.
+
+---
+
+## Technical Overview: The SCSS Tint & Shade Mixin
+
+Hardcoding individual color hex codes for hover, focus, active, and borders clutter files. Utilizing SCSS's built-in `mix()` function makes palette adjustments dynamic:
+
+```scss
+// SCSS Tint Mixin (Mixes base color with white)
+@function tint($color, $percentage) {
+  @return mix(#fff, $color, $percentage);
+}
+
+// SCSS Shade Mixin (Mixes base color with black)
+@function shade($color, $percentage) {
+  @return mix(#000, $color, $percentage);
+}
+
+// Swatch Outputs mapping
+.bg-purple-tint-20 {
+  background-color: tint(#7c3aed, 20%);
+}
+.bg-purple-shade-20 {
+  background-color: shade(#7c3aed, 20%);
+}
+```
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Review the color scales for Purple, Emerald, and Cyan.
+3. Verify the swatch steps render perfectly from light tints (left) to default base (middle) to dark shades (right).

--- a/submissions/examples/color-shading-tinting-27747-ag/demo.html
+++ b/submissions/examples/color-shading-tinting-27747-ag/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Color Shading & Tinting Mixins — EaseMotion CSS</title>
+  <meta name="description" content="Visual swatch dashboard illustrating SCSS shade and tint generators mapping color weight steps.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — SCSS Utilities</span>
+      <h1>Color Shading & Tinting</h1>
+      <p class="description">
+        Demonstrates dynamic palette steps. Mixes base colors with white (tints) and black (shades) 
+        across precise scale percentages.
+      </p>
+    </header>
+
+    <main class="dashboard">
+
+      <!-- Purple Swatches -->
+      <section class="palette-card">
+        <h2 class="section-title">Purple Engine (Base: #7c3aed)</h2>
+        <div class="swatch-grid">
+          <div class="swatch tint-40" style="background: #b18cf8;"><span>Tint 40%</span></div>
+          <div class="swatch tint-20" style="background: #9665f5;"><span>Tint 20%</span></div>
+          <div class="swatch base-color" style="background: #7c3aed; color: #fff;"><span>Base</span></div>
+          <div class="swatch shade-20" style="background: #632ebe;"><span>Shade 20%</span></div>
+          <div class="swatch shade-40" style="background: #4a228e;"><span>Shade 40%</span></div>
+        </div>
+      </section>
+
+      <!-- Emerald Swatches -->
+      <section class="palette-card">
+        <h2 class="section-title">Emerald Engine (Base: #10b981)</h2>
+        <div class="swatch-grid">
+          <div class="swatch tint-40" style="background: #70d5b4;"><span>Tint 40%</span></div>
+          <div class="swatch tint-20" style="background: #40c79b;"><span>Tint 20%</span></div>
+          <div class="swatch base-color" style="background: #10b981; color: #fff;"><span>Base</span></div>
+          <div class="swatch shade-20" style="background: #0d9467;"><span>Shade 20%</span></div>
+          <div class="swatch shade-40" style="background: #0a6f4d;"><span>Shade 40%</span></div>
+        </div>
+      </section>
+
+      <!-- Cyan Swatches -->
+      <section class="palette-card">
+        <h2 class="section-title">Cyan Engine (Base: #06b6d4)</h2>
+        <div class="swatch-grid">
+          <div class="swatch tint-40" style="background: #6ad3e5;"><span>Tint 40%</span></div>
+          <div class="swatch tint-20" style="background: #38c5dc;"><span>Tint 20%</span></div>
+          <div class="swatch base-color" style="background: #06b6d4; color: #fff;"><span>Base</span></div>
+          <div class="swatch shade-20" style="background: #0592aa;"><span>Shade 20%</span></div>
+          <div class="swatch shade-40" style="background: #046d7f;"><span>Shade 40%</span></div>
+        </div>
+      </section>
+
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/color-shading-tinting-27747-ag/style.css
+++ b/submissions/examples/color-shading-tinting-27747-ag/style.css
@@ -1,0 +1,141 @@
+/* ============================================================
+   Color Shading & Tinting Mixins — style.css
+   Submission for EaseMotion CSS Issue #27747
+   Color palette swatches, grids, and active cards
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 820px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Swatches Grid Layouts
+   ============================================================ */
+
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.palette-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  padding: 28px;
+  border-radius: 20px;
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+}
+
+.section-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+.swatch-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 12px;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+@media (max-width: 600px) {
+  .swatch-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.swatch {
+  height: 90px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: #111827;
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  transition: transform 0.2s ease;
+  cursor: pointer;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.swatch:hover {
+  transform: translateY(-4px);
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .swatch {
+    transition: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-color-shading-tinting` showcase. It demonstrates how to utilize SCSS `mix()` functions inside mixins to generate color shading and tinting palette ranges dynamically, presenting swatches mapping base color weights to light and dark variants.

## Root Cause
No color tinting or shading mixins existed in the library, requiring developers to write hardcoded hex variations manually.

## Changes Made
- `submissions/examples/color-shading-tinting-27747-ag/demo.html`: Grid displays featuring Purple, Emerald, and Cyan weight swatches.
- `submissions/examples/color-shading-tinting-27747-ag/style.css`: Swatch dimensions, border wraps, hover displacements, and text colors.
- `submissions/examples/color-shading-tinting-27747-ag/README.md`: Explains SCSS mix functions, shading structures, and validation checklists.

## How to Test
1. Open `demo.html` in a browser.
2. Confirm the swatches render consistent weight steps from 40% tint to 40% shade.

## Related Issue
Closes #27747