### PR TITLE
feat: add tag-removable-slide component (#31489)

### DIFF
--- a/submissions/examples/ease-tag-removable-slide-ij/README.md
+++ b/submissions/examples/ease-tag-removable-slide-ij/README.md
@@ -1,0 +1,14 @@
+# Tag Removable Slide
+
+Removable tag/chip with slide-out animation on dismiss. Tags have label and close button with smooth transform.
+
+## Features
+
+- Tag chip with label
+- Close button with slide-out via `--trs-hidden`
+- Transform slide + opacity animation
+- Smooth CSS transition
+
+## Usage
+
+Set `--trs-hidden` to `1` to trigger slide-out. JS handles the close button click and delayed removal.

--- a/submissions/examples/ease-tag-removable-slide-ij/demo.html
+++ b/submissions/examples/ease-tag-removable-slide-ij/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tag Removable Slide - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Topics</h1>
+    <div class="trs-tags" id="trsTags">
+      <span class="trs-tag" style="--trs-hidden: 0;">CSS <button class="trs-close" data-idx="0">&times;</button></span>
+      <span class="trs-tag" style="--trs-hidden: 0;">HTML <button class="trs-close" data-idx="1">&times;</button></span>
+      <span class="trs-tag" style="--trs-hidden: 0;">JavaScript <button class="trs-close" data-idx="2">&times;</button></span>
+      <span class="trs-tag" style="--trs-hidden: 0;">React <button class="trs-close" data-idx="3">&times;</button></span>
+      <span class="trs-tag" style="--trs-hidden: 0;">Node <button class="trs-close" data-idx="4">&times;</button></span>
+    </div>
+  </div>
+  <script>
+    document.querySelectorAll('.trs-close').forEach(btn => btn.addEventListener('click', function(e) {
+      const tag = this.parentElement;
+      const idx = parseInt(this.getAttribute('data-idx'));
+      tag.style.setProperty('--trs-hidden', 1);
+      setTimeout(() => { tag.style.display = 'none'; }, 350);
+      e.stopPropagation();
+    }));
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-tag-removable-slide-ij/style.css
+++ b/submissions/examples/ease-tag-removable-slide-ij/style.css
@@ -1,0 +1,71 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 2rem;
+  color: #94a3b8;
+}
+
+.trs-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: center;
+  max-width: 400px;
+}
+
+.trs-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.75rem;
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 20px;
+  font-size: 0.85rem;
+  color: #e2e8f0;
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.3s ease;
+  transform: translateX(0);
+  opacity: 1;
+}
+
+[style*="--trs-hidden: 1"] {
+  transform: translateX(20px);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.trs-close {
+  border: none;
+  background: transparent;
+  color: #94a3b8;
+  font-size: 1.1rem;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0;
+  transition: color 0.2s ease;
+}
+
+.trs-close:hover {
+  color: #e94560;
+}


### PR DESCRIPTION
## Component: ease-tag-removable-slide ? removable tag with slide-out animation

### What this adds
Removable tag/chip with slide-out animation on dismiss. Tags have label and close button with smooth transform.

### Acceptance Criteria covered
- Tag chip with label
- Close button with slide-out via --trs-hidden
- Transform slide + opacity animation
- Smooth CSS transition

### Files
- submissions/examples/ease-tag-removable-slide-ij/demo.html
- submissions/examples/ease-tag-removable-slide-ij/style.css
- submissions/examples/ease-tag-removable-slide-ij/README.md

### How to review
Open demo.html and click the close button on tags.

**Closes #31489**
