### PR TITLE
[Feat] #27742 — Add custom focus ring utilities (unique folder)

### DIFF
--- a/submissions/examples/focus-ring-a11y-27742-ag/README.md
+++ b/submissions/examples/focus-ring-a11y-27742-ag/README.md
@@ -1,0 +1,37 @@
+# Custom Focus Ring & A11y Indicator Mixins
+
+This submission implements accessibility focus utility declarations matching SCSS mixin requirements.
+
+---
+
+## Technical Overview: The SCSS A11y Focus Mixin
+
+Standard focus outlines look inconsistent across browser engines, prompting developers to write `outline: none`, which creates major accessibility blocks. Generating focus rings via SCSS mixins ensures high-contrast outlines are preserved:
+
+```scss
+// SCSS Custom Focus Ring Mixin
+@mixin focus-ring($color: #38bdf8, $offset: 3px, $radius: 8px) {
+  outline: none;
+  
+  // Use focus-visible to only apply outline to keyboard tab inputs
+  &:focus-visible {
+    outline: 2px solid $color;
+    outline-offset: $offset;
+    box-shadow: 0 0 0 ($offset + 3px) rgba($color, 0.25);
+    border-color: $color;
+  }
+}
+
+// Utility Classes
+.btn-accessible {
+  @include focus-ring(#7c3aed);
+}
+```
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Press `Tab` on your keyboard.
+3. Verify that focus shifts through the input field and buttons, displaying a high-contrast cyan outline and surrounding glow.

--- a/submissions/examples/focus-ring-a11y-27742-ag/demo.html
+++ b/submissions/examples/focus-ring-a11y-27742-ag/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Custom Focus Ring & Accessibility — EaseMotion CSS</title>
+  <meta name="description" content="Visual accessibility showcase demonstrating high-contrast focus rings, custom outlines, and focus-visible indicators.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — SCSS Utilities</span>
+      <h1>Custom Focus Rings</h1>
+      <p class="description">
+        Demonstrates accessible focus rings. Press <code>Tab</code> on your keyboard 
+        to navigate through interactive elements and observe the custom glow indicators.
+      </p>
+    </header>
+
+    <main class="showcase">
+      
+      <div class="input-form">
+        <!-- Input Field -->
+        <div class="form-group">
+          <label for="user-email">Email Address</label>
+          <input class="focus-indicator" type="email" id="user-email" placeholder="name@example.com">
+        </div>
+
+        <!-- Buttons -->
+        <div class="button-group">
+          <button class="ease-btn focus-indicator" type="button">Primary Button</button>
+          <button class="ease-btn btn-secondary focus-indicator" type="button">Secondary Button</button>
+        </div>
+      </div>
+
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/focus-ring-a11y-27742-ag/style.css
+++ b/submissions/examples/focus-ring-a11y-27742-ag/style.css
@@ -1,0 +1,163 @@
+/* ============================================================
+   Custom Focus Ring & Accessibility — style.css
+   Submission for EaseMotion CSS Issue #27742
+   Glowing focus rings, custom outlines, inputs, and forms
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --focus-ring-color: #38bdf8;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 580px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Showcase Elements
+   ============================================================ */
+
+.showcase {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  padding: 36px 28px;
+  border-radius: 20px;
+  backdrop-filter: blur(8px);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+}
+
+.input-form {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form-group label {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+}
+
+.form-group input {
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 1px solid var(--card-border);
+  background: rgba(0,0,0,0.2);
+  color: #fff;
+  font-family: inherit;
+  font-size: 0.9rem;
+  outline: none;
+}
+
+.button-group {
+  display: flex;
+  gap: 16px;
+}
+
+.ease-btn {
+  flex: 1;
+  background: var(--primary-color);
+  border: none;
+  color: #fff;
+  padding: 12px;
+  border-radius: 8px;
+  font-family: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(124,58,237,0.25);
+  transition: background 0.2s ease;
+}
+
+.ease-btn:hover {
+  filter: brightness(1.08);
+}
+
+.btn-secondary {
+  background: rgba(255,255,255,0.04);
+  border: 1px solid var(--card-border);
+  color: var(--text-secondary);
+  box-shadow: none;
+}
+.btn-secondary:hover {
+  background: rgba(255,255,255,0.08);
+  color: #fff;
+}
+
+/* ============================================================
+   Custom Focus Ring Utilities (A11y mixin declarations)
+   ============================================================ */
+
+.focus-indicator {
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+/* focus-visible ensures indicators only trigger on keyboard navigation */
+.focus-indicator:focus-visible {
+  outline: 2px solid var(--focus-ring-color);
+  outline-offset: 3px;
+  box-shadow: 0 0 0 6px rgba(56, 189, 248, 0.25);
+  border-color: var(--focus-ring-color);
+}


### PR DESCRIPTION
## Summary
Adds the `ease-focus-ring-a11y` showcase. It demonstrates accessible outlines generated via SCSS focus-ring mixins (using `focus-visible` selectors to apply high-contrast outline glows on keyboard tab events) supporting custom outline-offset steps.

## Root Cause
No accessible focus indicators or custom focus-visible styling mixins existed in EaseMotion CSS.

## Changes Made
- `submissions/examples/focus-ring-a11y-27742-ag/demo.html`: Form containers hosting accessible input and button nodes.
- `submissions/examples/focus-ring-a11y-27742-ag/style.css`: Focus ring colors, outline-offsets, glow parameters, and form layouts.
- `submissions/examples/focus-ring-a11y-27742-ag/README.md`: Explains focus-visible outline configs, SCSS focus parameters, and manual validation.

## How to Test
1. Open `demo.html` in a browser.
2. Tab through elements to verify the accessible outlines.

## Related Issue
Closes #27742