### PR TITLE
feat: add release readiness demo

### DIFF
--- a/submissions/examples/forge-release-readiness/README.md
+++ b/submissions/examples/forge-release-readiness/README.md
@@ -1,0 +1,14 @@
+# Forge Release Readiness Demo
+
+An engineering release view for summarizing completed checks, blockers, and deployment confidence before launch.
+
+## What is included
+
+- Responsive HTML structure for the release readiness demo.
+- CSS-only overview panel, metric list, and responsive insight cards.
+- Semantic sections with accessible labelling.
+
+## Files
+
+- `demo.html`
+- `style.css`

--- a/submissions/examples/forge-release-readiness/demo.html
+++ b/submissions/examples/forge-release-readiness/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Forge Release Readiness Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-page">
+    <section class="overview">
+      <div class="overview-copy">
+        <p class="eyebrow">Engineering release</p>
+        <h1>Release readiness board for launch teams</h1>
+        <p class="summary">An engineering release view for summarizing completed checks, blockers, and deployment confidence before launch.</p>
+      </div>
+      <ul class="metrics" aria-label="Release readiness metrics">
+          <li>
+            <span>Checks</span>
+            <strong>38</strong>
+          </li>
+          <li>
+            <span>Blockers</span>
+            <strong>2</strong>
+          </li>
+          <li>
+            <span>Confidence</span>
+            <strong>89%</strong>
+          </li>
+      </ul>
+    </section>
+
+    <section class="insight-grid" aria-label="Release readiness insights">
+        <article class="insight-card">
+          <span>Checks</span>
+          <h2>Launch coverage</h2>
+          <p>Completed checks are shown prominently so release owners can confirm readiness quickly.</p>
+        </article>
+        <article class="insight-card">
+          <span>Risk</span>
+          <h2>Blocker focus</h2>
+          <p>Blocker count stays isolated to keep attention on the work that still matters.</p>
+        </article>
+        <article class="insight-card">
+          <span>Decision</span>
+          <h2>Confidence read</h2>
+          <p>A confidence metric helps teams make a clear go or no-go call.</p>
+        </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/forge-release-readiness/style.css
+++ b/submissions/examples/forge-release-readiness/style.css
@@ -1,0 +1,131 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #1f282d;
+  background:
+    linear-gradient(140deg, rgba(88, 105, 176, 0.2), transparent 34%),
+    linear-gradient(230deg, rgba(213, 154, 68, 0.18), transparent 38%),
+    #f6f8f3;
+}
+
+.demo-page {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.overview {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 310px;
+  gap: 24px;
+  align-items: stretch;
+  padding: 32px;
+  border: 1px solid rgba(31, 40, 45, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 24px 70px rgba(31, 40, 45, 0.12);
+}
+
+.eyebrow,
+.insight-card span {
+  display: block;
+  margin-bottom: 10px;
+  color: #617078;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 780px;
+  margin-bottom: 16px;
+  font-size: clamp(2.35rem, 7vw, 5rem);
+  line-height: 0.96;
+  letter-spacing: 0;
+}
+
+.summary {
+  max-width: 700px;
+  margin-bottom: 0;
+  color: #53616a;
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.metrics {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.metrics li,
+.insight-card {
+  border: 1px solid rgba(31, 40, 45, 0.1);
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.metrics li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px;
+}
+
+.metrics span {
+  color: #64727b;
+  font-weight: 700;
+}
+
+.metrics strong {
+  font-size: 1.35rem;
+}
+
+.insight-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.insight-card {
+  min-height: 210px;
+  padding: 24px;
+}
+
+.insight-card h2 {
+  margin-bottom: 12px;
+  font-size: 1.32rem;
+}
+
+.insight-card p {
+  margin-bottom: 0;
+  color: #56646d;
+  line-height: 1.65;
+}
+
+@media (max-width: 820px) {
+  .overview,
+  .insight-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .overview {
+    padding: 24px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a new responsive release readiness example under `submissions/examples/forge-release-readiness`
- include semantic HTML, CSS-only layout styling, and mobile stacking support
- document the demo purpose and included files

## Testing
- not run locally; static HTML/CSS example only
