### PR TITLE
feat: add release checklist template with demo files

### DIFF
--- a/submissions/docs/release-checklist/README.md
+++ b/submissions/docs/release-checklist/README.md
@@ -1,0 +1,12 @@
+# Release Checklist Issue Template
+
+This template provides a standardized checklist for maintainers to ensure all release steps are completed.
+
+## How to use
+1. Copy the contents of `release-template.md`.
+2. Go to your GitHub Repository -> Settings -> Issues -> Set up templates.
+3. Add this template to ensure every release follows the same quality standards.
+
+## EaseMotion Classes Used
+- `ease-fade-in`: For a smooth appearance of the checklist container.
+- `ease-hover-scale`: For the "Finalize Release" action button.

--- a/submissions/docs/release-checklist/demo.html
+++ b/submissions/docs/release-checklist/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Release Checklist Template</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="container ease-fade-in">
+    <h1>🚀 Release Checklist</h1>
+    <p>Complete these tasks before publishing the new version.</p>
+    
+    <ul class="checklist">
+        <li><input type="checkbox"> CHANGELOG updated</li>
+        <li><input type="checkbox"> Version bumped in package.json</li>
+        <li><input type="checkbox"> npm run build passes</li>
+        <li><input type="checkbox"> All tests pass</li>
+        <li><input type="checkbox"> GitHub Release drafted</li>
+        <li><input type="checkbox"> npm publish completed</li>
+        <li><input type="checkbox"> Social announcement posted</li>
+    </ul>
+
+    <button class="ease-hover-scale">Finalize Release</button>
+</div>
+
+</body>
+</html>

--- a/submissions/docs/release-checklist/release-template.md
+++ b/submissions/docs/release-checklist/release-template.md
@@ -1,0 +1,11 @@
+## 📋 Release Checklist
+- [ ] CHANGELOG updated
+- [ ] Version bumped in package.json
+- [ ] npm run build passes
+- [ ] All tests pass
+- [ ] GitHub Release drafted
+- [ ] npm publish completed
+- [ ] Social announcement posted
+
+---
+*Created via EaseMotion Release Template.*

--- a/submissions/docs/release-checklist/style.css
+++ b/submissions/docs/release-checklist/style.css
@@ -1,0 +1,6 @@
+body { font-family: sans-serif; background: #f4f7f6; display: flex; justify-content: center; padding: 50px; }
+.container { background: white; padding: 30px; border-radius: 12px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); width: 100%; max-width: 400px; }
+.checklist { list-style: none; padding: 0; }
+.checklist li { padding: 10px 0; border-bottom: 1px solid #eee; display: flex; align-items: center; gap: 10px; }
+button { width: 100%; padding: 12px; background: #4f46e5; color: white; border: none; border-radius: 6px; cursor: pointer; margin-top: 20px; transition: 0.3s; }
+button:hover { background: #4338ca; }


### PR DESCRIPTION
Pull Request Description
This PR introduces a standardized Release Checklist Template within the documentation to ensure consistency, quality, and accuracy during the platform's release process. It provides a structured workflow for maintainers to track all critical deployment and documentation steps.

Type of Change
[x] 📝 Documentation improvement

[x] Other (Tooling/DevOps Enhancement)

Submission Checklist
[x] All changes are inside submissions/docs/

[x] Includes demo.html (Interactive checklist UI)

[x] Includes style.css

[x] Includes README.md

[x] No changes to core/

[x] No changes to components/

[x] One feature per PR

Feature Description
What does this add?
A dedicated GitHub issue template that itemizes mandatory release tasks, ranging from version bumping and build verification to social announcements.

How does a developer use it?

Markdown
- [ ] CHANGELOG updated
- [ ] Version bumped in package.json
- [ ] npm run build passes
Why does it fit EaseMotion CSS?
While EaseMotion focuses on animation, its philosophy of "minimal setup and clear structure" extends to our internal tooling. This checklist removes ambiguity from the release process, ensuring the team spends less time on manual checks and more on building.

Demo
[x] Demo added (demo.html illustrates the workflow UI)

Browser Testing
[x] Chrome

[x] Firefox

Notes for Maintainer
The template is located in submissions/docs/release-checklist/. I have included a demo HTML file to visualize how these release steps could be represented in a dashboard interface if the team chooses to integrate it further. Closes #20497.