### PR TITLE
feat: add typography scale utility classes (ease-text-xs to ease-text-7xl)

### DIFF
--- a/submissions/docs/core_changes-issue-30319/README.md
+++ b/submissions/docs/core_changes-issue-30319/README.md
@@ -1,0 +1,59 @@
+# Typography Scale Utilities — EaseMotion CSS
+
+**Issue:** [#30319 — Add font size scale utility classes (ease-text-xs to ease-text-7xl)](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/30319)
+
+A comprehensive typography utility system for EaseMotion CSS including font size scale, font weights, line heights, letter spacing, text alignment, text transform, and text wrapping utilities.
+
+## Structure
+
+```
+submissions/docs/core_changes-issue-30319/
+├── demo.html       # Live demo page showing all utilities
+├── style.css       # Utility styles
+└── README.md       # This file
+```
+
+## Classes
+
+### Font Size Scale
+
+| Class | Default Size |
+|-------|-------------|
+| `.ease-text-xs` | 0.75rem (12px) |
+| `.ease-text-sm` | 0.875rem (14px) |
+| `.ease-text-base` | 1rem (16px) |
+| `.ease-text-lg` | 1.125rem (18px) |
+| `.ease-text-xl` | 1.25rem (20px) |
+| `.ease-text-2xl` | 1.5rem (24px) |
+| `.ease-text-3xl` | 1.875rem (30px) |
+| `.ease-text-4xl` | 2.25rem (36px) |
+| `.ease-text-5xl` | 3rem (48px) |
+| `.ease-text-6xl` | 3.75rem (60px) |
+| `.ease-text-7xl` | 4.5rem (72px) |
+
+### Font Weight
+
+`ease-font-thin` (100) through `ease-font-black` (900), plus `ease-font-normal` (400), `ease-font-medium` (500), `ease-font-semibold` (600), `ease-font-bold` (700).
+
+### Line Height
+
+`ease-leading-none` (1) through `ease-leading-loose` (2).
+
+### Letter Spacing
+
+`ease-tracking-tighter` (-0.05em) through `ease-tracking-widest` (0.1em).
+
+### Text Alignment & Utilities
+
+Alignment: `ease-text-left`, `ease-text-center`, `ease-text-right`, `ease-text-justify`, `ease-text-start`, `ease-text-end`. Text wrap: `ease-text-balance`, `ease-text-pretty`, `ease-text-nowrap`. Transform: `ease-uppercase`, `ease-lowercase`, `ease-capitalize`. Utility: `ease-truncate`, `ease-text-clip`.
+
+### Responsive Variants
+
+Breakpoint-prefixed variants available: `ease-sm:`, `ease-md:`, `ease-lg:` for font size and text alignment.
+
+## Features
+
+- All sizes customizable via `--ease-text-*` CSS variables
+- Responsive breakpoint variants (sm, md, lg)
+- `@layer easemotion-utilities` for proper cascade ordering
+- `ease-text-balance` and `ease-truncate` for modern text handling

--- a/submissions/docs/core_changes-issue-30319/demo.html
+++ b/submissions/docs/core_changes-issue-30319/demo.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Typography Scale — EaseMotion CSS (Issue #30319)</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css@latest/easemotion.min.css" />
+  <link rel="stylesheet" href="./style.css" />
+  <style>
+    body {
+      font-family: "Inter", system-ui, -apple-system, sans-serif;
+      background: var(--ease-color-bg, #f8fafc);
+      color: var(--ease-color-text, #1e293b);
+      padding: 2rem 1rem;
+    }
+    .container { max-width: 860px; margin: 0 auto; }
+    section { margin-bottom: 3rem; }
+    .demo-table { width: 100%; border-collapse: collapse; }
+    .demo-table th, .demo-table td {
+      padding: 0.75rem 1rem;
+      border-bottom: 1px solid var(--ease-color-border, #e2e8f0);
+      text-align: left;
+    }
+    .demo-table th { font-weight: 600; color: var(--ease-color-muted, #64748b); font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.5px; }
+    .demo-table tr:hover td { background: var(--ease-color-neutral-50, #f8fafc); }
+    .preview-box {
+      background: var(--ease-color-surface, #fff);
+      border: 1px solid var(--ease-color-border, #e2e8f0);
+      border-radius: 12px;
+      padding: 1.25rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="ease-text-center ease-mb-8">
+      <span class="ease-badge ease-badge-sm ease-mb-3">Utilities</span>
+      <h1 class="ease-text-3xl ease-font-bold">Typography Scale <span style="font-size:1rem;color:var(--ease-color-muted)">#30319</span></h1>
+      <p class="ease-text-muted ease-mt-2">Font size scale, font weight, line height, letter spacing, and text alignment utilities.</p>
+    </div>
+
+    <section>
+      <h2 class="ease-text-xl ease-font-semibold ease-mb-4">Font Size Scale</h2>
+      <p class="ease-text-sm ease-text-muted ease-mb-4">Classes from <code>.ease-text-xs</code> to <code>.ease-text-7xl</code>. All sizes are customizable via <code>--ease-text-*</code> CSS variables.</p>
+      <div class="preview-box">
+        <table class="demo-table">
+          <thead><tr><th>Class</th><th>Size</th><th>Preview</th></tr></thead>
+          <tbody>
+            <tr><td><code>.ease-text-xs</code></td><td>0.75rem (12px)</td><td><span class="ease-text-xs">The quick brown fox jumps over the lazy dog.</span></td></tr>
+            <tr><td><code>.ease-text-sm</code></td><td>0.875rem (14px)</td><td><span class="ease-text-sm">The quick brown fox jumps over the lazy dog.</span></td></tr>
+            <tr><td><code>.ease-text-base</code></td><td>1rem (16px)</td><td><span class="ease-text-base">The quick brown fox jumps over the lazy dog.</span></td></tr>
+            <tr><td><code>.ease-text-lg</code></td><td>1.125rem (18px)</td><td><span class="ease-text-lg">The quick brown fox jumps over the lazy dog.</span></td></tr>
+            <tr><td><code>.ease-text-xl</code></td><td>1.25rem (20px)</td><td><span class="ease-text-xl">The quick brown fox jumps over the lazy dog.</span></td></tr>
+            <tr><td><code>.ease-text-2xl</code></td><td>1.5rem (24px)</td><td><span class="ease-text-2xl">The quick brown fox jumps.</span></td></tr>
+            <tr><td><code>.ease-text-3xl</code></td><td>1.875rem (30px)</td><td><span class="ease-text-3xl">The quick brown fox.</span></td></tr>
+            <tr><td><code>.ease-text-4xl</code></td><td>2.25rem (36px)</td><td><span class="ease-text-4xl">Quick brown fox.</span></td></tr>
+            <tr><td><code>.ease-text-5xl</code></td><td>3rem (48px)</td><td><span class="ease-text-5xl">Hello World</span></td></tr>
+            <tr><td><code>.ease-text-6xl</code></td><td>3.75rem (60px)</td><td><span class="ease-text-6xl">Display</span></td></tr>
+            <tr><td><code>.ease-text-7xl</code></td><td>4.5rem (72px)</td><td><span class="ease-text-7xl">Hero</span></td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section>
+      <h2 class="ease-text-xl ease-font-semibold ease-mb-4">Font Weight</h2>
+      <div class="preview-box">
+        <table class="demo-table">
+          <thead><tr><th>Class</th><th>Weight</th><th>Preview</th></tr></thead>
+          <tbody>
+            <tr><td><code>.ease-font-thin</code></td><td>100</td><td><span class="ease-font-thin ease-text-xl">The quick brown fox</span></td></tr>
+            <tr><td><code>.ease-font-extralight</code></td><td>200</td><td><span class="ease-font-extralight ease-text-xl">The quick brown fox</span></td></tr>
+            <tr><td><code>.ease-font-light</code></td><td>300</td><td><span class="ease-font-light ease-text-xl">The quick brown fox</span></td></tr>
+            <tr><td><code>.ease-font-normal</code></td><td>400</td><td><span class="ease-font-normal ease-text-xl">The quick brown fox</span></td></tr>
+            <tr><td><code>.ease-font-medium</code></td><td>500</td><td><span class="ease-font-medium ease-text-xl">The quick brown fox</span></td></tr>
+            <tr><td><code>.ease-font-semibold</code></td><td>600</td><td><span class="ease-font-semibold ease-text-xl">The quick brown fox</span></td></tr>
+            <tr><td><code>.ease-font-bold</code></td><td>700</td><td><span class="ease-font-bold ease-text-xl">The quick brown fox</span></td></tr>
+            <tr><td><code>.ease-font-extrabold</code></td><td>800</td><td><span class="ease-font-extrabold ease-text-xl">The quick brown fox</span></td></tr>
+            <tr><td><code>.ease-font-black</code></td><td>900</td><td><span class="ease-font-black ease-text-xl">The quick brown fox</span></td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section>
+      <h2 class="ease-text-xl ease-font-semibold ease-mb-4">Line Height</h2>
+      <div class="preview-box">
+        <table class="demo-table">
+          <thead><tr><th>Class</th><th>Value</th><th>Preview</th></tr></thead>
+          <tbody>
+            <tr><td><code>.ease-leading-none</code></td><td>1</td><td><span class="ease-leading-none">Tight line height</span></td></tr>
+            <tr><td><code>.ease-leading-tight</code></td><td>1.25</td><td><span class="ease-leading-tight">Slightly relaxed for headings</span></td></tr>
+            <tr><td><code>.ease-leading-normal</code></td><td>1.5</td><td><span class="ease-leading-normal">Default comfortable reading</span></td></tr>
+            <tr><td><code>.ease-leading-relaxed</code></td><td>1.625</td><td><span class="ease-leading-relaxed">More spacing for readability</span></td></tr>
+            <tr><td><code>.ease-leading-loose</code></td><td>2</td><td><span class="ease-leading-loose">Maximum line spacing</span></td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section>
+      <h2 class="ease-text-xl ease-font-semibold ease-mb-4">Letter Spacing</h2>
+      <div class="preview-box">
+        <table class="demo-table">
+          <thead><tr><th>Class</th><th>Value</th><th>Preview</th></tr></thead>
+          <tbody>
+            <tr><td><code>.ease-tracking-tighter</code></td><td>-0.05em</td><td class="ease-tracking-tighter">Condensed text for headlines</td></tr>
+            <tr><td><code>.ease-tracking-tight</code></td><td>-0.025em</td><td class="ease-tracking-tight">Slightly condensed</td></tr>
+            <tr><td><code>.ease-tracking-normal</code></td><td>0em</td><td class="ease-tracking-normal">Default tracking</td></tr>
+            <tr><td><code>.ease-tracking-wide</code></td><td>0.025em</td><td class="ease-tracking-wide">Slightly expanded</td></tr>
+            <tr><td><code>.ease-tracking-wider</code></td><td>0.05em</td><td class="ease-tracking-wider">Expanded for emphasis</td></tr>
+            <tr><td><code>.ease-tracking-widest</code></td><td>0.1em</td><td class="ease-tracking-widest">Maximum letter spacing</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section>
+      <h2 class="ease-text-xl ease-font-semibold ease-mb-4">Text Alignment</h2>
+      <div class="preview-box">
+        <p><code>.ease-text-left</code></p>
+        <p class="ease-text-left ease-mb-4" style="border:1px dashed var(--ease-color-border);padding:0.5rem">Left-aligned text is the default for LTR languages.</p>
+        <p><code>.ease-text-center</code></p>
+        <p class="ease-text-center ease-mb-4" style="border:1px dashed var(--ease-color-border);padding:0.5rem">Center alignment for headings and callouts.</p>
+        <p><code>.ease-text-right</code></p>
+        <p class="ease-text-right ease-mb-4" style="border:1px dashed var(--ease-color-border);padding:0.5rem">Right alignment for RTL or numeric data.</p>
+        <p><code>.ease-text-justify</code></p>
+        <p class="ease-text-justify" style="border:1px dashed var(--ease-color-border);padding:0.5rem">Justified text creates clean edges on both sides for magazine-style layouts.</p>
+      </div>
+    </section>
+
+    <section>
+      <h2 class="ease-text-xl ease-font-semibold ease-mb-4">Text Transform & Utilities</h2>
+      <div class="preview-box">
+        <table class="demo-table">
+          <thead><tr><th>Class</th><th>Preview</th></tr></thead>
+          <tbody>
+            <tr><td><code>.ease-uppercase</code></td><td class="ease-uppercase">Uppercase Text</td></tr>
+            <tr><td><code>.ease-lowercase</code></td><td class="ease-lowercase">Lowercase Text</td></tr>
+            <tr><td><code>.ease-capitalize</code></td><td class="ease-capitalize">capitalize each word</td></tr>
+            <tr><td><code>.ease-truncate</code></td><td><span class="ease-truncate" style="display:block;max-width:200px">This is a very long text that should be truncated with an ellipsis at the end of the line.</span></td></tr>
+            <tr><td><code>.ease-text-balance</code></td><td class="ease-text-balance">This heading text is balanced across lines for better visual presentation.</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <footer class="ease-text-center ease-mt-8 ease-pt-6" style="border-top:1px solid var(--ease-color-border)">
+      <p class="ease-text-sm ease-text-muted">Built with EaseMotion CSS • Typography Scale Utilities • Issue #30319</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30319/style.css
+++ b/submissions/docs/core_changes-issue-30319/style.css
@@ -1,0 +1,113 @@
+@layer easemotion-utilities {
+.ease-text-xs { font-size: var(--ease-text-xs, 0.75rem); }
+.ease-text-sm { font-size: var(--ease-text-sm, 0.875rem); }
+.ease-text-base { font-size: var(--ease-text-base, 1rem); }
+.ease-text-lg { font-size: var(--ease-text-lg, 1.125rem); }
+.ease-text-xl { font-size: var(--ease-text-xl, 1.25rem); }
+.ease-text-2xl { font-size: var(--ease-text-2xl, 1.5rem); }
+.ease-text-3xl { font-size: var(--ease-text-3xl, 1.875rem); }
+.ease-text-4xl { font-size: var(--ease-text-4xl, 2.25rem); }
+.ease-text-5xl { font-size: var(--ease-text-5xl, 3rem); }
+.ease-text-6xl { font-size: var(--ease-text-6xl, 3.75rem); }
+.ease-text-7xl { font-size: var(--ease-text-7xl, 4.5rem); }
+
+.ease-font-thin { font-weight: 100; }
+.ease-font-extralight { font-weight: 200; }
+.ease-font-light { font-weight: 300; }
+.ease-font-normal { font-weight: 400; }
+.ease-font-medium { font-weight: 500; }
+.ease-font-semibold { font-weight: 600; }
+.ease-font-bold { font-weight: 700; }
+.ease-font-extrabold { font-weight: 800; }
+.ease-font-black { font-weight: 900; }
+
+.ease-leading-none { line-height: 1; }
+.ease-leading-tight { line-height: 1.25; }
+.ease-leading-snug { line-height: 1.375; }
+.ease-leading-normal { line-height: 1.5; }
+.ease-leading-relaxed { line-height: 1.625; }
+.ease-leading-loose { line-height: 2; }
+
+.ease-tracking-tighter { letter-spacing: -0.05em; }
+.ease-tracking-tight { letter-spacing: -0.025em; }
+.ease-tracking-normal { letter-spacing: 0em; }
+.ease-tracking-wide { letter-spacing: 0.025em; }
+.ease-tracking-wider { letter-spacing: 0.05em; }
+.ease-tracking-widest { letter-spacing: 0.1em; }
+
+.ease-text-left { text-align: left; }
+.ease-text-center { text-align: center; }
+.ease-text-right { text-align: right; }
+.ease-text-justify { text-align: justify; }
+.ease-text-start { text-align: start; }
+.ease-text-end { text-align: end; }
+
+.ease-text-balance { text-wrap: balance; }
+.ease-text-pretty { text-wrap: pretty; }
+.ease-text-nowrap { white-space: nowrap; }
+
+.ease-lowercase { text-transform: lowercase; }
+.ease-uppercase { text-transform: uppercase; }
+.ease-capitalize { text-transform: capitalize; }
+.ease-normal-case { text-transform: none; }
+
+.ease-truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ease-text-clip {
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+@media (min-width: 640px) {
+  .ease-sm\:ease-text-xs { font-size: var(--ease-text-xs, 0.75rem); }
+  .ease-sm\:ease-text-sm { font-size: var(--ease-text-sm, 0.875rem); }
+  .ease-sm\:ease-text-base { font-size: var(--ease-text-base, 1rem); }
+  .ease-sm\:ease-text-lg { font-size: var(--ease-text-lg, 1.125rem); }
+  .ease-sm\:ease-text-xl { font-size: var(--ease-text-xl, 1.25rem); }
+  .ease-sm\:ease-text-2xl { font-size: var(--ease-text-2xl, 1.5rem); }
+  .ease-sm\:ease-text-3xl { font-size: var(--ease-text-3xl, 1.875rem); }
+  .ease-sm\:ease-text-4xl { font-size: var(--ease-text-4xl, 2.25rem); }
+  .ease-sm\:ease-text-center { text-align: center; }
+  .ease-sm\:ease-text-left { text-align: left; }
+  .ease-sm\:ease-text-right { text-align: right; }
+}
+
+@media (min-width: 768px) {
+  .ease-md\:ease-text-xs { font-size: var(--ease-text-xs, 0.75rem); }
+  .ease-md\:ease-text-sm { font-size: var(--ease-text-sm, 0.875rem); }
+  .ease-md\:ease-text-base { font-size: var(--ease-text-base, 1rem); }
+  .ease-md\:ease-text-lg { font-size: var(--ease-text-lg, 1.125rem); }
+  .ease-md\:ease-text-xl { font-size: var(--ease-text-xl, 1.25rem); }
+  .ease-md\:ease-text-2xl { font-size: var(--ease-text-2xl, 1.5rem); }
+  .ease-md\:ease-text-3xl { font-size: var(--ease-text-3xl, 1.875rem); }
+  .ease-md\:ease-text-4xl { font-size: var(--ease-text-4xl, 2.25rem); }
+  .ease-md\:ease-text-center { text-align: center; }
+  .ease-md\:ease-text-left { text-align: left; }
+  .ease-md\:ease-text-right { text-align: right; }
+}
+
+@media (min-width: 1024px) {
+  .ease-lg\:ease-text-xs { font-size: var(--ease-text-xs, 0.75rem); }
+  .ease-lg\:ease-text-sm { font-size: var(--ease-text-sm, 0.875rem); }
+  .ease-lg\:ease-text-base { font-size: var(--ease-text-base, 1rem); }
+  .ease-lg\:ease-text-lg { font-size: var(--ease-text-lg, 1.125rem); }
+  .ease-lg\:ease-text-xl { font-size: var(--ease-text-xl, 1.25rem); }
+  .ease-lg\:ease-text-2xl { font-size: var(--ease-text-2xl, 1.5rem); }
+  .ease-lg\:ease-text-3xl { font-size: var(--ease-text-3xl, 1.875rem); }
+  .ease-lg\:ease-text-4xl { font-size: var(--ease-text-4xl, 2.25rem); }
+  .ease-lg\:ease-text-center { text-align: center; }
+  .ease-lg\:ease-text-left { text-align: left; }
+  .ease-lg\:ease-text-right { text-align: right; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-truncate {
+    transition: none;
+  }
+}
+}


### PR DESCRIPTION
### Description
Add a comprehensive typography scale utility system for EaseMotion CSS. Provides 11 font-size steps (xs through 7xl), font weights, line heights, letter spacing, text alignment, transforms, and wrapping utilities — all customizable via `--ease-text-*` CSS variables.

### Root Cause
EaseMotion CSS lacked a systematic typography utility layer, forcing developers to write manual font-size/weight/alignment styles for each project.

### Changes Made
- `submissions/docs/core_changes-issue-30319/style.css`: Added utility classes under `@layer easemotion-utilities`
  - `.ease-text-xs` through `.ease-text-7xl` (11-step scale)
  - `.ease-font-thin` through `.ease-font-black` (9 weight levels)
  - `.ease-leading-none` through `.ease-leading-loose` (6 line-height values)
  - `.ease-tracking-tighter` through `.ease-tracking-widest` (6 letter-spacing values)
  - `.ease-text-left/center/right/justify/start/end`, `.ease-uppercase/lowercase/capitalize/normal-case`, `.ease-truncate`, `.ease-text-clip`, `.ease-text-balance/pretty/nowrap`
  - Responsive variants for `sm:`, `md:`, `lg:` breakpoints on font-size and alignment
- `submissions/docs/core_changes-issue-30319/demo.html`: Interactive demo with all utilities
- `submissions/docs/core_changes-issue-30319/README.md`: Full class reference

### Testing
- [x] All classes render correctly in Chrome and Firefox
- [x] Responsive variants activate at correct breakpoints (640px/768px/1024px)
- [x] CSS custom properties override scale values
- [x] `ease-truncate` properly clips overflow
- [x] Reduced-motion query does not conflict
- [x] Layer-based cascade integrates with existing easemotion styles

### Checklist
- [x] I have self-reviewed my code
- [x] No console errors or warnings
- [x] Code follows the project style guidelines

Fixes #30319