### PR TITLE
Fix: Add missing `@keyframes ease-icon-pop` animation

### DIFF
--- a/components/compare-table.css
+++ b/components/compare-table.css
@@ -101,6 +101,18 @@
     animation: ease-icon-draw 0.3s ease 0.1s both;
   }
   
+  @keyframes ease-icon-pop {
+    0% {
+      opacity: 0;
+      transform: scale(0) rotate(-10deg);
+    }
+
+    100% {
+      opacity: 1;
+      transform: scale(1) rotate(0);
+    }
+  }
+  
   @keyframes ease-icon-draw {
     from {
       opacity: 0;


### PR DESCRIPTION
### Description
Fixes the compare table icon animation not working due to a missing `@keyframes` definition. The `compare-table.css` file referenced an `ease-icon-pop` animation that was never defined, causing icons to not animate when table rows are compared.

### Related Issue
Closes #32198 

### Changes Made
- Added `@keyframes ease-icon-pop` definition to `compare-table.css`
- Animation transitions icons from `scale(0) rotate(-10deg)` with `opacity: 0` to `scale(1) rotate(0)` with `opacity: 1`

### Code Added
```css
@keyframes ease-icon-pop {
  0% {
    opacity: 0;
    transform: scale(0) rotate(-10deg);
  }
  100% {
    opacity: 1;
    transform: scale(1) rotate(0);
  }
}
```

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

### How Has This Been Tested?
- Opened the compare table component in a local demo
- Interacted with rows to trigger the animation
- Confirmed the icon pops in smoothly with the intended scale/rotate/opacity transition

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective (N/A — CSS-only change)