### PR TITLE
feat: add personalized pharmacogenomics drug design hub showcase

### DIFF
--- a/submissions/examples/personalized-pharmacogenomics-drug-design-hub-phase-793/README.md
+++ b/submissions/examples/personalized-pharmacogenomics-drug-design-hub-phase-793/README.md
@@ -1,0 +1,29 @@
+# Personalized Pharmacogenomics Drug Design Hub
+
+## What does this do?
+A single-page UI showcase visualizing a pharmacogenomics drug design hub — a spinning double-helix with pulsing genetic marker dots, a compound match score meter, and live analysis metric cards.
+
+## How is it used?
+```html
+<header class="pharma-header">...</header>
+
+<main class="pharma-grid">
+  <section class="panel helix-panel">
+    <div class="helix-view">
+      <span class="helix-strand strand-1"></span>
+      <span class="marker-dot dot-1"></span>
+    </div>
+  </section>
+  <section class="panel match-panel">
+    <div class="match-meter">
+      <div class="match-fill"></div>
+    </div>
+  </section>
+  <section class="panel card-grid">
+    <div class="metric-card card-1">...</div>
+  </section>
+</main>
+```
+
+## Why is it useful?
+It demonstrates layered entrance and continuous ambient animations (spinning helix strands, pulsing genetic markers, match meter fill, staggered metric cards) built entirely with CSS keyframes and animation-delay — no JS dependencies — fitting EaseMotion CSS's philosophy of smooth, dependency-free motion design. The grid layout is fully responsive down to mobile.

--- a/submissions/examples/personalized-pharmacogenomics-drug-design-hub-phase-793/demo.html
+++ b/submissions/examples/personalized-pharmacogenomics-drug-design-hub-phase-793/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Personalized Pharmacogenomics Drug Design Hub</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="pharma-header">
+    <h1>Personalized Pharmacogenomics Drug Design Hub</h1>
+    <p>Mapping genetic markers to optimized drug compound design in real time</p>
+  </header>
+
+  <main class="pharma-grid">
+
+    <section class="panel helix-panel">
+      <div class="panel-title">Genetic Marker Scan</div>
+      <div class="helix-view">
+        <span class="helix-strand strand-1"></span>
+        <span class="helix-strand strand-2"></span>
+        <span class="marker-dot dot-1"></span>
+        <span class="marker-dot dot-2"></span>
+        <span class="marker-dot dot-3"></span>
+      </div>
+    </section>
+
+    <section class="panel match-panel">
+      <div class="panel-title">Compound Match Score</div>
+      <div class="match-meter">
+        <div class="match-fill"></div>
+        <span class="match-value">91%</span>
+      </div>
+    </section>
+
+    <section class="panel card-grid">
+      <div class="metric-card card-1">
+        <span class="metric-label">Markers Analyzed</span>
+        <span class="metric-number">4,208</span>
+      </div>
+      <div class="metric-card card-2">
+        <span class="metric-label">Candidate Compounds</span>
+        <span class="metric-number">17</span>
+      </div>
+      <div class="metric-card card-3">
+        <span class="metric-label">Adverse Risk</span>
+        <span class="metric-number">Low</span>
+      </div>
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/personalized-pharmacogenomics-drug-design-hub-phase-793/style.css
+++ b/submissions/examples/personalized-pharmacogenomics-drug-design-hub-phase-793/style.css
@@ -1,0 +1,197 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', sans-serif;
+  background: #0d1117;
+  color: #e6edf3;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 40px 20px;
+}
+
+.pharma-header {
+  text-align: center;
+  margin-bottom: 32px;
+  animation: fadeSlideDown 0.6s ease-out;
+}
+
+.pharma-header h1 {
+  font-size: 26px;
+  background: linear-gradient(90deg, #a371f7, #58a6ff);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.pharma-header p {
+  color: #8b949e;
+  margin-top: 6px;
+  font-size: 14px;
+}
+
+.pharma-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 20px;
+  width: 100%;
+  max-width: 900px;
+}
+
+.panel {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 10px;
+  padding: 20px;
+  animation: fadeUp 0.6s ease-out both;
+}
+
+.panel-title {
+  font-size: 13px;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 12px;
+}
+
+/* Helix panel */
+.helix-panel { grid-row: span 2; }
+
+.helix-view {
+  position: relative;
+  height: 220px;
+  border-radius: 8px;
+  background: radial-gradient(circle at 50% 50%, #21262d 0%, #0d1117 80%);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.helix-strand {
+  position: absolute;
+  width: 90px;
+  height: 180px;
+  border: 1px solid #a371f7;
+  border-radius: 50%;
+  animation: helixSpin 4s linear infinite;
+}
+
+.strand-1 { transform: rotateY(0deg); }
+.strand-2 { transform: rotateY(90deg); border-color: #58a6ff; animation-delay: -2s; }
+
+.marker-dot {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #58a6ff;
+  box-shadow: 0 0 8px #58a6ff;
+  animation: markerPulse 2s ease-in-out infinite;
+}
+
+.dot-1 { top: 60px;  left: 90px; }
+.dot-2 { top: 110px; left: 160px; animation-delay: 0.6s; background: #a371f7; box-shadow: 0 0 8px #a371f7; }
+.dot-3 { top: 150px; left: 100px; animation-delay: 1.2s; }
+
+/* Match meter */
+.match-meter {
+  position: relative;
+  height: 14px;
+  background: #21262d;
+  border-radius: 7px;
+  overflow: hidden;
+}
+
+.match-fill {
+  position: absolute;
+  inset: 0;
+  width: 91%;
+  background: linear-gradient(90deg, #a371f7, #58a6ff);
+  border-radius: 7px;
+  transform: scaleX(0);
+  transform-origin: left;
+  animation: fillBar 1.2s ease-out 0.4s forwards;
+}
+
+.match-value {
+  display: block;
+  margin-top: 10px;
+  font-size: 20px;
+  font-weight: 600;
+  color: #a371f7;
+}
+
+/* Metric cards */
+.card-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.metric-card {
+  background: #21262d;
+  border-radius: 8px;
+  padding: 14px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  opacity: 0;
+  transform: translateY(10px);
+  animation: cardPop 0.5s ease-out forwards;
+}
+
+.card-1 { animation-delay: 0.3s; }
+.card-2 { animation-delay: 0.5s; }
+.card-3 { animation-delay: 0.7s; }
+
+.metric-label {
+  font-size: 13px;
+  color: #8b949e;
+}
+
+.metric-number {
+  font-size: 18px;
+  font-weight: 700;
+  color: #58a6ff;
+}
+
+/* Keyframes */
+@keyframes fadeSlideDown {
+  from { opacity: 0; transform: translateY(-12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(14px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes helixSpin {
+  to { transform: rotateY(360deg); }
+}
+
+@keyframes markerPulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.4; transform: scale(1.3); }
+}
+
+@keyframes fillBar {
+  to { transform: scaleX(1); }
+}
+
+@keyframes cardPop {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 700px) {
+  .pharma-grid {
+    grid-template-columns: 1fr;
+  }
+  .helix-panel { grid-row: auto; }
+}


### PR DESCRIPTION
Closes #28341

## Pull Request Description
Adds a self-contained HTML/CSS UI showcase for the Personalized Pharmacogenomics Drug Design Hub (Phase #793), per issue #28341.

---
## Type of Change
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/personalized-pharmacogenomics-drug-design-hub-phase-793/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A single-page UI showcase visualizing a pharmacogenomics drug design hub with a spinning double-helix, pulsing genetic marker dots, a compound match score meter, and live analysis metric cards.

**How does a developer use it?**
```html
<div class="helix-view">
  <span class="helix-strand strand-1"></span>
  <span class="marker-dot dot-1"></span>
</div>

<div class="match-meter">
  <div class="match-fill"></div>
</div>

<div class="metric-card card-1">...</div>
```

**Why does it fit EaseMotion CSS?**
It's built entirely with CSS keyframes and `animation-delay` for layered entrance and continuous ambient effects (spinning helix strands, pulsing markers, match fill, staggered metric cards) — zero external JS dependencies. Fully responsive down to mobile.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser, verified visually)

---
## Browser Testing
- [x] Chrome

---
## Notes for Maintainer
First pass on the helix-spin and marker-pulse timing — happy to adjust pacing if needed.