### PR TITLE
feat: Add React Context Menu Popup with Scale and Fade Entrance (#28120)

### DIFF
--- a/submissions/react/react-context-menu-popup-with-scale-fade-entrance-28120/ContextMenu.jsx
+++ b/submissions/react/react-context-menu-popup-with-scale-fade-entrance-28120/ContextMenu.jsx
@@ -1,0 +1,159 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+
+// ─── Separator component ──────────────────────────────────────────────────────
+const Separator = () => <div className="ease-ctx-separator" role="separator" />;
+
+// ─── Sub-menu item ────────────────────────────────────────────────────────────
+const SubMenu = ({ label, icon, items }) => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef(null);
+
+  return (
+    <div
+      className={`ease-ctx-item ease-ctx-has-submenu ${open ? 'is-open' : ''}`}
+      ref={ref}
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+      role="menuitem"
+      aria-haspopup="true"
+      aria-expanded={open}
+    >
+      {icon && <span className="ease-ctx-icon" aria-hidden="true">{icon}</span>}
+      <span className="ease-ctx-label">{label}</span>
+      <span className="ease-ctx-chevron" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+          <polyline points="9 18 15 12 9 6" />
+        </svg>
+      </span>
+
+      {/* Nested popup */}
+      <div className={`ease-ctx-submenu ${open ? 'is-visible' : ''}`} role="menu">
+        {items.map((item, i) =>
+          item.separator ? (
+            <Separator key={i} />
+          ) : (
+            <MenuItem key={item.id ?? i} {...item} />
+          )
+        )}
+      </div>
+    </div>
+  );
+};
+
+// ─── Single menu item ─────────────────────────────────────────────────────────
+const MenuItem = ({ label, icon, shortcut, danger, disabled, onClick, subItems }) => {
+  if (subItems) {
+    return <SubMenu label={label} icon={icon} items={subItems} />;
+  }
+
+  return (
+    <button
+      className={`ease-ctx-item ${danger ? 'is-danger' : ''} ${disabled ? 'is-disabled' : ''}`}
+      onClick={disabled ? undefined : onClick}
+      role="menuitem"
+      disabled={disabled}
+      aria-disabled={disabled}
+    >
+      {icon && <span className="ease-ctx-icon" aria-hidden="true">{icon}</span>}
+      <span className="ease-ctx-label">{label}</span>
+      {shortcut && <span className="ease-ctx-shortcut">{shortcut}</span>}
+    </button>
+  );
+};
+
+/**
+ * ContextMenu — a right-click context menu with scale & fade entrance animation.
+ *
+ * @param {Array}    items        - Menu item definitions (see README for schema)
+ * @param {ReactNode} children   - The trigger element (right-click area)
+ * @param {boolean}  disabled    - Disable the context menu entirely
+ * @param {string}   className   - Additional CSS class on the trigger wrapper
+ */
+const ContextMenu = ({ items = [], children, disabled = false, className = '' }) => {
+  const [visible, setVisible]   = useState(false);
+  const [pos, setPos]           = useState({ x: 0, y: 0 });
+  const [entering, setEntering] = useState(false);
+  const menuRef                 = useRef(null);
+  const wrapRef                 = useRef(null);
+
+  // ── Open at cursor position ─────────────────────────────────────────────
+  const open = useCallback((e) => {
+    if (disabled) return;
+    e.preventDefault();
+
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    const menuW = 220;
+    const menuH = items.length * 40 + 16; // rough estimate
+
+    let x = e.clientX;
+    let y = e.clientY;
+
+    // Clamp so menu doesn't overflow viewport
+    if (x + menuW > vw) x = vw - menuW - 8;
+    if (y + menuH > vh) y = vh - menuH - 8;
+
+    setPos({ x, y });
+    setVisible(true);
+    // Trigger entrance animation on next frame
+    requestAnimationFrame(() => setEntering(true));
+  }, [disabled, items.length]);
+
+  // ── Close on outside click / Escape ────────────────────────────────────
+  const close = useCallback(() => {
+    setEntering(false);
+    // Wait for exit animation before unmounting
+    setTimeout(() => setVisible(false), 200);
+  }, []);
+
+  useEffect(() => {
+    if (!visible) return;
+    const onKey   = (e) => e.key === 'Escape' && close();
+    const onClick = (e) => {
+      if (menuRef.current && !menuRef.current.contains(e.target)) close();
+    };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('mousedown', onClick);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('mousedown', onClick);
+    };
+  }, [visible, close]);
+
+  return (
+    <div
+      ref={wrapRef}
+      className={`ease-ctx-trigger ${className}`}
+      onContextMenu={open}
+    >
+      {children}
+
+      {visible && (
+        <div
+          ref={menuRef}
+          className={`ease-ctx-menu ${entering ? 'is-entering' : 'is-exiting'}`}
+          style={{ top: pos.y, left: pos.x }}
+          role="menu"
+          aria-label="Context menu"
+        >
+          {items.map((item, i) =>
+            item.separator ? (
+              <Separator key={i} />
+            ) : (
+              <MenuItem
+                key={item.id ?? i}
+                {...item}
+                onClick={() => {
+                  if (item.onClick) item.onClick();
+                  close();
+                }}
+              />
+            )
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ContextMenu;

--- a/submissions/react/react-context-menu-popup-with-scale-fade-entrance-28120/README.md
+++ b/submissions/react/react-context-menu-popup-with-scale-fade-entrance-28120/README.md
@@ -1,0 +1,69 @@
+# React Component: Context Menu Popup with Scale & Fade Entrance (#28120)
+
+A modular, copy-paste ready React `<ContextMenu>` component that appears on right-click with a spring-physics scale & fade entrance animation. Supports nested sub-menus, keyboard shortcut hints, danger/disabled item variants, and automatic viewport-edge clamping. Zero external dependencies — pure React hooks and EaseMotion CSS.
+
+## 📦 What's included?
+
+- `ContextMenu.jsx`: The React component managing open/close state, position clamping, sub-menu hover, and keyboard/click dismissal.
+- `style.css`: The CSS stylesheet driving the scale + fade entrance, hover nudge, sub-menu slide, danger/disabled variants, and separator styling.
+- `demo.html`: A self-contained demo with 3 file cards that each open a rich context menu with a nested "Share" sub-menu.
+
+## 🛠 Features
+
+- **Scale & Fade Entrance**: Opens from `scale(0.85) opacity(0)` → `scale(1) opacity(1)` using `cubic-bezier(0.34, 1.56, 0.64, 1)` for a spring overshoot that feels physical and snappy.
+- **Exit Animation**: Reverses to `scale(0.85) opacity(0)` before unmounting, so the dismiss feels intentional.
+- **Viewport Clamping**: Automatically repositions the popup so it never overflows the screen edges.
+- **Nested Sub-Menus**: Hover any item with `subItems` to reveal a second-level menu with its own slide-in animation.
+- **Keyboard Dismissal**: Press `Escape` to close the menu from anywhere.
+- **Danger & Disabled Items**: Red colour variant for destructive actions; dimmed + `cursor: not-allowed` for disabled items.
+- **Keyboard Shortcuts**: Optional shortcut hint string displayed right-aligned in the menu item.
+
+## 🚀 How to use
+
+```jsx
+import React from 'react';
+import ContextMenu from './ContextMenu';
+import './style.css';
+
+const menuItems = [
+  { id: 'open',   icon: '📂', label: 'Open',          shortcut: '↵',  onClick: () => console.log('Open') },
+  { id: 'rename', icon: '✏️',  label: 'Rename',        shortcut: 'F2', onClick: () => console.log('Rename') },
+  {
+    id: 'share', icon: '🔗', label: 'Share',
+    subItems: [
+      { id: 'copy-link', icon: '📋', label: 'Copy Link', onClick: () => console.log('Copy') },
+      { id: 'email',     icon: '📧', label: 'Email...',  onClick: () => console.log('Email') },
+    ]
+  },
+  { separator: true },
+  { id: 'delete', icon: '🗑️', label: 'Move to Trash', danger: true,    onClick: () => console.log('Delete') },
+];
+
+const MyPage = () => (
+  <ContextMenu items={menuItems}>
+    <div style={{ padding: 40, background: '#f1f5f9' }}>
+      Right-click me
+    </div>
+  </ContextMenu>
+);
+```
+
+## ⚙️ Item Schema
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `string` | Unique key |
+| `label` | `string` | Display text |
+| `icon` | `ReactNode` | Optional icon/emoji |
+| `shortcut` | `string` | Optional keyboard hint (e.g. `⌘K`) |
+| `danger` | `boolean` | Red destructive variant |
+| `disabled` | `boolean` | Grayed-out, non-interactive |
+| `onClick` | `function` | Click handler |
+| `subItems` | `Array` | Nested sub-menu items |
+| `separator` | `boolean` | Renders a horizontal divider |
+
+## 🎨 Why this fits EaseMotion
+
+**EaseMotion** is about making UI elements behave with physical predictability and delight.
+
+A context menu that simply appears instantly feels jarring and cheap. By animating the entrance with a `scale(0.85) → scale(1)` spring using `cubic-bezier(0.34, 1.56, 0.64, 1)`, the popup feels like it physically "pops" out of the cursor position. Combined with the matching exit collapse and the sub-menu slide-in from the side, every interaction in this component communicates spatial awareness — the user always knows where content came from and where it went.

--- a/submissions/react/react-context-menu-popup-with-scale-fade-entrance-28120/demo.html
+++ b/submissions/react/react-context-menu-popup-with-scale-fade-entrance-28120/demo.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>React Context Menu Demo</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="./style.css">
+
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+
+  <style>
+    body {
+      margin: 0;
+      background: #f1f5f9;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: system-ui, sans-serif;
+    }
+
+    .demo-hint {
+      font-size: 0.8rem;
+      color: #94a3b8;
+      text-align: center;
+      margin-top: 10px;
+      font-weight: 500;
+    }
+
+    /* ── Demo target zones ── */
+    .demo-file-card {
+      background: #ffffff;
+      border-radius: 14px;
+      padding: 20px 28px;
+      box-shadow: 0 2px 8px -2px rgba(0,0,0,0.08);
+      border: 1.5px dashed #cbd5e1;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: #334155;
+      transition: border-color 0.2s, background 0.2s;
+      margin-bottom: 10px;
+    }
+
+    .demo-file-card:hover {
+      border-color: #94a3b8;
+      background: #f8fafc;
+    }
+
+    .demo-file-icon {
+      font-size: 1.4rem;
+    }
+
+    .demo-wrapper {
+      width: 340px;
+    }
+
+    .demo-title {
+      font-size: 0.75rem;
+      font-weight: 700;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      color: #94a3b8;
+      margin-bottom: 14px;
+    }
+
+    #status-bar {
+      font-size: 0.8rem;
+      color: #3b82f6;
+      font-weight: 600;
+      min-height: 20px;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+
+  <script type="text/babel">
+    const { useState, useEffect, useRef, useCallback } = React;
+
+    const Separator = () => <div className="ease-ctx-separator" role="separator" />;
+
+    const SubMenu = ({ label, icon, items }) => {
+      const [open, setOpen] = useState(false);
+      return (
+        <div
+          className={`ease-ctx-item ease-ctx-has-submenu ${open ? 'is-open' : ''}`}
+          onMouseEnter={() => setOpen(true)}
+          onMouseLeave={() => setOpen(false)}
+          role="menuitem"
+        >
+          {icon && <span className="ease-ctx-icon">{icon}</span>}
+          <span className="ease-ctx-label">{label}</span>
+          <span className="ease-ctx-chevron">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+              <polyline points="9 18 15 12 9 6" />
+            </svg>
+          </span>
+          <div className={`ease-ctx-submenu ${open ? 'is-visible' : ''}`} role="menu">
+            {items.map((item, i) => item.separator
+              ? <Separator key={i} />
+              : <MenuItem key={item.id ?? i} {...item} />
+            )}
+          </div>
+        </div>
+      );
+    };
+
+    const MenuItem = ({ label, icon, shortcut, danger, disabled, onClick, subItems }) => {
+      if (subItems) return <SubMenu label={label} icon={icon} items={subItems} />;
+      return (
+        <button
+          className={`ease-ctx-item ${danger ? 'is-danger' : ''} ${disabled ? 'is-disabled' : ''}`}
+          onClick={disabled ? undefined : onClick}
+          role="menuitem"
+          disabled={disabled}
+        >
+          {icon && <span className="ease-ctx-icon">{icon}</span>}
+          <span className="ease-ctx-label">{label}</span>
+          {shortcut && <span className="ease-ctx-shortcut">{shortcut}</span>}
+        </button>
+      );
+    };
+
+    const ContextMenu = ({ items, children, disabled = false }) => {
+      const [visible, setVisible]   = useState(false);
+      const [pos, setPos]           = useState({ x: 0, y: 0 });
+      const [entering, setEntering] = useState(false);
+      const menuRef                 = useRef(null);
+
+      const open = useCallback((e) => {
+        if (disabled) return;
+        e.preventDefault();
+        const vw = window.innerWidth, vh = window.innerHeight;
+        let x = e.clientX, y = e.clientY;
+        if (x + 240 > vw) x = vw - 240 - 8;
+        if (y + 280 > vh) y = vh - 280 - 8;
+        setPos({ x, y });
+        setVisible(true);
+        requestAnimationFrame(() => setEntering(true));
+      }, [disabled]);
+
+      const close = useCallback(() => {
+        setEntering(false);
+        setTimeout(() => setVisible(false), 200);
+      }, []);
+
+      useEffect(() => {
+        if (!visible) return;
+        const onKey = (e) => e.key === 'Escape' && close();
+        const onClick = (e) => {
+          if (menuRef.current && !menuRef.current.contains(e.target)) close();
+        };
+        document.addEventListener('keydown', onKey);
+        document.addEventListener('mousedown', onClick);
+        return () => {
+          document.removeEventListener('keydown', onKey);
+          document.removeEventListener('mousedown', onClick);
+        };
+      }, [visible, close]);
+
+      return (
+        <div style={{ display: 'contents' }} onContextMenu={open}>
+          {children}
+          {visible && (
+            <div
+              ref={menuRef}
+              className={`ease-ctx-menu ${entering ? 'is-entering' : 'is-exiting'}`}
+              style={{ top: pos.y, left: pos.x }}
+              role="menu"
+            >
+              {items.map((item, i) => item.separator
+                ? <Separator key={i} />
+                : <MenuItem
+                    key={item.id ?? i}
+                    {...item}
+                    onClick={() => { if (item.onClick) item.onClick(); close(); }}
+                  />
+              )}
+            </div>
+          )}
+        </div>
+      );
+    };
+
+    const App = () => {
+      const [status, setStatus] = useState('Right-click any file card below');
+
+      const log = (msg) => setStatus(`✅ ${msg}`);
+
+      const fileMenuItems = [
+        { id: 'open',     icon: '📂', label: 'Open',          shortcut: '↵',      onClick: () => log('Open clicked') },
+        { id: 'rename',   icon: '✏️',  label: 'Rename',        shortcut: 'F2',     onClick: () => log('Rename clicked') },
+        { id: 'share',    icon: '🔗', label: 'Share',
+          subItems: [
+            { id: 'copy-link', icon: '📋', label: 'Copy Link',    onClick: () => log('Copy Link clicked') },
+            { id: 'email',     icon: '📧', label: 'Email...',     onClick: () => log('Email clicked') },
+            { separator: true },
+            { id: 'export',    icon: '📤', label: 'Export as PDF', onClick: () => log('Export clicked') },
+          ]
+        },
+        { separator: true },
+        { id: 'download', icon: '⬇️',  label: 'Download',      shortcut: '⌘D',     onClick: () => log('Download clicked') },
+        { id: 'favorite', icon: '⭐',  label: 'Add to Favourites',                 onClick: () => log('Favourited') },
+        { separator: true },
+        { id: 'props',    icon: 'ℹ️',  label: 'Properties',    disabled: true },
+        { id: 'delete',   icon: '🗑️',  label: 'Move to Trash', shortcut: '⌫', danger: true, onClick: () => log('Deleted') },
+      ];
+
+      const files = [
+        { name: 'design-system.fig', icon: '🎨' },
+        { name: 'project-report.pdf', icon: '📄' },
+        { name: 'app-bundle.zip', icon: '📦' },
+      ];
+
+      return (
+        <div className="demo-wrapper">
+          <p className="demo-title">Context Menu Demo</p>
+          {files.map(f => (
+            <ContextMenu key={f.name} items={fileMenuItems}>
+              <div className="demo-file-card">
+                <span className="demo-file-icon">{f.icon}</span>
+                {f.name}
+              </div>
+            </ContextMenu>
+          ))}
+          <p className="demo-hint">Right-click any card · Press Esc to dismiss</p>
+          <div id="status-bar">{status}</div>
+        </div>
+      );
+    };
+
+    ReactDOM.render(<App />, document.getElementById('root'));
+  </script>
+</body>
+</html>

--- a/submissions/react/react-context-menu-popup-with-scale-fade-entrance-28120/style.css
+++ b/submissions/react/react-context-menu-popup-with-scale-fade-entrance-28120/style.css
@@ -1,0 +1,170 @@
+/*
+  style.css
+  EaseMotion CSS - Context Menu Popup with Scale & Fade Entrance
+*/
+
+/* ── Trigger wrapper ─────────────────────────────────────────────────────────*/
+.ease-ctx-trigger {
+  display: contents; /* transparent wrapper — does not affect layout */
+}
+
+/* ── Menu popup ──────────────────────────────────────────────────────────────*/
+.ease-ctx-menu {
+  position: fixed;
+  z-index: 9999;
+  min-width: 220px;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 6px;
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.07),
+    0 10px 30px -5px rgba(0, 0, 0, 0.12);
+  font-family: system-ui, -apple-system, sans-serif;
+  user-select: none;
+
+  /* Entrance / Exit animation */
+  transform-origin: top left;
+  transition:
+    opacity 0.18s ease,
+    transform 0.22s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* Exiting state (default — before entering class applied) */
+.ease-ctx-menu.is-exiting {
+  opacity: 0;
+  transform: scale(0.85) translateY(-6px);
+  pointer-events: none;
+}
+
+/* Entering state — fully visible with spring overshoot */
+.ease-ctx-menu.is-entering {
+  opacity: 1;
+  transform: scale(1) translateY(0);
+  pointer-events: auto;
+}
+
+/* ── Menu item ───────────────────────────────────────────────────────────────*/
+.ease-ctx-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  background: transparent;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #1e293b;
+  cursor: pointer;
+  text-align: left;
+  transition:
+    background 0.14s ease,
+    color 0.14s ease,
+    transform 0.15s cubic-bezier(0.34, 1.56, 0.64, 1);
+  position: relative;
+}
+
+.ease-ctx-item:hover:not(.is-disabled) {
+  background: #f1f5f9;
+  transform: translateX(2px);
+}
+
+.ease-ctx-item:active:not(.is-disabled) {
+  transform: scale(0.97);
+  background: #e2e8f0;
+}
+
+/* Danger variant */
+.ease-ctx-item.is-danger {
+  color: #ef4444;
+}
+.ease-ctx-item.is-danger:hover:not(.is-disabled) {
+  background: #fef2f2;
+}
+
+/* Disabled variant */
+.ease-ctx-item.is-disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* ── Icon ────────────────────────────────────────────────────────────────────*/
+.ease-ctx-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+/* ── Label ───────────────────────────────────────────────────────────────────*/
+.ease-ctx-label {
+  flex: 1;
+}
+
+/* ── Keyboard shortcut hint ──────────────────────────────────────────────────*/
+.ease-ctx-shortcut {
+  font-size: 0.75rem;
+  color: #94a3b8;
+  font-weight: 400;
+  white-space: nowrap;
+}
+
+/* ── Separator ───────────────────────────────────────────────────────────────*/
+.ease-ctx-separator {
+  height: 1px;
+  background: #f1f5f9;
+  margin: 4px 6px;
+}
+
+/* ── Sub-menu chevron ────────────────────────────────────────────────────────*/
+.ease-ctx-chevron {
+  display: flex;
+  align-items: center;
+  margin-left: auto;
+  opacity: 0.5;
+}
+
+.ease-ctx-chevron svg {
+  width: 14px;
+  height: 14px;
+}
+
+/* ── Sub-menu popup ──────────────────────────────────────────────────────────*/
+.ease-ctx-has-submenu {
+  position: relative;
+}
+
+.ease-ctx-submenu {
+  position: absolute;
+  left: calc(100% + 6px);
+  top: -6px;
+  min-width: 200px;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 6px;
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.07),
+    0 10px 30px -5px rgba(0, 0, 0, 0.12);
+
+  /* Hidden by default */
+  opacity: 0;
+  transform: scale(0.88) translateX(-6px);
+  pointer-events: none;
+  transition:
+    opacity 0.18s ease,
+    transform 0.22s cubic-bezier(0.34, 1.56, 0.64, 1);
+  transform-origin: top left;
+  z-index: 10000;
+}
+
+.ease-ctx-submenu.is-visible {
+  opacity: 1;
+  transform: scale(1) translateX(0);
+  pointer-events: auto;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a modular, copy-paste ready React `<ContextMenu>` component with a spring-physics scale & fade entrance animation, nested sub-menu support, keyboard dismissal, viewport-edge clamping, and danger/disabled item variants. Zero external dependencies — pure React hooks and EaseMotion CSS. Addresses issue #28120 (#27490).

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/react/react-context-menu-popup-with-scale-fade-entrance-28120/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A `<ContextMenu>` React component that renders a right-click popup menu with a spring-physics `scale(0.85) → scale(1)` entrance and matching exit animation, nested sub-menu support on hover, automatic viewport-edge clamping, Escape-key dismissal, and item variants for shortcuts, danger actions, and disabled states.

**How does a developer use it?**

```jsx
import ContextMenu from './ContextMenu';
import './style.css';

const menuItems = [
  { id: 'open',   icon: '📂', label: 'Open',   shortcut: '↵',  onClick: () => {} },
  { id: 'rename', icon: '✏️',  label: 'Rename', shortcut: 'F2', onClick: () => {} },
  {
    id: 'share', icon: '🔗', label: 'Share',
    subItems: [
      { id: 'copy-link', icon: '📋', label: 'Copy Link', onClick: () => {} },
    ]
  },
  { separator: true },
  { id: 'delete', icon: '🗑️', label: 'Move to Trash', danger: true, onClick: () => {} },
];

<ContextMenu items={menuItems}>
  <div style={{ padding: 40 }}>Right-click me</div>
</ContextMenu>
