### PR TITLE
feat: add modal-scale-backdrop component (#31497)

### DIFF
--- a/submissions/examples/ease-modal-scale-backdrop-ij/README.md
+++ b/submissions/examples/ease-modal-scale-backdrop-ij/README.md
@@ -1,0 +1,14 @@
+# Modal Scale Backdrop
+
+Modal dialog with backdrop overlay. Modal scales in from center with backdrop fade.
+
+## Features
+
+- Backdrop overlay with fade
+- Modal content with scale-in
+- Close button functionality
+- Smooth CSS transitions via `--msb-open`
+
+## Usage
+
+Set `--msb-open` to `1` on `.msb-backdrop` to show modal. JS handles open/close click events.

--- a/submissions/examples/ease-modal-scale-backdrop-ij/demo.html
+++ b/submissions/examples/ease-modal-scale-backdrop-ij/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Modal Scale Backdrop - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Modal Dialog</h1>
+    <button id="msbOpen" class="msb-trigger">Open Modal</button>
+    <div class="msb-backdrop" id="msbBackdrop" style="--msb-open: 0;">
+      <div class="msb-modal">
+        <div class="msb-header">
+          <h2>Confirmation</h2>
+          <button class="msb-x" id="msbClose">&times;</button>
+        </div>
+        <div class="msb-body">
+          <p>Are you sure you want to proceed? This action cannot be undone.</p>
+        </div>
+        <div class="msb-footer">
+          <button class="msb-btn msb-cancel" id="msbCancel">Cancel</button>
+          <button class="msb-btn msb-confirm">Confirm</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script>
+    const backdrop = document.getElementById('msbBackdrop');
+    function openModal() { backdrop.style.setProperty('--msb-open', '1'); }
+    function closeModal() { backdrop.style.setProperty('--msb-open', '0'); }
+
+    document.getElementById('msbOpen').addEventListener('click', openModal);
+    document.getElementById('msbClose').addEventListener('click', closeModal);
+    document.getElementById('msbCancel').addEventListener('click', closeModal);
+    backdrop.addEventListener('click', (e) => { if (e.target === backdrop) closeModal(); });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-modal-scale-backdrop-ij/style.css
+++ b/submissions/examples/ease-modal-scale-backdrop-ij/style.css
@@ -1,0 +1,142 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 2rem;
+  color: #94a3b8;
+}
+
+.msb-trigger {
+  padding: 0.85rem 2rem;
+  border: none;
+  border-radius: 10px;
+  background: linear-gradient(135deg, #8b5cf6, #3b82f6);
+  color: #fff;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.msb-trigger:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(139, 92, 246, 0.3);
+}
+
+.msb-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 100;
+}
+
+[style*="--msb-open: 1"] {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.msb-modal {
+  background: #1e293b;
+  border-radius: 16px;
+  width: 90%;
+  max-width: 400px;
+  transform: scale(0.85);
+  transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+  overflow: hidden;
+}
+
+[style*="--msb-open: 1"] .msb-modal {
+  transform: scale(1);
+}
+
+.msb-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 1.5rem 0.5rem;
+}
+
+.msb-header h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.msb-x {
+  border: none;
+  background: transparent;
+  color: #64748b;
+  font-size: 1.5rem;
+  cursor: pointer;
+  line-height: 1;
+  transition: color 0.2s ease;
+}
+
+.msb-x:hover {
+  color: #e94560;
+}
+
+.msb-body {
+  padding: 0.75rem 1.5rem;
+  color: #94a3b8;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.msb-footer {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  padding: 0.75rem 1.5rem 1.25rem;
+}
+
+.msb-btn {
+  padding: 0.55rem 1.25rem;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  background: transparent;
+  color: #e2e8f0;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.msb-btn:hover {
+  background: #334155;
+}
+
+.msb-confirm {
+  background: #8b5cf6;
+  border-color: #8b5cf6;
+  color: #fff;
+}
+
+.msb-confirm:hover {
+  background: #7c3aed;
+}


### PR DESCRIPTION
## Component: ease-modal-scale-backdrop ? modal with scale-in and backdrop fade

### What this adds
Modal dialog with backdrop overlay. Modal scales in from center with backdrop fade. Close button and cancel functionality.

### Acceptance Criteria covered
- Backdrop overlay with fade
- Modal content with scale-in
- Close button functionality
- Smooth CSS transitions via --msb-open

### Files
- submissions/examples/ease-modal-scale-backdrop-ij/demo.html
- submissions/examples/ease-modal-scale-backdrop-ij/style.css
- submissions/examples/ease-modal-scale-backdrop-ij/README.md

### How to review
Open demo.html and click Open Modal button.

**Closes #31497**
