### PR TITLE
fix: resolve modal z-index conflict with tooltips

### DIFF
--- a/submissions/examples/fix-modal-zindex-32258/README.md
+++ b/submissions/examples/fix-modal-zindex-32258/README.md
@@ -1,0 +1,10 @@
+# Fix Modal Z-Index Conflict (Issue #9806)
+
+1. **What does this do?**  
+   Updates the `.ease-modal-overlay` z-index to exceed the tooltip z-index (`9999`), preventing background tooltips from bleeding through the active modal.
+
+2. **How is it used?**  
+   Update the z-index property in the `.ease-modal-overlay` class to a value higher than `var(--ease-z-toast, 9999)`.
+
+3. **Why is it useful?**  
+   Resolves bug #9806. It ensures proper stacking context management so background elements don't interfere with modal interactions.

--- a/submissions/examples/fix-modal-zindex-32258/demo.html
+++ b/submissions/examples/fix-modal-zindex-32258/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fix Modal Z-Index Demo</title>
+  <link rel="stylesheet" href="../../../easemotion.min.css">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+      margin: 0;
+      font-family: system-ui, -apple-system, sans-serif;
+      background-color: #f9fafb;
+    }
+  </style>
+</head>
+<body>
+  <!-- Background element with tooltip -->
+  <span class="ease-tooltip" data-position="top" data-tooltip="This should NOT appear over the modal">
+    Hover me (Background Tooltip)
+  </span>
+
+  <!-- Modal Overlay overriding the z-index -->
+  <div class="ease-modal-overlay" style="position: fixed; inset: 0; background: rgba(0,0,0,0.5); display: flex; justify-content: center; align-items: center;">
+    <div style="background: white; padding: 2rem; border-radius: 8px;">
+      <h2>Modal Active</h2>
+      <p>Try hovering over the background text. The tooltip will not bleed through.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-modal-zindex-32258/style.css
+++ b/submissions/examples/fix-modal-zindex-32258/style.css
@@ -1,0 +1,4 @@
+.ease-modal-overlay {
+  /* Increase z-index to be higher than tooltips (which are 9999) */
+  z-index: var(--ease-z-modal, 10000);
+}


### PR DESCRIPTION
Fixes #32258.

Updates the `.ease-modal-overlay` z-index to exceed the tooltip z-index (`9999`). This ensures proper stacking context management so background tooltips do not bleed through or interfere with active modal interactions.