### PR TITLE
feat: add bionic prosthetic neural feedback studio showcase

### DIFF
--- a/submissions/examples/bionic-prosthetic-neural-feedback-studio-phase-818/README.md
+++ b/submissions/examples/bionic-prosthetic-neural-feedback-studio-phase-818/README.md
@@ -1,0 +1,29 @@
+# Bionic Prosthetic Neural Feedback Studio
+
+## What does this do?
+A single-page UI showcase visualizing a bionic prosthetic control studio — blinking neural signal map, haptic feedback meter, and live sensor metric cards.
+
+## How is it used?
+```html
+<header class="bionic-header">...</header>
+
+<main class="bionic-grid">
+  <section class="panel signal-panel">
+    <div class="signal-view">
+      <span class="signal-node node-1"></span>
+      <span class="signal-path path-1"></span>
+    </div>
+  </section>
+  <section class="panel feedback-panel">
+    <div class="feedback-meter">
+      <div class="feedback-fill"></div>
+    </div>
+  </section>
+  <section class="panel card-grid">
+    <div class="metric-card card-1">...</div>
+  </section>
+</main>
+```
+
+## Why is it useful?
+It demonstrates layered entrance and ambient animations (blinking neural nodes, feedback meter fill, staggered metric cards) built entirely with CSS keyframes and animation-delay — no JS — fitting EaseMotion CSS's philosophy of smooth, dependency-free motion design. The grid layout is fully responsive down to mobile.

--- a/submissions/examples/bionic-prosthetic-neural-feedback-studio-phase-818/demo.html
+++ b/submissions/examples/bionic-prosthetic-neural-feedback-studio-phase-818/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Bionic Prosthetic Neural Feedback Studio</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="bionic-header">
+    <h1>Bionic Prosthetic Neural Feedback Studio</h1>
+    <p>Real-time neural signal mapping and haptic feedback calibration</p>
+  </header>
+
+  <main class="bionic-grid">
+
+    <section class="panel signal-panel">
+      <div class="panel-title">Neural Signal Map</div>
+      <div class="signal-view">
+        <span class="signal-node node-1"></span>
+        <span class="signal-node node-2"></span>
+        <span class="signal-node node-3"></span>
+        <span class="signal-path path-1"></span>
+        <span class="signal-path path-2"></span>
+      </div>
+    </section>
+
+    <section class="panel feedback-panel">
+      <div class="panel-title">Haptic Feedback Level</div>
+      <div class="feedback-meter">
+        <div class="feedback-fill"></div>
+        <span class="feedback-value">68%</span>
+      </div>
+    </section>
+
+    <section class="panel card-grid">
+      <div class="metric-card card-1">
+        <span class="metric-label">Signal Latency</span>
+        <span class="metric-number">8ms</span>
+      </div>
+      <div class="metric-card card-2">
+        <span class="metric-label">Grip Sensitivity</span>
+        <span class="metric-number">91%</span>
+      </div>
+      <div class="metric-card card-3">
+        <span class="metric-label">Active Channels</span>
+        <span class="metric-number">64</span>
+      </div>
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/bionic-prosthetic-neural-feedback-studio-phase-818/style.css
+++ b/submissions/examples/bionic-prosthetic-neural-feedback-studio-phase-818/style.css
@@ -1,0 +1,188 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', sans-serif;
+  background: #0d1117;
+  color: #e6edf3;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 40px 20px;
+}
+
+.bionic-header {
+  text-align: center;
+  margin-bottom: 32px;
+  animation: fadeSlideDown 0.6s ease-out;
+}
+
+.bionic-header h1 {
+  font-size: 26px;
+  background: linear-gradient(90deg, #ff6ad5, #58a6ff);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.bionic-header p {
+  color: #8b949e;
+  margin-top: 6px;
+  font-size: 14px;
+}
+
+.bionic-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 20px;
+  width: 100%;
+  max-width: 900px;
+}
+
+.panel {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 10px;
+  padding: 20px;
+  animation: fadeUp 0.6s ease-out both;
+}
+
+.panel-title {
+  font-size: 13px;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 12px;
+}
+
+/* Signal panel */
+.signal-panel { grid-row: span 2; }
+
+.signal-view {
+  position: relative;
+  height: 220px;
+  border-radius: 8px;
+  background: radial-gradient(circle at 50% 50%, #21262d 0%, #0d1117 80%);
+  overflow: hidden;
+}
+
+.signal-node {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #ff6ad5;
+  box-shadow: 0 0 10px #ff6ad5;
+  animation: nodeBlink 1.8s ease-in-out infinite;
+}
+
+.node-1 { top: 50px;  left: 60px; }
+.node-2 { top: 110px; left: 160px; animation-delay: 0.3s; background: #58a6ff; box-shadow: 0 0 10px #58a6ff; }
+.node-3 { top: 160px; left: 90px;  animation-delay: 0.6s; }
+
+.signal-path {
+  position: absolute;
+  height: 2px;
+  background: #30363d;
+  transform-origin: left center;
+}
+
+.path-1 { top: 58px;  left: 76px; width: 95px;  transform: rotate(20deg); }
+.path-2 { top: 118px; left: 105px; width: 75px; transform: rotate(-30deg); }
+
+/* Feedback meter */
+.feedback-meter {
+  position: relative;
+  height: 14px;
+  background: #21262d;
+  border-radius: 7px;
+  overflow: hidden;
+}
+
+.feedback-fill {
+  position: absolute;
+  inset: 0;
+  width: 68%;
+  background: linear-gradient(90deg, #ff6ad5, #58a6ff);
+  border-radius: 7px;
+  transform: scaleX(0);
+  transform-origin: left;
+  animation: fillBar 1.2s ease-out 0.4s forwards;
+}
+
+.feedback-value {
+  display: block;
+  margin-top: 10px;
+  font-size: 20px;
+  font-weight: 600;
+  color: #ff6ad5;
+}
+
+/* Metric cards */
+.card-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.metric-card {
+  background: #21262d;
+  border-radius: 8px;
+  padding: 14px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  opacity: 0;
+  transform: translateY(10px);
+  animation: cardPop 0.5s ease-out forwards;
+}
+
+.card-1 { animation-delay: 0.3s; }
+.card-2 { animation-delay: 0.5s; }
+.card-3 { animation-delay: 0.7s; }
+
+.metric-label {
+  font-size: 13px;
+  color: #8b949e;
+}
+
+.metric-number {
+  font-size: 18px;
+  font-weight: 700;
+  color: #58a6ff;
+}
+
+/* Keyframes */
+@keyframes fadeSlideDown {
+  from { opacity: 0; transform: translateY(-12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(14px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes nodeBlink {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.5; transform: scale(1.25); }
+}
+
+@keyframes fillBar {
+  to { transform: scaleX(1); }
+}
+
+@keyframes cardPop {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 700px) {
+  .bionic-grid {
+    grid-template-columns: 1fr;
+  }
+  .signal-panel { grid-row: auto; }
+}


### PR DESCRIPTION
Closes #28366

## Pull Request Description
Adds a self-contained HTML/CSS UI showcase for the Bionic Prosthetic Neural Feedback Studio (Phase #818), per issue #28366.

---
## Type of Change
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/bionic-prosthetic-neural-feedback-studio-phase-818/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A single-page UI showcase visualizing a bionic prosthetic control studio with a blinking neural signal map, haptic feedback meter, and live sensor metric cards.

**How does a developer use it?**
```html
<div class="signal-view">
  <span class="signal-node node-1"></span>
  <span class="signal-path path-1"></span>
</div>

<div class="feedback-meter">
  <div class="feedback-fill"></div>
</div>

<div class="metric-card card-1">
  <span class="metric-label">Signal Latency</span>
  <span class="metric-number">8ms</span>
</div>
```

**Why does it fit EaseMotion CSS?**
It's built entirely with CSS keyframes and `animation-delay` for layered and ambient effects (blinking neural nodes, feedback meter fill, staggered metric cards) — no JS — matching EaseMotion's smooth, dependency-free motion philosophy. Fully responsive down to mobile.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser, verified visually)

---
## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---
## Notes for Maintainer
First pass on the neural-node blink timing — happy to adjust pacing if needed.