### PR TITLE
feat(scss): Gradient Text Flow & Animation Utility Classes

### DIFF
--- a/submissions/scss/scss-gradient-text-flow-animation-utility-classes-sj6/README.md
+++ b/submissions/scss/scss-gradient-text-flow-animation-utility-classes-sj6/README.md
@@ -1,0 +1,139 @@
+# Gradient Text Flow & Animation Utility Classes (SCSS)
+
+Animated, looping multi-colour gradients painted **through** text. A moving `background-position` over a `background-clip: text` fill creates a smooth *flowing* effect — perfect for hero headings, logos, and call-to-action labels.
+
+> Track: `submissions/scss/` · Closes issue **#28277**
+
+---
+
+## What it does
+
+- A **`gradient-text-flow()`** mixin that handles the gradient, the text clipping, the animation, and a graceful fallback.
+- Four ready-made **preset gradients** (`brand`, `sunset`, `ocean`, `aurora`) whose first and last stops match, so the loop is **seamless**.
+- Auto-generated **utility classes** plus speed modifiers, usable straight from HTML.
+- Uses EaseMotion palette tokens (`--ease-color-primary`, `--ease-color-secondary`) with safe fallbacks, and compiles **standalone with no warnings** (Dart Sass 1.101.0).
+
+---
+
+## API
+
+| Kind | Signature | Purpose |
+|------|-----------|---------|
+| Mixin | `gradient-text-flow($colors, $duration, $angle, $fallback)` | Animated gradient text on any element. |
+| Keyframes | `ease-text-gradient-flow` | Slides the gradient one full width. |
+| Classes | `.ease-text-gradient-flow` | Default (brand) gradient. |
+| Classes | `.ease-text-gradient-flow-{brand\|sunset\|ocean\|aurora}` | One class per preset. |
+| Modifiers | `.ease-text-gradient-flow--slow` / `--fast` | Override the cycle speed (8s / 2s). |
+
+### `gradient-text-flow()` parameters
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `$colors` | brand preset | Two or more colour stops (repeat the first as the last for a seamless loop). |
+| `$duration` | `4s` | Time for one full flow cycle. |
+| `$angle` | `90deg` | Gradient direction. |
+| `$fallback` | `var(--ease-color-primary, #6c63ff)` | Solid colour shown where `background-clip: text` is unsupported. |
+
+Override the presets by re-declaring `$em-text-gradients` before the `@use` (it is `!default`).
+
+---
+
+## How to use
+
+### 1. As utility classes (no SCSS)
+
+```html
+<h1 class="ease-text-gradient-flow">EaseMotion</h1>
+<h2 class="ease-text-gradient-flow-sunset ease-text-gradient-flow--slow">Sunset, slowed down</h2>
+<span class="ease-text-gradient-flow-ocean">Ocean</span>
+```
+
+### 2. As a mixin
+
+```scss
+@use "gradient-text-flow-animation-utility-classes" as g;
+@use "sass:map";
+
+.headline   { @include g.gradient-text-flow($duration: 6s); }
+.brand-name { @include g.gradient-text-flow(map.get(g.$em-text-gradients, ocean), 5s, 120deg); }
+```
+
+---
+
+## Compiled CSS output
+
+Compiled with `sass` (Dart Sass 1.101.0). The keyframes and the default class:
+
+```css
+@keyframes ease-text-gradient-flow {
+  to { background-position: 200% center; }
+}
+
+.ease-text-gradient-flow {
+  color: var(--ease-color-primary, #6c63ff); /* fallback */
+}
+@supports ((-webkit-background-clip: text) or (background-clip: text)) {
+  .ease-text-gradient-flow {
+    background-image: linear-gradient(90deg,
+      var(--ease-color-primary, #6c63ff),
+      #ec4899,
+      var(--ease-color-secondary, #8b5cf6),
+      var(--ease-color-primary, #6c63ff));
+    background-size: 200% auto;
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: transparent;
+    animation: ease-text-gradient-flow 4s linear infinite;
+  }
+}
+```
+
+The `sunset` preset (others follow the same shape):
+
+```css
+@supports ((-webkit-background-clip: text) or (background-clip: text)) {
+  .ease-text-gradient-flow-sunset {
+    background-image: linear-gradient(90deg, #f43f5e, #fb923c, #facc15, #f43f5e);
+    background-size: 200% auto;
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: transparent;
+    animation: ease-text-gradient-flow 4s linear infinite;
+  }
+}
+```
+
+And the `@include` example:
+
+```css
+@supports ((-webkit-background-clip: text) or (background-clip: text)) {
+  .headline {
+    background-image: linear-gradient(90deg,
+      var(--ease-color-primary, #6c63ff),
+      #ec4899,
+      var(--ease-color-secondary, #8b5cf6),
+      var(--ease-color-primary, #6c63ff));
+    background-size: 200% auto;
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: transparent;
+    animation: ease-text-gradient-flow 6s linear infinite;
+  }
+}
+```
+
+---
+
+## Accessibility & robustness
+
+- **Reduced motion:** the animation runs on a compositor-friendly property (`background-position`); EaseMotion's global `prefers-reduced-motion` layer neutralises it, leaving a static gradient (text stays fully legible).
+- **Unsupported browsers:** an `@supports` guard means the transparent fill is applied **only** where `background-clip: text` works. Everywhere else, the solid `$fallback` colour keeps the text visible.
+
+## Compile it yourself
+
+```bash
+sass _gradient-text-flow-animation-utility-classes.scss
+```

--- a/submissions/scss/scss-gradient-text-flow-animation-utility-classes-sj6/_gradient-text-flow-animation-utility-classes.scss
+++ b/submissions/scss/scss-gradient-text-flow-animation-utility-classes-sj6/_gradient-text-flow-animation-utility-classes.scss
@@ -1,0 +1,92 @@
+// ============================================================
+//  EaseMotion CSS — Gradient Text Flow & Animation Utilities
+//  submissions/scss/scss-gradient-text-flow-animation-utility-classes-sj6
+// ------------------------------------------------------------
+//  Animated, looping multi-colour gradients painted *through*
+//  text. A moving `background-position` on a `background-clip:
+//  text` fill creates a smooth "flowing" effect — great for
+//  hero headings, logos and call-to-action labels.
+//
+//  Ships a mixin, a set of preset gradients, and ready-made
+//  utility classes. Self-contained: compiles standalone with
+//  `sass`, no external dependencies.
+// ============================================================
+
+@use "sass:map";
+
+// ── Keyframes ───────────────────────────────────────────────
+// Slides the (over-sized) gradient one full width across the
+// text. Preset gradients start and end on the same colour, so
+// the loop is seamless.
+@keyframes ease-text-gradient-flow {
+  to {
+    background-position: 200% center;
+  }
+}
+
+// ── Preset gradients ────────────────────────────────────────
+// name → list of colour stops (first == last for a seamless
+// loop). The brand preset uses EaseMotion palette tokens with
+// safe fallbacks. Marked `!default` so it can be overridden.
+// Each preset uses 3–4 clearly distinct stops so the flowing
+// band is easy to see, and repeats its first colour last so the
+// loop is seamless. `brand` anchors on the EaseMotion palette
+// tokens with a contrasting accent between them.
+$em-text-gradients: (
+  brand: (var(--ease-color-primary, #6c63ff), #ec4899, var(--ease-color-secondary, #8b5cf6), var(--ease-color-primary, #6c63ff)),
+  sunset: (#f43f5e, #fb923c, #facc15, #f43f5e),
+  ocean: (#0ea5e9, #22d3ee, #6366f1, #0ea5e9),
+  aurora: (#22c55e, #3b82f6, #a855f7, #22c55e),
+) !default;
+
+$em-text-gradient-speed: 4s !default;
+
+// ── Mixin: gradient-text-flow() ─────────────────────────────
+// Paints an animated gradient through the element's text.
+//
+// @param {List}   $colors   - two or more colour stops (default: brand preset)
+// @param {Time}   $duration - one full flow cycle          (default 4s)
+// @param {Angle}  $angle    - gradient direction           (default 90deg)
+// @param {Color}  $fallback - solid colour for browsers without
+//                             `background-clip: text`       (default brand primary)
+//
+// @example scss
+//   .headline { @include gradient-text-flow($duration: 6s); }
+@mixin gradient-text-flow(
+  $colors: map.get($em-text-gradients, brand),
+  $duration: $em-text-gradient-speed,
+  $angle: 90deg,
+  $fallback: var(--ease-color-primary, #6c63ff)
+) {
+  // Fallback: a solid colour so text stays visible where
+  // `background-clip: text` is unsupported.
+  color: $fallback;
+
+  @supports ((-webkit-background-clip: text) or (background-clip: text)) {
+    background-image: linear-gradient($angle, $colors);
+    background-size: 200% auto;
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: transparent;
+    animation: ease-text-gradient-flow $duration linear infinite;
+  }
+}
+
+// ── Utility classes ─────────────────────────────────────────
+// `.ease-text-gradient-flow`            → brand preset (default)
+// `.ease-text-gradient-flow-{preset}`   → one class per preset
+@each $name, $colors in $em-text-gradients {
+  .ease-text-gradient-flow-#{$name} {
+    @include gradient-text-flow($colors);
+  }
+}
+
+// Convenience alias for the default (brand) gradient.
+.ease-text-gradient-flow {
+  @include gradient-text-flow;
+}
+
+// Optional speed modifiers — pair with any gradient class.
+.ease-text-gradient-flow--slow { animation-duration: 8s; }
+.ease-text-gradient-flow--fast { animation-duration: 2s; }


### PR DESCRIPTION
## Summary
Adds an animated **gradient text flow** SCSS utility under `submissions/scss/`.

- A `gradient-text-flow()` mixin that paints a looping multi-colour gradient through text via `background-clip: text`
- Four seamless preset gradients — `brand`, `sunset`, `ocean`, `aurora` (first/last stops match for a smooth loop)
- Auto-generated utility classes (`.ease-text-gradient-flow`, `.ease-text-gradient-flow-{preset}`) plus `--slow` / `--fast` speed modifiers
- Uses EaseMotion palette tokens with safe fallbacks; `@supports` guard + solid fallback colour keep text legible on unsupported browsers
- Compiles standalone with **no warnings** on Dart Sass 1.101.0 (output shown in the README)

## Files
- `submissions/scss/scss-gradient-text-flow-animation-utility-classes-sj6/_gradient-text-flow-animation-utility-classes.scss`
- `submissions/scss/scss-gradient-text-flow-animation-utility-classes-sj6/README.md`

Only touches `submissions/scss/` per the contribution freeze — no `core/` or `component/` files changed.

Closes #27649

@SAPTARSHI-coder kindly review this PR . 
