### PR TITLE
fix: resolve theme-switcher print and countdown reduced-motion conflicts #30560

### DIFF
--- a/submissions/docs/core_changes-issue-28602/style.css
+++ b/submissions/docs/core_changes-issue-28602/style.css
@@ -4,104 +4,118 @@
    ============================================================ */
 
 @layer easemotion-components {
+  .ease-theme-switcher {
+    --ease-theme-switcher-size: 40px;
+    --ease-theme-switcher-bg: var(--ease-color-neutral-100);
+    --ease-theme-switcher-color: var(--ease-color-text);
 
-.ease-theme-switcher {
-  --ease-theme-switcher-size: 40px;
-  --ease-theme-switcher-bg: var(--ease-color-neutral-100);
-  --ease-theme-switcher-color: var(--ease-color-text);
-
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: var(--ease-theme-switcher-size);
-  height: var(--ease-theme-switcher-size);
-  padding: 0;
-  border: none;
-  border-radius: var(--ease-radius-full);
-  background: var(--ease-theme-switcher-bg);
-  color: var(--ease-theme-switcher-color);
-  cursor: pointer;
-  overflow: hidden;
-  transition: background var(--ease-speed-medium) var(--ease-ease),
-              color var(--ease-speed-medium) var(--ease-ease),
-              transform var(--ease-speed-fast) var(--ease-ease);
-  outline-offset: 2px;
-}
-
-.ease-theme-switcher:hover {
-  transform: scale(1.1);
-}
-
-.ease-theme-switcher:focus-visible {
-  outline: 2px solid var(--ease-color-primary);
-}
-
-/* ── Icon container ──────────────────────────────────────── */
-
-.ease-theme-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
-  position: relative;
-}
-
-.ease-theme-icon svg {
-  width: 60%;
-  height: 60%;
-  position: absolute;
-  transition: opacity var(--ease-speed-medium) var(--ease-ease),
-              transform var(--ease-speed-medium) var(--ease-ease);
-}
-
-/* Sun icon visible in light mode, hidden in dark */
-.ease-sun-icon {
-  opacity: 1;
-  transform: rotate(0deg) scale(1);
-}
-
-/* Moon icon hidden in light mode, visible in dark */
-.ease-moon-icon {
-  opacity: 0;
-  transform: rotate(90deg) scale(0);
-}
-
-/* ── Dark mode state ─────────────────────────────────────── */
-
-[data-theme="dark"] .ease-theme-switcher {
-  --ease-theme-switcher-bg: var(--ease-color-neutral-800);
-  --ease-theme-switcher-color: var(--ease-color-neutral-200);
-}
-
-[data-theme="dark"] .ease-sun-icon {
-  opacity: 0;
-  transform: rotate(-90deg) scale(0);
-}
-
-[data-theme="dark"] .ease-moon-icon {
-  opacity: 1;
-  transform: rotate(0deg) scale(1);
-}
-
-/* ── Reduced motion ──────────────────────────────────────── */
-
-@media (prefers-reduced-motion: reduce) {
-  .ease-theme-switcher,
-  .ease-theme-icon svg {
-    transition: none;
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--ease-theme-switcher-size);
+    height: var(--ease-theme-switcher-size);
+    padding: 0;
+    border: none;
+    border-radius: var(--ease-radius-full);
+    background: var(--ease-theme-switcher-bg);
+    color: var(--ease-theme-switcher-color);
+    cursor: pointer;
+    overflow: hidden;
+    transition:
+      background var(--ease-speed-medium) var(--ease-ease),
+      color var(--ease-speed-medium) var(--ease-ease),
+      transform var(--ease-speed-fast) var(--ease-ease);
+    outline-offset: 2px;
   }
-}
 
-/* ── Size variants ───────────────────────────────────────── */
+  .ease-theme-switcher:hover {
+    transform: scale(1.1);
+  }
 
-.ease-theme-switcher-sm {
-  --ease-theme-switcher-size: 32px;
-}
+  .ease-theme-switcher:focus-visible {
+    outline: 2px solid var(--ease-color-primary);
+  }
 
-.ease-theme-switcher-lg {
-  --ease-theme-switcher-size: 48px;
-}
+  /* ── Icon container ──────────────────────────────────────── */
 
+  .ease-theme-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    position: relative;
+  }
+
+  .ease-theme-icon svg {
+    width: 60%;
+    height: 60%;
+    position: absolute;
+    transition:
+      opacity var(--ease-speed-medium) var(--ease-ease),
+      transform var(--ease-speed-medium) var(--ease-ease);
+  }
+
+  /* Sun icon visible in light mode, hidden in dark */
+  .ease-sun-icon {
+    opacity: 1;
+    transform: rotate(0deg) scale(1);
+  }
+
+  /* Moon icon hidden in light mode, visible in dark */
+  .ease-moon-icon {
+    opacity: 0;
+    transform: rotate(90deg) scale(0);
+  }
+
+  /* ── Dark mode state ─────────────────────────────────────── */
+
+  [data-theme="dark"] .ease-theme-switcher {
+    --ease-theme-switcher-bg: var(--ease-color-neutral-800);
+    --ease-theme-switcher-color: var(--ease-color-neutral-200);
+  }
+
+  [data-theme="dark"] .ease-sun-icon {
+    opacity: 0;
+    transform: rotate(-90deg) scale(0);
+  }
+
+  [data-theme="dark"] .ease-moon-icon {
+    opacity: 1;
+    transform: rotate(0deg) scale(1);
+  }
+
+  :root {
+    --ease-print-color-scheme: light;
+  }
+
+  [data-theme="dark"] {
+    --ease-print-color-scheme: dark;
+  }
+
+  @media print {
+    [data-theme="dark"] {
+      color-scheme: dark !important;
+    }
+  }
+
+  /* ── Reduced motion ──────────────────────────────────────── */
+
+  @media (prefers-reduced-motion: reduce) {
+    .ease-theme-switcher,
+    .ease-theme-icon svg {
+      transition: none;
+    }
+  }
+
+  /* ── Size variants ───────────────────────────────────────── */
+
+  .ease-theme-switcher-sm {
+    --ease-theme-switcher-size: 32px;
+  }
+
+  .ease-theme-switcher-lg {
+    --ease-theme-switcher-size: 48px;
+  }
 }

--- a/submissions/docs/core_changes-issue-30389/style.css
+++ b/submissions/docs/core_changes-issue-30389/style.css
@@ -1,56 +1,63 @@
 @layer easemotion-utilities {
-@media print {
-  .ease-no-print {
-    display: none !important;
-  }
-
-  .ease-only-print {
-    display: block !important;
-  }
-
-  .ease-print-break-inside-avoid {
-    break-inside: avoid;
-    page-break-inside: avoid;
-  }
-
-  .ease-print-break-before {
-    break-before: page;
-    page-break-before: always;
-  }
-
-  .ease-print-break-after {
-    break-after: page;
-    page-break-after: always;
-  }
-
-  .ease-print-avoid-break {
-    break-inside: avoid;
-    page-break-inside: avoid;
-  }
-
-  a[href]::after {
-    content: " (" attr(href) ")";
-    font-size: 0.8em;
-    color: #666;
-  }
-
-  img {
-    max-width: 100% !important;
-    page-break-inside: avoid;
-  }
-
-  table {
-    font-size: 0.8em;
-  }
-
-  h1, h2, h3, h4 {
-    page-break-after: avoid;
-  }
-}
-
-.ease-no-print {
   @media print {
-    display: none !important;
+    :root {
+      color-scheme: var(--ease-print-color-scheme, light);
+    }
+
+    .ease-no-print {
+      display: none !important;
+    }
+
+    .ease-only-print {
+      display: block !important;
+    }
+
+    .ease-print-break-inside-avoid {
+      break-inside: avoid;
+      page-break-inside: avoid;
+    }
+
+    .ease-print-break-before {
+      break-before: page;
+      page-break-before: always;
+    }
+
+    .ease-print-break-after {
+      break-after: page;
+      page-break-after: always;
+    }
+
+    .ease-print-avoid-break {
+      break-inside: avoid;
+      page-break-inside: avoid;
+    }
+
+    a[href]::after {
+      content: " (" attr(href) ")";
+      font-size: 0.8em;
+      color: #666;
+    }
+
+    img {
+      max-width: 100% !important;
+      page-break-inside: avoid;
+    }
+
+    table {
+      font-size: 0.8em;
+    }
+
+    h1,
+    h2,
+    h3,
+    h4 {
+      page-break-after: avoid;
+    }
   }
-}
+
+  .ease-no-print {
+    @media print {
+      display: none !important;
+    }
+  }
 }

--- a/submissions/docs/core_changes-issue-30435/README.md
+++ b/submissions/docs/core_changes-issue-30435/README.md
@@ -4,16 +4,17 @@ Pure CSS countdown timer with bar and ring variants. Uses `animation-duration` d
 
 ## Classes
 
-| Class | Purpose |
-|-------|---------|
-| `.ease-countdown` | Timer container |
-| `.ease-countdown-display` | Numeric display |
-| `.ease-countdown-bar` | Linear progress track |
-| `.ease-countdown-bar-fill` | Shrinking bar fill |
-| `.ease-countdown-ring` | Circular SVG container |
-| `.ease-countdown-ring-fill` | SVG arc (dashoffset animation) |
-| `.ease-countdown-ring-label` | Center label |
-| `.ease-countdown-sm` / `-lg` | Size variants |
+| Class                        | Purpose                                                         |
+| ---------------------------- | --------------------------------------------------------------- |
+| `.ease-countdown`            | Timer container                                                 |
+| `.ease-countdown-display`    | Numeric display                                                 |
+| `.ease-countdown-bar`        | Linear progress track                                           |
+| `.ease-countdown-bar-fill`   | Shrinking bar fill                                              |
+| `.ease-countdown-ring`       | Circular SVG container                                          |
+| `.ease-countdown-ring-fill`  | SVG arc (dashoffset animation)                                  |
+| `.ease-countdown-ring-label` | Center label                                                    |
+| `.ease-countdown-no-reduce`  | Bypasses prefers-reduced-motion override (for essential timers) |
+| `.ease-countdown-sm` / `-lg` | Size variants                                                   |
 
 ## CSS Variables
 

--- a/submissions/docs/core_changes-issue-30435/demo.html
+++ b/submissions/docs/core_changes-issue-30435/demo.html
@@ -1,79 +1,168 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Countdown — EaseMotion CSS</title>
-<link rel="stylesheet" href="style.css">
-<style>
-body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 700px; margin: 0 auto; padding: 2rem; background: #f9fafb; color: #111; }
-h1 { margin-bottom: .5rem; }
-section { background: #fff; padding: 1.5rem; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 1.5rem; }
-h2 { margin: 0 0 1rem; font-size: 1rem; color: #374151; }
-.grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1.5rem; text-align: center; }
-code { background: #e5e7eb; padding: .15em .4em; border-radius: 4px; }
-.note { background: #fffbeb; border-left: 3px solid #f59e0b; padding: .75rem 1rem; border-radius: 4px; font-size: .85rem; margin-bottom: 1rem; }
-.btn { padding: .5rem 1rem; border: 1px solid #d1d5db; border-radius: 6px; background: #fff; cursor: pointer; }
-.btn:hover { background: #f3f4f6; }
-</style>
-</head>
-<body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Countdown — EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        max-width: 700px;
+        margin: 0 auto;
+        padding: 2rem;
+        background: #f9fafb;
+        color: #111;
+      }
+      h1 {
+        margin-bottom: 0.5rem;
+      }
+      section {
+        background: #fff;
+        padding: 1.5rem;
+        border-radius: 12px;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+        margin-bottom: 1.5rem;
+      }
+      h2 {
+        margin: 0 0 1rem;
+        font-size: 1rem;
+        color: #374151;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 1.5rem;
+        text-align: center;
+      }
+      code {
+        background: #e5e7eb;
+        padding: 0.15em 0.4em;
+        border-radius: 4px;
+      }
+      .note {
+        background: #fffbeb;
+        border-left: 3px solid #f59e0b;
+        padding: 0.75rem 1rem;
+        border-radius: 4px;
+        font-size: 0.85rem;
+        margin-bottom: 1rem;
+      }
+      .btn {
+        padding: 0.5rem 1rem;
+        border: 1px solid #d1d5db;
+        border-radius: 6px;
+        background: #fff;
+        cursor: pointer;
+      }
+      .btn:hover {
+        background: #f3f4f6;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>CSS Countdown Timer</h1>
+    <p class="note">
+      Animation restarts on page reload. Uses <code>--ease-cd-duration</code> in
+      seconds.
+    </p>
 
-<h1>CSS Countdown Timer</h1>
-<p class="note">Animation restarts on page reload. Uses <code>--ease-cd-duration</code> in seconds.</p>
-
-<section>
-<h2>Linear Bar Countdown</h2>
-<div class="ease-countdown" style="--ease-cd-duration:10">
-  <div class="ease-countdown-display">10</div>
-  <div class="ease-countdown-bar">
-    <span class="ease-countdown-bar-fill"></span>
-  </div>
-</div>
-</section>
-
-<section>
-<h2>Ring Countdown (10s)</h2>
-<div class="ease-countdown" style="--ease-cd-duration:10">
-  <div class="ease-countdown-ring">
-    <svg viewBox="0 0 100 100">
-      <circle class="ease-countdown-ring-track" cx="50" cy="50" r="45"/>
-      <circle class="ease-countdown-ring-fill" cx="50" cy="50" r="45"/>
-    </svg>
-    <span class="ease-countdown-ring-label">10</span>
-  </div>
-</div>
-</section>
-
-<section>
-<h2>Size & Color Variants (30s)</h2>
-<div class="grid">
-  <div>
-    <div class="ease-countdown ease-countdown-sm" style="--ease-cd-duration:30;--ease-cd-color:#22c55e">
-      <div class="ease-countdown-ring">
-        <svg viewBox="0 0 100 100">
-          <circle class="ease-countdown-ring-track" cx="50" cy="50" r="45"/>
-          <circle class="ease-countdown-ring-fill" cx="50" cy="50" r="45"/>
-        </svg>
-        <span class="ease-countdown-ring-label">30</span>
+    <section>
+      <h2>Linear Bar Countdown</h2>
+      <div class="ease-countdown" style="--ease-cd-duration: 10">
+        <div class="ease-countdown-display">10</div>
+        <div class="ease-countdown-bar">
+          <span class="ease-countdown-bar-fill"></span>
+        </div>
       </div>
-      <div style="font-size:.8rem;color:#6b7280">Small / Green</div>
-    </div>
-  </div>
-  <div>
-    <div class="ease-countdown ease-countdown-lg" style="--ease-cd-duration:30;--ease-cd-color:#ef4444">
-      <div class="ease-countdown-ring">
-        <svg viewBox="0 0 100 100">
-          <circle class="ease-countdown-ring-track" cx="50" cy="50" r="45"/>
-          <circle class="ease-countdown-ring-fill" cx="50" cy="50" r="45"/>
-        </svg>
-        <span class="ease-countdown-ring-label">30</span>
-      </div>
-      <div style="font-size:.8rem;color:#6b7280">Large / Red</div>
-    </div>
-  </div>
-</div>
-</section>
+    </section>
 
-</body>
+    <section>
+      <h2>Ring Countdown (10s)</h2>
+      <div class="ease-countdown" style="--ease-cd-duration: 10">
+        <div class="ease-countdown-ring">
+          <svg viewBox="0 0 100 100">
+            <circle class="ease-countdown-ring-track" cx="50" cy="50" r="45" />
+            <circle class="ease-countdown-ring-fill" cx="50" cy="50" r="45" />
+          </svg>
+          <span class="ease-countdown-ring-label">10</span>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Size & Color Variants (30s)</h2>
+      <div class="grid">
+        <div>
+          <div
+            class="ease-countdown ease-countdown-sm"
+            style="--ease-cd-duration: 30; --ease-cd-color: #22c55e"
+          >
+            <div class="ease-countdown-ring">
+              <svg viewBox="0 0 100 100">
+                <circle
+                  class="ease-countdown-ring-track"
+                  cx="50"
+                  cy="50"
+                  r="45"
+                />
+                <circle
+                  class="ease-countdown-ring-fill"
+                  cx="50"
+                  cy="50"
+                  r="45"
+                />
+              </svg>
+              <span class="ease-countdown-ring-label">30</span>
+            </div>
+            <div style="font-size: 0.8rem; color: #6b7280">Small / Green</div>
+          </div>
+        </div>
+        <div>
+          <div
+            class="ease-countdown ease-countdown-lg"
+            style="--ease-cd-duration: 30; --ease-cd-color: #ef4444"
+          >
+            <div class="ease-countdown-ring">
+              <svg viewBox="0 0 100 100">
+                <circle
+                  class="ease-countdown-ring-track"
+                  cx="50"
+                  cy="50"
+                  r="45"
+                />
+                <circle
+                  class="ease-countdown-ring-fill"
+                  cx="50"
+                  cy="50"
+                  r="45"
+                />
+              </svg>
+              <span class="ease-countdown-ring-label">30</span>
+            </div>
+            <div style="font-size: 0.8rem; color: #6b7280">Large / Red</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Reduced Motion Bypass</h2>
+      <p class="note">
+        By default, if the user prefers reduced motion, the countdown animation
+        is disabled. The <code>.ease-countdown-no-reduce</code> class re-applies
+        the original duration for essential, time-sensitive countdowns.
+      </p>
+      <div
+        class="ease-countdown ease-countdown-no-reduce"
+        style="--ease-cd-duration: 15"
+      >
+        <div class="ease-countdown-display">15</div>
+        <div class="ease-countdown-bar">
+          <span class="ease-countdown-bar-fill"></span>
+        </div>
+      </div>
+    </section>
+  </body>
 </html>

--- a/submissions/docs/core_changes-issue-30435/style.css
+++ b/submissions/docs/core_changes-issue-30435/style.css
@@ -1,106 +1,130 @@
 @layer easemotion-components {
-@property --ease-cd-value {
-  syntax: "<integer>";
-  initial-value: 0;
-  inherits: true;
-}
-
-.ease-countdown {
-  --ease-cd-duration: 60;
-  --ease-cd-size: 6rem;
-  --ease-cd-color: var(--ease-primary, #3b82f6);
-  --ease-cd-track: var(--ease-bg-tertiary, #e5e7eb);
-  --ease-cd-font-size: 2rem;
-
-  display: inline-flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.ease-countdown-display {
-  --ease-cd-value: var(--ease-cd-duration);
-  font-size: var(--ease-cd-font-size);
-  font-weight: 700;
-  font-variant-numeric: tabular-nums;
-  color: var(--ease-cd-color);
-  line-height: 1;
-}
-
-.ease-countdown-bar {
-  width: 100%;
-  height: 4px;
-  background: var(--ease-cd-track);
-  border-radius: 999px;
-  overflow: hidden;
-}
-
-.ease-countdown-bar-fill {
-  display: block;
-  height: 100%;
-  width: 100%;
-  background: var(--ease-cd-color);
-  animation: ease-cd-fill calc(var(--ease-cd-duration) * 1s) linear forwards;
-  transform-origin: left;
-}
-
-.ease-countdown-ring {
-  --ease-cd-ring-size: var(--ease-cd-size);
-  width: var(--ease-cd-ring-size);
-  height: var(--ease-cd-ring-size);
-  position: relative;
-}
-
-.ease-countdown-ring svg {
-  width: 100%;
-  height: 100%;
-  transform: rotate(-90deg);
-}
-
-.ease-countdown-ring-track {
-  fill: none;
-  stroke: var(--ease-cd-track);
-  stroke-width: 6;
-}
-
-.ease-countdown-ring-fill {
-  fill: none;
-  stroke: var(--ease-cd-color);
-  stroke-width: 6;
-  stroke-linecap: round;
-  stroke-dasharray: 283;
-  stroke-dashoffset: 0;
-  animation: ease-cd-ring calc(var(--ease-cd-duration) * 1s) linear forwards;
-}
-
-.ease-countdown-ring-label {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(var(--ease-cd-size) / 3);
-  font-weight: 700;
-  color: var(--ease-cd-color);
-}
-
-.ease-countdown-sm { --ease-cd-size: 4rem; --ease-cd-font-size: 1.25rem; }
-.ease-countdown-lg { --ease-cd-size: 8rem; --ease-cd-font-size: 2.5rem; }
-
-@keyframes ease-cd-fill {
-  from { transform: scaleX(1); }
-  to   { transform: scaleX(0); }
-}
-
-@keyframes ease-cd-ring {
-  from { stroke-dashoffset: 0; }
-  to   { stroke-dashoffset: 283; }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .ease-countdown-bar-fill,
-  .ease-countdown-ring-fill {
-    animation: none;
+  @property --ease-cd-value {
+    syntax: "<integer>";
+    initial-value: 0;
+    inherits: true;
   }
-}
+
+  .ease-countdown {
+    --ease-cd-duration: 60;
+    --ease-cd-size: 6rem;
+    --ease-cd-color: var(--ease-primary, #3b82f6);
+    --ease-cd-track: var(--ease-bg-tertiary, #e5e7eb);
+    --ease-cd-font-size: 2rem;
+
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .ease-countdown-display {
+    --ease-cd-value: var(--ease-cd-duration);
+    font-size: var(--ease-cd-font-size);
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    color: var(--ease-cd-color);
+    line-height: 1;
+  }
+
+  .ease-countdown-bar {
+    width: 100%;
+    height: 4px;
+    background: var(--ease-cd-track);
+    border-radius: 999px;
+    overflow: hidden;
+  }
+
+  .ease-countdown-bar-fill {
+    display: block;
+    height: 100%;
+    width: 100%;
+    background: var(--ease-cd-color);
+    animation: ease-cd-fill calc(var(--ease-cd-duration) * 1s) linear forwards;
+    transform-origin: left;
+  }
+
+  .ease-countdown-ring {
+    --ease-cd-ring-size: var(--ease-cd-size);
+    width: var(--ease-cd-ring-size);
+    height: var(--ease-cd-ring-size);
+    position: relative;
+  }
+
+  .ease-countdown-ring svg {
+    width: 100%;
+    height: 100%;
+    transform: rotate(-90deg);
+  }
+
+  .ease-countdown-ring-track {
+    fill: none;
+    stroke: var(--ease-cd-track);
+    stroke-width: 6;
+  }
+
+  .ease-countdown-ring-fill {
+    fill: none;
+    stroke: var(--ease-cd-color);
+    stroke-width: 6;
+    stroke-linecap: round;
+    stroke-dasharray: 283;
+    stroke-dashoffset: 0;
+    animation: ease-cd-ring calc(var(--ease-cd-duration) * 1s) linear forwards;
+  }
+
+  .ease-countdown-ring-label {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: calc(var(--ease-cd-size) / 3);
+    font-weight: 700;
+    color: var(--ease-cd-color);
+  }
+
+  .ease-countdown-sm {
+    --ease-cd-size: 4rem;
+    --ease-cd-font-size: 1.25rem;
+  }
+  .ease-countdown-lg {
+    --ease-cd-size: 8rem;
+    --ease-cd-font-size: 2.5rem;
+  }
+
+  @keyframes ease-cd-fill {
+    from {
+      transform: scaleX(1);
+    }
+    to {
+      transform: scaleX(0);
+    }
+  }
+
+  @keyframes ease-cd-ring {
+    from {
+      stroke-dashoffset: 0;
+    }
+    to {
+      stroke-dashoffset: 283;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    /* Disable animation by default for reduced motion */
+    .ease-countdown:not(.ease-countdown-no-reduce) .ease-countdown-bar-fill,
+    .ease-countdown:not(.ease-countdown-no-reduce) .ease-countdown-ring-fill {
+      animation: none;
+    }
+
+    /* Re-apply the animation with explicit duration using shorthand to override the cascade */
+    .ease-countdown.ease-countdown-no-reduce .ease-countdown-bar-fill {
+      animation: ease-cd-fill calc(var(--ease-cd-duration) * 1s) linear forwards !important;
+    }
+
+    .ease-countdown.ease-countdown-no-reduce .ease-countdown-ring-fill {
+      animation: ease-cd-ring calc(var(--ease-cd-duration) * 1s) linear forwards !important;
+    }
+  }
 }


### PR DESCRIPTION
Countdown Timer & prefers-reduced-motion Conflict (#30560)

  • Countdown Timer CSS ( submissions/docs/core_changes-issue-30435/style.css ):
      • Updated the  @media (prefers-reduced-motion: reduce)  block to disable animations
      by default ( :not(.ease-countdown-no-reduce) ).
      • Added styling for the  .ease-countdown-no-reduce  class using the  animation 
      shorthand with explicit duration and  !important  to override the cascade from the
      general reduced-motion utility.
  • Documentation & Demo ( submissions/docs/core_changes-issue-30435/ ):
      • Documented the  .ease-countdown-no-reduce  class in  README.md .
      • Added a section demonstrating the  .ease-countdown-no-reduce  bypass behavior in
      demo.html .