### PR TITLE
feat: add ease-color-swatch-picker component

### DIFF
--- a/submissions/examples/ease-color-swatch-picker-ij/README.md
+++ b/submissions/examples/ease-color-swatch-picker-ij/README.md
@@ -1,0 +1,17 @@
+# Ease Color Swatch Picker
+
+A lightweight, animated color swatch picker built with pure CSS and a small JS snippet for selection state.
+
+## Usage
+Include `style.css`, then copy the markup from `demo.html`. Set each swatch's color using the `--swatch-color` CSS variable.
+
+## Features
+- Smooth scale animation on hover
+- Animated checkmark reveal on selection
+- Keyboard accessible (`:focus-visible` outline)
+- Zero dependencies
+
+## Customization
+- `--swatch-size` — swatch diameter (default `40px`)
+- `--swatch-color` — fill color per swatch
+

--- a/submissions/examples/ease-color-swatch-picker-ij/demo.html
+++ b/submissions/examples/ease-color-swatch-picker-ij/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Ease Color Swatch Picker Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="ease-swatch-picker">
+    <button class="ease-swatch ease-swatch--selected" style="--swatch-color:#ef4444" aria-label="Red" aria-pressed="true"></button>
+    <button class="ease-swatch" style="--swatch-color:#f97316" aria-label="Orange" aria-pressed="false"></button>
+    <button class="ease-swatch" style="--swatch-color:#eab308" aria-label="Yellow" aria-pressed="false"></button>
+    <button class="ease-swatch" style="--swatch-color:#22c55e" aria-label="Green" aria-pressed="false"></button>
+    <button class="ease-swatch" style="--swatch-color:#3b82f6" aria-label="Blue" aria-pressed="false"></button>
+    <button class="ease-swatch" style="--swatch-color:#8b5cf6" aria-label="Purple" aria-pressed="false"></button>
+  </div>
+
+  <script>
+    document.querySelectorAll('.ease-swatch').forEach(swatch => {
+      swatch.addEventListener('click', () => {
+        document.querySelectorAll('.ease-swatch').forEach(s => {
+          s.classList.remove('ease-swatch--selected');
+          s.setAttribute('aria-pressed', 'false');
+        });
+        swatch.classList.add('ease-swatch--selected');
+        swatch.setAttribute('aria-pressed', 'true');
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-color-swatch-picker-ij/style.css
+++ b/submissions/examples/ease-color-swatch-picker-ij/style.css
@@ -1,0 +1,55 @@
+.ease-swatch-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 16px;
+}
+
+.ease-swatch {
+  --swatch-size: 40px;
+  width: var(--swatch-size);
+  height: var(--swatch-size);
+  border-radius: 50%;
+  border: 2px solid transparent;
+  background-color: var(--swatch-color, #ccc);
+  cursor: pointer;
+  position: relative;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.15);
+}
+
+.ease-swatch:hover {
+  transform: scale(1.15);
+}
+
+.ease-swatch:focus-visible {
+  outline: 2px solid var(--swatch-color, #333);
+  outline-offset: 3px;
+}
+
+.ease-swatch--selected {
+  transform: scale(1.1);
+  border-color: #fff;
+  box-shadow: 0 0 0 3px var(--swatch-color, #333), 0 2px 6px rgba(0,0,0,0.25);
+}
+
+.ease-swatch--selected::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 10px;
+  height: 6px;
+  border-left: 2px solid #fff;
+  border-bottom: 2px solid #fff;
+  transform: rotate(-45deg) scale(0);
+  animation: ease-swatch-check 0.25s ease forwards;
+}
+
+@keyframes ease-swatch-check {
+  from { transform: rotate(-45deg) scale(0); opacity: 0; }
+  to { transform: rotate(-45deg) scale(1); opacity: 1; }
+}
+
+
+


### PR DESCRIPTION
Closes #32295

Adds an animated color swatch picker component under submissions/examples/ease-color-swatch-picker-ij/.

Features:
- Semantic <button> elements for keyboard accessibility (aria-pressed, focus-visible outline)
- Animated checkmark reveal on selection instead of a text label
- CSS custom property (--swatch-color) for easy per-swatch theming
- Smooth hover scale animation

Note: a similar swatch-picker pattern exists at ease-color-picker-swatch-ij, but this implementation differs by using accessible button elements, an animated selection indicator, and CSS variable-based theming rather than inline styles.