### PR TITLE
feat: add image-blur-load-transition component (#32235)

### DIFF
--- a/submissions/examples/ease-image-blur-load-transition-ij/README.md
+++ b/submissions/examples/ease-image-blur-load-transition-ij/README.md
@@ -1,0 +1,26 @@
+# Image Blur Load Transition
+
+Image loads with a blur-to-clear transition effect. Starts blurred and scales in as the image finishes loading.
+
+## Features
+
+- Blur-up loading effect similar to Medium/LQIP
+- CSS `transition` on `filter` and `transform`
+- JS sets `--ibl-loaded` custom property on load event
+- Customizable duration and easing via `:root` variables
+
+## Usage
+
+Wrap an `<img>` inside `.ibl-container`. The image starts with `blur(20px)` and `scale(1.1)`. Once JavaScript detects the `load` event, it sets `--ibl-loaded` on the container, triggering the transition to `blur(0)` and `scale(1)`.
+
+```css
+.ibl-image {
+  filter: blur(20px);
+  transform: scale(1.1);
+  transition: filter 1.2s ease-out, transform 1.2s ease-out;
+}
+.ibl-container[style*="--ibl-loaded"] .ibl-image {
+  filter: blur(0);
+  transform: scale(1);
+}
+```

--- a/submissions/examples/ease-image-blur-load-transition-ij/demo.html
+++ b/submissions/examples/ease-image-blur-load-transition-ij/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Image Blur Load Transition - EaseMotion CSS</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <section class="demo-section">
+    <h1>Image Blur Load</h1>
+    <p class="desc">Image loads with a blur-to-clear transition effect</p>
+    <div class="ibl-container" id="iblContainer">
+      <img class="ibl-image" src="https://picsum.photos/seed/blur/600/400" alt="Demo image">
+    </div>
+  </section>
+  <script>
+    const container = document.getElementById('iblContainer');
+    const img = container.querySelector('.ibl-image');
+
+    img.addEventListener('load', () => {
+      container.style.setProperty('--ibl-loaded', '1');
+    });
+
+    if (img.complete) {
+      container.style.setProperty('--ibl-loaded', '1');
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-image-blur-load-transition-ij/style.css
+++ b/submissions/examples/ease-image-blur-load-transition-ij/style.css
@@ -1,0 +1,66 @@
+:root {
+  --ibl-primary: #94a3b8;
+  --ibl-easing: ease-out;
+  --ibl-duration: 1.2s;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-section {
+  text-align: center;
+}
+
+h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  background: linear-gradient(135deg, var(--ibl-primary), #475569);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.desc {
+  font-size: 0.95rem;
+  color: #64748b;
+  margin-bottom: 3rem;
+  font-weight: 400;
+  max-width: 360px;
+}
+
+.ibl-container {
+  width: 400px;
+  overflow: hidden;
+  border-radius: 20px;
+  border: 1px solid #334155;
+}
+
+.ibl-image {
+  display: block;
+  width: 100%;
+  height: auto;
+  filter: blur(20px);
+  transform: scale(1.1);
+  transition: filter var(--ibl-duration) var(--ibl-easing),
+              transform var(--ibl-duration) var(--ibl-easing);
+}
+
+.ibl-container[style*="--ibl-loaded"] .ibl-image {
+  filter: blur(0);
+  transform: scale(1);
+}


### PR DESCRIPTION
## Component: ease-image-blur-load-transition ? Image loads with blur-to-clear transition

### What this adds
A blur-up image loading transition. The image starts blurred and scaled in, then transitions to clear and full size once loaded.

### Acceptance Criteria covered
- Image starts with blur(20px) and scale(1.1)
- JS sets --ibl-loaded on load complete
- CSS transitions filter and transform smoothly

### Files
- submissions/examples/ease-image-blur-load-transition-ij/demo.html
- submissions/examples/ease-image-blur-load-transition-ij/style.css
- submissions/examples/ease-image-blur-load-transition-ij/README.md

### How to review
Open demo.html in a browser. Observe the image load from blurred to clear with smooth easing.

**Closes #32235**
