### PR TITLE
feat: add reusable SCSS keyframe wobble & pulse animation mixins

### DIFF
--- a/submissions/scss/scss-keyframe-wobble-pulse-animation-mixins-sr/README.md
+++ b/submissions/scss/scss-keyframe-wobble-pulse-animation-mixins-sr/README.md
@@ -1,0 +1,48 @@
+# Keyframe Wobble & Pulse Animation Mixins
+
+## Description
+
+This submission provides two reusable SCSS mixins:
+
+- Wobble Animation
+- Pulse Animation
+
+These mixins help create smooth micro-interactions for buttons, cards, icons, and UI components.
+
+---
+
+## Parameters
+
+### wobble()
+
+| Parameter | Default |
+|-----------|---------|
+| duration | 0.8s |
+| timing | ease-in-out |
+
+### pulse()
+
+| Parameter | Default |
+|-----------|---------|
+| duration | 1s |
+| scale | 1.05 |
+
+---
+
+## Usage
+
+```scss
+.button {
+  @include wobble();
+}
+
+.card {
+  @include pulse(1.5s, 1.1);
+}
+```
+
+---
+
+## CSS Compilation
+
+Compile this SCSS partial into your project stylesheet using your preferred SCSS compiler.

--- a/submissions/scss/scss-keyframe-wobble-pulse-animation-mixins-sr/_keyframe-wobble-pulse-animation-mixins-sr.scss
+++ b/submissions/scss/scss-keyframe-wobble-pulse-animation-mixins-sr/_keyframe-wobble-pulse-animation-mixins-sr.scss
@@ -1,0 +1,54 @@
+// =====================================
+// Keyframe Wobble Animation
+// Reusable mixin
+// =====================================
+
+@mixin wobble($duration: 0.8s, $timing: ease-in-out) {
+  animation: wobble $duration $timing;
+
+  @keyframes wobble {
+    0% {
+      transform: translateX(0);
+    }
+
+    25% {
+      transform: translateX(-5px) rotate(-3deg);
+    }
+
+    50% {
+      transform: translateX(5px) rotate(3deg);
+    }
+
+    75% {
+      transform: translateX(-3px) rotate(-2deg);
+    }
+
+    100% {
+      transform: translateX(0);
+    }
+  }
+}
+
+
+// =====================================
+// Pulse Animation
+// Reusable mixin
+// =====================================
+
+@mixin pulse($duration: 1s, $scale: 1.05) {
+  animation: pulse $duration infinite ease-in-out;
+
+  @keyframes pulse {
+    0% {
+      transform: scale(1);
+    }
+
+    50% {
+      transform: scale($scale);
+    }
+
+    100% {
+      transform: scale(1);
+    }
+  }
+}


### PR DESCRIPTION
# Pull Request Description

This PR adds a reusable SCSS utility for keyframe-based wobble and pulse animations under the SCSS submissions directory.

The submission includes:
- Reusable `wobble` SCSS mixin
- Reusable `pulse` SCSS mixin
- Well-commented SCSS code
- Documentation with parameters and usage examples

Closes #27739

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (SCSS Utility / Mixin)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [ ] Includes `demo.html`
- [ ] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

This submission adds reusable SCSS mixins for wobble and pulse keyframe animations that can be easily reused across UI components.

### How does a developer use it?

```scss
.button {
  @include wobble();
}

.card {
  @include pulse();
}
```

### Why does it fit EaseMotion CSS?

It provides lightweight, reusable animation mixins that improve UI micro-interactions while keeping styles modular and easy to maintain.

---

## Demo

- [ ] Demo added (`demo.html` works by opening directly in a browser)

*Not applicable for this SCSS utility submission.*

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---

## Notes for Maintainer

This submission follows the required SCSS contribution structure by adding a reusable SCSS partial and README documentation under the `submissions/scss/` directory. Feedback and improvements are welcome.