### PR TITLE
feat: add multi-theme switcher component with system/light/dark/sepia/high-contrast support

### DIFF
--- a/submissions/docs/core_changes-issue-30436/README.md
+++ b/submissions/docs/core_changes-issue-30436/README.md
@@ -1,0 +1,21 @@
+# Theme Switcher — Issue #30436
+
+Multi-theme switcher component supporting system, light, dark, sepia, and high-contrast themes.
+
+## Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-theme-switcher` | Toggle group container |
+| `.ease-theme-option` | Individual theme button |
+| `.ease-theme-option.is-active` | Active state |
+| `.ease-theme-system` | Follow prefers-color-scheme |
+| `.ease-theme-light` | Force light |
+| `.ease-theme-dark` | Force dark |
+| `.ease-theme-sepia` | Sepia/paper theme |
+| `.ease-theme-high-contrast` | High contrast a11y theme |
+| `.ease-theme-transition` | Smooth transitions on all elements |
+
+## CSS Variables
+
+- `--ease-ts-gap`, `--ease-ts-radius`, `--ease-ts-bg`, `--ease-ts-active`, `--ease-ts-shadow`

--- a/submissions/docs/core_changes-issue-30436/demo.html
+++ b/submissions/docs/core_changes-issue-30436/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Theme Switcher — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 2rem; background: var(--ease-bg,#f9fafb); color: var(--ease-text,#111); }
+h1 { margin-bottom: .5rem; }
+section { background: var(--ease-surface,#fff); padding: 1.5rem; border-radius: 12px; border: 1px solid var(--ease-border,#e5e7eb); margin-bottom: 1.5rem; }
+.card { background: var(--ease-bg-secondary,#f3f4f6); padding: 1rem; border-radius: 8px; margin-top: 1rem; }
+.btn { padding: .5rem 1rem; border: 1px solid var(--ease-border,#d1d5db); border-radius: 6px; background: var(--ease-surface,#fff); color: var(--ease-text,#111); cursor: pointer; }
+code { background: var(--ease-bg-tertiary,#e5e7eb); padding: .15em .4em; border-radius: 4px; }
+</style>
+</head>
+<body>
+<div class="ease-theme-transition">
+<h1>Theme Switcher</h1>
+<div class="ease-theme-switcher" style="margin-bottom:1.5rem">
+  <button class="ease-theme-option is-active" data-theme="system">System</button>
+  <button class="ease-theme-option" data-theme="light">Light</button>
+  <button class="ease-theme-option" data-theme="dark">Dark</button>
+  <button class="ease-theme-option" data-theme="sepia">Sepia</button>
+  <button class="ease-theme-option" data-theme="high-contrast">High Contrast</button>
+</div>
+<section>
+<h2>Sample Content</h2>
+<p>This text and the card below respond to the selected theme.</p>
+<div class="card">
+  <p><strong>Card Title</strong></p>
+  <p>This card uses theme CSS variables for colors.</p>
+  <button class="btn">Sample Button</button>
+</div>
+</section>
+</div>
+<script>
+document.querySelectorAll('.ease-theme-option').forEach(btn => {
+  btn.addEventListener('click', () => {
+    document.querySelectorAll('.ease-theme-option').forEach(b => b.classList.remove('is-active'));
+    btn.classList.add('is-active');
+    const theme = btn.dataset.theme;
+    document.documentElement.className = '';
+    if (theme === 'system') {
+      document.documentElement.classList.add('ease-dark-mode-auto');
+    } else if (theme !== 'light') {
+      document.documentElement.classList.add('ease-theme-' + theme);
+    }
+  });
+});
+</script>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30436/style.css
+++ b/submissions/docs/core_changes-issue-30436/style.css
@@ -1,0 +1,75 @@
+@layer easemotion-components {
+.ease-theme-switcher {
+  --ease-ts-gap: 0.25rem;
+  --ease-ts-radius: 0.5rem;
+  --ease-ts-bg: var(--ease-bg-secondary, #f3f4f6);
+  --ease-ts-active: var(--ease-surface, #fff);
+  --ease-ts-shadow: 0 1px 3px rgba(0,0,0,.1);
+
+  display: inline-flex;
+  gap: var(--ease-ts-gap);
+  padding: 0.25rem;
+  background: var(--ease-ts-bg);
+  border-radius: var(--ease-ts-radius);
+}
+
+.ease-theme-option {
+  padding: 0.375rem 0.75rem;
+  border: none;
+  border-radius: calc(var(--ease-ts-radius) - 2px);
+  background: transparent;
+  color: var(--ease-text-secondary, #4b5563);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s, box-shadow 0.2s;
+  white-space: nowrap;
+}
+
+.ease-theme-option:hover {
+  color: var(--ease-text, #111827);
+}
+
+.ease-theme-option.is-active {
+  background: var(--ease-ts-active);
+  color: var(--ease-text, #111827);
+  box-shadow: var(--ease-ts-shadow);
+}
+
+.ease-theme-system,
+.ease-theme-light,
+.ease-theme-dark,
+.ease-theme-sepia,
+.ease-theme-high-contrast {
+  /* Theme classes applied to html element */
+}
+
+html.ease-theme-sepia {
+  --ease-bg: #fbf3d9;
+  --ease-bg-secondary: #f5e9c4;
+  --ease-text: #5b4636;
+  --ease-text-secondary: #7d6b55;
+  --ease-border: #d5c4a1;
+  --ease-primary: #af6f4b;
+  color-scheme: light;
+}
+
+html.ease-theme-high-contrast {
+  --ease-bg: #000;
+  --ease-bg-secondary: #1a1a1a;
+  --ease-text: #fff;
+  --ease-text-secondary: #ccc;
+  --ease-border: #666;
+  --ease-primary: #ff0;
+  --ease-primary-text: #000;
+  --ease-focus-ring-color: #ff0;
+  color-scheme: dark;
+}
+
+.ease-theme-transition,
+.ease-theme-transition * {
+  transition: background-color 0.3s ease,
+              color 0.3s ease,
+              border-color 0.3s ease,
+              box-shadow 0.3s ease !important;
+}
+}

--- a/submissions/docs/core_changes-issue-30437/README.md
+++ b/submissions/docs/core_changes-issue-30437/README.md
@@ -1,0 +1,20 @@
+# Animated Number Counter — Issue #30437
+
+CSS-only animated number counter using @property for integer animation.
+
+## Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-number-counter` | Counter container |
+| `.ease-counter-value` | Animated number display |
+| `.ease-counter-animate` | Triggers count animation |
+| `.ease-counter-label` | Description text |
+| `.ease-counter-sm` / `-lg` | Size variants |
+
+## CSS Variables
+
+- `--ease-counter-from`, `--ease-counter-to` (start/end values)
+- `--ease-counter-duration`, `--ease-counter-delay`
+- `--ease-counter-font-size`, `--ease-counter-color`
+- `--ease-counter-prefix`, `--ease-counter-suffix`

--- a/submissions/docs/core_changes-issue-30437/demo.html
+++ b/submissions/docs/core_changes-issue-30437/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Number Counter — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 2rem; background: #f9fafb; color: #111; }
+h1 { margin-bottom: .5rem; }
+section { background: #fff; padding: 1.5rem; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 1.5rem; }
+h2 { margin: 0 0 1rem; font-size: 1rem; color: #374151; }
+.grid { display: grid; grid-template-columns: repeat(3,1fr); gap: 1rem; text-align: center; }
+code { background: #e5e7eb; padding: .15em .4em; border-radius: 4px; }
+.btn { padding: .5rem 1rem; border: 1px solid #d1d5db; border-radius: 6px; background: #fff; cursor: pointer; }
+</style>
+</head>
+<body>
+<h1>Animated Number Counter</h1>
+<button class="btn" onclick="document.querySelectorAll('.ease-counter-value').forEach(e=>{e.style.animation='none';void e.offsetWidth;e.style.animation=''});document.querySelectorAll('.ease-number-counter').forEach(e=>e.classList.remove('ease-counter-animate'));void document.querySelector('.ease-number-counter').offsetWidth;document.querySelectorAll('.ease-number-counter').forEach(e=>e.classList.add('ease-counter-animate'))">Replay Animations</button>
+<section>
+<h2>Basic Counters</h2>
+<div class="grid">
+  <div class="ease-number-counter ease-counter-animate" style="--ease-counter-from:0;--ease-counter-to:1000;--ease-counter-duration:3s">
+    <span class="ease-counter-value"></span>
+    <span class="ease-counter-label">Downloads</span>
+  </div>
+  <div class="ease-number-counter ease-counter-animate" style="--ease-counter-from:0;--ease-counter-to:500;--ease-counter-duration:2s;--ease-counter-color:#22c55e">
+    <span class="ease-counter-value"></span>
+    <span class="ease-counter-label">Users</span>
+  </div>
+  <div class="ease-number-counter ease-counter-animate" style="--ease-counter-from:0;--ease-counter-to:99;--ease-counter-duration:1.5s;--ease-counter-color:#ef4444">
+    <span class="ease-counter-value"></span>
+    <span class="ease-counter-label">Bugs Fixed</span>
+  </div>
+</div>
+</section>
+<section>
+<h2>With Prefix/Suffix</h2>
+<div class="grid">
+  <div class="ease-number-counter ease-counter-animate ease-counter-lg" style="--ease-counter-from:0;--ease-counter-to:9999;--ease-counter-color:#8b5cf6">
+    <span class="ease-counter-value" style="--ease-counter-prefix:'$'"></span>
+  </div>
+  <div class="ease-number-counter ease-counter-animate" style="--ease-counter-from:0;--ease-counter-to:100;--ease-counter-color:#f59e0b">
+    <span class="ease-counter-value" style="--ease-counter-suffix:'%'"></span>
+    <span class="ease-counter-label">Completion</span>
+  </div>
+</div>
+</section>
+<p>Uses CSS @property for integer animation. Click "Replay" to restart.</p>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30437/style.css
+++ b/submissions/docs/core_changes-issue-30437/style.css
@@ -1,0 +1,69 @@
+@layer easemotion-components {
+@property --ease-counter-num {
+  syntax: "<integer>";
+  initial-value: 0;
+  inherits: false;
+}
+
+.ease-number-counter {
+  --ease-counter-from: 0;
+  --ease-counter-to: 100;
+  --ease-counter-duration: 2s;
+  --ease-counter-delay: 0s;
+  --ease-counter-font-size: 2.5rem;
+  --ease-counter-color: var(--ease-primary, #3b82f6);
+
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.ease-counter-value {
+  --ease-counter-num: var(--ease-counter-from);
+  font-size: var(--ease-counter-font-size);
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  color: var(--ease-counter-color);
+  line-height: 1;
+  counter-reset: ease-counter var(--ease-counter-num);
+}
+
+.ease-counter-value::after {
+  content: counter(ease-counter);
+}
+
+.ease-counter-animate .ease-counter-value {
+  animation: ease-counter-count var(--ease-counter-duration) var(--ease-counter-delay) ease-out forwards;
+}
+
+.ease-counter-label {
+  font-size: 0.8rem;
+  color: var(--ease-text-secondary, #4b5563);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.ease-counter-prefix::before {
+  content: var(--ease-counter-prefix, "");
+}
+
+.ease-counter-suffix::after {
+  content: var(--ease-counter-suffix, "") !important;
+}
+
+.ease-counter-sm { --ease-counter-font-size: 1.5rem; }
+.ease-counter-lg { --ease-counter-font-size: 3.5rem; }
+
+@keyframes ease-counter-count {
+  from { --ease-counter-num: var(--ease-counter-from); }
+  to   { --ease-counter-num: var(--ease-counter-to); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-counter-animate .ease-counter-value {
+    animation: none;
+    --ease-counter-num: var(--ease-counter-to);
+  }
+}
+}

--- a/submissions/docs/core_changes-issue-30438/README.md
+++ b/submissions/docs/core_changes-issue-30438/README.md
@@ -1,0 +1,19 @@
+# Text Reveal / Typewriter — Issue #30438
+
+CSS-only text reveal animations including typewriter and character-by-character reveal.
+
+## Classes
+
+| Class | Effect |
+|-------|--------|
+| `.ease-typewriter` | Typewriter width-reveal |
+| `.ease-typewriter-cursor` | Blinking cursor |
+| `.ease-text-reveal` | Character fade-in (child spans) |
+| `.ease-text-reveal-fade-up` | Fade + slide up |
+
+## CSS Variables
+
+- `--ease-tw-speed` (seconds per char, default 0.08s)
+- `--ease-tw-steps` (number of characters)
+- `--ease-tr-duration` (each char animation, default 0.4s)
+- `--ease-tr-delay` (stagger delay between chars, default 0.05s)

--- a/submissions/docs/core_changes-issue-30438/demo.html
+++ b/submissions/docs/core_changes-issue-30438/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Text Reveal — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 2rem; background: #f9fafb; color: #111; }
+h1 { margin-bottom: .5rem; }
+section { background: #fff; padding: 1.5rem; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 1.5rem; }
+h2 { margin: 0 0 1rem; font-size: 1rem; color: #374151; }
+code { background: #e5e7eb; padding: .15em .4em; border-radius: 4px; }
+</style>
+</head>
+<body>
+<h1>Text Reveal & Typewriter</h1>
+<section>
+<h2>Typewriter</h2>
+<p class="ease-typewriter ease-typewriter-cursor" style="--ease-tw-steps:30;--ease-tw-speed:0.08s;font-family:monospace;background:#1f2937;color:#22c55e;padding:.75rem 1rem;border-radius:8px">
+Hello, this is a typewriter effect!
+</p>
+</section>
+<section>
+<h2>Character Reveal</h2>
+<p class="ease-text-reveal" style="font-size:1.25rem;font-weight:600">
+  <span>L</span><span>e</span><span>t</span><span>t</span><span>e</span><span>r</span>
+  <span> </span>
+  <span>b</span><span>y</span>
+  <span> </span>
+  <span>l</span><span>e</span><span>t</span><span>t</span><span>e</span><span>r</span>
+</p>
+</section>
+<section>
+<h2>Fade Up Reveal</h2>
+<p class="ease-text-reveal ease-text-reveal-fade-up" style="font-size:1.1rem">
+  <span>Each</span> <span>word</span> <span>fades</span> <span>and</span> <span>slides</span> <span>up</span>
+</p>
+</section>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30438/style.css
+++ b/submissions/docs/core_changes-issue-30438/style.css
@@ -1,0 +1,89 @@
+@layer easemotion-utilities {
+.ease-typewriter {
+  --ease-tw-speed: 0.08s;
+  --ease-tw-steps: 20;
+  --ease-tw-cursor: true;
+
+  display: inline-block;
+  overflow: hidden;
+  white-space: nowrap;
+  animation: ease-tw-typing calc(var(--ease-tw-steps) * var(--ease-tw-speed)) steps(var(--ease-tw-steps)) forwards;
+  max-width: fit-content;
+}
+
+.ease-typewriter-cursor {
+  border-right: 2px solid currentColor;
+  animation: ease-tw-blink 0.7s step-end infinite;
+  padding-right: 2px;
+}
+
+.ease-typewriter-cursor.ease-typewriter {
+  animation: ease-tw-typing calc(var(--ease-tw-steps) * var(--ease-tw-speed)) steps(var(--ease-tw-steps)) forwards,
+             ease-tw-blink 0.7s step-end infinite;
+  border-right-color: currentColor;
+}
+
+.ease-text-reveal {
+  --ease-tr-duration: 0.4s;
+  --ease-tr-delay: 0.05s;
+  --ease-tr-easing: ease-out;
+}
+
+.ease-text-reveal > span {
+  display: inline-block;
+  opacity: 0;
+  animation: ease-tr-reveal var(--ease-tr-duration) var(--ease-tr-easing) forwards;
+}
+
+.ease-text-reveal > span:nth-child(1)  { animation-delay: calc(var(--ease-tr-delay) * 1); }
+.ease-text-reveal > span:nth-child(2)  { animation-delay: calc(var(--ease-tr-delay) * 2); }
+.ease-text-reveal > span:nth-child(3)  { animation-delay: calc(var(--ease-tr-delay) * 3); }
+.ease-text-reveal > span:nth-child(4)  { animation-delay: calc(var(--ease-tr-delay) * 4); }
+.ease-text-reveal > span:nth-child(5)  { animation-delay: calc(var(--ease-tr-delay) * 5); }
+.ease-text-reveal > span:nth-child(6)  { animation-delay: calc(var(--ease-tr-delay) * 6); }
+.ease-text-reveal > span:nth-child(7)  { animation-delay: calc(var(--ease-tr-delay) * 7); }
+.ease-text-reveal > span:nth-child(8)  { animation-delay: calc(var(--ease-tr-delay) * 8); }
+.ease-text-reveal > span:nth-child(9)  { animation-delay: calc(var(--ease-tr-delay) * 9); }
+.ease-text-reveal > span:nth-child(10) { animation-delay: calc(var(--ease-tr-delay) * 10); }
+.ease-text-reveal > span:nth-child(11) { animation-delay: calc(var(--ease-tr-delay) * 11); }
+.ease-text-reveal > span:nth-child(12) { animation-delay: calc(var(--ease-tr-delay) * 12); }
+.ease-text-reveal > span:nth-child(13) { animation-delay: calc(var(--ease-tr-delay) * 13); }
+.ease-text-reveal > span:nth-child(14) { animation-delay: calc(var(--ease-tr-delay) * 14); }
+.ease-text-reveal > span:nth-child(15) { animation-delay: calc(var(--ease-tr-delay) * 15); }
+.ease-text-reveal > span:nth-child(16) { animation-delay: calc(var(--ease-tr-delay) * 16); }
+.ease-text-reveal > span:nth-child(17) { animation-delay: calc(var(--ease-tr-delay) * 17); }
+.ease-text-reveal > span:nth-child(18) { animation-delay: calc(var(--ease-tr-delay) * 18); }
+.ease-text-reveal > span:nth-child(19) { animation-delay: calc(var(--ease-tr-delay) * 19); }
+.ease-text-reveal > span:nth-child(20) { animation-delay: calc(var(--ease-tr-delay) * 20); }
+
+.ease-text-reveal-fade-up > span {
+  opacity: 0;
+  transform: translateY(0.5rem);
+  animation: ease-tr-reveal-up var(--ease-tr-duration) var(--ease-tr-easing) forwards;
+}
+
+@keyframes ease-tw-typing {
+  from { width: 0; }
+  to   { width: 100%; }
+}
+
+@keyframes ease-tw-blink {
+  50% { border-color: transparent; }
+}
+
+@keyframes ease-tr-reveal {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes ease-tr-reveal-up {
+  from { opacity: 0; transform: translateY(0.5rem); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-typewriter { animation: none; white-space: normal; overflow: visible; max-width: none; }
+  .ease-typewriter-cursor { border-right: none; animation: none; }
+  .ease-text-reveal > span { opacity: 1; animation: none; }
+}
+}

--- a/submissions/docs/core_changes-issue-30439/README.md
+++ b/submissions/docs/core_changes-issue-30439/README.md
@@ -1,0 +1,23 @@
+# 3D Card Flip — Issue #30439
+
+CSS-only 3D card flip component with hover and click activation.
+
+## Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-card-flip` | Perspective container |
+| `.ease-card-flip-inner` | Transform target (3D rotate) |
+| `.ease-card-flip-front` | Front face |
+| `.ease-card-flip-back` | Back face (hidden by default) |
+| `.ease-card-flip-hover` | Flip on :hover |
+| `.ease-card-flip-toggle` | Flip via checkbox :checked |
+| `.ease-card-flip-x` | Rotate on X axis |
+| `.ease-card-flip-y` | Rotate on Y axis |
+| `.ease-card-flip-sm/md/lg` | Preset sizes |
+
+## CSS Variables
+
+- `--ease-cf-perspective` (default 1000px)
+- `--ease-cf-duration` (default 0.6s)
+- `--ease-cf-easing`

--- a/submissions/docs/core_changes-issue-30439/demo.html
+++ b/submissions/docs/core_changes-issue-30439/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Card Flip — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 700px; margin: 0 auto; padding: 2rem; background: #f9fafb; color: #111; }
+h1 { margin-bottom: .5rem; }
+.grid { display: grid; grid-template-columns: repeat(auto-fit,280px); gap: 2rem; justify-content: center; }
+code { background: #e5e7eb; padding: .15em .4em; border-radius: 4px; }
+section { background: #fff; padding: 1.5rem; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 1.5rem; }
+h2 { margin: 0 0 1rem; font-size: 1rem; color: #374151; }
+.front { background: linear-gradient(135deg,#3b82f6,#8b5cf6); color: #fff; border-radius: 12px; font-weight: 700; font-size: 1.1rem; }
+.back { background: linear-gradient(135deg,#1e293b,#334155); color: #fff; border-radius: 12px; flex-direction: column; gap: .5rem; font-size: .875rem; }
+.back p { margin: 0; }
+</style>
+</head>
+<body>
+<h1>3D Card Flip</h1>
+<section>
+<h2>Hover to Flip (X axis)</h2>
+<div class="ease-card-flip ease-card-flip-x ease-card-flip-hover ease-card-flip-md" style="border-radius:12px">
+  <div class="ease-card-flip-inner">
+    <div class="ease-card-flip-front front">Hover me!</div>
+    <div class="ease-card-flip-back back"><p>Back Content</p><p>✦ ✦ ✦</p></div>
+  </div>
+</div>
+</section>
+<section>
+<h2>Click to Flip (Y axis, checkbox)</h2>
+<div class="ease-card-flip ease-card-flip-y ease-card-flip-md" style="border-radius:12px">
+  <input type="checkbox" class="ease-card-flip-toggle" id="flip1">
+  <label for="flip1" class="ease-card-flip-inner" style="cursor:pointer">
+    <div class="ease-card-flip-front front">Click me!</div>
+    <div class="ease-card-flip-back back"><p>Surprise!</p><p>🎉</p></div>
+  </label>
+</div>
+</section>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30439/style.css
+++ b/submissions/docs/core_changes-issue-30439/style.css
@@ -1,0 +1,64 @@
+@layer easemotion-components {
+.ease-card-flip {
+  --ease-cf-perspective: 1000px;
+  --ease-cf-duration: 0.6s;
+  --ease-cf-easing: cubic-bezier(0.4, 0, 0.2, 1);
+
+  perspective: var(--ease-cf-perspective);
+  display: inline-block;
+}
+
+.ease-card-flip-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transition: transform var(--ease-cf-duration) var(--ease-cf-easing);
+  transform-style: preserve-3d;
+}
+
+.ease-card-flip-x.ease-card-flip-hover:hover .ease-card-flip-inner,
+.ease-card-flip-x .ease-card-flip-toggle:checked ~ .ease-card-flip-inner {
+  transform: rotateX(180deg);
+}
+
+.ease-card-flip-y.ease-card-flip-hover:hover .ease-card-flip-inner,
+.ease-card-flip-y .ease-card-flip-toggle:checked ~ .ease-card-flip-inner {
+  transform: rotateY(180deg);
+}
+
+.ease-card-flip-front,
+.ease-card-flip-back {
+  position: absolute;
+  inset: 0;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: inherit;
+}
+
+.ease-card-flip-front {
+  z-index: 2;
+}
+
+.ease-card-flip-back {
+  transform: rotateX(180deg);
+}
+
+.ease-card-flip-y .ease-card-flip-back {
+  transform: rotateY(180deg);
+}
+
+.ease-card-flip-toggle {
+  display: none;
+}
+
+.ease-card-flip-sm { width: 200px; height: 150px; }
+.ease-card-flip-md { width: 280px; height: 200px; }
+.ease-card-flip-lg { width: 360px; height: 260px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-card-flip-inner { transition: none; }
+}
+}

--- a/submissions/docs/core_changes-issue-30440/README.md
+++ b/submissions/docs/core_changes-issue-30440/README.md
@@ -1,0 +1,17 @@
+# Pull to Refresh — Issue #30440
+
+CSS pull-to-refresh animation utility for mobile web apps.
+
+## Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-pull-refresh` | Scrollable container |
+| `.ease-pull-refresh-indicator` | Pull indicator area |
+| `.ease-pull-refresh-spinner` | Rotating spinner |
+| `.is-pulling` | Active pull state |
+
+## CSS Variables
+
+- `--ease-pr-indicator-size` (default 2.5rem)
+- `--ease-pr-color`, `--ease-pr-track`

--- a/submissions/docs/core_changes-issue-30440/demo.html
+++ b/submissions/docs/core_changes-issue-30440/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Pull to Refresh — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 500px; margin: 0 auto; padding: 2rem; background: #f9fafb; color: #111; }
+h1 { margin-bottom: .5rem; }
+code { background: #e5e7eb; padding: .15em .4em; border-radius: 4px; }
+.list-item { padding: 1rem; border-bottom: 1px solid #e5e7eb; background: #fff; }
+.list-item:last-child { border-bottom: none; }
+.note { background: #fffbeb; border-left: 3px solid #f59e0b; padding: .75rem 1rem; border-radius: 4px; font-size: .85rem; margin-bottom: 1rem; }
+</style>
+</head>
+<body>
+<h1>Pull to Refresh</h1>
+<p class="note">On mobile: pull down past the top to see the refresh indicator. Uses overscroll-behavior.</p>
+<div class="ease-pull-refresh" style="height:400px;background:#fff;border-radius:12px;box-shadow:0 1px 3px rgba(0,0,0,.08);overflow-y:auto" id="pullContainer">
+  <div class="ease-pull-refresh-indicator" id="pullIndicator">
+    <span class="ease-pull-refresh-spinner"></span>
+  </div>
+  <div style="padding:1rem">
+    <div class="list-item"><strong>Item 1</strong> — Latest update</div>
+    <div class="list-item"><strong>Item 2</strong> — New message</div>
+    <div class="list-item"><strong>Item 3</strong> — Comment reply</div>
+    <div class="list-item"><strong>Item 4</strong> — Friend request</div>
+    <div class="list-item"><strong>Item 5</strong> — System notification</div>
+    <div class="list-item"><strong>Item 6</strong> — Reminder</div>
+    <div class="list-item"><strong>Item 7</strong> — Weekly digest</div>
+    <div class="list-item"><strong>Item 8</strong> — Payment received</div>
+  </div>
+</div>
+<script>
+const container = document.getElementById('pullContainer');
+const indicator = document.getElementById('pullIndicator');
+let isPulling = false;
+container.addEventListener('scroll', () => {
+  if (container.scrollTop < -30 && !isPulling) {
+    isPulling = true;
+    container.classList.add('is-pulling');
+    setTimeout(() => {
+      container.classList.remove('is-pulling');
+      isPulling = false;
+    }, 1500);
+  }
+});
+</script>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-30440/style.css
+++ b/submissions/docs/core_changes-issue-30440/style.css
@@ -1,0 +1,45 @@
+@layer easemotion-components {
+.ease-pull-refresh {
+  --ease-pr-indicator-size: 2.5rem;
+  --ease-pr-color: var(--ease-primary, #3b82f6);
+  --ease-pr-track: var(--ease-bg-tertiary, #e5e7eb);
+
+  overflow-y: auto;
+  overscroll-behavior-y: contain;
+  position: relative;
+}
+
+.ease-pull-refresh-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 0;
+  overflow: hidden;
+  transition: height 0.2s;
+  color: var(--ease-pr-color);
+}
+
+.ease-pull-refresh.is-pulling .ease-pull-refresh-indicator {
+  height: var(--ease-pr-indicator-size);
+}
+
+.ease-pull-refresh-spinner {
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 2px solid var(--ease-pr-track);
+  border-top-color: var(--ease-pr-color);
+  border-radius: 50%;
+  animation: ease-pr-spin 0.6s linear infinite;
+}
+
+@keyframes ease-pr-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-pull-refresh-spinner {
+    animation: none;
+    opacity: 0.5;
+  }
+}
+}


### PR DESCRIPTION
Add a theme switcher component supporting multiple themes.

### Changes Made
- .ease-theme-switcher toggle group
- .ease-theme-option with is-active state
- .ease-theme-system/-light/-dark/-sepia/-high-contrast
- Sepia: warm paper tones
- High Contrast: black/yellow for a11y
- .ease-theme-transition for smooth switching

Fixes #30436