### PR TITLE
feat: add tabs-underline-slide component (#33722)

### DIFF
--- a/submissions/examples/ease-tabs-underline-slide-ij/README.md
+++ b/submissions/examples/ease-tabs-underline-slide-ij/README.md
@@ -1,0 +1,24 @@
+# Tabs Underline Slide
+
+A clean tabbed interface where an underline indicator slides smoothly between active tabs.
+
+## Features
+
+- Smooth underline slide transition using `left` / `width` CSS transitions
+- Accessible `role="tablist"`, `role="tab"`, and `aria-selected` attributes
+- Content panels change on tab click with a subtle fade-in animation
+- Fully customizable via CSS custom properties
+
+## CSS Custom Properties
+
+| Property                  | Default   | Description               |
+| ------------------------- | --------- | ------------------------- |
+| `--tab-duration`          | `300ms`   | Transition duration       |
+| `--tab-underline-color`   | `#6366f1` | Active underline color    |
+| `--tab-active-color`      | `#1e1b4b` | Active tab text color     |
+| `--tab-inactive-color`    | `#94a3b8` | Inactive tab text color   |
+| `--tab-bg`                | `transparent` | Tab background        |
+
+## Usage
+
+Open `index.html` in any modern browser. Click a tab to see the underline slide to the active tab and the corresponding content panel appear.

--- a/submissions/examples/ease-tabs-underline-slide-ij/demo.html
+++ b/submissions/examples/ease-tabs-underline-slide-ij/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tabs Underline Slide</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="tabs-demo">
+    <h1 class="tabs-title">Tabs Underline Slide</h1>
+
+    <div class="tabs" role="tablist">
+      <button class="tab" role="tab" aria-selected="true" data-tab="0">Home</button>
+      <button class="tab" role="tab" aria-selected="false" data-tab="1">Profile</button>
+      <button class="tab" role="tab" aria-selected="false" data-tab="2">Settings</button>
+      <button class="tab" role="tab" aria-selected="false" data-tab="3">Help</button>
+      <div class="tab-underline"></div>
+    </div>
+
+    <div class="panels">
+      <div class="panel active" data-panel="0">
+        <h2>Home</h2>
+        <p>Welcome to the home tab. This is the first content panel.</p>
+      </div>
+      <div class="panel" data-panel="1">
+        <h2>Profile</h2>
+        <p>Your profile information goes here. Edit your details anytime.</p>
+      </div>
+      <div class="panel" data-panel="2">
+        <h2>Settings</h2>
+        <p>Adjust your preferences and configuration options.</p>
+      </div>
+      <div class="panel" data-panel="3">
+        <h2>Help</h2>
+        <p>Find answers to common questions and support resources.</p>
+      </div>
+    </div>
+  </main>
+
+  <script>
+    const tabs = document.querySelectorAll('.tab');
+    const panels = document.querySelectorAll('.panel');
+    const underline = document.querySelector('.tab-underline');
+
+    function activateTab(index) {
+      tabs.forEach((tab, i) => {
+        tab.classList.toggle('active', i === index);
+        tab.setAttribute('aria-selected', i === index);
+      });
+      panels.forEach((panel, i) => {
+        panel.classList.toggle('active', i === index);
+      });
+      const activeTab = tabs[index];
+      underline.style.left = activeTab.offsetLeft + 'px';
+      underline.style.width = activeTab.offsetWidth + 'px';
+    }
+
+    tabs.forEach((tab) => {
+      tab.addEventListener('click', () => {
+        activateTab(parseInt(tab.dataset.tab));
+      });
+    });
+
+    activateTab(0);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-tabs-underline-slide-ij/style.css
+++ b/submissions/examples/ease-tabs-underline-slide-ij/style.css
@@ -1,0 +1,117 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --tab-duration: 300ms;
+  --tab-underline-color: #6366f1;
+  --tab-active-color: #1e1b4b;
+  --tab-inactive-color: #94a3b8;
+  --tab-bg: transparent;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+  background: #f8fafc;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tabs-demo {
+  width: 600px;
+  max-width: 90vw;
+  background: #fff;
+  border-radius: 12px;
+  padding: 2rem;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.06);
+}
+
+.tabs-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #0f172a;
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+
+.tabs {
+  position: relative;
+  display: flex;
+  gap: 0;
+  border-bottom: 2px solid #e2e8f0;
+  margin-bottom: 1.5rem;
+}
+
+.tab {
+  position: relative;
+  z-index: 1;
+  display: inline-block;
+  padding: 0.75rem 1.25rem;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--tab-inactive-color);
+  background: var(--tab-bg);
+  border: none;
+  cursor: pointer;
+  transition: color var(--tab-duration) ease;
+  user-select: none;
+}
+
+.tab:hover {
+  color: #64748b;
+}
+
+.tab.active {
+  color: var(--tab-active-color);
+}
+
+.tab-underline {
+  position: absolute;
+  bottom: -2px;
+  left: 0;
+  height: 2px;
+  background: var(--tab-underline-color);
+  transition: left var(--tab-duration) ease, width var(--tab-duration) ease;
+  z-index: 2;
+  border-radius: 1px;
+}
+
+.panel {
+  display: none;
+  animation: fadeIn 250ms ease forwards;
+}
+
+.panel.active {
+  display: block;
+}
+
+.panel h2 {
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: #0f172a;
+  margin-bottom: 0.5rem;
+}
+
+.panel p {
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: #475569;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION
## Component: ease-tabs-underline-slide ? Tab underline slides smoothly between active tabs

**Closes #33722**

### What this adds
Tab navigation with underline indicator that slides smoothly between active tabs using CSS transitions.

### Acceptance Criteria covered
- Smooth CSS transition animation
- Interactive trigger (click)
- Customizable via CSS variables

### Files
- \submissions/examples/ease-tabs-underline-slide-ij/demo.html\
- \submissions/examples/ease-tabs-underline-slide-ij/style.css\
- \submissions/examples/ease-tabs-underline-slide-ij/README.md\

### How to review
Open \demo.html\ directly in a browser. Click different tabs and watch the underline slide to the active tab.
