### PR TITLE
feat: Add SCSS Accordion Expand Collapse Max-Height Utilities (#28427)

### DIFF
--- a/submissions/scss/scss-accordion-expand-collapse-max-height-utilities/README.md
+++ b/submissions/scss/scss-accordion-expand-collapse-max-height-utilities/README.md
@@ -1,0 +1,51 @@
+# SCSS Utility: Accordion Expand/Collapse Utilities (#28427)
+
+A highly requested SCSS utility module for the EaseMotion CSS framework that resolves the notoriously difficult problem of animating element heights (for accordions, dropdowns, and collapsible panels) without layout jumping.
+
+## 📦 What's included?
+
+- `_accordion-expand-collapse-max-height-utilities.scss`: The SCSS partial providing both the classic `max-height` bezier trick and the modern `grid-template-rows` solution.
+- `style.css`: The compiled output.
+- `demo.html`: A functional interactive accordion using the classes.
+
+## 🛠 Usage via SCSS Mixins
+
+Import the partial and include the mixins on your collapsible content wrapper. Note: You will need to toggle an `.is-expanded` class on the element via JavaScript.
+
+```scss
+@import 'accordion-expand-collapse-max-height-utilities';
+
+// Approach 1: Classic Max-Height
+// Requires passing a max-height larger than your content will ever be.
+.my-dropdown-content {
+  @include ease-accordion-content(400px, 0.4s);
+}
+
+// Approach 2: Modern CSS Grid (Recommended)
+// Does not require hardcoding a height!
+.my-accordion-content {
+  @include ease-accordion-grid(0.4s);
+}
+```
+
+## 🛠 Usage via HTML Utility Classes
+
+```html
+<button onclick="toggleExpanded()">Toggle</button>
+
+<!-- Grid approach wrapper -->
+<div class="ease-accordion-grid" id="content">
+  <!-- MUST have an inner wrapper for the grid trick to work -->
+  <div>
+    Your dynamic content here...
+  </div>
+</div>
+```
+
+## 🚀 Why this fits EaseMotion
+
+**EaseMotion** is about making complex CSS animations accessible. Animating an element from `height: 0` to `height: auto` is impossible in standard CSS, leading developers to rely on heavy JavaScript recalculations.
+
+This module provides two elegant, CSS-only solutions:
+1. **The Max-Height Trick:** Utilizing a highly specific `cubic-bezier(0, 1, 0, 1)` to eliminate the "delay" typically associated with max-height transitions when collapsing.
+2. **The Grid Approach:** A modern layout trick animating `grid-template-rows` from `0fr` to `1fr`. This allows perfectly smooth, mathematically correct expansions regardless of the dynamic content height, representing the bleeding edge of modern CSS interaction design.

--- a/submissions/scss/scss-accordion-expand-collapse-max-height-utilities/_accordion-expand-collapse-max-height-utilities.scss
+++ b/submissions/scss/scss-accordion-expand-collapse-max-height-utilities/_accordion-expand-collapse-max-height-utilities.scss
@@ -1,0 +1,75 @@
+// _accordion-expand-collapse-max-height-utilities.scss
+// =======================================================
+// EaseMotion CSS - Accordion Max-Height Transitions
+// 
+// Provides SCSS mixins and utility classes to create smooth
+// expand and collapse animations for accordions, dropdowns,
+// and collapsible panels using max-height transitions.
+// =======================================================
+
+/// Applies smooth expanding/collapsing logic to an element.
+/// Note: The expanded state class (e.g. .is-open) must be toggled via JS or a checkbox hack.
+/// @param {Length} $max-height - The maximum expected height (must be larger than content)
+/// @param {Time} $duration - The speed of the animation
+@mixin ease-accordion-content($max-height: 1000px, $duration: 0.4s) {
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  // Use a cubic-bezier that starts fast and slows down to hide the max-height timing gap
+  transition: max-height $duration cubic-bezier(0, 1, 0, 1),
+              opacity $duration ease,
+              padding $duration ease,
+              margin $duration ease;
+
+  &.is-expanded {
+    max-height: $max-height;
+    opacity: 1;
+    // Switch to an ease-in-out when expanding for smoothness
+    transition: max-height $duration ease-in-out,
+                opacity $duration ease,
+                padding $duration ease,
+                margin $duration ease;
+  }
+}
+
+/// A modern alternative using CSS Grid (doesn't require a hardcoded max-height).
+/// Apply this to a wrapper, and place the content inside an inner div.
+@mixin ease-accordion-grid($duration: 0.4s) {
+  display: grid;
+  grid-template-rows: 0fr;
+  opacity: 0;
+  transition: grid-template-rows $duration cubic-bezier(0.4, 0, 0.2, 1),
+              opacity $duration cubic-bezier(0.4, 0, 0.2, 1);
+              
+  & > * {
+    overflow: hidden;
+  }
+  
+  &.is-expanded {
+    grid-template-rows: 1fr;
+    opacity: 1;
+  }
+}
+
+// -------------------------------------------------------
+// Default Initializations (Generated CSS utility classes)
+// -------------------------------------------------------
+
+// Classic Max-Height approach
+.ease-accordion-max-height {
+  @include ease-accordion-content(500px, 0.4s);
+}
+
+// Modern Grid approach
+.ease-accordion-grid {
+  @include ease-accordion-grid(0.4s);
+}
+
+// Optional utility to rotate an icon when expanded
+.ease-accordion-icon {
+  transition: transform 0.3s ease;
+  
+  .is-expanded & {
+    transform: rotate(180deg);
+  }
+}

--- a/submissions/scss/scss-accordion-expand-collapse-max-height-utilities/demo.html
+++ b/submissions/scss/scss-accordion-expand-collapse-max-height-utilities/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Accordion Utilities</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <div style="text-align: center; margin-bottom: 3rem;">
+    <h1 style="margin: 0 0 1rem 0;">Expand / Collapse</h1>
+    <p style="margin: 0; opacity: 0.8;">Click the headers to toggle the smooth transitions.</p>
+  </div>
+
+  <div class="demo-container">
+    
+    <!-- Classic Max-Height Implementation -->
+    <div class="accordion-item" id="item-1">
+      <button class="accordion-header" onclick="toggleAccordion('item-1', 'content-1')">
+        Classic Max-Height Transition
+        <svg class="ease-accordion-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+      </button>
+      <div id="content-1" class="ease-accordion-max-height">
+        <div class="accordion-content-inner">
+          This uses the classic <code>max-height</code> hack. It uses a specific <code>cubic-bezier(0, 1, 0, 1)</code> curve when collapsing to immediately snap the visual height to the content rather than waiting for the entire max-height delay.
+        </div>
+      </div>
+    </div>
+
+    <!-- Modern Grid Implementation -->
+    <div class="accordion-item" id="item-2">
+      <button class="accordion-header" onclick="toggleAccordion('item-2', 'content-2')">
+        Modern CSS Grid Transition
+        <svg class="ease-accordion-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+      </button>
+      <div id="content-2" class="ease-accordion-grid">
+        <div class="accordion-content-inner">
+          This uses the modern <code>grid-template-rows: 0fr -> 1fr</code> transition. This is vastly superior because it doesn't require hardcoding a max-height guess, and the animation timing is always perfectly matched to the actual content height.
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <script>
+    // Tiny script just to toggle the .is-expanded class for the demo
+    function toggleAccordion(itemId, contentId) {
+      const item = document.getElementById(itemId);
+      const content = document.getElementById(contentId);
+      
+      // Toggle expanded class on the content
+      content.classList.toggle('is-expanded');
+      
+      // Toggle expanded class on the parent for icon rotation
+      item.classList.toggle('is-expanded');
+    }
+  </script>
+</body>
+</html>

--- a/submissions/scss/scss-accordion-expand-collapse-max-height-utilities/style.css
+++ b/submissions/scss/scss-accordion-expand-collapse-max-height-utilities/style.css
@@ -1,0 +1,98 @@
+/* 
+  style.css
+  This file contains the compiled output of the SCSS mixin so that demo.html can function 
+  without requiring a local Sass compiler to be running.
+*/
+
+:root {
+  --bg-color: #f8fafc;
+  --text-color: #334155;
+  --border-color: #e2e8f0;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: system-ui, -apple-system, sans-serif;
+  color: var(--text-color);
+  background: var(--bg-color);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.demo-container {
+  width: 100%;
+  max-width: 600px;
+  background: white;
+  padding: 2rem;
+  border-radius: 1rem;
+  box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1);
+}
+
+.accordion-item {
+  border-bottom: 1px solid var(--border-color);
+}
+.accordion-item:last-child {
+  border-bottom: none;
+}
+
+.accordion-header {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem 0;
+  background: none;
+  border: none;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #0f172a;
+  cursor: pointer;
+  text-align: left;
+}
+
+.accordion-content-inner {
+  padding-bottom: 1.5rem;
+  line-height: 1.6;
+  color: #475569;
+}
+
+/* =======================================================
+   COMPILED SCSS OUTPUT (Accordion Utilities)
+   ======================================================= */
+
+.ease-accordion-max-height {
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition: max-height 0.4s cubic-bezier(0, 1, 0, 1), opacity 0.4s ease, padding 0.4s ease, margin 0.4s ease;
+}
+.ease-accordion-max-height.is-expanded {
+  max-height: 500px;
+  opacity: 1;
+  transition: max-height 0.4s ease-in-out, opacity 0.4s ease, padding 0.4s ease, margin 0.4s ease;
+}
+
+.ease-accordion-grid {
+  display: grid;
+  grid-template-rows: 0fr;
+  opacity: 0;
+  transition: grid-template-rows 0.4s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.ease-accordion-grid > * {
+  overflow: hidden;
+}
+.ease-accordion-grid.is-expanded {
+  grid-template-rows: 1fr;
+  opacity: 1;
+}
+
+.ease-accordion-icon {
+  transition: transform 0.3s ease;
+}
+.is-expanded .ease-accordion-icon {
+  transform: rotate(180deg);
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #27801 by introducing a highly requested SCSS utility module that tackles the notoriously difficult problem of animating CSS element heights (`height: 0` to `height: auto`) without layout jumping. It provides elegant, CSS-only solutions for accordions, dropdowns, and collapsible panels.

Closes #27801

---

## Type of Change

- [x] ✨ New animation / hover effect (Accordion Expand/Collapse)
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/scss/scss-accordion-expand-collapse-max-height-utilities/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] Includes `_accordion-expand-collapse-max-height-utilities.scss`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A suite of SCSS mixins and utility classes providing two elegant CSS-only height transition solutions:
1. `@include ease-accordion-content()`: The classic `max-height` trick.
2. `@include ease-accordion-grid()`: The modern `grid-template-rows` trick.

**How does a developer use it?**

```html
<!-- Grid approach wrapper (Recommended) -->
<div class="ease-accordion-grid is-expanded" id="content">
  <!-- MUST have an inner wrapper for the grid trick to work -->
  <div>
    Your dynamic content here...
  </div>
</div>
