### PR TITLE
feat: add tooltip-slide-up component (#31814)

### DIFF
--- a/submissions/examples/ease-tooltip-slide-up-ij/README.md
+++ b/submissions/examples/ease-tooltip-slide-up-ij/README.md
@@ -1,0 +1,14 @@
+# ease-tooltip-slide-up
+
+A trigger element with a tooltip that slides up from below on hover. The tooltip appears above the trigger with a smooth translateY + opacity transition.
+
+## Features
+
+- Hover-to-reveal tooltip above trigger
+- Slides up with translateY + opacity fade
+- Arrow indicator pointing down to trigger
+- Clean dark theme styling
+
+## CSS Custom Property Control
+
+- No `--` custom property needed; the tooltip uses CSS `:hover` on the trigger element to control the tooltip visibility.

--- a/submissions/examples/ease-tooltip-slide-up-ij/demo.html
+++ b/submissions/examples/ease-tooltip-slide-up-ij/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-tooltip-slide-up</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="tsu-container">
+    <div class="tsu-trigger">
+      Hover me
+      <span class="tsu-tooltip">This is a tooltip</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-tooltip-slide-up-ij/style.css
+++ b/submissions/examples/ease-tooltip-slide-up-ij/style.css
@@ -1,0 +1,57 @@
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #1a1a2e;
+  font-family: 'Segoe UI', sans-serif;
+}
+
+.tsu-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.tsu-trigger {
+  position: relative;
+  background: #6c63ff;
+  color: #fff;
+  padding: 0.75rem 1.5rem;
+  border-radius: 8px;
+  font-size: 1rem;
+  cursor: default;
+}
+
+.tsu-tooltip {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  transform: translateX(-50%) translateY(10px);
+  background: #16213e;
+  color: #e0e0e0;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  font-size: 0.8125rem;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+
+.tsu-tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-top-color: #16213e;
+}
+
+.tsu-trigger:hover .tsu-tooltip {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}


### PR DESCRIPTION
## Component: ease-tooltip-slide-up ? tooltip slides up on hover

### What this adds
Tooltip that slides up from below with fade. TranslateY and opacity transition on hover.

### Acceptance Criteria covered
- Tooltip slides up
- Fade entrance
- Hover trigger
- Pure CSS

### Files
- submissions/examples/ease-tooltip-slide-up-ij/demo.html
- submissions/examples/ease-tooltip-slide-up-ij/style.css
- submissions/examples/ease-tooltip-slide-up-ij/README.md

### How to review
Open demo.html and hover over the trigger element.

**Closes #31814**
