### PR TITLE
Fix case-sensitive repository URL validation in validate-package.mjs …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "easemotion-css",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "easemotion-css",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "jsdom": "^29.1.1",

--- a/scripts/validate-package.mjs
+++ b/scripts/validate-package.mjs
@@ -38,7 +38,7 @@ if (manifest.name !== "easemotion-css") {
   fail('expected package name to be "easemotion-css"');
 }
 
-if (!manifest.repository?.url?.includes("SAPTARSHI-coder/EaseMotion-css")) {
+if (!manifest.repository?.url?.toLowerCase().includes("SAPTARSHI-coder/EaseMotion-css".toLowerCase())) {
   fail("repository.url must point to SAPTARSHI-coder/EaseMotion-css");
 }
 


### PR DESCRIPTION
## Pull Request Description
Fixes case-sensitive repository URL validation in `scripts/validate-package.mjs`
(issue #33566). `npm run validate:release` was failing on a fresh clone because
the script's `.includes()` check against `repository.url` was case-sensitive,
while `package.json` uses a lowercase URL — even though the URL pointed to the
correct repository. This lowercases both sides of the comparison so casing
differences no longer cause a false failure.

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
> Not applicable — this PR fixes a validation script (`scripts/validate-package.mjs`),
> not a feature submission. There is no new content under `submissions/`.

- [ ] All changes are inside `submissions/` — N/A, this is a `scripts/` fix
- [ ] Includes `demo.html` — N/A
- [ ] Includes `style.css` — N/A
- [ ] Includes `README.md` — N/A
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (single, scoped fix — casing comparison only)

---

## Feature Description
N/A — this PR does not add a new animation, effect, or component. It fixes a
release-validation script so `npm run validate:release` passes regardless of
repository URL casing.

---

## Demo
- [ ] Demo added — N/A, not a visual/animation submission

---

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
> N/A — this is a Node.js build/release script fix, not browser-facing.

---

## Notes for Maintainer
This fixes issue #33566: `validate-package.mjs` (line ~41) used a
case-sensitive `.includes()` check against the repository URL, causing a
fatal validation error on a fresh clone even though `package.json`'s URL was
correct, just lowercase. Fix lowercases both sides of the comparison before
checking — it still correctly fails if the URL points to a genuinely
different repository, only casing is now tolerated. Ran `npm run
validate:release` after the fix to confirm it passes; also confirmed it still
rejects a mismatched repo URL.