### PR TITLE
feat: add Calendar Month View with Date Selection Highlight

### DIFF
--- a/submissions/react/react-calendar-month-view-with-date-selection-highlight/CalendarMonthView.jsx
+++ b/submissions/react/react-calendar-month-view-with-date-selection-highlight/CalendarMonthView.jsx
@@ -1,0 +1,124 @@
+﻿import React, { useMemo, useState } from 'react';
+import './style.css';
+
+const WEEKDAYS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+const MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+function getMonthGrid(year, month) {
+  const firstDay = new Date(year, month, 1);
+  const startWeekday = firstDay.getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+  const cells = [];
+  for (let i = 0; i < startWeekday; i++) {
+    cells.push(null);
+  }
+  for (let day = 1; day <= daysInMonth; day++) {
+    cells.push(day);
+  }
+  return cells;
+}
+
+function isSameDate(a, b) {
+  if (!a || !b) return false;
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+/**
+ * CalendarMonthView
+ * A month-view calendar grid with an animated highlight that glides
+ * to the selected date.
+ */
+export default function CalendarMonthView({ defaultDate = new Date(), onSelect }) {
+  const [viewDate, setViewDate] = useState(
+    new Date(defaultDate.getFullYear(), defaultDate.getMonth(), 1)
+  );
+  const [selected, setSelected] = useState(defaultDate);
+
+  const year = viewDate.getFullYear();
+  const month = viewDate.getMonth();
+  const cells = useMemo(() => getMonthGrid(year, month), [year, month]);
+
+  const today = new Date();
+
+  const goToPrevMonth = () => {
+    setViewDate(new Date(year, month - 1, 1));
+  };
+
+  const goToNextMonth = () => {
+    setViewDate(new Date(year, month + 1, 1));
+  };
+
+  const handleSelect = (day) => {
+    if (!day) return;
+    const newDate = new Date(year, month, day);
+    setSelected(newDate);
+    onSelect?.(newDate);
+  };
+
+  return (
+    <div className="ease-calendar">
+      <div className="ease-calendar__header">
+        <button
+          type="button"
+          className="ease-calendar__nav"
+          onClick={goToPrevMonth}
+          aria-label="Previous month"
+        >
+          ‹
+        </button>
+        <span className="ease-calendar__title">
+          {MONTH_NAMES[month]} {year}
+        </span>
+        <button
+          type="button"
+          className="ease-calendar__nav"
+          onClick={goToNextMonth}
+          aria-label="Next month"
+        >
+          ›
+        </button>
+      </div>
+
+      <div className="ease-calendar__weekdays">
+        {WEEKDAYS.map((wd) => (
+          <span key={wd} className="ease-calendar__weekday">
+            {wd}
+          </span>
+        ))}
+      </div>
+
+      <div className="ease-calendar__grid">
+        {cells.map((day, index) => {
+          if (!day) {
+            return <span key={`empty-${index}`} className="ease-calendar__cell ease-calendar__cell--empty" />;
+          }
+          const cellDate = new Date(year, month, day);
+          const isSelected = isSameDate(cellDate, selected);
+          const isToday = isSameDate(cellDate, today);
+
+          return (
+            <button
+              key={day}
+              type="button"
+              className={`ease-calendar__cell ${isSelected ? 'ease-calendar__cell--selected' : ''} ${
+                isToday ? 'ease-calendar__cell--today' : ''
+              }`}
+              onClick={() => handleSelect(day)}
+            >
+              <span className="ease-calendar__cell-highlight" />
+              <span className="ease-calendar__cell-label">{day}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/submissions/react/react-calendar-month-view-with-date-selection-highlight/README.md
+++ b/submissions/react/react-calendar-month-view-with-date-selection-highlight/README.md
@@ -1,0 +1,35 @@
+﻿# Calendar Month View with Date Selection Highlight
+
+A month-view calendar grid component with month navigation and a smooth, spring-animated highlight that glides to the selected date.
+
+## Props
+
+| Prop          | Type     | Default       | Description                                       |
+|---------------|----------|---------------|-----------------------------------------------------|
+| `defaultDate` | Date     | `new Date()`  | Initial visible month and initially selected date    |
+| `onSelect`    | function | —             | Called with the newly selected `Date` object          |
+
+## Installation
+
+Copy `CalendarMonthView.jsx` and `style.css` into your project. No external dependencies beyond React.
+
+## Usage
+
+```jsx
+import CalendarMonthView from './CalendarMonthView';
+
+<CalendarMonthView
+  defaultDate={new Date()}
+  onSelect={(date) => console.log('Selected:', date)}
+/>
+```
+
+## Behavior
+
+- Click the arrows to navigate between months; the grid recalculates automatically, including leading blank cells for the correct starting weekday.
+- Selecting a date animates a filled circular highlight into place with a spring-style easing curve.
+- Today's date is visually distinguished with a highlighted label color even when not selected.
+
+## Why it fits EaseMotion CSS
+
+Uses `ease-` prefixed class names and the framework's signature spring-style `cubic-bezier(0.34, 1.56, 0.64, 1)` easing curve for the selection highlight and nav button hover, consistent with existing submissions. Zero dependencies beyond React.

--- a/submissions/react/react-calendar-month-view-with-date-selection-highlight/demo.html
+++ b/submissions/react/react-calendar-month-view-with-date-selection-highlight/demo.html
@@ -1,0 +1,95 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Calendar Month View Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: -apple-system, sans-serif; background: #f9fafb; padding: 40px; }
+  </style>
+</head>
+<body>
+  <h2>Calendar Month View with Date Selection Highlight</h2>
+  <div id="root"></div>
+
+  <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+
+  <script type="text/babel">
+    const { useMemo, useState } = React;
+
+    const WEEKDAYS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+    const MONTH_NAMES = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+
+    function getMonthGrid(year, month) {
+      const firstDay = new Date(year, month, 1);
+      const startWeekday = firstDay.getDay();
+      const daysInMonth = new Date(year, month + 1, 0).getDate();
+      const cells = [];
+      for (let i = 0; i < startWeekday; i++) cells.push(null);
+      for (let day = 1; day <= daysInMonth; day++) cells.push(day);
+      return cells;
+    }
+
+    function isSameDate(a, b) {
+      if (!a || !b) return false;
+      return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+    }
+
+    function CalendarMonthView({ defaultDate = new Date(), onSelect }) {
+      const [viewDate, setViewDate] = useState(new Date(defaultDate.getFullYear(), defaultDate.getMonth(), 1));
+      const [selected, setSelected] = useState(defaultDate);
+      const year = viewDate.getFullYear();
+      const month = viewDate.getMonth();
+      const cells = useMemo(() => getMonthGrid(year, month), [year, month]);
+      const today = new Date();
+
+      const goToPrevMonth = () => setViewDate(new Date(year, month - 1, 1));
+      const goToNextMonth = () => setViewDate(new Date(year, month + 1, 1));
+      const handleSelect = (day) => {
+        if (!day) return;
+        const newDate = new Date(year, month, day);
+        setSelected(newDate);
+        onSelect && onSelect(newDate);
+      };
+
+      return (
+        <div className="ease-calendar">
+          <div className="ease-calendar__header">
+            <button type="button" className="ease-calendar__nav" onClick={goToPrevMonth} aria-label="Previous month">‹</button>
+            <span className="ease-calendar__title">{MONTH_NAMES[month]} {year}</span>
+            <button type="button" className="ease-calendar__nav" onClick={goToNextMonth} aria-label="Next month">›</button>
+          </div>
+          <div className="ease-calendar__weekdays">
+            {WEEKDAYS.map(wd => <span key={wd} className="ease-calendar__weekday">{wd}</span>)}
+          </div>
+          <div className="ease-calendar__grid">
+            {cells.map((day, index) => {
+              if (!day) return <span key={`empty-${index}`} className="ease-calendar__cell ease-calendar__cell--empty" />;
+              const cellDate = new Date(year, month, day);
+              const isSelected = isSameDate(cellDate, selected);
+              const isToday = isSameDate(cellDate, today);
+              return (
+                <button
+                  key={day}
+                  type="button"
+                  className={`ease-calendar__cell ${isSelected ? 'ease-calendar__cell--selected' : ''} ${isToday ? 'ease-calendar__cell--today' : ''}`}
+                  onClick={() => handleSelect(day)}
+                >
+                  <span className="ease-calendar__cell-highlight" />
+                  <span className="ease-calendar__cell-label">{day}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(
+      <CalendarMonthView onSelect={(d) => console.log('Selected:', d)} />
+    );
+  </script>
+</body>
+</html>

--- a/submissions/react/react-calendar-month-view-with-date-selection-highlight/style.css
+++ b/submissions/react/react-calendar-month-view-with-date-selection-highlight/style.css
@@ -1,0 +1,114 @@
+﻿.ease-calendar {
+  width: 320px;
+  padding: 16px;
+  border-radius: 14px;
+  border: 1px solid #e5e7eb;
+  background: #ffffff;
+  font-family: inherit;
+}
+
+.ease-calendar__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.ease-calendar__title {
+  font-size: 15px;
+  font-weight: 600;
+  color: #111827;
+}
+
+.ease-calendar__nav {
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: #4b5563;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  transition: background-color 0.25s ease, transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.ease-calendar__nav:hover {
+  background: #f3f4f6;
+  transform: scale(1.1);
+}
+
+.ease-calendar__weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  margin-bottom: 4px;
+}
+
+.ease-calendar__weekday {
+  text-align: center;
+  font-size: 11px;
+  font-weight: 600;
+  color: #9ca3af;
+  padding: 6px 0;
+}
+
+.ease-calendar__grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
+}
+
+.ease-calendar__cell {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  aspect-ratio: 1;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  border-radius: 50%;
+  font-size: 13px;
+  color: #374151;
+}
+
+.ease-calendar__cell--empty {
+  cursor: default;
+}
+
+.ease-calendar__cell-highlight {
+  position: absolute;
+  inset: 4px;
+  border-radius: 50%;
+  background: transparent;
+  transform: scale(0.6);
+  opacity: 0;
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.25s ease, background-color 0.25s ease;
+}
+
+.ease-calendar__cell:hover:not(.ease-calendar__cell--empty) .ease-calendar__cell-highlight {
+  background: #f3f4f6;
+  opacity: 1;
+  transform: scale(1);
+}
+
+.ease-calendar__cell--today .ease-calendar__cell-label {
+  color: #4f46e5;
+  font-weight: 700;
+}
+
+.ease-calendar__cell--selected .ease-calendar__cell-highlight {
+  background: #4f46e5;
+  opacity: 1;
+  transform: scale(1);
+}
+
+.ease-calendar__cell--selected .ease-calendar__cell-label {
+  color: #ffffff;
+  font-weight: 600;
+}
+
+.ease-calendar__cell-label {
+  position: relative;
+  z-index: 1;
+}


### PR DESCRIPTION
## Pull Request Description
Adds a modular, reusable React Calendar Month View component with month navigation and a spring-animated highlight that glides to the selected date. Resolves #27364

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/react/react-calendar-month-view-with-date-selection-highlight/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A `CalendarMonthView` React component that renders a full month-view calendar grid with previous/next month navigation and a spring-animated circular highlight that glides to the selected date.

**How does a developer use it?**
```jsx
import CalendarMonthView from "./CalendarMonthView";

<CalendarMonthView
  defaultDate={new Date()}
  onSelect={(date) => console.log('Selected:', date)}
/>
```

**Why does it fit EaseMotion CSS?**
Uses human-readable `ease-` prefixed class names and the framework's signature spring-style `cubic-bezier(0.34, 1.56, 0.64, 1)` easing curve for the date selection highlight and nav button hover, consistent with existing submissions. Zero dependencies beyond React.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome

---

## Notes for Maintainer
Month grid is computed dynamically (correct leading blank cells for the starting weekday, correct days-in-month per calendar month) using native `Date` — no date library dependency. Today's date is visually distinguished separately from the selected date. Happy to add keyboard navigation (arrow keys) or a min/max date range prop if preferred.