### PR TITLE
feat: add dropdown menu component with hover and click variants

### DIFF
--- a/submissions/docs/core_changes-issue-30305/README.md
+++ b/submissions/docs/core_changes-issue-30305/README.md
@@ -1,0 +1,51 @@
+# Dropdown Menu Component — EaseMotion CSS
+
+**Issue:** [#30305 — Add Dropdown Menu component with hover and click variants](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/30305)
+
+A CSS-only dropdown menu component supporting hover-triggered and click-triggered variants with smooth entrance animations, RTL-aware positioning, and keyboard accessibility.
+
+## Structure
+
+```
+submissions/docs/core_changes-issue-30305/
+├── demo.html       # Demo page showing all variants
+├── style.css       # Component styles
+└── README.md       # This file
+```
+
+## Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-dropdown` | Inline-block wrapper (position: relative) |
+| `.ease-dropdown-trigger` | Button/link that controls the dropdown |
+| `.ease-dropdown-menu` | Hidden menu panel (absolute positioned) |
+| `.ease-dropdown-item` | Individual menu option |
+| `.ease-dropdown-divider` | Separator line between items |
+| `.ease-dropdown-hover` | Opens on `:hover` / `:focus-within` |
+| `.ease-dropdown-click` | Opens via checkbox `:checked` hack |
+| `.ease-dropdown-checkbox` | Hidden checkbox for click variant |
+| `.ease-dropdown-menu-end` | Align menu to the right |
+| `.ease-dropdown-menu-top` | Open menu upward |
+| `.ease-dropdown-item-icon` | Icon slot within items |
+| `.ease-dropdown-item-text` | Text label within items |
+| `.ease-dropdown-item-shortcut` | Keyboard shortcut hint |
+
+## Variants
+
+### Hover (`.ease-dropdown-hover`)
+Opens on mouse hover, stays open when focus is inside the dropdown (keyboard accessible via `:focus-within`). Arrow rotates on open.
+
+### Click (`.ease-dropdown-click`)
+Uses a hidden `<input type="checkbox">` with `:checked ~ .ease-dropdown-menu`. An adjacent `<label>` serves as the trigger. Click the label to toggle open/closed.
+
+## Features
+
+- **CSS-only:** No JavaScript required for basic toggle behavior
+- **Entrance animation:** Slide-down + fade-in with `scale(0.98 → 1)`
+- **Arrow indicator:** Chevron rotates when open
+- **RTL-aware:** Uses `inset-inline-*` for positioning
+- **Keyboard accessible:** `:focus-within` fallback for hover variant
+- **Reduced motion:** Transitions disabled when `prefers-reduced-motion: reduce`
+- **Customizable:** All colors via `--ease-color-*` and spacing via `--ease-spacing-*` variables
+- **Composable:** Items support icons, labels, and shortcut hints

--- a/submissions/docs/core_changes-issue-30305/demo.html
+++ b/submissions/docs/core_changes-issue-30305/demo.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dropdown Menu — EaseMotion CSS (Issue #30305)</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css@latest/easemotion.min.css" />
+  <link rel="stylesheet" href="./style.css" />
+  <style>
+    body {
+      font-family: "Inter", system-ui, -apple-system, sans-serif;
+      background: var(--ease-color-bg, #f8fafc);
+      color: var(--ease-color-text, #1e293b);
+      padding: 2rem 1rem;
+    }
+    .container { max-width: 860px; margin: 0 auto; }
+    section { margin-bottom: 3rem; }
+    .demo-grid {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 2rem;
+      align-items: flex-start;
+    }
+    .demo-box {
+      background: var(--ease-color-surface, #fff);
+      border: 1px solid var(--ease-color-border, #e2e8f0);
+      border-radius: 12px;
+      padding: 1.5rem;
+      min-height: 180px;
+    }
+    .demo-box h3 {
+      font-size: 0.9rem;
+      font-weight: 600;
+      margin-bottom: 1rem;
+      color: var(--ease-color-muted);
+    }
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      border-radius: 0.375rem;
+      font-size: 0.875rem;
+      font-weight: 500;
+      border: 1px solid var(--ease-color-border, #e2e8f0);
+      background: var(--ease-color-surface, #fff);
+      color: var(--ease-color-text, #1e293b);
+      cursor: pointer;
+      font-family: inherit;
+      transition: background 0.15s ease;
+    }
+    .btn:hover { background: var(--ease-color-neutral-50, #f8fafc); }
+    .btn-primary {
+      background: var(--ease-color-primary, #3b82f6);
+      color: #fff;
+      border-color: var(--ease-color-primary, #3b82f6);
+    }
+    .btn-primary:hover { background: #2563eb; }
+    .btn-destructive { color: #ef4444; }
+    .btn-destructive:hover { background: #fef2f2; }
+    .space-y { display: flex; flex-direction: column; gap: 0.25rem; }
+    .docs-callout {
+      background: #eff6ff;
+      border: 1px solid #bfdbfe;
+      border-radius: 0.5rem;
+      padding: 1rem;
+      font-size: 0.875rem;
+      color: #1e40af;
+    }
+    .docs-callout code { background: #dbeafe; padding: 0.125rem 0.375rem; border-radius: 0.25rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="ease-text-center ease-mb-8">
+      <span class="ease-badge ease-badge-sm ease-mb-3">Components</span>
+      <h1 class="ease-text-3xl ease-font-bold">Dropdown Menu <span style="font-size:1rem;color:var(--ease-color-muted)">#30305</span></h1>
+      <p class="ease-text-muted ease-mt-2">Hover and click-triggered dropdown menus with smooth animations, RTL support, and accessibility.</p>
+    </div>
+
+    <section>
+      <h2 class="ease-text-xl ease-font-semibold ease-mb-4">Hover Variant</h2>
+      <p class="ease-text-sm ease-text-muted ease-mb-4">Use <code>.ease-dropdown-hover</code> — opens on hover with <code>:focus-within</code> fallback for keyboard users.</p>
+      <div class="demo-grid">
+        <div class="ease-dropdown ease-dropdown-hover">
+          <button class="btn btn-primary ease-dropdown-trigger">Actions</button>
+          <div class="ease-dropdown-menu">
+            <button class="ease-dropdown-item">Edit</button>
+            <button class="ease-dropdown-item">Duplicate</button>
+            <button class="ease-dropdown-item">Copy link</button>
+            <div class="ease-dropdown-divider"></div>
+            <button class="ease-dropdown-item btn-destructive">Delete</button>
+          </div>
+        </div>
+
+        <div class="ease-dropdown ease-dropdown-hover">
+          <button class="btn ease-dropdown-trigger">File</button>
+          <div class="ease-dropdown-menu">
+            <button class="ease-dropdown-item">New tab</button>
+            <button class="ease-dropdown-item">New window</button>
+            <div class="ease-dropdown-divider"></div>
+            <button class="ease-dropdown-item">Open file…</button>
+            <button class="ease-dropdown-item">Save</button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2 class="ease-text-xl ease-font-semibold ease-mb-4">Click Variant</h2>
+      <p class="ease-text-sm ease-text-muted ease-mb-4">Uses a hidden checkbox (<code>:checked</code>) for click-toggle — no JS required.</p>
+      <div class="demo-box" style="display:inline-block">
+        <div class="ease-dropdown ease-dropdown-click">
+          <input type="checkbox" class="ease-dropdown-checkbox" id="demo-click-1" />
+          <label for="demo-click-1" class="btn btn-primary ease-dropdown-trigger">Settings</label>
+          <div class="ease-dropdown-menu">
+            <button class="ease-dropdown-item">Profile</button>
+            <button class="ease-dropdown-item">Account</button>
+            <div class="ease-dropdown-divider"></div>
+            <button class="ease-dropdown-item">Preferences</button>
+            <button class="ease-dropdown-item">Keyboard shortcuts</button>
+            <div class="ease-dropdown-divider"></div>
+            <button class="ease-dropdown-item btn-destructive">Sign out</button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2 class="ease-text-xl ease-font-semibold ease-mb-4">Position Variants</h2>
+      <p class="ease-text-sm ease-text-muted ease-mb-4">Add <code>.ease-dropdown-menu-end</code> to align right, or <code>.ease-dropdown-menu-top</code> to open upward.</p>
+      <div class="demo-grid">
+        <div class="ease-dropdown ease-dropdown-hover">
+          <button class="btn ease-dropdown-trigger">Align end (right)</button>
+          <div class="ease-dropdown-menu ease-dropdown-menu-end">
+            <button class="ease-dropdown-item">Option A</button>
+            <button class="ease-dropdown-item">Option B</button>
+            <button class="ease-dropdown-item">Option C</button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2 class="ease-text-xl ease-font-semibold ease-mb-4">Rich Items</h2>
+      <p class="ease-text-sm ease-text-muted ease-mb-4">Dropdown items support icons, text labels, and keyboard shortcut hints.</p>
+      <div class="ease-dropdown ease-dropdown-hover">
+        <button class="btn btn-primary ease-dropdown-trigger">With details</button>
+        <div class="ease-dropdown-menu" style="min-width:16rem">
+          <button class="ease-dropdown-item">
+            <span class="ease-dropdown-item-icon">📋</span>
+            <span class="ease-dropdown-item-text">Copy</span>
+            <span class="ease-dropdown-item-shortcut">⌘C</span>
+          </button>
+          <button class="ease-dropdown-item">
+            <span class="ease-dropdown-item-icon">📄</span>
+            <span class="ease-dropdown-item-text">Paste</span>
+            <span class="ease-dropdown-item-shortcut">⌘V</span>
+          </button>
+          <button class="ease-dropdown-item">
+            <span class="ease-dropdown-item-icon">✂️</span>
+            <span class="ease-dropdown-item-text">Cut</span>
+            <span class="ease-dropdown-item-shortcut">⌘X</span>
+          </button>
+          <div class="ease-dropdown-divider"></div>
+          <button class="ease-dropdown-item">
+            <span class="ease-dropdown-item-icon">🔍</span>
+            <span class="ease-dropdown-item-text">Find</span>
+            <span class="ease-dropdown-item-shortcut">⌘F</span>
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2 class="ease-text-xl ease-font-semibold ease-mb-4">Usage Notes</h2>
+      <div class="docs-callout">
+        <strong>Hover variant:</strong> Wrap in <code>.ease-dropdown.ease-dropdown-hover</code>. The trigger must have <code>.ease-dropdown-trigger</code> and the menu must have <code>.ease-dropdown-menu</code>. Keyboard accessible via <code>:focus-within</code>.
+        <br /><br />
+        <strong>Click variant:</strong> Use <code>.ease-dropdown.ease-dropdown-click</code> with an <code>&lt;input type="checkbox" class="ease-dropdown-checkbox"&gt;</code> as the first child, and a <code>&lt;label for="..."&gt;</code> as the trigger. Toggle the checkbox to open/close.
+        <br /><br />
+        <strong>Positioning:</strong> Add <code>.ease-dropdown-menu-end</code> for right alignment, <code>.ease-dropdown-menu-top</code> to open upward. Default is bottom-left. RTL-aware via <code>inset-inline-*</code> properties.
+      </div>
+    </section>
+
+    <footer class="ease-text-center ease-mt-8 ease-pt-6" style="border-top:1px solid var(--ease-color-border)">
+      <p class="ease-text-sm ease-text-muted">Built with EaseMotion CSS • Dropdown Menu Component • Issue #30305</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30305/style.css
+++ b/submissions/docs/core_changes-issue-30305/style.css
@@ -1,0 +1,155 @@
+@layer easemotion-components {
+.ease-dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+.ease-dropdown-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ease-spacing-2, 0.5rem);
+  cursor: pointer;
+  user-select: none;
+}
+
+.ease-dropdown-trigger::after {
+  content: "";
+  display: inline-block;
+  width: 0.4rem;
+  height: 0.4rem;
+  border: 2px solid currentColor;
+  border-top: 0;
+  border-inline-start: 0;
+  transform: rotate(45deg);
+  margin-block-start: -0.15rem;
+  transition: transform 0.2s ease;
+}
+
+.ease-dropdown-menu {
+  position: absolute;
+  inset-block-start: 100%;
+  inset-inline-start: 0;
+  z-index: 50;
+  min-width: 14rem;
+  background: var(--ease-color-surface, #fff);
+  border: 1px solid var(--ease-color-border, #e2e8f0);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+  padding: var(--ease-spacing-1, 0.25rem) 0;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-4px) scale(0.98);
+  transition:
+    opacity 0.15s ease,
+    visibility 0.15s ease,
+    transform 0.15s ease;
+  pointer-events: none;
+}
+
+.ease-dropdown-item {
+  display: flex;
+  align-items: center;
+  gap: var(--ease-spacing-2, 0.5rem);
+  padding: 0.5rem 1rem;
+  color: var(--ease-color-text, #1e293b);
+  font-size: var(--ease-text-sm, 0.875rem);
+  cursor: pointer;
+  transition: background 0.12s ease;
+  text-decoration: none;
+  white-space: nowrap;
+  border: 0;
+  background: transparent;
+  width: 100%;
+  text-align: start;
+  font-family: inherit;
+}
+
+.ease-dropdown-item:hover,
+.ease-dropdown-item:focus-visible {
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  outline: none;
+}
+
+.ease-dropdown-item:active {
+  background: var(--ease-color-neutral-200, #e2e8f0);
+}
+
+.ease-dropdown-divider {
+  height: 1px;
+  background: var(--ease-color-border, #e2e8f0);
+  margin: var(--ease-spacing-1, 0.25rem) 0;
+}
+
+.ease-dropdown-hover:hover .ease-dropdown-menu,
+.ease-dropdown-hover:focus-within .ease-dropdown-menu {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.ease-dropdown-hover:hover .ease-dropdown-trigger::after,
+.ease-dropdown-hover:focus-within .ease-dropdown-trigger::after {
+  transform: rotate(-135deg);
+  margin-block-start: 0.15rem;
+}
+
+.ease-dropdown-click .ease-dropdown-trigger {
+  cursor: pointer;
+}
+
+.ease-dropdown-checkbox {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+.ease-dropdown-checkbox:checked ~ .ease-dropdown-menu {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.ease-dropdown-checkbox:checked ~ .ease-dropdown-trigger::after {
+  transform: rotate(-135deg);
+  margin-block-start: 0.15rem;
+}
+
+.ease-dropdown-menu-end {
+  inset-inline-start: auto;
+  inset-inline-end: 0;
+}
+
+.ease-dropdown-menu-top {
+  inset-block-start: auto;
+  inset-block-end: 100%;
+  margin-block-end: var(--ease-spacing-1, 0.25rem);
+}
+
+.ease-dropdown-item-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  flex-shrink: 0;
+  opacity: 0.7;
+}
+
+.ease-dropdown-item-text {
+  flex: 1;
+}
+
+.ease-dropdown-item-shortcut {
+  font-size: var(--ease-text-xs, 0.75rem);
+  color: var(--ease-color-muted, #94a3b8);
+  margin-inline-start: auto;
+  padding-inline-start: var(--ease-spacing-4, 1rem);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-dropdown-menu {
+    transition: none;
+  }
+}
+}


### PR DESCRIPTION
### Description
Add a CSS-only dropdown menu component with hover-triggered and click-triggered variants, smooth entrance animations, RTL-aware positioning, and keyboard accessibility.

### Root Cause
EaseMotion CSS had no dropdown menu component, forcing developers to hand-roll dropdown behavior or use JS libraries for navigation menus, action buttons, and settings panels.

### Changes Made
- `submissions/docs/core_changes-issue-30305/style.css`: Dropdown classes under `@layer easemotion-components`
  - `.ease-dropdown`, `.ease-dropdown-trigger`, `.ease-dropdown-menu`
  - `.ease-dropdown-hover`: opens via `:hover` / `:focus-within`
  - `.ease-dropdown-click`: opens via checkbox `:checked` hack (zero JS)
  - `.ease-dropdown-item`, `.ease-dropdown-divider`
  - `.ease-dropdown-menu-end`, `.ease-dropdown-menu-top` position variants
  - `.ease-dropdown-item-icon`, `.ease-dropdown-item-text`, `.ease-dropdown-item-shortcut`
  - Slide-down + fade-in + scale entrance animation
  - Chevron arrow indicator that rotates 180° on open
  - RTL-aware via `inset-inline-*` logical properties
  - `prefers-reduced-motion: reduce` disables transitions
- `submissions/docs/core_changes-issue-30305/demo.html`: Demos for hover, click, positioning, and rich item variants
- `submissions/docs/core_changes-issue-30305/README.md`: Full class reference

### Testing
- [x] Hover variant opens/closes on hover and focus-within
- [x] Click variant toggles via checkbox :checked with label
- [x] Entrance animation plays on open (slide + fade + scale)
- [x] Arrow chevron rotates on open/close
- [x] RTL logical properties work (inset-inline-*)
- [x] Reduced-motion query disables transitions
- [x] Layer-based cascade integrates with existing easemotion styles

### Checklist
- [x] I have self-reviewed my code
- [x] No console errors or warnings
- [x] Code follows the project style guidelines

Fixes #30305