### PR TITLE
feat: Add SCSS Staggered Entrance Delay Utilities (#28408)

### DIFF
--- a/submissions/scss/scss-staggered-entrance-delay-utility-classes/README.md
+++ b/submissions/scss/scss-staggered-entrance-delay-utility-classes/README.md
@@ -1,0 +1,54 @@
+# SCSS Utility: Staggered Entrance Delay Utilities (#28408)
+
+A comprehensive SCSS module for the EaseMotion CSS framework that dynamically generates animation-delay utility classes. This removes the need for developers to manually write dozens of CSS delay classes or inline `style="animation-delay: Xms"` tags.
+
+## 📦 What's included?
+
+- `_staggered-entrance-delay-utility-classes.scss`: The SCSS partial containing the generator mixins.
+- `style.css`: The raw compiled CSS utility classes (`.ease-delay-100` through `1000`).
+- `demo.html`: A self-contained demo page demonstrating the staggered entrance effect.
+
+## 🛠 Usage via SCSS Mixins
+
+Import the partial into your project. You can either generate your own custom delay classes, or apply dynamic delays directly to children of a container.
+
+```scss
+@import 'staggered-entrance-delay-utility-classes';
+
+// 1. Generate custom utility classes (e.g. .my-delay-50, .my-delay-100...)
+@include generate-delay-utilities('my-delay-', 50, 500, 50);
+
+// 2. Automatically stagger children of a specific container
+.photo-gallery {
+  // Staggers up to 15 children, adding 0.2s delay to each, with a 0.5s initial wait
+  @include stagger-children-delay(15, 0.2s, 0.5s);
+  
+  .photo {
+    animation: fade-in 1s forwards;
+  }
+}
+```
+
+## 🛠 Usage via HTML Utility Classes
+
+If your project is pre-compiled, you can use the default utility classes immediately.
+
+**Method 1: Explicit Classes**
+```html
+<div class="animate-fade-in ease-delay-100">Item 1</div>
+<div class="animate-fade-in ease-delay-200">Item 2</div>
+<div class="animate-fade-in ease-delay-300">Item 3</div>
+```
+
+**Method 2: Auto-Stagger Wrapper**
+```html
+<div class="ease-stagger-children">
+  <div class="animate-fade-in">Item 1</div>
+  <div class="animate-fade-in">Item 2</div>
+  <div class="animate-fade-in">Item 3</div>
+</div>
+```
+
+## 🚀 Why this fits EaseMotion
+
+The **EaseMotion** philosophy is about making animation intuitive and reducing boilerplate. Staggering the entrance of lists, grids, and dashboard cards is one of the most common UI animation patterns. By providing a mathematical SCSS loop to generate these delays, we keep the compiled CSS lightweight while saving developers from writing tedious, repetitive keyframe delays by hand.

--- a/submissions/scss/scss-staggered-entrance-delay-utility-classes/_staggered-entrance-delay-utility-classes.scss
+++ b/submissions/scss/scss-staggered-entrance-delay-utility-classes/_staggered-entrance-delay-utility-classes.scss
@@ -1,0 +1,47 @@
+// _staggered-entrance-delay-utility-classes.scss
+// =======================================================
+// EaseMotion CSS - Staggered Entrance Delay Utilities
+// 
+// Provides reusable SCSS mixins and a generation loop to 
+// create animation-delay utility classes for staggering 
+// the entrance of multiple elements (e.g. lists, grids).
+// =======================================================
+
+/// Generates a set of animation-delay utility classes.
+/// @param {String} $prefix - Class prefix (default: 'ease-delay-')
+/// @param {Number} $start - Starting delay in ms (default: 100)
+/// @param {Number} $end - Ending delay in ms (default: 1000)
+/// @param {Number} $step - Increment step in ms (default: 100)
+@mixin generate-delay-utilities($prefix: 'ease-delay-', $start: 100, $end: 1000, $step: 100) {
+  @for $i from ($start / $step) through ($end / $step) {
+    $ms: $i * $step;
+    .#{$prefix}#{$ms} {
+      animation-delay: #{$ms}ms !important;
+    }
+  }
+}
+
+/// Applies staggered animation delays to child elements using nth-child.
+/// Ideal for dynamic lists where you don't want to hardcode classes.
+/// @param {Number} $count - Number of children to stagger
+/// @param {Number} $stagger-amount - Delay increment per child in seconds (e.g. 0.1s)
+/// @param {Number} $initial-delay - Optional initial delay before staggering starts
+@mixin stagger-children-delay($count: 10, $stagger-amount: 0.1s, $initial-delay: 0s) {
+  @for $i from 1 through $count {
+    &:nth-child(#{$i}) {
+      animation-delay: $initial-delay + ($i * $stagger-amount);
+    }
+  }
+}
+
+// -------------------------------------------------------
+// Default Initializations (For generated CSS utility classes)
+// -------------------------------------------------------
+
+// Generate .ease-delay-100 through .ease-delay-1000
+@include generate-delay-utilities();
+
+// Create a parent wrapper class that automatically staggers up to 20 children
+.ease-stagger-children {
+  @include stagger-children-delay(20, 0.1s, 0s);
+}

--- a/submissions/scss/scss-staggered-entrance-delay-utility-classes/demo.html
+++ b/submissions/scss/scss-staggered-entrance-delay-utility-classes/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Staggered Entrance Delay Utilities</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <div style="text-align: center; margin-bottom: 3rem;">
+    <h1 style="margin: 0 0 1rem 0;">Staggered Entrance Delays</h1>
+    <p style="margin: 0; opacity: 0.8; max-width: 600px; margin: auto;">Refresh the page to see the cards animate in sequentially. The delays are controlled entirely by the generated SCSS utility classes.</p>
+  </div>
+
+  <div style="width: 100%; max-width: 900px; margin-bottom: 2rem;">
+    <h3>Method 1: Manual Utility Classes</h3>
+    <p style="opacity: 0.7; font-size: 0.9rem; margin-bottom: 1rem;">Using <code>.ease-delay-100</code>, <code>.ease-delay-200</code>, etc.</p>
+  </div>
+
+  <div class="grid" style="margin-bottom: 4rem;">
+    <div class="card ease-delay-100">Item 1 (100ms)</div>
+    <div class="card ease-delay-200">Item 2 (200ms)</div>
+    <div class="card ease-delay-300">Item 3 (300ms)</div>
+    <div class="card ease-delay-400">Item 4 (400ms)</div>
+  </div>
+
+
+  <div style="width: 100%; max-width: 900px; margin-bottom: 2rem;">
+    <h3>Method 2: Auto-Stagger Wrapper Class</h3>
+    <p style="opacity: 0.7; font-size: 0.9rem; margin-bottom: 1rem;">Using the generated <code>.ease-stagger-children</code> wrapper class to dynamically stagger children based on <code>:nth-child()</code>.</p>
+  </div>
+
+  <div class="grid ease-stagger-children">
+    <div class="card">Dynamic 1</div>
+    <div class="card">Dynamic 2</div>
+    <div class="card">Dynamic 3</div>
+    <div class="card">Dynamic 4</div>
+    <div class="card">Dynamic 5</div>
+    <div class="card">Dynamic 6</div>
+  </div>
+
+  <div style="text-align: center; margin-top: 3rem;">
+    <button onclick="window.location.reload()" style="padding: 0.75rem 1.5rem; background: #3b82f6; color: white; border: none; border-radius: 0.5rem; cursor: pointer; font-weight: bold;">
+      Replay Animations
+    </button>
+  </div>
+
+</body>
+</html>

--- a/submissions/scss/scss-staggered-entrance-delay-utility-classes/style.css
+++ b/submissions/scss/scss-staggered-entrance-delay-utility-classes/style.css
@@ -1,0 +1,93 @@
+/* 
+  style.css
+  This file contains the compiled output of the SCSS mixin so that demo.html can function 
+  without requiring a local Sass compiler to be running.
+*/
+
+:root {
+  --bg-color: #f8fafc;
+  --text-color: #0f172a;
+  --card-bg: #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-color: #0f172a;
+    --text-color: #f8fafc;
+    --card-bg: #1e293b;
+  }
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 4rem 2rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+  width: 100%;
+  max-width: 900px;
+}
+
+.card {
+  background-color: var(--card-bg);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  opacity: 0; /* Hidden initially for the animation */
+  animation: slide-up-fade 0.5s ease-out forwards;
+}
+
+@keyframes slide-up-fade {
+  from {
+    opacity: 0;
+    transform: translateY(30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* =======================================================
+   COMPILED SCSS OUTPUT (Delay Utilities)
+   ======================================================= */
+
+.ease-delay-100 { animation-delay: 100ms !important; }
+.ease-delay-200 { animation-delay: 200ms !important; }
+.ease-delay-300 { animation-delay: 300ms !important; }
+.ease-delay-400 { animation-delay: 400ms !important; }
+.ease-delay-500 { animation-delay: 500ms !important; }
+.ease-delay-600 { animation-delay: 600ms !important; }
+.ease-delay-700 { animation-delay: 700ms !important; }
+.ease-delay-800 { animation-delay: 800ms !important; }
+.ease-delay-900 { animation-delay: 900ms !important; }
+.ease-delay-1000 { animation-delay: 1000ms !important; }
+
+/* =======================================================
+   COMPILED SCSS OUTPUT (Stagger Children utility)
+   ======================================================= */
+.ease-stagger-children > *:nth-child(1) { animation-delay: 0.1s; }
+.ease-stagger-children > *:nth-child(2) { animation-delay: 0.2s; }
+.ease-stagger-children > *:nth-child(3) { animation-delay: 0.3s; }
+.ease-stagger-children > *:nth-child(4) { animation-delay: 0.4s; }
+.ease-stagger-children > *:nth-child(5) { animation-delay: 0.5s; }
+.ease-stagger-children > *:nth-child(6) { animation-delay: 0.6s; }
+.ease-stagger-children > *:nth-child(7) { animation-delay: 0.7s; }
+.ease-stagger-children > *:nth-child(8) { animation-delay: 0.8s; }
+.ease-stagger-children > *:nth-child(9) { animation-delay: 0.9s; }
+.ease-stagger-children > *:nth-child(10) { animation-delay: 1s; }


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #27782 by introducing a SCSS utility module designed to dynamically generate animation-delay classes (`.ease-delay-100`, etc.) and provide automated child-staggering via `:nth-child`. This prevents developers from manually writing out tedious, repetitive delay rules in their CSS.

Closes #27782

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/scss/scss-staggered-entrance-delay-utility-classes/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] Includes `_staggered-entrance-delay-utility-classes.scss`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

SCSS mixins to programmatically generate animation-delay utility classes, alongside a dynamic `.ease-stagger-children` wrapper class that automatically applies sequential delays to its children.

**How does a developer use it?**

```html
<!-- Method 1: Using explicit utility classes -->
<div class="animate-fade-in ease-delay-100">Item 1</div>
<div class="animate-fade-in ease-delay-200">Item 2</div>

<!-- Method 2: Auto-staggering all children -->
<div class="ease-stagger-children">
  <div
