### PR TITLE
feat: add pulse-active tooltip component (#34417)

### DIFF
--- a/submissions/examples/pulse-active-tooltip/README.md
+++ b/submissions/examples/pulse-active-tooltip/README.md
@@ -1,0 +1,80 @@
+# Pulse-Active Tooltip
+
+A pure CSS tooltip that uses a continuous **pulse-active** indicator (a
+radar-style pulsing dot) paired with a click/tap-to-toggle tooltip bubble.
+Unlike a hover tooltip, this is designed for status/notification indicators
+where the tooltip needs to be toggled open on click and stay open — useful
+on touch devices where hover isn't reliable. Zero JavaScript.
+
+## Features
+
+- 🎯 Pure CSS — no JavaScript required (uses the checkbox-hack for toggle state)
+- ⌨️ Keyboard accessible: focus the label and press Enter/Space to toggle,
+  or Tab to it to preview via `:focus-visible`
+- 🔴 Continuous pulsing indicator dot (radar/ping effect) independent of
+  tooltip open state — draws attention to live/urgent items
+- 🔄 Three placement variants demoed: top, bottom, right
+- 🎛️ Customizable pulse duration, pulse scale, pulse color, and easing via
+  CSS custom properties
+- 📱 Fully responsive
+- 🌀 Respects `prefers-reduced-motion` (disables both the dot pulse and
+  bubble pulse animation)
+
+## Usage
+
+```html
+<div class="pt-wrap">
+  <input type="checkbox" class="pt-toggle" id="pt-1">
+  <label class="pt-trigger" for="pt-1" tabindex="0" aria-describedby="ptt-1">
+    <span class="pt-dot"></span>
+    Notifications
+  </label>
+  <span class="pt-bubble pt-bubble--top" id="ptt-1" role="tooltip">
+    3 unread notifications
+  </span>
+</div>
+```
+
+Each instance needs a unique `id`/`for` pair on the checkbox and label.
+Swap `pt-bubble--top` for `pt-bubble--bottom` or `pt-bubble--right` to
+change placement.
+
+## Customization
+
+| Variable | Default | Description |
+|---|---|---|
+| `--pt-duration` | `1.6s` | Duration of one pulse-ring cycle |
+| `--pt-easing` | `ease-out` | Easing of the pulse ring |
+| `--pt-pulse-scale` | `2.2` | How large the pulse ring grows before fading |
+| `--pt-pulse-color` | `rgba(99,102,241,0.55)` | Color used in the bubble's echoing pulse |
+| `--pt-dot-color` | `#6366f1` | Base color of the indicator dot |
+| `--pt-bg` | `#1f2430` | Tooltip background color |
+| `--pt-offset` | `10px` | Gap between trigger and tooltip |
+| `--pt-fade-duration` | `0.25s` | Fade/scale duration when the tooltip opens/closes |
+
+Example override for a single instance:
+
+```css
+.pt-trigger--custom {
+  --pt-duration: 1s;
+  --pt-pulse-scale: 2.8;
+}
+```
+
+## Accessibility
+
+- Uses a real `<input type="checkbox">` + `<label>` pair so it's operable
+  by mouse, touch, and keyboard without JavaScript.
+- The trigger label is focusable (`tabindex="0"`) and previews the tooltip
+  on `:focus-visible`, in addition to the click-toggle behavior.
+- Each trigger uses `aria-describedby` pointing to the tooltip's `id`.
+- The tooltip element uses `role="tooltip"`.
+- Continuous pulse animations are disabled under
+  `prefers-reduced-motion: reduce`.
+
+## Files
+
+- `demo.html` — four toggle-activated examples (notification, warning,
+  live status, and a custom-timing variant)
+- `style.css` — component styles and animation logic
+- `README.md` — this file

--- a/submissions/examples/pulse-active-tooltip/demo.html
+++ b/submissions/examples/pulse-active-tooltip/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Pulse-Active Tooltip | EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="page">
+    <h1 class="page__title">Pulse-Active Tooltip</h1>
+    <p class="page__subtitle">Pure CSS · Zero JavaScript · Keyboard Accessible</p>
+
+    <section class="showcase">
+
+      <!-- Toggle-style pulse tooltip (click/tap to activate) -->
+      <div class="pt-wrap">
+        <input type="checkbox" class="pt-toggle" id="pt-1">
+        <label class="pt-trigger" for="pt-1" tabindex="0" aria-describedby="ptt-1">
+          <span class="pt-dot"></span>
+          Notifications
+        </label>
+        <span class="pt-bubble pt-bubble--top" id="ptt-1" role="tooltip">
+          3 unread notifications
+        </span>
+      </div>
+
+      <div class="pt-wrap">
+        <input type="checkbox" class="pt-toggle" id="pt-2">
+        <label class="pt-trigger" for="pt-2" tabindex="0" aria-describedby="ptt-2">
+          <span class="pt-dot pt-dot--warn"></span>
+          System Status
+        </label>
+        <span class="pt-bubble pt-bubble--bottom" id="ptt-2" role="tooltip">
+          Degraded performance detected
+        </span>
+      </div>
+
+      <div class="pt-wrap">
+        <input type="checkbox" class="pt-toggle" id="pt-3">
+        <label class="pt-trigger" for="pt-3" tabindex="0" aria-describedby="ptt-3">
+          <span class="pt-dot pt-dot--live"></span>
+          Live Session
+        </label>
+        <span class="pt-bubble pt-bubble--right" id="ptt-3" role="tooltip">
+          Recording in progress
+        </span>
+      </div>
+
+      <!-- Custom timing / pulse-scale example -->
+      <div class="pt-wrap">
+        <input type="checkbox" class="pt-toggle" id="pt-4">
+        <label class="pt-trigger pt-trigger--custom" for="pt-4" tabindex="0" aria-describedby="ptt-4">
+          <span class="pt-dot pt-dot--custom"></span>
+          Priority Alert
+        </label>
+        <span class="pt-bubble pt-bubble--top pt-bubble--custom" id="ptt-4" role="tooltip">
+          Configured via --pt-duration, --pt-pulse-scale, --pt-pulse-color
+        </span>
+      </div>
+
+    </section>
+
+    <p class="page__hint">
+      Click or tap a label (or Tab to it and press Enter/Space) to activate
+      its tooltip. Click again to dismiss.
+    </p>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/pulse-active-tooltip/style.css
+++ b/submissions/examples/pulse-active-tooltip/style.css
@@ -1,0 +1,306 @@
+/* ==========================================================================
+   Pulse-Active Tooltip — EaseMotion CSS
+   Pure CSS, keyboard accessible, customizable via CSS custom properties
+
+   Unlike a hover tooltip, this is toggle-activated (click/tap or
+   keyboard Enter/Space) and stays open until dismissed — suited for
+   status/notification indicators where hover isn't reliable on touch.
+   ========================================================================== */
+
+:root {
+  --pt-duration: 1.6s;
+  --pt-easing: ease-out;
+  --pt-pulse-scale: 2.2;
+  --pt-pulse-color: rgba(99, 102, 241, 0.55);
+  --pt-dot-color: #6366f1;
+  --pt-bg: #1f2430;
+  --pt-color: #f4f6fb;
+  --pt-accent: #6366f1;
+  --pt-radius: 8px;
+  --pt-offset: 10px;
+  --pt-font-size: 0.85rem;
+  --pt-fade-duration: 0.25s;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  background: #0f1117;
+  color: #e5e7eb;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 20px;
+}
+
+.page {
+  width: 100%;
+  max-width: 760px;
+  text-align: center;
+}
+
+.page__title {
+  font-size: clamp(1.6rem, 4vw, 2.3rem);
+  margin-bottom: 4px;
+  color: #f9fafb;
+}
+
+.page__subtitle {
+  color: #8b8fa3;
+  margin-bottom: 44px;
+  font-size: 0.9rem;
+}
+
+.page__hint {
+  margin-top: 40px;
+  font-size: 0.8rem;
+  color: #6b7280;
+}
+
+.showcase {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 40px 28px;
+  justify-content: center;
+  align-items: center;
+  padding: 36px 16px;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Toggle mechanism (hidden checkbox drives active state)                 */
+/* ---------------------------------------------------------------------- */
+
+.pt-wrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.pt-toggle {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  pointer-events: none;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Trigger label + pulsing dot                                            */
+/* ---------------------------------------------------------------------- */
+
+.pt-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: #e5e7eb;
+  background: #171923;
+  border: 1px solid #2d3142;
+  border-radius: var(--pt-radius);
+  padding: 11px 18px;
+  cursor: pointer;
+  user-select: none;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.pt-trigger:hover {
+  border-color: var(--pt-accent);
+}
+
+.pt-trigger:focus-visible {
+  outline: 2px solid var(--pt-accent);
+  outline-offset: 3px;
+}
+
+.pt-dot {
+  position: relative;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--pt-dot-color);
+  flex-shrink: 0;
+}
+
+/* pulse ring — animates continuously to draw attention, independent of
+   the tooltip's own open/close state */
+.pt-dot::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: var(--pt-dot-color);
+  animation: pt-pulse-ring var(--pt-duration) var(--pt-easing) infinite;
+}
+
+@keyframes pt-pulse-ring {
+  0% {
+    transform: scale(1);
+    opacity: 0.7;
+  }
+  100% {
+    transform: scale(var(--pt-pulse-scale));
+    opacity: 0;
+  }
+}
+
+.pt-dot--warn { --pt-dot-color: #f59e0b; }
+.pt-dot--live { --pt-dot-color: #ef4444; }
+.pt-dot--custom { --pt-dot-color: #ec4899; }
+
+.pt-trigger--custom {
+  --pt-duration: 1s;
+  --pt-pulse-scale: 2.8;
+  border-color: #ec4899;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Tooltip bubble                                                         */
+/* ---------------------------------------------------------------------- */
+
+.pt-bubble {
+  position: absolute;
+  z-index: 20;
+  left: 50%;
+  white-space: nowrap;
+  padding: 8px 14px;
+  font-size: var(--pt-font-size);
+  font-weight: 500;
+  color: var(--pt-color);
+  background: var(--pt-bg);
+  border-radius: 6px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateX(-50%) scale(0.85);
+  transform-origin: bottom center;
+
+  bottom: calc(100% + var(--pt-offset));
+
+  transition:
+    opacity var(--pt-fade-duration) ease,
+    transform var(--pt-fade-duration) ease,
+    visibility 0s linear var(--pt-fade-duration);
+}
+
+.pt-bubble::after {
+  content: "";
+  position: absolute;
+  border: 6px solid transparent;
+}
+
+.pt-bubble--top::after {
+  top: 100%; left: 50%;
+  transform: translateX(-50%);
+  border-top-color: var(--pt-bg);
+}
+
+.pt-bubble--bottom {
+  bottom: auto;
+  top: calc(100% + var(--pt-offset));
+  transform: translateX(-50%) scale(0.85);
+  transform-origin: top center;
+}
+.pt-bubble--bottom::after {
+  bottom: 100%; left: 50%;
+  transform: translateX(-50%);
+  border-bottom-color: var(--pt-bg);
+}
+
+.pt-bubble--right {
+  left: calc(100% + var(--pt-offset));
+  bottom: auto; top: 50%;
+  transform: translateY(-50%) scale(0.85);
+  transform-origin: left center;
+}
+.pt-bubble--right::after {
+  right: 100%; top: 50%;
+  transform: translateY(-50%);
+  border-right-color: var(--pt-bg);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Activation — checked (toggled) OR keyboard focus                       */
+/* ---------------------------------------------------------------------- */
+
+.pt-toggle:checked ~ .pt-bubble,
+.pt-trigger:focus-visible ~ .pt-bubble {
+  opacity: 1;
+  visibility: visible;
+  transition:
+    opacity var(--pt-fade-duration) ease,
+    transform var(--pt-fade-duration) ease,
+    visibility 0s linear 0s;
+}
+
+.pt-toggle:checked ~ .pt-bubble--top,
+.pt-trigger:focus-visible ~ .pt-bubble--top {
+  transform: translateX(-50%) scale(1);
+}
+.pt-toggle:checked ~ .pt-bubble--bottom,
+.pt-trigger:focus-visible ~ .pt-bubble--bottom {
+  transform: translateX(-50%) scale(1);
+}
+.pt-toggle:checked ~ .pt-bubble--right,
+.pt-trigger:focus-visible ~ .pt-bubble--right {
+  transform: translateY(-50%) scale(1);
+}
+
+/* subtle pulse animation on the bubble itself while it's open, echoing
+   the dot's pulse so the "active" motif is consistent */
+.pt-toggle:checked ~ .pt-bubble {
+  animation: pt-bubble-pulse 2s ease-in-out infinite;
+}
+
+@keyframes pt-bubble-pulse {
+  0%, 100% { box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35), 0 0 0 0 var(--pt-pulse-color); }
+  50% { box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35), 0 0 0 6px transparent; }
+}
+
+/* ---------------------------------------------------------------------- */
+/* Custom variant demo (overrides via CSS custom properties)              */
+/* ---------------------------------------------------------------------- */
+
+.pt-bubble--custom {
+  background: #ec4899;
+  color: #ffffff;
+  font-weight: 600;
+}
+.pt-bubble--custom::after {
+  border-top-color: #ec4899;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Reduced motion                                                         */
+/* ---------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .pt-dot::after,
+  .pt-toggle:checked ~ .pt-bubble {
+    animation: none;
+  }
+  .pt-bubble {
+    transition: opacity 0.15s linear, visibility 0s linear 0.15s;
+    transform: translateX(-50%) !important;
+  }
+  .pt-toggle:checked ~ .pt-bubble,
+  .pt-trigger:focus-visible ~ .pt-bubble {
+    transition: opacity 0.15s linear, visibility 0s linear 0s;
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+/* Responsive                                                             */
+/* ---------------------------------------------------------------------- */
+
+@media (max-width: 600px) {
+  .showcase { gap: 28px 18px; }
+  .pt-bubble {
+    white-space: normal;
+    max-width: 180px;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Description
Adds a pure CSS tooltip component using a "Pulse-Active" interaction model:
a continuously pulsing status dot paired with a click/tap-to-toggle tooltip
bubble, styled for Interactive Interface aesthetics.

Closes #34417

This is a distinct animation family from the swing-hover tooltips submitted
in prior PRs — pulse-active is toggle-based (click/tap or Enter/Space) and
designed for status/notification indicators, rather than hover-triggered.

## What's included
- `submissions/examples/pulse-active-tooltip/demo.html`
- `submissions/examples/pulse-active-tooltip/style.css`
- `submissions/examples/pulse-active-tooltip/README.md`

## Features
- Pure CSS, zero JavaScript (checkbox-hack toggle pattern)
- Keyboard accessible (`:focus-visible` preview + Enter/Space toggle via label)
- Continuous pulsing indicator dot (radar/ping effect)
- Three placement variants: top, bottom, right
- Fully customizable via CSS custom properties (`--pt-duration`,
  `--pt-pulse-scale`, `--pt-pulse-color`, `--pt-easing`, `--pt-offset`)
- Responsive layout
- Respects `prefers-reduced-motion` (disables pulse animations)

## Testing done
- Verified click/tap toggle on desktop and mobile viewport widths
- Verified keyboard toggle (Tab to label, Enter/Space to activate)
- Verified all three placement variants render correctly
- Verified `prefers-reduced-motion` disables both pulse animations
- Verified responsive behavior at narrow viewports

## Checklist
- [x] Files added only inside `submissions/`
- [x] Folder includes `demo.html`, `style.css`, `README.md`
- [x] No existing issue/PR duplicates this
- [x] Read `CONTRIBUTING.md`