### PR TITLE
[FIX] #32149: Move dangling margin-bottom into style attribute

### DIFF
--- a/examples/demo.html
+++ b/examples/demo.html
@@ -528,7 +528,7 @@
         </div>
         <!-- Sizing grid across Colors-->
          <div class="demo-chip">// 2. Sizing Scale(small to extra large)</div>
-         <div class="ease-grid ease-gap-4" style="grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));" margin-bottom: var(--ease-space-8);">
+         <div class="ease-grid ease-gap-4" style="grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); margin-bottom: var(--ease-space-8);">
           <div class="ease-flex ease-flex-direction-column ease-gap-2">
             <span class="tag" style="width: max-content;">ease-btn-sm</span>
             <div class="ease-flex ease-gap-2 ease-items-center">


### PR DESCRIPTION
## Description
Fixed malformed HTML in \examples/demo.html\ where a \margin-bottom: var(--ease-space-8);\ declaration was written **outside** the \style\ attribute due to a missing closing quote. This caused the browser to treat it as an invalid HTML attribute.

## Changes
- \examples/demo.html\: Moved \margin-bottom\ inside the \style\ attribute

## Impact
- ✅ The grid container in the Button Sizing section now has the intended bottom margin
- ✅ No more DOM parsing quirks in browsers

Fixes #32149