### PR TITLE
feat: add wobble-focus glass tooltip (wobble-tooltip-vn)

### DIFF
--- a/submissions/examples/wobble-tooltip-vn/README.md
+++ b/submissions/examples/wobble-tooltip-vn/README.md
@@ -1,0 +1,71 @@
+# Wobble-Focus Glass Tooltip
+
+**Submission ID:** `wobble-tooltip-vn`
+**Track:** Standard (HTML/CSS) — `submissions/examples/`
+
+## What does this do?
+A pure-CSS, zero-JavaScript tooltip that appears on hover or keyboard
+focus with a springy "wobble-focus" transition (a slight overshoot in
+scale and rotation before settling), rendered with a glassmorphism
+surface (blur, translucency, soft border) on top of any background.
+
+## How is it used?
+Wrap a trigger element and a `role="tooltip"` element together, and
+link them with `aria-describedby` for accessibility:
+
+```html
+<div class="tooltip-wrap">
+  <button class="tooltip-trigger" aria-describedby="tt-1">
+    Hover / Focus me
+  </button>
+  <span class="tooltip-bubble" role="tooltip" id="tt-1">
+    Helpful tooltip text
+  </span>
+</div>
+```
+
+Add `.tooltip-bottom`, `.tooltip-left`, or `.tooltip-right` on the
+`.tooltip-bubble` element to change which side it appears on
+(default is top). All animation parameters are exposed as CSS custom
+properties and can be overridden per-instance:
+
+```html
+<div class="tooltip-wrap"
+     style="--tooltip-duration: 1.1s;
+            --tooltip-easing: cubic-bezier(0.2, 2.6, 0.4, 1);
+            --tooltip-scale-start: 0.5;
+            --tooltip-wobble-rotate: 10deg;">
+  ...
+</div>
+```
+
+Available custom properties: `--tooltip-duration`, `--tooltip-delay`,
+`--tooltip-easing`, `--tooltip-scale-start`, `--tooltip-scale-end`,
+`--tooltip-offset`, `--tooltip-wobble-rotate`, `--tooltip-bg`,
+`--tooltip-border`, `--tooltip-text`, `--tooltip-blur`,
+`--tooltip-radius`, `--tooltip-shadow`.
+
+## Why is it useful?
+EaseMotion CSS is about expressive, zero-JS animation states, and
+tooltips are one of the most commonly reused UI primitives. This
+component:
+
+- Ships with **no JavaScript** — visibility is driven entirely by
+  `:hover` / `:focus-visible` and the adjacent-sibling combinator.
+- Is **keyboard accessible**: it responds to `:focus-visible`, uses
+  `role="tooltip"` + `aria-describedby`, and keeps a visible focus
+  ring as a fallback.
+- Respects `prefers-reduced-motion` by dropping the scale/rotation
+  wobble and keeping a plain fade.
+- Is fully **parameterized** via CSS custom properties, so consumers
+  can retheme timing, easing, scale, and glass appearance without
+  touching the source rules — fitting EaseMotion's philosophy of
+  configurable, composable motion primitives.
+
+## Notes for the maintainer
+- Class names are left as-is (`tooltip-wrap`, `tooltip-trigger`,
+  `tooltip-bubble`, `tooltip-bottom/left/right`) per the "contributors
+  don't need to pre-standardize" guidance — happy to have these
+  renamed to `ease-*` during integration.
+- `demo.html` is self-contained and opens directly in a browser with
+  no build step, server, or CDN dependency.

--- a/submissions/examples/wobble-tooltip-vn/demo.html
+++ b/submissions/examples/wobble-tooltip-vn/demo.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Wobble-Focus Glass Tooltip — EaseMotion CSS Submission</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body class="demo-page">
+
+  <div class="controls-panel">
+    <h2>Wobble-Focus Tooltip</h2>
+    <p>Hover or Tab to each button. All timing/scale values are CSS
+    custom properties — try overriding <code>--tooltip-duration</code>,
+    <code>--tooltip-easing</code>, <code>--tooltip-scale-start</code>,
+    or <code>--tooltip-wobble-rotate</code>.</p>
+  </div>
+
+  <!-- Default: tooltip above trigger -->
+  <div class="tooltip-wrap">
+    <button class="tooltip-trigger" aria-describedby="tt-top">
+      Hover / Focus me (top)
+    </button>
+    <span class="tooltip-bubble" role="tooltip" id="tt-top">
+      Default wobble-focus, positioned above.
+    </span>
+  </div>
+
+  <!-- Bottom variant -->
+  <div class="tooltip-wrap">
+    <button class="tooltip-trigger" aria-describedby="tt-bottom">
+      Bottom tooltip
+    </button>
+    <span class="tooltip-bubble tooltip-bottom" role="tooltip" id="tt-bottom">
+      Tooltip anchored below the trigger.
+    </span>
+  </div>
+
+  <!-- Left variant -->
+  <div class="tooltip-wrap">
+    <button class="tooltip-trigger" aria-describedby="tt-left">
+      Left tooltip
+    </button>
+    <span class="tooltip-bubble tooltip-left" role="tooltip" id="tt-left">
+      Tooltip anchored to the left.
+    </span>
+  </div>
+
+  <!-- Right variant -->
+  <div class="tooltip-wrap">
+    <button class="tooltip-trigger" aria-describedby="tt-right">
+      Right tooltip
+    </button>
+    <span class="tooltip-bubble tooltip-right" role="tooltip" id="tt-right">
+      Tooltip anchored to the right.
+    </span>
+  </div>
+
+  <!-- Custom-property override example: slower, more exaggerated wobble -->
+  <div class="tooltip-wrap"
+       style="--tooltip-duration: 1.1s;
+              --tooltip-easing: cubic-bezier(0.2, 2.6, 0.4, 1);
+              --tooltip-scale-start: 0.5;
+              --tooltip-wobble-rotate: 10deg;">
+    <button class="tooltip-trigger" aria-describedby="tt-exaggerated">
+      Exaggerated wobble
+    </button>
+    <span class="tooltip-bubble" role="tooltip" id="tt-exaggerated">
+      Same component, tuned via custom properties only.
+    </span>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/wobble-tooltip-vn/style.css
+++ b/submissions/examples/wobble-tooltip-vn/style.css
@@ -1,0 +1,251 @@
+/* =========================================================
+   Wobble-Focus Glass Tooltip
+   Pure CSS, zero JavaScript, keyboard accessible.
+   Rename classes to ease-* is handled by the maintainer.
+   ========================================================= */
+
+:root {
+  /* Exposed custom properties — override per-instance via inline style
+     or a scoped selector, e.g. .tooltip-wrap { --tooltip-duration: 1s; } */
+  --tooltip-duration: 0.55s;
+  --tooltip-delay: 0s;
+  --tooltip-easing: cubic-bezier(0.34, 1.9, 0.64, 1);
+  --tooltip-scale-start: 0.75;
+  --tooltip-scale-end: 1;
+  --tooltip-offset: 10px;
+  --tooltip-wobble-rotate: 4deg;
+
+  --tooltip-bg: rgba(255, 255, 255, 0.14);
+  --tooltip-border: rgba(255, 255, 255, 0.35);
+  --tooltip-text: #f5f6ff;
+  --tooltip-blur: 14px;
+  --tooltip-radius: 10px;
+  --tooltip-shadow: 0 8px 32px rgba(0, 0, 0, 0.28);
+}
+
+.tooltip-wrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.tooltip-trigger {
+  font: inherit;
+  color: inherit;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 8px;
+  padding: 0.6em 1.1em;
+  cursor: pointer;
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.tooltip-trigger:hover,
+.tooltip-trigger:focus-visible {
+  background: rgba(255, 255, 255, 0.16);
+}
+
+/* Outline handled by the tooltip's own visual feedback; keep a subtle
+   fallback ring for non-tooltip contexts / high-contrast mode. */
+.tooltip-trigger:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.6);
+  outline-offset: 2px;
+}
+
+.tooltip-bubble {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + var(--tooltip-offset));
+  transform: translate(-50%, 6px) scale(var(--tooltip-scale-start))
+    rotate(calc(var(--tooltip-wobble-rotate) * -1));
+  transform-origin: bottom center;
+
+  padding: 0.5em 0.9em;
+  min-width: max-content;
+  max-width: 220px;
+
+  color: var(--tooltip-text);
+  font-size: 0.85rem;
+  line-height: 1.35;
+  text-align: center;
+
+  background: var(--tooltip-bg);
+  border: 1px solid var(--tooltip-border);
+  border-radius: var(--tooltip-radius);
+  box-shadow: var(--tooltip-shadow);
+  backdrop-filter: blur(var(--tooltip-blur)) saturate(140%);
+  -webkit-backdrop-filter: blur(var(--tooltip-blur)) saturate(140%);
+
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+
+  transition:
+    opacity var(--tooltip-duration) var(--tooltip-easing) var(--tooltip-delay),
+    transform var(--tooltip-duration) var(--tooltip-easing) var(--tooltip-delay),
+    visibility 0s linear var(--tooltip-duration);
+  z-index: 20;
+}
+
+.tooltip-bubble::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  translate: -50% 0;
+  width: 10px;
+  height: 10px;
+  background: inherit;
+  border-right: 1px solid var(--tooltip-border);
+  border-bottom: 1px solid var(--tooltip-border);
+  clip-path: polygon(0 0, 100% 0, 0 100%);
+}
+
+/* Wobble-Focus: on hover / keyboard focus the tooltip springs in,
+   overshoots slightly (the "wobble"), then settles at full scale. */
+.tooltip-trigger:hover + .tooltip-bubble,
+.tooltip-trigger:focus-visible + .tooltip-bubble {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translate(-50%, 0) scale(var(--tooltip-scale-end)) rotate(0deg);
+  transition:
+    opacity var(--tooltip-duration) var(--tooltip-easing) var(--tooltip-delay),
+    transform var(--tooltip-duration) var(--tooltip-easing) var(--tooltip-delay),
+    visibility 0s linear;
+}
+
+/* Directional variants: flip the bubble to sit below, left, or right
+   of the trigger. Apply alongside .tooltip-bubble. */
+.tooltip-bottom {
+  bottom: auto;
+  top: calc(100% + var(--tooltip-offset));
+  transform: translate(-50%, -6px) scale(var(--tooltip-scale-start))
+    rotate(var(--tooltip-wobble-rotate));
+  transform-origin: top center;
+}
+.tooltip-bottom::after {
+  top: auto;
+  bottom: 100%;
+  border: none;
+  border-left: 1px solid var(--tooltip-border);
+  border-top: 1px solid var(--tooltip-border);
+  clip-path: polygon(0 100%, 100% 100%, 0 0);
+}
+.tooltip-trigger:hover + .tooltip-bottom,
+.tooltip-trigger:focus-visible + .tooltip-bottom {
+  transform: translate(-50%, 0) scale(var(--tooltip-scale-end)) rotate(0deg);
+}
+
+.tooltip-left {
+  left: auto;
+  right: calc(100% + var(--tooltip-offset));
+  bottom: 50%;
+  transform: translate(6px, 50%) scale(var(--tooltip-scale-start))
+    rotate(calc(var(--tooltip-wobble-rotate) * -1));
+  transform-origin: center right;
+}
+.tooltip-left::after {
+  top: 50%;
+  left: 100%;
+  translate: 0 -50%;
+  border: none;
+  border-top: 1px solid var(--tooltip-border);
+  border-right: 1px solid var(--tooltip-border);
+  clip-path: polygon(0 0, 100% 0, 100% 100%);
+}
+.tooltip-trigger:hover + .tooltip-left,
+.tooltip-trigger:focus-visible + .tooltip-left {
+  transform: translate(0, 50%) scale(var(--tooltip-scale-end)) rotate(0deg);
+}
+
+.tooltip-right {
+  left: calc(100% + var(--tooltip-offset));
+  bottom: 50%;
+  transform: translate(-6px, 50%) scale(var(--tooltip-scale-start))
+    rotate(var(--tooltip-wobble-rotate));
+  transform-origin: center left;
+}
+.tooltip-right::after {
+  top: 50%;
+  right: 100%;
+  translate: 0 -50%;
+  border: none;
+  border-bottom: 1px solid var(--tooltip-border);
+  border-left: 1px solid var(--tooltip-border);
+  clip-path: polygon(0 0, 100% 100%, 0 100%);
+}
+.tooltip-trigger:hover + .tooltip-right,
+.tooltip-trigger:focus-visible + .tooltip-right {
+  transform: translate(0, 50%) scale(var(--tooltip-scale-end)) rotate(0deg);
+}
+
+/* Respect users who've asked for reduced motion: keep the fade,
+   drop the wobble/scale/rotate entirely. */
+@media (prefers-reduced-motion: reduce) {
+  .tooltip-bubble,
+  .tooltip-bottom,
+  .tooltip-left,
+  .tooltip-right,
+  .tooltip-trigger:hover + .tooltip-bubble,
+  .tooltip-trigger:focus-visible + .tooltip-bubble,
+  .tooltip-trigger:hover + .tooltip-bottom,
+  .tooltip-trigger:focus-visible + .tooltip-bottom,
+  .tooltip-trigger:hover + .tooltip-left,
+  .tooltip-trigger:focus-visible + .tooltip-left,
+  .tooltip-trigger:hover + .tooltip-right,
+  .tooltip-trigger:focus-visible + .tooltip-right {
+    transform: none;
+    transition: opacity 0.15s linear, visibility 0s linear;
+  }
+}
+
+/* ---- Demo page scaffolding (not part of the component itself) ---- */
+body.demo-page {
+  min-height: 100vh;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-content: center;
+  justify-content: center;
+  gap: 4rem;
+  padding: 4rem 2rem;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #fff;
+  background: radial-gradient(circle at 20% 20%, #3a1c71, #16053b 60%),
+    radial-gradient(circle at 80% 80%, #6a3093 0%, transparent 55%);
+  background-blend-mode: screen;
+}
+
+.demo-caption {
+  position: absolute;
+  bottom: -1.6rem;
+  left: 50%;
+  translate: -50% 0;
+  font-size: 0.75rem;
+  opacity: 0.6;
+  white-space: nowrap;
+}
+
+.controls-panel {
+  position: fixed;
+  top: 1.5rem;
+  left: 1.5rem;
+  padding: 1rem 1.2rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 10px;
+  backdrop-filter: blur(10px);
+  font-size: 0.8rem;
+  max-width: 240px;
+}
+.controls-panel h2 {
+  margin: 0 0 0.5rem;
+  font-size: 0.9rem;
+}
+.controls-panel code {
+  background: rgba(0, 0, 0, 0.3);
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure-CSS "wobble-focus" tooltip with a glassmorphism surface — no JavaScript required. The tooltip springs in with a slight scale/rotation overshoot on hover or keyboard focus, then settles, and exposes its timing/easing/scale as CSS custom properties for easy retheming.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/wobble-tooltip-vn/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A zero-JS tooltip that appears on hover/focus with a springy wobble-scale-rotate entrance, styled with a glassmorphism (blurred, translucent) surface, and positionable on any of four sides.

**How does a developer use it?**
```html
<div class="tooltip-wrap">
  <button class="tooltip-trigger" aria-describedby="tt-1">
    Hover / Focus me
  </button>
  <span class="tooltip-bubble" role="tooltip" id="tt-1">
    Helpful tooltip text
  </span>
</div>
```
Add `.tooltip-bottom`, `.tooltip-left`, or `.tooltip-right` on `.tooltip-bubble` to change placement (default is top). Override `--tooltip-duration`, `--tooltip-easing`, `--tooltip-scale-start`, `--tooltip-wobble-rotate`, etc. per instance via inline style or a scoped selector.

**Why does it fit EaseMotion CSS?**
It's a common UI primitive delivered with zero JavaScript overhead, fully driven by `:hover`/`:focus-visible` and CSS custom properties — in line with EaseMotion's animation-first, configurable-by-default philosophy. It's also keyboard accessible (`:focus-visible`, `role="tooltip"`, `aria-describedby`) and respects `prefers-reduced-motion`.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Class names (`tooltip-wrap`, `tooltip-trigger`, `tooltip-bubble`, `tooltip-bottom/left/right`) are left unstandardized per the contributor guidelines — happy to have these renamed to `ease-*` during integration. Also included a `prefers-reduced-motion` fallback that drops the scale/rotate wobble and keeps a plain fade, in case that's useful to carry into the standardized version.