### PR TITLE
[Feat] #27672 — Add multi-layer box shadow elevation scale (unique folder)

### DIFF
--- a/submissions/examples/box-shadow-elevation-27672-ag/README.md
+++ b/submissions/examples/box-shadow-elevation-27672-ag/README.md
@@ -1,0 +1,41 @@
+# Multi-Layer Box Shadow Elevation Scale
+
+This guide details configuration specs for generating SCSS multi-layer elevation mixins.
+
+---
+
+## Technical Overview: The Elevation Mixin
+
+Using single offset shadows looks flat and artificial. Layering multiple translucent shadows with varying offsets simulates real-world diffuse ambient lighting:
+
+```scss
+// SCSS Multi-Layer Box Shadow Mixin
+@mixin box-shadow-elevation($level: 1) {
+  @if $level == 1 {
+    box-shadow: 
+      0 1px 3px rgba(0, 0, 0, 0.12), 
+      0 1px 2px rgba(0, 0, 0, 0.24);
+  } @else if $level == 2 {
+    box-shadow: 
+      0 3px 6px rgba(0, 0, 0, 0.16), 
+      0 3px 6px rgba(0, 0, 0, 0.23);
+  } @else if $level == 3 {
+    box-shadow: 
+      0 10px 20px rgba(0, 0, 0, 0.19), 
+      0 6px 6px rgba(0, 0, 0, 0.23);
+  }
+}
+
+// Utility class mapping
+.shadow-z1 {
+  @include box-shadow-elevation(1);
+}
+```
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Observe the different shadows under Z1, Z2, and Z3.
+3. Hover over the cards — verify that each card translates upward and elevates to the next shadow level.

--- a/submissions/examples/box-shadow-elevation-27672-ag/demo.html
+++ b/submissions/examples/box-shadow-elevation-27672-ag/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Multi-Layer Box Shadow Elevation — EaseMotion CSS</title>
+  <meta name="description" content="Visual box shadow elevation showcase demonstrating multi-layer ambient shadow outlines and steps.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — SCSS Utilities</span>
+      <h1>Box Shadow Elevation Scale</h1>
+      <p class="description">
+        Demonstrates multi-layer ambient shadow levels. Hover over each card 
+        to observe interactive depth changes.
+      </p>
+    </header>
+
+    <main class="showcase">
+      
+      <!-- Elevation Level 1 -->
+      <section class="elevation-card shadow-z1">
+        <h3>Elevation Z1</h3>
+        <p>Low elevation ambient shadows. Ideal for default buttons and fields.</p>
+        <span class="badge">shadow-z1</span>
+      </section>
+
+      <!-- Elevation Level 2 -->
+      <section class="elevation-card shadow-z2">
+        <h3>Elevation Z2</h3>
+        <p>Medium elevation shadows. Perfect for dropdown menus and cards.</p>
+        <span class="badge">shadow-z2</span>
+      </section>
+
+      <!-- Elevation Level 3 -->
+      <section class="elevation-card shadow-z3">
+        <h3>Elevation Z3</h3>
+        <p>High elevation shadows. Excellent for modals and floaters.</p>
+        <span class="badge">shadow-z3</span>
+      </section>
+
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/box-shadow-elevation-27672-ag/style.css
+++ b/submissions/examples/box-shadow-elevation-27672-ag/style.css
@@ -1,0 +1,167 @@
+/* ============================================================
+   Multi-Layer Box Shadow Elevation — style.css
+   Submission for EaseMotion CSS Issue #27672
+   Multi-layered ambient shadows, elevation scales, and cards
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 820px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Showcase Layout
+   ============================================================ */
+
+.showcase {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 28px;
+}
+
+.elevation-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  padding: 32px 28px;
+  border-radius: 20px;
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.elevation-card:hover {
+  transform: translateY(-4px);
+}
+
+.elevation-card h3 {
+  font-size: 1.1rem;
+  font-weight: 800;
+}
+
+.elevation-card p {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.badge {
+  align-self: flex-start;
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: #a78bfa;
+  background: rgba(167, 139, 250, 0.12);
+  border: 1px solid rgba(167, 139, 250, 0.2);
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-family: monospace;
+}
+
+/* ============================================================
+   Multi-Layer Shadows under Test (SCSS mixin maps)
+   ============================================================ */
+
+/* ── Z1 Elevation ── */
+.shadow-z1 {
+  box-shadow: 
+    0 1px 3px rgba(0, 0, 0, 0.12), 
+    0 1px 2px rgba(0, 0, 0, 0.24);
+}
+.shadow-z1:hover {
+  box-shadow: 
+    0 3px 6px rgba(0, 0, 0, 0.16), 
+    0 3px 6px rgba(0, 0, 0, 0.23);
+}
+
+/* ── Z2 Elevation ── */
+.shadow-z2 {
+  box-shadow: 
+    0 3px 6px rgba(0, 0, 0, 0.16), 
+    0 3px 6px rgba(0, 0, 0, 0.23);
+}
+.shadow-z2:hover {
+  box-shadow: 
+    0 10px 20px rgba(0, 0, 0, 0.19), 
+    0 6px 6px rgba(0, 0, 0, 0.23);
+}
+
+/* ── Z3 Elevation ── */
+.shadow-z3 {
+  box-shadow: 
+    0 10px 20px rgba(0, 0, 0, 0.19), 
+    0 6px 6px rgba(0, 0, 0, 0.23);
+}
+.shadow-z3:hover {
+  box-shadow: 
+    0 14px 28px rgba(0, 0, 0, 0.25), 
+    0 10px 10px rgba(0, 0, 0, 0.22);
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .elevation-card {
+    transition: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-box-shadow-elevation` showcase. It demonstrates ambient depth scaling generated via SCSS multi-layer box-shadow mixins (mapping diffuse shadows across levels z1, z2, and z3) supporting hover lifting offsets.

## Root Cause
No multi-layer ambient shadow generators or consistent elevation templates existed in EaseMotion CSS.

## Changes Made
- `submissions/examples/box-shadow-elevation-27672-ag/demo.html`: Container grid cards hosting elevation levels and class badges.
- `submissions/examples/box-shadow-elevation-27672-ag/style.css`: Multi-layered box-shadow declarations, transition times, translations, and layouts.
- `submissions/examples/box-shadow-elevation-27672-ag/README.md`: Explains diffuse light principles, SCSS levels, and manual testing.

## How to Test
1. Open `demo.html` in a browser.
2. Hover each card to confirm shadow density and offset transitions.

## Related Issue
Closes #27672