### PR TITLE
fix: replace placeholder submissions with real implementations

### DIFF
--- a/submissions/react/landing-page-tw/LandingPage.jsx
+++ b/submissions/react/landing-page-tw/LandingPage.jsx
@@ -1,0 +1,48 @@
+import React from "react";
+
+/**
+ * LandingPage
+ *
+ * A minimal, self-contained hero + feature-grid landing page section.
+ * Intended as a drop-in starting point that demonstrates EaseMotion CSS
+ * entrance and hover utilities working together on real content.
+ */
+export default function LandingPage({
+  title = "Build motion-first interfaces",
+  subtitle = "EaseMotion CSS gives you production-ready animation utilities without writing a single keyframe.",
+  ctaLabel = "Get Started",
+  onCtaClick,
+  features = [
+    { title: "Lightweight", desc: "No runtime, just utility classes." },
+    { title: "Composable", desc: "Combine classes for layered motion." },
+    { title: "Accessible", desc: "Respects prefers-reduced-motion." },
+  ],
+}) {
+  return (
+    <section className="ease-landing">
+      <div className="ease-landing-hero ease-fade-in">
+        <h1 className="ease-landing-title ease-slide-up">{title}</h1>
+        <p className="ease-landing-subtitle ease-slide-up">{subtitle}</p>
+        <button
+          type="button"
+          onClick={onCtaClick}
+          className="ease-btn ease-btn-primary ease-hover-lift ease-landing-cta"
+        >
+          {ctaLabel}
+        </button>
+      </div>
+
+      <div className="ease-landing-features">
+        {features.map((feature) => (
+          <div
+            key={feature.title}
+            className="ease-landing-feature-card ease-hover-scale ease-fade-in"
+          >
+            <h3 className="ease-landing-feature-title">{feature.title}</h3>
+            <p className="ease-landing-feature-desc">{feature.desc}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/submissions/react/landing-page-tw/README.md
+++ b/submissions/react/landing-page-tw/README.md
@@ -1,0 +1,42 @@
+# LandingPage
+
+A self-contained hero + feature-grid landing page section built with EaseMotion CSS.
+
+## Description
+
+`LandingPage` renders a hero block (title, subtitle, call-to-action button) followed by a responsive feature card grid. It's meant as a realistic, drop-in demonstration of EaseMotion's entrance (`ease-fade-in`, `ease-slide-up`) and hover (`ease-hover-lift`, `ease-hover-scale`) utilities used together on real marketing-page content, rather than an isolated single-element demo.
+
+## Props
+
+| Prop        | Type       | Default                              | Description                                    |
+| ----------- | ---------- | ------------------------------------- | ----------------------------------------------- |
+| `title`     | `string`   | `"Build motion-first interfaces"`     | Hero headline text.                             |
+| `subtitle`  | `string`   | *(see source)*                        | Supporting text under the headline.             |
+| `ctaLabel`  | `string`   | `"Get Started"`                       | Text shown on the call-to-action button.        |
+| `onCtaClick`| `function` | `undefined`                           | Handler fired when the CTA button is clicked.   |
+| `features`  | `Array<{title, desc}>` | 3 default items          | Feature cards rendered below the hero.          |
+
+## Usage
+
+```jsx
+import LandingPage from "./LandingPage";
+
+function App() {
+  return (
+    <LandingPage
+      title="Ship animations without the boilerplate"
+      subtitle="Utility classes for motion, done right."
+      ctaLabel="Try it now"
+      onCtaClick={() => console.log("CTA clicked")}
+      features={[
+        { title: "Fast", desc: "Zero JS runtime cost." },
+        { title: "Flexible", desc: "Works with any framework." },
+      ]}
+    />
+  );
+}
+```
+
+## Why this is useful
+
+New contributors and users often want to see EaseMotion classes applied to a full page section, not just an isolated button or card. This component gives a realistic, copy-pasteable starting point for a marketing/landing page that already wires up multiple EaseMotion utilities correctly together.

--- a/submissions/react/video-controls-tw/README.md
+++ b/submissions/react/video-controls-tw/README.md
@@ -1,0 +1,35 @@
+# VideoControls
+
+A lightweight, accessible custom control bar for the native `<video>` element, built with EaseMotion CSS utility classes for its hover/tap animations.
+
+## Description
+
+`VideoControls` wraps a native `<video>` element and replaces the default browser chrome with a custom play/pause button, seek bar, time display, volume slider, and fullscreen toggle. It's fully controlled via React state and uses standard HTMLMediaElement APIs, so it needs no external dependencies.
+
+## Props
+
+| Prop       | Type      | Default | Description                                  |
+| ---------- | --------- | ------- | --------------------------------------------- |
+| `src`      | `string`  | —       | **Required.** URL of the video file to play.  |
+| `poster`   | `string`  | `undefined` | Optional poster image shown before playback starts. |
+| `autoPlay` | `boolean` | `false` | Whether the video should start playing automatically. |
+
+## Usage
+
+```jsx
+import VideoControls from "./VideoControls";
+
+function App() {
+  return (
+    <VideoControls
+      src="/media/demo-clip.mp4"
+      poster="/media/demo-poster.jpg"
+      autoPlay={false}
+    />
+  );
+}
+```
+
+## Why this is useful
+
+Native video controls are inconsistent across browsers and can't be restyled directly. `VideoControls` gives contributors a consistent, themeable player skin that inherits EaseMotion's motion language (`ease-hover-scale`, `ease-hover-lift`, `ease-fade-in`, `ease-slide-up`) instead of shipping its own bespoke transitions — keeping video UI visually consistent with the rest of an EaseMotion-powered page.

--- a/submissions/react/video-controls-tw/VideoControls.jsx
+++ b/submissions/react/video-controls-tw/VideoControls.jsx
@@ -1,0 +1,140 @@
+import React, { useRef, useState, useEffect } from "react";
+
+/**
+ * VideoControls
+ *
+ * A lightweight, accessible custom control bar for the native <video> element.
+ * Wraps play/pause, seek, volume, and fullscreen behind EaseMotion CSS
+ * utility classes so hover/tap states get consistent motion for free.
+ */
+export default function VideoControls({ src, poster, autoPlay = false }) {
+  const videoRef = useRef(null);
+  const [isPlaying, setIsPlaying] = useState(autoPlay);
+  const [progress, setProgress] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [volume, setVolume] = useState(1);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    const onTimeUpdate = () => setProgress(video.currentTime);
+    const onLoadedMetadata = () => setDuration(video.duration);
+    const onFullscreenChange = () =>
+      setIsFullscreen(document.fullscreenElement === video.parentElement);
+
+    video.addEventListener("timeupdate", onTimeUpdate);
+    video.addEventListener("loadedmetadata", onLoadedMetadata);
+    document.addEventListener("fullscreenchange", onFullscreenChange);
+
+    return () => {
+      video.removeEventListener("timeupdate", onTimeUpdate);
+      video.removeEventListener("loadedmetadata", onLoadedMetadata);
+      document.removeEventListener("fullscreenchange", onFullscreenChange);
+    };
+  }, []);
+
+  const togglePlay = () => {
+    const video = videoRef.current;
+    if (!video) return;
+    if (video.paused) {
+      video.play();
+      setIsPlaying(true);
+    } else {
+      video.pause();
+      setIsPlaying(false);
+    }
+  };
+
+  const handleSeek = (e) => {
+    const video = videoRef.current;
+    const newTime = Number(e.target.value);
+    video.currentTime = newTime;
+    setProgress(newTime);
+  };
+
+  const handleVolume = (e) => {
+    const video = videoRef.current;
+    const newVolume = Number(e.target.value);
+    video.volume = newVolume;
+    setVolume(newVolume);
+  };
+
+  const toggleFullscreen = () => {
+    const container = videoRef.current?.parentElement;
+    if (!container) return;
+    if (!document.fullscreenElement) {
+      container.requestFullscreen();
+    } else {
+      document.exitFullscreen();
+    }
+  };
+
+  const formatTime = (seconds) => {
+    if (!Number.isFinite(seconds)) return "0:00";
+    const m = Math.floor(seconds / 60);
+    const s = Math.floor(seconds % 60)
+      .toString()
+      .padStart(2, "0");
+    return `${m}:${s}`;
+  };
+
+  return (
+    <div className="ease-video-wrapper ease-fade-in">
+      <video
+        ref={videoRef}
+        src={src}
+        poster={poster}
+        autoPlay={autoPlay}
+        className="ease-video-element"
+      />
+
+      <div className="ease-video-controls ease-slide-up">
+        <button
+          type="button"
+          onClick={togglePlay}
+          className="ease-btn ease-hover-scale ease-video-play-btn"
+          aria-label={isPlaying ? "Pause video" : "Play video"}
+        >
+          {isPlaying ? "❚❚" : "►"}
+        </button>
+
+        <span className="ease-video-time">{formatTime(progress)}</span>
+
+        <input
+          type="range"
+          min={0}
+          max={duration || 0}
+          step={0.1}
+          value={progress}
+          onChange={handleSeek}
+          className="ease-video-seekbar ease-hover-lift"
+          aria-label="Seek video"
+        />
+
+        <span className="ease-video-time">{formatTime(duration)}</span>
+
+        <input
+          type="range"
+          min={0}
+          max={1}
+          step={0.05}
+          value={volume}
+          onChange={handleVolume}
+          className="ease-video-volume ease-hover-lift"
+          aria-label="Volume"
+        />
+
+        <button
+          type="button"
+          onClick={toggleFullscreen}
+          className="ease-btn ease-hover-scale ease-video-fullscreen-btn"
+          aria-label={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+        >
+          {isFullscreen ? "⤡" : "⤢"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/submissions/scss/bounce-module-tw/README.md
+++ b/submissions/scss/bounce-module-tw/README.md
@@ -1,0 +1,51 @@
+# _bounce-module.scss
+
+A reusable bounce-entrance mixin for EaseMotion CSS.
+
+## What it does
+
+Provides a `ease-bounce-module-in` keyframe plus two mixins:
+
+- `ease-bounce-in` — a one-shot bounce entrance animation, ideal for cards, modals, and toasts appearing on screen.
+- `ease-bounce-pulse` — a repeating bounce, useful for drawing attention to badges or notification icons.
+
+Both mixins respect `prefers-reduced-motion` and fall back to a static, fully-visible state when the user has motion reduction enabled.
+
+## Parameters
+
+### `ease-bounce-in($duration, $timing, $delay)`
+
+| Parameter   | Type     | Default                        | Description                        |
+| ----------- | -------- | ------------------------------- | ----------------------------------- |
+| `$duration` | Number   | `$ease-bounce-duration` (600ms) | Total animation length.             |
+| `$timing`   | String   | `$ease-bounce-timing`           | Easing curve (back-out bounce).     |
+| `$delay`    | Number   | `0ms`                           | Delay before the animation starts.  |
+
+### `ease-bounce-pulse($duration, $iterations)`
+
+| Parameter     | Type   | Default      | Description                          |
+| ------------- | ------ | ------------ | ------------------------------------- |
+| `$duration`   | Number | `900ms`      | Length of a single pulse cycle.       |
+| `$iterations` | Number/Keyword | `infinite` | How many times the pulse repeats.  |
+
+## Usage
+
+```scss
+@use "bounce-module" as *;
+
+.notification-card {
+  @include ease-bounce-in;
+}
+
+.notification-card--delayed {
+  @include ease-bounce-in($duration: 450ms, $delay: 150ms);
+}
+
+.badge--unread {
+  @include ease-bounce-pulse($duration: 700ms);
+}
+```
+
+## Notes for maintainer
+
+The module defines its own `!default` fallback variables (`$ease-bounce-duration`, `$ease-bounce-timing`, `$ease-bounce-distance`) so it can compile standalone. If EaseMotion's core token file already defines equivalent duration/easing tokens, these can be aliased to those instead during integration.

--- a/submissions/scss/bounce-module-tw/_bounce-module.scss
+++ b/submissions/scss/bounce-module-tw/_bounce-module.scss
@@ -1,0 +1,65 @@
+// _bounce-module.scss
+// A reusable bounce-entrance mixin built on top of EaseMotion's timing
+// and easing tokens. Falls back to sensible defaults if the core
+// token file hasn't been imported, so this partial can be tested in
+// isolation.
+
+$ease-bounce-duration: 600ms !default;
+$ease-bounce-timing: cubic-bezier(0.34, 1.56, 0.64, 1) !default; // "back out" style bounce
+$ease-bounce-distance: 12px !default;
+
+@keyframes ease-bounce-module-in {
+  0% {
+    opacity: 0;
+    transform: translateY($ease-bounce-distance) scale(0.96);
+  }
+  60% {
+    opacity: 1;
+    transform: translateY(-2px) scale(1.01);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/// Applies a bounce-in entrance animation to an element.
+///
+/// @param {Number} $duration [$ease-bounce-duration] - Animation duration.
+/// @param {String} $timing [$ease-bounce-timing] - Easing function.
+/// @param {Number} $delay [0ms] - Optional animation delay.
+///
+/// @example scss - Basic usage
+///   .card {
+///     @include ease-bounce-in;
+///   }
+///
+/// @example scss - Custom duration and delay
+///   .card--staggered {
+///     @include ease-bounce-in($duration: 450ms, $delay: 150ms);
+///   }
+@mixin ease-bounce-in(
+  $duration: $ease-bounce-duration,
+  $timing: $ease-bounce-timing,
+  $delay: 0ms
+) {
+  animation: ease-bounce-module-in $duration $timing $delay both;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/// Applies a repeating attention-grabbing bounce (e.g. for notification badges).
+///
+/// @param {Number} $duration [900ms] - Duration of one bounce cycle.
+/// @param {Number} $iterations [infinite] - Number of times to repeat.
+@mixin ease-bounce-pulse($duration: 900ms, $iterations: infinite) {
+  animation: ease-bounce-module-in $duration $ease-bounce-timing $iterations alternate;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}

--- a/submissions/scss/dark-mode-tw/README.md
+++ b/submissions/scss/dark-mode-tw/README.md
@@ -1,0 +1,59 @@
+# _dark-mode.scss
+
+A mixin for applying dark-mode color overrides in EaseMotion CSS, supporting both automatic OS-level detection and manual toggling.
+
+## What it does
+
+Provides `ease-dark-mode`, a content mixin that wraps a block of styles in either:
+
+- a `prefers-color-scheme: dark` media query (`"auto"` mode),
+- a `.ease-dark &` ancestor selector for manual toggling (`"class"` mode), or
+- both at once (`"both"` mode, the default for the convenience mixin).
+
+Also includes `ease-dark-surface`, a shortcut that applies EaseMotion's default dark surface color, text color, border color, and a smooth color-scheme transition in one call.
+
+## Parameters
+
+### `ease-dark-mode($mode, $toggle-class)`
+
+| Parameter       | Type   | Default        | Description                                                        |
+| --------------- | ------ | -------------- | -------------------------------------------------------------------- |
+| `$mode`         | String | `"auto"`       | `"auto"`, `"class"`, or `"both"` — which trigger mechanism(s) to emit. |
+| `$toggle-class` | String | `".ease-dark"` | Class used for manual dark-mode toggling.                            |
+
+### `ease-dark-surface($mode)`
+
+| Parameter | Type   | Default  | Description                                   |
+| --------- | ------ | -------- | ---------------------------------------------- |
+| `$mode`   | String | `"both"` | Same options as `ease-dark-mode`.              |
+
+## Usage
+
+```scss
+@use "dark-mode" as *;
+
+// Automatic OS-level dark mode only
+.card {
+  background: #fff;
+  @include ease-dark-mode {
+    background: $ease-dark-surface;
+    color: $ease-dark-text;
+  }
+}
+
+// Manual toggle only, via <html class="ease-dark">
+.sidebar {
+  @include ease-dark-mode($mode: "class") {
+    background: $ease-dark-surface;
+  }
+}
+
+// Convenience shortcut: both triggers + transition, one line
+.panel {
+  @include ease-dark-surface;
+}
+```
+
+## Why this is useful
+
+Dark mode support is one of the most commonly requested features across contributor submissions, and everyone tends to reinvent it slightly differently. This mixin standardizes the two dominant strategies (OS preference vs. manual toggle) behind one API, so consumers can opt into either or both without duplicating media-query logic.

--- a/submissions/scss/dark-mode-tw/_dark-mode.scss
+++ b/submissions/scss/dark-mode-tw/_dark-mode.scss
@@ -1,0 +1,66 @@
+// _dark-mode.scss
+// A mixin for applying dark-mode color overrides, either via a
+// `prefers-color-scheme` media query or a manually toggled class
+// (e.g. `<html class="ease-dark">`), so consumers can pick whichever
+// strategy fits their app.
+
+$ease-dark-bg: #121212 !default;
+$ease-dark-surface: #1e1e1e !default;
+$ease-dark-text: #f5f5f5 !default;
+$ease-dark-muted: #a0a0a0 !default;
+$ease-dark-border: #2e2e2e !default;
+$ease-dark-transition-duration: 200ms !default;
+
+/// Applies dark-mode styles either automatically (via OS preference)
+/// or when a manual toggle class is present on an ancestor element.
+///
+/// @param {String} $mode ["auto"] - One of "auto", "class", or "both".
+///   - "auto"  wraps the content block in a `prefers-color-scheme: dark` query.
+///   - "class" wraps the content block in a `.ease-dark &` selector.
+///   - "both"  emits both, so either mechanism can trigger dark styles.
+/// @param {String} $toggle-class [".ease-dark"] - Class used for manual toggling.
+///
+/// @example scss - Automatic OS-level dark mode only
+///   .card {
+///     background: #fff;
+///     @include ease-dark-mode {
+///       background: $ease-dark-surface;
+///       color: $ease-dark-text;
+///     }
+///   }
+///
+/// @example scss - Manual toggle only
+///   .card {
+///     @include ease-dark-mode($mode: "class") {
+///       background: $ease-dark-surface;
+///     }
+///   }
+@mixin ease-dark-mode($mode: "auto", $toggle-class: ".ease-dark") {
+  @if $mode == "auto" or $mode == "both" {
+    @media (prefers-color-scheme: dark) {
+      @content;
+    }
+  }
+
+  @if $mode == "class" or $mode == "both" {
+    #{$toggle-class} & {
+      @content;
+    }
+  }
+}
+
+/// Convenience mixin that applies EaseMotion's default dark surface
+/// colors and a smooth color-scheme transition in one call.
+///
+/// @param {String} $mode ["both"] - Same options as `ease-dark-mode`.
+@mixin ease-dark-surface($mode: "both") {
+  transition: background-color $ease-dark-transition-duration ease,
+    color $ease-dark-transition-duration ease,
+    border-color $ease-dark-transition-duration ease;
+
+  @include ease-dark-mode($mode) {
+    background-color: $ease-dark-surface;
+    color: $ease-dark-text;
+    border-color: $ease-dark-border;
+  }
+}


### PR DESCRIPTION
Closes #27880

## Pull Request Description
Replaces four placeholder submissions flagged in #27880 with real, working implementations:
- `submissions/react/video-controls-tw/` — custom accessible video player controls (play/pause, seek, volume, fullscreen)
- `submissions/react/landing-page-tw/` — hero + feature-grid landing page section
- `submissions/scss/bounce-module-tw/` — bounce entrance mixin (`ease-bounce-in`, `ease-bounce-pulse`)
- `submissions/scss/dark-mode-tw/` — dark mode mixin supporting both OS-level and manual toggle strategies

---

## Type of Change
- [x] 🧩 New component
- [x] 🐛 Bug fix in an existing submission
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/react/` and `submissions/scss/`)
- [ ] Includes `demo.html` — N/A, this is a React/SCSS track submission, not Standard track (see Notes)
- [ ] Includes `style.css` — N/A for the same reason; each folder includes its own required track files instead
- [x] Includes `README.md` — each of the 4 folders has one, with usage docs and (for React) a props table
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR — *note: this PR bundles 4 small fixes closing the same tracking issue #27880; happy to split into 4 PRs if preferred, see Notes*

---

## Feature Description

**What does this add?**
Real implementations for two React components (video controls, landing page section) and two SCSS mixins (bounce entrance, dark mode), replacing placeholder text left in the legacy submission folders.

**How does a developer use it?**
```jsx
import VideoControls from "./VideoControls";
<VideoControls src="/media/demo-clip.mp4" autoPlay={false} />
```
```scss
@use "bounce-module" as *;
.card { @include ease-bounce-in; }
```

**Why does it fit EaseMotion CSS?**
Both React components consume EaseMotion utility classes (`ease-fade-in`, `ease-hover-lift`, `ease-hover-scale`, `ease-slide-up`) rather than inventing their own transitions, and both SCSS mixins are built to layer on top of EaseMotion's token/keyframe conventions with `!default` fallbacks so they compile standalone until integrated.

---

## Demo
- [ ] Demo added — N/A, no `demo.html` for React/SCSS track submissions per CONTRIBUTING.md

---

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

*(Note for maintainer: I haven't cross-browser tested yet — will do before this is marked ready, or can do on request.)*

---

## Notes for Maintainer
This PR closes 4 sub-items of #27880 at once since they were reported together in the same issue — let me know if you'd rather I split them into 4 separate PRs, happy to do that instead.

Also: the original placeholders lived under `submissions/react-v1/` and `submissions/scss-v1/`, which aren't part of the 4 directories currently listed in CONTRIBUTING.md. I placed these new implementations under `submissions/react/` and `submissions/scss/` instead. Should the old `-v1` folders be removed/archived as part of this fix, or left alone?

The demo.html/style.css checklist items above are for the Standard track — I left them unchecked (not failed) since this is React/SCSS track work with its own file requirements, which I did complete.