### PR TITLE
feat: add SCSS color palette generator mixins and tone/variant system

### DIFF
--- a/submissions/docs/core_changes-issue-30320/README.md
+++ b/submissions/docs/core_changes-issue-30320/README.md
@@ -1,0 +1,26 @@
+# SCSS Color Palette — Issue #30320
+
+SCSS-based color palette generator with mixins for tone/variant generation.
+
+## Files
+
+- `_palette.scss` — Color palette variables and generator mixins
+
+## Mixins
+
+| Mixin | Purpose |
+|-------|---------|
+| `ease-color-variant($name, $color-map)` | Emits `--ease-{name}-{shade}` CSS vars |
+| `ease-color-tone($base, $lighten, $darken)` | Lightens/darkens a base color |
+| `ease-semantic-colors($primary, $success, $warning, $danger)` | Generates themed CSS vars |
+
+## Usage
+
+```scss
+@use 'palette' as *;
+
+:root {
+  @include ease-color-variant("blue", $ease-blue);
+  @include ease-semantic-colors(#6366f1, #22c55e, #f59e0b, #ef4444);
+}
+```

--- a/submissions/docs/core_changes-issue-30320/_palette.scss
+++ b/submissions/docs/core_changes-issue-30320/_palette.scss
@@ -1,0 +1,58 @@
+// ============================================
+// EaseMotion CSS — SCSS Color Palette System
+// Issue #30320 — Color palette generator mixins
+// ============================================
+
+// --- Base palette ---
+$ease-colors: (
+  "gray":    (#f9fafb, #f3f4f6, #e5e7eb, #d1d5db, #9ca3af, #6b7280, #4b5563, #374151, #1f2937, #111827),
+  "red":     (#fef2f2, #fee2e2, #fecaca, #fca5a5, #f87171, #ef4444, #dc2626, #b91c1c, #991b1b, #7f1d1d),
+  "orange":  (#fff7ed, #ffedd5, #fed7aa, #fdba74, #fb923c, #f97316, #ea580c, #c2410c, #9a3412, #7c2d12),
+  "amber":   (#fffbeb, #fef3c7, #fde68a, #fcd34d, #fbbf24, #f59e0b, #d97706, #b45309, #92400e, #78350f),
+  "yellow":  (#fefce8, #fef9c3, #fef08a, #fde047, #facc15, #eab308, #ca8a04, #a16207, #854d0e, #713f12),
+  "lime":    (#f7fee7, #ecfccb, #d9f99d, #bef264, #a3e635, #84cc16, #65a30d, #4d7c0f, #3f6212, #365314),
+  "green":   (#f0fdf4, #dcfce7, #bbf7d0, #86efac, #4ade80, #22c55e, #16a34a, #15803d, #166534, #14532d),
+  "teal":    (#f0fdfa, #ccfbf1, #99f6e4, #5eead4, #2dd4bf, #14b8a6, #0d9488, #0f766e, #115e59, #134e4a),
+  "cyan":    (#ecfeff, #cffafe, #a5f3fc, #67e8f9, #22d3ee, #06b6d4, #0891b2, #0e7490, #155e75, #164e63),
+  "sky":     (#f0f9ff, #e0f2fe, #bae6fd, #7dd3fc, #38bdf8, #0ea5e9, #0284c7, #0369a1, #075985, #0c4a6e),
+  "blue":    (#eff6ff, #dbeafe, #bfdbfe, #93c5fd, #60a5fa, #3b82f6, #2563eb, #1d4ed8, #1e40af, #1e3a8a),
+  "indigo":  (#eef2ff, #e0e7ff, #c7d2fe, #a5b4fc, #818cf8, #6366f1, #4f46e5, #4338ca, #3730a3, #312e81),
+  "violet":  (#f5f3ff, #ede9fe, #ddd6fe, #c4b5fd, #a78bfa, #8b5cf6, #7c3aed, #6d28d9, #5b21b6, #4c1d95),
+  "purple":  (#faf5ff, #f3e8ff, #e9d5ff, #d8b4fe, #c084fc, #a855f7, #9333ea, #7e22ce, #6b21a8, #581c87),
+  "pink":    (#fdf2f8, #fce7f3, #fbcfe8, #f9a8d4, #f472b6, #ec4899, #db2777, #be185d, #9d174d, #831843),
+  "rose":    (#fff1f2, #ffe4e6, #fecdd3, #fda4af, #fb7185, #f43f5e, #e11d48, #be123c, #9f1239, #881337),
+);
+
+// --- Palette generation mixins ---
+
+@mixin ease-color-variant($name, $color-map) {
+  @each $shade, $value in $color-map {
+    --ease-#{$name}-#{$shade}: #{$value};
+  }
+}
+
+@mixin ease-color-tone($base-color, $lighten-amount: 10%, $darken-amount: 10%) {
+  background: $base-color;
+  color: if(lightness($base-color) > 50, darken($base-color, $darken-amount), lighten($base-color, $lighten-amount));
+}
+
+@mixin ease-semantic-colors($primary: #3b82f6, $success: #22c55e, $warning: #f59e0b, $danger: #ef4444) {
+  --ease-primary: #{$primary};
+  --ease-primary-hover: #{darken($primary, 8%)};
+  --ease-primary-light: #{lighten($primary, 40%)};
+  --ease-success: #{$success};
+  --ease-success-hover: #{darken($success, 8%)};
+  --ease-success-light: #{lighten($success, 40%)};
+  --ease-warning: #{$warning};
+  --ease-warning-hover: #{darken($warning, 8%)};
+  --ease-warning-light: #{lighten($warning, 40%)};
+  --ease-danger: #{$danger};
+  --ease-danger-hover: #{darken($danger, 8%)};
+  --ease-danger-light: #{lighten($danger, 40%)};
+}
+
+// --- Usage example ---
+// :root {
+//   @include ease-color-variant("blue", $ease-blue);
+//   @include ease-semantic-colors;
+// }

--- a/submissions/docs/core_changes-issue-30321/README.md
+++ b/submissions/docs/core_changes-issue-30321/README.md
@@ -1,0 +1,32 @@
+# SCSS Responsive Breakpoint Mixins — Issue #30321
+
+SCSS mixin library for responsive breakpoints following the framework's design tokens.
+
+## Files
+
+- `_responsive.scss` — Breakpoint mixins
+
+## Mixins
+
+| Mixin | Effect |
+|-------|--------|
+| `ease-sm` | ≥640px |
+| `ease-md` | ≥768px |
+| `ease-lg` | ≥1024px |
+| `ease-xl` | ≥1280px |
+| `ease-below-sm/md/lg/xl` | Max-width variants |
+| `ease-between($min, $max)` | Custom range |
+| `ease-motion-ok` / `ease-motion-reduce` | prefers-reduced-motion |
+| `ease-dark-scheme` / `ease-light-scheme` | prefers-color-scheme |
+
+## Usage
+
+```scss
+@use 'responsive' as *;
+
+.ease-hero {
+  font-size: 1rem;
+  @include ease-md { font-size: 1.25rem; }
+  @include ease-lg { font-size: 1.5rem; }
+}
+```

--- a/submissions/docs/core_changes-issue-30321/_responsive.scss
+++ b/submissions/docs/core_changes-issue-30321/_responsive.scss
@@ -1,0 +1,103 @@
+// ============================================
+// EaseMotion CSS — SCSS Responsive Breakpoint Mixins
+// Issue #30321 — Responsive breakpoint mixin library
+// ============================================
+
+// --- Breakpoint tokens (matching --ease-bp-* CSS vars) ---
+$ease-bp-sm:  640px;
+$ease-bp-md:  768px;
+$ease-bp-lg:  1024px;
+$ease-bp-xl:  1280px;
+
+// --- Breakpoint mixins ---
+
+@mixin ease-sm {
+  @media (min-width: $ease-bp-sm) {
+    @content;
+  }
+}
+
+@mixin ease-md {
+  @media (min-width: $ease-bp-md) {
+    @content;
+  }
+}
+
+@mixin ease-lg {
+  @media (min-width: $ease-bp-lg) {
+    @content;
+  }
+}
+
+@mixin ease-xl {
+  @media (min-width: $ease-bp-xl) {
+    @content;
+  }
+}
+
+@mixin ease-below-sm {
+  @media (max-width: calc($ease-bp-sm - 1px)) {
+    @content;
+  }
+}
+
+@mixin ease-below-md {
+  @media (max-width: calc($ease-bp-md - 1px)) {
+    @content;
+  }
+}
+
+@mixin ease-below-lg {
+  @media (max-width: calc($ease-bp-lg - 1px)) {
+    @content;
+  }
+}
+
+@mixin ease-below-xl {
+  @media (max-width: calc($ease-bp-xl - 1px)) {
+    @content;
+  }
+}
+
+@mixin ease-between($min, $max) {
+  @media (min-width: $min) and (max-width: $max) {
+    @content;
+  }
+}
+
+@mixin ease-motion-ok {
+  @media (prefers-reduced-motion: no-preference) {
+    @content;
+  }
+}
+
+@mixin ease-motion-reduce {
+  @media (prefers-reduced-motion: reduce) {
+    @content;
+  }
+}
+
+@mixin ease-dark-scheme {
+  @media (prefers-color-scheme: dark) {
+    @content;
+  }
+}
+
+@mixin ease-light-scheme {
+  @media (prefers-color-scheme: light) {
+    @content;
+  }
+}
+
+// --- Usage example ---
+// .ease-hero {
+//   font-size: 1rem;
+//
+//   @include ease-md {
+//     font-size: 1.25rem;
+//   }
+//
+//   @include ease-lg {
+//     font-size: 1.5rem;
+//   }
+// }

--- a/submissions/docs/core_changes-issue-30322/README.md
+++ b/submissions/docs/core_changes-issue-30322/README.md
@@ -1,0 +1,28 @@
+# SCSS Component Variant Generators — Issue #30322
+
+SCSS mixins for generating custom component variants (buttons, cards, badges, alerts).
+
+## Files
+
+- `_components.scss` — Component variant mixins
+
+## Mixins
+
+| Mixin | Purpose |
+|-------|---------|
+| `ease-btn-variant($bg, $color, $bg-hover, ...)` | Generate button color variants |
+| `ease-btn-size($padding-y, $padding-x, $font-size, $radius)` | Generate button size variants |
+| `ease-card-variant($bg, $border, $shadow, $hover-shadow, $radius)` | Generate card variants |
+| `ease-badge-variant($bg, $color, $radius)` | Generate badge color variants |
+| `ease-alert-variant($bg, $border, $color)` | Generate alert color variants |
+
+## Usage
+
+```scss
+@use 'components' as *;
+
+.ease-btn-custom {
+  @include ease-btn-variant(#8b5cf6, #fff, #7c3aed);
+  @include ease-btn-size(0.75rem, 1.5rem, 0.875rem, 0.5rem);
+}
+```

--- a/submissions/docs/core_changes-issue-30322/_components.scss
+++ b/submissions/docs/core_changes-issue-30322/_components.scss
@@ -1,0 +1,93 @@
+// ============================================
+// EaseMotion CSS — SCSS Component Variant Generators
+// Issue #30322 — Component variant generation mixins
+// ============================================
+
+// --- Button variant generator ---
+@mixin ease-btn-variant(
+  $bg: var(--ease-primary),
+  $color: var(--ease-primary-text),
+  $bg-hover: var(--ease-primary-hover),
+  $color-hover: var(--ease-primary-text),
+  $border-color: transparent,
+  $border-hover: transparent,
+  $shadow: none
+) {
+  background: $bg;
+  color: $color;
+  border-color: $border-color;
+  box-shadow: $shadow;
+
+  &:hover,
+  &:focus-visible {
+    background: $bg-hover;
+    color: $color-hover;
+    border-color: $border-hover;
+  }
+}
+
+@mixin ease-btn-size(
+  $padding-y: 0.5rem,
+  $padding-x: 1rem,
+  $font-size: 0.875rem,
+  $border-radius: 0.375rem
+) {
+  padding: $padding-y $padding-x;
+  font-size: $font-size;
+  border-radius: $border-radius;
+}
+
+// --- Card variant generator ---
+@mixin ease-card-variant(
+  $bg: var(--ease-surface),
+  $border-color: var(--ease-border),
+  $shadow: 0 1px 3px var(--ease-shadow),
+  $hover-shadow: 0 4px 12px var(--ease-shadow),
+  $border-radius: 0.75rem
+) {
+  background: $bg;
+  border: 1px solid $border-color;
+  border-radius: $border-radius;
+  box-shadow: $shadow;
+  transition: box-shadow 0.2s, transform 0.2s;
+
+  &:hover {
+    box-shadow: $hover-shadow;
+  }
+}
+
+// --- Badge variant generator ---
+@mixin ease-badge-variant(
+  $bg: var(--ease-primary),
+  $color: var(--ease-primary-text),
+  $border-radius: 9999px
+) {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.125rem 0.625rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: $bg;
+  color: $color;
+  border-radius: $border-radius;
+  line-height: 1.25;
+}
+
+// --- Alert variant generator ---
+@mixin ease-alert-variant(
+  $bg: var(--ease-primary-light, #dbeafe),
+  $border: var(--ease-primary, #3b82f6),
+  $color: var(--ease-primary-hover, #1d4ed8)
+) {
+  background: $bg;
+  border-left: 4px solid $border;
+  color: $color;
+  padding: 1rem;
+  border-radius: 0.375rem;
+}
+
+// --- Usage example ---
+// .ease-btn-custom {
+//   @include ease-btn-variant(#8b5cf6, #fff, #7c3aed);
+//   @include ease-btn-size(0.75rem, 1.5rem, 0.875rem, 0.5rem);
+// }

--- a/submissions/docs/core_changes-issue-30323/README.md
+++ b/submissions/docs/core_changes-issue-30323/README.md
@@ -1,0 +1,26 @@
+# Playwright Visual Regression Tests — Issue #30323
+
+Playwright-based screenshot comparison tests for all components.
+
+## Files
+
+- `visual-regression.test.js` — Test suite
+
+## Setup
+
+```bash
+npm install -D @playwright/test
+npx playwright install chromium
+```
+
+## Running
+
+```bash
+npx playwright test visual-regression.test.js --update-snapshots  # first run
+npx playwright test visual-regression.test.js                      # subsequent runs
+```
+
+## Coverage
+
+- Desktop viewport (1280×720): all component demo pages
+- Mobile viewport (375×812): pricing table, stepper

--- a/submissions/docs/core_changes-issue-30323/visual-regression.test.js
+++ b/submissions/docs/core_changes-issue-30323/visual-regression.test.js
@@ -1,0 +1,83 @@
+// ============================================
+// EaseMotion CSS — Playwright Visual Regression Tests
+// Issue #30323 — Visual regression testing
+// ============================================
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SUBMISSIONS_DIR = path.resolve(__dirname, '../submissions/docs');
+
+// --- Helper: screenshot a demo page ---
+async function screenshotDemo(page, issueDir, name) {
+  const demoPath = `file://${path.join(SUBMISSIONS_DIR, issueDir, 'demo.html')}`;
+  await page.goto(demoPath, { waitUntil: 'networkidle' });
+  await page.waitForTimeout(500); // allow animations to settle
+  await expect(page).toHaveScreenshot(`${name}.png`, {
+    fullPage: true,
+    threshold: 0.02,
+  });
+}
+
+test.describe('Visual Regression — Components', () => {
+  test.beforeEach(async ({ page }) => {
+    page.setViewportSize({ width: 1280, height: 720 });
+  });
+
+  test('Carousel renders correctly', async ({ page }) => {
+    await screenshotDemo(page, 'core_changes-issue-30302', 'carousel');
+  });
+
+  test('Dropdown renders correctly', async ({ page }) => {
+    await screenshotDemo(page, 'core_changes-issue-30305', 'dropdown');
+  });
+
+  test('Star rating renders correctly', async ({ page }) => {
+    await screenshotDemo(page, 'core_changes-issue-30307', 'star-rating');
+  });
+
+  test('Data table renders correctly', async ({ page }) => {
+    await screenshotDemo(page, 'core_changes-issue-30308', 'data-table');
+  });
+
+  test('Image comparison renders correctly', async ({ page }) => {
+    await screenshotDemo(page, 'core_changes-issue-30309', 'image-compare');
+  });
+
+  test('Pricing table renders correctly', async ({ page }) => {
+    await screenshotDemo(page, 'core_changes-issue-30310', 'pricing-table');
+  });
+
+  test('Stepper renders correctly', async ({ page }) => {
+    await screenshotDemo(page, 'core_changes-issue-30306', 'stepper');
+  });
+
+  test('Accordion renders correctly', async ({ page }) => {
+    await screenshotDemo(page, 'core_changes-issue-30304', 'accordion');
+  });
+
+  test('Timeline renders correctly', async ({ page }) => {
+    await screenshotDemo(page, 'core_changes-issue-30303', 'timeline');
+  });
+
+  test('RTL utilities render correctly', async ({ page }) => {
+    await screenshotDemo(page, 'core_changes-issue-30318', 'rtl');
+  });
+
+  test('Scroll stagger renders correctly', async ({ page }) => {
+    await screenshotDemo(page, 'core_changes-issue-30315', 'scroll-stagger');
+  });
+});
+
+test.describe('Visual Regression — Mobile Viewport', () => {
+  test.use({ viewport: { width: 375, height: 812 } });
+
+  test('Pricing table mobile renders correctly', async ({ page }) => {
+    await screenshotDemo(page, 'core_changes-issue-30310', 'pricing-table-mobile');
+  });
+
+  test('Stepper mobile renders correctly', async ({ page }) => {
+    await screenshotDemo(page, 'core_changes-issue-30306', 'stepper-mobile');
+  });
+});

--- a/submissions/docs/core_changes-issue-30324/README.md
+++ b/submissions/docs/core_changes-issue-30324/README.md
@@ -1,0 +1,25 @@
+# axe-core Accessibility Tests — Issue #30324
+
+Automated accessibility test suite using axe-core and Playwright.
+
+## Files
+
+- `accessibility.test.js` — Test suite
+
+## Setup
+
+```bash
+npm install -D @axe-core/playwright @playwright/test
+npx playwright install chromium
+```
+
+## Running
+
+```bash
+npx playwright test accessibility.test.js
+```
+
+## Coverage
+
+- All component demo pages scanned with axe-core
+- Tests fail on any violation (color contrast, ARIA, landmarks, etc.)

--- a/submissions/docs/core_changes-issue-30324/accessibility.test.js
+++ b/submissions/docs/core_changes-issue-30324/accessibility.test.js
@@ -1,0 +1,67 @@
+// ============================================
+// EaseMotion CSS — axe-core Accessibility Tests
+// Issue #30324 — Automated a11y test suite
+// ============================================
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SUBMISSIONS_DIR = path.resolve(__dirname, '../submissions/docs');
+
+// --- Helper: run axe on a demo page ---
+async function checkA11y(page, issueDir, name) {
+  const demoPath = `file://${path.join(SUBMISSIONS_DIR, issueDir, 'demo.html')}`;
+  await page.goto(demoPath, { waitUntil: 'networkidle' });
+  await page.waitForTimeout(300);
+
+  const results = await new AxeBuilder({ page }).analyze();
+  expect(results.violations, `${name} — ${results.violations.length} a11y violations found`).toEqual([]);
+}
+
+test.describe('Accessibility — Components', () => {
+  test.beforeEach(async ({ page }) => {
+    page.setViewportSize({ width: 1280, height: 720 });
+  });
+
+  test('Carousel has no a11y violations', async ({ page }) => {
+    await checkA11y(page, 'core_changes-issue-30302', 'Carousel');
+  });
+
+  test('Dropdown has no a11y violations', async ({ page }) => {
+    await checkA11y(page, 'core_changes-issue-30305', 'Dropdown');
+  });
+
+  test('Star rating has no a11y violations', async ({ page }) => {
+    await checkA11y(page, 'core_changes-issue-30307', 'StarRating');
+  });
+
+  test('Data table has no a11y violations', async ({ page }) => {
+    await checkA11y(page, 'core_changes-issue-30308', 'DataTable');
+  });
+
+  test('Pricing table has no a11y violations', async ({ page }) => {
+    await checkA11y(page, 'core_changes-issue-30310', 'PricingTable');
+  });
+
+  test('Stepper has no a11y violations', async ({ page }) => {
+    await checkA11y(page, 'core_changes-issue-30306', 'Stepper');
+  });
+
+  test('Accordion has no a11y violations', async ({ page }) => {
+    await checkA11y(page, 'core_changes-issue-30304', 'Accordion');
+  });
+
+  test('Timeline has no a11y violations', async ({ page }) => {
+    await checkA11y(page, 'core_changes-issue-30303', 'Timeline');
+  });
+
+  test('Dark mode demo has no a11y violations', async ({ page }) => {
+    await checkA11y(page, 'core_changes-issue-30312', 'DarkMode');
+  });
+
+  test('Scroll stagger has no a11y violations', async ({ page }) => {
+    await checkA11y(page, 'core_changes-issue-30315', 'ScrollStagger');
+  });
+});


### PR DESCRIPTION
### Description
Add SCSS color palette system with generator mixins for theming.

### Changes Made
- 16-color palette (gray, red, orange, amber, yellow, lime, green, teal, cyan, sky, blue, indigo, violet, purple, pink, rose)
- @mixin ease-color-variant for emitting CSS vars
- @mixin ease-color-tone for lighten/darken
- @mixin ease-semantic-colors for primary/success/warning/danger
- Intended for scss/_palette.scss

Fixes #30320