### PR TITLE
feat: add Zoom and Pan Image Reveal submission

### DIFF
--- a/submissions/examples/zoom-pan-image-uj/README.md
+++ b/submissions/examples/zoom-pan-image-uj/README.md
@@ -1,0 +1,25 @@
+# Zoom and Pan Image Reveal
+
+## What does this do?
+
+It produces a smooth zoom-in and slight translation camera pan across images when hovered, creating an interactive showcase.
+
+## How is it used?
+
+Apply the `card-zoom-uj` class to your image wrapper and `zoom-pan-img-uj` class to the image itself:
+
+```html
+<div class="card-zoom-uj">
+  <img src="product.jpg" class="zoom-pan-img-uj" alt="Product Title">
+</div>
+```
+
+Configure parameters using custom CSS variables or inline styles:
+- `--zoom-scale`: Target scale dimension multiplier (defaults to `1.1`).
+- `--pan-x`: Horizontal translation shift distance (defaults to `-2%`).
+- `--pan-y`: Vertical translation shift distance (defaults to `-1%`).
+- `--zoom-duration`: Duration of the transition (defaults to `0.5s`).
+
+## Why is this useful?
+
+This effect is popular in modern e-commerce sites, portfolio catalogs, and feature panels to showcase finer item details on hover. Running entirely via compositor-optimized transitions (`transform: scale` and `translate`), it performs smoothly on low-power devices, avoids layout recalculations, and falls back to a clean static display if users request a reduced motion environment.

--- a/submissions/examples/zoom-pan-image-uj/demo.html
+++ b/submissions/examples/zoom-pan-image-uj/demo.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Zoom and Pan Image Reveal Demo (uj)</title>
+
+  <!--
+    Self-contained demo. No server required, no CDN, no external frameworks.
+    All styles are inlined or loaded from style.css in the same folder.
+  -->
+
+  <style>
+    /* ── Design tokens ── */
+    :root {
+      --ease-color-primary:        #6c63ff;
+      --ease-color-bg:             #0f172a;
+      --ease-color-surface:        #1e293b;
+      --ease-color-text:           #f8fafc;
+      --ease-color-muted:          #64748b;
+      --ease-color-neutral-200:    #334155;
+      --ease-font-sans:            system-ui, -apple-system, sans-serif;
+      --ease-shadow-lg:            0 10px 15px -3px rgba(0,0,0,0.3);
+    }
+
+    @media (prefers-color-scheme: light) {
+      :root {
+        --ease-color-bg:           #f8fafc;
+        --ease-color-surface:      #ffffff;
+        --ease-color-text:         #0f172a;
+        --ease-color-muted:        #94a3b8;
+        --ease-color-neutral-200:  #e2e8f0;
+        --ease-shadow-lg:          0 10px 15px -3px rgba(0,0,0,0.05);
+      }
+    }
+
+    /* ── Page layout ── */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: var(--ease-font-sans);
+      background: var(--ease-color-bg);
+      color: var(--ease-color-text);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 3rem;
+      padding: 3rem 1.5rem;
+    }
+
+    .page-header {
+      text-align: center;
+      max-width: 560px;
+    }
+
+    .page-header h1 {
+      font-size: 1.8rem;
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+    }
+
+    .page-header p {
+      color: var(--ease-color-muted);
+      font-size: 0.95rem;
+      line-height: 1.6;
+    }
+
+    /* ── Product Grid ── */
+    .product-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 2rem;
+      width: 100%;
+      max-width: 900px;
+    }
+
+    .product-card {
+      background: var(--ease-color-surface);
+      border: 1px solid var(--ease-color-neutral-200);
+      box-shadow: var(--ease-shadow-lg);
+      border-radius: 1rem;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* Target wrapper class from style.css */
+    .card-zoom-wrapper {
+      height: 240px;
+    }
+
+    .product-details {
+      padding: 1.5rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .product-category {
+      color: var(--ease-color-primary);
+      font-size: 0.75rem;
+      font-weight: 700;
+      text-transform: uppercase;
+    }
+
+    .product-title {
+      font-size: 1.1rem;
+      font-weight: 700;
+    }
+
+    .product-desc {
+      color: var(--ease-color-muted);
+      font-size: 0.85rem;
+      line-height: 1.5;
+    }
+
+    .product-price {
+      font-weight: 800;
+      font-size: 1.2rem;
+      margin-top: 0.5rem;
+    }
+  </style>
+
+  <!-- Load the submission style -->
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>Zoom and Pan Image Reveal</h1>
+    <p>
+      Hover over the product cards below to explore details through a smooth zoom-in and position-shifting camera effect.
+    </p>
+  </header>
+
+  <main class="product-grid">
+
+    <!-- Card 1: Mountain Backpack -->
+    <article class="product-card">
+      <div class="card-zoom-uj card-zoom-wrapper">
+        <img src="https://images.unsplash.com/photo-1553062407-98eeb64c6a62?auto=format&fit=crop&w=600&q=80" 
+             class="zoom-pan-img-uj" 
+             alt="Venture Backpack">
+      </div>
+      <div class="product-details">
+        <span class="product-category">Gear</span>
+        <h2 class="product-title">Venture Backpack</h2>
+        <p class="product-desc">Waterproof, multiple pockets, built for weekend mountain trekking.</p>
+        <div class="product-price">$120.00</div>
+      </div>
+    </article>
+
+    <!-- Card 2: Minimalist Watch -->
+    <article class="product-card">
+      <div class="card-zoom-uj card-zoom-wrapper" style="--zoom-scale: 1.15; --pan-x: 2%; --pan-y: 2%;">
+        <img src="https://images.unsplash.com/photo-1523275335684-37898b6baf30?auto=format&fit=crop&w=600&q=80" 
+             class="zoom-pan-img-uj" 
+             alt="Classic Chronograph">
+      </div>
+      <div class="product-details">
+        <span class="product-category">Accessories</span>
+        <h2 class="product-title">Classic Watch</h2>
+        <p class="product-desc">Ultra-thin body with genuine leather strap and minimal dials.</p>
+        <div class="product-price">$180.00</div>
+      </div>
+    </article>
+
+    <!-- Card 3: Wireless Headphones -->
+    <article class="product-card">
+      <div class="card-zoom-uj card-zoom-wrapper" style="--zoom-scale: 1.2; --pan-x: -3%; --pan-y: -1.5%;">
+        <img src="https://images.unsplash.com/photo-1505740420928-5e560c06d30e?auto=format&fit=crop&w=600&q=80" 
+             class="zoom-pan-img-uj" 
+             alt="Studio Wireless Headphones">
+      </div>
+      <div class="product-details">
+        <span class="product-category">Audio</span>
+        <h2 class="product-title">Studio Headphones</h2>
+        <p class="product-desc">Active noise-canceling with up to 40 hours of continuous playback.</p>
+        <div class="product-price">$299.00</div>
+      </div>
+    </article>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/zoom-pan-image-uj/style.css
+++ b/submissions/examples/zoom-pan-image-uj/style.css
@@ -1,0 +1,29 @@
+/* =============================================================
+   Submission: zoom-pan-image-uj
+   Effect: Zoom and Pan Image Reveal
+   ============================================================= */
+
+.card-zoom-uj {
+  position: relative;
+  overflow: hidden;
+}
+
+.zoom-pan-img-uj {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform var(--zoom-duration, 0.5s) cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  transform: scale(1) translate(0, 0);
+}
+
+.card-zoom-uj:hover .zoom-pan-img-uj {
+  transform: scale(var(--zoom-scale, 1.1)) translate(var(--pan-x, -2%), var(--pan-y, -1%));
+}
+
+/* Accessibility Support for reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .zoom-pan-img-uj {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
Resolves #32043

## Description
Introduce a Zoom and Pan Image Reveal effect where images smoothly zoom in and slightly shift position on hover, creating a premium product showcase interaction.

## Checklist
- [x] This feature does not duplicate an existing EaseMotion CSS class.
- [x] I understand my naming will be standardized by the maintainer.
- [x] I will submit code inside `submissions/` only — not in `core/` or `components/`.