### PR TITLE
feat: add micro-interaction button ripple effect mixins

### DIFF
--- a/submissions/scss/scss-micro-interaction-button-ripple-effect-mixins-tw/README.md
+++ b/submissions/scss/scss-micro-interaction-button-ripple-effect-mixins-tw/README.md
@@ -1,0 +1,111 @@
+# _micro-interaction-button-ripple-effect-mixins-tw.scss
+
+A pure-CSS, zero-JavaScript "material-style" ripple micro-interaction for EaseMotion CSS.
+
+## What it does
+
+Adds a centered ripple that expands and fades out of a button (or any clickable element) on `:active`. Since there's no JavaScript tracking the actual click coordinates, the ripple originates from the element's center — a deliberate tradeoff that keeps this a pure-CSS utility with no event listeners required.
+
+Two mixins work together:
+
+- **`ease-ripple-container`** — sets up `position: relative`, `overflow: hidden`, and `isolation: isolate` on the host element so the ripple is positioned and clipped correctly.
+- **`ease-ripple($size, $color)`** — generates the `::after` ripple pseudo-element and its `:active` expand animation.
+
+Respects `prefers-reduced-motion` by hiding the ripple pseudo-element entirely for users who've requested reduced motion.
+
+## Parameters
+
+### `ease-ripple-container`
+No parameters.
+
+### `ease-ripple($size, $color)`
+
+| Parameter | Type          | Default                | Description                                                                 |
+| --------- | ------------- | ------------------------ | ------------------------------------------------------------------------------ |
+| `$size`   | Length/%      | `100%`                    | Starting diameter of the ripple, relative to the element. Increase for a ripple that starts larger before expanding. |
+| `$color`  | RGB triplet   | `$ease-ripple-color`      | Color of the ripple, as an unquoted `r, g, b` triplet (not a hex/named color). |
+
+### Configuration variables
+
+| Variable                     | Default             | Description                                    |
+| ------------------------------ | -------------------- | ------------------------------------------------- |
+| `$ease-ripple-color`           | `255, 255, 255`      | Default ripple color (white, for colored buttons). |
+| `$ease-ripple-duration`        | `550ms`               | Duration of the expand-and-fade animation.         |
+| `$ease-ripple-timing`          | `cubic-bezier(0.4, 0, 0.2, 1)` | Easing curve for the ripple animation.  |
+| `$ease-ripple-opacity-start`   | `0.35`                | Starting opacity of the ripple at the moment of press. |
+| `$ease-ripple-scale-end`       | `2.5`                 | Final scale multiplier the ripple grows to before fading out. |
+
+## Usage
+
+```scss
+@use "micro-interaction-button-ripple-effect-mixins-tw" as *;
+
+// Basic button ripple
+.btn {
+  @include ease-ripple-container;
+  @include ease-ripple;
+}
+
+// Dark ripple for a light/outline button
+.btn--outline {
+  @include ease-ripple-container;
+  @include ease-ripple($color: 15, 17, 23);
+}
+
+// Larger starting ripple, custom duration via the global variable
+$ease-ripple-duration: 700ms;
+
+.btn--large {
+  @include ease-ripple-container;
+  @include ease-ripple($size: 140%);
+}
+```
+
+## CSS compilation results
+
+`@include ease-ripple;` with all defaults compiles to approximately:
+
+```css
+.btn::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle,
+    rgba(255, 255, 255, 0.35) 0%,
+    rgba(255, 255, 255, 0) 70%
+  );
+  transform: translate(-50%, -50%) scale(0);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.btn:active::after {
+  animation: ease-ripple-expand 550ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .btn::after {
+    display: none;
+  }
+}
+
+@keyframes ease-ripple-expand {
+  0% {
+    transform: translate(-50%, -50%) scale(0);
+    opacity: 0.35;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(2.5);
+    opacity: 0;
+  }
+}
+```
+
+## Why this fits EaseMotion CSS
+
+Ripple feedback is one of the most requested micro-interactions for buttons, but most implementations require JavaScript click-coordinate tracking. This module gives EaseMotion a zero-dependency, CSS-only approximation that's good enough for most UI feedback needs, keeps the library's "no runtime" philosophy intact, and composes cleanly with EaseMotion's other hover/press utilities (e.g. `ease-hover-scale`) on the same element.

--- a/submissions/scss/scss-micro-interaction-button-ripple-effect-mixins-tw/_micro-interaction-button-ripple-effect-mixins-tw.scss
+++ b/submissions/scss/scss-micro-interaction-button-ripple-effect-mixins-tw/_micro-interaction-button-ripple-effect-mixins-tw.scss
@@ -1,0 +1,109 @@
+// _micro-interaction-button-ripple-effect-mixins-tw.scss
+//
+// A pure-CSS "material-style" ripple micro-interaction for buttons and
+// other clickable surfaces. No JavaScript required: the ripple is a
+// radial-gradient pseudo-element that scales outward from the center
+// of the element on `:active`, then fades. Because there's no pointer
+// coordinate tracking without JS, the ripple originates from the
+// element's center rather than the exact click point — a deliberate
+// tradeoff to keep this a zero-JS utility.
+//
+// Usage is two-part:
+//   1. `ease-ripple-container` → apply to the clickable element itself
+//      (sets up positioning/overflow so the ripple is clipped correctly)
+//   2. `ease-ripple`           → generates the ripple pseudo-element + animation
+
+// ---------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------
+
+$ease-ripple-color: 255, 255, 255 !default; // RGB triplet, works well on colored buttons
+$ease-ripple-duration: 550ms !default;
+$ease-ripple-timing: cubic-bezier(0.4, 0, 0.2, 1) !default;
+$ease-ripple-opacity-start: 0.35 !default;
+$ease-ripple-scale-end: 2.5 !default; // how far the ripple grows relative to its start size
+
+@keyframes ease-ripple-expand {
+  0% {
+    transform: translate(-50%, -50%) scale(0);
+    opacity: $ease-ripple-opacity-start;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(#{$ease-ripple-scale-end});
+    opacity: 0;
+  }
+}
+
+// ---------------------------------------------------------------------
+// Mixins
+// ---------------------------------------------------------------------
+
+/// Prepares an element to correctly host a ripple: relative positioning
+/// (so the ripple pseudo-element can be centered inside it) and hidden
+/// overflow (so the ripple is clipped to the element's bounds).
+///
+/// Apply this to the clickable element itself, alongside `ease-ripple`.
+///
+/// @example scss
+///   .btn {
+///     @include ease-ripple-container;
+///     @include ease-ripple;
+///   }
+@mixin ease-ripple-container {
+  position: relative;
+  overflow: hidden;
+  // Preserve any existing border-radius on the clip so the ripple
+  // doesn't square off a rounded button.
+  isolation: isolate;
+}
+
+/// Adds a centered, expanding ripple pseudo-element that plays on
+/// `:active` (mouse/touch press). Intended to be paired with
+/// `ease-ripple-container` on the same selector.
+///
+/// @param {Number} $size [100%] - Starting diameter of the ripple, as a
+///   percentage of the element's smaller dimension. 100% centers a
+///   ripple that just covers the element at rest; increase for a
+///   ripple that starts larger before expanding.
+/// @param {Color|List} $color [$ease-ripple-color] - RGB triplet for the ripple.
+///
+/// @example scss - Basic usage
+///   .btn {
+///     @include ease-ripple-container;
+///     @include ease-ripple;
+///   }
+///
+/// @example scss - Custom color for a dark-on-light button
+///   .btn--outline {
+///     @include ease-ripple-container;
+///     @include ease-ripple($color: 15, 17, 23);
+///   }
+@mixin ease-ripple($size: 100%, $color: $ease-ripple-color) {
+  &::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: $size;
+    height: $size;
+    border-radius: 50%;
+    background: radial-gradient(
+      circle,
+      rgba($color, $ease-ripple-opacity-start) 0%,
+      rgba($color, 0) 70%
+    );
+    transform: translate(-50%, -50%) scale(0);
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  &:active::after {
+    animation: ease-ripple-expand $ease-ripple-duration $ease-ripple-timing;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    &::after {
+      display: none;
+    }
+  }
+}


### PR DESCRIPTION
Closes #27838

## Pull Request Description
Adds a pure-CSS, zero-JavaScript "material-style" ripple micro-interaction for buttons, per the maintainer's spec in #27838.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/scss/scss-micro-interaction-button-ripple-effect-mixins-tw/`
- [ ] Includes `demo.html` — N/A, SCSS track requires a partial + README, not demo.html/style.css (see track table in CONTRIBUTING.md)
- [ ] Includes `style.css` — N/A for the same reason
- [x] Includes `README.md` — documents mixin parameters, usage, and compiled CSS output
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**
A `_micro-interaction-button-ripple-effect-mixins-tw.scss` partial providing `ease-ripple-container` (positioning/clipping setup) and `ease-ripple($size, $color)` (the expanding ripple pseudo-element + `:active` animation).

**How does a developer use it?**
```scss
@use "micro-interaction-button-ripple-effect-mixins-tw" as *;

.btn {
  @include ease-ripple-container;
  @include ease-ripple;
}
```

**Why does it fit EaseMotion CSS?**
Gives EaseMotion a zero-dependency ripple effect (no click-coordinate JS needed), consistent with the library's no-runtime philosophy, and composes with existing hover/press utilities.

---

## Demo
- [ ] Demo added — N/A, SCSS track submissions don't require `demo.html` per CONTRIBUTING.md

---

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

*(Note: SCSS-only submission, not yet compiled/tested visually in a browser — will do on request.)*

---

## Notes for Maintainer
Ripple originates from the element's center rather than the actual click point, since this is intentionally a zero-JS approximation (no pointer coordinate tracking). Also includes a `prefers-reduced-motion` fallback that hides the ripple entirely. Used a `-tw` suffix per the naming-collision policy in CONTRIBUTING.md — didn't find an existing submission at this base path, but flagging the convention in case of a future collision.