### PR TITLE
feat(examples): add CSS Text Reveal / Typewriter animation utility

### DIFF
--- a/submissions/examples/text-reveal-typewriter/README.md
+++ b/submissions/examples/text-reveal-typewriter/README.md
@@ -1,0 +1,21 @@
+# Text Reveal Typewriter
+
+A CSS-only typewriter text reveal animation — pure CSS.
+
+## Features
+- Typewriter typing effect with steps()
+- Blinking cursor via border-right
+- Customizable speed via --speed property
+
+## Usage
+```html
+<div class="typewriter">
+  <span class="type-text">Your text here</span>
+</div>
+```
+
+## Browser Support
+- Chrome 1+, Firefox 3.5+, Safari 3.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript

--- a/submissions/examples/text-reveal-typewriter/demo.html
+++ b/submissions/examples/text-reveal-typewriter/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Text Reveal Typewriter — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Text Reveal Typewriter</h1>
+  <p class="subtitle">A CSS-only typewriter text reveal animation — pure CSS.</p>
+  <section><h2>Demo</h2><div class="typewriter"><span class="type-text">Hello, welcome to EaseMotion CSS!</span></div><div class="typewriter" style="--speed:4s"><span class="type-text">Typewriter effect — no JavaScript needed.</span></div></section>
+  <section><h2>How It Works</h2><p>The text uses <code>overflow: hidden</code> with a <code>steps()</code> animation on <code>width</code> from 0 to full width, combined with a blinking cursor <code>::after</code> pseudo-element.</p></section>
+</body>
+</html>

--- a/submissions/examples/text-reveal-typewriter/style.css
+++ b/submissions/examples/text-reveal-typewriter/style.css
@@ -1,0 +1,12 @@
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+body { background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; padding: 4rem 1rem; text-align: center; }
+h1 { color: #fff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+.subtitle { color: #9ca3af; margin-bottom: 2rem; }
+section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; max-width: 500px; margin-left: auto; margin-right: auto; text-align: left; }
+h2 { color: #fff; font-size: 1.1rem; margin-bottom: 0.75rem; }
+p { color: #9ca3af; line-height: 1.8; margin-top: 1rem; }
+code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+.typewriter { display: inline-block; margin-bottom: 1rem; --speed: 3s; }
+.type-text { display: inline-block; overflow: hidden; white-space: nowrap; border-right: 2px solid #6366f1; width: 0; animation: typewrite var(--speed, 3s) steps(30) forwards; }
+.typewriter:last-child .type-text { border-color: #f97316; }
+@keyframes typewrite { to { width: 100%; } }


### PR DESCRIPTION
Closes #30438 — A CSS-only typewriter text reveal animation with steps().