### PR TITLE
feat: add tabs component with smooth underline glider

### DIFF
--- a/submissions/react/react-tabs-component-with-smooth-underline-glider-v2/README.md
+++ b/submissions/react/react-tabs-component-with-smooth-underline-glider-v2/README.md
@@ -1,0 +1,62 @@
+# React Component: Tabs Component with Smooth Underline Glider (#27354)
+
+A modular, copy-paste ready React component for the EaseMotion CSS framework. It renders a horizontal tab list where the active indicator physically slides and resizes to match whichever tab is selected — a "glider" — instead of jumping between fixed-width slots.
+
+## 📦 What's included?
+
+- `Tabs.jsx`: The React component. Manages the active tab in state and measures the active tab button's real position/width on every change (and on window resize) to animate the glider to the exact pixel.
+- `style.css`: The stylesheet powering the glider's slide/resize transition, tab label states, and a horizontally scrollable nav for small viewports.
+- `demo.html`: A self-contained browser demo running the component via Babel standalone, pre-loaded with sample tabs of varying label lengths.
+
+## 🛠 Features
+
+- **True Position Glider**: Rather than assuming equal-width tabs, the component reads each tab button's `offsetLeft` and `offsetWidth` directly from the DOM and applies them to the underline via `transform: translateX()` and `width`. This means labels of any length — "FAQ" next to "Features That Are Longer" — still get a pixel-accurate underline.
+- **Keyboard Accessible**: Implements the WAI-ARIA Tabs pattern — `role="tablist"`/`role="tab"`/`role="tabpanel"`, a roving `tabIndex`, and Arrow Left/Right/Home/End navigation that moves both selection and focus.
+- **Responsive by Default**: The nav scrolls horizontally instead of wrapping on narrow viewports, and a `resize` listener keeps the glider aligned if tab labels reflow.
+- **Reduced Motion Aware**: The glide transition is disabled under `prefers-reduced-motion: reduce`.
+- **Zero Dependencies**: Just React and the included stylesheet — no animation libraries.
+
+## 🔧 Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `tabs` | `Array<{ id, label, content }>` | `[]` (required) | The tabs to render, in order. `content` is optional — omit it to use `Tabs` as a standalone segmented control with no panel. |
+| `defaultActiveTab` | `string` | first tab's `id` | The `id` of the tab selected on mount. |
+| `onTabChange` | `(id: string) => void` | `undefined` | Called with the new tab's `id` whenever the selection changes. |
+
+## 🚀 How to use
+
+1. Copy `Tabs.jsx` into your React project's `components` directory.
+2. Copy `style.css` and import it alongside the component.
+3. Pass a `tabs` array shaped like the one below.
+
+```jsx
+import React from 'react';
+import Tabs from './Tabs';
+import './style.css';
+
+const ProductPage = () => {
+  const tabs = [
+    { id: 'overview', label: 'Overview', content: <p>A quick summary of the product.</p> },
+    { id: 'features', label: 'Features', content: <p>Everything the product can do.</p> },
+    { id: 'pricing', label: 'Pricing', content: <p>Plans and pricing details.</p> },
+    { id: 'faq', label: 'FAQ', content: <p>Answers to common questions.</p> },
+  ];
+
+  return (
+    <Tabs
+      tabs={tabs}
+      defaultActiveTab="overview"
+      onTabChange={(id) => console.log('Active tab:', id)}
+    />
+  );
+};
+
+export default ProductPage;
+```
+
+## 🎨 Why this fits EaseMotion
+
+**EaseMotion** is about making UI elements feel physical and responsive to their context.
+
+EaseMotion CSS's core `ease-tabs` component already establishes the sliding-underline idea, but its pure-CSS, radio-input implementation has to assume equal-width tabs to calculate the underline's position as a fixed percentage — real-world tab labels are rarely equal width. This component keeps that same physical, gliding feel but drives it from React state and real DOM measurements instead, so the underline always lands exactly under the active label regardless of how long its text is, while staying fully keyboard-accessible and motion-preference aware.

--- a/submissions/react/react-tabs-component-with-smooth-underline-glider-v2/Tabs.jsx
+++ b/submissions/react/react-tabs-component-with-smooth-underline-glider-v2/Tabs.jsx
@@ -1,0 +1,106 @@
+import React, { useState, useRef, useCallback, useLayoutEffect } from 'react';
+
+/**
+ * Tabs Component with Smooth Underline Glider
+ *
+ * A horizontal tab list where the active indicator physically slides and
+ * resizes to match whichever tab is selected, instead of jumping between
+ * fixed-width slots.
+ *
+ * @param {Array} tabs - Tab objects: { id, label, content }
+ * @param {String} defaultActiveTab - id of the tab selected on mount (defaults to the first tab)
+ * @param {Function} onTabChange - Called with the new active tab id whenever the selection changes
+ */
+const Tabs = ({ tabs = [], defaultActiveTab, onTabChange }) => {
+  const [activeId, setActiveId] = useState(defaultActiveTab || (tabs[0] && tabs[0].id));
+
+  const tabRefs = useRef({});
+  const underlineRef = useRef(null);
+
+  // Measures the active tab button and moves/resizes the underline to match it.
+  const glideToActiveTab = useCallback(() => {
+    const activeTabEl = tabRefs.current[activeId];
+    const underlineEl = underlineRef.current;
+    if (!activeTabEl || !underlineEl) return;
+
+    underlineEl.style.width = `${activeTabEl.offsetWidth}px`;
+    underlineEl.style.transform = `translateX(${activeTabEl.offsetLeft}px)`;
+  }, [activeId]);
+
+  // Reposition on mount, whenever the active tab changes, and on viewport
+  // resize (labels can reflow at smaller widths).
+  useLayoutEffect(() => {
+    glideToActiveTab();
+    window.addEventListener('resize', glideToActiveTab);
+    return () => window.removeEventListener('resize', glideToActiveTab);
+  }, [glideToActiveTab]);
+
+  const selectTab = (id) => {
+    if (id === activeId) return;
+    setActiveId(id);
+    if (onTabChange) onTabChange(id);
+  };
+
+  // Roving-tabindex keyboard support, per the WAI-ARIA Tabs pattern.
+  const handleKeyDown = (event, index) => {
+    const lastIndex = tabs.length - 1;
+    let nextIndex = null;
+
+    if (event.key === 'ArrowRight') nextIndex = index === lastIndex ? 0 : index + 1;
+    else if (event.key === 'ArrowLeft') nextIndex = index === 0 ? lastIndex : index - 1;
+    else if (event.key === 'Home') nextIndex = 0;
+    else if (event.key === 'End') nextIndex = lastIndex;
+    else return;
+
+    event.preventDefault();
+    const nextTab = tabs[nextIndex];
+    selectTab(nextTab.id);
+    const nextTabEl = tabRefs.current[nextTab.id];
+    if (nextTabEl) nextTabEl.focus();
+  };
+
+  const activeTab = tabs.find((tab) => tab.id === activeId);
+
+  return (
+    <div className="ease-tabs-glider">
+      <div className="ease-tabs-glider-nav" role="tablist" aria-orientation="horizontal">
+        {tabs.map((tab, index) => (
+          <button
+            key={tab.id}
+            ref={(el) => { tabRefs.current[tab.id] = el; }}
+            id={`ease-tabs-glider-tab-${tab.id}`}
+            type="button"
+            className={`ease-tabs-glider-tab${tab.id === activeId ? ' is-active' : ''}`}
+            role="tab"
+            aria-selected={tab.id === activeId}
+            aria-controls={`ease-tabs-glider-panel-${tab.id}`}
+            tabIndex={tab.id === activeId ? 0 : -1}
+            onClick={() => selectTab(tab.id)}
+            onKeyDown={(event) => handleKeyDown(event, index)}
+          >
+            {tab.label}
+          </button>
+        ))}
+
+        {/* The glider: one element that slides and resizes to the active tab,
+            instead of a static border. */}
+        <span className="ease-tabs-glider-underline" ref={underlineRef} />
+      </div>
+
+      {activeTab && activeTab.content && (
+        <div
+          key={activeTab.id}
+          id={`ease-tabs-glider-panel-${activeTab.id}`}
+          className="ease-tabs-glider-panel ease-fade-in"
+          role="tabpanel"
+          aria-labelledby={`ease-tabs-glider-tab-${activeTab.id}`}
+          tabIndex={0}
+        >
+          {activeTab.content}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Tabs;

--- a/submissions/react/react-tabs-component-with-smooth-underline-glider-v2/demo.html
+++ b/submissions/react/react-tabs-component-with-smooth-underline-glider-v2/demo.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>React Tabs - Smooth Underline Glider Demo</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="./style.css">
+
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+
+  <style>
+    body {
+      margin: 0;
+      background: #f8fafc;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 4rem 2rem;
+      box-sizing: border-box;
+      font-family: system-ui, sans-serif;
+    }
+
+    .demo-header {
+      text-align: center;
+      margin-bottom: 3rem;
+    }
+
+    h1 {
+      color: #0f172a;
+      font-size: 2.25rem;
+      font-weight: 800;
+      margin-bottom: 1rem;
+    }
+
+    p.subtitle {
+      color: #64748b;
+      font-size: 1.125rem;
+      max-width: 480px;
+      margin: 0 auto;
+    }
+
+    .demo-card {
+      width: 100%;
+      max-width: 560px;
+      background: #ffffff;
+      border-radius: 16px;
+      padding: 24px 28px 32px;
+      box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03);
+      border: 1px solid #f1f5f9;
+    }
+  </style>
+</head>
+<body>
+
+  <div id="root"></div>
+
+  <script type="text/babel">
+    const { useState, useRef, useCallback, useLayoutEffect } = React;
+
+    const Tabs = ({ tabs = [], defaultActiveTab, onTabChange }) => {
+      const [activeId, setActiveId] = useState(defaultActiveTab || (tabs[0] && tabs[0].id));
+
+      const tabRefs = useRef({});
+      const underlineRef = useRef(null);
+
+      const glideToActiveTab = useCallback(() => {
+        const activeTabEl = tabRefs.current[activeId];
+        const underlineEl = underlineRef.current;
+        if (!activeTabEl || !underlineEl) return;
+
+        underlineEl.style.width = `${activeTabEl.offsetWidth}px`;
+        underlineEl.style.transform = `translateX(${activeTabEl.offsetLeft}px)`;
+      }, [activeId]);
+
+      useLayoutEffect(() => {
+        glideToActiveTab();
+        window.addEventListener('resize', glideToActiveTab);
+        return () => window.removeEventListener('resize', glideToActiveTab);
+      }, [glideToActiveTab]);
+
+      const selectTab = (id) => {
+        if (id === activeId) return;
+        setActiveId(id);
+        if (onTabChange) onTabChange(id);
+      };
+
+      const handleKeyDown = (event, index) => {
+        const lastIndex = tabs.length - 1;
+        let nextIndex = null;
+
+        if (event.key === 'ArrowRight') nextIndex = index === lastIndex ? 0 : index + 1;
+        else if (event.key === 'ArrowLeft') nextIndex = index === 0 ? lastIndex : index - 1;
+        else if (event.key === 'Home') nextIndex = 0;
+        else if (event.key === 'End') nextIndex = lastIndex;
+        else return;
+
+        event.preventDefault();
+        const nextTab = tabs[nextIndex];
+        selectTab(nextTab.id);
+        const nextTabEl = tabRefs.current[nextTab.id];
+        if (nextTabEl) nextTabEl.focus();
+      };
+
+      const activeTab = tabs.find((tab) => tab.id === activeId);
+
+      return (
+        <div className="ease-tabs-glider">
+          <div className="ease-tabs-glider-nav" role="tablist" aria-orientation="horizontal">
+            {tabs.map((tab, index) => (
+              <button
+                key={tab.id}
+                ref={(el) => { tabRefs.current[tab.id] = el; }}
+                id={`ease-tabs-glider-tab-${tab.id}`}
+                type="button"
+                className={`ease-tabs-glider-tab${tab.id === activeId ? ' is-active' : ''}`}
+                role="tab"
+                aria-selected={tab.id === activeId}
+                aria-controls={`ease-tabs-glider-panel-${tab.id}`}
+                tabIndex={tab.id === activeId ? 0 : -1}
+                onClick={() => selectTab(tab.id)}
+                onKeyDown={(event) => handleKeyDown(event, index)}
+              >
+                {tab.label}
+              </button>
+            ))}
+
+            <span className="ease-tabs-glider-underline" ref={underlineRef} />
+          </div>
+
+          {activeTab && activeTab.content && (
+            <div
+              key={activeTab.id}
+              id={`ease-tabs-glider-panel-${activeTab.id}`}
+              className="ease-tabs-glider-panel ease-fade-in"
+              role="tabpanel"
+              aria-labelledby={`ease-tabs-glider-tab-${activeTab.id}`}
+              tabIndex={0}
+            >
+              {activeTab.content}
+            </div>
+          )}
+        </div>
+      );
+    };
+
+    const App = () => {
+      const tabs = [
+        { id: 'overview', label: 'Overview', content: 'A quick summary of the project, its goals, and how it fits into the wider EaseMotion CSS ecosystem.' },
+        { id: 'features', label: 'Features', content: 'Variable-width labels, keyboard navigation, and a glider that measures and glides to the exact pixel of the active tab.' },
+        { id: 'pricing', label: 'Pricing', content: 'EaseMotion CSS is free and open-source under its license - no pricing tiers here.' },
+        { id: 'faq', label: 'FAQ', content: 'Have a question the docs don\u2019t answer? Open a GitHub issue and the maintainer will take a look.' },
+      ];
+
+      return (
+        <div style={{ width: '100%', maxWidth: 560 }}>
+          <div className="demo-header">
+            <h1>Smooth Underline Glider</h1>
+            <p className="subtitle">Click a tab, or focus one and use the arrow keys - the underline glides to match.</p>
+          </div>
+          <div className="demo-card">
+            <Tabs tabs={tabs} defaultActiveTab="overview" />
+          </div>
+        </div>
+      );
+    };
+
+    ReactDOM.render(<App />, document.getElementById('root'));
+  </script>
+</body>
+</html>

--- a/submissions/react/react-tabs-component-with-smooth-underline-glider-v2/style.css
+++ b/submissions/react/react-tabs-component-with-smooth-underline-glider-v2/style.css
@@ -1,0 +1,83 @@
+/*
+  style.css
+  EaseMotion CSS - Tabs Component with Smooth Underline Glider
+*/
+
+.ease-tabs-glider {
+  width: 100%;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+/* --- Tab Nav --- */
+.ease-tabs-glider-nav {
+  position: relative;
+  display: flex;
+  gap: 4px;
+  border-bottom: 2px solid #e2e8f0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.ease-tabs-glider-nav::-webkit-scrollbar {
+  display: none;
+}
+
+.ease-tabs-glider-tab {
+  flex: none;
+  padding: 12px 20px;
+  background: transparent;
+  border: none;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #64748b;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.ease-tabs-glider-tab:hover {
+  color: #334155;
+}
+
+.ease-tabs-glider-tab.is-active {
+  color: #3b82f6;
+}
+
+.ease-tabs-glider-tab:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* --- The Glider ---
+   A single element that physically slides and resizes to the active tab's
+   measured position/width (set inline by the component), rather than a
+   static border under a fixed-width slot. */
+.ease-tabs-glider-underline {
+  position: absolute;
+  bottom: -2px;
+  left: 0;
+  width: 0;
+  height: 3px;
+  border-radius: 3px 3px 0 0;
+  background: #3b82f6;
+  transition:
+    transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    width 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* --- Panel --- */
+.ease-tabs-glider-panel {
+  margin-top: 20px;
+  color: #334155;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+/* Respect the user's motion preferences: keep the tab switch instant
+   instead of animating the glider across the nav. */
+@media (prefers-reduced-motion: reduce) {
+  .ease-tabs-glider-underline {
+    transition-duration: 0.01ms;
+  }
+}


### PR DESCRIPTION
## Description

Adds a copy-paste ready React `Tabs` component with a smooth, position-aware sliding underline ("glider") for the React track, closing #27354. Unlike the framework's core `.ease-tabs` (pure CSS, radio-input based, which has to assume equal-width tabs to calculate the underline's position as a fixed percentage), this measures each tab's real rendered `offsetLeft`/`offsetWidth` via refs and animates the underline to match - so it lands correctly under labels of any length.

---

## Type of Change

- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/react/react-tabs-component-with-smooth-underline-glider-v2/`
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A React Tabs component whose active-tab underline glides to the exact pixel position and width of whichever tab is selected, instead of assuming fixed-width tabs.

**How does a developer use it?**

```html
<div class="ease-tabs-glider">
  <div class="ease-tabs-glider-nav" role="tablist">
    <button class="ease-tabs-glider-tab is-active" role="tab" aria-selected="true">Overview</button>
    <button class="ease-tabs-glider-tab" role="tab" aria-selected="false">Features</button>
    <span class="ease-tabs-glider-underline"></span>
  </div>
  <div class="ease-tabs-glider-panel ease-fade-in" role="tabpanel">...</div>
</div>
```
(This markup is rendered by `<Tabs tabs={tabs} defaultActiveTab="overview" />` - full JSX usage is in `README.md`.)

**Why does it fit EaseMotion CSS?**

It keeps the same physical, gliding-motion language as core's `.ease-tabs`, but drives it from real DOM measurement instead of fixed-percentage CSS, so the underline works correctly for real (non-uniform) tab labels - while staying keyboard-accessible (`Arrow`/`Home`/`End`) and respecting `prefers-reduced-motion`.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)
<img width="1920" height="794" alt="screen-capture" src="https://github.com/user-attachments/assets/ecff1007-b52b-4aa6-b5bc-2128eeb6e361" />

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer

`submissions/react/react-tabs-component-with-smooth-underline-glider/` already exists on `main`. Since editing existing files isn't permitted for this track, I used a suffixed folder name (`-v2`) per the parallel-implementation convention in CONTRIBUTING.md rather than touching it.