### PR TITLE
Create a color palette picker with 3 files:

### DIFF
--- a/submissions/examples-v1/ease-horizontal-stepper-ij/style.css
+++ b/submissions/examples-v1/ease-horizontal-stepper-ij/style.css
@@ -15,7 +15,8 @@ body {
 }
 
 .container {
-  width: 600px;
+  width: 100%;
+  max-width: 600px;
   background: rgba(255, 255, 255, 0.05);
   backdrop-filter: blur(10px);
   border: 1px solid rgba(255, 255, 255, 0.1);
@@ -168,4 +169,32 @@ body {
 
 .nav-btn.primary:hover {
   background: #d63851;
+}
+
+@media (max-width: 480px) {
+  .container {
+    padding: 20px;
+  }
+  .stepper {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+  }
+  .step {
+    flex-direction: row;
+    align-items: center;
+    gap: 15px;
+    width: 100%;
+  }
+  .step-line {
+    width: 2px;
+    height: 30px;
+    margin: 4px 19px;
+  }
+  .step.active + .step-line {
+    background: linear-gradient(180deg, #e94560, rgba(255, 255, 255, 0.1));
+  }
+  .step.completed + .step-line {
+    background: #00c853;
+  }
 }


### PR DESCRIPTION
 the horizontal timeline/stepper component uses a fixed pixel width (width: 600px), which breaks and causes horizontal overflow on mobile viewports under ~480px. It's still open. Root fix: use flexbox with flex-wrap, %/clamp() widths, or switch to a vertical stacked layout via media query instead of a static container width.