### PR TITLE
feat: add scroll progress indicator (reading progress bar) with gradient and position variants

### DIFF
--- a/submissions/docs/core_changes-issue-30433/README.md
+++ b/submissions/docs/core_changes-issue-30433/README.md
@@ -1,0 +1,23 @@
+# Scroll Progress Indicator — Issue #30433
+
+A thin reading progress bar fixed at the top of the page that fills as the user scrolls.
+
+## Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-scroll-progress` | Fixed top progress bar |
+| `.ease-scroll-progress-gradient` | Gradient fill (uses `--ease-sp-color-to`) |
+| `.ease-scroll-progress-thin` | 2px height |
+| `.ease-scroll-progress-thick` | 5px height |
+| `.ease-scroll-progress-bottom` | Bottom-aligned instead of top |
+| `.ease-scroll-progress-shadow` | Glow shadow under bar |
+
+## CSS Variables
+
+- `--ease-sp-color` (default: primary blue)
+- `--ease-sp-color-to` (gradient end, for gradient variant)
+- `--ease-sp-height` (default: 3px)
+- `--ease-sp-z-index` (default: 9999)
+
+Requires a small JS snippet to update width on scroll (see demo).

--- a/submissions/docs/core_changes-issue-30433/demo.html
+++ b/submissions/docs/core_changes-issue-30433/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Scroll Progress — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 2rem; background: #f9fafb; color: #111; }
+h1 { margin-bottom: 2rem; }
+section { background: #fff; padding: 2rem; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 2rem; }
+p { line-height: 1.8; margin-bottom: 1rem; }
+.spacer { height: 100vh; display: flex; align-items: center; justify-content: center; color: #9ca3af; font-style: italic; }
+</style>
+</head>
+<body>
+
+<span class="ease-scroll-progress ease-scroll-progress-gradient" id="scrollProgress"></span>
+
+<h1>Scroll Progress Indicator</h1>
+<p>Scroll down — the thin bar at the top fills as you scroll.</p>
+
+<section><h2>Content</h2><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p><p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p></section>
+<section><h2>More</h2><p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</p><p>Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.</p></section>
+<div class="spacer">Keep scrolling...</div>
+<section><h2>Still Here</h2><p>At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident.</p></section>
+<div class="spacer">Almost done...</div>
+<section><h2>The End</h2><p>Similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio.</p></section>
+
+<script>
+const bar = document.getElementById('scrollProgress');
+window.addEventListener('scroll', () => {
+  const scrollTop = window.scrollY;
+  const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+  const progress = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0;
+  bar.style.width = progress + '%';
+});
+</script>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30433/style.css
+++ b/submissions/docs/core_changes-issue-30433/style.css
@@ -1,0 +1,44 @@
+@layer easemotion-components {
+.ease-scroll-progress {
+  --ease-sp-color: var(--ease-primary, #3b82f6);
+  --ease-sp-height: 3px;
+  --ease-sp-z-index: 9999;
+
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: var(--ease-sp-height);
+  background: var(--ease-sp-color);
+  z-index: var(--ease-sp-z-index);
+  border-radius: 0 2px 2px 0;
+  transition: width 0.1s linear;
+}
+
+.ease-scroll-progress-gradient {
+  background: linear-gradient(90deg, var(--ease-sp-color), var(--ease-sp-color-to, #8b5cf6));
+}
+
+.ease-scroll-progress-thin {
+  --ease-sp-height: 2px;
+}
+
+.ease-scroll-progress-thick {
+  --ease-sp-height: 5px;
+}
+
+.ease-scroll-progress-bottom {
+  top: auto;
+  bottom: 0;
+}
+
+.ease-scroll-progress-shadow {
+  box-shadow: 0 1px 4px color-mix(in srgb, var(--ease-sp-color) 40%, transparent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-scroll-progress {
+    transition: none;
+  }
+}
+}


### PR DESCRIPTION
### Description
Add a thin reading progress bar fixed at the top of the page that fills as the user scrolls.

### Changes Made
- .ease-scroll-progress fixed bar with dynamic width
- .ease-scroll-progress-gradient variant
- .ease-scroll-progress-thin / -thick size variants
- .ease-scroll-progress-bottom position variant
- .ease-scroll-progress-shadow glow effect
- CSS variables for full customization

Fixes #30433