### PR TITLE
feat: add nuclear thermal propulsion spacecraft bridge showcase

### DIFF
--- a/submissions/examples/nuclear-thermal-propulsion-spacecraft-bridge-phase-789/README.md
+++ b/submissions/examples/nuclear-thermal-propulsion-spacecraft-bridge-phase-789/README.md
@@ -1,0 +1,30 @@
+# Nuclear Thermal Propulsion Spacecraft Bridge
+
+## What does this do?
+A single-page UI showcase visualizing a nuclear thermal propulsion spacecraft bridge — a throbbing reactor core with spinning containment rings and exhaust puffs, a thrust output meter, and live propulsion metric cards.
+
+## How is it used?
+```html
+<header class="ntp-header">...</header>
+
+<main class="ntp-grid">
+  <section class="panel core-panel">
+    <div class="core-view">
+      <span class="core-glow"></span>
+      <span class="core-ring ring-1"></span>
+      <span class="exhaust-trail trail-1"></span>
+    </div>
+  </section>
+  <section class="panel thrust-panel">
+    <div class="thrust-meter">
+      <div class="thrust-fill"></div>
+    </div>
+  </section>
+  <section class="panel card-grid">
+    <div class="metric-card card-1">...</div>
+  </section>
+</main>
+```
+
+## Why is it useful?
+It demonstrates layered entrance and continuous ambient animations (throbbing reactor core, counter-rotating containment rings, exhaust puffs, thrust meter fill, staggered metric cards) built entirely with CSS keyframes and animation-delay — no JS dependencies — fitting EaseMotion CSS's philosophy of smooth, dependency-free motion design. The grid layout is fully responsive down to mobile.

--- a/submissions/examples/nuclear-thermal-propulsion-spacecraft-bridge-phase-789/demo.html
+++ b/submissions/examples/nuclear-thermal-propulsion-spacecraft-bridge-phase-789/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Nuclear Thermal Propulsion Spacecraft Bridge</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="ntp-header">
+    <h1>Nuclear Thermal Propulsion Spacecraft Bridge</h1>
+    <p>Reactor core telemetry and propulsion control for deep-space transit</p>
+  </header>
+
+  <main class="ntp-grid">
+
+    <section class="panel core-panel">
+      <div class="panel-title">Reactor Core</div>
+      <div class="core-view">
+        <span class="core-ring ring-1"></span>
+        <span class="core-ring ring-2"></span>
+        <span class="core-glow"></span>
+        <span class="exhaust-trail trail-1"></span>
+        <span class="exhaust-trail trail-2"></span>
+      </div>
+    </section>
+
+    <section class="panel thrust-panel">
+      <div class="panel-title">Thrust Output</div>
+      <div class="thrust-meter">
+        <div class="thrust-fill"></div>
+        <span class="thrust-value">83%</span>
+      </div>
+    </section>
+
+    <section class="panel card-grid">
+      <div class="metric-card card-1">
+        <span class="metric-label">Core Temp</span>
+        <span class="metric-number">2,850K</span>
+      </div>
+      <div class="metric-card card-2">
+        <span class="metric-label">Specific Impulse</span>
+        <span class="metric-number">920s</span>
+      </div>
+      <div class="metric-card card-3">
+        <span class="metric-label">Transit ETA</span>
+        <span class="metric-number">142d</span>
+      </div>
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/nuclear-thermal-propulsion-spacecraft-bridge-phase-789/style.css
+++ b/submissions/examples/nuclear-thermal-propulsion-spacecraft-bridge-phase-789/style.css
@@ -1,0 +1,209 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', sans-serif;
+  background: #0d1117;
+  color: #e6edf3;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 40px 20px;
+}
+
+.ntp-header {
+  text-align: center;
+  margin-bottom: 32px;
+  animation: fadeSlideDown 0.6s ease-out;
+}
+
+.ntp-header h1 {
+  font-size: 26px;
+  background: linear-gradient(90deg, #ff6b6b, #ffd43b);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.ntp-header p {
+  color: #8b949e;
+  margin-top: 6px;
+  font-size: 14px;
+}
+
+.ntp-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 20px;
+  width: 100%;
+  max-width: 900px;
+}
+
+.panel {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 10px;
+  padding: 20px;
+  animation: fadeUp 0.6s ease-out both;
+}
+
+.panel-title {
+  font-size: 13px;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 12px;
+}
+
+/* Core panel */
+.core-panel { grid-row: span 2; }
+
+.core-view {
+  position: relative;
+  height: 220px;
+  border-radius: 8px;
+  background: radial-gradient(circle at 50% 50%, #2a0e0e 0%, #0d1117 80%);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.core-glow {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: #ffd43b;
+  box-shadow: 0 0 24px #ff6b6b;
+  animation: coreThrob 1.6s ease-in-out infinite;
+}
+
+.core-ring {
+  position: absolute;
+  border: 1px solid #ff6b6b;
+  border-radius: 50%;
+  opacity: 0.5;
+}
+
+.ring-1 { width: 80px;  height: 80px;  animation: spin 6s linear infinite; }
+.ring-2 { width: 130px; height: 130px; animation: spin 9s linear infinite reverse; }
+
+.exhaust-trail {
+  position: absolute;
+  bottom: 10px;
+  width: 4px;
+  height: 30px;
+  background: linear-gradient(180deg, #ffd43b, transparent);
+  opacity: 0;
+  animation: exhaustPuff 1.4s ease-out infinite;
+}
+
+.trail-1 { left: 100px; }
+.trail-2 { left: 160px; animation-delay: 0.5s; }
+
+/* Thrust meter */
+.thrust-meter {
+  position: relative;
+  height: 14px;
+  background: #21262d;
+  border-radius: 7px;
+  overflow: hidden;
+}
+
+.thrust-fill {
+  position: absolute;
+  inset: 0;
+  width: 83%;
+  background: linear-gradient(90deg, #ff6b6b, #ffd43b);
+  border-radius: 7px;
+  transform: scaleX(0);
+  transform-origin: left;
+  animation: fillBar 1.2s ease-out 0.4s forwards;
+}
+
+.thrust-value {
+  display: block;
+  margin-top: 10px;
+  font-size: 20px;
+  font-weight: 600;
+  color: #ff6b6b;
+}
+
+/* Metric cards */
+.card-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.metric-card {
+  background: #21262d;
+  border-radius: 8px;
+  padding: 14px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  opacity: 0;
+  transform: translateY(10px);
+  animation: cardPop 0.5s ease-out forwards;
+}
+
+.card-1 { animation-delay: 0.3s; }
+.card-2 { animation-delay: 0.5s; }
+.card-3 { animation-delay: 0.7s; }
+
+.metric-label {
+  font-size: 13px;
+  color: #8b949e;
+}
+
+.metric-number {
+  font-size: 18px;
+  font-weight: 700;
+  color: #ffd43b;
+}
+
+/* Keyframes */
+@keyframes fadeSlideDown {
+  from { opacity: 0; transform: translateY(-12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(14px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes coreThrob {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.25); }
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes exhaustPuff {
+  0% { opacity: 0; transform: translateY(0); }
+  40% { opacity: 0.8; }
+  100% { opacity: 0; transform: translateY(20px); }
+}
+
+@keyframes fillBar {
+  to { transform: scaleX(1); }
+}
+
+@keyframes cardPop {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 700px) {
+  .ntp-grid {
+    grid-template-columns: 1fr;
+  }
+  .core-panel { grid-row: auto; }
+}


### PR DESCRIPTION
Closes #28349

## Pull Request Description
Adds a self-contained HTML/CSS UI showcase for the Nuclear Thermal Propulsion Spacecraft Bridge (Phase #789), per issue #28349.

---
## Type of Change
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/nuclear-thermal-propulsion-spacecraft-bridge-phase-789/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A single-page UI showcase visualizing a nuclear thermal propulsion spacecraft bridge with a throbbing reactor core, spinning containment rings, exhaust puffs, a thrust output meter, and live propulsion metric cards.

**How does a developer use it?**
```html
<div class="core-view">
  <span class="core-glow"></span>
  <span class="core-ring ring-1"></span>
  <span class="exhaust-trail trail-1"></span>
</div>

<div class="thrust-meter">
  <div class="thrust-fill"></div>
</div>

<div class="metric-card card-1">...</div>
```

**Why does it fit EaseMotion CSS?**
It's built entirely with CSS keyframes and `animation-delay` for layered entrance and continuous ambient effects (throbbing core, counter-rotating rings, exhaust puffs, thrust fill, staggered metric cards) — zero external JS dependencies. Fully responsive down to mobile.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser, verified visually)

---
## Browser Testing
- [x] Chrome

---
## Notes for Maintainer
First pass on the core-throb and exhaust-puff timing — happy to adjust pacing if needed.