### PR TITLE
feat: add ease-tag-remove-fade component #33528

### DIFF
--- a/submissions/examples/ease-tag-remove-fade-ij/README.md
+++ b/submissions/examples/ease-tag-remove-fade-ij/README.md
@@ -1,0 +1,15 @@
+# Ease Tag Remove Fade Component
+
+A lightweight ui tag layout featuring micro-interactions that cleanly handle state removal through combined opacity fades and dimensional spatial collapses.
+
+## Features
+- **Compound Keyframe Animation**: Orchestrates element translation, opacity fades, and width reductions simultaneously.
+- **Fluid Layout Compensation**: Collapses spatial boundaries dynamically to let sibling nodes fill empty voids naturally.
+- **Configurable Control Variables**: Leverages design-tokens (`--slide-distance`, `--animation-duration`) to adapt easily.
+
+## Structural File Tree
+```text
+ease-tag-remove-fade-ij/
+├── demo.html    # Layout sample hosting interactive removal script triggers
+├── style.css    # Layout properties, token entries, and collapse keyframe mappings
+└── README.md    # Documentation file

--- a/submissions/examples/ease-tag-remove-fade-ij/demo.html
+++ b/submissions/examples/ease-tag-remove-fade-ij/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ease Tag Remove Fade - Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="demo-wrapper">
+        <h2>Interactive Tag Dismissal</h2>
+        <p>Click the "×" on any tag to trigger the smooth fade-out and slide-left removal animation.</p>
+
+        <div class="tags-container">
+            <div class="dismissible-tag">
+                <span>Frontend</span>
+                <button class="remove-btn" onclick="removeTag(this)">&times;</button>
+            </div>
+            <div class="dismissible-tag">
+                <span>CSS3</span>
+                <button class="remove-btn" onclick="removeTag(this)">&times;</button>
+            </div>
+            <div class="dismissible-tag">
+                <span>Animation</span>
+                <button class="remove-btn" onclick="removeTag(this)">&times;</button>
+            </div>
+            <div class="dismissible-tag">
+                <span>Open Source</span>
+                <button class="remove-btn" onclick="removeTag(this)">&times;</button>
+            </div>
+        </div>
+        
+        <button class="reset-btn" onclick="location.reload()">Reset Tags</button>
+    </div>
+
+    <script>
+        function removeTag(button) {
+            const tag = button.parentElement;
+            // Add the animation class that triggers the CSS keyframes
+            tag.classList.add('removing');
+            
+            // Completely remove from DOM once the animation finishes
+            tag.addEventListener('animationend', () => {
+                tag.remove();
+            });
+        }
+    </script>
+</body>
+</html>

--- a/submissions/examples/ease-tag-remove-fade-ij/style.css
+++ b/submissions/examples/ease-tag-remove-fade-ij/style.css
@@ -1,0 +1,134 @@
+/* Customizable Component Variables */
+:root {
+    --tag-bg: #e0e7ff;
+    --tag-text: #4f46e5;
+    --tag-border-radius: 6px;
+    --remove-btn-hover: #ef4444;
+    
+    /* Animation Properties */
+    --animation-duration: 0.4s;
+    --animation-timing: cubic-bezier(0.4, 0, 0.2, 1);
+    --slide-distance: -20px; /* Distance shifted during removal */
+    
+    --font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+/* Base Presentation Architecture */
+body {
+    font-family: var(--font-family);
+    background-color: #f9fafb;
+    margin: 0;
+    padding: 2rem 1rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+}
+
+.demo-wrapper {
+    background: #ffffff;
+    padding: 2.5rem;
+    border-radius: 12px;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+    max-width: 450px;
+    width: 100%;
+    text-align: center;
+}
+
+.demo-wrapper h2 {
+    margin-top: 0;
+    color: #111827;
+    font-size: 1.4rem;
+}
+
+.demo-wrapper p {
+    color: #6b7280;
+    font-size: 0.9rem;
+    margin-bottom: 2rem;
+}
+
+/* --- Core Tag Component Architecture --- */
+.tags-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    justify-content: center;
+    margin-bottom: 2rem;
+}
+
+.dismissible-tag {
+    display: inline-flex;
+    align-items: center;
+    background-color: var(--tag-bg);
+    color: var(--tag-text);
+    padding: 6px 12px;
+    font-size: 0.9rem;
+    font-weight: 500;
+    border-radius: var(--tag-border-radius);
+    gap: 8px;
+    transform-origin: center left;
+    will-change: transform, opacity, max-width, margin;
+}
+
+.remove-btn {
+    background: none;
+    border: none;
+    color: inherit;
+    font-size: 1.2rem;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: color 0.2s ease;
+}
+
+.remove-btn:hover {
+    color: var(--remove-btn-hover);
+}
+
+/* --- Keyframe Removal Animation Hooks --- */
+.dismissible-tag.removing {
+    animation: fadeOutSlideLeft var(--animation-duration) var(--animation-timing) forwards;
+}
+
+@keyframes fadeOutSlideLeft {
+    0% {
+        opacity: 1;
+        transform: translateX(0);
+        max-width: 200px;
+        margin-right: 0;
+        padding-left: 12px;
+        padding-right: 12px;
+    }
+    50% {
+        opacity: 0;
+        transform: translateX(var(--slide-distance));
+    }
+    100% {
+        opacity: 0;
+        transform: translateX(var(--slide-distance));
+        /* Collapse space layout gaps smoothly */
+        max-width: 0;
+        margin-right: -10px; 
+        padding-left: 0;
+        padding-right: 0;
+        overflow: hidden;
+    }
+}
+
+/* Helper Reset Button */
+.reset-btn {
+    background: #f3f4f6;
+    border: 1px solid #d1d5db;
+    padding: 8px 16px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.85rem;
+    color: #4b5563;
+    transition: background 0.2s;
+}
+.reset-btn:hover {
+    background: #e5e7eb;
+}


### PR DESCRIPTION
### 🚀 Description
This PR addresses issue #33528 by introducing a smooth, interactive `ease-tag-remove-fade` component. It utilizes custom CSS `@keyframes` that combine horizontal translation (`translateX`), opacity fading, and a structural layout width collapse. This ensures that when a tag is dismissed, the surrounding tags reposition themselves smoothly without sudden jumps.

### 📋 Checklist / Acceptance Criteria
- [x] Smooth CSS exit animation orchestrated with keyframes and custom cubic-bezier timing.
- [x] Interactive click trigger bound to a close icon.
- [x] High customizability via decoupled CSS variables (`--slide-distance`, `--animation-duration`).
- [x] Fluid flexbox layout that adapts beautifully to both mobile environments and large containers.

### 📂 Files Created
- `submissions/examples/ease-tag-remove-fade-ij/demo.html`
- `submissions/examples/ease-tag-remove-fade-ij/style.css`
- `submissions/examples/ease-tag-remove-fade-ij/README.md`

Closes #33528