### PR TITLE
feat: add progress bar component with animated fill, color variants, and striped styles

### DIFF
--- a/submissions/docs/core_changes-issue-30379/README.md
+++ b/submissions/docs/core_changes-issue-30379/README.md
@@ -1,0 +1,23 @@
+# Bottom Navigation / Mobile Tab Bar — Issue #30379
+
+Fixed bottom navigation bar for mobile-first layouts with safe area support.
+
+## Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-bottom-nav` | Fixed bottom nav container |
+| `.ease-bottom-nav-item` | Individual tab button |
+| `.ease-bottom-nav-icon` | Icon area |
+| `.ease-bottom-nav-label` | Text label |
+| `.ease-bottom-nav-badge` | Notification badge |
+| `.ease-bottom-nav-icons-only` | Hides labels |
+| `.is-active` | Active tab state (accent bar) |
+
+## CSS Variables
+
+- `--ease-bottom-nav-bg`, `--ease-bottom-nav-color`, `--ease-bottom-nav-active`
+- `--ease-bottom-nav-height`, `--ease-bottom-nav-font-size`, `--ease-bottom-nav-icon-size`
+- `--ease-bottom-nav-border`
+
+Uses `env(safe-area-inset-*)` for notched phones. Dark mode supported.

--- a/submissions/docs/core_changes-issue-30379/demo.html
+++ b/submissions/docs/core_changes-issue-30379/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>Bottom Nav — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 500px; margin: 0 auto; padding: 2rem 2rem 6rem; background: #f9fafb; color: #111; }
+h1 { margin-bottom: .5rem; }
+section { background: #fff; padding: 1.5rem; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 1.5rem; }
+code { background: #e5e7eb; padding: .15em .4em; border-radius: 4px; font-size: .85em; }
+.btn { padding: .5rem 1rem; border: 1px solid #d1d5db; border-radius: 6px; cursor: pointer; font-size: .875rem; background: #fff; }
+.btn:hover { background: #f3f4f6; }
+.toggle-group { display: flex; gap: .5rem; margin-bottom: 1.5rem; }
+</style>
+</head>
+<body>
+
+<h1>Bottom Navigation</h1>
+
+<div class="toggle-group">
+  <button class="btn" onclick="toggleIcons()">Toggle Icons Only</button>
+  <button class="btn" onclick="setActive(event)">Set Active: Random</button>
+</div>
+
+<nav class="ease-bottom-nav" id="bottomNav">
+  <button class="ease-bottom-nav-item is-active" data-key="home">
+    <span class="ease-bottom-nav-icon">
+      <svg viewBox="0 0 24 24"><path d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/></svg>
+    </span>
+    <span class="ease-bottom-nav-label">Home</span>
+  </button>
+  <button class="ease-bottom-nav-item" data-key="search">
+    <span class="ease-bottom-nav-icon">
+      <svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
+    </span>
+    <span class="ease-bottom-nav-label">Search</span>
+  </button>
+  <button class="ease-bottom-nav-item" data-key="cart">
+    <span class="ease-bottom-nav-icon">
+      <svg viewBox="0 0 24 24"><path d="M6 2L3 6v14a2 2 0 002 2h14a2 2 0 002-2V6l-3-4z"/><line x1="3" y1="6" x2="21" y2="6"/><path d="M16 10a4 4 0 01-8 0"/></svg>
+    </span>
+    <span class="ease-bottom-nav-label">Cart</span>
+    <span class="ease-bottom-nav-badge">3</span>
+  </button>
+  <button class="ease-bottom-nav-item" data-key="profile">
+    <span class="ease-bottom-nav-icon">
+      <svg viewBox="0 0 24 24"><path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+    </span>
+    <span class="ease-bottom-nav-label">Profile</span>
+  </button>
+</nav>
+
+<script>
+function toggleIcons() {
+  document.getElementById('bottomNav').classList.toggle('ease-bottom-nav-icons-only');
+}
+function setActive(e) {
+  const items = document.querySelectorAll('.ease-bottom-nav-item');
+  items.forEach(i => i.classList.remove('is-active'));
+  const idx = Math.floor(Math.random() * items.length);
+  items[idx].classList.add('is-active');
+}
+</script>
+
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30379/style.css
+++ b/submissions/docs/core_changes-issue-30379/style.css
@@ -1,0 +1,125 @@
+@layer easemotion-components {
+.ease-bottom-nav {
+  --ease-bottom-nav-bg: var(--ease-surface, #ffffff);
+  --ease-bottom-nav-color: var(--ease-text-secondary, #4b5563);
+  --ease-bottom-nav-active: var(--ease-primary, #3b82f6);
+  --ease-bottom-nav-height: 3.5rem;
+  --ease-bottom-nav-font-size: 0.7rem;
+  --ease-bottom-nav-icon-size: 1.25rem;
+  --ease-bottom-nav-border: var(--ease-border-light, #e5e7eb);
+
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  height: var(--ease-bottom-nav-height);
+  background: var(--ease-bottom-nav-bg);
+  border-top: 1px solid var(--ease-bottom-nav-border);
+  padding: 0 env(safe-area-inset-right, 0) env(safe-area-inset-bottom, 0) env(safe-area-inset-left, 0);
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+}
+
+.ease-bottom-nav-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.125rem;
+  flex: 1;
+  height: 100%;
+  color: var(--ease-bottom-nav-color);
+  text-decoration: none;
+  cursor: pointer;
+  font-size: var(--ease-bottom-nav-font-size);
+  border: none;
+  background: none;
+  padding: 0.25rem 0.5rem;
+  position: relative;
+  transition: color 0.2s;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.ease-bottom-nav-item:hover {
+  color: var(--ease-bottom-nav-active);
+}
+
+.ease-bottom-nav-item.is-active {
+  color: var(--ease-bottom-nav-active);
+}
+
+.ease-bottom-nav-item.is-active::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 1.5rem;
+  height: 2px;
+  background: var(--ease-bottom-nav-active);
+  border-radius: 0 0 2px 2px;
+}
+
+.ease-bottom-nav-icon {
+  width: var(--ease-bottom-nav-icon-size);
+  height: var(--ease-bottom-nav-icon-size);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--ease-bottom-nav-icon-size);
+  line-height: 1;
+}
+
+.ease-bottom-nav-icon svg {
+  width: 100%;
+  height: 100%;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.ease-bottom-nav-label {
+  line-height: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.ease-bottom-nav-badge {
+  position: absolute;
+  top: 0.25rem;
+  right: 50%;
+  transform: translateX(calc(50% + var(--ease-bottom-nav-icon-size) / 2));
+  min-width: 1rem;
+  height: 1rem;
+  padding: 0 0.25rem;
+  font-size: 0.6rem;
+  font-weight: 700;
+  line-height: 1rem;
+  text-align: center;
+  background: var(--ease-primary, #ef4444);
+  color: #fff;
+  border-radius: 999px;
+}
+
+.ease-bottom-nav-icons-only .ease-bottom-nav-label {
+  display: none;
+}
+
+.ease-bottom-nav-icons-only .ease-bottom-nav-item.is-active::after {
+  display: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  .ease-bottom-nav {
+    --ease-bottom-nav-bg: var(--ease-surface, #1e293b);
+    --ease-bottom-nav-color: var(--ease-text-secondary, #94a3b8);
+    --ease-bottom-nav-border: var(--ease-border, #475569);
+  }
+}
+}

--- a/submissions/docs/core_changes-issue-30380/README.md
+++ b/submissions/docs/core_changes-issue-30380/README.md
@@ -1,0 +1,21 @@
+# Progress Bar Component — Issue #30380
+
+CSS-only progress/loading bar with animated fill, color variants, and striped styles.
+
+## Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-progress` | Container with `--ease-progress-value` |
+| `.ease-progress-bar` | Filled bar element |
+| `.ease-progress-sm` / `-lg` | Size variants |
+| `.ease-progress-success` / `-warning` / `-danger` | Color variants |
+| `.ease-progress-striped` | Diagonal stripe pattern |
+| `.ease-progress-animated` | Animated stripes |
+| `.ease-progress-label` | Label wrapper (left + right) |
+| `.ease-progress-label-value` | Value display |
+
+## CSS Variables
+
+- `--ease-progress-height`, `--ease-progress-radius`, `--ease-progress-bg`
+- `--ease-progress-color`, `--ease-progress-value` (0–100), `--ease-progress-duration`

--- a/submissions/docs/core_changes-issue-30380/demo.html
+++ b/submissions/docs/core_changes-issue-30380/demo.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Progress — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 2rem; background: #f9fafb; color: #111; }
+h1 { margin-bottom: .5rem; }
+section { background: #fff; padding: 1.5rem; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 1.5rem; }
+h2 { margin: 0 0 1rem; font-size: 1rem; color: #374151; }
+.btn { padding: .5rem 1rem; border: 1px solid #d1d5db; border-radius: 6px; cursor: pointer; font-size: .875rem; background: #fff; }
+.btn:hover { background: #f3f4f6; }
+code { background: #e5e7eb; padding: .15em .4em; border-radius: 4px; font-size: .85em; }
+.spacer { height: 1.5rem; }
+</style>
+</head>
+<body>
+
+<h1>Progress Bar</h1>
+
+<section>
+<h2>Default</h2>
+<div class="ease-progress-label"><span>Uploading...</span><span class="ease-progress-label-value" id="val1">60%</span></div>
+<div class="ease-progress" style="--ease-progress-value:60"><span class="ease-progress-bar"></span></div>
+</section>
+
+<section>
+<h2>Color Variants</h2>
+<div class="ease-progress-label"><span>Success</span><span class="ease-progress-label-value">85%</span></div>
+<div class="ease-progress ease-progress-success" style="--ease-progress-value:85"><span class="ease-progress-bar"></span></div>
+<div class="spacer"></div>
+<div class="ease-progress-label"><span>Warning</span><span class="ease-progress-label-value">45%</span></div>
+<div class="ease-progress ease-progress-warning" style="--ease-progress-value:45"><span class="ease-progress-bar"></span></div>
+<div class="spacer"></div>
+<div class="ease-progress-label"><span>Danger</span><span class="ease-progress-label-value">20%</span></div>
+<div class="ease-progress ease-progress-danger" style="--ease-progress-value:20"><span class="ease-progress-bar"></span></div>
+</section>
+
+<section>
+<h2>Size Variants</h2>
+<div style="display:flex;flex-direction:column;gap:.5rem">
+  <div class="ease-progress ease-progress-sm" style="--ease-progress-value:40"><span class="ease-progress-bar"></span></div>
+  <div class="ease-progress" style="--ease-progress-value:65"><span class="ease-progress-bar"></span></div>
+  <div class="ease-progress ease-progress-lg" style="--ease-progress-value:90"><span class="ease-progress-bar"></span></div>
+</div>
+</section>
+
+<section>
+<h2>Striped & Animated</h2>
+<div class="ease-progress-label"><span>Striped</span><span class="ease-progress-label-value">70%</span></div>
+<div class="ease-progress ease-progress-striped" style="--ease-progress-value:70"><span class="ease-progress-bar"></span></div>
+<div class="spacer"></div>
+<div class="ease-progress-label"><span>Animated Striped</span><span class="ease-progress-label-value">50%</span></div>
+<div class="ease-progress ease-progress-striped ease-progress-animated" style="--ease-progress-value:50"><span class="ease-progress-bar"></span></div>
+</section>
+
+<section>
+<h2>Interactive</h2>
+<button class="btn" onclick="animateProgress()">Animate to Random Value</button>
+<div class="spacer"></div>
+<div class="ease-progress" id="interactive" style="--ease-progress-value:0"><span class="ease-progress-bar"></span></div>
+</section>
+
+<script>
+function animateProgress() {
+  const val = Math.floor(Math.random() * 100);
+  const el = document.getElementById('interactive');
+  el.style.setProperty('--ease-progress-value', val);
+}
+</script>
+
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30380/style.css
+++ b/submissions/docs/core_changes-issue-30380/style.css
@@ -1,0 +1,78 @@
+@layer easemotion-components {
+.ease-progress {
+  --ease-progress-height: 0.625rem;
+  --ease-progress-radius: 999px;
+  --ease-progress-bg: var(--ease-bg-tertiary, #e5e7eb);
+  --ease-progress-color: var(--ease-primary, #3b82f6);
+  --ease-progress-value: 0;
+  --ease-progress-duration: 0.6s;
+
+  display: block;
+  width: 100%;
+  height: var(--ease-progress-height);
+  background: var(--ease-progress-bg);
+  border-radius: var(--ease-progress-radius);
+  overflow: hidden;
+  position: relative;
+}
+
+.ease-progress-bar {
+  display: block;
+  height: 100%;
+  width: calc(var(--ease-progress-value) * 1%);
+  background: var(--ease-progress-color);
+  border-radius: var(--ease-progress-radius);
+  transition: width var(--ease-progress-duration) cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+}
+
+.ease-progress-sm { --ease-progress-height: 0.375rem; }
+.ease-progress-lg { --ease-progress-height: 1rem; }
+
+.ease-progress-success { --ease-progress-color: var(--ease-green-500, #22c55e); }
+.ease-progress-warning { --ease-progress-color: var(--ease-amber-500, #f59e0b); }
+.ease-progress-danger  { --ease-progress-color: var(--ease-red-500, #ef4444); }
+
+.ease-progress-striped .ease-progress-bar::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    45deg,
+    transparent 25%,
+    rgba(255,255,255,.15) 25%,
+    rgba(255,255,255,.15) 50%,
+    transparent 50%,
+    transparent 75%,
+    rgba(255,255,255,.15) 75%
+  );
+  background-size: 1rem 1rem;
+}
+
+.ease-progress-animated .ease-progress-bar::after {
+  animation: ease-progress-stripe 1s linear infinite;
+}
+
+.ease-progress-label {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  color: var(--ease-text-secondary, #4b5563);
+  margin-bottom: 0.25rem;
+}
+
+.ease-progress-label-value {
+  font-weight: 600;
+  color: var(--ease-text, #111827);
+}
+
+@keyframes ease-progress-stripe {
+  from { background-position: 1rem 0; }
+  to   { background-position: 0 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-progress-bar { transition: none; }
+  .ease-progress-striped .ease-progress-bar::after { animation: none; }
+}
+}


### PR DESCRIPTION
### Description
Add a CSS-only progress/loading bar component driven by --ease-progress-value.

### Changes Made
- .ease-progress container with CSS var width control
- .ease-progress-bar fill element with smooth transition
- Size variants: sm (0.375rem), default (0.625rem), lg (1rem)
- Color variants: success, warning, danger
- .ease-progress-striped with repeating gradient
- .ease-progress-animated for moving stripes
- .ease-progress-label for accessible labeling

Fixes #30380