### PR TITLE
feat: Add SCSS Fluid Typography Clamp System (#28411)

### DIFF
--- a/submissions/scss/scss-fluid-typography-clamp-mixin-system/README.md
+++ b/submissions/scss/scss-fluid-typography-clamp-mixin-system/README.md
@@ -1,0 +1,53 @@
+# SCSS Utility: Fluid Typography & Clamp Mixin System (#28411)
+
+An advanced mathematical SCSS module for the EaseMotion CSS framework that dynamically calculates viewport-width based fluid typography using the CSS `clamp()` function. This enables text to scale seamlessly between a minimum and maximum size without abrupt media query breakpoints.
+
+## 📦 What's included?
+
+- `_fluid-typography-clamp-mixin-system.scss`: The SCSS partial containing the mathematical equation mixins.
+- `style.css`: The raw compiled CSS utility classes outputting the calculated `clamp()` rules.
+- `demo.html`: A self-contained demo page demonstrating the fluid scaling behavior.
+
+## 🛠 Usage via SCSS Mixins
+
+Import the partial into your project. You can apply the mixin directly to specific heading tags or component classes to define custom boundaries.
+
+```scss
+@import 'fluid-typography-clamp-mixin-system';
+
+// @include fluid-type($min-font-size, $max-font-size, $min-vw (optional), $max-vw (optional));
+
+.hero-title {
+  // Scales smoothly from 32px (on mobile) to 80px (on desktop)
+  @include fluid-type(32px, 80px);
+}
+
+.article-body {
+  // Scales from 16px to 20px
+  @include fluid-type(16px, 20px);
+}
+```
+
+*Note: The mixin automatically converts all pixel inputs into accessible `rem` units within the final `clamp()` output.*
+
+## 🛠 Usage via HTML Utility Classes
+
+If your project is pre-compiled, you can use the default utility classes immediately in your markup.
+
+```html
+<!-- Scales from 32px -> 72px -->
+<h1 class="ease-fluid-text-xl">Massive Headline</h1>
+
+<!-- Scales from 24px -> 48px -->
+<h2 class="ease-fluid-text-lg">Section Title</h2>
+
+<!-- Scales from 16px -> 24px -->
+<p class="ease-fluid-text-md">Introductory lead paragraph</p>
+
+<!-- Scales from 14px -> 18px -->
+<p class="ease-fluid-text-sm">Standard body copy</p>
+```
+
+## 🚀 Why this fits EaseMotion
+
+Fluid typography eliminates the need for maintaining dozens of `@media` query breakpoints just to resize headings. However, writing the mathematical slope equation (`y = mx + b`) for a `clamp()` function manually is virtually impossible for a developer to do on the fly. This SCSS module fully automates the math, outputting accessible `rem`-based `clamp()` strings, keeping layouts robust and animations completely free of sudden text-resizing layout shifts.

--- a/submissions/scss/scss-fluid-typography-clamp-mixin-system/_fluid-typography-clamp-mixin-system.scss
+++ b/submissions/scss/scss-fluid-typography-clamp-mixin-system/_fluid-typography-clamp-mixin-system.scss
@@ -1,0 +1,72 @@
+// _fluid-typography-clamp-mixin-system.scss
+// =======================================================
+// EaseMotion CSS - Fluid Typography Clamp System
+// 
+// Provides an advanced SCSS mixin to generate fluid typography 
+// that scales smoothly between a minimum and maximum font size 
+// based on the viewport width using the CSS clamp() function.
+// =======================================================
+
+@use "sass:math";
+
+/// Generates a CSS clamp() function for fluid typography.
+/// @param {Number} $min-font-size - The minimum font size in pixels (e.g. 16px)
+/// @param {Number} $max-font-size - The maximum font size in pixels (e.g. 32px)
+/// @param {Number} $min-vw - The minimum viewport width in pixels (default: 320px)
+/// @param {Number} $max-vw - The maximum viewport width in pixels (default: 1200px)
+@mixin fluid-type($min-font-size, $max-font-size, $min-vw: 320px, $max-vw: 1200px) {
+  
+  // Strip units for calculations
+  $u1: math.unit($min-vw);
+  $u2: math.unit($max-vw);
+  $u3: math.unit($min-font-size);
+  $u4: math.unit($max-font-size);
+
+  @if $u1 == $u2 and $u1 == $u3 and $u1 == $u4 {
+    
+    // Formula for fluid scaling:
+    // y = mx + b
+    // m = (maxSize - minSize) / (maxWidth - minWidth)
+    // b = minSize - (m * minWidth)
+    
+    $min-size: math.div($min-font-size, 1px);
+    $max-size: math.div($max-font-size, 1px);
+    $min-width: math.div($min-vw, 1px);
+    $max-width: math.div($max-vw, 1px);
+    
+    $slope: math.div($max-size - $min-size, $max-width - $min-width);
+    $y-axis-intersection: -1 * $min-width * $slope + $min-size;
+    
+    // Convert to rems for accessibility
+    $min-rem: math.div($min-size, 16) * 1rem;
+    $max-rem: math.div($max-size, 16) * 1rem;
+    $intersection-rem: math.div($y-axis-intersection, 16) * 1rem;
+    $slope-vw: $slope * 100vw;
+    
+    // Output the clamp property
+    font-size: clamp(#{$min-rem}, #{$intersection-rem} + #{$slope-vw}, #{$max-rem});
+    
+  } @else {
+    @error "Please ensure all values passed to `fluid-type` use the same unit (px).";
+  }
+}
+
+// -------------------------------------------------------
+// Default Initializations (For generated CSS utility classes)
+// -------------------------------------------------------
+
+.ease-fluid-text-sm {
+  @include fluid-type(14px, 18px);
+}
+
+.ease-fluid-text-md {
+  @include fluid-type(16px, 24px);
+}
+
+.ease-fluid-text-lg {
+  @include fluid-type(24px, 48px);
+}
+
+.ease-fluid-text-xl {
+  @include fluid-type(32px, 72px);
+}

--- a/submissions/scss/scss-fluid-typography-clamp-mixin-system/demo.html
+++ b/submissions/scss/scss-fluid-typography-clamp-mixin-system/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Fluid Typography Utilities</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <div style="text-align: center; margin-bottom: 3rem;">
+    <h1 style="margin: 0 0 1rem 0;">Fluid Typography System</h1>
+    <p style="margin: 0; opacity: 0.8; max-width: 600px; margin: auto;">Resize your browser window! Watch the text scale smoothly between its minimum and maximum bounds without any media query breakpoints.</p>
+  </div>
+
+  <div class="container">
+    
+    <!-- XL Fluid Text -->
+    <div class="card">
+      <p class="description">.ease-fluid-text-xl (Scales 32px to 72px)</p>
+      <h2 class="demo-text ease-fluid-text-xl">Hero Title Typography</h2>
+    </div>
+
+    <!-- LG Fluid Text -->
+    <div class="card">
+      <p class="description">.ease-fluid-text-lg (Scales 24px to 48px)</p>
+      <h3 class="demo-text ease-fluid-text-lg" style="color: #ec4899;">Section Heading Typography</h3>
+    </div>
+
+    <!-- MD Fluid Text -->
+    <div class="card">
+      <p class="description">.ease-fluid-text-md (Scales 16px to 24px)</p>
+      <p class="demo-text ease-fluid-text-md" style="color: #10b981;">Subheading or enlarged paragraph text that needs to remain comfortably legible across mobile and desktop displays.</p>
+    </div>
+
+    <!-- SM Fluid Text -->
+    <div class="card">
+      <p class="description">.ease-fluid-text-sm (Scales 14px to 18px)</p>
+      <p class="demo-text ease-fluid-text-sm" style="color: var(--text-color); font-weight: normal;">Standard body text that scales down slightly on smaller mobile devices to preserve screen real estate, while growing slightly on ultra-wide desktop monitors for better readability.</p>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/scss/scss-fluid-typography-clamp-mixin-system/style.css
+++ b/submissions/scss/scss-fluid-typography-clamp-mixin-system/style.css
@@ -1,0 +1,93 @@
+/* 
+  style.css
+  This file contains the compiled output of the SCSS mixin so that demo.html can function 
+  without requiring a local Sass compiler to be running.
+*/
+
+:root {
+  --bg-color: #f8fafc;
+  --text-color: #0f172a;
+  --card-bg: #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-color: #0f172a;
+    --text-color: #f8fafc;
+    --card-bg: #1e293b;
+  }
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 4rem 2rem;
+}
+
+.container {
+  width: 100%;
+  max-width: 1200px;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.card {
+  background-color: var(--card-bg);
+  border-radius: 1rem;
+  padding: 2rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.card p.description {
+  margin: 0;
+  opacity: 0.8;
+  font-size: 1rem;
+  font-family: monospace;
+  background: rgba(148, 163, 184, 0.1);
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  display: inline-block;
+  align-self: flex-start;
+}
+
+.demo-text {
+  margin: 0;
+  font-weight: 800;
+  line-height: 1.2;
+  color: #3b82f6;
+}
+
+/* =======================================================
+   COMPILED SCSS OUTPUT (Fluid Typography)
+   ======================================================= */
+
+.ease-fluid-text-sm {
+  /* Scales 14px -> 18px */
+  font-size: clamp(0.875rem, 0.7840909091rem + 0.4545454545vw, 1.125rem);
+}
+
+.ease-fluid-text-md {
+  /* Scales 16px -> 24px */
+  font-size: clamp(1rem, 0.8181818182rem + 0.9090909091vw, 1.5rem);
+}
+
+.ease-fluid-text-lg {
+  /* Scales 24px -> 48px */
+  font-size: clamp(1.5rem, 0.9545454545rem + 2.7272727273vw, 3rem);
+}
+
+.ease-fluid-text-xl {
+  /* Scales 32px -> 72px */
+  font-size: clamp(2rem, 1.0909090909rem + 4.5454545455vw, 4.5rem);
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #27785 by introducing a powerful, math-driven SCSS utility module that dynamically calculates fluid typography. Utilizing the CSS `clamp()` function and viewport-width scaling interpolation (`y = mx + b`), it allows developers to define minimum and maximum font sizes that perfectly scale across all devices without relying on tedious, rigid `@media` query breakpoints.

Closes #27785

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/scss/scss-fluid-typography-clamp-mixin-system/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] Includes `_fluid-typography-clamp-mixin-system.scss`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An advanced SCSS mixin (`@include fluid-type($min, $max)`) and a set of utility classes (`.ease-fluid-text-sm` through `xl`) that output accessible `rem`-based `clamp()` functions to ensure typography gracefully resizes according to viewport width.

**How does a developer use it?**

```scss
@import 'fluid-typography-clamp-mixin-system';

// Apply custom scaling limits to specific components
.hero-headline {
  /* Scales linearly from 32px to 80px between 320px and 1200px viewports */
  @include fluid-type(32px, 80px);
}
