### PR TITLE
 feat: add flex alignment and layout utility SCSS mixins

### DIFF
--- a/submissions/scss/scss-flex-alignment-and-layout-mixins/README.md
+++ b/submissions/scss/scss-flex-alignment-and-layout-mixins/README.md
@@ -1,0 +1,98 @@
+# Flex Alignment & Layout Mixins
+
+A lightweight, reusable SCSS utility for the **EaseMotion CSS** design system. Provides mixins for common flexbox alignment and layout patterns.
+
+## Files
+
+- `_flex-alignment-and-layout-mixins.scss` — the mixin partial
+- `main.scss` — example usage / compiles to style.css
+- `style.css` — compiled CSS output
+- `demo.html` — live demo page
+
+## Mixins
+
+### `flex-center($direction, $gap)`
+
+Centers content horizontally and vertically using flexbox.
+
+| Param | Default | Description |
+|---|---|---|
+| `$direction` | `row` | Flex direction (`row` or `column`) |
+| `$gap` | `0` | Gap between children |
+
+```scss
+.hero {
+  @include flex-center(column, 16px);
+}
+```
+
+### `flex-between($align, $direction)`
+
+Distributes children with `space-between` and configurable cross-axis alignment.
+
+| Param | Default | Description |
+|---|---|---|
+| `$align` | `center` | Cross-axis alignment (`align-items` value) |
+| `$direction` | `row` | Flex direction |
+
+```scss
+.navbar {
+  @include flex-between(center, row);
+}
+```
+
+### `flex-stack($breakpoint, $gap)`
+
+Lays children out in a row by default, stacking into a column below a given breakpoint — useful for responsive layouts.
+
+| Param | Default | Description |
+|---|---|---|
+| `$breakpoint` | `768px` | Max-width at which children stack into a column |
+| `$gap` | `16px` | Gap between children |
+
+```scss
+.card-group {
+  @include flex-stack(600px, 12px);
+}
+```
+
+### `flex-gap($gap, $direction)`
+
+Applies a gap between flex children, with a margin-based fallback for older browsers that don't support `gap` in flexbox.
+
+| Param | Default | Description |
+|---|---|---|
+| `$gap` | `16px` | Gap size |
+| `$direction` | `row` | Flex direction |
+
+```scss
+.button-group {
+  @include flex-gap(8px, row);
+}
+```
+
+## Usage
+
+```scss
+@import 'flex-alignment-and-layout-mixins';
+
+.my-element {
+  @include flex-center();
+  @include flex-gap(12px);
+}
+```
+
+## Compiling
+
+```bash
+sass main.scss style.css
+```
+
+## Demo
+
+Open `demo.html` in a browser to see all mixins in action. Resize the window to see `flex-stack()` switch from row to column layout.
+
+## Browser Support
+
+- Flexbox: all modern browsers
+- `gap` in flexbox: modern browsers (Chrome 84+, Firefox 63+, Safari 14.1+); `flex-gap()` includes a margin-based fallback for older browsers

--- a/submissions/scss/scss-flex-alignment-and-layout-mixins/_flex-alignment-and-layout-mixins.scss
+++ b/submissions/scss/scss-flex-alignment-and-layout-mixins/_flex-alignment-and-layout-mixins.scss
@@ -1,0 +1,114 @@
+// ==========================================================================
+// EaseMotion CSS — Flex Alignment & Layout Mixins
+// A lightweight SCSS utility for common flexbox alignment and layout
+// patterns used across the design system.
+// ==========================================================================
+
+// --------------------------------------------------------------------------
+// Mixin: flex-center
+// Centers content horizontally and/or vertically using flexbox.
+//
+// Params:
+//   $direction - Flex direction               (default: row)
+//   $gap       - Gap between children          (default: 0)
+//
+// Usage:
+//   .hero {
+//     @include flex-center(column, 16px);
+//   }
+// --------------------------------------------------------------------------
+@mixin flex-center($direction: row, $gap: 0) {
+  display: flex;
+  flex-direction: $direction;
+  align-items: center;
+  justify-content: center;
+
+  @if $gap != 0 {
+    gap: $gap;
+  }
+}
+
+// --------------------------------------------------------------------------
+// Mixin: flex-between
+// Distributes children with space-between and configurable cross-axis
+// alignment.
+//
+// Params:
+//   $align     - Cross-axis alignment          (default: center)
+//   $direction - Flex direction                 (default: row)
+//
+// Usage:
+//   .navbar {
+//     @include flex-between(center, row);
+//   }
+// --------------------------------------------------------------------------
+@mixin flex-between($align: center, $direction: row) {
+  display: flex;
+  flex-direction: $direction;
+  justify-content: space-between;
+  align-items: $align;
+}
+
+// --------------------------------------------------------------------------
+// Mixin: flex-stack
+// Lays children out in a row by default, stacking into a column below
+// a given breakpoint — useful for responsive layouts.
+//
+// Params:
+//   $breakpoint - Max-width at which to stack   (default: 768px)
+//   $gap        - Gap between children           (default: 16px)
+//
+// Usage:
+//   .card-group {
+//     @include flex-stack(600px, 12px);
+//   }
+// --------------------------------------------------------------------------
+@mixin flex-stack($breakpoint: 768px, $gap: 16px) {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: $gap;
+
+  @media (max-width: $breakpoint) {
+    flex-direction: column;
+  }
+}
+
+// --------------------------------------------------------------------------
+// Mixin: flex-gap
+// Applies a gap between flex children, with a margin-based fallback for
+// older browsers that don't support `gap` in flexbox.
+//
+// Params:
+//   $gap       - Gap size                        (default: 16px)
+//   $direction - Flex direction                   (default: row)
+//
+// Usage:
+//   .button-group {
+//     @include flex-gap(8px, row);
+//   }
+// --------------------------------------------------------------------------
+@mixin flex-gap($gap: 16px, $direction: row) {
+  display: flex;
+  flex-direction: $direction;
+  gap: $gap;
+
+  // Fallback for browsers without flexbox gap support
+  @supports not (gap: $gap) {
+    > * {
+      @if $direction == row {
+        margin-right: $gap;
+
+        &:last-child {
+          margin-right: 0;
+        }
+      } @else {
+        margin-bottom: $gap;
+
+        &:last-child {
+          margin-bottom: 0;
+        }
+      }
+    }
+  }
+}

--- a/submissions/scss/scss-flex-alignment-and-layout-mixins/demo.html
+++ b/submissions/scss/scss-flex-alignment-and-layout-mixins/demo.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Flex Alignment & Layout Mixins Demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: #fafafa;
+    padding: 40px;
+    color: #222;
+  }
+  h1 { font-size: 22px; margin-bottom: 8px; }
+  p.subtitle { color: #666; margin-bottom: 32px; }
+  section { margin-bottom: 40px; }
+  h2 { font-size: 16px; margin-bottom: 12px; }
+  .logo { font-weight: 700; }
+  .nav-links { display: flex; gap: 16px; }
+  .nav-links a { text-decoration: none; color: #333; font-size: 14px; }
+  .card h3 { margin: 0 0 8px; font-size: 15px; }
+  .card p { margin: 0; font-size: 13px; color: #666; }
+</style>
+</head>
+<body>
+
+  <h1>Flex Alignment & Layout Mixins</h1>
+  <p class="subtitle">EaseMotion CSS — SCSS utility demo</p>
+
+  <section>
+    <h2>1. flex-center()</h2>
+    <div class="center-box">Centered content</div>
+  </section>
+
+  <section>
+    <h2>2. flex-between()</h2>
+    <div class="navbar">
+      <div class="logo">Brand</div>
+      <div class="nav-links">
+        <a href="#">Home</a>
+        <a href="#">About</a>
+        <a href="#">Contact</a>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>3. flex-stack()</h2>
+    <div class="card-group">
+      <div class="card">
+        <h3>Card One</h3>
+        <p>Resize the window below 600px to see this stack into a column.</p>
+      </div>
+      <div class="card">
+        <h3>Card Two</h3>
+        <p>Flex-wrap and responsive stacking handled by the mixin.</p>
+      </div>
+      <div class="card">
+        <h3>Card Three</h3>
+        <p>Gap spacing stays consistent at any screen size.</p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>4. flex-gap()</h2>
+    <div class="button-group">
+      <button class="btn">Save</button>
+      <button class="btn">Cancel</button>
+      <button class="btn">Delete</button>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/scss/scss-flex-alignment-and-layout-mixins/main.scss
+++ b/submissions/scss/scss-flex-alignment-and-layout-mixins/main.scss
@@ -1,0 +1,50 @@
+// Demo file — shows the mixins in action.
+// Compile with: sass main.scss style.css
+
+@import 'flex-alignment-and-layout-mixins';
+
+.center-box {
+  height: 200px;
+  width: 100%;
+  background: #f1f1f1;
+  border-radius: 8px;
+
+  @include flex-center(row, 12px);
+}
+
+.navbar {
+  padding: 16px 24px;
+  background: #fff;
+  border-bottom: 1px solid #eee;
+
+  @include flex-between(center, row);
+}
+
+.card-group {
+  padding: 24px;
+
+  @include flex-stack(600px, 16px);
+}
+
+.card {
+  flex: 1;
+  padding: 20px;
+  background: #f9f9f9;
+  border-radius: 8px;
+  border: 1px solid #eee;
+}
+
+.button-group {
+  padding: 16px;
+
+  @include flex-gap(8px, row);
+}
+
+.btn {
+  padding: 10px 16px;
+  border: none;
+  border-radius: 6px;
+  background: #6c63ff;
+  color: #fff;
+  cursor: pointer;
+}

--- a/submissions/scss/scss-flex-alignment-and-layout-mixins/style.css
+++ b/submissions/scss/scss-flex-alignment-and-layout-mixins/style.css
@@ -1,0 +1,66 @@
+.center-box {
+  height: 200px;
+  width: 100%;
+  background: #f1f1f1;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+
+.navbar {
+  padding: 16px 24px;
+  background: #fff;
+  border-bottom: 1px solid #eee;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.card-group {
+  padding: 24px;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+@media (max-width: 600px) {
+  .card-group {
+    flex-direction: column;
+  }
+}
+
+.card {
+  flex: 1;
+  padding: 20px;
+  background: #f9f9f9;
+  border-radius: 8px;
+  border: 1px solid #eee;
+}
+
+.button-group {
+  padding: 16px;
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+}
+@supports not (gap: 8px) {
+  .button-group > * {
+    margin-right: 8px;
+  }
+  .button-group > *:last-child {
+    margin-right: 0;
+  }
+}
+
+.btn {
+  padding: 10px 16px;
+  border: none;
+  border-radius: 6px;
+  background: #6c63ff;
+  color: #fff;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a reusable SCSS utility for Flex Alignment & Layout mixins to the EaseMotion CSS design system.

It includes a well-documented mixin partial, a compiled CSS demo, an interactive HTML preview, and full README documentation covering all mixin parameters and usage.

Closes #28380

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## What's Included

- `_flex-alignment-and-layout-mixins.scss` — the core mixin partial with 4 mixins:
  - `flex-center()` — centers content horizontally/vertically
  - `flex-between()` — space-between with configurable alignment
  - `flex-stack()` — responsive row-to-column stacking
  - `flex-gap()` — gap with margin-based fallback for older browsers
- `main.scss` — example usage demonstrating all four mixins
- `style.css` — compiled CSS output
- `demo.html` — live browser demo of all mixins in action
- `README.md` — full documentation with parameter tables, defaults, usage snippets, and browser support notes

## File Location

`submissions/scss/scss-flex-alignment-and-layout-mixins/`

## Testing

- [x] Opened `demo.html` directly in the browser and verified all four layouts render and behave correctly
- [x] Resized the browser window to confirm `flex-stack()` switches from row to column at the breakpoint
- [x] Compiled `main.scss` to `style.css` successfully with no errors
- [x] Confirmed README renders correctly in Markdown preview
- [x] Confirmed no existing files were modified or deleted (`git status` showed only new files)

## Checklist

- [x] Code follows the project's contribution guidelines
- [x] Files placed only inside the `submissions/` directory
- [x] Included `demo.html`, compiled CSS, and `README.md` as required
- [x] No existing issue/PR duplicates this submission
- [x] No existing code modified or deleted
- [x] Self-reviewed the code and comments for clarity