### PR TITLE
feat: add research backlog demo

### DIFF
--- a/submissions/examples/vector-research-backlog/README.md
+++ b/submissions/examples/vector-research-backlog/README.md
@@ -1,0 +1,14 @@
+# Vector Research Backlog Demo
+
+A discovery planning panel that organizes pending interviews, synthesis work, and validated learning signals.
+
+## What is included
+
+- Responsive HTML structure for the research backlog demo.
+- CSS-only overview panel, metric list, and responsive insight cards.
+- Semantic sections with accessible labelling.
+
+## Files
+
+- `demo.html`
+- `style.css`

--- a/submissions/examples/vector-research-backlog/demo.html
+++ b/submissions/examples/vector-research-backlog/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Vector Research Backlog Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-page">
+    <section class="overview">
+      <div class="overview-copy">
+        <p class="eyebrow">User research</p>
+        <h1>Research backlog board for product discovery</h1>
+        <p class="summary">A discovery planning panel that organizes pending interviews, synthesis work, and validated learning signals.</p>
+      </div>
+      <ul class="metrics" aria-label="Research backlog metrics">
+          <li>
+            <span>Interviews</span>
+            <strong>18</strong>
+          </li>
+          <li>
+            <span>Synthesis</span>
+            <strong>7</strong>
+          </li>
+          <li>
+            <span>Signals</span>
+            <strong>45</strong>
+          </li>
+      </ul>
+    </section>
+
+    <section class="insight-grid" aria-label="Research backlog insights">
+        <article class="insight-card">
+          <span>Discovery</span>
+          <h2>Interview queue</h2>
+          <p>Interview count gives researchers a practical sense of upcoming scheduling work.</p>
+        </article>
+        <article class="insight-card">
+          <span>Synthesis</span>
+          <h2>Analysis load</h2>
+          <p>Synthesis work is called out so the team can reserve time for learning consolidation.</p>
+        </article>
+        <article class="insight-card">
+          <span>Learning</span>
+          <h2>Validated signals</h2>
+          <p>Validated signals show how research activity is turning into product insight.</p>
+        </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/vector-research-backlog/style.css
+++ b/submissions/examples/vector-research-backlog/style.css
@@ -1,0 +1,131 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #1f282d;
+  background:
+    linear-gradient(140deg, rgba(119, 94, 176, 0.2), transparent 34%),
+    linear-gradient(230deg, rgba(54, 139, 111, 0.18), transparent 38%),
+    #f6f8f3;
+}
+
+.demo-page {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.overview {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 310px;
+  gap: 24px;
+  align-items: stretch;
+  padding: 32px;
+  border: 1px solid rgba(31, 40, 45, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 24px 70px rgba(31, 40, 45, 0.12);
+}
+
+.eyebrow,
+.insight-card span {
+  display: block;
+  margin-bottom: 10px;
+  color: #617078;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 780px;
+  margin-bottom: 16px;
+  font-size: clamp(2.35rem, 7vw, 5rem);
+  line-height: 0.96;
+  letter-spacing: 0;
+}
+
+.summary {
+  max-width: 700px;
+  margin-bottom: 0;
+  color: #53616a;
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.metrics {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.metrics li,
+.insight-card {
+  border: 1px solid rgba(31, 40, 45, 0.1);
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.metrics li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px;
+}
+
+.metrics span {
+  color: #64727b;
+  font-weight: 700;
+}
+
+.metrics strong {
+  font-size: 1.35rem;
+}
+
+.insight-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.insight-card {
+  min-height: 210px;
+  padding: 24px;
+}
+
+.insight-card h2 {
+  margin-bottom: 12px;
+  font-size: 1.32rem;
+}
+
+.insight-card p {
+  margin-bottom: 0;
+  color: #56646d;
+  line-height: 1.65;
+}
+
+@media (max-width: 820px) {
+  .overview,
+  .insight-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .overview {
+    padding: 24px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a new responsive research backlog example under `submissions/examples/vector-research-backlog`
- include semantic HTML, CSS-only layout styling, and mobile stacking support
- document the demo purpose and included files

## Testing
- not run locally; static HTML/CSS example only
