### PR TITLE
fix: adapt progress bar background track to dark mode

### DIFF
--- a/submissions/docs/progress-bar-dark-mode-fix-lts/style.css
+++ b/submissions/docs/progress-bar-dark-mode-fix-lts/style.css
@@ -1,0 +1,54 @@
+@layer easemotion-components {
+  .ease-progress {
+    width: 100%;
+    height: 0.75rem;
+    background: var(--ease-color-neutral-200, #e2e8f0);
+    border-radius: 999px;
+    overflow: hidden;
+  }
+  
+  /* Dark mode overrides */
+  @media (prefers-color-scheme: dark) {
+    .ease-progress {
+      background: var(--ease-color-neutral-800, #1e293b);
+    }
+  }
+
+  [data-theme="dark"] .ease-progress {
+    background: var(--ease-color-neutral-800, #1e293b);
+  }
+
+  .ease-progress-bar {
+    height: 100%;
+    background: var(--ease-color-primary, #6c63ff);
+    border-radius: 999px;
+    transition: width 0.3s ease;
+    width: 0%;
+  }
+  
+  .ease-progress-sm { height: 0.375rem; }
+  
+  .ease-progress-lg { height: 1.125rem; }
+  
+  .ease-progress-success .ease-progress-bar { background: var(--ease-color-success, #22c55e); }
+  
+  .ease-progress-danger .ease-progress-bar { background: var(--ease-color-danger, #ef4444); }
+  
+  .ease-progress-warning .ease-progress-bar { background: var(--ease-color-warning, #f59e0b); }
+  
+  .ease-progress-striped .ease-progress-bar {
+    background-image: linear-gradient(45deg, rgba(255,255,255,0.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.15) 50%, rgba(255,255,255,0.15) 75%, transparent 75%, transparent);
+    background-size: 1rem 1rem;
+  }
+
+  .ease-progress-info .ease-progress-bar { background: var(--ease-color-info, #3b82f6); }
+
+  .ease-progress-animated .ease-progress-bar {
+    animation: ease-kf-progress-stripes 1s linear infinite;
+  }
+
+  @keyframes ease-kf-progress-stripes {
+    from { background-position: 1rem 0; }
+    to { background-position: 0 0; }
+  }
+}


### PR DESCRIPTION
ISSUE: #27862

The Issue: The progress bar container track (.ease-progress) had a hardcoded background color of #e2e8f0 which failed to adapt when switching to dark mode. This resulted in a bright gray bar that lacked proper contrast and disrupted the dark theme aesthetics.
The Fix: Modified the progress bar track background color to adapt dynamically using CSS custom properties. It now defaults to var(--ease-color-neutral-200, #e2e8f0) in light mode, and transitions to var(--ease-color-neutral-800, #1e293b) when in dark mode (supporting both @media (prefers-color-scheme: dark) and the [data-theme="dark"] attribute).
Scope: All changes are isolated within the submissions/docs/progress-bar-dark-mode-fix-lts/ folder, ensuring no direct modification of the core files.

closes #27862 