### PR TITLE
docs: improve footer keyframe namespace collision demo

### DIFF
--- a/submissions/docs/fix-footer-keyframe-prefixes-27881/README.md
+++ b/submissions/docs/fix-footer-keyframe-prefixes-27881/README.md
@@ -1,10 +1,10 @@
 # Footer Keyframe Namespace Collision Demo
 
-This demo reproduces the footer keyframe namespace collision described in **Issue #27881**.
+This documentation demo reproduces the footer keyframe namespace collision described in **Issue #27881** and demonstrates the proposed solution using framework-prefixed keyframe names.
 
 ## Issue
 
-The footer component currently uses generic global keyframe names:
+The footer component currently defines generic global keyframe names:
 
 ```css
 @keyframes float
@@ -18,27 +18,27 @@ animation: float 20s ease-in-out infinite;
 animation: heartbeat 1.5s ease-in-out infinite;
 ```
 
-Because CSS keyframes are global, these generic names can conflict with animations defined by an application or third-party library.
+Because CSS keyframes exist in the global animation namespace, generic names such as `float` and `heartbeat` can collide with animations defined by applications or third-party libraries.
 
 ## Proposed Fix
 
-Rename the footer keyframes using framework-prefixed names.
+Rename the footer keyframes to follow the existing EaseMotion CSS naming convention.
 
-**Before**
+### Before
 
 ```css
 @keyframes float
 @keyframes heartbeat
 ```
 
-**After**
+### After
 
 ```css
 @keyframes ease-kf-footer-float
 @keyframes ease-kf-footer-heartbeat
 ```
 
-Update the animation declarations accordingly:
+Update the corresponding animation declarations:
 
 ```css
 animation: ease-kf-footer-float 20s ease-in-out infinite;
@@ -47,20 +47,20 @@ animation: ease-kf-footer-heartbeat 1.5s ease-in-out infinite;
 
 ## Demo Files
 
-```
+```text
 README.md
 demo.html
 style.css
 ```
 
-* **demo.html** demonstrates the keyframe namespace collision and the proposed fix.
-* **style.css** includes both the current implementation (generic keyframes) and the proposed implementation (prefixed keyframes) for comparison.
+* **demo.html** demonstrates the namespace collision and the proposed prefixed keyframe solution.
+* **style.css** contains both the current implementation (generic keyframe names) and the proposed implementation (prefixed keyframe names) for comparison.
 
 ## Expected Result
 
-After introducing prefixed footer keyframes:
+After adopting the proposed keyframe names:
 
-* Footer animations behave exactly as before.
-* Generic keyframe namespace collisions are avoided.
+* Footer animations retain their existing visual behavior.
+* Generic keyframe namespace collisions are eliminated.
 * Footer animations are isolated from application and third-party CSS.
-* The framework follows the existing `ease-kf-*` naming convention without changing visual behavior.
+* The implementation follows the framework's existing `ease-kf-*` naming convention for improved consistency.

--- a/submissions/docs/fix-footer-keyframe-prefixes-27881/demo.html
+++ b/submissions/docs/fix-footer-keyframe-prefixes-27881/demo.html
@@ -5,64 +5,66 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Footer Keyframe Namespace Collision Demo</title>
 
-    <!-- Uncomment if using the built EaseMotion CSS -->
-    <!-- <link rel="stylesheet" href="../../easemotion.css"> -->
-
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
 
-<div class="container">
+<main class="container">
+
     <h1>Footer Keyframe Namespace Collision Demo</h1>
 
     <p>
         This demo reproduces the keyframe namespace collision described in
-        <strong>Issue #27881</strong>. It shows how generic keyframe names like
-        <code>float</code> and <code>heartbeat</code> can conflict with
-        application CSS, and how using prefixed names such as
-        <code>ease-kf-footer-float</code> and
-        <code>ease-kf-footer-heartbeat</code> avoids the conflict.
+        <strong>Issue #27881</strong>. It demonstrates how generic keyframe
+        names such as <code>float</code> and <code>heartbeat</code> can
+        conflict with application CSS and how prefixing them avoids these
+        collisions.
     </p>
 
-    <div class="section">
+    <section class="section">
         <h2>Application Animation</h2>
+
         <p>
-            The application defines its own generic
+            The application defines a generic
             <code>@keyframes float</code> animation.
         </p>
 
         <div class="box app-box"></div>
-    </div>
+    </section>
 
-    <div class="section">
+    <section class="section">
         <h2>Current Footer (Collision)</h2>
+
         <p>
-            The footer also uses the generic
-            <code>@keyframes float</code>, which shares the same global
-            namespace and may override or be overridden by application CSS.
+            The footer also defines
+            <code>@keyframes float</code>. Since CSS keyframes are global,
+            the framework and application may unintentionally override each
+            other's animations.
         </p>
 
         <div class="box footer-box"></div>
-    </div>
+    </section>
 
-    <div class="section">
-        <h2>Prefixed Footer (Proposed Fix)</h2>
+    <section class="section">
+        <h2>Proposed Fix</h2>
+
         <p>
-            Using the prefixed keyframe
-            <code>ease-kf-footer-float</code> keeps the footer animation
-            isolated from application styles while preserving the same visual
-            behavior.
+            Prefixing footer keyframes (for example,
+            <code>ease-kf-footer-float</code>) isolates the animation while
+            preserving the same visual behavior.
         </p>
 
         <div class="box fixed-box"></div>
-    </div>
+    </section>
 
-    <div class="section">
+    <section class="section">
         <h2>Heartbeat Animation</h2>
+
         <p>
             The same namespace collision can occur with
-            <code>@keyframes heartbeat</code>. Prefixing it as
-            <code>ease-kf-footer-heartbeat</code> prevents conflicts.
+            <code>@keyframes heartbeat</code>. Using
+            <code>ease-kf-footer-heartbeat</code> prevents conflicts with
+            application or third-party styles.
         </p>
 
         <div class="heart-row">
@@ -76,8 +78,19 @@
                 <span class="heart fixed-heart">❤️</span>
             </div>
         </div>
-    </div>
-</div>
+    </section>
+
+    <footer class="section">
+        <h2>Expected Result</h2>
+
+        <p>
+            The visual appearance remains unchanged while prefixed keyframe
+            names prevent global CSS namespace collisions and improve
+            compatibility with application and third-party styles.
+        </p>
+    </footer>
+
+</main>
 
 </body>
 </html>

--- a/submissions/docs/fix-footer-keyframe-prefixes-27881/style.css
+++ b/submissions/docs/fix-footer-keyframe-prefixes-27881/style.css
@@ -13,17 +13,14 @@ body {
 
 .container {
     max-width: 900px;
-    margin: auto;
+    margin: 0 auto;
 }
 
 h1 {
     margin-bottom: 12px;
 }
 
-h2 {
-    margin-bottom: 10px;
-}
-
+h2,
 h3 {
     margin-bottom: 10px;
 }
@@ -49,12 +46,12 @@ p {
     border-radius: 10px;
 }
 
-/* -------------------------------------------------
+/* =====================================================
    Application CSS
 
-   The application defines a generic global
+   The application defines its own generic
    @keyframes float animation.
--------------------------------------------------- */
+===================================================== */
 
 @keyframes float {
     from {
@@ -68,26 +65,26 @@ p {
 
 .app-box {
     background: #2563eb;
-    animation: float 20s ease-in-out infinite alternate;
+    animation: float 2s ease-in-out infinite alternate;
 }
 
-/* -------------------------------------------------
+/* =====================================================
    Current Footer (Collision)
 
-   The footer also uses the generic
-   @keyframes float name.
+   The footer also defines @keyframes float.
 
-   This simulates the namespace collision described
-   in Issue #27881.
--------------------------------------------------- */
+   Since keyframe names are global, this second
+   definition overrides the previous one and
+   demonstrates the namespace collision.
+===================================================== */
 
 .footer-box {
     background: #ef4444;
-    animation: float 20s ease-in-out infinite;
+    animation: float 2s ease-in-out infinite;
 }
 
-/* Simulates a framework stylesheet overriding
-   the application's generic @keyframes float. */
+/* Intentionally redefines @keyframes float
+   to simulate a framework collision. */
 
 @keyframes float {
     0%,
@@ -100,15 +97,16 @@ p {
     }
 }
 
-/* -------------------------------------------------
+/* =====================================================
    Proposed Fix
 
-   Uses a prefixed keyframe name to avoid collisions.
--------------------------------------------------- */
+   Uses a framework-prefixed keyframe name to
+   avoid namespace collisions.
+===================================================== */
 
 .fixed-box {
     background: #16a34a;
-    animation: ease-kf-footer-float 20s ease-in-out infinite;
+    animation: ease-kf-footer-float 2s ease-in-out infinite;
 }
 
 @keyframes ease-kf-footer-float {
@@ -122,9 +120,9 @@ p {
     }
 }
 
-/* -------------------------------------------------
-   Heartbeat Demo
--------------------------------------------------- */
+/* =====================================================
+   Heartbeat Animation Demo
+===================================================== */
 
 .heart-row {
     display: flex;
@@ -135,15 +133,15 @@ p {
 
 .heart {
     display: inline-block;
-    font-size: 48px;
     margin-top: 10px;
+    font-size: 48px;
 }
+
+/* Current implementation */
 
 .current-heart {
     animation: heartbeat 1.5s ease-in-out infinite;
 }
-
-/* Generic keyframe name */
 
 @keyframes heartbeat {
     0%,
@@ -164,7 +162,7 @@ p {
     }
 }
 
-/* Prefixed keyframe name */
+/* Proposed implementation */
 
 .fixed-heart {
     animation: ease-kf-footer-heartbeat 1.5s ease-in-out infinite;
@@ -190,10 +188,10 @@ p {
 }
 
 code {
-    background: #ececec;
     padding: 2px 6px;
+    background: #ececec;
     border-radius: 4px;
-    font-family: Consolas, monospace;
+    font-family: Consolas, Monaco, monospace;
 }
 
 @media (max-width: 600px) {
@@ -202,6 +200,15 @@ code {
     }
 
     .heart-row {
+        flex-direction: column;
         gap: 30px;
+    }
+
+    .box {
+        margin: 20px auto 0;
+    }
+
+    .section {
+        text-align: center;
     }
 }


### PR DESCRIPTION
## Pull Request Description

Closes #27881

This PR adds a documentation demo that reproduces the footer keyframe namespace collision caused by the generic `float` and `heartbeat` keyframe names. It demonstrates how adopting prefixed keyframe names (`ease-kf-footer-float` and `ease-kf-footer-heartbeat`) prevents global CSS namespace collisions while preserving the existing animation behavior.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — documents the issue, proposed fix, and demo
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A documentation demo illustrating the footer keyframe namespace collision and the proposed prefixed keyframe naming convention.

**How does a developer use it?**

Open `demo.html` directly in a browser to view the comparison between the current implementation and the proposed fix.

```html
<link rel="stylesheet" href="style.css">
```

**Why does it fit EaseMotion CSS?**

The demo documents a real issue affecting CSS keyframe namespacing and demonstrates a solution that aligns with EaseMotion's naming conventions while maintaining the existing visual behavior.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This submission is documentation only and does not modify the framework source. It provides a minimal reproduction of the namespace collision reported in #27881 and demonstrates the proposed prefixed keyframe naming convention for easier review and discussion.