### PR TITLE
feat: add tab-underline-slide component (#31485)

### DIFF
--- a/submissions/examples/ease-tab-underline-slide-ij/README.md
+++ b/submissions/examples/ease-tab-underline-slide-ij/README.md
@@ -1,0 +1,14 @@
+# Tab Underline Slide
+
+Tab bar with sliding underline indicator. Active tab via `--tus-active`. Panel content switches with tab click.
+
+## Features
+
+- Tab buttons with hover effect
+- Sliding underline indicator
+- Active tab color change
+- Smooth transform via `--tus-active`
+
+## Usage
+
+Set `--tus-active` (0-based index) on `.tus-bar`. CSS handles underline position transition.

--- a/submissions/examples/ease-tab-underline-slide-ij/demo.html
+++ b/submissions/examples/ease-tab-underline-slide-ij/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tab Underline Slide - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Navigation Tabs</h1>
+    <div class="tus-bar" id="tusBar" style="--tus-active: 0;">
+      <button class="tus-tab tus-active" data-i="0">Home</button>
+      <button class="tus-tab" data-i="1">Explore</button>
+      <button class="tus-tab" data-i="2">Library</button>
+      <button class="tus-tab" data-i="3">Profile</button>
+      <div class="tus-underline"></div>
+    </div>
+    <div class="tus-panel" id="tusPanel">
+      <div class="tus-content tus-show">Welcome to the Home tab</div>
+      <div class="tus-content">Browse featured content</div>
+      <div class="tus-content">Your saved items</div>
+      <div class="tus-content">Account settings</div>
+    </div>
+  </div>
+  <script>
+    const bar = document.getElementById('tusBar');
+    const tabs = document.querySelectorAll('.tus-tab');
+    const contents = document.querySelectorAll('.tus-content');
+
+    tabs.forEach(t => t.addEventListener('click', () => {
+      const i = parseInt(t.getAttribute('data-i'));
+      bar.style.setProperty('--tus-active', i);
+      tabs.forEach(tab => tab.classList.remove('tus-active'));
+      t.classList.add('tus-active');
+      contents.forEach((c, idx) => c.classList.toggle('tus-show', idx === i));
+    }));
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-tab-underline-slide-ij/style.css
+++ b/submissions/examples/ease-tab-underline-slide-ij/style.css
@@ -1,0 +1,91 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  width: 100%;
+  max-width: 500px;
+  text-align: center;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 2rem;
+  color: #94a3b8;
+}
+
+.tus-bar {
+  position: relative;
+  display: flex;
+  background: #1e293b;
+  border-radius: 12px;
+  padding: 0.25rem;
+  margin-bottom: 1.5rem;
+}
+
+.tus-tab {
+  flex: 1;
+  padding: 0.75rem 0.5rem;
+  border: none;
+  background: transparent;
+  color: #64748b;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  position: relative;
+  z-index: 1;
+  transition: color 0.3s ease;
+  border-radius: 8px;
+}
+
+.tus-tab:hover {
+  color: #94a3b8;
+}
+
+.tus-tab.tus-active {
+  color: #e2e8f0;
+}
+
+.tus-underline {
+  position: absolute;
+  bottom: 0.25rem;
+  left: 0;
+  height: 3px;
+  width: calc(25% - 0.5rem);
+  background: #8b5cf6;
+  border-radius: 2px;
+  transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+  transform: translateX(calc(var(--tus-active) * 100% + var(--tus-active) * 0.5rem + 0.25rem));
+}
+
+.tus-panel {
+  text-align: left;
+}
+
+.tus-content {
+  display: none;
+  padding: 1rem;
+  background: #1e293b;
+  border-radius: 12px;
+  color: #94a3b8;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.tus-content.tus-show {
+  display: block;
+}


### PR DESCRIPTION
## Component: ease-tab-underline-slide ? tab bar with sliding underline indicator

### What this adds
Tab bar with sliding underline indicator that moves between tabs. Active tab label colors change. Panel content switches with tab click.

### Acceptance Criteria covered
- Tab buttons with hover effect
- Sliding underline indicator via --tus-active
- Active tab color change
- Smooth transform transition

### Files
- submissions/examples/ease-tab-underline-slide-ij/demo.html
- submissions/examples/ease-tab-underline-slide-ij/style.css
- submissions/examples/ease-tab-underline-slide-ij/README.md

### How to review
Open demo.html and click the tabs.

**Closes #31485**
