### PR TITLE
fix: resolve ease-marquee jumping and catchup loops using visibility …

### DIFF
--- a/submissions/examples/ease-marquee-continuous/README.md
+++ b/submissions/examples/ease-marquee-continuous/README.md
@@ -1,0 +1,14 @@
+# ⚡ Fix ease-marquee Animation Pauses Unexpectedly on Tab Blur
+
+Maintains linear translation points for marquees shifting across background tabs.
+
+## ✨ What it does
+Prevents scrolling marquee text tracks from executing visual catch-up calculations or jumping snapping steps when browser tabs regain processing focus after being minimized or hidden.
+
+## 🚀 How to Use
+```html
+<div class="ease-marquee-continuous" id="marqueeTicker">
+  <div class="ease-marquee-continuous__track">
+    <span>Breaking News • Latest Updates •</span>
+  </div>
+</div>

--- a/submissions/examples/ease-marquee-continuous/demo.html
+++ b/submissions/examples/ease-marquee-continuous/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EaseMotion CSS — Continuous Marquee Loop Fix</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <div class="container">
+    <header class="hero">
+      <div class="badge">🐛 Bug Fix Showcase</div>
+      <h1>Continuous Blur-Safe Marquee</h1>
+      <p>Demonstrating a throttling-resilient marquee ticker. By pairing <code>will-change: transform</code> with programmatic state handling via the Page Visibility API, we prevent physics jumps and layout snapping when shifting browser tabs.</p>
+    </header>
+
+    <section class="section">
+      <h2 class="section-title">✨ Infinite Ticker (Try switching tabs and returning)</h2>
+      
+      <div class="ease-marquee-continuous" id="marqueeTicker">
+        <div class="ease-marquee-continuous__track">
+          <span>⚡ BROADCAST TICKER • STABLE SUBMISSION PIPE • CROSS-BROWSER INTERACTION • NO FOCUS JUMPS •&nbsp;</span>
+          <span>⚡ BROADCAST TICKER • STABLE SUBMISSION PIPE • CROSS-BROWSER INTERACTION • NO FOCUS JUMPS •&nbsp;</span>
+        </div>
+      </div>
+
+    </section>
+
+    <section class="code-section">
+      <h2>📄 How it Works</h2>
+      <p>Browsers aggressively throttle animation loops in inactive environments to conserve CPU threads. We lock the track translation state cleanly via the Page Visibility API to sync animation play-state matrices natively upon re-focus:</p>
+      <div class="code-block">
+        <pre><code>&lt;div class="ease-marquee-continuous" id="marqueeTicker"&gt;
+  &lt;div class="ease-marquee-continuous__track"&gt;
+    &lt;span&gt;Breaking News • Latest Updates •&lt;/span&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</code></pre>
+      </div>
+    </section>
+
+    <footer class="footer">
+      <p>Built with ⚡ EaseMotion CSS — Open Source UI Animation Library</p>
+    </footer>
+  </div>
+
+  <script>
+    document.addEventListener("visibilitychange", () => {
+      const track = document.querySelector(".ease-marquee-continuous__track");
+      if (track) {
+        if (document.hidden) {
+          // Pause animation when tab goes into background to prevent catch-up calculation jumps
+          track.style.animationPlayState = "paused";
+        } else {
+          // Instantly resume stream cleanly right from the exact pause matrix position
+          track.style.animationPlayState = "running";
+        }
+      }
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-marquee-continuous/style.css
+++ b/submissions/examples/ease-marquee-continuous/style.css
@@ -1,0 +1,155 @@
+/* ─── Reset ─────────────────────────────────────────── */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  background: #080810;
+  color: #e2e8f0;
+  min-height: 100vh;
+  padding: 2rem 1rem;
+}
+
+/* ─── Continuous Marquee Component (Focus Fixed) ───── */
+.ease-marquee-continuous {
+  overflow: hidden;
+  width: 100%;
+  background: #111122;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 1.25rem 0;
+  display: flex;
+  white-space: nowrap;
+  position: relative;
+}
+
+.ease-marquee-continuous__track {
+  display: inline-flex;
+  white-space: nowrap;
+  will-change: transform;
+  
+  /* Running linear marquee timeline assignment */
+  animation: marquee-scroll 25s linear infinite;
+}
+
+/* User interaction pause toggle matching framework rules */
+.ease-marquee-continuous:hover .ease-marquee-continuous__track {
+  animation-play-state: paused;
+}
+
+.ease-marquee-continuous__track span {
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: #38bdf8;
+  text-transform: uppercase;
+}
+
+/* ─── Animation Keyframes (Perfect Duplicated Offset) ─ */
+@keyframes marquee-scroll {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%); /* Shifts text halfway to perfectly loop duplicate tracks */
+  }
+}
+
+/* ─── Page Layout Container ─────────────────────────── */
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.hero {
+  text-align: center;
+  padding: 3rem 1rem;
+}
+
+.badge {
+  display: inline-block;
+  background: linear-gradient(135deg, #0ea5e9, #2563eb);
+  color: white;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  margin-bottom: 1.5rem;
+}
+
+.hero h1 {
+  font-size: clamp(2rem, 5vw, 3rem);
+  font-weight: 900;
+  background: linear-gradient(135deg, #38bdf8, #34d399);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 1rem;
+}
+
+.hero p {
+  font-size: 1.05rem;
+  color: #94a3b8;
+  max-width: 650px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.section {
+  margin: 4rem 0 2rem;
+}
+
+.section-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  text-align: center;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 1.5rem;
+}
+
+.code-section {
+  background: rgba(255, 255, 255, 0.01);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: 1.5rem;
+  padding: 2rem;
+  margin: 4rem 0 2rem;
+}
+
+.code-section h2 {
+  font-size: 1.25rem;
+  color: #f1f5f9;
+  margin-bottom: 0.5rem;
+}
+
+.code-section p {
+  color: #94a3b8;
+  margin-bottom: 1.25rem;
+  font-size: 0.95rem;
+}
+
+.code-block {
+  background: #020205;
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  overflow-x: auto;
+}
+
+.code-block pre {
+  font-size: 0.85rem;
+  color: #34d399;
+  line-height: 1.6;
+}
+
+.footer {
+  text-align: center;
+  padding: 2rem 0;
+  color: #475569;
+  font-size: 0.85rem;
+}


### PR DESCRIPTION
## Pull Request Description
Resolves Issue #32492. Integrates a lightweight Page Visibility play-state freezing hook into the marquee example to prevent browsers from stacking timeline calculation deltas while the view tab remains inactive in background contexts.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧩 New component / example layout optimization

## Submission Checklist
- [x] All changes are isolated inside `submissions/examples/ease-marquee-continuous/`
- [x] Includes standalone valid `demo.html`
- [x] Includes raw CSS solution via `style.css`
- [x] Includes context mapping documentation in `README.md`
- [x] No alterations made directly to `core/` or `components/` root paths

## Feature Description
**What does this add?**
It adds a tab-blur protection methodology that smoothly halts ticker track processing steps at their current transformation matrix instead of forcing layout snapping when processing context is reassigned to the main thread.

**Why does it fit EaseMotion CSS?**
Polishes standard horizontal tickers used in landing dashboards, ensuring a seamless multi-tasking experience without jarring text jumps for multi-window setups.

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari