### PR TITLE
fix: add data-theme=dark support to tooltips (#30737)

### DIFF
--- a/submissions/examples/tooltip-theme-fix/README.md
+++ b/submissions/examples/tooltip-theme-fix/README.md
@@ -1,0 +1,32 @@
+# Fix: Tooltip [data-theme="dark"] Support
+
+**Fixes:** [#30737](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/30737)
+
+---
+
+## 🐛 Bug Description
+
+The Tooltip component (`components/tooltips.css`) only implements dark-themed background and text color overrides within a `@media (prefers-color-scheme: dark)` media query (lines 14-20). It lacks support for the `[data-theme="dark"]` selector override. If a developer toggles the theme dynamically using `<html data-theme="dark">` via JavaScript, the tooltips do not invert their colors and remain stuck in light mode (dark background with white text, instead of light background with dark text).
+
+---
+
+## ✅ Fix
+
+Introduce `[data-theme="dark"]` selector overrides to map tooltip variables to light-theme colors in dark mode:
+
+```css
+[data-theme="dark"] {
+  --ease-tooltip-bg: var(--ease-color-neutral-100, #f3f4f6);
+  --ease-tooltip-text: var(--ease-color-neutral-900, #111827);
+}
+```
+
+---
+
+## 📁 Submission Contents
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Live demonstration of the tooltips in light & dark modes |
+| `style.css` | Raw CSS showing the proposed fix and demo page layout |
+| `README.md` | This documentation file |

--- a/submissions/examples/tooltip-theme-fix/demo.html
+++ b/submissions/examples/tooltip-theme-fix/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix #30737 — Tooltip Theme | EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <header>
+      <div>
+        <h1>Fix #30737 — Tooltip Theme</h1>
+        <p>Toggle dark mode to see if the tooltips correctly invert their colors</p>
+      </div>
+      <button class="toggle-btn" id="theme-toggle">🌙 Dark Mode</button>
+    </header>
+
+    <div class="panels">
+      <section class="panel">
+        <span class="badge bug">❌ Before (Bug)</span>
+        <div class="demo-box demo-buggy">
+          <span class="ease-tooltip" data-tooltip="Remains dark in dark mode" tabindex="0">Hover / Focus Me</span>
+        </div>
+      </section>
+
+      <section class="panel">
+        <span class="badge fix">✅ After (Fix)</span>
+        <div class="demo-box demo-fixed">
+          <span class="ease-tooltip" data-tooltip="Inverts to light in dark mode" tabindex="0">Hover / Focus Me</span>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  <script>
+    const btn = document.getElementById('theme-toggle');
+    const html = document.documentElement;
+
+    btn.addEventListener('click', function () {
+      const isDark = html.getAttribute('data-theme') === 'dark';
+      if (isDark) {
+        html.removeAttribute('data-theme');
+        btn.textContent = '🌙 Dark Mode';
+      } else {
+        html.setAttribute('data-theme', 'dark');
+        btn.textContent = '☀️ Light Mode';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/tooltip-theme-fix/style.css
+++ b/submissions/examples/tooltip-theme-fix/style.css
@@ -1,0 +1,99 @@
+/*
+ * EaseMotion CSS — Fix: Tooltip [data-theme="dark"] Support
+ * Issue: https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/30737
+ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', system-ui, sans-serif;
+  min-height: 100vh;
+  background: var(--ease-color-bg, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+  padding: 2rem;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.toggle-btn {
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  border: 1.5px solid var(--ease-color-primary, #6c63ff);
+  background: transparent;
+  color: var(--ease-color-primary, #6c63ff);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.panels {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+}
+
+.panel {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: 1rem;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.badge {
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  width: fit-content;
+}
+
+.badge.bug { background: #fee2e2; color: #ef4444; }
+.badge.fix { background: #dcfce7; color: #22c55e; }
+
+.demo-box {
+  padding: 2.5rem;
+  background: var(--ease-color-bg);
+  border-radius: 0.5rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* ── Buggy Simulation ── */
+.demo-buggy .ease-tooltip::after {
+  background: #1f2937 !important;
+  color: #ffffff !important;
+}
+.demo-buggy .ease-tooltip::before {
+  border-top-color: #1f2937 !important;
+}
+
+/* ── Fixed Implementation ── */
+[data-theme="dark"] .demo-fixed {
+  --ease-tooltip-bg: #f3f4f6;
+  --ease-tooltip-text: #111827;
+}
+[data-theme="dark"] .demo-fixed .ease-tooltip::before {
+  border-top-color: #f3f4f6 !important;
+}


### PR DESCRIPTION
## Pull Request Description

Fixes #30737

Adds `[data-theme="dark"]` attribute selector support for tooltips, mapping their background and text variables to light-theme colors in dark mode (matching the existing prefers-color-scheme media query).

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/tooltip-dark-theme-attribute/`)
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR
