### PR TITLE
[FIX] #32150: Remove stray 'main' text from docs code examples

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1318,7 +1318,6 @@
           <span class="docs-code-lang">html</span>
           <pre><code>&lt;div class="ease-padding-6 ease-margin-4"&gt; ... &lt;/div&gt;
 &lt;div class="ease-px-8 ease-py-4"&gt; ... &lt;/div&gt;</code></pre>
- main
         </div>
       </section>
 
@@ -1642,7 +1641,6 @@
             <div class="docs-code">
               <span class="docs-code-lang">html</span>
               <pre><code>&lt;!-- Staggered entrance sequence --&gt;
- main
 &lt;div class="ease-slide-up ease-delay-100"&gt;First&lt;/div&gt;
 &lt;div class="ease-slide-up ease-delay-200"&gt;Second&lt;/div&gt;
 &lt;div class="ease-slide-up ease-delay-300"&gt;Third&lt;/div&gt;</code></pre>


### PR DESCRIPTION
﻿## Description
Removed stray literal text **"main"** that was appearing in two code blocks on the documentation site (docs/index.html):
1. **Line 1321** — Spacing section code example
2. **Line 1645** — Delay Helpers section code example

This text was rendering as visible content on the docs page, breaking the appearance of the code examples and confusing readers.

## Changes
- docs/index.html: Removed stray main text at two locations

## Impact
- No more visible text artifacts on the documentation site
- Code examples now appear correctly without misleading extra text
- Improved professionalism and readability of the docs

Fixes #32150
