### PR TITLE
feat: add deep-brain stimulation neural tuning suite showcase

### DIFF
--- a/submissions/examples/deep-brain-stimulation-neural-tuning-suite-phase-837/README.md
+++ b/submissions/examples/deep-brain-stimulation-neural-tuning-suite-phase-837/README.md
@@ -1,0 +1,29 @@
+# Deep-Brain Stimulation Neural Tuning Suite
+
+## What does this do?
+A single-page UI showcase visualizing a deep-brain stimulation calibration suite — blinking electrode array nodes with expanding signal waves, a stimulation level meter, and live device metric cards.
+
+## How is it used?
+```html
+<header class="dbs-header">...</header>
+
+<main class="dbs-grid">
+  <section class="panel electrode-panel">
+    <div class="electrode-view">
+      <span class="electrode-node node-1"></span>
+      <span class="signal-wave wave-1"></span>
+    </div>
+  </section>
+  <section class="panel stim-panel">
+    <div class="stim-meter">
+      <div class="stim-fill"></div>
+    </div>
+  </section>
+  <section class="panel card-grid">
+    <div class="metric-card card-1">...</div>
+  </section>
+</main>
+```
+
+## Why is it useful?
+It demonstrates layered entrance and continuous ambient animations (blinking electrode nodes, expanding signal waves, stimulation meter fill, staggered metric cards) built entirely with CSS keyframes and animation-delay — no JS dependencies — fitting EaseMotion CSS's philosophy of smooth, dependency-free motion design. The grid layout is fully responsive down to mobile.

--- a/submissions/examples/deep-brain-stimulation-neural-tuning-suite-phase-837/demo.html
+++ b/submissions/examples/deep-brain-stimulation-neural-tuning-suite-phase-837/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Deep-Brain Stimulation Neural Tuning Suite</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="dbs-header">
+    <h1>Deep-Brain Stimulation Neural Tuning Suite</h1>
+    <p>Real-time electrode calibration and neural response monitoring</p>
+  </header>
+
+  <main class="dbs-grid">
+
+    <section class="panel electrode-panel">
+      <div class="panel-title">Electrode Array</div>
+      <div class="electrode-view">
+        <span class="electrode-node node-1"></span>
+        <span class="electrode-node node-2"></span>
+        <span class="electrode-node node-3"></span>
+        <span class="electrode-node node-4"></span>
+        <span class="signal-wave wave-1"></span>
+        <span class="signal-wave wave-2"></span>
+      </div>
+    </section>
+
+    <section class="panel stim-panel">
+      <div class="panel-title">Stimulation Level</div>
+      <div class="stim-meter">
+        <div class="stim-fill"></div>
+        <span class="stim-value">54%</span>
+      </div>
+    </section>
+
+    <section class="panel card-grid">
+      <div class="metric-card card-1">
+        <span class="metric-label">Tremor Reduction</span>
+        <span class="metric-number">87%</span>
+      </div>
+      <div class="metric-card card-2">
+        <span class="metric-label">Pulse Frequency</span>
+        <span class="metric-number">130Hz</span>
+      </div>
+      <div class="metric-card card-3">
+        <span class="metric-label">Battery Life</span>
+        <span class="metric-number">4.2y</span>
+      </div>
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/deep-brain-stimulation-neural-tuning-suite-phase-837/style.css
+++ b/submissions/examples/deep-brain-stimulation-neural-tuning-suite-phase-837/style.css
@@ -1,0 +1,197 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', sans-serif;
+  background: #0d1117;
+  color: #e6edf3;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 40px 20px;
+}
+
+.dbs-header {
+  text-align: center;
+  margin-bottom: 32px;
+  animation: fadeSlideDown 0.6s ease-out;
+}
+
+.dbs-header h1 {
+  font-size: 26px;
+  background: linear-gradient(90deg, #ff6ad5, #58a6ff);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.dbs-header p {
+  color: #8b949e;
+  margin-top: 6px;
+  font-size: 14px;
+}
+
+.dbs-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 20px;
+  width: 100%;
+  max-width: 900px;
+}
+
+.panel {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 10px;
+  padding: 20px;
+  animation: fadeUp 0.6s ease-out both;
+}
+
+.panel-title {
+  font-size: 13px;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 12px;
+}
+
+/* Electrode panel */
+.electrode-panel { grid-row: span 2; }
+
+.electrode-view {
+  position: relative;
+  height: 220px;
+  border-radius: 8px;
+  background: radial-gradient(circle at 50% 50%, #21262d 0%, #0d1117 80%);
+  overflow: hidden;
+}
+
+.electrode-node {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #ff6ad5;
+  box-shadow: 0 0 10px #ff6ad5;
+  animation: nodeBlink 1.6s ease-in-out infinite;
+}
+
+.node-1 { top: 60px;  left: 80px; }
+.node-2 { top: 60px;  left: 180px; animation-delay: 0.2s; background: #58a6ff; box-shadow: 0 0 10px #58a6ff; }
+.node-3 { top: 150px; left: 80px;  animation-delay: 0.4s; }
+.node-4 { top: 150px; left: 180px; animation-delay: 0.6s; background: #58a6ff; box-shadow: 0 0 10px #58a6ff; }
+
+.signal-wave {
+  position: absolute;
+  width: 60px;
+  height: 60px;
+  border: 1px solid #ff6ad5;
+  border-radius: 50%;
+  opacity: 0;
+  animation: waveExpand 2.4s ease-out infinite;
+}
+
+.wave-1 { top: 30px; left: 50px; }
+.wave-2 { top: 120px; left: 50px; animation-delay: 1.2s; border-color: #58a6ff; }
+
+/* Stim meter */
+.stim-meter {
+  position: relative;
+  height: 14px;
+  background: #21262d;
+  border-radius: 7px;
+  overflow: hidden;
+}
+
+.stim-fill {
+  position: absolute;
+  inset: 0;
+  width: 54%;
+  background: linear-gradient(90deg, #ff6ad5, #58a6ff);
+  border-radius: 7px;
+  transform: scaleX(0);
+  transform-origin: left;
+  animation: fillBar 1.2s ease-out 0.4s forwards;
+}
+
+.stim-value {
+  display: block;
+  margin-top: 10px;
+  font-size: 20px;
+  font-weight: 600;
+  color: #ff6ad5;
+}
+
+/* Metric cards */
+.card-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.metric-card {
+  background: #21262d;
+  border-radius: 8px;
+  padding: 14px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  opacity: 0;
+  transform: translateY(10px);
+  animation: cardPop 0.5s ease-out forwards;
+}
+
+.card-1 { animation-delay: 0.3s; }
+.card-2 { animation-delay: 0.5s; }
+.card-3 { animation-delay: 0.7s; }
+
+.metric-label {
+  font-size: 13px;
+  color: #8b949e;
+}
+
+.metric-number {
+  font-size: 18px;
+  font-weight: 700;
+  color: #58a6ff;
+}
+
+/* Keyframes */
+@keyframes fadeSlideDown {
+  from { opacity: 0; transform: translateY(-12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(14px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes nodeBlink {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.5; transform: scale(1.2); }
+}
+
+@keyframes waveExpand {
+  0% { transform: scale(0.3); opacity: 0.8; }
+  100% { transform: scale(1.4); opacity: 0; }
+}
+
+@keyframes fillBar {
+  to { transform: scaleX(1); }
+}
+
+@keyframes cardPop {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 700px) {
+  .dbs-grid {
+    grid-template-columns: 1fr;
+  }
+  .electrode-panel { grid-row: auto; }
+}


### PR DESCRIPTION
Closes #28385

## Pull Request Description
Adds a self-contained HTML/CSS UI showcase for the Deep-Brain Stimulation Neural Tuning Suite (Phase #837), per issue #28385.

---
## Type of Change
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/deep-brain-stimulation-neural-tuning-suite-phase-837/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A single-page UI showcase visualizing a deep-brain stimulation calibration suite with blinking electrode array nodes, expanding signal waves, a stimulation level meter, and live device metric cards.

**How does a developer use it?**
```html
<div class="electrode-view">
  <span class="electrode-node node-1"></span>
  <span class="signal-wave wave-1"></span>
</div>

<div class="stim-meter">
  <div class="stim-fill"></div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's built entirely with CSS keyframes and `animation-delay` for layered entrance and continuous ambient effects (blinking electrode nodes, expanding signal waves, stimulation fill, staggered metric cards) — zero external JS dependencies. Fully responsive down to mobile.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser, verified visually)

---
## Browser Testing
- [x] Chrome

---
## Notes for Maintainer
First pass on the signal-wave expansion timing — happy to adjust pacing if needed.