### PR TITLE
feat: add content calendar demo

### DIFF
--- a/submissions/examples/marble-content-calendar/README.md
+++ b/submissions/examples/marble-content-calendar/README.md
@@ -1,0 +1,14 @@
+# Marble Content Calendar Demo
+
+A clean editorial planning view for tracking scheduled posts, approvals, and campaign coverage.
+
+## What is included
+
+- Responsive HTML structure for the content calendar demo.
+- CSS-only panel, stat list, cards, and mobile layout behavior.
+- Semantic sections with accessible labelling.
+
+## Files
+
+- `demo.html`
+- `style.css`

--- a/submissions/examples/marble-content-calendar/demo.html
+++ b/submissions/examples/marble-content-calendar/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Marble Content Calendar Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="workspace">
+    <section class="summary-panel">
+      <div>
+        <p class="eyebrow">Editorial planning</p>
+        <h1>Content calendar summary for campaign teams</h1>
+        <p class="summary">A clean editorial planning view for tracking scheduled posts, approvals, and campaign coverage.</p>
+      </div>
+      <ul class="stats">
+          <li>
+            <span>Scheduled</span>
+            <strong>42</strong>
+          </li>
+          <li>
+            <span>Approvals</span>
+            <strong>8</strong>
+          </li>
+          <li>
+            <span>Channels</span>
+            <strong>5</strong>
+          </li>
+      </ul>
+    </section>
+
+    <section class="detail-grid" aria-label="Content calendar insights">
+        <article class="detail-card">
+          <span>Calendar</span>
+          <h2>Schedule clarity</h2>
+          <p>The scheduled count anchors the view while supporting cards explain campaign coverage.</p>
+        </article>
+        <article class="detail-card">
+          <span>Review</span>
+          <h2>Approval queue</h2>
+          <p>Pending approvals stay visible for editors who need to unblock upcoming content.</p>
+        </article>
+        <article class="detail-card">
+          <span>Coverage</span>
+          <h2>Channel spread</h2>
+          <p>Channel count gives teams a quick way to check whether the campaign is balanced.</p>
+        </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/marble-content-calendar/style.css
+++ b/submissions/examples/marble-content-calendar/style.css
@@ -1,0 +1,131 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #1e252b;
+  background:
+    linear-gradient(140deg, rgba(158, 90, 135, 0.2), transparent 35%),
+    linear-gradient(230deg, rgba(61, 137, 116, 0.18), transparent 38%),
+    #f7f8f4;
+}
+
+.workspace {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.summary-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 300px;
+  gap: 24px;
+  align-items: stretch;
+  padding: 32px;
+  border: 1px solid rgba(30, 37, 43, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 24px 72px rgba(30, 37, 43, 0.12);
+}
+
+.eyebrow,
+.detail-card span {
+  display: block;
+  margin-bottom: 10px;
+  color: #64727a;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 780px;
+  margin-bottom: 16px;
+  font-size: clamp(2.35rem, 7vw, 5rem);
+  line-height: 0.96;
+  letter-spacing: 0;
+}
+
+.summary {
+  max-width: 700px;
+  margin-bottom: 0;
+  color: #52606a;
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.stats {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.stats li,
+.detail-card {
+  border: 1px solid rgba(30, 37, 43, 0.1);
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.stats li {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+  padding: 18px;
+}
+
+.stats span {
+  color: #66747d;
+  font-weight: 700;
+}
+
+.stats strong {
+  font-size: 1.35rem;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.detail-card {
+  min-height: 210px;
+  padding: 24px;
+}
+
+.detail-card h2 {
+  margin-bottom: 12px;
+  font-size: 1.32rem;
+}
+
+.detail-card p {
+  margin-bottom: 0;
+  color: #56646d;
+  line-height: 1.65;
+}
+
+@media (max-width: 820px) {
+  .summary-panel,
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .summary-panel {
+    padding: 24px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a new responsive content calendar example under `submissions/examples/marble-content-calendar`
- include semantic HTML, CSS-only layout styling, and mobile stacking support
- document the demo purpose and included files

## Testing
- not run locally; static HTML/CSS example only
