### PR TITLE
fix: resolve firefox white flash gap during ease-flip card transition

### DIFF
--- a/submissions/examples/ease-flip-card-fixed/README.md
+++ b/submissions/examples/ease-flip-card-fixed/README.md
@@ -1,0 +1,15 @@
+# ⚡ Fix ease-flip White Gap Between Card Faces in Firefox
+
+Cross-browser rendering optimization fix for the 3D flip card rotation component layout.
+
+## ✨ What it does
+Resolves a known rendering bug where Firefox displays a temporary white flash/gap boundary frame between the front and back faces at the exact midpoint (90-degree transition matrix) of a 3D Y-axis flip rotation.
+
+## 🚀 How to Use
+```html
+<div class="ease-flip-card-fixed">
+  <div class="ease-flip-card-fixed__inner">
+    <div class="ease-flip-card-fixed__front">Front Content</div>
+    <div class="ease-flip-card-fixed__back">Back Content</div>
+  </div>
+</div>

--- a/submissions/examples/ease-flip-card-fixed/demo.html
+++ b/submissions/examples/ease-flip-card-fixed/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EaseMotion CSS — Flip Card Firefox Fix Showcase</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <div class="container">
+    <header class="hero">
+      <div class="badge">🐛 Bug Fix Showcase</div>
+      <h1>Firefox Flip Card Fix</h1>
+      <p>Demonstrating a seamless 3D flip card animation optimized for Firefox. This version eliminates the mid-rotation white flash gap by ensuring proper vendor prefixes and explicit face backgrounds.</p>
+    </header>
+
+    <section class="section">
+      <h2 class="section-title">✨ Live Demo (Hover to Flip)</h2>
+      <div class="card-grid">
+
+        <div class="ease-flip-card-fixed">
+          <div class="ease-flip-card-fixed__inner">
+            
+            <div class="ease-flip-card-fixed__front">
+              <div class="card-content">
+                <span class="icon">✨</span>
+                <h3>Front Face</h3>
+                <p>Hover me to spin seamlessly.</p>
+              </div>
+            </div>
+            
+            <div class="ease-flip-card-fixed__back">
+              <div class="card-content">
+                <span class="icon">🚀</span>
+                <h3>Back Face</h3>
+                <p>No white flashes or gaps in Firefox!</p>
+              </div>
+            </div>
+
+          </div>
+        </div>
+
+      </div>
+    </section>
+
+    <section class="code-section">
+      <h2>📄 How it Works</h2>
+      <p>Firefox requires explicit background declarations and both <code>-webkit-</code> and <code>-moz-</code> backface visibility rules applied directly to the rendering faces to prevent the 3D depth layer from leaking frame gaps:</p>
+      <div class="code-block">
+        <pre><code>&lt;div class="ease-flip-card-fixed"&gt;
+  &lt;div class="ease-flip-card-fixed__inner"&gt;
+    &lt;div class="ease-flip-card-fixed__front"&gt;Front&lt;/div&gt;
+    &lt;div class="ease-flip-card-fixed__back"&gt;Back&lt;/div&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</code></pre>
+      </div>
+    </section>
+
+    <footer class="footer">
+      <p>Built with ⚡ EaseMotion CSS — Open Source UI Animation Library</p>
+    </footer>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-flip-card-fixed/style.css
+++ b/submissions/examples/ease-flip-card-fixed/style.css
@@ -1,0 +1,187 @@
+/* ─── Reset ─────────────────────────────────────────── */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  background: #0f0f1a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  padding: 2rem 1rem;
+}
+
+/* ─── 3D Flip Card Component (Firefox Fixed) ───────── */
+.ease-flip-card-fixed {
+  background-color: transparent;
+  width: 300px;
+  height: 400px;
+  perspective: 1000px; /* Crucial for 3D depth */
+  margin: 0 auto;
+}
+
+.ease-flip-card-fixed__inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  transition: transform 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+  transform-style: preserve-3d;
+}
+
+/* Hover Action trigger */
+.ease-flip-card-fixed:hover .ease-flip-card-fixed__inner {
+  transform: rotateY(180deg);
+}
+
+/* Card Faces Container Base */
+.ease-flip-card-fixed__front,
+.ease-flip-card-fixed__back {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  
+  /* Hard Fixes for Firefox White Flash & Gap Leakage */
+  -webkit-backface-visibility: hidden;
+  -moz-backface-visibility: hidden;
+  backface-visibility: hidden;
+  background: #13131f; /* Explicit dark background overrides native browser fallback meshes */
+}
+
+/* Front Face Layout */
+.ease-flip-card-fixed__front {
+  background: linear-gradient(135deg, #1e1e38 0%, #13131f 100%);
+  color: #f1f5f9;
+}
+
+/* Back Face Layout */
+.ease-flip-card-fixed__back {
+  background: linear-gradient(135deg, #251b40 0%, #13131f 100%);
+  color: #a5b4fc;
+  transform: rotateY(180deg);
+}
+
+/* Decorative Card Content Inside Details */
+.card-content {
+  padding: 2rem;
+}
+
+.card-content .icon {
+  font-size: 3rem;
+  margin-bottom: 1.5rem;
+  display: block;
+}
+
+.card-content h3 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.card-content p {
+  font-size: 0.95rem;
+  color: #94a3b8;
+  line-height: 1.5;
+}
+
+/* ─── Page Layout Container ─────────────────────────── */
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.hero {
+  text-align: center;
+  padding: 3rem 1rem;
+}
+
+.badge {
+  display: inline-block;
+  background: linear-gradient(135deg, #ef4444, #f43f5e);
+  color: white;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  margin-bottom: 1.5rem;
+}
+
+.hero h1 {
+  font-size: clamp(2rem, 5vw, 3rem);
+  font-weight: 900;
+  background: linear-gradient(135deg, #3b82f6, #a855f7);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 1rem;
+}
+
+.hero p {
+  font-size: 1.05rem;
+  color: #94a3b8;
+  max-width: 650px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.section {
+  margin: 2rem 0;
+}
+
+.section-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  text-align: center;
+  color: #f1f5f9;
+  margin-bottom: 2rem;
+}
+
+.code-section {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 1.5rem;
+  padding: 2rem;
+  margin: 4rem 0 2rem;
+}
+
+.code-section h2 {
+  font-size: 1.25rem;
+  color: #f1f5f9;
+  margin-bottom: 0.5rem;
+}
+
+.code-section p {
+  color: #94a3b8;
+  margin-bottom: 1.25rem;
+  font-size: 0.95rem;
+}
+
+.code-block {
+  background: #05050b;
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  overflow-x: auto;
+}
+
+.code-block pre {
+  font-family: monospace;
+  font-size: 0.85rem;
+  color: #38bdf8;
+  line-height: 1.6;
+}
+
+.footer {
+  text-align: center;
+  padding: 2rem 0;
+  color: #475569;
+  font-size: 0.85rem;
+}


### PR DESCRIPTION
## Pull Request Description
Resolves Issue #32475. Fixes a rendering layout bug where an intermittent white flash/gap displays across Firefox screens at the midpoint transition threshold of the 3D flip card component rotation.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧩 New component / example layout optimization

## Submission Checklist
- [x] All changes are isolated inside `submissions/examples/ease-flip-card-fixed/`
- [x] Includes standalone valid `demo.html`
- [x] Includes raw CSS solution via `style.css`
- [x] Includes context mapping documentation in `README.md`
- [x] No alterations made directly to `core/` or `components/` root paths

## Feature Description
**What does this add?**
It provides an updated template variant for card components that applies robust webkit and moz rendering targets alongside fixed element color parameters to block empty matrix bleeding artifacts in Gecko/Firefox layouts.

**Why does it fit EaseMotion CSS?**
Ensures seamless cross-browser stability for popular UI elements out of the box, adhering to high-performance micro-interaction philosophies without complex JavaScript wrappers.

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari