### PR TITLE
[Feat] #27745 — Add grid auto-fit utilities (unique folder)

### DIFF
--- a/submissions/examples/grid-autofit-generator-27745-ag/README.md
+++ b/submissions/examples/grid-autofit-generator-27745-ag/README.md
@@ -1,0 +1,30 @@
+# Grid Auto-Fit Generator Mixin
+
+This guide details configuration specs for generating SCSS flexible grid auto-fit layout mixins.
+
+---
+
+## Technical Overview: The SCSS Auto-Fit Mixin
+
+Writing rigid layout column classes limits cards wrapping across viewports. Scoping grid columns dynamically utilizing SCSS mixins removes layout boundaries:
+
+```scss
+// SCSS CSS Grid Auto-Fit Generator Mixin
+@mixin grid-autofit($min-width: 220px, $gap: 16px) {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax($min-width, 1fr));
+  gap: $gap;
+}
+
+// Utility Classes
+.grid-pack-sm { @include grid-autofit(160px, 12px); }
+.grid-pack-md { @include grid-autofit(220px, 16px); }
+.grid-pack-lg { @include grid-autofit(300px, 20px); }
+```
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Adjust the **Cell Min-Width** slider — verify that grid columns reorganize and wrap dynamically as min-width sizes increase.

--- a/submissions/examples/grid-autofit-generator-27745-ag/demo.html
+++ b/submissions/examples/grid-autofit-generator-27745-ag/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Grid Auto-Fit Generator — EaseMotion CSS</title>
+  <meta name="description" content="Interactive grid generator demonstrating dynamic auto-fit minmax layouts, cell counts, and column flow.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — SCSS Utilities</span>
+      <h1>Grid Auto-Fit Generator</h1>
+      <p class="description">
+        Demonstrates auto-fit grid configurations. Adjust cell min-width properties below 
+        to observe responsive container packing.
+      </p>
+    </header>
+
+    <main class="dashboard">
+
+      <!-- Left Panel: Grid Settings -->
+      <section class="controls-panel">
+        <h2 class="section-title">Grid Configuration</h2>
+        <div class="control-group">
+          <label for="width-slider">Cell Min-Width: <span id="width-val">220px</span></label>
+          <input type="range" id="width-slider" min="150" max="320" value="220" step="10">
+        </div>
+      </section>
+
+      <!-- Right Panel: Grid Preview -->
+      <section class="preview-panel">
+        <h2 class="section-title">Grid Output</h2>
+        
+        <div class="grid-container" id="grid-container" style="--min-width: 220px;">
+          <div class="grid-cell"><span>Cell 1</span></div>
+          <div class="grid-cell"><span>Cell 2</span></div>
+          <div class="grid-cell"><span>Cell 3</span></div>
+          <div class="grid-cell"><span>Cell 4</span></div>
+        </div>
+      </section>
+
+    </main>
+  </div>
+
+  <script>
+    const slider = document.getElementById('width-slider');
+    const widthVal = document.getElementById('width-val');
+    const container = document.getElementById('grid-container');
+
+    slider.addEventListener('input', () => {
+      const minWidth = `${slider.value}px`;
+      widthVal.textContent = minWidth;
+      container.style.setProperty('--min-width', minWidth);
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/grid-autofit-generator-27745-ag/style.css
+++ b/submissions/examples/grid-autofit-generator-27745-ag/style.css
@@ -1,0 +1,161 @@
+/* ============================================================
+   CSS Grid Auto-Fit Generator — style.css
+   Submission for EaseMotion CSS Issue #27745
+   CSS grid auto-fit structures, settings sliders, and cells
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 900px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Dashboard Layout
+   ============================================================ */
+
+.dashboard {
+  display: grid;
+  grid-template-columns: 1fr 1.5fr;
+  gap: 28px;
+}
+
+@media (max-width: 768px) {
+  .dashboard { grid-template-columns: 1fr; }
+}
+
+.controls-panel,
+.preview-panel {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  padding: 28px;
+  border-radius: 20px;
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+}
+
+.section-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+/* Controls Panel */
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.control-group label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.control-group input[type="range"] {
+  accent-color: var(--primary-color);
+  cursor: pointer;
+}
+
+/* ── Grid Container under Test ── */
+.grid-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(var(--min-width, 220px), 1fr));
+  gap: 16px;
+  padding: 16px;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 12px;
+  transition: all 0.2s ease;
+}
+
+.grid-cell {
+  background: linear-gradient(135deg, rgba(124, 58, 237, 0.1), rgba(6, 182, 212, 0.1));
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  height: 100px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  color: #fff;
+  transition: transform 0.2s ease;
+  cursor: pointer;
+}
+
+.grid-cell:hover {
+  transform: scale(1.02);
+  border-color: rgba(124, 58, 237, 0.25);
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .grid-cell {
+    transition: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-grid-autofit-generator` showcase. It demonstrates how to generate responsive, wrapping grid structures utilizing SCSS grid-autofit mixins (mapping cell min-widths to column layout counts) coupled with a slider settings dashboard.

## Root Cause
No dynamic grid auto-fit mixins or modular cell packing column utility classes existed in the library.

## Changes Made
- `submissions/examples/grid-autofit-generator-27745-ag/demo.html`: Settings input panel and responsive preview grid blocks.
- `submissions/examples/grid-autofit-generator-27745-ag/style.css`: Grid auto-fit column variables, swatch cells, sliders, and borders.
- `submissions/examples/grid-autofit-generator-27745-ag/README.md`: Explains SCSS auto-fit mixin parameters, gap rules, and validation guides.

## How to Test
1. Open `demo.html` in a browser.
2. Drag the settings slider to verify column updates.

## Related Issue
Closes #27745