### PR TITLE
feat: add cognitive brain-computer interface training studio showcase

### DIFF
--- a/submissions/examples/cognitive-brain-computer-interface-training-studio-phase-798/README.md
+++ b/submissions/examples/cognitive-brain-computer-interface-training-studio-phase-798/README.md
@@ -1,0 +1,28 @@
+# Cognitive Brain-Computer Interface Training Studio
+
+## What does this do?
+A single-page UI showcase visualizing a brain-computer interface training studio — an animated live-drawing EEG waveform, a focus calibration meter, and live training session metric cards.
+
+## How is it used?
+```html
+<header class="bci-header">...</header>
+
+<main class="bci-grid">
+  <section class="panel eeg-panel">
+    <div class="eeg-view">
+      <svg class="eeg-wave"><path d="..." /></svg>
+    </div>
+  </section>
+  <section class="panel focus-panel">
+    <div class="focus-meter">
+      <div class="focus-fill"></div>
+    </div>
+  </section>
+  <section class="panel card-grid">
+    <div class="metric-card card-1">...</div>
+  </section>
+</main>
+```
+
+## Why is it useful?
+It demonstrates layered entrance and continuous ambient animations (a looping SVG stroke-draw waveform, focus meter fill, staggered metric cards) built entirely with CSS keyframes and animation-delay — no JS dependencies — fitting EaseMotion CSS's philosophy of smooth, dependency-free motion design. The grid layout is fully responsive down to mobile.

--- a/submissions/examples/cognitive-brain-computer-interface-training-studio-phase-798/demo.html
+++ b/submissions/examples/cognitive-brain-computer-interface-training-studio-phase-798/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Cognitive Brain-Computer Interface Training Studio</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="bci-header">
+    <h1>Cognitive Brain-Computer Interface Training Studio</h1>
+    <p>Live EEG signal training and cognitive command calibration</p>
+  </header>
+
+  <main class="bci-grid">
+
+    <section class="panel eeg-panel">
+      <div class="panel-title">EEG Waveform</div>
+      <div class="eeg-view">
+        <svg class="eeg-wave" viewBox="0 0 260 100" preserveAspectRatio="none">
+          <path d="M0,50 Q15,10 30,50 T60,50 T90,20 T120,50 T150,80 T180,50 T210,30 T240,50 T260,50" />
+        </svg>
+      </div>
+    </section>
+
+    <section class="panel focus-panel">
+      <div class="panel-title">Focus Calibration</div>
+      <div class="focus-meter">
+        <div class="focus-fill"></div>
+        <span class="focus-value">82%</span>
+      </div>
+    </section>
+
+    <section class="panel card-grid">
+      <div class="metric-card card-1">
+        <span class="metric-label">Commands Trained</span>
+        <span class="metric-number">18</span>
+      </div>
+      <div class="metric-card card-2">
+        <span class="metric-label">Signal Clarity</span>
+        <span class="metric-number">94%</span>
+      </div>
+      <div class="metric-card card-3">
+        <span class="metric-label">Session Time</span>
+        <span class="metric-number">12:04</span>
+      </div>
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/cognitive-brain-computer-interface-training-studio-phase-798/style.css
+++ b/submissions/examples/cognitive-brain-computer-interface-training-studio-phase-798/style.css
@@ -1,0 +1,181 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', sans-serif;
+  background: #0d1117;
+  color: #e6edf3;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 40px 20px;
+}
+
+.bci-header {
+  text-align: center;
+  margin-bottom: 32px;
+  animation: fadeSlideDown 0.6s ease-out;
+}
+
+.bci-header h1 {
+  font-size: 26px;
+  background: linear-gradient(90deg, #58a6ff, #ff6ad5);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.bci-header p {
+  color: #8b949e;
+  margin-top: 6px;
+  font-size: 14px;
+}
+
+.bci-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 20px;
+  width: 100%;
+  max-width: 900px;
+}
+
+.panel {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 10px;
+  padding: 20px;
+  animation: fadeUp 0.6s ease-out both;
+}
+
+.panel-title {
+  font-size: 13px;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 12px;
+}
+
+/* EEG panel */
+.eeg-panel { grid-row: span 2; }
+
+.eeg-view {
+  position: relative;
+  height: 220px;
+  border-radius: 8px;
+  background: radial-gradient(circle at 50% 50%, #21262d 0%, #0d1117 80%);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+}
+
+.eeg-wave {
+  width: 100%;
+  height: 100px;
+}
+
+.eeg-wave path {
+  fill: none;
+  stroke: #58a6ff;
+  stroke-width: 2;
+  stroke-dasharray: 600;
+  stroke-dashoffset: 600;
+  animation: drawWave 2.4s ease-out infinite;
+}
+
+/* Focus meter */
+.focus-meter {
+  position: relative;
+  height: 14px;
+  background: #21262d;
+  border-radius: 7px;
+  overflow: hidden;
+}
+
+.focus-fill {
+  position: absolute;
+  inset: 0;
+  width: 82%;
+  background: linear-gradient(90deg, #58a6ff, #ff6ad5);
+  border-radius: 7px;
+  transform: scaleX(0);
+  transform-origin: left;
+  animation: fillBar 1.2s ease-out 0.4s forwards;
+}
+
+.focus-value {
+  display: block;
+  margin-top: 10px;
+  font-size: 20px;
+  font-weight: 600;
+  color: #58a6ff;
+}
+
+/* Metric cards */
+.card-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.metric-card {
+  background: #21262d;
+  border-radius: 8px;
+  padding: 14px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  opacity: 0;
+  transform: translateY(10px);
+  animation: cardPop 0.5s ease-out forwards;
+}
+
+.card-1 { animation-delay: 0.3s; }
+.card-2 { animation-delay: 0.5s; }
+.card-3 { animation-delay: 0.7s; }
+
+.metric-label {
+  font-size: 13px;
+  color: #8b949e;
+}
+
+.metric-number {
+  font-size: 18px;
+  font-weight: 700;
+  color: #ff6ad5;
+}
+
+/* Keyframes */
+@keyframes fadeSlideDown {
+  from { opacity: 0; transform: translateY(-12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(14px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes drawWave {
+  0% { stroke-dashoffset: 600; }
+  60% { stroke-dashoffset: 0; }
+  100% { stroke-dashoffset: -600; }
+}
+
+@keyframes fillBar {
+  to { transform: scaleX(1); }
+}
+
+@keyframes cardPop {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 700px) {
+  .bci-grid {
+    grid-template-columns: 1fr;
+  }
+  .eeg-panel { grid-row: auto; }
+}


### PR DESCRIPTION
Closes #28346

## Pull Request Description
Adds a self-contained HTML/CSS UI showcase for the Cognitive Brain-Computer Interface Training Studio (Phase #798), per issue #28346.

---
## Type of Change
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/cognitive-brain-computer-interface-training-studio-phase-798/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A single-page UI showcase visualizing a brain-computer interface training studio with an animated live-drawing EEG waveform, a focus calibration meter, and live training session metric cards.

**How does a developer use it?**
```html
<div class="eeg-view">
  <svg class="eeg-wave"><path d="..." /></svg>
</div>

<div class="focus-meter">
  <div class="focus-fill"></div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's built entirely with CSS keyframes and `animation-delay` for layered entrance and continuous ambient effects (a looping SVG stroke-draw waveform, focus fill, staggered metric cards) — zero external JS dependencies. Fully responsive down to mobile.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser, verified visually)

---
## Browser Testing
- [x] Chrome

---
## Notes for Maintainer
First pass on the EEG wave-draw loop timing — happy to adjust pacing if needed.