### PR TITLE
feat: add card-lift-shadow-hover component (#32239)

### DIFF
--- a/submissions/examples/ease-card-lift-shadow-hover-ij/README.md
+++ b/submissions/examples/ease-card-lift-shadow-hover-ij/README.md
@@ -1,0 +1,12 @@
+# ease-card-lift-shadow-hover
+
+A responsive card grid where each card lifts upward with a deepened layered shadow on hover. Pure CSS — no JavaScript required.
+
+## Features
+- Smooth `translateY` lift combined with multi-layered `box-shadow` transition
+- Custom properties via `:root` for easy theming (`--clsh-lift`, `--clsh-primary`, etc.)
+- Responsive grid layout using `auto-fit` / `minmax`
+- Dark theme styling with Inter font
+
+## Usage
+Add the `.clsh-card` class to any element inside a `.clsh-grid` container. Hover to see the card lift and shadow deepen.

--- a/submissions/examples/ease-card-lift-shadow-hover-ij/demo.html
+++ b/submissions/examples/ease-card-lift-shadow-hover-ij/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+  <title>Card Lift Shadow Hover</title>
+</head>
+<body>
+  <section class="clsh-section">
+    <h1>Card Lift Shadow Hover</h1>
+    <p class="clsh-desc">Hover over a card to see it lift with a deepened shadow.</p>
+    <div class="clsh-grid">
+      <div class="clsh-card">
+        <h3>Explore</h3>
+        <p>Discover new horizons with interactive cards that respond to every move.</p>
+      </div>
+      <div class="clsh-card">
+        <h3>Create</h3>
+        <p>Build stunning interfaces with smooth lift effects and layered depth.</p>
+      </div>
+      <div class="clsh-card">
+        <h3>Design</h3>
+        <p>Craft polished experiences where every hover feels tactile and refined.</p>
+      </div>
+      <div class="clsh-card">
+        <h3>Ship</h3>
+        <p>Deliver delightful interactions that make your UI stand out.</p>
+      </div>
+    </div>
+  </section>
+</body>
+</html>

--- a/submissions/examples/ease-card-lift-shadow-hover-ij/style.css
+++ b/submissions/examples/ease-card-lift-shadow-hover-ij/style.css
@@ -1,0 +1,78 @@
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+:root {
+  --clsh-primary: #6366f1;
+  --clsh-bg: #0f0f1a;
+  --clsh-card-bg: #1a1a2e;
+  --clsh-text: #e2e8f0;
+  --clsh-muted: #94a3b8;
+  --clsh-lift: 8px;
+  --clsh-radius: 16px;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: var(--clsh-bg);
+  font-family: 'Inter', system-ui, sans-serif;
+  padding: 2rem;
+}
+
+.clsh-section {
+  max-width: 900px;
+  text-align: center;
+}
+
+.clsh-section h1 {
+  color: var(--clsh-text);
+  font-size: 2.25rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.clsh-desc {
+  color: var(--clsh-muted);
+  font-size: 1.05rem;
+  margin-bottom: 2.5rem;
+}
+
+.clsh-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+}
+
+.clsh-card {
+  background: var(--clsh-card-bg);
+  border-radius: var(--clsh-radius);
+  padding: 2rem 1.5rem;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  box-shadow:
+    0 2px 8px rgba(0, 0, 0, 0.3),
+    0 8px 24px rgba(0, 0, 0, 0.15);
+}
+
+.clsh-card:hover {
+  transform: translateY(calc(-1 * var(--clsh-lift)));
+  box-shadow:
+    0 8px 24px rgba(0, 0, 0, 0.35),
+    0 16px 48px rgba(0, 0, 0, 0.2),
+    0 32px 64px rgba(0, 0, 0, 0.1);
+}
+
+.clsh-card h3 {
+  color: var(--clsh-primary);
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.clsh-card p {
+  color: var(--clsh-muted);
+  font-size: 0.9rem;
+  line-height: 1.6;
+}


### PR DESCRIPTION
## Component: ease-card-lift-shadow-hover ? Card lifts with enhanced shadow on hover

### What this adds
Cards that lift vertically and cast a deeper shadow on hover, using CSS transitions on transform and box-shadow.

### Acceptance Criteria covered
- translateY lift on hover
- Box-shadow deepens for material feel
- Smooth easing transition

### Files
- submissions/examples/ease-card-lift-shadow-hover-ij/demo.html
- submissions/examples/ease-card-lift-shadow-hover-ij/style.css
- submissions/examples/ease-card-lift-shadow-hover-ij/README.md

### How to review
Open demo.html. Hover over cards to see them lift with animated shadow.

**Closes #32239**
