### PR TITLE
feat(scss): add animated border draw and glow keyframe mixins -sr

### DIFF
--- a/submissions/scss/scss-animated-border-draw-glow-keyframe-mixins-sr/README.md
+++ b/submissions/scss/scss-animated-border-draw-glow-keyframe-mixins-sr/README.md
@@ -1,0 +1,125 @@
+# Animated Border Draw & Glow Keyframe Mixins (SR)
+
+Reusable SCSS mixins for creating animated border draw and glow effects.
+
+---
+
+## Features
+
+- Reusable border draw animation
+- Reusable glow animation
+- Custom animation names
+- Configurable duration
+- Configurable colors
+- Adjustable border width
+- Adjustable border radius
+
+---
+
+## Files
+
+```
+_animated-border-draw-glow-keyframe-mixins-sr.scss
+README.md
+```
+
+---
+
+## Usage
+
+Import the partial.
+
+```scss
+@use "animated-border-draw-glow-keyframe-mixins-sr" as border;
+```
+
+Generate keyframes.
+
+```scss
+@include border.border-draw-keyframes();
+@include border.border-glow-keyframes();
+```
+
+Apply mixins.
+
+```scss
+.button{
+
+@include border.animated-border-draw(
+  $color:#06b6d4,
+  $duration:2s
+);
+
+@include border.animated-border-glow(
+  $color:#06b6d4
+);
+
+}
+```
+
+---
+
+# Parameters
+
+## border-draw-keyframes
+
+| Parameter | Default |
+|-----------|---------|
+| $name | border-draw-sr |
+
+---
+
+## border-glow-keyframes
+
+| Parameter | Default |
+|-----------|---------|
+| $name | border-glow-sr |
+
+---
+
+## animated-border-draw
+
+| Parameter | Default |
+|-----------|---------|
+| $color | #4f46e5 |
+| $width | 2px |
+| $duration | 1.6s |
+| $timing | ease |
+| $iteration | infinite |
+| $animation | border-draw-sr |
+
+---
+
+## animated-border-glow
+
+| Parameter | Default |
+|-----------|---------|
+| $color | #4f46e5 |
+| $radius | 12px |
+| $duration | 2s |
+| $timing | ease-in-out |
+| $iteration | infinite |
+| $animation | border-glow-sr |
+
+---
+
+# CSS Compilation Result
+
+Compiles into:
+
+- @keyframes border-draw-sr
+- @keyframes border-glow-sr
+- Standard CSS animations
+- Standard CSS gradients
+- Standard CSS box-shadow glow
+- No JavaScript dependency
+
+---
+
+# Browser Support
+
+Works in all modern browsers supporting:
+
+- CSS Animations
+- Linear Gradients
+- Box Shadow

--- a/submissions/scss/scss-animated-border-draw-glow-keyframe-mixins-sr/_animated-border-draw-glow-keyframe-mixins-sr.scss
+++ b/submissions/scss/scss-animated-border-draw-glow-keyframe-mixins-sr/_animated-border-draw-glow-keyframe-mixins-sr.scss
@@ -1,0 +1,147 @@
+// ============================================================
+// Animated Border Draw & Glow Keyframe Mixins
+// EaseMotion CSS Submission
+// Contributor: Sanju Rajak
+// ============================================================
+
+// ------------------------------------------------------------
+// Border Draw Keyframes
+// ------------------------------------------------------------
+
+@mixin border-draw-keyframes($name: border-draw-sr) {
+  @keyframes #{$name} {
+
+    0%{
+      background-size:
+      0% 2px,
+      2px 0%,
+      0% 2px,
+      2px 0%;
+    }
+
+    25%{
+      background-size:
+      100% 2px,
+      2px 0%,
+      0% 2px,
+      2px 0%;
+    }
+
+    50%{
+      background-size:
+      100% 2px,
+      2px 100%,
+      0% 2px,
+      2px 0%;
+    }
+
+    75%{
+      background-size:
+      100% 2px,
+      2px 100%,
+      100% 2px,
+      2px 0%;
+    }
+
+    100%{
+      background-size:
+      100% 2px,
+      2px 100%,
+      100% 2px,
+      2px 100%;
+    }
+  }
+}
+
+// ------------------------------------------------------------
+// Glow Keyframes
+// ------------------------------------------------------------
+
+@mixin border-glow-keyframes($name: border-glow-sr) {
+
+  @keyframes #{$name} {
+
+    0%,
+    100%{
+      box-shadow:
+      0 0 6px currentColor,
+      0 0 12px currentColor;
+    }
+
+    50%{
+      box-shadow:
+      0 0 15px currentColor,
+      0 0 30px currentColor,
+      0 0 45px currentColor;
+    }
+
+  }
+
+}
+
+// ------------------------------------------------------------
+// Animated Border Draw
+// ------------------------------------------------------------
+
+@mixin animated-border-draw(
+  $color:#4f46e5,
+  $width:2px,
+  $duration:1.6s,
+  $timing:ease,
+  $iteration:infinite,
+  $animation:border-draw-sr
+){
+
+  position:relative;
+
+  background-image:
+  linear-gradient($color,$color),
+  linear-gradient($color,$color),
+  linear-gradient($color,$color),
+  linear-gradient($color,$color);
+
+  background-repeat:no-repeat;
+
+  background-position:
+  top left,
+  top right,
+  bottom right,
+  bottom left;
+
+  background-size:
+  0% $width,
+  $width 0%,
+  0% $width,
+  $width 0%;
+
+  animation:
+  #{$animation}
+  $duration
+  $timing
+  $iteration;
+}
+
+// ------------------------------------------------------------
+// Animated Glow
+// ------------------------------------------------------------
+
+@mixin animated-border-glow(
+  $color:#4f46e5,
+  $radius:12px,
+  $duration:2s,
+  $timing:ease-in-out,
+  $iteration:infinite,
+  $animation:border-glow-sr
+){
+
+  border:2px solid $color;
+  border-radius:$radius;
+
+  color:$color;
+
+  animation:
+  #{$animation}
+  $duration
+  $timing
+  $iteration;
+}


### PR DESCRIPTION
## Description

This PR adds a reusable SCSS utility module for Animated Border Draw & Glow Keyframe Mixins.

### Changes Made

- Added a new isolated SCSS submission under:
  `submissions/scss/scss-animated-border-draw-glow-keyframe-mixins/`
- Added `_animated-border-draw-glow-keyframe-mixins.scss`
- Included reusable mixins for:
  - Animated border draw
  - Animated border glow
  - Border draw keyframes
  - Border glow keyframes
- Added detailed `README.md` with:
  - Mixin parameters
  - Usage examples
  - CSS compilation results

### Checklist

- [x] Added files only inside the `submissions/` directory
- [x] Did not modify any core framework files
- [x] Added documentation
- [x] Followed the repository contribution guidelines
