### PR TITLE
[Feat] #27694 — Add CSS container query wrapper classes (unique folder)

### DIFF
--- a/submissions/examples/container-queries-27694-ag/README.md
+++ b/submissions/examples/container-queries-27694-ag/README.md
@@ -1,0 +1,46 @@
+# CSS Container Query Wrapper Classes
+
+This guide details configuration specs for generating SCSS container query wrapper mixins.
+
+---
+
+## Technical Overview: The Container Query Mixin
+
+Relying exclusively on global `@media` queries limits component reusability since layout rules cannot check parent dimensions. Packaging inline-size parameters inside an SCSS mixin scales container boundaries:
+
+```scss
+// SCSS Container Query Mixin
+@mixin container-query-parent($name: query-parent) {
+  container-type: inline-size;
+  container-name: $name;
+}
+
+@mixin container-query-child($name: query-parent, $min-width: 400px) {
+  @container #{$name} (min-width: #{$min-width}) {
+    @content;
+  }
+}
+
+// Utility Classes
+.resize-container {
+  @include container-query-parent;
+}
+
+.query-card {
+  display: flex;
+  flex-direction: column;
+  
+  @include container-query-child(query-parent, 400px) {
+    flex-direction: row;
+  }
+}
+```
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Observe the responsive card.
+3. Slide the **Parent Wrapper Width** slider to resize the box.
+4. Verify that when width goes below `400px`, the card transitions from a row layout to a stacked column layout.

--- a/submissions/examples/container-queries-27694-ag/demo.html
+++ b/submissions/examples/container-queries-27694-ag/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Container Queries — EaseMotion CSS</title>
+  <meta name="description" content="Visual container queries showcase demonstrating parent-relative layouts and resizable sidebar grids.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — SCSS Utilities</span>
+      <h1>Container Queries</h1>
+      <p class="description">
+        Demonstrates parent-relative styling. Slide the slider below to resize 
+        the container and observe layout shifts without changing the viewport.
+      </p>
+    </header>
+
+    <main class="dashboard">
+      
+      <!-- Width Slider -->
+      <section class="controls-panel">
+        <h2 class="section-title">Container Controls</h2>
+        <div class="control-group">
+          <label for="width-slider">Parent Wrapper Width: <span id="width-val">500px</span></label>
+          <input type="range" id="width-slider" min="280" max="600" value="500" step="10">
+        </div>
+      </section>
+
+      <!-- Preview container -->
+      <section class="preview-panel">
+        <h2 class="section-title">Query Preview</h2>
+
+        <div class="resize-container" id="resize-box" style="width: 500px;">
+          <div class="query-card">
+            <div class="card-visual">📸</div>
+            <div class="card-text">
+              <h3>Responsive Card</h3>
+              <p>Stretches horizontally when parent is broad; stacks when narrow.</p>
+              <span class="badge">@container (min-width: 400px)</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+    </main>
+  </div>
+
+  <script>
+    const slider = document.getElementById('width-slider');
+    const widthVal = document.getElementById('width-val');
+    const box = document.getElementById('resize-box');
+
+    slider.addEventListener('input', () => {
+      const width = `${slider.value}px`;
+      widthVal.textContent = width;
+      box.style.width = width;
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/container-queries-27694-ag/style.css
+++ b/submissions/examples/container-queries-27694-ag/style.css
@@ -1,0 +1,198 @@
+/* ============================================================
+   CSS Container Queries — style.css
+   Submission for EaseMotion CSS Issue #27694
+   Container wrapper types, inline query limits, cards, and sliders
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 820px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Dashboard Layout
+   ============================================================ */
+
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.controls-panel,
+.preview-panel {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  padding: 28px;
+  border-radius: 20px;
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+}
+
+.section-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+/* Settings */
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.control-group label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.control-group input[type="range"] {
+  accent-color: var(--primary-color);
+  cursor: pointer;
+}
+
+/* ============================================================
+   Container Query Setup & Classes under Test
+   ============================================================ */
+
+.resize-container {
+  container-type: inline-size;
+  container-name: query-parent;
+  border: 1px dashed rgba(255, 255, 255, 0.15);
+  padding: 16px;
+  border-radius: 16px;
+  background: rgba(0, 0, 0, 0.1);
+  transition: width 0.1s ease;
+  margin: 0 auto;
+}
+
+.query-card {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--card-border);
+  padding: 24px;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: center;
+}
+
+.card-visual {
+  font-size: 2.5rem;
+  background: rgba(124, 58, 237, 0.1);
+  padding: 16px;
+  border-radius: 12px;
+}
+
+.card-text {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  text-align: center;
+}
+
+.card-text h3 {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.card-text p {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.badge {
+  align-self: center;
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: #22d3ee;
+  background: rgba(34, 211, 238, 0.08);
+  border: 1px solid rgba(34, 211, 238, 0.2);
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-family: monospace;
+  margin-top: 4px;
+}
+
+/* Container Media Query block */
+@container query-parent (min-width: 400px) {
+  .query-card {
+    flex-direction: row;
+    align-items: flex-start;
+    text-align: left;
+  }
+  .card-text {
+    text-align: left;
+  }
+  .badge {
+    align-self: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-container-queries` showcase. It demonstrates parent-relative element resizing generated via SCSS container query mixins (mapping container-type inline-size declarations with container rules) supporting width adjustment sliders.

## Root Cause
No parent-relative container query mixins or inline-size container wrappers existed in EaseMotion CSS.

## Changes Made
- `submissions/examples/container-queries-27694-ag/demo.html`: Container nodes, layout previews, width range inputs, and scripts.
- `submissions/examples/container-queries-27694-ag/style.css`: Container types, container names, container queries, flex shifts, and spacing.
- `submissions/examples/container-queries-27694-ag/README.md`: Explains container query inline-size settings, SCSS mixins, and manual testing.

## How to Test
1. Open `demo.html` in a browser.
2. Slide width boundaries to verify card layout shifts below 400px.

## Related Issue
Closes #27694