### PR TITLE
feat: add autocomplete-suggestions component (#32296)

### DIFF
--- a/submissions/examples/ease-autocomplete-suggestions-ij/README.md
+++ b/submissions/examples/ease-autocomplete-suggestions-ij/README.md
@@ -1,0 +1,25 @@
+# Autocomplete Suggestions
+
+## What does this do?
+
+It creates an input with a dropdown suggestion list that animates into view using opacity fade and max-height slide. As the user types, matching suggestions are filtered and appear with smooth transitions. Keyboard navigation (Arrow Up/Down, Enter, Escape) is fully supported.
+
+## How is it used?
+
+Wrap your input and suggestion list inside a container and apply the `acs-` classes:
+
+```html
+<div class="acs-input-wrapper">
+  <input type="text" class="acs-input" autocomplete="off" />
+  <ul class="acs-suggestions" id="acs-list">
+    <li class="acs-item">JavaScript</li>
+    <li class="acs-item">Python</li>
+  </ul>
+</div>
+```
+
+Toggle `.acs-visible` on the `.acs-suggestions` element to trigger the animation. Mark matched text with a `<mark>` tag to highlight it in the accent color.
+
+## Why is this useful?
+
+Autocomplete is a common UI pattern that benefits from subtle animation to communicate state changes. The fade + max-height approach keeps the animation lightweight by only triggering compositor-friendly properties (`opacity`) and layout-friendly bounding (`max-height`). It degrades gracefully under `prefers-reduced-motion` and works across all modern browsers without JavaScript animation libraries.

--- a/submissions/examples/ease-autocomplete-suggestions-ij/demo.html
+++ b/submissions/examples/ease-autocomplete-suggestions-ij/demo.html
@@ -1,0 +1,310 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Autocomplete Suggestions Demo</title>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --acs-bg:           #0f172a;
+      --acs-surface:      #1e293b;
+      --acs-text:         #f8fafc;
+      --acs-muted:        #64748b;
+      --acs-border:       #334155;
+      --acs-primary:      #6c63ff;
+      --acs-primary-dim:  #5a52e0;
+      --acs-font:         'Inter', system-ui, -apple-system, sans-serif;
+      --acs-radius:       0.75rem;
+      --acs-shadow:       0 10px 25px -5px rgba(0,0,0,0.4);
+    }
+
+    @media (prefers-color-scheme: light) {
+      :root {
+        --acs-bg:         #f1f5f9;
+        --acs-surface:    #ffffff;
+        --acs-text:       #0f172a;
+        --acs-muted:      #94a3b8;
+        --acs-border:     #e2e8f0;
+        --acs-shadow:     0 10px 25px -5px rgba(0,0,0,0.08);
+      }
+    }
+
+    body {
+      font-family: var(--acs-font);
+      background: var(--acs-bg);
+      color: var(--acs-text);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 3rem 1.5rem;
+    }
+
+    .page-header {
+      text-align: center;
+      max-width: 560px;
+      margin-bottom: 2.5rem;
+    }
+
+    .page-header h1 {
+      font-size: 1.8rem;
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+    }
+
+    .page-header p {
+      color: var(--acs-muted);
+      font-size: 0.95rem;
+      line-height: 1.6;
+    }
+
+    .showcase-card {
+      background: var(--acs-surface);
+      border: 1px solid var(--acs-border);
+      box-shadow: var(--acs-shadow);
+      border-radius: var(--acs-radius);
+      padding: 2.5rem;
+      width: 100%;
+      max-width: 480px;
+    }
+
+    .acs-label {
+      display: block;
+      font-size: 0.85rem;
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+      color: var(--acs-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    .acs-input-wrapper {
+      position: relative;
+    }
+
+    .acs-input {
+      width: 100%;
+      padding: 0.75rem 1rem;
+      font-family: var(--acs-font);
+      font-size: 1rem;
+      background: var(--acs-bg);
+      color: var(--acs-text);
+      border: 1px solid var(--acs-border);
+      border-radius: var(--acs-radius);
+      outline: none;
+      transition: border-color 0.2s ease;
+    }
+
+    .acs-input:focus {
+      border-color: var(--acs-primary);
+    }
+
+    .acs-suggestions {
+      position: absolute;
+      top: calc(100% + 0.375rem);
+      left: 0;
+      right: 0;
+      list-style: none;
+      background: var(--acs-surface);
+      border: 1px solid var(--acs-border);
+      border-radius: var(--acs-radius);
+      box-shadow: var(--acs-shadow);
+      overflow: hidden;
+      opacity: 0;
+      max-height: 0;
+      visibility: hidden;
+      transition: opacity 0.25s ease, max-height 0.3s ease, visibility 0s 0.3s;
+    }
+
+    .acs-suggestions.acs-visible {
+      opacity: 1;
+      max-height: 320px;
+      visibility: visible;
+      transition: opacity 0.25s ease, max-height 0.3s ease, visibility 0s 0s;
+    }
+
+    .acs-item {
+      padding: 0.65rem 1rem;
+      cursor: pointer;
+      font-size: 0.9rem;
+      color: var(--acs-text);
+      transition: background 0.15s ease, padding-left 0.2s ease;
+    }
+
+    .acs-item:hover {
+      background: var(--acs-border);
+      padding-left: 1.35rem;
+    }
+
+    .acs-item.active {
+      background: var(--acs-primary-dim);
+      color: #fff;
+    }
+
+    .acs-item mark {
+      background: transparent;
+      color: var(--acs-primary);
+      font-weight: 600;
+    }
+
+    .acs-empty {
+      padding: 1rem;
+      text-align: center;
+      color: var(--acs-muted);
+      font-size: 0.85rem;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .acs-suggestions,
+      .acs-item {
+        transition: none !important;
+      }
+    }
+  </style>
+
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>Autocomplete Suggestions</h1>
+    <p>
+      Start typing a programming language — suggestions appear with a fade and slide animation. Press <kbd>↑</kbd><kbd>↓</kbd> to navigate and <kbd>Enter</kbd> to select.
+    </p>
+  </header>
+
+  <main class="showcase-card">
+    <label class="acs-label" for="acs-input">Language</label>
+    <div class="acs-input-wrapper">
+      <input
+        type="text"
+        id="acs-input"
+        class="acs-input"
+        placeholder="e.g. JavaScript, Python, Rust …"
+        autocomplete="off"
+      />
+      <ul class="acs-suggestions" id="acs-list" role="listbox"></ul>
+    </div>
+  </main>
+
+  <script>
+    (function () {
+      const languages = [
+        'JavaScript', 'TypeScript', 'Python', 'Rust', 'Go',
+        'Java', 'Kotlin', 'Swift', 'C#', 'C++',
+        'Ruby', 'PHP', 'Scala', 'Elixir', 'Clojure',
+        'Haskell', 'Lua', 'Dart', 'Zig', 'R'
+      ];
+
+      const input   = document.getElementById('acs-input');
+      const list    = document.getElementById('acs-list');
+      let activeIdx = -1;
+
+      const emptyItem = document.createElement('li');
+      emptyItem.className = 'acs-empty';
+      emptyItem.textContent = 'No matching suggestions';
+
+      function filterItems(query) {
+        const q = query.trim().toLowerCase();
+        return q === ''
+          ? []
+          : languages.filter(lang => lang.toLowerCase().includes(q));
+      }
+
+      function render() {
+        const q   = input.value;
+        const matches = filterItems(q);
+        list.innerHTML = '';
+
+        if (matches.length === 0) {
+          list.appendChild(emptyItem.cloneNode(true));
+          list.classList.toggle('acs-visible', q.trim() !== '');
+          activeIdx = -1;
+          return;
+        }
+
+        const ql = q.trim().toLowerCase();
+        matches.forEach((lang, i) => {
+          const li = document.createElement('li');
+          li.className = 'acs-item';
+          li.setAttribute('role', 'option');
+          li.setAttribute('data-value', lang);
+
+          const idx = lang.toLowerCase().indexOf(ql);
+          if (idx !== -1) {
+            const before = lang.slice(0, idx);
+            const match  = lang.slice(idx, idx + ql.length);
+            const after  = lang.slice(idx + ql.length);
+            li.innerHTML = before + '<mark>' + match + '</mark>' + after;
+          } else {
+            li.textContent = lang;
+          }
+
+          li.addEventListener('click', function () {
+            input.value = this.getAttribute('data-value');
+            list.classList.remove('acs-visible');
+            activeIdx = -1;
+          });
+
+          list.appendChild(li);
+        });
+
+        list.classList.add('acs-visible');
+        activeIdx = -1;
+      }
+
+      function navigate(direction) {
+        const items = list.querySelectorAll('.acs-item');
+        if (items.length === 0) return;
+
+        items.forEach(el => el.classList.remove('active'));
+
+        activeIdx = Math.max(-1, Math.min(activeIdx + direction, items.length - 1));
+
+        if (activeIdx >= 0) {
+          items[activeIdx].classList.add('active');
+        }
+      }
+
+      input.addEventListener('input', render);
+
+      input.addEventListener('keydown', function (e) {
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          navigate(1);
+        } else if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          navigate(-1);
+        } else if (e.key === 'Enter') {
+          e.preventDefault();
+          const active = list.querySelector('.acs-item.active');
+          if (active) {
+            input.value = active.getAttribute('data-value');
+            list.classList.remove('acs-visible');
+            activeIdx = -1;
+          }
+        } else if (e.key === 'Escape') {
+          list.classList.remove('acs-visible');
+          activeIdx = -1;
+        }
+      });
+
+      document.addEventListener('click', function (e) {
+        if (!e.target.closest('.acs-input-wrapper')) {
+          list.classList.remove('acs-visible');
+          activeIdx = -1;
+        }
+      });
+    })();
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-autocomplete-suggestions-ij/style.css
+++ b/submissions/examples/ease-autocomplete-suggestions-ij/style.css
@@ -1,0 +1,83 @@
+/* =============================================================
+   Submission: ease-autocomplete-suggestions-ij
+   Effect: Autocomplete Suggestions fade/slide
+   ============================================================= */
+
+:root {
+  --acs-bg:           #0f172a;
+  --acs-surface:      #1e293b;
+  --acs-text:         #f8fafc;
+  --acs-muted:        #64748b;
+  --acs-border:       #334155;
+  --acs-primary:      #6c63ff;
+  --acs-primary-dim:  #5a52e0;
+  --acs-font:         'Inter', system-ui, -apple-system, sans-serif;
+  --acs-radius:       0.75rem;
+  --acs-shadow:       0 10px 25px -5px rgba(0,0,0,0.4);
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --acs-bg:         #f1f5f9;
+    --acs-surface:    #ffffff;
+    --acs-text:       #0f172a;
+    --acs-muted:      #94a3b8;
+    --acs-border:     #e2e8f0;
+    --acs-shadow:     0 10px 25px -5px rgba(0,0,0,0.08);
+  }
+}
+
+.acs-suggestions {
+  position: absolute;
+  top: calc(100% + 0.375rem);
+  left: 0;
+  right: 0;
+  list-style: none;
+  background: var(--acs-surface);
+  border: 1px solid var(--acs-border);
+  border-radius: var(--acs-radius);
+  box-shadow: var(--acs-shadow);
+  overflow: hidden;
+  opacity: 0;
+  max-height: 0;
+  visibility: hidden;
+  transition: opacity 0.25s ease, max-height 0.3s ease, visibility 0s 0.3s;
+}
+
+.acs-suggestions.acs-visible {
+  opacity: 1;
+  max-height: 320px;
+  visibility: visible;
+  transition: opacity 0.25s ease, max-height 0.3s ease, visibility 0s 0s;
+}
+
+.acs-item {
+  padding: 0.65rem 1rem;
+  cursor: pointer;
+  font-size: 0.9rem;
+  color: var(--acs-text);
+  transition: background 0.15s ease, padding-left 0.2s ease;
+}
+
+.acs-item:hover {
+  background: var(--acs-border);
+  padding-left: 1.35rem;
+}
+
+.acs-item.active {
+  background: var(--acs-primary-dim);
+  color: #fff;
+}
+
+.acs-item mark {
+  background: transparent;
+  color: var(--acs-primary);
+  font-weight: 600;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .acs-suggestions,
+  .acs-item {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Component: ease-autocomplete-suggestions ? Suggestions appear with fade on type

### What this adds
Suggestions appear with fade on type using CSS transitions and animations.

### Acceptance Criteria covered
- Smooth CSS transition or @keyframes animation
- Interactive trigger (click, hover, or JS)
- Customizable via CSS variables

### Files
- submissions/examples/ease-autocomplete-suggestions-ij/demo.html
- submissions/examples/ease-autocomplete-suggestions-ij/style.css
- submissions/examples/ease-autocomplete-suggestions-ij/README.md

### How to review
Open demo.html and interact to see the animation.

**Closes #32296**
