### PR TITLE
feat: add focus ring card stack demo

### DIFF
--- a/submissions/examples/focus-ring-card-stack/README.md
+++ b/submissions/examples/focus-ring-card-stack/README.md
@@ -1,0 +1,12 @@
+# Focus Ring Card Stack
+
+A responsive card stack demo that uses hover and keyboard focus states to lift cards, reveal a gradient edge, and show a strong focus ring.
+
+## Files
+
+- `demo.html` contains the feature card stack markup.
+- `style.css` contains the layout, hover transitions, focus-visible styles, and responsive behavior.
+
+## Usage
+
+Open `demo.html` in a browser. Hover the cards or press Tab to move through the links and view the focus animation.

--- a/submissions/examples/focus-ring-card-stack/demo.html
+++ b/submissions/examples/focus-ring-card-stack/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Focus Ring Card Stack</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="stack-page" aria-labelledby="stack-title">
+    <section class="stack-copy">
+      <p class="eyebrow">Keyboard friendly</p>
+      <h1 id="stack-title">Focus ring card stack</h1>
+      <p>Hover or tab through the cards to reveal layered motion, soft shadows, and clear focus treatment.</p>
+    </section>
+
+    <section class="card-stack" aria-label="Product workflow cards">
+      <a class="feature-card" href="#">
+        <span class="card-index">01</span>
+        <h2>Plan sprint</h2>
+        <p>Collect team goals and arrange priority lanes with a light stacked-card motion.</p>
+      </a>
+
+      <a class="feature-card" href="#">
+        <span class="card-index">02</span>
+        <h2>Review signals</h2>
+        <p>Surface activity, blockers, and feedback with a bright focus ring for keyboard users.</p>
+      </a>
+
+      <a class="feature-card" href="#">
+        <span class="card-index">03</span>
+        <h2>Ship update</h2>
+        <p>Publish a concise status card that lifts forward without moving neighboring content.</p>
+      </a>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/focus-ring-card-stack/style.css
+++ b/submissions/examples/focus-ring-card-stack/style.css
@@ -1,0 +1,209 @@
+:root {
+  --page: #eef4f2;
+  --ink: #17212b;
+  --muted: #5d6978;
+  --surface: #ffffff;
+  --blue: #2563eb;
+  --teal: #0f766e;
+  --coral: #ef6f5e;
+  --shadow: rgba(23, 33, 43, 0.14);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background:
+    linear-gradient(120deg, rgba(37, 99, 235, 0.13), transparent 42%),
+    linear-gradient(300deg, rgba(239, 111, 94, 0.16), transparent 36%),
+    var(--page);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.stack-page {
+  width: min(1080px, calc(100% - 32px));
+  display: grid;
+  grid-template-columns: minmax(260px, 0.85fr) minmax(320px, 1.15fr);
+  gap: 42px;
+  align-items: center;
+  padding: 48px 0;
+}
+
+.stack-copy {
+  max-width: 460px;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--teal);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 18px;
+  font-size: clamp(2.2rem, 5vw, 4rem);
+  line-height: 0.98;
+}
+
+.stack-copy p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.06rem;
+  line-height: 1.65;
+}
+
+.card-stack {
+  position: relative;
+  display: grid;
+  gap: 18px;
+}
+
+.feature-card {
+  position: relative;
+  isolation: isolate;
+  min-height: 156px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 22px;
+  align-items: start;
+  padding: 26px;
+  overflow: hidden;
+  border: 1px solid rgba(23, 33, 43, 0.12);
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.88);
+  color: inherit;
+  text-decoration: none;
+  box-shadow: 0 18px 42px var(--shadow);
+  transform: translateX(calc(var(--shift, 0) * 1px));
+  transition:
+    transform 240ms ease,
+    box-shadow 240ms ease,
+    border-color 240ms ease,
+    background 240ms ease;
+}
+
+.feature-card:nth-child(1) {
+  --shift: -16;
+}
+
+.feature-card:nth-child(2) {
+  --shift: 8;
+}
+
+.feature-card:nth-child(3) {
+  --shift: -4;
+}
+
+.feature-card::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 7px;
+  background: linear-gradient(180deg, var(--blue), var(--teal), var(--coral));
+  transform: scaleY(0.38);
+  transform-origin: top;
+  transition: transform 240ms ease;
+  z-index: -1;
+}
+
+.feature-card::after {
+  content: "";
+  position: absolute;
+  right: 24px;
+  bottom: 22px;
+  width: 72px;
+  height: 72px;
+  border: 1px solid rgba(37, 99, 235, 0.18);
+  border-radius: 50%;
+  transform: scale(0.72);
+  opacity: 0;
+  transition: opacity 240ms ease, transform 240ms ease;
+  z-index: -1;
+}
+
+.feature-card:hover,
+.feature-card:focus-visible {
+  transform: translateX(0) translateY(-8px);
+  border-color: rgba(37, 99, 235, 0.45);
+  background: #ffffff;
+  box-shadow: 0 28px 60px rgba(37, 99, 235, 0.18);
+}
+
+.feature-card:hover::before,
+.feature-card:focus-visible::before {
+  transform: scaleY(1);
+}
+
+.feature-card:hover::after,
+.feature-card:focus-visible::after {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.feature-card:focus-visible {
+  outline: 4px solid rgba(239, 111, 94, 0.42);
+  outline-offset: 5px;
+}
+
+.card-index {
+  display: grid;
+  width: 48px;
+  height: 48px;
+  place-items: center;
+  border-radius: 15px;
+  background: #17212b;
+  color: #ffffff;
+  font-weight: 900;
+}
+
+h2 {
+  margin-bottom: 8px;
+  font-size: 1.35rem;
+}
+
+.feature-card p {
+  margin-bottom: 0;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+@media (max-width: 820px) {
+  .stack-page {
+    grid-template-columns: 1fr;
+    gap: 28px;
+  }
+
+  .stack-copy {
+    max-width: none;
+    text-align: center;
+  }
+
+  .feature-card,
+  .feature-card:nth-child(1),
+  .feature-card:nth-child(2),
+  .feature-card:nth-child(3) {
+    transform: none;
+  }
+}
+
+@media (max-width: 520px) {
+  .feature-card {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a keyboard-friendly focus ring card stack demo
- include hover lift, gradient edge reveal, and responsive layout
- document files and browser usage

## Testing
- git diff --cached --check