### PR TITLE
[Feat] #27714 — Add CSS container query wrappers (unique folder)

### DIFF
--- a/submissions/examples/container-query-grid-27714-ag/README.md
+++ b/submissions/examples/container-query-grid-27714-ag/README.md
@@ -1,0 +1,41 @@
+# CSS Container Query Grid Wrapper Classes
+
+This guide details configuration specs for generating SCSS container query grid wrappers.
+
+---
+
+## Technical Overview: The Container Query Grid Mixin
+
+Media queries adapt styles to viewport dimensions, which fail when elements are nested within multi-column grid components. Declaring parent containers enables layout scaling based on localized parent dimensions:
+
+```scss
+// SCSS Container Query Mixin
+@mixin container-width($name, $threshold) {
+  @container #{$name} (min-width: #{$threshold}) {
+    @content;
+  }
+}
+
+// Parent declaration
+.query-wrapper {
+  container-type: inline-size;
+  container-name: grid-container;
+}
+
+// Child element query
+.grid-card {
+  padding: 16px;
+  
+  @include container-width(grid-container, 480px) {
+    padding: 28px;
+  }
+}
+```
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Watch the card container size and padding increments.
+3. Slide the **Parent Container Width** range above 480px — verify the padding expands and typography color/size scales dynamically.

--- a/submissions/examples/container-query-grid-27714-ag/demo.html
+++ b/submissions/examples/container-query-grid-27714-ag/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Container Query Grid — EaseMotion CSS</title>
+  <meta name="description" content="Visual container query showcase demonstrating container-relative font scales and styling rules.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — SCSS Utilities</span>
+      <h1>Container Query Grid</h1>
+      <p class="description">
+        Demonstrates parent-relative styling. Adjust parent container width slider 
+        below to shift padding metrics and header sizes dynamically.
+      </p>
+    </header>
+
+    <main class="dashboard">
+
+      <!-- Left Panel: Width Settings -->
+      <section class="controls-panel">
+        <h2 class="section-title">Parent Container Width</h2>
+        <div class="control-group">
+          <label for="width-slider">Width: <span id="width-val">400px</span></label>
+          <input type="range" id="width-slider" min="300" max="650" value="400" step="10">
+        </div>
+      </section>
+
+      <!-- Right Panel: Grid Wrapper -->
+      <section class="preview-panel">
+        <h2 class="section-title">Grid Preview</h2>
+        
+        <div class="query-wrapper" id="query-wrapper" style="width: 400px;">
+          <div class="grid-card">
+            <h3>Card Title</h3>
+            <p>Padding and typography scale dynamically according to container bounds.</p>
+          </div>
+        </div>
+      </section>
+
+    </main>
+  </div>
+
+  <script>
+    const slider = document.getElementById('width-slider');
+    const widthVal = document.getElementById('width-val');
+    const wrapper = document.getElementById('query-wrapper');
+
+    slider.addEventListener('input', () => {
+      const width = `${slider.value}px`;
+      widthVal.textContent = width;
+      wrapper.style.width = width;
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/container-query-grid-27714-ag/style.css
+++ b/submissions/examples/container-query-grid-27714-ag/style.css
@@ -1,0 +1,172 @@
+/* ============================================================
+   CSS Container Query Grid — style.css
+   Submission for EaseMotion CSS Issue #27714
+   Container wrapper types, padding scaling, and sliders
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 820px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Dashboard Layout
+   ============================================================ */
+
+.dashboard {
+  display: grid;
+  grid-template-columns: 1fr 1.3fr;
+  gap: 28px;
+}
+
+@media (max-width: 768px) {
+  .dashboard { grid-template-columns: 1fr; }
+}
+
+.controls-panel,
+.preview-panel {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  padding: 28px;
+  border-radius: 20px;
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+}
+
+.section-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+/* Width Controls range inputs */
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.control-group label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.control-group input[type="range"] {
+  accent-color: var(--primary-color);
+  cursor: pointer;
+}
+
+/* ============================================================
+   Container Query Grid Elements under Test
+   ============================================================ */
+
+/* Parent Container wrapper */
+.query-wrapper {
+  container-type: inline-size;
+  container-name: grid-container;
+  background: rgba(0,0,0,0.25);
+  border: 1px solid rgba(255,255,255,0.04);
+  border-radius: 12px;
+  padding: 12px;
+  transition: width 0.2s ease;
+  align-self: center;
+}
+
+/* Child base styles (Narrow container / default) */
+.grid-card {
+  background: rgba(255,255,255,0.02);
+  border: 1px solid var(--card-border);
+  padding: 16px;
+  border-radius: 8px;
+  transition: padding 0.2s ease;
+}
+
+.grid-card h3 {
+  font-size: 1.05rem;
+  font-weight: 700;
+  margin-bottom: 8px;
+  transition: font-size 0.2s ease, color 0.2s ease;
+}
+
+.grid-card p {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+/* Parent container width queries */
+@container grid-container (min-width: 480px) {
+  .grid-card {
+    padding: 28px;
+  }
+  .grid-card h3 {
+    font-size: 1.35rem;
+    color: #a78bfa;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-container-query-grid` showcase. It demonstrates parent-relative grid scaling generated via SCSS container query mixins (altering typography bounds and card paddings on parent container width shifts) supporting a width range slider widget.

## Root Cause
No container-relative padding transition mixins or parent-relative font scales existed in EaseMotion CSS.

## Changes Made
- `submissions/examples/container-query-grid-27714-ag/demo.html`: Container nodes hosting text blocks, card widgets, and parent width adjustor sliders.
- `submissions/examples/container-query-grid-27714-ag/style.css`: Parent inline-size settings, container query widths, padding updates, and colors.
- `submissions/examples/container-query-grid-27714-ag/README.md`: Explains container-relative grid mixins, SCSS parameters, and manual validation.

## How to Test
1. Open `demo.html` in a browser.
2. Drag width sliders above 480px to confirm padding and typography shifts.

## Related Issue
Closes #27714