### PR TITLE
feat: add clinic throughput demo

### DIFF
--- a/submissions/examples/harbor-clinic-throughput/README.md
+++ b/submissions/examples/harbor-clinic-throughput/README.md
@@ -1,0 +1,14 @@
+# Harbor Clinic Throughput Demo
+
+A healthcare operations view for monitoring patient flow, room utilization, and delayed visits.
+
+## What is included
+
+- Responsive HTML structure for the clinic throughput demo.
+- CSS-only overview panel, metric list, and responsive insight cards.
+- Semantic sections with accessible labelling.
+
+## Files
+
+- `demo.html`
+- `style.css`

--- a/submissions/examples/harbor-clinic-throughput/demo.html
+++ b/submissions/examples/harbor-clinic-throughput/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Harbor Clinic Throughput Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="overview-panel">
+      <div>
+        <p class="eyebrow">Care operations</p>
+        <h1>Clinic throughput panel for care coordinators</h1>
+        <p class="summary">A healthcare operations view for monitoring patient flow, room utilization, and delayed visits.</p>
+      </div>
+      <ul class="metric-list" aria-label="Clinic throughput metrics">
+          <li>
+            <span>Visits</span>
+            <strong>146</strong>
+          </li>
+          <li>
+            <span>Rooms</span>
+            <strong>78%</strong>
+          </li>
+          <li>
+            <span>Delayed</span>
+            <strong>9</strong>
+          </li>
+      </ul>
+    </section>
+
+    <section class="panel-grid" aria-label="Clinic throughput insights">
+        <article class="panel-card">
+          <span>Flow</span>
+          <h2>Visit pace</h2>
+          <p>Daily visit count gives care teams an immediate sense of clinic movement.</p>
+        </article>
+        <article class="panel-card">
+          <span>Space</span>
+          <h2>Room usage</h2>
+          <p>Room utilization helps coordinators understand whether capacity is constrained.</p>
+        </article>
+        <article class="panel-card">
+          <span>Delay</span>
+          <h2>Visit delays</h2>
+          <p>Delay count highlights where patient flow needs attention before the next block.</p>
+        </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/harbor-clinic-throughput/style.css
+++ b/submissions/examples/harbor-clinic-throughput/style.css
@@ -1,0 +1,131 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #20292f;
+  background:
+    linear-gradient(140deg, rgba(45, 132, 143, 0.2), transparent 35%),
+    linear-gradient(230deg, rgba(202, 118, 73, 0.18), transparent 39%),
+    #f7f8f4;
+}
+
+.demo-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.overview-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 312px;
+  gap: 24px;
+  align-items: stretch;
+  padding: 32px;
+  border: 1px solid rgba(32, 41, 47, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 24px 72px rgba(32, 41, 47, 0.12);
+}
+
+.eyebrow,
+.panel-card span {
+  display: block;
+  margin-bottom: 10px;
+  color: #63727b;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 780px;
+  margin-bottom: 16px;
+  font-size: clamp(2.35rem, 7vw, 5rem);
+  line-height: 0.96;
+  letter-spacing: 0;
+}
+
+.summary {
+  max-width: 700px;
+  margin-bottom: 0;
+  color: #54636c;
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.metric-list {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.metric-list li,
+.panel-card {
+  border: 1px solid rgba(32, 41, 47, 0.1);
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.metric-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px;
+}
+
+.metric-list span {
+  color: #65747d;
+  font-weight: 700;
+}
+
+.metric-list strong {
+  font-size: 1.35rem;
+}
+
+.panel-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.panel-card {
+  min-height: 210px;
+  padding: 24px;
+}
+
+.panel-card h2 {
+  margin-bottom: 12px;
+  font-size: 1.32rem;
+}
+
+.panel-card p {
+  margin-bottom: 0;
+  color: #57666f;
+  line-height: 1.65;
+}
+
+@media (max-width: 820px) {
+  .overview-panel,
+  .panel-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .overview-panel {
+    padding: 24px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a new responsive clinic throughput example under `submissions/examples/harbor-clinic-throughput`
- include semantic HTML, CSS-only layout styling, and mobile stacking support
- document the demo purpose and included files

## Testing
- not run locally; static HTML/CSS example only
