### PR TITLE
feat: add support load demo

### DIFF
--- a/submissions/examples/ember-support-load/README.md
+++ b/submissions/examples/ember-support-load/README.md
@@ -1,0 +1,14 @@
+# Ember Support Load Demo
+
+A service operations panel that highlights open tickets, response time, and escalation volume.
+
+## What is included
+
+- Responsive HTML structure for the support load demo.
+- CSS-only panel, stat list, cards, and mobile layout behavior.
+- Semantic sections with accessible labelling.
+
+## Files
+
+- `demo.html`
+- `style.css`

--- a/submissions/examples/ember-support-load/demo.html
+++ b/submissions/examples/ember-support-load/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ember Support Load Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="workspace">
+    <section class="summary-panel">
+      <div>
+        <p class="eyebrow">Customer support</p>
+        <h1>Support load tracker for service teams</h1>
+        <p class="summary">A service operations panel that highlights open tickets, response time, and escalation volume.</p>
+      </div>
+      <ul class="stats">
+          <li>
+            <span>Open tickets</span>
+            <strong>118</strong>
+          </li>
+          <li>
+            <span>Response</span>
+            <strong>22m</strong>
+          </li>
+          <li>
+            <span>Escalated</span>
+            <strong>13</strong>
+          </li>
+      </ul>
+    </section>
+
+    <section class="detail-grid" aria-label="Support load insights">
+        <article class="detail-card">
+          <span>Volume</span>
+          <h2>Queue pressure</h2>
+          <p>Open ticket volume is presented as the lead signal for daily support staffing decisions.</p>
+        </article>
+        <article class="detail-card">
+          <span>Speed</span>
+          <h2>Response target</h2>
+          <p>Response time remains visible so service leads can compare workload with customer expectations.</p>
+        </article>
+        <article class="detail-card">
+          <span>Priority</span>
+          <h2>Escalation focus</h2>
+          <p>The escalation card gives teams a clear place to track high-priority issues.</p>
+        </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ember-support-load/style.css
+++ b/submissions/examples/ember-support-load/style.css
@@ -1,0 +1,131 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #1e252b;
+  background:
+    linear-gradient(140deg, rgba(207, 95, 78, 0.2), transparent 35%),
+    linear-gradient(230deg, rgba(57, 129, 164, 0.18), transparent 38%),
+    #f7f8f4;
+}
+
+.workspace {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.summary-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 300px;
+  gap: 24px;
+  align-items: stretch;
+  padding: 32px;
+  border: 1px solid rgba(30, 37, 43, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 24px 72px rgba(30, 37, 43, 0.12);
+}
+
+.eyebrow,
+.detail-card span {
+  display: block;
+  margin-bottom: 10px;
+  color: #64727a;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 780px;
+  margin-bottom: 16px;
+  font-size: clamp(2.35rem, 7vw, 5rem);
+  line-height: 0.96;
+  letter-spacing: 0;
+}
+
+.summary {
+  max-width: 700px;
+  margin-bottom: 0;
+  color: #52606a;
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.stats {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.stats li,
+.detail-card {
+  border: 1px solid rgba(30, 37, 43, 0.1);
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.stats li {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+  padding: 18px;
+}
+
+.stats span {
+  color: #66747d;
+  font-weight: 700;
+}
+
+.stats strong {
+  font-size: 1.35rem;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.detail-card {
+  min-height: 210px;
+  padding: 24px;
+}
+
+.detail-card h2 {
+  margin-bottom: 12px;
+  font-size: 1.32rem;
+}
+
+.detail-card p {
+  margin-bottom: 0;
+  color: #56646d;
+  line-height: 1.65;
+}
+
+@media (max-width: 820px) {
+  .summary-panel,
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .summary-panel {
+    padding: 24px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a new responsive support load example under `submissions/examples/ember-support-load`
- include semantic HTML, CSS-only layout styling, and mobile stacking support
- document the demo purpose and included files

## Testing
- not run locally; static HTML/CSS example only
