### PR TITLE
feat: add menu-slide-side component (#33536)

### DIFF
--- a/submissions/examples/ease-menu-slide-side-ij/README.md
+++ b/submissions/examples/ease-menu-slide-side-ij/README.md
@@ -1,0 +1,22 @@
+# Menu Slide Side
+
+A hamburger button that slides a navigation menu in from the left with an overlay backdrop.
+
+## Features
+
+- Slide-in menu using CSS `transform: translateX`
+- Fading overlay backdrop
+- Toggle via hamburger button or overlay click
+
+## CSS Custom Properties
+
+| Property                    | Default   | Description             |
+| --------------------------- | --------- | ----------------------- |
+| `--mss-menu-width`          | `280px`   | Width of the side menu  |
+| `--mss-transition-duration` | `0.35s`   | Duration of animations  |
+| `--mss-menu-bg`             | `#1e1e2e` | Menu background color   |
+| `--mss-overlay-color`       | `rgba(0, 0, 0, 0.45)` | Overlay color |
+
+## Usage
+
+Toggle the `.mss-open` class on both the menu and overlay elements to show/hide.

--- a/submissions/examples/ease-menu-slide-side-ij/demo.html
+++ b/submissions/examples/ease-menu-slide-side-ij/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Menu Slide Side</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <button class="mss-hamburger" id="mssToggle" aria-label="Toggle menu">
+    <span></span>
+    <span></span>
+    <span></span>
+  </button>
+
+  <nav class="mss-menu" id="mssMenu">
+    <ul>
+      <li><a href="#">Home</a></li>
+      <li><a href="#">About</a></li>
+      <li><a href="#">Services</a></li>
+      <li><a href="#">Portfolio</a></li>
+      <li><a href="#">Contact</a></li>
+    </ul>
+  </nav>
+
+  <div class="mss-overlay" id="mssOverlay"></div>
+
+  <main>
+    <h1>Menu Slide Side</h1>
+    <p>Click the hamburger icon to toggle the side menu.</p>
+  </main>
+
+  <script>
+    const toggle = document.getElementById('mssToggle');
+    const menu = document.getElementById('mssMenu');
+    const overlay = document.getElementById('mssOverlay');
+
+    function toggleMenu() {
+      menu.classList.toggle('mss-open');
+      overlay.classList.toggle('mss-open');
+    }
+
+    toggle.addEventListener('click', toggleMenu);
+    overlay.addEventListener('click', toggleMenu);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-menu-slide-side-ij/style.css
+++ b/submissions/examples/ease-menu-slide-side-ij/style.css
@@ -1,0 +1,112 @@
+:root {
+  --mss-menu-width: 280px;
+  --mss-transition-duration: 0.35s;
+  --mss-menu-bg: #1e1e2e;
+  --mss-overlay-color: rgba(0, 0, 0, 0.45);
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  min-height: 100vh;
+  background: #f5f5f5;
+}
+
+.mss-hamburger {
+  position: fixed;
+  top: 1.25rem;
+  left: 1.25rem;
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 10px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+.mss-hamburger span {
+  display: block;
+  width: 26px;
+  height: 3px;
+  background: #333;
+  border-radius: 2px;
+  transition: background var(--mss-transition-duration);
+}
+
+.mss-menu {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 20;
+  width: var(--mss-menu-width);
+  height: 100vh;
+  background: var(--mss-menu-bg);
+  padding: 5rem 1.5rem 1.5rem;
+  transform: translateX(-100%);
+  transition: transform var(--mss-transition-duration) ease;
+}
+
+.mss-menu.mss-open {
+  transform: translateX(0);
+}
+
+.mss-menu ul {
+  list-style: none;
+}
+
+.mss-menu li + li {
+  margin-top: 1rem;
+}
+
+.mss-menu a {
+  color: #cdd6f4;
+  text-decoration: none;
+  font-size: 1.15rem;
+  transition: color var(--mss-transition-duration);
+}
+
+.mss-menu a:hover {
+  color: #fff;
+}
+
+.mss-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10;
+  background: var(--mss-overlay-color);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--mss-transition-duration) ease;
+}
+
+.mss-overlay.mss-open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 2rem;
+  text-align: center;
+}
+
+main h1 {
+  font-size: 2.5rem;
+  margin-bottom: 0.5rem;
+  color: #1e1e2e;
+}
+
+main p {
+  color: #555;
+}


### PR DESCRIPTION
## Component: ease-menu-slide-side ? Side menu slides in from left on toggle

### What this adds
Side menu slides in from left on toggle using CSS transitions and animations.

### Acceptance Criteria covered
- Smooth CSS transition or @keyframes animation
- Interactive trigger (hover, click, focus, or scroll)
- Customizable via CSS variables

### Files
- submissions/examples/ease-menu-slide-side-ij/demo.html
- submissions/examples/ease-menu-slide-side-ij/style.css
- submissions/examples/ease-menu-slide-side-ij/README.md

### How to review
Open demo.html and interact to see the animation.

**Closes #33536**
