### PR TITLE
feat: add Tabs Component with Smooth Underline Glider

### DIFF
--- a/submissions/react/react-tabs-component-with-smooth-underline-glider/README.md
+++ b/submissions/react/react-tabs-component-with-smooth-underline-glider/README.md
@@ -1,0 +1,55 @@
+# 🧭 Tabs Component with Smooth Underline Glider
+
+A modular, copy-paste ready React tabs component for the **EaseMotion CSS React Track**. Features an animated underline that smoothly glides between tabs on selection, using a spring-style easing curve consistent with EaseMotion's motion language.
+
+---
+
+## Features
+- Zero external dependencies — plain React + CSS.
+- Smooth gliding underline, measured via refs and animated with `transform: translateX`.
+- Spring-style `cubic-bezier(0.34, 1.56, 0.64, 1)` easing to match EaseMotion's motion feel.
+- Accessible — uses `role="tablist"`, `role="tab"`, and `aria-selected`.
+
+---
+
+## Props Reference
+
+| Prop | Type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `tabs` | `Array<{ label: string, value: string }>` | List of tabs to render. | `[]` |
+| `defaultActive` | `string` | Value of the tab active on initial render. | First tab's value |
+| `onChange` | `(value: string) => void` | Called with the new active tab's value on click. | `undefined` |
+
+---
+
+## Usage Example
+
+```jsx
+import React from 'react';
+import TabsUnderlineGlider from './submissions/react/react-tabs-component-with-smooth-underline-glider/TabsUnderlineGlider';
+
+function App() {
+  const tabs = [
+    { label: 'Overview', value: 'overview' },
+    { label: 'Features', value: 'features' },
+    { label: 'Pricing', value: 'pricing' },
+  ];
+
+  return (
+    <TabsUnderlineGlider
+      tabs={tabs}
+      defaultActive="overview"
+      onChange={(value) => console.log('Active tab:', value)}
+    />
+  );
+}
+
+export default App;
+```
+
+---
+
+## Notes
+- Zero console errors on render; tested locally with React 18.
+- No changes made to `core/` or `components/` — isolated submission only.
+- See `demo.html` for a standalone browser preview (uses React UMD builds + Babel standalone, no build step required).

--- a/submissions/react/react-tabs-component-with-smooth-underline-glider/TabsUnderlineGlider.jsx
+++ b/submissions/react/react-tabs-component-with-smooth-underline-glider/TabsUnderlineGlider.jsx
@@ -1,0 +1,54 @@
+import React, { useState, useRef, useEffect } from 'react';
+
+/**
+ * Tabs Component with Smooth Underline Glider
+ *
+ * @param {Array} tabs - Array of tab objects { label, value }
+ * @param {String} defaultActive - Value of the tab active on initial render
+ * @param {Function} onChange - Called with the new active tab's value
+ */
+const TabsUnderlineGlider = ({ tabs = [], defaultActive, onChange }) => {
+  const [active, setActive] = useState(defaultActive || (tabs[0] && tabs[0].value));
+  const [underlineStyle, setUnderlineStyle] = useState({ left: 0, width: 0 });
+  const tabRefs = useRef({});
+
+  useEffect(() => {
+    const node = tabRefs.current[active];
+    if (node) {
+      setUnderlineStyle({
+        left: node.offsetLeft,
+        width: node.offsetWidth,
+      });
+    }
+  }, [active, tabs]);
+
+  const handleClick = (value) => {
+    setActive(value);
+    if (onChange) onChange(value);
+  };
+
+  return (
+    <div className="ease-tabs-container">
+      <div className="ease-tabs-list" role="tablist">
+        {tabs.map((tab) => (
+          <button
+            key={tab.value}
+            ref={(el) => (tabRefs.current[tab.value] = el)}
+            className={`ease-tabs-tab ${active === tab.value ? 'is-active' : ''}`}
+            role="tab"
+            aria-selected={active === tab.value}
+            onClick={() => handleClick(tab.value)}
+          >
+            {tab.label}
+          </button>
+        ))}
+        <span
+          className="ease-tabs-underline"
+          style={{ transform: `translateX(${underlineStyle.left}px)`, width: underlineStyle.width }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default TabsUnderlineGlider;

--- a/submissions/react/react-tabs-component-with-smooth-underline-glider/demo.html
+++ b/submissions/react/react-tabs-component-with-smooth-underline-glider/demo.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Tabs Component with Smooth Underline Glider — Demo</title>
+<link rel="stylesheet" href="style.css" />
+<script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+<script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+<script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body style="padding: 48px; background: #f8fafc;">
+<div id="root"></div>
+<script type="text/babel">
+const { useState, useRef, useEffect } = React;
+
+const TabsUnderlineGlider = ({ tabs = [], defaultActive, onChange }) => {
+  const [active, setActive] = useState(defaultActive || (tabs[0] && tabs[0].value));
+  const [underlineStyle, setUnderlineStyle] = useState({ left: 0, width: 0 });
+  const tabRefs = useRef({});
+
+  useEffect(() => {
+    const node = tabRefs.current[active];
+    if (node) {
+      setUnderlineStyle({ left: node.offsetLeft, width: node.offsetWidth });
+    }
+  }, [active, tabs]);
+
+  const handleClick = (value) => {
+    setActive(value);
+    if (onChange) onChange(value);
+  };
+
+  return (
+    <div className="ease-tabs-container">
+      <div className="ease-tabs-list" role="tablist">
+        {tabs.map((tab) => (
+          <button
+            key={tab.value}
+            ref={(el) => (tabRefs.current[tab.value] = el)}
+            className={`ease-tabs-tab ${active === tab.value ? 'is-active' : ''}`}
+            role="tab"
+            aria-selected={active === tab.value}
+            onClick={() => handleClick(tab.value)}
+          >
+            {tab.label}
+          </button>
+        ))}
+        <span
+          className="ease-tabs-underline"
+          style={{ transform: `translateX(${underlineStyle.left}px)`, width: underlineStyle.width }}
+        />
+      </div>
+    </div>
+  );
+};
+
+const tabs = [
+  { label: 'Overview', value: 'overview' },
+  { label: 'Features', value: 'features' },
+  { label: 'Pricing', value: 'pricing' },
+  { label: 'FAQ', value: 'faq' },
+];
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <TabsUnderlineGlider tabs={tabs} defaultActive="overview" onChange={(v) => console.log('Active tab:', v)} />
+);
+</script>
+</body>
+</html>

--- a/submissions/react/react-tabs-component-with-smooth-underline-glider/style.css
+++ b/submissions/react/react-tabs-component-with-smooth-underline-glider/style.css
@@ -1,0 +1,49 @@
+/* 
+  style.css
+  EaseMotion CSS - Tabs Component with Smooth Underline Glider
+*/
+
+.ease-tabs-container {
+  font-family: system-ui, -apple-system, sans-serif;
+  width: 100%;
+  max-width: 600px;
+}
+
+.ease-tabs-list {
+  position: relative;
+  display: flex;
+  gap: 8px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.ease-tabs-tab {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 12px 18px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #64748b;
+  transition: color 0.3s ease;
+}
+
+.ease-tabs-tab:hover {
+  color: #0f172a;
+}
+
+.ease-tabs-tab.is-active {
+  color: #3b82f6;
+}
+
+.ease-tabs-underline {
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  height: 3px;
+  background-color: #3b82f6;
+  border-radius: 3px;
+
+  /* Physical spring-glide transition, matching EaseMotion's motion language */
+  transition: transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1),
+              width 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+}


### PR DESCRIPTION
## Pull Request Description
 Adds a modular React Tabs component with a smooth, animated underline that glides between tabs on selection. Resolves #27404 

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A reusable `TabsUnderlineGlider` React component that renders a tab list with an animated underline indicator that smoothly slides to the active tab.

**How does a developer use it?**

```html
<TabsUnderlineGlider
  tabs={[
    { label: 'Overview', value: 'overview' },
    { label: 'Features', value: 'features' },
    { label: 'Pricing', value: 'pricing' },
  ]}
  defaultActive="overview"
  onChange={(value) => console.log('Active tab:', value)}
/>
```

**Why does it fit EaseMotion CSS?**

It follows the project's motion-first philosophy with a spring-style `cubic-bezier(0.34, 1.56, 0.64, 1)` easing curve consistent with existing submissions, uses human-readable `ease-` prefixed class names, and requires zero external dependencies beyond React.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome

---

## Notes for Maintainer
Underline position/width is measured via refs on mount and on tab change, so it adapts automatically to variable-width tab labels. Happy to adjust the easing curve or add keyboard arrow-key navigation between tabs if preferred.