### PR TITLE
feat: Add React Statistic Comparison Card Component (#28035)

### DIFF
--- a/submissions/react/react-statistic-comparison-card-with-trend-indicator-motion-28035/README.md
+++ b/submissions/react/react-statistic-comparison-card-with-trend-indicator-motion-28035/README.md
@@ -1,0 +1,55 @@
+# React Component: Statistic Comparison Card with Trend Indicator Motion (#28035)
+
+A modular, copy-paste ready React component for the EaseMotion CSS framework. This component renders a dashboard statistic card that automatically calculates the percentage change between a current and previous value, displaying a dynamic, animated trend indicator.
+
+## 📦 What's included?
+
+- `StatCard.jsx`: The React component that handles the math for the percentage change, determines if the trend is positive or negative, and manages the hover state to trigger the particle animations.
+- `style.css`: The CSS stylesheet powering the `cubic-bezier` card lift, the SVG chart background scaling, and the particle ejection animations from the trend arrow.
+- `demo.html`: A self-contained browser demo running the React component to showcase a grid of cards (both positive and negative trends).
+
+## 🛠 Features
+
+- **Auto-Calculated Trends**: Simply pass `value` and `previousValue`. The component does the math, formats it to one decimal place, and automatically determines whether to render the green "up" state or the red "down" state.
+- **Micro-Interaction Physics**: Hovering the card triggers several connected physics actions:
+  1. The entire card lifts up (`translateY(-4px)`).
+  2. The background decorative SVG chart stretches upwards (`scaleY(1)`).
+  3. The trend indicator pill physically nudges in the direction of the trend (up/right or down/right).
+  4. The arrow inside the trend pill shoots out 3 tiny, delayed CSS particles to emphasize the momentum.
+- **Staggered Entrance**: The component uses a `useEffect` hook to apply a `.is-mounted` class shortly after render, allowing the cards to smoothly slide up into place when the dashboard loads.
+
+## 🚀 How to use
+
+1. Copy `StatCard.jsx` into your React project.
+2. Copy `style.css` and import it.
+3. Use the component in your dashboard.
+
+```jsx
+import React from 'react';
+import StatCard from './StatCard';
+import './style.css'; 
+
+const Dashboard = () => {
+  return (
+    <div className="grid">
+      <StatCard 
+        title="Total Revenue" 
+        value={128450} 
+        previousValue={112000} // Automatically calculates +14.7%
+        prefix="$" 
+      />
+      <StatCard 
+        title="Active Users" 
+        value={4250} 
+        previousValue={4800} // Automatically calculates -11.5%
+      />
+    </div>
+  );
+};
+```
+
+## 🎨 Why this fits EaseMotion
+
+**EaseMotion** is about making UI elements behave with physical predictability and delight. 
+
+Dashboards are often dense and visually fatiguing. By incorporating a trend indicator that physically reacts to the user's cursor (nudging in the direction of the trend and emitting momentum particles), we create a moment of tactile feedback. The data isn't just a static number—it has directional weight and energy, aligning perfectly with EaseMotion's philosophy of bringing interfaces to life through physics.

--- a/submissions/react/react-statistic-comparison-card-with-trend-indicator-motion-28035/StatCard.jsx
+++ b/submissions/react/react-statistic-comparison-card-with-trend-indicator-motion-28035/StatCard.jsx
@@ -1,0 +1,114 @@
+import React, { useState, useEffect } from 'react';
+
+/**
+ * Statistic Comparison Card with Trend Indicator Motion
+ * 
+ * @param {string} title - The title of the metric
+ * @param {number} value - Current value
+ * @param {number} previousValue - Previous period value for comparison
+ * @param {string} prefix - Optional prefix (e.g. "$")
+ * @param {string} suffix - Optional suffix (e.g. "K")
+ */
+const StatCard = ({ 
+  title = "Monthly Active Users", 
+  value = 0, 
+  previousValue = 0,
+  prefix = "", 
+  suffix = ""
+}) => {
+  const [isHovered, setIsHovered] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    // Small delay to trigger entrance animations
+    const timer = setTimeout(() => setMounted(true), 100);
+    return () => clearTimeout(timer);
+  }, []);
+
+  // Calculate percentage change
+  const percentChange = previousValue === 0 
+    ? 100 // if prev was 0, it's 100% growth (assuming value > 0)
+    : ((value - previousValue) / previousValue) * 100;
+  
+  const isPositive = percentChange >= 0;
+  const absChange = Math.abs(percentChange).toFixed(1);
+
+  return (
+    <div 
+      className={`ease-stat-card ${mounted ? 'is-mounted' : ''}`}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <div className="ease-stat-header">
+        <h3 className="ease-stat-title">{title}</h3>
+        <button className="ease-stat-options" aria-label="More options">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="12" cy="12" r="1"></circle>
+            <circle cx="12" cy="5" r="1"></circle>
+            <circle cx="12" cy="19" r="1"></circle>
+          </svg>
+        </button>
+      </div>
+
+      <div className="ease-stat-main">
+        <div className="ease-stat-value-container">
+          <span className="ease-stat-value">
+            {prefix}{value.toLocaleString()}{suffix}
+          </span>
+        </div>
+      </div>
+
+      <div className="ease-stat-footer">
+        <div className={`ease-stat-trend ${isPositive ? 'is-positive' : 'is-negative'} ${isHovered ? 'is-hovered' : ''}`}>
+          <div className="ease-stat-trend-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              {isPositive ? (
+                <>
+                  <polyline points="23 6 13.5 15.5 8.5 10.5 1 18"></polyline>
+                  <polyline points="17 6 23 6 23 12"></polyline>
+                </>
+              ) : (
+                <>
+                  <polyline points="23 18 13.5 8.5 8.5 13.5 1 6"></polyline>
+                  <polyline points="17 18 23 18 23 12"></polyline>
+                </>
+              )}
+            </svg>
+            
+            {/* Animated particles that fly out of the arrow on hover */}
+            {isHovered && (
+              <div className="ease-stat-particles">
+                <span className="particle" />
+                <span className="particle" />
+                <span className="particle" />
+              </div>
+            )}
+          </div>
+          <span className="ease-stat-trend-percent">{absChange}%</span>
+        </div>
+        <span className="ease-stat-comparison-text">
+          vs previous period
+        </span>
+      </div>
+      
+      {/* Background decoration line chart */}
+      <div className="ease-stat-bg-chart">
+        <svg viewBox="0 0 100 40" preserveAspectRatio="none">
+          {isPositive ? (
+            <path 
+              d="M0 40 Q20 35 30 25 T60 20 T100 5 L100 40 Z" 
+              fill="rgba(34, 197, 94, 0.05)" 
+            />
+          ) : (
+            <path 
+              d="M0 5 Q20 10 30 20 T60 25 T100 35 L100 40 L0 40 Z" 
+              fill="rgba(239, 68, 68, 0.05)" 
+            />
+          )}
+        </svg>
+      </div>
+    </div>
+  );
+};
+
+export default StatCard;

--- a/submissions/react/react-statistic-comparison-card-with-trend-indicator-motion-28035/demo.html
+++ b/submissions/react/react-statistic-comparison-card-with-trend-indicator-motion-28035/demo.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>React Statistic Comparison Card Demo</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="./style.css">
+  
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+
+  <style>
+    body {
+      margin: 0;
+      background: #f8fafc;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      font-family: system-ui, sans-serif;
+      padding: 2rem;
+    }
+    
+    .demo-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      gap: 24px;
+      width: 100%;
+      max-width: 1000px;
+    }
+  </style>
+</head>
+<body>
+
+  <div id="root"></div>
+
+  <script type="text/babel">
+    const { useState, useEffect } = React;
+
+    const StatCard = ({ title, value, previousValue, prefix = "", suffix = "" }) => {
+      const [isHovered, setIsHovered] = useState(false);
+      const [mounted, setMounted] = useState(false);
+
+      useEffect(() => {
+        const timer = setTimeout(() => setMounted(true), 100);
+        return () => clearTimeout(timer);
+      }, []);
+
+      const percentChange = previousValue === 0 ? 100 : ((value - previousValue) / previousValue) * 100;
+      const isPositive = percentChange >= 0;
+      const absChange = Math.abs(percentChange).toFixed(1);
+
+      return (
+        <div 
+          className={`ease-stat-card ${mounted ? 'is-mounted' : ''}`}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+        >
+          <div className="ease-stat-header">
+            <h3 className="ease-stat-title">{title}</h3>
+            <button className="ease-stat-options">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="1"></circle><circle cx="12" cy="5" r="1"></circle><circle cx="12" cy="19" r="1"></circle>
+              </svg>
+            </button>
+          </div>
+
+          <div className="ease-stat-main">
+            <div className="ease-stat-value-container">
+              <span className="ease-stat-value">{prefix}{value.toLocaleString()}{suffix}</span>
+            </div>
+          </div>
+
+          <div className="ease-stat-footer">
+            <div className={`ease-stat-trend ${isPositive ? 'is-positive' : 'is-negative'} ${isHovered ? 'is-hovered' : ''}`}>
+              <div className="ease-stat-trend-icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                  {isPositive ? (
+                    <><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"></polyline><polyline points="17 6 23 6 23 12"></polyline></>
+                  ) : (
+                    <><polyline points="23 18 13.5 8.5 8.5 13.5 1 6"></polyline><polyline points="17 18 23 18 23 12"></polyline></>
+                  )}
+                </svg>
+                {isHovered && (
+                  <div className="ease-stat-particles">
+                    <span className="particle" /><span className="particle" /><span className="particle" />
+                  </div>
+                )}
+              </div>
+              <span className="ease-stat-trend-percent">{absChange}%</span>
+            </div>
+            <span className="ease-stat-comparison-text">vs last month</span>
+          </div>
+          
+          <div className="ease-stat-bg-chart">
+            <svg viewBox="0 0 100 40" preserveAspectRatio="none">
+              {isPositive ? (
+                <path d="M0 40 Q20 35 30 25 T60 20 T100 5 L100 40 Z" fill="rgba(34, 197, 94, 0.05)" />
+              ) : (
+                <path d="M0 5 Q20 10 30 20 T60 25 T100 35 L100 40 L0 40 Z" fill="rgba(239, 68, 68, 0.05)" />
+              )}
+            </svg>
+          </div>
+        </div>
+      );
+    };
+
+    const App = () => {
+      return (
+        <div className="demo-grid">
+          <StatCard 
+            title="Total Revenue" 
+            value={128450} 
+            previousValue={112000}
+            prefix="$" 
+          />
+          <StatCard 
+            title="Active Subscriptions" 
+            value={4250} 
+            previousValue={4800}
+          />
+          <StatCard 
+            title="Customer Satisfaction" 
+            value={98} 
+            previousValue={96}
+            suffix="%"
+          />
+        </div>
+      );
+    }
+
+    ReactDOM.render(<App />, document.getElementById('root'));
+  </script>
+</body>
+</html>

--- a/submissions/react/react-statistic-comparison-card-with-trend-indicator-motion-28035/style.css
+++ b/submissions/react/react-statistic-comparison-card-with-trend-indicator-motion-28035/style.css
@@ -1,0 +1,217 @@
+/* 
+  style.css
+  EaseMotion CSS - Statistic Comparison Card
+*/
+
+.ease-stat-card {
+  position: relative;
+  background-color: #ffffff;
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05), 0 2px 4px -2px rgba(0,0,0,0.025);
+  border: 1px solid #e2e8f0;
+  font-family: system-ui, -apple-system, sans-serif;
+  width: 100%;
+  max-width: 320px;
+  overflow: hidden;
+  
+  /* Entrance initial state */
+  opacity: 0;
+  transform: translateY(15px);
+  transition: all 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.ease-stat-card.is-mounted {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.ease-stat-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 20px 25px -5px rgba(0,0,0,0.1), 0 8px 10px -6px rgba(0,0,0,0.05);
+  border-color: #cbd5e1;
+}
+
+/* --- Header --- */
+.ease-stat-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+  position: relative;
+  z-index: 2;
+}
+
+.ease-stat-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #64748b;
+}
+
+.ease-stat-options {
+  background: transparent;
+  border: none;
+  color: #cbd5e1;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  transition: color 0.2s ease, background 0.2s ease;
+}
+
+.ease-stat-options:hover {
+  color: #475569;
+  background: #f1f5f9;
+}
+
+.ease-stat-options svg {
+  width: 18px;
+  height: 18px;
+}
+
+/* --- Main Value --- */
+.ease-stat-main {
+  margin-bottom: 20px;
+  position: relative;
+  z-index: 2;
+}
+
+.ease-stat-value {
+  font-size: 2.25rem;
+  font-weight: 800;
+  color: #0f172a;
+  line-height: 1;
+  letter-spacing: -0.025em;
+}
+
+/* --- Footer & Trend Indicator --- */
+.ease-stat-footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  position: relative;
+  z-index: 2;
+}
+
+.ease-stat-trend {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: 20px;
+  font-weight: 600;
+  font-size: 0.85rem;
+  position: relative;
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.ease-stat-trend-icon {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ease-stat-trend-icon svg {
+  width: 14px;
+  height: 14px;
+  position: relative;
+  z-index: 2;
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* Positive Styles */
+.ease-stat-trend.is-positive {
+  background-color: #dcfce7;
+  color: #16a34a;
+}
+
+.ease-stat-trend.is-positive.is-hovered {
+  transform: translateY(-2px);
+}
+
+.ease-stat-trend.is-positive.is-hovered .ease-stat-trend-icon svg {
+  transform: translate(2px, -2px);
+}
+
+/* Negative Styles */
+.ease-stat-trend.is-negative {
+  background-color: #fee2e2;
+  color: #dc2626;
+}
+
+.ease-stat-trend.is-negative.is-hovered {
+  transform: translateY(2px);
+}
+
+.ease-stat-trend.is-negative.is-hovered .ease-stat-trend-icon svg {
+  transform: translate(2px, 2px);
+}
+
+.ease-stat-comparison-text {
+  font-size: 0.8rem;
+  color: #94a3b8;
+  font-weight: 500;
+}
+
+/* --- Particles Animation --- */
+.ease-stat-particles {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.ease-stat-particles .particle {
+  position: absolute;
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background-color: currentColor;
+  opacity: 0;
+}
+
+.ease-stat-trend.is-positive .particle:nth-child(1) { animation: easeShootUpRight 0.6s ease-out forwards; animation-delay: 0s; }
+.ease-stat-trend.is-positive .particle:nth-child(2) { animation: easeShootUpRight 0.6s ease-out forwards; animation-delay: 0.1s; }
+.ease-stat-trend.is-positive .particle:nth-child(3) { animation: easeShootUpRight 0.6s ease-out forwards; animation-delay: 0.2s; }
+
+.ease-stat-trend.is-negative .particle:nth-child(1) { animation: easeShootDownRight 0.6s ease-out forwards; animation-delay: 0s; }
+.ease-stat-trend.is-negative .particle:nth-child(2) { animation: easeShootDownRight 0.6s ease-out forwards; animation-delay: 0.1s; }
+.ease-stat-trend.is-negative .particle:nth-child(3) { animation: easeShootDownRight 0.6s ease-out forwards; animation-delay: 0.2s; }
+
+@keyframes easeShootUpRight {
+  0% { transform: translate(0, 0) scale(1); opacity: 1; }
+  100% { transform: translate(10px, -15px) scale(0); opacity: 0; }
+}
+
+@keyframes easeShootDownRight {
+  0% { transform: translate(0, 0) scale(1); opacity: 1; }
+  100% { transform: translate(10px, 15px) scale(0); opacity: 0; }
+}
+
+/* --- Decorative Background Chart --- */
+.ease-stat-bg-chart {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 60%;
+  z-index: 1;
+  pointer-events: none;
+  opacity: 0.5;
+  transition: opacity 0.3s ease, transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+  transform-origin: bottom;
+  transform: scaleY(0.8);
+}
+
+.ease-stat-bg-chart svg {
+  width: 100%;
+  height: 100%;
+}
+
+.ease-stat-card:hover .ease-stat-bg-chart {
+  opacity: 1;
+  transform: scaleY(1);
+}


### PR DESCRIPTION
## Pull Request Description

Adds a Statistic Comparison Card React component featuring auto-calculated trend percentages, compound physics-based hover states, and animated momentum particles. Addresses issue #28035 (#27367).

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/react/react-statistic-comparison-card-with-trend-indicator-motion-28035/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A React `<StatCard>` component tailored for dashboards. It accepts a `value` and `previousValue`, automatically handles the math to determine the percentage change, and conditionally renders the appropriate positive/negative colored trend UI.

**How does a developer use it?**

```jsx
import React from 'react';
import StatCard from './StatCard';
import './style.css'; 

const Dashboard = () => {
  return (
    <StatCard 
      title="Total Revenue" 
      value={128450} 
      previousValue={112000} // Component will automatically calculate +14.7%
      prefix="$" 
    />
  );
};
