### PR TITLE
feat: add tag-removable-fade component (#31811)

### DIFF
--- a/submissions/examples/ease-tag-removable-fade-ij/README.md
+++ b/submissions/examples/ease-tag-removable-fade-ij/README.md
@@ -1,0 +1,14 @@
+# ease-tag-removable-fade
+
+Tag/pill component with an X remove button. On click, the tag fades out, shrinks in scale, and collapses its width before being hidden from the DOM.
+
+## Features
+
+- Pill-shaped tags with label and close button
+- Smooth fade-out, scale-down, and width collapse on removal
+- Tags wrap naturally in a flex container
+- Accessible remove buttons with aria-label
+
+## CSS Custom Property Control
+
+- `--removing`: Set to `1` to trigger the removal animation (opacity → 0, scale → 0.7, width collapses). The JavaScript sets this property on the tag element before removing it after 400ms.

--- a/submissions/examples/ease-tag-removable-fade-ij/demo.html
+++ b/submissions/examples/ease-tag-removable-fade-ij/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-tag-removable-fade</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="trf-container">
+    <div class="trf-tag" id="trf-tag-1" style="--removing: 0">
+      <span class="trf-label">JavaScript</span>
+      <button class="trf-remove" data-target="trf-tag-1" aria-label="Remove">&times;</button>
+    </div>
+    <div class="trf-tag" id="trf-tag-2" style="--removing: 0">
+      <span class="trf-label">CSS</span>
+      <button class="trf-remove" data-target="trf-tag-2" aria-label="Remove">&times;</button>
+    </div>
+    <div class="trf-tag" id="trf-tag-3" style="--removing: 0">
+      <span class="trf-label">HTML</span>
+      <button class="trf-remove" data-target="trf-tag-3" aria-label="Remove">&times;</button>
+    </div>
+  </div>
+  <script>
+    document.querySelectorAll('.trf-remove').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const tag = document.getElementById(btn.dataset.target);
+        tag.style.setProperty('--removing', 1);
+        setTimeout(() => { tag.style.display = 'none'; }, 400);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-tag-removable-fade-ij/style.css
+++ b/submissions/examples/ease-tag-removable-fade-ij/style.css
@@ -1,0 +1,48 @@
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #1a1a2e;
+  font-family: 'Segoe UI', sans-serif;
+}
+
+.trf-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+  max-width: 500px;
+}
+
+.trf-tag {
+  --removing: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: #16213e;
+  padding: 0.5rem 1rem;
+  border-radius: 20px;
+  color: #e0e0e0;
+  font-size: 0.875rem;
+  transition: opacity 0.35s ease, transform 0.35s ease, width 0.35s ease;
+  opacity: calc(1 - var(--removing));
+  transform: scale(calc(1 - var(--removing) * 0.3));
+  overflow: hidden;
+  max-width: calc(200px * (1 - var(--removing) * 0.8));
+}
+
+.trf-remove {
+  background: none;
+  border: none;
+  color: #a0a0b8;
+  font-size: 1.1rem;
+  cursor: pointer;
+  padding: 0 0.1rem;
+  line-height: 1;
+  transition: color 0.2s ease;
+}
+
+.trf-remove:hover { color: #ff4757; }


### PR DESCRIPTION
## Component: ease-tag-removable-fade ? removable tag with fade out

### What this adds
Tag with remove button that fades out and slides away on removal. Smooth opacity and width transition.

### Acceptance Criteria covered
- Tag with remove button
- Fade out on remove
- Slide away on dismiss
- Smooth transition

### Files
- submissions/examples/ease-tag-removable-fade-ij/demo.html
- submissions/examples/ease-tag-removable-fade-ij/style.css
- submissions/examples/ease-tag-removable-fade-ij/README.md

### How to review
Open demo.html and click X to remove tag.

**Closes #31811**
