### PR TITLE
[Feat] #27643 — Add flexible CSS grid auto-fit generator mixin (unique folder)

### DIFF
--- a/submissions/examples/grid-autofit-generator-27643-ag/README.md
+++ b/submissions/examples/grid-autofit-generator-27643-ag/README.md
@@ -1,0 +1,31 @@
+# Flexible CSS Grid Auto-Fit Generator Mixin
+
+This guide details configuration specs for generating SCSS CSS Grid auto-fit mixins.
+
+---
+
+## Technical Overview: The Grid Auto-Fit Mixin
+
+Writing rigid responsive media queries for grids scales poorly. Generating grid template columns via SCSS auto-fit mixins simplifies wrapping:
+
+```scss
+// SCSS Grid Auto-Fit Generator Mixin
+@mixin grid-autofit($min-width: 200px, $gap: 16px) {
+  display: grid;
+  gap: $gap;
+  grid-template-columns: repeat(auto-fit, minmax($min-width, 1fr));
+}
+
+// Utility Classes
+.grid-parent {
+  @include grid-autofit(200px);
+}
+```
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Watch the columns of cards.
+3. Slide the **Minimum Column Width** range — verify that cards wrap to new rows when minmax thresholds are breached.

--- a/submissions/examples/grid-autofit-generator-27643-ag/demo.html
+++ b/submissions/examples/grid-autofit-generator-27643-ag/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Grid Auto-Fit Generator — EaseMotion CSS</title>
+  <meta name="description" content="Visual CSS Grid auto-fit showcase demonstrating responsive grid layouts and custom column limits.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — SCSS Utilities</span>
+      <h1>Grid Auto-Fit Generator</h1>
+      <p class="description">
+        Demonstrates responsive auto-fit grids. Slide the width range below 
+        to observe the columns wrapping dynamically.
+      </p>
+    </header>
+
+    <main class="dashboard">
+
+      <!-- Left Panel: Grid Settings -->
+      <section class="controls-panel">
+        <h2 class="section-title">Grid Configuration</h2>
+        <div class="control-group">
+          <label for="col-slider">Minimum Column Width: <span id="col-val">200px</span></label>
+          <input type="range" id="col-slider" min="120" max="300" value="200" step="10">
+        </div>
+      </section>
+
+      <!-- Right Panel: Grid Wrapper -->
+      <section class="preview-panel">
+        <h2 class="section-title">Grid Preview</h2>
+        
+        <div class="grid-parent" id="grid-parent" style="grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));">
+          <div class="grid-card">📸 Card 1</div>
+          <div class="grid-card">📸 Card 2</div>
+          <div class="grid-card">📸 Card 3</div>
+          <div class="grid-card">📸 Card 4</div>
+        </div>
+      </section>
+
+    </main>
+  </div>
+
+  <script>
+    const slider = document.getElementById('col-slider');
+    const colVal = document.getElementById('col-val');
+    const grid = document.getElementById('grid-parent');
+
+    slider.addEventListener('input', () => {
+      const minWidth = `${slider.value}px`;
+      colVal.textContent = minWidth;
+      grid.style.gridTemplateColumns = `repeat(auto-fit, minmax(${minWidth}, 1fr))`;
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/grid-autofit-generator-27643-ag/style.css
+++ b/submissions/examples/grid-autofit-generator-27643-ag/style.css
@@ -1,0 +1,147 @@
+/* ============================================================
+   Flexible CSS Grid Auto-Fit Generator — style.css
+   Submission for EaseMotion CSS Issue #27643
+   Grid containers, column wrapping, grid cards, and sliders
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 900px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Dashboard Layout
+   ============================================================ */
+
+.dashboard {
+  display: grid;
+  grid-template-columns: 1fr 1.5fr;
+  gap: 28px;
+}
+
+@media (max-width: 768px) {
+  .dashboard { grid-template-columns: 1fr; }
+}
+
+.controls-panel,
+.preview-panel {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  padding: 28px;
+  border-radius: 20px;
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+}
+
+.section-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+/* Settings sliders */
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.control-group label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.control-group input[type="range"] {
+  accent-color: var(--primary-color);
+  cursor: pointer;
+}
+
+/* ============================================================
+   CSS Grid Auto-Fit Generator Elements under Test
+   ============================================================ */
+
+.grid-parent {
+  display: grid;
+  gap: 16px;
+  width: 100%;
+}
+
+.grid-card {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--card-border);
+  padding: 24px;
+  border-radius: 12px;
+  font-weight: 700;
+  text-align: center;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100px;
+}


### PR DESCRIPTION
## Summary
Adds the `ease-grid-autofit-generator` showcase. It demonstrates flexible column wrapping generated via SCSS grid-autofit mixins (mapping auto-fit repeat properties with minmax bounds) supporting dynamic minimum column width controls.

## Root Cause
No reusable CSS grid auto-fit column generators existed in the styling system.

## Changes Made
- `submissions/examples/grid-autofit-generator-27643-ag/demo.html`: Container grids holding preview cards, range sliders, and dashboard layouts.
- `submissions/examples/grid-autofit-generator-27643-ag/style.css`: Column properties, minmax limits, grid gap mappings, and card elevations.
- `submissions/examples/grid-autofit-generator-27643-ag/README.md`: Explains SCSS grid repeat options, layout wrapping, and manual testing.

## How to Test
1. Open `demo.html` in a browser.
2. Drag min-width sliders to confirm column wrapping actions.

## Related Issue
Closes #27643