### PR TITLE
feat: add orbital solar power satellite energy receiver grid showcase

### DIFF
--- a/submissions/examples/orbital-solar-power-satellite-energy-receiver-grid-phase-797/README.md
+++ b/submissions/examples/orbital-solar-power-satellite-energy-receiver-grid-phase-797/README.md
@@ -1,0 +1,30 @@
+# Orbital Solar Power Satellite Energy Receiver Grid
+
+## What does this do?
+A single-page UI showcase visualizing an orbital solar power satellite beaming microwave energy to a ground receiver grid — pulsing power beam rays, glowing receiver cells, a transfer efficiency meter, and live output metric cards.
+
+## How is it used?
+```html
+<header class="solar-header">...</header>
+
+<main class="solar-grid">
+  <section class="panel beam-panel">
+    <div class="beam-view">
+      <span class="sat-node"></span>
+      <span class="beam-ray ray-1"></span>
+      <span class="receiver-cell cell-1"></span>
+    </div>
+  </section>
+  <section class="panel transfer-panel">
+    <div class="transfer-meter">
+      <div class="transfer-fill"></div>
+    </div>
+  </section>
+  <section class="panel card-grid">
+    <div class="metric-card card-1">...</div>
+  </section>
+</main>
+```
+
+## Why is it useful?
+It demonstrates layered entrance and continuous ambient animations (pulsing power beams, glowing receiver cells, transfer meter fill, staggered metric cards) built entirely with CSS keyframes and animation-delay — no JS dependencies — fitting EaseMotion CSS's philosophy of smooth, dependency-free motion design. The grid layout is fully responsive down to mobile.

--- a/submissions/examples/orbital-solar-power-satellite-energy-receiver-grid-phase-797/demo.html
+++ b/submissions/examples/orbital-solar-power-satellite-energy-receiver-grid-phase-797/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Orbital Solar Power Satellite Energy Receiver Grid</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="solar-header">
+    <h1>Orbital Solar Power Satellite Energy Receiver Grid</h1>
+    <p>Tracking microwave power beaming from orbit to ground receiver arrays</p>
+  </header>
+
+  <main class="solar-grid">
+
+    <section class="panel beam-panel">
+      <div class="panel-title">Power Beam Tracking</div>
+      <div class="beam-view">
+        <span class="sat-node"></span>
+        <span class="beam-ray ray-1"></span>
+        <span class="beam-ray ray-2"></span>
+        <span class="receiver-cell cell-1"></span>
+        <span class="receiver-cell cell-2"></span>
+        <span class="receiver-cell cell-3"></span>
+      </div>
+    </section>
+
+    <section class="panel transfer-panel">
+      <div class="panel-title">Transfer Efficiency</div>
+      <div class="transfer-meter">
+        <div class="transfer-fill"></div>
+        <span class="transfer-value">88%</span>
+      </div>
+    </section>
+
+    <section class="panel card-grid">
+      <div class="metric-card card-1">
+        <span class="metric-label">Power Output</span>
+        <span class="metric-number">2.1 GW</span>
+      </div>
+      <div class="metric-card card-2">
+        <span class="metric-label">Active Cells</span>
+        <span class="metric-number">14,302</span>
+      </div>
+      <div class="metric-card card-3">
+        <span class="metric-label">Beam Accuracy</span>
+        <span class="metric-number">99.4%</span>
+      </div>
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/orbital-solar-power-satellite-energy-receiver-grid-phase-797/style.css
+++ b/submissions/examples/orbital-solar-power-satellite-energy-receiver-grid-phase-797/style.css
@@ -1,0 +1,210 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', sans-serif;
+  background: #0d1117;
+  color: #e6edf3;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 40px 20px;
+}
+
+.solar-header {
+  text-align: center;
+  margin-bottom: 32px;
+  animation: fadeSlideDown 0.6s ease-out;
+}
+
+.solar-header h1 {
+  font-size: 26px;
+  background: linear-gradient(90deg, #ffd43b, #58a6ff);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.solar-header p {
+  color: #8b949e;
+  margin-top: 6px;
+  font-size: 14px;
+}
+
+.solar-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 20px;
+  width: 100%;
+  max-width: 900px;
+}
+
+.panel {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 10px;
+  padding: 20px;
+  animation: fadeUp 0.6s ease-out both;
+}
+
+.panel-title {
+  font-size: 13px;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 12px;
+}
+
+/* Beam panel */
+.beam-panel { grid-row: span 2; }
+
+.beam-view {
+  position: relative;
+  height: 220px;
+  border-radius: 8px;
+  background: radial-gradient(circle at 50% 20%, #21262d 0%, #0d1117 80%);
+  overflow: hidden;
+}
+
+.sat-node {
+  position: absolute;
+  top: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 16px;
+  height: 16px;
+  border-radius: 3px;
+  background: #ffd43b;
+  box-shadow: 0 0 12px #ffd43b;
+}
+
+.beam-ray {
+  position: absolute;
+  top: 40px;
+  left: 50%;
+  width: 2px;
+  height: 150px;
+  background: linear-gradient(180deg, #ffd43b, transparent);
+  transform-origin: top center;
+  animation: beamPulse 2.4s ease-in-out infinite;
+}
+
+.ray-1 { transform: translateX(-50%) rotate(-8deg); }
+.ray-2 { transform: translateX(-50%) rotate(8deg); animation-delay: 0.4s; }
+
+.receiver-cell {
+  position: absolute;
+  bottom: 24px;
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  background: #58a6ff;
+  box-shadow: 0 0 8px #58a6ff;
+  animation: cellGlow 2.4s ease-in-out infinite;
+}
+
+.cell-1 { left: 100px; }
+.cell-2 { left: 130px; animation-delay: 0.5s; }
+.cell-3 { left: 160px; animation-delay: 1s; }
+
+/* Transfer meter */
+.transfer-meter {
+  position: relative;
+  height: 14px;
+  background: #21262d;
+  border-radius: 7px;
+  overflow: hidden;
+}
+
+.transfer-fill {
+  position: absolute;
+  inset: 0;
+  width: 88%;
+  background: linear-gradient(90deg, #ffd43b, #58a6ff);
+  border-radius: 7px;
+  transform: scaleX(0);
+  transform-origin: left;
+  animation: fillBar 1.2s ease-out 0.4s forwards;
+}
+
+.transfer-value {
+  display: block;
+  margin-top: 10px;
+  font-size: 20px;
+  font-weight: 600;
+  color: #ffd43b;
+}
+
+/* Metric cards */
+.card-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.metric-card {
+  background: #21262d;
+  border-radius: 8px;
+  padding: 14px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  opacity: 0;
+  transform: translateY(10px);
+  animation: cardPop 0.5s ease-out forwards;
+}
+
+.card-1 { animation-delay: 0.3s; }
+.card-2 { animation-delay: 0.5s; }
+.card-3 { animation-delay: 0.7s; }
+
+.metric-label {
+  font-size: 13px;
+  color: #8b949e;
+}
+
+.metric-number {
+  font-size: 18px;
+  font-weight: 700;
+  color: #58a6ff;
+}
+
+/* Keyframes */
+@keyframes fadeSlideDown {
+  from { opacity: 0; transform: translateY(-12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(14px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes beamPulse {
+  0%, 100% { opacity: 0.4; }
+  50% { opacity: 1; }
+}
+
+@keyframes cellGlow {
+  0%, 100% { opacity: 0.6; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.15); }
+}
+
+@keyframes fillBar {
+  to { transform: scaleX(1); }
+}
+
+@keyframes cardPop {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 700px) {
+  .solar-grid {
+    grid-template-columns: 1fr;
+  }
+  .beam-panel { grid-row: auto; }
+}


### PR DESCRIPTION
Closes #28345

## Pull Request Description
Adds a self-contained HTML/CSS UI showcase for the Orbital Solar Power Satellite Energy Receiver Grid (Phase #797), per issue #28345.

---
## Type of Change
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/orbital-solar-power-satellite-energy-receiver-grid-phase-797/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A single-page UI showcase visualizing an orbital solar power satellite beaming microwave energy to a ground receiver grid, with pulsing power beam rays, glowing receiver cells, a transfer efficiency meter, and live output metric cards.

**How does a developer use it?**
```html
<div class="beam-view">
  <span class="sat-node"></span>
  <span class="beam-ray ray-1"></span>
  <span class="receiver-cell cell-1"></span>
</div>

<div class="transfer-meter">
  <div class="transfer-fill"></div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's built entirely with CSS keyframes and `animation-delay` for layered entrance and continuous ambient effects (pulsing power beams, glowing receiver cells, transfer fill, staggered metric cards) — zero external JS dependencies. Fully responsive down to mobile.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser, verified visually)

---
## Browser Testing
- [x] Chrome

---
## Notes for Maintainer
First pass on the beam-pulse and receiver-cell glow timing — happy to adjust pacing if needed.

⚠️ Flagging separately: the Auto-Merge workflow appears to be failing with `HTTP 401: Bad credentials` at the "Wait for checks to pass" step (see a recent failed run on PR #31711) — may be affecting this and other open PRs.