### PR TITLE
feat(scss): Flexbox Alignment & Layout Utility Mixins

### DIFF
--- a/submissions/scss/scss-flexbox-alignment-layout-utility-mixins-sj6/README.md
+++ b/submissions/scss/scss-flexbox-alignment-layout-utility-mixins-sj6/README.md
@@ -1,0 +1,125 @@
+# Flexbox Alignment & Layout Utility Mixins (SCSS)
+
+A small, composable set of SCSS **mixins + utility classes** for the flexbox patterns you reach for every day — centering, space-between rows, and vertical stacks — using short, human-readable names instead of memorising raw `justify-content` / `align-items` keywords.
+
+> Track: `submissions/scss/` · Closes issue **#28280**
+
+---
+
+## What it does
+
+- A single configurable **`flex()`** mixin, plus four shorthands for the most common layouts.
+- Friendly **name maps** (`start`, `center`, `between`, `evenly`, …) that resolve to the real flexbox keywords, with a helper that also lets you pass raw values.
+- Auto-generated **utility classes** (`.ease-flex`, `.ease-justify-*`, `.ease-items-*`) so the same patterns work straight from HTML.
+- Compiles **standalone** with zero external dependencies and **no deprecation warnings** (Dart Sass 1.101.0).
+
+---
+
+## API
+
+| Kind | Signature | Purpose |
+|------|-----------|---------|
+| Mixin | `flex($direction, $justify, $align, $wrap, $gap)` | Fully configurable flex container. |
+| Mixin | `flex-center($gap)` | Centered on both axes. |
+| Mixin | `flex-between($align, $gap)` | Space-between row, cross-axis centered. |
+| Mixin | `flex-column($align, $justify, $gap)` | Vertical stack. |
+| Mixin | `flex-center-column($gap)` | Vertical stack, centered both axes. |
+| Function | `em-flex-value($map, $key)` | Resolves an alias, or passes a raw keyword through. |
+| Classes | `.ease-flex`, `.ease-justify-*`, `.ease-items-*` | Drop-in HTML utilities. |
+
+### `flex()` parameters
+
+| Param | Default | Accepts |
+|-------|---------|---------|
+| `$direction` | `row` | `row` · `column` · `row-reverse` · `column-reverse` |
+| `$justify` | `start` | `start` `end` `center` `between` `around` `evenly` (or a raw keyword) |
+| `$align` | `stretch` | `start` `end` `center` `stretch` `baseline` (or a raw keyword) |
+| `$wrap` | `nowrap` | `nowrap` · `wrap` · `wrap-reverse` |
+| `$gap` | `0` | any length — only emitted when non-zero |
+
+Override the alias maps by re-declaring `$em-justify` / `$em-align` before the `@use` (both are `!default`).
+
+---
+
+## How to use
+
+### 1. As mixins
+
+```scss
+@use "flexbox-alignment-layout-utility-mixins" as f;
+
+.toolbar { @include f.flex(row, between, center, $gap: 1rem); }
+.modal   { @include f.flex-center; }
+.sidebar { @include f.flex-column($gap: 0.5rem); }
+.hero    { @include f.flex-center-column($gap: 1.5rem); }
+```
+
+### 2. As utility classes (no SCSS)
+
+```html
+<nav class="ease-flex ease-justify-between ease-items-center">…</nav>
+<div class="ease-flex-center">Perfectly centered</div>
+```
+
+---
+
+## Compiled CSS output
+
+Compiled with `sass` (Dart Sass 1.101.0). The `@include` examples above produce:
+
+```css
+.toolbar {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.modal {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: center;
+  align-items: center;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  justify-content: flex-start;
+  align-items: stretch;
+  gap: 0.5rem;
+}
+
+.hero {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  justify-content: center;
+  align-items: center;
+  gap: 1.5rem;
+}
+```
+
+A sample of the generated utility classes:
+
+```css
+.ease-flex        { display: flex; }
+.ease-inline-flex { display: inline-flex; }
+.ease-flex-center { display: flex; flex-direction: row; flex-wrap: nowrap; justify-content: center; align-items: center; }
+.ease-justify-between { justify-content: space-between; }
+.ease-justify-evenly  { justify-content: space-evenly; }
+.ease-items-center    { align-items: center; }
+.ease-items-baseline  { align-items: baseline; }
+```
+
+---
+
+## Compile it yourself
+
+```bash
+sass _flexbox-alignment-layout-utility-mixins.scss
+```

--- a/submissions/scss/scss-flexbox-alignment-layout-utility-mixins-sj6/_flexbox-alignment-layout-utility-mixins.scss
+++ b/submissions/scss/scss-flexbox-alignment-layout-utility-mixins-sj6/_flexbox-alignment-layout-utility-mixins.scss
@@ -1,0 +1,125 @@
+// ============================================================
+//  EaseMotion CSS — Flexbox Alignment & Layout Utility Mixins
+//  submissions/scss/scss-flexbox-alignment-layout-utility-mixins-sj6
+// ------------------------------------------------------------
+//  A small, composable set of SCSS mixins + utility classes for
+//  the flexbox patterns you reach for every day: centering,
+//  space-between rows, vertical stacks, and fine-grained
+//  alignment — using short, human-readable names instead of
+//  memorising the raw `justify-content` / `align-items` keywords.
+//
+//  Self-contained: compiles standalone with `sass`, no external
+//  dependencies.
+// ============================================================
+
+@use "sass:map";
+
+// ── Name maps ───────────────────────────────────────────────
+// Friendly aliases → real flexbox keywords. Marked `!default`
+// so a consumer can extend/override them before @use.
+$em-justify: (
+  start: flex-start,
+  end: flex-end,
+  center: center,
+  between: space-between,
+  around: space-around,
+  evenly: space-evenly,
+) !default;
+
+$em-align: (
+  start: flex-start,
+  end: flex-end,
+  center: center,
+  stretch: stretch,
+  baseline: baseline,
+) !default;
+
+// ── Helper: resolve a friendly alias, or pass a raw value ───
+// Lets every mixin accept either `center` (alias) or a literal
+// like `space-between` without breaking.
+@function em-flex-value($map, $key) {
+  @if map.has-key($map, $key) {
+    @return map.get($map, $key);
+  }
+  @return $key;
+}
+
+// ── Core mixin: flex() ──────────────────────────────────────
+// One configurable flex container. `gap` is only emitted when
+// set, so the output stays lean.
+//
+// @param {String} $direction - row | column | row-reverse | ... (default row)
+// @param {String} $justify   - alias or keyword for justify-content (default start)
+// @param {String} $align     - alias or keyword for align-items (default stretch)
+// @param {String} $wrap      - nowrap | wrap | wrap-reverse (default nowrap)
+// @param {Length} $gap       - gap between items (default 0 = omitted)
+//
+// @example scss
+//   .toolbar { @include flex(row, between, center, $gap: 1rem); }
+@mixin flex(
+  $direction: row,
+  $justify: start,
+  $align: stretch,
+  $wrap: nowrap,
+  $gap: 0
+) {
+  display: flex;
+  flex-direction: $direction;
+  flex-wrap: $wrap;
+  justify-content: em-flex-value($em-justify, $justify);
+  align-items: em-flex-value($em-align, $align);
+
+  @if $gap != 0 {
+    gap: $gap;
+  }
+}
+
+// ── Shorthand mixins (the common cases) ─────────────────────
+
+// Perfectly centered on both axes.
+@mixin flex-center($gap: 0) {
+  @include flex($justify: center, $align: center, $gap: $gap);
+}
+
+// Push children apart on the main axis, centered cross-axis —
+// the classic navbar / toolbar row.
+@mixin flex-between($align: center, $gap: 0) {
+  @include flex($justify: between, $align: $align, $gap: $gap);
+}
+
+// Vertical stack.
+@mixin flex-column($align: stretch, $justify: start, $gap: 0) {
+  @include flex(column, $justify, $align, nowrap, $gap);
+}
+
+// Vertical stack, centered on both axes (hero sections, empty states).
+@mixin flex-center-column($gap: 0) {
+  @include flex(column, center, center, nowrap, $gap);
+}
+
+// ── Utility classes ─────────────────────────────────────────
+// Drop-in classes so the same patterns work straight from HTML.
+
+.ease-flex        { display: flex; }
+.ease-inline-flex { display: inline-flex; }
+.ease-flex-row    { flex-direction: row; }
+.ease-flex-col    { flex-direction: column; }
+.ease-flex-wrap   { flex-wrap: wrap; }
+.ease-flex-nowrap { flex-wrap: nowrap; }
+
+.ease-flex-center { @include flex-center; }
+.ease-flex-between { @include flex-between; }
+
+// justify-content helpers: .ease-justify-start … .ease-justify-evenly
+@each $name, $value in $em-justify {
+  .ease-justify-#{$name} {
+    justify-content: $value;
+  }
+}
+
+// align-items helpers: .ease-items-start … .ease-items-baseline
+@each $name, $value in $em-align {
+  .ease-items-#{$name} {
+    align-items: $value;
+  }
+}


### PR DESCRIPTION
## Summary
Adds a composable set of **flexbox alignment & layout utility mixins** under `submissions/scss/`.

- A configurable `flex()` mixin plus shorthands: `flex-center()`, `flex-between()`, `flex-column()`, `flex-center-column()`
- Friendly alias maps (`start`, `center`, `between`, `evenly`, …) resolved via an `em-flex-value()` helper that also accepts raw keywords
- Auto-generated utility classes: `.ease-flex`, `.ease-inline-flex`, `.ease-justify-*`, `.ease-items-*`
- Compiles standalone with **no deprecation warnings** on Dart Sass 1.101.0 (output shown in the README)

## Files
- `submissions/scss/scss-flexbox-alignment-layout-utility-mixins-sj6/_flexbox-alignment-layout-utility-mixins.scss`
- `submissions/scss/scss-flexbox-alignment-layout-utility-mixins-sj6/README.md`

Only touches `submissions/scss/` per the contribution freeze — no `core/` or `component/` files changed.

Closes #27652

@SAPTARSHI-coder kindly review this PR . 
