### PR TITLE
[Feat] #27627 — Add smooth scrollbar styling & hover mixins (unique folder)

### DIFF
--- a/submissions/examples/smooth-scrollbar-27627-ag/README.md
+++ b/submissions/examples/smooth-scrollbar-27627-ag/README.md
@@ -1,0 +1,49 @@
+# Smooth Scrollbar Styling & Hover Mixins
+
+This guide details configuration specs for generating SCSS scrollbar styling mixins.
+
+---
+
+## Technical Overview: The Scrollbar Mixin
+
+Relying on default browser scrollbars often breaks visual dark theme flows. Customizing thumbs using webkit parameters ensures smooth integration:
+
+```scss
+// SCSS Scrollbar Mixin
+@mixin custom-scrollbar($width: 6px, $color: #7c3aed) {
+  // Webkit target browsers
+  &::-webkit-scrollbar {
+    width: $width;
+  }
+  
+  &::-webkit-scrollbar-track {
+    background: rgba(255, 255, 255, 0.02);
+  }
+  
+  &::-webkit-scrollbar-thumb {
+    background: rgba($color, 0.3);
+    border-radius: 999px;
+    
+    &:hover {
+      background: rgba($color, 0.6);
+    }
+  }
+  
+  // Firefox fallback
+  scrollbar-width: thin;
+  scrollbar-color: rgba($color, 0.3) rgba(255, 255, 255, 0.02);
+}
+
+// Class mapping
+.smooth-scrollbar {
+  @include custom-scrollbar(6px, #7c3aed);
+}
+```
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Scroll inside the **Interactive Logs Box**.
+3. Verify that the scrollbar is thin (6px) and color transitions from transparent purple to bright purple on scroll-thumb hover.

--- a/submissions/examples/smooth-scrollbar-27627-ag/demo.html
+++ b/submissions/examples/smooth-scrollbar-27627-ag/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Smooth Scrollbar Styling — EaseMotion CSS</title>
+  <meta name="description" content="Visual scrollbar showcase demonstrating custom scrollbar widths and hover color transitions.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — SCSS Utilities</span>
+      <h1>Smooth Scrollbar Styling</h1>
+      <p class="description">
+        Demonstrates custom scrollbar selectors. Scroll within the panels below 
+        to observe the thin scrolling thumb tracks.
+      </p>
+    </header>
+
+    <main class="showcase">
+      
+      <!-- Scroll Box 1: Custom Scroll -->
+      <section class="card scroll-box-container">
+        <h3>Interactive Logs Box</h3>
+        <div class="scroll-content smooth-scrollbar">
+          <p>[09:30:12] Initializing EaseMotion Core...</p>
+          <p>[09:30:14] Mounting 3D Tilt Mixins...</p>
+          <p>[09:30:18] Attaching Underline Draw Highlights...</p>
+          <p>[09:30:22] Mapping Border Glow Keyframes...</p>
+          <p>[09:30:25] Loading Container Query Bounds...</p>
+          <p>[09:30:30] Resolving Aspect Ratio Matrices...</p>
+          <p>[09:30:35] Syncing Color Palette Tints...</p>
+          <p>[09:30:40] Complete! System Ready.</p>
+        </div>
+        <span class="badge">scrollbar-width: thin</span>
+      </section>
+
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/smooth-scrollbar-27627-ag/style.css
+++ b/submissions/examples/smooth-scrollbar-27627-ag/style.css
@@ -1,0 +1,152 @@
+/* ============================================================
+   Smooth Scrollbar Styling & Hover Mixins — style.css
+   Submission for EaseMotion CSS Issue #27627
+   Webkit scrollbars, custom thumbs, scrollable log panels
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 620px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Showcase Log Container
+   ============================================================ */
+
+.scroll-box-container {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  padding: 32px;
+  border-radius: 20px;
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+}
+
+.scroll-box-container h3 {
+  font-size: 1.1rem;
+  font-weight: 800;
+}
+
+.scroll-content {
+  height: 180px;
+  overflow-y: auto;
+  background: rgba(0, 0, 0, 0.2);
+  border: 1px solid var(--card-border);
+  border-radius: 12px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.scroll-content p {
+  font-family: monospace;
+  font-size: 0.8rem;
+  color: #c4b5fd;
+}
+
+.badge {
+  align-self: flex-start;
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: #22d3ee;
+  background: rgba(34, 211, 238, 0.08);
+  border: 1px solid rgba(34, 211, 238, 0.2);
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-family: monospace;
+}
+
+/* ============================================================
+   Smooth Scrollbar Styles under Test (webkit overrides)
+   ============================================================ */
+
+/* Width and track bounds */
+.smooth-scrollbar::-webkit-scrollbar {
+  width: 6px;
+}
+
+.smooth-scrollbar::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 999px;
+}
+
+/* Thumb details */
+.smooth-scrollbar::-webkit-scrollbar-thumb {
+  background: rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  transition: background 0.2s ease;
+}
+
+.smooth-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: rgba(124, 58, 237, 0.6);
+}
+
+/* Standardized scrollbar properties for firefox compatibility */
+.smooth-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(124, 58, 237, 0.3) rgba(255, 255, 255, 0.02);
+}


### PR DESCRIPTION
## Summary
Adds the `ease-smooth-scrollbar` showcase. It demonstrates modular scrollbar styling generated via SCSS scrollbar-customizer mixins (setting webkit scrollbar track widths combined with interactive thumb hovers) supporting standardized Firefox scrollbar-width rules.

## Root Cause
No customized scrollbar style classes or thumb-coloring templates existed in EaseMotion CSS.

## Changes Made
- `submissions/examples/smooth-scrollbar-27627-ag/demo.html`: Container nodes hosting log boxes, console text snippets, and layout spans.
- `submissions/examples/smooth-scrollbar-27627-ag/style.css`: Webkit scrollbar width overrides, track backgrounds, thumb coloring states, and hover scales.
- `submissions/examples/smooth-scrollbar-27627-ag/README.md`: Details scrolling container overlays, SCSS selector patterns, and manual verification steps.

## How to Test
1. Open `demo.html` in a browser.
2. Scroll log windows to confirm custom thin scrollbar thumbs and hover highlights.

## Related Issue
Closes #27627