### PR TITLE
feat: Add React Language Selector Dropdown Component (#28240)

### DIFF
--- a/submissions/react/react-language-selector-dropdown-with-flag-fade-transitions-28240/LanguageSelector.jsx
+++ b/submissions/react/react-language-selector-dropdown-with-flag-fade-transitions-28240/LanguageSelector.jsx
@@ -1,0 +1,104 @@
+import React, { useState, useRef, useEffect } from 'react';
+
+/**
+ * Language Selector Dropdown with Flag Fade Transitions
+ * 
+ * @param {Array} languages - Array of language objects { code, name, flag }
+ * @param {String} defaultLanguage - The default language code to display
+ */
+const LanguageSelector = ({ languages = [], defaultLanguage = 'en' }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedLang, setSelectedLang] = useState(
+    languages.find(l => l.code === defaultLanguage) || languages[0]
+  );
+  const dropdownRef = useRef(null);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        setIsOpen(false);
+      }
+    };
+    
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleSelect = (lang) => {
+    setSelectedLang(lang);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="ease-lang-selector" ref={dropdownRef}>
+      
+      {/* The main trigger button */}
+      <button 
+        className={`ease-lang-trigger ${isOpen ? 'is-open' : ''}`}
+        onClick={() => setIsOpen(!isOpen)}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+      >
+        <div className="ease-lang-trigger-content">
+          {/* We use a key on the flag span to trigger the CSS fade-in animation on change */}
+          <span className="ease-lang-flag" key={`flag-${selectedLang.code}`}>
+            {selectedLang.flag}
+          </span>
+          <span className="ease-lang-code">{selectedLang.code.toUpperCase()}</span>
+        </div>
+        
+        {/* Animated Chevron */}
+        <svg 
+          className="ease-lang-chevron" 
+          viewBox="0 0 24 24" 
+          fill="none" 
+          stroke="currentColor" 
+          strokeWidth="2" 
+          strokeLinecap="round" 
+          strokeLinejoin="round"
+        >
+          <polyline points="6 9 12 15 18 9"></polyline>
+        </svg>
+      </button>
+
+      {/* The Dropdown Menu */}
+      <div 
+        className={`ease-lang-dropdown ${isOpen ? 'is-visible' : ''}`}
+        role="listbox"
+      >
+        <ul className="ease-lang-list">
+          {languages.map((lang, index) => {
+            const isSelected = lang.code === selectedLang.code;
+            return (
+              <li 
+                key={lang.code}
+                role="option"
+                aria-selected={isSelected}
+                className={`ease-lang-option ${isSelected ? 'is-selected' : ''}`}
+                onClick={() => handleSelect(lang)}
+                style={{ 
+                  // Stagger the entrance animation of list items
+                  transitionDelay: isOpen ? `${index * 0.05}s` : '0s' 
+                }}
+              >
+                <span className="ease-lang-option-flag">{lang.flag}</span>
+                <span className="ease-lang-option-name">{lang.name}</span>
+                
+                {/* Active checkmark */}
+                {isSelected && (
+                  <svg className="ease-lang-check" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                    <polyline points="20 6 9 17 4 12"></polyline>
+                  </svg>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+
+    </div>
+  );
+};
+
+export default LanguageSelector;

--- a/submissions/react/react-language-selector-dropdown-with-flag-fade-transitions-28240/README.md
+++ b/submissions/react/react-language-selector-dropdown-with-flag-fade-transitions-28240/README.md
@@ -1,0 +1,51 @@
+# React Component: Language Selector Dropdown with Flag Fade Transitions (#28240)
+
+A modular, copy-paste ready React component for the EaseMotion CSS framework. This component renders a premium, highly-interactive dropdown menu specifically tailored for language/locale selection, featuring staggered list entrances and CSS-driven flag fade-in animations on selection change.
+
+## 📦 What's included?
+
+- `LanguageSelector.jsx`: The React component that manages the open/closed state, handles the "click outside" dismissal logic, and maps the language data arrays into a staggered DOM structure.
+- `style.css`: The CSS stylesheet powering the dropdown's `cubic-bezier` spring entrance, the staggered staggered list item reveals, and the `key`-triggered flag fade animation.
+- `demo.html`: A self-contained browser demo running the React component inside a mock navigation bar to showcase the dropdown behavior.
+
+## 🛠 Features
+
+- **Flag Fade & Slide (`easeFlagFade`)**: When the user selects a new language, the component relies on a React `key` change trick on the trigger's flag `<span>` to force a re-mount. This triggers a crisp CSS `@keyframes` fade-and-slide up, providing immediate physical feedback that the language has changed.
+- **Staggered Menu Reveal**: When the dropdown opens, the menu itself scales in from the top right anchor point. Simultaneously, the `<li>` options stagger their entrance (sliding in from the right and fading up) by utilizing a dynamic React inline `transitionDelay` based on their index.
+- **Micro-Interactions**: The trigger button features an active `transform: scale(0.97)` click-push effect and a chevron that rotates smoothly on a spring curve.
+- **Accessibility Ready**: Built with `aria-haspopup`, `aria-expanded`, `role="listbox"`, and `role="option"` attributes.
+
+## 🚀 How to use
+
+1. Copy `LanguageSelector.jsx` into your React project.
+2. Copy `style.css` and import it.
+3. Pass an array of language objects to the component.
+
+```jsx
+import React from 'react';
+import LanguageSelector from './LanguageSelector';
+import './style.css'; 
+
+const Navbar = () => {
+  const supportedLocales = [
+    { code: 'en', name: 'English (US)', flag: '🇺🇸' },
+    { code: 'es', name: 'Español', flag: '🇪🇸' },
+    { code: 'fr', name: 'Français', flag: '🇫🇷' },
+  ];
+
+  return (
+    <nav>
+      <LanguageSelector 
+        languages={supportedLocales} 
+        defaultLanguage="en" 
+      />
+    </nav>
+  );
+};
+```
+
+## 🎨 Why this fits EaseMotion
+
+**EaseMotion** is about making standard UI elements feel like physical mechanisms. 
+
+A standard `<select>` dropdown is abrupt and lifeless. By adding a scaling `transform-origin: top right` to the menu container, the dropdown feels like it's physically unfurling from the trigger button. By utilizing a staggered transition delay on the menu items, the eyes are guided naturally down the list. Finally, the use of a remounting `@keyframes` animation on the selected flag makes the act of switching languages feel tactile and responsive.

--- a/submissions/react/react-language-selector-dropdown-with-flag-fade-transitions-28240/demo.html
+++ b/submissions/react/react-language-selector-dropdown-with-flag-fade-transitions-28240/demo.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>React Language Selector Demo</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="./style.css">
+  
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+
+  <style>
+    body {
+      margin: 0;
+      background: #f8fafc;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding-top: 10vh;
+      font-family: system-ui, sans-serif;
+    }
+    
+    .demo-navbar {
+      background: white;
+      padding: 1rem 2rem;
+      border-radius: 16px;
+      box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
+      width: 100%;
+      max-width: 600px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .brand {
+      font-weight: 700;
+      font-size: 1.2rem;
+      color: #0f172a;
+    }
+  </style>
+</head>
+<body>
+
+  <div id="root"></div>
+
+  <script type="text/babel">
+    const { useState, useRef, useEffect } = React;
+
+    const LanguageSelector = ({ languages = [], defaultLanguage = 'en' }) => {
+      const [isOpen, setIsOpen] = useState(false);
+      const [selectedLang, setSelectedLang] = useState(
+        languages.find(l => l.code === defaultLanguage) || languages[0]
+      );
+      const dropdownRef = useRef(null);
+
+      useEffect(() => {
+        const handleClickOutside = (event) => {
+          if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+            setIsOpen(false);
+          }
+        };
+        document.addEventListener('mousedown', handleClickOutside);
+        return () => document.removeEventListener('mousedown', handleClickOutside);
+      }, []);
+
+      const handleSelect = (lang) => {
+        setSelectedLang(lang);
+        setIsOpen(false);
+      };
+
+      return (
+        <div className="ease-lang-selector" ref={dropdownRef}>
+          <button 
+            className={`ease-lang-trigger ${isOpen ? 'is-open' : ''}`}
+            onClick={() => setIsOpen(!isOpen)}
+            aria-haspopup="listbox"
+            aria-expanded={isOpen}
+          >
+            <div className="ease-lang-trigger-content">
+              <span className="ease-lang-flag" key={`flag-${selectedLang.code}`}>
+                {selectedLang.flag}
+              </span>
+              <span className="ease-lang-code">{selectedLang.code.toUpperCase()}</span>
+            </div>
+            
+            <svg className="ease-lang-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </button>
+
+          <div className={`ease-lang-dropdown ${isOpen ? 'is-visible' : ''}`} role="listbox">
+            <ul className="ease-lang-list">
+              {languages.map((lang, index) => {
+                const isSelected = lang.code === selectedLang.code;
+                return (
+                  <li 
+                    key={lang.code}
+                    role="option"
+                    aria-selected={isSelected}
+                    className={`ease-lang-option ${isSelected ? 'is-selected' : ''}`}
+                    onClick={() => handleSelect(lang)}
+                    style={{ transitionDelay: isOpen ? `${index * 0.03}s` : '0s' }}
+                  >
+                    <span className="ease-lang-option-flag">{lang.flag}</span>
+                    <span className="ease-lang-option-name">{lang.name}</span>
+                    {isSelected && (
+                      <svg className="ease-lang-check" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                        <polyline points="20 6 9 17 4 12"></polyline>
+                      </svg>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        </div>
+      );
+    };
+
+    const App = () => {
+      const languages = [
+        { code: 'en', name: 'English (US)', flag: '🇺🇸' },
+        { code: 'es', name: 'Español', flag: '🇪🇸' },
+        { code: 'fr', name: 'Français', flag: '🇫🇷' },
+        { code: 'de', name: 'Deutsch', flag: '🇩🇪' },
+        { code: 'ja', name: '日本語', flag: '🇯🇵' },
+      ];
+
+      return (
+        <div className="demo-navbar">
+          <div className="brand">MyWebsite</div>
+          <LanguageSelector languages={languages} defaultLanguage="en" />
+        </div>
+      );
+    }
+
+    ReactDOM.render(<App />, document.getElementById('root'));
+  </script>
+</body>
+</html>

--- a/submissions/react/react-language-selector-dropdown-with-flag-fade-transitions-28240/style.css
+++ b/submissions/react/react-language-selector-dropdown-with-flag-fade-transitions-28240/style.css
@@ -1,0 +1,179 @@
+/* 
+  style.css
+  EaseMotion CSS - Language Selector Dropdown
+*/
+
+.ease-lang-selector {
+  position: relative;
+  font-family: system-ui, -apple-system, sans-serif;
+  display: inline-block;
+  user-select: none;
+}
+
+/* --- Trigger Button --- */
+.ease-lang-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 8px 16px;
+  cursor: pointer;
+  font-size: 0.95rem;
+  color: #334155;
+  outline: none;
+  /* Smooth scale push effect on click */
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+}
+
+.ease-lang-trigger:hover {
+  background: #f8fafc;
+  border-color: #cbd5e1;
+}
+
+.ease-lang-trigger:active {
+  transform: scale(0.97);
+}
+
+.ease-lang-trigger.is-open {
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+}
+
+.ease-lang-trigger-content {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* --- Flag Fade Animation --- */
+/* The key prop in React causes this node to re-mount, triggering the animation */
+.ease-lang-flag {
+  font-size: 1.2rem;
+  line-height: 1;
+  animation: easeFlagFade 0.4s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+@keyframes easeFlagFade {
+  0% {
+    opacity: 0;
+    transform: translateY(4px) scale(0.8);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.ease-lang-code {
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+/* --- Chevron Rotation --- */
+.ease-lang-chevron {
+  width: 16px;
+  height: 16px;
+  color: #94a3b8;
+  transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.ease-lang-trigger.is-open .ease-lang-chevron {
+  transform: rotate(180deg);
+  color: #3b82f6;
+}
+
+/* --- Dropdown Menu --- */
+.ease-lang-dropdown {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  min-width: 200px;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  box-shadow: 0 10px 25px -5px rgba(0,0,0,0.1), 0 8px 10px -6px rgba(0,0,0,0.1);
+  overflow: hidden;
+  z-index: 100;
+  
+  /* Hidden state */
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-10px) scale(0.95);
+  transform-origin: top right;
+  
+  /* Entrance spring animation */
+  transition: opacity 0.3s ease, 
+              visibility 0.3s ease, 
+              transform 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.ease-lang-dropdown.is-visible {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0) scale(1);
+}
+
+.ease-lang-list {
+  margin: 0;
+  padding: 8px;
+  list-style: none;
+}
+
+/* --- Dropdown Options --- */
+.ease-lang-option {
+  display: flex;
+  align-items: center;
+  padding: 10px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  color: #475569;
+  
+  /* Staggered entrance preparation */
+  opacity: 0;
+  transform: translateX(10px);
+  transition: background-color 0.2s ease,
+              opacity 0.4s ease,
+              transform 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.ease-lang-dropdown.is-visible .ease-lang-option {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.ease-lang-option:hover {
+  background-color: #f1f5f9;
+  color: #0f172a;
+}
+
+.ease-lang-option.is-selected {
+  background-color: #eff6ff;
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
+.ease-lang-option-flag {
+  font-size: 1.2rem;
+  margin-right: 12px;
+}
+
+.ease-lang-option-name {
+  flex-grow: 1;
+}
+
+.ease-lang-check {
+  width: 16px;
+  height: 16px;
+  color: #3b82f6;
+  /* Checkmark pop */
+  animation: easeCheckPop 0.3s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+@keyframes easeCheckPop {
+  0% { transform: scale(0.5); opacity: 0; }
+  100% { transform: scale(1); opacity: 1; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a premium Language Selector Dropdown React component featuring CSS-driven staggered option entrances and a flag fade-in transition. Addresses issue #28240 (#27426).

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/react/react-language-selector-dropdown-with-flag-fade-transitions-28240/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A robust, accessible React `<LanguageSelector>` component. It handles click-outside dismissal logic natively via `useRef` and utilizes a React `key` state trick to trigger smooth CSS animations whenever the selected language changes. 

**How does a developer use it?**

```jsx
import React from 'react';
import LanguageSelector from './LanguageSelector';
import './style.css'; 

const Navbar = () => {
  const supportedLocales = [
    { code: 'en', name: 'English (US)', flag: '🇺🇸' },
    { code: 'es', name: 'Español', flag: '🇪🇸' },
    { code: 'fr', name: 'Français', flag: '🇫🇷' },
  ];

  return (
    <nav>
      <LanguageSelector 
        languages={supportedLocales} 
        defaultLanguage="en" 
      />
    </nav>
  );
};
