### PR TITLE
fix(buttons): display loading spinner correctly

### DIFF
--- a/components/buttons.css
+++ b/components/buttons.css
@@ -218,13 +218,19 @@
 }
 
 /* Loading spinner inside button */
-.ease-btn-loading {
+/* .ease-btn-loading {
   pointer-events: none;
   position: relative;
   color: transparent !important;
+} */
+
+.ease-btn-loading {
+  position: relative;
+  pointer-events: none;
 }
 
-.ease-btn-loading > * {
+
+.ease-btn-loading > span {
   visibility: hidden;
 }
 

--- a/examples/demo.html
+++ b/examples/demo.html
@@ -701,7 +701,7 @@
           <button class="ease-btn ease-btn-primary ease-btn-pill">Pill Shape</button>
           <button class="ease-btn ease-btn-primary" disabled>Disabled</button>
           <button class="ease-btn ease-btn-outline ease-btn-loading"
-            style="border-color:var(--outline-btn-border); color:var(--outline-btn-color);">Loading</button>
+            style="border-color:var(--outline-btn-border); color:var(--outline-btn-color);"><span>Loading</span></button>
         </div>
         <div class="demo-chip" style="margin-top: var(--ease-space-8);">// Flex Wrap Utilities</div>
         <div class="ease-flex ease-flex-wrap ease-gap-3" style="margin-bottom: var(--ease-space-4);">
@@ -1329,6 +1329,7 @@
         bar.classList.add('ease-scroll-progress-' + theme);
       }
     }
+
   </script>
 
 </body>


### PR DESCRIPTION
## Pull Request Description
ISSUE #32177 

Fixes the loading button example in the Buttons showcase.

The loading button was rendering as an empty outlined button because the loading spinner was not visible. This PR updates the loading state styling so the spinner is displayed correctly while preserving the existing button appearance and behavior.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [ ] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md`
- [ ] No changes to `core/`
- [ ] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Fixes the loading button demo by ensuring the loading spinner is visible.

**How does a developer use it?**

```html
<button class="ease-btn ease-btn-outline ease-btn-loading">
  <span>Loading</span>
</button>