### PR TITLE
feat: add AI automated patent & scientific discovery engine showcase …

### DIFF
--- a/submissions/examples/ai-automated-patent-scientific-discovery-engine-phase-836/README.md
+++ b/submissions/examples/ai-automated-patent-scientific-discovery-engine-phase-836/README.md
@@ -1,0 +1,26 @@
+# AI Automated Patent & Scientific Discovery Engine
+
+## What does this do?
+A single-page UI showcase visualizing an AI engine that cross-references research literature and patent filings to surface novel discoveries — animated query stream, confidence meter, and live indexing metric cards.
+
+## How is it used?
+```html
+<header class="discovery-header">...</header>
+
+<main class="discovery-grid">
+  <section class="panel scan-panel">
+    <pre class="scan-stream">...</pre>
+  </section>
+  <section class="panel score-panel">
+    <div class="confidence-meter">
+      <div class="confidence-fill"></div>
+    </div>
+  </section>
+  <section class="panel card-grid">
+    <div class="metric-card card-1">...</div>
+  </section>
+</main>
+```
+
+## Why is it useful?
+It demonstrates layered entrance animations (line-by-line query reveal, confidence meter fill, staggered metric cards) built with pure CSS keyframes and animation-delay — no JS dependencies — fitting EaseMotion CSS's philosophy of smooth, dependency-free motion design. The grid layout is fully responsive down to mobile.

--- a/submissions/examples/ai-automated-patent-scientific-discovery-engine-phase-836/demo.html
+++ b/submissions/examples/ai-automated-patent-scientific-discovery-engine-phase-836/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>AI Automated Patent & Scientific Discovery Engine</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="discovery-header">
+    <h1>AI Automated Patent & Scientific Discovery Engine</h1>
+    <p>Cross-referencing research literature and patent filings to surface novel discoveries</p>
+  </header>
+
+  <main class="discovery-grid">
+
+    <section class="panel scan-panel">
+      <div class="panel-title">Live Query Stream</div>
+      <pre class="scan-stream">
+<span class="line l1">indexing corpus.fetch(domain="materials")</span>
+<span class="line l2">  similarity_search(threshold=0.88)</span>
+<span class="line l3">  cross-ref: 9,742 prior filings</span>
+<span class="line l4">  candidates: 2 novel patterns flagged</span>
+      </pre>
+    </section>
+
+    <section class="panel score-panel">
+      <div class="panel-title">Discovery Confidence</div>
+      <div class="confidence-meter">
+        <div class="confidence-fill"></div>
+        <span class="confidence-value">90%</span>
+      </div>
+    </section>
+
+    <section class="panel card-grid">
+      <div class="metric-card card-1">
+        <span class="metric-label">Papers Indexed</span>
+        <span class="metric-number">1.8M</span>
+      </div>
+      <div class="metric-card card-2">
+        <span class="metric-label">Patents Checked</span>
+        <span class="metric-number">352K</span>
+      </div>
+      <div class="metric-card card-3">
+        <span class="metric-label">Novel Findings</span>
+        <span class="metric-number">2</span>
+      </div>
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/ai-automated-patent-scientific-discovery-engine-phase-836/style.css
+++ b/submissions/examples/ai-automated-patent-scientific-discovery-engine-phase-836/style.css
@@ -1,0 +1,176 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', sans-serif;
+  background: #0d1117;
+  color: #e6edf3;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 40px 20px;
+}
+
+.discovery-header {
+  text-align: center;
+  margin-bottom: 32px;
+  animation: fadeSlideDown 0.6s ease-out;
+}
+
+.discovery-header h1 {
+  font-size: 26px;
+  background: linear-gradient(90deg, #58a6ff, #3fb950);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.discovery-header p {
+  color: #8b949e;
+  margin-top: 6px;
+  font-size: 14px;
+}
+
+.discovery-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 20px;
+  width: 100%;
+  max-width: 900px;
+}
+
+.panel {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 10px;
+  padding: 20px;
+  animation: fadeUp 0.6s ease-out both;
+}
+
+.panel-title {
+  font-size: 13px;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 12px;
+}
+
+/* Scan panel */
+.scan-panel { grid-row: span 2; }
+
+.scan-stream {
+  font-family: 'Consolas', monospace;
+  font-size: 13px;
+  line-height: 1.6;
+  color: #79c0ff;
+  overflow: hidden;
+  white-space: pre-wrap;
+}
+
+.line {
+  display: block;
+  opacity: 0;
+  transform: translateX(-8px);
+  animation: lineReveal 0.4s ease-out forwards;
+}
+
+.l1 { animation-delay: 0.2s; }
+.l2 { animation-delay: 0.5s; }
+.l3 { animation-delay: 0.8s; }
+.l4 { animation-delay: 1.1s; }
+
+/* Confidence meter */
+.confidence-meter {
+  position: relative;
+  height: 14px;
+  background: #21262d;
+  border-radius: 7px;
+  overflow: hidden;
+}
+
+.confidence-fill {
+  position: absolute;
+  inset: 0;
+  width: 90%;
+  background: linear-gradient(90deg, #3fb950, #58a6ff);
+  border-radius: 7px;
+  transform: scaleX(0);
+  transform-origin: left;
+  animation: fillBar 1.2s ease-out 0.4s forwards;
+}
+
+.confidence-value {
+  display: block;
+  margin-top: 10px;
+  font-size: 20px;
+  font-weight: 600;
+  color: #3fb950;
+}
+
+/* Metric cards */
+.card-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.metric-card {
+  background: #21262d;
+  border-radius: 8px;
+  padding: 14px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  opacity: 0;
+  transform: translateY(10px);
+  animation: cardPop 0.5s ease-out forwards;
+}
+
+.card-1 { animation-delay: 0.3s; }
+.card-2 { animation-delay: 0.5s; }
+.card-3 { animation-delay: 0.7s; }
+
+.metric-label {
+  font-size: 13px;
+  color: #8b949e;
+}
+
+.metric-number {
+  font-size: 18px;
+  font-weight: 700;
+  color: #58a6ff;
+}
+
+/* Keyframes */
+@keyframes fadeSlideDown {
+  from { opacity: 0; transform: translateY(-12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(14px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes lineReveal {
+  to { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes fillBar {
+  to { transform: scaleX(1); }
+}
+
+@keyframes cardPop {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 700px) {
+  .discovery-grid {
+    grid-template-columns: 1fr;
+  }
+  .scan-panel { grid-row: auto; }
+}


### PR DESCRIPTION
Closes #28384

## Pull Request Description
Adds a self-contained HTML/CSS UI showcase for the AI Automated Patent & Scientific Discovery Engine (Phase #836), per issue #28384.

---
## Type of Change
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ai-automated-patent-scientific-discovery-engine-phase-836/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A single-page UI showcase visualizing an AI engine that cross-references research literature and patent filings to surface novel discoveries, with an animated query stream, confidence meter, and live indexing metric cards.

**How does a developer use it?**
```html
<pre class="scan-stream">
  indexing corpus.fetch(domain="materials")
</pre>

<div class="confidence-meter">
  <div class="confidence-fill"></div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's built entirely with CSS keyframes and `animation-delay` for layered entrance effects (line-by-line query reveal, confidence fill, staggered card pop) — zero external JS dependencies. Fully responsive down to mobile.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser, verified visually)

---
## Browser Testing
- [x] Chrome

---
## Notes for Maintainer
This is Phase #836 — distinct folder from the earlier Phase #886 submission of a similarly-named issue, in case the maintainer wants to compare the two.