### PR TITLE
feat: Add SCSS Text Highlight Underline Draw Utilities (#28403)

### DIFF
--- a/submissions/scss/scss-text-highlight-underline-draw-utilities-28403/README.md
+++ b/submissions/scss/scss-text-highlight-underline-draw-utilities-28403/README.md
@@ -1,0 +1,58 @@
+# SCSS Utility: Text Highlight & Underline Draw Utilities (#28403)
+
+A suite of clean, reusable SCSS mixins for creating animated underline draw and text highlight effects using CSS `background-size` transitions. Zero JavaScript. Zero external dependencies. Pure CSS with well-commented SCSS.
+
+## 📦 What's included?
+
+- `_text-highlight-underline-draw-utilities.scss`: The SCSS partial containing 5 production-ready mixins.
+- `style.css`: Compiled CSS output showing utility classes generated from the mixins.
+- `demo.html`: A static demo page showcasing all 5 effects — hover each text to see the animation.
+
+## 🛠 Mixins
+
+| Mixin | Description |
+|-------|-------------|
+| `underline-draw($color, $thickness, $offset, $duration)` | Draws a line from left to right on hover |
+| `underline-draw-center($color, $thickness, $duration)` | Expands line from the center outward on hover |
+| `text-highlight($color, $height, $duration)` | Sweeps a background color up behind the text on hover |
+| `underline-draw-double($color1, $color2, $thickness, $gap, $duration)` | Draws two stacked underlines of different colors |
+| `strikethrough-draw($color, $thickness, $duration)` | Draws a strikethrough line across the text on hover |
+
+## 🚀 How to use
+
+Import the partial into your SCSS file:
+
+```scss
+@import 'text-highlight-underline-draw-utilities';
+
+// Navigation link with left-to-right underline draw
+.nav-link {
+  @include underline-draw(#3b82f6, 2px);
+}
+
+// Section heading with center-out draw
+.section-heading {
+  @include underline-draw-center(#f43f5e, 3px);
+}
+
+// Marketing page highlight keyword
+.keyword {
+  @include text-highlight(#fef08a, 40%);
+}
+
+// Hero text with decorative double underline
+.hero-title span {
+  @include underline-draw-double(#3b82f6, #f43f5e, 2px, 4px);
+}
+
+// Crossed-out original price
+.original-price {
+  @include strikethrough-draw(#ef4444, 2px);
+}
+```
+
+## 🎨 Why this fits EaseMotion
+
+**EaseMotion** is about making UI elements behave with physical predictability and delight.
+
+Text decoration is a deeply expressive tool in web design, but the native CSS `text-decoration` property offers almost no animation support. By hijacking `background-image: linear-gradient()` and animating `background-size` from `0%` to `100%`, these mixins turn something static into a fluid, directional micro-interaction. Each word the user reads can now reveal its meaning through motion — a draw that echoes the act of highlighting text with a physical marker.

--- a/submissions/scss/scss-text-highlight-underline-draw-utilities-28403/_text-highlight-underline-draw-utilities.scss
+++ b/submissions/scss/scss-text-highlight-underline-draw-utilities-28403/_text-highlight-underline-draw-utilities.scss
@@ -1,0 +1,193 @@
+/// EaseMotion CSS - Text Highlight & Underline Draw Utilities
+///
+/// A suite of clean, reusable SCSS mixins for creating animated underline draw
+/// and text highlight effects using CSS custom properties and background gradients.
+/// Zero external dependencies. Pure CSS animations.
+
+// ─────────────────────────────────────────────
+// SHARED TOKEN DEFAULTS
+// ─────────────────────────────────────────────
+
+/// Default animation duration for all draw effects
+$ease-underline-duration: 0.4s !default;
+
+/// Default easing curve — matches EaseMotion's physics feel
+$ease-underline-easing: cubic-bezier(0.25, 0.46, 0.45, 0.94) !default;
+
+
+// ─────────────────────────────────────────────
+// 1. UNDERLINE DRAW — left to right on hover
+// ─────────────────────────────────────────────
+/// Creates an animated underline that draws from left to right on hover.
+///
+/// @param {Color}  $color     [currentColor] - Underline color
+/// @param {Number} $thickness [2px]          - Underline thickness
+/// @param {Number} $offset    [0px]          - Distance below the text baseline
+/// @param {Number} $duration  [$ease-underline-duration] - Animation duration
+///
+/// @example scss
+///   .nav-link {
+///     @include underline-draw(#3b82f6, 2px);
+///   }
+@mixin underline-draw(
+  $color: currentColor,
+  $thickness: 2px,
+  $offset: 0px,
+  $duration: $ease-underline-duration
+) {
+  text-decoration: none;
+  background-image: linear-gradient($color, $color);
+  background-position: bottom #{$offset} left 0;
+  background-repeat: no-repeat;
+  background-size: 0% $thickness;
+  transition: background-size $duration $ease-underline-easing;
+
+  &:hover,
+  &:focus-visible {
+    background-size: 100% $thickness;
+  }
+}
+
+
+// ─────────────────────────────────────────────
+// 2. UNDERLINE DRAW — center outward on hover
+// ─────────────────────────────────────────────
+/// Creates an animated underline that expands from the center outward on hover.
+///
+/// @param {Color}  $color     [currentColor] - Underline color
+/// @param {Number} $thickness [2px]          - Underline thickness
+/// @param {Number} $duration  [$ease-underline-duration] - Animation duration
+///
+/// @example scss
+///   .section-title {
+///     @include underline-draw-center(#f43f5e, 3px);
+///   }
+@mixin underline-draw-center(
+  $color: currentColor,
+  $thickness: 2px,
+  $duration: $ease-underline-duration
+) {
+  text-decoration: none;
+  background-image: linear-gradient($color, $color);
+  background-position: bottom center;
+  background-repeat: no-repeat;
+  background-size: 0% $thickness;
+  transition: background-size $duration $ease-underline-easing;
+
+  &:hover,
+  &:focus-visible {
+    background-size: 100% $thickness;
+  }
+}
+
+
+// ─────────────────────────────────────────────
+// 3. TEXT HIGHLIGHT — fills behind text on hover
+// ─────────────────────────────────────────────
+/// Creates a background-fill highlight that sweeps under the text on hover.
+///
+/// @param {Color}  $color     [#fef08a] - Highlight background color
+/// @param {Number} $height    [40%]     - Height of the highlight relative to font-size
+/// @param {Number} $duration  [$ease-underline-duration] - Animation duration
+///
+/// @example scss
+///   .highlight-word {
+///     @include text-highlight(#bfdbfe, 50%);
+///   }
+@mixin text-highlight(
+  $color: #fef08a,
+  $height: 40%,
+  $duration: $ease-underline-duration
+) {
+  text-decoration: none;
+  background-image: linear-gradient(transparent calc(100% - #{$height}), $color calc(100% - #{$height}));
+  background-repeat: no-repeat;
+  background-size: 0% 100%;
+  background-position: left center;
+  transition: background-size $duration $ease-underline-easing;
+
+  &:hover,
+  &:focus-visible {
+    background-size: 100% 100%;
+  }
+}
+
+
+// ─────────────────────────────────────────────
+// 4. DOUBLE UNDERLINE — decorative stacked lines
+// ─────────────────────────────────────────────
+/// Draws a double underline using two layered background gradients.
+///
+/// @param {Color}  $color1    [currentColor] - Top line color
+/// @param {Color}  $color2    [currentColor] - Bottom line color
+/// @param {Number} $thickness [2px]          - Individual line thickness
+/// @param {Number} $gap       [3px]          - Gap between the two lines
+/// @param {Number} $duration  [$ease-underline-duration] - Animation duration
+///
+/// @example scss
+///   .hero-text {
+///     @include underline-draw-double(#3b82f6, #f43f5e, 2px, 4px);
+///   }
+@mixin underline-draw-double(
+  $color1: currentColor,
+  $color2: currentColor,
+  $thickness: 2px,
+  $gap: 3px,
+  $duration: $ease-underline-duration
+) {
+  text-decoration: none;
+  background-image:
+    linear-gradient($color1, $color1),
+    linear-gradient($color2, $color2);
+  background-position:
+    bottom #{$gap + $thickness} left 0,
+    bottom 0 left 0;
+  background-repeat: no-repeat;
+  background-size: 0% $thickness, 0% $thickness;
+  transition: background-size $duration $ease-underline-easing;
+
+  &:hover,
+  &:focus-visible {
+    background-size: 100% $thickness, 100% $thickness;
+  }
+}
+
+
+// ─────────────────────────────────────────────
+// 5. STRIKETHROUGH DRAW — animates left-to-right
+// ─────────────────────────────────────────────
+/// Draws an animated strikethrough line across the text on hover.
+///
+/// @param {Color}  $color     [currentColor] - Strikethrough color
+/// @param {Number} $thickness [1px]          - Line thickness
+/// @param {Number} $duration  [$ease-underline-duration] - Animation duration
+///
+/// @example scss
+///   .sale-price {
+///     @include strikethrough-draw(#ef4444, 2px);
+///   }
+@mixin strikethrough-draw(
+  $color: currentColor,
+  $thickness: 1px,
+  $duration: $ease-underline-duration
+) {
+  text-decoration: none;
+  position: relative;
+
+  &::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 0%;
+    height: $thickness;
+    background-color: $color;
+    transition: width $duration $ease-underline-easing;
+  }
+
+  &:hover::after,
+  &:focus-visible::after {
+    width: 100%;
+  }
+}

--- a/submissions/scss/scss-text-highlight-underline-draw-utilities-28403/demo.html
+++ b/submissions/scss/scss-text-highlight-underline-draw-utilities-28403/demo.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>SCSS Text Highlight & Underline Draw Demo</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="./style.css">
+
+  <style>
+    body {
+      margin: 0;
+      background: #f8fafc;
+      font-family: system-ui, -apple-system, sans-serif;
+      padding: 3rem 2rem;
+      color: #0f172a;
+    }
+
+    .demo-container {
+      max-width: 700px;
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      gap: 40px;
+    }
+
+    .demo-section {
+      background: #ffffff;
+      border-radius: 14px;
+      padding: 28px 32px;
+      box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
+      border: 1px solid #e2e8f0;
+    }
+
+    .demo-label {
+      font-size: 0.75rem;
+      font-weight: 700;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      color: #94a3b8;
+      margin: 0 0 16px 0;
+    }
+
+    .demo-text {
+      font-size: 1.5rem;
+      font-weight: 600;
+      display: inline;
+      cursor: pointer;
+    }
+
+    .demo-desc {
+      margin: 12px 0 0 0;
+      font-size: 0.85rem;
+      color: #64748b;
+      font-family: monospace;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="demo-container">
+
+    <div class="demo-section">
+      <p class="demo-label">1. underline-draw() — Left to Right</p>
+      <span class="demo-text ease-underline-draw">Hover me to draw underline</span>
+      <p class="demo-desc">@include underline-draw(#3b82f6, 2px);</p>
+    </div>
+
+    <div class="demo-section">
+      <p class="demo-label">2. underline-draw-center() — Center Outward</p>
+      <span class="demo-text ease-underline-draw-center">Hover to expand from center</span>
+      <p class="demo-desc">@include underline-draw-center(#f43f5e, 3px);</p>
+    </div>
+
+    <div class="demo-section">
+      <p class="demo-label">3. text-highlight() — Yellow Background Sweep</p>
+      <span class="demo-text ease-text-highlight">Hover to highlight this text</span>
+      <p class="demo-desc">@include text-highlight(#fef08a, 40%);</p>
+    </div>
+
+    <div class="demo-section">
+      <p class="demo-label">3b. text-highlight() — Blue Variant</p>
+      <span class="demo-text ease-text-highlight-blue">Hover for a blue highlight sweep</span>
+      <p class="demo-desc">@include text-highlight(#bfdbfe, 50%);</p>
+    </div>
+
+    <div class="demo-section">
+      <p class="demo-label">4. underline-draw-double() — Stacked Two-Color Lines</p>
+      <span class="demo-text ease-underline-draw-double">Hover for double underline</span>
+      <p class="demo-desc">@include underline-draw-double(#3b82f6, #f43f5e, 2px, 3px);</p>
+    </div>
+
+    <div class="demo-section">
+      <p class="demo-label">5. strikethrough-draw() — Left to Right Strike</p>
+      <span class="demo-text ease-strikethrough-draw">Hover to cross this out</span>
+      <p class="demo-desc">@include strikethrough-draw(#ef4444, 2px);</p>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/scss/scss-text-highlight-underline-draw-utilities-28403/style.css
+++ b/submissions/scss/scss-text-highlight-underline-draw-utilities-28403/style.css
@@ -1,0 +1,120 @@
+/*
+  style.css
+  EaseMotion CSS - Text Highlight & Underline Draw Utilities
+  Compiled CSS output of _text-highlight-underline-draw-utilities.scss
+*/
+
+/* ─────────────────────────────────────────────
+   1. underline-draw() — left to right
+   ───────────────────────────────────────────── */
+.ease-underline-draw {
+  text-decoration: none;
+  background-image: linear-gradient(#3b82f6, #3b82f6);
+  background-position: bottom 0px left 0;
+  background-repeat: no-repeat;
+  background-size: 0% 2px;
+  transition: background-size 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.ease-underline-draw:hover,
+.ease-underline-draw:focus-visible {
+  background-size: 100% 2px;
+}
+
+
+/* ─────────────────────────────────────────────
+   2. underline-draw-center() — center outward
+   ───────────────────────────────────────────── */
+.ease-underline-draw-center {
+  text-decoration: none;
+  background-image: linear-gradient(#f43f5e, #f43f5e);
+  background-position: bottom center;
+  background-repeat: no-repeat;
+  background-size: 0% 3px;
+  transition: background-size 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.ease-underline-draw-center:hover,
+.ease-underline-draw-center:focus-visible {
+  background-size: 100% 3px;
+}
+
+
+/* ─────────────────────────────────────────────
+   3. text-highlight() — background fill sweep
+   ───────────────────────────────────────────── */
+.ease-text-highlight {
+  text-decoration: none;
+  background-image: linear-gradient(transparent calc(100% - 40%), #fef08a calc(100% - 40%));
+  background-repeat: no-repeat;
+  background-size: 0% 100%;
+  background-position: left center;
+  transition: background-size 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.ease-text-highlight:hover,
+.ease-text-highlight:focus-visible {
+  background-size: 100% 100%;
+}
+
+.ease-text-highlight-blue {
+  text-decoration: none;
+  background-image: linear-gradient(transparent calc(100% - 50%), #bfdbfe calc(100% - 50%));
+  background-repeat: no-repeat;
+  background-size: 0% 100%;
+  background-position: left center;
+  transition: background-size 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.ease-text-highlight-blue:hover,
+.ease-text-highlight-blue:focus-visible {
+  background-size: 100% 100%;
+}
+
+
+/* ─────────────────────────────────────────────
+   4. underline-draw-double() — stacked lines
+   ───────────────────────────────────────────── */
+.ease-underline-draw-double {
+  text-decoration: none;
+  background-image:
+    linear-gradient(#3b82f6, #3b82f6),
+    linear-gradient(#f43f5e, #f43f5e);
+  background-position:
+    bottom 5px left 0,
+    bottom 0px left 0;
+  background-repeat: no-repeat;
+  background-size: 0% 2px, 0% 2px;
+  transition: background-size 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.ease-underline-draw-double:hover,
+.ease-underline-draw-double:focus-visible {
+  background-size: 100% 2px, 100% 2px;
+}
+
+
+/* ─────────────────────────────────────────────
+   5. strikethrough-draw() — left to right line
+   ───────────────────────────────────────────── */
+.ease-strikethrough-draw {
+  text-decoration: none;
+  position: relative;
+}
+
+.ease-strikethrough-draw::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 0%;
+  height: 2px;
+  background-color: #ef4444;
+  transition: width 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.ease-strikethrough-draw:hover::after,
+.ease-strikethrough-draw:focus-visible::after {
+  width: 100%;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a suite of 5 clean, reusable SCSS mixins for animated text highlight and underline draw effects using CSS `background-size` transitions. Zero JavaScript, zero external dependencies. Addresses issue #28403 (#27777).

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component (SCSS Utility)
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/scss/scss-text-highlight-underline-draw-utilities-28403/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature (compiled output)
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A clean SCSS partial (`_text-highlight-underline-draw-utilities.scss`) containing 5 semantic mixins: `underline-draw()`, `underline-draw-center()`, `text-highlight()
