### PR TITLE
feat: add neumorphic pin keypad component #33507

### DIFF
--- a/submissions/examples/neumorphic-pin-keypad/README.md
+++ b/submissions/examples/neumorphic-pin-keypad/README.md
@@ -1,0 +1,16 @@
+# Neumorphic PIN Keypad Component
+
+A high-fidelity soft-UI numeric entry keypad designed entirely in fluid, responsive pure CSS without any external dependencies.
+
+## Features
+- **True Soft UI Design:** Combines distinct drop-shadow arrays with matching color surfaces to achieve extruded structures.
+- **Pure CSS Pressed States:** Leverages immediate CSS `:active` actions backed by `inset` box-shadow transformations.
+- **Zero Dependencies:** Pure HTML/CSS architecture built for high compatibility.
+- **Customizable Base Profiles:** Tweak light channels, background foundations, and text spacing metrics instantly via CSS variables.
+
+## File Hierarchy
+```text
+neumorphic-pin-keypad/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/neumorphic-pin-keypad/demo.html
+++ b/submissions/examples/neumorphic-pin-keypad/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neumorphic PIN Keypad Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="demo-container">
+        <h2>Neumorphic PIN Keypad</h2>
+        <p class="subtitle">Pure CSS soft-UI interface with precise dual-shadow active push states.</p>
+
+        <div class="keypad-case">
+            <div class="keypad-display">
+                <div class="dot active"></div>
+                <div class="dot active"></div>
+                <div class="dot"></div>
+                <div class="dot"></div>
+            </div>
+
+            <div class="keypad-grid">
+                <button class="key-btn">1</button>
+                <button class="key-btn">2</button>
+                <button class="key-btn">3</button>
+                
+                <button class="key-btn">4</button>
+                <button class="key-btn">5</button>
+                <button class="key-btn">6</button>
+                
+                <button class="key-btn">7</button>
+                <button class="key-btn">8</button>
+                <button class="key-btn">9</button>
+                
+                <button class="key-btn action-btn text-danger">⌫</button>
+                <button class="key-btn">0</button>
+                <button class="key-btn action-btn text-success">✔</button>
+            </div>
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/neumorphic-pin-keypad/style.css
+++ b/submissions/examples/neumorphic-pin-keypad/style.css
@@ -1,0 +1,126 @@
+/* Neumorphic Shadow Configuration Variables */
+:root {
+    --bg-color: #e0e8f6;
+    --text-primary: #555f7d;
+    --light-shadow: -6px -6px 14px rgba(255, 255, 255, 0.7);
+    --dark-shadow: 6px 6px 14px rgba(163, 177, 198, 0.6);
+    --light-shadow-inset: inset -3px -3px 7px rgba(255, 255, 255, 0.7);
+    --dark-shadow-inset: inset 3px 3px 7px rgba(163, 177, 198, 0.65);
+    --transition-speed: 0.15s;
+}
+
+/* Base Document Styles */
+body {
+    margin: 0;
+    padding: 0;
+    font-family: 'Segoe UI', system-ui, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-primary);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+}
+
+.demo-container {
+    text-align: center;
+    width: 100%;
+    max-width: 400px;
+    padding: 20px;
+}
+
+h2 {
+    margin-bottom: 6px;
+    font-weight: 600;
+}
+
+.subtitle {
+    font-size: 0.9rem;
+    color: #7a869a;
+    margin-bottom: 35px;
+}
+
+/* Device Case Wrapper */
+.keypad-case {
+    background-color: var(--bg-color);
+    padding: 30px;
+    border-radius: 30px;
+    box-shadow: var(--light-shadow), var(--dark-shadow);
+}
+
+/* Neumorphic Concave Display Screen */
+.keypad-display {
+    height: 60px;
+    background-color: var(--bg-color);
+    border-radius: 16px;
+    box-shadow: var(--dark-shadow-inset), var(--light-shadow-inset);
+    margin-bottom: 30px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 15px;
+}
+
+.dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background-color: #b0bec5;
+    box-shadow: inset 1px 1px 2px rgba(0,0,0,0.1);
+    transition: background-color var(--transition-speed);
+}
+
+.dot.active {
+    background-color: #4f46e5;
+    box-shadow: 0 0 8px rgba(79, 70, 229, 0.6);
+}
+
+/* Keypad Grid Alignment */
+.keypad-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+}
+
+/* Neumorphic Button Elements */
+.key-btn {
+    background-color: var(--bg-color);
+    border: none;
+    aspect-ratio: 1;
+    border-radius: 50%;
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    cursor: pointer;
+    outline: none;
+    box-shadow: var(--light-shadow), var(--dark-shadow);
+    transition: all var(--transition-speed) ease-in-out;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    -webkit-tap-highlight-color: transparent;
+}
+
+/* Micro-interactions on Hover/Focus */
+.key-btn:hover, .key-btn:focus {
+    transform: scale(1.02);
+}
+
+/* Simulated Pressed Down Button Effect via CSS Active States */
+.key-btn:active {
+    transform: scale(0.98);
+    box-shadow: var(--dark-shadow-inset), var(--light-shadow-inset);
+}
+
+/* Color accents for functional buttons */
+.action-btn {
+    font-size: 1.3rem;
+}
+
+.text-danger {
+    color: #ef4444;
+}
+
+.text-success {
+    color: #10b981;
+}


### PR DESCRIPTION
### 🚀 Proposed Changes
This PR addresses issue #33507 by delivering a pure CSS-driven soft-UI Neumorphic PIN Keypad component.

- Programmed structural layout for code entry casing and grid-based buttons.
- Applied complex dual light/dark balance arrays (`box-shadow`) to construct an authentic soft plastic feeling.
- Attached high-performance interactive active states with inverse inset shading mappings.
- Documented styling rules and customization instructions inside the component folder.

### 📂 Files Added
- `submissions/examples/neumorphic-pin-keypad/demo.html`
- `submissions/examples/neumorphic-pin-keypad/style.css`
- `submissions/examples/neumorphic-pin-keypad/README.md`

### 📋 Checklist
- [x] My code follows the contribution guidelines of this project.
- [x] All file submissions reside strictly within the assigned `submissions/` directory tree.
- [x] The component relies completely on modern CSS transitions with no JavaScript.

### 🔗 Related Issue
Closes #33507