### PR TITLE
feat: add orbital space debris cleanup operation center showcase

### DIFF
--- a/submissions/examples/orbital-space-debris-cleanup-operation-center-phase-833/README.md
+++ b/submissions/examples/orbital-space-debris-cleanup-operation-center-phase-833/README.md
@@ -1,0 +1,30 @@
+# Orbital Space Debris Cleanup Operation Center
+
+## What does this do?
+A single-page UI showcase visualizing an orbital debris cleanup command center — rotating tracking rings, drifting debris fragments, a capture-craft, a cleanup progress meter, and live operations metric cards.
+
+## How is it used?
+```html
+<header class="debris-header">...</header>
+
+<main class="debris-grid">
+  <section class="panel orbit-panel">
+    <div class="orbit-view">
+      <span class="orbit-ring ring-1"></span>
+      <span class="debris-bit bit-1"></span>
+      <span class="capture-craft"></span>
+    </div>
+  </section>
+  <section class="panel cleanup-panel">
+    <div class="cleanup-meter">
+      <div class="cleanup-fill"></div>
+    </div>
+  </section>
+  <section class="panel card-grid">
+    <div class="metric-card card-1">...</div>
+  </section>
+</main>
+```
+
+## Why is it useful?
+It demonstrates layered entrance and continuous ambient animations (counter-rotating orbit rings, drifting debris fragments, cleanup meter fill, staggered metric cards) built entirely with CSS keyframes and animation-delay — no JS dependencies — fitting EaseMotion CSS's philosophy of smooth, dependency-free motion design. The grid layout is fully responsive down to mobile.

--- a/submissions/examples/orbital-space-debris-cleanup-operation-center-phase-833/demo.html
+++ b/submissions/examples/orbital-space-debris-cleanup-operation-center-phase-833/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Orbital Space Debris Cleanup Operation Center</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="debris-header">
+    <h1>Orbital Space Debris Cleanup Operation Center</h1>
+    <p>Tracking debris fields and autonomous capture-craft operations in real time</p>
+  </header>
+
+  <main class="debris-grid">
+
+    <section class="panel orbit-panel">
+      <div class="panel-title">Debris Field Tracking</div>
+      <div class="orbit-view">
+        <span class="orbit-ring ring-1"></span>
+        <span class="orbit-ring ring-2"></span>
+        <span class="debris-bit bit-1"></span>
+        <span class="debris-bit bit-2"></span>
+        <span class="debris-bit bit-3"></span>
+        <span class="capture-craft"></span>
+      </div>
+    </section>
+
+    <section class="panel cleanup-panel">
+      <div class="panel-title">Cleanup Progress</div>
+      <div class="cleanup-meter">
+        <div class="cleanup-fill"></div>
+        <span class="cleanup-value">61%</span>
+      </div>
+    </section>
+
+    <section class="panel card-grid">
+      <div class="metric-card card-1">
+        <span class="metric-label">Objects Tracked</span>
+        <span class="metric-number">9,412</span>
+      </div>
+      <div class="metric-card card-2">
+        <span class="metric-label">Captured Today</span>
+        <span class="metric-number">27</span>
+      </div>
+      <div class="metric-card card-3">
+        <span class="metric-label">Collision Risk</span>
+        <span class="metric-number">Low</span>
+      </div>
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/orbital-space-debris-cleanup-operation-center-phase-833/style.css
+++ b/submissions/examples/orbital-space-debris-cleanup-operation-center-phase-833/style.css
@@ -1,0 +1,201 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', sans-serif;
+  background: #0d1117;
+  color: #e6edf3;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 40px 20px;
+}
+
+.debris-header {
+  text-align: center;
+  margin-bottom: 32px;
+  animation: fadeSlideDown 0.6s ease-out;
+}
+
+.debris-header h1 {
+  font-size: 26px;
+  background: linear-gradient(90deg, #58a6ff, #e6edf3);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.debris-header p {
+  color: #8b949e;
+  margin-top: 6px;
+  font-size: 14px;
+}
+
+.debris-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 20px;
+  width: 100%;
+  max-width: 900px;
+}
+
+.panel {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 10px;
+  padding: 20px;
+  animation: fadeUp 0.6s ease-out both;
+}
+
+.panel-title {
+  font-size: 13px;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 12px;
+}
+
+/* Orbit panel */
+.orbit-panel { grid-row: span 2; }
+
+.orbit-view {
+  position: relative;
+  height: 220px;
+  border-radius: 8px;
+  background: radial-gradient(circle at 50% 50%, #21262d 0%, #0d1117 80%);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.orbit-ring {
+  position: absolute;
+  border: 1px dashed #30363d;
+  border-radius: 50%;
+}
+
+.ring-1 { width: 160px; height: 160px; animation: spin 10s linear infinite; }
+.ring-2 { width: 100px; height: 100px; animation: spin 7s linear infinite reverse; }
+
+.capture-craft {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  background: #58a6ff;
+  box-shadow: 0 0 10px #58a6ff;
+}
+
+.debris-bit {
+  position: absolute;
+  width: 5px;
+  height: 5px;
+  border-radius: 1px;
+  background: #8b949e;
+  animation: debrisDrift 4s linear infinite;
+}
+
+.bit-1 { top: 50px;  left: 70px; }
+.bit-2 { top: 140px; left: 200px; animation-delay: 1.2s; }
+.bit-3 { top: 100px; left: 230px; animation-delay: 2.4s; }
+
+/* Cleanup meter */
+.cleanup-meter {
+  position: relative;
+  height: 14px;
+  background: #21262d;
+  border-radius: 7px;
+  overflow: hidden;
+}
+
+.cleanup-fill {
+  position: absolute;
+  inset: 0;
+  width: 61%;
+  background: linear-gradient(90deg, #58a6ff, #e6edf3);
+  border-radius: 7px;
+  transform: scaleX(0);
+  transform-origin: left;
+  animation: fillBar 1.2s ease-out 0.4s forwards;
+}
+
+.cleanup-value {
+  display: block;
+  margin-top: 10px;
+  font-size: 20px;
+  font-weight: 600;
+  color: #58a6ff;
+}
+
+/* Metric cards */
+.card-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.metric-card {
+  background: #21262d;
+  border-radius: 8px;
+  padding: 14px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  opacity: 0;
+  transform: translateY(10px);
+  animation: cardPop 0.5s ease-out forwards;
+}
+
+.card-1 { animation-delay: 0.3s; }
+.card-2 { animation-delay: 0.5s; }
+.card-3 { animation-delay: 0.7s; }
+
+.metric-label {
+  font-size: 13px;
+  color: #8b949e;
+}
+
+.metric-number {
+  font-size: 18px;
+  font-weight: 700;
+  color: #58a6ff;
+}
+
+/* Keyframes */
+@keyframes fadeSlideDown {
+  from { opacity: 0; transform: translateY(-12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(14px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes debrisDrift {
+  0%, 100% { transform: translate(0, 0); opacity: 0.6; }
+  50% { transform: translate(8px, -6px); opacity: 1; }
+}
+
+@keyframes fillBar {
+  to { transform: scaleX(1); }
+}
+
+@keyframes cardPop {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 700px) {
+  .debris-grid {
+    grid-template-columns: 1fr;
+  }
+  .orbit-panel { grid-row: auto; }
+}


### PR DESCRIPTION
Closes #28381

## Pull Request Description
Adds a self-contained HTML/CSS UI showcase for the Orbital Space Debris Cleanup Operation Center (Phase #833), per issue #28381.

---
## Type of Change
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/orbital-space-debris-cleanup-operation-center-phase-833/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A single-page UI showcase visualizing an orbital debris cleanup command center with rotating tracking rings, drifting debris fragments, a capture-craft, a cleanup progress meter, and live operations metric cards.

**How does a developer use it?**
```html
<div class="orbit-view">
  <span class="orbit-ring ring-1"></span>
  <span class="debris-bit bit-1"></span>
  <span class="capture-craft"></span>
</div>

<div class="cleanup-meter">
  <div class="cleanup-fill"></div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's built entirely with CSS keyframes and `animation-delay` for layered entrance and continuous ambient effects (counter-rotating orbit rings, drifting debris, cleanup fill, staggered metric cards) — zero external JS dependencies. Fully responsive down to mobile.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser, verified visually)

---
## Browser Testing
- [x] Chrome

---
## Notes for Maintainer
First pass on the orbit-ring and debris-drift timing — happy to adjust pacing if needed.