### PR TITLE
[Submission] #32149: Grid Sizing with proper inline margin-bottom

### DIFF
--- a/submissions/examples/grid-sizing-fix/README.md
+++ b/submissions/examples/grid-sizing-fix/README.md
@@ -1,0 +1,15 @@
+# Grid Sizing with Proper Margin-bottom
+
+## What does this do?
+Demonstrates a responsive CSS grid with button sizing variants where the `margin-bottom` is correctly placed inside the inline `style` attribute.
+
+## How is it used?
+```html
+<div class="ease-grid ease-gap-4"
+     style="grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); margin-bottom: 32px;">
+  <!-- grid items -->
+</div>
+```
+
+## Why is it useful?
+In the original framework demo, `margin-bottom: var(--ease-space-8);` was dangling outside the `style` attribute due to a missing closing quote (issue #32149). This caused the margin to never apply and created malformed HTML. This submission demonstrates the corrected pattern with the CSS property properly included inside the `style` attribute.

--- a/submissions/examples/grid-sizing-fix/demo.html
+++ b/submissions/examples/grid-sizing-fix/demo.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Grid Sizing with Proper Margin</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: sans-serif;
+      background: #f4f4f4;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 40px;
+    }
+    h1 { font-size: 22px; color: #333; }
+    p { color: #666; font-size: 14px; max-width: 500px; text-align: center; }
+    .badge { background: #ffeaa7; padding: 4px 12px; border-radius: 20px; font-size: 12px; color: #333; }
+    .demo-chip {
+      background: #dfe6e9;
+      padding: 6px 14px;
+      border-radius: 20px;
+      font-size: 12px;
+      color: #555;
+      margin-bottom: 12px;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Grid Sizing — Proper <code>margin-bottom</code> Fix</h1>
+  <p>Demonstrates a grid container with <code>margin-bottom</code> correctly placed <strong>inside</strong> the <code>style</code> attribute (fix for the dangling attribute issue #32149).</p>
+
+  <div class="demo-chip">✅ 2. Sizing Scale (small to extra large)</div>
+
+  <!-- Fixed: margin-bottom is inside the style attribute -->
+  <div class="ease-grid ease-gap-4" style="grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); margin-bottom: 32px;">
+    <div class="ease-flex ease-flex-direction-column ease-gap-2">
+      <span class="tag" style="width: max-content;">ease-btn-sm</span>
+      <div class="ease-flex ease-gap-2 ease-items-center">
+        <button class="btn btn-primary btn-sm">Primary Sm</button>
+        <button class="btn btn-success btn-sm">Success Sm</button>
+      </div>
+    </div>
+    <div class="ease-flex ease-flex-direction-column ease-gap-2">
+      <span class="tag" style="width: max-content;">ease-btn-md</span>
+      <div class="ease-flex ease-gap-2 ease-items-center">
+        <button class="btn btn-primary">Primary Md</button>
+        <button class="btn btn-success">Success Md</button>
+      </div>
+    </div>
+    <div class="ease-flex ease-flex-direction-column ease-gap-2">
+      <span class="tag" style="width: max-content;">ease-btn-lg</span>
+      <div class="ease-flex ease-gap-2 ease-items-center">
+        <button class="btn btn-primary btn-lg">Primary Lg</button>
+        <button class="btn btn-success btn-lg">Success Lg</button>
+      </div>
+    </div>
+  </div>
+
+  <div style="margin-top: 30px; padding: 20px; background: #fff; border-radius: 10px; border-left: 4px solid #2ecc71; max-width: 500px;">
+    <p style="margin: 0; font-size: 13px; color: #555;">
+      <strong>✅ Fix applied:</strong> The <code>margin-bottom: 32px</code> is now inside the <code>style</code> attribute, not dangling outside as a separate invalid attribute.
+    </p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/grid-sizing-fix/style.css
+++ b/submissions/examples/grid-sizing-fix/style.css
@@ -1,0 +1,69 @@
+/* Grid layout */
+.ease-grid {
+  display: grid;
+}
+
+.ease-gap-4 {
+  gap: 16px;
+}
+
+.ease-gap-2 {
+  gap: 8px;
+}
+
+.ease-flex {
+  display: flex;
+}
+
+.ease-flex-direction-column {
+  flex-direction: column;
+}
+
+.ease-items-center {
+  align-items: center;
+}
+
+/* Buttons */
+.btn {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.btn:hover {
+  opacity: 0.85;
+}
+
+.btn-primary {
+  background: #6c63ff;
+  color: white;
+}
+
+.btn-success {
+  background: #2ecc71;
+  color: white;
+}
+
+.btn-sm {
+  padding: 6px 14px;
+  font-size: 12px;
+}
+
+.btn-lg {
+  padding: 14px 30px;
+  font-size: 16px;
+}
+
+.tag {
+  display: inline-block;
+  background: #dfe6e9;
+  padding: 2px 10px;
+  border-radius: 12px;
+  font-size: 11px;
+  color: #636e72;
+  font-family: monospace;
+}


### PR DESCRIPTION
## Description
This submission demonstrates a responsive grid with button sizing variants where the \margin-bottom\ is correctly placed **inside** the \style\ attribute (related to bug #32149).

## Files
\\\
submissions/examples/grid-sizing-fix/
├── demo.html    — Grid with small/medium/large buttons
├── style.css    — Grid layout + button sizing styles
└── README.md    — Usage guide
\\\

## What it shows
- ✅ \margin-bottom\ properly placed inside the \style\ attribute
- ✅ No dangling HTML attributes or malformed markup
- ✅ Responsive \uto-fit\ grid with \minmax\ columns

Relates to #32149