### PR TITLE
feat: add hover-scale-card component (#31801)

### DIFF
--- a/submissions/examples/ease-hover-scale-card-ij/README.md
+++ b/submissions/examples/ease-hover-scale-card-ij/README.md
@@ -1,0 +1,11 @@
+# ease-hover-scale-card
+
+A card that scales up on hover with an elevated shadow.
+
+## Features
+- Pure CSS, no JavaScript required
+- Smooth `transform` and `box-shadow` transition
+- Hover state scales card to 1.05x with enhanced shadow
+
+## CSS Custom Property Control
+Natively uses CSS `:hover` pseudo-class. No custom properties needed.

--- a/submissions/examples/ease-hover-scale-card-ij/demo.html
+++ b/submissions/examples/ease-hover-scale-card-ij/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-hover-scale-card</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="hsc-container">
+    <div class="hsc-card">
+      <h2 class="hsc-title">Hover Scale Card</h2>
+      <p class="hsc-desc">Hover over this card to see it scale up.</p>
+    </div>
+    <div class="hsc-card">
+      <h2 class="hsc-title">Another Card</h2>
+      <p class="hsc-desc">Each card smoothly scales and lifts.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-hover-scale-card-ij/style.css
+++ b/submissions/examples/ease-hover-scale-card-ij/style.css
@@ -1,0 +1,7 @@
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { min-height: 100vh; display: flex; justify-content: center; align-items: center; background: #1a1a2e; font-family: system-ui, sans-serif; }
+.hsc-container { display: flex; gap: 30px; flex-wrap: wrap; justify-content: center; padding: 20px; }
+.hsc-card { background: #16213e; padding: 40px; border-radius: 16px; color: #e0e0e0; width: 280px; text-align: center; transition: transform 0.3s ease, box-shadow 0.3s ease; cursor: pointer; }
+.hsc-card:hover { transform: scale(1.05); box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4); }
+.hsc-title { font-size: 1.4rem; margin-bottom: 12px; color: #0f3460; }
+.hsc-desc { line-height: 1.6; }


### PR DESCRIPTION
## Component: ease-hover-scale-card ? card scales up on hover with shadow

### What this adds
Card that scales up on hover with elevated shadow. Smooth transform transition.

### Acceptance Criteria covered
- Card scales on hover
- Elevated shadow effect
- Smooth transform transition
- Pure CSS, no JS required

### Files
- submissions/examples/ease-hover-scale-card-ij/demo.html
- submissions/examples/ease-hover-scale-card-ij/style.css
- submissions/examples/ease-hover-scale-card-ij/README.md

### How to review
Open demo.html and hover over the card.

**Closes #31801**
