### PR TITLE
feat: add incident handoff demo

### DIFF
--- a/submissions/examples/skyline-incident-handoff/README.md
+++ b/submissions/examples/skyline-incident-handoff/README.md
@@ -1,0 +1,14 @@
+# Skyline Incident Handoff Demo
+
+A focused incident handoff layout for summarizing active severity, owners, and pending recovery work.
+
+## What is included
+
+- Responsive HTML structure for the incident handoff component.
+- CSS-only layout, cards, metrics, and mobile stacking behavior.
+- Accessible section labelling with semantic content blocks.
+
+## Files
+
+- `demo.html`
+- `style.css`

--- a/submissions/examples/skyline-incident-handoff/demo.html
+++ b/submissions/examples/skyline-incident-handoff/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Skyline Incident Handoff Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="hero-panel">
+      <div>
+        <p class="eyebrow">Reliability operations</p>
+        <h1>Incident handoff board for on-call teams</h1>
+        <p class="summary">A focused incident handoff layout for summarizing active severity, owners, and pending recovery work.</p>
+      </div>
+      <ul class="metric-list">
+          <li>
+            <span>Severity</span>
+            <strong>SEV-2</strong>
+          </li>
+          <li>
+            <span>Owners</span>
+            <strong>4</strong>
+          </li>
+          <li>
+            <span>ETA</span>
+            <strong>28m</strong>
+          </li>
+      </ul>
+    </section>
+
+    <section class="insight-grid" aria-label="Incident handoff insights">
+        <article class="insight-card">
+          <span class="card-kicker">Context</span>
+          <h2>Current state</h2>
+          <p>The hero section captures the incident snapshot in a format suited for rapid handoff reviews.</p>
+        </article>
+        <article class="insight-card">
+          <span class="card-kicker">Ownership</span>
+          <h2>Clear responders</h2>
+          <p>Metric rows separate owners from severity so the next shift can quickly find accountability.</p>
+        </article>
+        <article class="insight-card">
+          <span class="card-kicker">Recovery</span>
+          <h2>Next checkpoint</h2>
+          <p>Supporting cards provide space for action notes without adding JavaScript or external assets.</p>
+        </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/skyline-incident-handoff/style.css
+++ b/submissions/examples/skyline-incident-handoff/style.css
@@ -1,0 +1,131 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #172026;
+  background:
+    linear-gradient(135deg, rgba(199, 85, 73, 0.18), transparent 34%),
+    linear-gradient(225deg, rgba(52, 132, 104, 0.2), transparent 36%),
+    #f6f8f5;
+}
+
+.demo-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.hero-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 28px;
+  align-items: stretch;
+  padding: 32px;
+  border: 1px solid rgba(23, 32, 38, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow: 0 22px 70px rgba(23, 32, 38, 0.12);
+}
+
+.eyebrow,
+.card-kicker {
+  margin: 0 0 10px;
+  color: #5c6b73;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 760px;
+  margin-bottom: 16px;
+  font-size: clamp(2.4rem, 7vw, 5.2rem);
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+.summary {
+  max-width: 680px;
+  margin-bottom: 0;
+  color: #48545c;
+  font-size: 1.08rem;
+  line-height: 1.7;
+}
+
+.metric-list {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.metric-list li,
+.insight-card {
+  border: 1px solid rgba(23, 32, 38, 0.1);
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.metric-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px;
+}
+
+.metric-list span {
+  color: #617079;
+  font-weight: 700;
+}
+
+.metric-list strong {
+  color: #172026;
+  font-size: 1.4rem;
+}
+
+.insight-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.insight-card {
+  min-height: 210px;
+  padding: 24px;
+}
+
+.insight-card h2 {
+  margin-bottom: 12px;
+  font-size: 1.35rem;
+}
+
+.insight-card p {
+  margin-bottom: 0;
+  color: #53616a;
+  line-height: 1.65;
+}
+
+@media (max-width: 820px) {
+  .hero-panel,
+  .insight-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-panel {
+    padding: 24px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a new responsive incident handoff example under `submissions/examples/skyline-incident-handoff`
- include semantic HTML, CSS-only layout styling, and mobile stacking support
- document the demo purpose and included files

## Testing
- not run locally; static HTML/CSS example only
