### PR TITLE
feat: add inventory health demo

### DIFF
--- a/submissions/examples/harbor-inventory-health/README.md
+++ b/submissions/examples/harbor-inventory-health/README.md
@@ -1,0 +1,14 @@
+# Harbor Inventory Health Demo
+
+A warehouse operations view that tracks stock health, reorder pressure, and cycle count coverage.
+
+## What is included
+
+- Responsive HTML structure for the inventory health demo.
+- CSS-only panel, stat list, cards, and mobile layout behavior.
+- Semantic sections with accessible labelling.
+
+## Files
+
+- `demo.html`
+- `style.css`

--- a/submissions/examples/harbor-inventory-health/demo.html
+++ b/submissions/examples/harbor-inventory-health/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Harbor Inventory Health Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="workspace">
+    <section class="summary-panel">
+      <div>
+        <p class="eyebrow">Operations planning</p>
+        <h1>Inventory health board for warehouse teams</h1>
+        <p class="summary">A warehouse operations view that tracks stock health, reorder pressure, and cycle count coverage.</p>
+      </div>
+      <ul class="stats">
+          <li>
+            <span>Healthy SKUs</span>
+            <strong>84%</strong>
+          </li>
+          <li>
+            <span>Reorders</span>
+            <strong>31</strong>
+          </li>
+          <li>
+            <span>Counts</span>
+            <strong>96</strong>
+          </li>
+      </ul>
+    </section>
+
+    <section class="detail-grid" aria-label="Inventory health insights">
+        <article class="detail-card">
+          <span>Stock</span>
+          <h2>Healthy coverage</h2>
+          <p>The health percentage gives operators a direct read on whether available stock is balanced.</p>
+        </article>
+        <article class="detail-card">
+          <span>Supply</span>
+          <h2>Reorder queue</h2>
+          <p>Reorder pressure is called out separately so purchasing work can be prioritized.</p>
+        </article>
+        <article class="detail-card">
+          <span>Audit</span>
+          <h2>Cycle counts</h2>
+          <p>Count coverage helps teams confirm that inventory data remains trustworthy.</p>
+        </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/harbor-inventory-health/style.css
+++ b/submissions/examples/harbor-inventory-health/style.css
@@ -1,0 +1,131 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #1e252b;
+  background:
+    linear-gradient(140deg, rgba(42, 132, 121, 0.2), transparent 35%),
+    linear-gradient(230deg, rgba(183, 112, 77, 0.18), transparent 38%),
+    #f7f8f4;
+}
+
+.workspace {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.summary-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 300px;
+  gap: 24px;
+  align-items: stretch;
+  padding: 32px;
+  border: 1px solid rgba(30, 37, 43, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 24px 72px rgba(30, 37, 43, 0.12);
+}
+
+.eyebrow,
+.detail-card span {
+  display: block;
+  margin-bottom: 10px;
+  color: #64727a;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 780px;
+  margin-bottom: 16px;
+  font-size: clamp(2.35rem, 7vw, 5rem);
+  line-height: 0.96;
+  letter-spacing: 0;
+}
+
+.summary {
+  max-width: 700px;
+  margin-bottom: 0;
+  color: #52606a;
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.stats {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.stats li,
+.detail-card {
+  border: 1px solid rgba(30, 37, 43, 0.1);
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.stats li {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+  padding: 18px;
+}
+
+.stats span {
+  color: #66747d;
+  font-weight: 700;
+}
+
+.stats strong {
+  font-size: 1.35rem;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.detail-card {
+  min-height: 210px;
+  padding: 24px;
+}
+
+.detail-card h2 {
+  margin-bottom: 12px;
+  font-size: 1.32rem;
+}
+
+.detail-card p {
+  margin-bottom: 0;
+  color: #56646d;
+  line-height: 1.65;
+}
+
+@media (max-width: 820px) {
+  .summary-panel,
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .summary-panel {
+    padding: 24px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a new responsive inventory health example under `submissions/examples/harbor-inventory-health`
- include semantic HTML, CSS-only layout styling, and mobile stacking support
- document the demo purpose and included files

## Testing
- not run locally; static HTML/CSS example only
