### PR TITLE
feat: add e-commerce checkout swing-hover tooltip (#34423)

### DIFF
--- a/submissions/examples/swing-hover-tooltip-ecommerce/README.md
+++ b/submissions/examples/swing-hover-tooltip-ecommerce/README.md
@@ -1,0 +1,79 @@
+# Swing-Hover Tooltip — E-Commerce Checkout
+
+A pure CSS tooltip with a spring-like "swing" entrance animation, styled
+for an e-commerce checkout flow (clean card surfaces, green primary/CTA
+accent, includes a realistic checkout-field help pattern). Triggered on
+hover and keyboard focus. Zero JavaScript.
+
+## Features
+
+- 🎯 Pure CSS — no JavaScript required
+- ⌨️ Keyboard accessible via `:focus-visible`
+- 🔄 Four placement variants: top, bottom, left, right
+- 🎛️ Customizable timing, easing, scale, offset via CSS variables
+- 🛒 Includes a realistic checkout-form usage example (info icons next to
+  card number / CVV / promo code fields)
+- 📱 Fully responsive
+- 🌀 Respects `prefers-reduced-motion`
+
+## Usage
+
+```html
+<div class="tooltip-wrap">
+  <button class="tt-trigger" aria-describedby="tt-1">Hover me</button>
+  <span class="tt-bubble tt-bubble--top" id="tt-1" role="tooltip">
+    Tooltip text here
+  </span>
+</div>
+```
+
+Swap `tt-bubble--top` for `tt-bubble--bottom`, `tt-bubble--left`, or
+`tt-bubble--right` to change placement.
+
+### Checkout field-help pattern
+
+```html
+<span class="tooltip-wrap">
+  <button class="info-icon" aria-describedby="tt-card">i</button>
+  <span class="tt-bubble tt-bubble--top" id="tt-card" role="tooltip">
+    16-digit number on the front of your card
+  </span>
+</span>
+```
+
+## Customization
+
+| Variable | Default | Description |
+|---|---|---|
+| `--tt-duration` | `0.3s` | Animation duration |
+| `--tt-easing` | `cubic-bezier(0.34, 1.56, 0.64, 1)` | Springy swing easing |
+| `--tt-scale` | `0.88` | Starting scale before swing-in |
+| `--tt-swing-angle` | `14deg` | Rotation angle of the swing |
+| `--tt-offset` | `10px` | Gap between trigger and tooltip |
+| `--tt-bg` | `#111827` | Tooltip background color |
+| `--tt-accent` | `#16a34a` | Primary green accent (checkout/CTA) |
+
+Example override for a single tooltip:
+
+```css
+.tt-bubble--custom {
+  --tt-duration: 0.5s;
+  --tt-scale: 0.6;
+  --tt-swing-angle: 26deg;
+}
+```
+
+## Accessibility
+
+- Revealed on both `:hover` and `:focus-visible`, so keyboard users get the
+  same experience as mouse users.
+- Each trigger uses `aria-describedby` pointing to the tooltip's `id`.
+- Tooltip element uses `role="tooltip"`.
+- Animation disabled for users with `prefers-reduced-motion: reduce`.
+
+## Files
+
+- `demo.html` — showcase with all four placements, a primary CTA example,
+  and a checkout-form field-help usage pattern
+- `style.css` — component styles and animation logic
+- `README.md` — this file

--- a/submissions/examples/swing-hover-tooltip-ecommerce/demo.html
+++ b/submissions/examples/swing-hover-tooltip-ecommerce/demo.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Swing-Hover Tooltip | E-Commerce Checkout | EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="page">
+    <header class="page__header">
+      <h1 class="page__title">Swing-Hover Tooltip</h1>
+      <p class="page__subtitle">E-Commerce Checkout · Pure CSS · Zero JavaScript</p>
+    </header>
+
+    <section class="showcase">
+      <div class="tooltip-wrap">
+        <button class="tt-trigger" aria-describedby="tt-top">Top</button>
+        <span class="tt-bubble tt-bubble--top" id="tt-top" role="tooltip">
+          Swing-hover from the top
+        </span>
+      </div>
+
+      <div class="tooltip-wrap">
+        <button class="tt-trigger" aria-describedby="tt-bottom">Bottom</button>
+        <span class="tt-bubble tt-bubble--bottom" id="tt-bottom" role="tooltip">
+          Swings in from below
+        </span>
+      </div>
+
+      <div class="tooltip-wrap">
+        <button class="tt-trigger" aria-describedby="tt-left">Left</button>
+        <span class="tt-bubble tt-bubble--left" id="tt-left" role="tooltip">
+          Swings from the left
+        </span>
+      </div>
+
+      <div class="tooltip-wrap">
+        <button class="tt-trigger" aria-describedby="tt-right">Right</button>
+        <span class="tt-bubble tt-bubble--right" id="tt-right" role="tooltip">
+          Swings in from the right
+        </span>
+      </div>
+
+      <div class="tooltip-wrap">
+        <button class="tt-trigger tt-trigger--primary" aria-describedby="tt-custom">
+          Place Order
+        </button>
+        <span class="tt-bubble tt-bubble--top tt-bubble--custom" id="tt-custom" role="tooltip">
+          Configured via --tt-duration, --tt-easing, --tt-scale
+        </span>
+      </div>
+    </section>
+
+    <section class="checkout-mock">
+      <p class="checkout-mock__text">
+        Realistic checkout usage — hover the info icons for field help:
+      </p>
+
+      <div class="checkout-field">
+        <label class="checkout-field__label">
+          Card number
+          <span class="tooltip-wrap">
+            <button class="info-icon" aria-describedby="tt-card">i</button>
+            <span class="tt-bubble tt-bubble--top" id="tt-card" role="tooltip">
+              16-digit number on the front of your card
+            </span>
+          </span>
+        </label>
+        <input class="checkout-field__input" type="text" placeholder="1234 5678 9012 3456" disabled>
+      </div>
+
+      <div class="checkout-field">
+        <label class="checkout-field__label">
+          CVV
+          <span class="tooltip-wrap">
+            <button class="info-icon" aria-describedby="tt-cvv">i</button>
+            <span class="tt-bubble tt-bubble--top" id="tt-cvv" role="tooltip">
+              3-digit code on the back of your card
+            </span>
+          </span>
+        </label>
+        <input class="checkout-field__input checkout-field__input--short" type="text" placeholder="123" disabled>
+      </div>
+
+      <div class="checkout-field">
+        <label class="checkout-field__label">
+          Promo code
+          <span class="tooltip-wrap">
+            <button class="info-icon" aria-describedby="tt-promo">i</button>
+            <span class="tt-bubble tt-bubble--top" id="tt-promo" role="tooltip">
+              One promo code per order
+            </span>
+          </span>
+        </label>
+        <input class="checkout-field__input" type="text" placeholder="SAVE10" disabled>
+      </div>
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/swing-hover-tooltip-ecommerce/style.css
+++ b/submissions/examples/swing-hover-tooltip-ecommerce/style.css
@@ -1,0 +1,364 @@
+/* ==========================================================================
+   Swing-Hover Tooltip — E-Commerce Checkout variant — EaseMotion CSS
+   Pure CSS, keyboard accessible, customizable via CSS custom properties
+   ========================================================================== */
+
+:root {
+  --tt-duration: 0.3s;
+  --tt-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --tt-scale: 0.88;
+  --tt-swing-angle: 14deg;
+  --tt-offset: 10px;
+  --tt-bg: #111827;
+  --tt-color: #f9fafb;
+  --tt-accent: #16a34a;
+  --tt-accent-soft: #dcfce7;
+  --tt-border: #e5e7eb;
+  --tt-radius: 8px;
+  --tt-font-size: 0.82rem;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+  background: #f9fafb;
+  color: #111827;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 20px;
+}
+
+.page {
+  width: 100%;
+  max-width: 720px;
+  text-align: center;
+}
+
+.page__header { margin-bottom: 36px; }
+
+.page__title {
+  font-size: clamp(1.5rem, 4vw, 2.1rem);
+  font-weight: 700;
+  margin: 0 0 6px;
+}
+
+.page__subtitle {
+  color: #6b7280;
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.showcase {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 36px 24px;
+  justify-content: center;
+  align-items: center;
+  padding: 28px 16px;
+  background: #ffffff;
+  border: 1px solid var(--tt-border);
+  border-radius: 14px;
+  margin-bottom: 32px;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Trigger elements                                                       */
+/* ---------------------------------------------------------------------- */
+
+.tooltip-wrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.tt-trigger {
+  font-family: inherit;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #111827;
+  background: #ffffff;
+  border: 1px solid var(--tt-border);
+  border-radius: var(--tt-radius);
+  padding: 11px 20px;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tt-trigger:hover,
+.tt-trigger:focus-visible {
+  transform: translateY(-1px);
+  border-color: var(--tt-accent);
+  box-shadow: 0 4px 12px rgba(22, 163, 74, 0.15);
+}
+
+.tt-trigger:focus-visible {
+  outline: 2px solid var(--tt-accent);
+  outline-offset: 2px;
+}
+
+.tt-trigger--primary {
+  background: var(--tt-accent);
+  color: #ffffff;
+  border-color: var(--tt-accent);
+}
+.tt-trigger--primary:hover,
+.tt-trigger--primary:focus-visible {
+  background: #15803d;
+  border-color: #15803d;
+}
+
+/* small circular "i" info icon used in checkout fields */
+.info-icon {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 1px solid #9ca3af;
+  background: #f3f4f6;
+  color: #6b7280;
+  font-size: 0.65rem;
+  font-style: italic;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 4px;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+.info-icon:hover,
+.info-icon:focus-visible {
+  background: var(--tt-accent);
+  border-color: var(--tt-accent);
+  color: #ffffff;
+}
+.info-icon:focus-visible {
+  outline: 2px solid var(--tt-accent);
+  outline-offset: 2px;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Tooltip bubble                                                         */
+/* ---------------------------------------------------------------------- */
+
+.tt-bubble {
+  position: absolute;
+  z-index: 20;
+  left: 50%;
+  white-space: nowrap;
+  padding: 7px 12px;
+  font-size: var(--tt-font-size);
+  font-weight: 500;
+  color: var(--tt-color);
+  background: var(--tt-bg);
+  border-radius: 6px;
+  box-shadow: 0 8px 18px rgba(17, 24, 39, 0.28);
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+
+  bottom: calc(100% + var(--tt-offset));
+  transform: translateX(-50%) translateY(6px) scale(var(--tt-scale)) rotate(var(--tt-swing-angle));
+  transform-origin: bottom center;
+
+  transition:
+    opacity var(--tt-duration) var(--tt-easing),
+    transform var(--tt-duration) var(--tt-easing),
+    visibility 0s linear var(--tt-duration);
+}
+
+.tt-bubble::after {
+  content: "";
+  position: absolute;
+  border: 5px solid transparent;
+}
+
+/* ---- Top variant (default) ---- */
+.tt-bubble--top::after {
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-top-color: var(--tt-bg);
+}
+
+/* ---- Bottom variant ---- */
+.tt-bubble--bottom {
+  bottom: auto;
+  top: calc(100% + var(--tt-offset));
+  transform: translateX(-50%) translateY(-6px) scale(var(--tt-scale)) rotate(calc(-1 * var(--tt-swing-angle)));
+  transform-origin: top center;
+}
+.tt-bubble--bottom::after {
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-bottom-color: var(--tt-bg);
+}
+
+/* ---- Left variant ---- */
+.tt-bubble--left {
+  left: auto;
+  right: calc(100% + var(--tt-offset));
+  bottom: auto;
+  top: 50%;
+  transform: translateY(-50%) translateX(6px) scale(var(--tt-scale)) rotate(calc(-1 * var(--tt-swing-angle)));
+  transform-origin: right center;
+}
+.tt-bubble--left::after {
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  border-left-color: var(--tt-bg);
+}
+
+/* ---- Right variant ---- */
+.tt-bubble--right {
+  left: calc(100% + var(--tt-offset));
+  bottom: auto;
+  top: 50%;
+  transform: translateY(-50%) translateX(-6px) scale(var(--tt-scale)) rotate(var(--tt-swing-angle));
+  transform-origin: left center;
+}
+.tt-bubble--right::after {
+  right: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  border-right-color: var(--tt-bg);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Reveal states — hover AND keyboard focus                               */
+/* ---------------------------------------------------------------------- */
+
+.tooltip-wrap:hover .tt-bubble,
+.tt-trigger:focus-visible + .tt-bubble,
+.tt-trigger:focus-visible ~ .tt-bubble,
+.info-icon:focus-visible + .tt-bubble {
+  opacity: 1;
+  visibility: visible;
+  transition:
+    opacity var(--tt-duration) var(--tt-easing),
+    transform var(--tt-duration) var(--tt-easing),
+    visibility 0s linear 0s;
+}
+
+.tooltip-wrap:hover .tt-bubble--top,
+.tt-trigger:focus-visible + .tt-bubble--top,
+.info-icon:focus-visible + .tt-bubble--top {
+  transform: translateX(-50%) translateY(0) scale(1) rotate(0deg);
+}
+
+.tooltip-wrap:hover .tt-bubble--bottom,
+.tt-trigger:focus-visible + .tt-bubble--bottom {
+  transform: translateX(-50%) translateY(0) scale(1) rotate(0deg);
+}
+
+.tooltip-wrap:hover .tt-bubble--left,
+.tt-trigger:focus-visible + .tt-bubble--left {
+  transform: translateY(-50%) translateX(0) scale(1) rotate(0deg);
+}
+
+.tooltip-wrap:hover .tt-bubble--right,
+.tt-trigger:focus-visible + .tt-bubble--right {
+  transform: translateY(-50%) translateX(0) scale(1) rotate(0deg);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Custom timing / scale demo                                             */
+/* ---------------------------------------------------------------------- */
+
+.tt-bubble--custom {
+  --tt-duration: 0.5s;
+  --tt-easing: cubic-bezier(0.68, -0.55, 0.27, 1.55);
+  --tt-scale: 0.6;
+  --tt-swing-angle: 26deg;
+  background: var(--tt-accent);
+  color: #ffffff;
+  font-weight: 600;
+}
+.tt-bubble--custom::after {
+  border-top-color: var(--tt-accent);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Checkout mock section                                                  */
+/* ---------------------------------------------------------------------- */
+
+.checkout-mock {
+  text-align: left;
+  background: #ffffff;
+  border: 1px solid var(--tt-border);
+  border-radius: 14px;
+  padding: 24px;
+}
+
+.checkout-mock__text {
+  color: #6b7280;
+  font-size: 0.85rem;
+  margin: 0 0 18px;
+  text-align: center;
+}
+
+.checkout-field {
+  margin-bottom: 16px;
+}
+.checkout-field:last-child { margin-bottom: 0; }
+
+.checkout-field__label {
+  display: flex;
+  align-items: center;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #374151;
+  margin-bottom: 6px;
+}
+
+.checkout-field__input {
+  width: 100%;
+  padding: 10px 12px;
+  font-size: 0.9rem;
+  font-family: inherit;
+  border: 1px solid var(--tt-border);
+  border-radius: 6px;
+  background: #f9fafb;
+  color: #9ca3af;
+}
+
+.checkout-field__input--short {
+  width: 100px;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Reduced motion                                                         */
+/* ---------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .tt-bubble {
+    transition: opacity 0.15s linear, visibility 0s linear 0.15s;
+    transform: translateX(-50%) !important;
+  }
+  .tooltip-wrap:hover .tt-bubble,
+  .tt-trigger:focus-visible + .tt-bubble,
+  .info-icon:focus-visible + .tt-bubble {
+    transition: opacity 0.15s linear, visibility 0s linear 0s;
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+/* Responsive                                                             */
+/* ---------------------------------------------------------------------- */
+
+@media (max-width: 600px) {
+  .showcase {
+    gap: 26px 16px;
+    padding: 20px 12px;
+  }
+  .tt-bubble {
+    white-space: normal;
+    max-width: 160px;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Description
Adds a pure CSS animated tooltip component using a smooth spring-based
"swing-hover" transition, styled for an e-commerce checkout context (green
CTA accent, includes a realistic checkout field-help usage example).

Closes #34423

## What's included
- `submissions/examples/swing-hover-tooltip-ecommerce/demo.html`
- `submissions/examples/swing-hover-tooltip-ecommerce/style.css`
- `submissions/examples/swing-hover-tooltip-ecommerce/README.md`

## Features
- Pure CSS, zero JavaScript
- Keyboard accessible (`:focus-visible`, `aria-describedby`, `role="tooltip"`)
- Four placement variants: top, bottom, left, right
- Fully customizable via CSS custom properties
- Includes a realistic checkout field-help tooltip pattern (card number, CVV, promo code)
- Responsive layout, tested down to mobile widths
- Respects `prefers-reduced-motion`

## Testing done
- Verified hover interaction on desktop (Chrome/Firefox/Edge)
- Verified keyboard-only navigation
- Verified all four placement variants render correctly
- Verified `prefers-reduced-motion` fallback
- Verified responsive behavior at narrow viewports

## Checklist
- [x] Files added only inside `submissions/`
- [x] Folder includes `demo.html`, `style.css`, `README.md`
- [x] No existing issue/PR duplicates this
- [x] Read `CONTRIBUTING.md`