### PR TITLE
feat: add language-selector-dropdown component (#35049)

### DIFF
--- a/submissions/examples/ease-language-selector-dropdown-ij/README.md
+++ b/submissions/examples/ease-language-selector-dropdown-ij/README.md
@@ -1,0 +1,15 @@
+# Language Selector Dropdown
+
+Language/country selector with emoji flags, staggered dropdown animation, and search/filter. Options slide in with translateY + opacity, each with a cascading delay.
+
+## Features
+
+- Flag icons + language labels in dropdown
+- Staggered entrance animation via `--lsd-stagger`
+- Search/filter for quick language lookup
+- Arrow rotation on open/close
+- Selected option highlighted with accent color
+
+## Usage
+
+Set `--lsd-open` to `1` on `.lsd-dropdown` to open. Options animate in with staggered delay. JS manages toggle, outside close, search filtering, and selection.

--- a/submissions/examples/ease-language-selector-dropdown-ij/demo.html
+++ b/submissions/examples/ease-language-selector-dropdown-ij/demo.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Language Selector Dropdown - EaseMotion CSS</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="lsd-wrapper">
+    <h1>Language Selector</h1>
+    <p class="lsd-desc">Select a language. Search/filter supported.</p>
+    <div class="lsd-dropdown" style="--lsd-open: 0">
+      <button class="lsd-toggle">
+        <span class="lsd-selected">
+          <span class="lsd-flag">🇬🇧</span>
+          <span class="lsd-selected-label">English</span>
+        </span>
+        <span class="lsd-arrow"></span>
+      </button>
+      <div class="lsd-menu">
+        <input class="lsd-search" type="text" placeholder="Search languages...">
+        <div class="lsd-options">
+          <div class="lsd-option" data-value="en" data-flag="🇬🇧" tabindex="0" role="option" aria-selected="true">English</div>
+          <div class="lsd-option" data-value="es" data-flag="🇪🇸" tabindex="0" role="option" aria-selected="false">Español</div>
+          <div class="lsd-option" data-value="fr" data-flag="🇫🇷" tabindex="0" role="option" aria-selected="false">Français</div>
+          <div class="lsd-option" data-value="de" data-flag="🇩🇪" tabindex="0" role="option" aria-selected="false">Deutsch</div>
+          <div class="lsd-option" data-value="it" data-flag="🇮🇹" tabindex="0" role="option" aria-selected="false">Italiano</div>
+          <div class="lsd-option" data-value="pt" data-flag="🇵🇹" tabindex="0" role="option" aria-selected="false">Português</div>
+          <div class="lsd-option" data-value="ru" data-flag="🇷🇺" tabindex="0" role="option" aria-selected="false">Русский</div>
+          <div class="lsd-option" data-value="ja" data-flag="🇯🇵" tabindex="0" role="option" aria-selected="false">日本語</div>
+          <div class="lsd-option" data-value="ko" data-flag="🇰🇷" tabindex="0" role="option" aria-selected="false">한국어</div>
+          <div class="lsd-option" data-value="zh" data-flag="🇨🇳" tabindex="0" role="option" aria-selected="false">中文</div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script>
+    (function() {
+      var dropdown = document.querySelector('.lsd-dropdown');
+      var toggle = document.querySelector('.lsd-toggle');
+      var menu = document.querySelector('.lsd-menu');
+      var search = document.querySelector('.lsd-search');
+      var options = document.querySelectorAll('.lsd-option');
+      var selectedFlag = document.querySelector('.lsd-flag');
+      var selectedLabel = document.querySelector('.lsd-selected-label');
+
+      toggle.addEventListener('click', function(e) {
+        e.stopPropagation();
+        var open = dropdown.style.getPropertyValue('--lsd-open') === '1' ? '0' : '1';
+        dropdown.style.setProperty('--lsd-open', open);
+        if (open === '1') { setTimeout(function() { search.focus(); }, 200); }
+      });
+
+      function selectOption(opt) {
+        options.forEach(function(o) { o.setAttribute('aria-selected', 'false'); });
+        opt.setAttribute('aria-selected', 'true');
+        selectedFlag.textContent = opt.getAttribute('data-flag');
+        selectedLabel.textContent = opt.textContent;
+        dropdown.style.setProperty('--lsd-open', '0');
+        search.value = '';
+        options.forEach(function(o) { o.style.display = ''; });
+      }
+
+      options.forEach(function(opt) {
+        opt.addEventListener('click', function() { selectOption(this); });
+        opt.addEventListener('keydown', function(e) { if (e.key === 'Enter') selectOption(this); });
+      });
+
+      document.addEventListener('click', function(e) {
+        if (!dropdown.contains(e.target)) {
+          dropdown.style.setProperty('--lsd-open', '0');
+          search.value = '';
+          options.forEach(function(o) { o.style.display = ''; });
+        }
+      });
+
+      search.addEventListener('input', function() {
+        var q = this.value.toLowerCase();
+        options.forEach(function(opt) {
+          opt.style.display = opt.textContent.toLowerCase().indexOf(q) > -1 ? '' : 'none';
+        });
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-language-selector-dropdown-ij/style.css
+++ b/submissions/examples/ease-language-selector-dropdown-ij/style.css
@@ -1,0 +1,175 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --lsd-duration: 0.3s;
+  --lsd-stagger: 0.04s;
+  --lsd-bg: #1e293b;
+  --lsd-hover-bg: #334155;
+  --lsd-text-color: #e2e8f0;
+  --lsd-radius: 10px;
+}
+
+body {
+  font-family: 'Inter', -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: var(--lsd-text-color);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.lsd-wrapper {
+  text-align: center;
+  width: 100%;
+  max-width: 320px;
+}
+
+h1 {
+  font-weight: 500;
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.lsd-desc {
+  font-size: 0.875rem;
+  color: #64748b;
+  margin-bottom: 2rem;
+}
+
+.lsd-dropdown {
+  position: relative;
+  text-align: left;
+}
+
+.lsd-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border: 1px solid #334155;
+  border-radius: var(--lsd-radius);
+  background: var(--lsd-bg);
+  color: var(--lsd-text-color);
+  font-family: inherit;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease;
+}
+
+[style*="--lsd-open: 1"] .lsd-toggle {
+  border-color: #facc15;
+}
+
+.lsd-selected {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.lsd-flag {
+  font-size: 1.2rem;
+  line-height: 1;
+}
+
+.lsd-arrow {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid #94a3b8;
+  border-bottom: 2px solid #94a3b8;
+  transform: rotate(45deg);
+  transition: transform var(--lsd-duration) cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+[style*="--lsd-open: 1"] .lsd-arrow {
+  transform: rotate(-135deg);
+}
+
+.lsd-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  background: var(--lsd-bg);
+  border: 1px solid #334155;
+  border-radius: var(--lsd-radius);
+  padding: 0.5rem;
+  opacity: 0;
+  transform: translateY(-10px);
+  pointer-events: none;
+  transition: opacity var(--lsd-duration) ease, transform var(--lsd-duration) ease;
+  z-index: 10;
+}
+
+[style*="--lsd-open: 1"] .lsd-menu {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.lsd-search {
+  width: 100%;
+  padding: 0.55rem 0.75rem;
+  border: 1px solid #334155;
+  border-radius: 6px;
+  background: #0f172a;
+  color: var(--lsd-text-color);
+  font-family: inherit;
+  font-size: 0.8rem;
+  outline: none;
+  margin-bottom: 0.35rem;
+  transition: border-color 0.2s ease;
+}
+
+.lsd-search:focus {
+  border-color: #facc15;
+}
+
+.lsd-options {
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.lsd-option {
+  padding: 0.55rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  opacity: 0;
+  transform: translateY(-8px);
+  transition: background 0.2s ease, opacity var(--lsd-duration) ease, transform var(--lsd-duration) ease;
+  transition-delay: calc(var(--lsd-stagger) * 0s);
+}
+
+[style*="--lsd-open: 1"] .lsd-option {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+[style*="--lsd-open: 1"] .lsd-option:nth-child(1) { transition-delay: calc(var(--lsd-stagger) * 1); }
+[style*="--lsd-open: 1"] .lsd-option:nth-child(2) { transition-delay: calc(var(--lsd-stagger) * 2); }
+[style*="--lsd-open: 1"] .lsd-option:nth-child(3) { transition-delay: calc(var(--lsd-stagger) * 3); }
+[style*="--lsd-open: 1"] .lsd-option:nth-child(4) { transition-delay: calc(var(--lsd-stagger) * 4); }
+[style*="--lsd-open: 1"] .lsd-option:nth-child(5) { transition-delay: calc(var(--lsd-stagger) * 5); }
+[style*="--lsd-open: 1"] .lsd-option:nth-child(6) { transition-delay: calc(var(--lsd-stagger) * 6); }
+[style*="--lsd-open: 1"] .lsd-option:nth-child(7) { transition-delay: calc(var(--lsd-stagger) * 7); }
+[style*="--lsd-open: 1"] .lsd-option:nth-child(8) { transition-delay: calc(var(--lsd-stagger) * 8); }
+[style*="--lsd-open: 1"] .lsd-option:nth-child(9) { transition-delay: calc(var(--lsd-stagger) * 9); }
+[style*="--lsd-open: 1"] .lsd-option:nth-child(10) { transition-delay: calc(var(--lsd-stagger) * 10); }
+
+.lsd-option:hover {
+  background: var(--lsd-hover-bg);
+}
+
+.lsd-option[aria-selected="true"] {
+  background: #334155;
+  color: #facc15;
+  font-weight: 500;
+}


### PR DESCRIPTION
## Component: ease-language-selector-dropdown - Language selector dropdown with stagger

**Closes #35049**

### What this adds
CSS animated language-selector-dropdown component.

### Acceptance Criteria covered
- Smooth CSS transition or @keyframes animation
- Interactive trigger (click, hover, or scroll)
- Customizable via CSS variables

### Files
- \submissions/examples/ease-language-selector-dropdown-ij/demo.html\
- \submissions/examples/ease-language-selector-dropdown-ij/style.css\
- \submissions/examples/ease-language-selector-dropdown-ij/README.md\

### How to review
Open \demo.html\ directly in a browser.
