### PR TITLE
feat: add switch-toggle-thumb component (#33730)

### DIFF
--- a/submissions/examples/ease-switch-toggle-thumb-ij/README.md
+++ b/submissions/examples/ease-switch-toggle-thumb-ij/README.md
@@ -1,0 +1,44 @@
+# Switch Toggle Thumb
+
+A custom switch toggle component with a sliding circular thumb. Built with CSS custom properties for easy theming.
+
+## Features
+
+- Smooth thumb sliding animation using CSS `translateX`
+- Customizable via `:root` CSS variables
+- Multiple color themes (default, blue, green, purple, orange)
+- Accessible — uses hidden `<input type="checkbox">`
+- ON/OFF status label updates on toggle
+
+## Usage
+
+```html
+<label class="switch" data-theme="blue">
+  <input type="checkbox">
+  <span class="switch-track">
+    <span class="switch-thumb"></span>
+  </span>
+  <span class="switch-label">OFF</span>
+</label>
+```
+
+## CSS Custom Properties
+
+| Variable | Default | Description |
+|---|---|---|
+| `--toggle-duration` | `0.3s` | Transition duration |
+| `--toggle-width` | `52px` | Track width |
+| `--toggle-height` | `26px` | Track / thumb height |
+| `--toggle-off-bg` | `#ccc` | Track background (off) |
+| `--toggle-on-bg` | `#4caf50` | Track background (on) |
+| `--toggle-thumb-color` | `#fff` | Thumb color |
+| `--toggle-thumb-shadow` | `0 1px 3px rgba(0,0,0,0.3)` | Thumb shadow |
+
+## Themes
+
+Set the `data-theme` attribute on `.switch`:
+- `default` — green
+- `blue` — blue
+- `green` — green
+- `purple` — purple
+- `orange` — orange

--- a/submissions/examples/ease-switch-toggle-thumb-ij/demo.html
+++ b/submissions/examples/ease-switch-toggle-thumb-ij/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Switch Toggle Thumb</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:opsz@14..32&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Switch Toggle Thumb</h1>
+
+  <div class="switch-group">
+    <div class="switch-row">
+      <label class="switch" data-theme="default">
+        <input type="checkbox">
+        <span class="switch-track">
+          <span class="switch-thumb"></span>
+        </span>
+        <span class="switch-label">OFF</span>
+      </label>
+    </div>
+
+    <div class="switch-row">
+      <label class="switch" data-theme="blue">
+        <input type="checkbox">
+        <span class="switch-track">
+          <span class="switch-thumb"></span>
+        </span>
+        <span class="switch-label">OFF</span>
+      </label>
+    </div>
+
+    <div class="switch-row">
+      <label class="switch" data-theme="green">
+        <input type="checkbox">
+        <span class="switch-track">
+          <span class="switch-thumb"></span>
+        </span>
+        <span class="switch-label">OFF</span>
+      </label>
+    </div>
+
+    <div class="switch-row">
+      <label class="switch" data-theme="purple">
+        <input type="checkbox">
+        <span class="switch-track">
+          <span class="switch-thumb"></span>
+        </span>
+        <span class="switch-label">OFF</span>
+      </label>
+    </div>
+
+    <div class="switch-row">
+      <label class="switch" data-theme="orange">
+        <input type="checkbox">
+        <span class="switch-track">
+          <span class="switch-thumb"></span>
+        </span>
+        <span class="switch-label">OFF</span>
+      </label>
+    </div>
+  </div>
+
+  <script>
+    document.querySelectorAll('.switch').forEach(function(sw) {
+      var input = sw.querySelector('input');
+      var label = sw.querySelector('.switch-label');
+      input.addEventListener('change', function() {
+        label.textContent = this.checked ? 'ON' : 'OFF';
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-switch-toggle-thumb-ij/style.css
+++ b/submissions/examples/ease-switch-toggle-thumb-ij/style.css
@@ -1,0 +1,112 @@
+:root {
+  --toggle-duration: 0.3s;
+  --toggle-width: 52px;
+  --toggle-height: 26px;
+  --toggle-off-bg: #ccc;
+  --toggle-on-bg: #4caf50;
+  --toggle-thumb-color: #fff;
+  --toggle-thumb-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  background: #f5f5f5;
+  padding: 20px;
+}
+
+h1 {
+  font-size: 2rem;
+  font-weight: 600;
+  margin-bottom: 40px;
+  color: #222;
+}
+
+.switch-group {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.switch-row {
+  display: flex;
+  align-items: center;
+}
+
+.switch {
+  --on-bg: var(--toggle-on-bg);
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.switch input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.switch-track {
+  position: relative;
+  width: var(--toggle-width);
+  height: var(--toggle-height);
+  background: var(--toggle-off-bg);
+  border-radius: calc(var(--toggle-height) / 2);
+  transition: background var(--toggle-duration) ease;
+  flex-shrink: 0;
+}
+
+.switch-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: calc(var(--toggle-height) - 4px);
+  height: calc(var(--toggle-height) - 4px);
+  background: var(--toggle-thumb-color);
+  border-radius: 50%;
+  box-shadow: var(--toggle-thumb-shadow);
+  transition: transform var(--toggle-duration) ease;
+}
+
+.switch input:checked + .switch-track {
+  background: var(--on-bg);
+}
+
+.switch input:checked + .switch-track .switch-thumb {
+  transform: translateX(calc(var(--toggle-width) - var(--toggle-height)));
+}
+
+.switch-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #555;
+  min-width: 32px;
+}
+
+[data-theme="blue"] {
+  --on-bg: #2196f3;
+}
+
+[data-theme="green"] {
+  --on-bg: #4caf50;
+}
+
+[data-theme="purple"] {
+  --on-bg: #9c27b0;
+}
+
+[data-theme="orange"] {
+  --on-bg: #ff9800;
+}


### PR DESCRIPTION
## Component: ease-switch-toggle-thumb ? Switch toggle with sliding thumb and color transition

**Closes #33730**

### What this adds
Toggle switches with sliding thumb and smooth color transitions. Multiple themed variants with ON/OFF status labels.

### Acceptance Criteria covered
- Smooth CSS transition animation
- Interactive trigger (click)
- Customizable via CSS variables

### Files
- \submissions/examples/ease-switch-toggle-thumb-ij/demo.html\
- \submissions/examples/ease-switch-toggle-thumb-ij/style.css\
- \submissions/examples/ease-switch-toggle-thumb-ij/README.md\

### How to review
Open \demo.html\ directly in a browser. Click any toggle switch to see the thumb slide and color transition.
