### PR TITLE
feat: add image zoom/lightbox component with CSS-only overlay using :target and checkbox methods

### DIFF
--- a/submissions/docs/core_changes-issue-30433/README.md
+++ b/submissions/docs/core_changes-issue-30433/README.md
@@ -1,0 +1,23 @@
+# Scroll Progress Indicator — Issue #30433
+
+A thin reading progress bar fixed at the top of the page that fills as the user scrolls.
+
+## Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-scroll-progress` | Fixed top progress bar |
+| `.ease-scroll-progress-gradient` | Gradient fill (uses `--ease-sp-color-to`) |
+| `.ease-scroll-progress-thin` | 2px height |
+| `.ease-scroll-progress-thick` | 5px height |
+| `.ease-scroll-progress-bottom` | Bottom-aligned instead of top |
+| `.ease-scroll-progress-shadow` | Glow shadow under bar |
+
+## CSS Variables
+
+- `--ease-sp-color` (default: primary blue)
+- `--ease-sp-color-to` (gradient end, for gradient variant)
+- `--ease-sp-height` (default: 3px)
+- `--ease-sp-z-index` (default: 9999)
+
+Requires a small JS snippet to update width on scroll (see demo).

--- a/submissions/docs/core_changes-issue-30433/demo.html
+++ b/submissions/docs/core_changes-issue-30433/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Scroll Progress — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 2rem; background: #f9fafb; color: #111; }
+h1 { margin-bottom: 2rem; }
+section { background: #fff; padding: 2rem; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 2rem; }
+p { line-height: 1.8; margin-bottom: 1rem; }
+.spacer { height: 100vh; display: flex; align-items: center; justify-content: center; color: #9ca3af; font-style: italic; }
+</style>
+</head>
+<body>
+
+<span class="ease-scroll-progress ease-scroll-progress-gradient" id="scrollProgress"></span>
+
+<h1>Scroll Progress Indicator</h1>
+<p>Scroll down — the thin bar at the top fills as you scroll.</p>
+
+<section><h2>Content</h2><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p><p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p></section>
+<section><h2>More</h2><p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</p><p>Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.</p></section>
+<div class="spacer">Keep scrolling...</div>
+<section><h2>Still Here</h2><p>At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident.</p></section>
+<div class="spacer">Almost done...</div>
+<section><h2>The End</h2><p>Similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio.</p></section>
+
+<script>
+const bar = document.getElementById('scrollProgress');
+window.addEventListener('scroll', () => {
+  const scrollTop = window.scrollY;
+  const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+  const progress = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0;
+  bar.style.width = progress + '%';
+});
+</script>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30433/style.css
+++ b/submissions/docs/core_changes-issue-30433/style.css
@@ -1,0 +1,44 @@
+@layer easemotion-components {
+.ease-scroll-progress {
+  --ease-sp-color: var(--ease-primary, #3b82f6);
+  --ease-sp-height: 3px;
+  --ease-sp-z-index: 9999;
+
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: var(--ease-sp-height);
+  background: var(--ease-sp-color);
+  z-index: var(--ease-sp-z-index);
+  border-radius: 0 2px 2px 0;
+  transition: width 0.1s linear;
+}
+
+.ease-scroll-progress-gradient {
+  background: linear-gradient(90deg, var(--ease-sp-color), var(--ease-sp-color-to, #8b5cf6));
+}
+
+.ease-scroll-progress-thin {
+  --ease-sp-height: 2px;
+}
+
+.ease-scroll-progress-thick {
+  --ease-sp-height: 5px;
+}
+
+.ease-scroll-progress-bottom {
+  top: auto;
+  bottom: 0;
+}
+
+.ease-scroll-progress-shadow {
+  box-shadow: 0 1px 4px color-mix(in srgb, var(--ease-sp-color) 40%, transparent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-scroll-progress {
+    transition: none;
+  }
+}
+}

--- a/submissions/docs/core_changes-issue-30434/README.md
+++ b/submissions/docs/core_changes-issue-30434/README.md
@@ -1,0 +1,21 @@
+# Image Zoom / Lightbox — Issue #30434
+
+CSS-only lightbox/image zoom component with fullscreen overlay. Two activation methods: `:target` and checkbox `:checked`.
+
+## Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-lightbox` | Anchor wrapper for :target method |
+| `.ease-lightbox-trigger` | Label wrapper for checkbox method |
+| `.ease-lightbox-toggle` | Hidden checkbox (checked → show) |
+| `.ease-lightbox-overlay` | Fullscreen dark overlay |
+| `.ease-lightbox-img` | Expanded image (centered) |
+| `.ease-lightbox-close` | Close button (&times;) |
+| `.ease-lightbox-caption` | Bottom caption text |
+
+## CSS Variables
+
+- `--ease-lb-overlay` (default: rgba(0,0,0,0.85))
+- `--ease-lb-transition` (default: 0.3s ease)
+- `--ease-lb-max-size` (default: 90vw)

--- a/submissions/docs/core_changes-issue-30434/demo.html
+++ b/submissions/docs/core_changes-issue-30434/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Lightbox — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 700px; margin: 0 auto; padding: 2rem; background: #f9fafb; color: #111; }
+h1 { margin-bottom: .5rem; }
+.gallery { display: grid; grid-template-columns: repeat(3, 1fr); gap: .75rem; }
+.gallery img { width: 100%; border-radius: 8px; display: block; }
+section { background: #fff; padding: 1.5rem; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 1.5rem; }
+code { background: #e5e7eb; padding: .15em .4em; border-radius: 4px; }
+.demo-img { width: 200px; border-radius: 8px; }
+</style>
+</head>
+<body>
+
+<h1>Image Zoom / Lightbox</h1>
+
+<section>
+<h2>Method 1: :target (click to open, click overlay to close)</h2>
+<a href="#lightbox1" class="ease-lightbox">
+  <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='150' viewBox='0 0 200 150'%3E%3Crect fill='%233b82f6' width='200' height='150'/%3E%3Ctext fill='white' x='100' y='85' text-anchor='middle' font-size='16'%3EClick to zoom%3C/text%3E%3C/svg%3E" alt="Demo image" class="demo-img">
+</a>
+
+<div class="ease-lightbox-overlay" id="lightbox1">
+  <a href="#" class="ease-lightbox-close">&times;</a>
+  <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='600' viewBox='0 0 800 600'%3E%3Crect fill='%233b82f6' width='800' height='600'/%3E%3Ctext fill='white' x='400' y='310' text-anchor='middle' font-size='32'%3EFull size image%3C/text%3E%3C/svg%3E" alt="Demo full" class="ease-lightbox-img">
+  <span class="ease-lightbox-caption">A beautiful blue demo image</span>
+</div>
+<p>Click the image to open. Click the overlay background or &times; to close.</p>
+</section>
+
+<section>
+<h2>Method 2: Checkbox :checked (CSS-only toggle)</h2>
+<input type="checkbox" class="ease-lightbox-toggle" id="lbToggle">
+<label for="lbToggle" class="ease-lightbox-trigger">
+  <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='150' viewBox='0 0 200 150'%3E%3Crect fill='%238b5cf6' width='200' height='150'/%3E%3Ctext fill='white' x='100' y='85' text-anchor='middle' font-size='16'%3EClick to zoom%3C/text%3E%3C/svg%3E" alt="Demo image 2" class="demo-img">
+</label>
+
+<div class="ease-lightbox-overlay">
+  <label for="lbToggle" class="ease-lightbox-close">&times;</label>
+  <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='600' viewBox='0 0 800 600'%3E%3Crect fill='%238b5cf6' width='800' height='600'/%3E%3Ctext fill='white' x='400' y='310' text-anchor='middle' font-size='32'%3EFull size image%3C/text%3E%3C/svg%3E" alt="Demo full 2" class="ease-lightbox-img">
+</div>
+</section>
+
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30434/style.css
+++ b/submissions/docs/core_changes-issue-30434/style.css
@@ -1,0 +1,110 @@
+@layer easemotion-components {
+.ease-lightbox {
+  --ease-lb-overlay: rgba(0, 0, 0, 0.85);
+  --ease-lb-transition: 0.3s ease;
+  --ease-lb-max-size: 90vw;
+
+  display: inline-block;
+  cursor: zoom-in;
+  line-height: 0;
+}
+
+.ease-lightbox-trigger {
+  display: inline-block;
+  cursor: zoom-in;
+}
+
+.ease-lightbox-trigger img {
+  transition: transform 0.2s;
+  max-width: 100%;
+  height: auto;
+}
+
+.ease-lightbox-trigger:hover img {
+  transform: scale(1.02);
+}
+
+.ease-lightbox-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--ease-lb-overlay);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--ease-lb-transition);
+  cursor: zoom-out;
+}
+
+.ease-lightbox-overlay:target,
+.ease-lightbox-toggle:checked ~ .ease-lightbox-overlay {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.ease-lightbox-toggle {
+  display: none;
+}
+
+.ease-lightbox-img {
+  max-width: var(--ease-lb-max-size);
+  max-height: 85vh;
+  border-radius: 4px;
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.5);
+  transform: scale(0.9);
+  transition: transform var(--ease-lb-transition);
+  cursor: default;
+}
+
+.ease-lightbox-overlay:target .ease-lightbox-img,
+.ease-lightbox-toggle:checked ~ .ease-lightbox-overlay .ease-lightbox-img {
+  transform: scale(1);
+}
+
+.ease-lightbox-close {
+  position: absolute;
+  top: 1rem;
+  right: 1.5rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 1.75rem;
+  text-decoration: none;
+  cursor: pointer;
+  opacity: 0.7;
+  transition: opacity 0.2s, transform 0.2s;
+  border: none;
+  background: transparent;
+  line-height: 1;
+}
+
+.ease-lightbox-close:hover {
+  opacity: 1;
+  transform: rotate(90deg);
+}
+
+.ease-lightbox-caption {
+  position: absolute;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  color: #fff;
+  font-size: 0.875rem;
+  opacity: 0.8;
+  text-align: center;
+  max-width: 80%;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-lightbox-img,
+  .ease-lightbox-close,
+  .ease-lightbox-trigger img {
+    transition: none;
+  }
+}
+}


### PR DESCRIPTION
### Description
Add a CSS-only lightbox/image zoom component with two activation methods.

### Changes Made
- .ease-lightbox: :target-based overlay toggle
- .ease-lightbox-toggle: checkbox-based toggle
- .ease-lightbox-overlay fullscreen dark overlay
- .ease-lightbox-img with scale-in animation
- .ease-lightbox-close close button
- .ease-lightbox-caption bottom caption
- CSS custom properties for overlay, transition, max-size
- prefers-reduced-motion support

Fixes #30434