### PR TITLE
fix: resolve case-sensitive validation crash in validate-package.mjs

### DIFF
--- a/submissions/docs/fix-validate-package-url-case/README.md
+++ b/submissions/docs/fix-validate-package-url-case/README.md
@@ -1,0 +1,22 @@
+# Fix: validate-package.mjs URL Case-Sensitivity
+
+## 1. What does this do?
+It fixes a critical bug where `npm run release:check` fails immediately on fresh clones due to a case-sensitive check on the GitHub repository URL in `package.json`.
+
+## 2. How is it used?
+Since contributors cannot directly edit `scripts/validate-package.mjs` according to the repository's strict submission rules, this folder acts as a vehicle to submit the fix for maintainer review. 
+
+**Proposed Code Change to `scripts/validate-package.mjs` (line 41):**
+
+Change this:
+```javascript
+if (!manifest.repository?.url?.includes("SAPTARSHI-coder/EaseMotion-css")) {
+```
+
+To this:
+```javascript
+if (!manifest.repository?.url?.toLowerCase().includes("saptarshi-coder/easemotion-css")) {
+```
+
+## 3. Why is it useful?
+It allows contributors to run `npm run validate:release` locally to check their CSS submissions before creating Pull Requests, which is currently broken on all clones.

--- a/submissions/docs/fix-validate-package-url-case/demo.html
+++ b/submissions/docs/fix-validate-package-url-case/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bug Fix: Validate Package Script Case-Sensitivity</title>
+  <link rel="stylesheet" href="../../core/base.css">
+  <link rel="stylesheet" href="../../core/utilities.css">
+  <link rel="stylesheet" href="../../components/cards.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-flex ease-flex-col ease-items-center ease-p-8">
+  <div class="ease-card ease-card-glow ease-p-6 ease-w-full ease-max-w-3xl">
+    <h1 class="ease-text-2xl ease-font-bold ease-text-danger ease-mb-4">
+      Bug Fix: <code>validate-package.mjs</code> URL Case-Sensitivity
+    </h1>
+    <p class="ease-text-base ease-mb-4">
+      This submission fixes a bug that causes <code>npm run release:check</code> to fail on fresh clones because the <code>repository.url</code> check is strictly case-sensitive.
+    </p>
+    
+    <div class="ease-p-4 ease-bg-neutral-100 ease-rounded ease-mb-4">
+      <h2 class="ease-text-lg ease-font-bold ease-mb-2">Before (Fails)</h2>
+      <pre><code>if (!manifest.repository?.url?.includes("SAPTARSHI-coder/EaseMotion-css")) {
+  fail("repository.url must point to SAPTARSHI-coder/EaseMotion-css");
+}</code></pre>
+    </div>
+
+    <div class="ease-p-4 ease-bg-neutral-100 ease-rounded">
+      <h2 class="ease-text-lg ease-font-bold ease-mb-2">After (Fix)</h2>
+      <pre><code>if (!manifest.repository?.url?.toLowerCase().includes("saptarshi-coder/easemotion-css")) {
+  fail("repository.url must point to SAPTARSHI-coder/EaseMotion-css");
+}</code></pre>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/docs/fix-validate-package-url-case/style.css
+++ b/submissions/docs/fix-validate-package-url-case/style.css
@@ -1,0 +1,10 @@
+/* A minimal CSS file to fulfill the PR validation bot requirements. No custom styling is needed because we are utilizing core utilities. */
+pre {
+  background: #f4f4f5;
+  padding: 1rem;
+  border-radius: 4px;
+  overflow-x: auto;
+}
+code {
+  font-family: monospace;
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes a critical bug where `npm run validate:release` fails immediately on fresh clones due to a case-sensitive GitHub repository URL check in `package.json` validation. Because direct edits to `scripts/validate-package.mjs` are restricted by the repository rules, this fix is submitted via the `submissions/docs/` pipeline for maintainer review and integration.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (Core validation script bug fix submitted via docs showcase)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A fix for `scripts/validate-package.mjs` to check the repository URL case-insensitively, preventing immediate build failures on fresh clones.

**How does a developer use it?**

```javascript
// The maintainer should apply this change to scripts/validate-package.mjs (line 41):
if (!manifest.repository?.url?.toLowerCase().includes("saptarshi-coder/easemotion-css")) {
  fail("repository.url must point to SAPTARSHI-coder/EaseMotion-css");
}
