### PR TITLE
feat: add next-gen biomimetic materials synthesis lab showcase

### DIFF
--- a/submissions/examples/next-gen-biomimetic-materials-synthesis-lab-phase-827/README.md
+++ b/submissions/examples/next-gen-biomimetic-materials-synthesis-lab-phase-827/README.md
@@ -1,0 +1,29 @@
+# Next-Gen Biomimetic Materials Synthesis Lab
+
+## What does this do?
+A single-page UI showcase visualizing a biomimetic materials synthesis lab — pulsing self-assembling molecular structure, synthesis progress meter, and live material property metric cards.
+
+## How is it used?
+```html
+<header class="lab-header">...</header>
+
+<main class="lab-grid">
+  <section class="panel structure-panel">
+    <div class="structure-view">
+      <span class="cell-node node-1"></span>
+      <span class="cell-link link-1"></span>
+    </div>
+  </section>
+  <section class="panel synth-panel">
+    <div class="synth-meter">
+      <div class="synth-fill"></div>
+    </div>
+  </section>
+  <section class="panel card-grid">
+    <div class="metric-card card-1">...</div>
+  </section>
+</main>
+```
+
+## Why is it useful?
+It demonstrates layered entrance and ambient animations (pulsing molecular nodes, synthesis meter fill, staggered metric cards) built entirely with CSS keyframes and animation-delay — no JS dependencies — fitting EaseMotion CSS's philosophy of smooth, dependency-free motion design. The grid layout is fully responsive down to mobile.

--- a/submissions/examples/next-gen-biomimetic-materials-synthesis-lab-phase-827/demo.html
+++ b/submissions/examples/next-gen-biomimetic-materials-synthesis-lab-phase-827/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Next-Gen Biomimetic Materials Synthesis Lab</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="lab-header">
+    <h1>Next-Gen Biomimetic Materials Synthesis Lab</h1>
+    <p>Synthesizing nature-inspired materials with self-healing molecular structures</p>
+  </header>
+
+  <main class="lab-grid">
+
+    <section class="panel structure-panel">
+      <div class="panel-title">Molecular Self-Assembly</div>
+      <div class="structure-view">
+        <span class="cell-node node-1"></span>
+        <span class="cell-node node-2"></span>
+        <span class="cell-node node-3"></span>
+        <span class="cell-node node-4"></span>
+        <span class="cell-link link-1"></span>
+        <span class="cell-link link-2"></span>
+        <span class="cell-link link-3"></span>
+      </div>
+    </section>
+
+    <section class="panel synth-panel">
+      <div class="panel-title">Synthesis Progress</div>
+      <div class="synth-meter">
+        <div class="synth-fill"></div>
+        <span class="synth-value">79%</span>
+      </div>
+    </section>
+
+    <section class="panel card-grid">
+      <div class="metric-card card-1">
+        <span class="metric-label">Tensile Strength</span>
+        <span class="metric-number">+44%</span>
+      </div>
+      <div class="metric-card card-2">
+        <span class="metric-label">Self-Heal Rate</span>
+        <span class="metric-number">96%</span>
+      </div>
+      <div class="metric-card card-3">
+        <span class="metric-label">Samples Synthesized</span>
+        <span class="metric-number">512</span>
+      </div>
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/next-gen-biomimetic-materials-synthesis-lab-phase-827/style.css
+++ b/submissions/examples/next-gen-biomimetic-materials-synthesis-lab-phase-827/style.css
@@ -1,0 +1,190 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', sans-serif;
+  background: #0d1117;
+  color: #e6edf3;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 40px 20px;
+}
+
+.lab-header {
+  text-align: center;
+  margin-bottom: 32px;
+  animation: fadeSlideDown 0.6s ease-out;
+}
+
+.lab-header h1 {
+  font-size: 26px;
+  background: linear-gradient(90deg, #3fb950, #a371f7);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.lab-header p {
+  color: #8b949e;
+  margin-top: 6px;
+  font-size: 14px;
+}
+
+.lab-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 20px;
+  width: 100%;
+  max-width: 900px;
+}
+
+.panel {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 10px;
+  padding: 20px;
+  animation: fadeUp 0.6s ease-out both;
+}
+
+.panel-title {
+  font-size: 13px;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 12px;
+}
+
+/* Structure panel */
+.structure-panel { grid-row: span 2; }
+
+.structure-view {
+  position: relative;
+  height: 220px;
+  border-radius: 8px;
+  background: radial-gradient(circle at 50% 50%, #21262d 0%, #0d1117 80%);
+  overflow: hidden;
+}
+
+.cell-node {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #3fb950;
+  box-shadow: 0 0 10px #3fb950;
+  animation: nodePulse 2.4s ease-in-out infinite;
+}
+
+.node-1 { top: 40px;  left: 60px; }
+.node-2 { top: 90px;  left: 170px; animation-delay: 0.3s; background: #a371f7; box-shadow: 0 0 10px #a371f7; }
+.node-3 { top: 160px; left: 90px;  animation-delay: 0.6s; }
+.node-4 { top: 150px; left: 220px; animation-delay: 0.9s; background: #a371f7; box-shadow: 0 0 10px #a371f7; }
+
+.cell-link {
+  position: absolute;
+  height: 2px;
+  background: #30363d;
+  transform-origin: left center;
+}
+
+.link-1 { top: 48px;  left: 76px;  width: 105px; transform: rotate(15deg); }
+.link-2 { top: 98px;  left: 110px; width: 80px;  transform: rotate(-28deg); }
+.link-3 { top: 168px; left: 106px; width: 118px; transform: rotate(-4deg); }
+
+/* Synth meter */
+.synth-meter {
+  position: relative;
+  height: 14px;
+  background: #21262d;
+  border-radius: 7px;
+  overflow: hidden;
+}
+
+.synth-fill {
+  position: absolute;
+  inset: 0;
+  width: 79%;
+  background: linear-gradient(90deg, #3fb950, #a371f7);
+  border-radius: 7px;
+  transform: scaleX(0);
+  transform-origin: left;
+  animation: fillBar 1.2s ease-out 0.4s forwards;
+}
+
+.synth-value {
+  display: block;
+  margin-top: 10px;
+  font-size: 20px;
+  font-weight: 600;
+  color: #3fb950;
+}
+
+/* Metric cards */
+.card-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.metric-card {
+  background: #21262d;
+  border-radius: 8px;
+  padding: 14px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  opacity: 0;
+  transform: translateY(10px);
+  animation: cardPop 0.5s ease-out forwards;
+}
+
+.card-1 { animation-delay: 0.3s; }
+.card-2 { animation-delay: 0.5s; }
+.card-3 { animation-delay: 0.7s; }
+
+.metric-label {
+  font-size: 13px;
+  color: #8b949e;
+}
+
+.metric-number {
+  font-size: 18px;
+  font-weight: 700;
+  color: #a371f7;
+}
+
+/* Keyframes */
+@keyframes fadeSlideDown {
+  from { opacity: 0; transform: translateY(-12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(14px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes nodePulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.3); }
+}
+
+@keyframes fillBar {
+  to { transform: scaleX(1); }
+}
+
+@keyframes cardPop {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 700px) {
+  .lab-grid {
+    grid-template-columns: 1fr;
+  }
+  .structure-panel { grid-row: auto; }
+}


### PR DESCRIPTION
Closes #28375

## Pull Request Description
Adds a self-contained HTML/CSS UI showcase for the Next-Gen Biomimetic Materials Synthesis Lab (Phase #827), per issue #28375.

---
## Type of Change
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/next-gen-biomimetic-materials-synthesis-lab-phase-827/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A single-page UI showcase visualizing a biomimetic materials synthesis lab with a pulsing self-assembling molecular structure, a synthesis progress meter, and live material property metric cards.

**How does a developer use it?**
```html
<div class="structure-view">
  <span class="cell-node node-1"></span>
  <span class="cell-link link-1"></span>
</div>

<div class="synth-meter">
  <div class="synth-fill"></div>
</div>

<div class="metric-card card-1">
  <span class="metric-label">Tensile Strength</span>
  <span class="metric-number">+44%</span>
</div>
```

**Why does it fit EaseMotion CSS?**
It's built entirely with CSS keyframes and `animation-delay` for layered entrance and ambient effects (pulsing molecular nodes, synthesis fill, staggered metric cards) — zero external JS dependencies, per the issue's requirement. Fully responsive down to mobile.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser, verified visually)

---
## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---
## Notes for Maintainer
First pass on the node-pulse timing — happy to adjust pacing if needed.