### PR TITLE
feat: add sidebar-menu-slide component (#33734)

### DIFF
--- a/submissions/examples/ease-sidebar-menu-slide-ij/README.md
+++ b/submissions/examples/ease-sidebar-menu-slide-ij/README.md
@@ -1,0 +1,14 @@
+# Sidebar Menu Slide
+
+## Overview
+A sidebar navigation panel that slides in/out from the left side of the viewport. Uses CSS `translateX` transitions for smooth animation, `margin-left` push for main content offset, and a backdrop overlay for visual focus.
+
+## Sandbox Configuration Files
+- `demo.html` — Interactive demonstration with hamburger toggle, close button, and navigation menu items.
+- `style.css` — Scoped styling utilizing CSS custom properties for duration, sizing, background, hover states, and overlay color.
+
+## Key Interaction Mechanics
+1. **Slide Transition:** The sidebar slides using `transform: translateX()` controlled by the `--sidebar-duration` custom property.
+2. **Content Push:** Main content area uses a `margin-left` transition to create a fluid push when the sidebar opens.
+3. **Backdrop Overlay:** A semi-transparent overlay with backdrop blur fades in behind the sidebar, with click-to-close behavior.
+4. **Hover Effects:** Navigation items feature background color, text color, and padding shifts on hover for visual feedback.

--- a/submissions/examples/ease-sidebar-menu-slide-ij/demo.html
+++ b/submissions/examples/ease-sidebar-menu-slide-ij/demo.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS Sandbox — Sidebar Menu Slide</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <div class="sms-container">
+    <aside class="sms-sidebar" id="sidebar">
+      <div class="sms-sidebar-header">
+        <span class="sms-logo">EaseMotion</span>
+        <button class="sms-close-btn" id="closeBtn" aria-label="Close sidebar">&times;</button>
+      </div>
+      <nav class="sms-nav">
+        <a href="#" class="sms-nav-item active">Dashboard</a>
+        <a href="#" class="sms-nav-item">Analytics</a>
+        <a href="#" class="sms-nav-item">Projects</a>
+        <a href="#" class="sms-nav-item">Team</a>
+        <a href="#" class="sms-nav-item">Settings</a>
+        <a href="#" class="sms-nav-item">Help</a>
+      </nav>
+    </aside>
+
+    <div class="sms-overlay" id="overlay"></div>
+
+    <div class="sms-main" id="mainContent">
+      <header class="sms-topbar">
+        <button class="sms-toggle" id="toggleBtn" aria-label="Toggle sidebar">
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+        <h1>Sidebar Menu Slide</h1>
+      </header>
+      <main class="sms-content">
+        <p>Click the hamburger icon to toggle the sidebar navigation panel.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+      </main>
+    </div>
+  </div>
+
+  <script>
+    const sidebar = document.getElementById('sidebar');
+    const overlay = document.getElementById('overlay');
+    const toggleBtn = document.getElementById('toggleBtn');
+    const closeBtn = document.getElementById('closeBtn');
+
+    function openSidebar() {
+      sidebar.classList.add('open');
+      overlay.classList.add('show');
+    }
+
+    function closeSidebar() {
+      sidebar.classList.remove('open');
+      overlay.classList.remove('show');
+    }
+
+    toggleBtn.addEventListener('click', function () {
+      if (sidebar.classList.contains('open')) {
+        closeSidebar();
+      } else {
+        openSidebar();
+      }
+    });
+
+    closeBtn.addEventListener('click', closeSidebar);
+    overlay.addEventListener('click', closeSidebar);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-sidebar-menu-slide-ij/style.css
+++ b/submissions/examples/ease-sidebar-menu-slide-ij/style.css
@@ -1,0 +1,195 @@
+/* ============================================================
+   EaseMotion CSS Sandbox — ease-sidebar-menu-slide-ij/style.css
+   ============================================================ */
+
+@import "../../../core/variables.css";
+@import "../../../core/utilities.css";
+
+:root {
+  --sidebar-duration: 0.3s;
+  --sidebar-width: 280px;
+  --sidebar-bg: #1e293b;
+  --sidebar-text-color: #cbd5e1;
+  --sidebar-hover-bg: #334155;
+  --sidebar-overlay-color: rgba(0, 0, 0, 0.5);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", var(--ease-font-sans, system-ui, sans-serif);
+  background: #0f172a;
+  color: var(--ease-color-text, #f8fafc);
+  min-height: 100vh;
+}
+
+.sms-container {
+  position: relative;
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+/* ── Sidebar ──────────────────────────────────────────────── */
+.sms-sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: var(--sidebar-width);
+  height: 100vh;
+  background: var(--sidebar-bg);
+  color: var(--sidebar-text-color);
+  z-index: 1000;
+  transform: translateX(-100%);
+  transition: transform var(--sidebar-duration) ease;
+  display: flex;
+  flex-direction: column;
+}
+
+.sms-sidebar.open {
+  transform: translateX(0);
+}
+
+.sms-sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.sms-logo {
+  font-weight: 700;
+  font-size: 1.125rem;
+  color: #f8fafc;
+}
+
+.sms-close-btn {
+  background: none;
+  border: none;
+  color: var(--sidebar-text-color);
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0.25rem;
+  line-height: 1;
+  transition: color var(--ease-speed-fast, 150ms) ease;
+}
+
+.sms-close-btn:hover {
+  color: #f8fafc;
+}
+
+/* ── Navigation ────────────────────────────────────────────── */
+.sms-nav {
+  display: flex;
+  flex-direction: column;
+  padding: 0.75rem 0;
+}
+
+.sms-nav-item {
+  display: block;
+  padding: 0.75rem 1.25rem;
+  color: var(--sidebar-text-color);
+  text-decoration: none;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  transition:
+    background var(--ease-speed-fast, 150ms) ease,
+    color var(--ease-speed-fast, 150ms) ease,
+    border-color var(--ease-speed-fast, 150ms) ease;
+  border-left: 3px solid transparent;
+}
+
+.sms-nav-item:hover {
+  background: var(--sidebar-hover-bg);
+  color: #f8fafc;
+  padding-left: 1.5rem;
+}
+
+.sms-nav-item.active {
+  background: var(--sidebar-hover-bg);
+  color: var(--ease-color-primary, #6c63ff);
+  border-left-color: var(--ease-color-primary, #6c63ff);
+}
+
+/* ── Overlay ──────────────────────────────────────────────── */
+.sms-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--sidebar-overlay-color);
+  z-index: 999;
+  opacity: 0;
+  visibility: hidden;
+  transition:
+    opacity var(--sidebar-duration) ease,
+    visibility var(--sidebar-duration) ease;
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+}
+
+.sms-overlay.show {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* ── Main Content ─────────────────────────────────────────── */
+.sms-main {
+  min-height: 100vh;
+  transition: margin-left var(--sidebar-duration) ease;
+}
+
+.sms-sidebar.open ~ .sms-main {
+  margin-left: var(--sidebar-width);
+}
+
+.sms-topbar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  background: rgba(255, 255, 255, 0.03);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.sms-topbar h1 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+/* ── Hamburger Toggle ─────────────────────────────────────── */
+.sms-toggle {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.5rem;
+}
+
+.sms-toggle span {
+  display: block;
+  width: 24px;
+  height: 2px;
+  background: var(--ease-color-text, #f8fafc);
+  border-radius: 2px;
+  transition: background var(--ease-speed-fast, 150ms) ease;
+}
+
+.sms-toggle:hover span {
+  background: var(--ease-color-primary, #6c63ff);
+}
+
+/* ── Content Area ─────────────────────────────────────────── */
+.sms-content {
+  padding: 2rem 1.5rem;
+  max-width: 800px;
+  line-height: 1.7;
+  color: var(--ease-color-muted, #94a3b8);
+}


### PR DESCRIPTION
## Component: ease-sidebar-menu-slide ? Sidebar menu slides in/out with push content animation

**Closes #33734**

### What this adds
Sidebar navigation panel that slides in/out from the left with content push and overlay. Toggle via hamburger button.

### Acceptance Criteria covered
- Smooth CSS transition animation
- Interactive trigger (click)
- Customizable via CSS variables

### Files
- \submissions/examples/ease-sidebar-menu-slide-ij/demo.html\
- \submissions/examples/ease-sidebar-menu-slide-ij/style.css\
- \submissions/examples/ease-sidebar-menu-slide-ij/README.md\

### How to review
Open \demo.html\ directly in a browser. Click the hamburger icon to toggle the sidebar.
