### PR TITLE
fix(css): add ease-prefixed aliases for component selectors

### DIFF
--- a/components/breadcrumb.css
+++ b/components/breadcrumb.css
@@ -49,7 +49,8 @@
     font-size: 1rem;
   }
   
-  .bg-dark .ease-breadcrumb-active {
+  .ease-bg-dark .ease-breadcrumb-active,
+  .bg-dark .ease-breadcrumb-active /* @deprecated */ {
     color: #9ca3af;
   }
 }

--- a/components/skeleton.css
+++ b/components/skeleton.css
@@ -15,33 +15,35 @@
   
   .ease-skeleton-lg { height: 2rem; }
 
-.ease-skeleton-card {
-  height: 200px;
-  border-radius: 0.5rem;
-}
+  .ease-skeleton-card {
+    height: 200px;
+    border-radius: 0.5rem;
+  }
 
-.ease-skeleton-text:last-child {
-  width: 60%;
-}
+  .ease-skeleton-text:last-child {
+    width: 60%;
+  }
 
-.ease-skeleton-avatar {
-  width: 40px;
-  height: 40px;
-  border-radius: 9999px;
-  flex-shrink: 0;
-}
+  .ease-skeleton-avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 9999px;
+    flex-shrink: 0;
+  }
 
-.ease-skeleton-image {
-  width: 100%;
-  height: 140px;
-  border-radius: 0.5rem;
-}
+  .ease-skeleton-image {
+    width: 100%;
+    height: 140px;
+    border-radius: 0.5rem;
+  }
 
-.skeleton-card-header .ease-skeleton-text {
-  flex: 1;
-}
+  .ease-skeleton-card-header .ease-skeleton-text,
+  .skeleton-card-header .ease-skeleton-text /* @deprecated */ {
+    flex: 1;
+  }
 
-.skeleton-card-header .ease-skeleton-text:first-child {
-  width: 40%;
-}
+  .ease-skeleton-card-header .ease-skeleton-text:first-child,
+  .skeleton-card-header .ease-skeleton-text:first-child /* @deprecated */ {
+    width: 40%;
+  }
 }


### PR DESCRIPTION
## Pull Request Description

Closes #27882

This PR fixes the remaining shipped component selectors that did not follow the `ease-*` naming convention while preserving backward compatibility.

### Changes
- Added `ease-bg-dark` as the preferred selector for breadcrumb active state.
- Added `ease-skeleton-card-header` as the preferred selector for skeleton components.
- Retained `.bg-dark` and `.skeleton-card-header` as deprecated aliases to avoid breaking existing implementations.
- Verified that all existing tests continue to pass.

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

> ⚠️ This PR is a bug fix for existing component CSS, so submission-specific items are not applicable.

- [ ] All changes are inside `submissions/`
- [ ] Includes `demo.html`
- [ ] Includes `style.css`
- [ ] Includes `README.md`
- [x] **No changes to `core/`**
- [ ] **No changes to `components/`** *(Intentionally modified to fix the reported bug.)*
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds `ease-*` aliases for the remaining generic component selectors while preserving the legacy selectors as deprecated aliases.

**How does a developer use it?**

```html
<div class="ease-bg-dark">
  <span class="ease-breadcrumb-active">Current Page</span>
</div>

<div class="ease-skeleton-card-header">
  <div class="ease-skeleton-text"></div>
</div>
```

**Why does it fit EaseMotion CSS?**

It improves selector consistency by aligning public component selectors with the framework's `ease-*` naming convention while maintaining backward compatibility.

---

## Demo

- [ ] Demo added *(Not applicable for this bug fix.)*

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Validation

```text
> npm test
> vitest run

✓ tests/smoke.test.js (13 tests)

Test Files  1 passed (1)
Tests       13 passed (13)
Duration    3.72s
```

---

## Notes for Maintainer

- Preserves backward compatibility by keeping the legacy selectors as deprecated aliases.
- Follows the same deprecation pattern already used for the badge component selectors.
- No behavioral changes; only selector naming consistency was improved.