### PR TITLE
feat: add manufacturing shift demo

### DIFF
--- a/submissions/examples/rivet-manufacturing-shift/README.md
+++ b/submissions/examples/rivet-manufacturing-shift/README.md
@@ -1,0 +1,14 @@
+# Rivet Manufacturing Shift Demo
+
+A production floor dashboard that tracks output, downtime, and quality checks across a shift.
+
+## What is included
+
+- Responsive HTML structure for the manufacturing shift demo.
+- CSS-only hero panel, metric list, and responsive signal cards.
+- Semantic sections with accessible labelling.
+
+## Files
+
+- `demo.html`
+- `style.css`

--- a/submissions/examples/rivet-manufacturing-shift/demo.html
+++ b/submissions/examples/rivet-manufacturing-shift/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Rivet Manufacturing Shift Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="hero-panel">
+      <div>
+        <p class="eyebrow">Production floor</p>
+        <h1>Manufacturing shift summary for line leads</h1>
+        <p class="summary">A production floor dashboard that tracks output, downtime, and quality checks across a shift.</p>
+      </div>
+      <ul class="metric-list" aria-label="Manufacturing shift metrics">
+          <li>
+            <span>Output</span>
+            <strong>1.2k</strong>
+          </li>
+          <li>
+            <span>Downtime</span>
+            <strong>18m</strong>
+          </li>
+          <li>
+            <span>Checks</span>
+            <strong>44</strong>
+          </li>
+      </ul>
+    </section>
+
+    <section class="signal-grid" aria-label="Manufacturing shift insights">
+        <article class="signal-card">
+          <span>Output</span>
+          <h2>Shift pace</h2>
+          <p>Output stays prominent so line leads can compare progress against the shift target.</p>
+        </article>
+        <article class="signal-card">
+          <span>Downtime</span>
+          <h2>Stop tracking</h2>
+          <p>Downtime is isolated to keep recovery work visible during handoff.</p>
+        </article>
+        <article class="signal-card">
+          <span>Quality</span>
+          <h2>Check coverage</h2>
+          <p>Quality checks show whether the production pace is supported by inspection discipline.</p>
+        </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/rivet-manufacturing-shift/style.css
+++ b/submissions/examples/rivet-manufacturing-shift/style.css
@@ -1,0 +1,131 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #202a30;
+  background:
+    linear-gradient(140deg, rgba(88, 104, 171, 0.2), transparent 35%),
+    linear-gradient(230deg, rgba(210, 150, 69, 0.18), transparent 39%),
+    #f7f8f4;
+}
+
+.demo-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.hero-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 310px;
+  gap: 24px;
+  align-items: stretch;
+  padding: 32px;
+  border: 1px solid rgba(32, 42, 48, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 24px 72px rgba(32, 42, 48, 0.12);
+}
+
+.eyebrow,
+.signal-card span {
+  display: block;
+  margin-bottom: 10px;
+  color: #62717a;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 780px;
+  margin-bottom: 16px;
+  font-size: clamp(2.35rem, 7vw, 5rem);
+  line-height: 0.96;
+  letter-spacing: 0;
+}
+
+.summary {
+  max-width: 700px;
+  margin-bottom: 0;
+  color: #54626b;
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.metric-list {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.metric-list li,
+.signal-card {
+  border: 1px solid rgba(32, 42, 48, 0.1);
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.metric-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px;
+}
+
+.metric-list span {
+  color: #65737c;
+  font-weight: 700;
+}
+
+.metric-list strong {
+  font-size: 1.35rem;
+}
+
+.signal-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.signal-card {
+  min-height: 210px;
+  padding: 24px;
+}
+
+.signal-card h2 {
+  margin-bottom: 12px;
+  font-size: 1.32rem;
+}
+
+.signal-card p {
+  margin-bottom: 0;
+  color: #56656e;
+  line-height: 1.65;
+}
+
+@media (max-width: 820px) {
+  .hero-panel,
+  .signal-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-panel {
+    padding: 24px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a new responsive manufacturing shift example under `submissions/examples/rivet-manufacturing-shift`
- include semantic HTML, CSS-only layout styling, and mobile stacking support
- document the demo purpose and included files

## Testing
- not run locally; static HTML/CSS example only
