### PR TITLE
feat: add nav-link-underline component (#33523)

### DIFF
--- a/submissions/examples/ease-nav-link-underline-ij/README.md
+++ b/submissions/examples/ease-nav-link-underline-ij/README.md
@@ -1,0 +1,21 @@
+# ease-nav-link-underline
+
+A horizontal navigation bar where each link's underline expands from the center on hover. The active link maintains a persistent underline with a color change.
+
+## Features
+
+- Underline animates from center via `::after` pseudo-element with `scaleX` transition
+- Active link retains permanent underline and custom text color
+- CSS custom properties for easy theming
+- JavaScript toggles active state on click
+
+## Usage
+
+Add `class="nlu-link"` to anchor elements inside a `nav.nlu-nav`. The first link is active by default. Click any link to mark it active. Customize via `:root` variables:
+
+```css
+--nlu-underline-color  /* underline color */
+--nlu-underline-height /* underline thickness */
+--nlu-transition-duration  /* animation speed */
+--nlu-active-color /* active link text color */
+```

--- a/submissions/examples/ease-nav-link-underline-ij/demo.html
+++ b/submissions/examples/ease-nav-link-underline-ij/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-nav-link-underline</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main>
+    <h1 class="nlu-title">Nav Link Underline</h1>
+    <nav class="nlu-nav">
+      <a href="#" class="nlu-link active">Home</a>
+      <a href="#" class="nlu-link">About</a>
+      <a href="#" class="nlu-link">Services</a>
+      <a href="#" class="nlu-link">Portfolio</a>
+      <a href="#" class="nlu-link">Contact</a>
+    </nav>
+  </main>
+  <script>
+    document.querySelectorAll('.nlu-link').forEach(link => {
+      link.addEventListener('click', function (e) {
+        e.preventDefault();
+        document.querySelectorAll('.nlu-link').forEach(l => l.classList.remove('active'));
+        this.classList.add('active');
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-nav-link-underline-ij/style.css
+++ b/submissions/examples/ease-nav-link-underline-ij/style.css
@@ -1,0 +1,78 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+:root {
+  --nlu-underline-color: #e94560;
+  --nlu-underline-height: 2px;
+  --nlu-transition-duration: 0.3s;
+  --nlu-active-color: #ffffff;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #1a1a2e;
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+}
+
+.nlu-title {
+  color: #fff;
+  font-size: 2rem;
+  font-weight: 700;
+  text-align: center;
+  margin-bottom: 2.5rem;
+  letter-spacing: -0.02em;
+}
+
+.nlu-nav {
+  display: flex;
+  gap: 2.5rem;
+  padding: 1.25rem 2.5rem;
+  background: #16213e;
+  border-radius: 12px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.nlu-link {
+  position: relative;
+  color: #aaa;
+  text-decoration: none;
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 0.5rem 0;
+  transition: color var(--nlu-transition-duration) ease;
+}
+
+.nlu-link::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: var(--nlu-underline-height);
+  background: var(--nlu-underline-color);
+  transform: scaleX(0);
+  transform-origin: center;
+  transition: transform var(--nlu-transition-duration) ease;
+}
+
+.nlu-link:hover {
+  color: #fff;
+}
+
+.nlu-link:hover::after {
+  transform: scaleX(1);
+}
+
+.nlu-link.active {
+  color: var(--nlu-active-color);
+}
+
+.nlu-link.active::after {
+  transform: scaleX(1);
+}


### PR DESCRIPTION
## Component: ease-nav-link-underline ? Nav link underline expands from center on hover

### What this adds
Nav link underline expands from center on hover using CSS transitions and animations.

### Acceptance Criteria covered
- Smooth CSS transition or @keyframes animation
- Interactive trigger (hover)
- Customizable via CSS variables

### Files
- submissions/examples/ease-nav-link-underline-ij/demo.html
- submissions/examples/ease-nav-link-underline-ij/style.css
- submissions/examples/ease-nav-link-underline-ij/README.md

### How to review
Open demo.html and hover over nav links.

**Closes #33523**
