### PR TITLE
Fixing the loading spinner button issue #32177

### DIFF
--- a/submissions/examples/fix-loading-button-spinner/README.md
+++ b/submissions/examples/fix-loading-button-spinner/README.md
@@ -1,0 +1,12 @@
+# Fix Button Focus Visible (Issue #32177)
+
+
+1. **What does this do?**  
+   it shows pill-style loading button and added aria-label and aria-label that improves the accessiblity to the loading button.
+
+2. **How is it used?**  
+   - Open 'demo.html' in server. 
+   - The button uses demo classes shown in html file.
+
+3. **Why is it useful?**  
+   it provides the clean, self-contained example of loading button state which matches the EaseMotion style.

--- a/submissions/examples/fix-loading-button-spinner/demo.html
+++ b/submissions/examples/fix-loading-button-spinner/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Fix Loading Button Spinner</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <!-- Hover effects -->
+        <div class="demo-chip">// With ease-btn-hover</div>
+        <div class="ease-flex ease-flex-wrap ease-gap-3" style="margin-bottom: var(--ease-space-8);">
+          <button class="ease-btn ease-btn-primary ease-btn-hover">Hover me ✨</button>
+          <button class="ease-btn ease-btn-outline ease-btn-hover"
+            style="border-color:rgba(255,255,255,0.3); color: var(--page-text);">Hover me 🚀</button>
+          <button class="ease-btn ease-btn-success ease-btn-hover">Hover me 🌿</button>
+        </div>
+
+         <!-- Sizes -->
+        <div class="demo-chip">// Sizes</div>
+        <div class="ease-flex ease-flex-wrap ease-items-center ease-gap-3" style="margin-bottom: var(--ease-space-8);">
+          <button class="ease-btn ease-btn-primary ease-btn-sm">Small</button>
+          <button class="ease-btn ease-btn-primary">Default</button>
+          <button class="ease-btn ease-btn-primary ease-btn-lg">Large</button>
+          <button class="ease-btn ease-btn-primary ease-btn-xl">X-Large</button>
+        </div>
+
+        <!-- Squish -->
+        <div class="demo-chip">// Squish Button Utility</div>
+        <div class="ease-flex ease-flex-wrap ease-gap-3" style="margin-bottom: var(--ease-space-8);">
+          <button class="ease-btn ease-btn-primary ease-squish-button">Squish Me </button>
+        </div>
+
+        <!-- Shapes & States -->
+        <div class="demo-chip">// Pill · Disabled · Loading</div>
+        <div class="ease-flex ease-flex-wrap ease-items-center ease-gap-3">
+          <button class="ease-btn ease-btn-primary ease-btn-pill">Pill Shape</button>
+          <button class="ease-btn ease-btn-primary" disabled>Disabled</button>
+          <button class="ease-btn ease-btn-outline ease-btn-pill ease-btn-loading" disabled
+                  aria-busy="true"
+                  aria-label="loading"
+            style="border-color:rgba(255,255,255,0.3); color:#fff;">Loading</button>
+        </div>
+      </div>
+    
+</body>
+</html>

--- a/submissions/examples/fix-loading-button-spinner/style.css
+++ b/submissions/examples/fix-loading-button-spinner/style.css
@@ -1,0 +1,48 @@
+@keyframes ease-kf-btn-spin {
+  
+  to {
+    transform: translate(-50%, -50%) rotate(360deg);
+  }
+}
+/* from {
+    transform: translate(-50%, -50%) rotate(0deg);
+  }
+
+  to {
+    transform: translate(-50%, -50%) rotate(360deg);
+  }
+} */
+
+/* Loading spinner inside button */
+.ease-btn-loading {
+  pointer-events: none;
+  position: relative;
+  color: #111 !important;
+}
+
+
+.ease-btn-outline.ease-btn-loading,
+.ease-btn-pill.ease-btn-loading {
+  --ease-btn-loading-color: #111;
+}
+
+.ease-btn-loading > * {
+  visibility: hidden;
+}
+
+.ease-btn-loading::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0.85em;
+  height: 0.85em;
+  transform: translate(-50%, -50%);
+  font-size: var(--ease-text-base, 1rem);
+ 
+  
+  border: 2px solid var(--ease-btn-loading-color, #111);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: ease-kf-btn-spin 0.7s linear infinite;
+}


### PR DESCRIPTION
 **Pull Request Description**

This PR improves the loading spinner button addresses issue #32177 under submissions folder with a completely self contained demo.html, matching style.css and README.md files explaining the feature and how it fits EaseMotion CSS.


**Type of Change**

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ✓] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)



**Submission Checklist**

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [ ✓] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [ ✓] Includes `demo.html` — self-contained, opens in browser with no server
- [ ✓] Includes `style.css` — raw CSS for the proposed feature
- [✓ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [ ✓] **No changes to `core/`**
- [✓ ] **No changes to `components/`**




**Feature Description**

**What does this add?**
A new EaseMotion CSS submission with a polished demo and accompanying documentation and also added aria-label and aria-busy label to help the user to find the loading button.


How does a developer use it?
<button class="ease-btn ease-btn-outline ease-btn-pill ease-btn-loading" disabled
                  aria-busy="true"
                  aria-label="loading"
            style="border-color:rgba(255,255,255,0.3); **color:#fff;">Loading</button>




Why does it fit EaseMotion CSS?
It follows the animation-first, human-readable approach by keeping the effect simple, reusable and it also improves the user experience with the loading button.

---

**Demo**

- [✓ ] Demo added (`demo.html` works by opening directly in a browser)



**Browser Testing**

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*


**Notes for Maintainer**

-The submission is kept isolated under **submissions/** and avoids changes to **core and components** as the community contribution guidelines.


