### PR TITLE
[Feat] #27638 — Add accordion expand/collapse max-height utilities (unique folder)

### DIFF
--- a/submissions/examples/accordion-maxheight-27638-ag/README.md
+++ b/submissions/examples/accordion-maxheight-27638-ag/README.md
@@ -1,0 +1,40 @@
+# Accordion Expand/Collapse Max-Height Utilities
+
+This guide details configuration specs for generating SCSS accordion collapse mixins.
+
+---
+
+## Technical Overview: The Accordion Height Mixin
+
+CSS height values (e.g. `height: auto`) cannot be transitioned. Utilizing a dynamic `max-height` transition curve creates smooth collapsible widgets:
+
+```scss
+// SCSS Accordion Collapse Mixin
+@mixin accordion-transition($duration: 0.4s, $max-height-bound: 200px) {
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition: 
+    max-height $duration cubic-bezier(0.16, 1, 0.3, 1), 
+    opacity $duration ease;
+    
+  // Selector target for expanded parent
+  .active & {
+    max-height: $max-height-bound;
+    opacity: 1;
+  }
+}
+
+// Utility Class mapping
+.accordion-content {
+  @include accordion-transition;
+}
+```
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Click the accordion headers to toggle active state classes.
+3. Verify that panels expand and collapse smoothly, and the chevrons rotate in sync.

--- a/submissions/examples/accordion-maxheight-27638-ag/demo.html
+++ b/submissions/examples/accordion-maxheight-27638-ag/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Accordion Max-Height Transitions — EaseMotion CSS</title>
+  <meta name="description" content="Visual accordion showcase demonstrating max-height transition animations and collapsible panels.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — SCSS Utilities</span>
+      <h1>Accordion Transitions</h1>
+      <p class="description">
+        Demonstrates smooth expand/collapse heights. Click the headers below 
+        to toggle visibility.
+      </p>
+    </header>
+
+    <main class="showcase">
+      
+      <!-- Accordion Item 1 -->
+      <section class="accordion-item" id="item-1">
+        <header class="accordion-header" onclick="toggleAccordion('item-1')">
+          <h3>Section One Title</h3>
+          <span class="chevron">▼</span>
+        </header>
+        <div class="accordion-content">
+          <div class="content-inner">
+            <p>
+              This panel uses css max-height variables to transition between closed and expanded states. 
+              Using max-height ensures smooth vertical expansion.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- Accordion Item 2 -->
+      <section class="accordion-item" id="item-2">
+        <header class="accordion-header" onclick="toggleAccordion('item-2')">
+          <h3>Section Two Title</h3>
+          <span class="chevron">▼</span>
+        </header>
+        <div class="accordion-content">
+          <div class="content-inner">
+            <p>
+              This panel uses css max-height variables to transition between closed and expanded states. 
+              Using max-height ensures smooth vertical expansion.
+            </p>
+          </div>
+        </div>
+      </section>
+
+    </main>
+  </div>
+
+  <script>
+    function toggleAccordion(id) {
+      const el = document.getElementById(id);
+      el.classList.toggle('active');
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/accordion-maxheight-27638-ag/style.css
+++ b/submissions/examples/accordion-maxheight-27638-ag/style.css
@@ -1,0 +1,149 @@
+/* ============================================================
+   Accordion Expand/Collapse Max-Height Utilities — style.css
+   Submission for EaseMotion CSS Issue #27638
+   Accordion headers, content wrapper heights, transitions, chevrons
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 620px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Showcase Accordion Elements
+   ============================================================ */
+
+.showcase {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.accordion-item {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+  transition: border-color 0.2s ease;
+}
+
+.accordion-item:hover {
+  border-color: rgba(124, 58, 237, 0.25);
+}
+
+.accordion-header {
+  padding: 20px 24px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+  user-select: none;
+}
+
+.accordion-header h3 {
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.chevron {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  transition: transform 0.3s ease;
+}
+
+/* Active header state adjustments */
+.accordion-item.active .chevron {
+  transform: rotate(180deg);
+  color: #a78bfa;
+}
+
+/* ============================================================
+   Accordion Transitions under Test (max-height configurations)
+   ============================================================ */
+
+.accordion-content {
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition: max-height 0.4s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.4s ease;
+}
+
+.accordion-item.active .accordion-content {
+  max-height: 200px; /* Safe upper bound limit */
+  opacity: 1;
+}
+
+.content-inner {
+  padding: 0 24px 24px;
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .accordion-content {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-accordion-maxheight` showcase. It demonstrates collapsible widgets generated via SCSS accordion height mixins (utilizing transitionable max-height boundaries and opacity curves) supporting rotating indicator chevrons.

## Root Cause
No reusable height-collapsible mixins or max-height transition selectors existed in the styling system.

## Changes Made
- `submissions/examples/accordion-maxheight-27638-ag/demo.html`: Accordion headers, rotating chevron indicators, details inner panels, and active selector triggers.
- `submissions/examples/accordion-maxheight-27638-ag/style.css`: Max-height bounds, opacity curves, bezier curves, active highlights, and spacing.
- `submissions/examples/accordion-maxheight-27638-ag/README.md`: Explains collapsible container styling, SCSS mixins, and manual testing.

## How to Test
1. Open `demo.html` in a browser.
2. Click header items to confirm vertical toggle collapse movements.

## Related Issue
Closes #27638