### PR TITLE
feat: add dark mode with CSS custom properties and prefers-color-scheme support

### DIFF
--- a/submissions/docs/core_changes-issue-30306/README.md
+++ b/submissions/docs/core_changes-issue-30306/README.md
@@ -1,0 +1,31 @@
+# Stepper Component — Issue #30306
+
+A CSS-only stepper/progress indicator for multi-step workflows.
+
+## Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-stepper` | Horizontal stepper container (`<ol>`) |
+| `.ease-stepper-vertical` | Vertical layout modifier |
+| `.ease-step` | Individual step item |
+| `.ease-step-indicator` | Circular step number/icon |
+| `.ease-step-number` | Step number inside indicator |
+| `.ease-step-indicator-icon` | Checkmark icon (shown on complete) |
+| `.ease-step-label` | Step description |
+| `.ease-step-connector` | Line connecting steps |
+| `.is-active` | Current active step |
+| `.is-complete` | Completed step |
+| `.ease-stepper-clickable` | Enables hover scale on steps |
+| `.ease-stepper-sm` | Small size |
+| `.eastepper-lg` | Large size (note: `.ease-stepper-lg`) |
+
+## CSS Variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `--ease-step-size` | 2.5rem | Indicator diameter |
+| `--ease-step-color` | gray-300 | Inactive color |
+| `--ease-step-active-color` | blue-500 | Active indicator |
+| `--ease-step-complete-color` | green-500 | Complete indicator |
+| `--ease-step-connector-thickness` | 2px | Connector line width |

--- a/submissions/docs/core_changes-issue-30306/demo.html
+++ b/submissions/docs/core_changes-issue-30306/demo.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Stepper Component — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 800px; margin: 0 auto; padding: 2rem; background: #f9fafb; color: #111; }
+h2 { margin-top: 3rem; margin-bottom: 1rem; font-weight: 600; }
+h2:first-of-type { margin-top: 0; }
+section { background: #fff; padding: 2rem; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 2rem; }
+code { background: #e5e7eb; padding: .15em .4em; border-radius: 4px; font-size: .85em; }
+</style>
+</head>
+<body>
+
+<h1>Stepper Component</h1>
+
+<section>
+<h2>Horizontal Stepper (3 steps, step 2 active)</h2>
+<ol class="ease-stepper">
+  <li class="ease-step is-complete">
+    <span class="ease-step-indicator">
+      <span class="ease-step-number">1</span>
+      <span class="ease-step-indicator-icon" aria-hidden="true"></span>
+    </span>
+    <span class="ease-step-label">Cart</span>
+    <span class="ease-step-connector"></span>
+  </li>
+  <li class="ease-step is-active">
+    <span class="ease-step-indicator">
+      <span class="ease-step-number">2</span>
+      <span class="ease-step-indicator-icon" aria-hidden="true"></span>
+    </span>
+    <span class="ease-step-label">Shipping</span>
+    <span class="ease-step-connector"></span>
+  </li>
+  <li class="ease-step">
+    <span class="ease-step-indicator">
+      <span class="ease-step-number">3</span>
+      <span class="ease-step-indicator-icon" aria-hidden="true"></span>
+    </span>
+    <span class="ease-step-label">Payment</span>
+  </li>
+</ol>
+</section>
+
+<section>
+<h2>Vertical Stepper (4 steps, step 3 active)</h2>
+<ol class="ease-stepper ease-stepper-vertical">
+  <li class="ease-step is-complete">
+    <span class="ease-step-indicator">
+      <span class="ease-step-number">1</span>
+      <span class="ease-step-indicator-icon" aria-hidden="true"></span>
+    </span>
+    <span class="ease-step-label">Requirements</span>
+    <span class="ease-step-connector"></span>
+  </li>
+  <li class="ease-step is-complete">
+    <span class="ease-step-indicator">
+      <span class="ease-step-number">2</span>
+      <span class="ease-step-indicator-icon" aria-hidden="true"></span>
+    </span>
+    <span class="ease-step-label">Design</span>
+    <span class="ease-step-connector"></span>
+  </li>
+  <li class="ease-step is-active">
+    <span class="ease-step-indicator">
+      <span class="ease-step-number">3</span>
+      <span class="ease-step-indicator-icon" aria-hidden="true"></span>
+    </span>
+    <span class="ease-step-label">Development</span>
+    <span class="ease-step-connector"></span>
+  </li>
+  <li class="ease-step">
+    <span class="ease-step-indicator">
+      <span class="ease-step-number">4</span>
+      <span class="ease-step-indicator-icon" aria-hidden="true"></span>
+    </span>
+    <span class="ease-step-label">Deploy</span>
+  </li>
+</ol>
+</section>
+
+<section>
+<h2>Small Size (clickable)</h2>
+<ol class="ease-stepper ease-stepper-sm ease-stepper-clickable ease-stepper-numbers">
+  <li class="ease-step is-complete">
+    <span class="ease-step-indicator"><span class="ease-step-number">1</span><span class="ease-step-indicator-icon" aria-hidden="true"></span></span>
+    <span class="ease-step-label">Step 1</span>
+    <span class="ease-step-connector"></span>
+  </li>
+  <li class="ease-step is-active">
+    <span class="ease-step-indicator"><span class="ease-step-number">2</span><span class="ease-step-indicator-icon" aria-hidden="true"></span></span>
+    <span class="ease-step-label">Step 2</span>
+    <span class="ease-step-connector"></span>
+  </li>
+  <li class="ease-step">
+    <span class="ease-step-indicator"><span class="ease-step-number">3</span><span class="ease-step-indicator-icon" aria-hidden="true"></span></span>
+    <span class="ease-step-label">Step 3</span>
+  </li>
+</ol>
+</section>
+
+<section>
+<h2>Large Size (4 steps, all complete)</h2>
+<ol class="ease-stepper ease-stepper-lg">
+  <li class="ease-step is-complete">
+    <span class="ease-step-indicator"><span class="ease-step-number">1</span><span class="ease-step-indicator-icon" aria-hidden="true"></span></span>
+    <span class="ease-step-label">Research</span>
+    <span class="ease-step-connector"></span>
+  </li>
+  <li class="ease-step is-complete">
+    <span class="ease-step-indicator"><span class="ease-step-number">2</span><span class="ease-step-indicator-icon" aria-hidden="true"></span></span>
+    <span class="ease-step-label">Wireframe</span>
+    <span class="ease-step-connector"></span>
+  </li>
+  <li class="ease-step is-complete">
+    <span class="ease-step-indicator"><span class="ease-step-number">3</span><span class="ease-step-indicator-icon" aria-hidden="true"></span></span>
+    <span class="ease-step-label">Prototype</span>
+    <span class="ease-step-connector"></span>
+  </li>
+  <li class="ease-step is-complete">
+    <span class="ease-step-indicator"><span class="ease-step-number">4</span><span class="ease-step-indicator-icon" aria-hidden="true"></span></span>
+    <span class="ease-step-label">Launch</span>
+  </li>
+</ol>
+</section>
+
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30306/style.css
+++ b/submissions/docs/core_changes-issue-30306/style.css
@@ -1,0 +1,160 @@
+@layer easemotion-components {
+.ease-stepper {
+  --ease-step-size: 2.5rem;
+  --ease-step-color: var(--ease-gray-300, #d1d5db);
+  --ease-step-active-color: var(--ease-blue-500, #3b82f6);
+  --ease-step-complete-color: var(--ease-green-500, #22c55e);
+  --ease-step-text-color: var(--ease-gray-600, #4b5563);
+  --ease-step-active-text: var(--ease-blue-600, #2563eb);
+  --ease-step-complete-text: var(--ease-white, #fff);
+  --ease-step-font-size: 0.875rem;
+  --ease-step-label-font-size: 0.875rem;
+  --ease-step-gap: 0;
+  --ease-step-connector-thickness: 2px;
+
+  display: flex;
+  gap: var(--ease-step-gap);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.ease-stepper-vertical {
+  flex-direction: column;
+}
+
+.ease-step {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  position: relative;
+}
+
+.ease-stepper-vertical .ease-step {
+  flex: none;
+}
+
+.ease-step-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--ease-step-size);
+  height: var(--ease-step-size);
+  border-radius: 50%;
+  background: var(--ease-step-color);
+  color: var(--ease-step-text-color);
+  font-size: var(--ease-step-font-size);
+  font-weight: 600;
+  flex-shrink: 0;
+  position: relative;
+  transition: background 0.3s, color 0.3s, transform 0.3s;
+}
+
+.ease-step.is-active .ease-step-indicator {
+  background: var(--ease-step-active-color);
+  color: var(--ease-step-complete-text);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--ease-step-active-color) 25%, transparent),
+              0 2px 8px color-mix(in srgb, var(--ease-step-active-color) 40%, transparent);
+}
+
+.ease-step.is-complete .ease-step-indicator {
+  background: var(--ease-step-complete-color);
+  color: var(--ease-step-complete-text);
+}
+
+.ease-step-indicator-icon {
+  --ease-icon-check: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20 6 9 17 4 12'%3E%3C/polyline%3E%3C/svg%3E");
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  vertical-align: middle;
+}
+
+.ease-step.is-complete .ease-step-number {
+  display: none;
+}
+
+.ease-step.is-complete .ease-step-indicator-icon {
+  display: inline-block;
+}
+
+.ease-step:not(.is-complete) .ease-step-indicator-icon {
+  display: none;
+}
+
+.ease-step-connector {
+  flex: 1;
+  height: var(--ease-step-connector-thickness);
+  background: var(--ease-step-color);
+  margin: 0 0.5rem;
+  position: relative;
+  transition: background 0.3s;
+}
+
+.ease-stepper-vertical .ease-step-connector {
+  width: var(--ease-step-connector-thickness);
+  height: 2rem;
+  margin: 0.25rem 0;
+  margin-left: calc(var(--ease-step-size) / 2 - var(--ease-step-connector-thickness) / 2);
+  flex: none;
+}
+
+.ease-step.is-complete + .ease-step .ease-step-connector,
+.ease-step.is-complete .ease-step-connector {
+  background: var(--ease-step-complete-color);
+}
+
+.ease-step-label {
+  margin-left: 0.5rem;
+  font-size: var(--ease-step-label-font-size);
+  color: var(--ease-step-text-color);
+  font-weight: 400;
+  white-space: nowrap;
+}
+
+.ease-stepper-vertical .ease-step-label {
+  margin-left: 0.75rem;
+  white-space: normal;
+}
+
+.ease-step.is-active .ease-step-label {
+  color: var(--ease-step-active-text);
+  font-weight: 600;
+}
+
+.ease-step.is-complete .ease-step-label {
+  color: var(--ease-step-complete-color);
+}
+
+.ease-stepper-clickable .ease-step {
+  cursor: pointer;
+}
+
+.ease-stepper-clickable .ease-step:hover .ease-step-indicator {
+  transform: scale(1.1);
+}
+
+.ease-stepper-numbers .ease-step-number {
+  font-variant-numeric: tabular-nums;
+}
+
+.ease-stepper-sm {
+  --ease-step-size: 1.75rem;
+  --ease-step-font-size: 0.75rem;
+  --ease-step-label-font-size: 0.75rem;
+}
+
+.ease-stepper-lg {
+  --ease-step-size: 3rem;
+  --ease-step-font-size: 1rem;
+  --ease-step-label-font-size: 1rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-step-indicator,
+  .ease-stepper-clickable .ease-step:hover .ease-step-indicator {
+    transition: none;
+    transform: none;
+  }
+}
+}

--- a/submissions/docs/core_changes-issue-30312/README.md
+++ b/submissions/docs/core_changes-issue-30312/README.md
@@ -1,0 +1,20 @@
+# Dark Mode — Issue #30312
+
+CSS custom property-based dark mode with multiple activation methods.
+
+## Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-dark` | Force dark mode on container |
+| `.ease-dark-mode-auto` | Follow system `prefers-color-scheme` |
+| `.ease-theme-light` | Force light scheme (override) |
+| `.ease-theme-dark` | Force dark scheme (override) |
+| `.ease-no-theme-transition` | Disable theme transitions |
+| `.ease-theme-toggle` | Styled toggle button |
+
+## CSS Variables Exposed
+
+`--ease-bg`, `--ease-bg-secondary`, `--ease-bg-tertiary`, `--ease-text`, `--ease-text-secondary`, `--ease-text-tertiary`, `--ease-border`, `--ease-border-light`, `--ease-primary`, `--ease-primary-text`, `--ease-primary-hover`, `--ease-accent`, `--ease-surface`, `--ease-surface-hover`, `--ease-shadow`
+
+Set on `:root` with smooth transitions for seamless theme switching.

--- a/submissions/docs/core_changes-issue-30312/demo.html
+++ b/submissions/docs/core_changes-issue-30312/demo.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Dark Mode — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 800px; margin: 0 auto; padding: 2rem; background: var(--ease-bg); color: var(--ease-text); }
+section { background: var(--ease-surface); padding: 2rem; border-radius: 12px; border: 1px solid var(--ease-border); margin-bottom: 2rem; }
+h1, h2 { color: var(--ease-text); }
+.card-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; margin-top: 1rem; }
+.card { background: var(--ease-bg-secondary); padding: 1.5rem; border-radius: 8px; border: 1px solid var(--ease-border-light); }
+.card h3 { margin: 0 0 .5rem; color: var(--ease-primary); }
+.card p { margin: 0; color: var(--ease-text-secondary); }
+.btn { display: inline-block; padding: .5rem 1rem; background: var(--ease-primary); color: var(--ease-primary-text); border: none; border-radius: 6px; cursor: pointer; font-size: .9rem; }
+.btn:hover { background: var(--ease-primary-hover); }
+code { background: var(--ease-bg-tertiary); padding: .15em .4em; border-radius: 4px; }
+.toggle-bar { display: flex; align-items: center; gap: 1rem; margin-bottom: 2rem; }
+</style>
+</head>
+<body>
+
+<div class="toggle-bar">
+  <button class="ease-theme-toggle" id="themeToggle" aria-label="Toggle theme">🌙</button>
+  <span>Click to toggle dark/light mode</span>
+</div>
+
+<h1>Dark Mode Support</h1>
+
+<section>
+<h2>Cards (respond to theme)</h2>
+<div class="card-grid">
+  <div class="card">
+    <h3>Primary</h3>
+    <p>var(--ease-primary) drives accent colors</p>
+  </div>
+  <div class="card">
+    <h3>Surface</h3>
+    <p>var(--ease-surface) for elevated elements</p>
+  </div>
+  <div class="card">
+    <h3>Text</h3>
+    <p>var(--ease-text) / var(--ease-text-secondary)</p>
+  </div>
+</div>
+</section>
+
+<section>
+<h2>Theme Classes</h2>
+<p>Use <code>.ease-theme-dark</code> or <code>.ease-theme-light</code> on any container to force a scheme.</p>
+<div style="display:flex;gap:1rem;flex-wrap:wrap;margin-top:1rem">
+  <div class="ease-theme-light" style="padding:1rem;border-radius:8px;border:1px solid var(--ease-border);background:var(--ease-bg);color:var(--ease-text)">
+    <strong>.ease-theme-light</strong>
+    <p style="color:var(--ease-text-secondary);margin:.5rem 0 0">Always light</p>
+  </div>
+  <div class="ease-theme-dark" style="padding:1rem;border-radius:8px;border:1px solid var(--ease-border);background:var(--ease-bg);color:var(--ease-text)">
+    <strong>.ease-theme-dark</strong>
+    <p style="color:var(--ease-text-secondary);margin:.5rem 0 0">Always dark</p>
+  </div>
+</div>
+</section>
+
+<section>
+<h2>Auto Mode</h2>
+<p>Add <code>.ease-dark-mode-auto</code> to <code>&lt;html&gt;</code> to follow <code>prefers-color-scheme</code>.</p>
+<p>Add <code>.ease-dark</code> to force dark regardless of system preference.</p>
+</section>
+
+<script>
+const toggle = document.getElementById('themeToggle');
+toggle.addEventListener('click', () => {
+  document.documentElement.classList.toggle('ease-theme-dark');
+  toggle.textContent = document.documentElement.classList.contains('ease-theme-dark') ? '☀️' : '🌙';
+});
+</script>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30312/style.css
+++ b/submissions/docs/core_changes-issue-30312/style.css
@@ -1,0 +1,153 @@
+@layer easemotion-utilities {
+:root {
+  --ease-color-scheme: light;
+  color-scheme: var(--ease-color-scheme);
+
+  --ease-bg: #ffffff;
+  --ease-bg-secondary: #f3f4f6;
+  --ease-bg-tertiary: #e5e7eb;
+  --ease-text: #111827;
+  --ease-text-secondary: #4b5563;
+  --ease-text-tertiary: #9ca3af;
+  --ease-border: #d1d5db;
+  --ease-border-light: #e5e7eb;
+  --ease-primary: #3b82f6;
+  --ease-primary-text: #ffffff;
+  --ease-primary-hover: #2563eb;
+  --ease-accent: #8b5cf6;
+  --ease-surface: #ffffff;
+  --ease-surface-hover: #f9fafb;
+  --ease-shadow: rgba(0, 0, 0, 0.08);
+
+  --ease-theme-transition-duration: 0.3s;
+  --ease-theme-transition-timing: ease;
+
+  transition:
+    background-color var(--ease-theme-transition-duration) var(--ease-theme-transition-timing),
+    color var(--ease-theme-transition-duration) var(--ease-theme-transition-timing),
+    border-color var(--ease-theme-transition-duration) var(--ease-theme-transition-timing),
+    box-shadow var(--ease-theme-transition-duration) var(--ease-theme-transition-timing);
+}
+
+.ease-dark,
+[data-theme="dark"],
+.ease-dark-mode-auto {
+  --ease-color-scheme: dark;
+  color-scheme: dark;
+
+  --ease-bg: #0f172a;
+  --ease-bg-secondary: #1e293b;
+  --ease-bg-tertiary: #334155;
+  --ease-text: #f1f5f9;
+  --ease-text-secondary: #94a3b8;
+  --ease-text-tertiary: #64748b;
+  --ease-border: #475569;
+  --ease-border-light: #334155;
+  --ease-primary: #60a5fa;
+  --ease-primary-text: #0f172a;
+  --ease-primary-hover: #93c5fd;
+  --ease-accent: #a78bfa;
+  --ease-surface: #1e293b;
+  --ease-surface-hover: #334155;
+  --ease-shadow: rgba(0, 0, 0, 0.3);
+}
+
+@media (prefers-color-scheme: dark) {
+  .ease-dark-mode-auto {
+    --ease-color-scheme: dark;
+    color-scheme: dark;
+
+    --ease-bg: #0f172a;
+    --ease-bg-secondary: #1e293b;
+    --ease-bg-tertiary: #334155;
+    --ease-text: #f1f5f9;
+    --ease-text-secondary: #94a3b8;
+    --ease-text-tertiary: #64748b;
+    --ease-border: #475569;
+    --ease-border-light: #334155;
+    --ease-primary: #60a5fa;
+    --ease-primary-text: #0f172a;
+    --ease-primary-hover: #93c5fd;
+    --ease-accent: #a78bfa;
+    --ease-surface: #1e293b;
+    --ease-surface-hover: #334155;
+    --ease-shadow: rgba(0, 0, 0, 0.3);
+  }
+}
+
+.ease-theme-light {
+  --ease-color-scheme: light;
+  color-scheme: light;
+
+  --ease-bg: #ffffff;
+  --ease-bg-secondary: #f3f4f6;
+  --ease-bg-tertiary: #e5e7eb;
+  --ease-text: #111827;
+  --ease-text-secondary: #4b5563;
+  --ease-text-tertiary: #9ca3af;
+  --ease-border: #d1d5db;
+  --ease-border-light: #e5e7eb;
+  --ease-primary: #3b82f6;
+  --ease-primary-text: #ffffff;
+  --ease-primary-hover: #2563eb;
+  --ease-accent: #8b5cf6;
+  --ease-surface: #ffffff;
+  --ease-surface-hover: #f9fafb;
+  --ease-shadow: rgba(0, 0, 0, 0.08);
+}
+
+.ease-theme-dark {
+  --ease-color-scheme: dark;
+  color-scheme: dark;
+
+  --ease-bg: #0f172a;
+  --ease-bg-secondary: #1e293b;
+  --ease-bg-tertiary: #334155;
+  --ease-text: #f1f5f9;
+  --ease-text-secondary: #94a3b8;
+  --ease-text-tertiary: #64748b;
+  --ease-border: #475569;
+  --ease-border-light: #334155;
+  --ease-primary: #60a5fa;
+  --ease-primary-text: #0f172a;
+  --ease-primary-hover: #93c5fd;
+  --ease-accent: #a78bfa;
+  --ease-surface: #1e293b;
+  --ease-surface-hover: #334155;
+  --ease-shadow: rgba(0, 0, 0, 0.3);
+}
+
+.ease-no-theme-transition,
+.ease-no-theme-transition * {
+  transition: none !important;
+}
+
+.ease-theme-toggle {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 9999px;
+  border: 1px solid var(--ease-border);
+  background: var(--ease-surface);
+  color: var(--ease-text);
+  font-size: 1.25rem;
+  transition: background var(--ease-theme-transition-duration) var(--ease-theme-transition-timing),
+              color var(--ease-theme-transition-duration) var(--ease-theme-transition-timing),
+              border-color var(--ease-theme-transition-duration) var(--ease-theme-transition-timing);
+}
+
+.ease-theme-toggle:hover {
+  background: var(--ease-surface-hover);
+  border-color: var(--ease-primary);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root,
+  .ease-theme-toggle {
+    transition: none !important;
+  }
+}
+}


### PR DESCRIPTION
### Description
Add dark mode support via CSS custom properties with multiple activation methods.

### Root Cause
EaseMotion CSS was missing theme support, making it unusable in dark environments.

### Changes Made
- :root default light theme variables (--ease-bg, --ease-text, --ease-primary, etc.)
- .ease-dark / .ease-theme-dark for forced dark mode
- .ease-theme-light for forced light mode
- .ease-dark-mode-auto for prefers-color-scheme detection
- .ease-theme-toggle styled toggle button
- .ease-no-theme-transition utility
- Smooth transitions on theme change
- prefers-reduced-motion override

Fixes #30312