### PR TITLE
feat: Add SCSS Custom Focus Ring A11y Indicator Mixins (#28429)

### DIFF
--- a/submissions/scss/scss-custom-focus-ring-a11y-indicator-mixins/README.md
+++ b/submissions/scss/scss-custom-focus-ring-a11y-indicator-mixins/README.md
@@ -1,0 +1,49 @@
+# SCSS Utility: Custom Focus Ring & A11y Indicator Mixins (#28429)
+
+A critical accessibility (A11y) SCSS utility module for the EaseMotion CSS framework that replaces harsh, browser-default focus outlines with beautiful, animated, and highly visible custom focus indicators.
+
+## 📦 What's included?
+
+- `_custom-focus-ring-a11y-indicator-mixins.scss`: The SCSS partial containing configurable mixins utilizing `:focus-visible`, `outline-offset`, and `box-shadow`.
+- `style.css`: The compiled output of the standard utility classes.
+- `demo.html`: An interactive form meant to be navigated via the `Tab` key to test the focus states.
+
+## 🛠 Usage via SCSS Mixins
+
+Import the partial and include the mixins on your interactive elements (`a`, `button`, `input`, `select`, etc.).
+
+```scss
+@import 'custom-focus-ring-a11y-indicator-mixins';
+
+.my-text-input {
+  // @include ease-focus-ring($ring-color, $ring-width, $ring-offset, $duration);
+  @include ease-focus-ring(rgba(59, 130, 246, 0.5), 3px, 2px);
+}
+
+.my-pill-button {
+  // Uses a double box-shadow technique instead of outline, 
+  // which sometimes handles complex border-radii better in older browsers.
+  @include ease-focus-ring-shadow();
+}
+
+.my-inline-link {
+  // A subtle animated underline instead of a bounding box
+  @include ease-focus-underline(#ec4899);
+}
+```
+
+## 🛠 Usage via HTML Utility Classes
+
+If your project is pre-compiled, simply add the classes to your focusable elements.
+
+```html
+<input type="text" class="ease-focus-ring" placeholder="Primary focus...">
+<input type="text" class="ease-focus-ring-success" placeholder="Green focus...">
+<input type="text" class="ease-focus-ring-danger" placeholder="Red focus...">
+```
+
+## 🚀 Why this fits EaseMotion
+
+**EaseMotion** is about making user interfaces feel premium. Unfortunately, the default browser focus ring (`outline: auto`) often looks terrible, clashing with carefully designed color palettes and border radii. As a result, developers frequently set `outline: none;` and forget to replace it, severely damaging keyboard accessibility.
+
+This module provides an elegant solution. By utilizing `:focus-visible` (which only shows the ring when navigating via keyboard, not when clicking with a mouse) and combining smooth `box-shadow` or `outline-offset` transitions, we create focus indicators that look incredibly polished, animate smoothly, and ensure your application remains fully accessible.

--- a/submissions/scss/scss-custom-focus-ring-a11y-indicator-mixins/_custom-focus-ring-a11y-indicator-mixins.scss
+++ b/submissions/scss/scss-custom-focus-ring-a11y-indicator-mixins/_custom-focus-ring-a11y-indicator-mixins.scss
@@ -1,0 +1,107 @@
+// _custom-focus-ring-a11y-indicator-mixins.scss
+// =======================================================
+// EaseMotion CSS - Custom Focus Rings & A11y Mixins
+// 
+// Provides reusable SCSS mixins and utility classes to 
+// replace harsh browser-default focus outlines with 
+// beautiful, animated, and accessible focus indicators.
+// =======================================================
+
+// -------------------------------------------------------
+// 1. Core Focus Mixins
+// -------------------------------------------------------
+
+/// Removes the default outline and applies a smooth, custom box-shadow ring
+/// when an element receives keyboard focus (using :focus-visible).
+/// @param {Color} $ring-color - The color of the outer focus ring
+/// @param {Length} $ring-width - The thickness of the focus ring
+/// @param {Length} $ring-offset - The gap between the element and the ring
+/// @param {Time} $duration - The speed of the ring animation
+@mixin ease-focus-ring(
+  $ring-color: rgba(59, 130, 246, 0.5), 
+  $ring-width: 3px, 
+  $ring-offset: 2px,
+  $duration: 0.2s
+) {
+  // Ensure we transition the shadow smoothly
+  transition: box-shadow $duration cubic-bezier(0.4, 0, 0.2, 1);
+  outline: none; // We are replacing this with box-shadow
+
+  &:focus-visible {
+    // We use a double box-shadow to create the offset gap.
+    // The first shadow acts as the transparent gap (matching the background).
+    // The second shadow acts as the actual focus ring.
+    // Note: If the element is on a non-white background, the gap color should match it,
+    // but typically CSS variables or transparent outlines are used. Here we use an actual outline offset.
+    
+    // Modern CSS approach using outline properties (highly accessible and respects border-radius automatically)
+    outline: $ring-width solid $ring-color;
+    outline-offset: $ring-offset;
+    // Add a subtle glow
+    box-shadow: 0 0 0 $ring-offset transparent, 0 0 10px $ring-color;
+  }
+}
+
+/// A variant that uses box-shadow exclusively for inset/offset rings 
+/// where `outline` might not respect complex border-radii in older browsers.
+/// @param {Color} $ring-color - The color of the focus ring
+@mixin ease-focus-ring-shadow(
+  $ring-color: rgba(99, 102, 241, 0.6),
+  $ring-width: 3px,
+  $gap-width: 2px,
+  $gap-color: #ffffff,
+  $duration: 0.2s
+) {
+  outline: none;
+  transition: box-shadow $duration cubic-bezier(0.4, 0, 0.2, 1);
+
+  &:focus-visible {
+    // Gap shadow + Ring shadow
+    box-shadow: 0 0 0 $gap-width $gap-color, 0 0 0 ($gap-width + $ring-width) $ring-color;
+  }
+}
+
+/// A subtle underline focus indicator, perfect for inline links
+@mixin ease-focus-underline($color: #3b82f6) {
+  outline: none;
+  text-decoration-line: underline;
+  text-decoration-style: solid;
+  text-decoration-color: transparent;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 4px;
+  transition: text-decoration-color 0.2s ease, text-underline-offset 0.2s ease;
+
+  &:focus-visible {
+    text-decoration-color: $color;
+    text-underline-offset: 2px;
+  }
+}
+
+// -------------------------------------------------------
+// 2. Utility Classes (Generated CSS)
+// -------------------------------------------------------
+
+// Default primary focus ring
+.ease-focus-ring {
+  @include ease-focus-ring();
+}
+
+// Success (green) focus ring
+.ease-focus-ring-success {
+  @include ease-focus-ring(rgba(16, 185, 129, 0.5), 3px, 2px);
+}
+
+// Danger (red) focus ring
+.ease-focus-ring-danger {
+  @include ease-focus-ring(rgba(239, 68, 68, 0.5), 3px, 2px);
+}
+
+// Shadow-based focus ring (better for pills/heavy border-radius)
+.ease-focus-shadow {
+  @include ease-focus-ring-shadow();
+}
+
+// Link underline focus
+.ease-focus-link {
+  @include ease-focus-underline();
+}

--- a/submissions/scss/scss-custom-focus-ring-a11y-indicator-mixins/demo.html
+++ b/submissions/scss/scss-custom-focus-ring-a11y-indicator-mixins/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Custom Focus Rings</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <div style="text-align: center; margin-bottom: 2rem;">
+    <h1 style="margin: 0 0 1rem 0;">A11y Focus Indicators</h1>
+    <p style="margin: 0; opacity: 0.8;">Press <kbd>Tab</kbd> repeatedly to navigate the elements and see the custom focus states.</p>
+  </div>
+
+  <div class="demo-container">
+    
+    <div>
+      <label for="input1" style="display:block; margin-bottom: 0.5rem; font-weight: 500;">Standard Input (Primary Ring)</label>
+      <input type="text" id="input1" class="demo-input ease-focus-ring" placeholder="Tab to me...">
+    </div>
+
+    <div>
+      <label for="input2" style="display:block; margin-bottom: 0.5rem; font-weight: 500;">Valid Input (Success Ring)</label>
+      <input type="text" id="input2" class="demo-input ease-focus-ring-success" placeholder="Tab to me...">
+    </div>
+
+    <div>
+      <button class="demo-button ease-focus-shadow">Pill Button (Shadow Ring)</button>
+    </div>
+
+    <div>
+      <p style="margin:0;">Read our <a href="#" class="demo-link ease-focus-link">terms and conditions</a> for more details.</p>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/scss/scss-custom-focus-ring-a11y-indicator-mixins/style.css
+++ b/submissions/scss/scss-custom-focus-ring-a11y-indicator-mixins/style.css
@@ -1,0 +1,116 @@
+/* 
+  style.css
+  This file contains the compiled output of the SCSS mixin so that demo.html can function 
+  without requiring a local Sass compiler to be running.
+*/
+
+:root {
+  --bg-color: #f8fafc;
+  --text-color: #334155;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: system-ui, -apple-system, sans-serif;
+  color: var(--text-color);
+  background: var(--bg-color);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.demo-container {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  width: 100%;
+  max-width: 500px;
+  background: white;
+  padding: 3rem;
+  border-radius: 1rem;
+  box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1);
+}
+
+.demo-input {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+  box-sizing: border-box;
+}
+
+.demo-button {
+  padding: 0.75rem 1.5rem;
+  background: #f1f5f9;
+  border: 1px solid #cbd5e1;
+  border-radius: 2rem; /* heavy radius to test shadows */
+  font-weight: 600;
+  color: #0f172a;
+  cursor: pointer;
+}
+
+.demo-link {
+  color: #3b82f6;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+/* =======================================================
+   COMPILED SCSS OUTPUT (Focus Rings)
+   ======================================================= */
+
+.ease-focus-ring {
+  transition: box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  outline: none;
+}
+.ease-focus-ring:focus-visible {
+  outline: 3px solid rgba(59, 130, 246, 0.5);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 2px transparent, 0 0 10px rgba(59, 130, 246, 0.5);
+}
+
+.ease-focus-ring-success {
+  transition: box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  outline: none;
+}
+.ease-focus-ring-success:focus-visible {
+  outline: 3px solid rgba(16, 185, 129, 0.5);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 2px transparent, 0 0 10px rgba(16, 185, 129, 0.5);
+}
+
+.ease-focus-ring-danger {
+  transition: box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  outline: none;
+}
+.ease-focus-ring-danger:focus-visible {
+  outline: 3px solid rgba(239, 68, 68, 0.5);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 2px transparent, 0 0 10px rgba(239, 68, 68, 0.5);
+}
+
+.ease-focus-shadow {
+  outline: none;
+  transition: box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.ease-focus-shadow:focus-visible {
+  box-shadow: 0 0 0 2px #ffffff, 0 0 0 5px rgba(99, 102, 241, 0.6);
+}
+
+.ease-focus-link {
+  outline: none;
+  text-decoration-line: underline;
+  text-decoration-style: solid;
+  text-decoration-color: transparent;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 4px;
+  transition: text-decoration-color 0.2s ease, text-underline-offset 0.2s ease;
+}
+.ease-focus-link:focus-visible {
+  text-decoration-color: #3b82f6;
+  text-underline-offset: 2px;
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #27803 by introducing a critical accessibility (A11y) SCSS utility module. It replaces harsh, inconsistent browser-default focus outlines with beautiful, animated custom focus indicators utilizing `:focus-visible` and `outline-offset` / `box-shadow` transitions.

Closes #27803

---

## Type of Change

- [x] ✨ New animation / hover effect (Animated Focus Rings)
- [x] 🧩 New component (A11y Utilities)
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/scss/scss-custom-focus-ring-a11y-indicator-mixins/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] Includes `_custom-focus-ring-a11y-indicator-mixins.scss`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A suite of highly configurable SCSS mixins (`@include ease-focus-ring()`, `@include ease-focus-ring-shadow()`, `@include ease-focus-underline()`) and their corresponding utility classes to instantly upgrade the keyboard navigation experience.

**How does a developer use it?**

```html
<!-- Apply directly to focusable elements -->
<input type="text" class="ease-focus-ring" placeholder="Primary focus...">
<input type="text" class="ease-focus-ring-success" placeholder="Green focus...">
<input type="text" class="ease-focus-ring-danger" placeholder="Red focus...">
