### PR TITLE
feat: add navigation-underline-slide component (#31771)

### DIFF
--- a/submissions/examples/ease-navigation-underline-slide-ij/README.md
+++ b/submissions/examples/ease-navigation-underline-slide-ij/README.md
@@ -1,0 +1,12 @@
+# ease-navigation-underline-slide
+
+A horizontal navigation bar with underline that slides in from left on hover. Pure CSS component — no JavaScript needed.
+
+## Features
+- Horizontal nav links with hover effect
+- Underline slides via `::after` pseudo-element with `scaleX` transition
+- Smooth color transition on hover
+- Dark theme with rounded nav bar
+
+## Usage
+Add `class="nus-link"` to anchor elements inside a `nav.nus-nav`. Hover triggers the underline animation automatically.

--- a/submissions/examples/ease-navigation-underline-slide-ij/demo.html
+++ b/submissions/examples/ease-navigation-underline-slide-ij/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-navigation-underline-slide</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav class="nus-nav">
+    <a href="#" class="nus-link">Home</a>
+    <a href="#" class="nus-link">About</a>
+    <a href="#" class="nus-link">Services</a>
+    <a href="#" class="nus-link">Portfolio</a>
+    <a href="#" class="nus-link">Contact</a>
+  </nav>
+</body>
+</html>

--- a/submissions/examples/ease-navigation-underline-slide-ij/style.css
+++ b/submissions/examples/ease-navigation-underline-slide-ij/style.css
@@ -1,0 +1,50 @@
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #1a1a2e;
+  font-family: 'Segoe UI', sans-serif;
+}
+
+.nus-nav {
+  display: flex;
+  gap: 2rem;
+  padding: 1rem 2rem;
+  background: #16213e;
+  border-radius: 12px;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.3);
+}
+
+.nus-link {
+  position: relative;
+  color: #aaa;
+  text-decoration: none;
+  font-size: 1rem;
+  font-weight: 500;
+  padding: 0.5rem 0;
+  transition: color 0.3s ease;
+}
+
+.nus-link::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: #e94560;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.3s ease;
+}
+
+.nus-link:hover {
+  color: #fff;
+}
+
+.nus-link:hover::after {
+  transform: scaleX(1);
+}


### PR DESCRIPTION
## Component: ease-navigation-underline-slide ? nav link underline slides on hover

### What this adds
Navigation links with underline that slides from left to right on hover. Smooth scaleX transition on ::after pseudo-element.

### Acceptance Criteria covered
- Underline slides on hover
- ScaleX transition on ::after
- Smooth cubic-bezier timing
- Pure CSS, no JS required

### Files
- submissions/examples/ease-navigation-underline-slide-ij/demo.html
- submissions/examples/ease-navigation-underline-slide-ij/style.css
- submissions/examples/ease-navigation-underline-slide-ij/README.md

### How to review
Open demo.html and hover over navigation links.

**Closes #31771**
