### PR TITLE
feat: Add SCSS Truncate Multi-Line Clamp Utility Classes (#28430)

### DIFF
--- a/submissions/scss/scss-truncate-multi-line-clamp-utility-classes/README.md
+++ b/submissions/scss/scss-truncate-multi-line-clamp-utility-classes/README.md
@@ -1,0 +1,47 @@
+# SCSS Utility: Truncate Multi-Line Clamp Utility Classes (#28430)
+
+A layout SCSS utility module for the EaseMotion CSS framework that provides robust text truncation to a specific number of lines (1, 2, 3, etc.) using modern `-webkit-line-clamp` properties, complete with an ellipsis (`...`).
+
+## 📦 What's included?
+
+- `_truncate-multi-line-clamp-utility-classes.scss`: The SCSS partial containing the `@mixin` and utility class generator loop.
+- `style.css`: The compiled output of the generator loop (1-6 lines).
+- `demo.html`: A grid of cards demonstrating 1, 2, and 4-line truncation.
+
+## 🛠 Usage via SCSS Mixins
+
+Import the partial and use the `ease-line-clamp` mixin to enforce a maximum number of lines on any text element.
+
+```scss
+@import 'truncate-multi-line-clamp-utility-classes';
+
+.product-title {
+  // Truncate cleanly after 2 lines
+  @include ease-line-clamp(2);
+}
+
+.product-description {
+  // Truncate cleanly after 4 lines
+  @include ease-line-clamp(4);
+}
+```
+
+## 🛠 Usage via HTML Utility Classes
+
+If your project is pre-compiled, simply attach the corresponding clamp class to your text element.
+
+```html
+<h2 class="ease-clamp-1">Single line title that gets truncated...</h2>
+
+<p class="ease-clamp-3">
+  A multi-line paragraph that will span exactly three lines before 
+  being cut off with an ellipsis. This is very useful for keeping 
+  grid items at a uniform height...
+</p>
+```
+
+## 🚀 Why this fits EaseMotion
+
+While **EaseMotion** focuses heavily on animations and hover states, maintaining a beautiful, consistent layout is the prerequisite for good motion design. If your CSS grid items are bouncing all over the place because user-generated text is different lengths, your animations will look broken.
+
+Standard CSS truncation (`white-space: nowrap`) only works for a single line. This utility leverages the highly supported `-webkit-line-clamp` property to allow beautiful, multi-line truncation, ensuring your cards and layouts remain perfectly aligned regardless of content length.

--- a/submissions/scss/scss-truncate-multi-line-clamp-utility-classes/_truncate-multi-line-clamp-utility-classes.scss
+++ b/submissions/scss/scss-truncate-multi-line-clamp-utility-classes/_truncate-multi-line-clamp-utility-classes.scss
@@ -1,0 +1,64 @@
+// _truncate-multi-line-clamp-utility-classes.scss
+// =======================================================
+// EaseMotion CSS - Multi-Line Truncation (Line Clamp)
+// 
+// Provides SCSS mixins and utility classes to cleanly 
+// truncate text with an ellipsis (...) after a specific 
+// number of lines, using the highly supported -webkit-line-clamp.
+// =======================================================
+
+// -------------------------------------------------------
+// 1. Core Line Clamp Mixin
+// -------------------------------------------------------
+
+/// Truncates text after a specific number of lines using an ellipsis.
+/// @param {Number} $lines [1] - The maximum number of lines to display before truncating.
+@mixin ease-line-clamp($lines: 1) {
+  @if $lines == 1 {
+    // Single line truncation is more efficient with standard white-space: nowrap
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  } @else {
+    // Multi-line truncation requires the webkit flexbox implementation
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: $lines;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    // Word break helps ensure long URLs or continuous strings don't break the layout
+    word-break: break-word;
+  }
+}
+
+// -------------------------------------------------------
+// 2. Generator Loop for Utility Classes
+// -------------------------------------------------------
+
+/// Generates a suite of utility classes for clamping (e.g., .ease-clamp-1, .ease-clamp-2)
+/// @param {Number} $max-lines [5] - The maximum number of lines to generate classes for.
+@mixin generate-ease-clamps($max-lines: 5) {
+  @for $i from 1 through $max-lines {
+    .ease-clamp-#{$i} {
+      @include ease-line-clamp($i);
+    }
+  }
+}
+
+// -------------------------------------------------------
+// 3. Utility Classes (Generated CSS)
+// -------------------------------------------------------
+
+// Generate .ease-clamp-1 through .ease-clamp-6
+@include generate-ease-clamps(6);
+
+// Provide a reset class for responsive adjustments 
+// (e.g. clamp on mobile, un-clamp on desktop)
+.ease-clamp-none {
+  display: block;
+  -webkit-line-clamp: unset;
+  overflow: visible;
+  text-overflow: clip;
+  white-space: normal;
+  word-break: normal;
+}

--- a/submissions/scss/scss-truncate-multi-line-clamp-utility-classes/demo.html
+++ b/submissions/scss/scss-truncate-multi-line-clamp-utility-classes/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Line Clamp Utilities</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <div style="text-align: center; margin-top: 3rem;">
+    <h1 style="margin: 0 0 0.5rem 0; color: #0f172a;">Multi-Line Text Truncation</h1>
+    <p style="margin: 0; opacity: 0.8;">Cleanly clamp long text to maintain rigid grid layouts.</p>
+  </div>
+
+  <div class="demo-container">
+    
+    <div class="card">
+      <span class="tag">.ease-clamp-1</span>
+      <h3 class="ease-clamp-1">This is a really long article title that absolutely must be truncated to a single line so it doesn't break the layout.</h3>
+      <p class="content">The title above is clamped to exactly 1 line using standard white-space nowrap.</p>
+    </div>
+
+    <div class="card">
+      <span class="tag">.ease-clamp-2</span>
+      <h3 class="ease-clamp-1">Article Excerpt</h3>
+      <p class="content ease-clamp-2">This is a paragraph of text that should be clamped to exactly two lines. Anything that goes beyond the second line will be hidden and replaced with a beautiful ellipsis at the very end of the visible text block.</p>
+    </div>
+
+    <div class="card">
+      <span class="tag">.ease-clamp-4</span>
+      <h3 class="ease-clamp-1">Long Description</h3>
+      <p class="content ease-clamp-4">This block of text is allowed to be a little bit longer. It will take up exactly four lines before it gets truncated. This is incredibly useful for product description cards in an e-commerce grid, where you want to show a good amount of context but you still need all the cards in the row to be exactly the same height so the layout doesn't look messy and disorganized.</p>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/scss/scss-truncate-multi-line-clamp-utility-classes/style.css
+++ b/submissions/scss/scss-truncate-multi-line-clamp-utility-classes/style.css
@@ -1,0 +1,127 @@
+/* 
+  style.css
+  This file contains the compiled output of the SCSS mixin so that demo.html can function 
+  without requiring a local Sass compiler to be running.
+*/
+
+:root {
+  --bg-color: #f1f5f9;
+  --text-color: #334155;
+  --heading-color: #0f172a;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: system-ui, -apple-system, sans-serif;
+  color: var(--text-color);
+  background: var(--bg-color);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.demo-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 2rem;
+  width: 100%;
+  max-width: 900px;
+  padding: 2rem;
+  box-sizing: border-box;
+}
+
+.card {
+  background: white;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1);
+}
+
+h3 {
+  margin: 0 0 1rem 0;
+  color: var(--heading-color);
+  font-size: 1.25rem;
+}
+
+p.content {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.tag {
+  display: inline-block;
+  background: #e0e7ff;
+  color: #4338ca;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+/* =======================================================
+   COMPILED SCSS OUTPUT (Line Clamp Utilities)
+   ======================================================= */
+
+.ease-clamp-1 {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ease-clamp-2 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: break-word;
+}
+
+.ease-clamp-3 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: break-word;
+}
+
+.ease-clamp-4 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: break-word;
+}
+
+.ease-clamp-5 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 5;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: break-word;
+}
+
+.ease-clamp-6 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 6;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: break-word;
+}
+
+.ease-clamp-none {
+  display: block;
+  -webkit-line-clamp: unset;
+  overflow: visible;
+  text-overflow: clip;
+  white-space: normal;
+  word-break: normal;
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #27804 by introducing a structural SCSS utility module for multi-line text truncation. It utilizes the `-webkit-line-clamp` property to cleanly truncate overflowing text with an ellipsis, which is critical for maintaining rigid grid layouts and uniform card heights.

Closes #27804

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component (Layout & Typography Utility)
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/scss/scss-truncate-multi-line-clamp-utility-classes/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] Includes `_truncate-multi-line-clamp-utility-classes.scss`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An SCSS mixin (`@include ease-line-clamp($lines)`) and a generated suite of utility classes (`.ease-clamp-1` through `.ease-clamp-6`) that force text blocks to truncate cleanly at a specific line count rather than wrapping indefinitely and breaking layouts.

**How does a developer use it?**

```html
<!-- Apply the utility class to any block of text
