### PR TITLE
feat: add autonomous lunar mining & processing rover command showcase

### DIFF
--- a/submissions/examples/autonomous-lunar-mining-processing-rover-command-phase-799/README.md
+++ b/submissions/examples/autonomous-lunar-mining-processing-rover-command-phase-799/README.md
@@ -1,0 +1,30 @@
+# Autonomous Lunar Mining & Processing Rover Command
+
+## What does this do?
+A single-page UI showcase visualizing an autonomous lunar mining command center — a rover excavation site with rising dust puffs and ore veins, an ore processing meter, and live fleet metric cards.
+
+## How is it used?
+```html
+<header class="rover-header">...</header>
+
+<main class="rover-grid">
+  <section class="panel dig-panel">
+    <div class="dig-view">
+      <span class="rover-body"></span>
+      <span class="dust-particle d-1"></span>
+      <span class="ore-vein vein-1"></span>
+    </div>
+  </section>
+  <section class="panel process-panel">
+    <div class="process-meter">
+      <div class="process-fill"></div>
+    </div>
+  </section>
+  <section class="panel card-grid">
+    <div class="metric-card card-1">...</div>
+  </section>
+</main>
+```
+
+## Why is it useful?
+It demonstrates layered entrance and continuous ambient animations (rising dust puffs, ore processing meter fill, staggered metric cards) built entirely with CSS keyframes and animation-delay — no JS dependencies — fitting EaseMotion CSS's philosophy of smooth, dependency-free motion design. The grid layout is fully responsive down to mobile.

--- a/submissions/examples/autonomous-lunar-mining-processing-rover-command-phase-799/demo.html
+++ b/submissions/examples/autonomous-lunar-mining-processing-rover-command-phase-799/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Autonomous Lunar Mining & Processing Rover Command</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="rover-header">
+    <h1>Autonomous Lunar Mining & Processing Rover Command</h1>
+    <p>Tracking regolith excavation, ore processing, and rover fleet status</p>
+  </header>
+
+  <main class="rover-grid">
+
+    <section class="panel dig-panel">
+      <div class="panel-title">Excavation Site</div>
+      <div class="dig-view">
+        <span class="rover-body"></span>
+        <span class="dust-particle d-1"></span>
+        <span class="dust-particle d-2"></span>
+        <span class="dust-particle d-3"></span>
+        <span class="ore-vein vein-1"></span>
+        <span class="ore-vein vein-2"></span>
+      </div>
+    </section>
+
+    <section class="panel process-panel">
+      <div class="panel-title">Ore Processing</div>
+      <div class="process-meter">
+        <div class="process-fill"></div>
+        <span class="process-value">71%</span>
+      </div>
+    </section>
+
+    <section class="panel card-grid">
+      <div class="metric-card card-1">
+        <span class="metric-label">Regolith Mined</span>
+        <span class="metric-number">3,420 kg</span>
+      </div>
+      <div class="metric-card card-2">
+        <span class="metric-label">Active Rovers</span>
+        <span class="metric-number">6</span>
+      </div>
+      <div class="metric-card card-3">
+        <span class="metric-label">Helium-3 Yield</span>
+        <span class="metric-number">+9%</span>
+      </div>
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/autonomous-lunar-mining-processing-rover-command-phase-799/style.css
+++ b/submissions/examples/autonomous-lunar-mining-processing-rover-command-phase-799/style.css
@@ -1,0 +1,203 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', sans-serif;
+  background: #0d1117;
+  color: #e6edf3;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 40px 20px;
+}
+
+.rover-header {
+  text-align: center;
+  margin-bottom: 32px;
+  animation: fadeSlideDown 0.6s ease-out;
+}
+
+.rover-header h1 {
+  font-size: 26px;
+  background: linear-gradient(90deg, #e6edf3, #ffd43b);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.rover-header p {
+  color: #8b949e;
+  margin-top: 6px;
+  font-size: 14px;
+}
+
+.rover-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 20px;
+  width: 100%;
+  max-width: 900px;
+}
+
+.panel {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 10px;
+  padding: 20px;
+  animation: fadeUp 0.6s ease-out both;
+}
+
+.panel-title {
+  font-size: 13px;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 12px;
+}
+
+/* Dig panel */
+.dig-panel { grid-row: span 2; }
+
+.dig-view {
+  position: relative;
+  height: 220px;
+  border-radius: 8px;
+  background: radial-gradient(circle at 50% 70%, #21262d 0%, #0d1117 80%);
+  overflow: hidden;
+}
+
+.rover-body {
+  position: absolute;
+  bottom: 30px;
+  left: 110px;
+  width: 36px;
+  height: 18px;
+  border-radius: 4px;
+  background: #e6edf3;
+  box-shadow: 0 0 10px rgba(230,237,243,0.4);
+}
+
+.dust-particle {
+  position: absolute;
+  bottom: 30px;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: #ffd43b;
+  opacity: 0;
+  animation: dustPuff 2s ease-out infinite;
+}
+
+.d-1 { left: 100px; animation-delay: 0.2s; }
+.d-2 { left: 130px; animation-delay: 0.8s; }
+.d-3 { left: 150px; animation-delay: 1.4s; }
+
+.ore-vein {
+  position: absolute;
+  width: 50px;
+  height: 6px;
+  border-radius: 3px;
+  background: #ffd43b;
+  opacity: 0.4;
+}
+
+.vein-1 { top: 90px;  left: 60px;  transform: rotate(20deg); }
+.vein-2 { top: 130px; left: 170px; transform: rotate(-15deg); }
+
+/* Process meter */
+.process-meter {
+  position: relative;
+  height: 14px;
+  background: #21262d;
+  border-radius: 7px;
+  overflow: hidden;
+}
+
+.process-fill {
+  position: absolute;
+  inset: 0;
+  width: 71%;
+  background: linear-gradient(90deg, #e6edf3, #ffd43b);
+  border-radius: 7px;
+  transform: scaleX(0);
+  transform-origin: left;
+  animation: fillBar 1.2s ease-out 0.4s forwards;
+}
+
+.process-value {
+  display: block;
+  margin-top: 10px;
+  font-size: 20px;
+  font-weight: 600;
+  color: #ffd43b;
+}
+
+/* Metric cards */
+.card-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.metric-card {
+  background: #21262d;
+  border-radius: 8px;
+  padding: 14px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  opacity: 0;
+  transform: translateY(10px);
+  animation: cardPop 0.5s ease-out forwards;
+}
+
+.card-1 { animation-delay: 0.3s; }
+.card-2 { animation-delay: 0.5s; }
+.card-3 { animation-delay: 0.7s; }
+
+.metric-label {
+  font-size: 13px;
+  color: #8b949e;
+}
+
+.metric-number {
+  font-size: 18px;
+  font-weight: 700;
+  color: #ffd43b;
+}
+
+/* Keyframes */
+@keyframes fadeSlideDown {
+  from { opacity: 0; transform: translateY(-12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(14px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes dustPuff {
+  0% { opacity: 0; transform: translateY(0); }
+  40% { opacity: 0.7; }
+  100% { opacity: 0; transform: translateY(-30px); }
+}
+
+@keyframes fillBar {
+  to { transform: scaleX(1); }
+}
+
+@keyframes cardPop {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 700px) {
+  .rover-grid {
+    grid-template-columns: 1fr;
+  }
+  .dig-panel { grid-row: auto; }
+}


### PR DESCRIPTION
Closes #28347

## Pull Request Description
Adds a self-contained HTML/CSS UI showcase for the Autonomous Lunar Mining & Processing Rover Command (Phase #799), per issue #28347.

---
## Type of Change
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/autonomous-lunar-mining-processing-rover-command-phase-799/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A single-page UI showcase visualizing an autonomous lunar mining command center with a rover excavation site, rising dust puffs, ore veins, an ore processing meter, and live fleet metric cards.

**How does a developer use it?**
```html
<div class="dig-view">
  <span class="rover-body"></span>
  <span class="dust-particle d-1"></span>
  <span class="ore-vein vein-1"></span>
</div>

<div class="process-meter">
  <div class="process-fill"></div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's built entirely with CSS keyframes and `animation-delay` for layered entrance and continuous ambient effects (rising dust puffs, processing fill, staggered metric cards) — zero external JS dependencies. Fully responsive down to mobile.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser, verified visually)

---
## Browser Testing
- [x] Chrome

---
## Notes for Maintainer
First pass on the dust-puff rise timing — happy to adjust pacing if needed.