### PR TITLE
feat: add card hover lift and perspective tilt utility

### DIFF
--- a/submissions/scss/scss-card-hover-lift-perspective-tilt-utility-harshap0/README.md
+++ b/submissions/scss/scss-card-hover-lift-perspective-tilt-utility-harshap0/README.md
@@ -1,0 +1,57 @@
+# SCSS Utility: Card Hover Lift & Perspective Tilt Utility
+
+A reusable SCSS mixin that lifts a card on hover and applies a subtle 3D perspective tilt, combined with a soft elevated shadow for a sense of depth.
+
+---
+
+## Features
+
+- Lift effect on hover (`translateY`)
+- 3D perspective tilt (`rotateX` / `rotateY`)
+- Elevated box-shadow on hover
+- Fully configurable parameters
+- Utility classes included
+
+---
+
+## Usage
+
+```scss
+.card {
+  @include card-hover-lift-tilt();
+}
+```
+
+```scss
+.featured-card {
+  @include card-hover-lift-tilt($lift: 12px, $tilt-x: 6deg, $tilt-y: 6deg);
+}
+```
+
+---
+
+## Parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `$lift` | `8px` | Vertical lift distance on hover |
+| `$tilt-x` | `4deg` | Rotation around the X-axis |
+| `$tilt-y` | `4deg` | Rotation around the Y-axis |
+| `$duration` | `0.3s` | Transition duration |
+| `$shadow-color` | `rgba(0,0,0,0.2)` | Shadow color on hover |
+
+---
+
+## Utility Classes
+
+```scss
+.card-hover-lift
+.card-hover-lift-strong
+.card-hover-lift-subtle
+```
+
+---
+
+## Compilation Result
+
+On hover, the element lifts upward, tilts slightly in 3D space via `perspective` and `rotateX`/`rotateY`, and gains a soft elevated shadow — creating a tactile, floating card effect.

--- a/submissions/scss/scss-card-hover-lift-perspective-tilt-utility-harshap0/_card-hover-lift-perspective-tilt-utility-harshap0.scss
+++ b/submissions/scss/scss-card-hover-lift-perspective-tilt-utility-harshap0/_card-hover-lift-perspective-tilt-utility-harshap0.scss
@@ -1,0 +1,38 @@
+// ==========================================================================
+// Card Hover Lift & Perspective Tilt Utility
+// A reusable SCSS mixin that lifts a card on hover and applies a subtle
+// 3D perspective tilt, combined with an elevated shadow for depth.
+// ==========================================================================
+
+@mixin card-hover-lift-tilt(
+  $lift: 8px,
+  $tilt-x: 4deg,
+  $tilt-y: 4deg,
+  $duration: 0.3s,
+  $shadow-color: rgba(0, 0, 0, 0.2)
+) {
+  transform-style: preserve-3d;
+  transition: transform #{$duration} ease, box-shadow #{$duration} ease;
+  will-change: transform, box-shadow;
+
+  &:hover {
+    transform: translateY(-#{$lift}) perspective(800px) rotateX(#{$tilt-x}) rotateY(#{$tilt-y});
+    box-shadow: 0 20px 30px -10px #{$shadow-color};
+  }
+}
+
+// ==========================================================================
+// Utility Classes
+// ==========================================================================
+
+.card-hover-lift {
+  @include card-hover-lift-tilt();
+}
+
+.card-hover-lift-strong {
+  @include card-hover-lift-tilt($lift: 14px, $tilt-x: 8deg, $tilt-y: 8deg);
+}
+
+.card-hover-lift-subtle {
+  @include card-hover-lift-tilt($lift: 4px, $tilt-x: 2deg, $tilt-y: 2deg);
+}


### PR DESCRIPTION
## Pull Request Description

Adds a reusable SCSS mixin (`card-hover-lift-tilt`) that gives cards a hover lift, 
a subtle 3D perspective tilt, and an intensified shadow for a sense of depth. 
The effect is fully configurable via mixin parameters and comes with three 
ready-to-use utility classes for common use cases.

Closes #28345

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] My submission follows the folder and file naming convention
- [x] I have included a README.md explaining usage and parameters
- [x] I have tested this in the browser and it works as expected
- [x] My code is original and does not copy another contributor's submission
- [x] I have not modified any files outside my submission folder

---

## Additional Notes

Mixin accepts `$lift`, `$tilt-x`, `$tilt-y`, `$duration`, and `$shadow-color` 
as configurable parameters. Utility classes provided: `.card-hover-lift`, 
`.card-hover-lift-strong`, and `.card-hover-lift-subtle`.