### PR TITLE
feat: add Text Outline to Filled Transition submission

### DIFF
--- a/submissions/examples/text-outline-fill-uj/README.md
+++ b/submissions/examples/text-outline-fill-uj/README.md
@@ -1,0 +1,27 @@
+# Text Outline to Filled Transition
+
+## What does this do?
+
+It creates a typography effect where outlined text smoothly fills with solid color from left to right on hover.
+
+## How is it used?
+
+Apply the `text-outline-fill-uj` class and define the `data-text` attribute with matching text content:
+
+```html
+<h1 class="text-outline-fill-uj" data-text="Creative">
+  Creative
+</h1>
+```
+
+You can change the fill color by modifying the text color of the element:
+
+```css
+.text-outline-fill-uj {
+  color: #ff5a5f; /* Change outline and fill color */
+}
+```
+
+## Why is this useful?
+
+This effect offers a premium interactive experience for hero headings, titles, and branding layouts. It runs entirely on the GPU utilizing compositor-friendly properties (`width` transition on a pseudoelement), preserves clean layouts without reflows, and falls back to fully colored text when `prefers-reduced-motion` is active.

--- a/submissions/examples/text-outline-fill-uj/demo.html
+++ b/submissions/examples/text-outline-fill-uj/demo.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Text Outline to Filled Transition Demo (uj)</title>
+
+  <!--
+    Self-contained demo. No server required, no CDN, no external frameworks.
+    All styles are inlined or loaded from style.css in the same folder.
+  -->
+
+  <style>
+    /* ── Design tokens ── */
+    :root {
+      --ease-color-bg:             #0f172a;
+      --ease-color-text:           #f8fafc;
+      --ease-color-muted:          #64748b;
+      --ease-font-sans:            system-ui, -apple-system, sans-serif;
+    }
+
+    @media (prefers-color-scheme: light) {
+      :root {
+        --ease-color-bg:           #f8fafc;
+        --ease-color-text:         #0f172a;
+        --ease-color-muted:        #94a3b8;
+      }
+    }
+
+    /* ── Page layout ── */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: var(--ease-font-sans);
+      background: var(--ease-color-bg);
+      color: var(--ease-color-text);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 3rem;
+      padding: 3rem 1.5rem;
+    }
+
+    .page-header {
+      text-align: center;
+      max-width: 560px;
+    }
+
+    .page-header h1 {
+      font-size: 1.8rem;
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+    }
+
+    .page-header p {
+      color: var(--ease-color-muted);
+      font-size: 0.95rem;
+      line-height: 1.6;
+    }
+
+    /* ── Typography Showcase ── */
+    .showcase-container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 2rem;
+      width: 100%;
+      max-width: 600px;
+      text-align: center;
+    }
+
+    .display-word {
+      font-size: 4rem;
+      font-weight: 900;
+      text-transform: uppercase;
+      letter-spacing: 2px;
+      cursor: pointer;
+    }
+
+    @media (max-width: 600px) {
+      .display-word {
+        font-size: 2.5rem;
+      }
+    }
+
+    /* Color variations */
+    .color-primary {
+      color: #6c63ff;
+    }
+
+    .color-coral {
+      color: #ff5a5f;
+    }
+
+    .color-emerald {
+      color: #10b981;
+    }
+  </style>
+
+  <!-- Load the submission style -->
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>Text Outline to Filled Transition</h1>
+    <p>
+      Hover over the display headings below to see the outlined text smoothly fill with solid color from left to right.
+    </p>
+  </header>
+
+  <main class="showcase-container">
+    <h2 class="text-outline-fill-uj display-word color-primary" data-text="Creative">
+      Creative
+    </h2>
+    <h2 class="text-outline-fill-uj display-word color-coral" data-text="Minimal">
+      Minimal
+    </h2>
+    <h2 class="text-outline-fill-uj display-word color-emerald" data-text="Dynamic">
+      Dynamic
+    </h2>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/text-outline-fill-uj/style.css
+++ b/submissions/examples/text-outline-fill-uj/style.css
@@ -1,0 +1,39 @@
+/* =============================================================
+   Submission: text-outline-fill-uj
+   Effect: Text Outline to Filled Transition
+   ============================================================= */
+
+.text-outline-fill-uj {
+  position: relative;
+  color: transparent;
+  -webkit-text-stroke: 1px currentColor;
+  display: inline-block;
+  white-space: nowrap;
+}
+
+.text-outline-fill-uj::after {
+  content: attr(data-text);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 100%;
+  color: currentColor;
+  overflow: hidden;
+  transition: width 0.4s ease-in-out;
+  -webkit-text-stroke: 0px transparent;
+}
+
+.text-outline-fill-uj:hover::after {
+  width: 100%;
+}
+
+/* Accessibility Support for reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .text-outline-fill-uj {
+    color: currentColor;
+  }
+  .text-outline-fill-uj::after {
+    display: none;
+  }
+}


### PR DESCRIPTION
Resolves #31937

## Description
Create a typography effect where outlined text smoothly fills with color from left to right on hover using pure CSS.

## Checklist
- [x] This feature does not duplicate an existing EaseMotion CSS class.
- [x] I understand my naming will be standardized by the maintainer.
- [x] I will submit code inside `submissions/` only — not in `core/` or `components/`.