### PR TITLE
feat: add modal-backdrop-blur component (#33721)

### DIFF
--- a/submissions/examples/ease-modal-backdrop-blur-ij/README.md
+++ b/submissions/examples/ease-modal-backdrop-blur-ij/README.md
@@ -1,0 +1,55 @@
+# Modal Backdrop Blur
+
+A CSS modal component with a blurred backdrop overlay and scaled content entrance animation.
+
+## Features
+
+- Backdrop blur via `backdrop-filter`
+- Content scales from 0.8 to 1 on open
+- Smooth opacity transitions
+- Escape key and click-outside-to-close
+- Multiple independent modal instances
+
+## Usage
+
+Include the stylesheet and the markup:
+
+```html
+<link rel="stylesheet" href="style.css">
+
+<div class="modal-overlay" id="my-modal">
+  <div class="modal-content">
+    <button class="modal-close" data-close>&times;</button>
+    <h2>Modal Title</h2>
+    <p>Modal content goes here.</p>
+  </div>
+</div>
+```
+
+Open the modal by adding the `active` class to the overlay:
+
+```js
+document.getElementById('my-modal').classList.add('active');
+```
+
+## CSS Custom Properties
+
+| Property                  | Default  | Description                    |
+| ------------------------- | -------- | ------------------------------ |
+| `--modal-duration`        | `0.3s`   | Transition duration            |
+| `--modal-backdrop-blur`   | `8px`    | Backdrop blur radius           |
+| `--modal-bg`              | `rgba(0,0,0,0.5)` | Backdrop background  |
+| `--modal-content-bg`      | `#fff`   | Modal content background       |
+| `--modal-border-radius`   | `12px`   | Modal content border radius    |
+| `--modal-max-width`       | `480px`  | Maximum width of modal content |
+
+## Browser Support
+
+- Chrome / Edge 76+
+- Firefox 103+
+- Safari 9+
+- Opera 64+
+
+## License
+
+MIT

--- a/submissions/examples/ease-modal-backdrop-blur-ij/demo.html
+++ b/submissions/examples/ease-modal-backdrop-blur-ij/demo.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Modal Backdrop Blur</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="page">
+    <h1>Modal Backdrop Blur</h1>
+    <button class="open-btn" data-modal="modal-1">Open Modal</button>
+
+    <div class="modal-overlay" id="modal-1">
+      <div class="modal-content">
+        <button class="modal-close" data-close>&times;</button>
+        <h2>Hello World</h2>
+        <p>This modal has a blurred backdrop effect. Press <kbd>Esc</kbd> or click outside to close.</p>
+        <button class="open-btn" data-modal="modal-2">Open Nested Example</button>
+      </div>
+    </div>
+
+    <div class="modal-overlay" id="modal-2">
+      <div class="modal-content">
+        <button class="modal-close" data-close>&times;</button>
+        <h2>Nested Modal</h2>
+        <p>Multiple modals work independently. Close this and try the first one again.</p>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const overlays = document.querySelectorAll('.modal-overlay');
+    const openBtns = document.querySelectorAll('[data-modal]');
+    const closeBtns = document.querySelectorAll('[data-close]');
+
+    function openModal(id) {
+      const overlay = document.getElementById(id);
+      if (!overlay) return;
+      overlay.classList.add('active');
+    }
+
+    function closeModal(overlay) {
+      overlay.classList.remove('active');
+    }
+
+    openBtns.forEach(btn => {
+      btn.addEventListener('click', e => {
+        e.stopPropagation();
+        openModal(btn.dataset.modal);
+      });
+    });
+
+    closeBtns.forEach(btn => {
+      btn.addEventListener('click', e => {
+        e.stopPropagation();
+        closeModal(btn.closest('.modal-overlay'));
+      });
+    });
+
+    overlays.forEach(overlay => {
+      overlay.addEventListener('click', e => {
+        if (e.target === overlay) closeModal(overlay);
+      });
+    });
+
+    document.addEventListener('keydown', e => {
+      if (e.key === 'Escape') {
+        const active = document.querySelector('.modal-overlay.active');
+        if (active) closeModal(active);
+      }
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-modal-backdrop-blur-ij/style.css
+++ b/submissions/examples/ease-modal-backdrop-blur-ij/style.css
@@ -1,0 +1,140 @@
+:root {
+  --modal-duration: 0.3s;
+  --modal-backdrop-blur: 8px;
+  --modal-bg: rgba(0, 0, 0, 0.5);
+  --modal-content-bg: #fff;
+  --modal-border-radius: 12px;
+  --modal-max-width: 480px;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+  line-height: 1.6;
+  color: #111;
+  background: #f5f5f5;
+}
+
+.page {
+  max-width: 640px;
+  margin: 80px auto;
+  padding: 0 24px;
+  text-align: center;
+}
+
+.page h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 24px;
+}
+
+.open-btn {
+  font-family: 'Inter', sans-serif;
+  font-size: 1rem;
+  font-weight: 500;
+  padding: 12px 28px;
+  border: none;
+  border-radius: 8px;
+  background: #111;
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.open-btn:hover {
+  background: #333;
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  background: var(--modal-bg);
+  backdrop-filter: blur(var(--modal-backdrop-blur));
+  -webkit-backdrop-filter: blur(var(--modal-backdrop-blur));
+  opacity: 0;
+  visibility: hidden;
+  transition:
+    opacity var(--modal-duration) ease,
+    visibility var(--modal-duration) ease;
+}
+
+.modal-overlay.active {
+  opacity: 1;
+  visibility: visible;
+}
+
+.modal-content {
+  background: var(--modal-content-bg);
+  border-radius: var(--modal-border-radius);
+  max-width: var(--modal-max-width);
+  width: 90%;
+  padding: 40px 32px;
+  position: relative;
+  text-align: left;
+  transform: scale(0.8);
+  opacity: 0;
+  transition:
+    transform var(--modal-duration) ease,
+    opacity var(--modal-duration) ease;
+}
+
+.modal-overlay.active .modal-content {
+  transform: scale(1);
+  opacity: 1;
+}
+
+.modal-close {
+  position: absolute;
+  top: 12px;
+  right: 16px;
+  font-size: 1.5rem;
+  line-height: 1;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #666;
+  padding: 4px;
+  transition: color 0.2s;
+}
+
+.modal-close:hover {
+  color: #111;
+}
+
+.modal-content h2 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 12px;
+}
+
+.modal-content p {
+  font-size: 0.95rem;
+  color: #444;
+  margin-bottom: 16px;
+}
+
+.modal-content kbd {
+  display: inline-block;
+  padding: 2px 8px;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.85rem;
+  background: #eee;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+}
+
+.modal-content .open-btn {
+  font-size: 0.9rem;
+  padding: 10px 22px;
+}


### PR DESCRIPTION
## Component: ease-modal-backdrop-blur ? Modal opens with backdrop blur and content scale-in

**Closes #33721**

### What this adds
Modal dialog that opens with backdrop blur effect and content scale-in animation. Supports close on Esc key and click outside.

### Acceptance Criteria covered
- Smooth CSS animation (backdrop blur + scale)
- Interactive trigger (click to open/close)
- Customizable via CSS variables

### Files
- \submissions/examples/ease-modal-backdrop-blur-ij/demo.html\
- \submissions/examples/ease-modal-backdrop-blur-ij/style.css\
- \submissions/examples/ease-modal-backdrop-blur-ij/README.md\

### How to review
Open \demo.html\ directly in a browser. Click the button to open the modal; watch the backdrop blur and content scale in. Close with the X button, Esc key, or click outside.
