### PR TITLE
feat: add chip-remove-slide-out component (#33735)

### DIFF
--- a/submissions/examples/ease-chip-remove-slide-out-ij/README.md
+++ b/submissions/examples/ease-chip-remove-slide-out-ij/README.md
@@ -1,0 +1,34 @@
+# Chip Remove Slide Out
+
+A CSS animation demo where chips slide out and fade away when dismissed via a close button.
+
+## Features
+
+- Inline-flex chip components with close buttons
+- Slide-out + fade exit animation (`translateX` + `opacity`)
+- Scale-in entrance animation for new chips
+- Fully customizable via CSS custom properties
+- Different colored chips with per-chip overrides
+- "Add chip" button to dynamically insert new chips
+
+## CSS Custom Properties
+
+| Property                | Default   | Description              |
+| ----------------------- | --------- | ------------------------ |
+| `--chip-duration`       | `0.35s`   | Remove animation duration |
+| `--chip-bg`             | `#e0e0e0` | Chip background          |
+| `--chip-text-color`     | `#212121` | Chip label color         |
+| `--chip-border-radius`  | `8px`     | Chip border radius       |
+| `--chip-remove-color`   | `#616161` | Close button color       |
+| `--chip-hover-bg`       | `#bdbdbd` | Chip hover background    |
+
+## Usage
+
+```html
+<div class="chip">
+  <span class="chip-label">Label</span>
+  <button class="chip-close">&times;</button>
+</div>
+```
+
+Add the `chip-removing` class to trigger the slide-out animation. The element is removed from the DOM after `animationend`.

--- a/submissions/examples/ease-chip-remove-slide-out-ij/demo.html
+++ b/submissions/examples/ease-chip-remove-slide-out-ij/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chip Remove Slide Out</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Chip Remove Slide Out</h1>
+    <div class="chip-list" id="chipList">
+      <div class="chip" style="--chip-bg: #e3f2fd; --chip-text-color: #1565c0; --chip-remove-color: #1565c0; --chip-hover-bg: #bbdefb;">
+        <span class="chip-label">JavaScript</span>
+        <button class="chip-close" aria-label="Remove">&times;</button>
+      </div>
+      <div class="chip" style="--chip-bg: #fce4ec; --chip-text-color: #c62828; --chip-remove-color: #c62828; --chip-hover-bg: #f8bbd0;">
+        <span class="chip-label">CSS</span>
+        <button class="chip-close" aria-label="Remove">&times;</button>
+      </div>
+      <div class="chip" style="--chip-bg: #e8f5e9; --chip-text-color: #2e7d32; --chip-remove-color: #2e7d32; --chip-hover-bg: #c8e6c9;">
+        <span class="chip-label">HTML</span>
+        <button class="chip-close" aria-label="Remove">&times;</button>
+      </div>
+      <div class="chip" style="--chip-bg: #fff3e0; --chip-text-color: #e65100; --chip-remove-color: #e65100; --chip-hover-bg: #ffe0b2;">
+        <span class="chip-label">React</span>
+        <button class="chip-close" aria-label="Remove">&times;</button>
+      </div>
+      <div class="chip" style="--chip-bg: #f3e5f5; --chip-text-color: #6a1b9a; --chip-remove-color: #6a1b9a; --chip-hover-bg: #e1bee7;">
+        <span class="chip-label">TypeScript</span>
+        <button class="chip-close" aria-label="Remove">&times;</button>
+      </div>
+    </div>
+    <button class="add-chip" id="addChip">+ Add chip</button>
+  </div>
+  <script>
+    document.getElementById('chipList').addEventListener('click', (e) => {
+      const btn = e.target.closest('.chip-close');
+      if (!btn) return;
+      const chip = btn.closest('.chip');
+      chip.classList.add('chip-removing');
+      chip.addEventListener('animationend', () => chip.remove(), { once: true });
+    });
+
+    document.getElementById('addChip').addEventListener('click', () => {
+      const colors = [
+        { bg: '#e0f2f1', text: '#00695c', remove: '#00695c', hover: '#b2dfdb', label: 'Vue' },
+        { bg: '#fff8e1', text: '#f57f17', remove: '#f57f17', hover: '#ffecb3', label: 'Angular' },
+        { bg: '#e8eaf6', text: '#283593', remove: '#283593', hover: '#c5cae9', label: 'Svelte' },
+        { bg: '#fbe9e7', text: '#bf360c', remove: '#bf360c', hover: '#ffccbc', label: 'Next.js' },
+        { bg: '#f1f8e9', text: '#558b2f', remove: '#558b2f', hover: '#dcedc8', label: 'Node' },
+      ];
+      const c = colors[Math.floor(Math.random() * colors.length)];
+      const chip = document.createElement('div');
+      chip.className = 'chip';
+      chip.style.cssText = `--chip-bg: ${c.bg}; --chip-text-color: ${c.text}; --chip-remove-color: ${c.remove}; --chip-hover-bg: ${c.hover};`;
+      chip.innerHTML = `<span class="chip-label">${c.label}</span><button class="chip-close" aria-label="Remove">&times;</button>`;
+      document.getElementById('chipList').appendChild(chip);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-chip-remove-slide-out-ij/style.css
+++ b/submissions/examples/ease-chip-remove-slide-out-ij/style.css
@@ -1,0 +1,129 @@
+:root {
+  --chip-duration: 0.35s;
+  --chip-bg: #e0e0e0;
+  --chip-text-color: #212121;
+  --chip-border-radius: 8px;
+  --chip-remove-color: #616161;
+  --chip-hover-bg: #bdbdbd;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', system-ui, sans-serif;
+  background: #fafafa;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  color: #212121;
+}
+
+.container {
+  text-align: center;
+  padding: 2rem;
+}
+
+h1 {
+  font-weight: 600;
+  font-size: 1.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0.75rem;
+  background: var(--chip-bg);
+  color: var(--chip-text-color);
+  border-radius: var(--chip-border-radius);
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: background 0.2s;
+  animation: chip-enter 0.25s ease-out both;
+}
+
+.chip:hover {
+  background: var(--chip-hover-bg);
+}
+
+.chip-label {
+  user-select: none;
+}
+
+.chip-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  border: none;
+  background: transparent;
+  color: var(--chip-remove-color);
+  font-size: 1.125rem;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: 50%;
+  transition: background 0.15s, color 0.15s;
+  padding: 0;
+}
+
+.chip-close:hover {
+  background: rgba(0, 0, 0, 0.1);
+}
+
+.chip-removing {
+  pointer-events: none;
+  animation: chip-slide-out var(--chip-duration) ease-in forwards;
+}
+
+.add-chip {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 0.875rem;
+  font-weight: 500;
+  padding: 0.5rem 1.25rem;
+  border: 2px dashed #bdbdbd;
+  background: transparent;
+  color: #616161;
+  border-radius: var(--chip-border-radius);
+  cursor: pointer;
+  transition: border-color 0.2s, color 0.2s;
+}
+
+.add-chip:hover {
+  border-color: #616161;
+  color: #212121;
+}
+
+@keyframes chip-enter {
+  from {
+    opacity: 0;
+    transform: scale(0.85);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes chip-slide-out {
+  to {
+    opacity: 0;
+    transform: translateX(40px);
+  }
+}


### PR DESCRIPTION
## Component: ease-chip-remove-slide-out ? Chip slides out and fades on remove with smooth exit

**Closes #33735**

### What this adds
Chip/tag components with smooth slide-out and fade exit animation on remove. Supports adding new chips interactively.

### Acceptance Criteria covered
- Smooth CSS @keyframes animation
- Interactive trigger (click to remove)
- Customizable via CSS variables

### Files
- \submissions/examples/ease-chip-remove-slide-out-ij/demo.html\
- \submissions/examples/ease-chip-remove-slide-out-ij/style.css\
- \submissions/examples/ease-chip-remove-slide-out-ij/README.md\

### How to review
Open \demo.html\ directly in a browser. Click the X on any chip to see it slide out and fade; click Add Chip to create new ones.
