### PR TITLE
feat: add mobile-pull-refresh-spinner component (#31713)

### DIFF
--- a/submissions/examples/ease-mobile-pull-refresh-spinner-ij/README.md
+++ b/submissions/examples/ease-mobile-pull-refresh-spinner-ij/README.md
@@ -1,15 +1,14 @@
 # Mobile Pull Refresh Spinner
 
-A "pull to refresh" interaction with circular spinner rotation tied to pull progress via `--pull-progress`. Past the threshold, releasing triggers a full rotation animation. Content translates down with the pull gesture.
+A "pull to refresh" interaction. The circular spinner rotates proportionally to the pull distance via `--pull-progress`. Past the threshold, releasing triggers a full rotation animation.
 
 ## Features
 
-- Circular spinner rotates proportionally to pull distance via `--pull-progress`
-- CSS handles visual rotation; JS sets progress from drag distance
-- Past threshold triggers full refresh animation
+- Circular spinner rotation tied to pull progress
+- CSS handles visual rotation via `--pull-progress`
+- JS sets progress variable from drag distance
 - Content translates down with pull gesture
-- Smooth cubic-bezier transitions
 
 ## Usage
 
-Set `--pull-progress` (0 to 1) on `.pr-spinner`. CSS uses `transform: rotate(calc(var(--pull-progress) * 360deg))` for rotation. Add `.pr-refreshing` class for the continuous spin animation.
+Set `--pull-progress` (0-1) on `.mpr-spinner`. Add `.mpr-refreshing` class for full rotation animation.

--- a/submissions/examples/ease-mobile-pull-refresh-spinner-ij/demo.html
+++ b/submissions/examples/ease-mobile-pull-refresh-spinner-ij/demo.html
@@ -7,72 +7,71 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <div class="demo-wrapper">
-    <h1>Pull to Refresh</h1>
-    <p class="desc">Drag down to see the spinner rotate. Release past threshold to trigger refresh.</p>
-    <div class="pr-container" id="prContainer">
-      <div class="pr-spinner-area" id="prSpinnerArea">
-        <div class="pr-spinner" id="prSpinner" style="--pull-progress: 0;"></div>
+  <div class="mpr-container" id="mprContainer">
+    <div class="mpr-header">Pull to Refresh</div>
+    <div class="mpr-content" id="mprContent">
+      <div class="mpr-spinner" id="mprSpinner" style="--pull-progress: 0;">
+        <svg viewBox="0 0 40 40" class="mpr-svg">
+          <circle cx="20" cy="20" r="16" class="mpr-circle" />
+        </svg>
       </div>
-      <div class="pr-content" id="prContent">
-        <div class="pr-row"><span>Item 1</span><span>Details</span></div>
-        <div class="pr-row"><span>Item 2</span><span>Details</span></div>
-        <div class="pr-row"><span>Item 3</span><span>Details</span></div>
-        <div class="pr-row"><span>Item 4</span><span>Details</span></div>
-        <div class="pr-row"><span>Item 5</span><span>Details</span></div>
-      </div>
+      <ul class="mpr-list" id="mprList">
+        <li>Item 1 — Latest update</li>
+        <li>Item 2 — Recent changes</li>
+        <li>Item 3 — Notifications</li>
+        <li>Item 4 — Messages</li>
+      </ul>
     </div>
-    <p class="pr-status" id="prStatus">Pull down to refresh</p>
   </div>
   <script>
-    const container = document.getElementById('prContainer');
-    const spinner = document.getElementById('prSpinner');
-    const content = document.getElementById('prContent');
-    const status = document.getElementById('prStatus');
-    let startY = 0;
-    let pulling = false;
-    let pullDist = 0;
-    const threshold = 80;
+    const content = document.getElementById('mprContent');
+    const spinner = document.getElementById('mprSpinner');
+    const list = document.getElementById('mprList');
+    const THRESHOLD = 80;
+    let pulling = false, startY = 0, pullDist = 0, pullProgress = 0;
 
-    container.addEventListener('mousedown', (e) => {
-      if (container.scrollTop > 0) return;
-      startY = e.clientY;
+    content.addEventListener('mousedown', startPull);
+    content.addEventListener('touchstart', function(e) { startPull(e.touches[0]); }, {passive: true});
+    document.addEventListener('mousemove', movePull);
+    document.addEventListener('touchmove', function(e) { movePull(e.touches[0]); }, {passive: false});
+    document.addEventListener('mouseup', endPull);
+    document.addEventListener('touchend', endPull);
+
+    function startPull(e) {
+      if (content.scrollTop > 0) return;
       pulling = true;
-      pullDist = 0;
-      container.classList.add('pr-pulling');
-    });
+      startY = e.clientY;
+    }
 
-    document.addEventListener('mousemove', (e) => {
+    function movePull(e) {
       if (!pulling) return;
-      const dist = Math.max(0, (e.clientY - startY) * 0.5);
-      pullDist = dist;
-      const progress = Math.min(1, dist / threshold);
-      spinner.style.setProperty('--pull-progress', progress);
-      content.style.setProperty('--pr-translate', Math.min(dist, 120) + 'px');
-      status.textContent = progress >= 1 ? 'Release to refresh' : 'Pull down to refresh';
-    });
+      pullDist = Math.max(0, e.clientY - startY);
+      pullProgress = Math.min(pullDist / THRESHOLD, 1);
+      spinner.style.setProperty('--pull-progress', pullProgress);
+      content.style.setProperty('--pull-offset', Math.min(pullDist, 120) + 'px');
+      list.style.transform = 'translateY(' + (pullDist * 0.3) + 'px)';
+    }
 
-    document.addEventListener('mouseup', () => {
+    function endPull() {
       if (!pulling) return;
       pulling = false;
-      container.classList.remove('pr-pulling');
-      if (pullDist >= threshold) {
-        status.textContent = 'Refreshing...';
-        spinner.classList.add('pr-refreshing');
-        setTimeout(() => {
-          spinner.classList.remove('pr-refreshing');
+      if (pullProgress >= 1) {
+        spinner.classList.add('mpr-refreshing');
+        list.innerHTML = '<li>Refreshed — New data loaded</li><li>Updated just now</li>';
+        setTimeout(function() {
+          spinner.classList.remove('mpr-refreshing');
           spinner.style.setProperty('--pull-progress', 0);
-          content.style.setProperty('--pr-translate', '0px');
-          status.textContent = 'Updated!';
-          setTimeout(() => { status.textContent = 'Pull down to refresh'; }, 1000);
+          content.style.setProperty('--pull-offset', '0px');
+          list.style.transform = 'translateY(0)';
         }, 1500);
       } else {
         spinner.style.setProperty('--pull-progress', 0);
-        content.style.setProperty('--pr-translate', '0px');
-        status.textContent = 'Pull down to refresh';
+        content.style.setProperty('--pull-offset', '0px');
+        list.style.transform = 'translateY(0)';
       }
       pullDist = 0;
-    });
+      pullProgress = 0;
+    }
   </script>
 </body>
 </html>

--- a/submissions/examples/ease-mobile-pull-refresh-spinner-ij/style.css
+++ b/submissions/examples/ease-mobile-pull-refresh-spinner-ij/style.css
@@ -11,105 +11,94 @@ body {
   min-height: 100vh;
   display: flex;
   justify-content: center;
-  align-items: flex-start;
   padding: 2rem 1rem;
-  user-select: none;
 }
 
-.demo-wrapper {
-  text-align: center;
+.mpr-container {
   width: 100%;
   max-width: 380px;
 }
 
-h1 {
-  font-size: 1.5rem;
-  font-weight: 300;
-  margin-bottom: 0.5rem;
-  color: #94a3b8;
-}
-
-.desc {
-  font-size: 0.85rem;
+.mpr-header {
+  text-align: center;
+  padding: 0.75rem;
+  font-size: 0.8rem;
   color: #64748b;
-  margin-bottom: 1.5rem;
-  padding: 0 0.5rem;
-  line-height: 1.5;
+  letter-spacing: 0.05em;
 }
 
-.pr-container {
+.mpr-content {
+  position: relative;
   background: #1e293b;
-  border-radius: 20px;
+  border-radius: 16px;
   overflow: hidden;
   cursor: grab;
-  position: relative;
 }
 
-.pr-container:active {
+.mpr-content:active {
   cursor: grabbing;
 }
 
-.pr-spinner-area {
+.mpr-spinner {
+  position: absolute;
+  top: -10px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 36px;
+  height: 36px;
+  z-index: 2;
   display: flex;
-  justify-content: center;
   align-items: center;
-  height: 0;
-  overflow: hidden;
-  transition: height 0.2s ease;
+  justify-content: center;
+  transition: top 0.3s ease;
 }
 
-.pr-pulling .pr-spinner-area {
-  height: 60px;
+[style*="--pull-offset"] .mpr-spinner {
+  top: calc(10px + var(--pull-offset, 0px) * 0.5);
 }
 
-.pr-spinner {
-  --pull-progress: 0;
-  width: 32px;
-  height: 32px;
-  border: 3px solid #334155;
-  border-top-color: #e94560;
-  border-radius: 50%;
-  transform: rotate(calc(var(--pull-progress) * 360deg));
-  transition: transform 0.1s linear;
+.mpr-svg {
+  width: 100%;
+  height: 100%;
 }
 
-.pr-spinner.pr-refreshing {
-  animation: prSpin 0.6s linear infinite;
-  border-top-color: #e94560;
+.mpr-circle {
+  fill: none;
+  stroke: #8b5cf6;
+  stroke-width: 4;
+  stroke-linecap: round;
+  stroke-dasharray: 100;
+  stroke-dashoffset: calc(100 - (var(--pull-progress, 0) * 80));
+  transform: rotate(calc(var(--pull-progress, 0) * 360deg));
+  transition: stroke-dashoffset 0.1s ease;
+  transform-origin: center;
 }
 
-@keyframes prSpin {
-  to { transform: rotate(360deg); }
+.mpr-refreshing .mpr-circle {
+  animation: mpr-spin 0.8s linear infinite;
+  stroke-dashoffset: 20;
 }
 
-.pr-content {
-  --pr-translate: 0px;
-  padding: 1rem;
-  transform: translateY(var(--pr-translate));
-  transition: transform 0.15s ease-out;
+.mpr-list {
+  padding: 1.25rem;
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
-.pr-row {
-  display: flex;
-  justify-content: space-between;
-  padding: 0.875rem 1rem;
-  border-bottom: 1px solid #334155;
+.mpr-list li {
+  padding: 0.85rem 1rem;
+  margin-bottom: 0.5rem;
+  background: #0f172a;
+  border-radius: 10px;
+  list-style: none;
+  color: #e2e8f0;
   font-size: 0.9rem;
-  color: #cbd5e1;
-  transition: background 0.2s ease;
+  border: 1px solid #334155;
 }
 
-.pr-row:last-child {
-  border-bottom: none;
+.mpr-list li:last-child {
+  margin-bottom: 0;
 }
 
-.pr-row:hover {
-  background: #334155;
-}
-
-.pr-status {
-  margin-top: 1rem;
-  font-size: 0.8rem;
-  color: #64748b;
-  transition: color 0.3s ease;
+@keyframes mpr-spin {
+  to { transform: rotate(360deg); }
 }


### PR DESCRIPTION
## Component: ease-mobile-pull-refresh-spinner ? circular spinner rotation tied to pull progress, CSS handles visuals

### What this adds
A 'pull to refresh' interaction. The circular spinner rotates proportionally to the pull distance via --pull-progress CSS variable. Past the threshold, releasing triggers a full rotation animation. Content translates down with the pull gesture.

### Acceptance Criteria covered
- Circular spinner with rotation tied to pull progress
- CSS handles visual rotation via --pull-progress
- JS sets progress variable from drag distance
- Past threshold triggers refresh animation

### Files
- submissions/examples/ease-mobile-pull-refresh-spinner-ij/demo.html
- submissions/examples/ease-mobile-pull-refresh-spinner-ij/style.css
- submissions/examples/ease-mobile-pull-refresh-spinner-ij/README.md

### How to review
Open demo.html directly in a browser. Click and drag down on the list area; watch the spinner rotate proportionally; release past threshold to trigger refresh animation.

**Closes #31713**
