### PR TITLE
feat: add chart-donut-animate component (#34758)

### DIFF
--- a/submissions/examples/ease-chart-donut-animate-ij/README.md
+++ b/submissions/examples/ease-chart-donut-animate-ij/README.md
@@ -1,0 +1,20 @@
+# Donut Chart Animate
+
+An animated donut chart that fills its segments from 0 to their target percentage on load. Includes a colour-coded legend and a Replay button to re-trigger the animation.
+
+## Features
+
+- SVG circle with `stroke-dasharray` animation
+- Staggered segment fill on page load
+- Colour-matched legend with percentage labels
+- Replay button to restart animation
+- Customisable via CSS custom properties
+
+## Custom Properties
+
+| Property                | Default  | Description            |
+| ----------------------- | -------- | ---------------------- |
+| `--donut-duration`      | `1.2s`   | Segment fill duration  |
+| `--donut-size`          | `260px`  | Chart container size   |
+| `--donut-stroke-width`  | `8`      | SVG stroke width       |
+| `--donut-bg`            | `#f8f9fa`| Page background        |

--- a/submissions/examples/ease-chart-donut-animate-ij/demo.html
+++ b/submissions/examples/ease-chart-donut-animate-ij/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Donut Chart Animate</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Animated Donut Chart</h1>
+
+  <div class="donut-wrapper">
+    <div class="donut-chart" role="img" aria-label="Donut chart showing data distribution">
+      <svg viewBox="0 0 100 100" class="donut-svg">
+        <circle class="donut-ring" cx="50" cy="50" r="40"/>
+        <circle class="donut-segment" id="seg1" cx="50" cy="50" r="40"
+          data-pct="40" style="--pct: 40; --color: #4a90d9; stroke-dasharray: 0 251.2"/>
+        <circle class="donut-segment" id="seg2" cx="50" cy="50" r="40"
+          data-pct="25" style="--pct: 25; --color: #e67e22; stroke-dasharray: 0 251.2"/>
+        <circle class="donut-segment" id="seg3" cx="50" cy="50" r="40"
+          data-pct="20" style="--pct: 20; --color: #2ecc71; stroke-dasharray: 0 251.2"/>
+        <circle class="donut-segment" id="seg4" cx="50" cy="50" r="40"
+          data-pct="15" style="--pct: 15; --color: #e74c3c; stroke-dasharray: 0 251.2"/>
+      </svg>
+      <div class="donut-centre">100%</div>
+    </div>
+
+    <ul class="donut-legend" id="legend">
+      <li><span class="legend-dot" style="background:#4a90d9"></span> Design <span class="legend-pct">40%</span></li>
+      <li><span class="legend-dot" style="background:#e67e22"></span> Development <span class="legend-pct">25%</span></li>
+      <li><span class="legend-dot" style="background:#2ecc71"></span> Marketing <span class="legend-pct">20%</span></li>
+      <li><span class="legend-dot" style="background:#e74c3c"></span> Research <span class="legend-pct">15%</span></li>
+    </ul>
+
+    <button class="donut-replay" id="replayBtn">Replay</button>
+  </div>
+
+  <script>
+    const segments = document.querySelectorAll('.donut-segment');
+    let animated = false;
+
+    function animateDonut() {
+      const circumference = 2 * Math.PI * 40;
+      segments.forEach((seg, i) => {
+        const pct = parseFloat(seg.dataset.pct);
+        const offset = circumference * (1 - pct / 100);
+        const delay = i * 0.15;
+        seg.style.setProperty('--offset', offset);
+        seg.style.animation = 'none';
+        seg.offsetHeight;
+        seg.style.animation = `fillDonut var(--donut-duration) ${delay}s ease-out forwards`;
+        seg.style.stroke = seg.style.getPropertyValue('--color');
+      });
+      animated = true;
+    }
+
+    document.getElementById('replayBtn').addEventListener('click', () => {
+      segments.forEach(s => { s.style.animation = 'none'; });
+      setTimeout(animateDonut, 50);
+    });
+
+    window.addEventListener('load', animateDonut);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-chart-donut-animate-ij/style.css
+++ b/submissions/examples/ease-chart-donut-animate-ij/style.css
@@ -1,0 +1,125 @@
+:root {
+  --donut-duration: 1.2s;
+  --donut-size: 260px;
+  --donut-stroke-width: 8;
+  --donut-bg: #f8f9fa;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+  background: var(--donut-bg);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+
+h1 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin-bottom: 2rem;
+  color: #222;
+  text-align: center;
+}
+
+.donut-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.donut-chart {
+  position: relative;
+  width: var(--donut-size);
+  height: var(--donut-size);
+}
+
+.donut-svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.donut-ring {
+  fill: none;
+  stroke: #e0e0e0;
+  stroke-width: var(--donut-stroke-width);
+}
+
+.donut-segment {
+  fill: none;
+  stroke-width: var(--donut-stroke-width);
+  stroke-linecap: round;
+  stroke-dasharray: 0 251.2;
+}
+
+@keyframes fillDonut {
+  from { stroke-dasharray: 0 251.2; }
+  to { stroke-dasharray: var(--offset) 251.2; }
+}
+
+.donut-centre {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: #333;
+  pointer-events: none;
+}
+
+.donut-legend {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem 1.5rem;
+  justify-content: center;
+}
+
+.donut-legend li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #444;
+}
+
+.legend-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.legend-pct {
+  font-weight: 600;
+  color: #222;
+}
+
+.donut-replay {
+  padding: 0.6rem 1.8rem;
+  border: none;
+  border-radius: 8px;
+  background: #4a90d9;
+  color: #fff;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.donut-replay:hover {
+  background: #357abd;
+}


### PR DESCRIPTION
## Component: ease-chart-donut-animate - Donut chart animated fill on load

**Closes #34758**

### What this adds
CSS animated chart-donut-animate component.

### Acceptance Criteria covered
- Smooth CSS transition or @keyframes animation
- Interactive trigger (click, hover, or scroll)
- Customizable via CSS variables

### Files
- \submissions/examples/ease-chart-donut-animate-ij/demo.html\
- \submissions/examples/ease-chart-donut-animate-ij/style.css\
- \submissions/examples/ease-chart-donut-animate-ij/README.md\

### How to review
Open \demo.html\ directly in a browser.
