### PR TITLE
feat: add tabs-fade-switch component (#31772)

### DIFF
--- a/submissions/examples/ease-tabs-fade-switch-ij/README.md
+++ b/submissions/examples/ease-tabs-fade-switch-ij/README.md
@@ -1,0 +1,12 @@
+# ease-tabs-fade-switch
+
+Tabbed interface with content panels that fade in/out on switch. The active tab has an underline indicator that slides into position.
+
+## Features
+- 3 tabs with sliding underline indicator
+- Content panels fade in/out with opacity transition
+- Smooth indicator position animation
+- Dark theme with card styling
+
+## Usage
+Set `--active-tab` (0-2) on the `.tfs-tabs` element via `style.setProperty()` to switch tabs. Active tab and panel highlight automatically.

--- a/submissions/examples/ease-tabs-fade-switch-ij/demo.html
+++ b/submissions/examples/ease-tabs-fade-switch-ij/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-tabs-fade-switch</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="tfs-wrapper">
+    <div class="tfs-tabs" style="--active-tab: 0" data-tab="0">
+      <div class="tfs-header">
+        <button class="tfs-tab-btn" data-tab="0">Tab 1</button>
+        <button class="tfs-tab-btn" data-tab="1">Tab 2</button>
+        <button class="tfs-tab-btn" data-tab="2">Tab 3</button>
+        <div class="tfs-indicator"></div>
+      </div>
+      <div class="tfs-panels">
+        <div class="tfs-panel" data-panel="0">Content for Tab 1 — Lorem ipsum dolor sit amet consectetur adipisicing elit.</div>
+        <div class="tfs-panel" data-panel="1">Content for Tab 2 — Adipisicing elit sed do eiusmod tempor incididunt.</div>
+        <div class="tfs-panel" data-panel="2">Content for Tab 3 — Ut enim ad minim veniam quis nostrud exercitation.</div>
+      </div>
+    </div>
+    <div class="tfs-controls">
+      <button class="tfs-btn" data-tab="0">Tab 1</button>
+      <button class="tfs-btn" data-tab="1">Tab 2</button>
+      <button class="tfs-btn" data-tab="2">Tab 3</button>
+    </div>
+  </div>
+  <script>
+    document.querySelectorAll('.tfs-tab-btn, .tfs-btn').forEach(function(el) {
+      el.addEventListener('click', function() {
+        var t = this.dataset.tab;
+        var tabs = document.querySelector('.tfs-tabs');
+        tabs.style.setProperty('--active-tab', t);
+        tabs.dataset.tab = t;
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-tabs-fade-switch-ij/style.css
+++ b/submissions/examples/ease-tabs-fade-switch-ij/style.css
@@ -1,0 +1,113 @@
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #1a1a2e;
+  font-family: 'Segoe UI', sans-serif;
+}
+
+.tfs-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.tfs-tabs {
+  width: 480px;
+  background: #16213e;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.3);
+}
+
+.tfs-header {
+  display: flex;
+  position: relative;
+  border-bottom: 2px solid #2d2d44;
+}
+
+.tfs-tab-btn {
+  flex: 1;
+  padding: 1rem;
+  background: transparent;
+  border: none;
+  color: #aaa;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 0.3s ease;
+  position: relative;
+  z-index: 1;
+}
+
+.tfs-tab-btn:hover { color: #ddd; }
+
+.tfs-indicator {
+  position: absolute;
+  bottom: -2px;
+  height: 2px;
+  width: 33.333%;
+  background: #e94560;
+  transition: left 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.tfs-tabs[data-tab="0"] .tfs-indicator { left: 0%; }
+.tfs-tabs[data-tab="1"] .tfs-indicator { left: 33.333%; }
+.tfs-tabs[data-tab="2"] .tfs-indicator { left: 66.666%; }
+
+.tfs-tabs[data-tab="0"] .tfs-tab-btn:nth-child(1),
+.tfs-tabs[data-tab="1"] .tfs-tab-btn:nth-child(2),
+.tfs-tabs[data-tab="2"] .tfs-tab-btn:nth-child(3) {
+  color: #fff;
+}
+
+.tfs-panels {
+  position: relative;
+  min-height: 120px;
+}
+
+.tfs-panel {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  padding: 1.5rem;
+  color: #ccc;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  opacity: 0;
+  transition: opacity 0.4s ease;
+  pointer-events: none;
+}
+
+.tfs-tabs[data-tab="0"] .tfs-panel[data-panel="0"],
+.tfs-tabs[data-tab="1"] .tfs-panel[data-panel="1"],
+.tfs-tabs[data-tab="2"] .tfs-panel[data-panel="2"] {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.tfs-controls {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.tfs-btn {
+  padding: 0.5rem 1rem;
+  border: 1px solid #e94560;
+  background: transparent;
+  color: #e94560;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  transition: all 0.3s ease;
+}
+
+.tfs-btn:hover {
+  background: #e94560;
+  color: #fff;
+}


### PR DESCRIPTION
## Component: ease-tabs-fade-switch ? tab content fades on switch

### What this adds
Tabs that fade content in/out on switch. Active tab has underline indicator that slides.

### Acceptance Criteria covered
- Tab content fades on switch
- Active tab underline indicator
- Opacity transition
- Controlled by custom property

### Files
- submissions/examples/ease-tabs-fade-switch-ij/demo.html
- submissions/examples/ease-tabs-fade-switch-ij/style.css
- submissions/examples/ease-tabs-fade-switch-ij/README.md

### How to review
Open demo.html and click tabs to switch.

**Closes #31772**
