### PR TITLE
[Feat] #28372 — Add underwater maglev transit operating platform showcase (unique folder)

### DIFF
--- a/submissions/examples/underwater-maglev-transit-28372-ag/README.md
+++ b/submissions/examples/underwater-maglev-transit-28372-ag/README.md
@@ -1,0 +1,11 @@
+# Underwater Maglev Rapid Transit Operating Platform
+
+This is the UI Design & Transit Station Operating Platform Showcase for **Underwater Maglev Rapid Transit Operating Platform (Phase #824)**.
+
+---
+
+## Features
+- **Velocity Vector Indicator:** Subsea maglev velocity meters.
+- **Levitation Fields:** Displays electromagnetic suspension index.
+- **Track Depth Level:** Outer water column indicators.
+- **Emergency Braking Switch:** Interactive brakes bypass control loops.

--- a/submissions/examples/underwater-maglev-transit-28372-ag/demo.html
+++ b/submissions/examples/underwater-maglev-transit-28372-ag/demo.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Underwater Maglev Operating Platform — EaseMotion CSS</title>
+  <meta name="description" content="Visual transit operating platform console demonstrating subsea maglev transit metrics and safety overrides.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">Phase #824 — Underwater Maglev Transit</span>
+      <h1>Subsea Maglev Platform</h1>
+      <p class="description">
+        Velocity vectors, magnetic levitation force, and deepwater seal safety streams.
+      </p>
+    </header>
+
+    <main class="dashboard-grid">
+      
+      <!-- Card 1: Velocity -->
+      <section class="card stats-card">
+        <div class="card-header">
+          <span class="status-dot pulsing-cyan"></span>
+          <h2>Velocity Vector</h2>
+        </div>
+        <div class="metric" id="velocity-metric">620 <span class="unit">KM/H</span></div>
+        <p class="card-desc" id="velocity-desc">Tube vacuum stability bounds maintained.</p>
+      </section>
+
+      <!-- Card 2: Maglev Field -->
+      <section class="card stats-card">
+        <div class="card-header">
+          <span class="status-dot pulsing-cyan"></span>
+          <h2>Levitation Field</h2>
+        </div>
+        <div class="metric">98.4 <span class="unit">%</span></div>
+        <p class="card-desc">Magnetic suspension alignment optimal.</p>
+      </section>
+
+      <!-- Card 3: Deep Water Pressure -->
+      <section class="card stats-card warning-card">
+        <div class="card-header">
+          <span class="status-dot pulsing-orange"></span>
+          <h2>External Depth</h2>
+        </div>
+        <div class="metric">-1,240 <span class="unit">M</span></div>
+        <p class="card-desc">External pressure loads steady.</p>
+      </section>
+
+      <!-- Panel Controls -->
+      <section class="card controls-card">
+        <h2>Emergency Speed Reducer</h2>
+        <div class="control-actions">
+          <button class="ease-btn brake-btn" id="btn-brake" type="button">Apply Maglev Brake</button>
+        </div>
+      </section>
+
+    </main>
+  </div>
+
+  <script>
+    const btn = document.getElementById('btn-brake');
+    const velocity = document.getElementById('velocity-metric');
+    const desc = document.getElementById('velocity-desc');
+
+    btn.addEventListener('click', () => {
+      velocity.textContent = '0 KM/H';
+      velocity.style.color = '#ef4444';
+      desc.textContent = 'Transit stopped. Tube locks stabilized.';
+      btn.textContent = 'Maglev Braked';
+      btn.disabled = true;
+      btn.style.background = 'rgba(255,255,255,0.05)';
+      btn.style.borderColor = 'rgba(255,255,255,0.1)';
+      btn.style.color = 'rgba(255,255,255,0.3)';
+      btn.style.boxShadow = 'none';
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/underwater-maglev-transit-28372-ag/style.css
+++ b/submissions/examples/underwater-maglev-transit-28372-ag/style.css
@@ -1,0 +1,196 @@
+/* ============================================================
+   Underwater Maglev Rapid Transit Operating Platform — style.css
+   Submission for EaseMotion CSS Issue #28372
+   Subsea dark themes, neon blue borders, metrics, and brake buttons
+   ============================================================ */
+
+:root {
+  --primary-color: #0ea5e9;
+  --accent-color: #f97316;
+  --warning-color: #f97316;
+  --bg-gradient: linear-gradient(135deg, #02070f 0%, #06111e 100%);
+  --card-bg: rgba(6, 17, 30, 0.65);
+  --card-border: rgba(255, 255, 255, 0.05);
+  --text-primary: #f9fafb;
+  --text-secondary: #0284c7;
+  --text-muted: #0369a1;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 900px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(14, 165, 233, 0.12);
+  border: 1px solid rgba(14, 165, 233, 0.25);
+  border-radius: 999px;
+  color: #38bdf8;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #38bdf8, #f97316);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: #94a3b8;
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Showcase Dashboard Layout
+   ============================================================ */
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 24px;
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  padding: 28px;
+  border-radius: 20px;
+  backdrop-filter: blur(12px);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 15px 35px rgba(14, 165, 233, 0.15);
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.card-header h2 {
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+}
+
+/* Values */
+.metric {
+  font-size: 2.2rem;
+  font-weight: 800;
+  color: #fff;
+  font-family: monospace;
+}
+
+.unit {
+  font-size: 1.1rem;
+  font-weight: 400;
+  color: var(--text-muted);
+  margin-left: 4px;
+}
+
+.card-desc {
+  font-size: 0.8rem;
+  color: #38bdf8;
+  line-height: 1.5;
+}
+
+/* Warnings and Alerts */
+.warning-card:hover {
+  box-shadow: 0 15px 35px rgba(249, 115, 22, 0.15);
+}
+
+.warning-card .metric {
+  color: var(--warning-color);
+}
+
+/* Controls */
+.controls-card {
+  grid-column: 1 / -1;
+}
+
+.control-actions {
+  display: flex;
+  justify-content: center;
+}
+
+.brake-btn {
+  background: var(--warning-color);
+  border: none;
+  color: #fff;
+  padding: 14px 28px;
+  border-radius: 8px;
+  font-family: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(249,115,22,0.25);
+  transition: all 0.25s ease;
+}
+
+.brake-btn:hover {
+  filter: brightness(1.08);
+}
+
+/* Indicator Lights */
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.pulsing-cyan {
+  background: #38bdf8;
+  box-shadow: 0 0 8px #38bdf8;
+}
+
+.pulsing-orange {
+  background: var(--warning-color);
+  box-shadow: 0 0 8px var(--warning-color);
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .card, .brake-btn {
+    transition: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-underwater-maglev-transit` UI showcase. It demonstrates velocity vectors, magnetic levitation suspenders, track depth monitors, and emergency brakes overrides for Phase #824 using subsea ocean operating styles.

## Root Cause
No subsea maglev transit operating station dashboards or maglev telemetry console showcases existed.

## Changes Made
- `submissions/examples/underwater-maglev-transit-28372-ag/demo.html`: Speed counters, suspension metrics, external ocean depths, and emergency brake override toggles.
- `submissions/examples/underwater-maglev-transit-28372-ag/style.css`: Subsea blue templates, glowing warnings, custom buttons, and grid layouts.
- `submissions/examples/underwater-maglev-transit-28372-ag/README.md`: Explains UI structure and subsea transit metrics.

## How to Test
1. Open `demo.html` in a browser.
2. Click emergency brake to stop speed meters.

## Related Issue
Closes #28372