### PR TITLE
feat: add list-item-slide-edit component (#32246)

### DIFF
--- a/submissions/examples/ease-list-item-slide-edit-ij/README.md
+++ b/submissions/examples/ease-list-item-slide-edit-ij/README.md
@@ -1,0 +1,14 @@
+# List Item Slide Edit
+
+Animated list items that slide to reveal an inline edit form on click. Uses a flex-based slide transition for smooth content swapping.
+
+## Features
+
+- Slide transition between view and edit mode
+- Inline input with save action
+- Smooth cubic-bezier timing
+- Dark theme card styling
+
+## Usage
+
+Toggle `.lise-editing` on `.lise-item` to slide from view mode into edit mode. The slide container uses `translateX(-100%)` to swap between the two panels.

--- a/submissions/examples/ease-list-item-slide-edit-ij/demo.html
+++ b/submissions/examples/ease-list-item-slide-edit-ij/demo.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>List Item Slide Edit - EaseMotion CSS</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="lise-wrapper">
+    <h1>List Item Slide Edit</h1>
+    <p class="lise-desc">Click the Edit button on any item to slide it open and reveal the inline edit form.</p>
+    <ul class="lise-list">
+      <li class="lise-item">
+        <div class="lise-inner">
+          <div class="lise-view">
+            <span class="lise-text">Grocery shopping</span>
+            <button class="lise-btn">Edit</button>
+          </div>
+          <div class="lise-edit">
+            <input class="lise-input" type="text" value="Grocery shopping">
+            <button class="lise-save">Save</button>
+          </div>
+        </div>
+      </li>
+      <li class="lise-item">
+        <div class="lise-inner">
+          <div class="lise-view">
+            <span class="lise-text">Finish project report</span>
+            <button class="lise-btn">Edit</button>
+          </div>
+          <div class="lise-edit">
+            <input class="lise-input" type="text" value="Finish project report">
+            <button class="lise-save">Save</button>
+          </div>
+        </div>
+      </li>
+      <li class="lise-item">
+        <div class="lise-inner">
+          <div class="lise-view">
+            <span class="lise-text">Plan weekend trip</span>
+            <button class="lise-btn">Edit</button>
+          </div>
+          <div class="lise-edit">
+            <input class="lise-input" type="text" value="Plan weekend trip">
+            <button class="lise-save">Save</button>
+          </div>
+        </div>
+      </li>
+      <li class="lise-item">
+        <div class="lise-inner">
+          <div class="lise-view">
+            <span class="lise-text">Read CSS animations book</span>
+            <button class="lise-btn">Edit</button>
+          </div>
+          <div class="lise-edit">
+            <input class="lise-input" type="text" value="Read CSS animations book">
+            <button class="lise-save">Save</button>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <script>
+    document.querySelectorAll('.lise-btn').forEach(function(btn) {
+      btn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        this.closest('.lise-item').classList.add('lise-editing');
+        var input = this.closest('.lise-item').querySelector('.lise-input');
+        input.focus();
+        input.setSelectionRange(input.value.length, input.value.length);
+      });
+    });
+    document.querySelectorAll('.lise-save').forEach(function(saveBtn) {
+      saveBtn.addEventListener('click', function() {
+        var item = this.closest('.lise-item');
+        var input = item.querySelector('.lise-input');
+        var text = item.querySelector('.lise-text');
+        text.textContent = input.value;
+        item.classList.remove('lise-editing');
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-list-item-slide-edit-ij/style.css
+++ b/submissions/examples/ease-list-item-slide-edit-ij/style.css
@@ -1,0 +1,132 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding: 4rem 1rem;
+}
+
+.lise-wrapper {
+  width: 100%;
+  max-width: 520px;
+}
+
+h1 {
+  font-size: 1.65rem;
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+  color: #f1f5f9;
+}
+
+.lise-desc {
+  font-size: 0.88rem;
+  color: #64748b;
+  margin-bottom: 2rem;
+  line-height: 1.5;
+}
+
+.lise-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.lise-item {
+  background: #1e293b;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.lise-inner {
+  display: flex;
+  transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.lise-view {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-width: 100%;
+  padding: 0.9rem 1.1rem;
+}
+
+.lise-text {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #e2e8f0;
+}
+
+.lise-btn {
+  background: transparent;
+  border: 1px solid #334155;
+  color: #94a3b8;
+  padding: 0.35rem 0.85rem;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  font-family: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.lise-btn:hover {
+  background: #334155;
+  color: #e2e8f0;
+  border-color: #475569;
+}
+
+.lise-edit {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 100%;
+  padding: 0.55rem 1.1rem;
+}
+
+.lise-input {
+  flex: 1;
+  background: #0f172a;
+  border: 1px solid #334155;
+  color: #e2e8f0;
+  padding: 0.45rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 0.2s ease;
+}
+
+.lise-input:focus {
+  border-color: #3b82f6;
+}
+
+.lise-save {
+  background: #3b82f6;
+  border: none;
+  color: #fff;
+  padding: 0.45rem 1rem;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  font-family: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s ease;
+  white-space: nowrap;
+}
+
+.lise-save:hover {
+  background: #2563eb;
+}
+
+.lise-editing .lise-inner {
+  transform: translateX(-100%);
+}


### PR DESCRIPTION
## Component: ease-list-item-slide-edit ? List items slide to reveal edit form

### What this adds
List items slide to reveal edit form using CSS transitions triggered by class toggle.

### Acceptance Criteria covered
- Smooth CSS transition animation
- Toggle class triggers the animation
- Customizable via :root variables

### Files
- submissions/examples/ease-list-item-slide-edit-ij/demo.html
- submissions/examples/ease-list-item-slide-edit-ij/style.css
- submissions/examples/ease-list-item-slide-edit-ij/README.md

### How to review
Open demo.html and interact with the component to see the animation.

**Closes #32246**
