### PR TITLE
fix: add missing @keyframes ease-kf-hover-pulse-glow definition

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -1373,6 +1373,21 @@
                 filter var(--ease-speed-medium) var(--ease-ease-bounce);
   }
   
+  @keyframes ease-kf-hover-pulse-glow {
+    0% {
+      transform: scale(1);
+      filter: brightness(1) drop-shadow(0 0 0px rgba(108, 99, 255, 0));
+    }
+    50% {
+      transform: scale(1.08);
+      filter: brightness(1.15) drop-shadow(0 0 12px rgba(108, 99, 255, 0.5));
+    }
+    100% {
+      transform: scale(1);
+      filter: brightness(1) drop-shadow(0 0 0px rgba(108, 99, 255, 0));
+    }
+  }
+
   .ease-hover-pulse-glow:hover {
     animation: ease-kf-hover-pulse-glow var(--ease-speed-medium) var(--ease-ease-bounce) forwards;
   }


### PR DESCRIPTION
Closes #34885

The `.ease-hover-pulse-glow:hover` class references `ease-kf-hover-pulse-glow` in its animation property but the `@keyframes` block was never defined. Hovering elements with this class silently does nothing.

Adds the missing keyframe definition with pulse-glow animation.