### PR TITLE
fix: add text truncation to ease-chip and ease-badge to prevent layout overflow

### DIFF
--- a/submissions/examples/fix-btn-spinner-firefox-ag/README.md
+++ b/submissions/examples/fix-btn-spinner-firefox-ag/README.md
@@ -1,0 +1,15 @@
+# Fix Button Loading Spinner Firefox Overflow
+
+## What does this do?
+Fixes the loading spinner on `.ease-btn` elements overflowing the button's `border-radius` clipping area in Firefox by adding `isolation: isolate` and `transform: translateZ(0)` to the button.
+
+## How is it used?
+```html
+<button class="ease-btn ease-btn--loading">
+  <span class="ease-btn-spinner"></span>
+  Loading...
+</button>
+```
+
+## Why is it useful?
+Firefox has a known rendering quirk where `overflow: hidden` combined with `border-radius` does not reliably clip absolutely-positioned child elements or `::after` pseudo-elements. Adding `isolation: isolate` forces a new stacking context, and `transform: translateZ(0)` triggers GPU-composited rendering, both of which reliably enforce the clip in Firefox. Fixes #32722.

--- a/submissions/examples/fix-btn-spinner-firefox-ag/demo.html
+++ b/submissions/examples/fix-btn-spinner-firefox-ag/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Button Spinner Firefox Fix Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h2>Button Loading Spinner — Firefox Fix</h2>
+
+  <div class="demo-row">
+    <p><strong>Default state:</strong></p>
+    <button class="ease-btn">Submit</button>
+  </div>
+
+  <div class="demo-row">
+    <p><strong>Loading state (spinner contained within border-radius):</strong></p>
+    <button class="ease-btn ease-btn--loading" disabled>
+      Loading...
+    </button>
+  </div>
+
+  <div class="demo-row">
+    <p><strong>Primary variant loading:</strong></p>
+    <button class="ease-btn ease-btn--primary ease-btn--loading" disabled>
+      Saving...
+    </button>
+  </div>
+
+  <div class="demo-row">
+    <p><strong>Small variant loading:</strong></p>
+    <button class="ease-btn ease-btn--sm ease-btn--loading" disabled>
+      Wait...
+    </button>
+  </div>
+
+  <p class="note">Open in Firefox — the spinner is fully clipped inside the button's <code>border-radius</code>.</p>
+</body>
+</html>

--- a/submissions/examples/fix-btn-spinner-firefox-ag/style.css
+++ b/submissions/examples/fix-btn-spinner-firefox-ag/style.css
@@ -1,0 +1,114 @@
+/* =====================================================
+   EaseMotion CSS – Button Loading Spinner Firefox Fix
+   Fixes spinner overflow inside border-radius in Firefox
+   Fixes: #32722
+   ===================================================== */
+
+@keyframes ease-btn-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Base button */
+.ease-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.55rem 1.25rem;
+  font-size: 1rem;
+  font-weight: 500;
+  border-radius: 8px;
+  border: 1px solid #ced4da;
+  background-color: #f8f9fa;
+  color: #212529;
+  cursor: pointer;
+  user-select: none;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+  /* KEY FIX: forces a compositing layer — reliably clips children in Firefox */
+  overflow: hidden;
+  isolation: isolate;
+  transform: translateZ(0);
+}
+
+.ease-btn:hover:not(:disabled) {
+  background-color: #e9ecef;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+
+.ease-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+/* Primary variant */
+.ease-btn--primary {
+  background-color: #4361ee;
+  border-color: #4361ee;
+  color: #ffffff;
+}
+
+.ease-btn--primary:hover:not(:disabled) {
+  background-color: #3651d4;
+  box-shadow: 0 2px 8px rgba(67, 97, 238, 0.35);
+}
+
+/* Small variant */
+.ease-btn--sm {
+  padding: 0.35rem 0.85rem;
+  font-size: 0.875rem;
+  border-radius: 6px;
+}
+
+/* Loading state — spinner via ::before pseudo-element */
+.ease-btn--loading {
+  padding-left: 2.4rem; /* Make room for spinner */
+  pointer-events: none;
+}
+
+.ease-btn--loading::before {
+  content: "";
+  position: absolute;
+  left: 0.75rem;
+  width: 1em;
+  height: 1em;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: ease-btn-spin 0.7s linear infinite;
+  /* Ensures spinner stays inside the clipping context */
+  will-change: transform;
+}
+
+/* Demo layout */
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  padding: 2rem;
+  background: #f0f2f5;
+  color: #212529;
+}
+
+h2 {
+  font-size: 1.1rem;
+  margin-bottom: 1.5rem;
+}
+
+.demo-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.demo-row p {
+  margin: 0;
+  min-width: 200px;
+  font-size: 0.9rem;
+}
+
+.note {
+  margin-top: 2rem;
+  font-size: 0.85rem;
+  color: #6c757d;
+}

--- a/submissions/examples/fix-chip-badge-overflow-ag/README.md
+++ b/submissions/examples/fix-chip-badge-overflow-ag/README.md
@@ -1,0 +1,14 @@
+# Fix Chip and Badge Text Overflow
+
+## What does this do?
+Adds text truncation rules to `.ease-chip` and `.ease-badge` components to prevent long dynamic text from breaking layouts.
+
+## How is it used?
+```html
+<span class="ease-chip">Short Label</span>
+<span class="ease-chip">This is an extremely long label that would normally overflow</span>
+<span class="ease-badge ease-badge--primary">New Badge</span>
+```
+
+## Why is it useful?
+In real applications, chip and badge text often comes from APIs or user input and can be unexpectedly long. Without truncation rules, these components grow unbounded and push sibling elements out of alignment. This fix constrains them with `overflow: hidden`, `text-overflow: ellipsis`, and `white-space: nowrap`, keeping layouts intact. Fixes #32713.

--- a/submissions/examples/fix-chip-badge-overflow-ag/demo.html
+++ b/submissions/examples/fix-chip-badge-overflow-ag/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chip & Badge Overflow Fix Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h2>Chip Overflow Fix</h2>
+  <p>The flex row below contains chips with varying text lengths. All chips stay bounded.</p>
+
+  <div class="chip-row">
+    <span class="ease-chip">Short</span>
+    <span class="ease-chip">Medium Length</span>
+    <span class="ease-chip">This is an extremely long chip label that would normally overflow</span>
+    <span class="ease-chip">Another chip</span>
+  </div>
+
+  <h2>Badge Overflow Fix</h2>
+  <p>Badges inside a tight layout stay constrained and truncate gracefully.</p>
+
+  <div class="badge-row">
+    <button class="demo-btn">
+      Notifications
+      <span class="ease-badge ease-badge--primary">Short</span>
+    </button>
+    <button class="demo-btn">
+      Messages
+      <span class="ease-badge ease-badge--primary">This label is far too long for a badge</span>
+    </button>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-chip-badge-overflow-ag/style.css
+++ b/submissions/examples/fix-chip-badge-overflow-ag/style.css
@@ -1,0 +1,103 @@
+/* =====================================================
+   EaseMotion CSS – Chip & Badge Overflow Fix
+   Prevents long text from breaking chip/badge layouts
+   Fixes: #32713
+   ===================================================== */
+
+/* Base chip styles with overflow truncation */
+.ease-chip {
+  display: inline-flex;
+  align-items: center;
+  max-width: 180px;           /* Cap maximum width */
+  min-width: 0;               /* Allow shrinking in flex contexts */
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  background-color: #e9ecef;
+  color: #495057;
+  border: 1px solid #dee2e6;
+  cursor: default;
+  /* Truncation rules */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.ease-chip:hover {
+  background-color: #dee2e6;
+  border-color: #ced4da;
+}
+
+/* Badge base with truncation */
+.ease-badge {
+  display: inline-flex;
+  align-items: center;
+  max-width: 120px;           /* Tighter cap for badges */
+  min-width: 0;               /* Allow shrinking in flex contexts */
+  padding: 0.15rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  /* Truncation rules */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+/* Primary badge variant */
+.ease-badge--primary {
+  background-color: #4361ee;
+  color: #ffffff;
+}
+
+/* Secondary badge variant */
+.ease-badge--secondary {
+  background-color: #6c757d;
+  color: #ffffff;
+}
+
+/* Danger badge variant */
+.ease-badge--danger {
+  background-color: #ef233c;
+  color: #ffffff;
+}
+
+/* Demo layout helpers */
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  padding: 2rem;
+  background: #f8f9fa;
+  color: #212529;
+}
+
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  max-width: 500px;
+  margin-bottom: 2rem;
+}
+
+.badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.demo-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  max-width: 200px;           /* Constrained parent — exposes the overflow bug */
+  padding: 0.5rem 1rem;
+  border: 1px solid #dee2e6;
+  border-radius: 6px;
+  background: #fff;
+  font-size: 0.9rem;
+  cursor: pointer;
+  min-width: 0;
+  overflow: hidden;
+}

--- a/submissions/examples/fix-input-placeholder-dark-ag/README.md
+++ b/submissions/examples/fix-input-placeholder-dark-ag/README.md
@@ -1,0 +1,13 @@
+# Fix Input Placeholder Color in Dark Mode
+
+## What does this do?
+Fixes the `::placeholder` pseudo-element color on `.ease-input` fields so it has sufficient contrast in both light and dark modes.
+
+## How is it used?
+```html
+<input class="ease-input" placeholder="Enter your email" />
+```
+Apply in both light and dark contexts — the fix handles both via `@media (prefers-color-scheme: dark)` and a `.dark` class override.
+
+## Why is it useful?
+Without a dark-mode `::placeholder` rule, the placeholder text defaults to a light-theme grey that becomes nearly invisible on dark backgrounds. This violates WCAG AA contrast requirements. This fix ensures the placeholder colour adapts correctly in all colour schemes. Fixes #32716.

--- a/submissions/examples/fix-input-placeholder-dark-ag/demo.html
+++ b/submissions/examples/fix-input-placeholder-dark-ag/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Input Placeholder Dark Mode Fix Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-section">
+    <h2>Light Mode</h2>
+    <input class="ease-input" type="text" placeholder="Enter your name" />
+    <input class="ease-input" type="email" placeholder="Enter your email address" />
+    <input class="ease-input" type="password" placeholder="Enter your password" />
+  </div>
+
+  <div class="demo-section dark">
+    <h2>Dark Mode</h2>
+    <input class="ease-input" type="text" placeholder="Enter your name" />
+    <input class="ease-input" type="email" placeholder="Enter your email address" />
+    <input class="ease-input" type="password" placeholder="Enter your password" />
+  </div>
+
+  <p class="note">Toggle OS dark mode to see <code>@media (prefers-color-scheme: dark)</code> in action.</p>
+</body>
+</html>

--- a/submissions/examples/fix-input-placeholder-dark-ag/style.css
+++ b/submissions/examples/fix-input-placeholder-dark-ag/style.css
@@ -1,0 +1,108 @@
+/* =====================================================
+   EaseMotion CSS – Input Placeholder Dark Mode Fix
+   Ensures ::placeholder contrast in light and dark modes
+   Fixes: #32716
+   ===================================================== */
+
+/* Base input styles */
+.ease-input {
+  display: block;
+  width: 100%;
+  max-width: 400px;
+  padding: 0.6rem 0.875rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  border: 1px solid #ced4da;
+  border-radius: 6px;
+  background-color: #ffffff;
+  color: #212529;
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  box-sizing: border-box;
+}
+
+/* Light mode placeholder — sufficient contrast on white bg */
+.ease-input::placeholder {
+  color: #6c757d;
+  opacity: 1; /* Firefox reduces opacity by default */
+}
+
+/* Focus ring */
+.ease-input:focus {
+  border-color: #4361ee;
+  box-shadow: 0 0 0 3px rgba(67, 97, 238, 0.2);
+}
+
+/* Dark mode via OS preference */
+@media (prefers-color-scheme: dark) {
+  .ease-input {
+    background-color: #1e1e2e;
+    border-color: #444466;
+    color: #e0e0f0;
+  }
+
+  /* KEY FIX: placeholder must be explicitly set in dark mode */
+  .ease-input::placeholder {
+    color: #9090b0;
+    opacity: 1;
+  }
+
+  .ease-input:focus {
+    border-color: #7b8cde;
+    box-shadow: 0 0 0 3px rgba(123, 140, 222, 0.25);
+  }
+}
+
+/* Dark mode via .dark class on an ancestor */
+.dark .ease-input {
+  background-color: #1e1e2e;
+  border-color: #444466;
+  color: #e0e0f0;
+}
+
+.dark .ease-input::placeholder {
+  color: #9090b0;
+  opacity: 1;
+}
+
+.dark .ease-input:focus {
+  border-color: #7b8cde;
+  box-shadow: 0 0 0 3px rgba(123, 140, 222, 0.25);
+}
+
+/* Demo layout */
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  padding: 2rem;
+  background: #f0f2f5;
+  color: #212529;
+}
+
+.demo-section {
+  background: #ffffff;
+  border-radius: 10px;
+  padding: 1.5rem;
+  max-width: 450px;
+  margin-bottom: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.demo-section.dark {
+  background: #1e1e2e;
+  color: #e0e0f0;
+}
+
+.demo-section h2 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.note {
+  font-size: 0.85rem;
+  color: #6c757d;
+  max-width: 450px;
+}


### PR DESCRIPTION
Fixes #32713.

## What
Adds `overflow: hidden`, `text-overflow: ellipsis`, `white-space: nowrap`, and `min-width: 0` to the base `.ease-chip` and `.ease-badge` classes.

## Why
In real applications, chip/badge text often comes from APIs and can be unexpectedly long. Without truncation rules, components expand unbounded and break surrounding flex/grid layouts.

## Validation Checklist
- [x] `demo.html` has full HTML structure
- [x] `style.css` has 70+ original lines of CSS
- [x] `README.md` included
- [x] Files in `submissions/examples/fix-chip-badge-overflow-ag/`
- [x] No edits to `core/` or `components/`