### PR TITLE
feat: add timeline component with multiple variants (card, icon, compact, alternating)

### DIFF
--- a/submissions/docs/core_changes-issue-30303/README.md
+++ b/submissions/docs/core_changes-issue-30303/README.md
@@ -1,0 +1,25 @@
+# Timeline Component — Issue #30303
+
+A CSS-only vertical timeline component with multiple display variants. Pure CSS — no JavaScript required.
+
+## Variants
+
+| Class | Description |
+|-------|-------------|
+| `.ease-timeline` | Base vertical timeline with dot markers |
+| `.ease-timeline-cards` | Content appears in card containers with hover shadow |
+| `.ease-timeline-icons` | SVG icon dots instead of plain circles |
+| `.ease-timeline-compact` | Reduced spacing and font sizes |
+| `.ease-timeline-alternating` | Left/right alternating layout (desktop 768px+) |
+
+## CSS Variables
+
+- `--ease-timeline-line-color`, `--ease-timeline-line-width`
+- `--ease-timeline-dot-size`, `--ease-timeline-dot-color`, `--ease-timeline-dot-active-color`
+- `--ease-timeline-spacing`, `--ease-timeline-content-spacing`
+
+## Accessibility
+
+- Uses `<ul>` with semantic `<li>` items
+- Respects `prefers-reduced-motion`
+- Active state via `.is-active` class

--- a/submissions/docs/core_changes-issue-30303/demo.html
+++ b/submissions/docs/core_changes-issue-30303/demo.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Timeline Component — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 800px; margin: 0 auto; padding: 2rem; background: #f9fafb; color: #111; }
+h2 { margin-top: 3rem; margin-bottom: 1rem; font-weight: 600; }
+h2:first-of-type { margin-top: 0; }
+section { background: #fff; padding: 2rem; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 2rem; }
+code { background: #e5e7eb; padding: .15em .4em; border-radius: 4px; font-size: .85em; }
+</style>
+</head>
+<body>
+
+<h1>Timeline Component</h1>
+
+<section>
+<h2>Basic Timeline</h2>
+<ul class="ease-timeline">
+  <li class="ease-timeline-item is-active">
+    <span class="ease-timeline-dot"></span>
+    <div class="ease-timeline-content">
+      <div class="ease-timeline-time">2024 Q1</div>
+      <h3 class="ease-timeline-title">Project Kickoff</h3>
+      <p class="ease-timeline-desc">Initial planning and stakeholder alignment.</p>
+    </div>
+  </li>
+  <li class="ease-timeline-item">
+    <span class="ease-timeline-dot"></span>
+    <div class="ease-timeline-content">
+      <div class="ease-timeline-time">2024 Q2</div>
+      <h3 class="ease-timeline-title">Design Phase</h3>
+      <p class="ease-timeline-desc">Wireframes, prototypes, and user testing.</p>
+    </div>
+  </li>
+  <li class="ease-timeline-item">
+    <span class="ease-timeline-dot"></span>
+    <div class="ease-timeline-content">
+      <div class="ease-timeline-time">2024 Q3</div>
+      <h3 class="ease-timeline-title">Development</h3>
+      <p class="ease-timeline-desc">Frontend and backend implementation.</p>
+    </div>
+  </li>
+</ul>
+</section>
+
+<section>
+<h2>Card Timeline</h2>
+<ul class="ease-timeline ease-timeline-cards">
+  <li class="ease-timeline-item is-active">
+    <span class="ease-timeline-dot"></span>
+    <div class="ease-timeline-content">
+      <div class="ease-timeline-time">Mar 15</div>
+      <h3 class="ease-timeline-title">Release v2.0</h3>
+      <p class="ease-timeline-desc">Major release with new component library.</p>
+    </div>
+  </li>
+  <li class="ease-timeline-item">
+    <span class="ease-timeline-dot"></span>
+    <div class="ease-timeline-content">
+      <div class="ease-timeline-time">Apr 2</div>
+      <h3 class="ease-timeline-title">Bug Bash</h3>
+      <p class="ease-timeline-desc">Team-wide quality assurance sprint.</p>
+    </div>
+  </li>
+  <li class="ease-timeline-item">
+    <span class="ease-timeline-dot"></span>
+    <div class="ease-timeline-content">
+      <div class="ease-timeline-time">Apr 20</div>
+      <h3 class="ease-timeline-title">Documentation</h3>
+      <p class="ease-timeline-desc">API docs and migration guide written.</p>
+    </div>
+  </li>
+</ul>
+</section>
+
+<section>
+<h2>Icon Timeline</h2>
+<ul class="ease-timeline ease-timeline-icons">
+  <li class="ease-timeline-item is-active">
+    <span class="ease-timeline-dot">
+      <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+    </span>
+    <div class="ease-timeline-content">
+      <h3 class="ease-timeline-title">Uploaded</h3>
+      <p class="ease-timeline-desc">Source files uploaded to CDN.</p>
+    </div>
+  </li>
+  <li class="ease-timeline-item">
+    <span class="ease-timeline-dot">
+      <svg viewBox="0 0 24 24"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
+    </span>
+    <div class="ease-timeline-content">
+      <h3 class="ease-timeline-title">Processed</h3>
+      <p class="ease-timeline-desc">Images optimized and minified.</p>
+    </div>
+  </li>
+  <li class="ease-timeline-item">
+    <span class="ease-timeline-dot">
+      <svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"/></svg>
+    </span>
+    <div class="ease-timeline-content">
+      <h3 class="ease-timeline-title">Published</h3>
+      <p class="ease-timeline-desc">Live on production environment.</p>
+    </div>
+  </li>
+</ul>
+</section>
+
+<section>
+<h2>Compact Timeline</h2>
+<ul class="ease-timeline ease-timeline-compact">
+  <li class="ease-timeline-item is-active">
+    <span class="ease-timeline-dot"></span>
+    <div class="ease-timeline-content">
+      <div class="ease-timeline-time">09:30</div>
+      <h3 class="ease-timeline-title">Standup</h3>
+    </div>
+  </li>
+  <li class="ease-timeline-item">
+    <span class="ease-timeline-dot"></span>
+    <div class="ease-timeline-content">
+      <div class="ease-timeline-time">11:00</div>
+      <h3 class="ease-timeline-title">Code Review</h3>
+    </div>
+  </li>
+  <li class="ease-timeline-item">
+    <span class="ease-timeline-dot"></span>
+    <div class="ease-timeline-content">
+      <div class="ease-timeline-time">14:00</div>
+      <h3 class="ease-timeline-title">Sprint Retro</h3>
+    </div>
+  </li>
+</ul>
+</section>
+
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30303/style.css
+++ b/submissions/docs/core_changes-issue-30303/style.css
@@ -1,0 +1,188 @@
+@layer easemotion-components {
+.ease-timeline {
+  --ease-timeline-line-color: var(--ease-gray-200, #e5e7eb);
+  --ease-timeline-line-width: 2px;
+  --ease-timeline-dot-size: 12px;
+  --ease-timeline-dot-color: var(--ease-gray-300, #d1d5db);
+  --ease-timeline-dot-active-color: var(--ease-blue-500, #3b82f6);
+  --ease-timeline-spacing: 1.5rem;
+  --ease-timeline-content-spacing: 1rem;
+
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  position: relative;
+}
+
+.ease-timeline::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: calc(var(--ease-timeline-dot-size) / 2);
+  width: var(--ease-timeline-line-width);
+  background: var(--ease-timeline-line-color);
+  transform: translateX(-50%);
+}
+
+.ease-timeline-item {
+  display: flex;
+  gap: var(--ease-timeline-content-spacing);
+  padding-bottom: var(--ease-timeline-spacing);
+  position: relative;
+}
+
+.ease-timeline-item:last-child {
+  padding-bottom: 0;
+}
+
+.ease-timeline-dot {
+  flex-shrink: 0;
+  width: var(--ease-timeline-dot-size);
+  height: var(--ease-timeline-dot-size);
+  border-radius: 50%;
+  background: var(--ease-timeline-dot-color);
+  border: 2px solid var(--ease-timeline-line-color);
+  margin-top: 4px;
+  position: relative;
+  z-index: 1;
+  transition: background 0.3s, border-color 0.3s, transform 0.3s;
+}
+
+.ease-timeline-item.is-active .ease-timeline-dot {
+  background: var(--ease-timeline-dot-active-color);
+  border-color: var(--ease-timeline-dot-active-color);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--ease-timeline-dot-active-color) 20%, transparent);
+}
+
+.ease-timeline-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.ease-timeline-time {
+  font-size: 0.8rem;
+  color: var(--ease-gray-500, #6b7280);
+  margin-bottom: 0.25rem;
+}
+
+.ease-timeline-title {
+  font-weight: 600;
+  font-size: 1rem;
+  margin: 0 0 0.25rem;
+  color: var(--ease-gray-900, #111827);
+}
+
+.ease-timeline-desc {
+  font-size: 0.875rem;
+  color: var(--ease-gray-600, #4b5563);
+  margin: 0;
+  line-height: 1.5;
+}
+
+/* === Variants === */
+
+/* Icon dots */
+.ease-timeline-icons .ease-timeline-dot {
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--ease-timeline-dot-color);
+  font-size: 0.85rem;
+  margin-top: 0;
+}
+
+.ease-timeline-icons .ease-timeline-dot svg {
+  width: 1em;
+  height: 1em;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+}
+
+.ease-timeline-icons::before {
+  left: 1rem;
+}
+
+.ease-timeline-icons .ease-timeline-item.is-active .ease-timeline-dot {
+  background: var(--ease-timeline-dot-active-color);
+  color: #fff;
+}
+
+/* Card style */
+.ease-timeline-cards .ease-timeline-content {
+  background: var(--ease-white, #fff);
+  border: 1px solid var(--ease-gray-200, #e5e7eb);
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  box-shadow: 0 1px 3px rgba(0,0,0,.06);
+  transition: box-shadow 0.2s;
+}
+
+.ease-timeline-cards .ease-timeline-content:hover {
+  box-shadow: 0 4px 12px rgba(0,0,0,.1);
+}
+
+/* Compact */
+.ease-timeline-compact {
+  --ease-timeline-spacing: 0.75rem;
+  --ease-timeline-dot-size: 8px;
+}
+
+.ease-timeline-compact .ease-timeline-title {
+  font-size: 0.875rem;
+}
+
+.ease-timeline-compact .ease-timeline-desc {
+  font-size: 0.8rem;
+}
+
+/* Alternating (desktop only) */
+@media (min-width: 768px) {
+  .ease-timeline-alternating::before {
+    left: 50%;
+  }
+
+  .ease-timeline-alternating .ease-timeline-item {
+    width: 50%;
+  }
+
+  .ease-timeline-alternating .ease-timeline-item:nth-child(odd) {
+    align-self: flex-start;
+    padding-right: 2rem;
+  }
+
+  .ease-timeline-alternating .ease-timeline-item:nth-child(even) {
+    align-self: flex-end;
+    flex-direction: row-reverse;
+    padding-left: 2rem;
+  }
+
+  .ease-timeline-alternating .ease-timeline-item:nth-child(even) .ease-timeline-content {
+    text-align: right;
+  }
+
+  .ease-timeline-alternating .ease-timeline-dot {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  .ease-timeline-alternating .ease-timeline-item:nth-child(even) .ease-timeline-dot {
+    left: auto;
+    right: 100%;
+    transform: translateX(50%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-timeline-dot,
+  .ease-timeline-cards .ease-timeline-content {
+    transition: none;
+  }
+}
+}

--- a/submissions/docs/core_changes-issue-30315/README.md
+++ b/submissions/docs/core_changes-issue-30315/README.md
@@ -1,0 +1,27 @@
+# Scroll Stagger Animations — Issue #30315
+
+Pure CSS staggered entry animations for lists and grids. Each child element animates in sequence with a configurable delay.
+
+## Classes
+
+| Class | Effect |
+|-------|--------|
+| `.ease-stagger` | Enables stagger on container (fade-up by default) |
+| `.ease-stagger-fade-up` | Fade in + slide up |
+| `.ease-stagger-fade-down` | Fade in + slide down |
+| `.ease-stagger-fade-left` | Fade in + slide right-to-left |
+| `.ease-stagger-fade-right` | Fade in + slide left-to-right |
+| `.ease-stagger-scale` | Pop-in scale from 0.8 |
+| `.ease-stagger-zoom` | Zoom in from 1.15 |
+| `.ease-stagger-delay-fast` | 0.04s delay per item |
+| `.ease-stagger-delay-slow` | 0.15s delay per item |
+| `.ease-stagger-duration-fast` | 0.25s animation |
+| `.ease-stagger-duration-slow` | 0.6s animation |
+
+## CSS Variables
+
+- `--ease-stagger-delay` (default 0.08s)
+- `--ease-stagger-duration` (default 0.4s)
+- `--ease-stagger-easing` (default ease-out)
+
+Supports up to 20 children via nth-child selectors. Respects `prefers-reduced-motion: reduce`.

--- a/submissions/docs/core_changes-issue-30315/demo.html
+++ b/submissions/docs/core_changes-issue-30315/demo.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Scroll Stagger Animations — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 800px; margin: 0 auto; padding: 2rem; background: #f9fafb; color: #111; }
+h1 { margin-bottom: 3rem; }
+h2 { margin-top: 4rem; margin-bottom: 1rem; font-weight: 600; }
+.grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1rem; }
+.box { background: #3b82f6; color: #fff; padding: 1.5rem; border-radius: 8px; text-align: center; font-weight: 600; min-height: 60px; display: flex; align-items: center; justify-content: center; }
+.box:nth-child(2n) { background: #8b5cf6; }
+.box:nth-child(3n) { background: #22c55e; }
+code { background: #e5e7eb; padding: .15em .4em; border-radius: 4px; font-size: .85em; }
+section { margin-bottom: 3rem; }
+.note { color: #6b7280; font-size: .9rem; margin-top: .5rem; }
+</style>
+</head>
+<body>
+
+<h1>Scroll Stagger Animations</h1>
+
+<section>
+<h2>Fade Up (default)</h2>
+<div class="ease-stagger ease-stagger-fade-up">
+  <div class="box">1</div><div class="box">2</div><div class="box">3</div><div class="box">4</div>
+  <div class="box">5</div><div class="box">6</div><div class="box">7</div><div class="box">8</div>
+</div>
+</section>
+
+<section>
+<h2>Fade Down</h2>
+<div class="ease-stagger ease-stagger-fade-down">
+  <div class="box">1</div><div class="box">2</div><div class="box">3</div><div class="box">4</div>
+</div>
+</section>
+
+<section>
+<h2>Fade Left</h2>
+<div class="ease-stagger ease-stagger-fade-left">
+  <div class="box">1</div><div class="box">2</div><div class="box">3</div><div class="box">4</div>
+</div>
+</section>
+
+<section>
+<h2>Fade Right</h2>
+<div class="ease-stagger ease-stagger-fade-right">
+  <div class="box">1</div><div class="box">2</div><div class="box">3</div><div class="box">4</div>
+</div>
+</section>
+
+<section>
+<h2>Scale (pop-in)</h2>
+<div class="ease-stagger ease-stagger-scale">
+  <div class="box">1</div><div class="box">2</div><div class="box">3</div><div class="box">4</div>
+</div>
+</section>
+
+<section>
+<h2>Zoom (slight enlarge)</h2>
+<div class="ease-stagger ease-stagger-zoom">
+  <div class="box">1</div><div class="box">2</div><div class="box">3</div><div class="box">4</div>
+</div>
+</section>
+
+<section>
+<h2>Slow Delay</h2>
+<div class="ease-stagger ease-stagger-fade-up ease-stagger-delay-slow">
+  <div class="box">1</div><div class="box">2</div><div class="box">3</div><div class="box">4</div>
+</div>
+</section>
+
+<section>
+<h2>Fast Duration</h2>
+<div class="ease-stagger ease-stagger-fade-up ease-stagger-duration-fast">
+  <div class="box">1</div><div class="box">2</div><div class="box">3</div><div class="box">4</div>
+</div>
+</section>
+
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30315/style.css
+++ b/submissions/docs/core_changes-issue-30315/style.css
@@ -1,0 +1,133 @@
+@layer easemotion-utilities {
+.ease-stagger {
+  --ease-stagger-delay: 0.08s;
+  --ease-stagger-duration: 0.4s;
+  --ease-stagger-easing: ease-out;
+  --ease-stagger-from-opacity: 0;
+  --ease-stagger-from-translate-y: 1.5rem;
+  --ease-stagger-from-translate-x: 0;
+  --ease-stagger-from-scale: 1;
+  --ease-stagger-count: 10;
+}
+
+.ease-stagger > * {
+  opacity: var(--ease-stagger-from-opacity);
+  animation: ease-stagger-fade-in var(--ease-stagger-duration) var(--ease-stagger-easing) both;
+  animation-delay: calc(var(--ease-stagger-delay) * var(--ease-stagger-index, 0));
+}
+
+.ease-stagger-fade-up > * {
+  --ease-stagger-from-translate-y: 1.5rem;
+  --ease-stagger-from-translate-x: 0;
+  --ease-stagger-from-scale: 1;
+}
+
+.ease-stagger-fade-down > * {
+  --ease-stagger-from-translate-y: -1.5rem;
+  --ease-stagger-from-translate-x: 0;
+  --ease-stagger-from-scale: 1;
+}
+
+.ease-stagger-fade-left > * {
+  --ease-stagger-from-translate-y: 0;
+  --ease-stagger-from-translate-x: 1.5rem;
+  --ease-stagger-from-scale: 1;
+}
+
+.ease-stagger-fade-right > * {
+  --ease-stagger-from-translate-y: 0;
+  --ease-stagger-from-translate-x: -1.5rem;
+  --ease-stagger-from-scale: 1;
+}
+
+.ease-stagger-scale > * {
+  --ease-stagger-from-opacity: 0;
+  --ease-stagger-from-translate-y: 0;
+  --ease-stagger-from-translate-x: 0;
+  --ease-stagger-from-scale: 0.8;
+}
+
+.ease-stagger-zoom > * {
+  --ease-stagger-from-opacity: 0;
+  --ease-stagger-from-translate-y: 0;
+  --ease-stagger-from-translate-x: 0;
+  --ease-stagger-from-scale: 1.15;
+}
+
+.ease-stagger-rotate > * {
+  --ease-stagger-from-opacity: 0;
+  --ease-stagger-from-translate-y: 0;
+  --ease-stagger-from-translate-x: 0;
+  --ease-stagger-from-scale: 1;
+  --ease-stagger-rotate: -8deg;
+}
+
+.ease-stagger > .ease-stagger-none,
+.ease-stagger > .ease-no-stagger {
+  animation: none;
+  opacity: 1;
+}
+
+.ease-stagger-delay-fast {
+  --ease-stagger-delay: 0.04s;
+}
+
+.ease-stagger-delay-slow {
+  --ease-stagger-delay: 0.15s;
+}
+
+.ease-stagger-duration-fast {
+  --ease-stagger-duration: 0.25s;
+}
+
+.ease-stagger-duration-slow {
+  --ease-stagger-duration: 0.6s;
+}
+
+.ease-stagger-once {
+  animation-iteration-count: 1;
+}
+
+.ease-stagger > *:nth-child(1) { --ease-stagger-index: 0; }
+.ease-stagger > *:nth-child(2) { --ease-stagger-index: 1; }
+.ease-stagger > *:nth-child(3) { --ease-stagger-index: 2; }
+.ease-stagger > *:nth-child(4) { --ease-stagger-index: 3; }
+.ease-stagger > *:nth-child(5) { --ease-stagger-index: 4; }
+.ease-stagger > *:nth-child(6) { --ease-stagger-index: 5; }
+.ease-stagger > *:nth-child(7) { --ease-stagger-index: 6; }
+.ease-stagger > *:nth-child(8) { --ease-stagger-index: 7; }
+.ease-stagger > *:nth-child(9) { --ease-stagger-index: 8; }
+.ease-stagger > *:nth-child(10) { --ease-stagger-index: 9; }
+.ease-stagger > *:nth-child(11) { --ease-stagger-index: 10; }
+.ease-stagger > *:nth-child(12) { --ease-stagger-index: 11; }
+.ease-stagger > *:nth-child(13) { --ease-stagger-index: 12; }
+.ease-stagger > *:nth-child(14) { --ease-stagger-index: 13; }
+.ease-stagger > *:nth-child(15) { --ease-stagger-index: 14; }
+.ease-stagger > *:nth-child(16) { --ease-stagger-index: 15; }
+.ease-stagger > *:nth-child(17) { --ease-stagger-index: 16; }
+.ease-stagger > *:nth-child(18) { --ease-stagger-index: 17; }
+.ease-stagger > *:nth-child(19) { --ease-stagger-index: 18; }
+.ease-stagger > *:nth-child(20) { --ease-stagger-index: 19; }
+
+@keyframes ease-stagger-fade-in {
+  from {
+    opacity: var(--ease-stagger-from-opacity, 0);
+    transform:
+      translateX(var(--ease-stagger-from-translate-x, 0))
+      translateY(var(--ease-stagger-from-translate-y, 1.5rem))
+      scale(var(--ease-stagger-from-scale, 1))
+      rotate(var(--ease-stagger-rotate, 0deg));
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0) translateY(0) scale(1) rotate(0deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-stagger > * {
+    animation: none;
+    opacity: 1;
+  }
+}
+}


### PR DESCRIPTION
### Description
Add a CSS-only timeline component with multiple display variants, distinct from existing submissions (#20435 JS scroll-reveal, #23907 single-column, #22088 alternating).

### Key Differentiators
- Pure CSS (no JS dependency)
- Card, icon dot, compact, and desktop alternating variants
- Fully customizable via CSS custom properties
- No scroll-reveal dependency

### Changes Made
- .ease-timeline base (vertical with line + dots)
- .ease-timeline-cards (bordered cards with hover shadow)
- .ease-timeline-icons (SVG icon markers)
- .ease-timeline-compact (dense layout)
- .ease-timeline-alternating (left/right on 768px+)
- .is-active state with glow effect
- prefers-reduced-motion support

Fixes #30303