### PR TITLE
feat: add workforce coverage demo

### DIFF
--- a/submissions/examples/aurora-workforce-coverage/README.md
+++ b/submissions/examples/aurora-workforce-coverage/README.md
@@ -1,0 +1,14 @@
+# Aurora Workforce Coverage Demo
+
+A staffing operations panel for reviewing assigned coverage, open shifts, and overtime exposure.
+
+## What is included
+
+- Responsive HTML structure for the workforce coverage demo.
+- CSS-only overview panel, metric list, and responsive insight cards.
+- Semantic sections with accessible labelling.
+
+## Files
+
+- `demo.html`
+- `style.css`

--- a/submissions/examples/aurora-workforce-coverage/demo.html
+++ b/submissions/examples/aurora-workforce-coverage/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Aurora Workforce Coverage Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="overview-panel">
+      <div>
+        <p class="eyebrow">Operations staffing</p>
+        <h1>Workforce coverage board for shift planners</h1>
+        <p class="summary">A staffing operations panel for reviewing assigned coverage, open shifts, and overtime exposure.</p>
+      </div>
+      <ul class="metric-list" aria-label="Workforce coverage metrics">
+          <li>
+            <span>Covered</span>
+            <strong>94%</strong>
+          </li>
+          <li>
+            <span>Open shifts</span>
+            <strong>11</strong>
+          </li>
+          <li>
+            <span>Overtime</span>
+            <strong>7h</strong>
+          </li>
+      </ul>
+    </section>
+
+    <section class="panel-grid" aria-label="Workforce coverage insights">
+        <article class="panel-card">
+          <span>Coverage</span>
+          <h2>Staffing fit</h2>
+          <p>Coverage percentage helps planners quickly judge whether the schedule is stable.</p>
+        </article>
+        <article class="panel-card">
+          <span>Queue</span>
+          <h2>Open shifts</h2>
+          <p>Unfilled shifts remain visible so dispatch work can happen before service gaps appear.</p>
+        </article>
+        <article class="panel-card">
+          <span>Load</span>
+          <h2>Overtime watch</h2>
+          <p>Overtime exposure gives managers a concise signal for balancing workload.</p>
+        </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/aurora-workforce-coverage/style.css
+++ b/submissions/examples/aurora-workforce-coverage/style.css
@@ -1,0 +1,131 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #20292f;
+  background:
+    linear-gradient(140deg, rgba(71, 137, 103, 0.2), transparent 35%),
+    linear-gradient(230deg, rgba(190, 103, 82, 0.18), transparent 39%),
+    #f7f8f4;
+}
+
+.demo-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.overview-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 312px;
+  gap: 24px;
+  align-items: stretch;
+  padding: 32px;
+  border: 1px solid rgba(32, 41, 47, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 24px 72px rgba(32, 41, 47, 0.12);
+}
+
+.eyebrow,
+.panel-card span {
+  display: block;
+  margin-bottom: 10px;
+  color: #63727b;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 780px;
+  margin-bottom: 16px;
+  font-size: clamp(2.35rem, 7vw, 5rem);
+  line-height: 0.96;
+  letter-spacing: 0;
+}
+
+.summary {
+  max-width: 700px;
+  margin-bottom: 0;
+  color: #54636c;
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.metric-list {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.metric-list li,
+.panel-card {
+  border: 1px solid rgba(32, 41, 47, 0.1);
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.metric-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px;
+}
+
+.metric-list span {
+  color: #65747d;
+  font-weight: 700;
+}
+
+.metric-list strong {
+  font-size: 1.35rem;
+}
+
+.panel-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.panel-card {
+  min-height: 210px;
+  padding: 24px;
+}
+
+.panel-card h2 {
+  margin-bottom: 12px;
+  font-size: 1.32rem;
+}
+
+.panel-card p {
+  margin-bottom: 0;
+  color: #57666f;
+  line-height: 1.65;
+}
+
+@media (max-width: 820px) {
+  .overview-panel,
+  .panel-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .overview-panel {
+    padding: 24px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a new responsive workforce coverage example under `submissions/examples/aurora-workforce-coverage`
- include semantic HTML, CSS-only layout styling, and mobile stacking support
- document the demo purpose and included files

## Testing
- not run locally; static HTML/CSS example only
