### PR TITLE
fix: theme toggle icon invisible in light mode

### DIFF
--- a/submissions/examples/theme-toggle-icon-fix-ss/README.md
+++ b/submissions/examples/theme-toggle-icon-fix-ss/README.md
@@ -1,0 +1,19 @@
+# Theme Toggle Icon Fix
+
+Submission for EaseMotion CSS · Fixes Issue #33752
+
+## What does this do?
+
+Fixes the theme toggle button's moon icon so it stays visible in light mode.
+
+## Bug
+
+The moon icon inherited `color: var(--page-text)`, which flips from white (dark mode) to near-black (light mode). Since the header bar stays dark in both themes, the icon became invisible in light mode.
+
+## Fix
+
+Introduced a dedicated `--header-icon-color` variable, always white, decoupled from the page's general text color, since the header background doesn't change between themes.
+
+## How is it used?
+
+Apply `color: var(--header-icon-color)` to `.theme-toggle-btn` instead of `var(--page-text)`.

--- a/submissions/examples/theme-toggle-icon-fix-ss/demo.html
+++ b/submissions/examples/theme-toggle-icon-fix-ss/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Theme Toggle Icon Fix</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="demo-header">
+    <nav class="demo-nav">
+      <a href="#" class="active">Buttons</a>
+      <a href="#">Cards</a>
+      <a href="#">Animations</a>
+    </nav>
+    <button id="theme-toggle" class="theme-toggle-btn" aria-label="Toggle theme">
+      <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="12" r="5"></circle>
+        <line x1="12" y1="1" x2="12" y2="3"></line>
+        <line x1="12" y1="21" x2="12" y2="23"></line>
+      </svg>
+      <svg class="moon-icon" viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+      </svg>
+    </button>
+  </header>
+
+  <script>
+    const btn = document.getElementById('theme-toggle');
+    btn.addEventListener('click', () => {
+      const current = document.documentElement.getAttribute('data-theme');
+      document.documentElement.setAttribute('data-theme', current === 'light' ? 'dark' : 'light');
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/theme-toggle-icon-fix-ss/style.css
+++ b/submissions/examples/theme-toggle-icon-fix-ss/style.css
@@ -1,0 +1,56 @@
+:root {
+  --header-bg: #1a1a2e;
+  --header-icon-color: #ffffff;
+}
+
+body {
+  margin: 0;
+  font-family: sans-serif;
+}
+
+.demo-header {
+  background: var(--header-bg);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 24px;
+}
+
+.demo-nav a {
+  color: #ccc;
+  text-decoration: none;
+  margin-right: 20px;
+  padding: 8px 14px;
+  border-radius: 6px;
+}
+
+.demo-nav a.active {
+  background: rgba(108, 99, 255, 0.15);
+  color: #fff;
+}
+
+/* Theme toggle button — icon color is fixed, not tied to page text color */
+.theme-toggle-btn {
+  background: none;
+  border: 1px solid rgba(255,255,255,0.2);
+  color: var(--header-icon-color);
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
+.theme-toggle-btn svg {
+  position: absolute;
+  transition: opacity 0.3s, transform 0.3s;
+}
+
+.sun-icon { opacity: 1; }
+.moon-icon { opacity: 0; }
+
+[data-theme="light"] .sun-icon { opacity: 0; }
+[data-theme="light"] .moon-icon { opacity: 1; }


### PR DESCRIPTION
## Pull Request Description

## What this fixes
The theme toggle button's moon icon was invisible in light mode because it inherited `color: var(--page-text)`, which flips to a dark color in light mode. Since the header bar stays dark in both themes, this made the icon disappear.

## Fix
Added a dedicated `--header-icon-color` variable (always white) so the icon color is decoupled from the page's general text color, since it needs to stay visible against the dark header regardless of theme.

## Demo
Self-contained demo included at `submissions/examples/theme-toggle-icon-fix-ss/demo.html` — open directly in browser and click the toggle button to see both icons stay visible in both states.

Fixes #33752
---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description
Fixes the theme toggle icon (moon icon) so it stays visible in light mode instead of blending into the dark header.

<!-- Show the class usage in HTML -->
```
<button class="theme-toggle-btn">
  <svg class="sun-icon">...</svg>
  <svg class="moon-icon">...</svg>
</button>

.theme-toggle-btn {
  color: var(--header-icon-color);
}

**Why does it fit EaseMotion CSS?**

This keeps the theme toggle accessible and visible in both light and dark modes, aligning with EaseMotion's focus on clean, human-readable, and functional UI components.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [ ] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

<!-- Anything the maintainer should know when reviewing or integrating.
     e.g. "I wasn't sure about the timing — feel free to adjust."
     e.g. "Inspired by Material UI's shimmer effect." -->

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
