### PR TITLE
[Feat] #27674 — Add CSS container query wrapper classes (unique folder)

### DIFF
--- a/submissions/examples/container-queries-27674-ag/README.md
+++ b/submissions/examples/container-queries-27674-ag/README.md
@@ -1,0 +1,39 @@
+# CSS Container Query Wrapper Classes
+
+This guide details configuration specs for generating SCSS container query mixins.
+
+---
+
+## Technical Overview: The Container Query Mixin
+
+Relying on global viewport queries (`@media`) causes elements inside nested sidebars or widgets to scale incorrectly. Setting container queries ensures local element scalability:
+
+```scss
+// SCSS Container Queries Mixin
+@mixin container-wrapper($min-width: 450px) {
+  // Establish parent container type
+  container-type: inline-size;
+  
+  // Scoped child layout updates
+  @container (min-width: #{$min-width}) {
+    @content;
+  }
+}
+
+// Class mapping
+.query-container {
+  @include container-wrapper(450px) {
+    .responsive-card {
+      flex-direction: row;
+    }
+  }
+}
+```
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Observe the card inside the simulated container box.
+3. Slide the **Target Container Width** range slider — verify that the layout shifts from vertical stack (under 450px) to horizontal row (450px and above) dynamically.

--- a/submissions/examples/container-queries-27674-ag/demo.html
+++ b/submissions/examples/container-queries-27674-ag/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Container Queries — EaseMotion CSS</title>
+  <meta name="description" content="Visual container query showcase demonstrating container-type inline-size layouts and responsive sub-cards.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — SCSS Utilities</span>
+      <h1>Container Query Wrappers</h1>
+      <p class="description">
+        Demonstrates CSS Container Queries. Slide the range input below to resize 
+        the container, triggering styling updates independent of the viewport.
+      </p>
+    </header>
+
+    <main class="dashboard">
+
+      <!-- Width Slider -->
+      <section class="controls-panel">
+        <h2 class="section-title">Container Width Controller</h2>
+        <div class="control-group">
+          <label for="width-slider">Target Container Width: <span id="width-val">400px</span></label>
+          <input type="range" id="width-slider" min="300" max="600" value="400" step="10">
+        </div>
+      </section>
+
+      <!-- Container query wrapper -->
+      <section class="preview-panel">
+        <h2 class="section-title">Query Preview</h2>
+
+        <div class="query-container" id="query-box" style="width: 400px;">
+          <div class="responsive-card">
+            <div class="card-visual">📢</div>
+            <div class="card-body">
+              <h3>Adaptable Widget Card</h3>
+              <p>
+                This card changes layout (column to row) based on the width of its parent container, 
+                rather than viewport size.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+    </main>
+  </div>
+
+  <script>
+    const slider = document.getElementById('width-slider');
+    const widthVal = document.getElementById('width-val');
+    const box = document.getElementById('query-box');
+
+    slider.addEventListener('input', () => {
+      const width = `${slider.value}px`;
+      widthVal.textContent = width;
+      box.style.width = width;
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/container-queries-27674-ag/style.css
+++ b/submissions/examples/container-queries-27674-ag/style.css
@@ -1,0 +1,177 @@
+/* ============================================================
+   CSS Container Query Wrapper Classes — style.css
+   Submission for EaseMotion CSS Issue #27674
+   Container scopes, inline-size types, adaptive cards, and sliders
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 820px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Dashboard Layout
+   ============================================================ */
+
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.controls-panel,
+.preview-panel {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  padding: 28px;
+  border-radius: 20px;
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+}
+
+.section-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+/* Width Controls */
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.control-group label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.control-group input[type="range"] {
+  accent-color: var(--primary-color);
+  cursor: pointer;
+}
+
+/* ============================================================
+   CSS Container Queries elements under Test
+   ============================================================ */
+
+/* Establish the container context (crucial requirement) */
+.query-container {
+  container-type: inline-size;
+  margin: 0 auto;
+  transition: width 0.15s ease;
+  background: rgba(0,0,0,0.15);
+  border: 1px dashed rgba(255,255,255,0.15);
+  border-radius: 16px;
+  padding: 16px;
+}
+
+.responsive-card {
+  display: flex;
+  flex-direction: column; /* Default: vertical stack */
+  gap: 16px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--card-border);
+  padding: 24px;
+  border-radius: 12px;
+}
+
+.card-visual {
+  font-size: 2rem;
+}
+
+.card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.card-body h3 {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.card-body p {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+/* ── Container query rules ── */
+@container (min-width: 450px) {
+  .responsive-card {
+    flex-direction: row; /* Switch layout to row when container is wider */
+    align-items: center;
+  }
+  .card-visual {
+    padding-right: 12px;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-container-queries` showcase. It demonstrates modular element scaling generated via SCSS container query mixins (declaring `container-type: inline-size` parent boundaries combined with relative layout shifts) supporting interactive simulated width selectors.

## Root Cause
No parent-relative container query mixins or inline-size wrapper classes existed in EaseMotion CSS.

## Changes Made
- `submissions/examples/container-queries-27674-ag/demo.html`: Width adjustment sliders, preview cards, visual badge indicators, and simulated container frames.
- `submissions/examples/container-queries-27674-ag/style.css`: Parent container-types, responsive grid flex directions, spacing variables, and border properties.
- `submissions/examples/container-queries-27674-ag/README.md`: Details container-type setups, SCSS @container rules, and manual testing.

## How to Test
1. Open `demo.html` in a browser.
2. Slide width controllers to verify column-to-row adaptive layout changes.

## Related Issue
Closes #27674