### PR TITLE
feat: add tooltip-pop-appear component (#33720)

### DIFF
--- a/submissions/examples/ease-tooltip-pop-appear-ij/README.md
+++ b/submissions/examples/ease-tooltip-pop-appear-ij/README.md
@@ -1,0 +1,35 @@
+# Tooltip Pop Appear
+
+A tooltip UI pattern where tooltips appear with a **scale + opacity** pop animation on hover.
+
+## Features
+
+-   Scale (0 → 1) and opacity fade-in transition
+-   Four positions: top, bottom, left, right
+-   CSS custom properties for easy theming
+-   Arrow pseudo-elements pointing to the trigger element
+-   Works on buttons and links
+
+## Usage
+
+Include the stylesheet and add `data-tooltip` (tooltip text) and `data-pos` (position) attributes to any element:
+
+```html
+<button class="tooltip-btn" data-tooltip="Hello" data-pos="top">Hover me</button>
+```
+
+## Customisation
+
+Override the following CSS custom properties in `:root`:
+
+| Variable                  | Default   | Description              |
+| ------------------------- | --------- | ------------------------ |
+| `--tooltip-duration`      | `0.25s`   | Transition duration      |
+| `--tooltip-bg`            | `#1e293b` | Tooltip background color |
+| `--tooltip-text-color`    | `#f8fafc` | Tooltip text color       |
+| `--tooltip-arrow-size`    | `6px`     | Arrow triangle size      |
+| `--tooltip-offset`        | `10px`    | Gap between trigger and tooltip |
+
+## Browser Support
+
+All modern browsers that support CSS custom properties and transitions.

--- a/submissions/examples/ease-tooltip-pop-appear-ij/demo.html
+++ b/submissions/examples/ease-tooltip-pop-appear-ij/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tooltip Pop Appear</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo">
+    <h1>Tooltip Pop Appear</h1>
+    <p class="subtitle">Hover the buttons to see tooltips pop in with a scale+opacity transition</p>
+
+    <div class="grid">
+      <button class="tooltip-btn" data-tooltip="Top tooltip" data-pos="top">Top</button>
+      <button class="tooltip-btn" data-tooltip="Bottom tooltip" data-pos="bottom">Bottom</button>
+      <button class="tooltip-btn" data-tooltip="Left tooltip" data-pos="left">Left</button>
+      <button class="tooltip-btn" data-tooltip="Right tooltip" data-pos="right">Right</button>
+    </div>
+
+    <div class="grid links">
+      <a href="#" class="tooltip-btn" data-tooltip="Visit ease-motion.css" data-pos="top">Link top</a>
+      <a href="#" class="tooltip-btn" data-tooltip="More info" data-pos="bottom">Link bottom</a>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-tooltip-pop-appear-ij/style.css
+++ b/submissions/examples/ease-tooltip-pop-appear-ij/style.css
@@ -1,0 +1,179 @@
+:root {
+  --tooltip-duration: 0.25s;
+  --tooltip-bg: #1e293b;
+  --tooltip-text-color: #f8fafc;
+  --tooltip-arrow-size: 6px;
+  --tooltip-offset: 10px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: Inter, system-ui, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f1f5f9;
+}
+
+.demo {
+  text-align: center;
+}
+
+h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #0f172a;
+  margin-bottom: 0.5rem;
+}
+
+.subtitle {
+  color: #475569;
+  margin-bottom: 2.5rem;
+}
+
+.grid {
+  display: flex;
+  gap: 1.5rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.links {
+  margin-top: 1.5rem;
+}
+
+.tooltip-btn {
+  position: relative;
+  font-family: inherit;
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 0.65rem 1.4rem;
+  border: none;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #0f172a;
+  cursor: pointer;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  text-decoration: none;
+  display: inline-block;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.tooltip-btn:hover {
+  background: #e2e8f0;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+}
+
+.tooltip-btn::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  white-space: nowrap;
+  background: var(--tooltip-bg);
+  color: var(--tooltip-text-color);
+  font-size: 0.8rem;
+  font-weight: 400;
+  padding: 0.4rem 0.75rem;
+  border-radius: 6px;
+  pointer-events: none;
+  opacity: 0;
+  transform: scale(0);
+  transition: opacity var(--tooltip-duration) ease, transform var(--tooltip-duration) ease;
+}
+
+.tooltip-btn::before {
+  content: "";
+  position: absolute;
+  border: var(--tooltip-arrow-size) solid transparent;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity var(--tooltip-duration) ease;
+}
+
+.tooltip-btn:hover::after,
+.tooltip-btn:hover::before {
+  opacity: 1;
+}
+
+.tooltip-btn:hover::after {
+  transform: scale(1);
+}
+
+[data-pos="top"]::after {
+  bottom: calc(100% + var(--tooltip-offset));
+  left: 50%;
+  transform: translateX(-50%) scale(0);
+  transform-origin: bottom center;
+}
+
+[data-pos="top"]:hover::after {
+  transform: translateX(-50%) scale(1);
+}
+
+[data-pos="top"]::before {
+  top: calc(-1 * var(--tooltip-offset));
+  left: 50%;
+  transform: translateX(-50%);
+  border-top-color: var(--tooltip-bg);
+}
+
+[data-pos="bottom"]::after {
+  top: calc(100% + var(--tooltip-offset));
+  left: 50%;
+  transform: translateX(-50%) scale(0);
+  transform-origin: top center;
+}
+
+[data-pos="bottom"]:hover::after {
+  transform: translateX(-50%) scale(1);
+}
+
+[data-pos="bottom"]::before {
+  bottom: calc(-1 * var(--tooltip-offset));
+  left: 50%;
+  transform: translateX(-50%);
+  border-bottom-color: var(--tooltip-bg);
+}
+
+[data-pos="left"]::after {
+  right: calc(100% + var(--tooltip-offset));
+  top: 50%;
+  transform: translateY(-50%) scale(0);
+  transform-origin: right center;
+}
+
+[data-pos="left"]:hover::after {
+  transform: translateY(-50%) scale(1);
+}
+
+[data-pos="left"]::before {
+  right: calc(-1 * var(--tooltip-offset));
+  top: 50%;
+  transform: translateY(-50%);
+  border-left-color: var(--tooltip-bg);
+}
+
+[data-pos="right"]::after {
+  left: calc(100% + var(--tooltip-offset));
+  top: 50%;
+  transform: translateY(-50%) scale(0);
+  transform-origin: left center;
+}
+
+[data-pos="right"]:hover::after {
+  transform: translateY(-50%) scale(1);
+}
+
+[data-pos="right"]::before {
+  left: calc(-1 * var(--tooltip-offset));
+  top: 50%;
+  transform: translateY(-50%);
+  border-right-color: var(--tooltip-bg);
+}


### PR DESCRIPTION
## Component: ease-tooltip-pop-appear ? Tooltip pops up with scale and fade animation

**Closes #33720**

### What this adds
Tooltips that pop up with scale and fade animation on hover. Supports multiple positions (top, bottom, left, right).

### Acceptance Criteria covered
- Smooth CSS scale/opacity animation
- Interactive trigger (hover)
- Customizable via CSS variables

### Files
- \submissions/examples/ease-tooltip-pop-appear-ij/demo.html\
- \submissions/examples/ease-tooltip-pop-appear-ij/style.css\
- \submissions/examples/ease-tooltip-pop-appear-ij/README.md\

### How to review
Open \demo.html\ directly in a browser. Hover over any button or link to see the tooltip appear with a pop animation.
