### PR TITLE
[Submission] #32145: Shimmer Sweep + Squish Button demo (closing brace fix)

### DIFF
--- a/submissions/examples/shimmer-sweep-fix/README.md
+++ b/submissions/examples/shimmer-sweep-fix/README.md
@@ -1,0 +1,13 @@
+# Shimmer Sweep + Squish Button
+
+## What does this do?
+Demonstrates the `.ease-shimmer-sweep` background animation alongside the `.ease-squish-button` press effect, showing that both rules work correctly when properly separated by a closing brace.
+
+## How is it used?
+```html
+<div class="ease-shimmer-sweep">Shimmer background</div>
+<button class="ease-squish-button">Click me</button>
+```
+
+## Why is it useful?
+A missing closing brace in `.ease-shimmer-sweep` caused `.ease-squish-button` to be parsed as a nested selector, breaking both animations. This demo shows the corrected separation — each rule parses independently, matching the intended behavior described in issue #32145.

--- a/submissions/examples/shimmer-sweep-fix/demo.html
+++ b/submissions/examples/shimmer-sweep-fix/demo.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Shimmer Sweep + Squish Button Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: sans-serif;
+      background: #1a1a2e;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 40px;
+      gap: 40px;
+      color: #fff;
+    }
+    h1 { font-size: 24px; margin: 0; }
+    p { color: #aaa; font-size: 14px; max-width: 500px; text-align: center; margin: 0; }
+    .card {
+      background: #16213e;
+      border-radius: 12px;
+      padding: 30px;
+      width: 400px;
+      text-align: center;
+      border: 1px solid #0f3460;
+    }
+    .card h2 { font-size: 18px; margin: 0 0 10px; color: #e94560; }
+  </style>
+</head>
+<body>
+
+  <h1>Shimmer Sweep + Squish Button</h1>
+  <p>Demonstrates <code>.ease-shimmer-sweep</code> with the missing closing brace fix, shown alongside <code>.ease-squish-button</code> working as a separate rule.</p>
+
+  <div class="card">
+    <h2>Shimmer Sweep</h2>
+    <div class="shimmer-card">Hover over the button below</div>
+    <div class="ease-shimmer-sweep shimmer-box">✦ Shimmer Sweep Active ✦</div>
+  </div>
+
+  <div class="card">
+    <h2>Squish Button</h2>
+    <p>Hover, focus, or click the button to see the squish effect</p>
+    <button class="ease-squish-button">Click Me</button>
+  </div>
+
+  <div class="card">
+    <h2>Both Combined</h2>
+    <p>Shimmer background + squish on click — works because the closing brace separates the rules</p>
+    <div class="ease-shimmer-sweep combined-area">
+      <button class="ease-squish-button">Squish Me</button>
+    </div>
+  </div>
+
+  <script>
+    // Re-trigger animations on click for demo purposes
+    document.querySelectorAll('.ease-squish-button').forEach(btn => {
+      btn.addEventListener('click', function() {
+        this.style.animation = 'none';
+        void this.offsetHeight;
+        this.style.animation = '';
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/shimmer-sweep-fix/style.css
+++ b/submissions/examples/shimmer-sweep-fix/style.css
@@ -1,0 +1,62 @@
+/* Shimmer Sweep animation */
+@keyframes shimmer-sweep {
+  0% { background-position: -200% center; }
+  100% { background-position: 200% center; }
+}
+
+.shimmer-card {
+  background: #0f3460;
+  padding: 12px 20px;
+  border-radius: 8px;
+  margin-bottom: 16px;
+  color: #8899aa;
+  font-size: 13px;
+}
+
+.shimmer-box {
+  padding: 20px 30px;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 16px;
+}
+
+.ease-shimmer-sweep {
+  background: linear-gradient(120deg,
+      transparent 30%,
+      rgba(255, 255, 255, 0.15) 50%,
+      transparent 70%);
+  background-size: 200% auto;
+  animation: shimmer-sweep 3s ease-in-out infinite;
+}
+
+/* Squish Button — must be a SEPARATE rule (requires closing brace above) */
+.ease-squish-button {
+  padding: 14px 36px;
+  background: #e94560;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease;
+}
+
+.ease-squish-button:hover,
+.ease-squish-button:focus-visible,
+.ease-squish-button:active {
+  animation: squish 0.3s ease both;
+}
+
+@keyframes squish {
+  0%   { transform: scaleX(1) scaleY(1); }
+  50%  { transform: scaleX(1.08) scaleY(0.92); }
+  100% { transform: scaleX(1) scaleY(1); }
+}
+
+.combined-area {
+  padding: 24px;
+  border-radius: 10px;
+  display: flex;
+  justify-content: center;
+}


### PR DESCRIPTION
## Description
This submission demonstrates the corrected .ease-shimmer-sweep and .ease-squish-button rules with proper closing brace separation (related to bug #32145).

## Files
\\\
submissions/examples/shimmer-sweep-fix/
├── demo.html    — Interactive demo showing both animations working
├── style.css    — Shimmer sweep + squish button CSS
└── README.md    — Usage guide
\\\

## What it shows
- ✅ \.ease-shimmer-sweep\ working correctly as a standalone rule
- ✅ \.ease-squish-button:hover\, \:focus-visible\, \:active\ as independent selectors
- ✅ Both animations used together without CSS parsing conflicts

Relates to #32145