### PR TITLE
fix: resolve IE11 transform-origin issue in ease-zoom animation

### DIFF
--- a/submissions/examples/ease-zoom-fixed/README.md
+++ b/submissions/examples/ease-zoom-fixed/README.md
@@ -1,0 +1,19 @@
+# Ease Zoom Fixed
+
+## Description
+
+This example fixes the `ease-zoom` animation for Internet Explorer 11 by adding the missing `-ms-transform-origin` property.
+
+## Files
+
+- demo.html
+- style.css
+- README.md
+
+## Browser Support
+
+- Chrome
+- Firefox
+- Edge
+- Safari
+- Internet Explorer 11

--- a/submissions/examples/ease-zoom-fixed/demo.html
+++ b/submissions/examples/ease-zoom-fixed/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ease Zoom Fixed</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="ease-zoom-fixed">
+    Zooms from center on all browsers
+</div>
+
+</body>
+</html>

--- a/submissions/examples/ease-zoom-fixed/style.css
+++ b/submissions/examples/ease-zoom-fixed/style.css
@@ -1,0 +1,34 @@
+body{
+    margin:0;
+    display:flex;
+    justify-content:center;
+    align-items:center;
+    height:100vh;
+    background:#f5f5f5;
+    font-family:Arial,sans-serif;
+}
+
+.ease-zoom-fixed{
+    padding:20px 40px;
+    background:#4f46e5;
+    color:#fff;
+    border-radius:10px;
+
+    -ms-transform-origin:center center;
+    -webkit-transform-origin:center center;
+    transform-origin:center center;
+
+    -webkit-animation:zoom-in .4s ease forwards;
+    animation:zoom-in .4s ease forwards;
+}
+
+@keyframes zoom-in{
+    from{
+        transform:scale(.8);
+        opacity:0;
+    }
+    to{
+        transform:scale(1);
+        opacity:1;
+    }
+}


### PR DESCRIPTION
## Summary

Added the missing `-ms-transform-origin` property to the ease-zoom animation so that it scales from the center in Internet Explorer 11.

## Changes

- Added `-ms-transform-origin`
- Added demo.html
- Added style.css
- Added README.md

Fixes #34590