### PR TITLE
fix: add dark mode support to modal header and footer (#30736)

### DIFF
--- a/submissions/examples/modal-header-footer-dark-fix/README.md
+++ b/submissions/examples/modal-header-footer-dark-fix/README.md
@@ -1,0 +1,47 @@
+# Fix: Modal Header Borders & Footer Background/Borders Dark Mode Support
+
+**Fixes:** [#30736](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/30736)
+
+---
+
+## 🐛 Bug Description
+
+The Modal component (`components/modals.css`) lacks dark mode overrides for its header borders, footer backgrounds, and footer borders. 
+
+In `components/modals.css`, the header uses `border-bottom: 1px solid var(--ease-color-neutral-200, #e5e7eb)` and the footer uses `background: var(--ease-color-neutral-50, #f9fafb)` and `border-top: 1px solid var(--ease-color-neutral-200, #e5e7eb)`. Since `neutral-200` and `neutral-50` do not have dark-mode overrides in `core/variables.css` (they are absolute colors), the modal header/footer borders and footer background remain bright white/light-gray in dark mode, breaking theme styling.
+
+---
+
+## ✅ Fix
+
+Introduce dark mode overrides (for both `@media (prefers-color-scheme: dark)` and `[data-theme="dark"]`) using darker backgrounds and borders:
+
+```css
+@media (prefers-color-scheme: dark) {
+  .ease-modal-header {
+    border-bottom-color: var(--ease-color-neutral-800, #1e293b);
+  }
+  .ease-modal-footer {
+    background: var(--ease-color-neutral-900, #0f172a);
+    border-top-color: var(--ease-color-neutral-800, #1e293b);
+  }
+}
+
+[data-theme="dark"] .ease-modal-header {
+  border-bottom-color: #1e293b;
+}
+[data-theme="dark"] .ease-modal-footer {
+  background: #0f172a;
+  border-top-color: #1e293b;
+}
+```
+
+---
+
+## 📁 Submission Contents
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Live demonstration of the modal header/footer in light & dark modes |
+| `style.css` | Raw CSS showing the proposed fix and demo page layout |
+| `README.md` | This documentation file |

--- a/submissions/examples/modal-header-footer-dark-fix/demo.html
+++ b/submissions/examples/modal-header-footer-dark-fix/demo.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix #30736 — Modal Header/Footer Dark | EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <header>
+      <div>
+        <h1>Fix #30736 — Modal Header/Footer Dark</h1>
+        <p>Toggle dark mode to see if the modal header borders and footer background adapt correctly</p>
+      </div>
+      <button class="toggle-btn" id="theme-toggle">🌙 Dark Mode</button>
+    </header>
+
+    <div class="panels">
+      <section class="panel">
+        <span class="badge bug">❌ Before (Bug)</span>
+        <div class="demo-buggy">
+          <div class="ease-modal" style="position: relative; display: block; opacity: 1; transform: none; width: 100%;">
+            <div class="ease-modal-header">
+              <h2>Modal Header</h2>
+            </div>
+            <div class="ease-modal-body">
+              <p>The header border and footer background remain bright gray/white in dark mode.</p>
+            </div>
+            <div class="ease-modal-footer">
+              <button class="ease-btn" style="padding: 0.25rem 0.75rem; font-size: 0.75rem;">Close</button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="panel">
+        <span class="badge fix">✅ After (Fix)</span>
+        <div class="demo-fixed">
+          <div class="ease-modal" style="position: relative; display: block; opacity: 1; transform: none; width: 100%;">
+            <div class="ease-modal-header">
+              <h2>Modal Header</h2>
+            </div>
+            <div class="ease-modal-body">
+              <p>The header border and footer background blend beautifully with dark mode.</p>
+            </div>
+            <div class="ease-modal-footer">
+              <button class="ease-btn" style="padding: 0.25rem 0.75rem; font-size: 0.75rem;">Close</button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  <script>
+    const btn = document.getElementById('theme-toggle');
+    const html = document.documentElement;
+
+    btn.addEventListener('click', function () {
+      const isDark = html.getAttribute('data-theme') === 'dark';
+      if (isDark) {
+        html.removeAttribute('data-theme');
+        btn.textContent = '🌙 Dark Mode';
+      } else {
+        html.setAttribute('data-theme', 'dark');
+        btn.textContent = '☀️ Light Mode';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/modal-header-footer-dark-fix/style.css
+++ b/submissions/examples/modal-header-footer-dark-fix/style.css
@@ -1,0 +1,99 @@
+/*
+ * EaseMotion CSS — Fix: Modal Header/Footer Dark Mode Support
+ * Issue: https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/30736
+ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', system-ui, sans-serif;
+  min-height: 100vh;
+  background: var(--ease-color-bg, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+  padding: 2rem;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.toggle-btn {
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  border: 1.5px solid var(--ease-color-primary, #6c63ff);
+  background: transparent;
+  color: var(--ease-color-primary, #6c63ff);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.panels {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+}
+
+.panel {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: 1rem;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.badge {
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  width: fit-content;
+}
+
+.badge.bug { background: #fee2e2; color: #ef4444; }
+.badge.fix { background: #dcfce7; color: #22c55e; }
+
+/* ── Buggy Simulation ── */
+.demo-buggy .ease-modal-header {
+  border-bottom: 1px solid #e5e7eb !important;
+}
+.demo-buggy .ease-modal-footer {
+  background: #f9fafb !important;
+  border-top: 1px solid #e5e7eb !important;
+}
+
+/* ── Fixed Implementation ── */
+[data-theme="dark"] .demo-fixed .ease-modal-header {
+  border-bottom-color: #1e293b !important;
+}
+[data-theme="dark"] .demo-fixed .ease-modal-footer {
+  background: #0f172a !important;
+  border-top-color: #1e293b !important;
+}
+@media (prefers-color-scheme: dark) {
+  .demo-fixed .ease-modal-header {
+    border-bottom-color: #1e293b !important;
+  }
+  .demo-fixed .ease-modal-footer {
+    background: #0f172a !important;
+    border-top-color: #1e293b !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Fixes #30736

Adds dark mode overrides for the Modal header borders, footer backgrounds, and footer borders. This prevents them from remaining bright white/light-gray in dark mode, maintaining a consistent dark aesthetic.

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/modal-header-footer-dark-theme/`)
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR
