### PR TITLE
feat: Add SCSS Responsive Aspect Ratio Utilities (#28415)

### DIFF
--- a/submissions/scss/scss-responsive-aspect-ratio-utility-classes/README.md
+++ b/submissions/scss/scss-responsive-aspect-ratio-utility-classes/README.md
@@ -1,0 +1,56 @@
+# SCSS Utility: Responsive Aspect Ratio Utility Classes (#28415)
+
+A lightweight SCSS module for the EaseMotion CSS framework that dynamically generates CSS `aspect-ratio` utility classes. This completely eliminates the need for the outdated padding-bottom "hack" when embedding responsive videos, images, or maps.
+
+## 📦 What's included?
+
+- `_responsive-aspect-ratio-utility-classes.scss`: The SCSS partial containing the aspect ratio mixins and list generator.
+- `style.css`: The raw compiled CSS utility classes (`.ease-aspect-video`, `.ease-aspect-square`, etc.).
+- `demo.html`: A self-contained demo page demonstrating how images perfectly crop inside the ratio bounds.
+
+## 🛠 Usage via SCSS Mixins
+
+Import the partial into your project. You can apply custom aspect ratios to any specific component.
+
+```scss
+@import 'responsive-aspect-ratio-utility-classes';
+
+// @include ease-aspect-ratio($width-ratio, $height-ratio);
+
+.custom-hero-banner {
+  // A super-wide custom aspect ratio for a specific design
+  @include ease-aspect-ratio(32, 9);
+}
+```
+
+## 🛠 Usage via HTML Utility Classes
+
+If your project is pre-compiled, you can use the predefined preset classes on wrappers containing `<img>`, `<video>`, or `<iframe>` tags. The mixin ensures that direct children automatically fill the space using `object-fit: cover;` so images are never distorted or stretched.
+
+```html
+<!-- Perfect for YouTube Embeds -->
+<div class="ease-aspect-video">
+  <iframe src="..."></iframe>
+</div>
+
+<!-- Perfect for Instagram-style Grid Posts -->
+<div class="ease-aspect-square">
+  <img src="avatar.jpg" alt="Profile">
+</div>
+
+<!-- Perfect for Mobile App Mockups or TikTok videos -->
+<div class="ease-aspect-portrait">
+  <video src="..."></video>
+</div>
+```
+
+**Available Preset Classes:**
+- `.ease-aspect-square` (1:1)
+- `.ease-aspect-video` (16:9)
+- `.ease-aspect-portrait` (3:4)
+- `.ease-aspect-landscape` (4:3)
+- `.ease-aspect-cinematic` (21:9)
+
+## 🚀 Why this fits EaseMotion
+
+The **EaseMotion** philosophy is about reducing developer friction and maintaining perfect layouts. Without strict aspect ratios, loading images or cross-domain iframes causes severe Cumulative Layout Shift (CLS) as the browser figures out how tall the content is. This pushes your UI down abruptly and ruins any smooth entrance animations. By utilizing modern CSS `aspect-ratio`, the browser reserves the exact mathematical space before the asset even loads, ensuring perfectly stable, jitter-free animation timelines.

--- a/submissions/scss/scss-responsive-aspect-ratio-utility-classes/_responsive-aspect-ratio-utility-classes.scss
+++ b/submissions/scss/scss-responsive-aspect-ratio-utility-classes/_responsive-aspect-ratio-utility-classes.scss
@@ -1,0 +1,51 @@
+// _responsive-aspect-ratio-utility-classes.scss
+// =======================================================
+// EaseMotion CSS - Responsive Aspect Ratio Utilities
+// 
+// Provides an SCSS mixin and generated utility classes to perfectly
+// crop and scale images, videos, and iframe embeds using the modern
+// CSS `aspect-ratio` property.
+// =======================================================
+
+@use "sass:math";
+
+/// Applies a specific aspect ratio to an element.
+/// @param {Number} $width - The width ratio (e.g., 16 for 16:9).
+/// @param {Number} $height - The height ratio (e.g., 9 for 16:9).
+@mixin ease-aspect-ratio($width, $height) {
+  aspect-ratio: #{$width} / #{$height};
+  
+  // Ensure the content inside (like an <img> or <video>) fills the container properly
+  // without distorting or stretching.
+  > * {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+/// Generates a set of aspect ratio utility classes from a predefined map.
+/// @param {Map} $ratios - A map of class name suffixes to their width/height lists.
+@mixin generate-aspect-ratio-utilities($ratios) {
+  @each $name, $ratio in $ratios {
+    .ease-aspect-#{$name} {
+      @include ease-aspect-ratio(nth($ratio, 1), nth($ratio, 2));
+    }
+  }
+}
+
+// -------------------------------------------------------
+// Default Initializations (For generated CSS utility classes)
+// -------------------------------------------------------
+
+$default-aspect-ratios: (
+  "square": (1, 1),      // 1:1 Instagram-style
+  "video": (16, 9),      // 16:9 YouTube/Standard Video
+  "portrait": (3, 4),    // 3:4 Mobile Portrait / TikTok
+  "landscape": (4, 3),   // 4:3 Classic Photography
+  "cinematic": (21, 9),  // 21:9 Ultrawide
+  "auto": (auto, auto)   // Revert to intrinsic sizing
+);
+
+// Generate classes: .ease-aspect-square, .ease-aspect-video, etc.
+@include generate-aspect-ratio-utilities($default-aspect-ratios);

--- a/submissions/scss/scss-responsive-aspect-ratio-utility-classes/demo.html
+++ b/submissions/scss/scss-responsive-aspect-ratio-utility-classes/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Aspect Ratio Utilities</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <div style="text-align: center; margin-bottom: 3rem;">
+    <h1 style="margin: 0 0 1rem 0;">Aspect Ratio Utilities</h1>
+    <p style="margin: 0; opacity: 0.8; max-width: 600px; margin: auto;">Perfectly crop and scale images or video embeds without distortion. Resize the browser to watch the aspect ratios maintain perfect proportions.</p>
+  </div>
+
+  <div class="container">
+    
+    <!-- Video / Widescreen (16:9) -->
+    <div class="ratio-demo-wrapper">
+      <h3>16:9 Standard Video <code>.ease-aspect-video</code></h3>
+      <div class="image-placeholder ease-aspect-video">
+        <img src="https://images.unsplash.com/photo-1707343843437-caacff5cfa74?q=80&w=1200&auto=format&fit=crop" alt="Demo Image">
+      </div>
+    </div>
+
+    <!-- Cinematic (21:9) -->
+    <div class="ratio-demo-wrapper">
+      <h3>21:9 Ultrawide Cinematic <code>.ease-aspect-cinematic</code></h3>
+      <div class="image-placeholder ease-aspect-cinematic">
+        <img src="https://images.unsplash.com/photo-1707343843437-caacff5cfa74?q=80&w=1200&auto=format&fit=crop" alt="Demo Image">
+      </div>
+    </div>
+
+    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 2rem;">
+      <!-- Square (1:1) -->
+      <div class="ratio-demo-wrapper">
+        <h3>1:1 Square <code>.ease-aspect-square</code></h3>
+        <div class="image-placeholder ease-aspect-square">
+          <img src="https://images.unsplash.com/photo-1707343843437-caacff5cfa74?q=80&w=800&auto=format&fit=crop" alt="Demo Image">
+        </div>
+      </div>
+
+      <!-- Portrait (3:4) -->
+      <div class="ratio-demo-wrapper">
+        <h3>3:4 Mobile Portrait <code>.ease-aspect-portrait</code></h3>
+        <div class="image-placeholder ease-aspect-portrait">
+          <img src="https://images.unsplash.com/photo-1707343843437-caacff5cfa74?q=80&w=800&auto=format&fit=crop" alt="Demo Image">
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/scss/scss-responsive-aspect-ratio-utility-classes/style.css
+++ b/submissions/scss/scss-responsive-aspect-ratio-utility-classes/style.css
@@ -1,0 +1,137 @@
+/* 
+  style.css
+  This file contains the compiled output of the SCSS mixin so that demo.html can function 
+  without requiring a local Sass compiler to be running.
+*/
+
+:root {
+  --bg-color: #f8fafc;
+  --text-color: #0f172a;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-color: #0f172a;
+    --text-color: #f8fafc;
+  }
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: system-ui, -apple-system, sans-serif;
+  color: var(--text-color);
+  background: var(--bg-color);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 4rem 2rem;
+}
+
+.container {
+  width: 100%;
+  max-width: 900px;
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+.ratio-demo-wrapper {
+  background: rgba(148, 163, 184, 0.1);
+  border-radius: 1rem;
+  padding: 2rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.ratio-demo-wrapper h3 {
+  margin: 0 0 1rem 0;
+  color: #3b82f6;
+  font-size: 1.25rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+code {
+  background: rgba(148, 163, 184, 0.2);
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.875rem;
+  font-family: monospace;
+  font-weight: bold;
+}
+
+/* Image styling for demo purposes */
+.image-placeholder {
+  width: 100%;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  background-color: #cbd5e1;
+  position: relative;
+}
+
+.image-placeholder img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+/* =======================================================
+   COMPILED SCSS OUTPUT (Aspect Ratio Utilities)
+   ======================================================= */
+
+.ease-aspect-square {
+  aspect-ratio: 1 / 1;
+}
+.ease-aspect-square > * {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.ease-aspect-video {
+  aspect-ratio: 16 / 9;
+}
+.ease-aspect-video > * {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.ease-aspect-portrait {
+  aspect-ratio: 3 / 4;
+}
+.ease-aspect-portrait > * {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.ease-aspect-landscape {
+  aspect-ratio: 4 / 3;
+}
+.ease-aspect-landscape > * {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.ease-aspect-cinematic {
+  aspect-ratio: 21 / 9;
+}
+.ease-aspect-cinematic > * {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.ease-aspect-auto {
+  aspect-ratio: auto / auto;
+}
+.ease-aspect-auto > * {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #27789 by introducing a reusable SCSS module designed to enforce strict aspect ratios on elements (like images, videos, and iframes). By leveraging the modern CSS `aspect-ratio` property paired with `object-fit: cover`, this completely eliminates the need for the legacy "padding-bottom hack" and prevents Cumulative Layout Shifts (CLS) while assets are loading.

Closes #27789

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/scss/scss-responsive-aspect-ratio-utility-classes/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] Includes `_responsive-aspect-ratio-utility-classes.scss`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An SCSS mixin (`@include ease-aspect-ratio(w, h)`) and five predefined utility classes (`.ease-aspect-video`, `.ease-aspect-square`, `.ease-aspect-portrait`, `.ease-aspect-landscape`, `.ease-aspect-cinematic`) that perfectly crop and scale internal content.

**How does a developer use it?**

```html
<!-- Automatically crop a raw, non-square avatar image into a perfect 1:1 square -->
<div class="ease-aspect-square">
  <img src="avatar-original.jpg" alt="Profile">
</div>

<!-- Ensure a YouTube embed always remains perfectly 16:9 as the browser resizes -->
<div class="ease-aspect-video">
  <iframe src="..."></iframe>
</div>
