### PR TITLE
feat: add gradient text utility classes with named presets and direction variants

### DIFF
--- a/submissions/docs/core_changes-issue-30391/README.md
+++ b/submissions/docs/core_changes-issue-30391/README.md
@@ -1,0 +1,19 @@
+# Container Query Utilities — Issue #30391
+
+Container query utility classes for container-based responsive design.
+
+## Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-container` | Basic container (inline-size) |
+| `.ease-container-sm/md/lg/xl` | Named containers with breakpoints |
+| `.ease-cq:flex-row` | Column→row at container sm |
+| `.ease-cq:grid-2` | 1→2 columns at container md |
+| `.ease-cq:grid-3` | 1→3 columns at container lg |
+| `.ease-cq:show` / `.ease-cq:hide` | Visibility toggle by container size |
+
+## CSS Variables
+
+- `--ease-container-sm` (640px), `--ease-container-md` (768px)
+- `--ease-container-lg` (1024px), `--ease-container-xl` (1280px)

--- a/submissions/docs/core_changes-issue-30391/demo.html
+++ b/submissions/docs/core_changes-issue-30391/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>Container Query — EaseMotion CSS</title><link rel="stylesheet" href="style.css"><style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 800px; margin: 0 auto; padding: 2rem; background: #f9fafb; color: #111; }
+h1 { margin-bottom: .5rem; }
+section { background: #fff; padding: 1.5rem; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 1.5rem; }
+code { background: #e5e7eb; padding: .15em .4em; border-radius: 4px; }
+.demo-inner { display: flex; gap: 1rem; flex-wrap: wrap; }
+.cq-box { border: 2px dashed #3b82f6; padding: .5rem; border-radius: 8px; }
+.note { background: #eff6ff; border-left: 3px solid #3b82f6; padding: .75rem 1rem; border-radius: 4px; font-size: .85rem; }
+</style></head>
+<body>
+<h1>Container Query Utilities</h1>
+<p class="note">Resize browser or the container to see responsive behavior without viewport media queries.</p>
+<section>
+<h2>Container with responsive flex direction</h2>
+<div class="ease-container cq-box" style="container-name:ease-sm;width:100%">
+  <div class="ease-cq\:flex-row" style="gap:.5rem">
+    <div style="flex:1;background:#dbeafe;padding:.75rem;border-radius:6px;text-align:center">Card A</div>
+    <div style="flex:1;background:#dbeafe;padding:.75rem;border-radius:6px;text-align:center">Card B</div>
+  </div>
+</div>
+</section>
+<section>
+<h2>Container with responsive grid</h2>
+<div class="ease-container-md cq-box" style="width:100%">
+  <div class="ease-cq\:grid-2" style="gap:.5rem">
+    <div style="background:#dbeafe;padding:.75rem;border-radius:6px;text-align:center">1</div>
+    <div style="background:#dbeafe;padding:.75rem;border-radius:6px;text-align:center">2</div>
+  </div>
+</div>
+</section>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30391/style.css
+++ b/submissions/docs/core_changes-issue-30391/style.css
@@ -1,0 +1,43 @@
+@layer easemotion-utilities {
+:root {
+  --ease-container-sm: 640px;
+  --ease-container-md: 768px;
+  --ease-container-lg: 1024px;
+  --ease-container-xl: 1280px;
+}
+
+.ease-container {
+  container-type: inline-size;
+}
+
+.ease-container-sm { container-type: inline-size; container-name: ease-sm; }
+.ease-container-md { container-type: inline-size; container-name: ease-md; }
+.ease-container-lg { container-type: inline-size; container-name: ease-lg; }
+.ease-container-xl { container-type: inline-size; container-name: ease-xl; }
+
+.ease-cq\:flex-row { display: flex; flex-direction: column; }
+
+@container ease-sm (min-width: 0) {
+  .ease-cq\:flex-row { flex-direction: row; }
+}
+
+.ease-cq\:grid-2 { display: grid; grid-template-columns: 1fr; }
+
+@container ease-md (min-width: 768px) {
+  .ease-cq\:grid-2 { grid-template-columns: 1fr 1fr; }
+}
+
+.ease-cq\:grid-3 { display: grid; grid-template-columns: 1fr; }
+
+@container ease-lg (min-width: 1024px) {
+  .ease-cq\:grid-3 { grid-template-columns: 1fr 1fr 1fr; }
+}
+
+.ease-cq\:show { display: none; }
+.ease-cq\:hide { display: block; }
+
+@container ease-sm (min-width: 640px) {
+  .ease-cq\:show { display: block; }
+  .ease-cq\:hide { display: none; }
+}
+}

--- a/submissions/docs/core_changes-issue-30392/README.md
+++ b/submissions/docs/core_changes-issue-30392/README.md
@@ -1,0 +1,20 @@
+# Scroll-Driven Animations — Issue #30392
+
+Utility classes using the CSS Scroll-Driven Animations API (animation-timeline: view()).
+
+## Browser Support
+Chrome 115+, Edge 115+. Currently experimental.
+
+## Classes
+
+| Class | Effect |
+|-------|--------|
+| `.ease-scroll-animate` | Base: animation-timeline: view() |
+| `.ease-scroll-fade-in` | Opacity 0→1 on scroll |
+| `.ease-scroll-slide-up` | Fade + translateY |
+| `.ease-scroll-slide-left` | Fade + translateX(right→left) |
+| `.ease-scroll-slide-right` | Fade + translateX(left→right) |
+| `.ease-scroll-scale` | Fade + scale(0.8→1) |
+| `.ease-scroll-range-start/end` | Customize animation range |
+
+Respects prefers-reduced-motion: reduce.

--- a/submissions/docs/core_changes-issue-30392/demo.html
+++ b/submissions/docs/core_changes-issue-30392/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>Scroll Animations — EaseMotion CSS</title><link rel="stylesheet" href="style.css"><style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 700px; margin: 0 auto; padding: 2rem; background: #f9fafb; color: #111; }
+h1 { margin-bottom: 3rem; }
+.spacer { height: 100vh; }
+.demo-item { background: #3b82f6; color: #fff; padding: 2rem; border-radius: 12px; text-align: center; font-weight: 600; margin-bottom: 2rem; min-height: 100px; display: flex; align-items: center; justify-content: center; }
+.demo-item:nth-child(2n) { background: #8b5cf6; }
+.demo-item:nth-child(3n) { background: #22c55e; }
+code { background: #e5e7eb; padding: .15em .4em; border-radius: 4px; }
+.note { background: #fef3c7; border-left: 3px solid #f59e0b; padding: .75rem 1rem; border-radius: 4px; font-size: .85rem; margin-bottom: 2rem; }
+</style></head>
+<body>
+<h1>Scroll-Driven Animations</h1>
+<p class="note">Requires Chrome 115+. Scroll down to see animations triggered by scroll position.</p>
+<div class="spacer"></div>
+<div class="demo-item ease-scroll-fade-in">Fade In</div>
+<div class="demo-item ease-scroll-slide-up">Slide Up</div>
+<div class="demo-item ease-scroll-slide-left">Slide Left</div>
+<div class="demo-item ease-scroll-slide-right">Slide Right</div>
+<div class="demo-item ease-scroll-scale">Scale In</div>
+<div class="spacer"></div>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30392/style.css
+++ b/submissions/docs/core_changes-issue-30392/style.css
@@ -1,0 +1,79 @@
+@layer easemotion-utilities {
+.ease-scroll-animate {
+  animation-timeline: view();
+  animation-range: entry 0% entry 100%;
+}
+
+.ease-scroll-fade-in {
+  animation: ease-scroll-fade-in linear both;
+  animation-timeline: view();
+  animation-range: entry 0% entry 100%;
+}
+
+.ease-scroll-slide-up {
+  animation: ease-scroll-slide-up linear both;
+  animation-timeline: view();
+  animation-range: entry 0% entry 100%;
+}
+
+.ease-scroll-slide-left {
+  animation: ease-scroll-slide-left linear both;
+  animation-timeline: view();
+  animation-range: entry 0% entry 100%;
+}
+
+.ease-scroll-slide-right {
+  animation: ease-scroll-slide-right linear both;
+  animation-timeline: view();
+  animation-range: entry 0% entry 100%;
+}
+
+.ease-scroll-scale {
+  animation: ease-scroll-scale linear both;
+  animation-timeline: view();
+  animation-range: entry 0% entry 100%;
+}
+
+.ease-scroll-range-start {
+  --ease-scroll-range-start: entry 0%;
+  animation-range: var(--ease-scroll-range-start) var(--ease-scroll-range-end, entry 100%);
+}
+
+.ease-scroll-range-end {
+  --ease-scroll-range-end: entry 100%;
+  animation-range: var(--ease-scroll-range-start, entry 0%) var(--ease-scroll-range-end);
+}
+
+@keyframes ease-scroll-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes ease-scroll-slide-up {
+  from { opacity: 0; transform: translateY(2rem); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes ease-scroll-slide-left {
+  from { opacity: 0; transform: translateX(2rem); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes ease-scroll-slide-right {
+  from { opacity: 0; transform: translateX(-2rem); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes ease-scroll-scale {
+  from { opacity: 0; transform: scale(0.8); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [class*="ease-scroll-"] {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}
+}

--- a/submissions/docs/core_changes-issue-30393/README.md
+++ b/submissions/docs/core_changes-issue-30393/README.md
@@ -1,0 +1,20 @@
+# Gradient Text — Issue #30393
+
+Gradient text fill utilities using background-clip for decorative headings.
+
+## Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-text-gradient` | Base gradient text (uses CSS vars) |
+| `.ease-text-gradient-primary` | Blue→violet |
+| `.ease-text-gradient-sunset` | Orange→red→pink |
+| `.ease-text-gradient-ocean` | Cyan→blue→indigo |
+| `.ease-text-gradient-forest` | Green→teal→cyan |
+| `.ease-text-gradient-neutral` | Gray scale |
+| `.ease-text-gradient-to-r/l/t/b/tr/bl` | Direction variants |
+| `.ease-text-gradient-no-wrap` | Inline-block to prevent text breaking |
+
+## CSS Variables
+
+`--ease-gradient-from`, `--ease-gradient-via`, `--ease-gradient-to`

--- a/submissions/docs/core_changes-issue-30393/demo.html
+++ b/submissions/docs/core_changes-issue-30393/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>Gradient Text — EaseMotion CSS</title><link rel="stylesheet" href="style.css"><style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 700px; margin: 0 auto; padding: 2rem; background: #f9fafb; color: #111; }
+h1 { margin-bottom: .5rem; }
+section { background: #fff; padding: 1.5rem; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 1.5rem; }
+h2 { margin: 0 0 1rem; font-size: 1rem; color: #374151; margin-top: 0; }
+.demo-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+.demo-item { padding: 1rem; border-radius: 8px; background: #f3f4f6; font-size: 1.5rem; font-weight: 800; text-align: center; }
+code { background: #e5e7eb; padding: .15em .4em; border-radius: 4px; }
+</style></head>
+<body>
+<h1>Gradient Text</h1>
+<section>
+<h2>Named Gradients</h2>
+<div class="demo-grid">
+  <div class="demo-item ease-text-gradient ease-text-gradient-primary ease-text-gradient-no-wrap">Primary</div>
+  <div class="demo-item ease-text-gradient ease-text-gradient-sunset ease-text-gradient-no-wrap">Sunset</div>
+  <div class="demo-item ease-text-gradient ease-text-gradient-ocean ease-text-gradient-no-wrap">Ocean</div>
+  <div class="demo-item ease-text-gradient ease-text-gradient-forest ease-text-gradient-no-wrap">Forest</div>
+  <div class="demo-item ease-text-gradient ease-text-gradient-neutral ease-text-gradient-no-wrap">Neutral</div>
+</div>
+</section>
+<section>
+<h2>Direction Variants</h2>
+<div class="demo-item ease-text-gradient ease-text-gradient-primary ease-text-gradient-to-r" style="margin-bottom:.5rem">Right (default)</div>
+<div class="demo-item ease-text-gradient ease-text-gradient-sunset ease-text-gradient-to-t" style="margin-bottom:.5rem">Top</div>
+<div class="demo-item ease-text-gradient ease-text-gradient-ocean ease-text-gradient-to-l">Left</div>
+</section>
+<section>
+<h2>Custom via CSS Variables</h2>
+<div class="demo-item ease-text-gradient ease-text-gradient-no-wrap" style="--ease-gradient-from:#f43f5e;--ease-gradient-to:#f97316;font-size:2rem">Custom Rose → Orange</div>
+</section>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30393/style.css
+++ b/submissions/docs/core_changes-issue-30393/style.css
@@ -1,0 +1,59 @@
+@layer easemotion-utilities {
+:root {
+  --ease-gradient-from: #3b82f6;
+  --ease-gradient-via: #8b5cf6;
+  --ease-gradient-to: #ec4899;
+}
+
+.ease-text-gradient {
+  background: linear-gradient(
+    to right,
+    var(--ease-gradient-from),
+    var(--ease-gradient-via, var(--ease-gradient-from)),
+    var(--ease-gradient-to, var(--ease-gradient-via, var(--ease-gradient-from)))
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+}
+
+.ease-text-gradient-primary {
+  --ease-gradient-from: #3b82f6;
+  --ease-gradient-to: #8b5cf6;
+}
+
+.ease-text-gradient-sunset {
+  --ease-gradient-from: #f97316;
+  --ease-gradient-via: #ef4444;
+  --ease-gradient-to: #ec4899;
+}
+
+.ease-text-gradient-ocean {
+  --ease-gradient-from: #06b6d4;
+  --ease-gradient-via: #3b82f6;
+  --ease-gradient-to: #6366f1;
+}
+
+.ease-text-gradient-forest {
+  --ease-gradient-from: #22c55e;
+  --ease-gradient-via: #14b8a6;
+  --ease-gradient-to: #06b6d4;
+}
+
+.ease-text-gradient-neutral {
+  --ease-gradient-from: #1f2937;
+  --ease-gradient-to: #6b7280;
+}
+
+.ease-text-gradient-to-r { background: linear-gradient(to right, var(--ease-gradient-from), var(--ease-gradient-to)); }
+.ease-text-gradient-to-l { background: linear-gradient(to left, var(--ease-gradient-from), var(--ease-gradient-to)); }
+.ease-text-gradient-to-t { background: linear-gradient(to top, var(--ease-gradient-from), var(--ease-gradient-to)); }
+.ease-text-gradient-to-b { background: linear-gradient(to bottom, var(--ease-gradient-from), var(--ease-gradient-to)); }
+.ease-text-gradient-to-tr { background: linear-gradient(to top right, var(--ease-gradient-from), var(--ease-gradient-to)); }
+.ease-text-gradient-to-bl { background: linear-gradient(to bottom left, var(--ease-gradient-from), var(--ease-gradient-to)); }
+
+.ease-text-gradient-no-wrap {
+  display: inline-block;
+}
+}

--- a/submissions/docs/core_changes-issue-30394/README.md
+++ b/submissions/docs/core_changes-issue-30394/README.md
@@ -1,0 +1,18 @@
+# Selection Color — Issue #30394
+
+::selection styling utilities for branded text selection.
+
+## Classes
+
+| Class | Selection Color |
+|-------|----------------|
+| `.ease-selection-primary` | Primary blue |
+| `.ease-selection-accent` | Violet accent |
+| `.ease-selection-success` | Green |
+| `.ease-selection-warning` | Amber |
+| `.ease-selection-danger` | Red |
+| `.ease-selection-dark` | Dark gray |
+| `.ease-selection-none` | Transparent |
+| `.ease-selection-custom` | Uses --ease-selection-bg/color vars |
+
+Applies to both `::selection` and `*::selection` within the element.

--- a/submissions/docs/core_changes-issue-30394/demo.html
+++ b/submissions/docs/core_changes-issue-30394/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>Selection — EaseMotion CSS</title><link rel="stylesheet" href="style.css"><style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 700px; margin: 0 auto; padding: 2rem; background: #f9fafb; color: #111; }
+h1 { margin-bottom: .5rem; }
+section { background: #fff; padding: 1.5rem; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 1.5rem; }
+h2 { margin: 0 0 1rem; font-size: 1rem; color: #374151; }
+code { background: #e5e7eb; padding: .15em .4em; border-radius: 4px; font-size: .85em; }
+.demo-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+.demo-box { padding: 1rem; border-radius: 8px; background: #f3f4f6; }
+</style></head>
+<body>
+<h1>Selection Color</h1>
+<p>Select text in each box to see custom selection colors.</p>
+<section>
+<div class="demo-grid">
+  <div class="demo-box ease-selection-primary"><code>.ease-selection-primary</code><p>Select this text to see blue selection.</p></div>
+  <div class="demo-box ease-selection-accent"><code>.ease-selection-accent</code><p>Select this text to see purple selection.</p></div>
+  <div class="demo-box ease-selection-success"><code>.ease-selection-success</code><p>Select this text to see green selection.</p></div>
+  <div class="demo-box ease-selection-danger"><code>.ease-selection-danger</code><p>Select this text to see red selection.</p></div>
+  <div class="demo-box ease-selection-warning"><code>.ease-selection-warning</code><p>Select this text to see amber selection.</p></div>
+  <div class="demo-box ease-selection-dark"><code>.ease-selection-dark</code><p>Select this text to see dark selection.</p></div>
+</div>
+</section>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30394/style.css
+++ b/submissions/docs/core_changes-issue-30394/style.css
@@ -1,0 +1,54 @@
+@layer easemotion-utilities {
+:root {
+  --ease-selection-bg: var(--ease-primary, #3b82f6);
+  --ease-selection-color: var(--ease-primary-text, #fff);
+}
+
+.ease-selection-primary::selection,
+.ease-selection-primary *::selection {
+  background: var(--ease-primary, #3b82f6);
+  color: var(--ease-primary-text, #fff);
+}
+
+.ease-selection-accent::selection,
+.ease-selection-accent *::selection {
+  background: var(--ease-accent, #8b5cf6);
+  color: #fff;
+}
+
+.ease-selection-success::selection,
+.ease-selection-success *::selection {
+  background: var(--ease-green-500, #22c55e);
+  color: #fff;
+}
+
+.ease-selection-warning::selection,
+.ease-selection-warning *::selection {
+  background: var(--ease-amber-500, #f59e0b);
+  color: #fff;
+}
+
+.ease-selection-danger::selection,
+.ease-selection-danger *::selection {
+  background: var(--ease-red-500, #ef4444);
+  color: #fff;
+}
+
+.ease-selection-dark::selection,
+.ease-selection-dark *::selection {
+  background: var(--ease-gray-800, #1f2937);
+  color: #fff;
+}
+
+.ease-selection-none::selection,
+.ease-selection-none *::selection {
+  background: transparent;
+  color: inherit;
+}
+
+.ease-selection-custom::selection,
+.ease-selection-custom *::selection {
+  background: var(--ease-selection-bg);
+  color: var(--ease-selection-color);
+}
+}

--- a/submissions/docs/core_changes-issue-30395/README.md
+++ b/submissions/docs/core_changes-issue-30395/README.md
@@ -1,0 +1,18 @@
+# Text Balance & Pretty — Issue #30395
+
+Modern CSS text wrapping control utilities.
+
+## Classes
+
+| Class | Property |
+|-------|----------|
+| `.ease-text-balance` | text-wrap: balance |
+| `.ease-text-pretty` | text-wrap: pretty |
+| `.ease-text-nowrap` | white-space: nowrap |
+| `.ease-text-wrap` | white-space: normal |
+| `.ease-text-truncate` | overflow hidden + ellipsis |
+| `.ease-text-clip` | overflow hidden + clip |
+| `.ease-text-hyphens` | hyphens: auto |
+| `.ease-text-no-hyphens` | hyphens: none |
+| `.ease-text-break-words` | overflow-wrap: break-word |
+| `.ease-text-break-all` | word-break: break-all |

--- a/submissions/docs/core_changes-issue-30395/demo.html
+++ b/submissions/docs/core_changes-issue-30395/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>Text Balance — EaseMotion CSS</title><link rel="stylesheet" href="style.css"><style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 700px; margin: 0 auto; padding: 2rem; background: #f9fafb; color: #111; }
+h1 { margin-bottom: .5rem; }
+section { background: #fff; padding: 1.5rem; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 1.5rem; }
+h2 { margin: 0 0 .5rem; font-size: 1rem; color: #374151; }
+code { background: #e5e7eb; padding: .15em .4em; border-radius: 4px; font-size: .85em; }
+.comparison { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+.col { border: 1px solid #e5e7eb; border-radius: 8px; padding: 1rem; }
+.col h3 { margin: 0 0 .5rem; font-size: .8rem; text-transform: uppercase; letter-spacing: .05em; color: #6b7280; }
+.balanced-demo { max-width: 300px; margin: 0 auto; }
+</style></head>
+<body>
+<h1>Text Balance & Pretty</h1>
+<section>
+<h2>text-wrap: balance vs normal</h2>
+<div class="comparison">
+  <div class="col">
+    <h3>Normal</h3>
+    <p style="max-width:300px">This is a long heading that wraps unevenly on smaller containers leaving one word on the last line which looks unbalanced.</p>
+  </div>
+  <div class="col">
+    <h3>.ease-text-balance</h3>
+    <p class="ease-text-balance" style="max-width:300px">This is a long heading that wraps unevenly on smaller containers leaving one word on the last line which looks unbalanced.</p>
+  </div>
+</div>
+</section>
+<section>
+<h2>Other Text Utilities</h2>
+<div style="display:flex;flex-direction:column;gap:.5rem">
+  <p><code>.ease-text-pretty</code>: <span class="ease-text-pretty">Prevents orphans (single words on last line) by enabling pretty wrapping.</span></p>
+  <p><code>.ease-text-truncate</code>: <span class="ease-text-truncate" style="display:block;max-width:250px;border:1px solid #e5e7eb;padding:.25rem">This is very long text that should be truncated with ellipsis...</span></p>
+  <p><code>.ease-text-hyphens</code>: <span class="ease-text-hyphens" style="max-width:150px;display:block;border:1px solid #e5e7eb;padding:.25rem">Antidisestablishmentarianism utilizes hyphenation.</span></p>
+</div>
+</section>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30395/style.css
+++ b/submissions/docs/core_changes-issue-30395/style.css
@@ -1,0 +1,53 @@
+@layer easemotion-utilities {
+.ease-text-balance {
+  text-wrap: balance;
+}
+
+.ease-text-pretty {
+  text-wrap: pretty;
+}
+
+.ease-text-nowrap {
+  white-space: nowrap;
+}
+
+.ease-text-wrap {
+  white-space: normal;
+  text-wrap: wrap;
+}
+
+.ease-text-truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ease-text-clip {
+  overflow: hidden;
+  text-overflow: clip;
+  white-space: nowrap;
+}
+
+.ease-text-hyphens {
+  hyphens: auto;
+  -webkit-hyphens: auto;
+}
+
+.ease-text-no-hyphens {
+  hyphens: none;
+  -webkit-hyphens: none;
+}
+
+.ease-text-break-normal {
+  overflow-wrap: normal;
+  word-break: normal;
+}
+
+.ease-text-break-words {
+  overflow-wrap: break-word;
+}
+
+.ease-text-break-all {
+  word-break: break-all;
+}
+}

--- a/submissions/docs/core_changes-issue-30396/README.md
+++ b/submissions/docs/core_changes-issue-30396/README.md
@@ -1,0 +1,16 @@
+# Focus Within Utilities — Issue #30396
+
+:focus-within pattern utilities for CSS-only interactivity.
+
+## Classes
+
+| Class | Effect |
+|-------|--------|
+| `.ease-focus-within-ring` | Outline ring when child focused |
+| `.ease-focus-within-shadow` | Box-shadow when child focused |
+| `.ease-focus-within-scale` | Scale transform when child focused |
+| `.ease-focus-within-bg` | Background highlight when child focused |
+| `.ease-focus-within-dropdown` | CSS-only dropdown using :focus-within |
+| `.ease-focus-within-dropdown-menu` | Hidden menu shown on focus-within |
+| `.ease-group-focus` | Parent indicator for focus state |
+| `.ease-group-focus-target` | Child that changes on parent focus |

--- a/submissions/docs/core_changes-issue-30396/demo.html
+++ b/submissions/docs/core_changes-issue-30396/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>Focus Within — EaseMotion CSS</title><link rel="stylesheet" href="style.css"><style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 700px; margin: 0 auto; padding: 2rem; background: #f9fafb; color: #111; }
+h1 { margin-bottom: .5rem; }
+section { background: #fff; padding: 1.5rem; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 1.5rem; }
+h2 { margin: 0 0 1rem; font-size: 1rem; color: #374151; }
+code { background: #e5e7eb; padding: .15em .4em; border-radius: 4px; font-size: .85em; }
+.demo-row { display: flex; gap: 1rem; flex-wrap: wrap; }
+.demo-box { padding: 1rem; border: 2px dashed #d1d5db; border-radius: 8px; }
+.demo-box input { margin-top: .5rem; padding: .375rem .5rem; border: 1px solid #d1d5db; border-radius: 4px; }
+.dropdown-trigger { padding: .5rem 1rem; border: 1px solid #d1d5db; border-radius: 6px; background: #fff; cursor: pointer; }
+</style></head>
+<body>
+<h1>Focus Within Utilities</h1>
+<p>Tab through elements inside each box to see the :focus-within effect.</p>
+
+<section>
+<h2>Ring on focus-within</h2>
+<div class="ease-focus-within-ring demo-box" style="width:250px">
+  <label>Name <input type="text" placeholder="Focus me"></label>
+</div>
+</section>
+
+<section>
+<h2>Scale on focus-within</h2>
+<div class="ease-focus-within-scale demo-box" style="width:250px">
+  <label>Email <input type="email" placeholder="Focus me"></label>
+</div>
+</section>
+
+<section>
+<h2>CSS-only Dropdown (focus-within)</h2>
+<div class="ease-focus-within-dropdown">
+  <button class="dropdown-trigger">Hover or Tab here ▾</button>
+  <div class="ease-focus-within-dropdown-menu">
+    <a href="#">Profile</a>
+    <a href="#">Settings</a>
+    <a href="#">Logout</a>
+  </div>
+</div>
+<p>Tab to the button, then tab again through the menu items.</p>
+</section>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30396/style.css
+++ b/submissions/docs/core_changes-issue-30396/style.css
@@ -1,0 +1,75 @@
+@layer easemotion-utilities {
+.ease-focus-within:focus-within {
+  outline: none;
+}
+
+.ease-group-focus:focus-within {
+  outline: none;
+}
+
+.ease-group-focus:focus-within .ease-group-focus-target {
+  color: var(--ease-primary, #3b82f6);
+}
+
+.ease-focus-within-ring:focus-within {
+  outline: 2px solid var(--ease-primary, #3b82f6);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.ease-focus-within-shadow:focus-within {
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ease-primary, #3b82f6) 20%, transparent);
+  border-radius: 4px;
+}
+
+.ease-focus-within-scale:focus-within {
+  transform: scale(1.02);
+  transition: transform 0.2s;
+}
+
+.ease-focus-within-bg:focus-within {
+  background: color-mix(in srgb, var(--ease-primary, #3b82f6) 8%, transparent);
+  border-radius: 4px;
+}
+
+.ease-focus-within-dropdown {
+  position: relative;
+}
+
+.ease-focus-within-dropdown > .ease-focus-within-dropdown-menu {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  min-width: 12rem;
+  background: var(--ease-surface, #fff);
+  border: 1px solid var(--ease-border, #e5e7eb);
+  border-radius: 0.5rem;
+  box-shadow: 0 4px 16px rgba(0,0,0,.1);
+  padding: 0.25rem;
+  z-index: 50;
+}
+
+.ease-focus-within-dropdown:focus-within > .ease-focus-within-dropdown-menu {
+  display: block;
+}
+
+.ease-focus-within-dropdown-menu a {
+  display: block;
+  padding: 0.5rem 0.75rem;
+  color: var(--ease-text, #111827);
+  text-decoration: none;
+  border-radius: 0.25rem;
+  font-size: 0.875rem;
+}
+
+.ease-focus-within-dropdown-menu a:hover {
+  background: var(--ease-bg-secondary, #f3f4f6);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-focus-within-scale:focus-within {
+    transform: none;
+  }
+}
+}


### PR DESCRIPTION
Add gradient text fill utilities.

### Changes Made
- .ease-text-gradient with background-clip:text
- Named presets: primary, sunset, ocean, forest, neutral
- Direction variants: to-r, to-l, to-t, to-b, to-tr, to-bl
- .ease-text-gradient-no-wrap for inline-block
- CSS variables: --ease-gradient-from/via/to

Fixes #30393