### PR TITLE
docs: add footer keyframe collision demo

### DIFF
--- a/submissions/docs/footer-keyframe-collision-demo/README.md
+++ b/submissions/docs/footer-keyframe-collision-demo/README.md
@@ -1,0 +1,66 @@
+# Footer Keyframe Namespace Collision Demo
+
+This documentation demo reproduces the footer keyframe namespace collision described in **Issue #27881** and demonstrates the proposed solution using framework-prefixed keyframe names.
+
+## Issue
+
+The footer component currently defines generic global keyframe names:
+
+```css
+@keyframes float
+@keyframes heartbeat
+```
+
+These keyframes are referenced by the footer animations:
+
+```css
+animation: float 20s ease-in-out infinite;
+animation: heartbeat 1.5s ease-in-out infinite;
+```
+
+Because CSS keyframes exist in the global animation namespace, generic names such as `float` and `heartbeat` can collide with animations defined by applications or third-party libraries.
+
+## Proposed Fix
+
+Rename the footer keyframes to follow the existing EaseMotion CSS naming convention.
+
+### Before
+
+```css
+@keyframes float
+@keyframes heartbeat
+```
+
+### After
+
+```css
+@keyframes ease-kf-footer-float
+@keyframes ease-kf-footer-heartbeat
+```
+
+Update the corresponding animation declarations:
+
+```css
+animation: ease-kf-footer-float 20s ease-in-out infinite;
+animation: ease-kf-footer-heartbeat 1.5s ease-in-out infinite;
+```
+
+## Demo Files
+
+```text
+README.md
+demo.html
+style.css
+```
+
+* **demo.html** demonstrates the namespace collision and the proposed prefixed keyframe solution.
+* **style.css** contains both the current implementation (generic keyframe names) and the proposed implementation (prefixed keyframe names) for comparison.
+
+## Expected Result
+
+After adopting the proposed keyframe names:
+
+* Footer animations retain their existing visual behavior.
+* Generic keyframe namespace collisions are eliminated.
+* Footer animations are isolated from application and third-party CSS.
+* The implementation follows the framework's existing `ease-kf-*` naming convention for improved consistency.

--- a/submissions/docs/footer-keyframe-collision-demo/demo.html
+++ b/submissions/docs/footer-keyframe-collision-demo/demo.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Footer Keyframe Namespace Collision Demo</title>
+
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<main class="container">
+
+    <h1>Footer Keyframe Namespace Collision Demo</h1>
+
+    <p>
+        This demo reproduces the keyframe namespace collision described in
+        <strong>Issue #27881</strong>. It demonstrates how generic keyframe
+        names such as <code>float</code> and <code>heartbeat</code> can
+        conflict with application CSS and how prefixing them avoids these
+        collisions.
+    </p>
+
+    <section class="section">
+        <h2>Application Animation</h2>
+
+        <p>
+            The application defines a generic
+            <code>@keyframes float</code> animation.
+        </p>
+
+        <div class="box app-box"></div>
+    </section>
+
+    <section class="section">
+        <h2>Current Footer (Collision)</h2>
+
+        <p>
+            The footer also defines
+            <code>@keyframes float</code>. Since CSS keyframes are global,
+            the framework and application may unintentionally override each
+            other's animations.
+        </p>
+
+        <div class="box footer-box"></div>
+    </section>
+
+    <section class="section">
+        <h2>Proposed Fix</h2>
+
+        <p>
+            Prefixing footer keyframes (for example,
+            <code>ease-kf-footer-float</code>) isolates the animation while
+            preserving the same visual behavior.
+        </p>
+
+        <div class="box fixed-box"></div>
+    </section>
+
+    <section class="section">
+        <h2>Heartbeat Animation</h2>
+
+        <p>
+            The same namespace collision can occur with
+            <code>@keyframes heartbeat</code>. Using
+            <code>ease-kf-footer-heartbeat</code> prevents conflicts with
+            application or third-party styles.
+        </p>
+
+        <div class="heart-row">
+            <div>
+                <h3>Current</h3>
+                <span class="heart current-heart">❤️</span>
+            </div>
+
+            <div>
+                <h3>Proposed Fix</h3>
+                <span class="heart fixed-heart">❤️</span>
+            </div>
+        </div>
+    </section>
+
+    <footer class="section">
+        <h2>Expected Result</h2>
+
+        <p>
+            The visual appearance remains unchanged while prefixed keyframe
+            names prevent global CSS namespace collisions and improve
+            compatibility with application and third-party styles.
+        </p>
+    </footer>
+
+</main>
+
+</body>
+</html>

--- a/submissions/docs/footer-keyframe-collision-demo/style.css
+++ b/submissions/docs/footer-keyframe-collision-demo/style.css
@@ -1,0 +1,214 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: Arial, Helvetica, sans-serif;
+    background: #f5f5f5;
+    color: #222;
+    padding: 40px;
+}
+
+.container {
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+h1 {
+    margin-bottom: 12px;
+}
+
+h2,
+h3 {
+    margin-bottom: 10px;
+}
+
+p {
+    margin-bottom: 20px;
+    line-height: 1.6;
+}
+
+.section {
+    margin: 40px 0;
+    padding: 20px;
+    background: #fff;
+    border: 1px solid #ddd;
+    border-radius: 10px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+
+.box {
+    width: 80px;
+    height: 80px;
+    margin-top: 20px;
+    border-radius: 10px;
+}
+
+/* =====================================================
+   Application CSS
+
+   The application defines its own generic
+   @keyframes float animation.
+===================================================== */
+
+@keyframes float {
+    from {
+        transform: translateY(0);
+    }
+
+    to {
+        transform: translateY(-60px);
+    }
+}
+
+.app-box {
+    background: #2563eb;
+    animation: float 2s ease-in-out infinite alternate;
+}
+
+/* =====================================================
+   Current Footer (Collision)
+
+   The footer also defines @keyframes float.
+
+   Since keyframe names are global, this second
+   definition overrides the previous one and
+   demonstrates the namespace collision.
+===================================================== */
+
+.footer-box {
+    background: #ef4444;
+    animation: float 2s ease-in-out infinite;
+}
+
+/* Intentionally redefines @keyframes float
+   to simulate a framework collision. */
+
+@keyframes float {
+    0%,
+    100% {
+        transform: translateY(0);
+    }
+
+    50% {
+        transform: translateY(-10px);
+    }
+}
+
+/* =====================================================
+   Proposed Fix
+
+   Uses a framework-prefixed keyframe name to
+   avoid namespace collisions.
+===================================================== */
+
+.fixed-box {
+    background: #16a34a;
+    animation: ease-kf-footer-float 2s ease-in-out infinite;
+}
+
+@keyframes ease-kf-footer-float {
+    0%,
+    100% {
+        transform: translateY(0);
+    }
+
+    50% {
+        transform: translateY(-10px);
+    }
+}
+
+/* =====================================================
+   Heartbeat Animation Demo
+===================================================== */
+
+.heart-row {
+    display: flex;
+    gap: 80px;
+    margin-top: 20px;
+    flex-wrap: wrap;
+}
+
+.heart {
+    display: inline-block;
+    margin-top: 10px;
+    font-size: 48px;
+}
+
+/* Current implementation */
+
+.current-heart {
+    animation: heartbeat 1.5s ease-in-out infinite;
+}
+
+@keyframes heartbeat {
+    0%,
+    100% {
+        transform: scale(1);
+    }
+
+    25% {
+        transform: scale(1.2);
+    }
+
+    50% {
+        transform: scale(1);
+    }
+
+    75% {
+        transform: scale(1.2);
+    }
+}
+
+/* Proposed implementation */
+
+.fixed-heart {
+    animation: ease-kf-footer-heartbeat 1.5s ease-in-out infinite;
+}
+
+@keyframes ease-kf-footer-heartbeat {
+    0%,
+    100% {
+        transform: scale(1);
+    }
+
+    25% {
+        transform: scale(1.2);
+    }
+
+    50% {
+        transform: scale(1);
+    }
+
+    75% {
+        transform: scale(1.2);
+    }
+}
+
+code {
+    padding: 2px 6px;
+    background: #ececec;
+    border-radius: 4px;
+    font-family: Consolas, Monaco, monospace;
+}
+
+@media (max-width: 600px) {
+    body {
+        padding: 20px;
+    }
+
+    .heart-row {
+        flex-direction: column;
+        gap: 30px;
+    }
+
+    .box {
+        margin: 20px auto 0;
+    }
+
+    .section {
+        text-align: center;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #27881

This PR adds a documentation demo that reproduces the footer keyframe namespace collision caused by the generic `float` and `heartbeat` keyframe names. It demonstrates how adopting prefixed keyframe names (`ease-kf-footer-float` and `ease-kf-footer-heartbeat`) prevents global CSS namespace collisions while preserving the existing animation behavior.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — documents the issue, proposed fix, and demo
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A documentation demo illustrating the footer keyframe namespace collision and the proposed prefixed keyframe naming convention.

**How does a developer use it?**

Open `demo.html` directly in a browser to view the comparison between the current implementation and the proposed fix.

```html
<link rel="stylesheet" href="style.css">
```

**Why does it fit EaseMotion CSS?**

The demo documents a real issue affecting CSS keyframe namespacing and demonstrates a solution that aligns with EaseMotion's naming conventions while maintaining the existing visual behavior.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This submission is documentation only and does not modify the framework source. It provides a minimal reproduction of the namespace collision reported in #27881 and demonstrates the proposed prefixed keyframe naming convention for easier review and discussion.