### PR TITLE
fix: add :focus-visible styles to base ease-btn class

### DIFF
--- a/submissions/examples/fix-btn-focus-31406/README.md
+++ b/submissions/examples/fix-btn-focus-31406/README.md
@@ -1,0 +1,10 @@
+# Fix Button Focus Visible (Issue #9804)
+
+1. **What does this do?**  
+   Adds `:focus-visible` styles to the base `.ease-btn` component to improve keyboard accessibility.
+
+2. **How is it used?**  
+   Apply these additional styles to the existing `.ease-btn` class definition.
+
+3. **Why is it useful?**  
+   Resolves bug #9804. It ensures keyboard users get a clear, distinct focus ring when tabbing through buttons, while preventing unnecessary focus rings when clicking with a mouse.

--- a/submissions/examples/fix-btn-focus-31406/demo.html
+++ b/submissions/examples/fix-btn-focus-31406/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fix Button Focus Visible Demo</title>
+  <link rel="stylesheet" href="../../../easemotion.min.css">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+      margin: 0;
+      gap: 1rem;
+      font-family: system-ui, -apple-system, sans-serif;
+      background-color: #f9fafb;
+    }
+  </style>
+</head>
+<body>
+  <!-- Use Tab key to navigate to these buttons -->
+  <button class="ease-btn">Default Button</button>
+  <button class="ease-btn ease-btn-primary">Primary Button</button>
+</body>
+</html>

--- a/submissions/examples/fix-btn-focus-31406/style.css
+++ b/submissions/examples/fix-btn-focus-31406/style.css
@@ -1,0 +1,10 @@
+.ease-btn:focus-visible {
+  outline: 2px solid var(--ease-color-primary-500, #3b82f6);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px var(--ease-color-primary-100, #dbeafe);
+}
+
+/* Optional generic removal of default outline for non-keyboard focus */
+.ease-btn:focus:not(:focus-visible) {
+  outline: none;
+}


### PR DESCRIPTION
Fixes #31406.

This PR adds `:focus-visible` outline styling to the `.ease-btn` class to ensure clear focus rings for keyboard users while preventing unnecessary persistent outlines when mouse users click the button.