### PR TITLE
docs: add documentation contribution showcase for readme consistency

### DIFF
--- a/submissions/docs/readme-contribution-guidance-docs-track/README.md
+++ b/submissions/docs/readme-contribution-guidance-docs-track/README.md
@@ -1,0 +1,36 @@
+# README Contribution Guidance Consistency Showcase
+
+## Overview
+
+This documentation showcase proposes updates to the repository's README to ensure it remains consistent with the contribution guidelines defined in CONTRIBUTING.md.
+
+## Problem Statement
+
+The current README omits `submissions/docs/` from several sections describing valid contribution tracks. However, `CONTRIBUTING.md` recognizes `submissions/docs/` as a valid directory for documentation showcase submissions.
+
+This inconsistency may cause contributors to overlook documentation contributions or submit them using an incorrect structure.
+
+| Section                      | Current               | Proposed                    |
+| ---------------------------- | --------------------- | --------------------------- |
+| Temporary Restriction Notice | examples, react, scss | examples, react, scss, docs |
+| Submission Guide             | examples, react, scss | examples, react, scss, docs |
+| Contributor Checklist        | examples, react, scss | examples, react, scss, docs |
+
+## Benefits
+
+- Keeps README aligned with CONTRIBUTING.md.
+- Clearly documents all supported contribution tracks.
+- Reduces confusion for new contributors.
+- Improves consistency across repository documentation.
+
+## Folder Structure
+
+```text
+submissions/docs/readme-contribution-guidance-docs-track/
+├── demo.html
+├── style.css
+└── README.md
+
+## How to Preview
+
+Open `demo.html` in any modern web browser to view the documentation showcase demonstrating the proposed README updates.

--- a/submissions/docs/readme-contribution-guidance-docs-track/demo.html
+++ b/submissions/docs/readme-contribution-guidance-docs-track/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>README Contribution Guidance Consistency</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header>
+        <h1>README Contribution Guidance Consistency</h1>
+        <p>
+            This documentation showcase demonstrates the proposed README
+            updates to include <code>submissions/docs/</code> as a valid
+            contribution track.
+        </p>
+
+        <h2>Affected Sections:</h2>
+        <ul>
+            <li>Temporary Restriction Notice</li>
+            <li>Contribution Submission Guide</li>
+            <li>Contributor Checklist</li>
+        </ul>
+    </header>
+    <main>
+        <section class="card">
+            <h2>Proposed Documentation Updates</h2>
+
+            <div class="comparison">
+                <article>
+                    <h3>Current Guidance</h3>
+                    <pre><code>
+submissions/examples/
+submissions/react/
+submissions/scss/
+                    </code></pre>
+                </article>
+
+                <article>
+                    <h3>Updated Guidance</h3>
+                    <pre><code>
+submissions/examples/
+submissions/react/
+submissions/scss/
+submissions/docs/
+                    </code></pre>
+                </article>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        <p>Documentation Showcase for EaseMotion CSS</p>
+    </footer>
+
+</body>
+</html>

--- a/submissions/docs/readme-contribution-guidance-docs-track/style.css
+++ b/submissions/docs/readme-contribution-guidance-docs-track/style.css
@@ -1,0 +1,85 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+body {
+    font-family: "Inter", sans-serif;
+    background: linear-gradient(135deg, #f8fafc, #eef2ff);
+    color: #1f2937;
+    padding: 24px;
+    line-height: 1.5;
+    overflow-x: hidden;
+}
+header {
+    text-align: center;
+    margin-bottom: 24px;
+}
+h1 {
+    font-size: 1.8rem;
+    font-weight: 700;
+    color: #0f172a;
+    margin-bottom: 8px;
+}
+header p {
+    color: #475569;
+    max-width: 720px;
+    margin: 0 auto 12px;
+    font-size: 0.95rem;
+}
+h2 {
+    font-size: 1.1rem;
+    margin-top: 10px;
+    color: #1e293b;
+}
+ul {
+    list-style: none;
+    text-align: center;
+    margin-top: 8px;
+}
+ul li {
+    margin: 4px 0;
+    color: #334155;
+    font-size: 0.9rem;
+}
+.card {
+    max-width: 780px;
+    margin: 0 auto;
+    background: rgba(255, 255, 255, 0.85);
+    backdrop-filter: blur(10px);
+    padding: 20px;
+    border-radius: 14px;
+    box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+}
+.comparison {
+    display: flex;
+    gap: 20px;
+    margin-top: 16px;
+    flex-wrap: wrap;
+}
+article {
+    flex: 1;
+    min-width: 240px;
+    background: #f1f5f9;
+    padding: 14px;
+    border-radius: 10px;
+}
+h3 {
+    font-size: 1rem;
+    margin-bottom: 8px;
+    color: #0f172a;
+}
+pre {
+    background: #0f172a;
+    color: #e2e8f0;
+    padding: 12px;
+    border-radius: 10px;
+    overflow-x: auto;
+    font-size: 0.85rem;
+}
+footer {
+    text-align: center;
+    margin-top: 24px;
+    color: #64748b;
+    font-size: 0.85rem;
+}


### PR DESCRIPTION
## Pull Request Description
This PR resolves an inconsistency between the main repository `README.md` and `CONTRIBUTING.md` by introducing a documentation showcase. It configures the `submissions/docs/readme-contribution-guidance-docs-track/` directory with `demo.html`, `style.css`, and `README.md` to formally demonstrate how `submissions/docs/` functions as a valid contribution track.

## Affected Sections
*   Temporary Restriction Notice
*   Contribution Submission Guide
*   Contributor Checklist

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**

closes #27883 