### PR TITLE
fix: resolve undefined --ease-color-text-muted variable in modal body…

### DIFF
--- a/submissions/examples/modal-body-text-typo-fix/README.md
+++ b/submissions/examples/modal-body-text-typo-fix/README.md
@@ -1,0 +1,33 @@
+# Fix: Undefined --ease-color-text-muted Variable in Modal Body
+
+**Fixes:** [#30735](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/30735)
+
+---
+
+## 🐛 Bug Description
+
+In `components/modals.css`, the `.ease-modal-body` class defines its text color using `color: var(--ease-color-text-muted, #4b5563)` on line 127. However, there is no `--ease-color-text-muted` variable defined anywhere in the design tokens (`core/variables.css`). 
+
+Because this variable is undefined, the text color falls back to the hardcoded `#4b5563` (dark-gray) in both light and dark modes. In dark mode, this dark-gray text is placed on a dark background (`#141e33`), making the modal body text completely illegible.
+
+---
+
+## ✅ Fix
+
+Map the text color to the correct, existing design token `var(--ease-color-muted, #4b5563)`:
+
+```css
+.ease-modal-body {
+  color: var(--ease-color-muted, #4b5563);
+}
+```
+
+---
+
+## 📁 Submission Contents
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Live demonstration of the modal body text readability in dark mode |
+| `style.css` | Raw CSS showing the proposed fix and demo page layout |
+| `README.md` | This documentation file |

--- a/submissions/examples/modal-body-text-typo-fix/demo.html
+++ b/submissions/examples/modal-body-text-typo-fix/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix #30735 — Modal Body Text Typo | EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <header>
+      <div>
+        <h1>Fix #30735 — Modal Body Text Typo</h1>
+        <p>Toggle dark mode to see if the modal body text has sufficient contrast</p>
+      </div>
+      <button class="toggle-btn" id="theme-toggle">🌙 Dark Mode</button>
+    </header>
+
+    <div class="panels">
+      <section class="panel">
+        <span class="badge bug">❌ Before (Bug)</span>
+        <div class="demo-buggy">
+          <div class="ease-modal" style="position: relative; display: block; opacity: 1; transform: none; width: 100%;">
+            <div class="ease-modal-body">
+              <p>This text uses the undefined variable, falling back to dark gray (#4b5563) which is completely unreadable in dark mode.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="panel">
+        <span class="badge fix">✅ After (Fix)</span>
+        <div class="demo-fixed">
+          <div class="ease-modal" style="position: relative; display: block; opacity: 1; transform: none; width: 100%;">
+            <div class="ease-modal-body">
+              <p>This text uses the correct --ease-color-muted variable, mapping to a readable light-gray color in dark mode.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  <script>
+    const btn = document.getElementById('theme-toggle');
+    const html = document.documentElement;
+
+    btn.addEventListener('click', function () {
+      const isDark = html.getAttribute('data-theme') === 'dark';
+      if (isDark) {
+        html.removeAttribute('data-theme');
+        btn.textContent = '🌙 Dark Mode';
+      } else {
+        html.setAttribute('data-theme', 'dark');
+        btn.textContent = '☀️ Light Mode';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/modal-body-text-typo-fix/style.css
+++ b/submissions/examples/modal-body-text-typo-fix/style.css
@@ -1,0 +1,87 @@
+/*
+ * EaseMotion CSS — Fix: Undefined --ease-color-text-muted Variable in Modal Body
+ * Issue: https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/30735
+ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', system-ui, sans-serif;
+  min-height: 100vh;
+  background: var(--ease-color-bg, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+  padding: 2rem;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.toggle-btn {
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  border: 1.5px solid var(--ease-color-primary, #6c63ff);
+  background: transparent;
+  color: var(--ease-color-primary, #6c63ff);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.panels {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+}
+
+.panel {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: 1rem;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.badge {
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  width: fit-content;
+}
+
+.badge.bug { background: #fee2e2; color: #ef4444; }
+.badge.fix { background: #dcfce7; color: #22c55e; }
+
+/* ── Buggy Simulation ── */
+.demo-buggy .ease-modal-body {
+  color: #4b5563 !important;
+}
+
+/* ── Fixed Implementation ── */
+[data-theme="dark"] .demo-fixed .ease-modal-body {
+  color: var(--ease-color-muted, #94a3b8);
+}
+@media (prefers-color-scheme: dark) {
+  .demo-fixed .ease-modal-body {
+    color: var(--ease-color-muted, #94a3b8);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Fixes #30735

Resolves an undefined variable typo (`--ease-color-text-muted` instead of `--ease-color-muted`) in the Modal body text styling. This fix ensures modal body text automatically scales to a readable light-gray color in dark mode instead of falling back to unreadable dark-gray.

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/modal-body-text-contrast-fix/`)
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR
