### PR TITLE
feat: add breadcrumb-arrow-slide component (#33731)

### DIFF
--- a/submissions/examples/ease-breadcrumb-arrow-slide-ij/README.md
+++ b/submissions/examples/ease-breadcrumb-arrow-slide-ij/README.md
@@ -1,0 +1,30 @@
+# Breadcrumb Arrow Slide
+
+A breadcrumb navigation component with arrow separators and slide transitions.
+
+## Preview
+
+Breadcrumb items connected by arrow separators. Active step is highlighted. When navigating forward/backward, items slide in from the direction of travel with a translateX + opacity transition.
+
+## Usage
+
+Open `demo.html` in a browser. Use the **Back** and **Forward** buttons to navigate through breadcrumb levels.
+
+## CSS Variables
+
+| Variable                  | Description                    |
+| ------------------------- | ------------------------------ |
+| `--crumb-duration`        | Transition duration (default `0.35s`) |
+| `--crumb-arrow-color`     | Arrow separator color          |
+| `--crumb-active-color`    | Active breadcrumb item color   |
+| `--crumb-inactive-color`  | Inactive breadcrumb item color |
+| `--crumb-bg`              | Component background           |
+
+## Features
+
+- 5-step breadcrumb trail with arrow separators
+- Forward/backward slide animation with translateX and opacity
+- Active step highlight with distinct color
+- Prev/next items fade/slide directionally
+- Disabled state on boundary buttons
+- Inter font, clean modern design

--- a/submissions/examples/ease-breadcrumb-arrow-slide-ij/demo.html
+++ b/submissions/examples/ease-breadcrumb-arrow-slide-ij/demo.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Breadcrumb Arrow Slide</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="demo">
+    <h1>Breadcrumb Arrow Slide</h1>
+
+    <nav aria-label="Breadcrumb" class="crumb">
+      <ol class="crumb__list" id="crumbList">
+        <li class="crumb__item crumb__item--active" data-step="0">Home</li>
+        <li class="crumb__item" data-step="1">Products</li>
+        <li class="crumb__item" data-step="2">Category</li>
+        <li class="crumb__item" data-step="3">Subcategory</li>
+        <li class="crumb__item" data-step="4">Item Detail</li>
+      </ol>
+    </nav>
+
+    <div class="controls">
+      <button id="backBtn" class="btn" disabled>← Back</button>
+      <span class="controls__label" id="stepLabel">Step 1 of 5</span>
+      <button id="forwardBtn" class="btn">Forward →</button>
+    </div>
+  </main>
+
+  <script>
+    const items = document.querySelectorAll('.crumb__item');
+    const backBtn = document.getElementById('backBtn');
+    const forwardBtn = document.getElementById('forwardBtn');
+    const stepLabel = document.getElementById('stepLabel');
+    const list = document.getElementById('crumbList');
+    let current = 0;
+    const total = items.length;
+
+    function update() {
+      items.forEach((item, i) => {
+        const isActive = i === current;
+
+        item.classList.toggle('crumb__item--active', isActive);
+        item.classList.toggle('crumb__item--prev', i < current);
+        item.classList.toggle('crumb__item--next', i > current);
+
+        item.style.setProperty('--crumb-index', i);
+      });
+
+      backBtn.disabled = current === 0;
+      forwardBtn.disabled = current === total - 1;
+      stepLabel.textContent = `Step ${current + 1} of ${total}`;
+    }
+
+    forwardBtn.addEventListener('click', () => {
+      if (current < total - 1) {
+        list.classList.add('crumb__list--forward');
+        list.classList.remove('crumb__list--back');
+        current++;
+        update();
+      }
+    });
+
+    backBtn.addEventListener('click', () => {
+      if (current > 0) {
+        list.classList.add('crumb__list--back');
+        list.classList.remove('crumb__list--forward');
+        current--;
+        update();
+      }
+    });
+
+    update();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-breadcrumb-arrow-slide-ij/style.css
+++ b/submissions/examples/ease-breadcrumb-arrow-slide-ij/style.css
@@ -1,0 +1,172 @@
+:root {
+  --crumb-duration: 0.35s;
+  --crumb-arrow-color: #94a3b8;
+  --crumb-active-color: #2563eb;
+  --crumb-inactive-color: #64748b;
+  --crumb-bg: #ffffff;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  background: #f1f5f9;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.demo {
+  background: var(--crumb-bg);
+  border-radius: 16px;
+  padding: 48px 40px;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.06);
+  max-width: 800px;
+  width: 100%;
+  margin: 24px;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #0f172a;
+  margin-bottom: 32px;
+  letter-spacing: -0.02em;
+}
+
+.crumb__list {
+  display: flex;
+  align-items: center;
+  list-style: none;
+  gap: 0;
+  overflow: hidden;
+}
+
+.crumb__item {
+  display: flex;
+  align-items: center;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--crumb-inactive-color);
+  white-space: nowrap;
+  padding: 8px 4px 8px 0;
+  transition: color var(--crumb-duration) ease, opacity var(--crumb-duration) ease, transform var(--crumb-duration) ease;
+  position: relative;
+}
+
+.crumb__item + .crumb__item::before {
+  content: '';
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  border-left: 6px solid var(--crumb-arrow-color);
+  margin: 0 12px;
+  transition: border-left-color var(--crumb-duration) ease;
+}
+
+.crumb__item--active {
+  color: var(--crumb-active-color);
+  font-weight: 600;
+}
+
+.crumb__item--active + .crumb__item::before {
+  border-left-color: var(--crumb-active-color);
+}
+
+.crumb__item--prev {
+  opacity: 0.6;
+}
+
+.crumb__item--next {
+  opacity: 0.4;
+}
+
+.crumb__list--forward .crumb__item {
+  transform: translateX(0);
+  opacity: 1;
+}
+
+.crumb__list--forward .crumb__item--prev {
+  transform: translateX(-8px);
+  opacity: 0.5;
+}
+
+.crumb__list--forward .crumb__item--active {
+  transform: translateX(0);
+  opacity: 1;
+}
+
+.crumb__list--forward .crumb__item--next {
+  transform: translateX(12px);
+  opacity: 0;
+}
+
+.crumb__list--back .crumb__item {
+  transform: translateX(0);
+  opacity: 1;
+}
+
+.crumb__list--back .crumb__item--prev {
+  transform: translateX(-12px);
+  opacity: 0;
+}
+
+.crumb__list--back .crumb__item--active {
+  transform: translateX(0);
+  opacity: 1;
+}
+
+.crumb__list--back .crumb__item--next {
+  transform: translateX(8px);
+  opacity: 0.5;
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  margin-top: 36px;
+  padding-top: 24px;
+  border-top: 1px solid #e2e8f0;
+}
+
+.controls__label {
+  font-size: 0.875rem;
+  color: #64748b;
+  font-weight: 500;
+  min-width: 90px;
+  text-align: center;
+}
+
+.btn {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  font-size: 0.875rem;
+  font-weight: 500;
+  padding: 8px 20px;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+  background: #ffffff;
+  color: #0f172a;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, opacity 0.15s ease;
+}
+
+.btn:hover:not(:disabled) {
+  background: #f8fafc;
+  border-color: #cbd5e1;
+}
+
+.btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
## Component: ease-breadcrumb-arrow-slide ? Breadcrumb arrows slide in with progressive reveal

**Closes #33731**

### What this adds
Breadcrumb navigation with arrow separators that slide in progressively. Forward/back navigation with directional transitions.

### Acceptance Criteria covered
- Smooth CSS transition animation
- Interactive trigger (click)
- Customizable via CSS variables

### Files
- \submissions/examples/ease-breadcrumb-arrow-slide-ij/demo.html\
- \submissions/examples/ease-breadcrumb-arrow-slide-ij/style.css\
- \submissions/examples/ease-breadcrumb-arrow-slide-ij/README.md\

### How to review
Open \demo.html\ directly in a browser. Click next/back buttons to navigate breadcrumb steps and see arrows slide.
