### PR TITLE
feat: add shipping window demo

### DIFF
--- a/submissions/examples/atlas-shipping-window/README.md
+++ b/submissions/examples/atlas-shipping-window/README.md
@@ -1,0 +1,15 @@
+# Atlas Shipping Window
+
+A compact logistics dashboard card that demonstrates route motion, shipment status pulsing, and a live loading window using CSS-only animations.
+
+## Files
+
+- `demo.html` contains the demo markup.
+- `style.css` contains the responsive layout and animation utilities.
+
+## Animation details
+
+- `atlas-pulse` highlights the active shipment status.
+- `atlas-route-flow` animates the route line across ports.
+- `atlas-ship-bob` adds subtle movement to the shipment marker.
+- `atlas-load-window` updates the progress track for a live-window effect.

--- a/submissions/examples/atlas-shipping-window/demo.html
+++ b/submissions/examples/atlas-shipping-window/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Atlas Shipping Window Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="shipping-board" aria-label="Animated shipping window dashboard">
+    <section class="window-card">
+      <div class="route-header">
+        <span class="status-dot"></span>
+        <div>
+          <p class="eyebrow">Atlas Freight</p>
+          <h1>Shipping Window</h1>
+        </div>
+      </div>
+
+      <div class="route-map" aria-hidden="true">
+        <span class="port port-a">NYC</span>
+        <span class="route-line"></span>
+        <span class="cargo-ship">CSS</span>
+        <span class="port port-b">AMS</span>
+      </div>
+
+      <div class="shipment-grid">
+        <article>
+          <span>Departure</span>
+          <strong>08:30</strong>
+        </article>
+        <article>
+          <span>Dock</span>
+          <strong>B12</strong>
+        </article>
+        <article>
+          <span>Load</span>
+          <strong>84%</strong>
+        </article>
+      </div>
+
+      <div class="progress-track" aria-label="Shipment progress">
+        <span></span>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/atlas-shipping-window/style.css
+++ b/submissions/examples/atlas-shipping-window/style.css
@@ -1,0 +1,191 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #f2f6f1;
+  color: #13201d;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.shipping-board {
+  width: min(92vw, 720px);
+  padding: 24px;
+}
+
+.window-card {
+  position: relative;
+  overflow: hidden;
+  padding: clamp(24px, 5vw, 44px);
+  border: 1px solid rgba(19, 32, 29, 0.12);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(227, 241, 237, 0.94)),
+    repeating-linear-gradient(90deg, rgba(31, 118, 95, 0.08) 0 1px, transparent 1px 88px);
+  box-shadow: 0 24px 70px rgba(20, 40, 35, 0.16);
+}
+
+.route-header {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.status-dot {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #28a56f;
+  box-shadow: 0 0 0 0 rgba(40, 165, 111, 0.45);
+  animation: atlas-pulse 1.8s ease-out infinite;
+}
+
+.eyebrow {
+  margin: 0 0 4px;
+  color: #4d6d65;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 7vw, 4.6rem);
+  line-height: 0.96;
+  letter-spacing: 0;
+}
+
+.route-map {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  align-items: center;
+  gap: 14px;
+  margin: 44px 0 34px;
+}
+
+.port {
+  display: grid;
+  place-items: center;
+  width: 58px;
+  height: 58px;
+  border-radius: 50%;
+  background: #142e2a;
+  color: #f7fbf8;
+  font-size: 0.76rem;
+  font-weight: 800;
+}
+
+.route-line {
+  height: 4px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #2e8f76, #e1a93c, #2e8f76);
+  background-size: 220% 100%;
+  animation: atlas-route-flow 2.4s linear infinite;
+}
+
+.cargo-ship {
+  display: grid;
+  place-items: center;
+  width: 66px;
+  height: 38px;
+  border-radius: 8px 8px 18px 18px;
+  background: #e1a93c;
+  color: #13201d;
+  font-size: 0.75rem;
+  font-weight: 900;
+  transform-origin: center bottom;
+  animation: atlas-ship-bob 1.7s ease-in-out infinite;
+}
+
+.shipment-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
+
+.shipment-grid article {
+  min-width: 0;
+  padding: 16px;
+  border: 1px solid rgba(19, 32, 29, 0.1);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.shipment-grid span {
+  display: block;
+  color: #5c716b;
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.shipment-grid strong {
+  display: block;
+  margin-top: 8px;
+  font-size: clamp(1.3rem, 4vw, 2rem);
+}
+
+.progress-track {
+  height: 8px;
+  margin-top: 18px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(19, 32, 29, 0.12);
+}
+
+.progress-track span {
+  display: block;
+  height: 100%;
+  width: 62%;
+  border-radius: inherit;
+  background: #2e8f76;
+  animation: atlas-load-window 2.8s ease-in-out infinite;
+}
+
+@keyframes atlas-pulse {
+  70% {
+    box-shadow: 0 0 0 18px rgba(40, 165, 111, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(40, 165, 111, 0);
+  }
+}
+
+@keyframes atlas-route-flow {
+  to {
+    background-position: -220% 0;
+  }
+}
+
+@keyframes atlas-ship-bob {
+  50% {
+    transform: translateY(-8px) rotate(-2deg);
+  }
+}
+
+@keyframes atlas-load-window {
+  0%, 100% {
+    width: 62%;
+  }
+  50% {
+    width: 86%;
+  }
+}
+
+@media (max-width: 560px) {
+  .shipment-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .route-map {
+    grid-template-columns: auto 1fr auto;
+  }
+
+  .port-b {
+    grid-column: 3;
+  }
+}


### PR DESCRIPTION
## Summary
- add Atlas Shipping Window CSS-only logistics demo
- include responsive route card with pulse, route-flow, ship-bob, and progress-window animations
- keep the contribution isolated under submissions/examples/atlas-shipping-window

## Validation
- git diff --check