### PR TITLE
fix: add dark mode ::placeholder color to ease-input

### DIFF
--- a/submissions/examples/fix-btn-spinner-firefox-ag/README.md
+++ b/submissions/examples/fix-btn-spinner-firefox-ag/README.md
@@ -1,0 +1,12 @@
+# Fix Button Loading Spinner Firefox Overflow
+
+## What does this do?
+Fixes the loading spinner on `.ease-btn` overflowing the button border-radius in Firefox using `isolation: isolate` and `transform: translateZ(0)`.
+
+## How is it used?
+```html
+<button class="ease-btn ease-btn--loading" disabled>Loading...</button>
+```
+
+## Why is it useful?
+Firefox does not reliably clip absolutely-positioned pseudo-elements with `overflow: hidden` + `border-radius`. `isolation: isolate` forces a new stacking context and `transform: translateZ(0)` triggers GPU compositing, both enforcing the clip reliably in Firefox. Fixes #32722.

--- a/submissions/examples/fix-btn-spinner-firefox-ag/demo.html
+++ b/submissions/examples/fix-btn-spinner-firefox-ag/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Button Spinner Firefox Fix</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h2>Button Loading Spinner — Firefox Fix</h2>
+  <div class="demo-row">
+    <button class="ease-btn">Submit</button>
+    <button class="ease-btn ease-btn--loading" disabled>Loading...</button>
+    <button class="ease-btn ease-btn--primary ease-btn--loading" disabled>Saving...</button>
+  </div>
+  <p class="note">Open in Firefox — spinner stays inside border-radius.</p>
+</body>
+</html>

--- a/submissions/examples/fix-btn-spinner-firefox-ag/style.css
+++ b/submissions/examples/fix-btn-spinner-firefox-ag/style.css
@@ -1,0 +1,43 @@
+/* EaseMotion CSS – Button Spinner Firefox Fix. Fixes: #32722 */
+@keyframes ease-btn-spin { to { transform: rotate(360deg); } }
+.ease-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.55rem 1.25rem;
+  font-size: 1rem;
+  font-weight: 500;
+  border-radius: 8px;
+  border: 1px solid #ced4da;
+  background-color: #f8f9fa;
+  color: #212529;
+  cursor: pointer;
+  user-select: none;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+  overflow: hidden;
+  isolation: isolate;
+  transform: translateZ(0);
+}
+.ease-btn:hover:not(:disabled) { background-color: #e9ecef; box-shadow: 0 2px 6px rgba(0,0,0,0.1); }
+.ease-btn:disabled { cursor: not-allowed; opacity: 0.7; }
+.ease-btn--primary { background-color: #4361ee; border-color: #4361ee; color: #fff; }
+.ease-btn--primary:hover:not(:disabled) { background-color: #3651d4; }
+.ease-btn--loading { padding-left: 2.4rem; pointer-events: none; }
+.ease-btn--loading::before {
+  content: "";
+  position: absolute;
+  left: 0.75rem;
+  width: 1em;
+  height: 1em;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: ease-btn-spin 0.7s linear infinite;
+  will-change: transform;
+}
+body { font-family: system-ui, sans-serif; padding: 2rem; background: #f0f2f5; }
+h2 { font-size: 1.1rem; margin-bottom: 1.5rem; }
+.demo-row { display: flex; gap: 1rem; flex-wrap: wrap; margin-bottom: 1rem; }
+.note { font-size: 0.85rem; color: #6c757d; }

--- a/submissions/examples/fix-input-placeholder-dark-ag/README.md
+++ b/submissions/examples/fix-input-placeholder-dark-ag/README.md
@@ -1,0 +1,13 @@
+# Fix Input Placeholder Color in Dark Mode
+
+## What does this do?
+Fixes the `::placeholder` pseudo-element color on `.ease-input` fields so it has sufficient contrast in both light and dark modes.
+
+## How is it used?
+```html
+<input class="ease-input" placeholder="Enter your email" />
+```
+Apply in both light and dark contexts — the fix handles both via `@media (prefers-color-scheme: dark)` and a `.dark` class override.
+
+## Why is it useful?
+Without a dark-mode `::placeholder` rule, the placeholder text defaults to a light-theme grey that becomes nearly invisible on dark backgrounds. This violates WCAG AA contrast requirements. This fix ensures the placeholder colour adapts correctly in all colour schemes. Fixes #32716.

--- a/submissions/examples/fix-input-placeholder-dark-ag/demo.html
+++ b/submissions/examples/fix-input-placeholder-dark-ag/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Input Placeholder Dark Mode Fix Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-section">
+    <h2>Light Mode</h2>
+    <input class="ease-input" type="text" placeholder="Enter your name" />
+    <input class="ease-input" type="email" placeholder="Enter your email address" />
+  </div>
+  <div class="demo-section dark">
+    <h2>Dark Mode</h2>
+    <input class="ease-input" type="text" placeholder="Enter your name" />
+    <input class="ease-input" type="email" placeholder="Enter your email address" />
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-input-placeholder-dark-ag/style.css
+++ b/submissions/examples/fix-input-placeholder-dark-ag/style.css
@@ -1,0 +1,30 @@
+/* EaseMotion CSS – Input Placeholder Dark Mode Fix. Fixes: #32716 */
+.ease-input {
+  display: block;
+  width: 100%;
+  max-width: 400px;
+  padding: 0.6rem 0.875rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  border: 1px solid #ced4da;
+  border-radius: 6px;
+  background-color: #ffffff;
+  color: #212529;
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  box-sizing: border-box;
+}
+.ease-input::placeholder { color: #6c757d; opacity: 1; }
+.ease-input:focus { border-color: #4361ee; box-shadow: 0 0 0 3px rgba(67,97,238,0.2); }
+@media (prefers-color-scheme: dark) {
+  .ease-input { background-color: #1e1e2e; border-color: #444466; color: #e0e0f0; }
+  .ease-input::placeholder { color: #9090b0; opacity: 1; }
+  .ease-input:focus { border-color: #7b8cde; box-shadow: 0 0 0 3px rgba(123,140,222,0.25); }
+}
+.dark .ease-input { background-color: #1e1e2e; border-color: #444466; color: #e0e0f0; }
+.dark .ease-input::placeholder { color: #9090b0; opacity: 1; }
+.dark .ease-input:focus { border-color: #7b8cde; box-shadow: 0 0 0 3px rgba(123,140,222,0.25); }
+body { font-family: system-ui, sans-serif; padding: 2rem; background: #f0f2f5; color: #212529; }
+.demo-section { background: #fff; border-radius: 10px; padding: 1.5rem; max-width: 450px; margin-bottom: 1.5rem; display: flex; flex-direction: column; gap: 0.75rem; }
+.demo-section.dark { background: #1e1e2e; color: #e0e0f0; }
+.demo-section h2 { margin: 0 0 0.5rem; font-size: 1rem; }


### PR DESCRIPTION
Fixes #32716.

## What
Adds `::placeholder` color rules inside `@media (prefers-color-scheme: dark)` and `.dark` class overrides for `.ease-input` to ensure sufficient contrast in dark mode.

## Why
Without dark-mode placeholder rules, placeholder text becomes invisible on dark backgrounds, violating WCAG AA contrast requirements.

## Validation Checklist
- [x] `demo.html` with full HTML structure (light + dark sections)
- [x] `style.css` with original CSS (30+ lines, both light/dark modes)
- [x] `README.md` included
- [x] Files in `submissions/examples/fix-input-placeholder-dark-ag/`
- [x] No edits to `core/` or `components/`