### PR TITLE
feat: add multi-layer box-shadow elevation scale mixin

### DIFF
--- a/submissions/scss/scss-multi-layer-box-shadow-elevation-scale-tw/README.md
+++ b/submissions/scss/scss-multi-layer-box-shadow-elevation-scale-tw/README.md
@@ -1,0 +1,90 @@
+# _multi-layer-box-shadow-elevation-scale-tw.scss
+
+A multi-layer box-shadow elevation system for EaseMotion CSS.
+
+## What it does
+
+Provides a 6-step elevation scale (levels `0`–`5`), where each level stacks two shadow layers — a tighter "key" shadow and a softer, wider "ambient" shadow — to create a more convincing sense of physical depth than a single flat `box-shadow` can. Higher levels use larger offsets/blur and slightly higher opacity, so elevation reads as a continuous, believable scale rather than an abrupt jump.
+
+Exposes two entry points:
+
+- **`ease-elevation-shadow($level)`** — a function that returns the raw `box-shadow` value for a level, for use inline or in your own composed declarations.
+- **`ease-elevation($level, $transition: true)`** — a mixin that applies the shadow directly and (optionally) a smooth transition, for elements whose elevation changes on hover/focus.
+
+## Parameters
+
+### `ease-elevation-shadow($level)`
+
+| Parameter | Type   | Description                                             |
+| --------- | ------ | --------------------------------------------------------- |
+| `$level`  | Number | Elevation key, `0`–`5`, matching `$ease-elevation-levels`. |
+
+### `ease-elevation($level, $transition)`
+
+| Parameter     | Type    | Default | Description                                              |
+| ------------- | ------- | ------- | ---------------------------------------------------------- |
+| `$level`      | Number  | —       | **Required.** Elevation key, `0`–`5`.                       |
+| `$transition` | Boolean | `true`  | Whether to include a `box-shadow` transition on the rule.  |
+
+### Configuration variables
+
+| Variable                                | Default        | Description                                  |
+| ---------------------------------------- | -------------- | ---------------------------------------------- |
+| `$ease-elevation-color`                  | `15, 17, 23`   | RGB triplet used as the shadow color base.      |
+| `$ease-elevation-transition-duration`    | `200ms`        | Duration for the mixin's optional transition.   |
+| `$ease-elevation-transition-timing`      | `ease`         | Easing for the optional transition.             |
+| `$ease-elevation-levels`                 | *(map, see source)* | The level → shadow-layers definition, overridable before `@use`. |
+
+## Usage
+
+```scss
+@use "multi-layer-box-shadow-elevation-scale-tw" as *;
+
+// Static elevation
+.card {
+  @include ease-elevation(1);
+}
+
+// Elevation that rises on hover, using the function directly
+.card--interactive {
+  @include ease-elevation(1);
+
+  &:hover {
+    box-shadow: ease-elevation-shadow(3);
+  }
+}
+
+// Custom color, e.g. a colored glow instead of neutral shadow
+.card--brand {
+  $ease-elevation-color: 91, 33, 182; // override before use
+  @include ease-elevation(2);
+}
+```
+
+## CSS compilation results
+
+For reference, here is what each level compiles to with the default `$ease-elevation-color: 15, 17, 23`:
+
+```css
+/* Level 0 */
+box-shadow: 0 0 0 0 rgba(15, 17, 23, 0);
+
+/* Level 1 */
+box-shadow: 0 1px 2px 0 rgba(15, 17, 23, 0.1), 0 1px 3px 1px rgba(15, 17, 23, 0.08);
+
+/* Level 2 */
+box-shadow: 0 2px 4px 0 rgba(15, 17, 23, 0.12), 0 3px 6px 2px rgba(15, 17, 23, 0.1);
+
+/* Level 3 */
+box-shadow: 0 4px 8px 0 rgba(15, 17, 23, 0.14), 0 6px 12px 3px rgba(15, 17, 23, 0.12);
+
+/* Level 4 */
+box-shadow: 0 8px 16px 0 rgba(15, 17, 23, 0.16), 0 10px 20px 4px rgba(15, 17, 23, 0.14);
+
+/* Level 5 */
+box-shadow: 0 16px 28px 0 rgba(15, 17, 23, 0.18), 0 20px 36px 6px rgba(15, 17, 23, 0.16);
+```
+
+## Why this fits EaseMotion CSS
+
+Elevation is a common but frequently reinvented pattern — most projects hardcode one-off `box-shadow` values per component, which drifts out of sync over time. This module centralizes elevation as a single overridable scale with a documented API, so any EaseMotion component (cards, modals, dropdowns, toasts) can opt into a consistent depth system, and pairs naturally with EaseMotion's existing hover/motion utilities for elements that "lift" on interaction.

--- a/submissions/scss/scss-multi-layer-box-shadow-elevation-scale-tw/_multi-layer-box-shadow-elevation-scale-tw.scss
+++ b/submissions/scss/scss-multi-layer-box-shadow-elevation-scale-tw/_multi-layer-box-shadow-elevation-scale-tw.scss
@@ -1,0 +1,122 @@
+// _multi-layer-box-shadow-elevation-scale-tw.scss
+//
+// A multi-layer elevation system for EaseMotion CSS, modeled on the
+// "ambient + key light" approach used by Material-style design systems:
+// each elevation level stacks a soft, low-opacity ambient shadow with a
+// tighter, more directional key shadow, so surfaces read as physically
+// "lifted" rather than just blurred.
+//
+// Usage is two-part:
+//   1. `ease-elevation-shadow($level)`  → returns a box-shadow value
+//   2. `ease-elevation($level)`         → mixin that applies it (+ optional transition)
+
+// ---------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------
+
+/// Base shadow color. Kept as a plain RGB triplet (not rgba) so opacity
+/// can be layered per-level via rgba() below.
+$ease-elevation-color: 15, 17, 23 !default; // near-black, matches dark UI surfaces
+
+/// Duration used when `ease-elevation` applies a transition between levels.
+$ease-elevation-transition-duration: 200ms !default;
+$ease-elevation-transition-timing: ease !default;
+
+/// Elevation map: level → list of shadow layers.
+/// Each layer is (x-offset, y-offset, blur, spread, opacity).
+/// Levels are unitless keys (0–5) representing increasing "height".
+$ease-elevation-levels: (
+  0: (
+    (0, 0, 0, 0, 0)
+  ),
+  1: (
+    (0, 1px, 2px, 0, 0.10),
+    (0, 1px, 3px, 1px, 0.08)
+  ),
+  2: (
+    (0, 2px, 4px, 0, 0.12),
+    (0, 3px, 6px, 2px, 0.10)
+  ),
+  3: (
+    (0, 4px, 8px, 0, 0.14),
+    (0, 6px, 12px, 3px, 0.12)
+  ),
+  4: (
+    (0, 8px, 16px, 0, 0.16),
+    (0, 10px, 20px, 4px, 0.14)
+  ),
+  5: (
+    (0, 16px, 28px, 0, 0.18),
+    (0, 20px, 36px, 6px, 0.16)
+  )
+) !default;
+
+// ---------------------------------------------------------------------
+// Function
+// ---------------------------------------------------------------------
+
+/// Builds the box-shadow value for a given elevation level by
+/// concatenating all of its shadow layers into one comma-separated
+/// box-shadow declaration.
+///
+/// @param {Number} $level - Elevation level key present in $ease-elevation-levels.
+/// @return {List} A box-shadow-ready value, e.g. `0 1px 2px 0 rgba(...), 0 1px 3px 1px rgba(...)`
+///
+/// @example scss
+///   .card {
+///     box-shadow: ease-elevation-shadow(2);
+///   }
+@function ease-elevation-shadow($level) {
+  @if not map-has-key($ease-elevation-levels, $level) {
+    @warn "ease-elevation-shadow: level `#{$level}` not found in $ease-elevation-levels. Falling back to level 0.";
+    $level: 0;
+  }
+
+  $layers: map-get($ease-elevation-levels, $level);
+  $shadow-list: ();
+
+  @each $layer in $layers {
+    $x: nth($layer, 1);
+    $y: nth($layer, 2);
+    $blur: nth($layer, 3);
+    $spread: nth($layer, 4);
+    $opacity: nth($layer, 5);
+
+    $shadow: $x $y $blur $spread rgba($ease-elevation-color, $opacity);
+    $shadow-list: append($shadow-list, $shadow, comma);
+  }
+
+  @return $shadow-list;
+}
+
+// ---------------------------------------------------------------------
+// Mixin
+// ---------------------------------------------------------------------
+
+/// Applies a full multi-layer elevation shadow to an element, with an
+/// optional smooth transition for use on interactive elements that
+/// change elevation on hover/focus (e.g. cards, buttons, modals).
+///
+/// @param {Number} $level - Elevation level to apply.
+/// @param {Boolean} $transition [true] - Whether to include a box-shadow transition.
+///
+/// @example scss - Static elevation
+///   .card {
+///     @include ease-elevation(1);
+///   }
+///
+/// @example scss - Elevation that rises on hover
+///   .card {
+///     @include ease-elevation(1);
+///
+///     &:hover {
+///       @include ease-elevation(3, $transition: false); // transition already set above
+///     }
+///   }
+@mixin ease-elevation($level, $transition: true) {
+  box-shadow: ease-elevation-shadow($level);
+
+  @if $transition {
+    transition: box-shadow $ease-elevation-transition-duration $ease-elevation-transition-timing;
+  }
+}


### PR DESCRIPTION
Closes #27833

## Pull Request Description
Adds a multi-layer (ambient + key shadow) box-shadow elevation scale for EaseMotion CSS, per the maintainer's spec in #27833.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/scss/scss-multi-layer-box-shadow-elevation-scale-tw/`
- [ ] Includes `demo.html` — N/A, SCSS track requires a partial + README, not demo.html/style.css (see track table in CONTRIBUTING.md)
- [ ] Includes `style.css` — N/A for the same reason
- [x] Includes `README.md` — documents mixin parameters, usage, and compiled CSS output
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**
A `_multi-layer-box-shadow-elevation-scale-tw.scss` partial providing a 6-level (0–5) elevation scale, via `ease-elevation-shadow($level)` (function) and `ease-elevation($level, $transition)` (mixin).

**How does a developer use it?**
```scss
@use "multi-layer-box-shadow-elevation-scale-tw" as *;

.card {
  @include ease-elevation(1);

  &:hover {
    box-shadow: ease-elevation-shadow(3);
  }
}
```

**Why does it fit EaseMotion CSS?**
Centralizes a commonly-reinvented pattern (elevation shadows) into one overridable, documented API that pairs with EaseMotion's existing hover/motion utilities for elements that visually "lift" on interaction.

---

## Demo
- [ ] Demo added — N/A, SCSS track submissions don't require `demo.html` per CONTRIBUTING.md

---

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

*(Note: SCSS-only submission, not yet compiled/tested visually in a browser — will do on request.)*

---

## Notes for Maintainer
Heads up: `submissions/scss/scss-multi-layer-box-shadow-elevation-scale/` (no `-tw` suffix) already exists on `main`, referencing #28479 with different content. I used the `-tw` suffix per the naming-collision policy in CONTRIBUTING.md to avoid overwriting that existing submission. Flagging in case #27833 and #28479 turn out to be duplicate/related issues worth reconciling on your end.