### PR TITLE
feat: Add SCSS Accordion Expand/Collapse Max-Height Utilities (#28407)

### DIFF
--- a/submissions/scss/scss-accordion-expand-collapse-max-height-utilities/README.md
+++ b/submissions/scss/scss-accordion-expand-collapse-max-height-utilities/README.md
@@ -1,0 +1,50 @@
+# SCSS Utility: Accordion Expand/Collapse Max-Height (#28407)
+
+A robust SCSS utility module for the EaseMotion CSS framework that abstracts the "CSS Max-Height Hack" for smoothly animating accordions, dropdowns, and collapsible panels without resorting to JavaScript-calculated pixel heights.
+
+## 📦 What's included?
+
+- `_accordion-expand-collapse-max-height-utilities.scss`: The SCSS partial containing the mixins.
+- `style.css`: The raw compiled CSS utility classes.
+- `demo.html`: A self-contained demo page demonstrating the smooth transitions using Vanilla JS to simply toggle the `.is-expanded` class.
+
+## 🛠 Usage via SCSS
+
+Import the partial into your project and use the `@include ease-accordion-content()` mixin on the wrapper element you want to collapse. 
+
+```scss
+@import 'accordion-expand-collapse-max-height-utilities';
+
+.my-dropdown-menu {
+  // Parameters: $duration, $easing, $max-height-expanded
+  @include ease-accordion-content(0.4s, ease-in-out, 500px);
+}
+```
+
+*Note: The `$max-height-expanded` value should be slightly larger than the maximum expected height of your content. If you make it too large (e.g. 9999px for a 50px item), the transition will feel noticeably delayed.*
+
+## 🛠 Usage via HTML Utility Classes
+
+If your project is pre-compiled, you can use the default utility classes directly in your HTML markup based on your expected content size.
+
+```html
+<button onclick="document.getElementById('faq-1').classList.toggle('is-expanded')">
+  Toggle Small FAQ
+</button>
+
+<!-- Use -sm, -md, or -lg based on content length -->
+<div id="faq-1" class="ease-accordion-sm">
+  <div class="inner-padding-wrapper">
+    <p>Short answer here...</p>
+  </div>
+</div>
+```
+
+**Available Classes:**
+- `.ease-accordion-sm`: 0.3s duration, max 300px height.
+- `.ease-accordion-md`: 0.5s duration, max 800px height.
+- `.ease-accordion-lg`: 0.8s duration, max 2000px height.
+
+## 🚀 Why this fits EaseMotion
+
+Animating `height: auto` directly is not supported in CSS. This limitation often forces developers to write complex JavaScript ResizeObservers to calculate exact pixel heights. This SCSS utility abstracts the standard CSS workaround (transitioning `max-height`) into a clean, human-readable format that perfectly aligns with EaseMotion's goal of making complex UI animations effortless to implement.

--- a/submissions/scss/scss-accordion-expand-collapse-max-height-utilities/_accordion-expand-collapse-max-height-utilities.scss
+++ b/submissions/scss/scss-accordion-expand-collapse-max-height-utilities/_accordion-expand-collapse-max-height-utilities.scss
@@ -1,0 +1,59 @@
+// _accordion-expand-collapse-max-height-utilities.scss
+// =======================================================
+// EaseMotion CSS - Accordion Expand/Collapse Max-Height Utilities
+// 
+// Provides reusable SCSS mixins for smoothly animating 
+// elements between collapsed (0 height) and expanded states 
+// using the max-height transition technique.
+// =======================================================
+
+/// Mixin for the container that holds the expandable content
+/// @param {Time} $duration - The duration of the expand/collapse animation
+/// @param {String} $easing - The easing function to use
+/// @param {Number} $max-height-expanded - The maximum possible height when expanded (must be larger than actual content)
+@mixin ease-accordion-content(
+  $duration: 0.5s, 
+  $easing: cubic-bezier(0.4, 0, 0.2, 1),
+  $max-height-expanded: 1000px
+) {
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  transition: max-height $duration $easing, opacity $duration $easing, padding $duration $easing;
+  will-change: max-height, opacity, padding;
+  
+  // Expanded state
+  &.is-expanded {
+    max-height: $max-height-expanded;
+    opacity: 1;
+    // Note: padding should be managed explicitly if needed, as padding cannot 
+    // be easily collapsed without affecting the smooth max-height transition 
+    // unless managed inside an inner wrapper.
+  }
+}
+
+/// Generates utility classes for different sizes of accordions
+/// so developers don't have to guess the max-height needed.
+@mixin generate-accordion-utilities() {
+  
+  // For small content like FAQs (up to 300px)
+  .ease-accordion-sm {
+    @include ease-accordion-content(0.3s, ease-in-out, 300px);
+  }
+  
+  // For medium content like nested menus (up to 800px)
+  .ease-accordion-md {
+    @include ease-accordion-content(0.5s, ease-in-out, 800px);
+  }
+  
+  // For large content like full text blocks (up to 2000px)
+  .ease-accordion-lg {
+    @include ease-accordion-content(0.8s, ease-in-out, 2000px);
+  }
+}
+
+// -------------------------------------------------------
+// Default Initializations (For generated CSS utility classes)
+// -------------------------------------------------------
+
+@include generate-accordion-utilities();

--- a/submissions/scss/scss-accordion-expand-collapse-max-height-utilities/demo.html
+++ b/submissions/scss/scss-accordion-expand-collapse-max-height-utilities/demo.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Accordion Expand/Collapse Utilities</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <div style="text-align: center; margin-bottom: 3rem;">
+    <h1 style="margin: 0 0 1rem 0;">Accordion Max-Height Utilities</h1>
+    <p style="margin: 0; opacity: 0.8; max-width: 600px; margin: auto;">Smoothly transition elements between collapsed (height: 0) and expanded states using the max-height technique.</p>
+  </div>
+
+  <div class="accordion-container">
+    
+    <!-- Small Accordion -->
+    <div class="accordion-item">
+      <button class="accordion-header" onclick="toggleAccordion('content-1', this)">
+        Small Content (max 300px)
+        <span class="icon">↓</span>
+      </button>
+      <div id="content-1" class="ease-accordion-sm">
+        <div class="accordion-content-inner">
+          <p>This section uses <code>.ease-accordion-sm</code>, optimized for short content like FAQs. The animation duration is slightly faster (0.3s) and the maximum height is capped at 300px to ensure the transition doesn't feel sluggish.</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Medium Accordion -->
+    <div class="accordion-item">
+      <button class="accordion-header" onclick="toggleAccordion('content-2', this)">
+        Medium Content (max 800px)
+        <span class="icon">↓</span>
+      </button>
+      <div id="content-2" class="ease-accordion-md">
+        <div class="accordion-content-inner">
+          <p>This section uses <code>.ease-accordion-md</code>, optimized for medium-length content like nested navigation menus or feature descriptions. The animation duration is 0.5s with a max-height of 800px.</p>
+          <p>By using the max-height CSS technique, we avoid the jarring layout snapping that occurs when simply toggling <code>display: none</code> to <code>display: block</code>, providing a much smoother user experience.</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Large Accordion -->
+    <div class="accordion-item">
+      <button class="accordion-header" onclick="toggleAccordion('content-3', this)">
+        Large Content (max 2000px)
+        <span class="icon">↓</span>
+      </button>
+      <div id="content-3" class="ease-accordion-lg">
+        <div class="accordion-content-inner">
+          <p>This section uses <code>.ease-accordion-lg</code>, designed for massive text blocks or long lists.</p>
+          <p>It has a longer duration (0.8s) and a huge max-height of 2000px. The max-height trick works by transitioning from max-height: 0 to a value larger than the content will ever realistically reach.</p>
+          <br><br><br>
+          <p>(Simulated long content...)</p>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <script>
+    function toggleAccordion(contentId, headerElement) {
+      const content = document.getElementById(contentId);
+      
+      // Toggle class on the content
+      content.classList.toggle('is-expanded');
+      
+      // Toggle class on the header for icon rotation
+      headerElement.classList.toggle('is-expanded');
+    }
+  </script>
+</body>
+</html>

--- a/submissions/scss/scss-accordion-expand-collapse-max-height-utilities/style.css
+++ b/submissions/scss/scss-accordion-expand-collapse-max-height-utilities/style.css
@@ -1,0 +1,125 @@
+/* 
+  style.css
+  This file contains the compiled output of the SCSS mixin so that demo.html can function 
+  without requiring a local Sass compiler to be running.
+*/
+
+:root {
+  --bg-color: #f8fafc;
+  --text-color: #0f172a;
+  --card-bg: #ffffff;
+  --border-color: rgba(148, 163, 184, 0.3);
+  --primary: #3b82f6;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-color: #0f172a;
+    --text-color: #f8fafc;
+    --card-bg: #1e293b;
+    --border-color: rgba(148, 163, 184, 0.2);
+  }
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 4rem 2rem;
+}
+
+.accordion-container {
+  width: 100%;
+  max-width: 600px;
+  background: var(--card-bg);
+  border-radius: 0.5rem;
+  border: 1px solid var(--border-color);
+  overflow: hidden;
+}
+
+.accordion-item {
+  border-bottom: 1px solid var(--border-color);
+}
+.accordion-item:last-child {
+  border-bottom: none;
+}
+
+.accordion-header {
+  width: 100%;
+  padding: 1.25rem 1.5rem;
+  background: none;
+  border: none;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-color);
+  cursor: pointer;
+  text-align: left;
+}
+
+.accordion-header:hover {
+  background: rgba(148, 163, 184, 0.05);
+}
+
+.icon {
+  transition: transform 0.3s ease;
+  color: var(--primary);
+  font-weight: bold;
+}
+.is-expanded .icon {
+  transform: rotate(180deg);
+}
+
+.accordion-content-inner {
+  padding: 0 1.5rem 1.5rem 1.5rem;
+  line-height: 1.6;
+  opacity: 0.8;
+}
+
+/* =======================================================
+   COMPILED SCSS OUTPUT
+   ======================================================= */
+
+.ease-accordion-sm {
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  transition: max-height 0.3s ease-in-out, opacity 0.3s ease-in-out, padding 0.3s ease-in-out;
+  will-change: max-height, opacity, padding;
+}
+.ease-accordion-sm.is-expanded {
+  max-height: 300px;
+  opacity: 1;
+}
+
+.ease-accordion-md {
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  transition: max-height 0.5s ease-in-out, opacity 0.5s ease-in-out, padding 0.5s ease-in-out;
+  will-change: max-height, opacity, padding;
+}
+.ease-accordion-md.is-expanded {
+  max-height: 800px;
+  opacity: 1;
+}
+
+.ease-accordion-lg {
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  transition: max-height 0.8s ease-in-out, opacity 0.8s ease-in-out, padding 0.8s ease-in-out;
+  will-change: max-height, opacity, padding;
+}
+.ease-accordion-lg.is-expanded {
+  max-height: 2000px;
+  opacity: 1;
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #27781 by introducing a robust SCSS utility module that abstracts the widely used "CSS Max-Height Hack" for animating collapsible elements. It provides an intuitive `@include ease-accordion-content()` mixin and several pre-compiled utility classes designed to smoothly transition accordions, dropdowns, and collapsible panels without the need for JavaScript-calculated pixel heights.

Closes #27781

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/scss/scss-accordion-expand-collapse-max-height-utilities/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] Includes `_accordion-expand-collapse-max-height-utilities.scss`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An SCSS mixin and corresponding utility classes (`.ease-accordion-sm`, `.ease-accordion-md`, `.ease-accordion-lg`) that animate an element between `max-height: 0` and a predefined max-height, providing a smooth expand/collapse transition.

**How does a developer use it?**

```html
<button onclick="document.getElementById('faq').classList.toggle('is-expanded')">
  Toggle Menu
</button>

<!-- Use a utility class based on expected content size -->
<div id="faq" class="ease-accordion-md">
  <p>Your nested navigation or FAQ content here...</p>
</div>
