### PR TITLE
feat: add dropdown-menu-slide-down component (#33401)

### DIFF
--- a/submissions/examples/ease-dropdown-menu-slide-down-ij/README.md
+++ b/submissions/examples/ease-dropdown-menu-slide-down-ij/README.md
@@ -1,0 +1,38 @@
+# Dropdown Menu Slide Down
+
+A CSS component that creates a smooth sliding dropdown menu triggered by clicking a navigation item.
+
+## What does this do?
+
+Each navigation item in a horizontal bar reveals its associated dropdown panel with a downward slide animation when clicked. The animation uses `max-height` and `opacity` transitions, and dropdown links have staggered hover effects.
+
+## How is it used?
+
+Include the `style.css` stylesheet and use the following HTML structure:
+
+```html
+<nav class="dmsd-nav">
+  <div class="dmsd-nav-item">
+    <button class="dmsd-nav-btn" data-dropdown="dd-example">Label</button>
+    <div class="dmsd-dropdown" id="dd-example">
+      <a href="#">Item 1</a>
+      <a href="#">Item 2</a>
+    </div>
+  </div>
+</nav>
+```
+
+Toggle the `.dmsd-open` class on the `.dmsd-dropdown` element to trigger the slide-down animation.
+
+Customize the component with these CSS variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `--dmsd-transition-duration` | `0.3s` | Speed of slide-down and fade-in |
+| `--dmsd-bg-color` | `#ffffff` | Dropdown background |
+| `--dmsd-item-hover-bg` | `#f3f4f6` | Hover background for links |
+| `--dmsd-border-color` | `#e5e7eb` | Border color for nav and dropdown |
+
+## Why is this useful?
+
+Dropdown menus are a core UI pattern for navigation-heavy sites. This component keeps the animation lightweight (pure CSS transitions) and accessible, with a minimal JavaScript toggle that can be adapted to any framework or vanilla project.

--- a/submissions/examples/ease-dropdown-menu-slide-down-ij/demo.html
+++ b/submissions/examples/ease-dropdown-menu-slide-down-ij/demo.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS - Dropdown Menu Slide Down</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>Dropdown Menu Slide Down</h1>
+  </header>
+
+  <nav class="dmsd-nav">
+    <div class="dmsd-nav-item">
+      <button class="dmsd-nav-btn" data-dropdown="dd-products">Products</button>
+      <div class="dmsd-dropdown" id="dd-products">
+        <a href="#">Analytics</a>
+        <a href="#">Dashboard</a>
+        <a href="#">Reports</a>
+        <a href="#">Integrations</a>
+      </div>
+    </div>
+    <div class="dmsd-nav-item">
+      <button class="dmsd-nav-btn" data-dropdown="dd-solutions">Solutions</button>
+      <div class="dmsd-dropdown" id="dd-solutions">
+        <a href="#">Enterprise</a>
+        <a href="#">Startups</a>
+        <a href="#">Government</a>
+        <a href="#">Education</a>
+        <a href="#">Healthcare</a>
+      </div>
+    </div>
+    <div class="dmsd-nav-item">
+      <button class="dmsd-nav-btn" data-dropdown="dd-resources">Resources</button>
+      <div class="dmsd-dropdown" id="dd-resources">
+        <a href="#">Documentation</a>
+        <a href="#">API Reference</a>
+        <a href="#">Blog</a>
+        <a href="#">Community</a>
+      </div>
+    </div>
+  </nav>
+
+  <main class="dmsd-main">
+    <p>Click a navigation item to toggle its dropdown menu. The menu slides down with a smooth max-height and opacity transition.</p>
+  </main>
+
+  <script>
+    document.querySelectorAll('.dmsd-nav-btn').forEach(function(btn) {
+      btn.addEventListener('click', function(e) {
+        var targetId = this.getAttribute('data-dropdown');
+        var dropdown = document.getElementById(targetId);
+
+        document.querySelectorAll('.dmsd-dropdown.dmsd-open').forEach(function(d) {
+          if (d.id !== targetId) {
+            d.classList.remove('dmsd-open');
+          }
+        });
+
+        dropdown.classList.toggle('dmsd-open');
+        e.stopPropagation();
+      });
+    });
+
+    document.addEventListener('click', function() {
+      document.querySelectorAll('.dmsd-dropdown.dmsd-open').forEach(function(d) {
+        d.classList.remove('dmsd-open');
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-dropdown-menu-slide-down-ij/style.css
+++ b/submissions/examples/ease-dropdown-menu-slide-down-ij/style.css
@@ -1,0 +1,118 @@
+:root {
+  --dmsd-transition-duration: 0.3s;
+  --dmsd-bg-color: #ffffff;
+  --dmsd-item-hover-bg: #f3f4f6;
+  --dmsd-border-color: #e5e7eb;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  background: #f9fafb;
+  min-height: 100vh;
+}
+
+header {
+  text-align: center;
+  padding: 2rem 1rem 1rem;
+}
+
+header h1 {
+  font-size: 2rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.dmsd-nav {
+  display: flex;
+  justify-content: center;
+  gap: 0;
+  background: var(--dmsd-bg-color);
+  border-bottom: 1px solid var(--dmsd-border-color);
+  padding: 0 1rem;
+}
+
+.dmsd-nav-item {
+  position: relative;
+}
+
+.dmsd-nav-btn {
+  background: none;
+  border: none;
+  padding: 1rem 1.5rem;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #374151;
+  cursor: pointer;
+  transition: background var(--dmsd-transition-duration), color var(--dmsd-transition-duration);
+  font-family: inherit;
+}
+
+.dmsd-nav-btn:hover,
+.dmsd-nav-btn:focus {
+  background: var(--dmsd-item-hover-bg);
+  color: #111827;
+  outline: none;
+}
+
+.dmsd-nav-btn::after {
+  content: " \25BE";
+  font-size: 0.75rem;
+  opacity: 0.6;
+}
+
+.dmsd-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  min-width: 200px;
+  background: var(--dmsd-bg-color);
+  border: 1px solid var(--dmsd-border-color);
+  border-radius: 8px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+  max-height: 0;
+  opacity: 0;
+  transition: max-height var(--dmsd-transition-duration) ease, opacity var(--dmsd-transition-duration) ease;
+  z-index: 10;
+}
+
+.dmsd-dropdown.dmsd-open {
+  max-height: 500px;
+  opacity: 1;
+}
+
+.dmsd-dropdown a {
+  display: block;
+  padding: 0.7rem 1.25rem;
+  text-decoration: none;
+  color: #374151;
+  font-size: 0.9rem;
+  transition: background var(--dmsd-transition-duration), padding-left var(--dmsd-transition-duration);
+}
+
+.dmsd-dropdown a:hover {
+  background: var(--dmsd-item-hover-bg);
+  padding-left: 1.75rem;
+  color: #111827;
+}
+
+.dmsd-dropdown a:nth-child(1) { transition-delay: 0s; }
+.dmsd-dropdown a:nth-child(2) { transition-delay: 0.03s; }
+.dmsd-dropdown a:nth-child(3) { transition-delay: 0.06s; }
+.dmsd-dropdown a:nth-child(4) { transition-delay: 0.09s; }
+.dmsd-dropdown a:nth-child(5) { transition-delay: 0.12s; }
+
+.dmsd-main {
+  max-width: 800px;
+  margin: 3rem auto;
+  padding: 0 1rem;
+  text-align: center;
+  color: #6b7280;
+  line-height: 1.6;
+}


### PR DESCRIPTION
## Component: ease-dropdown-menu-slide-down ? Dropdown menu slides down with fade transition

### What this adds
Dropdown menu slides down with fade transition using CSS transitions and animations.

### Acceptance Criteria covered
- Smooth CSS transition or @keyframes animation
- Interactive trigger (click)
- Customizable via CSS variables

### Files
- submissions/examples/ease-dropdown-menu-slide-down-ij/demo.html
- submissions/examples/ease-dropdown-menu-slide-down-ij/style.css
- submissions/examples/ease-dropdown-menu-slide-down-ij/README.md

### How to review
Open demo.html and click nav items to see dropdowns.

**Closes #33401**
