### PR TITLE
[Feat] #27642 — Add fluid typography & clamp mixin system (unique folder)

### DIFF
--- a/submissions/examples/fluid-typography-27642-ag/README.md
+++ b/submissions/examples/fluid-typography-27642-ag/README.md
@@ -1,0 +1,39 @@
+# Fluid Typography & Clamp Mixin System
+
+This guide details configuration specs for generating SCSS fluid typography clamp mixins.
+
+---
+
+## Technical Overview: The Fluid Typography Mixin
+
+Setting rigid typography values using static pixels results in uneven viewport jumps. Utilizing CSS clamp scaling provides smooth font-size scaling:
+
+```scss
+// SCSS Fluid Typography Mixin
+@mixin fluid-type($min-size, $max-size, $min-vw: 320px, $max-vw: 1200px) {
+  // Convert boundaries to unitless factors
+  $u1: unit($min-size);
+  $u2: unit($max-size);
+  
+  @if $u1 == $u2 {
+    font-size: clamp(
+      $min-size,
+      calc(#{$min-size} + (#{$max-size} - #{$min-size}) * ((100vw - #{$min-vw}) / (#{$max-vw} - #{$min-vw}))),
+      $max-size
+    );
+  }
+}
+
+// Utility Class mapping
+.fluid-title {
+  @include fluid-type(1.4rem, 2.5rem);
+}
+```
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a browser.
+2. Observe the headers inside the dashed simulated viewport.
+3. Slide the **Simulated Container Width** range — verify that title font-sizes shrink and grow dynamically in a smooth curve.

--- a/submissions/examples/fluid-typography-27642-ag/demo.html
+++ b/submissions/examples/fluid-typography-27642-ag/demo.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fluid Typography &amp; Clamp — EaseMotion CSS</title>
+  <meta name="description" content="Visual fluid typography showcase demonstrating clamp font-size scaling and viewport widths.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — SCSS Utilities</span>
+      <h1>Fluid Typography Scale</h1>
+      <p class="description">
+        Demonstrates CSS clamp text scaling. Adjust the container width slider 
+        below to observe the headers scaling fluidly.
+      </p>
+    </header>
+
+    <main class="dashboard">
+
+      <!-- Width Slider -->
+      <section class="controls-panel">
+        <h2 class="section-title">Viewport Width Controller</h2>
+        <div class="control-group">
+          <label for="width-slider">Simulated Container Width: <span id="width-val">600px</span></label>
+          <input type="range" id="width-slider" min="320" max="1000" value="600" step="20">
+        </div>
+      </section>
+
+      <!-- Preview container -->
+      <section class="preview-panel">
+        <h2 class="section-title">Typography Preview</h2>
+
+        <div class="fluid-container" id="fluid-box" style="width: 600px;">
+          <h2 class="fluid-title">Fluid Header Title</h2>
+          <p class="fluid-body">
+            This paragraph text scales using fluid font-size formulas. As the parent width 
+            compresses, the font size decreases down to its defined minimum bound.
+          </p>
+          <span class="badge">font-size: clamp()</span>
+        </div>
+      </section>
+
+    </main>
+  </div>
+
+  <script>
+    const slider = document.getElementById('width-slider');
+    const widthVal = document.getElementById('width-val');
+    const box = document.getElementById('fluid-box');
+
+    slider.addEventListener('input', () => {
+      const width = `${slider.value}px`;
+      widthVal.textContent = width;
+      box.style.width = width;
+      
+      // Map simulated container width to a CSS variable to drive local container-based fluid scaling
+      box.style.setProperty('--simulated-width', `${slider.value}`);
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/fluid-typography-27642-ag/style.css
+++ b/submissions/examples/fluid-typography-27642-ag/style.css
@@ -1,0 +1,165 @@
+/* ============================================================
+   Fluid Typography & Clamp Mixin System — style.css
+   Submission for EaseMotion CSS Issue #27642
+   Fluid font sizes, clamp parameters, dashboard layouts, labels
+   ============================================================ */
+
+:root {
+  --primary-color: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+  --text-muted: #64748b;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 820px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Dashboard Layout
+   ============================================================ */
+
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.controls-panel,
+.preview-panel {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  padding: 28px;
+  border-radius: 20px;
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+}
+
+.section-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+/* Width Controls */
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.control-group label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.control-group input[type="range"] {
+  accent-color: var(--primary-color);
+  cursor: pointer;
+}
+
+/* ============================================================
+   Fluid Typography Scaling under Test (clamp overrides)
+   ============================================================ */
+
+.fluid-container {
+  background: rgba(0, 0, 0, 0.15);
+  border: 1px dashed rgba(255, 255, 255, 0.15);
+  border-radius: 16px;
+  padding: 24px;
+  margin: 0 auto;
+  transition: width 0.15s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  --simulated-width: 600; /* Fallback baseline */
+}
+
+/* Uses clamp formula relative to simulated-width var to show scaling inside slider container */
+.fluid-title {
+  font-weight: 800;
+  color: #fff;
+  /* Simulating fluid viewport width changes using css variables */
+  font-size: calc(1.3rem + (2.5 - 1.3) * ((var(--simulated-width) - 320) / (1000 - 320)) * 1rem);
+  /* Fallback using standard viewport clamp */
+  font-size: clamp(1.4rem, 4vw + 0.5rem, 2.5rem);
+}
+
+.fluid-body {
+  color: var(--text-secondary);
+  line-height: 1.6;
+  font-size: calc(0.85rem + (1.1 - 0.85) * ((var(--simulated-width) - 320) / (1000 - 320)) * 1rem);
+  font-size: clamp(0.85rem, 1.5vw + 0.5rem, 1.1rem);
+}
+
+.badge {
+  align-self: flex-start;
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: #22d3ee;
+  background: rgba(34, 211, 238, 0.08);
+  border: 1px solid rgba(34, 211, 238, 0.2);
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-family: monospace;
+}


### PR DESCRIPTION
## Summary
Adds the `ease-fluid-typography` showcase. It demonstrates text scaling curves generated via SCSS fluid-type mixins (utilizing CSS clamp bounds mapping minimum font sizes, viewports, and maximum capacities) supporting simulated layout scaling.

## Root Cause
No fluid clamp typography mixins or responsive viewport scaling formulas existed in the project.

## Changes Made
- `submissions/examples/fluid-typography-27642-ag/demo.html`: Container nodes hosting text blocks, width sliders, and active container boundaries.
- `submissions/examples/fluid-typography-27642-ag/style.css`: Viewport calc operations, clamp mappings, minmax sizes, text alignments, and border styles.
- `submissions/examples/fluid-typography-27642-ag/README.md`: Explains typography scale curves, SCSS clamp equations, and manual verification.

## How to Test
1. Open `demo.html` in a browser.
2. Slide width controllers to verify smooth title scaling transitions.

## Related Issue
Closes #27642