### PR TITLE
feat: add radio-button-ripple component (#31018)

### DIFF
--- a/submissions/examples/ease-radio-button-ripple-ij/README.md
+++ b/submissions/examples/ease-radio-button-ripple-ij/README.md
@@ -1,0 +1,16 @@
+# Radio Button Ripple
+
+Custom radio button with ripple animation on selection. Inner dot scales up with ripple ring expansion via ::after pseudo-element and @keyframes.
+
+## Features
+
+- Custom styled radio button
+- Ripple ring on selection via ::after animation
+- Inner dot scale animation
+- Scale effect on checked state
+- Smooth cubic-bezier transitions
+- No JS required
+
+## Usage
+
+Custom radio using hidden input + styled ::after pseudo-element. CSS handles all animations; no JS required.

--- a/submissions/examples/ease-radio-button-ripple-ij/demo.html
+++ b/submissions/examples/ease-radio-button-ripple-ij/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Radio Button Ripple - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Radio Ripple</h1>
+    <p class="desc">Custom radio buttons with ripple animation</p>
+    <div class="rr-card">
+      <label class="rr-option">
+        <input type="radio" name="rr" class="rr-input" checked>
+        <span class="rr-radio">
+          <span class="rr-dot"></span>
+        </span>
+        <span class="rr-text">Option A</span>
+      </label>
+      <label class="rr-option">
+        <input type="radio" name="rr" class="rr-input">
+        <span class="rr-radio">
+          <span class="rr-dot"></span>
+        </span>
+        <span class="rr-text">Option B</span>
+      </label>
+      <label class="rr-option">
+        <input type="radio" name="rr" class="rr-input">
+        <span class="rr-radio">
+          <span class="rr-dot"></span>
+        </span>
+        <span class="rr-text">Option C</span>
+      </label>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-radio-button-ripple-ij/style.css
+++ b/submissions/examples/ease-radio-button-ripple-ij/style.css
@@ -1,0 +1,123 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  text-align: center;
+  width: 100%;
+  max-width: 380px;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 0.5rem;
+  color: #94a3b8;
+}
+
+.desc {
+  font-size: 0.875rem;
+  color: #64748b;
+  margin-bottom: 2rem;
+}
+
+.rr-card {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 20px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  text-align: left;
+}
+
+.rr-option {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: #0f172a;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.rr-option:hover {
+  background: #1a2332;
+}
+
+.rr-input {
+  display: none;
+}
+
+.rr-radio {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 2px solid #475569;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: border-color 0.25s ease, transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+  position: relative;
+}
+
+.rr-input:checked + .rr-radio {
+  border-color: #e94560;
+  transform: scale(1.05);
+}
+
+.rr-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #e94560;
+  transform: scale(0);
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.rr-input:checked + .rr-radio .rr-dot {
+  transform: scale(1);
+}
+
+.rr-radio::after {
+  content: '';
+  position: absolute;
+  inset: -6px;
+  border-radius: 50%;
+  border: 2px solid #e94560;
+  opacity: 0;
+  transform: scale(0.5);
+  transition: all 0.3s ease;
+}
+
+.rr-input:checked + .rr-radio::after {
+  opacity: 0.3;
+  transform: scale(1.2);
+  animation: rrRipple 0.4s ease-out;
+}
+
+@keyframes rrRipple {
+  0% { opacity: 0.5; transform: scale(0.8); }
+  100% { opacity: 0; transform: scale(1.5); }
+}
+
+.rr-text {
+  font-size: 0.9rem;
+  color: #cbd5e1;
+}


### PR DESCRIPTION
## Component: ease-radio-button-ripple ? custom radio with ripple ring animation via ::after and @keyframes

### What this adds
Custom radio button with ripple animation on selection. Inner dot scales up with ripple ring expansion via ::after pseudo-element and @keyframes.

### Acceptance Criteria covered
- Custom styled radio button
- Ripple ring on selection via ::after animation
- Inner dot scale animation
- Scale effect on checked state
- Smooth cubic-bezier transitions
- No JS required

### Files
- submissions/examples/ease-radio-button-ripple-ij/demo.html
- submissions/examples/ease-radio-button-ripple-ij/style.css
- submissions/examples/ease-radio-button-ripple-ij/README.md

### How to review
Open demo.html and click radio options to see the ripple animation.

**Closes #31018**
