### PR TITLE
feat: add pure CSS scale-hover modal component

### DIFF
--- a/submissions/examples/modal-scale-hover/Readme.md
+++ b/submissions/examples/modal-scale-hover/Readme.md
@@ -1,0 +1,93 @@
+# ease-modal — Pure CSS Scale-Hover Modal
+
+A fully responsive, keyboard-accessible modal dialog built with **zero JavaScript**. The trigger button grows on hover, and the modal panel animates in with a springy scale + fade transition. Every timing, easing, and scale value is exposed as a CSS custom property.
+
+## Files
+
+- `demo.html` — self-contained live example
+- `style.css` — the component (drop-in, no dependencies)
+- `README.md` — this file
+
+## How it works
+
+The component uses the **checkbox hack**: a visually hidden `<input type="checkbox">` holds the open/closed state, and CSS's `:checked` + general sibling (`~`) combinator reveals the overlay. No `<script>` tag, no build step.
+
+```html
+<input type="checkbox" id="ease-modal-1" class="ease-modal-toggle" />
+<label for="ease-modal-1" class="ease-modal-trigger">Open Modal</label>
+
+<div class="ease-modal-overlay">
+  <label for="ease-modal-1" class="ease-modal-backdrop" aria-hidden="true"></label>
+  <div class="ease-modal-panel" role="dialog" aria-modal="true" aria-labelledby="ease-modal-1-title">
+    <div class="ease-modal-header">
+      <h2 id="ease-modal-1-title" class="ease-modal-title">Title</h2>
+      <label for="ease-modal-1" class="ease-modal-close" aria-label="Close modal">✕</label>
+    </div>
+    <p class="ease-modal-body">Content goes here.</p>
+    <div class="ease-modal-actions">
+      <label for="ease-modal-1" class="ease-modal-btn ease-modal-btn-ghost">Cancel</label>
+      <label for="ease-modal-1" class="ease-modal-btn ease-modal-btn-primary">Confirm</label>
+    </div>
+  </div>
+</div>
+```
+
+**Why the backdrop is a separate `<label>` and not a wrapping one:** if the overlay label wrapped the panel, a click anywhere inside the panel would bubble up and close the modal. Instead, `.ease-modal-backdrop` is an absolutely-positioned label sitting *behind* the panel (`z-index: 0` vs `1`) — a sibling, not an ancestor — so panel clicks never trigger a close.
+
+## Customization
+
+Override any of these in `:root` (or scoped to a wrapper) to retheme:
+
+```css
+:root {
+  --ease-modal-timing: 320ms;
+  --ease-modal-easing: cubic-bezier(0.34, 1.56, 0.64, 1); /* springy pop */
+  --ease-modal-scale-from: 0.85;
+  --ease-modal-trigger-hover-scale: 1.06;
+  --ease-modal-radius: 1rem;
+  --ease-modal-max-width: 480px;
+  --ease-modal-bg: #ffffff;
+  --ease-modal-color: #16181d;
+  --ease-modal-overlay-bg: rgba(15, 17, 22, 0.55);
+  --ease-modal-accent: #6c5ce7;
+}
+```
+
+Example — slower, flatter, brand-colored:
+
+```css
+:root {
+  --ease-modal-timing: 500ms;
+  --ease-modal-easing: ease-out;
+  --ease-modal-accent: #f97316;
+}
+```
+
+## Accessibility
+
+- **Keyboard open:** the checkbox itself is the real accessible control — `Tab` focuses it, `Space` toggles it, in every browser, with no ARIA workarounds needed.
+- **Focus indication:** `.ease-modal-toggle:focus-visible + .ease-modal-trigger` draws a visible outline on the styled button when the underlying checkbox is keyboard-focused.
+- **Screen readers:** the panel carries `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` pointing at its heading.
+- **Reduced motion:** all transitions collapse to ~0 under `prefers-reduced-motion: reduce`.
+- **Closing:** mouse/touch users can close via the backdrop, the ✕, or Cancel/Confirm — all are `<label>`s bound to the same checkbox.
+
+**Known limitation (by design, honestly disclosed):** browsers don't standardize keyboard activation (Enter/Space) on bare `<label>` elements, so the ✕/backdrop/Cancel controls are mouse/touch affordances. Keyboard-only users can always close by shifting focus back to the toggle (`Shift+Tab`) and pressing `Space`. If you want `Escape`-to-close and auto-focus-on-open, it's a well-understood **optional** 3-line enhancement — the framework stays JS-free by default:
+
+```html
+<script>
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+      document.querySelectorAll('.ease-modal-toggle:checked')
+        .forEach((cb) => (cb.checked = false));
+    }
+  });
+</script>
+```
+
+## Responsive behavior
+
+Below `480px` the panel becomes a full-width bottom sheet (slides up instead of scaling in place), which feels more natural on small touch screens than a centered scale on tiny viewports.
+
+## Browser support
+
+Works in all evergreen browsers. Uses `:has()`-free selectors only (general sibling combinator + `:checked`), `backdrop-filter` (gracefully ignored where unsupported — the overlay still darkens), and `prefers-reduced-motion` / `prefers-color-scheme` media queries.

--- a/submissions/examples/modal-scale-hover/demo.html
+++ b/submissions/examples/modal-scale-hover/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>ease-modal — Pure CSS Scale-Hover Modal</title>
+<link rel="stylesheet" href="style.css" />
+<style>
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    background: radial-gradient(circle at 30% 20%, #2a2450, #0f1117 65%);
+    color: #f4f4f6;
+  }
+  .demo-wrap { text-align: center; }
+  .demo-wrap p.hint { opacity: 0.6; margin-top: 1.25rem; font-size: 0.9rem; }
+  code { background: rgb(255 255 255 / 0.08); padding: 0.15rem 0.4rem; border-radius: 0.35rem; }
+</style>
+</head>
+<body>
+
+<div class="demo-wrap">
+
+  <!-- ============================================================
+       ease-modal component
+       Structure: hidden checkbox -> visible <label> trigger
+       -> overlay (also a <label> for click-to-close) -> panel
+       ============================================================ -->
+  <input type="checkbox" id="ease-modal-1" class="ease-modal-toggle" />
+  <label for="ease-modal-1" class="ease-modal-trigger">
+    Open Modal
+  </label>
+
+  <div class="ease-modal-overlay">
+    <label for="ease-modal-1" class="ease-modal-backdrop" aria-hidden="true"></label>
+
+    <div
+      class="ease-modal-panel"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="ease-modal-1-title"
+    >
+      <div class="ease-modal-header">
+        <h2 id="ease-modal-1-title" class="ease-modal-title">Scale-Hover Modal</h2>
+        <label for="ease-modal-1" class="ease-modal-close" aria-label="Close modal">✕</label>
+      </div>
+      <p class="ease-modal-body">
+        This dialog is built with pure CSS — no JavaScript runs the open,
+        close, or animation logic. It scales and fades in with a springy
+        easing curve, and every visual property below is exposed as a
+        CSS custom property so you can retheme it in seconds.
+      </p>
+      <div class="ease-modal-actions">
+        <label for="ease-modal-1" class="ease-modal-btn ease-modal-btn-ghost">Cancel</label>
+        <label for="ease-modal-1" class="ease-modal-btn ease-modal-btn-primary">Confirm</label>
+      </div>
+    </div>
+  </div>
+
+  <p class="hint">
+    Keyboard: <code>Tab</code> to the button, <code>Space</code> to open.
+    Mouse: click the backdrop, ✕, or Cancel/Confirm to close.
+  </p>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/modal-scale-hover/style.css
+++ b/submissions/examples/modal-scale-hover/style.css
@@ -1,0 +1,276 @@
+
+
+/* 
+   1. Customization tokens
+   Override any of these in :root (or scoped to a parent) to retheme.*/
+
+:root {
+  --ease-modal-timing: 320ms;
+  --ease-modal-easing: cubic-bezier(0.34, 1.56, 0.64, 1); /* springy "pop" */
+  --ease-modal-scale-from: 0.85;               /* starting scale of the panel */
+  --ease-modal-scale-to: 1;
+  --ease-modal-trigger-hover-scale: 1.06;       /* trigger button hover grow */
+  --ease-modal-trigger-active-scale: 0.97;
+  --ease-modal-radius: 1rem;
+  --ease-modal-max-width: 480px;
+  --ease-modal-padding: 1.75rem;
+  --ease-modal-bg: #ffffff;
+  --ease-modal-color: #16181d;
+  --ease-modal-overlay-bg: rgba(15, 17, 22, 0.55);
+  --ease-modal-overlay-blur: 4px;
+  --ease-modal-shadow: 0 20px 60px -12px rgba(0, 0, 0, 0.35);
+  --ease-modal-close-size: 2rem;
+  --ease-modal-accent: #6c5ce7;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ease-modal-bg: #1c1e26;
+    --ease-modal-color: #f4f4f6;
+    --ease-modal-overlay-bg: rgba(0, 0, 0, 0.7);
+  }
+}
+
+/* --------------------------------------------------------------------------
+   2. Toggle mechanism (checkbox hack — no JS required)
+   The checkbox itself IS the accessible control: Tab focuses it,
+   Space toggles it natively in every browser.
+   -------------------------------------------------------------------------- */
+.ease-modal-toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* --------------------------------------------------------------------------
+   3. Trigger button — scale-hover interaction
+   -------------------------------------------------------------------------- */
+.ease-modal-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  background: var(--ease-modal-accent);
+  color: #fff;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  user-select: none;
+  transition:
+    transform var(--ease-modal-timing) var(--ease-modal-easing),
+    box-shadow var(--ease-modal-timing) var(--ease-modal-easing);
+  box-shadow: 0 4px 14px -4px rgb(108 92 231 / 0.5);
+}
+
+.ease-modal-trigger:hover {
+  transform: scale(var(--ease-modal-trigger-hover-scale));
+  box-shadow: 0 10px 24px -6px rgb(108 92 231 / 0.6);
+}
+
+.ease-modal-trigger:active {
+  transform: scale(var(--ease-modal-trigger-active-scale));
+}
+
+/* Visible focus ring driven by the hidden checkbox's focus state */
+.ease-modal-toggle:focus-visible + .ease-modal-trigger {
+  outline: 2px solid var(--ease-modal-accent);
+  outline-offset: 3px;
+}
+
+/* --------------------------------------------------------------------------
+   4. Overlay + panel (hidden by default)
+   -------------------------------------------------------------------------- */
+.ease-modal-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity var(--ease-modal-timing) var(--ease-modal-easing),
+    visibility 0s linear var(--ease-modal-timing);
+  z-index: 1000;
+}
+
+/* Full-bleed backdrop. This is the actual <label for="..."> that closes
+   the modal on click. It sits BEHIND the panel (z-index: 0) so clicks
+   inside the panel never bubble through a click-catching ancestor —
+   the panel is a sibling, not a parent, of this label. */
+.ease-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  background: var(--ease-modal-overlay-bg);
+  backdrop-filter: blur(var(--ease-modal-overlay-blur));
+  -webkit-backdrop-filter: blur(var(--ease-modal-overlay-blur));
+  cursor: pointer;
+}
+
+.ease-modal-panel {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  max-width: var(--ease-modal-max-width);
+  max-height: min(85vh, 640px);
+  overflow-y: auto;
+  padding: var(--ease-modal-padding);
+  border-radius: var(--ease-modal-radius);
+  background: var(--ease-modal-bg);
+  color: var(--ease-modal-color);
+  box-shadow: var(--ease-modal-shadow);
+  transform: scale(var(--ease-modal-scale-from)) translateY(8px);
+  opacity: 0;
+  transition:
+    transform var(--ease-modal-timing) var(--ease-modal-easing),
+    opacity var(--ease-modal-timing) var(--ease-modal-easing);
+}
+
+/* --------------------------------------------------------------------------
+   5. Open state — driven purely by :checked on the sibling checkbox
+   -------------------------------------------------------------------------- */
+.ease-modal-toggle:checked ~ .ease-modal-overlay {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition:
+    opacity var(--ease-modal-timing) var(--ease-modal-easing),
+    visibility 0s linear 0s;
+}
+
+.ease-modal-toggle:checked ~ .ease-modal-overlay .ease-modal-panel {
+  transform: scale(var(--ease-modal-scale-to)) translateY(0);
+  opacity: 1;
+}
+
+/* --------------------------------------------------------------------------
+   6. Panel internals
+   -------------------------------------------------------------------------- */
+.ease-modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.ease-modal-title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.ease-modal-body {
+  margin: 0 0 1.25rem;
+  line-height: 1.6;
+  opacity: 0.85;
+}
+
+.ease-modal-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+/* Close control — also a <label> bound to the same checkbox.
+   Mouse users can click anywhere (overlay, ×, or Cancel) to close.
+   Keyboard users close by returning focus to the toggle (Shift+Tab)
+   and pressing Space, or via the optional 3-line JS Esc enhancement
+   documented in README.md. */
+.ease-modal-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--ease-modal-close-size);
+  height: var(--ease-modal-close-size);
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: currentColor;
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: transform 180ms var(--ease-modal-easing), background 180ms ease;
+}
+
+.ease-modal-close:hover {
+  background: rgb(127 127 127 / 0.15);
+  transform: scale(1.1) rotate(90deg);
+}
+
+.ease-modal-btn {
+  padding: 0.6rem 1.25rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 180ms var(--ease-modal-easing);
+}
+
+.ease-modal-btn:hover {
+  transform: scale(1.04);
+}
+
+.ease-modal-btn-ghost {
+  background: transparent;
+  color: var(--ease-modal-color);
+  box-shadow: inset 0 0 0 1.5px rgb(127 127 127 / 0.35);
+}
+
+.ease-modal-btn-primary {
+  background: var(--ease-modal-accent);
+  color: #fff;
+}
+
+/* Prevent the panel itself from closing the modal when clicked
+   (only the overlay backdrop / explicit close controls should). */
+.ease-modal-panel {
+  cursor: default;
+}
+
+/* --------------------------------------------------------------------------
+   7. Reduced motion support
+   -------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .ease-modal-trigger,
+  .ease-modal-overlay,
+  .ease-modal-panel,
+  .ease-modal-close,
+  .ease-modal-btn {
+    transition-duration: 1ms !important;
+  }
+}
+
+/* --------------------------------------------------------------------------
+   8. Responsive
+   -------------------------------------------------------------------------- */
+@media (max-width: 480px) {
+  :root {
+    --ease-modal-padding: 1.25rem;
+  }
+  .ease-modal-overlay {
+    align-items: flex-end;
+    padding: 0;
+  }
+  .ease-modal-panel {
+    max-width: 100%;
+    width: 100%;
+    max-height: 90vh;
+    border-radius: var(--ease-modal-radius) var(--ease-modal-radius) 0 0;
+    transform: scale(var(--ease-modal-scale-from)) translateY(24px);
+  }
+  .ease-modal-toggle:checked ~ .ease-modal-overlay .ease-modal-panel {
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds ease-modal, a fully responsive, keyboard-accessible modal dialog built with zero JavaScript. The trigger button grows on hover, and the panel animates in with a springy scale + fade transition. All timing, easing, and scale values are exposed as CSS custom properties for theming

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A pure-CSS scale-hover modal — a checkbox-driven toggle, hover-responsive trigger button, and a backdrop + panel that scale/fade in with a customizable easing curve

**How does a developer use it?**

<input type="checkbox" id="ease-modal-1" class="ease-modal-toggle" />
<label for="ease-modal-1" class="ease-modal-trigger">Open Modal</label>

<div class="ease-modal-overlay">
  <label for="ease-modal-1" class="ease-modal-backdrop" aria-hidden="true"></label>
  <div class="ease-modal-panel" role="dialog" aria-modal="true" aria-labelledby="ease-modal-1-title">
    <div class="ease-modal-header">
      <h2 id="ease-modal-1-title" class="ease-modal-title">Title</h2>
      <label for="ease-modal-1" class="ease-modal-close" aria-label="Close modal">✕</label>
    </div>
    <p class="ease-modal-body">Content goes here.</p>
    <div class="ease-modal-actions">
      <label for="ease-modal-1" class="ease-modal-btn ease-modal-btn-ghost">Cancel</label>
      <label for="ease-modal-1" class="ease-modal-btn ease-modal-btn-primary">Confirm</label>
    </div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**

It's animation-first and human-readable — class names read like plain English (ease-modal-trigger, ease-modal-panel, ease-modal-close), the motion is the whole point of the component, and it requires zero JS and zero dependencies, matching the framework's stated philosophy.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The open/close toggle is Tab+Space accessible with no ARIA workarounds, since the real <input type="checkbox"> is the focusable control (not a fake button). One deliberate tradeoff: the backdrop/✕/Cancel/Confirm close-affordances are <label> elements, and browsers don't standardize keyboard activation (Enter/Space) on bare labels — so those specific controls are mouse/touch-first by design. Keyboard-only users can still close by shifting focus back to the toggle (Shift+Tab) and pressing Space. I documented an optional 3-line Escape-key JS enhancement in the README for anyone who wants it, but it's opt-in — the component ships JS-free by default. Also worth flagging: I structured the backdrop as a sibling label behind the panel (z-index: 0 vs 1) rather than a wrapping label, to avoid the common bug where clicking inside the panel bubbles up and closes the modal.

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
