### PR TITLE
feat: Add SCSS Truncate Multi-Line Clamp Utilities (#28410)

### DIFF
--- a/submissions/scss/scss-truncate-multi-line-clamp-utility-classes/README.md
+++ b/submissions/scss/scss-truncate-multi-line-clamp-utility-classes/README.md
@@ -1,0 +1,45 @@
+# SCSS Utility: Truncate Multi-Line Clamp Utilities (#28410)
+
+A lightweight SCSS module for the EaseMotion CSS framework that dynamically generates `line-clamp` utility classes. This allows developers to gracefully truncate text that spans multiple lines, appending an ellipsis `...` at the exact cut-off point.
+
+## 📦 What's included?
+
+- `_truncate-multi-line-clamp-utility-classes.scss`: The SCSS partial containing the clamp mixins.
+- `style.css`: The raw compiled CSS utility classes (`.ease-line-clamp-1` through `6`).
+- `demo.html`: A self-contained demo page demonstrating the truncation behavior.
+
+## 🛠 Usage via SCSS Mixins
+
+Import the partial into your project. You can either apply the clamp mixin directly to a specific selector, or generate your own custom set of utility classes.
+
+```scss
+@import 'truncate-multi-line-clamp-utility-classes';
+
+// 1. Apply directly to a specific class
+.blog-post-excerpt {
+  @include ease-line-clamp(3); // Truncates after 3 lines
+}
+
+// 2. Generate a custom range of utility classes (e.g. .my-clamp-1 to .my-clamp-10)
+@include generate-line-clamp-utilities(10);
+```
+
+## 🛠 Usage via HTML Utility Classes
+
+If your project is pre-compiled, you can use the default utility classes (`.ease-line-clamp-1` through `6`) immediately in your markup.
+
+```html
+<!-- Single line truncation (Standard text-overflow) -->
+<h2 class="ease-line-clamp-1">Extremely long title that needs to fit on one line</h2>
+
+<!-- Multi-line truncation -->
+<p class="ease-line-clamp-3">
+  This is a very long paragraph that serves as a preview for an article. 
+  Instead of taking up massive vertical space, it will smoothly cut off 
+  after exactly three lines, leaving an ellipsis to indicate more content...
+</p>
+```
+
+## 🚀 Why this fits EaseMotion
+
+The **EaseMotion** philosophy focuses on creating clean, predictable user interfaces. When dealing with dynamic content (like blog excerpts or user reviews), inconsistent text lengths can ruin grid layouts and disrupt animation flows (especially height-based animations). By providing an effortless multi-line clamp utility, developers can enforce strict typographical boundaries, ensuring that card heights remain uniform and entrance animations remain perfectly staggered.

--- a/submissions/scss/scss-truncate-multi-line-clamp-utility-classes/_truncate-multi-line-clamp-utility-classes.scss
+++ b/submissions/scss/scss-truncate-multi-line-clamp-utility-classes/_truncate-multi-line-clamp-utility-classes.scss
@@ -1,0 +1,48 @@
+// _truncate-multi-line-clamp-utility-classes.scss
+// =======================================================
+// EaseMotion CSS - Multi-Line Clamp Utilities
+// 
+// Provides reusable SCSS mixins and generated utility classes
+// for smoothly truncating text after a specified number of lines.
+// Utilizing -webkit-line-clamp (supported universally in modern browsers).
+// =======================================================
+
+/// Core mixin for multi-line clamping.
+/// @param {Number} $lines - Number of lines to clamp at before showing ellipsis.
+@mixin ease-line-clamp($lines: 2) {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: $lines;
+  
+  // Standard CSS fallbacks for non-WebKit layout scenarios
+  overflow: hidden;
+  text-overflow: ellipsis;
+  
+  // Ensure words break properly if a single long word exceeds width
+  word-break: break-word;
+}
+
+/// Generates a series of line clamp utility classes.
+/// @param {Number} $max-lines - The maximum number of lines to generate classes for.
+@mixin generate-line-clamp-utilities($max-lines: 6) {
+  @for $i from 1 through $max-lines {
+    .ease-line-clamp-#{$i} {
+      @include ease-line-clamp($i);
+    }
+  }
+}
+
+// -------------------------------------------------------
+// Default Initializations (For generated CSS utility classes)
+// -------------------------------------------------------
+
+// Generate .ease-line-clamp-1 through .ease-line-clamp-6
+@include generate-line-clamp-utilities(6);
+
+// Provide an explicit un-clamp utility for responsive design overrides
+.ease-line-clamp-none {
+  display: block;
+  -webkit-line-clamp: none;
+  overflow: visible;
+  text-overflow: clip;
+}

--- a/submissions/scss/scss-truncate-multi-line-clamp-utility-classes/demo.html
+++ b/submissions/scss/scss-truncate-multi-line-clamp-utility-classes/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Truncate Multi-Line Clamp Utilities</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <div style="text-align: center; margin-bottom: 3rem;">
+    <h1 style="margin: 0 0 1rem 0;">Multi-Line Text Truncation</h1>
+    <p style="margin: 0; opacity: 0.8; max-width: 600px; margin: auto;">Easily truncate long blocks of text across multiple lines using the generated SCSS clamp utilities.</p>
+  </div>
+
+  <div class="grid">
+    <!-- Clamp 1 -->
+    <div class="card">
+      <h3>1-Line Clamp (Standard Truncate)</h3>
+      <code>.ease-line-clamp-1</code>
+      <p class="ease-line-clamp-1">
+        This is a very long block of text that will be aggressively truncated after exactly one line. Any text that overflows past this first line will be hidden and replaced with an ellipsis automatically by the browser's rendering engine. This is perfect for single-line titles or narrow column headers that cannot wrap.
+      </p>
+    </div>
+
+    <!-- Clamp 2 -->
+    <div class="card">
+      <h3>2-Line Clamp</h3>
+      <code>.ease-line-clamp-2</code>
+      <p class="ease-line-clamp-2">
+        This is a very long block of text that will be truncated after exactly two lines. Any text that overflows past the second line will be hidden and replaced with an ellipsis automatically by the browser's rendering engine. This is typically used for article subtitles or secondary preview text on blog cards.
+      </p>
+    </div>
+
+    <!-- Clamp 3 -->
+    <div class="card">
+      <h3>3-Line Clamp</h3>
+      <code>.ease-line-clamp-3</code>
+      <p class="ease-line-clamp-3">
+        This is a very long block of text that will be truncated after exactly three lines. Any text that overflows past the third line will be hidden and replaced with an ellipsis automatically by the browser's rendering engine. This is ideal for paragraph previews, comment sections, or product descriptions in e-commerce grids.
+      </p>
+    </div>
+
+    <!-- Unclamped -->
+    <div class="card" style="grid-column: 1 / -1; max-width: 600px; margin: 0 auto;">
+      <h3>Unclamped (Original)</h3>
+      <p>
+        This is a very long block of text that will <strong>not be truncated</strong>. Any text that overflows past this first line will simply continue to wrap to the next line as standard HTML paragraph elements naturally do. This demonstrates the original length of the text blocks clamped in the examples above.
+      </p>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/scss/scss-truncate-multi-line-clamp-utility-classes/style.css
+++ b/submissions/scss/scss-truncate-multi-line-clamp-utility-classes/style.css
@@ -1,0 +1,136 @@
+/* 
+  style.css
+  This file contains the compiled output of the SCSS mixin so that demo.html can function 
+  without requiring a local Sass compiler to be running.
+*/
+
+:root {
+  --bg-color: #f8fafc;
+  --text-color: #0f172a;
+  --card-bg: #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-color: #0f172a;
+    --text-color: #f8fafc;
+    --card-bg: #1e293b;
+  }
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 4rem 2rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+  width: 100%;
+  max-width: 900px;
+}
+
+.card {
+  background-color: var(--card-bg);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.card h3 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #3b82f6;
+}
+
+.card p {
+  margin: 0;
+  line-height: 1.6;
+  opacity: 0.8;
+}
+
+code {
+  background: rgba(148, 163, 184, 0.2);
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.875rem;
+  font-weight: bold;
+  align-self: flex-start;
+}
+
+/* =======================================================
+   COMPILED SCSS OUTPUT (Line Clamp Utilities)
+   ======================================================= */
+
+.ease-line-clamp-1 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: break-word;
+}
+
+.ease-line-clamp-2 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: break-word;
+}
+
+.ease-line-clamp-3 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: break-word;
+}
+
+.ease-line-clamp-4 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: break-word;
+}
+
+.ease-line-clamp-5 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 5;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: break-word;
+}
+
+.ease-line-clamp-6 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 6;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: break-word;
+}
+
+.ease-line-clamp-none {
+  display: block;
+  -webkit-line-clamp: none;
+  overflow: visible;
+  text-overflow: clip;
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #27784 by introducing a reusable SCSS module for generating `.ease-line-clamp-*` utility classes. This allows developers to gracefully truncate text that spans multiple lines without writing complex `-webkit-box` vendor prefixes or relying on JavaScript character counting.

Closes #27784

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/scss/scss-truncate-multi-line-clamp-utility-classes/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] Includes `_truncate-multi-line-clamp-utility-classes.scss`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An SCSS utility mixin (`@include ease-line-clamp(N)`) and pre-generated utility classes (`.ease-line-clamp-1` through `.ease-line-clamp-6`) that automatically truncate overflow text after a specified number of lines, appending an ellipsis (`...`).

**How does a developer use it?**

```html
<!-- Simply apply the class based on how many lines you want to allow -->
<p class="ease-line-clamp-3">
  This is a very long paragraph that serves as a preview for an article. 
  Instead of taking up massive vertical space and ruining card height consistency, 
  it will smoothly cut off after exactly three lines, leaving an ellipsis...
</p>
