### PR TITLE
[Feat] #27743 — Add truncate multi-line clamp utilities (unique folder)

### DIFF
--- a/submissions/examples/multiline-clamp-27743-ag/README.md
+++ b/submissions/examples/multiline-clamp-27743-ag/README.md
@@ -1,0 +1,31 @@
+# Truncate Multi-Line Clamp Utilities
+
+This guide details configuration specs for generating SCSS multi-line clamp mixin helpers.
+
+---
+
+## Technical Overview: The Multi-Line Clamp Mixin
+
+Standard text truncation utilizing `text-overflow: ellipsis` only supports single-line headings, breaking layout flows for card body paragraphs. Generating line-clamps via SCSS mixins preserves spacing:
+
+```scss
+// SCSS Multi-Line Clamp Truncation Mixin
+@mixin line-clamp($lines: 2) {
+  display: -webkit-box;
+  -webkit-line-clamp: $lines;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+// Utility Classes
+.line-clamp-2 { @include line-clamp(2); }
+.line-clamp-3 { @include line-clamp(3); }
+```
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Toggle the **Clamp 2 Lines** and **Clamp 3 Lines** buttons — verify the preview paragraph displays exactly 2 or 3 lines of text appended with trailing ellipses.
+3. Click **Expand Text** — verify the full description expands cleanly.

--- a/submissions/examples/multiline-clamp-27743-ag/demo.html
+++ b/submissions/examples/multiline-clamp-27743-ag/demo.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Multi-Line Truncation Clamp — EaseMotion CSS</title>
+  <meta name="description" content="Visual utility showcasing multi-line clamp truncation selectors and CSS-based paragraph limits.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — SCSS Utilities</span>
+      <h1>Multi-Line Text Clamp</h1>
+      <p class="description">
+        Demonstrates line-clamp truncation. Click buttons below 
+        to dynamically change the clamped line count constraints.
+      </p>
+    </header>
+
+    <main class="dashboard">
+
+      <!-- Left Panel: Clamp Settings -->
+      <section class="controls-panel">
+        <h2 class="section-title">Clamp Configuration</h2>
+        
+        <div class="selector-buttons">
+          <button class="ease-btn active" id="btn-clamp-2" type="button">Clamp 2 Lines</button>
+          <button class="ease-btn" id="btn-clamp-3" type="button">Clamp 3 Lines</button>
+          <button class="ease-btn" id="btn-clamp-none" type="button">Expand Text</button>
+        </div>
+      </section>
+
+      <!-- Right Panel: Text Box -->
+      <section class="preview-panel">
+        <h2 class="section-title">Clamped Output</h2>
+        
+        <div class="text-card">
+          <h3>Article Preview</h3>
+          <p class="clamp-text line-clamp-2" id="clamp-paragraph">
+            EaseMotion CSS is a premium, framework-agnostic CSS design system. It supplies web developers with ultra-high performance keyframe structures, interactive components, responsive grid generators, and accessibility focus layers to build gorgeous, state-of-the-art web interfaces that look premium on any device size.
+          </p>
+        </div>
+      </section>
+
+    </main>
+  </div>
+
+  <script>
+    const paragraph = document.getElementById('clamp-paragraph');
+    
+    const btn2 = document.getElementById('btn-clamp-2');
+    const btn3 = document.getElementById('btn-clamp-3');
+    const btnNone = document.getElementById('btn-clamp-none');
+    
+    const btns = [btn2, btn3, btnNone];
+
+    const selectBtn = (activeBtn) => {
+      btns.forEach(b => b.classList.remove('active'));
+      activeBtn.classList.add('active');
+    };
+
+    btn2.addEventListener('click', () => {
+      selectBtn(btn2);
+      paragraph.className = 'clamp-text line-clamp-2';
+    });
+
+    btn3.addEventListener('click', () => {
+      selectBtn(btn3);
+      paragraph.className = 'clamp-text line-clamp-3';
+    });
+
+    btnNone.addEventListener('click', () => {
+      selectBtn(btnNone);
+      paragraph.className = 'clamp-text';
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/multiline-clamp-27743-ag/style.css
+++ b/submissions/examples/multiline-clamp-27743-ag/style.css
@@ -1,0 +1,178 @@
+/* ============================================================
+   Multi-Line Truncation Clamp — style.css
+   Submission for EaseMotion CSS Issue #27743
+   Line-clamp selectors, control buttons, and text cards
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 820px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Dashboard Layout
+   ============================================================ */
+
+.dashboard {
+  display: grid;
+  grid-template-columns: 1fr 1.3fr;
+  gap: 28px;
+}
+
+@media (max-width: 768px) {
+  .dashboard { grid-template-columns: 1fr; }
+}
+
+.controls-panel,
+.preview-panel {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  padding: 28px;
+  border-radius: 20px;
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+}
+
+.section-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+/* Controls Panel */
+.selector-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  justify-content: center;
+  height: 100%;
+}
+
+.ease-btn {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--card-border);
+  color: var(--text-secondary);
+  padding: 12px;
+  border-radius: 8px;
+  font-family: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.ease-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+}
+
+.ease-btn.active {
+  background: var(--primary-color);
+  border-color: var(--primary-color);
+  color: #fff;
+  box-shadow: 0 4px 12px rgba(124,58,237,0.25);
+}
+
+/* Text Card */
+.text-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.text-card h3 {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+/* ── Multi-Line Truncation under Test (Clamp Utilities) ── */
+.clamp-text {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.line-clamp-2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.line-clamp-3 {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-btn {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-multiline-clamp` showcase. It demonstrates multi-line truncation utilities generated via SCSS line-clamp mixins (using WebKit box-orient properties coupled with line-clamp limits) supporting interactive toggle selectors.

## Root Cause
No multi-line text truncation mixins or variable paragraph line-clamp utilities existed in EaseMotion CSS.

## Changes Made
- `submissions/examples/multiline-clamp-27743-ag/demo.html`: Container panels hosting settings widgets and responsive paragraph cells.
- `submissions/examples/multiline-clamp-27743-ag/style.css`: WebKit box-orient definitions, line clamp boundaries, button shapes, and borders.
- `submissions/examples/multiline-clamp-27743-ag/README.md`: Explains SCSS clamp mixin parameters, layout fallbacks, and validation guides.

## How to Test
1. Open `demo.html` in a browser.
2. Toggle button presets to confirm paragraph limits and trailing ellipses.

## Related Issue
Closes #27743