### PR TITLE
feat: add course enrollment demo

### DIFF
--- a/submissions/examples/summit-course-enrollment/README.md
+++ b/submissions/examples/summit-course-enrollment/README.md
@@ -1,0 +1,14 @@
+# Summit Course Enrollment Demo
+
+An academic operations dashboard that compares enrollment, waitlist pressure, and seat availability.
+
+## What is included
+
+- Responsive HTML structure for the course enrollment demo.
+- CSS-only overview panel, metric list, and responsive insight cards.
+- Semantic sections with accessible labelling.
+
+## Files
+
+- `demo.html`
+- `style.css`

--- a/submissions/examples/summit-course-enrollment/demo.html
+++ b/submissions/examples/summit-course-enrollment/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Summit Course Enrollment Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="overview-panel">
+      <div>
+        <p class="eyebrow">Education operations</p>
+        <h1>Course enrollment tracker for academic teams</h1>
+        <p class="summary">An academic operations dashboard that compares enrollment, waitlist pressure, and seat availability.</p>
+      </div>
+      <ul class="metric-list" aria-label="Course enrollment metrics">
+          <li>
+            <span>Enrolled</span>
+            <strong>312</strong>
+          </li>
+          <li>
+            <span>Waitlist</span>
+            <strong>28</strong>
+          </li>
+          <li>
+            <span>Seats</span>
+            <strong>46</strong>
+          </li>
+      </ul>
+    </section>
+
+    <section class="panel-grid" aria-label="Course enrollment insights">
+        <article class="panel-card">
+          <span>Demand</span>
+          <h2>Enrollment pace</h2>
+          <p>Enrollment total provides a quick read on course demand across the term.</p>
+        </article>
+        <article class="panel-card">
+          <span>Pressure</span>
+          <h2>Waitlist signal</h2>
+          <p>Waitlist count helps coordinators decide where extra sections may be needed.</p>
+        </article>
+        <article class="panel-card">
+          <span>Capacity</span>
+          <h2>Seat planning</h2>
+          <p>Open seats keep capacity decisions clear for academic operations teams.</p>
+        </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/summit-course-enrollment/style.css
+++ b/submissions/examples/summit-course-enrollment/style.css
@@ -1,0 +1,131 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #20292f;
+  background:
+    linear-gradient(140deg, rgba(88, 105, 174, 0.2), transparent 35%),
+    linear-gradient(230deg, rgba(213, 153, 69, 0.18), transparent 39%),
+    #f7f8f4;
+}
+
+.demo-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.overview-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 312px;
+  gap: 24px;
+  align-items: stretch;
+  padding: 32px;
+  border: 1px solid rgba(32, 41, 47, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 24px 72px rgba(32, 41, 47, 0.12);
+}
+
+.eyebrow,
+.panel-card span {
+  display: block;
+  margin-bottom: 10px;
+  color: #63727b;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 780px;
+  margin-bottom: 16px;
+  font-size: clamp(2.35rem, 7vw, 5rem);
+  line-height: 0.96;
+  letter-spacing: 0;
+}
+
+.summary {
+  max-width: 700px;
+  margin-bottom: 0;
+  color: #54636c;
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.metric-list {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.metric-list li,
+.panel-card {
+  border: 1px solid rgba(32, 41, 47, 0.1);
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.metric-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px;
+}
+
+.metric-list span {
+  color: #65747d;
+  font-weight: 700;
+}
+
+.metric-list strong {
+  font-size: 1.35rem;
+}
+
+.panel-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.panel-card {
+  min-height: 210px;
+  padding: 24px;
+}
+
+.panel-card h2 {
+  margin-bottom: 12px;
+  font-size: 1.32rem;
+}
+
+.panel-card p {
+  margin-bottom: 0;
+  color: #57666f;
+  line-height: 1.65;
+}
+
+@media (max-width: 820px) {
+  .overview-panel,
+  .panel-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .overview-panel {
+    padding: 24px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a new responsive course enrollment example under `submissions/examples/summit-course-enrollment`
- include semantic HTML, CSS-only layout styling, and mobile stacking support
- document the demo purpose and included files

## Testing
- not run locally; static HTML/CSS example only
