### PR TITLE
feat: add ease animated progress ring / donut chart component

### DIFF
--- a/submissions/examples/ease-progress-ring-aan22/README.md
+++ b/submissions/examples/ease-progress-ring-aan22/README.md
@@ -1,0 +1,19 @@
+# Ease Animated Progress Ring / Donut Chart
+
+## What does this do?
+Circular SVG progress rings that animate from 0 to their target value when they enter the viewport. Features a percentage label in the center, smooth stroke-dashoffset animation, gradient/custom stroke color, and multiple size variants.
+
+## How is it used?
+```html
+<div class="ease-progress-ring" data-progress="75" data-color="#6366f1">
+  <svg viewBox="0 0 100 100">
+    <circle class="ease-progress-ring__track" cx="50" cy="50" r="42"/>
+    <circle class="ease-progress-ring__fill" cx="50" cy="50" r="42"/>
+  </svg>
+  <div class="ease-progress-ring__label">75%</div>
+</div>
+```
+Use `ease-progress-ring--sm` or `ease-progress-ring--lg` modifier classes for size variants. A small amount of vanilla JS (included in `demo.html`) reads `data-progress`/`data-color` and uses an `IntersectionObserver` to trigger the fill animation once the ring scrolls into view.
+
+## Why is it useful?
+Circular progress indicators are visually impressive and widely used on portfolios and dashboards. This fits EaseMotion's animation-first philosophy — animated rings draw attention to key metrics in a visually compelling way.

--- a/submissions/examples/ease-progress-ring-aan22/demo.html
+++ b/submissions/examples/ease-progress-ring-aan22/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Ease Animated Progress Ring / Donut Chart</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body style="background:#0d1117; padding: 4rem 1.5rem; min-height: 100vh; display:flex; flex-wrap:wrap; gap:2.5rem; align-items:center; justify-content:center;">
+
+  <div class="ease-progress-ring" data-progress="75" data-color="#6366f1">
+    <svg viewBox="0 0 100 100">
+      <circle class="ease-progress-ring__track" cx="50" cy="50" r="42"/>
+      <circle class="ease-progress-ring__fill" cx="50" cy="50" r="42"/>
+    </svg>
+    <div class="ease-progress-ring__label">75%</div>
+  </div>
+
+  <div class="ease-progress-ring ease-progress-ring--lg"
+       data-progress="90" data-color="#10b981">
+    <svg viewBox="0 0 100 100">
+      <circle class="ease-progress-ring__track" cx="50" cy="50" r="42"/>
+      <circle class="ease-progress-ring__fill" cx="50" cy="50" r="42"/>
+    </svg>
+    <div class="ease-progress-ring__label">90%</div>
+  </div>
+
+  <div class="ease-progress-ring ease-progress-ring--sm"
+       data-progress="42" data-color="#f59e0b">
+    <svg viewBox="0 0 100 100">
+      <circle class="ease-progress-ring__track" cx="50" cy="50" r="42"/>
+      <circle class="ease-progress-ring__fill" cx="50" cy="50" r="42"/>
+    </svg>
+    <div class="ease-progress-ring__label">42%</div>
+  </div>
+
+  <script>
+    const rings = document.querySelectorAll('.ease-progress-ring');
+
+    rings.forEach(ring => {
+      const progress = ring.dataset.progress || 0;
+      const color = ring.dataset.color || '#6366f1';
+      ring.style.setProperty('--progress', progress);
+      const fillCircle = ring.querySelector('.ease-progress-ring__fill');
+      if (fillCircle) fillCircle.style.stroke = color;
+    });
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('animated');
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.4 });
+
+    rings.forEach(ring => observer.observe(ring));
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-progress-ring-aan22/style.css
+++ b/submissions/examples/ease-progress-ring-aan22/style.css
@@ -1,0 +1,41 @@
+.ease-progress-ring {
+  position: relative;
+  width: 120px;
+  height: 120px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.ease-progress-ring--lg { width: 160px; height: 160px; }
+.ease-progress-ring--sm { width: 80px; height: 80px; }
+.ease-progress-ring svg {
+  position: absolute;
+  inset: 0;
+  transform: rotate(-90deg);
+  width: 100%;
+  height: 100%;
+}
+.ease-progress-ring__track {
+  fill: none;
+  stroke: rgba(255,255,255,0.08);
+  stroke-width: 8;
+}
+.ease-progress-ring__fill {
+  fill: none;
+  stroke: #6366f1;
+  stroke-width: 8;
+  stroke-linecap: round;
+  stroke-dasharray: 264;
+  stroke-dashoffset: 264;
+  transition: stroke-dashoffset 1.5s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.ease-progress-ring.animated .ease-progress-ring__fill {
+  stroke-dashoffset: calc(264 - (264 * var(--progress, 75)) / 100);
+}
+.ease-progress-ring__label {
+  position: relative;
+  z-index: 1;
+  font-size: 1.4rem;
+  font-weight: 900;
+  color: #f1f5f9;
+}


### PR DESCRIPTION
Closes #32500

## Pull Request Description
Adds a self-contained, animated circular SVG progress ring component for EaseMotion CSS that fills from 0 to a target percentage when scrolled into view, with a centered label and multiple size variants.

---
## Type of Change
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-progress-ring-aan22/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
Circular SVG progress rings that animate from 0 to their target value when they enter the viewport, with a percentage label in the center, smooth stroke-dashoffset animation, customizable stroke color, and small/default/large size variants.

**How does a developer use it?**
```html
<div class="ease-progress-ring" data-progress="75" data-color="#6366f1">
  <svg viewBox="0 0 100 100">
    <circle class="ease-progress-ring__track" cx="50" cy="50" r="42"/>
    <circle class="ease-progress-ring__fill" cx="50" cy="50" r="42"/>
  </svg>
  <div class="ease-progress-ring__label">75%</div>
</div>
```
Use `ease-progress-ring--sm` / `ease-progress-ring--lg` for size variants. A small amount of vanilla JS (included in `demo.html`) reads `data-progress`/`data-color` and uses an `IntersectionObserver` to trigger the fill animation on scroll-into-view.

**Why does it fit EaseMotion CSS?**
Circular progress indicators are visually impressive and widely used on portfolios and dashboards. This fits EaseMotion's animation-first philosophy — animated rings draw attention to key metrics in a visually compelling way.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser, verified visually)

---
## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---
## Notes for Maintainer
Built from the spec provided in issue #32500. Happy to adjust the fill duration/easing if needed.