### PR TITLE
fix: remove unnecessary quotes around Inter font family

### DIFF
--- a/examples/react-vite/src/App.css
+++ b/examples/react-vite/src/App.css
@@ -17,7 +17,7 @@ body {
   padding: 0;
   background-color: var(--bg-primary);
   color: var(--text-primary);
-  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  font-family: Inter, system-ui, -apple-system, sans-serif;
   overflow-x: hidden;
 }
 


### PR DESCRIPTION
## Pull Request Description

This PR fixes a Stylelint error in the React Vite example by removing unnecessary quotes around the single-word font family `Inter` in `examples/react-vite/src/App.css`.

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] Other

---

## Changes Made

- Removed unnecessary quotes around `Inter` in the `font-family` declaration.
- Ensures `npm run lint` passes without Stylelint errors.

---

## Notes for Maintainer

Fixes issue #27861.