### PR TITLE
Fix/progress bar dark mode lts

### DIFF
--- a/submissions/docs/progress-bar-dark-mode-fix-lts/README.md
+++ b/submissions/docs/progress-bar-dark-mode-fix-lts/README.md
@@ -1,0 +1,15 @@
+# Progress Bar Dark Mode Track Background Adaptation Fix
+
+### 1. What does this do?
+It fixes the progress bar container track (`.ease-progress`) background color so that it adapts dynamically to dark mode rather than remaining a hardcoded light gray (`#e2e8f0`).
+
+### 2. How is it used?
+The progress bar component automatically applies the correct background styling depending on the user's theme preference or the `[data-theme="dark"]` attribute.
+```html
+<div class="ease-progress">
+  <div class="ease-progress-bar" style="width: 50%;"></div>
+</div>
+```
+
+### 3. Why is it useful?
+It ensures visual harmony, proper contrast, and aesthetic consistency across light and dark interfaces, aligning with EaseMotion's focus on seamless out-of-the-box styling support.

--- a/submissions/docs/progress-bar-dark-mode-fix-lts/demo.html
+++ b/submissions/docs/progress-bar-dark-mode-fix-lts/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Progress Bar Dark Mode Adaptation Demo</title>
+  <!-- Load base framework styles -->
+  <link rel="stylesheet" href="../../../../easemotion.css">
+  <!-- Load the local bug fix styles -->
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body style="font-family: system-ui, -apple-system, sans-serif; padding: 3rem; background: #f8fafc; color: #0f172a; margin: 0; transition: background 0.3s, color 0.3s;">
+
+  <div style="max-width: 600px; margin: 0 auto;">
+    <header style="margin-bottom: 2rem;">
+      <h1 style="font-size: 2rem; font-weight: 800; color: #6c63ff; margin-bottom: 0.5rem;">Progress Bar Dark Mode Fix</h1>
+      <p style="color: #64748b; margin: 0;">Demonstration of the progress track background color adapting to dark mode settings.</p>
+    </header>
+
+    <!-- Light Mode Preview -->
+    <div style="background: #ffffff; border: 1px solid #e2e8f0; border-radius: 12px; padding: 2rem; margin-bottom: 2rem; box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);">
+      <h3 style="margin-top: 0; color: #0f172a;">Light Mode Preview</h3>
+      <p style="font-size: 0.875rem; color: #64748b; margin-bottom: 1.5rem;">Track should adapt to a light gray background (`#e2e8f0`).</p>
+      
+      <div class="ease-progress">
+        <div class="ease-progress-bar" style="width: 50%;"></div>
+      </div>
+    </div>
+
+    <!-- Dark Mode Preview (Forced via [data-theme="dark"]) -->
+    <div data-theme="dark" style="background: #0b1121; border: 1px solid #1e293b; border-radius: 12px; padding: 2rem; color: #f8fafc; box-shadow: 0 10px 15px -3px rgba(0,0,0,0.3);">
+      <h3 style="margin-top: 0; color: #f8fafc;">Dark Mode Preview</h3>
+      <p style="font-size: 0.875rem; color: #94a3b8; margin-bottom: 1.5rem;">Track should adapt to a subtle dark neutral color (`#1e293b` / `var(--ease-color-neutral-800)`).</p>
+      
+      <div class="ease-progress">
+        <div class="ease-progress-bar" style="width: 50%;"></div>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/docs/progress-bar-dark-mode-fix-lts/style.css
+++ b/submissions/docs/progress-bar-dark-mode-fix-lts/style.css
@@ -1,0 +1,54 @@
+@layer easemotion-components {
+  .ease-progress {
+    width: 100%;
+    height: 0.75rem;
+    background: var(--ease-color-neutral-200, #e2e8f0);
+    border-radius: 999px;
+    overflow: hidden;
+  }
+  
+  /* Dark mode overrides */
+  @media (prefers-color-scheme: dark) {
+    .ease-progress {
+      background: var(--ease-color-neutral-800, #1e293b);
+    }
+  }
+
+  [data-theme="dark"] .ease-progress {
+    background: var(--ease-color-neutral-800, #1e293b);
+  }
+
+  .ease-progress-bar {
+    height: 100%;
+    background: var(--ease-color-primary, #6c63ff);
+    border-radius: 999px;
+    transition: width 0.3s ease;
+    width: 0%;
+  }
+  
+  .ease-progress-sm { height: 0.375rem; }
+  
+  .ease-progress-lg { height: 1.125rem; }
+  
+  .ease-progress-success .ease-progress-bar { background: var(--ease-color-success, #22c55e); }
+  
+  .ease-progress-danger .ease-progress-bar { background: var(--ease-color-danger, #ef4444); }
+  
+  .ease-progress-warning .ease-progress-bar { background: var(--ease-color-warning, #f59e0b); }
+  
+  .ease-progress-striped .ease-progress-bar {
+    background-image: linear-gradient(45deg, rgba(255,255,255,0.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.15) 50%, rgba(255,255,255,0.15) 75%, transparent 75%, transparent);
+    background-size: 1rem 1rem;
+  }
+
+  .ease-progress-info .ease-progress-bar { background: var(--ease-color-info, #3b82f6); }
+
+  .ease-progress-animated .ease-progress-bar {
+    animation: ease-kf-progress-stripes 1s linear infinite;
+  }
+
+  @keyframes ease-kf-progress-stripes {
+    from { background-position: 1rem 0; }
+    to { background-position: 0 0; }
+  }
+}


### PR DESCRIPTION
ISSUE: #27862

The Issue: The progress bar container track (.ease-progress) had a hardcoded background color of #e2e8f0 which failed to adapt when switching to dark mode. This resulted in a bright gray bar that lacked proper contrast and disrupted the dark theme aesthetics.
The Fix: Modified the progress bar track background color to adapt dynamically using CSS custom properties. It now defaults to var(--ease-color-neutral-200, #e2e8f0) in light mode, and transitions to var(--ease-color-neutral-800, #1e293b) when in dark mode (supporting both @media (prefers-color-scheme: dark) and the [data-theme="dark"] attribute).
Scope: All changes are isolated within the submissions/docs/progress-bar-dark-mode-fix-lts/ folder, ensuring no direct modification of the core files.

closes #27862 