### PR TITLE
feat: Add SCSS Smooth Scrollbar Styling Utilities (#28416)

### DIFF
--- a/submissions/scss/scss-smooth-scrollbar-styling-hover-mixins/README.md
+++ b/submissions/scss/scss-smooth-scrollbar-styling-hover-mixins/README.md
@@ -1,0 +1,54 @@
+# SCSS Utility: Smooth Scrollbar Styling & Hover Mixins (#28416)
+
+A clean SCSS module for the EaseMotion CSS framework that standardizes custom scrollbar styling across all major browsers. It replaces the clunky default Windows/Linux scrollbars with sleek, rounded, Mac OS-style floating scrollbars featuring hover interactions.
+
+## 📦 What's included?
+
+- `_smooth-scrollbar-styling-hover-mixins.scss`: The SCSS partial containing the scrollbar mixin supporting both WebKit prefixes and standard CSS properties.
+- `style.css`: The raw compiled CSS utility classes (`.ease-scrollbar-minimal`, etc.).
+- `demo.html`: A self-contained demo page with three overflow containers to demonstrate the hover effects and styling.
+
+## 🛠 Usage via SCSS Mixins
+
+Import the partial into your project. You can apply the mixin to a specific overflow container, or directly to the `body` tag to theme the entire website.
+
+```scss
+@import 'smooth-scrollbar-styling-hover-mixins';
+
+// @include ease-custom-scrollbar($thumb-color, $track-color, $width, $thumb-hover-color);
+
+body {
+  // Apply a custom purple scrollbar to the entire page
+  @include ease-custom-scrollbar(
+    rgba(168, 85, 247, 0.6), // Thumb Color
+    #f8fafc,                 // Track Color
+    12px,                    // Width
+    rgba(147, 51, 234, 1)    // Hover Color
+  );
+}
+```
+
+## 🛠 Usage via HTML Utility Classes
+
+If your project is pre-compiled, you can use the predefined preset classes on any container that has `overflow: auto` or `overflow: scroll`.
+
+```html
+<!-- Sleek, transparent scrollbar that darkens on hover -->
+<div class="ease-scrollbar-minimal" style="overflow-y: auto; max-height: 400px;">
+  ... massive content ...
+</div>
+
+<!-- Scrollbar is completely invisible, but mousewheel scrolling still works -->
+<div class="ease-scrollbar-hidden" style="overflow-y: auto; max-height: 400px;">
+  ... massive content ...
+</div>
+```
+
+**Available Preset Classes:**
+- `.ease-scrollbar-minimal`: Thin (6px), transparent track, subtle thumb that darkens on hover.
+- `.ease-scrollbar-brand`: Thicker (10px), light track, bold primary-color thumb.
+- `.ease-scrollbar-hidden`: Completely hides the scrollbar UI while preserving scroll functionality (perfect for horizontal carousels).
+
+## 🚀 Why this fits EaseMotion
+
+The **EaseMotion** design system prioritizes a premium user experience. Nothing breaks the immersion of a beautifully animated, sleek interface faster than a jarring, blocky, default OS scrollbar suddenly appearing in the middle of a modal or sidebar. By providing an easy-to-use scrollbar mixin, developers can ensure that even the browser's native UI elements feel cohesive, smooth, and intentionally designed.

--- a/submissions/scss/scss-smooth-scrollbar-styling-hover-mixins/_smooth-scrollbar-styling-hover-mixins.scss
+++ b/submissions/scss/scss-smooth-scrollbar-styling-hover-mixins/_smooth-scrollbar-styling-hover-mixins.scss
@@ -1,0 +1,79 @@
+// _smooth-scrollbar-styling-hover-mixins.scss
+// =======================================================
+// EaseMotion CSS - Smooth Custom Scrollbar Utilities
+// 
+// Provides SCSS mixins and utility classes to customize webkit 
+// scrollbars, giving them a premium, Mac OS-style feel across 
+// all platforms (Chrome, Edge, Safari). Features smooth hover 
+// transitions for the scroll thumb.
+// =======================================================
+
+/// Customizes the scrollbar for the given element.
+/// @param {Color} $thumb-color - The color of the draggable scroll thumb.
+/// @param {Color} $track-color - The background color of the scrollbar track.
+/// @param {Number} $width - The width of the scrollbar (e.g., 8px).
+/// @param {Color} $thumb-hover-color - The color of the thumb when hovered.
+@mixin ease-custom-scrollbar($thumb-color: rgba(148, 163, 184, 0.5), $track-color: transparent, $width: 8px, $thumb-hover-color: rgba(148, 163, 184, 0.8)) {
+  
+  // Standard CSS scrollbar (Firefox support)
+  scrollbar-width: thin;
+  scrollbar-color: $thumb-color $track-color;
+  
+  // WebKit Scrollbar (Chrome, Safari, Edge)
+  &::-webkit-scrollbar {
+    width: $width;
+    height: $width;
+  }
+  
+  &::-webkit-scrollbar-track {
+    background: $track-color;
+    border-radius: 10px;
+  }
+  
+  &::-webkit-scrollbar-thumb {
+    background: $thumb-color;
+    border-radius: 10px;
+    
+    // In pure CSS, we can't transition pseudo-elements like ::-webkit-scrollbar-thumb
+    // However, some modern browsers are beginning to support it. We add it here for future-proofing.
+    transition: background 0.3s ease;
+  }
+  
+  &::-webkit-scrollbar-thumb:hover {
+    background: $thumb-hover-color;
+  }
+}
+
+// -------------------------------------------------------
+// Default Initializations (For generated CSS utility classes)
+// -------------------------------------------------------
+
+// A subtle, minimal scrollbar that only becomes prominent on hover
+.ease-scrollbar-minimal {
+  @include ease-custom-scrollbar(
+    $thumb-color: rgba(148, 163, 184, 0.3),
+    $track-color: transparent,
+    $width: 6px,
+    $thumb-hover-color: rgba(148, 163, 184, 0.8)
+  );
+}
+
+// A bold, branded scrollbar
+.ease-scrollbar-brand {
+  @include ease-custom-scrollbar(
+    $thumb-color: rgba(59, 130, 246, 0.6), // Blue 500
+    $track-color: rgba(241, 245, 249, 1),
+    $width: 10px,
+    $thumb-hover-color: rgba(37, 99, 235, 1) // Blue 600
+  );
+}
+
+// A hidden scrollbar (allows scrolling, but hides the bar completely)
+.ease-scrollbar-hidden {
+  scrollbar-width: none; // Firefox
+  -ms-overflow-style: none; // IE/Edge
+  
+  &::-webkit-scrollbar {
+    display: none; // Chrome, Safari, Opera
+  }
+}

--- a/submissions/scss/scss-smooth-scrollbar-styling-hover-mixins/demo.html
+++ b/submissions/scss/scss-smooth-scrollbar-styling-hover-mixins/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Smooth Scrollbar Utilities</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <div style="text-align: center; margin-bottom: 3rem;">
+    <h1 style="margin: 0 0 1rem 0;">Smooth Scrollbar Utilities</h1>
+    <p style="margin: 0; opacity: 0.8; max-width: 600px; margin: auto;">Scroll through the containers below to see the custom Mac OS-style scrollbars. Hover over the scroll thumb to see the color transition.</p>
+  </div>
+
+  <div class="container">
+    
+    <!-- Minimal Scrollbar -->
+    <div class="scroll-container ease-scrollbar-minimal">
+      <h3>Minimal Scrollbar<br><code>.ease-scrollbar-minimal</code></h3>
+      <p style="opacity: 0.8; font-size: 0.9rem;">Very thin, transparent track. Thumb becomes darker only on hover. Best for sleek UI panels.</p>
+      <div class="content-block">Scroll Down ↓</div>
+    </div>
+
+    <!-- Branded Scrollbar -->
+    <div class="scroll-container ease-scrollbar-brand">
+      <h3>Brand Scrollbar<br><code>.ease-scrollbar-brand</code></h3>
+      <p style="opacity: 0.8; font-size: 0.9rem;">Wider track with a solid background. Thumb is blue and darkens on hover. Good for main page layouts.</p>
+      <div class="content-block">Scroll Down ↓</div>
+    </div>
+
+    <!-- Hidden Scrollbar -->
+    <div class="scroll-container ease-scrollbar-hidden">
+      <h3>Hidden Scrollbar<br><code>.ease-scrollbar-hidden</code></h3>
+      <p style="opacity: 0.8; font-size: 0.9rem;">The scrollbar is completely hidden visually, but scrolling still functions normally using trackpad/mousewheel.</p>
+      <div class="content-block">Scroll Down ↓</div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/scss/scss-smooth-scrollbar-styling-hover-mixins/style.css
+++ b/submissions/scss/scss-smooth-scrollbar-styling-hover-mixins/style.css
@@ -1,0 +1,142 @@
+/* 
+  style.css
+  This file contains the compiled output of the SCSS mixin so that demo.html can function 
+  without requiring a local Sass compiler to be running.
+*/
+
+:root {
+  --bg-color: #f8fafc;
+  --text-color: #0f172a;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-color: #0f172a;
+    --text-color: #f8fafc;
+  }
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: system-ui, -apple-system, sans-serif;
+  color: var(--text-color);
+  background: var(--bg-color);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 4rem 2rem;
+}
+
+.container {
+  width: 100%;
+  max-width: 900px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+}
+
+.scroll-container {
+  background: #ffffff;
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  height: 300px;
+  overflow-y: auto;
+  padding: 1.5rem;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+}
+
+@media (prefers-color-scheme: dark) {
+  .scroll-container {
+    background: #1e293b;
+  }
+}
+
+.scroll-container h3 {
+  margin-top: 0;
+  position: sticky;
+  top: 0;
+  background: inherit;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.content-block {
+  height: 600px;
+  background: repeating-linear-gradient(
+    45deg,
+    rgba(148, 163, 184, 0.1),
+    rgba(148, 163, 184, 0.1) 10px,
+    transparent 10px,
+    transparent 20px
+  );
+  border-radius: 0.5rem;
+  margin-top: 1rem;
+  display: flex;
+  justify-content: center;
+  padding-top: 2rem;
+  opacity: 0.5;
+}
+
+code {
+  background: rgba(148, 163, 184, 0.2);
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.875rem;
+  font-family: monospace;
+}
+
+/* =======================================================
+   COMPILED SCSS OUTPUT (Custom Scrollbar Utilities)
+   ======================================================= */
+
+.ease-scrollbar-minimal {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(148, 163, 184, 0.3) transparent;
+}
+.ease-scrollbar-minimal::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+.ease-scrollbar-minimal::-webkit-scrollbar-track {
+  background: transparent;
+  border-radius: 10px;
+}
+.ease-scrollbar-minimal::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.3);
+  border-radius: 10px;
+  transition: background 0.3s ease;
+}
+.ease-scrollbar-minimal::-webkit-scrollbar-thumb:hover {
+  background: rgba(148, 163, 184, 0.8);
+}
+
+.ease-scrollbar-brand {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(59, 130, 246, 0.6) #f1f5f9;
+}
+.ease-scrollbar-brand::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+.ease-scrollbar-brand::-webkit-scrollbar-track {
+  background: #f1f5f9;
+  border-radius: 10px;
+}
+.ease-scrollbar-brand::-webkit-scrollbar-thumb {
+  background: rgba(59, 130, 246, 0.6);
+  border-radius: 10px;
+  transition: background 0.3s ease;
+}
+.ease-scrollbar-brand::-webkit-scrollbar-thumb:hover {
+  background: #2563eb;
+}
+
+.ease-scrollbar-hidden {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.ease-scrollbar-hidden::-webkit-scrollbar {
+  display: none;
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #27790 by introducing a reusable SCSS module designed to override the default, blocky operating system scrollbars with premium, Mac OS-style floating scrollbars. It leverages WebKit pseudo-elements (`::-webkit-scrollbar`) with smooth hover transitions, while providing a fallback to the standard CSS `scrollbar-color` specification for Firefox.

Closes #27790

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/scss/scss-smooth-scrollbar-styling-hover-mixins/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] Includes `_smooth-scrollbar-styling-hover-mixins.scss`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An SCSS mixin (`@include ease-custom-scrollbar($thumb, $track, $width, $hover)`) and three predefined utility classes (`.ease-scrollbar-minimal`, `.ease-scrollbar-brand`, `.ease-scrollbar-hidden`) that instantly modernize scrolling areas.

**How does a developer use it?**

```html
<!-- Apply to any container with overflow: auto -->
<div class="ease-scrollbar-minimal" style="overflow-y: auto; height: 300px;">
  <!-- Very thin, transparent track with a thumb that darkens on hover -->
  <p>Scrollable Content...</p>
</div>
