### PR TITLE
docs: document easemotion/all.css as legacy/partial bundle

### DIFF
--- a/submissions/docs/easemotion-all-bundle-notice-tw/README.md
+++ b/submissions/docs/easemotion-all-bundle-notice-tw/README.md
@@ -1,0 +1,31 @@
+# easemotion/all.css — Legacy Bundle Notice
+
+Documents the coverage gap between `easemotion.css` and `easemotion/all.css`, addressing #27879.
+
+## What does this do?
+
+Adds a clear, visual reference page explaining that `easemotion/all.css` is a legacy/partial bundle that does not always include every component shipped through the main `easemotion.css` entrypoint — and lists which newer components may be missing from it.
+
+## How is it used?
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<table class="bundle-table">
+  <!-- rows comparing easemotion.css vs easemotion/all.css coverage -->
+</table>
+
+<div class="bundle-notice__callout">
+  <!-- warns that easemotion/all.css may lag behind newer components -->
+</div>
+```
+
+The `.bundle-table` and `.bundle-notice__callout` classes are demo-only presentational styles for this reference page — not proposed EaseMotion utility classes.
+
+## Why is it useful?
+
+Issue #27879 reported that `easemotion/all.css` is documented as a full modular bundle but is missing many components that `easemotion.css` imports (e.g. `announce-bar.css`, `avatar.css`, `breadcrumb.css`, `btn-magnetic.css`, `command-palette.css`, `compare-table.css`, `connection-status.css`).
+
+The issue's own "Expected behavior" section proposes two acceptable fixes: either make `easemotion/all.css` match `easemotion.css`'s import surface, or **document it as a legacy/partial bundle** so users aren't misled.
+
+Editing `easemotion/all.css` and `easemotion.css` directly would require changes inside `core/`, which is currently under the repository's temporary contribution freeze (per CONTRIBUTING.md: *"PRs modifying core files, workflows, configs, or shared framework code are temporarily restricted"*). This submission implements the second, freeze-compliant option — clear documentation — so the coverage gap is communicated to users immediately, without needing core write access. It can be superseded once core access reopens and the bundle itself is reconciled.

--- a/submissions/docs/easemotion-all-bundle-notice-tw/demo.html
+++ b/submissions/docs/easemotion-all-bundle-notice-tw/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>easemotion/all.css — Legacy Bundle Notice</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="bundle-notice">
+    <h1>Bundle Import Reference</h1>
+    <p class="bundle-notice__intro">
+      This page documents the difference between the two EaseMotion CSS entrypoints,
+      addressing <strong>#27879</strong> — where <code>easemotion/all.css</code> was
+      undocumented as a partial bundle relative to <code>easemotion.css</code>.
+    </p>
+
+    <table class="bundle-table">
+      <thead>
+        <tr>
+          <th>Entrypoint</th>
+          <th>Coverage</th>
+          <th>Recommended use</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>easemotion.css</code></td>
+          <td class="status status--full">Full component surface (current, always up to date)</td>
+          <td>Default choice for new projects</td>
+        </tr>
+        <tr>
+          <td><code>easemotion/all.css</code></td>
+          <td class="status status--legacy">Legacy / partial bundle — may lag behind newly added components</td>
+          <td>Existing projects already depending on this entrypoint</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="bundle-notice__callout">
+      <strong>Heads up:</strong> <code>easemotion/all.css</code> is not guaranteed to include every
+      component shipped in <code>easemotion.css</code>. Newer components (e.g. <code>announce-bar</code>,
+      <code>avatar</code>, <code>breadcrumb</code>, <code>btn-magnetic</code>, <code>command-palette</code>,
+      <code>compare-table</code>, <code>connection-status</code>) may only be available through the main
+      entrypoint until the legacy bundle is refreshed.
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/docs/easemotion-all-bundle-notice-tw/style.css
+++ b/submissions/docs/easemotion-all-bundle-notice-tw/style.css
@@ -1,0 +1,100 @@
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #0f1117;
+  color: #e6e6e6;
+  margin: 0;
+  padding: 40px 20px;
+  display: flex;
+  justify-content: center;
+}
+
+.bundle-notice {
+  max-width: 720px;
+  width: 100%;
+}
+
+.bundle-notice h1 {
+  font-size: 1.6rem;
+  margin-bottom: 12px;
+}
+
+.bundle-notice__intro {
+  color: #b3b3b3;
+  line-height: 1.5;
+  margin-bottom: 24px;
+}
+
+.bundle-notice__intro code {
+  background: #1c1f28;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+
+.bundle-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 24px;
+  overflow: hidden;
+  border-radius: 8px;
+  border: 1px solid #2a2d38;
+}
+
+.bundle-table th,
+.bundle-table td {
+  text-align: left;
+  padding: 12px 14px;
+  border-bottom: 1px solid #2a2d38;
+  font-size: 0.92rem;
+}
+
+.bundle-table th {
+  background: #171922;
+  color: #9aa0ac;
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+}
+
+.bundle-table td code {
+  background: #1c1f28;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.bundle-table tr:last-child td {
+  border-bottom: none;
+}
+
+.status {
+  display: inline-block;
+}
+
+.status--full::before {
+  content: "●";
+  color: #4ade80;
+  margin-right: 6px;
+}
+
+.status--legacy::before {
+  content: "●";
+  color: #facc15;
+  margin-right: 6px;
+}
+
+.bundle-notice__callout {
+  background: #201c10;
+  border: 1px solid #4d3d12;
+  color: #f2d98a;
+  padding: 14px 16px;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.bundle-notice__callout code {
+  background: #2b2410;
+  padding: 2px 6px;
+  border-radius: 4px;
+}


### PR DESCRIPTION
Closes #27879

## Pull Request Description
Adds a documentation reference page clarifying that `easemotion/all.css` is a legacy/partial bundle and does not always mirror the full component surface of `easemotion.css`.

---

## Type of Change
- [x] 📝 Documentation improvement
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/docs/easemotion-all-bundle-notice-tw/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the reference page
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**
A visual comparison table + callout documenting that `easemotion/all.css` lags behind `easemotion.css` in component coverage.

**How does a developer use it?**
```html
<link rel="stylesheet" href="style.css" />
<table class="bundle-table">...</table>
<div class="bundle-notice__callout">...</div>
```

**Why does it fit EaseMotion CSS?**
It directly implements the documentation-based fix suggested in #27879's "Expected behavior" section, without requiring the core-file changes that are currently under the repo-wide contribution freeze.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

*(Note: haven't cross-browser tested yet — will do before marked ready.)*

---

## Notes for Maintainer
Issue #27879 proposed two possible fixes: reconciling `easemotion/all.css`'s imports with `easemotion.css` (a `core/` change), or documenting the gap (a `submissions/docs/` change). Given the active core-file freeze in CONTRIBUTING.md, I went with the documentation route so this can merge now. If/when core access reopens, the actual bundle mismatch in `easemotion/all.css` should still be fixed directly — this PR doesn't replace that, just documents the gap in the meantime.