### PR TITLE
fix: add dark mode support to read more component (#30740)

### DIFF
--- a/submissions/examples/read-more-dark-fix/README.md
+++ b/submissions/examples/read-more-dark-fix/README.md
@@ -1,0 +1,51 @@
+# Fix: Read More Component Dark Mode Support
+
+**Fixes:** [#30740](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/30740)
+
+---
+
+## 🐛 Bug Description
+
+The Read More component (`components/read-more.css`) lacks dark mode support entirely. 
+
+It uses a hardcoded white-to-transparent gradient background (`linear-gradient(transparent, #fff)`) on line 20 to create the bottom fade-out effect. In dark mode, this fade-out remains bright white, creating a severe visual glitch. Additionally, the summary link uses a hardcoded `#6c63ff` and the body text uses a hardcoded `#475569` which has extremely poor contrast on dark backgrounds.
+
+---
+
+## ✅ Fix
+
+Introduce dark mode overrides (for both `@media (prefers-color-scheme: dark)` and `[data-theme="dark"]`) using theme-appropriate design tokens:
+
+```css
+@media (prefers-color-scheme: dark) {
+  .ease-read-more details .ease-read-more-content::after {
+    background: linear-gradient(transparent, var(--ease-color-surface, #1e293b)) !important;
+  }
+  .ease-read-more summary {
+    color: var(--ease-color-primary-light, #a09af8);
+  }
+  .ease-read-more .ease-read-more-text {
+    color: var(--ease-color-muted, #94a3b8);
+  }
+}
+
+[data-theme="dark"] .ease-read-more details .ease-read-more-content::after {
+  background: linear-gradient(transparent, #1e293b) !important;
+}
+[data-theme="dark"] .ease-read-more summary {
+  color: #a09af8;
+}
+[data-theme="dark"] .ease-read-more .ease-read-more-text {
+  color: #94a3b8;
+}
+```
+
+---
+
+## 📁 Submission Contents
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Live demonstration of the read more component in light & dark modes |
+| `style.css` | Raw CSS showing the proposed fix and demo page layout |
+| `README.md` | This documentation file |

--- a/submissions/examples/read-more-dark-fix/demo.html
+++ b/submissions/examples/read-more-dark-fix/demo.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix #30740 — Read More Dark Mode | EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <header>
+      <div>
+        <h1>Fix #30740 — Read More Dark Mode</h1>
+        <p>Toggle dark mode to see if the read-more bottom fade-out gradient and text colors adapt correctly</p>
+      </div>
+      <button class="toggle-btn" id="theme-toggle">🌙 Dark Mode</button>
+    </header>
+
+    <div class="panels">
+      <section class="panel">
+        <span class="badge bug">❌ Before (Bug)</span>
+        <div class="demo-box demo-buggy">
+          <div class="ease-read-more">
+            <details>
+              <div class="ease-read-more-content">
+                <p class="ease-read-more-text">
+                  This is a very long paragraph that serves as a preview for an article.
+                  Instead of taking up massive vertical space and ruining card height consistency,
+                  it will smoothly cut off after exactly three lines, leaving an ellipsis...
+                </p>
+              </div>
+              <summary>
+                <span>Read More</span>
+                <span class="ease-read-more-chevron"></span>
+              </summary>
+            </details>
+          </div>
+        </div>
+      </section>
+
+      <section class="panel">
+        <span class="badge fix">✅ After (Fix)</span>
+        <div class="demo-box demo-fixed">
+          <div class="ease-read-more">
+            <details>
+              <div class="ease-read-more-content">
+                <p class="ease-read-more-text">
+                  This is a very long paragraph that serves as a preview for an article.
+                  Instead of taking up massive vertical space and ruining card height consistency,
+                  it will smoothly cut off after exactly three lines, leaving an ellipsis...
+                </p>
+              </div>
+              <summary>
+                <span>Read More</span>
+                <span class="ease-read-more-chevron"></span>
+              </summary>
+            </details>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  <script>
+    const btn = document.getElementById('theme-toggle');
+    const html = document.documentElement;
+
+    btn.addEventListener('click', function () {
+      const isDark = html.getAttribute('data-theme') === 'dark';
+      if (isDark) {
+        html.removeAttribute('data-theme');
+        btn.textContent = '🌙 Dark Mode';
+      } else {
+        html.setAttribute('data-theme', 'dark');
+        btn.textContent = '☀️ Light Mode';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/read-more-dark-fix/style.css
+++ b/submissions/examples/read-more-dark-fix/style.css
@@ -1,0 +1,111 @@
+/*
+ * EaseMotion CSS — Fix: Read More Component Dark Mode Support
+ * Issue: https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/30740
+ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', system-ui, sans-serif;
+  min-height: 100vh;
+  background: var(--ease-color-bg, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+  padding: 2rem;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.toggle-btn {
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  border: 1.5px solid var(--ease-color-primary, #6c63ff);
+  background: transparent;
+  color: var(--ease-color-primary, #6c63ff);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.panels {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+}
+
+.panel {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: 1rem;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.badge {
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  width: fit-content;
+}
+
+.badge.bug { background: #fee2e2; color: #ef4444; }
+.badge.fix { background: #dcfce7; color: #22c55e; }
+
+.demo-box {
+  padding: 1.5rem;
+  background: var(--ease-color-bg);
+  border-radius: 0.5rem;
+}
+
+/* ── Buggy Simulation ── */
+.demo-buggy .ease-read-more details .ease-read-more-content::after {
+  background: linear-gradient(transparent, #fff) !important;
+}
+.demo-buggy .ease-read-more summary {
+  color: #6c63ff !important;
+}
+.demo-buggy .ease-read-more .ease-read-more-text {
+  color: #475569 !important;
+}
+
+/* ── Fixed Implementation ── */
+[data-theme="dark"] .demo-fixed .ease-read-more details .ease-read-more-content::after {
+  background: linear-gradient(transparent, #1e293b) !important;
+}
+[data-theme="dark"] .demo-fixed .ease-read-more summary {
+  color: #a09af8 !important;
+}
+[data-theme="dark"] .demo-fixed .ease-read-more .ease-read-more-text {
+  color: #94a3b8 !important;
+}
+@media (prefers-color-scheme: dark) {
+  .demo-fixed .ease-read-more details .ease-read-more-content::after {
+    background: linear-gradient(transparent, #1e293b) !important;
+  }
+  .demo-fixed .ease-read-more summary {
+    color: #a09af8 !important;
+  }
+  .demo-fixed .ease-read-more .ease-read-more-text {
+    color: #94a3b8 !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Fixes #30740

Adds dark mode support to the Read More component (`components/read-more.css`). It overrides the hardcoded white-to-transparent fade-out gradient (`#fff`), summary link color, and body text color with theme-appropriate design tokens.

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/read-more-fade-out-dark/`)
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR
