### PR TITLE
feat: add dropdown-menu-expand component (#33717)

### DIFF
--- a/submissions/examples/ease-dropdown-menu-expand-ij/README.md
+++ b/submissions/examples/ease-dropdown-menu-expand-ij/README.md
@@ -1,0 +1,42 @@
+# Dropdown Menu Expand
+
+A lightweight, pure CSS dropdown menu component with smooth expand/collapse transitions.
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| Smooth Animation | Uses `max-height` transition for fluid open/close |
+| Hover Feedback | Menu items highlight on hover with background and indent |
+| Accessible | ARIA attributes managed via JavaScript |
+| Click-Outside | Closes menu when clicking outside |
+| Customizable | Easily themed via CSS custom properties |
+
+## Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `--dd-transition-duration` | `300ms` | Duration of open/close and hover transitions |
+| `--dd-bg` | `#ffffff` | Background color of dropdown trigger and menu |
+| `--dd-hover-bg` | `#f0f4ff` | Background color of menu item on hover |
+| `--dd-border-color` | `#e0e0e0` | Border color of the dropdown trigger |
+| `--dd-text-color` | `#1a1a2e` | Text color for all dropdown elements |
+
+## How to Use
+
+1. Include `style.css` in your HTML file.
+2. Add the Inter font (optional — used in demo).
+3. Structure your HTML as follows:
+
+```html
+<div class="dropdown">
+  <button class="dd-trigger" aria-expanded="false">Label</button>
+  <div class="dd-menu">
+    <div class="dd-item" data-value="option1">Option 1</div>
+    <div class="dd-item" data-value="option2">Option 2</div>
+  </div>
+</div>
+```
+
+4. Add the JavaScript to toggle the `.open` class and manage `aria-expanded`.
+5. Customize using the CSS custom properties above.

--- a/submissions/examples/ease-dropdown-menu-expand-ij/demo.html
+++ b/submissions/examples/ease-dropdown-menu-expand-ij/demo.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dropdown Menu Expand</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Dropdown Menu Expand</h1>
+
+    <div class="dropdown" data-dd="files">
+      <button class="dd-trigger" aria-expanded="false">Files</button>
+      <div class="dd-menu">
+        <div class="dd-item" data-value="new">New File</div>
+        <div class="dd-item" data-value="open">Open</div>
+        <div class="dd-item" data-value="save">Save</div>
+        <div class="dd-item" data-value="export">Export</div>
+      </div>
+    </div>
+
+    <div class="dropdown" data-dd="edit">
+      <button class="dd-trigger" aria-expanded="false">Edit</button>
+      <div class="dd-menu">
+        <div class="dd-item" data-value="undo">Undo</div>
+        <div class="dd-item" data-value="redo">Redo</div>
+        <div class="dd-item" data-value="copy">Copy</div>
+        <div class="dd-item" data-value="paste">Paste</div>
+      </div>
+    </div>
+
+    <div class="dropdown" data-dd="view">
+      <button class="dd-trigger" aria-expanded="false">View</button>
+      <div class="dd-menu">
+        <div class="dd-item" data-value="zoom-in">Zoom In</div>
+        <div class="dd-item" data-value="zoom-out">Zoom Out</div>
+        <div class="dd-item" data-value="fullscreen">Fullscreen</div>
+        <div class="dd-item" data-value="sidebar">Toggle Sidebar</div>
+      </div>
+    </div>
+
+    <p class="selected-display">Selected: <span id="selected-label">—</span></p>
+  </div>
+
+  <script>
+    document.querySelectorAll('.dropdown').forEach(dd => {
+      const trigger = dd.querySelector('.dd-trigger');
+      const menu = dd.querySelector('.dd-menu');
+      const label = document.getElementById('selected-label');
+
+      trigger.addEventListener('click', e => {
+        e.stopPropagation();
+        const isOpen = dd.classList.toggle('open');
+        trigger.setAttribute('aria-expanded', isOpen);
+        document.querySelectorAll('.dropdown.open').forEach(other => {
+          if (other !== dd) {
+            other.classList.remove('open');
+            other.querySelector('.dd-trigger').setAttribute('aria-expanded', 'false');
+          }
+        });
+      });
+
+      menu.querySelectorAll('.dd-item').forEach(item => {
+        item.addEventListener('click', e => {
+          e.stopPropagation();
+          label.textContent = item.textContent;
+          dd.classList.remove('open');
+          trigger.setAttribute('aria-expanded', 'false');
+        });
+      });
+    });
+
+    document.addEventListener('click', () => {
+      document.querySelectorAll('.dropdown.open').forEach(dd => {
+        dd.classList.remove('open');
+        dd.querySelector('.dd-trigger').setAttribute('aria-expanded', 'false');
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-dropdown-menu-expand-ij/style.css
+++ b/submissions/examples/ease-dropdown-menu-expand-ij/style.css
@@ -1,0 +1,113 @@
+:root {
+  --dd-transition-duration: 300ms;
+  --dd-bg: #ffffff;
+  --dd-hover-bg: #f0f4ff;
+  --dd-border-color: #e0e0e0;
+  --dd-text-color: #1a1a2e;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+  background: #f8f9fc;
+  color: var(--dd-text-color);
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 420px;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  text-align: center;
+  margin-bottom: 0.5rem;
+}
+
+.dd-trigger {
+  display: block;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--dd-text-color);
+  background: var(--dd-bg);
+  border: 1px solid var(--dd-border-color);
+  border-radius: 6px;
+  cursor: pointer;
+  text-align: left;
+  transition: border-color var(--dd-transition-duration) ease,
+              box-shadow var(--dd-transition-duration) ease;
+}
+
+.dd-trigger:hover {
+  border-color: #b0b8c8;
+}
+
+.dd-trigger:focus-visible {
+  outline: 2px solid #4a6cf7;
+  outline-offset: 2px;
+}
+
+.dd-menu {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height var(--dd-transition-duration) ease,
+              opacity var(--dd-transition-duration) ease,
+              margin var(--dd-transition-duration) ease;
+  opacity: 0;
+  margin-top: 0;
+}
+
+.dropdown.open .dd-menu {
+  max-height: 300px;
+  opacity: 1;
+  margin-top: 0.25rem;
+}
+
+.dd-item {
+  padding: 0.65rem 1rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background var(--dd-transition-duration) ease,
+              padding-left var(--dd-transition-duration) ease;
+}
+
+.dd-item:hover {
+  background: var(--dd-hover-bg);
+  padding-left: 1.35rem;
+}
+
+.dd-item:active {
+  background: #dce4f5;
+}
+
+.selected-display {
+  text-align: center;
+  font-size: 0.9rem;
+  color: #666;
+  margin-top: 0.5rem;
+}
+
+#selected-label {
+  font-weight: 600;
+  color: var(--dd-text-color);
+}


### PR DESCRIPTION
## Component: ease-dropdown-menu-expand ? Dropdown menu expands with smooth height transition

**Closes #33717**

### What this adds
Dropdown menus that expand with smooth height transition. Each menu reveals items with staggered hover effects and a label displays the currently selected option.

### Acceptance Criteria covered
- Smooth CSS height transition animation
- Interactive trigger (click to open/close)
- Customizable via CSS variables

### Files
- \submissions/examples/ease-dropdown-menu-expand-ij/demo.html\
- \submissions/examples/ease-dropdown-menu-expand-ij/style.css\
- \submissions/examples/ease-dropdown-menu-expand-ij/README.md\

### How to review
Open \demo.html\ directly in a browser. Click any dropdown button to expand the menu; click an item to select it; click again to close.
