### PR TITLE
feat: add nanotech molecular assembler control panel showcase

### DIFF
--- a/submissions/examples/nanotech-molecular-assembler-control-panel-phase-884/README.md
+++ b/submissions/examples/nanotech-molecular-assembler-control-panel-phase-884/README.md
@@ -1,0 +1,29 @@
+# Nanotech Molecular Assembler Control Panel
+
+## What does this do?
+A single-page UI showcase visualizing a nanotech molecular assembler dashboard — pulsing atomic lattice, assembly progress meter, and live synthesis metric cards.
+
+## How is it used?
+```html
+<header class="assembler-header">...</header>
+
+<main class="assembler-grid">
+  <section class="panel lattice-panel">
+    <div class="lattice-view">
+      <span class="atom atom-1"></span>
+      <span class="bond bond-1"></span>
+    </div>
+  </section>
+  <section class="panel sync-panel">
+    <div class="sync-meter">
+      <div class="sync-fill"></div>
+    </div>
+  </section>
+  <section class="panel card-grid">
+    <div class="metric-card card-1">...</div>
+  </section>
+</main>
+```
+
+## Why is it useful?
+It demonstrates layered entrance and ambient animations (pulsing atoms, assembly meter fill, staggered metric cards) built entirely with CSS keyframes and animation-delay — no JS — fitting EaseMotion CSS's philosophy of smooth, dependency-free motion design. The grid layout is fully responsive down to mobile.

--- a/submissions/examples/nanotech-molecular-assembler-control-panel-phase-884/demo.html
+++ b/submissions/examples/nanotech-molecular-assembler-control-panel-phase-884/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Nanotech Molecular Assembler Control Panel</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="assembler-header">
+    <h1>Nanotech Molecular Assembler Control Panel</h1>
+    <p>Live monitoring of atomic-scale assembly and synthesis processes</p>
+  </header>
+
+  <main class="assembler-grid">
+
+    <section class="panel lattice-panel">
+      <div class="panel-title">Molecular Lattice</div>
+      <div class="lattice-view">
+        <span class="atom atom-1"></span>
+        <span class="atom atom-2"></span>
+        <span class="atom atom-3"></span>
+        <span class="atom atom-4"></span>
+        <span class="bond bond-1"></span>
+        <span class="bond bond-2"></span>
+        <span class="bond bond-3"></span>
+      </div>
+    </section>
+
+    <section class="panel sync-panel">
+      <div class="panel-title">Assembly Progress</div>
+      <div class="sync-meter">
+        <div class="sync-fill"></div>
+        <span class="sync-value">76%</span>
+      </div>
+    </section>
+
+    <section class="panel card-grid">
+      <div class="metric-card card-1">
+        <span class="metric-label">Atoms Placed</span>
+        <span class="metric-number">48,204</span>
+      </div>
+      <div class="metric-card card-2">
+        <span class="metric-label">Bond Stability</span>
+        <span class="metric-number">99.1%</span>
+      </div>
+      <div class="metric-card card-3">
+        <span class="metric-label">Temp</span>
+        <span class="metric-number">4.2K</span>
+      </div>
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/nanotech-molecular-assembler-control-panel-phase-884/style.css
+++ b/submissions/examples/nanotech-molecular-assembler-control-panel-phase-884/style.css
@@ -1,0 +1,190 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', sans-serif;
+  background: #0d1117;
+  color: #e6edf3;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 40px 20px;
+}
+
+.assembler-header {
+  text-align: center;
+  margin-bottom: 32px;
+  animation: fadeSlideDown 0.6s ease-out;
+}
+
+.assembler-header h1 {
+  font-size: 26px;
+  background: linear-gradient(90deg, #58a6ff, #3fb950);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.assembler-header p {
+  color: #8b949e;
+  margin-top: 6px;
+  font-size: 14px;
+}
+
+.assembler-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 20px;
+  width: 100%;
+  max-width: 900px;
+}
+
+.panel {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 10px;
+  padding: 20px;
+  animation: fadeUp 0.6s ease-out both;
+}
+
+.panel-title {
+  font-size: 13px;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 12px;
+}
+
+/* Lattice panel */
+.lattice-panel { grid-row: span 2; }
+
+.lattice-view {
+  position: relative;
+  height: 220px;
+  border-radius: 8px;
+  background: radial-gradient(circle at 50% 50%, #21262d 0%, #0d1117 80%);
+  overflow: hidden;
+}
+
+.atom {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #58a6ff;
+  box-shadow: 0 0 10px #58a6ff;
+  animation: atomPulse 2.4s ease-in-out infinite;
+}
+
+.atom-1 { top: 50px;  left: 70px; }
+.atom-2 { top: 90px;  left: 160px; animation-delay: 0.3s; background: #3fb950; box-shadow: 0 0 10px #3fb950; }
+.atom-3 { top: 150px; left: 90px;  animation-delay: 0.6s; }
+.atom-4 { top: 140px; left: 200px; animation-delay: 0.9s; background: #a371f7; box-shadow: 0 0 10px #a371f7; }
+
+.bond {
+  position: absolute;
+  height: 2px;
+  background: #30363d;
+  transform-origin: left center;
+}
+
+.bond-1 { top: 58px;  left: 86px;  width: 80px;  transform: rotate(18deg); }
+.bond-2 { top: 98px;  left: 105px; width: 70px;  transform: rotate(-25deg); }
+.bond-3 { top: 158px; left: 106px; width: 95px;  transform: rotate(8deg); }
+
+/* Sync meter */
+.sync-meter {
+  position: relative;
+  height: 14px;
+  background: #21262d;
+  border-radius: 7px;
+  overflow: hidden;
+}
+
+.sync-fill {
+  position: absolute;
+  inset: 0;
+  width: 76%;
+  background: linear-gradient(90deg, #3fb950, #58a6ff);
+  border-radius: 7px;
+  transform: scaleX(0);
+  transform-origin: left;
+  animation: fillBar 1.2s ease-out 0.4s forwards;
+}
+
+.sync-value {
+  display: block;
+  margin-top: 10px;
+  font-size: 20px;
+  font-weight: 600;
+  color: #3fb950;
+}
+
+/* Metric cards */
+.card-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.metric-card {
+  background: #21262d;
+  border-radius: 8px;
+  padding: 14px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  opacity: 0;
+  transform: translateY(10px);
+  animation: cardPop 0.5s ease-out forwards;
+}
+
+.card-1 { animation-delay: 0.3s; }
+.card-2 { animation-delay: 0.5s; }
+.card-3 { animation-delay: 0.7s; }
+
+.metric-label {
+  font-size: 13px;
+  color: #8b949e;
+}
+
+.metric-number {
+  font-size: 18px;
+  font-weight: 700;
+  color: #58a6ff;
+}
+
+/* Keyframes */
+@keyframes fadeSlideDown {
+  from { opacity: 0; transform: translateY(-12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(14px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes atomPulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.3); }
+}
+
+@keyframes fillBar {
+  to { transform: scaleX(1); }
+}
+
+@keyframes cardPop {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 700px) {
+  .assembler-grid {
+    grid-template-columns: 1fr;
+  }
+  .lattice-panel { grid-row: auto; }
+}


### PR DESCRIPTION
Closes #28432

## Pull Request Description
Adds a self-contained HTML/CSS UI showcase for the Nanotech Molecular Assembler Control Panel (Phase #884), per issue #28432.

---
## Type of Change
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/nanotech-molecular-assembler-control-panel-phase-884/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A single-page UI showcase visualizing a nanotech molecular assembler dashboard with a pulsing atomic lattice, assembly progress meter, and live synthesis metric cards.

**How does a developer use it?**
```html
<div class="lattice-view">
  <span class="atom atom-1"></span>
  <span class="bond bond-1"></span>
</div>

<div class="sync-meter">
  <div class="sync-fill"></div>
</div>

<div class="metric-card card-1">
  <span class="metric-label">Atoms Placed</span>
  <span class="metric-number">48,204</span>
</div>
```

**Why does it fit EaseMotion CSS?**
It's built entirely with CSS keyframes and `animation-delay` for layered and ambient effects (pulsing atoms, assembly fill, staggered metric cards) — no JS — matching EaseMotion's smooth, dependency-free motion philosophy. Fully responsive down to mobile.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser, verified visually)

---
## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---
## Notes for Maintainer
First pass on the atom-pulse timing — happy to adjust if you'd like a slower or faster cadence.