### PR TITLE
feat: Add React Notification Center Drawer Component (#28096)

### DIFF
--- a/submissions/react/react-notification-center-drawer-with-slide-in-28096/NotificationDrawer.jsx
+++ b/submissions/react/react-notification-center-drawer-with-slide-in-28096/NotificationDrawer.jsx
@@ -1,0 +1,124 @@
+import React, { useState, useEffect, useRef } from 'react';
+
+/**
+ * Notification Center Drawer with Slide-In
+ * 
+ * @param {Array} initialNotifications - List of notification objects
+ * @param {Boolean} isOpen - Controls visibility of the drawer
+ * @param {Function} onClose - Callback to handle closing the drawer
+ */
+const NotificationDrawer = ({ initialNotifications = [], isOpen, onClose }) => {
+  const [notifications, setNotifications] = useState(initialNotifications);
+  const [isRendered, setIsRendered] = useState(isOpen);
+  const drawerRef = useRef(null);
+
+  // Mount/Unmount logic to allow CSS exit animations
+  useEffect(() => {
+    if (isOpen) {
+      setIsRendered(true);
+    } else {
+      const timeout = setTimeout(() => setIsRendered(false), 400); // match CSS duration
+      return () => clearTimeout(timeout);
+    }
+  }, [isOpen]);
+
+  // Handle clicking outside to close
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (isOpen && drawerRef.current && !drawerRef.current.contains(event.target)) {
+        onClose();
+      }
+    };
+    
+    // Add small delay so the click that opened it doesn't immediately close it
+    const timeoutId = setTimeout(() => {
+      document.addEventListener('mousedown', handleClickOutside);
+    }, 50);
+    
+    return () => {
+      clearTimeout(timeoutId);
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen, onClose]);
+
+  const removeNotification = (id) => {
+    setNotifications(prev => prev.filter(n => n.id !== id));
+  };
+
+  const markAllRead = () => {
+    setNotifications(prev => prev.map(n => ({ ...n, isRead: true })));
+  };
+
+  if (!isRendered) return null;
+
+  return (
+    <div className={`ease-drawer-overlay ${isOpen ? 'is-open' : 'is-closed'}`}>
+      <aside 
+        ref={drawerRef}
+        className={`ease-notification-drawer ${isOpen ? 'slide-in' : 'slide-out'}`}
+      >
+        <div className="ease-drawer-header">
+          <div className="ease-drawer-title-group">
+            <h3>Notifications</h3>
+            {notifications.filter(n => !n.isRead).length > 0 && (
+              <span className="ease-badge">
+                {notifications.filter(n => !n.isRead).length} new
+              </span>
+            )}
+          </div>
+          <div className="ease-drawer-actions">
+            <button className="ease-text-btn" onClick={markAllRead}>Mark all read</button>
+            <button className="ease-close-btn" onClick={onClose} aria-label="Close drawer">
+              &times;
+            </button>
+          </div>
+        </div>
+
+        <div className="ease-drawer-content">
+          {notifications.length === 0 ? (
+            <div className="ease-empty-state">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"></path>
+                <path d="M13.73 21a2 2 0 0 1-3.46 0"></path>
+              </svg>
+              <p>You're all caught up!</p>
+            </div>
+          ) : (
+            <ul className="ease-notification-list">
+              {notifications.map((notification) => (
+                <li 
+                  key={notification.id} 
+                  className={`ease-notification-item ${!notification.isRead ? 'unread' : ''}`}
+                >
+                  <div className="ease-notification-avatar">
+                    {notification.avatar ? (
+                      <img src={notification.avatar} alt="" />
+                    ) : (
+                      <div className="ease-avatar-placeholder">
+                        {notification.title.charAt(0).toUpperCase()}
+                      </div>
+                    )}
+                  </div>
+                  <div className="ease-notification-body">
+                    <h4>{notification.title}</h4>
+                    <p>{notification.message}</p>
+                    <span className="ease-time">{notification.time}</span>
+                  </div>
+                  <button 
+                    className="ease-dismiss-btn" 
+                    onClick={() => removeNotification(notification.id)}
+                    aria-label="Dismiss notification"
+                  >
+                    &times;
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </aside>
+    </div>
+  );
+};
+
+export default NotificationDrawer;

--- a/submissions/react/react-notification-center-drawer-with-slide-in-28096/README.md
+++ b/submissions/react/react-notification-center-drawer-with-slide-in-28096/README.md
@@ -1,0 +1,57 @@
+# React Component: Notification Center Drawer with Slide-In (#28096)
+
+A modular, copy-paste ready React component for the EaseMotion CSS framework. This component provides a fluid, off-canvas notification drawer that slides in from the right edge of the viewport. It includes state management for unread statuses, dismissing notifications, and smooth entrance/exit animations.
+
+## 📦 What's included?
+
+- `NotificationDrawer.jsx`: The React component that manages open/close state, delayed unmounting for exit animations, click-outside-to-close logic, and array manipulation for dismissing or reading notifications.
+- `style.css`: The CSS stylesheet powering the backdrop blur, the cubic-bezier `slide-in` and `slide-out` keyframes, and the micro-interactions on the notification list items (hover shifts and reveal buttons).
+- `demo.html`: A self-contained browser demo running the React component via Babel standalone.
+
+## 🛠 Features
+
+- **Delayed Unmount Animation**: Uses a dual-state boolean system (`isOpen` vs `isRendered`) and a `setTimeout` tied to the CSS transition duration to ensure the drawer smoothly slides off-screen *before* React removes it from the DOM.
+- **Fluid Spring Physics**: The slide-in animation uses `cubic-bezier(0.16, 1, 0.3, 1)` to create a fast entry that gently decelerates into place, feeling responsive and premium.
+- **Micro-Interactions**: Hovering over individual notifications applies a subtle `translateX(4px)` shift, and reveals a red dismiss button that scales into view.
+- **Click Outside Support**: Automatically listens for `mousedown` events outside the drawer `aside` ref to cleanly close the drawer.
+
+## 🚀 How to use
+
+1. Copy `NotificationDrawer.jsx` into your React project's `components` directory.
+2. Copy `style.css` and import it into your global styles or alongside the component.
+3. Manage the `isOpen` state in a parent component (like your Navbar).
+
+```jsx
+import React, { useState } from 'react';
+import NotificationDrawer from './NotificationDrawer';
+import './style.css'; 
+
+const Navbar = () => {
+  const [showDrawer, setShowDrawer] = useState(false);
+  const data = [
+    { id: 1, title: 'Alert', message: 'Something happened.', time: 'Just now', isRead: false }
+  ];
+
+  return (
+    <nav>
+      <button onClick={() => setShowDrawer(true)}>
+        Bell Icon
+      </button>
+
+      <NotificationDrawer 
+        isOpen={showDrawer}
+        onClose={() => setShowDrawer(false)}
+        initialNotifications={data}
+      />
+    </nav>
+  );
+};
+
+export default Navbar;
+```
+
+## 🎨 Why this fits EaseMotion
+
+**EaseMotion** emphasizes that UI elements should obey the laws of physics.
+
+A drawer that simply appears and disappears instantly feels jarring and disrupts spatial awareness. By animating the entry from the right, the user understands exactly where the panel came from and where it belongs in the z-axis of the application. The use of custom easing curves prevents the linear, robotic feel common in basic UI libraries.

--- a/submissions/react/react-notification-center-drawer-with-slide-in-28096/demo.html
+++ b/submissions/react/react-notification-center-drawer-with-slide-in-28096/demo.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>React Notification Drawer Demo</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="./style.css">
+  
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+
+  <style>
+    body {
+      margin: 0;
+      background: #f1f5f9;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+      box-sizing: border-box;
+      font-family: system-ui, sans-serif;
+    }
+    
+    .demo-container {
+      text-align: center;
+    }
+
+    h1 {
+      color: #0f172a;
+      margin-top: 0;
+      margin-bottom: 1rem;
+      font-size: 2.5rem;
+      font-weight: 800;
+    }
+
+    .open-btn {
+      padding: 12px 24px;
+      font-size: 1rem;
+      font-weight: 600;
+      background: #0f172a;
+      color: white;
+      border: none;
+      border-radius: 8px;
+      cursor: pointer;
+      box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1);
+      transition: transform 0.2s, box-shadow 0.2s;
+    }
+
+    .open-btn:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1);
+    }
+    
+    .open-btn:active {
+      transform: translateY(0);
+    }
+  </style>
+</head>
+<body>
+
+  <div id="root"></div>
+
+  <script type="text/babel">
+    const { useState, useEffect, useRef } = React;
+
+    const NotificationDrawer = ({ initialNotifications = [], isOpen, onClose }) => {
+      const [notifications, setNotifications] = useState(initialNotifications);
+      const [isRendered, setIsRendered] = useState(isOpen);
+      const drawerRef = useRef(null);
+
+      useEffect(() => {
+        if (isOpen) {
+          setIsRendered(true);
+        } else {
+          const timeout = setTimeout(() => setIsRendered(false), 400); 
+          return () => clearTimeout(timeout);
+        }
+      }, [isOpen]);
+
+      useEffect(() => {
+        const handleClickOutside = (event) => {
+          if (isOpen && drawerRef.current && !drawerRef.current.contains(event.target)) {
+            onClose();
+          }
+        };
+        
+        const timeoutId = setTimeout(() => {
+          document.addEventListener('mousedown', handleClickOutside);
+        }, 50);
+        
+        return () => {
+          clearTimeout(timeoutId);
+          document.removeEventListener('mousedown', handleClickOutside);
+        };
+      }, [isOpen, onClose]);
+
+      const removeNotification = (id) => {
+        setNotifications(prev => prev.filter(n => n.id !== id));
+      };
+
+      const markAllRead = () => {
+        setNotifications(prev => prev.map(n => ({ ...n, isRead: true })));
+      };
+
+      if (!isRendered) return null;
+
+      return (
+        <div className={`ease-drawer-overlay ${isOpen ? 'is-open' : 'is-closed'}`}>
+          <aside 
+            ref={drawerRef}
+            className={`ease-notification-drawer ${isOpen ? 'slide-in' : 'slide-out'}`}
+          >
+            <div className="ease-drawer-header">
+              <div className="ease-drawer-title-group">
+                <h3>Notifications</h3>
+                {notifications.filter(n => !n.isRead).length > 0 && (
+                  <span className="ease-badge">
+                    {notifications.filter(n => !n.isRead).length} new
+                  </span>
+                )}
+              </div>
+              <div className="ease-drawer-actions">
+                <button className="ease-text-btn" onClick={markAllRead}>Mark all read</button>
+                <button className="ease-close-btn" onClick={onClose} aria-label="Close">&times;</button>
+              </div>
+            </div>
+
+            <div className="ease-drawer-content">
+              {notifications.length === 0 ? (
+                <div className="ease-empty-state">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"></path><path d="M13.73 21a2 2 0 0 1-3.46 0"></path></svg>
+                  <p>You're all caught up!</p>
+                </div>
+              ) : (
+                <ul className="ease-notification-list">
+                  {notifications.map((n) => (
+                    <li key={n.id} className={`ease-notification-item ${!n.isRead ? 'unread' : ''}`}>
+                      <div className="ease-notification-avatar">
+                        <div className="ease-avatar-placeholder">{n.title.charAt(0)}</div>
+                      </div>
+                      <div className="ease-notification-body">
+                        <h4>{n.title}</h4>
+                        <p>{n.message}</p>
+                        <span className="ease-time">{n.time}</span>
+                      </div>
+                      <button className="ease-dismiss-btn" onClick={() => removeNotification(n.id)}>&times;</button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </aside>
+        </div>
+      );
+    };
+
+    const App = () => {
+      const [drawerOpen, setDrawerOpen] = useState(false);
+      
+      const sampleNotifications = [
+        {
+          id: 1,
+          title: "Emma sent you a message",
+          message: "Hey! Are we still on for the meeting tomorrow at 10?",
+          time: "5m ago",
+          isRead: false
+        },
+        {
+          id: 2,
+          title: "System Update",
+          message: "EaseMotion CSS v2.1 has been successfully installed.",
+          time: "1h ago",
+          isRead: false
+        },
+        {
+          id: 3,
+          title: "Project Alpha",
+          message: "Your pull request was merged by Sarah.",
+          time: "Yesterday",
+          isRead: true
+        }
+      ];
+
+      return (
+        <div className="demo-container">
+          <h1>Dashboard</h1>
+          <button className="open-btn" onClick={() => setDrawerOpen(true)}>
+            Open Notifications
+          </button>
+
+          <NotificationDrawer 
+            isOpen={drawerOpen} 
+            onClose={() => setDrawerOpen(false)}
+            initialNotifications={sampleNotifications}
+          />
+        </div>
+      );
+    }
+
+    ReactDOM.render(<App />, document.getElementById('root'));
+  </script>
+</body>
+</html>

--- a/submissions/react/react-notification-center-drawer-with-slide-in-28096/style.css
+++ b/submissions/react/react-notification-center-drawer-with-slide-in-28096/style.css
@@ -1,0 +1,275 @@
+/* 
+  style.css
+  EaseMotion CSS - Notification Center Drawer
+*/
+
+/* --- Overlay --- */
+.ease-drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.4);
+  backdrop-filter: blur(4px);
+  z-index: 9999;
+  display: flex;
+  justify-content: flex-end;
+  /* Smooth fade for the overlay */
+  transition: opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  opacity: 0;
+}
+
+.ease-drawer-overlay.is-open {
+  opacity: 1;
+}
+
+.ease-drawer-overlay.is-closed {
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* --- Drawer Panel --- */
+.ease-notification-drawer {
+  width: 100%;
+  max-width: 400px;
+  height: 100%;
+  background: #ffffff;
+  box-shadow: -10px 0 25px -5px rgba(0, 0, 0, 0.1), -5px 0 10px -5px rgba(0, 0, 0, 0.04);
+  display: flex;
+  flex-direction: column;
+  font-family: system-ui, -apple-system, sans-serif;
+  
+  /* Initial state off-screen to the right */
+  transform: translateX(100%);
+}
+
+/* Slide-in animation using a fluid spring-like easing */
+.ease-notification-drawer.slide-in {
+  animation: easeDrawerSlideIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+.ease-notification-drawer.slide-out {
+  animation: easeDrawerSlideOut 0.4s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+
+@keyframes easeDrawerSlideIn {
+  0% { transform: translateX(100%); }
+  100% { transform: translateX(0); }
+}
+
+@keyframes easeDrawerSlideOut {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(100%); }
+}
+
+
+/* --- Header --- */
+.ease-drawer-header {
+  padding: 24px;
+  border-bottom: 1px solid #e2e8f0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.ease-drawer-title-group {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.ease-drawer-header h3 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.ease-badge {
+  background: #3b82f6;
+  color: #ffffff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 4px 8px;
+  border-radius: 99px;
+}
+
+.ease-drawer-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.ease-text-btn {
+  background: transparent;
+  border: none;
+  color: #3b82f6;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+  transition: color 0.2s;
+}
+.ease-text-btn:hover {
+  color: #2563eb;
+  text-decoration: underline;
+}
+
+.ease-close-btn {
+  background: #f1f5f9;
+  border: none;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  font-size: 1.5rem;
+  line-height: 1;
+  color: #64748b;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s, color 0.2s;
+}
+
+.ease-close-btn:hover {
+  background: #e2e8f0;
+  color: #0f172a;
+}
+
+/* --- Content / List --- */
+.ease-drawer-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+}
+
+.ease-notification-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ease-notification-item {
+  position: relative;
+  display: flex;
+  gap: 16px;
+  padding: 16px;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.2s ease, border-color 0.2s;
+}
+
+.ease-notification-item.unread {
+  background: #f8fafc;
+  border-color: #cbd5e1;
+}
+
+.ease-notification-item.unread::before {
+  content: '';
+  position: absolute;
+  top: 16px;
+  left: -4px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #3b82f6;
+}
+
+.ease-notification-item:hover {
+  transform: translateX(4px);
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+}
+
+.ease-notification-avatar {
+  flex-shrink: 0;
+}
+
+.ease-avatar-placeholder {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #3b82f6, #8b5cf6);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 1.2rem;
+}
+
+.ease-notification-body {
+  flex: 1;
+}
+
+.ease-notification-body h4 {
+  margin: 0 0 4px 0;
+  font-size: 0.95rem;
+  color: #0f172a;
+}
+
+.ease-notification-body p {
+  margin: 0 0 8px 0;
+  font-size: 0.875rem;
+  color: #475569;
+  line-height: 1.4;
+}
+
+.ease-time {
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+/* Dismiss Button reveals on item hover */
+.ease-dismiss-btn {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: #f1f5f9;
+  border: none;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #64748b;
+  cursor: pointer;
+  opacity: 0;
+  transform: scale(0.8);
+  transition: opacity 0.2s, transform 0.2s, background 0.2s;
+}
+
+.ease-notification-item:hover .ease-dismiss-btn {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.ease-dismiss-btn:hover {
+  background: #ef4444;
+  color: white;
+}
+
+/* --- Empty State --- */
+.ease-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: #94a3b8;
+  text-align: center;
+}
+
+.ease-empty-state svg {
+  width: 48px;
+  height: 48px;
+  margin-bottom: 16px;
+  opacity: 0.5;
+}
+
+.ease-empty-state p {
+  font-weight: 600;
+  font-size: 1.1rem;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a React component for a Notification Center Drawer with smooth slide-in/out animations, addressing issue #28096 (#27466).

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/react/react-notification-center-drawer-with-slide-in-28096/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A modular, highly interactive React Notification Drawer component. It features a delayed-unmount architecture that allows CSS exit animations to play smoothly before the component leaves the DOM.

**How does a developer use it?**

```jsx
import React, { useState } from 'react';
import NotificationDrawer from './NotificationDrawer';
import './style.css';

const App = () => {
  const [showDrawer, setShowDrawer] = useState(false);
  const data = [{ id: 1, title: 'Alert', message: 'Something happened.', time: 'Just now', isRead: false }];

  return (
    <div>
      <button onClick={() => setShowDrawer(true)}>Open Notifications</button>
      <NotificationDrawer 
