### PR TITLE
feat: add blur-entrance tooltip component

### DIFF
--- a/submissions/examples/basic-blur-entrance-tooltip/README.md
+++ b/submissions/examples/basic-blur-entrance-tooltip/README.md
@@ -1,0 +1,46 @@
+# Ease Blur-Entrance Tooltip
+
+## Description
+A pure CSS tooltip that transitions in using a "blur-entrance" effect — the tooltip animates from blurred/scaled-down/transparent to sharp/full-scale/opaque, rather than a plain fade or slide. Zero JavaScript.
+
+## Features
+- Blur-to-sharp entrance using `filter: blur()`
+- Combined scale + vertical offset + opacity for a layered entrance feel
+- Triggers on both `:hover` and keyboard `:focus` (via `:focus-within` and `:focus-visible`) for full keyboard accessibility
+- Fully customizable via CSS custom properties — no need to edit the core rules
+- Respects `prefers-reduced-motion` (disables blur/scale, keeps a simple opacity fade)
+
+## Usage
+```html
+<span class="ease-tooltip">
+  <button class="tooltip-trigger">Hover me</button>
+  <span class="tooltip-bubble" role="tooltip">Tooltip text here</span>
+</span>
+```
+
+## Customization (CSS custom properties)
+| Property | Default | Description |
+|---|---|---|
+| `--tooltip-duration` | `0.3s` | Animation duration |
+| `--tooltip-easing` | `cubic-bezier(0.16, 1, 0.3, 1)` | Timing function |
+| `--tooltip-blur` | `6px` | Starting blur amount |
+| `--tooltip-scale-start` | `0.92` | Starting scale before entrance |
+| `--tooltip-offset` | `10px` | Distance between trigger and tooltip |
+| `--tooltip-bg` | `#1a1a2e` | Tooltip background color |
+| `--tooltip-fg` | `#f5f7fa` | Tooltip text color |
+| `--tooltip-accent` | `#38bdf8` | Trigger button accent color |
+
+Example override:
+```html
+<span class="ease-tooltip" style="--tooltip-duration: 0.6s; --tooltip-blur: 12px;">
+  ...
+</span>
+```
+
+## Accessibility
+The tooltip is exposed via `role="tooltip"` and triggers on keyboard focus (`:focus-within`/`:focus-visible`), not just mouse hover, so keyboard-only users can access the same information.
+
+## Files
+- `demo.html` — live working example with three timing/style variants
+- `style.css` — component styles
+- `README.md` — this file

--- a/submissions/examples/basic-blur-entrance-tooltip/demo.html
+++ b/submissions/examples/basic-blur-entrance-tooltip/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ease Blur-Entrance Tooltip — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 60px;
+      background: #0f172a;
+      font-family: system-ui, sans-serif;
+    }
+    .demo-note {
+      position: fixed;
+      top: 24px;
+      left: 50%;
+      transform: translateX(-50%);
+      color: #94a3b8;
+      font-size: 0.85rem;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+
+  <p class="demo-note">Hover or Tab-focus each button to see the blur-entrance tooltip</p>
+
+  <span class="ease-tooltip">
+    <button class="tooltip-trigger" type="button">Default</button>
+    <span class="tooltip-bubble" role="tooltip">Default blur-entrance tooltip</span>
+  </span>
+
+  <span class="ease-tooltip" style="--tooltip-duration: 0.6s; --tooltip-blur: 12px; --tooltip-accent: #f97316;">
+    <button class="tooltip-trigger" type="button" style="background:#f97316;">Slow & heavy blur</button>
+    <span class="tooltip-bubble" role="tooltip">Custom timing + stronger blur</span>
+  </span>
+
+  <span class="ease-tooltip" style="--tooltip-duration: 0.15s; --tooltip-scale-start: 0.98; --tooltip-accent: #22c55e;">
+    <button class="tooltip-trigger" type="button" style="background:#22c55e;">Fast & subtle</button>
+    <span class="tooltip-bubble" role="tooltip">Fast timing, minimal scale change</span>
+  </span>
+
+</body>
+</html>

--- a/submissions/examples/basic-blur-entrance-tooltip/style.css
+++ b/submissions/examples/basic-blur-entrance-tooltip/style.css
@@ -1,0 +1,87 @@
+/* Ease Blur-Entrance Tooltip */
+
+.ease-tooltip {
+  --tooltip-bg: #1a1a2e;
+  --tooltip-fg: #f5f7fa;
+  --tooltip-accent: #38bdf8;
+  --tooltip-duration: 0.3s;
+  --tooltip-easing: cubic-bezier(0.16, 1, 0.3, 1);
+  --tooltip-blur: 6px;
+  --tooltip-scale-start: 0.92;
+  --tooltip-offset: 10px;
+  --tooltip-font-size: 0.8rem;
+
+  position: relative;
+  display: inline-flex;
+}
+
+.ease-tooltip .tooltip-bubble {
+  position: absolute;
+  bottom: calc(100% + var(--tooltip-offset));
+  left: 50%;
+  transform: translateX(-50%) translateY(6px) scale(var(--tooltip-scale-start));
+  white-space: nowrap;
+  background: var(--tooltip-bg);
+  color: var(--tooltip-fg);
+  font-size: var(--tooltip-font-size);
+  padding: 6px 12px;
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+
+  opacity: 0;
+  visibility: hidden;
+  filter: blur(var(--tooltip-blur));
+  pointer-events: none;
+
+  transition:
+    opacity var(--tooltip-duration) var(--tooltip-easing),
+    transform var(--tooltip-duration) var(--tooltip-easing),
+    filter var(--tooltip-duration) var(--tooltip-easing),
+    visibility var(--tooltip-duration);
+}
+
+.ease-tooltip .tooltip-bubble::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-top-color: var(--tooltip-bg);
+}
+
+/* Trigger on hover AND keyboard focus for accessibility */
+.ease-tooltip:hover .tooltip-bubble,
+.ease-tooltip:focus-within .tooltip-bubble,
+.ease-tooltip .tooltip-trigger:focus-visible ~ .tooltip-bubble {
+  opacity: 1;
+  visibility: visible;
+  filter: blur(0);
+  transform: translateX(-50%) translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.ease-tooltip .tooltip-trigger {
+  background: var(--tooltip-accent);
+  color: #0b0f19;
+  border: none;
+  font-family: inherit;
+  font-weight: 600;
+  font-size: 0.9rem;
+  padding: 10px 20px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.ease-tooltip .tooltip-trigger:focus-visible {
+  outline: 2px solid var(--tooltip-accent);
+  outline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-tooltip .tooltip-bubble {
+    transition: opacity var(--tooltip-duration) ease, visibility var(--tooltip-duration);
+    filter: none;
+    transform: translateX(-50%);
+  }
+}


### PR DESCRIPTION
Closes #34361

## Pull Request Description
Adds a pure CSS tooltip with a "blur-entrance" animation — the tooltip transitions in from a blurred, scaled-down, transparent state to fully sharp and visible, rather than a plain fade or slide. Fully responsive, keyboard accessible, and customizable via CSS custom properties, with zero JavaScript.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/basic-blur-entrance-tooltip/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS tooltip component that animates in using a blur-to-sharp entrance combined with scale and vertical offset, rather than a simple fade.

**How does a developer use it?**
```html
<span class="ease-tooltip">
  <button class="tooltip-trigger">Hover me</button>
  <span class="tooltip-bubble" role="tooltip">Tooltip text here</span>
</span>
```

**Why does it fit EaseMotion CSS?**
Zero-JavaScript, pure CSS animation using `filter: blur()`, `transform`, and `opacity` transitions, fully controllable via custom properties (`--tooltip-duration`, `--tooltip-blur`, `--tooltip-scale-start`, etc.) without touching core rules — consistent with the framework's animation-first, human-readable philosophy. Triggers on both `:hover` and keyboard `:focus` for accessibility, and respects `prefers-reduced-motion`.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser, includes 3 variants showing different timing/blur/scale customization)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Tooltip triggers on `:focus-within`/`:focus-visible` in addition to `:hover` to ensure keyboard-only users can access it, since hover-only tooltips are a common accessibility gap. Includes a reduced-motion fallback that keeps a simple opacity fade instead of the blur/scale entrance.