### PR TITLE
feat: add Animated Tooltip React Component (ease-tooltip-viidhii) #30877

### DIFF
--- a/submissions/react/ease-tooltip-viidhii/README.md
+++ b/submissions/react/ease-tooltip-viidhii/README.md
@@ -1,0 +1,29 @@
+# Animated Tooltip (ease-tooltip-viidhii)
+
+A reusable React tooltip component that leverages EaseMotion utility classes for smooth entrance animations.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `content` | `string` | required | The text to display inside the tooltip bubble. |
+| `position` | `'top' \| 'bottom' \| 'left' \| 'right'` | `'top'` | The placement of the tooltip relative to its child. |
+| `children` | `ReactNode` | required | The wrapped element that triggers the tooltip on hover. |
+
+## Usage
+
+```jsx
+import React from 'react';
+import Tooltip from './Tooltip';
+import './style.css';
+
+function App() {
+  return (
+    <Tooltip content="This is a top tooltip!" position="top">
+      <button className="ease-btn ease-btn-primary">Hover Me</button>
+    </Tooltip>
+  );
+}
+
+export default App;
+```

--- a/submissions/react/ease-tooltip-viidhii/Tooltip.jsx
+++ b/submissions/react/ease-tooltip-viidhii/Tooltip.jsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import './style.css';
+
+const Tooltip = ({ content, position = 'top', children }) => {
+  const [isHovered, setIsHovered] = useState(false);
+
+  const getPositionStyles = () => {
+    switch (position) {
+      case 'bottom':
+        return { top: '100%', left: '50%', transform: 'translateX(-50%)', marginTop: '8px', zIndex: 10 };
+      case 'left':
+        return { top: '50%', right: '100%', transform: 'translateY(-50%)', marginRight: '8px', zIndex: 10 };
+      case 'right':
+        return { top: '50%', left: '100%', transform: 'translateY(-50%)', marginLeft: '8px', zIndex: 10 };
+      case 'top':
+      default:
+        return { bottom: '100%', left: '50%', transform: 'translateX(-50%)', marginBottom: '8px', zIndex: 10 };
+    }
+  };
+
+  return (
+    <div 
+      className="ease-tooltip-wrapper"
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      {children}
+      {isHovered && (
+        <div 
+          className="ease-absolute ease-fade-in ease-slide-up ease-card-glass ease-padding-16"
+          style={{ 
+            ...getPositionStyles(),
+            whiteSpace: 'nowrap'
+          }}
+        >
+          {content}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Tooltip;

--- a/submissions/react/ease-tooltip-viidhii/demo.html
+++ b/submissions/react/ease-tooltip-viidhii/demo.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Tooltip Demo</title>
+  
+  <!-- EaseMotion Core CSS -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
+  
+  <!-- Local Component Styles -->
+  <link rel="stylesheet" href="style.css" />
+  
+  <!-- React 18 & ReactDOM 18 -->
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  
+  <!-- Babel -->
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+
+  <style>
+    body {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      background-color: #f3f4f6;
+      margin: 0;
+    }
+    .demo-container {
+      display: flex;
+      gap: 3rem;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+
+  <script type="text/babel">
+    const { useState } = React;
+
+    const Tooltip = ({ content, position = 'top', children }) => {
+      const [isHovered, setIsHovered] = useState(false);
+
+      const getPositionStyles = () => {
+        switch (position) {
+          case 'bottom':
+            return { top: '100%', left: '50%', transform: 'translateX(-50%)', marginTop: '8px', zIndex: 10 };
+          case 'left':
+            return { top: '50%', right: '100%', transform: 'translateY(-50%)', marginRight: '8px', zIndex: 10 };
+          case 'right':
+            return { top: '50%', left: '100%', transform: 'translateY(-50%)', marginLeft: '8px', zIndex: 10 };
+          case 'top':
+          default:
+            return { bottom: '100%', left: '50%', transform: 'translateX(-50%)', marginBottom: '8px', zIndex: 10 };
+        }
+      };
+
+      return (
+        <div 
+          className="ease-tooltip-wrapper"
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+        >
+          {children}
+          {isHovered && (
+            <div 
+              className="ease-absolute ease-fade-in ease-slide-up ease-card-glass ease-padding-16"
+              style={{ 
+                ...getPositionStyles(),
+                whiteSpace: 'nowrap'
+              }}
+            >
+              {content}
+            </div>
+          )}
+        </div>
+      );
+    };
+
+    const App = () => {
+      return (
+        <div className="demo-container">
+          <Tooltip content="Tooltip on top" position="top">
+            <button className="ease-btn ease-btn-primary">Top Tooltip</button>
+          </Tooltip>
+
+          <Tooltip content="Tooltip on bottom" position="bottom">
+            <button className="ease-btn ease-btn-primary">Bottom Tooltip</button>
+          </Tooltip>
+
+          <Tooltip content="Tooltip on left" position="left">
+            <button className="ease-btn ease-btn-primary">Left Tooltip</button>
+          </Tooltip>
+
+          <Tooltip content="Tooltip on right" position="right">
+            <button className="ease-btn ease-btn-primary">Right Tooltip</button>
+          </Tooltip>
+        </div>
+      );
+    };
+
+    const root = ReactDOM.createRoot(document.getElementById('root'));
+    root.render(<App />);
+  </script>
+</body>
+</html>

--- a/submissions/react/ease-tooltip-viidhii/style.css
+++ b/submissions/react/ease-tooltip-viidhii/style.css
@@ -1,0 +1,5 @@
+.ease-tooltip-wrapper {
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #30877 by adding a reusable React `<Tooltip>` component to the `submissions/react/` track. It utilizes EaseMotion's existing utility classes (`ease-fade-in`, `ease-slide-up`, `ease-card-glass`) to provide a smooth, animated, and state-driven tooltip element.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A reusable React component that wraps any element in a beautifully animated tooltip bubble on hover.

**How does a developer use it?**

```jsx
<Tooltip content="This is a top tooltip!" position="top">
  <button className="ease-btn ease-btn-primary">Hover Me</button>
</Tooltip>
```

**Why does it fit EaseMotion CSS?**

This component proves that EaseMotion's animation-first, human-readable philosophy extends beautifully into modern frontend component frameworks like React. By simply applying `ease-fade-in` and `ease-slide-up` inside a state-driven wrapper, developers can achieve premium micro-interactions with zero custom keyframes.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This submission targets the React Track as outlined in `CONTRIBUTING.md`. Even though `demo.html` is technically a standard track requirement, I have included a standalone Babel/React 18 `demo.html` file so you can easily review and test the component directly in the browser without spinning up a dev server!

Resolves #30877

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
