### PR TITLE
feat(react): add Context Menu Popup with Scale & Fade Entrance

### DIFF
--- a/submissions/react/react-context-menu-popup-with-scale-fade-entrance/ContextMenuPopup.jsx
+++ b/submissions/react/react-context-menu-popup-with-scale-fade-entrance/ContextMenuPopup.jsx
@@ -1,0 +1,47 @@
+import { useState, useEffect } from "react";
+import "./style.css";
+
+export default function ContextMenuPopup() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    function handleKeyDown(e) {
+      if (e.key === "Escape") {
+        setOpen(false);
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, []);
+
+  return (
+    <div className="context-demo">
+      <button
+        className="menu-btn"
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+        aria-haspopup="true"
+      >
+        Open Menu
+      </button>
+
+      {open && (
+        <div
+          className="context-menu"
+          role="menu"
+        >
+          <button role="menuitem">Edit</button>
+          <button role="menuitem">Duplicate</button>
+          <button role="menuitem">Share</button>
+          <button className="danger" role="menuitem">
+            Delete
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/submissions/react/react-context-menu-popup-with-scale-fade-entrance/README.md
+++ b/submissions/react/react-context-menu-popup-with-scale-fade-entrance/README.md
@@ -1,0 +1,43 @@
+# React Context Menu Popup with Scale & Fade Entrance
+
+A reusable React context menu component featuring a smooth scale-and-fade entrance animation built with React Hooks and pure CSS.
+
+## Features
+
+- Smooth zoom-in and fade animation
+- Built with React Hooks
+- Keyboard accessible (Escape key closes the menu)
+- Responsive layout
+- Customizable using CSS variables
+- No external dependencies
+
+## Installation
+
+Copy the component folder into your project.
+
+```jsx
+import ContextMenuPopup from "./ContextMenuPopup";
+```
+
+## Usage
+
+```jsx
+<ContextMenuPopup />
+```
+
+## CSS Variables
+
+```css
+:root {
+  --popup-scale: 0.85;
+  --popup-duration: 0.25s;
+  --popup-easing: cubic-bezier(.22,1,.36,1);
+  --popup-radius: 14px;
+}
+```
+
+## Files
+
+- ContextMenuPopup.jsx
+- style.css
+- README.md

--- a/submissions/react/react-context-menu-popup-with-scale-fade-entrance/style.css
+++ b/submissions/react/react-context-menu-popup-with-scale-fade-entrance/style.css
@@ -1,0 +1,94 @@
+:root {
+  --popup-scale: 0.85;
+  --popup-duration: 0.25s;
+  --popup-easing: cubic-bezier(.22,1,.36,1);
+  --popup-radius: 14px;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+.context-demo {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #0f172a;
+  font-family: Arial, Helvetica, sans-serif;
+  position: relative;
+}
+
+.menu-btn {
+  padding: 14px 28px;
+  border: none;
+  border-radius: 10px;
+  background: #2563eb;
+  color: white;
+  cursor: pointer;
+  font-size: 16px;
+  transition: 0.3s ease;
+}
+
+.menu-btn:hover {
+  background: #1d4ed8;
+}
+
+.context-menu {
+  position: absolute;
+  top: 55%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(var(--popup-scale));
+  width: 220px;
+
+  background: white;
+  border-radius: var(--popup-radius);
+
+  box-shadow: 0 18px 40px rgba(0,0,0,.25);
+
+  padding: 8px;
+
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  animation: zoomFade
+           var(--popup-duration)
+           var(--popup-easing)
+           forwards;
+}
+
+.context-menu button {
+  background: transparent;
+  border: none;
+  text-align: left;
+  padding: 12px 16px;
+  font-size: 15px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: .2s;
+}
+
+.context-menu button:hover {
+  background: #f3f4f6;
+}
+
+.danger {
+  color: #dc2626;
+}
+
+@keyframes zoomFade {
+
+  from {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(var(--popup-scale));
+  }
+
+  to {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+  }
+
+}


### PR DESCRIPTION
## Pull Request Description

Implemented a reusable **React Context Menu Popup with Scale & Fade Entrance** using React Hooks and pure CSS. The component provides a smooth zoom-in animation, fade transition, keyboard accessibility, customizable CSS variables, and a lightweight implementation without external dependencies.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes React component source
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

A reusable React context menu component with a smooth scale-and-fade entrance animation suitable for dashboards, admin panels, and modern web applications.

### How does a developer use it?

```jsx
import ContextMenuPopup from "./ContextMenuPopup";

function App() {
  return <ContextMenuPopup />;
}

Closes #27581 