### PR TITLE
feat: add smart cyber-physical power grid command showcase

### DIFF
--- a/submissions/examples/smart-cyber-physical-power-grid-command-phase-790/README.md
+++ b/submissions/examples/smart-cyber-physical-power-grid-command-phase-790/README.md
@@ -1,0 +1,29 @@
+# Smart Cyber-Physical Power Grid Command
+
+## What does this do?
+A single-page UI showcase visualizing a cyber-physical power grid command center — pulsing grid nodes, animated connection lines, a load balance meter, and live power output metric cards.
+
+## How is it used?
+```html
+<header class="grid-header">...</header>
+
+<main class="grid-main">
+  <section class="panel network-panel">
+    <div class="network-view">
+      <span class="grid-node node-1"></span>
+      <span class="pulse-line line-1"></span>
+    </div>
+  </section>
+  <section class="panel load-panel">
+    <div class="load-meter">
+      <div class="load-fill"></div>
+    </div>
+  </section>
+  <section class="panel card-grid">
+    <div class="metric-card card-1">...</div>
+  </section>
+</main>
+```
+
+## Why is it useful?
+It demonstrates layered entrance and continuous ambient animations (pulsing grid nodes, animated connection lines, load meter fill, staggered metric cards) built entirely with CSS keyframes and animation-delay — no JS dependencies — fitting EaseMotion CSS's philosophy of smooth, dependency-free motion design. The grid layout is fully responsive down to mobile.

--- a/submissions/examples/smart-cyber-physical-power-grid-command-phase-790/demo.html
+++ b/submissions/examples/smart-cyber-physical-power-grid-command-phase-790/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Smart Cyber-Physical Power Grid Command</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="grid-header">
+    <h1>Smart Cyber-Physical Power Grid Command</h1>
+    <p>Monitoring load balancing, node health, and grid stability in real time</p>
+  </header>
+
+  <main class="grid-main">
+
+    <section class="panel network-panel">
+      <div class="panel-title">Grid Network</div>
+      <div class="network-view">
+        <span class="grid-node node-1"></span>
+        <span class="grid-node node-2"></span>
+        <span class="grid-node node-3"></span>
+        <span class="grid-node node-4"></span>
+        <span class="pulse-line line-1"></span>
+        <span class="pulse-line line-2"></span>
+      </div>
+    </section>
+
+    <section class="panel load-panel">
+      <div class="panel-title">Load Balance</div>
+      <div class="load-meter">
+        <div class="load-fill"></div>
+        <span class="load-value">78%</span>
+      </div>
+    </section>
+
+    <section class="panel card-grid">
+      <div class="metric-card card-1">
+        <span class="metric-label">Active Nodes</span>
+        <span class="metric-number">312</span>
+      </div>
+      <div class="metric-card card-2">
+        <span class="metric-label">Power Output</span>
+        <span class="metric-number">4.8MW</span>
+      </div>
+      <div class="metric-card card-3">
+        <span class="metric-label">Fault Risk</span>
+        <span class="metric-number">Low</span>
+      </div>
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/smart-cyber-physical-power-grid-command-phase-790/style.css
+++ b/submissions/examples/smart-cyber-physical-power-grid-command-phase-790/style.css
@@ -1,0 +1,194 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', sans-serif;
+  background: #0d1117;
+  color: #e6edf3;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 40px 20px;
+}
+
+.grid-header {
+  text-align: center;
+  margin-bottom: 32px;
+  animation: fadeSlideDown 0.6s ease-out;
+}
+
+.grid-header h1 {
+  font-size: 26px;
+  background: linear-gradient(90deg, #f7c948, #58a6ff);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.grid-header p {
+  color: #8b949e;
+  margin-top: 6px;
+  font-size: 14px;
+}
+
+.grid-main {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 20px;
+  width: 100%;
+  max-width: 900px;
+}
+
+.panel {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 10px;
+  padding: 20px;
+  animation: fadeUp 0.6s ease-out both;
+}
+
+.panel-title {
+  font-size: 13px;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 12px;
+}
+
+/* Network panel */
+.network-panel { grid-row: span 2; }
+
+.network-view {
+  position: relative;
+  height: 220px;
+  border-radius: 8px;
+  background: radial-gradient(circle at 50% 50%, #20232b 0%, #0d1117 80%);
+  overflow: hidden;
+}
+
+.grid-node {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #f7c948;
+  box-shadow: 0 0 10px #f7c948;
+  animation: nodePulse 2s ease-in-out infinite;
+}
+
+.node-1 { top: 40px;  left: 60px; }
+.node-2 { top: 60px;  left: 200px; animation-delay: 0.4s; background: #58a6ff; box-shadow: 0 0 10px #58a6ff; }
+.node-3 { top: 150px; left: 90px;  animation-delay: 0.8s; }
+.node-4 { top: 160px; left: 220px; animation-delay: 1.2s; background: #58a6ff; box-shadow: 0 0 10px #58a6ff; }
+
+.pulse-line {
+  position: absolute;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, #f7c948, transparent);
+  animation: linePulse 2.4s ease-in-out infinite;
+}
+
+.line-1 { top: 50px;  left: 70px;  width: 130px; }
+.line-2 { top: 158px; left: 100px; width: 120px; animation-delay: 1s; }
+
+/* Load meter */
+.load-meter {
+  position: relative;
+  height: 14px;
+  background: #21262d;
+  border-radius: 7px;
+  overflow: hidden;
+}
+
+.load-fill {
+  position: absolute;
+  inset: 0;
+  width: 78%;
+  background: linear-gradient(90deg, #f7c948, #58a6ff);
+  border-radius: 7px;
+  transform: scaleX(0);
+  transform-origin: left;
+  animation: fillBar 1.2s ease-out 0.4s forwards;
+}
+
+.load-value {
+  display: block;
+  margin-top: 10px;
+  font-size: 20px;
+  font-weight: 600;
+  color: #f7c948;
+}
+
+/* Metric cards */
+.card-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.metric-card {
+  background: #21262d;
+  border-radius: 8px;
+  padding: 14px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  opacity: 0;
+  transform: translateY(10px);
+  animation: cardPop 0.5s ease-out forwards;
+}
+
+.card-1 { animation-delay: 0.3s; }
+.card-2 { animation-delay: 0.5s; }
+.card-3 { animation-delay: 0.7s; }
+
+.metric-label {
+  font-size: 13px;
+  color: #8b949e;
+}
+
+.metric-number {
+  font-size: 18px;
+  font-weight: 700;
+  color: #58a6ff;
+}
+
+/* Keyframes */
+@keyframes fadeSlideDown {
+  from { opacity: 0; transform: translateY(-12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(14px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes nodePulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.5; transform: scale(1.3); }
+}
+
+@keyframes linePulse {
+  0%, 100% { opacity: 0.3; }
+  50% { opacity: 1; }
+}
+
+@keyframes fillBar {
+  to { transform: scaleX(1); }
+}
+
+@keyframes cardPop {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 700px) {
+  .grid-main {
+    grid-template-columns: 1fr;
+  }
+  .network-panel { grid-row: auto; }
+}


### PR DESCRIPTION
Closes #28338

## Pull Request Description
Adds a self-contained HTML/CSS UI showcase for the Smart Cyber-Physical Power Grid Command (Phase #790), per issue #28338.

---
## Type of Change
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/smart-cyber-physical-power-grid-command-phase-790/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A single-page UI showcase visualizing a cyber-physical power grid command center with pulsing grid nodes, animated connection lines, a load balance meter, and live power output metric cards.

**Why does it fit EaseMotion CSS?**
It's built entirely with CSS keyframes and `animation-delay` for layered entrance and continuous ambient effects (node pulse, line pulse, load fill, staggered metric cards) — zero external JS dependencies. Fully responsive down to mobile.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser, verified visually)

---
## Browser Testing
- [x] Chrome

---
## Notes for Maintainer
First pass on the node-pulse and line-pulse timing — happy to adjust pacing if needed.