### PR TITLE
feat: add empty-state-card component (#34790)

### DIFF
--- a/submissions/examples/ease-empty-state-card-ij/README.md
+++ b/submissions/examples/ease-empty-state-card-ij/README.md
@@ -1,0 +1,39 @@
+# Empty State Card
+
+A card component for empty-state scenarios with a staggered entrance animation and a bounce/pulse SVG icon. Includes a toggle to switch between empty state and populated content view.
+
+## Features
+
+- Animated SVG icon (bounce + scale on appear)
+- Staggered fade-in of title, description, and CTA button
+- Interactive toggle between empty state and content state
+- Smooth hover/active feedback on the CTA
+- Fully customizable via CSS custom properties
+
+## CSS Custom Properties
+
+| Property             | Default  | Description                  |
+|----------------------|----------|------------------------------|
+| `--empty-duration`   | `0.6s`   | Animation duration           |
+| `--empty-stagger`    | `0.15s`  | Delay between each element   |
+| `--empty-card-bg`    | `#ffffff`| Card background color        |
+| `--empty-text-color` | `#374151`| Primary text color           |
+| `--empty-icon-color` | `#6366f1`| SVG icon color               |
+| `--empty-btn-bg`     | `#6366f1`| CTA button background        |
+| `--empty-radius`     | `16px`   | Card border-radius           |
+
+## Usage
+
+```html
+<link rel="stylesheet" href="style.css">
+<!-- include demo.html markup -->
+```
+
+Adjust any variable at the root level to match your brand:
+
+```css
+:root {
+  --empty-btn-bg: #0ea5e9;
+  --empty-icon-color: #0ea5e9;
+}
+```

--- a/submissions/examples/ease-empty-state-card-ij/demo.html
+++ b/submissions/examples/ease-empty-state-card-ij/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Empty State Card — EaseMotion</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="esc-container">
+    <button class="esc-toggle" id="toggleBtn">Show content</button>
+
+    <!-- Empty State -->
+    <div class="esc-card" id="emptyState">
+      <svg class="esc-icon" width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <rect x="8" y="12" width="64" height="56" rx="8" stroke="currentColor" stroke-width="3" fill="none"/>
+        <line x1="40" y1="28" x2="40" y2="52" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+        <line x1="28" y1="40" x2="52" y2="40" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+        <circle cx="16" cy="16" r="3" fill="currentColor"/>
+        <circle cx="24" cy="16" r="3" fill="currentColor"/>
+        <circle cx="32" cy="16" r="3" fill="currentColor"/>
+      </svg>
+      <h2 class="esc-title">No items yet</h2>
+      <p class="esc-desc">Get started by adding your first item. It will appear here once created.</p>
+      <button class="esc-cta">+ Add item</button>
+    </div>
+
+    <!-- Content State (hidden initially) -->
+    <div class="esc-card esc-content-state" id="contentState">
+      <h2 class="esc-title">Your items</h2>
+      <ul class="esc-list">
+        <li class="esc-list-item">Item one</li>
+        <li class="esc-list-item">Item two</li>
+        <li class="esc-list-item">Item three</li>
+      </ul>
+    </div>
+  </div>
+
+  <script>
+    const toggleBtn = document.getElementById('toggleBtn');
+    const emptyState = document.getElementById('emptyState');
+    const contentState = document.getElementById('contentState');
+    let showingContent = false;
+
+    toggleBtn.addEventListener('click', () => {
+      showingContent = !showingContent;
+      emptyState.classList.toggle('esc-hidden', showingContent);
+      contentState.classList.toggle('esc-hidden', !showingContent);
+      toggleBtn.textContent = showingContent ? 'Show empty state' : 'Show content';
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-empty-state-card-ij/style.css
+++ b/submissions/examples/ease-empty-state-card-ij/style.css
@@ -1,0 +1,162 @@
+:root {
+  --empty-duration: 0.6s;
+  --empty-stagger: 0.15s;
+  --empty-card-bg: #ffffff;
+  --empty-text-color: #374151;
+  --empty-icon-color: #6366f1;
+  --empty-btn-bg: #6366f1;
+  --empty-radius: 16px;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f3f4f6;
+  padding: 1.5rem;
+}
+
+.esc-container {
+  position: relative;
+  width: 100%;
+  max-width: 400px;
+}
+
+.esc-toggle {
+  position: absolute;
+  top: -2.75rem;
+  right: 0;
+  background: #e5e7eb;
+  border: none;
+  padding: 0.4rem 1rem;
+  border-radius: 8px;
+  cursor: pointer;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.85rem;
+  color: #374151;
+  transition: background 0.2s;
+}
+
+.esc-toggle:hover {
+  background: #d1d5db;
+}
+
+.esc-card {
+  background: var(--empty-card-bg);
+  border-radius: var(--empty-radius);
+  padding: 3rem 2rem;
+  text-align: center;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.06);
+  opacity: 0;
+  animation: escFadeIn var(--empty-duration) ease forwards;
+}
+
+.esc-hidden {
+  display: none;
+}
+
+.esc-icon {
+  color: var(--empty-icon-color);
+  margin-bottom: 1.5rem;
+  animation: escBounce var(--empty-duration) ease forwards;
+}
+
+.esc-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--empty-text-color);
+  margin-bottom: 0.5rem;
+  opacity: 0;
+  animation: escFadeIn var(--empty-duration) calc(var(--empty-stagger) * 1) ease forwards;
+}
+
+.esc-desc {
+  font-size: 0.95rem;
+  color: #6b7280;
+  line-height: 1.6;
+  margin-bottom: 1.75rem;
+  opacity: 0;
+  animation: escFadeIn var(--empty-duration) calc(var(--empty-stagger) * 2) ease forwards;
+}
+
+.esc-cta {
+  background: var(--empty-btn-bg);
+  color: #fff;
+  border: none;
+  padding: 0.75rem 2rem;
+  border-radius: 10px;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
+  opacity: 0;
+  animation: escFadeIn var(--empty-duration) calc(var(--empty-stagger) * 3) ease forwards;
+}
+
+.esc-cta:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(99, 102, 241, 0.3);
+}
+
+.esc-cta:active {
+  transform: scale(0.97);
+}
+
+.esc-list {
+  list-style: none;
+  text-align: left;
+}
+
+.esc-list-item {
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid #e5e7eb;
+  color: var(--empty-text-color);
+  font-size: 0.95rem;
+}
+
+.esc-list-item:last-child {
+  border-bottom: none;
+}
+
+.esc-content-state .esc-title {
+  margin-bottom: 1.25rem;
+}
+
+@keyframes escFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes escBounce {
+  0% {
+    opacity: 0;
+    transform: scale(0.6);
+  }
+  50% {
+    transform: scale(1.12);
+  }
+  70% {
+    transform: scale(0.95);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}


### PR DESCRIPTION
## Component: ease-empty-state-card - Empty state card with illustration animation

**Closes #34790**

### What this adds
CSS animated empty-state-card component.

### Acceptance Criteria covered
- Smooth CSS transition or @keyframes animation
- Interactive trigger (click, hover, or scroll)
- Customizable via CSS variables

### Files
- \submissions/examples/ease-empty-state-card-ij/demo.html\
- \submissions/examples/ease-empty-state-card-ij/style.css\
- \submissions/examples/ease-empty-state-card-ij/README.md\

### How to review
Open \demo.html\ directly in a browser.
