### PR TITLE
feat: add speed dial / FAB with expandable action buttons and CSS-only toggle

### DIFF
--- a/submissions/docs/core_changes-issue-30380/README.md
+++ b/submissions/docs/core_changes-issue-30380/README.md
@@ -1,0 +1,21 @@
+# Progress Bar Component — Issue #30380
+
+CSS-only progress/loading bar with animated fill, color variants, and striped styles.
+
+## Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-progress` | Container with `--ease-progress-value` |
+| `.ease-progress-bar` | Filled bar element |
+| `.ease-progress-sm` / `-lg` | Size variants |
+| `.ease-progress-success` / `-warning` / `-danger` | Color variants |
+| `.ease-progress-striped` | Diagonal stripe pattern |
+| `.ease-progress-animated` | Animated stripes |
+| `.ease-progress-label` | Label wrapper (left + right) |
+| `.ease-progress-label-value` | Value display |
+
+## CSS Variables
+
+- `--ease-progress-height`, `--ease-progress-radius`, `--ease-progress-bg`
+- `--ease-progress-color`, `--ease-progress-value` (0–100), `--ease-progress-duration`

--- a/submissions/docs/core_changes-issue-30380/demo.html
+++ b/submissions/docs/core_changes-issue-30380/demo.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Progress — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 2rem; background: #f9fafb; color: #111; }
+h1 { margin-bottom: .5rem; }
+section { background: #fff; padding: 1.5rem; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 1.5rem; }
+h2 { margin: 0 0 1rem; font-size: 1rem; color: #374151; }
+.btn { padding: .5rem 1rem; border: 1px solid #d1d5db; border-radius: 6px; cursor: pointer; font-size: .875rem; background: #fff; }
+.btn:hover { background: #f3f4f6; }
+code { background: #e5e7eb; padding: .15em .4em; border-radius: 4px; font-size: .85em; }
+.spacer { height: 1.5rem; }
+</style>
+</head>
+<body>
+
+<h1>Progress Bar</h1>
+
+<section>
+<h2>Default</h2>
+<div class="ease-progress-label"><span>Uploading...</span><span class="ease-progress-label-value" id="val1">60%</span></div>
+<div class="ease-progress" style="--ease-progress-value:60"><span class="ease-progress-bar"></span></div>
+</section>
+
+<section>
+<h2>Color Variants</h2>
+<div class="ease-progress-label"><span>Success</span><span class="ease-progress-label-value">85%</span></div>
+<div class="ease-progress ease-progress-success" style="--ease-progress-value:85"><span class="ease-progress-bar"></span></div>
+<div class="spacer"></div>
+<div class="ease-progress-label"><span>Warning</span><span class="ease-progress-label-value">45%</span></div>
+<div class="ease-progress ease-progress-warning" style="--ease-progress-value:45"><span class="ease-progress-bar"></span></div>
+<div class="spacer"></div>
+<div class="ease-progress-label"><span>Danger</span><span class="ease-progress-label-value">20%</span></div>
+<div class="ease-progress ease-progress-danger" style="--ease-progress-value:20"><span class="ease-progress-bar"></span></div>
+</section>
+
+<section>
+<h2>Size Variants</h2>
+<div style="display:flex;flex-direction:column;gap:.5rem">
+  <div class="ease-progress ease-progress-sm" style="--ease-progress-value:40"><span class="ease-progress-bar"></span></div>
+  <div class="ease-progress" style="--ease-progress-value:65"><span class="ease-progress-bar"></span></div>
+  <div class="ease-progress ease-progress-lg" style="--ease-progress-value:90"><span class="ease-progress-bar"></span></div>
+</div>
+</section>
+
+<section>
+<h2>Striped & Animated</h2>
+<div class="ease-progress-label"><span>Striped</span><span class="ease-progress-label-value">70%</span></div>
+<div class="ease-progress ease-progress-striped" style="--ease-progress-value:70"><span class="ease-progress-bar"></span></div>
+<div class="spacer"></div>
+<div class="ease-progress-label"><span>Animated Striped</span><span class="ease-progress-label-value">50%</span></div>
+<div class="ease-progress ease-progress-striped ease-progress-animated" style="--ease-progress-value:50"><span class="ease-progress-bar"></span></div>
+</section>
+
+<section>
+<h2>Interactive</h2>
+<button class="btn" onclick="animateProgress()">Animate to Random Value</button>
+<div class="spacer"></div>
+<div class="ease-progress" id="interactive" style="--ease-progress-value:0"><span class="ease-progress-bar"></span></div>
+</section>
+
+<script>
+function animateProgress() {
+  const val = Math.floor(Math.random() * 100);
+  const el = document.getElementById('interactive');
+  el.style.setProperty('--ease-progress-value', val);
+}
+</script>
+
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30380/style.css
+++ b/submissions/docs/core_changes-issue-30380/style.css
@@ -1,0 +1,78 @@
+@layer easemotion-components {
+.ease-progress {
+  --ease-progress-height: 0.625rem;
+  --ease-progress-radius: 999px;
+  --ease-progress-bg: var(--ease-bg-tertiary, #e5e7eb);
+  --ease-progress-color: var(--ease-primary, #3b82f6);
+  --ease-progress-value: 0;
+  --ease-progress-duration: 0.6s;
+
+  display: block;
+  width: 100%;
+  height: var(--ease-progress-height);
+  background: var(--ease-progress-bg);
+  border-radius: var(--ease-progress-radius);
+  overflow: hidden;
+  position: relative;
+}
+
+.ease-progress-bar {
+  display: block;
+  height: 100%;
+  width: calc(var(--ease-progress-value) * 1%);
+  background: var(--ease-progress-color);
+  border-radius: var(--ease-progress-radius);
+  transition: width var(--ease-progress-duration) cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+}
+
+.ease-progress-sm { --ease-progress-height: 0.375rem; }
+.ease-progress-lg { --ease-progress-height: 1rem; }
+
+.ease-progress-success { --ease-progress-color: var(--ease-green-500, #22c55e); }
+.ease-progress-warning { --ease-progress-color: var(--ease-amber-500, #f59e0b); }
+.ease-progress-danger  { --ease-progress-color: var(--ease-red-500, #ef4444); }
+
+.ease-progress-striped .ease-progress-bar::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    45deg,
+    transparent 25%,
+    rgba(255,255,255,.15) 25%,
+    rgba(255,255,255,.15) 50%,
+    transparent 50%,
+    transparent 75%,
+    rgba(255,255,255,.15) 75%
+  );
+  background-size: 1rem 1rem;
+}
+
+.ease-progress-animated .ease-progress-bar::after {
+  animation: ease-progress-stripe 1s linear infinite;
+}
+
+.ease-progress-label {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  color: var(--ease-text-secondary, #4b5563);
+  margin-bottom: 0.25rem;
+}
+
+.ease-progress-label-value {
+  font-weight: 600;
+  color: var(--ease-text, #111827);
+}
+
+@keyframes ease-progress-stripe {
+  from { background-position: 1rem 0; }
+  to   { background-position: 0 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-progress-bar { transition: none; }
+  .ease-progress-striped .ease-progress-bar::after { animation: none; }
+}
+}

--- a/submissions/docs/core_changes-issue-30381/README.md
+++ b/submissions/docs/core_changes-issue-30381/README.md
@@ -1,0 +1,22 @@
+# Speed Dial / FAB — Issue #30381
+
+Fixed floating action button with expandable action buttons. Uses checkbox `:checked` hack for CSS-only toggle.
+
+## Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-speed-dial` | Fixed container (default: bottom-right) |
+| `.ease-speed-dial-left` | Left-aligned variant |
+| `.ease-speed-dial-down` | Expand downward |
+| `.ease-speed-dial-fab` | Main FAB button |
+| `.ease-speed-dial-fab-check` | Hidden checkbox for toggle |
+| `.ease-speed-dial-actions` | Expandable action list |
+| `.ease-speed-dial-action` | Individual action button |
+| `.ease-speed-dial-action-tooltip` | Label tooltip |
+
+## CSS Variables
+
+- `--ease-speed-dial-size`, `--ease-speed-dial-bg`, `--ease-speed-dial-color`
+- `--ease-speed-dial-gap`, `--ease-speed-dial-radius`, `--ease-speed-dial-shadow`
+- `--ease-speed-dial-transition` (bouncy cubic-bezier)

--- a/submissions/docs/core_changes-issue-30381/demo.html
+++ b/submissions/docs/core_changes-issue-30381/demo.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Speed Dial — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 700px; margin: 0 auto; padding: 2rem 2rem 8rem; background: #f9fafb; color: #111; }
+h1 { margin-bottom: .5rem; }
+section { background: #fff; padding: 1.5rem; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 1.5rem; }
+h2 { margin: 0 0 1rem; font-size: 1rem; color: #374151; }
+code { background: #e5e7eb; padding: .15em .4em; border-radius: 4px; font-size: .85em; }
+
+/* CSS-only toggle using checkbox */
+.ease-speed-dial-fab-check {
+  display: none;
+}
+.ease-speed-dial-fab-check:checked ~ .ease-speed-dial-actions .ease-speed-dial-action {
+  opacity: 1;
+  transform: scale(1);
+  pointer-events: auto;
+}
+.ease-speed-dial-fab-check:checked + .ease-speed-dial-fab svg {
+  transform: rotate(45deg);
+}
+
+.dial-wrapper {
+  position: relative;
+  display: inline-block;
+}
+.demo-dial {
+  position: relative !important;
+  bottom: auto !important;
+  right: auto !important;
+  display: inline-flex !important;
+  margin: 1rem 0;
+}
+</style>
+</head>
+<body>
+
+<h1>Speed Dial / FAB</h1>
+<p>Hover or click the FAB to expand actions.</p>
+
+<section>
+<h2>Default (Up, Right)</h2>
+<div class="ease-speed-dial demo-dial">
+  <input type="checkbox" class="ease-speed-dial-fab-check" id="fab1">
+  <label for="fab1" class="ease-speed-dial-fab">
+    <svg viewBox="0 0 24 24"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+  </label>
+  <div class="ease-speed-dial-actions">
+    <button class="ease-speed-dial-action" title="Edit">✏️</button>
+    <button class="ease-speed-dial-action" title="Share">📤</button>
+    <button class="ease-speed-dial-action" title="Delete">🗑️</button>
+  </div>
+</div>
+</section>
+
+<section>
+<h2>Left-aligned</h2>
+<div class="ease-speed-dial ease-speed-dial-left demo-dial">
+  <input type="checkbox" class="ease-speed-dial-fab-check" id="fab2">
+  <label for="fab2" class="ease-speed-dial-fab">
+    <svg viewBox="0 0 24 24"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+  </label>
+  <div class="ease-speed-dial-actions">
+    <button class="ease-speed-dial-action">✏️</button>
+    <button class="ease-speed-dial-action">📤</button>
+    <button class="ease-speed-dial-action">🗑️</button>
+    <button class="ease-speed-dial-action">📌</button>
+  </div>
+</div>
+</section>
+
+<section>
+<h2>Down direction</h2>
+<div class="ease-speed-dial ease-speed-dial-down demo-dial">
+  <input type="checkbox" class="ease-speed-dial-fab-check" id="fab3">
+  <label for="fab3" class="ease-speed-dial-fab">
+    <svg viewBox="0 0 24 24"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+  </label>
+  <div class="ease-speed-dial-actions">
+    <button class="ease-speed-dial-action">✏️</button>
+    <button class="ease-speed-dial-action">📤</button>
+    <button class="ease-speed-dial-action">🗑️</button>
+  </div>
+</div>
+</section>
+
+<div style="height:200px"></div>
+
+<!-- fixed demo at bottom right -->
+<div class="ease-speed-dial" style="position:fixed;bottom:1.5rem;right:1.5rem">
+  <input type="checkbox" class="ease-speed-dial-fab-check" id="fabFixed">
+  <label for="fabFixed" class="ease-speed-dial-fab">
+    <svg viewBox="0 0 24 24"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+  </label>
+  <div class="ease-speed-dial-actions">
+    <button class="ease-speed-dial-action">
+      ✏️
+      <span class="ease-speed-dial-action-tooltip">Edit</span>
+    </button>
+    <button class="ease-speed-dial-action">
+      📤
+      <span class="ease-speed-dial-action-tooltip">Share</span>
+    </button>
+    <button class="ease-speed-dial-action">
+      🗑️
+      <span class="ease-speed-dial-action-tooltip">Delete</span>
+    </button>
+  </div>
+</div>
+
+<p><code>.ease-speed-dial</code> uses a checkbox <code>:checked</code> hack for CSS-only toggle. The live demo is fixed at bottom-right.</p>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30381/style.css
+++ b/submissions/docs/core_changes-issue-30381/style.css
@@ -1,0 +1,154 @@
+@layer easemotion-components {
+.ease-speed-dial {
+  --ease-speed-dial-size: 3.5rem;
+  --ease-speed-dial-bg: var(--ease-primary, #3b82f6);
+  --ease-speed-dial-color: var(--ease-primary-text, #fff);
+  --ease-speed-dial-bg-hover: var(--ease-primary-hover, #2563eb);
+  --ease-speed-dial-gap: 0.5rem;
+  --ease-speed-dial-radius: 9999px;
+  --ease-speed-dial-shadow: 0 4px 16px rgba(0,0,0,.2);
+  --ease-speed-dial-transition: 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  display: flex;
+  flex-direction: column-reverse;
+  align-items: center;
+  gap: var(--ease-speed-dial-gap);
+  z-index: 200;
+}
+
+.ease-speed-dial-left {
+  right: auto;
+  left: 1.5rem;
+}
+
+.ease-speed-dial-up {
+  flex-direction: column-reverse;
+}
+
+.ease-speed-dial-down {
+  flex-direction: column;
+}
+
+.ease-speed-dial-fab {
+  width: var(--ease-speed-dial-size);
+  height: var(--ease-speed-dial-size);
+  border-radius: var(--ease-speed-dial-radius);
+  background: var(--ease-speed-dial-bg);
+  color: var(--ease-speed-dial-color);
+  border: none;
+  box-shadow: var(--ease-speed-dial-shadow);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  transition: background 0.2s, transform 0.2s, box-shadow 0.2s;
+  z-index: 1;
+  position: relative;
+}
+
+.ease-speed-dial-fab:hover,
+.ease-speed-dial-fab:focus-visible {
+  background: var(--ease-speed-dial-bg-hover);
+  transform: scale(1.05);
+  box-shadow: 0 6px 20px rgba(0,0,0,.25);
+}
+
+.ease-speed-dial-fab svg {
+  width: 1.25rem;
+  height: 1.25rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  transition: transform var(--ease-speed-dial-transition);
+}
+
+.ease-speed-dial.is-open .ease-speed-dial-fab svg {
+  transform: rotate(45deg);
+}
+
+.ease-speed-dial-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--ease-speed-dial-gap);
+  pointer-events: none;
+}
+
+.ease-speed-dial-up .ease-speed-dial-actions {
+  flex-direction: column-reverse;
+}
+
+.ease-speed-dial-down .ease-speed-dial-actions {
+  flex-direction: column;
+}
+
+.ease-speed-dial-action {
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 9999px;
+  background: var(--ease-surface, #fff);
+  color: var(--ease-text, #111827);
+  border: 1px solid var(--ease-border, #d1d5db);
+  box-shadow: 0 2px 8px rgba(0,0,0,.1);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  opacity: 0;
+  transform: scale(0.5);
+  transition: opacity var(--ease-speed-dial-transition),
+              transform var(--ease-speed-dial-transition),
+              background 0.2s;
+  pointer-events: none;
+  position: relative;
+}
+
+.ease-speed-dial.is-open .ease-speed-dial-action {
+  opacity: 1;
+  transform: scale(1);
+  pointer-events: auto;
+}
+
+.ease-speed-dial.is-open .ease-speed-dial-action:hover {
+  background: var(--ease-bg-secondary, #f3f4f6);
+}
+
+.ease-speed-dial-action-tooltip {
+  position: absolute;
+  right: calc(100% + 0.5rem);
+  white-space: nowrap;
+  background: var(--ease-gray-800, #1f2937);
+  color: #fff;
+  padding: 0.25rem 0.625rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.ease-speed-dial-left .ease-speed-dial-action-tooltip {
+  right: auto;
+  left: calc(100% + 0.5rem);
+}
+
+.ease-speed-dial-action:hover .ease-speed-dial-action-tooltip {
+  opacity: 1;
+}
+
+.ease-speed-dial-action:nth-child(1) { transition-delay: 0s; }
+.ease-speed-dial-action:nth-child(2) { transition-delay: 0.04s; }
+.ease-speed-dial-action:nth-child(3) { transition-delay: 0.08s; }
+.ease-speed-dial-action:nth-child(4) { transition-delay: 0.12s; }
+.ease-speed-dial-action:nth-child(5) { transition-delay: 0.16s; }
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-speed-dial-action { transition: none; opacity: 1; transform: scale(1); pointer-events: auto; }
+}
+}


### PR DESCRIPTION
### Description
Add a floating action button (FAB) that expands into multiple quick actions.

### Changes Made
- .ease-speed-dial fixed container (bottom-right)
- .ease-speed-dial-left variant
- .ease-speed-dial-down direction variant
- .ease-speed-dial-fab with hover/focus scale effect
- Checkbox :checked hack for CSS-only toggle
- .ease-speed-dial-action with staggered entrance animation
- .ease-speed-dial-action-tooltip for labels

Fixes #30381