### PR TITLE
[Submission] #32150: Clean code examples for docs (stray text fix)

### DIFF
--- a/submissions/examples/clean-code-docs/README.md
+++ b/submissions/examples/clean-code-docs/README.md
@@ -1,0 +1,20 @@
+# Clean Code Examples for Documentation
+
+## What does this do?
+Demonstrates properly formatted documentation code blocks without stray text artifacts, matching the intended fix for the docs site.
+
+## How is it used?
+```html
+<!-- Staggered entrance sequence -->
+<div class="ease-slide-up ease-delay-100">First</div>
+<div class="ease-slide-up ease-delay-200">Second</div>
+<div class="ease-slide-up ease-delay-300">Third</div>
+```
+
+```html
+<div class="ease-padding-6 ease-margin-4"> ... </div>
+<div class="ease-px-8 ease-py-4"> ... </div>
+```
+
+## Why is it useful?
+The documentation at `docs/index.html` had stray literal "main" text appearing inside code blocks at two locations (Spacing section and Delay Helpers section - issue #32150). This text rendered as visible content, breaking code examples and confusing readers. This submission shows how the code blocks should look when properly cleaned.

--- a/submissions/examples/clean-code-docs/demo.html
+++ b/submissions/examples/clean-code-docs/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Clean Code Examples — Docs Fix</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <div class="container">
+    <h1>Clean Code Examples for Documentation</h1>
+    <p>Demonstrates properly formatted code blocks without stray text artifacts (fix for issue #32150).</p>
+
+    <section class="section">
+      <h2>Spacing Example</h2>
+      <div class="docs-code">
+        <span class="docs-code-lang">html</span>
+        <pre><code>&lt;div class="ease-padding-6 ease-margin-4"&gt; ... &lt;/div&gt;
+&lt;div class="ease-px-8 ease-py-4"&gt; ... &lt;/div&gt;</code></pre>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>Delay Helpers Example</h2>
+      <div class="docs-code">
+        <span class="docs-code-lang">html</span>
+        <pre><code>&lt;!-- Staggered entrance sequence --&gt;
+&lt;div class="ease-slide-up ease-delay-100"&gt;First&lt;/div&gt;
+&lt;div class="ease-slide-up ease-delay-200"&gt;Second&lt;/div&gt;
+&lt;div class="ease-slide-up ease-delay-300"&gt;Third&lt;/div&gt;</code></pre>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>Live Preview</h2>
+      <div class="preview">
+        <div class="preview-box ease-slide-up ease-delay-100">First</div>
+        <div class="preview-box ease-slide-up ease-delay-200">Second</div>
+        <div class="preview-box ease-slide-up ease-delay-300">Third</div>
+      </div>
+    </section>
+  </div>
+
+  <script>
+    // Re-trigger entrance animations on click
+    document.querySelectorAll('.preview-box').forEach(box => {
+      box.addEventListener('click', function() {
+        this.style.animation = 'none';
+        void this.offsetHeight;
+        this.style.animation = '';
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/clean-code-docs/style.css
+++ b/submissions/examples/clean-code-docs/style.css
@@ -1,0 +1,107 @@
+/* Demo page styles */
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #0d1117;
+  color: #c9d1d9;
+}
+
+.container {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 40px 20px;
+}
+
+h1 {
+  font-size: 26px;
+  margin-bottom: 8px;
+  color: #f0f6fc;
+}
+
+h2 {
+  font-size: 18px;
+  margin: 30px 0 12px;
+  color: #58a6ff;
+}
+
+p {
+  color: #8b949e;
+  font-size: 14px;
+  margin-bottom: 24px;
+}
+
+.section {
+  margin-bottom: 32px;
+}
+
+/* Code block matching docs style */
+.docs-code {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.docs-code-lang {
+  display: inline-block;
+  background: #21262d;
+  color: #8b949e;
+  font-size: 11px;
+  padding: 4px 12px;
+  border-bottom: 1px solid #30363d;
+  border-right: 1px solid #30363d;
+  border-radius: 0 0 4px 0;
+  font-family: monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.docs-code pre {
+  margin: 0;
+  padding: 16px;
+  overflow-x: auto;
+}
+
+.docs-code code {
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 13px;
+  line-height: 1.6;
+  color: #c9d1d9;
+}
+
+/* Preview area */
+.preview {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+
+.preview-box {
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 16px 24px;
+  font-size: 14px;
+  color: #c9d1d9;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.preview-box:hover {
+  background: #30363d;
+}
+
+/* Entrance animation */
+@keyframes slide-up {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.ease-slide-up {
+  animation: slide-up 0.5s ease forwards;
+}
+
+.ease-delay-100 { animation-delay: 0.1s; }
+.ease-delay-200 { animation-delay: 0.2s; }
+.ease-delay-300 { animation-delay: 0.3s; }


### PR DESCRIPTION
## Description
This submission demonstrates properly formatted documentation code blocks without stray text artifacts (related to bug #32150).

## Files
\\\
submissions/examples/clean-code-docs/
├── demo.html    — Live preview of spacing + delay-helper code blocks
├── style.css    — Docs-themed styling
└── README.md    — Usage guide
\\\

## What it shows
- ✅ Clean spacing code examples without stray text
- ✅ Clean delay-helper code examples without stray text
- ✅ Live preview with entrance animations

Relates to #32150