### PR TITLE
feat: add neumorphic soft shadow elevation mixin

### DIFF
--- a/submissions/scss/scss-neumorphic-soft-shadow-elevation-mixin-harshap0/README.md
+++ b/submissions/scss/scss-neumorphic-soft-shadow-elevation-mixin-harshap0/README.md
@@ -1,0 +1,46 @@
+# SCSS Utility: Neumorphic Soft Shadow Elevation Mixin
+
+A reusable SCSS utility that generates soft neumorphic shadow effects using a simple mixin.
+
+---
+
+## Features
+
+- Flat shadow preset
+- Pressed (inset) shadow preset
+- Raised shadow preset
+- Reusable SCSS mixin
+- Utility classes included
+- Lightweight and easy to customize
+
+---
+
+## Usage
+
+```scss
+.card {
+  @include neumorphic-shadow(raised);
+}
+```
+
+```scss
+.panel {
+  @include neumorphic-shadow(pressed, #edf1f5);
+}
+```
+
+---
+
+## Utility Classes
+
+```scss
+.neu-flat
+.neu-pressed
+.neu-raised
+```
+
+---
+
+## Compilation Result
+
+The mixin generates the appropriate background color along with dual light and dark box-shadow values based on the selected elevation level.

--- a/submissions/scss/scss-neumorphic-soft-shadow-elevation-mixin-harshap0/_neumorphic-soft-shadow-elevation-mixin-harshap0.scss
+++ b/submissions/scss/scss-neumorphic-soft-shadow-elevation-mixin-harshap0/_neumorphic-soft-shadow-elevation-mixin-harshap0.scss
@@ -1,0 +1,62 @@
+///
+/// Neumorphic Soft Shadow Elevation Mixin
+/// --------------------------------------
+/// Reusable SCSS mixin for creating neumorphic
+/// light and dark soft shadow elevation effects.
+///
+
+/// Shadow presets
+$neumorphic-elevations: (
+  flat: (
+    dark: 6px 6px 12px rgba(0, 0, 0, 0.15),
+    light: -6px -6px 12px rgba(255, 255, 255, 0.9)
+  ),
+  pressed: (
+    dark: inset 4px 4px 8px rgba(0, 0, 0, 0.15),
+    light: inset -4px -4px 8px rgba(255, 255, 255, 0.9)
+  ),
+  raised: (
+    dark: 10px 10px 20px rgba(0, 0, 0, 0.18),
+    light: -10px -10px 20px rgba(255, 255, 255, 1)
+  )
+);
+
+/// Mixin
+/// @param $level flat | pressed | raised
+/// @param $background background color
+@mixin neumorphic-shadow(
+  $level: flat,
+  $background: #e0e5ec
+) {
+
+  $config: map-get($neumorphic-elevations, $level);
+
+  @if $config {
+
+    background: $background;
+
+    box-shadow:
+      map-get($config, dark),
+      map-get($config, light);
+
+  } @else {
+
+    @warn "Unknown neumorphic shadow level: #{$level}";
+
+  }
+
+}
+
+/// Utility classes
+
+.neu-flat {
+  @include neumorphic-shadow(flat);
+}
+
+.neu-pressed {
+  @include neumorphic-shadow(pressed);
+}
+
+.neu-raised {
+  @include neumorphic-shadow(raised);
+}


### PR DESCRIPTION
## Pull Request Description

Adds a reusable SCSS mixin for generating neumorphic-style soft shadow effects. It supports three presets — flat, pressed (inset), and raised — producing dual light/dark box-shadow values based on the selected elevation level. Includes ready-to-use utility classes (`.neu-flat`, `.neu-pressed`, `.neu-raised`) for quick application without writing custom SCSS.

---

## Type of Change

- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)
Closes #28338