### PR TITLE
feat: add image zoom magnify component

### DIFF
--- a/submissions/examples/image-zoom-magnify-aan22/README.md
+++ b/submissions/examples/image-zoom-magnify-aan22/README.md
@@ -1,0 +1,16 @@
+# Image Zoom Magnify
+
+## What does this do?
+A hover-activated magnifying lens that follows the cursor over an image, showing a zoomed-in view of the area beneath it — useful for product photos, galleries, and detail previews.
+
+## How is it used?
+```html
+<div class="zoom-magnify-container">
+  <img class="zoom-magnify-img" src="your-image.jpg" alt="Description">
+  <div class="zoom-magnify-lens"></div>
+</div>
+```
+Hovering over `.zoom-magnify-container` reveals `.zoom-magnify-lens`, a circular lens that tracks the mouse and renders a magnified (2.5x) view of the image at that point using a small amount of vanilla JS to position the lens and background.
+
+## Why is it useful?
+EaseMotion CSS focuses on smooth, purposeful motion and interaction feedback. This component gives users an intuitive way to inspect image detail without leaving the page or opening a modal, fitting the framework's philosophy of lightweight, delightful micro-interactions.

--- a/submissions/examples/image-zoom-magnify-aan22/demo.html
+++ b/submissions/examples/image-zoom-magnify-aan22/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Image Zoom Magnify Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <h1>Image Zoom Magnify</h1>
+  <p>Hover over the image to see the magnify lens follow your cursor.</p>
+
+  <div class="zoom-magnify-container">
+    <img
+      class="zoom-magnify-img"
+      src="https://images.unsplash.com/photo-1501785888041-af3ef285b470?w=800"
+      alt="Sample landscape used to demo the zoom magnify effect"
+    >
+    <div class="zoom-magnify-lens"></div>
+  </div>
+
+  <script>
+    const container = document.querySelector('.zoom-magnify-container');
+    const img = document.querySelector('.zoom-magnify-img');
+    const lens = document.querySelector('.zoom-magnify-lens');
+
+    container.addEventListener('mouseenter', () => {
+      lens.style.display = 'block';
+      lens.style.backgroundImage = `url(${img.src})`;
+    });
+
+    container.addEventListener('mousemove', (e) => {
+      const rect = container.getBoundingClientRect();
+      let x = e.clientX - rect.left;
+      let y = e.clientY - rect.top;
+
+      const lensSize = lens.offsetWidth;
+      x = Math.max(lensSize / 2, Math.min(x, rect.width - lensSize / 2));
+      y = Math.max(lensSize / 2, Math.min(y, rect.height - lensSize / 2));
+
+      lens.style.left = `${x - lensSize / 2}px`;
+      lens.style.top = `${y - lensSize / 2}px`;
+
+      const zoomFactor = 2.5;
+      const bgX = (x / rect.width) * 100;
+      const bgY = (y / rect.height) * 100;
+
+      lens.style.backgroundSize = `${rect.width * zoomFactor}px ${rect.height * zoomFactor}px`;
+      lens.style.backgroundPosition = `${bgX}% ${bgY}%`;
+    });
+
+    container.addEventListener('mouseleave', () => {
+      lens.style.display = 'none';
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/image-zoom-magnify-aan22/style.css
+++ b/submissions/examples/image-zoom-magnify-aan22/style.css
@@ -1,0 +1,49 @@
+body {
+  font-family: system-ui, sans-serif;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 60px 20px;
+  background: #0f0f10;
+  color: #f5f5f5;
+}
+
+h1 {
+  margin-bottom: 4px;
+}
+
+p {
+  color: #b3b3b3;
+  margin-bottom: 32px;
+}
+
+.zoom-magnify-container {
+  position: relative;
+  width: 500px;
+  max-width: 90vw;
+  border-radius: 12px;
+  overflow: hidden;
+  cursor: crosshair;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+}
+
+.zoom-magnify-img {
+  display: block;
+  width: 100%;
+  height: auto;
+  user-select: none;
+  pointer-events: none;
+}
+
+.zoom-magnify-lens {
+  display: none;
+  position: absolute;
+  width: 160px;
+  height: 160px;
+  border-radius: 50%;
+  border: 3px solid #ffffff;
+  background-repeat: no-repeat;
+  pointer-events: none;
+  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.15), 0 8px 24px rgba(0, 0, 0, 0.5);
+  transition: opacity 0.15s ease;
+}


### PR DESCRIPTION
Closes #29742

## Pull Request Description
Adds a self-contained HTML/CSS/JS image zoom magnify component for EaseMotion CSS — a hover-activated magnifying lens that follows the cursor.

---
## Type of Change
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/image-zoom-magnify-aan22/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A hover-activated magnifying lens that follows the cursor over an image, showing a zoomed-in view of the area beneath it.

**How does a developer use it?**
```html
<div class="zoom-magnify-container">
  <img class="zoom-magnify-img" src="your-image.jpg" alt="Description">
  <div class="zoom-magnify-lens"></div>
</div>
```

**Why does it fit EaseMotion CSS?**
It gives users an intuitive, lightweight way to inspect image detail without leaving the page or opening a modal — matching EaseMotion's philosophy of smooth, delightful micro-interactions.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---
## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---
## Notes for Maintainer
Demo uses an external Unsplash image URL for the sample photo — happy to swap to a local/base64 image if preferred for full self-containment.