### PR TITLE
feat: add orbital space debris cleanup operation center showcase

### DIFF
--- a/submissions/examples/orbital-space-debris-cleanup-operation-center-phase-783/README.md
+++ b/submissions/examples/orbital-space-debris-cleanup-operation-center-phase-783/README.md
@@ -1,0 +1,31 @@
+# Orbital Space Debris Cleanup Operation Center
+
+## What does this do?
+A single-page UI showcase visualizing an orbital debris cleanup operation center — expanding orbit rings, pulsing debris tracking markers, a capture progress meter, and live mission metric cards.
+
+## How is it used?
+```html
+<header class="debris-header">...</header>
+
+<main class="debris-grid">
+  <section class="panel orbit-panel">
+    <div class="orbit-view">
+      <span class="orbit-ring ring-1"></span>
+      <span class="debris-dot dot-1"></span>
+    </div>
+  </section>
+  <section class="panel capture-panel">
+    <div class="capture-meter">
+      <div class="capture-fill"></div>
+    </div>
+  </section>
+  <section class="panel card-grid">
+    <div class="metric-card card-1">...</div>
+  </section>
+</main>
+```
+
+## Why is it useful?
+It demonstrates layered entrance and continuous ambient animations (expanding orbit rings, pulsing debris dots, capture meter fill, staggered metric cards) built entirely with CSS keyframes and animation-delay — no JS dependencies — fitting EaseMotion CSS's philosophy of smooth, dependency-free motion design. The grid layout is fully responsive down to mobile.
+
+**Note:** purely a decorative UI showcase — no real orbital-tracking or mission-control functionality.

--- a/submissions/examples/orbital-space-debris-cleanup-operation-center-phase-783/demo.html
+++ b/submissions/examples/orbital-space-debris-cleanup-operation-center-phase-783/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Orbital Space Debris Cleanup Operation Center</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="debris-header">
+    <h1>Orbital Space Debris Cleanup Operation Center</h1>
+    <p>Tracking debris capture, orbital paths, and cleanup mission telemetry in real time</p>
+  </header>
+
+  <main class="debris-grid">
+
+    <section class="panel orbit-panel">
+      <div class="panel-title">Orbital Tracking</div>
+      <div class="orbit-view">
+        <span class="orbit-ring ring-1"></span>
+        <span class="orbit-ring ring-2"></span>
+        <span class="debris-dot dot-1"></span>
+        <span class="debris-dot dot-2"></span>
+        <span class="debris-dot dot-3"></span>
+      </div>
+    </section>
+
+    <section class="panel capture-panel">
+      <div class="panel-title">Capture Progress</div>
+      <div class="capture-meter">
+        <div class="capture-fill"></div>
+        <span class="capture-value">57%</span>
+      </div>
+    </section>
+
+    <section class="panel card-grid">
+      <div class="metric-card card-1">
+        <span class="metric-label">Debris Tracked</span>
+        <span class="metric-number">2,140</span>
+      </div>
+      <div class="metric-card card-2">
+        <span class="metric-label">Objects Captured</span>
+        <span class="metric-number">318</span>
+      </div>
+      <div class="metric-card card-3">
+        <span class="metric-label">Collision Risk</span>
+        <span class="metric-number">Low</span>
+      </div>
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/orbital-space-debris-cleanup-operation-center-phase-783/style.css
+++ b/submissions/examples/orbital-space-debris-cleanup-operation-center-phase-783/style.css
@@ -1,0 +1,198 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', sans-serif;
+  background: #0d1117;
+  color: #e6edf3;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 40px 20px;
+}
+
+.debris-header {
+  text-align: center;
+  margin-bottom: 32px;
+  animation: fadeSlideDown 0.6s ease-out;
+}
+
+.debris-header h1 {
+  font-size: 26px;
+  background: linear-gradient(90deg, #58a6ff, #bc8cff);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.debris-header p {
+  color: #8b949e;
+  margin-top: 6px;
+  font-size: 14px;
+}
+
+.debris-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 20px;
+  width: 100%;
+  max-width: 900px;
+}
+
+.panel {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 10px;
+  padding: 20px;
+  animation: fadeUp 0.6s ease-out both;
+}
+
+.panel-title {
+  font-size: 13px;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 12px;
+}
+
+/* Orbit panel */
+.orbit-panel { grid-row: span 2; }
+
+.orbit-view {
+  position: relative;
+  height: 220px;
+  border-radius: 8px;
+  background: radial-gradient(circle at 50% 50%, #1a1f2e 0%, #0d1117 80%);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.orbit-ring {
+  position: absolute;
+  border: 1px solid #58a6ff;
+  border-radius: 50%;
+  opacity: 0;
+  animation: ringExpand 3s ease-out infinite;
+}
+
+.ring-1 { width: 60px; height: 60px; animation-delay: 0s; }
+.ring-2 { width: 60px; height: 60px; animation-delay: 1.5s; border-color: #bc8cff; }
+
+.debris-dot {
+  position: absolute;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #58a6ff;
+  box-shadow: 0 0 8px #58a6ff;
+  animation: dotPulse 2s ease-in-out infinite;
+}
+
+.dot-1 { top: 70px;  left: 140px; }
+.dot-2 { top: 130px; left: 90px;  animation-delay: 0.5s; background: #bc8cff; box-shadow: 0 0 8px #bc8cff; }
+.dot-3 { top: 150px; left: 190px; animation-delay: 1s; }
+
+/* Capture meter */
+.capture-meter {
+  position: relative;
+  height: 14px;
+  background: #21262d;
+  border-radius: 7px;
+  overflow: hidden;
+}
+
+.capture-fill {
+  position: absolute;
+  inset: 0;
+  width: 57%;
+  background: linear-gradient(90deg, #58a6ff, #bc8cff);
+  border-radius: 7px;
+  transform: scaleX(0);
+  transform-origin: left;
+  animation: fillBar 1.2s ease-out 0.4s forwards;
+}
+
+.capture-value {
+  display: block;
+  margin-top: 10px;
+  font-size: 20px;
+  font-weight: 600;
+  color: #58a6ff;
+}
+
+/* Metric cards */
+.card-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.metric-card {
+  background: #21262d;
+  border-radius: 8px;
+  padding: 14px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  opacity: 0;
+  transform: translateY(10px);
+  animation: cardPop 0.5s ease-out forwards;
+}
+
+.card-1 { animation-delay: 0.3s; }
+.card-2 { animation-delay: 0.5s; }
+.card-3 { animation-delay: 0.7s; }
+
+.metric-label {
+  font-size: 13px;
+  color: #8b949e;
+}
+
+.metric-number {
+  font-size: 18px;
+  font-weight: 700;
+  color: #bc8cff;
+}
+
+/* Keyframes */
+@keyframes fadeSlideDown {
+  from { opacity: 0; transform: translateY(-12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(14px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes ringExpand {
+  0% { opacity: 0.8; transform: scale(0.6); }
+  70% { opacity: 0; transform: scale(2.2); }
+  100% { opacity: 0; transform: scale(2.2); }
+}
+
+@keyframes dotPulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.5; transform: scale(1.3); }
+}
+
+@keyframes fillBar {
+  to { transform: scaleX(1); }
+}
+
+@keyframes cardPop {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 700px) {
+  .debris-grid {
+    grid-template-columns: 1fr;
+  }
+  .orbit-panel { grid-row: auto; }
+}


### PR DESCRIPTION
Closes #28331

## Pull Request Description
Adds a self-contained HTML/CSS UI showcase for the Orbital Space Debris Cleanup Operation Center (Phase #783), per issue #28331.

---
## Type of Change
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/orbital-space-debris-cleanup-operation-center-phase-783/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A single-page UI showcase visualizing an orbital debris cleanup operation center with expanding orbit rings, pulsing debris tracking markers, a capture progress meter, and live mission metric cards.

**Why does it fit EaseMotion CSS?**
It's built entirely with CSS keyframes and `animation-delay` for layered entrance and continuous ambient effects (orbit ring expansion, debris pulse, capture fill, staggered metric cards) — zero external JS dependencies. Fully responsive down to mobile.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser, verified visually)

---
## Browser Testing
- [x] Chrome

---
## Notes for Maintainer
Purely a decorative UI showcase, no real orbital-tracking functionality — happy to adjust pacing/visuals if needed.