### PR TITLE
feat: add CSS blur-entrance tooltip for cyberpunk neon layouts (#34355)

### DIFF
--- a/submissions/examples/blur-entrance-cyberpunk-tooltips/README.md
+++ b/submissions/examples/blur-entrance-cyberpunk-tooltips/README.md
@@ -1,0 +1,17 @@
+# Pure CSS Blur-Entrance Cyberpunk Tooltip
+
+A declarative, high-contrast user interface tooltip overlay system built with hardware-accelerated filters to deliver clean digital reveal sequences inside cyberpunk, tech-noir, and futuristic terminal grids.
+
+## Features
+- **Zero JS Execution Overhead:** Coordinates multiple complex filter property interpolations using standard CSS rendering mechanics.
+- **Progressive Digital De-Blur:** Smoothly scales, shifts, and transitions from an initial pixelated blur setting straight to structural clarity on trigger activation.
+- **Cyberpunk Terminal Aesthetic:** Custom-built around hard angular boundaries, neon illumination drop shadows, scanline grids, and terminal tags.
+- **Responsive Focus Engine:** Fully integrated with clear layout interactive focus elements to support native accessibility rules.
+
+## Configurable Layout Tokens
+
+| Property Variable Token | Component Utility Target Assignment | Initial Baseline Value |
+| :--- | :--- | :--- |
+| `--tooltip-initial-blur` | Baseline blur strength applied before tooltips open | `12px` |
+| `--tooltip-entrance-speed` | Overall duration of the visibility transition track | `0.35s` |
+| `--tooltip-initial-scale` | Starting scale threshold value before popping out | `0.94` |

--- a/submissions/examples/blur-entrance-cyberpunk-tooltips/demo.html
+++ b/submissions/examples/blur-entrance-cyberpunk-tooltips/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Blur-Entrance Tooltip - Cyberpunk Neon</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="scanlines"></div>
+
+  <main class="cyber-container">
+    <header class="cyber-header">
+      <span class="cyber-badge-top">SYSTEM STATUS: BREACHED</span>
+      <h1 data-text="NET RUNNER HUB">NET RUNNER HUB</h1>
+      <p>Decentralized mainframe console. Hover or focus on terminal nodes to activate the de-blurring entrance sequence.</p>
+    </header>
+
+    <div class="cyber-grid">
+      <section class="cyber-card">
+        <div class="card-glitch-line"></div>
+        <div class="card-header">
+          <span class="node-id">[LN-908]</span>
+          <h3>Data Vault Core</h3>
+        </div>
+        <p>Encrypted memory arrays containing telemetry keys from sector-9 mainframes.</p>
+        <button class="cyber-btn tooltip-container" aria-describedby="tip-vault">
+          De-Cipher Shard
+          <span id="tip-vault" class="cyber-tooltip tooltip" role="tooltip">
+            ⚠️ WARNING: Decryption trace active on sub-grid.
+          </span>
+        </button>
+      </section>
+
+      <section class="cyber-card">
+        <div class="card-glitch-line"></div>
+        <div class="card-header">
+          <span class="node-id">[LN-412]</span>
+          <h3>Proxy Uplink Grid</h3>
+        </div>
+        <p>Bypasses commercial network protocols via high-bandwidth dark fiber layers.</p>
+        <button class="cyber-btn tooltip-container" aria-describedby="tip-uplink">
+          Overclock Signal
+          <span id="tip-uplink" class="cyber-tooltip tooltip" role="tooltip">
+            ⚡ OVERCLOCKING: Bandwidth threshold scaled by 240%.
+          </span>
+        </button>
+      </section>
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/blur-entrance-cyberpunk-tooltips/style.css
+++ b/submissions/examples/blur-entrance-cyberpunk-tooltips/style.css
@@ -1,0 +1,232 @@
+/* ==========================================================================
+   CSS Custom Properties (Configurable Parameters)
+   ========================================================================== */
+:root {
+  /* High-Contrast Cyberpunk Palette */
+  --cyber-bg: #030712;
+  --cyber-surface: #0b0f19;
+  --cyber-border: #f43f5e;     /* Neon Rose Magenta */
+  --cyber-accent: #06b6d4;     /* Neon Cyan */
+  --cyber-yellow: #facc15;     /* Warning Yellow */
+  --cyber-text: #f1f5f9;
+  --cyber-text-muted: #6b7280;
+
+  /* Tooltip Animation Token Configuration */
+  --tooltip-bg: #000000;
+  --tooltip-border: var(--cyber-accent);
+  --tooltip-radius: 0px;       /* Hard sharp angles match cyberpunk grids */
+  
+  --tooltip-entrance-speed: 0.35s;
+  --tooltip-initial-blur: 12px;
+  --tooltip-initial-scale: 0.94;
+}
+
+/* ==========================================================================
+   Tooltip Base Layout & Blur Transition Engineering
+   ========================================================================== */
+.tooltip-container {
+  position: relative;
+  outline: none;
+}
+
+.cyber-tooltip {
+  position: absolute;
+  bottom: 145%;
+  left: 50%;
+  
+  /* Initial states: scaled down, shifted slightly, and heavily blurred */
+  transform: translateX(-50%) translateY(4px) scale(var(--tooltip-initial-scale));
+  filter: blur(var(--tooltip-initial-blur));
+  
+  background-color: var(--tooltip-bg);
+  color: var(--cyber-text);
+  border: 1px solid var(--tooltip-border);
+  padding: 10px 14px;
+  font-family: monospace;
+  font-size: 0.74rem;
+  font-weight: bold;
+  border-radius: var(--tooltip-radius);
+  white-space: nowrap;
+  
+  /* High-intensity neon text-shadow drop glows */
+  box-shadow: 0 0 15px rgba(6, 182, 212, 0.25), inset 0 0 8px rgba(6, 182, 212, 0.1);
+  z-index: 100;
+  
+  /* Hidden alignment metrics */
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  
+  /* Crisp, snap-like transition timings for high-tech aesthetic */
+  transition: opacity var(--tooltip-entrance-speed) cubic-bezier(0.19, 1, 0.22, 1),
+              visibility var(--tooltip-entrance-speed) cubic-bezier(0.19, 1, 0.22, 1),
+              filter var(--tooltip-entrance-speed) cubic-bezier(0.19, 1, 0.22, 1),
+              transform var(--tooltip-entrance-speed) cubic-bezier(0.19, 1, 0.22, 1);
+}
+
+/* Hard triangular sharp downward neon point caret */
+.cyber-tooltip::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 5px;
+  border-style: solid;
+  border-color: var(--tooltip-border) transparent transparent transparent;
+}
+
+/* Trigger activation paths mapped on focus tracking loops */
+.tooltip-container:hover .cyber-tooltip,
+.tooltip-container:focus-within .cyber-tooltip {
+  opacity: 1;
+  visibility: visible;
+  /* Clears the blur out entirely and snaps to full clarity scales */
+  filter: blur(0px);
+  transform: translateX(-50%) translateY(0px) scale(1);
+}
+
+/* ==========================================================================
+   Cyberpunk Scaffolding & Terminal Page Layout Styles
+   ========================================================================== */
+body {
+  margin: 0;
+  font-family: monospace, system-ui, sans-serif;
+  background-color: var(--cyber-bg);
+  color: var(--cyber-text);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  position: relative;
+  overflow-x: hidden;
+}
+
+/* Retro CRT monitor scanning line effect */
+.scanlines {
+  position: fixed;
+  top: 0; left: 0; width: 100%; height: 100%;
+  background: linear-gradient(rgba(18, 16, 16, 0) 50%, rgba(0, 0, 0, 0.25) 50%), linear-gradient(90deg, rgba(255, 0, 0, 0.06), rgba(0, 255, 0, 0.02), rgba(0, 0, 255, 0.06));
+  background-size: 100% 4px, 6px 100%;
+  z-index: 999;
+  pointer-events: none;
+}
+
+.cyber-container {
+  width: 90%;
+  max-width: 740px;
+  padding: 20px;
+  z-index: 10;
+}
+
+.cyber-header {
+  text-align: center;
+  margin-bottom: 48px;
+  border: 1px solid rgba(244, 63, 94, 0.2);
+  padding: 24px;
+  background: rgba(11, 15, 25, 0.6);
+}
+
+.cyber-badge-top {
+  color: var(--cyber-yellow);
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  font-weight: 700;
+  display: block;
+  margin-bottom: 8px;
+}
+
+.cyber-header h1 {
+  margin: 0 0 12px 0;
+  font-size: 2.25rem;
+  font-weight: 900;
+  color: #ffffff;
+  letter-spacing: -0.01em;
+  text-shadow: 0 0 10px var(--cyber-border);
+}
+
+.cyber-header p {
+  margin: 0;
+  color: var(--cyber-text-muted);
+  font-size: 0.88rem;
+  line-height: 1.5;
+  max-width: 540px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.cyber-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+/* Sharp Edged Cyber Terminal Card Component */
+.cyber-card {
+  background-color: var(--cyber-surface);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-left: 3px solid var(--cyber-border);
+  padding: 24px;
+  position: relative;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.card-glitch-line {
+  position: absolute;
+  top: 0; left: 0; width: 40px; height: 2px;
+  background-color: var(--cyber-accent);
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.node-id {
+  color: var(--cyber-accent);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.cyber-card h3 {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.cyber-card p {
+  margin: 0 0 24px 0;
+  color: var(--cyber-text-muted);
+  font-size: 0.84rem;
+  line-height: 1.6;
+}
+
+/* High Contrast Digital Execution Button Trigger */
+.cyber-btn {
+  width: 100%;
+  background-color: transparent;
+  color: var(--cyber-yellow);
+  border: 1px solid var(--cyber-yellow);
+  padding: 11px;
+  font-family: monospace;
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.cyber-btn:hover {
+  background-color: var(--cyber-yellow);
+  color: #000000;
+  box-shadow: 0 0 15px rgba(250, 204, 21, 0.4);
+}
+
+.cyber-btn:focus-visible {
+  outline: 2px solid var(--cyber-accent);
+  outline-offset: 3px;
+}


### PR DESCRIPTION
### 📝 Description
This PR addresses issue #34355 by introducing a zero-JS pure CSS Tooltip featuring a hardware-accelerated **Blur-Entrance progressive de-blurring transition**, custom-styled for high-contrast Cyberpunk Neon console grids.

### 🎯 Motivation & Context
Closes #34355

Supplies the example framework library with an elegant, tech-noir inspired interface interaction component that manages filter and scale shifts cleanly via the GPU layer without increasing runtime script weight.

### ✨ Technical Breakdown
- **Cyberpunk Neon Aesthetic:** Styled with razor-sharp corners, scanline grid systems, glow shadows, and high-contrast alert highlights.
- **Hardware-Accelerated De-Blur:** Seamlessly interpolates native `filter: blur()` properties along with multi-axis translation mappings via CSS variables (`--tooltip-initial-blur`) to create a high-tech tracking look.
- **Keyboard Traversal Ready:** Utilizes explicit hidden state controls (`opacity` synchronized with `visibility`) to maintain full compliance with screen readers during system focus tab loops.

### 📂 Created Components Checkpoint
- `submissions/examples/blur-entrance-cyberpunk-tooltips/demo.html`
- `submissions/examples/blur-entrance-cyberpunk-tooltips/style.css`
- `submissions/examples/blur-entrance-cyberpunk-tooltips/README.md`