### PR TITLE
feat: Add React Rich Text Editor Toolbar Component (#28069)

### DIFF
--- a/submissions/react/react-rich-text-editor-toolbar-with-animated-tooltips-28069/EditorToolbar.jsx
+++ b/submissions/react/react-rich-text-editor-toolbar-with-animated-tooltips-28069/EditorToolbar.jsx
@@ -1,0 +1,118 @@
+import React, { useState } from 'react';
+
+/**
+ * Rich Text Editor Toolbar with Animated Tooltips
+ */
+const EditorToolbar = () => {
+  const [activeFormats, setActiveFormats] = useState({
+    bold: false,
+    italic: false,
+    underline: false,
+    alignLeft: true,
+    alignCenter: false,
+    alignRight: false,
+  });
+
+  const toggleFormat = (format) => {
+    // Handle alignment mutually exclusive logic
+    if (format.startsWith('align')) {
+      setActiveFormats(prev => ({
+        ...prev,
+        alignLeft: format === 'alignLeft',
+        alignCenter: format === 'alignCenter',
+        alignRight: format === 'alignRight'
+      }));
+    } else {
+      setActiveFormats(prev => ({
+        ...prev,
+        [format]: !prev[format]
+      }));
+    }
+  };
+
+  const ToolbarButton = ({ id, icon, label, shortcut }) => {
+    const isActive = activeFormats[id];
+    
+    return (
+      <div className="ease-toolbar-item">
+        <button 
+          className={`ease-toolbar-btn ${isActive ? 'is-active' : ''}`}
+          onClick={() => toggleFormat(id)}
+          aria-label={label}
+          aria-pressed={isActive}
+        >
+          {icon}
+        </button>
+        {/* Animated Tooltip */}
+        <div className="ease-toolbar-tooltip" role="tooltip">
+          <span className="ease-tooltip-label">{label}</span>
+          {shortcut && <span className="ease-tooltip-shortcut">{shortcut}</span>}
+        </div>
+      </div>
+    );
+  };
+
+  const Divider = () => <div className="ease-toolbar-divider" aria-hidden="true"></div>;
+
+  return (
+    <div className="ease-toolbar-container" role="toolbar" aria-label="Text Formatting">
+      <div className="ease-toolbar-group">
+        <ToolbarButton 
+          id="bold" 
+          label="Bold" 
+          shortcut="⌘B"
+          icon={<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M6 4h8a4 4 0 0 1 4 4 4 4 0 0 1-4 4H6z"></path><path d="M6 12h9a4 4 0 0 1 4 4 4 4 0 0 1-4 4H6z"></path></svg>} 
+        />
+        <ToolbarButton 
+          id="italic" 
+          label="Italic" 
+          shortcut="⌘I"
+          icon={<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><line x1="19" y1="4" x2="10" y2="4"></line><line x1="14" y1="20" x2="5" y2="20"></line><line x1="15" y1="4" x2="9" y2="20"></line></svg>} 
+        />
+        <ToolbarButton 
+          id="underline" 
+          label="Underline" 
+          shortcut="⌘U"
+          icon={<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M6 3v7a6 6 0 0 0 6 6 6 6 0 0 0 6-6V3"></path><line x1="4" y1="21" x2="20" y2="21"></line></svg>} 
+        />
+      </div>
+
+      <Divider />
+
+      <div className="ease-toolbar-group">
+        <ToolbarButton 
+          id="alignLeft" 
+          label="Align Left" 
+          shortcut="⌘⇧L"
+          icon={<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><line x1="17" y1="10" x2="3" y2="10"></line><line x1="21" y1="6" x2="3" y2="6"></line><line x1="21" y1="14" x2="3" y2="14"></line><line x1="17" y1="18" x2="3" y2="18"></line></svg>} 
+        />
+        <ToolbarButton 
+          id="alignCenter" 
+          label="Align Center" 
+          shortcut="⌘⇧E"
+          icon={<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="10" x2="6" y2="10"></line><line x1="21" y1="6" x2="3" y2="6"></line><line x1="21" y1="14" x2="3" y2="14"></line><line x1="18" y1="18" x2="6" y2="18"></line></svg>} 
+        />
+        <ToolbarButton 
+          id="alignRight" 
+          label="Align Right" 
+          shortcut="⌘⇧R"
+          icon={<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><line x1="21" y1="10" x2="7" y2="10"></line><line x1="21" y1="6" x2="3" y2="6"></line><line x1="21" y1="14" x2="3" y2="14"></line><line x1="21" y1="18" x2="7" y2="18"></line></svg>} 
+        />
+      </div>
+      
+      <Divider />
+
+      <div className="ease-toolbar-group">
+        <ToolbarButton 
+          id="link" 
+          label="Insert Link" 
+          shortcut="⌘K"
+          icon={<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>} 
+        />
+      </div>
+
+    </div>
+  );
+};
+
+export default EditorToolbar;

--- a/submissions/react/react-rich-text-editor-toolbar-with-animated-tooltips-28069/README.md
+++ b/submissions/react/react-rich-text-editor-toolbar-with-animated-tooltips-28069/README.md
@@ -1,0 +1,47 @@
+# React Component: Rich Text Editor Toolbar with Animated Tooltips (#28069)
+
+A modular, copy-paste ready React component for the EaseMotion CSS framework. This component renders a modern, floating style WYSIWYG editor toolbar featuring tactile button states and spring-animated contextual tooltips with keyboard shortcut indicators.
+
+## 📦 What's included?
+
+- `EditorToolbar.jsx`: The React component that manages active formatting states (including mutually exclusive alignment logic) and maps out the icon buttons.
+- `style.css`: The CSS stylesheet powering the active state background shifts, the button press scale micro-interaction, and the `cubic-bezier` tooltip entrance.
+- `demo.html`: A self-contained browser demo running the React component inside a mocked editor frame to showcase the hover states.
+
+## 🛠 Features
+
+- **Delayed Spring Tooltips**: Hovering a button triggers a tooltip to appear from above. To prevent chaotic flashing when a user quickly moves their mouse across the whole toolbar, the tooltip includes a `transition-delay: 0.3s` before springing into view via `cubic-bezier(0.34, 1.56, 0.64, 1)`.
+- **Tactile Button Press**: Clicking a formatting button triggers a physical `transform: scale(0.92)` on the button and an additional `scale(0.9)` on the SVG icon, providing a deeply satisfying "click" feel.
+- **Active State Morphing**: When a format (like Bold) is active, the button seamlessly transitions to a distinct blue tint (`#eff6ff`), indicating its toggled state clearly.
+- **Accessibility Ready**: Built with `role="toolbar"`, `role="tooltip"`, `aria-label`, and `aria-pressed` for screen readers, along with clear `:focus-visible` outline rings for keyboard navigation.
+
+## 🚀 How to use
+
+1. Copy `EditorToolbar.jsx` into your React project.
+2. Copy `style.css` and import it.
+3. Hook up the `toggleFormat` state dispatcher to your actual rich text editor logic (e.g. Draft.js, Slate, or TipTap).
+
+```jsx
+import React from 'react';
+import EditorToolbar from './EditorToolbar';
+import './style.css'; 
+
+const MyEditor = () => {
+  return (
+    <div className="editor-wrapper">
+      <EditorToolbar />
+      <div className="editor-content" contentEditable>
+        Start typing...
+      </div>
+    </div>
+  );
+};
+```
+
+## 🎨 Why this fits EaseMotion
+
+**EaseMotion** is about making UI elements behave with physical predictability and delight. 
+
+Standard rich text toolbars are rigid. The buttons instantly change color when clicked, and native browser `title` attributes are slow and ugly. 
+
+By utilizing a subtle 300ms delay on custom HTML tooltips that physically scale and slide down into place, we create an interface that feels responsive but not hyperactive. The physical push-down scaling on active clicks makes software buttons mimic hardware switches.

--- a/submissions/react/react-rich-text-editor-toolbar-with-animated-tooltips-28069/demo.html
+++ b/submissions/react/react-rich-text-editor-toolbar-with-animated-tooltips-28069/demo.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>React Rich Text Toolbar Demo</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="./style.css">
+  
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+
+  <style>
+    body {
+      margin: 0;
+      background: #f8fafc;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      font-family: system-ui, sans-serif;
+    }
+    
+    .demo-editor-mockup {
+      background: white;
+      border-radius: 16px;
+      box-shadow: 0 10px 15px -3px rgba(0,0,0,0.05);
+      width: 100%;
+      max-width: 600px;
+      overflow: hidden;
+      border: 1px solid #e2e8f0;
+    }
+
+    .demo-toolbar-header {
+      background: #f8fafc;
+      padding: 12px 16px;
+      border-bottom: 1px solid #e2e8f0;
+      display: flex;
+      justify-content: center;
+    }
+
+    .demo-editor-body {
+      padding: 32px;
+      min-height: 200px;
+      color: #334155;
+      line-height: 1.6;
+    }
+
+    .demo-editor-body h1 {
+      margin-top: 0;
+      color: #0f172a;
+    }
+  </style>
+</head>
+<body>
+
+  <div id="root"></div>
+
+  <script type="text/babel">
+    const { useState } = React;
+
+    const EditorToolbar = () => {
+      const [activeFormats, setActiveFormats] = useState({
+        bold: false,
+        italic: false,
+        underline: false,
+        alignLeft: true,
+        alignCenter: false,
+        alignRight: false,
+      });
+
+      const toggleFormat = (format) => {
+        if (format.startsWith('align')) {
+          setActiveFormats(prev => ({
+            ...prev,
+            alignLeft: format === 'alignLeft',
+            alignCenter: format === 'alignCenter',
+            alignRight: format === 'alignRight'
+          }));
+        } else {
+          setActiveFormats(prev => ({
+            ...prev,
+            [format]: !prev[format]
+          }));
+        }
+      };
+
+      const ToolbarButton = ({ id, icon, label, shortcut }) => {
+        const isActive = activeFormats[id];
+        return (
+          <div className="ease-toolbar-item">
+            <button 
+              className={`ease-toolbar-btn ${isActive ? 'is-active' : ''}`}
+              onClick={() => toggleFormat(id)}
+              aria-label={label}
+              aria-pressed={isActive}
+            >
+              {icon}
+            </button>
+            <div className="ease-toolbar-tooltip" role="tooltip">
+              <span className="ease-tooltip-label">{label}</span>
+              {shortcut && <span className="ease-tooltip-shortcut">{shortcut}</span>}
+            </div>
+          </div>
+        );
+      };
+
+      const Divider = () => <div className="ease-toolbar-divider" aria-hidden="true"></div>;
+
+      return (
+        <div className="ease-toolbar-container" role="toolbar" aria-label="Text Formatting">
+          <div className="ease-toolbar-group">
+            <ToolbarButton id="bold" label="Bold" shortcut="⌘B" icon={<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M6 4h8a4 4 0 0 1 4 4 4 4 0 0 1-4 4H6z"></path><path d="M6 12h9a4 4 0 0 1 4 4 4 4 0 0 1-4 4H6z"></path></svg>} />
+            <ToolbarButton id="italic" label="Italic" shortcut="⌘I" icon={<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><line x1="19" y1="4" x2="10" y2="4"></line><line x1="14" y1="20" x2="5" y2="20"></line><line x1="15" y1="4" x2="9" y2="20"></line></svg>} />
+            <ToolbarButton id="underline" label="Underline" shortcut="⌘U" icon={<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M6 3v7a6 6 0 0 0 6 6 6 6 0 0 0 6-6V3"></path><line x1="4" y1="21" x2="20" y2="21"></line></svg>} />
+          </div>
+          <Divider />
+          <div className="ease-toolbar-group">
+            <ToolbarButton id="alignLeft" label="Align Left" shortcut="⌘⇧L" icon={<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><line x1="17" y1="10" x2="3" y2="10"></line><line x1="21" y1="6" x2="3" y2="6"></line><line x1="21" y1="14" x2="3" y2="14"></line><line x1="17" y1="18" x2="3" y2="18"></line></svg>} />
+            <ToolbarButton id="alignCenter" label="Align Center" shortcut="⌘⇧E" icon={<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="10" x2="6" y2="10"></line><line x1="21" y1="6" x2="3" y2="6"></line><line x1="21" y1="14" x2="3" y2="14"></line><line x1="18" y1="18" x2="6" y2="18"></line></svg>} />
+            <ToolbarButton id="alignRight" label="Align Right" shortcut="⌘⇧R" icon={<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><line x1="21" y1="10" x2="7" y2="10"></line><line x1="21" y1="6" x2="3" y2="6"></line><line x1="21" y1="14" x2="3" y2="14"></line><line x1="21" y1="18" x2="7" y2="18"></line></svg>} />
+          </div>
+          <Divider />
+          <div className="ease-toolbar-group">
+            <ToolbarButton id="link" label="Insert Link" shortcut="⌘K" icon={<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>} />
+          </div>
+        </div>
+      );
+    };
+
+    const App = () => {
+      return (
+        <div className="demo-editor-mockup">
+          <div className="demo-toolbar-header">
+            <EditorToolbar />
+          </div>
+          <div className="demo-editor-body">
+            <h1>Start writing...</h1>
+            <p>Hover over the toolbar buttons to see the animated tooltips and keyboard shortcuts.</p>
+          </div>
+        </div>
+      );
+    }
+
+    ReactDOM.render(<App />, document.getElementById('root'));
+  </script>
+</body>
+</html>

--- a/submissions/react/react-rich-text-editor-toolbar-with-animated-tooltips-28069/style.css
+++ b/submissions/react/react-rich-text-editor-toolbar-with-animated-tooltips-28069/style.css
@@ -1,0 +1,153 @@
+/* 
+  style.css
+  EaseMotion CSS - Rich Text Editor Toolbar
+*/
+
+.ease-toolbar-container {
+  display: inline-flex;
+  align-items: center;
+  background-color: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 6px;
+  box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05), 0 2px 4px -2px rgba(0,0,0,0.05);
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.ease-toolbar-group {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+/* --- Divider --- */
+.ease-toolbar-divider {
+  width: 1px;
+  height: 24px;
+  background-color: #e2e8f0;
+  margin: 0 8px;
+}
+
+/* --- Toolbar Item Wrapper --- */
+.ease-toolbar-item {
+  position: relative;
+  display: flex;
+  justify-content: center;
+}
+
+/* --- Buttons --- */
+.ease-toolbar-btn {
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  border-radius: 8px;
+  color: #64748b;
+  cursor: pointer;
+  outline: none;
+  position: relative;
+  
+  /* Smooth transitions for hover and active states */
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.ease-toolbar-btn svg {
+  width: 18px;
+  height: 18px;
+  transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.ease-toolbar-btn:hover {
+  background-color: #f1f5f9;
+  color: #0f172a;
+}
+
+/* Active State */
+.ease-toolbar-btn.is-active {
+  background-color: #eff6ff;
+  color: #3b82f6;
+}
+
+/* Press effect */
+.ease-toolbar-btn:active {
+  transform: scale(0.92);
+}
+
+.ease-toolbar-btn:active svg {
+  transform: scale(0.9);
+}
+
+/* Focus Ring */
+.ease-toolbar-btn:focus-visible {
+  box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #3b82f6;
+}
+
+/* --- Animated Tooltips --- */
+.ease-toolbar-tooltip {
+  position: absolute;
+  bottom: calc(100% + 8px); /* Position above button */
+  left: 50%;
+  transform: translateX(-50%) translateY(5px) scale(0.95);
+  transform-origin: bottom center;
+  
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  
+  background-color: #0f172a;
+  color: #ffffff;
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  white-space: nowrap;
+  pointer-events: none;
+  
+  /* Hidden State */
+  opacity: 0;
+  visibility: hidden;
+  
+  /* Entrance Spring */
+  transition: opacity 0.2s ease, 
+              visibility 0.2s ease, 
+              transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  z-index: 100;
+}
+
+/* Tooltip Caret */
+.ease-toolbar-tooltip::after {
+  content: '';
+  position: absolute;
+  bottom: -4px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 4px 4px 0 4px;
+  border-style: solid;
+  border-color: #0f172a transparent transparent transparent;
+}
+
+.ease-tooltip-label {
+  color: #f8fafc;
+}
+
+.ease-tooltip-shortcut {
+  color: #94a3b8;
+  font-size: 0.7rem;
+  letter-spacing: 0.5px;
+  background-color: rgba(255,255,255,0.1);
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+
+/* Show Tooltip on Hover or Focus of the button */
+.ease-toolbar-btn:hover + .ease-toolbar-tooltip,
+.ease-toolbar-btn:focus-visible + .ease-toolbar-tooltip {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0) scale(1);
+  /* Add a slight delay before showing so it doesn't flash when moving mouse quickly across toolbar */
+  transition-delay: 0.3s;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a floating-style React Rich Text Editor Toolbar featuring physically tactile button presses and delayed spring-animated tooltips. Addresses issue #28069 (#27401).

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/react/react-rich-text-editor-toolbar-with-animated-tooltips-28069/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A React `<EditorToolbar>` component that handles mutual exclusivity logic (e.g., for alignments) and renders an array of formatting buttons. Hovering over any button reveals a custom CSS tooltip displaying the format name and its associated keyboard shortcut.

**How does a developer use it?**

```jsx
import React from 'react';
import EditorToolbar from './EditorToolbar';
import './style.css'; 

const MyEditor = () => {
  return (
    <div className="editor-wrapper">
      <EditorToolbar />
      
      <div className="editor-content" contentEditable>
        Start typing...
      </div>
    </div>
  );
};
