### PR TITLE
feat: add Filter Chip Group with Smooth Select Transitions

### DIFF
--- a/submissions/react/react-filter-chip-group-with-smooth-select-transitions/FilterChipGroup.jsx
+++ b/submissions/react/react-filter-chip-group-with-smooth-select-transitions/FilterChipGroup.jsx
@@ -1,0 +1,53 @@
+﻿import React, { useState } from 'react';
+import './style.css';
+
+/**
+ * FilterChipGroup
+ * A group of selectable filter chips with a smooth scale/fade transition
+ * on select and deselect. Supports single or multi-select.
+ */
+export default function FilterChipGroup({
+  options,
+  multiSelect = true,
+  defaultSelected = [],
+  onChange,
+}) {
+  const [selected, setSelected] = useState(defaultSelected);
+
+  const toggleChip = (value) => {
+    let next;
+    if (multiSelect) {
+      next = selected.includes(value)
+        ? selected.filter((v) => v !== value)
+        : [...selected, value];
+    } else {
+      next = selected.includes(value) ? [] : [value];
+    }
+    setSelected(next);
+    onChange?.(next);
+  };
+
+  return (
+    <div className="ease-chip-group" role="group" aria-label="Filter options">
+      {options.map((option) => {
+        const isActive = selected.includes(option.value);
+        return (
+          <button
+            key={option.value}
+            type="button"
+            className={`ease-chip ${isActive ? 'ease-chip--active' : ''}`}
+            aria-pressed={isActive}
+            onClick={() => toggleChip(option.value)}
+          >
+            <span className="ease-chip__label">{option.label}</span>
+            <span className="ease-chip__check" aria-hidden="true">
+              <svg viewBox="0 0 24 24" width="12" height="12">
+                <path d="M20 6L9 17l-5-5" />
+              </svg>
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/submissions/react/react-filter-chip-group-with-smooth-select-transitions/README.md
+++ b/submissions/react/react-filter-chip-group-with-smooth-select-transitions/README.md
@@ -1,0 +1,44 @@
+﻿# Filter Chip Group with Smooth Select Transitions
+
+A reusable React component that renders a group of toggleable filter chips with a spring-style scale animation and animated checkmark on selection.
+
+## Props
+
+| Prop              | Type       | Default | Description                                      |
+|-------------------|------------|---------|---------------------------------------------------|
+| `options`         | array      | —       | Array of `{ label, value }` objects                |
+| `multiSelect`     | boolean    | `true`  | Allow multiple chips selected at once               |
+| `defaultSelected` | array      | `[]`    | Array of initially selected values                  |
+| `onChange`        | function   | —       | Called with the updated array of selected values    |
+
+## Installation
+
+Copy `FilterChipGroup.jsx` and `style.css` into your project. No external dependencies beyond React.
+
+## Usage
+
+```jsx
+import FilterChipGroup from './FilterChipGroup';
+
+const options = [
+  { label: 'All', value: 'all' },
+  { label: 'Design', value: 'design' },
+  { label: 'Development', value: 'dev' },
+];
+
+<FilterChipGroup
+  options={options}
+  defaultSelected={['all']}
+  onChange={(selected) => console.log(selected)}
+/>
+```
+
+## Behavior
+
+- Selecting a chip triggers a spring-style scale-up (`cubic-bezier(0.34, 1.56, 0.64, 1)`) and reveals an animated checkmark.
+- Supports both single-select and multi-select modes via the `multiSelect` prop.
+- Fully keyboard accessible (`aria-pressed`, focusable buttons).
+
+## Why it fits EaseMotion CSS
+
+Uses `ease-` prefixed class names and the framework's signature spring easing curve for hover/select transitions, consistent with existing submissions. Zero dependencies beyond React.

--- a/submissions/react/react-filter-chip-group-with-smooth-select-transitions/demo.html
+++ b/submissions/react/react-filter-chip-group-with-smooth-select-transitions/demo.html
@@ -1,0 +1,71 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Filter Chip Group Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: -apple-system, sans-serif; background: #f9fafb; padding: 40px; }
+  </style>
+</head>
+<body>
+  <h2>Filter Chip Group with Smooth Select Transitions</h2>
+  <div id="root"></div>
+
+  <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+
+  <script type="text/babel">
+    const { useState } = React;
+
+    function FilterChipGroup({ options, multiSelect = true, defaultSelected = [], onChange }) {
+      const [selected, setSelected] = useState(defaultSelected);
+      const toggleChip = (value) => {
+        let next;
+        if (multiSelect) {
+          next = selected.includes(value) ? selected.filter(v => v !== value) : [...selected, value];
+        } else {
+          next = selected.includes(value) ? [] : [value];
+        }
+        setSelected(next);
+        onChange && onChange(next);
+      };
+      return (
+        <div className="ease-chip-group" role="group" aria-label="Filter options">
+          {options.map(option => {
+            const isActive = selected.includes(option.value);
+            return (
+              <button
+                key={option.value}
+                type="button"
+                className={`ease-chip ${isActive ? 'ease-chip--active' : ''}`}
+                aria-pressed={isActive}
+                onClick={() => toggleChip(option.value)}
+              >
+                <span className="ease-chip__label">{option.label}</span>
+                <span className="ease-chip__check" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" width="12" height="12"><path d="M20 6L9 17l-5-5" /></svg>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      );
+    }
+
+    function Demo() {
+      const options = [
+        { label: 'All', value: 'all' },
+        { label: 'Design', value: 'design' },
+        { label: 'Development', value: 'dev' },
+        { label: 'Marketing', value: 'marketing' },
+        { label: 'Sales', value: 'sales' },
+      ];
+      return <FilterChipGroup options={options} defaultSelected={['all']} onChange={(v) => console.log('Selected:', v)} />;
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<Demo />);
+  </script>
+</body>
+</html>

--- a/submissions/react/react-filter-chip-group-with-smooth-select-transitions/style.css
+++ b/submissions/react/react-filter-chip-group-with-smooth-select-transitions/style.css
@@ -1,0 +1,62 @@
+﻿.ease-chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.ease-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  border-radius: 999px;
+  border: 1.5px solid #e5e7eb;
+  background: #ffffff;
+  color: #374151;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
+    background-color 0.25s ease, border-color 0.25s ease, color 0.25s ease;
+}
+
+.ease-chip:hover {
+  transform: translateY(-2px);
+  border-color: #a5b4fc;
+}
+
+.ease-chip:active {
+  transform: scale(0.96);
+}
+
+.ease-chip--active {
+  background: #4f46e5;
+  border-color: #4f46e5;
+  color: #ffffff;
+  transform: scale(1.03);
+}
+
+.ease-chip__check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 0;
+  opacity: 0;
+  transform: scale(0.5);
+  transition: width 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
+    opacity 0.25s ease, transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.ease-chip--active .ease-chip__check {
+  width: 12px;
+  opacity: 1;
+  transform: scale(1);
+}
+
+.ease-chip__check svg {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 3;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}


### PR DESCRIPTION
## Pull Request Description
Adds a modular, reusable React Filter Chip Group component with smooth spring-style scale transitions and an animated checkmark on select/deselect. Resolves #27609

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/react/react-filter-chip-group-with-smooth-select-transitions/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A reusable `FilterChipGroup` React component that renders a group of toggleable filter chips with a spring-style scale animation and an animated checkmark reveal on selection. Supports both single-select and multi-select modes.

**How does a developer use it?**
```jsx
import FilterChipGroup from "./FilterChipGroup";

const options = [
  { label: 'All', value: 'all' },
  { label: 'Design', value: 'design' },
  { label: 'Development', value: 'dev' },
];

<FilterChipGroup
  options={options}
  defaultSelected={['all']}
  onChange={(selected) => console.log(selected)}
/>
```

**Why does it fit EaseMotion CSS?**
Uses human-readable `ease-` prefixed class names and the framework's signature spring-style `cubic-bezier(0.34, 1.56, 0.64, 1)` easing curve for hover and select transitions, consistent with existing submissions. Zero dependencies beyond React.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome

---

## Notes for Maintainer
Built as a self-contained React component using `useState` for selection state. Supports both single and multi-select via the `multiSelect` prop. Chips are fully keyboard-accessible (`aria-pressed`, focusable buttons). Happy to adjust the easing curve or add keyboard arrow navigation if preferred.