### PR TITLE
feat: add modal-scale-overlay component (#33397)

### DIFF
--- a/submissions/examples/ease-modal-scale-overlay-ij/README.md
+++ b/submissions/examples/ease-modal-scale-overlay-ij/README.md
@@ -1,0 +1,44 @@
+# Modal Scale Overlay
+
+## What does this do?
+
+It opens a centered modal panel with a dark blurred overlay behind it. The content box enters with an elastic scale-up transition (0.7 → 1.0) while the overlay fades in.
+
+## How is it used?
+
+Wrap your modal markup with the `.modal-scale-overlay-ij` container and use the child classes `.mso-overlay-ij` (backdrop), `.mso-content-ij` (panel), and `.mso-close-ij` (close button). Toggle the `.mso-open` class on the container to show/hide the modal.
+
+```html
+<div class="modal-scale-overlay-ij" id="modal">
+  <div class="mso-overlay-ij" id="overlay"></div>
+  <div class="mso-content-ij">
+    <button class="mso-close-ij">&times;</button>
+    Your content here
+  </div>
+</div>
+```
+
+```js
+// Open
+modal.classList.add('mso-open');
+document.body.style.overflow = 'hidden';
+
+// Close
+modal.classList.remove('mso-open');
+document.body.style.overflow = '';
+```
+
+Customize the look by overriding these `:root` variables:
+
+```css
+:root {
+  --mso-overlay-color: rgba(0, 0, 0, 0.55);
+  --mso-content-bg: #fff;
+  --mso-transition-duration: 0.3s;
+  --mso-max-width: 480px;
+}
+```
+
+## Why is this useful?
+
+This provides a lightweight, accessible modal pattern with a polished scale animation. It relies only on CSS transforms and opacity transitions (GPU-composited) for smooth performance. The reduced-motion query disables all transitions when the user prefers it.

--- a/submissions/examples/ease-modal-scale-overlay-ij/demo.html
+++ b/submissions/examples/ease-modal-scale-overlay-ij/demo.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Modal Scale Overlay Demo (ij)</title>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:opsz@14..32&display=swap" rel="stylesheet" />
+
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: "Inter", system-ui, -apple-system, sans-serif;
+      background: #f1f5f9;
+      color: #0f172a;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 3rem 1.5rem;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body {
+        background: #0f172a;
+        color: #f8fafc;
+      }
+    }
+
+    .page-header {
+      text-align: center;
+      max-width: 520px;
+    }
+
+    .page-header h1 {
+      font-size: 1.8rem;
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+    }
+
+    .page-header p {
+      color: #64748b;
+      font-size: 0.95rem;
+      line-height: 1.6;
+    }
+
+    .open-btn {
+      margin-top: 2rem;
+      background: #6c63ff;
+      color: #fff;
+      border: none;
+      padding: 0.75rem 2rem;
+      font-size: 1rem;
+      font-weight: 600;
+      border-radius: 8px;
+      cursor: pointer;
+      font-family: inherit;
+    }
+
+    .open-btn:hover {
+      background: #5b52e5;
+    }
+  </style>
+
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>Modal Scale Overlay</h1>
+    <p>
+      A clean modal with a blurred overlay background and an elastic scale transition on the content panel. Click the button below to open it.
+    </p>
+    <button class="open-btn" id="openModalBtn">Open Modal</button>
+  </header>
+
+  <div class="modal-scale-overlay-ij" id="modal">
+    <div class="mso-overlay-ij" id="overlay"></div>
+    <div class="mso-content-ij">
+      <button class="mso-close-ij" id="closeBtn">&times;</button>
+      <h2 style="margin-bottom: 1rem; font-size: 1.4rem;">Hello from the Modal</h2>
+      <p style="color: #475569; line-height: 1.7;">
+        This content box scales up from 0.7 to 1.0 with an overshoot easing curve. The overlay fades in with a subtle backdrop blur. Click outside or the close button to dismiss.
+      </p>
+    </div>
+  </div>
+
+  <script>
+    const modal = document.getElementById('modal');
+    const overlay = document.getElementById('overlay');
+    const closeBtn = document.getElementById('closeBtn');
+    const openBtn = document.getElementById('openModalBtn');
+
+    function openModal() {
+      modal.classList.add('mso-open');
+      document.body.style.overflow = 'hidden';
+    }
+
+    function closeModal() {
+      modal.classList.remove('mso-open');
+      document.body.style.overflow = '';
+    }
+
+    openBtn.addEventListener('click', openModal);
+    closeBtn.addEventListener('click', closeModal);
+    overlay.addEventListener('click', closeModal);
+
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && modal.classList.contains('mso-open')) {
+        closeModal();
+      }
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-modal-scale-overlay-ij/style.css
+++ b/submissions/examples/ease-modal-scale-overlay-ij/style.css
@@ -1,0 +1,87 @@
+/* =============================================================
+   Submission: ease-modal-scale-overlay-ij
+   Effect: Modal Scale Overlay
+   ============================================================= */
+
+:root {
+  --mso-overlay-color: rgba(0, 0, 0, 0.55);
+  --mso-content-bg: #fff;
+  --mso-transition-duration: 0.3s;
+  --mso-max-width: 480px;
+}
+
+.modal-scale-overlay-ij {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-scale-overlay-ij.mso-open {
+  display: flex;
+}
+
+.mso-overlay-ij {
+  position: absolute;
+  inset: 0;
+  background: var(--mso-overlay-color);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  opacity: 0;
+  transition: opacity var(--mso-transition-duration) ease;
+}
+
+.modal-scale-overlay-ij.mso-open .mso-overlay-ij {
+  opacity: 1;
+}
+
+.mso-content-ij {
+  position: relative;
+  background: var(--mso-content-bg);
+  max-width: var(--mso-max-width);
+  width: 90%;
+  border-radius: 12px;
+  padding: 2rem;
+  transform: scale(0.7);
+  transition: transform var(--mso-transition-duration) cubic-bezier(0.34, 1.56, 0.64, 1);
+  z-index: 1;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+}
+
+.modal-scale-overlay-ij.mso-open .mso-content-ij {
+  transform: scale(1);
+}
+
+.mso-close-ij {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: transparent;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+  color: inherit;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.mso-close-ij:hover {
+  background: rgba(0, 0, 0, 0.08);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mso-overlay-ij,
+  .mso-content-ij {
+    transition: none !important;
+  }
+  .mso-content-ij {
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Component: ease-modal-scale-overlay ? Modal scales in with overlay fade on open

### What this adds
Modal scales in with overlay fade on open using CSS transitions and animations.

### Acceptance Criteria covered
- Smooth CSS transition or @keyframes animation
- Interactive trigger (click)
- Customizable via CSS variables

### Files
- submissions/examples/ease-modal-scale-overlay-ij/demo.html
- submissions/examples/ease-modal-scale-overlay-ij/style.css
- submissions/examples/ease-modal-scale-overlay-ij/README.md

### How to review
Open demo.html and click to open the modal.

**Closes #33397**
