### PR TITLE
feat: add SaaS showcase swing-hover tooltip (#34424)

### DIFF
--- a/submissions/examples/swing-hover-tooltip-saas/README.md
+++ b/submissions/examples/swing-hover-tooltip-saas/README.md
@@ -1,0 +1,80 @@
+# Swing-Hover Tooltip — SaaS Showcase
+
+A pure CSS tooltip with a spring-like "swing" entrance animation, styled
+for a modern SaaS product UI (clean white card surfaces, indigo accent,
+pricing/feature-list context). Triggered on hover and keyboard focus.
+Zero JavaScript.
+
+## Features
+
+- 🎯 Pure CSS — no JavaScript required
+- ⌨️ Keyboard accessible via `:focus-visible`
+- 🔄 Four placement variants: top, bottom, left, right
+- 🎛️ Customizable timing, easing, scale, offset via CSS variables
+- 💼 Includes a realistic SaaS feature-list usage example (checkmark icons
+  with tooltips), not just isolated buttons
+- 📱 Fully responsive
+- 🌀 Respects `prefers-reduced-motion`
+
+## Usage
+
+```html
+<div class="tooltip-wrap">
+  <button class="tt-trigger" aria-describedby="tt-1">Hover me</button>
+  <span class="tt-bubble tt-bubble--top" id="tt-1" role="tooltip">
+    Tooltip text here
+  </span>
+</div>
+```
+
+Swap `tt-bubble--top` for `tt-bubble--bottom`, `tt-bubble--left`, or
+`tt-bubble--right` to change placement.
+
+### Feature-list pattern
+
+```html
+<span class="tooltip-wrap">
+  <button class="feature-icon" aria-describedby="tt-feature-1">✓</button>
+  <span class="tt-bubble tt-bubble--top" id="tt-feature-1" role="tooltip">
+    Explanation of the feature
+  </span>
+</span>
+Feature name
+```
+
+## Customization
+
+| Variable | Default | Description |
+|---|---|---|
+| `--tt-duration` | `0.32s` | Animation duration |
+| `--tt-easing` | `cubic-bezier(0.34, 1.56, 0.64, 1)` | Springy swing easing |
+| `--tt-scale` | `0.88` | Starting scale before swing-in |
+| `--tt-swing-angle` | `15deg` | Rotation angle of the swing |
+| `--tt-offset` | `10px` | Gap between trigger and tooltip |
+| `--tt-bg` | `#0f172a` | Tooltip background color |
+| `--tt-accent` | `#6366f1` | Primary indigo accent used on triggers |
+
+Example override for a single tooltip:
+
+```css
+.tt-bubble--custom {
+  --tt-duration: 0.5s;
+  --tt-scale: 0.6;
+  --tt-swing-angle: 28deg;
+}
+```
+
+## Accessibility
+
+- Revealed on both `:hover` and `:focus-visible`, so keyboard users get the
+  same experience as mouse users.
+- Each trigger uses `aria-describedby` pointing to the tooltip's `id`.
+- Tooltip element uses `role="tooltip"`.
+- Animation disabled for users with `prefers-reduced-motion: reduce`.
+
+## Files
+
+- `demo.html` — showcase with all four placements, a primary CTA example,
+  and a SaaS feature-list usage pattern
+- `style.css` — component styles and animation logic
+- `README.md` — this file

--- a/submissions/examples/swing-hover-tooltip-saas/demo.html
+++ b/submissions/examples/swing-hover-tooltip-saas/demo.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Swing-Hover Tooltip | SaaS Showcase | EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="page">
+    <header class="page__header">
+      <span class="page__badge">EaseMotion CSS</span>
+      <h1 class="page__title">Swing-Hover Tooltip</h1>
+      <p class="page__subtitle">SaaS Showcase · Pure CSS · Zero JavaScript</p>
+    </header>
+
+    <section class="showcase">
+
+      <div class="tooltip-wrap">
+        <button class="tt-trigger" aria-describedby="tt-top">
+          Top
+        </button>
+        <span class="tt-bubble tt-bubble--top" id="tt-top" role="tooltip">
+          Swing-hover from the top
+        </span>
+      </div>
+
+      <div class="tooltip-wrap">
+        <button class="tt-trigger" aria-describedby="tt-bottom">
+          Bottom
+        </button>
+        <span class="tt-bubble tt-bubble--bottom" id="tt-bottom" role="tooltip">
+          Swings in from below
+        </span>
+      </div>
+
+      <div class="tooltip-wrap">
+        <button class="tt-trigger" aria-describedby="tt-left">
+          Left
+        </button>
+        <span class="tt-bubble tt-bubble--left" id="tt-left" role="tooltip">
+          Swings from the left
+        </span>
+      </div>
+
+      <div class="tooltip-wrap">
+        <button class="tt-trigger" aria-describedby="tt-right">
+          Right
+        </button>
+        <span class="tt-bubble tt-bubble--right" id="tt-right" role="tooltip">
+          Swings in from the right
+        </span>
+      </div>
+
+      <div class="tooltip-wrap">
+        <button class="tt-trigger tt-trigger--primary" aria-describedby="tt-custom">
+          Upgrade Plan
+        </button>
+        <span class="tt-bubble tt-bubble--top tt-bubble--custom" id="tt-custom" role="tooltip">
+          Configured via --tt-duration, --tt-easing, --tt-scale
+        </span>
+      </div>
+
+    </section>
+
+    <section class="feature-row">
+      <p class="feature-row__text">
+        Hover a feature icon to see a swing-hover tooltip in a typical
+        SaaS pricing/feature-list context:
+      </p>
+      <ul class="feature-list">
+        <li class="feature-item">
+          <span class="tooltip-wrap">
+            <button class="feature-icon" aria-describedby="tt-feature-1">✓</button>
+            <span class="tt-bubble tt-bubble--top" id="tt-feature-1" role="tooltip">
+              Unlimited team members
+            </span>
+          </span>
+          Team collaboration
+        </li>
+        <li class="feature-item">
+          <span class="tooltip-wrap">
+            <button class="feature-icon" aria-describedby="tt-feature-2">✓</button>
+            <span class="tt-bubble tt-bubble--top" id="tt-feature-2" role="tooltip">
+              Priority response under 1 hour
+            </span>
+          </span>
+          Priority support
+        </li>
+        <li class="feature-item">
+          <span class="tooltip-wrap">
+            <button class="feature-icon" aria-describedby="tt-feature-3">✓</button>
+            <span class="tt-bubble tt-bubble--top" id="tt-feature-3" role="tooltip">
+              Includes custom dashboards
+            </span>
+          </span>
+          Advanced analytics
+        </li>
+      </ul>
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/swing-hover-tooltip-saas/style.css
+++ b/submissions/examples/swing-hover-tooltip-saas/style.css
@@ -1,0 +1,365 @@
+/* ==========================================================================
+   Swing-Hover Tooltip — SaaS Showcase variant — EaseMotion CSS
+   Pure CSS, keyboard accessible, customizable via CSS custom properties
+   ========================================================================== */
+
+:root {
+  --tt-duration: 0.32s;
+  --tt-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --tt-scale: 0.88;
+  --tt-swing-angle: 15deg;
+  --tt-offset: 10px;
+  --tt-bg: #0f172a;
+  --tt-color: #f8fafc;
+  --tt-accent: #6366f1;
+  --tt-accent-soft: #eef2ff;
+  --tt-border: #e2e8f0;
+  --tt-radius: 8px;
+  --tt-font-size: 0.83rem;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+  background: #f8fafc;
+  color: #0f172a;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 20px;
+}
+
+.page {
+  width: 100%;
+  max-width: 880px;
+  text-align: center;
+}
+
+.page__header { margin-bottom: 40px; }
+
+.page__badge {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--tt-accent);
+  background: var(--tt-accent-soft);
+  padding: 4px 12px;
+  border-radius: 999px;
+  margin-bottom: 12px;
+}
+
+.page__title {
+  font-size: clamp(1.6rem, 4vw, 2.3rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0 0 6px;
+}
+
+.page__subtitle {
+  color: #64748b;
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.showcase {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 40px 28px;
+  justify-content: center;
+  align-items: center;
+  padding: 32px 16px;
+  background: #ffffff;
+  border: 1px solid var(--tt-border);
+  border-radius: 16px;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.06);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Trigger element                                                        */
+/* ---------------------------------------------------------------------- */
+
+.tooltip-wrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.tt-trigger {
+  font-family: inherit;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #1e293b;
+  background: #ffffff;
+  border: 1px solid var(--tt-border);
+  border-radius: var(--tt-radius);
+  padding: 11px 20px;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tt-trigger:hover,
+.tt-trigger:focus-visible {
+  transform: translateY(-1px);
+  border-color: var(--tt-accent);
+  box-shadow: 0 4px 12px rgba(99, 102, 241, 0.15);
+}
+
+.tt-trigger:focus-visible {
+  outline: 2px solid var(--tt-accent);
+  outline-offset: 2px;
+}
+
+.tt-trigger--primary {
+  background: var(--tt-accent);
+  color: #ffffff;
+  border-color: var(--tt-accent);
+}
+.tt-trigger--primary:hover,
+.tt-trigger--primary:focus-visible {
+  background: #4f46e5;
+  border-color: #4f46e5;
+}
+
+/* feature-icon variant used in the feature list example */
+.feature-icon {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: none;
+  background: var(--tt-accent-soft);
+  color: var(--tt-accent);
+  font-size: 0.8rem;
+  font-weight: 700;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+.feature-icon:hover,
+.feature-icon:focus-visible {
+  background: var(--tt-accent);
+  color: #ffffff;
+  transform: translateY(-1px);
+}
+.feature-icon:focus-visible {
+  outline: 2px solid var(--tt-accent);
+  outline-offset: 2px;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Tooltip bubble                                                         */
+/* ---------------------------------------------------------------------- */
+
+.tt-bubble {
+  position: absolute;
+  z-index: 20;
+  left: 50%;
+  white-space: nowrap;
+  padding: 7px 13px;
+  font-size: var(--tt-font-size);
+  font-weight: 500;
+  color: var(--tt-color);
+  background: var(--tt-bg);
+  border-radius: 6px;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.25);
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+
+  bottom: calc(100% + var(--tt-offset));
+  transform: translateX(-50%) translateY(6px) scale(var(--tt-scale)) rotate(var(--tt-swing-angle));
+  transform-origin: bottom center;
+
+  transition:
+    opacity var(--tt-duration) var(--tt-easing),
+    transform var(--tt-duration) var(--tt-easing),
+    visibility 0s linear var(--tt-duration);
+}
+
+.tt-bubble::after {
+  content: "";
+  position: absolute;
+  border: 5px solid transparent;
+}
+
+/* ---- Top variant (default) ---- */
+.tt-bubble--top::after {
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-top-color: var(--tt-bg);
+}
+
+/* ---- Bottom variant ---- */
+.tt-bubble--bottom {
+  bottom: auto;
+  top: calc(100% + var(--tt-offset));
+  transform: translateX(-50%) translateY(-6px) scale(var(--tt-scale)) rotate(calc(-1 * var(--tt-swing-angle)));
+  transform-origin: top center;
+}
+.tt-bubble--bottom::after {
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-bottom-color: var(--tt-bg);
+}
+
+/* ---- Left variant ---- */
+.tt-bubble--left {
+  left: auto;
+  right: calc(100% + var(--tt-offset));
+  bottom: auto;
+  top: 50%;
+  transform: translateY(-50%) translateX(6px) scale(var(--tt-scale)) rotate(calc(-1 * var(--tt-swing-angle)));
+  transform-origin: right center;
+}
+.tt-bubble--left::after {
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  border-left-color: var(--tt-bg);
+}
+
+/* ---- Right variant ---- */
+.tt-bubble--right {
+  left: calc(100% + var(--tt-offset));
+  bottom: auto;
+  top: 50%;
+  transform: translateY(-50%) translateX(-6px) scale(var(--tt-scale)) rotate(var(--tt-swing-angle));
+  transform-origin: left center;
+}
+.tt-bubble--right::after {
+  right: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  border-right-color: var(--tt-bg);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Reveal states — hover AND keyboard focus                               */
+/* ---------------------------------------------------------------------- */
+
+.tooltip-wrap:hover .tt-bubble,
+.tt-trigger:focus-visible + .tt-bubble,
+.tt-trigger:focus-visible ~ .tt-bubble,
+.feature-icon:focus-visible + .tt-bubble {
+  opacity: 1;
+  visibility: visible;
+  transition:
+    opacity var(--tt-duration) var(--tt-easing),
+    transform var(--tt-duration) var(--tt-easing),
+    visibility 0s linear 0s;
+}
+
+.tooltip-wrap:hover .tt-bubble--top,
+.tt-trigger:focus-visible + .tt-bubble--top,
+.feature-icon:focus-visible + .tt-bubble--top {
+  transform: translateX(-50%) translateY(0) scale(1) rotate(0deg);
+}
+
+.tooltip-wrap:hover .tt-bubble--bottom,
+.tt-trigger:focus-visible + .tt-bubble--bottom {
+  transform: translateX(-50%) translateY(0) scale(1) rotate(0deg);
+}
+
+.tooltip-wrap:hover .tt-bubble--left,
+.tt-trigger:focus-visible + .tt-bubble--left {
+  transform: translateY(-50%) translateX(0) scale(1) rotate(0deg);
+}
+
+.tooltip-wrap:hover .tt-bubble--right,
+.tt-trigger:focus-visible + .tt-bubble--right {
+  transform: translateY(-50%) translateX(0) scale(1) rotate(0deg);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Custom timing / scale demo (overrides via CSS custom properties)       */
+/* ---------------------------------------------------------------------- */
+
+.tt-bubble--custom {
+  --tt-duration: 0.5s;
+  --tt-easing: cubic-bezier(0.68, -0.55, 0.27, 1.55);
+  --tt-scale: 0.6;
+  --tt-swing-angle: 28deg;
+  background: var(--tt-accent);
+  color: #ffffff;
+  font-weight: 600;
+}
+.tt-bubble--custom::after {
+  border-top-color: var(--tt-accent);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Feature list example section                                           */
+/* ---------------------------------------------------------------------- */
+
+.feature-row {
+  margin-top: 40px;
+  text-align: left;
+}
+
+.feature-row__text {
+  color: #64748b;
+  font-size: 0.85rem;
+  margin-bottom: 16px;
+  text-align: center;
+}
+
+.feature-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px 28px;
+  justify-content: center;
+}
+
+.feature-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.9rem;
+  color: #334155;
+  font-weight: 500;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Reduced motion                                                         */
+/* ---------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .tt-bubble {
+    transition: opacity 0.15s linear, visibility 0s linear 0.15s;
+    transform: translateX(-50%) !important;
+  }
+  .tooltip-wrap:hover .tt-bubble,
+  .tt-trigger:focus-visible + .tt-bubble,
+  .feature-icon:focus-visible + .tt-bubble {
+    transition: opacity 0.15s linear, visibility 0s linear 0s;
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+/* Responsive                                                             */
+/* ---------------------------------------------------------------------- */
+
+@media (max-width: 600px) {
+  .showcase {
+    gap: 30px 18px;
+    padding: 24px 12px;
+  }
+  .tt-bubble {
+    white-space: normal;
+    max-width: 170px;
+    text-align: center;
+  }
+  .feature-list {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 14px;
+  }
+}


### PR DESCRIPTION
## Description
Adds a pure CSS animated tooltip component using a smooth spring-based
"swing-hover" transition, styled for a SaaS product context (clean card
surfaces, indigo accent, includes a feature-list usage example).

Closes #34424

## What's included
- `submissions/examples/swing-hover-tooltip-saas/demo.html`
- `submissions/examples/swing-hover-tooltip-saas/style.css`
- `submissions/examples/swing-hover-tooltip-saas/README.md`

## Features
- Pure CSS, zero JavaScript
- Keyboard accessible (`:focus-visible`, `aria-describedby`, `role="tooltip"`)
- Four placement variants: top, bottom, left, right
- Fully customizable via CSS custom properties
- Includes a realistic SaaS feature-list tooltip pattern, not just isolated buttons
- Responsive layout, tested down to mobile widths
- Respects `prefers-reduced-motion`

## Testing done
- Verified hover interaction on desktop (Chrome/Firefox/Edge)
- Verified keyboard-only navigation
- Verified all four placement variants render correctly
- Verified `prefers-reduced-motion` fallback
- Verified responsive behavior at narrow viewports

## Checklist
- [x] Files added only inside `submissions/`
- [x] Folder includes `demo.html`, `style.css`, `README.md`
- [x] No existing issue/PR duplicates this
- [x] Read `CONTRIBUTING.md`

## Note for maintainer
This is one of five near-identical "swing-hover tooltip" issues
(#34424, #34425, #34426, #34427, #34432). I've asked in the issue thread
whether a consolidated themeable component would be preferred going forward.