### PR TITLE
feat: add text highlight underline draw utilities

### DIFF
--- a/submissions/scss/scss-text-highlight-underline-draw-utilities-tw/README.md
+++ b/submissions/scss/scss-text-highlight-underline-draw-utilities-tw/README.md
@@ -1,0 +1,86 @@
+# _text-highlight-underline-draw-utilities-tw.scss
+
+Pure-CSS "drawn underline" utilities for EaseMotion CSS.
+
+## What it does
+
+Provides `ease-underline-draw`, a mixin that gives inline text (links, nav items, headings) an animated underline that "draws" itself in on hover — left-to-right, right-to-left, or growing outward from the center — instead of just appearing or fading. It's implemented with a `background-image` gradient sized at `0%` and animated to `100%`, not `text-decoration` or an extra pseudo-element, so it drops onto existing inline elements without changing markup.
+
+## Parameters
+
+### `ease-underline-draw($origin, $color, $thickness, $trigger)`
+
+| Parameter     | Type   | Default                        | Description                                                        |
+| ------------- | ------ | -------------------------------- | ---------------------------------------------------------------------- |
+| `$origin`     | String | `"left"`                         | Draw direction: `"left"`, `"right"`, or `"center"`.                    |
+| `$color`      | Color  | `$ease-underline-color` (`currentColor`) | Underline color.                                              |
+| `$thickness`  | Length | `$ease-underline-thickness` (`2px`) | Underline thickness.                                             |
+| `$trigger`    | String | `"hover"`                         | `"hover"` animates on hover/focus; `"always"` shows the underline drawn immediately (e.g. for an active nav link). |
+
+### Configuration variables
+
+| Variable                      | Default        | Description                                  |
+| -------------------------------| -------------- | ------------------------------------------------ |
+| `$ease-underline-color`        | `currentColor` | Default underline color, inherits text color.    |
+| `$ease-underline-thickness`    | `2px`          | Default underline thickness.                     |
+| `$ease-underline-offset`       | `0.15em`       | Gap between the text baseline and the underline.  |
+| `$ease-underline-duration`     | `350ms`        | Draw animation duration.                          |
+| `$ease-underline-timing`       | `ease-out`     | Draw animation easing.                            |
+
+## Usage
+
+```scss
+@use "text-highlight-underline-draw-utilities-tw" as *;
+
+// Default: draws left-to-right on hover
+.link {
+  @include ease-underline-draw;
+}
+
+// Draws from the center, thicker, brand color
+.link--brand {
+  @include ease-underline-draw($origin: "center", $thickness: 3px, $color: #5b21b6);
+}
+
+// Right-to-left variant
+.link--rtl-style {
+  @include ease-underline-draw($origin: "right");
+}
+
+// Always-drawn underline, e.g. for the current page's nav link
+.nav-link.is-active {
+  @include ease-underline-draw($trigger: "always");
+}
+```
+
+## CSS compilation results
+
+`@include ease-underline-draw;` with all defaults compiles to approximately:
+
+```css
+.link {
+  display: inline-block;
+  text-decoration: none;
+  background-image: linear-gradient(to right, currentColor, currentColor);
+  background-repeat: no-repeat;
+  background-size: 0% 2px;
+  background-position: 0% 100%;
+  padding-bottom: 0.15em;
+  transition: background-size 350ms ease-out;
+}
+
+.link:hover,
+.link:focus-visible {
+  background-size: 100% 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .link {
+    transition: none;
+  }
+}
+```
+
+## Why this fits EaseMotion CSS
+
+Text-level motion is an underrepresented category in most CSS animation libraries, which tend to focus on cards and buttons. This utility gives EaseMotion a lightweight, markup-free way to add intentional motion to inline text and navigation — a common request for link hover states — while staying consistent with the framework's zero-JS, utility-first approach and respecting `prefers-reduced-motion`.

--- a/submissions/scss/scss-text-highlight-underline-draw-utilities-tw/_text-highlight-underline-draw-utilities-tw.scss
+++ b/submissions/scss/scss-text-highlight-underline-draw-utilities-tw/_text-highlight-underline-draw-utilities-tw.scss
@@ -1,0 +1,90 @@
+// _text-highlight-underline-draw-utilities-tw.scss
+//
+// Pure-CSS "drawn underline" utilities for inline text and links.
+// Instead of a static `border-bottom` or `text-decoration`, these
+// mixins use a background-image gradient sized at 0% and animate its
+// width to 100% on trigger — producing the effect of the underline
+// being "drawn" left-to-right, right-to-left, or growing from center.
+//
+// No pseudo-elements or extra markup required; this works directly on
+// the text element via `background-size` + `background-position`,
+// which keeps it usable on inline elements like <a> and <span>.
+
+// ---------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------
+
+$ease-underline-color: currentColor !default;
+$ease-underline-thickness: 2px !default;
+$ease-underline-offset: 0.15em !default; // gap between text baseline and underline
+$ease-underline-duration: 350ms !default;
+$ease-underline-timing: ease-out !default;
+
+// ---------------------------------------------------------------------
+// Mixin
+// ---------------------------------------------------------------------
+
+/// Applies a drawn-underline effect to inline text, animated on hover
+/// by default. The underline is implemented as a background gradient,
+/// not `text-decoration` or a pseudo-element, so it works on any
+/// inline or inline-block element without extra markup.
+///
+/// @param {String} $origin ["left"] - Direction the underline draws from.
+///   One of "left", "right", or "center".
+/// @param {Color} $color [$ease-underline-color] - Underline color.
+/// @param {Length} $thickness [$ease-underline-thickness] - Underline thickness.
+/// @param {String} $trigger ["hover"] - One of "hover" or "always".
+///   "always" draws the underline immediately (e.g. for active/current nav links).
+///
+/// @example scss - Draws left-to-right on hover (default)
+///   .link {
+///     @include ease-underline-draw;
+///   }
+///
+/// @example scss - Draws from center, thicker, brand color
+///   .link--brand {
+///     @include ease-underline-draw($origin: "center", $thickness: 3px, $color: #5b21b6);
+///   }
+///
+/// @example scss - Always-visible underline (e.g. current page nav link)
+///   .nav-link.is-active {
+///     @include ease-underline-draw($trigger: "always");
+///   }
+@mixin ease-underline-draw(
+  $origin: "left",
+  $color: $ease-underline-color,
+  $thickness: $ease-underline-thickness,
+  $trigger: "hover"
+) {
+  display: inline-block;
+  text-decoration: none;
+  background-image: linear-gradient(to right, $color, $color);
+  background-repeat: no-repeat;
+  background-size: 0% $thickness;
+  padding-bottom: $ease-underline-offset;
+  transition: background-size $ease-underline-duration $ease-underline-timing;
+
+  @if $origin == "left" {
+    background-position: 0% 100%;
+  } @else if $origin == "right" {
+    background-position: 100% 100%;
+  } @else if $origin == "center" {
+    background-position: 50% 100%;
+  } @else {
+    @warn "ease-underline-draw: unknown $origin `#{$origin}`, defaulting to left.";
+    background-position: 0% 100%;
+  }
+
+  @if $trigger == "always" {
+    background-size: 100% $thickness;
+  } @else {
+    &:hover,
+    &:focus-visible {
+      background-size: 100% $thickness;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #27837

## Pull Request Description
Adds a pure-CSS "drawn underline" mixin for inline text and links, per the maintainer's spec in #27837.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/scss/scss-text-highlight-underline-draw-utilities-tw/`
- [ ] Includes `demo.html` — N/A, SCSS track requires a partial + README, not demo.html/style.css (see track table in CONTRIBUTING.md)
- [ ] Includes `style.css` — N/A for the same reason
- [x] Includes `README.md` — documents mixin parameters, usage, and compiled CSS output
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**
A `_text-highlight-underline-draw-utilities-tw.scss` partial providing `ease-underline-draw($origin, $color, $thickness, $trigger)`, which animates an underline "drawing in" left-to-right, right-to-left, or from center.

**How does a developer use it?**
```scss
@use "text-highlight-underline-draw-utilities-tw" as *;

.link {
  @include ease-underline-draw;
}

.nav-link.is-active {
  @include ease-underline-draw($trigger: "always");
}
```

**Why does it fit EaseMotion CSS?**
Adds motion to a category (inline text/links) most animation libraries skip in favor of cards/buttons, using a markup-free background-gradient technique consistent with EaseMotion's zero-JS approach.

---

## Demo
- [ ] Demo added — N/A, SCSS track submissions don't require `demo.html` per CONTRIBUTING.md

---

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

*(Note: SCSS-only submission, not yet compiled/tested visually in a browser — will do on request.)*

---

## Notes for Maintainer
Implemented via animated `background-size`/`background-position` rather than `text-decoration` or a pseudo-element, so it works on inline elements without extra markup. Includes a `$trigger: "always"` mode for cases like an active nav link that should show the underline without requiring hover. Used the `-tw` suffix per the naming-collision policy in CONTRIBUTING.md.