### PR TITLE
fix: add data-theme=dark support to accent cards (#30733)

### DIFF
--- a/submissions/examples/accent-card-theme-fix/README.md
+++ b/submissions/examples/accent-card-theme-fix/README.md
@@ -1,0 +1,32 @@
+# Fix: Accent Card Borders [data-theme="dark"] Support
+
+**Fixes:** [#30733](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/30733)
+
+---
+
+## 🐛 Bug Description
+
+The Accent Cards (`.ease-card-accent`, `.ease-card-accent-success`, etc.) in `components/cards.css` only implement dark-theme border colors within a `@media (prefers-color-scheme: dark)` media query (lines 258-263). They lack support for the `[data-theme="dark"]` selector override. If a developer toggles the theme dynamically using `<html data-theme="dark">` via JavaScript, the accent borders do not adapt and remain stuck in their light-theme versions.
+
+---
+
+## ✅ Fix
+
+Introduce `[data-theme="dark"]` selector overrides alongside the media query rules:
+
+```css
+[data-theme="dark"] .ease-card-accent { border-left-color: var(--ease-color-primary-light, #a09af8); }
+[data-theme="dark"] .ease-card-accent-success { border-left-color: var(--ease-color-success-light, #86efac); }
+[data-theme="dark"] .ease-card-accent-danger { border-left-color: var(--ease-color-danger-light, #fca5a5); }
+[data-theme="dark"] .ease-card-accent-warning { border-left-color: var(--ease-color-warning-light, #fcd34d); }
+```
+
+---
+
+## 📁 Submission Contents
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Live demonstration of the accent cards in light & dark modes |
+| `style.css` | Raw CSS showing the proposed fix and demo page layout |
+| `README.md` | This documentation file |

--- a/submissions/examples/accent-card-theme-fix/demo.html
+++ b/submissions/examples/accent-card-theme-fix/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix #30733 — Accent Card Theme | EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <header>
+      <div>
+        <h1>Fix #30733 — Accent Card Theme</h1>
+        <p>Toggle dark mode to see if the accent card borders adapt correctly</p>
+      </div>
+      <button class="toggle-btn" id="theme-toggle">🌙 Dark Mode</button>
+    </header>
+
+    <div class="panels">
+      <section class="panel">
+        <span class="badge bug">❌ Before (Bug)</span>
+        <div class="demo-box demo-buggy">
+          <div class="ease-card ease-card-accent">
+            <div class="ease-card-body">Primary Accent</div>
+          </div>
+          <div class="ease-card ease-card-accent-success">
+            <div class="ease-card-body">Success Accent</div>
+          </div>
+        </div>
+      </section>
+
+      <section class="panel">
+        <span class="badge fix">✅ After (Fix)</span>
+        <div class="demo-box demo-fixed">
+          <div class="ease-card ease-card-accent">
+            <div class="ease-card-body">Primary Accent</div>
+          </div>
+          <div class="ease-card ease-card-accent-success">
+            <div class="ease-card-body">Success Accent</div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  <script>
+    const btn = document.getElementById('theme-toggle');
+    const html = document.documentElement;
+
+    btn.addEventListener('click', function () {
+      const isDark = html.getAttribute('data-theme') === 'dark';
+      if (isDark) {
+        html.removeAttribute('data-theme');
+        btn.textContent = '🌙 Dark Mode';
+      } else {
+        html.setAttribute('data-theme', 'dark');
+        btn.textContent = '☀️ Light Mode';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/accent-card-theme-fix/style.css
+++ b/submissions/examples/accent-card-theme-fix/style.css
@@ -1,0 +1,89 @@
+/*
+ * EaseMotion CSS — Fix: Accent Card Borders [data-theme="dark"] Support
+ * Issue: https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/30733
+ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', system-ui, sans-serif;
+  min-height: 100vh;
+  background: var(--ease-color-bg, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+  padding: 2rem;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.toggle-btn {
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  border: 1.5px solid var(--ease-color-primary, #6c63ff);
+  background: transparent;
+  color: var(--ease-color-primary, #6c63ff);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.panels {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+}
+
+.panel {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: 1rem;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.badge {
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  width: fit-content;
+}
+
+.badge.bug { background: #fee2e2; color: #ef4444; }
+.badge.fix { background: #dcfce7; color: #22c55e; }
+
+.demo-box {
+  padding: 1.5rem;
+  background: var(--ease-color-bg);
+  border-radius: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* ── Buggy Simulation ── */
+.demo-buggy [data-theme="dark"] .ease-card-accent { border-left-color: #6c63ff !important; }
+.demo-buggy [data-theme="dark"] .ease-card-accent-success { border-left-color: #22c55e !important; }
+
+/* ── Fixed Implementation ── */
+[data-theme="dark"] .demo-fixed .ease-card-accent { border-left-color: var(--ease-color-primary-light, #a09af8); }
+[data-theme="dark"] .demo-fixed .ease-card-accent-success { border-left-color: var(--ease-color-success-light, #86efac); }


### PR DESCRIPTION
## Pull Request Description

Fixes #30733

Adds `[data-theme="dark"]` attribute selector overrides for the Accent Card borders (`.ease-card-accent`, `.ease-card-accent-success`, etc.). This ensures the borders adapt correctly when the theme is toggled dynamically via JavaScript.

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/accent-card-dark-theme/`)
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR
