### PR TITLE
feat: add sprint capacity demo

### DIFF
--- a/submissions/examples/beacon-sprint-capacity/README.md
+++ b/submissions/examples/beacon-sprint-capacity/README.md
@@ -1,0 +1,14 @@
+# Beacon Sprint Capacity Demo
+
+A compact delivery dashboard that balances capacity, committed work, and review load in a clean responsive interface.
+
+## What is included
+
+- Responsive HTML structure for the sprint capacity component.
+- CSS-only layout, cards, metrics, and mobile stacking behavior.
+- Accessible section labelling with semantic content blocks.
+
+## Files
+
+- `demo.html`
+- `style.css`

--- a/submissions/examples/beacon-sprint-capacity/demo.html
+++ b/submissions/examples/beacon-sprint-capacity/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Beacon Sprint Capacity Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="hero-panel">
+      <div>
+        <p class="eyebrow">Delivery planning</p>
+        <h1>Sprint capacity dashboard for product squads</h1>
+        <p class="summary">A compact delivery dashboard that balances capacity, committed work, and review load in a clean responsive interface.</p>
+      </div>
+      <ul class="metric-list">
+          <li>
+            <span>Capacity</span>
+            <strong>82%</strong>
+          </li>
+          <li>
+            <span>Stories</span>
+            <strong>34</strong>
+          </li>
+          <li>
+            <span>Reviews</span>
+            <strong>9</strong>
+          </li>
+      </ul>
+    </section>
+
+    <section class="insight-grid" aria-label="Sprint capacity insights">
+        <article class="insight-card">
+          <span class="card-kicker">Planning</span>
+          <h2>Capacity fit</h2>
+          <p>The primary metric helps teams understand whether scope fits before sprint commitments lock.</p>
+        </article>
+        <article class="insight-card">
+          <span class="card-kicker">Flow</span>
+          <h2>Review pressure</h2>
+          <p>Review load is surfaced alongside story count so handoffs can be balanced earlier.</p>
+        </article>
+        <article class="insight-card">
+          <span class="card-kicker">Focus</span>
+          <h2>Readable density</h2>
+          <p>The layout keeps enough information on screen while retaining strong spacing on mobile.</p>
+        </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/beacon-sprint-capacity/style.css
+++ b/submissions/examples/beacon-sprint-capacity/style.css
@@ -1,0 +1,131 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #172026;
+  background:
+    linear-gradient(135deg, rgba(74, 99, 181, 0.18), transparent 34%),
+    linear-gradient(225deg, rgba(233, 151, 65, 0.2), transparent 36%),
+    #f6f8f5;
+}
+
+.demo-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.hero-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 28px;
+  align-items: stretch;
+  padding: 32px;
+  border: 1px solid rgba(23, 32, 38, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow: 0 22px 70px rgba(23, 32, 38, 0.12);
+}
+
+.eyebrow,
+.card-kicker {
+  margin: 0 0 10px;
+  color: #5c6b73;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 760px;
+  margin-bottom: 16px;
+  font-size: clamp(2.4rem, 7vw, 5.2rem);
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+.summary {
+  max-width: 680px;
+  margin-bottom: 0;
+  color: #48545c;
+  font-size: 1.08rem;
+  line-height: 1.7;
+}
+
+.metric-list {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.metric-list li,
+.insight-card {
+  border: 1px solid rgba(23, 32, 38, 0.1);
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.metric-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px;
+}
+
+.metric-list span {
+  color: #617079;
+  font-weight: 700;
+}
+
+.metric-list strong {
+  color: #172026;
+  font-size: 1.4rem;
+}
+
+.insight-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.insight-card {
+  min-height: 210px;
+  padding: 24px;
+}
+
+.insight-card h2 {
+  margin-bottom: 12px;
+  font-size: 1.35rem;
+}
+
+.insight-card p {
+  margin-bottom: 0;
+  color: #53616a;
+  line-height: 1.65;
+}
+
+@media (max-width: 820px) {
+  .hero-panel,
+  .insight-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-panel {
+    padding: 24px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a new responsive sprint capacity example under `submissions/examples/beacon-sprint-capacity`
- include semantic HTML, CSS-only layout styling, and mobile stacking support
- document the demo purpose and included files

## Testing
- not run locally; static HTML/CSS example only
