### PR TITLE
feat: add renewal readiness demo

### DIFF
--- a/submissions/examples/cobalt-renewal-readiness/README.md
+++ b/submissions/examples/cobalt-renewal-readiness/README.md
@@ -1,0 +1,14 @@
+# Cobalt Renewal Readiness Demo
+
+A customer account dashboard that surfaces renewal confidence, decision blockers, and expansion opportunities.
+
+## What is included
+
+- Responsive HTML structure for the renewal readiness demo.
+- CSS-only overview panel, metric list, and responsive insight cards.
+- Semantic sections with accessible labelling.
+
+## Files
+
+- `demo.html`
+- `style.css`

--- a/submissions/examples/cobalt-renewal-readiness/demo.html
+++ b/submissions/examples/cobalt-renewal-readiness/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cobalt Renewal Readiness Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="overview-panel">
+      <div>
+        <p class="eyebrow">Account planning</p>
+        <h1>Renewal readiness view for account teams</h1>
+        <p class="summary">A customer account dashboard that surfaces renewal confidence, decision blockers, and expansion opportunities.</p>
+      </div>
+      <ul class="metric-list" aria-label="Renewal readiness metrics">
+          <li>
+            <span>Ready</span>
+            <strong>81%</strong>
+          </li>
+          <li>
+            <span>Blockers</span>
+            <strong>6</strong>
+          </li>
+          <li>
+            <span>Expansion</span>
+            <strong>$42k</strong>
+          </li>
+      </ul>
+    </section>
+
+    <section class="panel-grid" aria-label="Renewal readiness insights">
+        <article class="panel-card">
+          <span>Confidence</span>
+          <h2>Renewal health</h2>
+          <p>The readiness score gives account owners a direct signal before renewal calls.</p>
+        </article>
+        <article class="panel-card">
+          <span>Risk</span>
+          <h2>Decision blockers</h2>
+          <p>Blocker count stays visible so teams can clear issues before commercial review.</p>
+        </article>
+        <article class="panel-card">
+          <span>Growth</span>
+          <h2>Expansion path</h2>
+          <p>Expansion value connects renewal planning with potential account growth.</p>
+        </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/cobalt-renewal-readiness/style.css
+++ b/submissions/examples/cobalt-renewal-readiness/style.css
@@ -1,0 +1,131 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #20292f;
+  background:
+    linear-gradient(140deg, rgba(50, 119, 164, 0.2), transparent 35%),
+    linear-gradient(230deg, rgba(217, 143, 72, 0.18), transparent 39%),
+    #f7f8f4;
+}
+
+.demo-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.overview-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 312px;
+  gap: 24px;
+  align-items: stretch;
+  padding: 32px;
+  border: 1px solid rgba(32, 41, 47, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 24px 72px rgba(32, 41, 47, 0.12);
+}
+
+.eyebrow,
+.panel-card span {
+  display: block;
+  margin-bottom: 10px;
+  color: #63727b;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 780px;
+  margin-bottom: 16px;
+  font-size: clamp(2.35rem, 7vw, 5rem);
+  line-height: 0.96;
+  letter-spacing: 0;
+}
+
+.summary {
+  max-width: 700px;
+  margin-bottom: 0;
+  color: #54636c;
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.metric-list {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.metric-list li,
+.panel-card {
+  border: 1px solid rgba(32, 41, 47, 0.1);
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.metric-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px;
+}
+
+.metric-list span {
+  color: #65747d;
+  font-weight: 700;
+}
+
+.metric-list strong {
+  font-size: 1.35rem;
+}
+
+.panel-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.panel-card {
+  min-height: 210px;
+  padding: 24px;
+}
+
+.panel-card h2 {
+  margin-bottom: 12px;
+  font-size: 1.32rem;
+}
+
+.panel-card p {
+  margin-bottom: 0;
+  color: #57666f;
+  line-height: 1.65;
+}
+
+@media (max-width: 820px) {
+  .overview-panel,
+  .panel-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .overview-panel {
+    padding: 24px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a new responsive renewal readiness example under `submissions/examples/cobalt-renewal-readiness`
- include semantic HTML, CSS-only layout styling, and mobile stacking support
- document the demo purpose and included files

## Testing
- not run locally; static HTML/CSS example only
