### PR TITLE
feat: add css tada-click tooltip for neumorphic soft layouts #34442

### DIFF
--- a/submissions/examples/neumorphic-tada-tooltip/README.md
+++ b/submissions/examples/neumorphic-tada-tooltip/README.md
@@ -1,0 +1,15 @@
+# Neumorphic Tada-Click Tooltip (Pure CSS)
+
+An interactive, responsive, and accessible tooltip component styled specifically for Neumorphic Soft UI design guidelines. Built with 100% pure CSS animation timelines and state tracking without relying on heavy JavaScript runtimes.
+
+## Features
+- **Zero-JS Core Logic:** Uses the hidden checkbox hack variant to track toggled states cleanly via CSS.
+- **Tada Animation Elasticity:** Implements customized hardware-accelerated transformation keyframes.
+- **Configurable Architecture:** Exposes high-level motion and structural tokens through native CSS variables (`:root`).
+- **A11y Considerations:** Keyboard accessible via focus tracking fallback states (`:focus-within`) alongside semantic element layouts.
+
+## Customization Parameters
+Tweak variables inside `style.css` to fit your design system:
+- `--anim-duration`: Changes the speed of the tada shake.
+- `--tada-scale-mid`: Changes how high the tooltip scales out dynamically during its bounce pattern.
+- `--tada-rotate-angle`: Customizes the shake intensity.

--- a/submissions/examples/neumorphic-tada-tooltip/demo.html
+++ b/submissions/examples/neumorphic-tada-tooltip/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neumorphic Tada-Click Tooltip</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <main class="container">
+        <header class="header">
+            <h1>Neumorphic Tada-Click Tooltip</h1>
+            <p>A pure CSS, accessible tooltip engineered for soft UI aesthetics.</p>
+        </header>
+
+        <div class="tooltip-container">
+            <input type="checkbox" id="tooltip-toggle" class="tooltip-checkbox">
+            
+            <label for="tooltip-toggle" class="tooltip-trigger" tabindex="0" role="button" aria-haspopup="true" aria-expanded="false" aria-label="Toggle information tooltip">
+                Click Me
+            </label>
+
+            <div class="tooltip-bubble" role="tooltip">
+                <p><strong>Success!</strong> This is a smooth, hardware-accelerated Tada animation running entirely on pure CSS variables.</p>
+                <div class="tooltip-arrow"></div>
+            </div>
+        </div>
+    </main>
+
+    <script>
+        // Accessibility Enhancement: Allow Enter/Space to trigger the checkbox via the focused label
+        document.querySelector('.tooltip-trigger').addEventListener('keydown', function(e) {
+            if (e.key === ' ' || e.key === 'Enter') {
+                e.preventDefault();
+                document.getElementById('tooltip-toggle').click();
+            }
+        });
+
+        // Sync aria-expanded attribute dynamically for screen readers
+        const checkbox = document.getElementById('tooltip-toggle');
+        const trigger = document.querySelector('.tooltip-trigger');
+        checkbox.addEventListener('change', function() {
+            trigger.setAttribute('aria-expanded', this.checked);
+        });
+    </script>
+</body>
+</html>

--- a/submissions/examples/neumorphic-tada-tooltip/style.css
+++ b/submissions/examples/neumorphic-tada-tooltip/style.css
@@ -1,0 +1,200 @@
+/* ==========================================================================
+   Customizable Design Tokens & Configuration
+   ========================================================================== */
+:root {
+    /* Neumorphic Palette (Soft Light Mode Base) */
+    --nm-bg: #e0e8f5;
+    --nm-light-shadow: #ffffff;
+    --nm-dark-shadow: #b8c4d9;
+    --nm-text: #4a5568;
+    
+    /* Tooltip Specific Styling */
+    --tooltip-bg: #e0e8f5;
+    --tooltip-text: #2d3748;
+    --tooltip-border-radius: 16px;
+    
+    /* Animation Control Parameters */
+    --anim-duration: 0.6s;
+    --anim-easing: cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    --tada-scale-start: 0.9;
+    --tada-scale-mid: 1.1;
+    --tada-rotate-angle: 3deg;
+}
+
+/* ==========================================================================
+   Layout & Reset
+   ========================================================================== */
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background-color: var(--nm-bg);
+    color: var(--nm-text);
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    padding: 20px;
+}
+
+.container {
+    text-align: center;
+}
+
+.header {
+    margin-bottom: 3rem;
+}
+
+.header h1 {
+    font-size: 1.8rem;
+    margin-bottom: 0.5rem;
+    color: #334155;
+}
+
+.header p {
+    font-size: 0.95rem;
+    opacity: 0.8;
+}
+
+/* ==========================================================================
+   Neumorphic Elements
+   ========================================================================== */
+.tooltip-container {
+    position: relative;
+    display: inline-block;
+}
+
+/* Hidden Utility Checkbox */
+.tooltip-checkbox {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+    z-index: -1;
+}
+
+/* Neumorphic Trigger Button */
+.tooltip-trigger {
+    display: inline-block;
+    padding: 14px 28px;
+    font-weight: 600;
+    color: var(--nm-text);
+    background: var(--nm-bg);
+    border: none;
+    border-radius: 12px;
+    cursor: pointer;
+    user-select: none;
+    outline: none;
+    transition: all 0.2s ease;
+    
+    /* Classic Soft UI Extrusion */
+    box-shadow: 6px 6px 12px var(--nm-dark-shadow), 
+                -6px -6px 12px var(--nm-light-shadow);
+}
+
+/* Hover State */
+.tooltip-trigger:hover {
+    color: #1a202c;
+}
+
+/* Focus Indicators for Keyboard Access */
+.tooltip-trigger:focus-visible,
+.tooltip-container:focus-within .tooltip-trigger {
+    box-shadow: inset 1px 1px 3px var(--nm-dark-shadow),
+                inset -1px -1px 3px var(--nm-light-shadow),
+                0 0 0 3px rgba(66, 153, 225, 0.6);
+}
+
+/* Active / Checked State (Depressed Neumorphism) */
+.tooltip-checkbox:checked + .tooltip-trigger {
+    box-shadow: inset 6px 6px 12px var(--nm-dark-shadow), 
+                inset -6px -6px 12px var(--nm-light-shadow);
+}
+
+/* ==========================================================================
+   The Tooltip Bubble (Hidden by Default)
+   ========================================================================== */
+.tooltip-bubble {
+    position: absolute;
+    bottom: 140%;
+    left: 50%;
+    transform: translateX(-50%) scale(0.85);
+    width: 260px;
+    padding: 16px;
+    background: var(--tooltip-bg);
+    color: var(--tooltip-text);
+    font-size: 0.9rem;
+    line-height: 1.4;
+    border-radius: var(--tooltip-border-radius);
+    text-align: left;
+    pointer-events: none;
+    opacity: 0;
+    visibility: hidden;
+    
+    /* Neumorphic Floating Shadow */
+    box-shadow: 10px 10px 20px var(--nm-dark-shadow), 
+                -10px -10px 20px var(--nm-light-shadow);
+}
+
+/* Neumorphic Soft Tooltip Arrow */
+.tooltip-arrow {
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 0;
+    height: 0;
+    border-left: 8px solid transparent;
+    border-right: 8px solid transparent;
+    border-top: 8px solid var(--tooltip-bg);
+}
+
+/* ==========================================================================
+   State Activation & Tada Keyframe Trigger
+   ========================================================================== */
+.tooltip-checkbox:checked ~ .tooltip-bubble {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    
+    /* Hardware accelerated transition using parameters */
+    animation: cssTada var(--anim-duration) var(--anim-easing) forwards;
+    will-change: transform, opacity;
+}
+
+/* ==========================================================================
+   CSS Tada Keyframes (Using Configurable Design Tokens)
+   ========================================================================== */
+@keyframes cssTada {
+    0% {
+        transform: translateX(-50%) scale(var(--tada-scale-start));
+        opacity: 0;
+    }
+    15% {
+        transform: translateX(-50%) scale(var(--tada-scale-start)) rotate(calc(var(--tada-rotate-angle) * -1));
+        opacity: 0.5;
+    }
+    30%, 50%, 70%, 90% {
+        transform: translateX(-50%) scale(var(--tada-scale-mid)) rotate(var(--tada-rotate-angle));
+        opacity: 1;
+    }
+    40%, 60%, 80% {
+        transform: translateX(-50%) scale(var(--tada-scale-mid)) rotate(calc(var(--tada-rotate-angle) * -1));
+    }
+    100% {
+        transform: translateX(-50%) scale(1) rotate(0deg);
+        opacity: 1;
+    }
+}
+
+/* Responsive handling for narrow displays */
+@media (max-width: 480px) {
+    .tooltip-bubble {
+        width: 220px;
+        font-size: 0.85rem;
+    }
+}


### PR DESCRIPTION
### 🚀 Pull Request: Add CSS Tada-Click Tooltip for Neumorphic Soft Layouts

#### 🔗 Linked Issue
Closes #34442

#### 📝 Description
This PR implements a pure CSS-animated Tooltip built with a hardware-accelerated "Tada-Click" interaction transition. The design language strictly adheres to Neumorphic Soft UI design ethics, leveraging soft, organic extrusions and indentations.

- **Zero JavaScript Overhead:** Utilizes the semantic checkbox-hack technique to handle persistent click-toggle states seamlessly.
- **Highly Configurable:** Key animation variables (scale, rotation, duration, and easing) are exposed as native CSS custom properties (`:root`) for trivial maintenance and tuning.
- **Accessibility (A11y):** Keyboard navigable using focus-tracking fallback states (`:focus-within`) alongside descriptive ARIA roles and labels, complete with a tiny progressive-enhancement snippet for keyboard execution (`Space` / `Enter`).
- **Responsive Design:** Gracefully scales down font layouts and boundaries on viewports under `480px`.

#### 📂 Submission Directory Structure
As per the contributor checklist, all assets have been strictly isolated under the `submissions/` scope:
```text
submissions/examples/neumorphic-tada-tooltip/
├── demo.html
├── style.css
└── README.md