### PR TITLE
feat: add minimalist tech swing-hover tooltip (#34426)

### DIFF
--- a/submissions/examples/swing-hover-tooltip-minimal-tech/README.md
+++ b/submissions/examples/swing-hover-tooltip-minimal-tech/README.md
@@ -1,0 +1,66 @@
+# Swing-Hover Tooltip — Minimalist Tech
+
+A pure CSS tooltip with a spring-like "swing" entrance animation, styled
+with a clean minimalist tech aesthetic (light background, subtle borders,
+blue accent). Triggered on hover and keyboard focus. Zero JavaScript.
+
+## Features
+
+- 🎯 Pure CSS — no JavaScript required
+- ⌨️ Keyboard accessible via `:focus-visible`
+- 🔄 Four placement variants: top, bottom, left, right
+- 🎛️ Customizable timing, easing, scale, offset via CSS variables
+- 🎨 Clean minimalist styling with subtle shadows and a single blue accent
+- 📱 Fully responsive
+- 🌀 Respects `prefers-reduced-motion`
+
+## Usage
+
+```html
+<div class="tooltip-wrap">
+  <button class="tt-trigger" aria-describedby="tt-1">Hover me</button>
+  <span class="tt-bubble tt-bubble--top" id="tt-1" role="tooltip">
+    Tooltip text here
+  </span>
+</div>
+```
+
+Swap `tt-bubble--top` for `tt-bubble--bottom`, `tt-bubble--left`, or
+`tt-bubble--right` to change placement.
+
+## Customization
+
+| Variable | Default | Description |
+|---|---|---|
+| `--tt-duration` | `0.3s` | Animation duration |
+| `--tt-easing` | `cubic-bezier(0.34, 1.56, 0.64, 1)` | Springy swing easing |
+| `--tt-scale` | `0.9` | Starting scale before swing-in |
+| `--tt-swing-angle` | `14deg` | Rotation angle of the swing |
+| `--tt-offset` | `10px` | Gap between trigger and tooltip |
+| `--tt-bg` | `#1a1a1a` | Tooltip background color |
+| `--tt-color` | `#fafafa` | Tooltip text color |
+| `--tt-accent` | `#3b82f6` | Accent color used on trigger/focus states |
+
+Example override for a single tooltip:
+
+```css
+.tt-bubble--custom {
+  --tt-duration: 0.5s;
+  --tt-scale: 0.65;
+  --tt-swing-angle: 26deg;
+}
+```
+
+## Accessibility
+
+- Revealed on both `:hover` and `:focus-visible`, so keyboard users get the
+  same experience as mouse users.
+- Each trigger uses `aria-describedby` pointing to the tooltip's `id`.
+- Tooltip element uses `role="tooltip"`.
+- Animation disabled for users with `prefers-reduced-motion: reduce`.
+
+## Files
+
+- `demo.html` — showcase with all four placements plus a custom-timing example
+- `style.css` — component styles and animation logic
+- `README.md` — this file

--- a/submissions/examples/swing-hover-tooltip-minimal-tech/demo.html
+++ b/submissions/examples/swing-hover-tooltip-minimal-tech/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Swing-Hover Tooltip | Minimalist Tech | EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="page">
+    <h1 class="page__title">Swing-Hover Tooltip</h1>
+    <p class="page__subtitle">Minimalist Tech · Pure CSS · Zero JavaScript</p>
+
+    <section class="showcase">
+
+      <div class="tooltip-wrap">
+        <button class="tt-trigger" aria-describedby="tt-top">
+          Top
+        </button>
+        <span class="tt-bubble tt-bubble--top" id="tt-top" role="tooltip">
+          Swing-hover from the top
+        </span>
+      </div>
+
+      <div class="tooltip-wrap">
+        <button class="tt-trigger" aria-describedby="tt-bottom">
+          Bottom
+        </button>
+        <span class="tt-bubble tt-bubble--bottom" id="tt-bottom" role="tooltip">
+          Swings in from below
+        </span>
+      </div>
+
+      <div class="tooltip-wrap">
+        <button class="tt-trigger" aria-describedby="tt-left">
+          Left
+        </button>
+        <span class="tt-bubble tt-bubble--left" id="tt-left" role="tooltip">
+          Swings from the left
+        </span>
+      </div>
+
+      <div class="tooltip-wrap">
+        <button class="tt-trigger" aria-describedby="tt-right">
+          Right
+        </button>
+        <span class="tt-bubble tt-bubble--right" id="tt-right" role="tooltip">
+          Swings in from the right
+        </span>
+      </div>
+
+      <div class="tooltip-wrap">
+        <button class="tt-trigger tt-trigger--alt" aria-describedby="tt-custom">
+          Custom Timing
+        </button>
+        <span class="tt-bubble tt-bubble--top tt-bubble--custom" id="tt-custom" role="tooltip">
+          Configured via --tt-duration, --tt-easing, --tt-scale
+        </span>
+      </div>
+
+      <p class="showcase__text">
+        This paragraph contains an inline
+        <span class="tooltip-wrap tooltip-wrap--inline">
+          <a href="#" class="tt-trigger tt-trigger--link" aria-describedby="tt-inline">reference term</a>
+          <span class="tt-bubble tt-bubble--top" id="tt-inline" role="tooltip">
+            Inline swing-hover tooltip example
+          </span>
+        </span>
+        to demonstrate usage within text.
+      </p>
+
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/swing-hover-tooltip-minimal-tech/style.css
+++ b/submissions/examples/swing-hover-tooltip-minimal-tech/style.css
@@ -1,0 +1,295 @@
+/* ==========================================================================
+   Swing-Hover Tooltip — Minimalist Tech variant — EaseMotion CSS
+   Pure CSS, keyboard accessible, customizable via CSS custom properties
+   ========================================================================== */
+
+:root {
+  --tt-duration: 0.3s;
+  --tt-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --tt-scale: 0.9;
+  --tt-swing-angle: 14deg;
+  --tt-offset: 10px;
+  --tt-bg: #1a1a1a;
+  --tt-color: #fafafa;
+  --tt-accent: #3b82f6;
+  --tt-border: #e4e4e7;
+  --tt-radius: 4px;
+  --tt-font-size: 0.82rem;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
+  background: #fafafa;
+  color: #18181b;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 20px;
+}
+
+.page {
+  width: 100%;
+  max-width: 880px;
+  text-align: center;
+}
+
+.page__title {
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  margin-bottom: 4px;
+  color: #09090b;
+}
+
+.page__subtitle {
+  color: #71717a;
+  margin-bottom: 48px;
+  font-size: 0.9rem;
+}
+
+.showcase {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 44px 28px;
+  justify-content: center;
+  align-items: center;
+  padding: 40px 16px;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Trigger element                                                        */
+/* ---------------------------------------------------------------------- */
+
+.tooltip-wrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.tooltip-wrap--inline {
+  display: inline;
+}
+
+.tt-trigger {
+  font-family: inherit;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #18181b;
+  background: #ffffff;
+  border: 1px solid var(--tt-border);
+  border-radius: var(--tt-radius);
+  padding: 11px 18px;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tt-trigger:hover,
+.tt-trigger:focus-visible {
+  transform: translateY(-1px);
+  border-color: var(--tt-accent);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.tt-trigger:focus-visible {
+  outline: 2px solid var(--tt-accent);
+  outline-offset: 2px;
+}
+
+.tt-trigger--alt {
+  border-color: var(--tt-accent);
+}
+
+.tt-trigger--link {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--tt-accent);
+  text-decoration: underline dotted;
+  box-shadow: none;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Tooltip bubble                                                         */
+/* ---------------------------------------------------------------------- */
+
+.tt-bubble {
+  position: absolute;
+  z-index: 20;
+  left: 50%;
+  white-space: nowrap;
+  padding: 7px 12px;
+  font-size: var(--tt-font-size);
+  font-weight: 500;
+  color: var(--tt-color);
+  background: var(--tt-bg);
+  border-radius: var(--tt-radius);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.16);
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+
+  bottom: calc(100% + var(--tt-offset));
+  transform: translateX(-50%) translateY(6px) scale(var(--tt-scale)) rotate(var(--tt-swing-angle));
+  transform-origin: bottom center;
+
+  transition:
+    opacity var(--tt-duration) var(--tt-easing),
+    transform var(--tt-duration) var(--tt-easing),
+    visibility 0s linear var(--tt-duration);
+}
+
+.tt-bubble::after {
+  content: "";
+  position: absolute;
+  border: 5px solid transparent;
+}
+
+/* ---- Top variant (default) ---- */
+.tt-bubble--top::after {
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-top-color: var(--tt-bg);
+}
+
+/* ---- Bottom variant ---- */
+.tt-bubble--bottom {
+  bottom: auto;
+  top: calc(100% + var(--tt-offset));
+  transform: translateX(-50%) translateY(-6px) scale(var(--tt-scale)) rotate(calc(-1 * var(--tt-swing-angle)));
+  transform-origin: top center;
+}
+.tt-bubble--bottom::after {
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-bottom-color: var(--tt-bg);
+}
+
+/* ---- Left variant ---- */
+.tt-bubble--left {
+  left: auto;
+  right: calc(100% + var(--tt-offset));
+  bottom: auto;
+  top: 50%;
+  transform: translateY(-50%) translateX(6px) scale(var(--tt-scale)) rotate(calc(-1 * var(--tt-swing-angle)));
+  transform-origin: right center;
+}
+.tt-bubble--left::after {
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  border-left-color: var(--tt-bg);
+}
+
+/* ---- Right variant ---- */
+.tt-bubble--right {
+  left: calc(100% + var(--tt-offset));
+  bottom: auto;
+  top: 50%;
+  transform: translateY(-50%) translateX(-6px) scale(var(--tt-scale)) rotate(var(--tt-swing-angle));
+  transform-origin: left center;
+}
+.tt-bubble--right::after {
+  right: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  border-right-color: var(--tt-bg);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Reveal states — hover AND keyboard focus                               */
+/* ---------------------------------------------------------------------- */
+
+.tooltip-wrap:hover .tt-bubble,
+.tt-trigger:focus-visible + .tt-bubble,
+.tt-trigger:focus-visible ~ .tt-bubble {
+  opacity: 1;
+  visibility: visible;
+  transition:
+    opacity var(--tt-duration) var(--tt-easing),
+    transform var(--tt-duration) var(--tt-easing),
+    visibility 0s linear 0s;
+}
+
+.tooltip-wrap:hover .tt-bubble--top,
+.tt-trigger:focus-visible + .tt-bubble--top {
+  transform: translateX(-50%) translateY(0) scale(1) rotate(0deg);
+}
+
+.tooltip-wrap:hover .tt-bubble--bottom,
+.tt-trigger:focus-visible + .tt-bubble--bottom {
+  transform: translateX(-50%) translateY(0) scale(1) rotate(0deg);
+}
+
+.tooltip-wrap:hover .tt-bubble--left,
+.tt-trigger:focus-visible + .tt-bubble--left {
+  transform: translateY(-50%) translateX(0) scale(1) rotate(0deg);
+}
+
+.tooltip-wrap:hover .tt-bubble--right,
+.tt-trigger:focus-visible + .tt-bubble--right {
+  transform: translateY(-50%) translateX(0) scale(1) rotate(0deg);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Custom timing / scale demo (overrides via CSS custom properties)       */
+/* ---------------------------------------------------------------------- */
+
+.tt-bubble--custom {
+  --tt-duration: 0.5s;
+  --tt-easing: cubic-bezier(0.68, -0.55, 0.27, 1.55);
+  --tt-scale: 0.65;
+  --tt-swing-angle: 26deg;
+  background: var(--tt-accent);
+  color: #ffffff;
+  font-weight: 600;
+}
+.tt-bubble--custom::after {
+  border-top-color: var(--tt-accent);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Inline text paragraph                                                  */
+/* ---------------------------------------------------------------------- */
+
+.showcase__text {
+  flex-basis: 100%;
+  max-width: 540px;
+  margin: 24px auto 0;
+  color: #52525b;
+  line-height: 1.7;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Reduced motion                                                         */
+/* ---------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .tt-bubble {
+    transition: opacity 0.15s linear, visibility 0s linear 0.15s;
+    transform: translateX(-50%) !important;
+  }
+  .tooltip-wrap:hover .tt-bubble,
+  .tt-trigger:focus-visible + .tt-bubble {
+    transition: opacity 0.15s linear, visibility 0s linear 0s;
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+/* Responsive                                                             */
+/* ---------------------------------------------------------------------- */
+
+@media (max-width: 600px) {
+  .showcase {
+    gap: 32px 18px;
+  }
+  .tt-bubble {
+    white-space: normal;
+    max-width: 170px;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Description
Adds a pure CSS animated tooltip component using a smooth spring-based
"swing-hover" transition, styled with a Minimalist Tech aesthetic (light
background, subtle borders, single blue accent, clean sans-serif type).

Closes #34426

## What's included
- `submissions/examples/swing-hover-tooltip-minimal-tech/demo.html`
- `submissions/examples/swing-hover-tooltip-minimal-tech/style.css`
- `submissions/examples/swing-hover-tooltip-minimal-tech/README.md`

## Features
- Pure CSS, zero JavaScript
- Keyboard accessible (`:focus-visible`, `aria-describedby`, `role="tooltip"`)
- Four placement variants: top, bottom, left, right
- Fully customizable via CSS custom properties (`--tt-duration`,
  `--tt-easing`, `--tt-scale`, `--tt-swing-angle`, `--tt-offset`)
- Includes a custom timing/scale demo showing how consumers can override
  the defaults per-instance
- Responsive layout, tested down to mobile widths
- Respects `prefers-reduced-motion`

## Screenshots / Demo
_(Add a screenshot or short GIF of the tooltip swinging in on hover before submitting.)_

## Testing done
- Verified hover interaction on desktop (Chrome/Firefox/Edge)
- Verified keyboard-only navigation (Tab to trigger → tooltip appears,
  Tab away → tooltip hides)
- Verified all four placement variants render correctly
- Verified `prefers-reduced-motion` fallback disables the swing
- Verified responsive behavior at narrow viewports

## Checklist
- [x] Files added only inside `submissions/`
- [x] Folder includes `demo.html`, `style.css`, `README.md`
- [x] No existing issue/PR duplicates this
- [x] Read `CONTRIBUTING.md`

## Note for maintainer
This is one of three near-identical "swing-hover tooltip" issues
(#34426, #34427, #34432) opened in quick succession with different theme
variants. Flagging in case you'd prefer these consolidated into a single
themeable component rather than three separate example folders.