### PR TITLE
feat: add menu-dropdown-scale component (#31813)

### DIFF
--- a/submissions/examples/ease-menu-dropdown-scale-ij/README.md
+++ b/submissions/examples/ease-menu-dropdown-scale-ij/README.md
@@ -1,0 +1,14 @@
+# ease-menu-dropdown-scale
+
+A dropdown menu that scales in from the top with `transform-origin: top`. A trigger button opens the menu which animates using scaleY and opacity.
+
+## Features
+
+- Button trigger with click toggle
+- Menu scales in vertically from the top edge
+- Smooth scaleY + opacity transition
+- Hover effects on menu items
+
+## CSS Custom Property Control
+
+- `--open`: Set to `1` to show the menu, `0` to hide. Toggled by clicking the button or using the checkbox.

--- a/submissions/examples/ease-menu-dropdown-scale-ij/demo.html
+++ b/submissions/examples/ease-menu-dropdown-scale-ij/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-menu-dropdown-scale</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="mds-container">
+    <div class="mds-dropdown">
+      <button class="mds-trigger" onclick="toggleMenu()">Menu ▾</button>
+      <ul class="mds-menu" id="mds-menu" style="--open: 0">
+        <li class="mds-item">Profile</li>
+        <li class="mds-item">Settings</li>
+        <li class="mds-item">Account</li>
+        <li class="mds-item">Help</li>
+        <li class="mds-item">Logout</li>
+      </ul>
+    </div>
+    <label class="mds-toggle">
+      <input type="checkbox" onchange="document.getElementById('mds-menu').style.setProperty('--open', this.checked ? 1 : 0)">
+      <span>Open menu</span>
+    </label>
+  </div>
+  <script>
+    function toggleMenu() {
+      const menu = document.getElementById('mds-menu');
+      const val = menu.style.getPropertyValue('--open').trim();
+      menu.style.setProperty('--open', val === '1' ? 0 : 1);
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-menu-dropdown-scale-ij/style.css
+++ b/submissions/examples/ease-menu-dropdown-scale-ij/style.css
@@ -1,0 +1,74 @@
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #1a1a2e;
+  font-family: 'Segoe UI', sans-serif;
+}
+
+.mds-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+}
+
+.mds-dropdown {
+  position: relative;
+}
+
+.mds-trigger {
+  background: #6c63ff;
+  color: #fff;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 8px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.mds-trigger:hover { background: #5a52e0; }
+
+.mds-menu {
+  --open: 0;
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  min-width: 200px;
+  background: #16213e;
+  border-radius: 8px;
+  overflow: hidden;
+  list-style: none;
+  transform-origin: top;
+  transform: scaleY(var(--open));
+  opacity: calc(0.4 + var(--open) * 0.6);
+  transition: transform 0.25s ease, opacity 0.2s ease;
+  pointer-events: var(--open) = 1 ? auto : none;
+}
+
+.mds-item {
+  padding: 0.75rem 1.25rem;
+  color: #c0c0d0;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+}
+
+.mds-item:hover {
+  background: #1e2a4a;
+  color: #fff;
+}
+
+.mds-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #a0a0b8;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+.mds-toggle input { accent-color: #6c63ff; }


### PR DESCRIPTION
## Component: ease-menu-dropdown-scale ? menu dropdown scales in

### What this adds
Dropdown menu that scales in from top with opacity. Transform scaleY with origin top.

### Acceptance Criteria covered
- Dropdown menu
- Scale in from top
- Opacity transition
- Controlled by custom property

### Files
- submissions/examples/ease-menu-dropdown-scale-ij/demo.html
- submissions/examples/ease-menu-dropdown-scale-ij/style.css
- submissions/examples/ease-menu-dropdown-scale-ij/README.md

### How to review
Open demo.html and click button to toggle dropdown.

**Closes #31813**
