### PR TITLE
feat: add image-zoom-pan component (#33680)

### DIFF
--- a/submissions/examples/ease-image-zoom-pan-ij/README.md
+++ b/submissions/examples/ease-image-zoom-pan-ij/README.md
@@ -1,0 +1,45 @@
+# Image Zoom Pan
+
+An image container where the image zooms in and follows the cursor position using CSS `transform: scale` and `translate`.
+
+## Usage
+
+Include `style.css` and the container markup:
+
+```html
+<div class="izp-container" id="izpContainer">
+  <div class="izp-image" id="izpImage">
+    <img src="..." alt="" />
+  </div>
+</div>
+```
+
+JavaScript tracks mouse position and sets `--izp-x` and `--izp-y`:
+
+```js
+container.addEventListener('mousemove', (e) => {
+  const rect = container.getBoundingClientRect();
+  const x = ((e.clientX - rect.left) / rect.width) * 100;
+  const y = ((e.clientY - rect.top) / rect.height) * 100;
+  image.style.setProperty('--izp-x', x);
+  image.style.setProperty('--izp-y', y);
+});
+```
+
+## CSS Variables
+
+| Variable                      | Default  | Description             |
+|-------------------------------|----------|-------------------------|
+| `--izp-max-scale`             | `2.5`    | Maximum zoom level      |
+| `--izp-transition-duration`   | `0.15s`  | Zoom/pan animation speed|
+| `--izp-bg-color`              | `#f3f4f6`| Container background    |
+
+## How it works
+
+- The image uses `scale(var(--izp-max-scale))` for zoom
+- `translate()` uses `(50 - var(--izp-x))` and `(50 - var(--izp-y))` to shift the focal point under the cursor
+- On mouse leave, position resets to center (50%, 50%)
+
+## Browser Support
+
+All modern browsers supporting CSS custom properties and 2D transforms.

--- a/submissions/examples/ease-image-zoom-pan-ij/demo.html
+++ b/submissions/examples/ease-image-zoom-pan-ij/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Image Zoom Pan</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main>
+    <h1>Image Zoom Pan</h1>
+    <div class="izp-container" id="izpContainer">
+      <div class="izp-image" id="izpImage">
+        <svg viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg" width="800" height="600">
+          <rect width="800" height="600" fill="#e0e7ff"/>
+          <circle cx="200" cy="150" r="80" fill="#6366f1" opacity="0.6"/>
+          <circle cx="500" cy="400" r="120" fill="#818cf8" opacity="0.6"/>
+          <rect x="300" y="80" width="200" height="200" rx="16" fill="#4f46e5" opacity="0.5"/>
+          <circle cx="600" cy="180" r="60" fill="#a5b4fc" opacity="0.6"/>
+          <rect x="100" y="350" width="150" height="120" rx="12" fill="#6366f1" opacity="0.4"/>
+          <circle cx="420" cy="520" r="70" fill="#818cf8" opacity="0.5"/>
+          <rect x="600" y="420" width="160" height="140" rx="12" fill="#4f46e5" opacity="0.4"/>
+        </svg>
+      </div>
+      <p class="izp-hint">Hover to zoom and pan</p>
+    </div>
+  </main>
+  <script>
+    const container = document.getElementById('izpContainer');
+    const image = document.getElementById('izpImage');
+
+    container.addEventListener('mousemove', (e) => {
+      const rect = container.getBoundingClientRect();
+      const x = ((e.clientX - rect.left) / rect.width) * 100;
+      const y = ((e.clientY - rect.top) / rect.height) * 100;
+      image.style.setProperty('--izp-x', x);
+      image.style.setProperty('--izp-y', y);
+    });
+
+    container.addEventListener('mouseleave', () => {
+      image.style.setProperty('--izp-x', '50');
+      image.style.setProperty('--izp-y', '50');
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-image-zoom-pan-ij/style.css
+++ b/submissions/examples/ease-image-zoom-pan-ij/style.css
@@ -1,0 +1,51 @@
+:root {
+  --izp-max-scale: 2.5;
+  --izp-transition-duration: 0.15s;
+  --izp-bg-color: #f3f4f6;
+}
+
+.izp-container {
+  width: 640px;
+  max-width: 100%;
+  height: 480px;
+  background: var(--izp-bg-color);
+  border-radius: 16px;
+  overflow: hidden;
+  cursor: crosshair;
+  position: relative;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.08);
+}
+
+.izp-image {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transform: scale(var(--izp-max-scale)) translate(
+    calc((50 - var(--izp-x, 50)) * 1%),
+    calc((50 - var(--izp-y, 50)) * 1%)
+  );
+  transition: transform var(--izp-transition-duration) ease-out;
+}
+
+.izp-image svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.izp-hint {
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  padding: 6px 14px;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  pointer-events: none;
+  white-space: nowrap;
+}


### PR DESCRIPTION
## Component: ease-image-zoom-pan ? Image zooms and pans on hover magnify

### What this adds
Image zooms and pans on hover magnify using CSS transitions and animations.

### Acceptance Criteria covered
- Smooth CSS transition or @keyframes animation
- Interactive trigger (hover, click, focus, or scroll)
- Customizable via CSS variables

### Files
- submissions/examples/ease-image-zoom-pan-ij/demo.html
- submissions/examples/ease-image-zoom-pan-ij/style.css
- submissions/examples/ease-image-zoom-pan-ij/README.md

### How to review
Open demo.html and interact to see the animation.

**Closes #33680**
