### PR TITLE
[Feat] #27655 — Add text highlight underline draw utilities (unique folder)

### DIFF
--- a/submissions/examples/underline-draw-27655-ag/README.md
+++ b/submissions/examples/underline-draw-27655-ag/README.md
@@ -1,0 +1,47 @@
+# Text Highlight Underline Draw Utilities
+
+This guide details configuration specs for generating SCSS text underline drawing mixins.
+
+---
+
+## Technical Overview: The Underline Mixin
+
+Declaring manual relative block offsets repeatedly makes stylesheet files verbose. Utilizing pseudo-elements coupled with 2D scale transformations ensures clean layout scaling:
+
+```scss
+// SCSS Underline Draw Mixin
+@mixin underline-draw($color: #7c3aed, $height: 2px, $origin: left) {
+  position: relative;
+  text-decoration: none;
+  
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: $height;
+    background-color: $color;
+    transform: scaleX(0);
+    transform-origin: $origin;
+    transition: transform 0.3s ease-in-out;
+  }
+  
+  &:hover::after {
+    transform: scaleX(1);
+  }
+}
+
+// Utility Class mapping
+.draw-left-right {
+  @include underline-draw(#7c3aed, 2px, left);
+}
+```
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Hover over the **Left to Right Draw** link — verify that the underline draws horizontally starting from the left.
+3. Hover over the **Center Expand Draw** link — verify that the underline expands outwards from the center.

--- a/submissions/examples/underline-draw-27655-ag/demo.html
+++ b/submissions/examples/underline-draw-27655-ag/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Text Underline Draw — EaseMotion CSS</title>
+  <meta name="description" content="Visual typography showcase demonstrating text underline drawing transitions on hover.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — SCSS Utilities</span>
+      <h1>Underline Draw Highlight</h1>
+      <p class="description">
+        Demonstrates animated text underlines. Hover over the links below 
+        to trigger the drawing transition.
+      </p>
+    </header>
+
+    <main class="showcase">
+      
+      <!-- Underline Type 1: Left to Right -->
+      <section class="card">
+        <h3><a href="#" class="draw-link draw-left-right">Left to Right Draw</a></h3>
+        <span class="badge">scaleX(0) to scaleX(1)</span>
+      </section>
+
+      <!-- Underline Type 2: Center Expand -->
+      <section class="card">
+        <h3><a href="#" class="draw-link draw-center">Center Expand Draw</a></h3>
+        <span class="badge">transform-origin: center</span>
+      </section>
+
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/underline-draw-27655-ag/style.css
+++ b/submissions/examples/underline-draw-27655-ag/style.css
@@ -1,0 +1,147 @@
+/* ============================================================
+   Text Highlight Underline Draw Utilities — style.css
+   Submission for EaseMotion CSS Issue #27655
+   Link underlines, pseudo-element scales, hover transitions, cards
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 620px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Showcase Elements
+   ============================================================ */
+
+.showcase {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  padding: 32px;
+  border-radius: 20px;
+  backdrop-filter: blur(8px);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+}
+
+.badge {
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: #a78bfa;
+  background: rgba(167, 139, 250, 0.12);
+  border: 1px solid rgba(167, 139, 250, 0.2);
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-family: monospace;
+}
+
+/* ============================================================
+   Underline Draw Classes under Test (pseudo-element scales)
+   ============================================================ */
+
+.draw-link {
+  color: #fff;
+  text-decoration: none;
+  position: relative;
+  padding-bottom: 4px;
+}
+
+.draw-link::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background-color: var(--primary-color);
+  transform: scaleX(0);
+  transition: transform 0.3s ease-in-out;
+}
+
+.draw-link:hover::after {
+  transform: scaleX(1);
+}
+
+/* ── Origin variants ── */
+.draw-left-right::after {
+  transform-origin: left;
+}
+
+.draw-center::after {
+  transform-origin: center;
+  background-color: #22d3ee;
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .draw-link::after {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-underline-draw` showcase. It demonstrates text highlight underlines generated via SCSS drawing mixins (leveraging relative anchors and pseudo-element scaleX transformations) supporting left-origin and center-origin hover triggers.

## Root Cause
No interactive text underline drawing highlights or pseudo-element scale mixins existed in EaseMotion CSS.

## Changes Made
- `submissions/examples/underline-draw-27655-ag/demo.html`: Container nodes hosting text links, class labels, and card panels.
- `submissions/examples/underline-draw-27655-ag/style.css`: Underline pseudo-elements, scaleX parameters, transform origins, hover shifts, and spacing.
- `submissions/examples/underline-draw-27655-ag/README.md`: Explains pseudo-element scales, SCSS origin options, and manual testing.

## How to Test
1. Open `demo.html` in a browser.
2. Hover over links to verify left-origin and center-origin underline expansions.

## Related Issue
Closes #27655