### PR TITLE
Fix: resolve ease-slide-up flicker inside overflow hidden (#34599)

### DIFF
--- a/submissions/examples/34599-ease-slide-up-flicker-fix/README.md
+++ b/submissions/examples/34599-ease-slide-up-flicker-fix/README.md
@@ -1,0 +1,5 @@
+# Fix for Ease-Slide-Up Flicker (#34599)
+
+This example demonstrates the fix for the `ease-slide-up` animation flickering issue on Chrome when the parent container has `overflow: hidden`.
+
+Adding `will-change: transform` to the parent `.ease-overflow-parent` resolves the GPU layer promotion conflict during the animation.

--- a/submissions/examples/34599-ease-slide-up-flicker-fix/demo.html
+++ b/submissions/examples/34599-ease-slide-up-flicker-fix/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion Fix #34599</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="ease-overflow-parent">
+    <div class="ease-slide-up-fixed">
+      No flicker inside overflow hidden!
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/34599-ease-slide-up-flicker-fix/style.css
+++ b/submissions/examples/34599-ease-slide-up-flicker-fix/style.css
@@ -1,0 +1,28 @@
+body {
+  background-color: #f4f4f9;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  margin: 0;
+  font-family: sans-serif;
+}
+
+.ease-overflow-parent {
+  overflow: hidden;
+  will-change: transform;
+  border-radius: 1rem;
+  background: white;
+  padding: 2rem;
+  box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+}
+
+.ease-slide-up-fixed {
+  -webkit-animation: slide-up 0.5s ease forwards;
+  animation: slide-up 0.5s ease forwards;
+}
+
+@keyframes slide-up {
+  from { transform: translateY(100%); opacity: 0; }
+  to   { transform: translateY(0); opacity: 1; }
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes the rendering bug where the `ease-slide-up` animation flickers at the start and end frames on Chrome when placed inside a container with `overflow: hidden`. Adding `will-change: transform` to the parent resolves the GPU layer promotion conflict.

Closes #34599

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Fixes a Chrome rendering flicker for the `ease-slide-up` animation when used inside `overflow: hidden` containers by applying `will-change: transform`.

**How does a developer use it?**

```html
<div class="ease-overflow-parent">
  <div class="ease-slide-up-fixed">
    No flicker inside overflow hidden!
  </div>
</div>