### PR TITLE
feat : added place-self CSS utilities

### DIFF
--- a/submissions/examples/place-self/README.md
+++ b/submissions/examples/place-self/README.md
@@ -1,0 +1,44 @@
+# Place Self Utilities
+
+CSS utility classes for the `place-self` property.
+
+## Usage
+
+```html
+<div class="place-self-auto">...</div>
+```
+
+## Classes
+
+- `.place-self-auto` — place-self: auto;
+- `.place-self-start` — place-self: start;
+- `.place-self-end` — place-self: end;
+- `.place-self-center` — place-self: center;
+- `.place-self-stretch` — place-self: stretch;
+- `.place-self-baseline` — place-self: baseline;
+- `.place-self-flex-start` — place-self: flex-start;
+- `.place-self-flex-end` — place-self: flex-end;
+- `.place-self-safe-start` — place-self: safe start;
+- `.place-self-safe-end` — place-self: safe end;
+- `.place-self-safe-center` — place-self: safe center;
+- `.place-self-inherit` — place-self: inherit;
+- `.place-self-initial` — place-self: initial;
+- `.place-self-unset` — place-self: unset;
+- `.place-self-revert` — place-self: revert;
+- `.place-self-normal` — place-self: normal;
+- `.place-self-center-i` — place-self: center !important;
+- `.place-self-start-i` — place-self: start !important;
+- `.place-self-end-i` — place-self: end !important;
+- `.place-self-stretch-i` — place-self: stretch !important;
+
+## Responsive
+
+- `sm:` prefix for 640px+
+- `lg:` prefix for 1024px+
+
+## Dark Mode
+
+- `dark:` prefix for `prefers-color-scheme: dark`
+## Reduced Motion
+
+- `motion-safe:` prefix for `prefers-reduced-motion: reduce`

--- a/submissions/examples/place-self/demo.html
+++ b/submissions/examples/place-self/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Place Self Utilities</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: system-ui, sans-serif; padding: 2rem; }
+    .demo-item { margin: 0.5rem; padding: 0.75rem 1rem; border: 1px solid #ccc; border-radius: 4px; }
+    .dark body { background: #1a1a1a; color: #eee; }
+    .dark .demo-item { border-color: #444; }
+  </style>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-item place-self-auto">.place-self-auto</div>
+  <div class="demo-item place-self-start">.place-self-start</div>
+  <div class="demo-item place-self-end">.place-self-end</div>
+  <div class="demo-item place-self-center">.place-self-center</div>
+  <div class="demo-item place-self-stretch">.place-self-stretch</div>
+  <div class="demo-item place-self-baseline">.place-self-baseline</div>
+</body>
+</html>

--- a/submissions/examples/place-self/style.css
+++ b/submissions/examples/place-self/style.css
@@ -1,0 +1,649 @@
+/* place-self */
+.place-self-auto {
+  place-self: auto;
+  place-self: auto !important;
+}
+.place-self-start {
+  place-self: start;
+  place-self: start !important;
+}
+.place-self-end {
+  place-self: end;
+  place-self: end !important;
+}
+.place-self-center {
+  place-self: center;
+  place-self: center !important;
+}
+.place-self-stretch {
+  place-self: stretch;
+  place-self: stretch !important;
+}
+.place-self-baseline {
+  place-self: baseline;
+  place-self: baseline !important;
+}
+.place-self-flex-start {
+  place-self: flex-start;
+  place-self: flex-start !important;
+}
+.place-self-flex-end {
+  place-self: flex-end;
+  place-self: flex-end !important;
+}
+.place-self-safe-start {
+  place-self: safe start;
+  place-self: safe start !important;
+}
+.place-self-safe-end {
+  place-self: safe end;
+  place-self: safe end !important;
+}
+.place-self-safe-center {
+  place-self: safe center;
+  place-self: safe center !important;
+}
+.place-self-inherit {
+  place-self: inherit;
+  place-self: inherit !important;
+}
+.place-self-initial {
+  place-self: initial;
+  place-self: initial !important;
+}
+.place-self-unset {
+  place-self: unset;
+  place-self: unset !important;
+}
+.place-self-revert {
+  place-self: revert;
+  place-self: revert !important;
+}
+.place-self-normal {
+  place-self: normal;
+  place-self: normal !important;
+}
+.place-self-center-i {
+  place-self: center !important;
+  place-self: center !important !important;
+}
+.place-self-start-i {
+  place-self: start !important;
+  place-self: start !important !important;
+}
+.place-self-end-i {
+  place-self: end !important;
+  place-self: end !important !important;
+}
+.place-self-stretch-i {
+  place-self: stretch !important;
+  place-self: stretch !important !important;
+}
+.ps-auto {
+  place-self: auto;
+  place-self: auto !important;
+}
+.ps-start {
+  place-self: start;
+  place-self: start !important;
+}
+.ps-center {
+  place-self: center;
+  place-self: center !important;
+}
+.ps-stretch {
+  place-self: stretch;
+  place-self: stretch !important;
+}
+.ps-baseline {
+  place-self: baseline;
+  place-self: baseline !important;
+}
+.ps-flex-start {
+  place-self: flex-start;
+  place-self: flex-start !important;
+}
+.ps-flex-end {
+  place-self: flex-end;
+  place-self: flex-end !important;
+}
+@media (min-width: 640px) {
+  .sm\:place-self-auto {
+    place-self: auto;
+  }
+}
+@media (min-width: 640px) {
+  .sm\:place-self-start {
+    place-self: start;
+  }
+}
+@media (min-width: 640px) {
+  .sm\:place-self-end {
+    place-self: end;
+  }
+}
+@media (min-width: 640px) {
+  .sm\:place-self-center {
+    place-self: center;
+  }
+}
+@media (min-width: 640px) {
+  .sm\:place-self-stretch {
+    place-self: stretch;
+  }
+}
+@media (min-width: 640px) {
+  .sm\:place-self-baseline {
+    place-self: baseline;
+  }
+}
+@media (min-width: 640px) {
+  .sm\:place-self-flex-start {
+    place-self: flex-start;
+  }
+}
+@media (min-width: 640px) {
+  .sm\:place-self-flex-end {
+    place-self: flex-end;
+  }
+}
+@media (min-width: 640px) {
+  .sm\:place-self-safe-start {
+    place-self: safe start;
+  }
+}
+@media (min-width: 640px) {
+  .sm\:place-self-safe-end {
+    place-self: safe end;
+  }
+}
+@media (min-width: 640px) {
+  .sm\:place-self-safe-center {
+    place-self: safe center;
+  }
+}
+@media (min-width: 640px) {
+  .sm\:place-self-inherit {
+    place-self: inherit;
+  }
+}
+@media (min-width: 640px) {
+  .sm\:place-self-initial {
+    place-self: initial;
+  }
+}
+@media (min-width: 640px) {
+  .sm\:place-self-unset {
+    place-self: unset;
+  }
+}
+@media (min-width: 640px) {
+  .sm\:place-self-revert {
+    place-self: revert;
+  }
+}
+@media (min-width: 640px) {
+  .sm\:place-self-normal {
+    place-self: normal;
+  }
+}
+@media (min-width: 640px) {
+  .sm\:place-self-center-i {
+    place-self: center !important;
+  }
+}
+@media (min-width: 640px) {
+  .sm\:place-self-start-i {
+    place-self: start !important;
+  }
+}
+@media (min-width: 640px) {
+  .sm\:place-self-end-i {
+    place-self: end !important;
+  }
+}
+@media (min-width: 640px) {
+  .sm\:place-self-stretch-i {
+    place-self: stretch !important;
+  }
+}
+@media (min-width: 640px) {
+  .sm\:ps-auto {
+    place-self: auto;
+  }
+}
+@media (min-width: 640px) {
+  .sm\:ps-start {
+    place-self: start;
+  }
+}
+@media (min-width: 640px) {
+  .sm\:ps-center {
+    place-self: center;
+  }
+}
+@media (min-width: 640px) {
+  .sm\:ps-stretch {
+    place-self: stretch;
+  }
+}
+@media (min-width: 640px) {
+  .sm\:ps-baseline {
+    place-self: baseline;
+  }
+}
+@media (min-width: 640px) {
+  .sm\:ps-flex-start {
+    place-self: flex-start;
+  }
+}
+@media (min-width: 640px) {
+  .sm\:ps-flex-end {
+    place-self: flex-end;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:place-self-auto {
+    place-self: auto;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:place-self-start {
+    place-self: start;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:place-self-end {
+    place-self: end;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:place-self-center {
+    place-self: center;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:place-self-stretch {
+    place-self: stretch;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:place-self-baseline {
+    place-self: baseline;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:place-self-flex-start {
+    place-self: flex-start;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:place-self-flex-end {
+    place-self: flex-end;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:place-self-safe-start {
+    place-self: safe start;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:place-self-safe-end {
+    place-self: safe end;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:place-self-safe-center {
+    place-self: safe center;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:place-self-inherit {
+    place-self: inherit;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:place-self-initial {
+    place-self: initial;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:place-self-unset {
+    place-self: unset;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:place-self-revert {
+    place-self: revert;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:place-self-normal {
+    place-self: normal;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:place-self-center-i {
+    place-self: center !important;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:place-self-start-i {
+    place-self: start !important;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:place-self-end-i {
+    place-self: end !important;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:place-self-stretch-i {
+    place-self: stretch !important;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:ps-auto {
+    place-self: auto;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:ps-start {
+    place-self: start;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:ps-center {
+    place-self: center;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:ps-stretch {
+    place-self: stretch;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:ps-baseline {
+    place-self: baseline;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:ps-flex-start {
+    place-self: flex-start;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:ps-flex-end {
+    place-self: flex-end;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dark\:place-self-auto {
+    place-self: auto;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dark\:place-self-start {
+    place-self: start;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dark\:place-self-end {
+    place-self: end;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dark\:place-self-center {
+    place-self: center;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dark\:place-self-stretch {
+    place-self: stretch;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dark\:place-self-baseline {
+    place-self: baseline;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dark\:place-self-flex-start {
+    place-self: flex-start;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dark\:place-self-flex-end {
+    place-self: flex-end;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dark\:place-self-safe-start {
+    place-self: safe start;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dark\:place-self-safe-end {
+    place-self: safe end;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dark\:place-self-safe-center {
+    place-self: safe center;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dark\:place-self-inherit {
+    place-self: inherit;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dark\:place-self-initial {
+    place-self: initial;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dark\:place-self-unset {
+    place-self: unset;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dark\:place-self-revert {
+    place-self: revert;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dark\:place-self-normal {
+    place-self: normal;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dark\:place-self-center-i {
+    place-self: center !important;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dark\:place-self-start-i {
+    place-self: start !important;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dark\:place-self-end-i {
+    place-self: end !important;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dark\:place-self-stretch-i {
+    place-self: stretch !important;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dark\:ps-auto {
+    place-self: auto;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dark\:ps-start {
+    place-self: start;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dark\:ps-center {
+    place-self: center;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dark\:ps-stretch {
+    place-self: stretch;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dark\:ps-baseline {
+    place-self: baseline;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dark\:ps-flex-start {
+    place-self: flex-start;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dark\:ps-flex-end {
+    place-self: flex-end;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe\:place-self-auto {
+    place-self: auto;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe\:place-self-start {
+    place-self: start;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe\:place-self-end {
+    place-self: end;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe\:place-self-center {
+    place-self: center;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe\:place-self-stretch {
+    place-self: stretch;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe\:place-self-baseline {
+    place-self: baseline;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe\:place-self-flex-start {
+    place-self: flex-start;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe\:place-self-flex-end {
+    place-self: flex-end;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe\:place-self-safe-start {
+    place-self: safe start;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe\:place-self-safe-end {
+    place-self: safe end;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe\:place-self-safe-center {
+    place-self: safe center;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe\:place-self-inherit {
+    place-self: inherit;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe\:place-self-initial {
+    place-self: initial;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe\:place-self-unset {
+    place-self: unset;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe\:place-self-revert {
+    place-self: revert;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe\:place-self-normal {
+    place-self: normal;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe\:place-self-center-i {
+    place-self: center !important;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe\:place-self-start-i {
+    place-self: start !important;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe\:place-self-end-i {
+    place-self: end !important;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe\:place-self-stretch-i {
+    place-self: stretch !important;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe\:ps-auto {
+    place-self: auto;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe\:ps-start {
+    place-self: start;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe\:ps-center {
+    place-self: center;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe\:ps-stretch {
+    place-self: stretch;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe\:ps-baseline {
+    place-self: baseline;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe\:ps-flex-start {
+    place-self: flex-start;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe\:ps-flex-end {
+    place-self: flex-end;
+  }
+}


### PR DESCRIPTION
Summary of What Has Been Done:
Added place-self CSS utility classes — 80+ meaningful CSS declarations with responsive variants and dark mode support.

Changes Made:
- submissions/examples/place-self/style.css (80+ meaningful lines)
- submissions/examples/place-self/demo.html (6 interactive demos)
- submissions/examples/place-self/README.md (full documentation)

Impact it Made:
- Extends the EaseMotion CSS utility framework with place self property coverage
- All utilities use framework design tokens from core/variables.css