### PR TITLE
feat: add deep-brain stimulation neural tuning suite showcase

### DIFF
--- a/submissions/examples/deep-brain-stimulation-neural-tuning-suite-phase-787/README.md
+++ b/submissions/examples/deep-brain-stimulation-neural-tuning-suite-phase-787/README.md
@@ -1,0 +1,31 @@
+# Deep-Brain Stimulation Neural Tuning Suite
+
+## What does this do?
+A single-page UI showcase visualizing a deep-brain stimulation neural tuning interface — expanding signal rings, pulsing electrode markers, a stimulation frequency meter, and live device metric cards.
+
+## How is it used?
+```html
+<header class="dbs-header">...</header>
+
+<main class="dbs-grid">
+  <section class="panel signal-panel">
+    <div class="signal-view">
+      <span class="signal-ring ring-1"></span>
+      <span class="electrode-dot dot-1"></span>
+    </div>
+  </section>
+  <section class="panel freq-panel">
+    <div class="freq-meter">
+      <div class="freq-fill"></div>
+    </div>
+  </section>
+  <section class="panel card-grid">
+    <div class="metric-card card-1">...</div>
+  </section>
+</main>
+```
+
+## Why is it useful?
+It demonstrates layered entrance and continuous ambient animations (expanding signal rings, pulsing electrode dots, frequency meter fill, staggered metric cards) built entirely with CSS keyframes and animation-delay — no JS dependencies — fitting EaseMotion CSS's philosophy of smooth, dependency-free motion design. The grid layout is fully responsive down to mobile.
+
+**Note:** purely a decorative UI showcase — no real EEG/DBS data, signal processing, or clinical functionality.

--- a/submissions/examples/deep-brain-stimulation-neural-tuning-suite-phase-787/demo.html
+++ b/submissions/examples/deep-brain-stimulation-neural-tuning-suite-phase-787/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Deep-Brain Stimulation Neural Tuning Suite</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="dbs-header">
+    <h1>Deep-Brain Stimulation Neural Tuning Suite</h1>
+    <p>Visualizing electrode targeting, stimulation frequency, and signal metrics</p>
+  </header>
+
+  <main class="dbs-grid">
+
+    <section class="panel signal-panel">
+      <div class="panel-title">Neural Signal Map</div>
+      <div class="signal-view">
+        <span class="signal-ring ring-1"></span>
+        <span class="signal-ring ring-2"></span>
+        <span class="electrode-dot dot-1"></span>
+        <span class="electrode-dot dot-2"></span>
+        <span class="electrode-dot dot-3"></span>
+      </div>
+    </section>
+
+    <section class="panel freq-panel">
+      <div class="panel-title">Stimulation Frequency</div>
+      <div class="freq-meter">
+        <div class="freq-fill"></div>
+        <span class="freq-value">130Hz</span>
+      </div>
+    </section>
+
+    <section class="panel card-grid">
+      <div class="metric-card card-1">
+        <span class="metric-label">Active Electrodes</span>
+        <span class="metric-number">8</span>
+      </div>
+      <div class="metric-card card-2">
+        <span class="metric-label">Amplitude</span>
+        <span class="metric-number">3.2mA</span>
+      </div>
+      <div class="metric-card card-3">
+        <span class="metric-label">Signal Quality</span>
+        <span class="metric-number">High</span>
+      </div>
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/deep-brain-stimulation-neural-tuning-suite-phase-787/style.css
+++ b/submissions/examples/deep-brain-stimulation-neural-tuning-suite-phase-787/style.css
@@ -1,0 +1,198 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', sans-serif;
+  background: #0d1117;
+  color: #e6edf3;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 40px 20px;
+}
+
+.dbs-header {
+  text-align: center;
+  margin-bottom: 32px;
+  animation: fadeSlideDown 0.6s ease-out;
+}
+
+.dbs-header h1 {
+  font-size: 26px;
+  background: linear-gradient(90deg, #bc8cff, #58a6ff);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.dbs-header p {
+  color: #8b949e;
+  margin-top: 6px;
+  font-size: 14px;
+}
+
+.dbs-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 20px;
+  width: 100%;
+  max-width: 900px;
+}
+
+.panel {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 10px;
+  padding: 20px;
+  animation: fadeUp 0.6s ease-out both;
+}
+
+.panel-title {
+  font-size: 13px;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 12px;
+}
+
+/* Signal panel */
+.signal-panel { grid-row: span 2; }
+
+.signal-view {
+  position: relative;
+  height: 220px;
+  border-radius: 8px;
+  background: radial-gradient(circle at 50% 50%, #1f1a2e 0%, #0d1117 80%);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.signal-ring {
+  position: absolute;
+  border: 1px solid #bc8cff;
+  border-radius: 50%;
+  opacity: 0;
+  animation: ringExpand 3s ease-out infinite;
+}
+
+.ring-1 { width: 60px; height: 60px; animation-delay: 0s; }
+.ring-2 { width: 60px; height: 60px; animation-delay: 1.5s; border-color: #58a6ff; }
+
+.electrode-dot {
+  position: absolute;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #bc8cff;
+  box-shadow: 0 0 8px #bc8cff;
+  animation: dotPulse 2s ease-in-out infinite;
+}
+
+.dot-1 { top: 70px;  left: 140px; }
+.dot-2 { top: 130px; left: 90px;  animation-delay: 0.5s; background: #58a6ff; box-shadow: 0 0 8px #58a6ff; }
+.dot-3 { top: 150px; left: 190px; animation-delay: 1s; }
+
+/* Frequency meter */
+.freq-meter {
+  position: relative;
+  height: 14px;
+  background: #21262d;
+  border-radius: 7px;
+  overflow: hidden;
+}
+
+.freq-fill {
+  position: absolute;
+  inset: 0;
+  width: 65%;
+  background: linear-gradient(90deg, #bc8cff, #58a6ff);
+  border-radius: 7px;
+  transform: scaleX(0);
+  transform-origin: left;
+  animation: fillBar 1.2s ease-out 0.4s forwards;
+}
+
+.freq-value {
+  display: block;
+  margin-top: 10px;
+  font-size: 20px;
+  font-weight: 600;
+  color: #bc8cff;
+}
+
+/* Metric cards */
+.card-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.metric-card {
+  background: #21262d;
+  border-radius: 8px;
+  padding: 14px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  opacity: 0;
+  transform: translateY(10px);
+  animation: cardPop 0.5s ease-out forwards;
+}
+
+.card-1 { animation-delay: 0.3s; }
+.card-2 { animation-delay: 0.5s; }
+.card-3 { animation-delay: 0.7s; }
+
+.metric-label {
+  font-size: 13px;
+  color: #8b949e;
+}
+
+.metric-number {
+  font-size: 18px;
+  font-weight: 700;
+  color: #58a6ff;
+}
+
+/* Keyframes */
+@keyframes fadeSlideDown {
+  from { opacity: 0; transform: translateY(-12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(14px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes ringExpand {
+  0% { opacity: 0.8; transform: scale(0.6); }
+  70% { opacity: 0; transform: scale(2.2); }
+  100% { opacity: 0; transform: scale(2.2); }
+}
+
+@keyframes dotPulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.5; transform: scale(1.3); }
+}
+
+@keyframes fillBar {
+  to { transform: scaleX(1); }
+}
+
+@keyframes cardPop {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 700px) {
+  .dbs-grid {
+    grid-template-columns: 1fr;
+  }
+  .signal-panel { grid-row: auto; }
+}


### PR DESCRIPTION
Closes #28335

## Pull Request Description
Adds a self-contained HTML/CSS UI showcase for the Deep-Brain Stimulation Neural Tuning Suite (Phase #787), per issue #28335.

---
## Type of Change
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/deep-brain-stimulation-neural-tuning-suite-phase-787/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A single-page UI showcase visualizing a deep-brain stimulation neural tuning interface with expanding signal rings, pulsing electrode markers, a stimulation frequency meter, and live device metric cards.

**Why does it fit EaseMotion CSS?**
It's built entirely with CSS keyframes and `animation-delay` for layered entrance and continuous ambient effects (signal ring expansion, electrode pulse, frequency fill, staggered metric cards) — zero external JS dependencies. Fully responsive down to mobile.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser, verified visually)

---
## Browser Testing
- [x] Chrome

---
## Notes for Maintainer
Purely a decorative UI showcase, no real EEG/DBS data or clinical functionality — happy to adjust pacing/visuals if needed.