### PR TITLE
feat: Add React Floating Action Button (FAB) Speed Dial Menu (#28106)

### DIFF
--- a/submissions/react/react-floating-action-button-fab-speed-dial-menu-28106/README.md
+++ b/submissions/react/react-floating-action-button-fab-speed-dial-menu-28106/README.md
@@ -1,0 +1,60 @@
+# React Component: Floating Action Button (FAB) Speed Dial Menu (#28106)
+
+A modular, copy-paste ready React `<SpeedDial>` component that provides a floating action button which expands into a menu of secondary actions. Features staggered spring-physics entrance, cross-fading toggle icons, automatic tooltip positioning, and 4-way expansion support (up, down, left, right). Zero external dependencies — pure React hooks and EaseMotion CSS.
+
+## 📦 What's included?
+
+- `SpeedDial.jsx`: The React component that manages open/close state, outside-click and Escape-key dismissal, and maps through the action array.
+- `style.css`: The CSS stylesheet powering the staggered `cubic-bezier` action entrance, tooltip slide-in, icon rotation/cross-fade, and flex-direction structural layout.
+- `demo.html`: A self-contained demo showcasing 3 different placements and directions (`up`, `down`, `left`) with custom colors and icons — opens directly in a browser.
+
+## 🛠 Features
+
+- **Staggered Spring Entrance**: Secondary action buttons pop out with a `scale(0.5) → scale(1)` animation using `cubic-bezier(0.34, 1.56, 0.64, 1)`. The entrance is staggered by `45ms` per item using CSS custom property delays injected by React.
+- **Icon Cross-fade Rotation**: The main FAB icon smoothly rotates and cross-fades into the close icon (`rotate(90deg)` + opacity cross-fade) to provide clear state feedback.
+- **4-Way Expansion**: Supports opening `up` (default), `down`, `left`, or `right`. The flex layout and tooltip positioning automatically adjust based on the chosen direction.
+- **Animated Tooltips**: Hovering a secondary action slides in a tooltip label. Tooltips intelligently position themselves (e.g. to the right when opening up/down, or below when opening left/right).
+- **Dismissal Handling**: Automatically closes if an action is clicked, the `Escape` key is pressed, or the user clicks outside the component container.
+
+## 🚀 How to use
+
+```jsx
+import SpeedDial from './SpeedDial';
+import './style.css';
+
+const actions = [
+  { icon: '📋', name: 'Copy', onClick: () => console.log('Copied') },
+  { icon: '🔗', name: 'Share', onClick: () => console.log('Shared') },
+  { icon: '🖨️', name: 'Print', onClick: () => console.log('Printing') },
+];
+
+const MyLayout = () => (
+  <div style={{ position: 'relative', height: '100vh' }}>
+    {/* Page content */}
+    
+    <div style={{ position: 'absolute', bottom: 32, right: 32 }}>
+      <SpeedDial
+        actions={actions}
+        direction="up"
+        color="#3b82f6"
+      />
+    </div>
+  </div>
+);
+```
+
+## ⚙️ Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `actions` | `Array<{icon, name, onClick}>` | `[]` | Array of action objects to render. |
+| `mainIcon` | `ReactNode` | `<svg>` (Plus) | Custom icon for the FAB when closed. |
+| `closeIcon` | `ReactNode` | `<svg>` (Cross) | Custom icon for the FAB when opened. |
+| `direction` | `string` | `'up'` | Expansion direction: `'up'` \| `'down'` \| `'left'` \| `'right'` |
+| `color` | `string` | `'#3b82f6'` | Background color of the main FAB |
+
+## 🎨 Why this fits EaseMotion
+
+**EaseMotion** is about making UI elements behave with physical predictability and delight.
+
+A speed dial menu can easily feel like a clunky dropdown if the items just appear instantly. By adding a staggered `cubic-bezier(0.34, 1.56, 0.64, 1)` spring to the secondary actions, the menu feels like it is physically unfolding from the main button, dealing cards one by one. The icon cross-fade with rotation reinforces the idea that the button physically transforms its state, bridging the interaction gap smoothly.

--- a/submissions/react/react-floating-action-button-fab-speed-dial-menu-28106/SpeedDial.jsx
+++ b/submissions/react/react-floating-action-button-fab-speed-dial-menu-28106/SpeedDial.jsx
@@ -1,0 +1,119 @@
+import React, { useState, useEffect, useRef } from 'react';
+
+/**
+ * SpeedDial — A Floating Action Button (FAB) that expands into a menu of secondary actions.
+ *
+ * @param {Array}    actions   - Array of { icon, name, onClick } objects
+ * @param {ReactNode} mainIcon - Icon for the main FAB when closed (default: '+')
+ * @param {ReactNode} closeIcon- Icon for the main FAB when opened (default: '×')
+ * @param {string}   direction - Expand direction: 'up' | 'down' | 'left' | 'right' (default: 'up')
+ * @param {string}   color     - Base CSS color for the main button (default: '#3b82f6')
+ */
+const SpeedDial = ({
+  actions = [],
+  mainIcon,
+  closeIcon,
+  direction = 'up',
+  color = '#3b82f6',
+}) => {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef(null);
+
+  // Close on outside click or Escape key
+  useEffect(() => {
+    if (!open) return;
+
+    const handleClickOutside = (event) => {
+      if (containerRef.current && !containerRef.current.contains(event.target)) {
+        setOpen(false);
+      }
+    };
+
+    const handleEscape = (event) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [open]);
+
+  const toggle = () => setOpen(prev => !prev);
+
+  // Default icons if none provided
+  const iconDefault = (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+  );
+  const iconCloseDefault = (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  );
+
+  return (
+    <div 
+      className={`ease-speed-dial ease-speed-dial--${direction} ${open ? 'is-open' : ''}`}
+      ref={containerRef}
+      style={{ '--ease-sd-color': color }}
+    >
+      {/* ── Main FAB ── */}
+      <button
+        className="ease-sd-main"
+        onClick={toggle}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-label="Toggle speed dial"
+      >
+        <span className="ease-sd-icon ease-sd-icon--main" aria-hidden="true">
+          {mainIcon || iconDefault}
+        </span>
+        <span className="ease-sd-icon ease-sd-icon--close" aria-hidden="true">
+          {closeIcon || iconCloseDefault}
+        </span>
+      </button>
+
+      {/* ── Actions List ── */}
+      <div 
+        className="ease-sd-actions" 
+        role="menu"
+        aria-hidden={!open}
+      >
+        {actions.map((action, index) => (
+          <div
+            key={action.name}
+            className="ease-sd-action-wrap"
+            style={{ '--ease-sd-delay': `${index * 45}ms` }}
+          >
+            {/* Tooltip Label */}
+            <span className="ease-sd-tooltip" role="tooltip">
+              {action.name}
+            </span>
+            
+            {/* Secondary Action Button */}
+            <button
+              className="ease-sd-btn"
+              onClick={() => {
+                if (action.onClick) action.onClick();
+                setOpen(false);
+              }}
+              role="menuitem"
+              aria-label={action.name}
+              tabIndex={open ? 0 : -1}
+            >
+              {action.icon}
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default SpeedDial;

--- a/submissions/react/react-floating-action-button-fab-speed-dial-menu-28106/demo.html
+++ b/submissions/react/react-floating-action-button-fab-speed-dial-menu-28106/demo.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>React FAB Speed Dial Demo</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="./style.css">
+
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+
+  <style>
+    body {
+      margin: 0;
+      background: #f1f5f9;
+      min-height: 100vh;
+      font-family: system-ui, sans-serif;
+      padding: 3rem 2rem;
+      color: #0f172a;
+    }
+
+    .demo-container { max-width: 800px; margin: 0 auto; display: flex; flex-direction: column; gap: 40px; }
+
+    .demo-section {
+      background: #ffffff;
+      border-radius: 16px;
+      padding: 32px;
+      box-shadow: 0 2px 8px -2px rgba(0,0,0,0.06);
+      border: 1px solid #e2e8f0;
+      position: relative; /* For absolutely positioning the dials */
+      min-height: 300px;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden; /* contain the dial overflow for the embedded demo */
+    }
+
+    .demo-label {
+      font-size: 0.72rem;
+      font-weight: 700;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      color: #94a3b8;
+      margin: 0 0 24px 0;
+    }
+
+    .demo-caption {
+      font-size: 0.85rem;
+      color: #64748b;
+      margin: 14px 0 0 0;
+    }
+
+    /* Positioning the dials within the demo boxes */
+    .dial-bottom-right { position: absolute; bottom: 32px; right: 32px; }
+    .dial-top-left { position: absolute; top: 32px; left: 32px; }
+    .dial-center-right { position: absolute; top: 50%; right: 32px; transform: translateY(-50%); }
+
+    /* Icons for demo */
+    .icon-svg { width: 20px; height: 20px; fill: none; stroke: currentColor; stroke-width: 2.5; stroke-linecap: round; stroke-linejoin: round; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+
+  <script type="text/babel">
+    const { useState, useEffect, useRef } = React;
+
+    /* ── Reusable SpeedDial Component ── */
+    const SpeedDial = ({ actions, mainIcon, closeIcon, direction = 'up', color = '#3b82f6' }) => {
+      const [open, setOpen] = useState(false);
+      const containerRef = useRef(null);
+
+      useEffect(() => {
+        if (!open) return;
+        const handleClickOutside = (e) => { if (containerRef.current && !containerRef.current.contains(e.target)) setOpen(false); };
+        const handleEscape = (e) => { if (e.key === 'Escape') setOpen(false); };
+        document.addEventListener('mousedown', handleClickOutside);
+        document.addEventListener('keydown', handleEscape);
+        return () => { document.removeEventListener('mousedown', handleClickOutside); document.removeEventListener('keydown', handleEscape); };
+      }, [open]);
+
+      const toggle = () => setOpen(prev => !prev);
+
+      const defaultIcon = <svg className="icon-svg" viewBox="0 0 24 24"><line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" /></svg>;
+      const defaultClose = <svg className="icon-svg" viewBox="0 0 24 24"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>;
+
+      return (
+        <div className={`ease-speed-dial ease-speed-dial--${direction} ${open ? 'is-open' : ''}`} ref={containerRef} style={{ '--ease-sd-color': color }}>
+          <button className="ease-sd-main" onClick={toggle} aria-expanded={open} aria-label="Toggle menu">
+            <span className="ease-sd-icon ease-sd-icon--main" aria-hidden="true">{mainIcon || defaultIcon}</span>
+            <span className="ease-sd-icon ease-sd-icon--close" aria-hidden="true">{closeIcon || defaultClose}</span>
+          </button>
+          <div className="ease-sd-actions" role="menu" aria-hidden={!open}>
+            {actions.map((action, i) => (
+              <div key={action.name} className="ease-sd-action-wrap" style={{ '--ease-sd-delay': `${i * 45}ms` }}>
+                <span className="ease-sd-tooltip" role="tooltip">{action.name}</span>
+                <button className="ease-sd-btn" onClick={() => { if (action.onClick) action.onClick(); setOpen(false); }} aria-label={action.name} tabIndex={open ? 0 : -1}>
+                  {action.icon}
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      );
+    };
+
+    /* ── Demo Icons ── */
+    const IcoCopy = <svg className="icon-svg" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>;
+    const IcoShare = <svg className="icon-svg" viewBox="0 0 24 24"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>;
+    const IcoPrint = <svg className="icon-svg" viewBox="0 0 24 24"><polyline points="6 9 6 2 18 2 18 9"/><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><rect x="6" y="14" width="12" height="8"/></svg>;
+    const IcoMail = <svg className="icon-svg" viewBox="0 0 24 24"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>;
+    
+    const IcoPen = <svg className="icon-svg" viewBox="0 0 24 24"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>;
+
+    /* ── Demo App ── */
+    const App = () => {
+      const actions = [
+        { icon: IcoCopy, name: 'Copy', onClick: () => alert('Copied') },
+        { icon: IcoShare, name: 'Share', onClick: () => alert('Shared') },
+        { icon: IcoPrint, name: 'Print', onClick: () => alert('Printing') },
+        { icon: IcoMail, name: 'Email', onClick: () => alert('Emailing') },
+      ];
+
+      return (
+        <div className="demo-container">
+
+          <div className="demo-section">
+            <p className="demo-label">1. Standard Bottom-Right (direction="up")</p>
+            <p className="demo-caption">The classic Material FAB pattern. Actions open upwards, tooltips appear to the left.</p>
+            <div className="dial-bottom-right">
+              <SpeedDial actions={actions} direction="up" color="#ef4444" />
+            </div>
+          </div>
+
+          <div className="demo-section">
+            <p className="demo-label">2. Top-Left Placement (direction="down")</p>
+            <p className="demo-caption">Using a custom "Edit/Pencil" icon for the main state.</p>
+            <div className="dial-top-left">
+              <SpeedDial actions={actions} direction="down" color="#10b981" mainIcon={IcoPen} />
+            </div>
+          </div>
+
+          <div className="demo-section">
+            <p className="demo-label">3. Center-Right Placement (direction="left")</p>
+            <p className="demo-caption">Actions expand horizontally to the left, tooltips appear below.</p>
+            <div className="dial-center-right">
+              <SpeedDial actions={actions} direction="left" color="#8b5cf6" />
+            </div>
+          </div>
+
+        </div>
+      );
+    };
+
+    ReactDOM.render(<App />, document.getElementById('root'));
+  </script>
+</body>
+</html>

--- a/submissions/react/react-floating-action-button-fab-speed-dial-menu-28106/style.css
+++ b/submissions/react/react-floating-action-button-fab-speed-dial-menu-28106/style.css
@@ -1,0 +1,206 @@
+/*
+  style.css
+  EaseMotion CSS - Floating Action Button (FAB) Speed Dial Menu
+*/
+
+/* ── Container ───────────────────────────────────────────────────────────────*/
+.ease-speed-dial {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: system-ui, -apple-system, sans-serif;
+  z-index: 50;
+}
+
+/* Base directions */
+.ease-speed-dial--up { flex-direction: column-reverse; }
+.ease-speed-dial--down { flex-direction: column; }
+.ease-speed-dial--left { flex-direction: row-reverse; }
+.ease-speed-dial--right { flex-direction: row; }
+
+/* ── Main FAB ────────────────────────────────────────────────────────────────*/
+.ease-sd-main {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: var(--ease-sd-color, #3b82f6);
+  color: #ffffff;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  position: relative;
+  z-index: 2;
+  transition:
+    transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1),
+    box-shadow 0.2s ease,
+    background 0.2s ease;
+}
+
+.ease-sd-main:hover {
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+  transform: scale(1.05);
+}
+
+.ease-sd-main:active {
+  transform: scale(0.95);
+}
+
+/* Main Icon Cross-fade & Rotate Animation */
+.ease-sd-icon {
+  position: absolute;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1),
+    opacity 0.25s ease;
+}
+
+.ease-sd-icon svg { width: 100%; height: 100%; }
+
+/* Default state (closed) */
+.ease-sd-icon--main { transform: rotate(0deg) scale(1); opacity: 1; }
+.ease-sd-icon--close { transform: rotate(-90deg) scale(0.5); opacity: 0; }
+
+/* Opened state */
+.is-open .ease-sd-icon--main { transform: rotate(90deg) scale(0.5); opacity: 0; }
+.is-open .ease-sd-icon--close { transform: rotate(0deg) scale(1); opacity: 1; }
+
+/* Optional: Slight button rotation on open */
+.is-open .ease-sd-main {
+  transform: rotate(45deg);
+}
+
+/* If the close icon is distinct (like a pencil vs 'x'), we don't want the whole button to rotate.
+   But if it's the default '+' turning into 'x', rotating the button is a classic pattern.
+   For safety with custom icons, we'll keep the button static and only rotate the icons inside. */
+.is-open .ease-sd-main {
+  transform: scale(1); /* Reset hover scale to avoid jitter during transition */
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1); /* flatten slightly when open */
+}
+
+/* ── Actions List Container ──────────────────────────────────────────────────*/
+.ease-sd-actions {
+  display: flex;
+  pointer-events: none; /* Ignore clicks when closed */
+  gap: 12px;
+  /* Direction-based spacing */
+  padding: 0;
+}
+
+.ease-speed-dial--up .ease-sd-actions { flex-direction: column-reverse; margin-bottom: 16px; }
+.ease-speed-dial--down .ease-sd-actions { flex-direction: column; margin-top: 16px; }
+.ease-speed-dial--left .ease-sd-actions { flex-direction: row-reverse; margin-right: 16px; }
+.ease-speed-dial--right .ease-sd-actions { flex-direction: row; margin-left: 16px; }
+
+/* Enable interaction when open */
+.is-open .ease-sd-actions {
+  pointer-events: auto;
+}
+
+/* ── Secondary Action Wrapper ────────────────────────────────────────────────*/
+.ease-sd-action-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ── Secondary Action Button ─────────────────────────────────────────────────*/
+.ease-sd-btn {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: #ffffff;
+  color: #475569;
+  border: 1px solid #e2e8f0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  font-size: 1.1rem;
+  
+  /* Entrance/Exit Animation */
+  opacity: 0;
+  transform: scale(0.5);
+  transition:
+    transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1),
+    opacity 0.2s ease,
+    background 0.15s ease,
+    color 0.15s ease;
+  transition-delay: 0s; /* exit delay */
+}
+
+.ease-sd-btn svg { width: 20px; height: 20px; }
+
+.ease-sd-btn:hover {
+  background: #f8fafc;
+  color: var(--ease-sd-color, #3b82f6);
+  transform: scale(1.1) !important; /* Override open state scale */
+}
+
+.ease-sd-btn:active {
+  transform: scale(0.9) !important;
+}
+
+/* Open State — Staggered Entrance */
+.is-open .ease-sd-btn {
+  opacity: 1;
+  transform: scale(1);
+  transition-delay: var(--ease-sd-delay);
+}
+
+/* ── Tooltips ────────────────────────────────────────────────────────────────*/
+.ease-sd-tooltip {
+  position: absolute;
+  background: rgba(15, 23, 42, 0.85);
+  color: #ffffff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 6px;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  
+  /* Slide entrance on hover */
+  transform: translateX(10px);
+  transition:
+    opacity 0.2s ease,
+    transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1),
+    visibility 0.2s ease;
+}
+
+/* Tooltip Positioning based on SpeedDial direction */
+/* If dial goes UP/DOWN, tooltips go to the RIGHT */
+.ease-speed-dial--up .ease-sd-tooltip,
+.ease-speed-dial--down .ease-sd-tooltip {
+  left: 100%;
+  margin-left: 14px;
+  transform: translateX(8px);
+}
+
+/* If dial goes LEFT/RIGHT, tooltips go to the BOTTOM */
+.ease-speed-dial--left .ease-sd-tooltip,
+.ease-speed-dial--right .ease-sd-tooltip {
+  top: 100%;
+  margin-top: 14px;
+  transform: translateY(8px);
+}
+
+/* Show tooltip on button hover (only if the dial is actually open) */
+.is-open .ease-sd-btn:hover ~ .ease-sd-tooltip, /* If DOM order was flipped */
+.is-open .ease-sd-action-wrap:hover .ease-sd-tooltip {
+  opacity: 1;
+  visibility: visible;
+  transform: translate(0);
+}


### PR DESCRIPTION
## Pull Request Description

Adds a modular React `<SpeedDial>` component that provides a Floating Action Button (FAB) which expands into a menu of secondary actions. Features staggered spring-physics entrance, cross-fading toggle icons, automatic tooltip positioning, and 4-way expansion support (up, down, left, right). Zero external dependencies — pure React hooks and EaseMotion CSS. Addresses issue #28106 (#27476).

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/react/react-floating-action-button-fab-speed-dial-menu-28106/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A React `<SpeedDial>` component that manages a primary Floating Action Button which, when clicked, reveals a staggered menu of secondary actions with hover tooltips. Supports 4 expansion directions, dismissal on outside click or Escape key, and custom icons.

**How does a developer use it?**

```jsx
import SpeedDial from './SpeedDial';
import './style.css';

const actions = [
  { icon: '📋', name: 'Copy', onClick: () => console.log('Copied') },
  { icon: '🔗', name: 'Share', onClick: () => console.log('Shared') },
  { icon: '🖨️', name: 'Print', onClick: () => console.log('Printing') },
];

<SpeedDial
  actions={actions}
  direction="up"
  color="#3b82f6"
/>
