### PR TITLE
feat: Accessible Animated Multi-Step Stepper (submission)

### DIFF
--- a/submissions/examples/accessible-animated-stepper/README.md
+++ b/submissions/examples/accessible-animated-stepper/README.md
@@ -1,0 +1,27 @@
+# Accessible Animated Stepper (EaseMotion CSS submission)
+
+Demo for: Accessible Animated Multi-Step Form Stepper with Keyboard Navigation.
+
+Key points:
+- Visual states and animations are pure CSS.
+- Minimal vanilla JS only to:
+  - synchronize content panels with the currently selected step,
+  - provide Arrow key navigation and improved keyboard behavior,
+  - update an aria-live region for screen readers.
+- No external JavaScript frameworks; CSS is the animation engine.
+- Responsive: horizontal on desktop, vertical on small screens.
+- Supports prefers-reduced-motion.
+
+Usage
+1. Place `demo.html` and `style.css` in the same folder and open `demo.html` in a browser.
+2. Or run a local server and visit http://localhost:8000/submissions/examples/accessible-animated-stepper/demo.html
+
+Accessibility notes
+- Step markers use radio inputs under the hood to provide native keyboard semantics (Tab + Arrow keys).
+- Label + input pattern ensures screen reader announces current state and focus.
+- aria-live region is updated for screen readers on step change.
+- respects prefers-reduced-motion.
+
+Converting to pure CSS-only (no JS)
+- Remove the script and rely on radio :checked rules to show content/panels.
+- With radio-only approach arrow keys still work if focus lands on input; however, extra ARIA announcements require JS to update live region.

--- a/submissions/examples/accessible-animated-stepper/demo.html
+++ b/submissions/examples/accessible-animated-stepper/demo.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Accessible Animated Stepper — Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-wrap">
+    <h1>Accessible Animated Stepper (demo)</h1>
+
+    <!-- Live region (updates announced by screen readers when JS updates) -->
+    <div id="step-announcer" aria-live="polite" class="visually-hidden"></div>
+
+    <div class="stepper" role="list" aria-label="Form progress">
+      <!-- Step 1 -->
+      <input class="step-input" type="radio" name="step" id="step-1" checked>
+      <div class="stepper-step" data-step="1" role="listitem" aria-labelledby="label-1">
+        <label class="step-marker" for="step-1" id="label-1" tabindex="0" role="button" aria-label="Step 1: Personal Information">
+          <span class="step-number">1</span>
+          <svg class="step-checkmark" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
+            <polyline points="20 6 9 17 4 12" stroke="currentColor" stroke-width="2" fill="none"/>
+          </svg>
+        </label>
+        <div class="step-connector" aria-hidden="true"></div>
+        <div class="step-label">Personal Info</div>
+      </div>
+
+      <!-- Step 2 -->
+      <input class="step-input" type="radio" name="step" id="step-2">
+      <div class="stepper-step" data-step="2" role="listitem" aria-labelledby="label-2">
+        <label class="step-marker" for="step-2" id="label-2" tabindex="0" role="button" aria-label="Step 2: Address">
+          <span class="step-number">2</span>
+          <svg class="step-checkmark" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
+            <polyline points="20 6 9 17 4 12" stroke="currentColor" stroke-width="2" fill="none"/>
+          </svg>
+        </label>
+        <div class="step-connector" aria-hidden="true"></div>
+        <div class="step-label">Address</div>
+      </div>
+
+      <!-- Step 3 -->
+      <input class="step-input" type="radio" name="step" id="step-3">
+      <div class="stepper-step" data-step="3" role="listitem" aria-labelledby="label-3">
+        <label class="step-marker" for="step-3" id="label-3" tabindex="0" role="button" aria-label="Step 3: Confirmation">
+          <span class="step-number">3</span>
+          <svg class="step-checkmark" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
+            <polyline points="20 6 9 17 4 12" stroke="currentColor" stroke-width="2" fill="none"/>
+          </svg>
+        </label>
+        <div class="step-connector" aria-hidden="true"></div>
+        <div class="step-label">Confirmation</div>
+      </div>
+
+    </div>
+
+    <section class="demo-panels">
+      <div class="panel" id="panel-1">
+        <h2>Personal Information</h2>
+        <p>Example fields: name, email, phone (demo only).</p>
+      </div>
+      <div class="panel" id="panel-2" hidden>
+        <h2>Address</h2>
+        <p>Example fields: street, city, zip (demo only).</p>
+      </div>
+      <div class="panel" id="panel-3" hidden>
+        <h2>Confirmation</h2>
+        <p>Summary and confirm (demo only).</p>
+      </div>
+    </section>
+  </main>
+
+  <!-- Small vanilla JS only to: 1) sync panels with checked radio; 2) provide arrow key nav between steps; 3) update live region -->
+  <script>
+    (function () {
+      const inputs = Array.from(document.querySelectorAll('.step-input'));
+      const panels = [
+        document.getElementById('panel-1'),
+        document.getElementById('panel-2'),
+        document.getElementById('panel-3')
+      ];
+      const announcer = document.getElementById('step-announcer');
+
+      function updateUI() {
+        const checkedIndex = inputs.findIndex(i => i.checked);
+        // Panels
+        panels.forEach((p, i) => {
+          if (!p) return;
+          p.hidden = (i !== checkedIndex);
+        });
+        // Step classes and aria
+        document.querySelectorAll('.stepper-step').forEach((stepEl, i) => {
+          stepEl.classList.toggle('step-active', i === checkedIndex);
+          stepEl.classList.toggle('step-completed', i < checkedIndex);
+          stepEl.classList.toggle('step-disabled', i > checkedIndex + 1);
+        });
+        // announce
+        const labelText = document.querySelector('.stepper-step.step-active .step-label')?.textContent || '';
+        announcer.textContent = `Step ${checkedIndex + 1}: ${labelText}`;
+      }
+
+      // initial UI
+      updateUI();
+
+      // listen for changes
+      inputs.forEach((input, index) => {
+        input.addEventListener('change', updateUI);
+      });
+
+      // keyboard on marker label: left/right arrow moves radios
+      document.querySelectorAll('.step-marker').forEach((marker, idx) => {
+        marker.addEventListener('keydown', (e) => {
+          if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+            e.preventDefault();
+            const next = inputs[Math.min(inputs.length - 1, idx + 1)];
+            next.focus();
+            next.checked = true;
+            updateUI();
+          } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+            e.preventDefault();
+            const prev = inputs[Math.max(0, idx - 1)];
+            prev.focus();
+            prev.checked = true;
+            updateUI();
+          } else if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            const id = marker.getAttribute('for');
+            const input = document.getElementById(id);
+            input.checked = true;
+            input.focus();
+            updateUI();
+          }
+        });
+
+        // click also updates UI (label click toggles input automatically)
+        marker.addEventListener('click', () => {
+          const id = marker.getAttribute('for');
+          const input = document.getElementById(id);
+          input.checked = true;
+          input.focus();
+          updateUI();
+        });
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/accessible-animated-stepper/style.css
+++ b/submissions/examples/accessible-animated-stepper/style.css
@@ -1,0 +1,120 @@
+:root{
+  --color-border:#e5e7eb;
+  --color-primary:#6c63ff;
+  --color-success:#10b981;
+  --color-text:#111827;
+  --speed-fast:120ms;
+  --speed-medium:360ms;
+  --stepper-gap:1.25rem;
+  --stepper-padding:1.5rem;
+}
+
+/* reset for demo */
+* {box-sizing:border-box}
+body{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,"Helvetica Neue",Arial;line-height:1.4;color:var(--color-text);padding:2rem;background:#f9fafb}
+
+.visually-hidden{position:absolute!important;height:1px;width:1px;overflow:hidden;clip:rect(1px,1px,1px,1px);white-space:nowrap;border:0;padding:0;margin:-1px}
+
+/* Stepper container */
+.stepper{display:flex;gap:var(--stepper-gap);padding:var(--stepper-padding);background:transparent;margin:0;align-items:flex-start}
+
+/* make inputs focusable but visually hidden (so keyboard arrow navigation works) */
+.step-input{
+  position:absolute;
+  opacity:0;
+  width:1px;
+  height:1px;
+  margin:-1px;
+  overflow:hidden;
+  clip:rect(1px,1px,1px,1px);
+}
+
+/* Step wrapper */
+.stepper-step{
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  flex:1;
+  position:relative;
+  transition:opacity var(--speed-medium) ease-in-out, transform var(--speed-medium);
+}
+
+/* Marker circle */
+.step-marker{
+  position:relative;
+  width:48px;height:48px;border-radius:50%;
+  background:var(--color-border);
+  border:2px solid var(--color-border);
+  display:flex;align-items:center;justify-content:center;
+  cursor:pointer;transition:all var(--speed-medium) cubic-bezier(.4,0,.2,1);
+  outline-offset:4px;
+}
+.step-marker:focus{outline:3px solid var(--color-primary);outline-offset:4px}
+
+/* number and check */
+.step-number{font-weight:600;font-size:1rem;color:var(--color-text);transition:opacity var(--speed-fast)}
+.step-checkmark{position:absolute;inset:0;margin:auto;opacity:0;transform:scale(.8);stroke:white;transition:all var(--speed-medium) cubic-bezier(.34,1.56,.64,1)}
+
+/* connector line */
+.step-connector{
+  position:absolute;
+  height:4px;
+  background:linear-gradient(to right,var(--color-success) 0%, var(--color-success) 0%, var(--color-border) 0%, var(--color-border) 100%);
+  top:24px; left:calc(50% + 28px); width:calc(100% - 56px);
+  border-radius:2px;
+  transition:background 0.3s ease, width 0.3s ease;
+}
+
+/* label */
+.step-label{margin-top:0.75rem;font-size:.875rem;font-weight:500;color:var(--color-text);text-align:center;max-width:100px;transition:color var(--speed-fast)}
+
+/* Active step (based on JS-driven class or radio checked state) */
+.stepper-step.step-active .step-marker,
+.step-input:checked + .stepper-step .step-marker{
+  background:var(--color-primary);
+  border-color:var(--color-primary);
+  box-shadow:0 0 0 6px rgba(108,99,255,0.08);
+  transform:scale(1.06);
+}
+.stepper-step.step-active .step-number,
+.step-input:checked + .stepper-step .step-number{color:#fff}
+.stepper-step.step-active .step-label,
+.step-input:checked + .stepper-step .step-label{color:var(--color-primary);font-weight:600}
+
+/* Completed */
+.stepper-step.step-completed .step-marker{
+  background:var(--color-success);border-color:var(--color-success);animation:stepper-complete .5s ease;
+}
+.stepper-step.step-completed .step-number{opacity:0}
+.stepper-step.step-completed .step-checkmark{opacity:1;transform:scale(1)}
+/* Connector fill when preceding step is completed or active.
+   For demo we rely on the .step-completed class set by JS; we also support the radio checked styling for the active connector. */
+.stepper-step.step-completed .step-connector,
+.step-input:checked + .stepper-step .step-connector{
+  background:linear-gradient(to right,var(--color-success) 0%, var(--color-success) 100%);
+}
+
+/* Disabled (visual) */
+.stepper-step.step-disabled .step-marker{opacity:.5;cursor:not-allowed}
+
+/* Panels */
+.demo-panels{margin-top:1.5rem;padding:1rem;border-radius:8px;background:white;box-shadow:0 1px 2px rgba(16,24,40,0.04)}
+.panel{display:block}
+
+/* Animations */
+@keyframes stepper-complete{
+  0%{transform:scale(1)}
+  50%{transform:scale(1.15)}
+  100%{transform:scale(1)}
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce){
+  .step-marker,.step-connector,.stepper-step{transition:none!important;animation:none!important}
+}
+
+/* Responsive: vertical on small screens */
+@media (max-width:640px){
+  .stepper{flex-direction:column;gap:1.25rem}
+  .step-connector{position:absolute;left:22px;top:48px;height:calc(100% - 64px);width:4px}
+}


### PR DESCRIPTION
Summary 

This adds an accessible, animated, multi-step form stepper demo as a submission under submissions/examples/accessible-animated-stepper. The component prioritizes animation-first design while preserving accessibility: keyboard navigation, ARIA live updates, focus-visible styling, and prefers-reduced-motion support.

What this implements

Implements issue #33373 — "Accessible Animated Multi-Step Form Stepper with Keyboard Navigation".
New files:
submissions/examples/accessible-animated-stepper/demo.html
submissions/examples/accessible-animated-stepper/style.css
submissions/examples/accessible-animated-stepper/README.md

Why this change

Provides a reusable example that demonstrates accessible motion, keyboard navigation, and a CSS-first approach for animated UI components consistent with EaseMotion’s philosophy (human-readable, animation-first, composable).
Submission is isolated under submissions/ as requested by the project contribution guidelines.
Implementation details

Visual animations and state transitions are implemented in CSS (style.css).
Minimal vanilla JS (demo.html) only to:
synchronize content panels with the selected step,
provide Arrow key navigation and Enter/Space activation,
update an aria-live region to announce step changes to screen readers.
The markup uses semantic HTML with radio + label patterns to preserve native keyboard semantics where possible.
The demo supports prefers-reduced-motion and provides clear focus-visible styling.
Accessibility notes

Keyboard navigation:
Tab to the step markers, use ArrowRight / ArrowLeft (ArrowDown / ArrowUp on vertical) to move among steps; Enter/Space activates selection.
Screen readers:
aria-live region updates announce the current step when it changes.
Semantic roles: role="list" and role="listitem" for the stepper and steps, and label associations for markers.
Visual:
Sufficient contrast for colors used in the demo; focus-visible outlines follow WCAG guidance.
prefers-reduced-motion supported via @media (prefers-reduced-motion: reduce).
