### PR TITLE
feat: add missing open graph SEO meta tags to demo header #33906

### DIFF
--- a/submissions/examples/easemotion-seo-fix/README.md
+++ b/submissions/examples/easemotion-seo-fix/README.md
@@ -1,0 +1,13 @@
+# EaseMotion CSS — SEO Meta Fix (Issue #33906)
+
+This submission addresses issue #33906 by implementing Open Graph (OG) meta tags inside the header of the demo file to improve SEO and social link sharing card previews.
+
+## Implemented Tags
+- `og:title`: Specifies the title of the page/library.
+- `og:description`: Summarizes what EaseMotion CSS provides.
+- `og:image`: Adds a visually appealing card thumbnail image for social media previews.
+- `og:type` & `og:url`: Formats metadata to match standard social crawler protocols.
+
+## File Structure
+- `demo.html` — The structured HTML markup showing the layout and referencing the stylesheet.
+- `style.css` — Custom layout styles, colors, and keyframe animations.

--- a/submissions/examples/easemotion-seo-fix/demo.html
+++ b/submissions/examples/easemotion-seo-fix/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EaseMotion CSS — Demo & SEO Fix</title>
+
+    <!-- Open Graph SEO Meta Tags (Resolves Issue #33906) -->
+    <meta property="og:title" content="EaseMotion CSS — Lightweight Animation Library">
+    <meta property="og:description" content="A self-contained demo page demonstrating custom CSS transitions and animation libraries.">
+    <meta property="og:image" content="https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?auto=format&fit=crop&w=1200&h=630&q=80">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://saptarshi-coder.github.io/EaseMotion-css/">
+
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="card">
+        <h1>EaseMotion CSS</h1>
+        <p class="tagline">Lightweight, smooth, custom animations.</p>
+        
+        <div class="demo-box">
+            <div class="circle animate-pulse"></div>
+        </div>
+
+        <div class="status-badge">
+            <span>SEO Meta Fix (Issue #33906)</span>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/easemotion-seo-fix/style.css
+++ b/submissions/examples/easemotion-seo-fix/style.css
@@ -1,0 +1,81 @@
+:root {
+    --bg-dark: #0f172a;
+    --card-bg: #1e293b;
+    --accent: #6366f1;
+    --text-main: #f8fafc;
+    --text-dim: #94a3b8;
+}
+
+body {
+    margin: 0;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background-color: var(--bg-dark);
+    color: var(--text-main);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+}
+
+.card {
+    background-color: var(--card-bg);
+    padding: 40px;
+    border-radius: 16px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+    text-align: center;
+    max-width: 400px;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+h1 {
+    margin: 0 0 10px 0;
+    color: var(--text-main);
+    font-size: 28px;
+}
+
+.tagline {
+    color: var(--text-dim);
+    margin: 0 0 30px 0;
+    font-size: 14px;
+}
+
+.demo-box {
+    margin: 20px 0;
+    display: flex;
+    justify-content: center;
+}
+
+.circle {
+    width: 80px;
+    height: 80px;
+    background: linear-gradient(135deg, var(--accent), #a855f7);
+    border-radius: 50%;
+    box-shadow: 0 0 20px rgba(99, 102, 241, 0.4);
+}
+
+.animate-pulse {
+    animation: pulse 2s infinite ease-in-out;
+}
+
+@keyframes pulse {
+    0%, 100% {
+        transform: scale(1);
+        opacity: 1;
+    }
+    50% {
+        transform: scale(1.1);
+        opacity: 0.7;
+        box-shadow: 0 0 35px rgba(99, 102, 241, 0.6);
+    }
+}
+
+.status-badge {
+    margin-top: 30px;
+    display: inline-block;
+    padding: 6px 12px;
+    background-color: rgba(99, 102, 241, 0.15);
+    color: #818cf8;
+    border-radius: 20px;
+    font-size: 12px;
+    font-weight: 600;
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #33906 by adding the missing Open Graph (OG) meta tags (`og:title`, `og:description`, `og:image`, `og:type`, `og:url`) to the demo header structure inside the submissions directory to fix the website's SEO audit warnings.

Closes #33906

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds missing Open Graph SEO meta tags into the page header of our custom submission.

**How does a developer use it?**

```html
<meta property="og:title" content="EaseMotion CSS — Demo & SEO Fix">
<meta property="og:image" content="https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe">