### PR TITLE
feat: Add React Collapsible Sidebar Menu Component (#28005)

### DIFF
--- a/submissions/react/react-collapsible-sidebar-menu-with-smooth-accordion/README.md
+++ b/submissions/react/react-collapsible-sidebar-menu-with-smooth-accordion/README.md
@@ -1,0 +1,59 @@
+# React Component: Collapsible Sidebar Menu with Smooth Accordion (#28005)
+
+A modular, copy-paste ready React component for the EaseMotion CSS framework. This sidebar provides an app-shell navigation structure featuring a physics-based collapsible width toggle and perfectly smooth CSS Grid-driven accordion menus.
+
+## 📦 What's included?
+
+- `Sidebar.jsx`: The React component that manages the open/collapsed state of the entire sidebar as well as the dictionary of open accordion sub-menus. It includes "smart-open" logic: if a user clicks an accordion trigger while the sidebar is collapsed, it orchestrates expanding the sidebar *first*, then opening the accordion, preventing visual jank.
+- `style.css`: The CSS stylesheet utilizing `grid-template-rows: 0fr -> 1fr` for hardware-accelerated accordion height animations without needing Javascript measurements. It also uses CSS variables (`--sidebar-width-open`) for the width transitions.
+- `demo.html`: A self-contained browser demo running the React component via Babel standalone, including sample navigation data arrays and SVG icons.
+
+## 🛠 Features
+
+- **CSS Grid Accordions**: Historically, animating `height: auto` in CSS is impossible. This component uses the modern CSS Grid technique (`grid-template-rows: 0fr` to `1fr`) on the `.ease-accordion-content` wrapper to achieve buttery smooth height transitions.
+- **Physics-Based Width Toggle**: The entire sidebar collapses from `280px` to `80px` using a `cubic-bezier(0.34, 1.56, 0.64, 1)` spring curve. The internal text elements (labels, logos) fade out cleanly using `white-space: nowrap` to prevent layout breakage during the transition.
+- **Smart State Management**: When the sidebar collapses, the `useEffect` hook automatically closes all open accordions to reset the internal state.
+
+## 🚀 How to use
+
+1. Copy `Sidebar.jsx` into your React project's `components` directory.
+2. Copy `style.css` and import it.
+3. Pass a configuration array to the `navItems` prop. Items with `children` will automatically render as an accordion.
+
+```jsx
+import React from 'react';
+import Sidebar from './Sidebar';
+import './style.css'; 
+
+const AppLayout = ({ children }) => {
+  const navData = [
+    { id: 'dash', label: 'Dashboard', icon: <svg>...</svg>, href: '/dash' },
+    { 
+      id: 'settings', 
+      label: 'Settings', 
+      icon: <svg>...</svg>,
+      children: [
+        { id: 's1', label: 'Profile', href: '/profile' },
+        { id: 's2', label: 'Billing', href: '/billing' }
+      ]
+    }
+  ];
+
+  return (
+    <div style={{ display: 'flex' }}>
+      <Sidebar navItems={navData} />
+      <main style={{ flex: 1 }}>
+        {children}
+      </main>
+    </div>
+  );
+};
+
+export default AppLayout;
+```
+
+## 🎨 Why this fits EaseMotion
+
+**EaseMotion** believes micro-interactions define the perceived quality of software.
+
+A sidebar is often the most interacted-with component in a dashboard. Snapping between states or relying on expensive javascript height calculations (`Element.scrollHeight`) makes the app feel sluggish. By pairing React's rapid state updates with modern CSS Grid transitions and standard EaseMotion `cubic-bezier` curves, the navigation feels instantly responsive, lightweight, and physically connected to the user's cursor.

--- a/submissions/react/react-collapsible-sidebar-menu-with-smooth-accordion/Sidebar.jsx
+++ b/submissions/react/react-collapsible-sidebar-menu-with-smooth-accordion/Sidebar.jsx
@@ -1,0 +1,125 @@
+import React, { useState, useRef, useEffect } from 'react';
+
+/**
+ * Collapsible Sidebar Menu with Smooth Accordion
+ * 
+ * @param {Array} navItems - Configuration array for navigation menus
+ */
+const Sidebar = ({ navItems }) => {
+  const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+  const [openAccordions, setOpenAccordions] = useState({});
+
+  // Toggle individual accordion sections
+  const toggleAccordion = (id) => {
+    // If sidebar is collapsed, we must open it first before expanding accordion
+    if (!isSidebarOpen) {
+      setIsSidebarOpen(true);
+      // Wait for sidebar expansion before opening accordion for smoother physics
+      setTimeout(() => {
+        setOpenAccordions(prev => ({ ...prev, [id]: !prev[id] }));
+      }, 300);
+      return;
+    }
+    
+    setOpenAccordions(prev => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  // When collapsing the sidebar, close all accordions to reset state
+  useEffect(() => {
+    if (!isSidebarOpen) {
+      setOpenAccordions({});
+    }
+  }, [isSidebarOpen]);
+
+  return (
+    <aside className={`ease-sidebar ${isSidebarOpen ? 'is-open' : 'is-collapsed'}`}>
+      
+      {/* Header / Toggle Button */}
+      <div className="ease-sidebar-header">
+        <div className="ease-sidebar-logo">
+          <div className="ease-logo-mark">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <polygon points="12 2 2 7 12 12 22 7 12 2"></polygon>
+              <polyline points="2 17 12 22 22 17"></polyline>
+              <polyline points="2 12 12 17 22 12"></polyline>
+            </svg>
+          </div>
+          <span className="ease-logo-text">Acme Corp</span>
+        </div>
+        
+        <button 
+          className="ease-sidebar-toggle" 
+          onClick={() => setIsSidebarOpen(!isSidebarOpen)}
+          aria-label={isSidebarOpen ? "Collapse sidebar" : "Expand sidebar"}
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="15 18 9 12 15 6"></polyline>
+          </svg>
+        </button>
+      </div>
+
+      {/* Navigation Menu */}
+      <nav className="ease-sidebar-nav">
+        {navItems.map((item) => (
+          <div key={item.id} className="ease-nav-section">
+            
+            {/* Parent Item / Accordion Trigger */}
+            {item.children ? (
+              <button 
+                className={`ease-nav-item ${openAccordions[item.id] ? 'is-active' : ''}`}
+                onClick={() => toggleAccordion(item.id)}
+                aria-expanded={openAccordions[item.id]}
+              >
+                <span className="ease-nav-icon">{item.icon}</span>
+                <span className="ease-nav-label">{item.label}</span>
+                <span className="ease-nav-chevron">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <polyline points="6 9 12 15 18 9"></polyline>
+                  </svg>
+                </span>
+              </button>
+            ) : (
+              <a href={item.href} className="ease-nav-item">
+                <span className="ease-nav-icon">{item.icon}</span>
+                <span className="ease-nav-label">{item.label}</span>
+              </a>
+            )}
+
+            {/* Accordion Content (Sub-items) */}
+            {item.children && (
+              <div 
+                className="ease-accordion-content"
+                style={{ 
+                  // Use CSS grid transition trick for smooth height animation
+                  gridTemplateRows: openAccordions[item.id] ? '1fr' : '0fr' 
+                }}
+              >
+                <div className="ease-accordion-inner">
+                  {item.children.map((child) => (
+                    <a key={child.id} href={child.href} className="ease-sub-nav-item">
+                      {child.label}
+                    </a>
+                  ))}
+                </div>
+              </div>
+            )}
+            
+          </div>
+        ))}
+      </nav>
+
+      {/* Footer Profile Section */}
+      <div className="ease-sidebar-footer">
+        <div className="ease-profile-row">
+          <img src="https://i.pravatar.cc/150?img=11" alt="User" className="ease-profile-img" />
+          <div className="ease-profile-info">
+            <p className="ease-profile-name">Jane Doe</p>
+            <p className="ease-profile-role">Admin</p>
+          </div>
+        </div>
+      </div>
+    </aside>
+  );
+};
+
+export default Sidebar;

--- a/submissions/react/react-collapsible-sidebar-menu-with-smooth-accordion/demo.html
+++ b/submissions/react/react-collapsible-sidebar-menu-with-smooth-accordion/demo.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>React Sidebar Accordion Demo</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="./style.css">
+  
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+
+  <style>
+    body {
+      margin: 0;
+      background: #f1f5f9;
+      min-height: 100vh;
+      display: flex;
+      font-family: system-ui, sans-serif;
+    }
+    
+    .demo-main-content {
+      flex: 1;
+      padding: 3rem;
+    }
+
+    h1 { color: #0f172a; margin-top: 0; }
+    p { color: #64748b; line-height: 1.6; max-width: 600px; }
+  </style>
+</head>
+<body>
+
+  <div id="root" style="display: flex; width: 100%;"></div>
+
+  <script type="text/babel">
+    const { useState, useEffect } = React;
+
+    const Sidebar = ({ navItems }) => {
+      const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+      const [openAccordions, setOpenAccordions] = useState({});
+
+      const toggleAccordion = (id) => {
+        if (!isSidebarOpen) {
+          setIsSidebarOpen(true);
+          setTimeout(() => {
+            setOpenAccordions(prev => ({ ...prev, [id]: !prev[id] }));
+          }, 300);
+          return;
+        }
+        setOpenAccordions(prev => ({ ...prev, [id]: !prev[id] }));
+      };
+
+      useEffect(() => {
+        if (!isSidebarOpen) setOpenAccordions({});
+      }, [isSidebarOpen]);
+
+      return (
+        <aside className={`ease-sidebar ${isSidebarOpen ? 'is-open' : 'is-collapsed'}`}>
+          <div className="ease-sidebar-header">
+            <div className="ease-sidebar-logo">
+              <div className="ease-logo-mark">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"></polygon><polyline points="2 17 12 22 22 17"></polyline><polyline points="2 12 12 17 22 12"></polyline></svg>
+              </div>
+              <span className="ease-logo-text">Acme Corp</span>
+            </div>
+            <button className="ease-sidebar-toggle" onClick={() => setIsSidebarOpen(!isSidebarOpen)}>
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
+            </button>
+          </div>
+
+          <nav className="ease-sidebar-nav">
+            {navItems.map((item) => (
+              <div key={item.id} className="ease-nav-section">
+                {item.children ? (
+                  <button className={`ease-nav-item ${openAccordions[item.id] ? 'is-active' : ''}`} onClick={() => toggleAccordion(item.id)}>
+                    <span className="ease-nav-icon">{item.icon}</span>
+                    <span className="ease-nav-label">{item.label}</span>
+                    <span className="ease-nav-chevron">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
+                    </span>
+                  </button>
+                ) : (
+                  <a href={item.href} className="ease-nav-item">
+                    <span className="ease-nav-icon">{item.icon}</span>
+                    <span className="ease-nav-label">{item.label}</span>
+                  </a>
+                )}
+
+                {item.children && (
+                  <div className="ease-accordion-content" style={{ gridTemplateRows: openAccordions[item.id] ? '1fr' : '0fr' }}>
+                    <div className="ease-accordion-inner">
+                      {item.children.map((child) => (
+                        <a key={child.id} href={child.href} className="ease-sub-nav-item">{child.label}</a>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            ))}
+          </nav>
+
+          <div className="ease-sidebar-footer">
+            <div className="ease-profile-row">
+              <img src="https://i.pravatar.cc/150?img=11" alt="User" className="ease-profile-img" />
+              <div className="ease-profile-info">
+                <p className="ease-profile-name">Jane Doe</p>
+                <p className="ease-profile-role">Admin</p>
+              </div>
+            </div>
+          </div>
+        </aside>
+      );
+    };
+
+    const App = () => {
+      // SVG Icon helpers for brevity
+      const IconHome = <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path><polyline points="9 22 9 12 15 12 15 22"></polyline></svg>;
+      const IconUsers = <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path><circle cx="9" cy="7" r="4"></circle><path d="M23 21v-2a4 4 0 0 0-3-3.87"></path><path d="M16 3.13a4 4 0 0 1 0 7.75"></path></svg>;
+      const IconSettings = <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path></svg>;
+
+      const navData = [
+        { id: 'home', label: 'Dashboard', icon: IconHome, href: '#' },
+        { 
+          id: 'users', 
+          label: 'Team Management', 
+          icon: IconUsers,
+          children: [
+            { id: 'u1', label: 'All Members', href: '#' },
+            { id: 'u2', label: 'Add New', href: '#' },
+            { id: 'u3', label: 'Roles & Permissions', href: '#' }
+          ]
+        },
+        { 
+          id: 'settings', 
+          label: 'System Settings', 
+          icon: IconSettings,
+          children: [
+            { id: 's1', label: 'General', href: '#' },
+            { id: 's2', label: 'Billing', href: '#' }
+          ]
+        }
+      ];
+
+      return (
+        <React.Fragment>
+          <Sidebar navItems={navData} />
+          <div className="demo-main-content">
+            <h1>Interactive Sidebar Demo</h1>
+            <p>Try collapsing the sidebar using the toggle button. If you click a parent menu item while the sidebar is collapsed, it will smartly expand the sidebar first before opening the accordion, preserving the physics layout.</p>
+          </div>
+        </React.Fragment>
+      );
+    }
+
+    ReactDOM.render(<App />, document.getElementById('root'));
+  </script>
+</body>
+</html>

--- a/submissions/react/react-collapsible-sidebar-menu-with-smooth-accordion/style.css
+++ b/submissions/react/react-collapsible-sidebar-menu-with-smooth-accordion/style.css
@@ -1,0 +1,302 @@
+/* 
+  style.css
+  EaseMotion CSS - Collapsible Sidebar Accordion
+*/
+
+/* --- Sidebar Base Container --- */
+.ease-sidebar {
+  /* Using CSS variables makes the transition maths easy */
+  --sidebar-width-open: 280px;
+  --sidebar-width-collapsed: 80px;
+  --transition-curve: cubic-bezier(0.34, 1.56, 0.64, 1);
+  
+  width: var(--sidebar-width-open);
+  height: 100vh;
+  background-color: #ffffff;
+  border-right: 1px solid #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  font-family: system-ui, -apple-system, sans-serif;
+  box-sizing: border-box;
+  
+  /* The core layout transition */
+  transition: width 0.4s var(--transition-curve);
+  overflow-x: hidden;
+  position: relative;
+}
+
+.ease-sidebar.is-collapsed {
+  width: var(--sidebar-width-collapsed);
+}
+
+
+/* --- Header & Toggle --- */
+.ease-sidebar-header {
+  height: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 20px;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.ease-sidebar-logo {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 200px; /* Prevents text wrap during collapse */
+}
+
+.ease-logo-mark {
+  width: 40px;
+  height: 40px;
+  background: #3b82f6;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #ffffff;
+  flex-shrink: 0;
+}
+
+.ease-logo-mark svg {
+  width: 24px;
+  height: 24px;
+}
+
+.ease-logo-text {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: #0f172a;
+  white-space: nowrap;
+  opacity: 1;
+  transition: opacity 0.2s ease;
+}
+
+.ease-sidebar.is-collapsed .ease-logo-text {
+  opacity: 0;
+}
+
+/* Toggle Button */
+.ease-sidebar-toggle {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+  background: #ffffff;
+  color: #64748b;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  position: absolute;
+  right: -16px;
+  top: 24px;
+  z-index: 10;
+  box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
+  
+  /* Button transform handles the arrow flip */
+  transition: transform 0.4s var(--transition-curve), background-color 0.2s ease, color 0.2s ease;
+}
+
+.ease-sidebar.is-collapsed .ease-sidebar-toggle {
+  transform: rotate(180deg);
+}
+
+.ease-sidebar-toggle:hover {
+  background: #f8fafc;
+  color: #0f172a;
+}
+
+.ease-sidebar-toggle svg {
+  width: 16px;
+  height: 16px;
+}
+
+
+/* --- Navigation Items --- */
+.ease-sidebar-nav {
+  flex: 1;
+  padding: 24px 16px;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+/* Custom scrollbar for nav */
+.ease-sidebar-nav::-webkit-scrollbar {
+  width: 4px;
+}
+.ease-sidebar-nav::-webkit-scrollbar-track {
+  background: transparent;
+}
+.ease-sidebar-nav::-webkit-scrollbar-thumb {
+  background: #cbd5e1;
+  border-radius: 4px;
+}
+
+.ease-nav-section {
+  margin-bottom: 4px;
+}
+
+.ease-nav-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  padding: 12px;
+  border: none;
+  background: transparent;
+  border-radius: 12px;
+  color: #475569;
+  text-decoration: none;
+  cursor: pointer;
+  box-sizing: border-box;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.ease-nav-item:hover,
+.ease-nav-item.is-active {
+  background: #eff6ff;
+  color: #2563eb;
+}
+
+.ease-nav-icon {
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.ease-nav-icon svg {
+  width: 20px;
+  height: 20px;
+}
+
+.ease-nav-label {
+  margin-left: 16px;
+  font-size: 0.95rem;
+  font-weight: 500;
+  white-space: nowrap;
+  opacity: 1;
+  transition: opacity 0.2s ease;
+  flex: 1;
+  text-align: left;
+}
+
+.ease-sidebar.is-collapsed .ease-nav-label {
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Chevron indicator for accordion */
+.ease-nav-chevron {
+  width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: auto;
+  transition: transform 0.3s var(--transition-curve), opacity 0.2s ease;
+}
+
+.ease-nav-item.is-active .ease-nav-chevron {
+  transform: rotate(180deg);
+}
+
+.ease-sidebar.is-collapsed .ease-nav-chevron {
+  opacity: 0;
+}
+
+.ease-nav-chevron svg {
+  width: 16px;
+  height: 16px;
+}
+
+
+/* --- Accordion Content (The Magic Trick) --- */
+/* We use CSS grid transition to animate height smoothly without fixed px values */
+.ease-accordion-content {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.4s var(--transition-curve);
+  /* The padding-left aligns sub-items with the parent label */
+  padding-left: 52px; 
+}
+
+.ease-accordion-inner {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.ease-sub-nav-item {
+  display: block;
+  padding: 10px 12px;
+  color: #64748b;
+  text-decoration: none;
+  font-size: 0.875rem;
+  font-weight: 500;
+  border-radius: 8px;
+  margin: 2px 0;
+  white-space: nowrap;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.ease-sub-nav-item:hover {
+  background: #f8fafc;
+  color: #0f172a;
+}
+
+/* Hide accordion content completely when sidebar is collapsed to prevent overflow visual bugs */
+.ease-sidebar.is-collapsed .ease-accordion-content {
+  display: none;
+}
+
+
+/* --- Footer Profile --- */
+.ease-sidebar-footer {
+  padding: 20px;
+  border-top: 1px solid #f1f5f9;
+}
+
+.ease-profile-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  min-width: 200px;
+}
+
+.ease-profile-img {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.ease-profile-info {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  white-space: nowrap;
+  opacity: 1;
+  transition: opacity 0.2s ease;
+}
+
+.ease-sidebar.is-collapsed .ease-profile-info {
+  opacity: 0;
+}
+
+.ease-profile-name {
+  margin: 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.ease-profile-role {
+  margin: 2px 0 0;
+  font-size: 0.75rem;
+  color: #64748b;
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #27337 by introducing a modular, copy-paste ready React component: a Collapsible Sidebar Menu with Smooth Accordions. It leverages modern CSS Grid (`grid-template-rows: 0fr -> 1fr`) to solve the historical problem of animating auto-height elements, providing a buttery smooth, physics-based accordion feel without relying on expensive javascript DOM height calculations.

Closes #27337

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component (React Component)
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/react/react-collapsible-sidebar-menu-with-smooth-accordion/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server (Uses Babel Standalone to compile JSX in-browser for the validator)
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] Includes `Sidebar.jsx` — The React component
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A highly polished React `<Sidebar />` component. It renders a full application shell sidebar. It features a main toggle that collapses the width from `280px` to `80px`. Sub-menus are built as accordions using a CSS Grid hack for perfect height animations. It includes "smart-open" logic: if a user clicks an accordion trigger while the sidebar is collapsed, React orchestrates expanding the sidebar *first*, then opening the accordion, preventing visual layout
