### PR TITLE
feat: add CSS neumorphic blur-entrance tooltip #34356

### DIFF
--- a/submissions/examples/blur-entrance-tooltip/README.md
+++ b/submissions/examples/blur-entrance-tooltip/README.md
@@ -1,0 +1,17 @@
+# Blur-Entrance Tooltip (Neumorphic Soft Layouts)
+
+A sleek, pure CSS tooltip designed around soft, extrusion-based Neumorphic UI standards. It incorporates an architectural transition that decants background filters smoothly from a blurry state to clean readability.
+
+## Structural Design Details
+- **Hardware Accelerated Blur:** Employs the CSS `filter: blur()` property optimized alongside scale transitions for a soft, fluid appearance.
+- **Pure Soft Neumorphism:** Uses opposing dark/light drop-shadow vectors to produce an extruded surface look matching the body baseline.
+
+## Customization Control
+
+Variables exposed inside the `:root` pseudo-class:
+
+| Target Property | Default Settings | Implementation Purpose |
+| :--- | :--- | :--- |
+| `--tooltip-blur-start` | `8px` | Maximum focal blur width applied to the hidden element container |
+| `--tooltip-scale-start` | `0.92` | Base scale offset factor before entrance interpolation loops |
+| `--tooltip-duration` | `0.35s` | Total animation velocity loop length |

--- a/submissions/examples/blur-entrance-tooltip/demo.html
+++ b/submissions/examples/blur-entrance-tooltip/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Blur-Entrance Tooltip (Neumorphic) - EaseMotion</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="nm-card">
+    <h2 style="margin-top: 0; font-size: 1.3rem; margin-bottom: 0.5rem;">Storage Cloud</h2>
+    <p style="color: var(--text-muted); font-size: 0.9rem; margin-bottom: 2rem;">
+      Manage your system backups dynamically with custom configurations.
+    </p>
+
+    <div class="tooltip-wrapper">
+      <button class="tooltip-trigger" aria-describedby="nm-blur-tooltip">
+        Sync Protocol
+      </button>
+      
+      <div class="tooltip-box" id="nm-blur-tooltip" role="tooltip">
+        <strong style="display: block; margin-bottom: 2px; color: #1e293b;">Automated Tasks</strong>
+        Syncs every 15 minutes over securely partitioned local arrays.
+      </div>
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/blur-entrance-tooltip/style.css
+++ b/submissions/examples/blur-entrance-tooltip/style.css
@@ -1,0 +1,137 @@
+/* ==========================================================================
+   CSS Custom Properties (Parameters)
+   ========================================================================== */
+:root {
+  /* Animation Parameters */
+  --tooltip-duration: 0.35s;
+  --tooltip-easing: cubic-bezier(0.4, 0, 0.2, 1);
+  --tooltip-blur-start: 8px;
+  --tooltip-scale-start: 0.92;
+  
+  /* Neumorphic Soft Theme System (Light Slate Gray) */
+  --bg-neumorphic: #e0e8f0;
+  --text-primary: #475569;
+  --text-muted: #64748b;
+  
+  /* Neumorphic Shadow Pairs (Extruded & Sunken) */
+  --nm-raised: 9px 9px 16px #be99cf0, -9px -9px 16px #ffffff;
+  --nm-sunken: inset 4px 4px 8px #c8d0d9, inset -4px -4px 8px #f8fafc;
+  --nm-tooltip-shadow: 6px 6px 12px #c8d0d9, -6px -6px 12px #ffffff;
+}
+
+/* Demo Base Layout */
+body {
+  margin: 0;
+  padding: 0;
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: var(--bg-neumorphic);
+  color: var(--text-primary);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.nm-card {
+  background: var(--bg-neumorphic);
+  padding: 2.5rem;
+  border-radius: 24px;
+  box-shadow: var(--nm-raised);
+  text-align: center;
+  max-width: 320px;
+}
+
+/* ==========================================================================
+   Tooltip Component Layout & Interaction
+   ========================================================================== */
+.tooltip-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+/* Neumorphic Interactive Soft Button */
+.tooltip-trigger {
+  background: var(--bg-neumorphic);
+  border: none;
+  color: var(--text-primary);
+  padding: 0.8rem 1.6rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  border-radius: 12px;
+  box-shadow: var(--nm-raised);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.tooltip-trigger:hover,
+.tooltip-trigger:focus {
+  outline: none;
+  color: #2563eb;
+  box-shadow: var(--nm-sunken);
+}
+
+/* Neumorphic Soft Tooltip Box */
+.tooltip-box {
+  position: absolute;
+  bottom: 140%;
+  left: 50%;
+  
+  /* Blurs out and scales down context natively */
+  transform: translateX(-50%) translateY(6px) scale(var(--tooltip-scale-start));
+  filter: blur(var(--tooltip-blur-start));
+  
+  background-color: var(--bg-neumorphic);
+  color: var(--text-primary);
+  padding: 12px 16px;
+  border-radius: 14px;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  width: 220px;
+  box-shadow: var(--nm-tooltip-shadow);
+  z-index: 100;
+  
+  /* State Initialization */
+  opacity: 0;
+  pointer-events: none;
+  
+  /* Transition Definitions */
+  transition: 
+    opacity var(--tooltip-duration) var(--tooltip-easing),
+    transform var(--tooltip-duration) var(--tooltip-easing),
+    filter var(--tooltip-duration) var(--tooltip-easing);
+  
+  /* Hardware Acceleration Optimization */
+  will-change: transform, filter, opacity;
+}
+
+/* Soft Indicator Triangle Pointer */
+.tooltip-box::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 6px;
+  border-style: solid;
+  border-color: var(--bg-neumorphic) transparent transparent transparent;
+}
+
+/* ==========================================================================
+   Activation Layer
+   ========================================================================== */
+.tooltip-wrapper:hover .tooltip-box,
+.tooltip-wrapper:focus-within .tooltip-box {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateX(-50%) translateY(0) scale(1);
+  filter: blur(0px); /* Clears focus smoothly */
+}
+
+/* Accessibility Guardrail: Motion Preferences */
+@media (prefers-reduced-motion: reduce) {
+  .tooltip-box {
+    transform: translateX(-50%) translateY(0) scale(1) !important;
+    filter: blur(0px) !important;
+    transition: opacity 0.15s linear !important;
+  }
+}


### PR DESCRIPTION
## 🚀 Description
This PR addresses Issue #34356 by engineering an elegant, pure CSS Blur-Entrance Tooltip component. The animation framework blends CSS filters and soft dimensional aesthetics to complement Neumorphic Soft interface layouts with zero JavaScript dependencies.

## 🎯 Proposed Changes
- **Pure CSS Blur-Entrance Transition:** Implemented hardware-accelerated transitions utilizing `filter: blur()` paired with scale transformations to smoothly transition the content from a blurry, organic soft state into clear readability.
- **Soft Neumorphic Architecture:** Styled using mirrored light/dark soft `box-shadow` structures to produce extruded surfaces and soft elevations characteristic of modern neumorphic design guidelines.
- **Parametric Flexibility:** Exposed clear custom properties (`--tooltip-blur-start`, `--tooltip-scale-start`, and `--tooltip-duration`) directly inside the `:root` pseudo-class for seamless layout tweaks.
- **A11y Adaptive Hooks:** Configured with semantic `role="tooltip"`, precise `aria-describedby` linking, and keyboard active `:focus-within` selectors. Includes a fallback media query for `prefers-reduced-motion` to immediately neutralize blur/scale modifications for motion-sensitive users.

## 📁 File Structure Added
The complete workflow operates inside its isolated directory structure under the required path:
- `submissions/examples/blur-entrance-tooltip/demo.html`
- `submissions/examples/blur-entrance-tooltip/style.css`
- `submissions/examples/blur-entrance-tooltip/README.md`

## 📸 Screenshots / Demos
- **Trigger State:** Hovering or focusing on the "Sync Protocol" button switches it into a sunken inset state, smoothly clearing up and fading in the blurred tooltip above it.
- **Motion Safe Mode:** Instantly defaults to a standard opacity toggle if system level motion restrictions are activated.

## 📝 Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] All new files are placed strictly inside the `submissions/` directory.
- [x] The submission includes `demo.html`, `style.css`, and a descriptive `README.md`.
- [x] This PR closes #34356.