### PR TITLE
[Feat] #27754 — Add CSS container query wrappers (unique folder)

### DIFF
--- a/submissions/examples/container-queries-27754-ag/README.md
+++ b/submissions/examples/container-queries-27754-ag/README.md
@@ -1,0 +1,46 @@
+# CSS Container Query Wrapper Classes
+
+This submission implements responsive parent-relative container query utilities matching SCSS mixin specifications.
+
+---
+
+## Technical Overview: SCSS Container Queries Mixin
+
+Viewport-relative media queries (`@media`) scale sizing parameters matching screen dimensions. However, if a component resides in a split sidebar or nested card column, screen-based scaling fails.
+
+### The Remediation
+
+Using parent containers (`container-type: inline-size`) allows components to query the size of their parent element rather than the screen size:
+
+```scss
+// SCSS Container Query Mixin
+@mixin container-query($name, $min-width) {
+  @container #{$name} (min-width: #{$min-width}) {
+    @content;
+  }
+}
+
+// Parent declaration
+.query-parent {
+  container-type: inline-size;
+  container-name: card-container;
+}
+
+// Child responsive styling
+.responsive-card {
+  display: flex;
+  flex-direction: column;
+  
+  @include container-query(card-container, 450px) {
+    flex-direction: row;
+  }
+}
+```
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Observe layout wraps to stacked view at startup width.
+3. Slide the **Container Width** slider above 450px — verify the card adapts into a horizontal flex row layout dynamically.

--- a/submissions/examples/container-queries-27754-ag/demo.html
+++ b/submissions/examples/container-queries-27754-ag/demo.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Container Query Wrapper Classes — EaseMotion CSS</title>
+  <meta name="description" content="Visual container queries showcase demonstrating parent-relative responsive layouts and styling thresholds.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — SCSS Utilities</span>
+      <h1>Container Query Wrappers</h1>
+      <p class="description">
+        Demonstrates parent-relative container queries. Slide the width range below 
+        to observe the card layout transition from stacked (vertical) to row (horizontal).
+      </p>
+    </header>
+
+    <main class="dashboard">
+
+      <!-- Left Panel: Width Settings -->
+      <section class="controls-panel">
+        <h2 class="section-title">Parent Container Width</h2>
+        <div class="control-group">
+          <label for="width-slider">Container Width: <span id="width-val">500px</span></label>
+          <input type="range" id="width-slider" min="320" max="650" value="500" step="10">
+        </div>
+      </section>
+
+      <!-- Right Panel: Query Target Wrapper -->
+      <section class="preview-panel">
+        <h2 class="section-title">Container Preview</h2>
+        
+        <div class="query-parent" id="query-parent" style="width: 500px;">
+          
+          <div class="responsive-card">
+            <div class="card-thumb">📸</div>
+            <div class="card-body">
+              <h3>Responsive Card</h3>
+              <p>This layout adapts dynamically according to its parent container width, completely independent of the screen size.</p>
+            </div>
+          </div>
+
+        </div>
+      </section>
+
+    </main>
+  </div>
+
+  <script>
+    const slider = document.getElementById('width-slider');
+    const widthVal = document.getElementById('width-val');
+    const parent = document.getElementById('query-parent');
+
+    slider.addEventListener('input', () => {
+      const width = `${slider.value}px`;
+      widthVal.textContent = width;
+      parent.style.width = width;
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/container-queries-27754-ag/style.css
+++ b/submissions/examples/container-queries-27754-ag/style.css
@@ -1,0 +1,190 @@
+/* ============================================================
+   CSS Container Query Wrapper Classes — style.css
+   Submission for EaseMotion CSS Issue #27754
+   Container wrappers, responsive card transitions, and sliders
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 900px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Dashboard Layout
+   ============================================================ */
+
+.dashboard {
+  display: grid;
+  grid-template-columns: 1fr 1.5fr;
+  gap: 28px;
+}
+
+@media (max-width: 768px) {
+  .dashboard { grid-template-columns: 1fr; }
+}
+
+.controls-panel,
+.preview-panel {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  padding: 28px;
+  border-radius: 20px;
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+}
+
+.section-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+/* Controls Panel */
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.control-group label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.control-group input[type="range"] {
+  accent-color: var(--primary-color);
+  cursor: pointer;
+}
+
+/* ============================================================
+   Container Query Elements under Test
+   ============================================================ */
+
+/* Parent Container declaration */
+.query-parent {
+  container-type: inline-size;
+  container-name: card-container;
+  background: rgba(0, 0, 0, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: 12px;
+  padding: 16px;
+  transition: width 0.2s ease;
+  align-self: center;
+}
+
+/* Card base style (Stacked layout by default / Mobile-first) */
+.responsive-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background: rgba(255,255,255,0.02);
+  border: 1px solid rgba(255,255,255,0.04);
+  padding: 20px;
+  border-radius: 8px;
+}
+
+.card-thumb {
+  height: 120px;
+  background: linear-gradient(135deg, rgba(124, 58, 237, 0.15), rgba(6, 182, 212, 0.15));
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.2rem;
+}
+
+.card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.card-body h3 {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.card-body p {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+/* Parent container width query */
+@container card-container (min-width: 450px) {
+  .responsive-card {
+    flex-direction: row;
+    align-items: center;
+  }
+  .card-thumb {
+    width: 140px;
+    height: 100px;
+    flex-shrink: 0;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-container-queries` showcase. It demonstrates parent-relative responsive layouts generated via SCSS container query mixins (mapping container-types and inline sizes to element layout changes) coupled with a parent width adjustor settings slider.

## Root Cause
No container query mixins or inline-size responsive layout utilities existed in EaseMotion CSS.

## Changes Made
- `submissions/examples/container-queries-27754-ag/demo.html`: Container wrappers hosting responsive thumbnail cards and parent width settings range inputs.
- `submissions/examples/container-queries-27754-ag/style.css`: Parent container declarations, container query media thresholds, flex row overrides, and text blocks.
- `submissions/examples/container-queries-27754-ag/README.md`: Explains inline-size container setups, SCSS mixin formats, and manual verification steps.

## How to Test
1. Open `demo.html` in a browser.
2. Drag the slider below and above 450px to confirm parent-relative card formatting updates.

## Related Issue
Closes #27754