### PR TITLE
fix: add data-theme=dark support to neumorphic cards (#30734)

### DIFF
--- a/submissions/examples/neumorphic-card-theme-fix/README.md
+++ b/submissions/examples/neumorphic-card-theme-fix/README.md
@@ -1,0 +1,42 @@
+# Fix: Neumorphic Card [data-theme="dark"] Support
+
+**Fixes:** [#30734](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/30734)
+
+---
+
+## 🐛 Bug Description
+
+The Neumorphic Card (`.ease-card-neumorphic`) in `components/cards.css` only implements dark-theme background and shadow overrides within a `@media (prefers-color-scheme: dark)` media query (lines 180-201). It lacks support for the `[data-theme="dark"]` selector override. If a developer toggles the theme dynamically using `<html data-theme="dark">` via JavaScript, the neumorphic cards do not adapt and remain stuck in light mode.
+
+---
+
+## ✅ Fix
+
+Introduce `[data-theme="dark"]` selector overrides alongside the media query rules:
+
+```css
+[data-theme="dark"] .ease-card-neumorphic {
+  background-color: var(--ease-color-surface, #141e33) !important;
+  box-shadow:
+    8px 8px 20px rgba(0, 0, 0, 0.32),
+    -8px -8px 20px rgba(255, 255, 255, 0.04) !important;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  [data-theme="dark"] .ease-card-neumorphic:hover {
+    box-shadow:
+      12px 12px 26px rgba(0, 0, 0, 0.36),
+      -10px -10px 24px rgba(255, 255, 255, 0.055) !important;
+  }
+}
+```
+
+---
+
+## 📁 Submission Contents
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Live demonstration of the neumorphic cards in light & dark modes |
+| `style.css` | Raw CSS showing the proposed fix and demo page layout |
+| `README.md` | This documentation file |

--- a/submissions/examples/neumorphic-card-theme-fix/demo.html
+++ b/submissions/examples/neumorphic-card-theme-fix/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix #30740 — Neumorphic Card Theme | EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <header>
+      <div>
+        <h1>Fix #30734 — Neumorphic Card Theme</h1>
+        <p>Toggle dark mode to see if the neumorphic cards adapt correctly</p>
+      </div>
+      <button class="toggle-btn" id="theme-toggle">🌙 Dark Mode</button>
+    </header>
+
+    <div class="panels">
+      <section class="panel">
+        <span class="badge bug">❌ Before (Bug)</span>
+        <div class="demo-box demo-buggy">
+          <div class="ease-card ease-card-neumorphic" style="width: 200px; height: 100px; display: flex; align-items: center; justify-content: center;">
+            <span>Neumorphic</span>
+          </div>
+        </div>
+      </section>
+
+      <section class="panel">
+        <span class="badge fix">✅ After (Fix)</span>
+        <div class="demo-box demo-fixed">
+          <div class="ease-card ease-card-neumorphic" style="width: 200px; height: 100px; display: flex; align-items: center; justify-content: center;">
+            <span>Neumorphic</span>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  <script>
+    const btn = document.getElementById('theme-toggle');
+    const html = document.documentElement;
+
+    btn.addEventListener('click', function () {
+      const isDark = html.getAttribute('data-theme') === 'dark';
+      if (isDark) {
+        html.removeAttribute('data-theme');
+        btn.textContent = '🌙 Dark Mode';
+      } else {
+        html.setAttribute('data-theme', 'dark');
+        btn.textContent = '☀️ Light Mode';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/neumorphic-card-theme-fix/style.css
+++ b/submissions/examples/neumorphic-card-theme-fix/style.css
@@ -1,0 +1,95 @@
+/*
+ * EaseMotion CSS — Fix: Neumorphic Card [data-theme="dark"] Support
+ * Issue: https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/30734
+ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', system-ui, sans-serif;
+  min-height: 100vh;
+  background: var(--ease-color-bg, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+  padding: 2rem;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.toggle-btn {
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  border: 1.5px solid var(--ease-color-primary, #6c63ff);
+  background: transparent;
+  color: var(--ease-color-primary, #6c63ff);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.panels {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+}
+
+.panel {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: 1rem;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.badge {
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  width: fit-content;
+}
+
+.badge.bug { background: #fee2e2; color: #ef4444; }
+.badge.fix { background: #dcfce7; color: #22c55e; }
+
+.demo-box {
+  padding: 2rem;
+  background: var(--ease-color-bg);
+  border-radius: 0.5rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* ── Buggy Simulation ── */
+.demo-buggy [data-theme="dark"] .ease-card-neumorphic {
+  background-color: #f8fafc !important;
+  box-shadow: 8px 8px 20px rgba(15, 23, 42, 0.12), -8px -8px 20px rgba(255, 255, 255, 0.78) !important;
+}
+
+/* ── Fixed Implementation ── */
+[data-theme="dark"] .demo-fixed .ease-card-neumorphic {
+  background-color: var(--ease-color-surface, #141e33);
+  box-shadow:
+    8px 8px 20px rgba(0, 0, 0, 0.32),
+    -8px -8px 20px rgba(255, 255, 255, 0.04) !important;
+}


### PR DESCRIPTION
## Pull Request Description

Fixes #30734

Adds `[data-theme="dark"]` attribute selector overrides for the Neumorphic Card background and box shadows. This ensures that the neumorphic cards adapt correctly when the theme is toggled dynamically via JavaScript.

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/neumorphic-soft-card-dark/`)
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR
