### PR TITLE
feat: add dashboard analytics swing-hover tooltip (#34419)

### DIFF
--- a/submissions/examples/swing-hover-tooltip-dashboard-analytics/README.md
+++ b/submissions/examples/swing-hover-tooltip-dashboard-analytics/README.md
@@ -1,0 +1,87 @@
+# Swing-Hover Tooltip — Dashboard Analytics
+
+A pure CSS tooltip with a spring-like "swing" entrance animation, applied
+to **chart data points** rather than nav items or stat cards. Includes a
+hoverable bar chart (weekly sessions) and a hoverable line chart
+(conversion rate over 6 months), each revealing exact values on
+hover/focus. Zero JavaScript.
+
+This is intentionally distinct from the "Modern SaaS Dashboard" example:
+that one covers sidebar-nav and stat-card tooltips; this one covers
+in-chart data-point tooltips, which is a different interaction pattern
+(many small hover targets positioned dynamically).
+
+## Features
+
+- 🎯 Pure CSS — no JavaScript required
+- ⌨️ Keyboard accessible via `:focus-visible` (tab through bars/points)
+- 🔄 Four placement variants available: top, bottom, left, right
+- 🎛️ Customizable timing, easing, scale, offset via CSS variables
+- 📊 Bar chart example: 7 hoverable bars, each with a value tooltip
+- 📈 Line chart example: 6 hoverable data points positioned over an SVG
+  polyline, each with a value tooltip
+- 📱 Fully responsive
+- 🌀 Respects `prefers-reduced-motion`
+
+## Usage
+
+```html
+<div class="tooltip-wrap">
+  <button class="tt-trigger" aria-describedby="tt-1">Hover me</button>
+  <span class="tt-bubble tt-bubble--top" id="tt-1" role="tooltip">
+    Tooltip text here
+  </span>
+</div>
+```
+
+### Bar chart data-point pattern
+
+```html
+<span class="tooltip-wrap bar-wrap">
+  <button class="bar" style="--bar-h: 71%;" aria-describedby="tt-bar-3">
+    <span class="bar__day">Wed</span>
+  </button>
+  <span class="tt-bubble tt-bubble--top" id="tt-bar-3" role="tooltip">2,090 sessions</span>
+</span>
+```
+
+### Line chart data-point pattern
+
+Points are absolutely positioned over an SVG polyline using inline
+`left`/`top` matching the polyline's coordinate space:
+
+```html
+<span class="tooltip-wrap point-wrap" style="left: 284px; top: 55px;">
+  <button class="point" aria-describedby="tt-pt-4"></button>
+  <span class="tt-bubble tt-bubble--top" id="tt-pt-4" role="tooltip">Apr · 3.2%</span>
+</span>
+```
+
+## Customization
+
+| Variable | Default | Description |
+|---|---|---|
+| `--tt-duration` | `0.3s` | Animation duration |
+| `--tt-easing` | `cubic-bezier(0.34, 1.56, 0.64, 1)` | Springy swing easing |
+| `--tt-scale` | `0.85` | Starting scale before swing-in |
+| `--tt-swing-angle` | `15deg` | Rotation angle of the swing |
+| `--tt-offset` | `10px` | Gap between trigger and tooltip |
+| `--tt-bg` | `#1e293b` | Tooltip background color |
+| `--tt-accent` | `#f59e0b` | Amber accent (peak/highlight values) |
+| `--tt-accent-2` | `#3b82f6` | Blue accent (bars, line, points) |
+
+## Accessibility
+
+- Revealed on both `:hover` and `:focus-visible`, so keyboard users can tab
+  through every bar and data point and get the same value readout.
+- Each trigger uses `aria-describedby` pointing to the tooltip's `id`.
+- Tooltip element uses `role="tooltip"`.
+- Charts use `role="img"` with a descriptive `aria-label` as a fallback
+  summary for screen reader users who don't interact point-by-point.
+- Animation disabled for users with `prefers-reduced-motion: reduce`.
+
+## Files
+
+- `demo.html` — placement showcase, bar chart, and line chart examples
+- `style.css` — component styles and animation logic
+- `README.md` — this file

--- a/submissions/examples/swing-hover-tooltip-dashboard-analytics/demo.html
+++ b/submissions/examples/swing-hover-tooltip-dashboard-analytics/demo.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Swing-Hover Tooltip | Dashboard Analytics | EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="page">
+    <header class="page__header">
+      <h1 class="page__title">Swing-Hover Tooltip</h1>
+      <p class="page__subtitle">Dashboard Analytics · Pure CSS · Zero JavaScript</p>
+    </header>
+
+    <!-- Base placement showcase -->
+    <section class="showcase">
+      <div class="tooltip-wrap">
+        <button class="tt-trigger" aria-describedby="tt-top">Top</button>
+        <span class="tt-bubble tt-bubble--top" id="tt-top" role="tooltip">
+          Swing-hover from the top
+        </span>
+      </div>
+
+      <div class="tooltip-wrap">
+        <button class="tt-trigger" aria-describedby="tt-bottom">Bottom</button>
+        <span class="tt-bubble tt-bubble--bottom" id="tt-bottom" role="tooltip">
+          Swings in from below
+        </span>
+      </div>
+
+      <div class="tooltip-wrap">
+        <button class="tt-trigger" aria-describedby="tt-left">Left</button>
+        <span class="tt-bubble tt-bubble--left" id="tt-left" role="tooltip">
+          Swings from the left
+        </span>
+      </div>
+
+      <div class="tooltip-wrap">
+        <button class="tt-trigger" aria-describedby="tt-right">Right</button>
+        <span class="tt-bubble tt-bubble--right" id="tt-right" role="tooltip">
+          Swings in from the right
+        </span>
+      </div>
+    </section>
+
+    <!-- Bar chart with data-point tooltips -->
+    <section class="chart-card">
+      <div class="chart-card__head">
+        <h2 class="chart-card__title">Weekly Sessions</h2>
+        <span class="chart-card__badge">Last 7 days</span>
+      </div>
+
+      <div class="bar-chart" role="img" aria-label="Bar chart of weekly sessions">
+        <span class="tooltip-wrap bar-wrap">
+          <button class="bar" style="--bar-h: 42%;" aria-describedby="tt-bar-1"><span class="bar__day">Mon</span></button>
+          <span class="tt-bubble tt-bubble--top" id="tt-bar-1" role="tooltip">1,240 sessions</span>
+        </span>
+        <span class="tooltip-wrap bar-wrap">
+          <button class="bar" style="--bar-h: 58%;" aria-describedby="tt-bar-2"><span class="bar__day">Tue</span></button>
+          <span class="tt-bubble tt-bubble--top" id="tt-bar-2" role="tooltip">1,710 sessions</span>
+        </span>
+        <span class="tooltip-wrap bar-wrap">
+          <button class="bar" style="--bar-h: 71%;" aria-describedby="tt-bar-3"><span class="bar__day">Wed</span></button>
+          <span class="tt-bubble tt-bubble--top" id="tt-bar-3" role="tooltip">2,090 sessions</span>
+        </span>
+        <span class="tooltip-wrap bar-wrap">
+          <button class="bar" style="--bar-h: 50%;" aria-describedby="tt-bar-4"><span class="bar__day">Thu</span></button>
+          <span class="tt-bubble tt-bubble--top" id="tt-bar-4" role="tooltip">1,480 sessions</span>
+        </span>
+        <span class="tooltip-wrap bar-wrap">
+          <button class="bar" style="--bar-h: 84%;" aria-describedby="tt-bar-5"><span class="bar__day">Fri</span></button>
+          <span class="tt-bubble tt-bubble--top" id="tt-bar-5" role="tooltip">2,470 sessions</span>
+        </span>
+        <span class="tooltip-wrap bar-wrap">
+          <button class="bar" style="--bar-h: 33%;" aria-describedby="tt-bar-6"><span class="bar__day">Sat</span></button>
+          <span class="tt-bubble tt-bubble--top" id="tt-bar-6" role="tooltip">980 sessions</span>
+        </span>
+        <span class="tooltip-wrap bar-wrap">
+          <button class="bar bar--accent" style="--bar-h: 95%;" aria-describedby="tt-bar-7"><span class="bar__day">Sun</span></button>
+          <span class="tt-bubble tt-bubble--top tt-bubble--custom" id="tt-bar-7" role="tooltip">2,810 sessions (peak)</span>
+        </span>
+      </div>
+    </section>
+
+    <!-- Line chart with data-point tooltips -->
+    <section class="chart-card">
+      <div class="chart-card__head">
+        <h2 class="chart-card__title">Conversion Rate</h2>
+        <span class="chart-card__badge">Last 6 months</span>
+      </div>
+
+      <div class="line-chart" role="img" aria-label="Line chart of conversion rate over 6 months">
+        <svg class="line-chart__svg" viewBox="0 0 560 140" preserveAspectRatio="none" aria-hidden="true">
+          <polyline points="20,100 108,80 196,90 284,55 372,65 460,30" />
+        </svg>
+
+        <span class="tooltip-wrap point-wrap" style="left: 20px; top: 100px;">
+          <button class="point" aria-describedby="tt-pt-1"></button>
+          <span class="tt-bubble tt-bubble--top" id="tt-pt-1" role="tooltip">Jan · 2.1%</span>
+        </span>
+        <span class="tooltip-wrap point-wrap" style="left: 108px; top: 80px;">
+          <button class="point" aria-describedby="tt-pt-2"></button>
+          <span class="tt-bubble tt-bubble--top" id="tt-pt-2" role="tooltip">Feb · 2.6%</span>
+        </span>
+        <span class="tooltip-wrap point-wrap" style="left: 196px; top: 90px;">
+          <button class="point" aria-describedby="tt-pt-3"></button>
+          <span class="tt-bubble tt-bubble--top" id="tt-pt-3" role="tooltip">Mar · 2.4%</span>
+        </span>
+        <span class="tooltip-wrap point-wrap" style="left: 284px; top: 55px;">
+          <button class="point" aria-describedby="tt-pt-4"></button>
+          <span class="tt-bubble tt-bubble--top" id="tt-pt-4" role="tooltip">Apr · 3.2%</span>
+        </span>
+        <span class="tooltip-wrap point-wrap" style="left: 372px; top: 65px;">
+          <button class="point" aria-describedby="tt-pt-5"></button>
+          <span class="tt-bubble tt-bubble--top" id="tt-pt-5" role="tooltip">May · 3.0%</span>
+        </span>
+        <span class="tooltip-wrap point-wrap" style="left: 460px; top: 30px;">
+          <button class="point point--accent" aria-describedby="tt-pt-6"></button>
+          <span class="tt-bubble tt-bubble--top tt-bubble--custom" id="tt-pt-6" role="tooltip">Jun · 3.9% (best)</span>
+        </span>
+      </div>
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/swing-hover-tooltip-dashboard-analytics/style.css
+++ b/submissions/examples/swing-hover-tooltip-dashboard-analytics/style.css
@@ -1,0 +1,370 @@
+/* ==========================================================================
+   Swing-Hover Tooltip — Dashboard Analytics variant — EaseMotion CSS
+   Pure CSS, keyboard accessible, customizable via CSS custom properties
+
+   Distinct from the "Modern SaaS Dashboard" variant: focuses on chart
+   data-point tooltips (bar chart + line chart) rather than nav/stat-cards,
+   in a lighter analytics-report visual style.
+   ========================================================================== */
+
+:root {
+  --tt-duration: 0.3s;
+  --tt-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --tt-scale: 0.85;
+  --tt-swing-angle: 15deg;
+  --tt-offset: 10px;
+  --tt-bg: #1e293b;
+  --tt-color: #f1f5f9;
+  --tt-accent: #f59e0b;
+  --tt-accent-2: #3b82f6;
+  --tt-border: #e2e8f0;
+  --tt-radius: 8px;
+  --tt-font-size: 0.8rem;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+  background: #f8fafc;
+  color: #0f172a;
+  padding: 40px 20px;
+  display: flex;
+  justify-content: center;
+}
+
+.page {
+  width: 100%;
+  max-width: 720px;
+}
+
+.page__header {
+  text-align: center;
+  margin-bottom: 32px;
+}
+
+.page__title {
+  font-size: clamp(1.5rem, 4vw, 2.1rem);
+  font-weight: 700;
+  margin: 0 0 6px;
+}
+
+.page__subtitle {
+  color: #64748b;
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Base placement showcase                                                */
+/* ---------------------------------------------------------------------- */
+
+.showcase {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 28px 22px;
+  justify-content: center;
+  align-items: center;
+  padding: 24px;
+  background: #ffffff;
+  border: 1px solid var(--tt-border);
+  border-radius: 14px;
+  margin-bottom: 28px;
+}
+
+.tooltip-wrap { position: relative; display: inline-flex; }
+
+.tt-trigger {
+  font-family: inherit;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: #0f172a;
+  background: #ffffff;
+  border: 1px solid var(--tt-border);
+  border-radius: var(--tt-radius);
+  padding: 10px 18px;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.tt-trigger:hover,
+.tt-trigger:focus-visible {
+  transform: translateY(-1px);
+  border-color: var(--tt-accent-2);
+  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.15);
+}
+.tt-trigger:focus-visible {
+  outline: 2px solid var(--tt-accent-2);
+  outline-offset: 2px;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Tooltip bubble (shared)                                                */
+/* ---------------------------------------------------------------------- */
+
+.tt-bubble {
+  position: absolute;
+  z-index: 20;
+  left: 50%;
+  white-space: nowrap;
+  padding: 6px 11px;
+  font-size: var(--tt-font-size);
+  font-weight: 600;
+  color: var(--tt-color);
+  background: var(--tt-bg);
+  border-radius: 6px;
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.28);
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+
+  bottom: calc(100% + var(--tt-offset));
+  transform: translateX(-50%) translateY(6px) scale(var(--tt-scale)) rotate(var(--tt-swing-angle));
+  transform-origin: bottom center;
+
+  transition:
+    opacity var(--tt-duration) var(--tt-easing),
+    transform var(--tt-duration) var(--tt-easing),
+    visibility 0s linear var(--tt-duration);
+}
+
+.tt-bubble::after {
+  content: "";
+  position: absolute;
+  border: 5px solid transparent;
+}
+
+.tt-bubble--top::after {
+  top: 100%; left: 50%;
+  transform: translateX(-50%);
+  border-top-color: var(--tt-bg);
+}
+
+.tt-bubble--bottom {
+  bottom: auto;
+  top: calc(100% + var(--tt-offset));
+  transform: translateX(-50%) translateY(-6px) scale(var(--tt-scale)) rotate(calc(-1 * var(--tt-swing-angle)));
+  transform-origin: top center;
+}
+.tt-bubble--bottom::after {
+  bottom: 100%; left: 50%;
+  transform: translateX(-50%);
+  border-bottom-color: var(--tt-bg);
+}
+
+.tt-bubble--left {
+  left: auto;
+  right: calc(100% + var(--tt-offset));
+  bottom: auto; top: 50%;
+  transform: translateY(-50%) translateX(6px) scale(var(--tt-scale)) rotate(calc(-1 * var(--tt-swing-angle)));
+  transform-origin: right center;
+}
+.tt-bubble--left::after {
+  left: 100%; top: 50%;
+  transform: translateY(-50%);
+  border-left-color: var(--tt-bg);
+}
+
+.tt-bubble--right {
+  left: calc(100% + var(--tt-offset));
+  bottom: auto; top: 50%;
+  transform: translateY(-50%) translateX(-6px) scale(var(--tt-scale)) rotate(var(--tt-swing-angle));
+  transform-origin: left center;
+}
+.tt-bubble--right::after {
+  right: 100%; top: 50%;
+  transform: translateY(-50%);
+  border-right-color: var(--tt-bg);
+}
+
+.tooltip-wrap:hover .tt-bubble,
+.tt-trigger:focus-visible + .tt-bubble,
+.tt-trigger:focus-visible ~ .tt-bubble {
+  opacity: 1;
+  visibility: visible;
+  transition:
+    opacity var(--tt-duration) var(--tt-easing),
+    transform var(--tt-duration) var(--tt-easing),
+    visibility 0s linear 0s;
+}
+.tooltip-wrap:hover .tt-bubble--top,
+.tt-trigger:focus-visible + .tt-bubble--top { transform: translateX(-50%) translateY(0) scale(1) rotate(0deg); }
+.tooltip-wrap:hover .tt-bubble--bottom,
+.tt-trigger:focus-visible + .tt-bubble--bottom { transform: translateX(-50%) translateY(0) scale(1) rotate(0deg); }
+.tooltip-wrap:hover .tt-bubble--left,
+.tt-trigger:focus-visible + .tt-bubble--left { transform: translateY(-50%) translateX(0) scale(1) rotate(0deg); }
+.tooltip-wrap:hover .tt-bubble--right,
+.tt-trigger:focus-visible + .tt-bubble--right { transform: translateY(-50%) translateX(0) scale(1) rotate(0deg); }
+
+.tt-bubble--custom {
+  --tt-duration: 0.5s;
+  --tt-easing: cubic-bezier(0.68, -0.55, 0.27, 1.55);
+  --tt-scale: 0.6;
+  --tt-swing-angle: 26deg;
+  background: var(--tt-accent);
+  color: #1c1200;
+}
+.tt-bubble--custom::after { border-top-color: var(--tt-accent); }
+
+/* ---------------------------------------------------------------------- */
+/* Chart card shell                                                       */
+/* ---------------------------------------------------------------------- */
+
+.chart-card {
+  background: #ffffff;
+  border: 1px solid var(--tt-border);
+  border-radius: 14px;
+  padding: 24px;
+  margin-bottom: 24px;
+}
+
+.chart-card__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+.chart-card__title {
+  font-size: 1rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.chart-card__badge {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: #64748b;
+  background: #f1f5f9;
+  padding: 4px 10px;
+  border-radius: 999px;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Bar chart with data-point tooltips                                     */
+/* ---------------------------------------------------------------------- */
+
+.bar-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 14px;
+  height: 160px;
+  padding: 0 4px;
+}
+
+.bar-wrap {
+  flex: 1;
+  display: flex;
+  align-items: flex-end;
+  height: 100%;
+}
+
+.bar {
+  width: 100%;
+  height: var(--bar-h, 40%);
+  background: var(--tt-accent-2);
+  border: none;
+  border-radius: 6px 6px 2px 2px;
+  cursor: pointer;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding-bottom: 6px;
+  transition: filter 0.2s ease, transform 0.2s ease;
+  position: relative;
+}
+.bar:hover,
+.bar:focus-visible {
+  filter: brightness(1.1);
+  transform: translateY(-2px);
+}
+.bar:focus-visible {
+  outline: 2px solid var(--tt-accent-2);
+  outline-offset: 2px;
+}
+.bar--accent { background: var(--tt-accent); }
+
+.bar__day {
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Line chart with data-point tooltips                                    */
+/* ---------------------------------------------------------------------- */
+
+.line-chart {
+  position: relative;
+  height: 140px;
+}
+
+.line-chart__svg {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  inset: 0;
+}
+.line-chart__svg polyline {
+  fill: none;
+  stroke: var(--tt-accent-2);
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.point-wrap {
+  position: absolute;
+  transform: translate(-50%, -50%);
+}
+
+.point {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #ffffff;
+  border: 3px solid var(--tt-accent-2);
+  cursor: pointer;
+  padding: 0;
+  transition: transform 0.2s ease;
+}
+.point:hover,
+.point:focus-visible {
+  transform: scale(1.25);
+}
+.point:focus-visible {
+  outline: 2px solid var(--tt-accent-2);
+  outline-offset: 3px;
+}
+.point--accent { border-color: var(--tt-accent); }
+
+/* ---------------------------------------------------------------------- */
+/* Reduced motion                                                         */
+/* ---------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .tt-bubble {
+    transition: opacity 0.15s linear, visibility 0s linear 0.15s;
+    transform: translateX(-50%) !important;
+  }
+  .tooltip-wrap:hover .tt-bubble,
+  .tt-trigger:focus-visible + .tt-bubble {
+    transition: opacity 0.15s linear, visibility 0s linear 0s;
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+/* Responsive                                                             */
+/* ---------------------------------------------------------------------- */
+
+@media (max-width: 600px) {
+  .showcase { gap: 18px 14px; padding: 18px; }
+  .bar-chart { gap: 8px; height: 130px; }
+  .chart-card { padding: 18px; }
+  .tt-bubble {
+    white-space: normal;
+    max-width: 150px;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Description
Adds a pure CSS animated tooltip component using a smooth spring-based
"swing-hover" transition, applied to chart data points (bar chart + line
chart) rather than nav items or stat cards.

Closes #34419

Distinct from the "Modern SaaS Dashboard" submission (#34418): that one
covers sidebar-nav and stat-card tooltips; this one covers in-chart
data-point tooltips on a hoverable bar chart and line chart, which is a
different interaction pattern (many small dynamically-positioned targets).

## What's included
- `submissions/examples/swing-hover-tooltip-dashboard-analytics/demo.html`
- `submissions/examples/swing-hover-tooltip-dashboard-analytics/style.css`
- `submissions/examples/swing-hover-tooltip-dashboard-analytics/README.md`

## Features
- Pure CSS, zero JavaScript
- Keyboard accessible (`:focus-visible`, `aria-describedby`, `role="tooltip"`)
- Bar chart: 7 hoverable/focusable bars, each with a value tooltip
- Line chart: 6 hoverable/focusable data points over an SVG polyline
- Fully customizable via CSS custom properties
- Charts use `role="img"` + `aria-label` as a screen-reader fallback summary
- Responsive layout, tested down to mobile widths
- Respects `prefers-reduced-motion`

## Testing done
- Verified hover interaction on desktop (Chrome/Firefox/Edge)
- Verified keyboard-only navigation through all bars and points
- Verified `prefers-reduced-motion` fallback
- Verified responsive behavior at narrow viewports

## Checklist
- [x] Files added only inside `submissions/`
- [x] Folder includes `demo.html`, `style.css`, `README.md`
- [x] No existing issue/PR duplicates this
- [x] Read `CONTRIBUTING.md`