### PR TITLE
[Feat] #27630 — Add multi-layer box shadow elevation scale (unique folder)

### DIFF
--- a/submissions/examples/box-shadow-elevation-27630-ag/README.md
+++ b/submissions/examples/box-shadow-elevation-27630-ag/README.md
@@ -1,0 +1,41 @@
+# Multi-Layer Box Shadow Elevation Scale
+
+This guide details configuration specs for generating SCSS multi-layer box shadow mixins.
+
+---
+
+## Technical Overview: The Elevation Mixin
+
+Using simple single-line box shadows often produces flat, artificial looks. Combining multiple shadow offsets generates organic depth scales:
+
+```scss
+// SCSS Box Shadow Elevation Mixin
+@mixin shadow-elevation($level: 1) {
+  @if $level == 1 {
+    box-shadow: 
+      0 1px 2px rgba(0, 0, 0, 0.1),
+      0 2px 4px rgba(0, 0, 0, 0.1);
+  } @else if $level == 2 {
+    box-shadow: 
+      0 4px 6px rgba(0, 0, 0, 0.15),
+      0 10px 15px rgba(0, 0, 0, 0.12);
+  } @else if $level == 3 {
+    box-shadow: 
+      0 10px 20px rgba(0, 0, 0, 0.2),
+      0 20px 40px rgba(0, 0, 0, 0.25);
+  }
+}
+
+// Class mapping
+.card-medium {
+  @include shadow-elevation(2);
+}
+```
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Review the three shadow cards (Level 1, Level 2, Level 3).
+3. Verify that cards cast realistic multi-tiered depths that intensify per level.

--- a/submissions/examples/box-shadow-elevation-27630-ag/demo.html
+++ b/submissions/examples/box-shadow-elevation-27630-ag/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Box Shadow Elevation Scale — EaseMotion CSS</title>
+  <meta name="description" content="Visual shadow elevation showcase demonstrating multi-layer box shadows and depth layers.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — SCSS Utilities</span>
+      <h1>Box Shadow Elevations</h1>
+      <p class="description">
+        Demonstrates layered depth shadows. Observe the realistic shadow casting 
+        offsets on the cards below.
+      </p>
+    </header>
+
+    <main class="showcase">
+      
+      <!-- Shadow Level 1: Low -->
+      <section class="card shadow-level-1">
+        <h3>Elevation Level 1</h3>
+        <p>Subtle shadow height, suitable for inline layout widgets.</p>
+        <span class="badge">depth: low</span>
+      </section>
+
+      <!-- Shadow Level 2: Medium -->
+      <section class="card shadow-level-2">
+        <h3>Elevation Level 2</h3>
+        <p>Medium shadow height, suitable for grid cards and hover states.</p>
+        <span class="badge">depth: medium</span>
+      </section>
+
+      <!-- Shadow Level 3: High -->
+      <section class="card shadow-level-3">
+        <h3>Elevation Level 3</h3>
+        <p>Deep shadow height, suitable for dropdown modals and flyouts.</p>
+        <span class="badge">depth: high</span>
+      </section>
+
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/box-shadow-elevation-27630-ag/style.css
+++ b/submissions/examples/box-shadow-elevation-27630-ag/style.css
@@ -1,0 +1,152 @@
+/* ============================================================
+   Multi-Layer Box Shadow Elevation Scale — style.css
+   Submission for EaseMotion CSS Issue #27630
+   Box shadows, multi-layered depth levels, card grid overlays
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 900px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Showcase Card Grid Layout
+   ============================================================ */
+
+.showcase {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 28px;
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  padding: 32px 28px;
+  border-radius: 24px;
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+}
+
+.card h3 {
+  font-size: 1.15rem;
+  font-weight: 800;
+}
+
+.card p {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.badge {
+  align-self: flex-start;
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: #a78bfa;
+  background: rgba(167, 139, 250, 0.12);
+  border: 1px solid rgba(167, 139, 250, 0.2);
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-family: monospace;
+}
+
+/* ============================================================
+   Layered Box Shadow Presets under Test (SCSS mixin configurations)
+   ============================================================ */
+
+/* ── Depth Level 1 ── */
+.shadow-level-1 {
+  box-shadow: 
+    0 1px 2px rgba(0, 0, 0, 0.1),
+    0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+/* ── Depth Level 2 ── */
+.shadow-level-2 {
+  box-shadow: 
+    0 4px 6px rgba(0, 0, 0, 0.15),
+    0 10px 15px rgba(0, 0, 0, 0.12);
+}
+
+/* ── Depth Level 3 ── */
+.shadow-level-3 {
+  box-shadow: 
+    0 10px 20px rgba(0, 0, 0, 0.2),
+    0 20px 40px rgba(0, 0, 0, 0.25);
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .card {
+    transition: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-box-shadow-elevation` showcase. It demonstrates multi-tiered depth scales generated via SCSS shadow-elevation mixins (declaring stacked shadow lists containing varying offset bounds) supporting high, medium, and low styles.

## Root Cause
No organic multi-layer shadow generators or depth classes existed in EaseMotion CSS.

## Changes Made
- `submissions/examples/box-shadow-elevation-27630-ag/demo.html`: Card panels showcasing Level 1, 2, and 3 elevation layouts.
- `submissions/examples/box-shadow-elevation-27630-ag/style.css`: Layered box-shadow strings, offset boundaries, grid columns, card positioning, and transitions.
- `submissions/examples/box-shadow-elevation-27630-ag/README.md`: Explains shadow layering math, SCSS parameter settings, and manual testing.

## How to Test
1. Open `demo.html` in a browser.
2. Verify visual shadow gradients on cards to confirm multi-layer depth elevation.

## Related Issue
Closes #27630