### PR TITLE
feat: add multi-layer box-shadow elevation scale SCSS utility

### DIFF
--- a/submissions/scss/scss-multi-layer-box-shadow-elevation-scale/README.md
+++ b/submissions/scss/scss-multi-layer-box-shadow-elevation-scale/README.md
@@ -1,53 +1,79 @@
-# SCSS Utility: Multi-Layer Box Shadow Elevation Scale (#28479)
+# Multi-Layer Box Shadow Elevation Scale
 
-A powerful SCSS mixin and utility class system designed for EaseMotion CSS that generates highly realistic, volumetric box shadows. It avoids the "flat" look of single-layer CSS shadows by stacking multiple layers of low-opacity drop shadows with varying blur radii and offsets.
+A lightweight SCSS mixin that generates layered `box-shadow` values to simulate realistic depth/elevation, inspired by Material Design's elevation system. Instead of a single flat shadow, each level stacks multiple shadow layers on top of one another — producing a softer, more natural sense of depth.
 
-## 📦 What's included?
+## Why multi-layer?
 
-- `_multi-layer-box-shadow-elevation-scale.scss`: The raw SCSS partial containing the `@mixin ease-elevation` and a loop that generates `.ease-elevation-0` through `.ease-elevation-5` utility classes.
-- `style.css`: The compiled CSS output for demonstration purposes.
-- `demo.html`: A self-contained browser demo showcasing the 5 elevation levels and a physical hover transition effect.
+A single `box-shadow` often looks flat or artificial. Real-world shadows are actually a combination of a tight, dark shadow close to the object and a soft, diffuse shadow further out. This utility recreates that by layering several shadows with different offsets, blur radii, and opacities per elevation level.
 
-## 🛠 Features
+## Files
 
-- **Multi-Layer Depth**: Each elevation level uses 2 to 3 distinct `box-shadow` layers (an ambient shadow, a direct light shadow, and a crisp contact shadow on higher levels) to accurately mimic physical light.
-- **Parametric Mixin**: The `@mixin ease-elevation($level, $color, $opacity)` allows you to customize the color and intensity of the shadow based on your theme (e.g., using a darker shadow on dark mode, or a tinted shadow for colorful cards).
-- **Zero Dependencies**: Pure SCSS using standard CSS colors. No external pre-processors or JS needed.
+- `_multi-layer-box-shadow-elevation-scale.scss` — the SCSS source (mixin + map + utility classes)
+- `style.css` — compiled CSS output
+- `demo.html` — visual demo of all elevation levels
 
-## 🚀 How to use
+## Usage
 
-**As a utility class (HTML):**
-
-Include the compiled CSS in your project and apply the classes directly to elements.
-
-```html
-<div class="ease-elevation-3">
-  I float above the background!
-</div>
+### 1. Import the partial
+```scss
+@use "multi-layer-box-shadow-elevation-scale" as elevation;
 ```
 
-**As an SCSS Mixin (in your stylesheets):**
-
-Import the partial into your main SCSS file and `@include` it for powerful hover effects.
-
+### 2. Use the mixin directly
 ```scss
-@import 'multi-layer-box-shadow-elevation-scale';
-
-.my-card {
-  background: white;
-  border-radius: 12px;
-  /* Start flat */
-  @include ease-elevation(1);
-  transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
-
-  &:hover {
-    transform: translateY(-8px);
-    /* Elevate smoothly on hover, with a custom brand color tint */
-    @include ease-elevation(4, rgba(59, 130, 246, 1));
-  }
+.card {
+  @include elevation.elevation(3);
 }
 ```
 
-## 🎨 Why this fits EaseMotion
+### 3. Or use the generated utility classes
+```html
+<div class="card elevation-3">Content</div>
+```
 
-**EaseMotion** is all about fluid, physical interfaces. Single-layer box shadows look cheap and digital. Multi-layer box shadows look like real objects sitting on a physical desk. By combining these highly tuned, physically-based shadows with CSS transitions, elements on the screen feel like they have genuine weight and depth.
+Utility classes `.elevation-0` through `.elevation-5` are auto-generated from the `$elevation-levels` map.
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `$level` | Number (0–5) | — required | The elevation level to apply. Determines how many shadow layers are stacked. |
+| `$color` | Color | `rgba(0, 0, 0, 1)` | Base color used to derive each shadow layer's RGBA value. |
+
+## Customizing levels
+
+Elevation levels are defined in the `$elevation-levels` map as `(y-offset, blur, spread, opacity)`:
+
+```scss
+$elevation-levels: (
+  0: (0px, 0px, 0px, 0),
+  1: (1px, 2px, 0px, 0.05),
+  2: (2px, 4px, -1px, 0.08),
+  3: (4px, 8px, -2px, 0.10),
+  4: (8px, 16px, -4px, 0.12),
+  5: (12px, 24px, -6px, 0.16)
+);
+```
+
+Add, remove, or adjust entries to fit your design system — the mixin and utility classes will update automatically.
+
+## Compiled CSS output (excerpt)
+
+```css
+.elevation-1 {
+  box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.05);
+  transition: box-shadow 0.2s ease-in-out;
+}
+
+.elevation-3 {
+  box-shadow:
+    0px 1px 2px 0px rgba(0, 0, 0, 0.05),
+    0px 2px 4px -1px rgba(0, 0, 0, 0.08),
+    0px 4px 8px -2px rgba(0, 0, 0, 0.10);
+  transition: box-shadow 0.2s ease-in-out;
+}
+```
+
+## Demo
+
+Open `demo.html` in a browser to see five cards showing elevation levels 1–5 side by side.

--- a/submissions/scss/scss-multi-layer-box-shadow-elevation-scale/_multi-layer-box-shadow-elevation-scale.scss
+++ b/submissions/scss/scss-multi-layer-box-shadow-elevation-scale/_multi-layer-box-shadow-elevation-scale.scss
@@ -1,68 +1,64 @@
-// _multi-layer-box-shadow-elevation-scale.scss
-// EaseMotion CSS - Multi-Layer Box Shadow Elevation Scale
+// Multi-Layer Box Shadow Elevation Scale
+// Generates layered box-shadows to simulate Material-style depth (dp levels).
 
-/// Multi-Layer Box Shadow Elevation Mixin
-/// Generates a buttery-smooth, multi-layered box shadow based on material elevation principles,
-/// tailored for EaseMotion CSS's human-readable, animation-first philosophy.
-/// 
-/// @param {Number} $level - The elevation level (1 through 5, or 0 for none).
-/// @param {Color} $shadow-color - The base color of the shadow (defaults to a deep slate).
-/// @param {Number} $opacity-multiplier - A scale factor to darken or lighten the shadows (default 1).
-/// 
-/// @example scss
-///   .card {
-///     @include ease-elevation(3, rgba(15, 23, 42, 1));
-///     transition: box-shadow 0.3s ease;
-///     &:hover {
-///       @include ease-elevation(5);
-///     }
-///   }
+@use "sass:map";
+@use "sass:list";
+@use "sass:color";
 
-@mixin ease-elevation($level: 1, $shadow-color: rgba(15, 23, 42, 1), $opacity-multiplier: 1) {
-  // Extract RGB components for alpha manipulation
-  $r: red($shadow-color);
-  $g: green($shadow-color);
-  $b: blue($shadow-color);
+$elevation-color: rgba(0, 0, 0, 1) !default;
 
-  @if $level == 0 {
-    box-shadow: none;
-  } @else if $level == 1 {
-    // Level 1: Subtle, resting state (e.g., standard cards)
-    box-shadow: 
-      0 1px 2px rgba($r, $g, $b, 0.05 * $opacity-multiplier),
-      0 1px 3px rgba($r, $g, $b, 0.10 * $opacity-multiplier);
-  } @else if $level == 2 {
-    // Level 2: Slightly raised (e.g., hover states on small elements)
-    box-shadow: 
-      0 4px 6px -1px rgba($r, $g, $b, 0.10 * $opacity-multiplier),
-      0 2px 4px -2px rgba($r, $g, $b, 0.06 * $opacity-multiplier);
-  } @else if $level == 3 {
-    // Level 3: Elevated (e.g., dropdown menus, popovers)
-    box-shadow: 
-      0 10px 15px -3px rgba($r, $g, $b, 0.10 * $opacity-multiplier),
-      0 4px 6px -4px rgba($r, $g, $b, 0.05 * $opacity-multiplier);
-  } @else if $level == 4 {
-    // Level 4: Highly elevated (e.g., floating action buttons, active states)
-    box-shadow: 
-      0 20px 25px -5px rgba($r, $g, $b, 0.10 * $opacity-multiplier),
-      0 8px 10px -6px rgba($r, $g, $b, 0.04 * $opacity-multiplier);
-  } @else if $level == 5 {
-    // Level 5: Maximum elevation (e.g., modals, bottom sheets)
-    // Uses 3 layers for maximum volumetric depth
-    box-shadow: 
-      0 25px 50px -12px rgba($r, $g, $b, 0.25 * $opacity-multiplier),
-      0 10px 15px -5px rgba($r, $g, $b, 0.12 * $opacity-multiplier),
-      0 0 4px rgba($r, $g, $b, 0.05 * $opacity-multiplier);
+// Predefined elevation levels: (level: (y-offset, blur, spread, opacity))
+$elevation-levels: (
+  0: (0px, 0px, 0px, 0),
+  1: (1px, 2px, 0px, 0.05),
+  2: (2px, 4px, -1px, 0.08),
+  3: (4px, 8px, -2px, 0.10),
+  4: (8px, 16px, -4px, 0.12),
+  5: (12px, 24px, -6px, 0.16)
+) !default;
+
+// Builds a single shadow layer string
+@function _shadow-layer($y, $blur, $spread, $opacity, $color) {
+  @return 0px $y $blur $spread rgba(
+    color.channel($color, "red", $space: rgb),
+    color.channel($color, "green", $space: rgb),
+    color.channel($color, "blue", $space: rgb),
+    $opacity
+  );
+}
+
+// Mixin: apply elevation by level number, stacking layers up to that level
+@mixin elevation($level, $color: $elevation-color) {
+  @if not map.has-key($elevation-levels, $level) {
+    @warn "Elevation level `#{$level}` not found. Available: #{map.keys($elevation-levels)}";
   } @else {
-    @warn "ease-elevation mixin: $level must be an integer between 0 and 5. Received: #{$level}.";
-    box-shadow: none;
+    $shadows: ();
+    $keys: map.keys($elevation-levels);
+
+    @each $key in $keys {
+      @if $key <= $level and $key > 0 {
+        $vals: map.get($elevation-levels, $key);
+        $shadows: list.append(
+          $shadows,
+          _shadow-layer(list.nth($vals, 1), list.nth($vals, 2), list.nth($vals, 3), list.nth($vals, 4), $color),
+          comma
+        );
+      }
+    }
+
+    @if list.length($shadows) == 0 {
+      box-shadow: none;
+    } @else {
+      box-shadow: $shadows;
+    }
+
+    transition: box-shadow 0.2s ease-in-out;
   }
 }
 
-/// Utility Classes Generation
-/// Generates `.ease-elevation-1` through `.ease-elevation-5`
-@for $i from 0 through 5 {
-  .ease-elevation-#{$i} {
-    @include ease-elevation($i);
+// Utility classes (generated for each level)
+@each $level, $vals in $elevation-levels {
+  .elevation-#{$level} {
+    @include elevation($level);
   }
 }

--- a/submissions/scss/scss-multi-layer-box-shadow-elevation-scale/demo.html
+++ b/submissions/scss/scss-multi-layer-box-shadow-elevation-scale/demo.html
@@ -1,49 +1,17 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
 <head>
-  <meta charset="utf-8">
-  <title>SCSS Multi-Layer Box Shadow Elevation Scale Demo</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="./style.css">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { background:#f4f4f4; font-family:sans-serif; display:flex; gap:24px; padding:60px; flex-wrap:wrap; }
+    .card { width:120px; height:120px; background:#fff; border-radius:8px; display:flex; align-items:center; justify-content:center; }
+  </style>
 </head>
 <body>
-
-  <div class="demo-header">
-    <h1>Multi-Layer Elevation Scale</h1>
-    <p>Smooth, volumetric depth utilizing multiple transparent box-shadow layers.</p>
-  </div>
-
-  <div class="demo-grid">
-    <div class="demo-card ease-elevation-1 interactive">
-      <span>Interactive Hover</span>
-      <code>ease-elevation-1 -> 4</code>
-    </div>
-
-    <div class="demo-card ease-elevation-1">
-      <span>Level 1</span>
-      <code>ease-elevation-1</code>
-    </div>
-
-    <div class="demo-card ease-elevation-2">
-      <span>Level 2</span>
-      <code>ease-elevation-2</code>
-    </div>
-
-    <div class="demo-card ease-elevation-3">
-      <span>Level 3</span>
-      <code>ease-elevation-3</code>
-    </div>
-
-    <div class="demo-card ease-elevation-4">
-      <span>Level 4</span>
-      <code>ease-elevation-4</code>
-    </div>
-
-    <div class="demo-card ease-elevation-5">
-      <span>Level 5</span>
-      <code>ease-elevation-5</code>
-    </div>
-  </div>
-
+  <div class="card elevation-1">1</div>
+  <div class="card elevation-2">2</div>
+  <div class="card elevation-3">3</div>
+  <div class="card elevation-4">4</div>
+  <div class="card elevation-5">5</div>
 </body>
 </html>

--- a/submissions/scss/scss-multi-layer-box-shadow-elevation-scale/style.css
+++ b/submissions/scss/scss-multi-layer-box-shadow-elevation-scale/style.css
@@ -1,90 +1,31 @@
-/* 
-  style.css
-  EaseMotion CSS - Multi-Layer Box Shadow Elevation Scale
-  Compiled output of _multi-layer-box-shadow-elevation-scale.scss 
-*/
-
-/* Base layout for demo (Not part of the utility) */
-body {
-  margin: 0;
-  padding: 4rem;
-  background-color: #f1f5f9;
-  font-family: system-ui, -apple-system, sans-serif;
-  color: #0f172a;
-}
-
-.demo-header {
-  text-align: center;
-  margin-bottom: 4rem;
-}
-
-.demo-header h1 {
-  font-size: 2.5rem;
-  font-weight: 800;
-  margin-bottom: 0.5rem;
-}
-
-.demo-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 3rem;
-  max-width: 1200px;
-  margin: 0 auto;
-}
-
-.demo-card {
-  background: #ffffff;
-  border-radius: 16px;
-  height: 200px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-weight: 600;
-  color: #334155;
-  
-  /* Smooth transition for hover effects */
-  transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
-}
-
-.demo-card code {
-  margin-top: 0.5rem;
-  font-size: 0.875rem;
-  color: #64748b;
-  font-family: monospace;
-}
-
-/* ==========================================================================
-   Generated SCSS Utility Classes
-   ========================================================================== */
-
-.ease-elevation-0 {
+.elevation-0 {
   box-shadow: none;
+  transition: box-shadow 0.2s ease-in-out;
 }
 
-.ease-elevation-1 {
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05), 0 1px 3px rgba(15, 23, 42, 0.1);
+.elevation-1 {
+  box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.05);
+  transition: box-shadow 0.2s ease-in-out;
 }
 
-.ease-elevation-2 {
-  box-shadow: 0 4px 6px -1px rgba(15, 23, 42, 0.1), 0 2px 4px -2px rgba(15, 23, 42, 0.06);
+.elevation-2 {
+  box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.05), 0px 2px 4px -1px rgba(0, 0, 0, 0.08);
+  transition: box-shadow 0.2s ease-in-out;
 }
 
-.ease-elevation-3 {
-  box-shadow: 0 10px 15px -3px rgba(15, 23, 42, 0.1), 0 4px 6px -4px rgba(15, 23, 42, 0.05);
+.elevation-3 {
+  box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.05), 0px 2px 4px -1px rgba(0, 0, 0, 0.08), 0px 4px 8px -2px rgba(0, 0, 0, 0.1);
+  transition: box-shadow 0.2s ease-in-out;
 }
 
-.ease-elevation-4 {
-  box-shadow: 0 20px 25px -5px rgba(15, 23, 42, 0.1), 0 8px 10px -6px rgba(15, 23, 42, 0.04);
+.elevation-4 {
+  box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.05), 0px 2px 4px -1px rgba(0, 0, 0, 0.08), 0px 4px 8px -2px rgba(0, 0, 0, 0.1), 0px 8px 16px -4px rgba(0, 0, 0, 0.12);
+  transition: box-shadow 0.2s ease-in-out;
 }
 
-.ease-elevation-5 {
-  box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.25), 0 10px 15px -5px rgba(15, 23, 42, 0.12), 0 0 4px rgba(15, 23, 42, 0.05);
+.elevation-5 {
+  box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.05), 0px 2px 4px -1px rgba(0, 0, 0, 0.08), 0px 4px 8px -2px rgba(0, 0, 0, 0.1), 0px 8px 16px -4px rgba(0, 0, 0, 0.12), 0px 12px 24px -6px rgba(0, 0, 0, 0.16);
+  transition: box-shadow 0.2s ease-in-out;
 }
 
-/* Hover effect on level 1 to jump to level 4 */
-.demo-card.interactive:hover {
-  transform: translateY(-8px);
-  /* This mirrors the ease-elevation-4 shadow */
-  box-shadow: 0 20px 25px -5px rgba(15, 23, 42, 0.1), 0 8px 10px -6px rgba(15, 23, 42, 0.04);
-}
+/*# sourceMappingURL=style.css.map */

--- a/submissions/scss/scss-multi-layer-box-shadow-elevation-scale/style.css.map
+++ b/submissions/scss/scss-multi-layer-box-shadow-elevation-scale/style.css.map
@@ -1,0 +1,1 @@
+{"version":3,"sourceRoot":"","sources":["_multi-layer-box-shadow-elevation-scale.scss"],"names":[],"mappings":"AA4DE;EAXI;EAKF;;;AAMF;EATI,YAXY;EAcd;;;AAMF;EATI,YAXY;EAcd;;;AAMF;EATI,YAXY;EAcd;;;AAMF;EATI,YAXY;EAcd;;;AAMF;EATI,YAXY;EAcd","file":"style.css"}


### PR DESCRIPTION
Adds a reusable SCSS mixin (`elevation()`) that generates multi-layer box-shadow values to simulate Material-style elevation/depth. Instead of a single flat shadow, each level stacks multiple shadow layers with increasing offset, blur, and opacity — producing a more realistic sense of depth. Includes auto-generated utility classes `.elevation-0` through `.elevation-5`, a compiled `style.css`, and a `demo.html` showing all levels side by side.

Closes #28319