### PR TITLE
[FIX] #32145: Add missing closing brace in .ease-shimmer-sweep

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -723,6 +723,7 @@
       transparent 70%);
   background-size: 200% auto;
   animation: ease-kf-shimmer-sweep var(--ease-speed-slow) var(--ease-ease) infinite;
+}
 
 .ease-squish-button:hover,
 .ease-squish-button:focus-visible,


### PR DESCRIPTION
## Description
Added the missing closing brace \}\ at the end of the \.ease-shimmer-sweep\ rule in \core/animations.css\. This was a **critical CSS syntax error** that caused the subsequent \.ease-squish-button\ rules to be parsed as part of \.ease-shimmer-sweep\, breaking CSS parsing in strict modes.

## Changes
- \core/animations.css\: Added missing closing brace after line 725

## Impact
- ✅ \.ease-shimmer-sweep\ animation now applies correctly
- ✅ \.ease-squish-button:hover\, \.ease-squish-button:focus-visible\, and \.ease-squish-button:active\ are now properly parsed as separate rules
- ✅ Stylesheet no longer fails in strict CSS environments

Fixes #32145