### PR TITLE
feat: add label-edit-inline component (#35047)

### DIFF
--- a/submissions/examples/ease-label-edit-inline-ij/README.md
+++ b/submissions/examples/ease-label-edit-inline-ij/README.md
@@ -1,0 +1,14 @@
+# Label Edit Inline
+
+Click a label to switch to inline edit mode. Save on blur or Enter, cancel on Escape. Smooth scale + opacity transitions between display and edit states.
+
+## Features
+
+- Inline editable labels with click-to-edit interaction
+- Smooth scale + opacity transition between display and input
+- Save on blur or Enter key; cancel on Escape
+- Focus border highlight via `--lei-editing` custom property
+
+## Usage
+
+Set `--lei-editing` to `1` on `.lei-row` to switch to edit mode. The display label fades out while the input fades in. The JS manages click-to-edit, blur-save, and keyboard events.

--- a/submissions/examples/ease-label-edit-inline-ij/demo.html
+++ b/submissions/examples/ease-label-edit-inline-ij/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Label Edit Inline - EaseMotion CSS</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="lei-wrapper">
+    <h1>Inline Editable Labels</h1>
+    <p class="lei-desc">Click a label to edit. Save: Enter/Blur &middot; Cancel: Escape</p>
+    <div class="lei-list">
+      <div class="lei-row" style="--lei-editing: 0">
+        <span class="lei-display">Username</span>
+        <input class="lei-input" type="text" value="Username">
+      </div>
+      <div class="lei-row" style="--lei-editing: 0">
+        <span class="lei-display">user@example.com</span>
+        <input class="lei-input" type="text" value="user@example.com">
+      </div>
+      <div class="lei-row" style="--lei-editing: 0">
+        <span class="lei-display">Full Stack Developer</span>
+        <input class="lei-input" type="text" value="Full Stack Developer">
+      </div>
+    </div>
+  </div>
+  <script>
+    document.querySelectorAll('.lei-row').forEach(function(row) {
+      var display = row.querySelector('.lei-display');
+      var input = row.querySelector('.lei-input');
+      var editing = false;
+
+      function enterEdit() {
+        editing = true;
+        row.style.setProperty('--lei-editing', 1);
+        input.value = display.textContent;
+        input.focus();
+        input.select();
+      }
+
+      function exitEdit(save) {
+        if (!editing) return;
+        editing = false;
+        if (save) display.textContent = input.value;
+        row.style.setProperty('--lei-editing', 0);
+      }
+
+      display.addEventListener('click', enterEdit);
+
+      input.addEventListener('blur', function() { exitEdit(true); });
+
+      input.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter') { e.preventDefault(); exitEdit(true); }
+        if (e.key === 'Escape') { e.preventDefault(); exitEdit(false); }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-label-edit-inline-ij/style.css
+++ b/submissions/examples/ease-label-edit-inline-ij/style.css
@@ -1,0 +1,100 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --lei-duration: 0.3s;
+  --lei-label-color: #94a3b8;
+  --lei-input-border: #334155;
+  --lei-focus-color: #facc15;
+  --lei-bg: #1e293b;
+}
+
+body {
+  font-family: 'Inter', -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.lei-wrapper {
+  text-align: center;
+  width: 100%;
+  max-width: 420px;
+}
+
+h1 {
+  font-weight: 500;
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.lei-desc {
+  font-size: 0.875rem;
+  color: #64748b;
+  margin-bottom: 2rem;
+}
+
+.lei-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.lei-row {
+  --lei-editing: 0;
+  position: relative;
+  background: var(--lei-bg);
+  border: 1px solid var(--lei-input-border);
+  border-radius: 10px;
+  padding: 0.85rem 1rem;
+  text-align: left;
+  cursor: text;
+  transition: border-color var(--lei-duration) ease;
+}
+
+[style*="--lei-editing: 1"] {
+  border-color: var(--lei-focus-color);
+}
+
+.lei-display {
+  display: block;
+  font-size: 0.95rem;
+  color: var(--lei-label-color);
+  transition: opacity var(--lei-duration) ease, transform var(--lei-duration) ease;
+  opacity: calc(1 - var(--lei-editing));
+  transform: scale(calc(1 - var(--lei-editing) * 0.08));
+  pointer-events: calc(1 - var(--lei-editing));
+  user-select: none;
+}
+
+[style*="--lei-editing: 1"] .lei-display {
+  pointer-events: none;
+}
+
+.lei-input {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  top: 50%;
+  transform: translateY(-50%) scale(0.92);
+  background: transparent;
+  border: none;
+  outline: none;
+  color: #e2e8f0;
+  font-family: inherit;
+  font-size: 0.95rem;
+  opacity: 0;
+  transition: opacity var(--lei-duration) ease, transform var(--lei-duration) ease;
+}
+
+[style*="--lei-editing: 1"] .lei-input {
+  opacity: 1;
+  transform: translateY(-50%) scale(1);
+}


### PR DESCRIPTION
## Component: ease-label-edit-inline - Inline editable label with smooth transition

**Closes #35047**

### What this adds
CSS animated label-edit-inline component.

### Acceptance Criteria covered
- Smooth CSS transition or @keyframes animation
- Interactive trigger (click, hover, or scroll)
- Customizable via CSS variables

### Files
- \submissions/examples/ease-label-edit-inline-ij/demo.html\
- \submissions/examples/ease-label-edit-inline-ij/style.css\
- \submissions/examples/ease-label-edit-inline-ij/README.md\

### How to review
Open \demo.html\ directly in a browser.
