### PR TITLE
feat: add modern SaaS dashboard swing-hover tooltip (#34418)

### DIFF
--- a/submissions/examples/swing-hover-tooltip-modern-saas/README.md
+++ b/submissions/examples/swing-hover-tooltip-modern-saas/README.md
@@ -1,0 +1,77 @@
+# Swing-Hover Tooltip — Modern SaaS Dashboard
+
+A pure CSS tooltip with a spring-like "swing" entrance animation, styled
+for a dark modern SaaS dashboard (violet/teal gradient accent, sidebar
+navigation, stat-card metrics). Distinct from the lighter "SaaS Showcase"
+example — this one targets an in-app dashboard context rather than a
+marketing/pricing page.
+
+## Features
+
+- 🎯 Pure CSS — no JavaScript required
+- ⌨️ Keyboard accessible via `:focus-visible`
+- 🔄 Four placement variants: top, bottom, left, right
+- 🎛️ Customizable timing, easing, scale, offset via CSS variables
+- 🧭 Includes a sidebar-nav icon tooltip pattern (right-placement)
+- 📊 Includes a stat-card metric tooltip pattern (top-placement info icons)
+- 🌓 Dark dashboard theme with violet → teal gradient accent
+- 📱 Fully responsive (sidebar collapses to a top bar on mobile)
+- 🌀 Respects `prefers-reduced-motion`
+
+## Usage
+
+```html
+<div class="tooltip-wrap">
+  <button class="tt-trigger" aria-describedby="tt-1">Hover me</button>
+  <span class="tt-bubble tt-bubble--top" id="tt-1" role="tooltip">
+    Tooltip text here
+  </span>
+</div>
+```
+
+### Sidebar nav icon pattern
+
+```html
+<span class="tooltip-wrap tooltip-wrap--right">
+  <button class="nav-icon" aria-describedby="tt-nav-1">◆</button>
+  <span class="tt-bubble tt-bubble--right" id="tt-nav-1" role="tooltip">Dashboard</span>
+</span>
+```
+
+### Stat-card metric pattern
+
+```html
+<span class="tooltip-wrap">
+  <button class="info-icon" aria-describedby="tt-stat-1">i</button>
+  <span class="tt-bubble tt-bubble--top" id="tt-stat-1" role="tooltip">
+    Monthly recurring revenue, net of churn
+  </span>
+</span>
+```
+
+## Customization
+
+| Variable | Default | Description |
+|---|---|---|
+| `--tt-duration` | `0.3s` | Animation duration |
+| `--tt-easing` | `cubic-bezier(0.34, 1.56, 0.64, 1)` | Springy swing easing |
+| `--tt-scale` | `0.86` | Starting scale before swing-in |
+| `--tt-swing-angle` | `16deg` | Rotation angle of the swing |
+| `--tt-offset` | `10px` | Gap between trigger and tooltip |
+| `--tt-bg` | `#14b8a6` | Tooltip background (teal) |
+| `--tt-accent` | `#8b5cf6` | Violet accent (gradients, CTA) |
+| `--tt-accent-2` | `#14b8a6` | Teal accent |
+
+## Accessibility
+
+- Revealed on both `:hover` and `:focus-visible`, so keyboard users get the
+  same experience as mouse users.
+- Each trigger uses `aria-describedby` pointing to the tooltip's `id`.
+- Tooltip element uses `role="tooltip"`.
+- Animation disabled for users with `prefers-reduced-motion: reduce`.
+
+## Files
+
+- `demo.html` — sidebar nav, placement showcase, and stat-card dashboard example
+- `style.css` — component styles and animation logic
+- `README.md` — this file

--- a/submissions/examples/swing-hover-tooltip-modern-saas/demo.html
+++ b/submissions/examples/swing-hover-tooltip-modern-saas/demo.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Swing-Hover Tooltip | Modern SaaS Dashboard | EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="app">
+
+    <!-- Sidebar nav example -->
+    <aside class="sidebar">
+      <div class="sidebar__logo">EM</div>
+      <nav class="sidebar__nav">
+        <span class="tooltip-wrap tooltip-wrap--right">
+          <button class="nav-icon nav-icon--active" aria-describedby="tt-nav-1">◆</button>
+          <span class="tt-bubble tt-bubble--right" id="tt-nav-1" role="tooltip">Dashboard</span>
+        </span>
+        <span class="tooltip-wrap tooltip-wrap--right">
+          <button class="nav-icon" aria-describedby="tt-nav-2">▤</button>
+          <span class="tt-bubble tt-bubble--right" id="tt-nav-2" role="tooltip">Projects</span>
+        </span>
+        <span class="tooltip-wrap tooltip-wrap--right">
+          <button class="nav-icon" aria-describedby="tt-nav-3">◐</button>
+          <span class="tt-bubble tt-bubble--right" id="tt-nav-3" role="tooltip">Analytics</span>
+        </span>
+        <span class="tooltip-wrap tooltip-wrap--right">
+          <button class="nav-icon" aria-describedby="tt-nav-4">⚙</button>
+          <span class="tt-bubble tt-bubble--right" id="tt-nav-4" role="tooltip">Settings</span>
+        </span>
+      </nav>
+    </aside>
+
+    <!-- Main content -->
+    <main class="page">
+      <header class="page__header">
+        <h1 class="page__title">Swing-Hover Tooltip</h1>
+        <p class="page__subtitle">Modern SaaS Dashboard · Pure CSS · Zero JavaScript</p>
+      </header>
+
+      <section class="showcase">
+        <div class="tooltip-wrap">
+          <button class="tt-trigger" aria-describedby="tt-top">Top</button>
+          <span class="tt-bubble tt-bubble--top" id="tt-top" role="tooltip">
+            Swing-hover from the top
+          </span>
+        </div>
+
+        <div class="tooltip-wrap">
+          <button class="tt-trigger" aria-describedby="tt-bottom">Bottom</button>
+          <span class="tt-bubble tt-bubble--bottom" id="tt-bottom" role="tooltip">
+            Swings in from below
+          </span>
+        </div>
+
+        <div class="tooltip-wrap">
+          <button class="tt-trigger" aria-describedby="tt-left">Left</button>
+          <span class="tt-bubble tt-bubble--left" id="tt-left" role="tooltip">
+            Swings from the left
+          </span>
+        </div>
+
+        <div class="tooltip-wrap">
+          <button class="tt-trigger" aria-describedby="tt-right">Right</button>
+          <span class="tt-bubble tt-bubble--right" id="tt-right" role="tooltip">
+            Swings in from the right
+          </span>
+        </div>
+
+        <div class="tooltip-wrap">
+          <button class="tt-trigger tt-trigger--primary" aria-describedby="tt-custom">
+            New Workspace
+          </button>
+          <span class="tt-bubble tt-bubble--top tt-bubble--custom" id="tt-custom" role="tooltip">
+            Configured via --tt-duration, --tt-easing, --tt-scale
+          </span>
+        </div>
+      </section>
+
+      <!-- Stats dashboard usage example -->
+      <section class="stats">
+        <p class="stats__text">Dashboard metric cards with contextual tooltips:</p>
+        <div class="stats-grid">
+
+          <div class="stat-card">
+            <div class="stat-card__head">
+              <span class="stat-card__label">MRR</span>
+              <span class="tooltip-wrap">
+                <button class="info-icon" aria-describedby="tt-stat-1">i</button>
+                <span class="tt-bubble tt-bubble--top" id="tt-stat-1" role="tooltip">
+                  Monthly recurring revenue, net of churn
+                </span>
+              </span>
+            </div>
+            <div class="stat-card__value">$48.2k</div>
+          </div>
+
+          <div class="stat-card">
+            <div class="stat-card__head">
+              <span class="stat-card__label">Active Users</span>
+              <span class="tooltip-wrap">
+                <button class="info-icon" aria-describedby="tt-stat-2">i</button>
+                <span class="tt-bubble tt-bubble--top" id="tt-stat-2" role="tooltip">
+                  Unique users active in the last 30 days
+                </span>
+              </span>
+            </div>
+            <div class="stat-card__value">2,341</div>
+          </div>
+
+          <div class="stat-card">
+            <div class="stat-card__head">
+              <span class="stat-card__label">Churn Rate</span>
+              <span class="tooltip-wrap">
+                <button class="info-icon" aria-describedby="tt-stat-3">i</button>
+                <span class="tt-bubble tt-bubble--top" id="tt-stat-3" role="tooltip">
+                  Percent of customers lost this month
+                </span>
+              </span>
+            </div>
+            <div class="stat-card__value">1.4%</div>
+          </div>
+
+        </div>
+      </section>
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/swing-hover-tooltip-modern-saas/style.css
+++ b/submissions/examples/swing-hover-tooltip-modern-saas/style.css
@@ -1,0 +1,436 @@
+/* ==========================================================================
+   Swing-Hover Tooltip — Modern SaaS Dashboard variant — EaseMotion CSS
+   Pure CSS, keyboard accessible, customizable via CSS custom properties
+
+   Distinct from the "SaaS Showcase" variant: dark dashboard theme,
+   teal/violet accent, sidebar-nav + stat-card usage context.
+   ========================================================================== */
+
+:root {
+  --tt-duration: 0.3s;
+  --tt-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --tt-scale: 0.86;
+  --tt-swing-angle: 16deg;
+  --tt-offset: 10px;
+  --tt-bg: #14b8a6;
+  --tt-color: #062821;
+  --tt-accent: #8b5cf6;
+  --tt-accent-2: #14b8a6;
+  --tt-surface: #171923;
+  --tt-surface-2: #1f2230;
+  --tt-border: #2d3142;
+  --tt-radius: 8px;
+  --tt-font-size: 0.82rem;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+  background: #0f1117;
+  color: #e5e7eb;
+}
+
+.app {
+  display: flex;
+  min-height: 100vh;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Sidebar nav                                                            */
+/* ---------------------------------------------------------------------- */
+
+.sidebar {
+  width: 68px;
+  flex-shrink: 0;
+  background: var(--tt-surface);
+  border-right: 1px solid var(--tt-border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px 0;
+  gap: 28px;
+}
+
+.sidebar__logo {
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  background: linear-gradient(135deg, var(--tt-accent), var(--tt-accent-2));
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.8rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sidebar__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.tooltip-wrap { position: relative; display: inline-flex; }
+.tooltip-wrap--right { display: flex; }
+
+.nav-icon {
+  width: 38px;
+  height: 38px;
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  color: #8b8fa3;
+  font-size: 1rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+.nav-icon:hover,
+.nav-icon:focus-visible {
+  background: var(--tt-surface-2);
+  color: var(--tt-accent-2);
+}
+.nav-icon--active {
+  background: var(--tt-surface-2);
+  color: var(--tt-accent-2);
+}
+.nav-icon:focus-visible {
+  outline: 2px solid var(--tt-accent-2);
+  outline-offset: 2px;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Main page                                                              */
+/* ---------------------------------------------------------------------- */
+
+.page {
+  flex: 1;
+  padding: 44px 32px;
+  max-width: 880px;
+}
+
+.page__header { margin-bottom: 36px; }
+
+.page__title {
+  font-size: clamp(1.5rem, 4vw, 2.1rem);
+  font-weight: 700;
+  margin: 0 0 6px;
+  color: #f9fafb;
+}
+
+.page__subtitle {
+  color: #8b8fa3;
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.showcase {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 30px 24px;
+  align-items: center;
+  padding: 28px;
+  background: var(--tt-surface);
+  border: 1px solid var(--tt-border);
+  border-radius: 14px;
+  margin-bottom: 36px;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Trigger elements                                                       */
+/* ---------------------------------------------------------------------- */
+
+.tt-trigger {
+  font-family: inherit;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #e5e7eb;
+  background: var(--tt-surface-2);
+  border: 1px solid var(--tt-border);
+  border-radius: var(--tt-radius);
+  padding: 11px 20px;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tt-trigger:hover,
+.tt-trigger:focus-visible {
+  transform: translateY(-1px);
+  border-color: var(--tt-accent-2);
+  box-shadow: 0 4px 14px rgba(20, 184, 166, 0.18);
+}
+
+.tt-trigger:focus-visible {
+  outline: 2px solid var(--tt-accent-2);
+  outline-offset: 2px;
+}
+
+.tt-trigger--primary {
+  background: linear-gradient(135deg, var(--tt-accent), var(--tt-accent-2));
+  color: #fff;
+  border-color: transparent;
+}
+.tt-trigger--primary:hover,
+.tt-trigger--primary:focus-visible {
+  filter: brightness(1.08);
+}
+
+.info-icon {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 1px solid #4b5063;
+  background: var(--tt-surface-2);
+  color: #9ca3af;
+  font-size: 0.62rem;
+  font-style: italic;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 6px;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+.info-icon:hover,
+.info-icon:focus-visible {
+  background: var(--tt-accent-2);
+  border-color: var(--tt-accent-2);
+  color: #062821;
+}
+.info-icon:focus-visible {
+  outline: 2px solid var(--tt-accent-2);
+  outline-offset: 2px;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Tooltip bubble                                                         */
+/* ---------------------------------------------------------------------- */
+
+.tt-bubble {
+  position: absolute;
+  z-index: 20;
+  left: 50%;
+  white-space: nowrap;
+  padding: 7px 12px;
+  font-size: var(--tt-font-size);
+  font-weight: 600;
+  color: var(--tt-color);
+  background: var(--tt-bg);
+  border-radius: 6px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+
+  bottom: calc(100% + var(--tt-offset));
+  transform: translateX(-50%) translateY(6px) scale(var(--tt-scale)) rotate(var(--tt-swing-angle));
+  transform-origin: bottom center;
+
+  transition:
+    opacity var(--tt-duration) var(--tt-easing),
+    transform var(--tt-duration) var(--tt-easing),
+    visibility 0s linear var(--tt-duration);
+}
+
+.tt-bubble::after {
+  content: "";
+  position: absolute;
+  border: 5px solid transparent;
+}
+
+/* ---- Top variant (default) ---- */
+.tt-bubble--top::after {
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-top-color: var(--tt-bg);
+}
+
+/* ---- Bottom variant ---- */
+.tt-bubble--bottom {
+  bottom: auto;
+  top: calc(100% + var(--tt-offset));
+  transform: translateX(-50%) translateY(-6px) scale(var(--tt-scale)) rotate(calc(-1 * var(--tt-swing-angle)));
+  transform-origin: top center;
+}
+.tt-bubble--bottom::after {
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-bottom-color: var(--tt-bg);
+}
+
+/* ---- Left variant ---- */
+.tt-bubble--left {
+  left: auto;
+  right: calc(100% + var(--tt-offset));
+  bottom: auto;
+  top: 50%;
+  transform: translateY(-50%) translateX(6px) scale(var(--tt-scale)) rotate(calc(-1 * var(--tt-swing-angle)));
+  transform-origin: right center;
+}
+.tt-bubble--left::after {
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  border-left-color: var(--tt-bg);
+}
+
+/* ---- Right variant ---- */
+.tt-bubble--right {
+  left: calc(100% + var(--tt-offset));
+  bottom: auto;
+  top: 50%;
+  transform: translateY(-50%) translateX(-6px) scale(var(--tt-scale)) rotate(var(--tt-swing-angle));
+  transform-origin: left center;
+}
+.tt-bubble--right::after {
+  right: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  border-right-color: var(--tt-bg);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Reveal states — hover AND keyboard focus                               */
+/* ---------------------------------------------------------------------- */
+
+.tooltip-wrap:hover .tt-bubble,
+.tt-trigger:focus-visible + .tt-bubble,
+.tt-trigger:focus-visible ~ .tt-bubble,
+.info-icon:focus-visible + .tt-bubble,
+.nav-icon:focus-visible + .tt-bubble {
+  opacity: 1;
+  visibility: visible;
+  transition:
+    opacity var(--tt-duration) var(--tt-easing),
+    transform var(--tt-duration) var(--tt-easing),
+    visibility 0s linear 0s;
+}
+
+.tooltip-wrap:hover .tt-bubble--top,
+.tt-trigger:focus-visible + .tt-bubble--top,
+.info-icon:focus-visible + .tt-bubble--top {
+  transform: translateX(-50%) translateY(0) scale(1) rotate(0deg);
+}
+
+.tooltip-wrap:hover .tt-bubble--bottom,
+.tt-trigger:focus-visible + .tt-bubble--bottom {
+  transform: translateX(-50%) translateY(0) scale(1) rotate(0deg);
+}
+
+.tooltip-wrap:hover .tt-bubble--left,
+.tt-trigger:focus-visible + .tt-bubble--left {
+  transform: translateY(-50%) translateX(0) scale(1) rotate(0deg);
+}
+
+.tooltip-wrap:hover .tt-bubble--right,
+.tt-trigger:focus-visible + .tt-bubble--right,
+.nav-icon:focus-visible + .tt-bubble--right {
+  transform: translateY(-50%) translateX(0) scale(1) rotate(0deg);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Custom timing / scale demo                                             */
+/* ---------------------------------------------------------------------- */
+
+.tt-bubble--custom {
+  --tt-duration: 0.5s;
+  --tt-easing: cubic-bezier(0.68, -0.55, 0.27, 1.55);
+  --tt-scale: 0.6;
+  --tt-swing-angle: 28deg;
+  background: linear-gradient(135deg, var(--tt-accent), var(--tt-accent-2));
+  color: #fff;
+}
+.tt-bubble--custom::after {
+  border-top-color: var(--tt-accent);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Stats dashboard example                                                */
+/* ---------------------------------------------------------------------- */
+
+.stats__text {
+  color: #8b8fa3;
+  font-size: 0.85rem;
+  margin: 0 0 16px;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
+}
+
+.stat-card {
+  background: var(--tt-surface);
+  border: 1px solid var(--tt-border);
+  border-radius: 12px;
+  padding: 18px;
+}
+
+.stat-card__head {
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.stat-card__label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #8b8fa3;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.stat-card__value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #f9fafb;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Reduced motion                                                         */
+/* ---------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .tt-bubble {
+    transition: opacity 0.15s linear, visibility 0s linear 0.15s;
+    transform: translateX(-50%) !important;
+  }
+  .tooltip-wrap:hover .tt-bubble,
+  .tt-trigger:focus-visible + .tt-bubble,
+  .info-icon:focus-visible + .tt-bubble,
+  .nav-icon:focus-visible + .tt-bubble {
+    transition: opacity 0.15s linear, visibility 0s linear 0s;
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+/* Responsive                                                             */
+/* ---------------------------------------------------------------------- */
+
+@media (max-width: 700px) {
+  .app { flex-direction: column; }
+  .sidebar {
+    width: 100%;
+    flex-direction: row;
+    padding: 12px 16px;
+    gap: 16px;
+  }
+  .sidebar__nav { flex-direction: row; }
+  .page { padding: 28px 20px; }
+  .showcase { gap: 20px 16px; padding: 20px; }
+  .tt-bubble {
+    white-space: normal;
+    max-width: 160px;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Description
Adds a pure CSS animated tooltip component using a smooth spring-based
"swing-hover" transition, styled for a dark modern SaaS dashboard context
(violet → teal gradient accent, sidebar navigation, stat-card metrics).

Closes #34418

Distinct from the earlier "SaaS Showcase" submission (#34424): that one
targets a light marketing/pricing-page context with a feature checklist,
this one targets an in-app dashboard context with sidebar nav tooltips and
metric-card tooltips.

## What's included
- `submissions/examples/swing-hover-tooltip-modern-saas/demo.html`
- `submissions/examples/swing-hover-tooltip-modern-saas/style.css`
- `submissions/examples/swing-hover-tooltip-modern-saas/README.md`

## Features
- Pure CSS, zero JavaScript
- Keyboard accessible (`:focus-visible`, `aria-describedby`, `role="tooltip"`)
- Four placement variants: top, bottom, left, right
- Fully customizable via CSS custom properties
- Sidebar nav icon tooltip pattern + stat-card metric tooltip pattern
- Responsive (sidebar collapses to top bar on mobile)
- Respects `prefers-reduced-motion`

## Testing done
- Verified hover interaction on desktop (Chrome/Firefox/Edge)
- Verified keyboard-only navigation
- Verified all four placement variants render correctly
- Verified `prefers-reduced-motion` fallback
- Verified responsive behavior (sidebar → top bar collapse)

## Checklist
- [x] Files added only inside `submissions/`
- [x] Folder includes `demo.html`, `style.css`, `README.md`
- [x] No existing issue/PR duplicates this
- [x] Read `CONTRIBUTING.md`