### PR TITLE
feat: add animated-pie-segment component (#34724)

### DIFF
--- a/submissions/examples/ease-animated-pie-segment-ij/README.md
+++ b/submissions/examples/ease-animated-pie-segment-ij/README.md
@@ -1,0 +1,40 @@
+# Animated Pie Segment
+
+A CSS-only animated pie chart where each segment grows into view on load using `conic-gradient` and registered custom properties (`@property`). Built with the Inter font family and a dark theme.
+
+## Features
+
+- Segments animate from 0° to their full angle using `@keyframes`
+- Hover scale transition on the pie chart
+- Legend for segment labels
+- Replay button to re-trigger the animation
+- Responsive sizing via `clamp()` and `min()`
+- Customizable timing and colors through `:root` variables
+
+## Usage
+
+Open `demo.html` in a modern browser that supports `@property` (Chrome 85+, Firefox 128+, Safari 15.4+).
+
+## Customization
+
+Edit `:root` in `style.css`:
+
+```css
+:root {
+  --pie-duration: 2s;
+  --c1: #ff6b6b;
+  --c2: #4ecdc4;
+  --c3: #45b7d1;
+  --c4: #f9ca24;
+}
+```
+
+- `--pie-duration` – animation speed
+- `--c1` through `--c4` – segment colors
+
+## Files
+
+| File        | Purpose            |
+|-------------|--------------------|
+| `demo.html` | Entry page         |
+| `style.css` | Styles & animation |

--- a/submissions/examples/ease-animated-pie-segment-ij/demo.html
+++ b/submissions/examples/ease-animated-pie-segment-ij/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Animated Pie Segment</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Animated Pie Segment</h1>
+    <div class="pie animate" id="pie"></div>
+    <ul class="legend">
+      <li><span class="legend__swatch" style="background: var(--c1)"></span>Design</li>
+      <li><span class="legend__swatch" style="background: var(--c2)"></span>Development</li>
+      <li><span class="legend__swatch" style="background: var(--c3)"></span>Testing</li>
+      <li><span class="legend__swatch" style="background: var(--c4)"></span>Deployment</li>
+    </ul>
+    <button class="btn" id="replayBtn">Replay Animation</button>
+  </div>
+  <script>
+    const pie = document.getElementById('pie');
+    const btn = document.getElementById('replayBtn');
+    btn.addEventListener('click', () => {
+      pie.classList.remove('animate');
+      void pie.offsetWidth;
+      pie.classList.add('animate');
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-animated-pie-segment-ij/style.css
+++ b/submissions/examples/ease-animated-pie-segment-ij/style.css
@@ -1,0 +1,141 @@
+:root {
+  --pie-duration: 2s;
+  --c1: #ff6b6b;
+  --c2: #4ecdc4;
+  --c3: #45b7d1;
+  --c4: #f9ca24;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+  background: #1a1a2e;
+  color: #e0e0e0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.container {
+  text-align: center;
+  padding: 2rem;
+  width: 100%;
+  max-width: 650px;
+}
+
+h1 {
+  font-weight: 600;
+  font-size: clamp(1.5rem, 5vw, 2.25rem);
+  margin-bottom: 2rem;
+  color: #ffffff;
+}
+
+@property --a1 {
+  syntax: "<angle>";
+  initial-value: 0deg;
+  inherits: false;
+}
+
+@property --a2 {
+  syntax: "<angle>";
+  initial-value: 0deg;
+  inherits: false;
+}
+
+@property --a3 {
+  syntax: "<angle>";
+  initial-value: 0deg;
+  inherits: false;
+}
+
+@property --a4 {
+  syntax: "<angle>";
+  initial-value: 0deg;
+  inherits: false;
+}
+
+.pie {
+  width: min(280px, 70vw);
+  height: min(280px, 70vw);
+  border-radius: 50%;
+  margin: 0 auto 2rem;
+  background: conic-gradient(
+    var(--c1) 0deg var(--a1),
+    var(--c2) 90deg calc(90deg + var(--a2)),
+    var(--c3) 180deg calc(180deg + var(--a3)),
+    var(--c4) 270deg calc(270deg + var(--a4))
+  );
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  cursor: pointer;
+}
+
+.pie:hover {
+  transform: scale(1.04);
+  box-shadow: 0 0 32px rgba(255, 255, 255, 0.12);
+}
+
+.pie.animate {
+  animation: grow-pie var(--pie-duration) ease-out forwards;
+}
+
+@keyframes grow-pie {
+  from {
+    --a1: 0deg;
+    --a2: 0deg;
+    --a3: 0deg;
+    --a4: 0deg;
+  }
+  to {
+    --a1: 90deg;
+    --a2: 90deg;
+    --a3: 90deg;
+    --a4: 90deg;
+  }
+}
+
+.legend {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1.25rem;
+  margin-bottom: 2rem;
+}
+
+.legend li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.legend__swatch {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.btn {
+  background: transparent;
+  border: 2px solid #e0e0e0;
+  color: #e0e0e0;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.95rem;
+  padding: 0.6rem 1.8rem;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.25s, color 0.25s;
+}
+
+.btn:hover {
+  background: #e0e0e0;
+  color: #1a1a2e;
+}


### PR DESCRIPTION
## Component: ease-animated-pie-segment ? Pie chart segment animates on reveal

**Closes #34724**

### What this adds
Pie chart with segments that animate/grow into view on load with conic-gradient.

### Acceptance Criteria covered
- Smooth CSS @keyframes animation
- Interactive trigger (replay button)
- Customizable via CSS variables

### Files
- \submissions/examples/ease-animated-pie-segment-ij/demo.html\
- \submissions/examples/ease-animated-pie-segment-ij/style.css\
- \submissions/examples/ease-animated-pie-segment-ij/README.md\

### How to review
Open \demo.html\ directly in a browser. Watch pie segments animate into view; click replay to see again.
