### PR TITLE
feat: add split view resizable panel demo submission

### DIFF
--- a/submissions/examples/split-view-resizable-panel-tg/README.md
+++ b/submissions/examples/split-view-resizable-panel-tg/README.md
@@ -1,0 +1,13 @@
+# Split View Resizable Panel
+
+### 1. What does this do?
+
+Creates a split-view layout with a draggable divider that allows users to resize two content panels.
+
+### 2. How is it used?
+
+Open `demo.html` in a browser and drag the divider between the two panels to resize them.
+
+### 3. Why is it useful?
+
+It provides an intuitive layout for dashboards, editors, file explorers, and similar interfaces while remaining lightweight and easy to integrate.

--- a/submissions/examples/split-view-resizable-panel-tg/demo.html
+++ b/submissions/examples/split-view-resizable-panel-tg/demo.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Split View Resizable Panel</title>
+    <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+<div class="split-container">
+
+    <div class="panel left-panel">
+        <h2>Left Panel</h2>
+        <p>
+            This panel can contain navigation, files, settings,
+            documentation, or any other content.
+        </p>
+    </div>
+
+    <div class="divider" id="divider"></div>
+
+    <div class="panel right-panel">
+        <h2>Right Panel</h2>
+        <p>
+            Resize the divider by dragging it left or right.
+            The layout updates smoothly.
+        </p>
+    </div>
+
+</div>
+
+<script>
+const container = document.querySelector(".split-container");
+const leftPanel = document.querySelector(".left-panel");
+const divider = document.getElementById("divider");
+
+let dragging = false;
+
+divider.addEventListener("mousedown", () => {
+    dragging = true;
+    document.body.style.cursor = "col-resize";
+});
+
+document.addEventListener("mouseup", () => {
+    dragging = false;
+    document.body.style.cursor = "default";
+});
+
+document.addEventListener("mousemove", (e) => {
+
+    if (!dragging) return;
+
+    const rect = container.getBoundingClientRect();
+
+    let width = e.clientX - rect.left;
+
+    const min = 180;
+    const max = rect.width - 180;
+
+    width = Math.max(min, Math.min(max, width));
+
+    leftPanel.style.flexBasis = `${width}px`;
+
+});
+</script>
+
+</body>
+</html>

--- a/submissions/examples/split-view-resizable-panel-tg/style.css
+++ b/submissions/examples/split-view-resizable-panel-tg/style.css
@@ -1,0 +1,72 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: Arial, Helvetica, sans-serif;
+    background: #f4f4f4;
+    height: 100vh;
+}
+
+.split-container {
+    display: flex;
+    width: 100%;
+    height: 100vh;
+    overflow: hidden;
+}
+
+.panel {
+    padding: 30px;
+    overflow: auto;
+    transition: flex-basis 0.2s ease;
+}
+
+.left-panel {
+    flex: 0 0 50%;
+    background: #ffffff;
+}
+
+.right-panel {
+    flex: 1;
+    background: #e9ecef;
+}
+
+.divider {
+    width: 8px;
+    cursor: col-resize;
+    background: #999;
+    transition: background 0.2s ease;
+}
+
+.divider:hover {
+    background: #444;
+}
+
+h2 {
+    margin-bottom: 20px;
+}
+
+p {
+    line-height: 1.7;
+}
+
+@media (max-width: 768px) {
+
+    .split-container {
+        flex-direction: column;
+    }
+
+    .divider {
+        width: 100%;
+        height: 8px;
+        cursor: row-resize;
+    }
+
+    .left-panel,
+    .right-panel {
+        flex: 1;
+    }
+
+}


### PR DESCRIPTION
## Pull Request Description

Fixes #27352
Adds a self-contained split view resizable panel demo with a draggable divider and responsive layout. The demo is implemented using only HTML, CSS, and minimal vanilla JavaScript, following the repository's submission guidelines.

---

## Type of Change

* [ ] ✨ New animation / hover effect
* [x] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

* [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] **No changes to `core/`**
* [x] **No changes to `components/`**
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A responsive split view layout with a draggable divider that allows users to resize two panels smoothly.

**How does a developer use it?**

```html
<link rel="stylesheet" href="./style.css">

<div class="split-container">
  <div class="panel left-panel">Left Panel</div>
  <div class="divider"></div>
  <div class="panel right-panel">Right Panel</div>
</div>
```

**Why does it fit EaseMotion CSS?**

The component demonstrates a clean, interactive UI pattern with smooth motion and responsive behavior while remaining lightweight, dependency-free, and easy to understand.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [ ] Chrome
* [ ] Firefox
* [x] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This submission is fully self-contained under `submissions/examples/split-view-resizable-panel-tg/` and does not modify any framework source files. Feedback and standardization of class names are welcome.

