### PR TITLE
feat: add ease-radio-button-fill component #33524

### DIFF
--- a/submissions/examples/ease-radio-button-fill-ij/README.md
+++ b/submissions/examples/ease-radio-button-fill-ij/README.md
@@ -1,0 +1,17 @@
+# Ease Radio Button Fill
+
+A clean, responsive custom radio button UI wrapper component featuring an elegant inner-node scaling transition and subtle card-background fill highlights upon selection.
+
+## Features
+- **Pure CSS Execution:** No complex interaction listeners or external helper scripts required.
+- **Accessible Layout Foundation:** Built securely over native hidden input controls ensuring screen-readers and sequential tab-focus patterns are retained seamlessly.
+- **Tokens/Variable Driven:** Centralized CSS custom property variables inside the root node allow complete adjustments over accent hues, sizes, container glows, and animation speed properties.
+
+## Animation Mechanics
+This module relies on the sibling selection indicator layout tree combinator rules (`~`). The visual inner radio circle node is prepared via a hidden pseudo-element placeholder (`::before` layer inside `.custom-radio`) transformed out of sight using `transform: scale(0)`.
+
+When the native checkbox register changes via the browser engine layer:
+```css
+.radio-label input[type="radio"]:checked ~ .custom-radio::before {
+    transform: scale(1);
+}

--- a/submissions/examples/ease-radio-button-fill-ij/demo.html
+++ b/submissions/examples/ease-radio-button-fill-ij/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ease Radio Button Fill</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="card">
+        <h2>Choose Your Plan</h2>
+        <p class="subtitle">Select an option below to see the fill transition</p>
+        
+        <form class="radio-group">
+            <label class="radio-label">
+                <input type="radio" name="plan" value="starter" checked>
+                <span class="custom-radio"></span>
+                <span class="radio-text">
+                    <strong>Starter Pack</strong>
+                    <span class="desc">Free access to basic components</span>
+                </span>
+            </label>
+
+            <label class="radio-label">
+                <input type="radio" name="plan" value="pro">
+                <span class="custom-radio"></span>
+                <span class="radio-text">
+                    <strong>Pro Motion</strong>
+                    <span class="desc">Advanced transitions & premium support</span>
+                </span>
+            </label>
+
+            <label class="radio-label">
+                <input type="radio" name="plan" value="enterprise">
+                <span class="custom-radio"></span>
+                <span class="radio-text">
+                    <strong>Enterprise Custom</strong>
+                    <span class="desc">Tailored layout tokens for large teams</span>
+                </span>
+            </label>
+        </form>
+    </div>
+</body>
+</html>

--- a/submissions/examples/ease-radio-button-fill-ij/style.css
+++ b/submissions/examples/ease-radio-button-fill-ij/style.css
@@ -1,0 +1,169 @@
+/* Design Tokens & Configurable CSS Variables */
+:root {
+    --bg-main: #0b0f19;
+    --card-bg: #111827;
+    --border-color: #374151;
+    --radio-border-hover: #4b5563;
+    
+    /* Interactive States (Color Fill Customization) */
+    --accent-color: #6366f1;
+    --accent-glow: rgba(99, 102, 241, 0.15);
+    --text-primary: #f9fafb;
+    --text-muted: #9ca3af;
+    
+    /* Animation Configurations */
+    --transition-speed: 0.25s;
+    --transition-timing: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Reset & Center Layout */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    background-color: var(--bg-main);
+    color: var(--text-primary);
+    font-family: system-ui, -apple-system, sans-serif;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 20px;
+}
+
+/* Card Container */
+.card {
+    background-color: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 16px;
+    padding: 32px;
+    width: 100%;
+    max-width: 440px;
+    box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.3);
+}
+
+h2 {
+    font-size: 1.5rem;
+    margin-bottom: 6px;
+}
+
+.subtitle {
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    margin-bottom: 24px;
+}
+
+/* Form Structure */
+.radio-group {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+/* Wrapper Label acting as interactive surface */
+.radio-label {
+    display: flex;
+    align-items: flex-start;
+    padding: 16px;
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    cursor: pointer;
+    position: relative;
+    transition: background-color var(--transition-speed), border-color var(--transition-speed);
+}
+
+/* Screen reader accessible hidden original radio input */
+.radio-label input[type="radio"] {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+/* Hover Adjustments */
+.radio-label:hover {
+    border-color: var(--radio-border-hover);
+    background-color: rgba(255, 255, 255, 0.02);
+}
+
+.radio-label:hover .custom-radio {
+    border-color: var(--radio-border-hover);
+}
+
+/* Custom Visual Component Wrapper */
+.custom-radio {
+    position: relative;
+    flex-shrink: 0;
+    width: 22px;
+    height: 22px;
+    border: 2px solid var(--border-color);
+    border-radius: 50%;
+    margin-top: 2px;
+    margin-right: 14px;
+    transition: border-color var(--transition-speed) var(--transition-timing);
+}
+
+/* The expanding fill node container */
+.custom-radio::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    margin: auto;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background-color: var(--accent-color);
+    /* Set baseline state to fully shrunk out of sight */
+    transform: scale(0);
+    transition: transform var(--transition-speed) var(--transition-timing);
+}
+
+/* Checked States Mechanics Mapping */
+.radio-label input[type="radio"]:checked ~ .custom-radio {
+    border-color: var(--accent-color);
+}
+
+.radio-label input[type="radio"]:checked ~ .custom-radio::before {
+    transform: scale(1);
+}
+
+.radio-label input[type="radio"]:checked {
+    border-color: var(--accent-color);
+    background-color: var(--accent-glow);
+}
+
+/* Keyboard Focus States Indicator for Accessibility */
+.radio-label input[type="radio"]:focus-visible ~ .custom-radio {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 4px;
+}
+
+/* Text Element Layouts */
+.radio-text {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.radio-text strong {
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.radio-text .desc {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+    line-height: 1.4;
+}
+
+/* Responsive Scaling down */
+@media (max-width: 400px) {
+    .card { padding: 20px; }
+    .radio-label { padding: 12px; }
+}


### PR DESCRIPTION
## 📝 Description
Implements the `ease-radio-button-fill` component, offering a premium interactive radio list group experience. Features a smooth inner-dot color fill scaling transition built entirely via CSS.

## 🎯 Motivation & Context
Fixes #33524

Provides the library with a fully accessible custom radio configuration framework. It maintains perfect focus outlines for keyboard navigation while delivering custom hover and selection animations with zero JavaScript.

## 💡 Acceptance Criteria Met
- Smooth hardware-accelerated scaling transitions used.
- Handles hover, tap selection click, and `focus-visible` states beautifully.
- Complete visual styling (colors, transitions, sizing) can be adjusted cleanly via CSS variables.
- Clean folder structure mapped strictly within: `submissions/examples/ease-radio-button-fill-ij/`