### PR TITLE
feat: add CSS minimalist tech blur-entrance tooltip #34354

### DIFF
--- a/submissions/examples/minimalist-tech-tooltip/README.md
+++ b/submissions/examples/minimalist-tech-tooltip/README.md
@@ -1,0 +1,17 @@
+# Blur-Entrance Tooltip (Minimalist Tech Layouts)
+
+A zero-dependency, pure CSS tooltip designed for industrial, high-end minimalist developer interfaces. It delivers a rapid blur-dissolve entryway sequence utilizing hardware-optimized filter curves.
+
+## Technical Composition
+- **Sleek Ease-Out Easing:** Configured with a specialized matrix `cubic-bezier(0.16, 1, 0.3, 1)` that yields instantaneous spatial distribution matching developer utilities.
+- **Glassmorphism Backdrop Integration:** Pairs `filter: blur()` entrance transitions safely alongside native `backdrop-filter` elements to keep overlay interactions perfectly clean.
+
+## Exposed Parameters
+
+Variables accessible for customization inside `:root`:
+
+| Property | Default Value | Functional Usage |
+| :--- | :--- | :--- |
+| `--tooltip-blur-start` | `12px` | Density of the visual distortion threshold applied prior to trigger |
+| `--tooltip-scale-start` | `0.96` | Base component dimensions scale factor on initialization |
+| `--tooltip-duration` | `0.28s` | Speed constraint parameter for high-frequency user actions |

--- a/submissions/examples/minimalist-tech-tooltip/demo.html
+++ b/submissions/examples/minimalist-tech-tooltip/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Blur-Entrance Tooltip (Minimalist Tech) - EaseMotion</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="tech-panel">
+    <div style="font-family: ui-monospace, monospace; font-size: 0.75rem; color: var(--border-active); margin-bottom: 0.5rem;">CORE // NODE_01</div>
+    <h2 style="margin: 0 0 1.5rem 0; font-size: 1.25rem; font-weight: 500;">CPU Pipeline Cluster</h2>
+
+    <div class="tooltip-wrapper">
+      <button class="tooltip-trigger" aria-describedby="tech-blur-tooltip">
+        SYS_STATUS
+      </button>
+      
+      <div class="tooltip-box" id="tech-blur-tooltip" role="tooltip">
+        <span class="tech-label">Telemetry Feed</span>
+        Sub-threads optimizing gracefully. Current runtime latency sits at 1.4ms.
+      </div>
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/minimalist-tech-tooltip/style.css
+++ b/submissions/examples/minimalist-tech-tooltip/style.css
@@ -1,0 +1,148 @@
+/* ==========================================================================
+   CSS Custom Properties (Parameters)
+   ========================================================================== */
+:root {
+  /* Animation Parameters */
+  --tooltip-duration: 0.28s;
+  --tooltip-easing: cubic-bezier(0.16, 1, 0.3, 1); /* Ultra-sleek ease-out */
+  --tooltip-blur-start: 12px;
+  --tooltip-scale-start: 0.96;
+  --tooltip-translate-start: translateY(4px);
+  
+  /* Minimalist Tech Interface Aesthetics */
+  --bg-canvas: #09090b;       /* Pure dark tech canvas */
+  --bg-tooltip: #18181b;      /* Matte zinc dark */
+  --border-tech: #27272a;     /* Sharp, thin dividing border */
+  --border-active: #52525b;   /* Highlighted tech border */
+  --text-pure: #ffffff;
+  --text-muted: #a1a1aa;      /* Technical gray subtext */
+  --shadow-minimal: 0 4px 20px -2px rgba(0, 0, 0, 0.5);
+}
+
+/* Demo Base Layout */
+body {
+  margin: 0;
+  padding: 0;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background-color: var(--bg-canvas);
+  color: var(--text-pure);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  letter-spacing: -0.01em;
+}
+
+.tech-panel {
+  background: var(--bg-canvas);
+  border: 1px solid var(--border-tech);
+  padding: 2rem 2.5rem;
+  border-radius: 8px;
+  text-align: center;
+  max-width: 340px;
+}
+
+/* ==========================================================================
+   Tooltip Component Layout & Interaction
+   ========================================================================== */
+.tooltip-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+/* Minimalist Tech Trigger Button */
+.tooltip-trigger {
+  background: transparent;
+  border: 1px solid var(--border-tech);
+  color: var(--text-pure);
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-weight: 500;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.tooltip-trigger:hover,
+.tooltip-trigger:focus {
+  outline: none;
+  border-color: var(--border-active);
+  background: #18181b;
+}
+
+/* Minimalist Tech Tooltip Box */
+.tooltip-box {
+  position: absolute;
+  bottom: 145%;
+  left: 50%;
+  
+  /* Initial hidden spatial states */
+  transform: translateX(-50%) var(--tooltip-translate-start) scale(var(--tooltip-scale-start));
+  filter: blur(var(--tooltip-blur-start));
+  opacity: 0;
+  pointer-events: none;
+  
+  background-color: rgba(24, 24, 27, 0.85); /* Semitransparent tech slate */
+  backdrop-filter: blur(8px);                 /* Native glass backdrop layer */
+  border: 1px solid var(--border-tech);
+  color: var(--text-pure);
+  padding: 10px 12px;
+  border-radius: 4px;
+  font-size: 0.813rem;
+  line-height: 1.4;
+  width: 210px;
+  box-shadow: var(--shadow-minimal);
+  z-index: 100;
+  
+  /* Transition Definitions */
+  transition: 
+    opacity var(--tooltip-duration) var(--tooltip-easing),
+    transform var(--tooltip-duration) var(--tooltip-easing),
+    filter var(--tooltip-duration) var(--tooltip-easing);
+  
+  /* Hardware Performance Hint */
+  will-change: transform, filter, opacity;
+}
+
+/* Sharp Micro Indicator Arrow */
+.tooltip-box::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 5px;
+  border-style: solid;
+  border-color: var(--border-tech) transparent transparent transparent;
+}
+
+/* ==========================================================================
+   Activation States
+   ========================================================================== */
+.tooltip-wrapper:hover .tooltip-box,
+.tooltip-wrapper:focus-within .tooltip-box {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateX(-50%) translateY(0) scale(1);
+  filter: blur(0px);
+}
+
+.tech-label {
+  display: block;
+  font-family: ui-monospace, monospace;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  margin-bottom: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Accessibility: Safe Mode Motion fallback */
+@media (prefers-reduced-motion: reduce) {
+  .tooltip-box {
+    transform: translateX(-50%) translateY(0) scale(1) !important;
+    filter: blur(0px) !important;
+    transition: opacity 0.1s linear !important;
+  }
+}


### PR DESCRIPTION
## 🚀 Description
This PR addresses Issue #34354 by implementing a sleek, pure CSS Blur-Entrance Tooltip component. The animation framework features ultra-sharp typography, thin modern panel borders, and a fast hardware-accelerated blur-dissolve sequence designed specifically to complement minimalist developer tools and technical dashboard environments.

## 🎯 Proposed Changes
- **Pure CSS Minimalist Blur-Entrance:** Combines a rapid `cubic-bezier(0.16, 1, 0.3, 1)` ease-out curve with hardware-optimized `filter: blur()` to create an instant, high-end technical transition.
- **Glassmorphism Backdrop Integration:** Utilizes a semi-transparent slate theme paired with a subtle `backdrop-filter: blur(8px)` layer to ensure readability while overlaying dense dashboard elements.
- **Parametric Properties:** Exposed granular control variables (`--tooltip-blur-start`, `--tooltip-scale-start`, `--tooltip-duration`) inside the global `:root` scope for frictionless aesthetic overrides.
- **A11y and Accessibility Safe:** Configured using semantic HTML wrapper states, `aria-describedby` links, and full keyboard-accessible `:focus-within` triggers. Features a `prefers-reduced-motion` media query to guarantee accessibility for motion-sensitive users.

## 📁 File Structure Added
The implementation assets are fully contained within the required submissions tree:
- `submissions/examples/minimalist-tech-tooltip/demo.html`
- `submissions/examples/minimalist-tech-tooltip/style.css`
- `submissions/examples/minimalist-tech-tooltip/README.md`

## 📸 Screenshots / Demos
- **Trigger State:** Hovering or focusing on the monospaced `SYS_STATUS` toggle button triggers a swift, crisp fade-in and focus effect for the tooltip module above it.
- **Motion Safe Mode:** Instantly strips the translational offset and blur transformations if system-level motion suppression is active.

## 📝 Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] All new files are placed strictly inside the `submissions/` directory.
- [x] The submission includes `demo.html`, `style.css`, and a descriptive `README.md`.
- [x] This PR closes #34354.