### PR TITLE
feat: add CSS neon glow neumorphic tooltip #34371

### DIFF
--- a/submissions/examples/neon-glow-neumorphic-tooltip/README.md
+++ b/submissions/examples/neon-glow-neumorphic-tooltip/README.md
@@ -1,0 +1,17 @@
+# Neon Glow Tooltip (Neumorphic Soft Layouts)
+
+A sleek, zero-JavaScript tooltip system showcasing an experimental bridge between traditional, tactile Neumorphic soft shadows and modern electric neon illumination paths.
+
+## Design Architecture
+- **Soft Extrusion:** Uses multi-layered `box-shadow` structures to seamlessly lift the component directly out of its structural canvas layout.
+- **Neon Emission Layer:** Leverages high-intensity alpha-channeled shadows along structural border tracks to project an interactive luminescent aura without using scripts.
+
+## Parameter Variables
+
+Configure parameters directly in `style.css`:
+
+| Variable Metric | Default Assignment | Structural Function |
+| :--- | :--- | :--- |
+| `--neon-accent` | `#10b981` | Core hexadecimal indicator track color signature |
+| `--tooltip-duration` | `0.35s` | Timing speed limit covering deployment interpolation |
+| `--tooltip-scale-start` | `0.94` | Starting dimensional footprint boundaries before hover |

--- a/submissions/examples/neon-glow-neumorphic-tooltip/demo.html
+++ b/submissions/examples/neon-glow-neumorphic-tooltip/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Neon Glow Neumorphic Tooltip - EaseMotion</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="nm-neon-card">
+    <h2 style="margin-top: 0; font-size: 1.3rem; margin-bottom: 0.5rem;">Core Grid</h2>
+    <p style="color: var(--text-muted); font-size: 0.9rem; margin-bottom: 2rem;">
+      Inspect environmental matrix variables and node generation pipelines.
+    </p>
+
+    <div class="tooltip-wrapper">
+      <button class="tooltip-trigger" aria-describedby="nm-neon-tooltip">
+        Power Array
+      </button>
+      
+      <div class="tooltip-box" id="nm-neon-tooltip" role="tooltip">
+        <span class="neon-title">Grid Optimizing</span>
+        Performance values are tracking stably within safe nominal bounds.
+      </div>
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/neon-glow-neumorphic-tooltip/style.css
+++ b/submissions/examples/neon-glow-neumorphic-tooltip/style.css
@@ -1,0 +1,149 @@
+/* ==========================================================================
+   CSS Custom Properties (Parameters)
+   ========================================================================== */
+:root {
+  /* Animation Parameters */
+  --tooltip-duration: 0.35s;
+  --tooltip-easing: cubic-bezier(0.25, 0.8, 0.25, 1);
+  --tooltip-scale-start: 0.94;
+  --tooltip-translate-start: translateY(6px);
+  
+  /* Color Palette (Neumorphic Slate Base with Cyber Electric Lime) */
+  --bg-nm: #e2e8f0;
+  --text-main: #334155;
+  --text-muted: #64748b;
+  --neon-accent: #10b981; /* High-contrast emerald/neon green */
+  
+  /* Neumorphic Shadows */
+  --nm-raised: 8px 8px 16px #cbd5e1, -8px -8px 16px #ffffff;
+  --nm-sunken: inset 4px 4px 8px #cbd5e1, inset -4px -4px 8px #ffffff;
+  
+  /* Ambient Neon Soft Glow Combo */
+  --neon-glow: 0px 0px 14px rgba(16, 185, 129, 0.6), 0px 0px 4px rgba(16, 185, 129, 0.3);
+}
+
+/* Demo Canvas Setup */
+body {
+  margin: 0;
+  padding: 0;
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: var(--bg-nm);
+  color: var(--text-main);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.nm-neon-card {
+  background: var(--bg-nm);
+  padding: 2.5rem;
+  border-radius: 20px;
+  box-shadow: var(--nm-raised);
+  text-align: center;
+  max-width: 320px;
+}
+
+/* ==========================================================================
+   Tooltip Component Layout & Interaction
+   ========================================================================== */
+.tooltip-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+/* Neumorphic Trigger Trigger */
+.tooltip-trigger {
+  background: var(--bg-nm);
+  border: 2px solid transparent;
+  color: var(--text-main);
+  padding: 0.75rem 1.5rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  border-radius: 12px;
+  box-shadow: var(--nm-raised);
+  cursor: pointer;
+  transition: all var(--tooltip-duration) ease;
+}
+
+.tooltip-trigger:hover,
+.tooltip-trigger:focus {
+  outline: none;
+  border-color: var(--neon-accent);
+  box-shadow: var(--nm-sunken), var(--neon-glow);
+  color: var(--neon-accent);
+}
+
+/* Tooltip Box with Hybrid Styling */
+.tooltip-box {
+  position: absolute;
+  bottom: 140%;
+  left: 50%;
+  
+  /* Initial Spatial & Opacity State */
+  transform: translateX(-50%) var(--tooltip-translate-start) scale(var(--tooltip-scale-start));
+  opacity: 0;
+  pointer-events: none;
+  
+  background-color: var(--bg-nm);
+  border: 2px solid transparent;
+  color: var(--text-main);
+  padding: 12px 16px;
+  border-radius: 12px;
+  font-size: 0.85rem;
+  line-height: 1.45;
+  width: 220px;
+  box-shadow: var(--nm-raised);
+  z-index: 100;
+  
+  /* Smooth Transition Configuration */
+  transition: 
+    opacity var(--tooltip-duration) var(--tooltip-easing),
+    transform var(--tooltip-duration) var(--tooltip-easing),
+    border-color var(--tooltip-duration) var(--tooltip-easing),
+    box-shadow var(--tooltip-duration) var(--tooltip-easing);
+    
+  will-change: transform, opacity, box-shadow;
+}
+
+/* Neumorphic Indicator Pointer */
+.tooltip-box::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 6px;
+  border-style: solid;
+  border-color: var(--bg-nm) transparent transparent transparent;
+}
+
+/* ==========================================================================
+   Activation States
+   ========================================================================== */
+.tooltip-wrapper:hover .tooltip-box,
+.tooltip-wrapper:focus-within .tooltip-box {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateX(-50%) translateY(0) scale(1);
+  border-color: var(--neon-accent);
+  box-shadow: var(--nm-raised), var(--neon-glow);
+}
+
+.neon-title {
+  display: block;
+  font-weight: 700;
+  color: var(--neon-accent);
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  margin-bottom: 4px;
+}
+
+/* Accessibility: Support OS reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .tooltip-box {
+    transform: translateX(-50%) translateY(0) scale(1) !important;
+    transition: opacity 0.1s linear !important;
+  }
+}


### PR DESCRIPTION
## 🚀 Description
This PR addresses Issue #34371 by engineering a hybrid, pure CSS Neon Glow Tooltip component tailored specifically for Neumorphic Soft layouts. The component blends tactile, extruded soft shadow structures with a responsive fluorescent color emission layer, requiring zero JavaScript overhead.

## 🎯 Proposed Changes
- **Hybrid Soft & Glowing Architecture:** Created an innovative design bridge by stacking dual neumorphic light/dark `box-shadow` values alongside high-intensity alpha-channeled glowing layers (`--neon-glow`).
- **Parametric Properties:** Maintained full customization freedom by exposing functional layout parameters (`--neon-accent`, `--tooltip-duration`, and `--tooltip-scale-start`) within the global `:root` scope.
- **Flawless Keyboard & Screen-Reader Integration:** Leveraged semantic markup (`role="tooltip"`), clean connection attributes (`aria-describedby`), and keyboard focus selectors (`:focus-within`) to keep layout metrics completely accessible.
- **Motion Safe Fallback:** Wrapped active translation scales in a `prefers-reduced-motion` media query to immediately neutralize kinetic layout movement for motion-sensitive users.

## 📁 File Structure Added
All files have been cleanly added inside an isolated space under the required path:
- `submissions/examples/neon-glow-neumorphic-tooltip/demo.html`
- `submissions/examples/neon-glow-neumorphic-tooltip/style.css`
- `submissions/examples/neon-glow-neumorphic-tooltip/README.md`

## 📸 Screenshots / Demos
- **Trigger State:** Hovering or focusing on the neumorphic "Power Array" button switches it from a raised state into a sunken state, blooming an emerald green luminescent aura while deploying the soft tooltip above it.
- **Motion Safe Mode:** Instantly forces a simple opacity fade-in with no scale changes if system-level motion suppression rules are active.

## 📝 Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] All new files are placed strictly inside the `submissions/` directory.
- [x] The submission includes `demo.html`, `style.css`, and a descriptive `README.md`.
- [x] This PR closes #34371.