### PR TITLE
feat: add CSS countdown timer with linear bar and circular ring variants driven by animation-duration

### DIFF
--- a/submissions/docs/core_changes-issue-30434/README.md
+++ b/submissions/docs/core_changes-issue-30434/README.md
@@ -1,0 +1,21 @@
+# Image Zoom / Lightbox — Issue #30434
+
+CSS-only lightbox/image zoom component with fullscreen overlay. Two activation methods: `:target` and checkbox `:checked`.
+
+## Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-lightbox` | Anchor wrapper for :target method |
+| `.ease-lightbox-trigger` | Label wrapper for checkbox method |
+| `.ease-lightbox-toggle` | Hidden checkbox (checked → show) |
+| `.ease-lightbox-overlay` | Fullscreen dark overlay |
+| `.ease-lightbox-img` | Expanded image (centered) |
+| `.ease-lightbox-close` | Close button (&times;) |
+| `.ease-lightbox-caption` | Bottom caption text |
+
+## CSS Variables
+
+- `--ease-lb-overlay` (default: rgba(0,0,0,0.85))
+- `--ease-lb-transition` (default: 0.3s ease)
+- `--ease-lb-max-size` (default: 90vw)

--- a/submissions/docs/core_changes-issue-30434/demo.html
+++ b/submissions/docs/core_changes-issue-30434/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Lightbox — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 700px; margin: 0 auto; padding: 2rem; background: #f9fafb; color: #111; }
+h1 { margin-bottom: .5rem; }
+.gallery { display: grid; grid-template-columns: repeat(3, 1fr); gap: .75rem; }
+.gallery img { width: 100%; border-radius: 8px; display: block; }
+section { background: #fff; padding: 1.5rem; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 1.5rem; }
+code { background: #e5e7eb; padding: .15em .4em; border-radius: 4px; }
+.demo-img { width: 200px; border-radius: 8px; }
+</style>
+</head>
+<body>
+
+<h1>Image Zoom / Lightbox</h1>
+
+<section>
+<h2>Method 1: :target (click to open, click overlay to close)</h2>
+<a href="#lightbox1" class="ease-lightbox">
+  <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='150' viewBox='0 0 200 150'%3E%3Crect fill='%233b82f6' width='200' height='150'/%3E%3Ctext fill='white' x='100' y='85' text-anchor='middle' font-size='16'%3EClick to zoom%3C/text%3E%3C/svg%3E" alt="Demo image" class="demo-img">
+</a>
+
+<div class="ease-lightbox-overlay" id="lightbox1">
+  <a href="#" class="ease-lightbox-close">&times;</a>
+  <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='600' viewBox='0 0 800 600'%3E%3Crect fill='%233b82f6' width='800' height='600'/%3E%3Ctext fill='white' x='400' y='310' text-anchor='middle' font-size='32'%3EFull size image%3C/text%3E%3C/svg%3E" alt="Demo full" class="ease-lightbox-img">
+  <span class="ease-lightbox-caption">A beautiful blue demo image</span>
+</div>
+<p>Click the image to open. Click the overlay background or &times; to close.</p>
+</section>
+
+<section>
+<h2>Method 2: Checkbox :checked (CSS-only toggle)</h2>
+<input type="checkbox" class="ease-lightbox-toggle" id="lbToggle">
+<label for="lbToggle" class="ease-lightbox-trigger">
+  <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='150' viewBox='0 0 200 150'%3E%3Crect fill='%238b5cf6' width='200' height='150'/%3E%3Ctext fill='white' x='100' y='85' text-anchor='middle' font-size='16'%3EClick to zoom%3C/text%3E%3C/svg%3E" alt="Demo image 2" class="demo-img">
+</label>
+
+<div class="ease-lightbox-overlay">
+  <label for="lbToggle" class="ease-lightbox-close">&times;</label>
+  <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='600' viewBox='0 0 800 600'%3E%3Crect fill='%238b5cf6' width='800' height='600'/%3E%3Ctext fill='white' x='400' y='310' text-anchor='middle' font-size='32'%3EFull size image%3C/text%3E%3C/svg%3E" alt="Demo full 2" class="ease-lightbox-img">
+</div>
+</section>
+
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30434/style.css
+++ b/submissions/docs/core_changes-issue-30434/style.css
@@ -1,0 +1,110 @@
+@layer easemotion-components {
+.ease-lightbox {
+  --ease-lb-overlay: rgba(0, 0, 0, 0.85);
+  --ease-lb-transition: 0.3s ease;
+  --ease-lb-max-size: 90vw;
+
+  display: inline-block;
+  cursor: zoom-in;
+  line-height: 0;
+}
+
+.ease-lightbox-trigger {
+  display: inline-block;
+  cursor: zoom-in;
+}
+
+.ease-lightbox-trigger img {
+  transition: transform 0.2s;
+  max-width: 100%;
+  height: auto;
+}
+
+.ease-lightbox-trigger:hover img {
+  transform: scale(1.02);
+}
+
+.ease-lightbox-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--ease-lb-overlay);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--ease-lb-transition);
+  cursor: zoom-out;
+}
+
+.ease-lightbox-overlay:target,
+.ease-lightbox-toggle:checked ~ .ease-lightbox-overlay {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.ease-lightbox-toggle {
+  display: none;
+}
+
+.ease-lightbox-img {
+  max-width: var(--ease-lb-max-size);
+  max-height: 85vh;
+  border-radius: 4px;
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.5);
+  transform: scale(0.9);
+  transition: transform var(--ease-lb-transition);
+  cursor: default;
+}
+
+.ease-lightbox-overlay:target .ease-lightbox-img,
+.ease-lightbox-toggle:checked ~ .ease-lightbox-overlay .ease-lightbox-img {
+  transform: scale(1);
+}
+
+.ease-lightbox-close {
+  position: absolute;
+  top: 1rem;
+  right: 1.5rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 1.75rem;
+  text-decoration: none;
+  cursor: pointer;
+  opacity: 0.7;
+  transition: opacity 0.2s, transform 0.2s;
+  border: none;
+  background: transparent;
+  line-height: 1;
+}
+
+.ease-lightbox-close:hover {
+  opacity: 1;
+  transform: rotate(90deg);
+}
+
+.ease-lightbox-caption {
+  position: absolute;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  color: #fff;
+  font-size: 0.875rem;
+  opacity: 0.8;
+  text-align: center;
+  max-width: 80%;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-lightbox-img,
+  .ease-lightbox-close,
+  .ease-lightbox-trigger img {
+    transition: none;
+  }
+}
+}

--- a/submissions/docs/core_changes-issue-30435/README.md
+++ b/submissions/docs/core_changes-issue-30435/README.md
@@ -1,0 +1,22 @@
+# CSS Countdown Timer — Issue #30435
+
+Pure CSS countdown timer with bar and ring variants. Uses `animation-duration` driven by `--ease-cd-duration` CSS variable.
+
+## Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-countdown` | Timer container |
+| `.ease-countdown-display` | Numeric display |
+| `.ease-countdown-bar` | Linear progress track |
+| `.ease-countdown-bar-fill` | Shrinking bar fill |
+| `.ease-countdown-ring` | Circular SVG container |
+| `.ease-countdown-ring-fill` | SVG arc (dashoffset animation) |
+| `.ease-countdown-ring-label` | Center label |
+| `.ease-countdown-sm` / `-lg` | Size variants |
+
+## CSS Variables
+
+- `--ease-cd-duration` (seconds, default 60)
+- `--ease-cd-size` (ring diameter, default 6rem)
+- `--ease-cd-color`, `--ease-cd-track`, `--ease-cd-font-size`

--- a/submissions/docs/core_changes-issue-30435/demo.html
+++ b/submissions/docs/core_changes-issue-30435/demo.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Countdown — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 700px; margin: 0 auto; padding: 2rem; background: #f9fafb; color: #111; }
+h1 { margin-bottom: .5rem; }
+section { background: #fff; padding: 1.5rem; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 1.5rem; }
+h2 { margin: 0 0 1rem; font-size: 1rem; color: #374151; }
+.grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1.5rem; text-align: center; }
+code { background: #e5e7eb; padding: .15em .4em; border-radius: 4px; }
+.note { background: #fffbeb; border-left: 3px solid #f59e0b; padding: .75rem 1rem; border-radius: 4px; font-size: .85rem; margin-bottom: 1rem; }
+.btn { padding: .5rem 1rem; border: 1px solid #d1d5db; border-radius: 6px; background: #fff; cursor: pointer; }
+.btn:hover { background: #f3f4f6; }
+</style>
+</head>
+<body>
+
+<h1>CSS Countdown Timer</h1>
+<p class="note">Animation restarts on page reload. Uses <code>--ease-cd-duration</code> in seconds.</p>
+
+<section>
+<h2>Linear Bar Countdown</h2>
+<div class="ease-countdown" style="--ease-cd-duration:10">
+  <div class="ease-countdown-display">10</div>
+  <div class="ease-countdown-bar">
+    <span class="ease-countdown-bar-fill"></span>
+  </div>
+</div>
+</section>
+
+<section>
+<h2>Ring Countdown (10s)</h2>
+<div class="ease-countdown" style="--ease-cd-duration:10">
+  <div class="ease-countdown-ring">
+    <svg viewBox="0 0 100 100">
+      <circle class="ease-countdown-ring-track" cx="50" cy="50" r="45"/>
+      <circle class="ease-countdown-ring-fill" cx="50" cy="50" r="45"/>
+    </svg>
+    <span class="ease-countdown-ring-label">10</span>
+  </div>
+</div>
+</section>
+
+<section>
+<h2>Size & Color Variants (30s)</h2>
+<div class="grid">
+  <div>
+    <div class="ease-countdown ease-countdown-sm" style="--ease-cd-duration:30;--ease-cd-color:#22c55e">
+      <div class="ease-countdown-ring">
+        <svg viewBox="0 0 100 100">
+          <circle class="ease-countdown-ring-track" cx="50" cy="50" r="45"/>
+          <circle class="ease-countdown-ring-fill" cx="50" cy="50" r="45"/>
+        </svg>
+        <span class="ease-countdown-ring-label">30</span>
+      </div>
+      <div style="font-size:.8rem;color:#6b7280">Small / Green</div>
+    </div>
+  </div>
+  <div>
+    <div class="ease-countdown ease-countdown-lg" style="--ease-cd-duration:30;--ease-cd-color:#ef4444">
+      <div class="ease-countdown-ring">
+        <svg viewBox="0 0 100 100">
+          <circle class="ease-countdown-ring-track" cx="50" cy="50" r="45"/>
+          <circle class="ease-countdown-ring-fill" cx="50" cy="50" r="45"/>
+        </svg>
+        <span class="ease-countdown-ring-label">30</span>
+      </div>
+      <div style="font-size:.8rem;color:#6b7280">Large / Red</div>
+    </div>
+  </div>
+</div>
+</section>
+
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30435/style.css
+++ b/submissions/docs/core_changes-issue-30435/style.css
@@ -1,0 +1,106 @@
+@layer easemotion-components {
+@property --ease-cd-value {
+  syntax: "<integer>";
+  initial-value: 0;
+  inherits: true;
+}
+
+.ease-countdown {
+  --ease-cd-duration: 60;
+  --ease-cd-size: 6rem;
+  --ease-cd-color: var(--ease-primary, #3b82f6);
+  --ease-cd-track: var(--ease-bg-tertiary, #e5e7eb);
+  --ease-cd-font-size: 2rem;
+
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.ease-countdown-display {
+  --ease-cd-value: var(--ease-cd-duration);
+  font-size: var(--ease-cd-font-size);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--ease-cd-color);
+  line-height: 1;
+}
+
+.ease-countdown-bar {
+  width: 100%;
+  height: 4px;
+  background: var(--ease-cd-track);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.ease-countdown-bar-fill {
+  display: block;
+  height: 100%;
+  width: 100%;
+  background: var(--ease-cd-color);
+  animation: ease-cd-fill calc(var(--ease-cd-duration) * 1s) linear forwards;
+  transform-origin: left;
+}
+
+.ease-countdown-ring {
+  --ease-cd-ring-size: var(--ease-cd-size);
+  width: var(--ease-cd-ring-size);
+  height: var(--ease-cd-ring-size);
+  position: relative;
+}
+
+.ease-countdown-ring svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.ease-countdown-ring-track {
+  fill: none;
+  stroke: var(--ease-cd-track);
+  stroke-width: 6;
+}
+
+.ease-countdown-ring-fill {
+  fill: none;
+  stroke: var(--ease-cd-color);
+  stroke-width: 6;
+  stroke-linecap: round;
+  stroke-dasharray: 283;
+  stroke-dashoffset: 0;
+  animation: ease-cd-ring calc(var(--ease-cd-duration) * 1s) linear forwards;
+}
+
+.ease-countdown-ring-label {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: calc(var(--ease-cd-size) / 3);
+  font-weight: 700;
+  color: var(--ease-cd-color);
+}
+
+.ease-countdown-sm { --ease-cd-size: 4rem; --ease-cd-font-size: 1.25rem; }
+.ease-countdown-lg { --ease-cd-size: 8rem; --ease-cd-font-size: 2.5rem; }
+
+@keyframes ease-cd-fill {
+  from { transform: scaleX(1); }
+  to   { transform: scaleX(0); }
+}
+
+@keyframes ease-cd-ring {
+  from { stroke-dashoffset: 0; }
+  to   { stroke-dashoffset: 283; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-countdown-bar-fill,
+  .ease-countdown-ring-fill {
+    animation: none;
+  }
+}
+}


### PR DESCRIPTION
### Description
Add a pure CSS countdown timer using animation-duration and @property for the display value.

### Changes Made
- .ease-countdown container with --ease-cd-duration
- .ease-countdown-display with @property integer animation
- .ease-countdown-bar with shrinking fill animation
- .ease-countdown-ring with SVG stroke-dashoffset animation
- .ease-countdown-ring-label center number
- .ease-countdown-sm / -lg size variants

Fixes #30435