### PR TITLE
feat: add QA coverage demo

### DIFF
--- a/submissions/examples/signal-qa-coverage/README.md
+++ b/submissions/examples/signal-qa-coverage/README.md
@@ -1,0 +1,14 @@
+# Signal QA Coverage Demo
+
+A release-readiness panel that highlights coverage, unresolved defects, and regression status for QA teams.
+
+## What is included
+
+- Responsive HTML structure for the QA coverage component.
+- CSS-only layout, cards, metrics, and mobile stacking behavior.
+- Accessible section labelling with semantic content blocks.
+
+## Files
+
+- `demo.html`
+- `style.css`

--- a/submissions/examples/signal-qa-coverage/demo.html
+++ b/submissions/examples/signal-qa-coverage/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Signal QA Coverage Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="hero-panel">
+      <div>
+        <p class="eyebrow">Quality assurance</p>
+        <h1>QA coverage panel for release readiness</h1>
+        <p class="summary">A release-readiness panel that highlights coverage, unresolved defects, and regression status for QA teams.</p>
+      </div>
+      <ul class="metric-list">
+          <li>
+            <span>Coverage</span>
+            <strong>91%</strong>
+          </li>
+          <li>
+            <span>Defects</span>
+            <strong>6</strong>
+          </li>
+          <li>
+            <span>Suites</span>
+            <strong>14</strong>
+          </li>
+      </ul>
+    </section>
+
+    <section class="insight-grid" aria-label="QA coverage insights">
+        <article class="insight-card">
+          <span class="card-kicker">Coverage</span>
+          <h2>Test confidence</h2>
+          <p>Coverage is presented as the lead signal so release owners can judge readiness quickly.</p>
+        </article>
+        <article class="insight-card">
+          <span class="card-kicker">Defects</span>
+          <h2>Open issues</h2>
+          <p>The unresolved defect count remains visible without overwhelming the rest of the readiness view.</p>
+        </article>
+        <article class="insight-card">
+          <span class="card-kicker">Regression</span>
+          <h2>Suite status</h2>
+          <p>The third card gives QA teams space to describe final suite coverage and release notes.</p>
+        </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/signal-qa-coverage/style.css
+++ b/submissions/examples/signal-qa-coverage/style.css
@@ -1,0 +1,131 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #172026;
+  background:
+    linear-gradient(135deg, rgba(88, 122, 71, 0.18), transparent 34%),
+    linear-gradient(225deg, rgba(210, 93, 92, 0.2), transparent 36%),
+    #f6f8f5;
+}
+
+.demo-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.hero-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 28px;
+  align-items: stretch;
+  padding: 32px;
+  border: 1px solid rgba(23, 32, 38, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow: 0 22px 70px rgba(23, 32, 38, 0.12);
+}
+
+.eyebrow,
+.card-kicker {
+  margin: 0 0 10px;
+  color: #5c6b73;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 760px;
+  margin-bottom: 16px;
+  font-size: clamp(2.4rem, 7vw, 5.2rem);
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+.summary {
+  max-width: 680px;
+  margin-bottom: 0;
+  color: #48545c;
+  font-size: 1.08rem;
+  line-height: 1.7;
+}
+
+.metric-list {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.metric-list li,
+.insight-card {
+  border: 1px solid rgba(23, 32, 38, 0.1);
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.metric-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px;
+}
+
+.metric-list span {
+  color: #617079;
+  font-weight: 700;
+}
+
+.metric-list strong {
+  color: #172026;
+  font-size: 1.4rem;
+}
+
+.insight-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.insight-card {
+  min-height: 210px;
+  padding: 24px;
+}
+
+.insight-card h2 {
+  margin-bottom: 12px;
+  font-size: 1.35rem;
+}
+
+.insight-card p {
+  margin-bottom: 0;
+  color: #53616a;
+  line-height: 1.65;
+}
+
+@media (max-width: 820px) {
+  .hero-panel,
+  .insight-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-panel {
+    padding: 24px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a new responsive QA coverage example under `submissions/examples/signal-qa-coverage`
- include semantic HTML, CSS-only layout styling, and mobile stacking support
- document the demo purpose and included files

## Testing
- not run locally; static HTML/CSS example only
