### PR TITLE
Added the github repository link on line 540 to demo page nav bar

### DIFF
--- a/examples/demo.html
+++ b/examples/demo.html
@@ -537,6 +537,7 @@
         <li><a href="#animations">Animations</a></li>
         <li><a href="#layout">Layout</a></li>
         <li><a href="../docs/index.html">Docs</a></li>
+        <li><a href="https://github.com/saptarshi-coder/easemotion-css" target="_blank" rel="noopener noreferrer">GitHub</a></li>
         <li>
           <button id="theme-toggle" class="theme-toggle-btn ease-hover-grow" aria-label="Toggle dark/light theme">
             <!-- Sun Icon -->


### PR DESCRIPTION


What does this PR do?
- Adds a GitHub repository link to the demo page navbar.
- Places the link before the theme toggle button while preserving the existing navigation layout.

Type of Change
- [x] Documentation improvement / UI enhancement

Issue Solved
Fixes #30747

Testing
- Verified the GitHub link appears in the demo navbar.
- Verified it opens the official EaseMotion CSS repository in a new tab.
