### PR TITLE
fix: resolve iOS Safari page jump in ease-float animation

### DIFF
--- a/submissions/examples/ease-float-fixed/README.md
+++ b/submissions/examples/ease-float-fixed/README.md
@@ -1,0 +1,18 @@
+# Ease Float Safari Fix
+
+## Description
+
+This example fixes the page jump issue on iOS Safari by enabling smooth touch scrolling with `-webkit-overflow-scrolling: touch` while preserving the floating animation.
+
+## Files
+
+- demo.html
+- style.css
+- README.md
+
+## Browser Support
+
+- Safari (iOS)
+- Chrome
+- Firefox
+- Edge

--- a/submissions/examples/ease-float-fixed/demo.html
+++ b/submissions/examples/ease-float-fixed/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ease Float Safari Fix</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="container">
+    <div class="ease-float-fixed">
+        I float smoothly on iOS Safari too!
+    </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/ease-float-fixed/style.css
+++ b/submissions/examples/ease-float-fixed/style.css
@@ -1,0 +1,56 @@
+*{
+    margin:0;
+    padding:0;
+    box-sizing:border-box;
+}
+
+body{
+    font-family:Arial, Helvetica, sans-serif;
+    background:#f4f4f4;
+    display:flex;
+    justify-content:center;
+    align-items:center;
+    height:100vh;
+}
+
+.container{
+    -webkit-overflow-scrolling:touch;
+    overflow:auto;
+    padding:20px;
+}
+
+.ease-float-fixed{
+    padding:20px 40px;
+    background:#2563eb;
+    color:#fff;
+    border-radius:10px;
+
+    -webkit-transform:translateZ(0);
+    transform:translateZ(0);
+
+    -webkit-backface-visibility:hidden;
+    backface-visibility:hidden;
+
+    -webkit-animation:float-smooth 3s ease-in-out infinite;
+    animation:float-smooth 3s ease-in-out infinite;
+}
+
+@-webkit-keyframes float-smooth{
+    0%,100%{
+        -webkit-transform:translateY(0) translateZ(0);
+    }
+
+    50%{
+        -webkit-transform:translateY(-15px) translateZ(0);
+    }
+}
+
+@keyframes float-smooth{
+    0%,100%{
+        transform:translateY(0) translateZ(0);
+    }
+
+    50%{
+        transform:translateY(-15px) translateZ(0);
+    }
+}


### PR DESCRIPTION
## Summary

This PR fixes the page jump issue in the `ease-float` animation on iOS Safari by adding `-webkit-overflow-scrolling: touch` and providing a demo example.

## Changes

- Added `-webkit-overflow-scrolling: touch`
- Added demo.html
- Added style.css
- Added README.md

Fixes #34503