### PR TITLE
feat: add print stylesheet utilities with @media print overrides

### DIFF
--- a/submissions/docs/core_changes-issue-30386/README.md
+++ b/submissions/docs/core_changes-issue-30386/README.md
@@ -1,0 +1,31 @@
+# Focus Visible Ring — Issue #30386
+
+Focus-visible ring utilities using `:focus-visible` pseudo-class.
+
+## Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-focus-ring` | Default focus ring (2px solid) |
+| `.ease-focus-ring-sm` | 1px outline width |
+| `.ease-focus-ring-lg` | 3px outline width, 3px offset |
+| `.ease-focus-ring-inset` | Inset outline offset |
+| `.ease-focus-ring-soft` | Shadow-based ring (no outline) |
+| `.ease-focus-ring-glow` | Glow effect with box-shadow |
+| `.ease-focus-ring-none` | Removes focus outline |
+| `.ease-focus-ring-auto` | Auto-styled 2px solid ring |
+| `.ease-focus-ring-color-primary` | Primary color ring |
+| `.ease-focus-ring-color-accent` | Accent color ring |
+| `.ease-focus-ring-color-success` | Success color ring |
+| `.ease-focus-ring-color-danger` | Danger color ring |
+| `.ease-focus-ring-offset-0` | 0px offset |
+| `.ease-focus-ring-offset-1` | 1px offset |
+| `.ease-focus-ring-offset-2` | 2px offset |
+| `.ease-focus-ring-offset-4` | 4px offset |
+
+## CSS Variables
+
+- `--ease-focus-ring-color` (default `--ease-primary`, `#3b82f6`)
+- `--ease-focus-ring-width` (default `2px`)
+- `--ease-focus-ring-offset` (default `2px`)
+- `--ease-focus-ring-style` (default `solid`)

--- a/submissions/docs/core_changes-issue-30386/demo.html
+++ b/submissions/docs/core_changes-issue-30386/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Focus Ring — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 2rem; background: #f9fafb; color: #111; }
+h1 { margin-bottom: .5rem; }
+section { background: #fff; padding: 1.5rem; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 1.5rem; }
+h2 { margin: 0 0 1rem; font-size: 1rem; color: #374151; }
+code { background: #e5e7eb; padding: .15em .4em; border-radius: 4px; font-size: .85em; }
+.btn-row { display: flex; gap: .5rem; flex-wrap: wrap; }
+.demo-btn { padding: .5rem 1rem; border: 1px solid #d1d5db; border-radius: 4px; background: #fff; cursor: pointer; font-size: .875rem; }
+</style>
+</head>
+<body>
+<h1>Focus Visible Ring</h1>
+<p>Tab through the buttons to see focus rings.</p>
+<section>
+<h2>Default Ring</h2>
+<div class="btn-row">
+  <button class="demo-btn ease-focus-ring">Default</button>
+  <button class="demo-btn ease-focus-ring-sm">Small</button>
+  <button class="demo-btn ease-focus-ring-lg">Large</button>
+  <button class="demo-btn ease-focus-ring-soft">Soft (shadow)</button>
+  <button class="demo-btn ease-focus-ring-glow">Glow</button>
+  <button class="demo-btn ease-focus-ring-none">None</button>
+</div>
+</section>
+<section>
+<h2>Color Variants</h2>
+<div class="btn-row">
+  <button class="demo-btn ease-focus-ring ease-focus-ring-color-primary">Primary</button>
+  <button class="demo-btn ease-focus-ring ease-focus-ring-color-accent">Accent</button>
+  <button class="demo-btn ease-focus-ring ease-focus-ring-color-success">Success</button>
+  <button class="demo-btn ease-focus-ring ease-focus-ring-color-danger">Danger</button>
+</div>
+</section>
+<section>
+<h2>Offset Variants</h2>
+<div class="btn-row">
+  <button class="demo-btn ease-focus-ring ease-focus-ring-offset-0">Offset 0</button>
+  <button class="demo-btn ease-focus-ring ease-focus-ring-offset-2">Offset 2</button>
+  <button class="demo-btn ease-focus-ring ease-focus-ring-offset-4">Offset 4</button>
+  <button class="demo-btn ease-focus-ring ease-focus-ring-inset">Inset</button>
+</div>
+</section>
+<p>Uses <code>:focus-visible</code> — only shows on keyboard focus, not click.</p>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30386/style.css
+++ b/submissions/docs/core_changes-issue-30386/style.css
@@ -1,0 +1,57 @@
+@layer easemotion-utilities {
+:root {
+  --ease-focus-ring-color: var(--ease-primary, #3b82f6);
+  --ease-focus-ring-width: 2px;
+  --ease-focus-ring-offset: 2px;
+  --ease-focus-ring-style: solid;
+}
+
+.ease-focus-ring:focus-visible {
+  outline: var(--ease-focus-ring-width) var(--ease-focus-ring-style) var(--ease-focus-ring-color);
+  outline-offset: var(--ease-focus-ring-offset);
+}
+
+.ease-focus-ring-sm:focus-visible {
+  outline-width: 1px;
+}
+
+.ease-focus-ring-lg:focus-visible {
+  outline-width: 3px;
+  outline-offset: 3px;
+}
+
+.ease-focus-ring-inset:focus-visible {
+  outline-offset: calc(-1 * var(--ease-focus-ring-offset));
+}
+
+.ease-focus-ring-offset-0:focus-visible { outline-offset: 0; }
+.ease-focus-ring-offset-1:focus-visible { outline-offset: 1px; }
+.ease-focus-ring-offset-2:focus-visible { outline-offset: 2px; }
+.ease-focus-ring-offset-4:focus-visible { outline-offset: 4px; }
+
+.ease-focus-ring-color-primary:focus-visible { outline-color: var(--ease-primary, #3b82f6); }
+.ease-focus-ring-color-accent:focus-visible { outline-color: var(--ease-accent, #8b5cf6); }
+.ease-focus-ring-color-success:focus-visible { outline-color: var(--ease-green-500, #22c55e); }
+.ease-focus-ring-color-danger:focus-visible { outline-color: var(--ease-red-500, #ef4444); }
+
+.ease-focus-ring-auto:focus-visible {
+  outline: 2px solid var(--ease-focus-ring-color);
+  outline-offset: 2px;
+}
+
+.ease-focus-ring-none:focus-visible {
+  outline: none;
+}
+
+.ease-focus-ring-soft:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 var(--ease-focus-ring-width) var(--ease-focus-ring-color);
+}
+
+.ease-focus-ring-glow:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 var(--ease-focus-ring-width) var(--ease-focus-ring-color),
+    0 0 12px color-mix(in srgb, var(--ease-focus-ring-color) 50%, transparent);
+}
+}

--- a/submissions/docs/core_changes-issue-30387/README.md
+++ b/submissions/docs/core_changes-issue-30387/README.md
@@ -1,0 +1,20 @@
+# Custom Scrollbar — Issue #30387
+
+Custom scrollbar styling utilities.
+
+## Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-scrollbar-thin` | Thin scrollbar width |
+| `.ease-scrollbar-none` | Hides scrollbar (still scrollable) |
+| `.ease-scrollbar-themed` | Themed scrollbar with custom colors and radius |
+| `.ease-scrollbar-auto-hide` | Auto-hiding thin scrollbar on hover/focus |
+
+## CSS Variables
+
+- `--ease-scrollbar-width` (default `thin`)
+- `--ease-scrollbar-track` (track background)
+- `--ease-scrollbar-thumb` (thumb color)
+- `--ease-scrollbar-thumb-hover` (thumb color on hover)
+- `--ease-scrollbar-radius` (default `999px`)

--- a/submissions/docs/core_changes-issue-30387/demo.html
+++ b/submissions/docs/core_changes-issue-30387/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Scrollbar — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 2rem; background: #f9fafb; color: #111; }
+h1 { margin-bottom: .5rem; }
+section { background: #fff; padding: 1.5rem; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 1.5rem; }
+h2 { margin: 0 0 1rem; font-size: 1rem; color: #374151; }
+code { background: #e5e7eb; padding: .15em .4em; border-radius: 4px; }
+.scroll-demo { height: 120px; overflow-y: auto; padding: .5rem; border: 1px solid #d1d5db; border-radius: 8px; }
+.scroll-demo p { margin: 0 0 .5rem; font-size: .875rem; }
+</style>
+</head>
+<body>
+<h1>Custom Scrollbar</h1>
+<section>
+<h2>Thin</h2>
+<div class="scroll-demo ease-scrollbar-themed">
+  <p>Line 1</p><p>Line 2</p><p>Line 3</p><p>Line 4</p><p>Line 5</p><p>Line 6</p><p>Line 7</p><p>Line 8</p>
+</div>
+</section>
+<section>
+<h2>Auto-hide</h2>
+<div class="scroll-demo ease-scrollbar-auto-hide" style="height:100px">
+  <p>Item 1</p><p>Item 2</p><p>Item 3</p><p>Item 4</p><p>Item 5</p><p>Item 6</p><p>Item 7</p><p>Item 8</p>
+</div>
+<p>Hover to reveal scrollbar.</p>
+</section>
+<section>
+<h2>None</h2>
+<div class="scroll-demo ease-scrollbar-none">
+  <p>Hidden scrollbar (still scrollable)</p><p>Item 2</p><p>Item 3</p><p>Item 4</p><p>Item 5</p>
+</div>
+</section>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30387/style.css
+++ b/submissions/docs/core_changes-issue-30387/style.css
@@ -1,0 +1,65 @@
+@layer easemotion-utilities {
+:root {
+  --ease-scrollbar-width: thin;
+  --ease-scrollbar-track: var(--ease-bg-secondary, #f3f4f6);
+  --ease-scrollbar-thumb: var(--ease-gray-300, #d1d5db);
+  --ease-scrollbar-thumb-hover: var(--ease-gray-400, #9ca3af);
+  --ease-scrollbar-radius: 999px;
+}
+
+.ease-scrollbar-thin {
+  scrollbar-width: thin;
+}
+
+.ease-scrollbar-none {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.ease-scrollbar-none::-webkit-scrollbar {
+  display: none;
+}
+
+.ease-scrollbar-themed {
+  scrollbar-width: var(--ease-scrollbar-width);
+}
+
+.ease-scrollbar-themed::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+.ease-scrollbar-themed::-webkit-scrollbar-track {
+  background: var(--ease-scrollbar-track);
+  border-radius: var(--ease-scrollbar-radius);
+}
+
+.ease-scrollbar-themed::-webkit-scrollbar-thumb {
+  background: var(--ease-scrollbar-thumb);
+  border-radius: var(--ease-scrollbar-radius);
+}
+
+.ease-scrollbar-themed::-webkit-scrollbar-thumb:hover {
+  background: var(--ease-scrollbar-thumb-hover);
+}
+
+.ease-scrollbar-auto-hide {
+  scrollbar-width: thin;
+}
+
+.ease-scrollbar-auto-hide::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+.ease-scrollbar-auto-hide::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: var(--ease-scrollbar-radius);
+  transition: background 0.2s;
+}
+
+.ease-scrollbar-auto-hide:hover::-webkit-scrollbar-thumb,
+.ease-scrollbar-auto-hide:focus::-webkit-scrollbar-thumb {
+  background: var(--ease-scrollbar-thumb);
+}
+}

--- a/submissions/docs/core_changes-issue-30388/README.md
+++ b/submissions/docs/core_changes-issue-30388/README.md
@@ -1,0 +1,32 @@
+# Aspect Ratio — Issue #30388
+
+Aspect ratio and object-fit utilities.
+
+## Classes
+
+| Class | Ratio |
+|-------|-------|
+| `.ease-aspect-square` | 1:1 |
+| `.ease-aspect-video` | 16:9 |
+| `.ease-aspect-portrait` | 3:4 |
+| `.ease-aspect-wide` | 21:9 |
+| `.ease-aspect-ultrawide` | 32:9 |
+| `.ease-aspect-portrait-lg` | 9:16 |
+| `.ease-aspect-auto` | auto |
+| `.ease-aspect-1\/1` | 1/1 |
+| `.ease-aspect-4\/3` | 4/3 |
+| `.ease-aspect-3\/2` | 3/2 |
+| `.ease-aspect-5\/4` | 5/4 |
+| `.ease-aspect-10\/8` | 10/8 |
+
+## Object-fit Classes
+
+| Class | Value |
+|-------|-------|
+| `.ease-object-contain` | `contain` |
+| `.ease-object-cover` | `cover` |
+| `.ease-object-fill` | `fill` |
+| `.ease-object-none` | `none` |
+| `.ease-object-scale-down` | `scale-down` |
+
+No CSS variables required.

--- a/submissions/docs/core_changes-issue-30388/demo.html
+++ b/submissions/docs/core_changes-issue-30388/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Aspect Ratio — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 700px; margin: 0 auto; padding: 2rem; background: #f9fafb; color: #111; }
+h1 { margin-bottom: .5rem; }
+.grid { display: grid; grid-template-columns: repeat(3,1fr); gap: 1rem; }
+.item { background: #3b82f6; color: #fff; display: flex; align-items: center; justify-content: center; border-radius: 8px; font-weight: 600; font-size: .875rem; text-align: center; padding: .5rem; }
+code { background: #e5e7eb; padding: .15em .4em; border-radius: 4px; }
+section { background: #fff; padding: 1.5rem; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 1.5rem; }
+h2 { margin: 0 0 1rem; font-size: 1rem; color: #374151; }
+img { width: 100%; height: 100%; object-fit: cover; border-radius: 8px; }
+</style>
+</head>
+<body>
+<h1>Aspect Ratio</h1>
+<section>
+<h2>Named Ratios</h2>
+<div class="grid">
+  <div class="item ease-aspect-square">Square 1:1</div>
+  <div class="item ease-aspect-video">Video 16:9</div>
+  <div class="item ease-aspect-portrait">Portrait 3:4</div>
+  <div class="item ease-aspect-wide">Wide 21:9</div>
+  <div class="item ease-aspect-ultrawide">Ultrawide 32:9</div>
+  <div class="item ease-aspect-portrait-lg">P-LG 9:16</div>
+</div>
+</section>
+<section>
+<h2>Fractional Ratios</h2>
+<div class="grid">
+  <div class="item ease-aspect-1\/1">1/1</div>
+  <div class="item ease-aspect-4\/3">4/3</div>
+  <div class="item ease-aspect-3\/2">3/2</div>
+  <div class="item ease-aspect-5\/4">5/4</div>
+  <div class="item ease-aspect-10\/8">10/8</div>
+</div>
+</section>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30388/style.css
+++ b/submissions/docs/core_changes-issue-30388/style.css
@@ -1,0 +1,21 @@
+@layer easemotion-utilities {
+.ease-aspect-square { aspect-ratio: 1 / 1; }
+.ease-aspect-video   { aspect-ratio: 16 / 9; }
+.ease-aspect-portrait { aspect-ratio: 3 / 4; }
+.ease-aspect-wide    { aspect-ratio: 21 / 9; }
+.ease-aspect-ultrawide { aspect-ratio: 32 / 9; }
+.ease-aspect-portrait-lg { aspect-ratio: 9 / 16; }
+.ease-aspect-auto    { aspect-ratio: auto; }
+
+.ease-aspect-1\/1  { aspect-ratio: 1 / 1; }
+.ease-aspect-4\/3  { aspect-ratio: 4 / 3; }
+.ease-aspect-3\/2  { aspect-ratio: 3 / 2; }
+.ease-aspect-5\/4  { aspect-ratio: 5 / 4; }
+.ease-aspect-10\/8 { aspect-ratio: 10 / 8; }
+
+.ease-object-contain { object-fit: contain; }
+.ease-object-cover   { object-fit: cover; }
+.ease-object-fill    { object-fit: fill; }
+.ease-object-none    { object-fit: none; }
+.ease-object-scale-down { object-fit: scale-down; }
+}

--- a/submissions/docs/core_changes-issue-30389/README.md
+++ b/submissions/docs/core_changes-issue-30389/README.md
@@ -1,0 +1,23 @@
+# Print Stylesheet — Issue #30389
+
+Print-specific utility classes wrapped in `@media print`.
+
+## Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-no-print` | Hides element when printing |
+| `.ease-only-print` | Shows element only when printing |
+| `.ease-print-break-inside-avoid` | Avoids page break inside element |
+| `.ease-print-break-before` | Forces page break before element |
+| `.ease-print-break-after` | Forces page break after element |
+| `.ease-print-avoid-break` | Alias for break-inside avoid |
+
+## Print Resets (applied via `@media print`)
+
+- `a[href]::after` — displays link URLs in print
+- `img` — max-width 100%, page-break-inside avoid
+- `table` — font-size reduced
+- `h1, h2, h3, h4` — page-break-after avoid
+
+No CSS variables required.

--- a/submissions/docs/core_changes-issue-30389/demo.html
+++ b/submissions/docs/core_changes-issue-30389/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Print — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 2rem; background: #f9fafb; color: #111; }
+h1 { margin-bottom: .5rem; }
+section { background: #fff; padding: 1.5rem; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 1.5rem; }
+code { background: #e5e7eb; padding: .15em .4em; border-radius: 4px; }
+.nav { display: flex; gap: 1rem; padding: 1rem; background: #1f2937; color: #fff; border-radius: 8px; margin-bottom: 1rem; }
+.nav a { color: #93c5fd; }
+.btn-print { padding: .5rem 1rem; border: none; border-radius: 6px; background: #3b82f6; color: #fff; cursor: pointer; }
+</style>
+</head>
+<body>
+<h1>Print Stylesheet</h1>
+<p>Use <button class="btn-print" onclick="window.print()">Print Preview (Ctrl+P)</button> to see print behavior.</p>
+<div class="nav">
+  <a href="/">Home</a>
+  <a href="/about">About</a>
+  <a href="/contact">Contact</a>
+  <span class="ease-only-print" style="display:none">— Printed on <script>document.write(new Date().toLocaleDateString())</script></span>
+</div>
+<section>
+<h2>Hide on Print</h2>
+<p class="ease-no-print">This paragraph is hidden when printing (<code>.ease-no-print</code>).</p>
+<p>This paragraph always shows.</p>
+</section>
+<section>
+<h2>Print-only Content</h2>
+<p class="ease-only-print" style="display:none">This message appears <strong>only</strong> in print.</p>
+<p class="ease-print-break-inside-avoid" style="padding:1rem;background:#f3f4f6;border-radius:8px">
+  This block avoids page breaks. <code>.ease-print-break-inside-avoid</code>
+</p>
+</section>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30389/style.css
+++ b/submissions/docs/core_changes-issue-30389/style.css
@@ -1,0 +1,56 @@
+@layer easemotion-utilities {
+@media print {
+  .ease-no-print {
+    display: none !important;
+  }
+
+  .ease-only-print {
+    display: block !important;
+  }
+
+  .ease-print-break-inside-avoid {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .ease-print-break-before {
+    break-before: page;
+    page-break-before: always;
+  }
+
+  .ease-print-break-after {
+    break-after: page;
+    page-break-after: always;
+  }
+
+  .ease-print-avoid-break {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  a[href]::after {
+    content: " (" attr(href) ")";
+    font-size: 0.8em;
+    color: #666;
+  }
+
+  img {
+    max-width: 100% !important;
+    page-break-inside: avoid;
+  }
+
+  table {
+    font-size: 0.8em;
+  }
+
+  h1, h2, h3, h4 {
+    page-break-after: avoid;
+  }
+}
+
+.ease-no-print {
+  @media print {
+    display: none !important;
+  }
+}
+}

--- a/submissions/docs/core_changes-issue-30390/README.md
+++ b/submissions/docs/core_changes-issue-30390/README.md
@@ -1,0 +1,24 @@
+# List Utilities — Issue #30390
+
+List reset, layout, and style utilities.
+
+## Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-list-none` | Removes list-style, padding, margin |
+| `.ease-list-inline` | Horizontal flex list with gap |
+| `.ease-list-dividers` | Vertical list with border separators |
+| `.ease-list-dividers-horizontal` | Horizontal list with border separators |
+| `.ease-list-striped` | Alternating row background |
+| `.ease-list-disc` | `list-style-type: disc` |
+| `.ease-list-decimal` | `list-style-type: decimal` |
+| `.ease-list-circle` | `list-style-type: circle` |
+| `.ease-list-square` | `list-style-type: square` |
+| `.ease-list-roman` | `list-style-type: lower-roman` |
+| `.ease-list-alpha` | `list-style-type: lower-alpha` |
+| `.ease-list-inside` | `list-style-position: inside` |
+
+## CSS Variables
+
+- `--ease-list-gap` (default `1rem`) — used by `.ease-list-inline` and `.ease-list-dividers-horizontal`

--- a/submissions/docs/core_changes-issue-30390/demo.html
+++ b/submissions/docs/core_changes-issue-30390/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>List — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 2rem; background: #f9fafb; color: #111; }
+h1 { margin-bottom: .5rem; }
+section { background: #fff; padding: 1.5rem; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 1.5rem; }
+h2 { margin: 0 0 1rem; font-size: 1rem; color: #374151; }
+code { background: #e5e7eb; padding: .15em .4em; border-radius: 4px; }
+.grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+</style>
+</head>
+<body>
+<h1>List Utilities</h1>
+<section>
+<h2>Reset & Inline</h2>
+<div class="grid">
+  <div><code>.ease-list-none</code><ul class="ease-list-none"><li>Item 1</li><li>Item 2</li><li>Item 3</li></ul></div>
+  <div><code>.ease-list-inline</code><ul class="ease-list-inline"><li>Item 1</li><li>Item 2</li><li>Item 3</li></ul></div>
+</div>
+</section>
+<section>
+<h2>Dividers</h2>
+<div class="grid">
+  <div><code>.ease-list-dividers</code><ul class="ease-list-dividers"><li>Item 1</li><li>Item 2</li><li>Item 3</li></ul></div>
+  <div><code>.ease-list-dividers-horizontal</code><ul class="ease-list-dividers-horizontal"><li>Item 1</li><li>Item 2</li><li>Item 3</li></ul></div>
+</div>
+</section>
+<section>
+<h2>Striped</h2>
+<ul class="ease-list-striped"><li>Item 1</li><li>Item 2</li><li>Item 3</li><li>Item 4</li></ul>
+</section>
+<section>
+<h2>Style Types</h2>
+<div class="grid">
+  <ul class="ease-list-disc"><li>Disc</li><li>Disc</li></ul>
+  <ul class="ease-list-decimal"><li>First</li><li>Second</li></ul>
+  <ul class="ease-list-circle"><li>Circle</li><li>Circle</li></ul>
+  <ul class="ease-list-square"><li>Square</li><li>Square</li></ul>
+  <ol class="ease-list-roman"><li>Roman i</li><li>Roman ii</li></ol>
+  <ol class="ease-list-alpha"><li>Alpha a</li><li>Alpha b</li></ol>
+</div>
+</section>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30390/style.css
+++ b/submissions/docs/core_changes-issue-30390/style.css
@@ -1,0 +1,67 @@
+@layer easemotion-utilities {
+.ease-list-none {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.ease-list-inline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ease-list-gap, 1rem);
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.ease-list-inline > * {
+  margin: 0;
+}
+
+.ease-list-dividers {
+  display: flex;
+  flex-direction: column;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.ease-list-dividers > * + * {
+  border-top: 1px solid var(--ease-border-light, #e5e7eb);
+}
+
+.ease-list-dividers-horizontal {
+  display: flex;
+  flex-wrap: wrap;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.ease-list-dividers-horizontal > * + * {
+  border-left: 1px solid var(--ease-border-light, #e5e7eb);
+  padding-left: var(--ease-list-gap, 1rem);
+  margin-left: var(--ease-list-gap, 1rem);
+}
+
+.ease-list-striped > *:nth-child(odd) {
+  background: var(--ease-bg-secondary, #f3f4f6);
+  border-radius: 0.25rem;
+}
+
+.ease-list-striped > * {
+  padding: 0.375rem 0.5rem;
+}
+
+.ease-list-disc { list-style-type: disc; padding-left: 1.5rem; }
+.ease-list-decimal { list-style-type: decimal; padding-left: 1.5rem; }
+.ease-list-circle { list-style-type: circle; padding-left: 1.5rem; }
+.ease-list-square { list-style-type: square; padding-left: 1.5rem; }
+.ease-list-roman { list-style-type: lower-roman; padding-left: 1.5rem; }
+.ease-list-alpha { list-style-type: lower-alpha; padding-left: 1.5rem; }
+
+.ease-list-inside {
+  list-style-position: inside;
+  padding-left: 0;
+}
+}


### PR DESCRIPTION
Add print-specific utility classes.

### Changes Made
- .ease-no-print (hide on print)
- .ease-only-print (show only on print)
- .ease-print-break-inside-avoid / -before / -after
- @media print resets for links, images, tables

Fixes #30389