### PR TITLE
[Feat] #33643 — Add iOS startup animation component (unique folder)

### DIFF
--- a/submissions/examples/ios-boot-33643-ag/README.md
+++ b/submissions/examples/ios-boot-33643-ag/README.md
@@ -1,0 +1,18 @@
+# Pure CSS iOS Startup Animation
+
+A complete iOS boot and lock screen transition build utilizing only HTML/CSS.
+
+---
+
+## What is Included
+
+1. **`demo.html`**: A simulated mobile device window containing the Apple branding logo, progress bar trackers, status labels, and a lock screen widget layout.
+2. **`style.css`**: Device layouts, progress bar fillers, fade out boot states, and swipe-up bounces.
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a web browser.
+2. Watch the Apple logo load with a progressive loading bar.
+3. Verify that after the progress bar reaches 100%, the screen transitions smoothly into the iOS Lock Screen (showing the time, widgets, and swipe bar).

--- a/submissions/examples/ios-boot-33643-ag/demo.html
+++ b/submissions/examples/ios-boot-33643-ag/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>iOS Startup Animation — EaseMotion CSS</title>
+  <meta name="description" content="Visual showcase of a pure CSS iOS startup boot sequence, progress bar loader, and lock screen transition.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="device-frame">
+    <!-- Boot Screen Layer -->
+    <div class="boot-screen">
+      <div class="apple-logo-wrap">
+        <!-- Apple Logo SVG -->
+        <svg class="apple-logo" viewBox="0 0 170 170" width="80" height="80">
+          <path fill="#ffffff" d="M150.37 130.25c-2.45 5.66-5.35 10.87-8.71 15.66-4.58 6.53-8.33 11.05-11.22 13.56-4.48 4.12-9.28 6.23-14.42 6.35-3.69 0-8.14-1.05-13.32-3.18-5.19-2.12-9.97-3.17-14.34-3.17-4.58 0-9.49 1.05-14.75 3.17-5.26 2.13-9.5 3.24-12.74 3.35-4.34.13-9.04-1.92-14.12-6.15-3.69-3.08-7.79-7.9-12.32-14.47-7.79-11.39-13.88-24.96-18.28-40.75-4.4-15.79-6.61-30.68-6.61-44.66 0-14.94 3.73-27.18 11.19-36.71 7.46-9.53 16.73-14.42 27.81-14.67 5.48 0 11.23 1.54 17.26 4.63 6.03 3.09 10.15 4.63 12.35 4.63 2.01 0 6.09-1.54 12.24-4.63 6.15-3.09 12.06-4.57 17.72-4.46 16.73.56 29.56 6.8 38.48 18.72-13.72 8.31-20.45 19.98-20.19 35 0.28 11.72 4.63 21.6 13.06 29.62 8.43 8.03 18.66 12.34 30.69 12.95-2.58 7.57-5.83 15.22-9.75 22.95zM119.22 9.89c0-8.59 3.03-16.14 9.09-22.65 6.06-6.52 13.33-10.1 21.82-10.74.11 1.01.17 2 .17 3 0 8.15-3.19 15.71-9.56 22.68-6.37 6.97-13.72 10.71-22.06 11.22-0.22-1.01-0.34-2.18-0.34-3.51z"/>
+        </svg>
+      </div>
+      
+      <div class="loader-container">
+        <div class="progress-bar"></div>
+      </div>
+      
+      <div class="status-msg">Loading system resources...</div>
+    </div>
+
+    <!-- iOS Lock Screen Layer (fades in after boot) -->
+    <div class="lock-screen">
+      <div class="time-container">
+        <div class="time">09:41</div>
+        <div class="date">Friday, July 3</div>
+      </div>
+
+      <div class="widgets-grid">
+        <div class="widget">☀️ 72°</div>
+        <div class="widget">🔋 100%</div>
+      </div>
+
+      <div class="unlock-prompt">
+        Swipe up to open
+        <div class="swipe-bar"></div>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ios-boot-33643-ag/style.css
+++ b/submissions/examples/ios-boot-33643-ag/style.css
@@ -1,0 +1,218 @@
+/* ============================================================
+   iOS Boot & Startup Animation — style.css
+   Submission for EaseMotion CSS Issue #33643
+   Device frames, dark modes, loading bars, system transitions
+   ============================================================ */
+
+:root {
+  --device-bg: #000000;
+  --ios-blue: #007aff;
+  --lock-bg: linear-gradient(180deg, #1b263b 0%, #0d1b2a 100%);
+  --text-white: #ffffff;
+  --text-muted: rgba(255, 255, 255, 0.6);
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  background: #111827;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  overflow: hidden;
+}
+
+/* ── Device Simulator Frame ── */
+.device-frame {
+  width: 320px;
+  height: 640px;
+  background: var(--device-bg);
+  border: 12px solid #2d3748;
+  border-radius: 40px;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+}
+
+/* ============================================================
+   Boot Screen Layer Animations
+   ============================================================ */
+
+.boot-screen {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: #000;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 10;
+  animation: fadeOutBoot 0.8s ease 4.6s forwards;
+}
+
+.apple-logo-wrap {
+  margin-bottom: 48px;
+  animation: logoPulse 2s ease-in-out infinite;
+}
+
+.loader-container {
+  width: 140px;
+  height: 4px;
+  background: #222;
+  border-radius: 2px;
+  overflow: hidden;
+  margin-bottom: 24px;
+}
+
+.progress-bar {
+  height: 100%;
+  width: 0%;
+  background: #fff;
+  border-radius: 2px;
+  animation: fillProgress 4s cubic-bezier(0.25, 0.46, 0.45, 0.94) 0.5s forwards;
+}
+
+.status-msg {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  animation: messageSequence 4s steps(1) 0.5s forwards;
+}
+
+/* ============================================================
+   iOS Lock Screen Layer (Fades In)
+   ============================================================ */
+
+.lock-screen {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--lock-bg);
+  padding: 48px 24px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  opacity: 0;
+  transform: scale(1.05);
+  animation: fadeInLock 0.8s cubic-bezier(0.16, 1, 0.3, 1) 4.8s forwards;
+}
+
+.time-container {
+  text-align: center;
+  color: var(--text-white);
+}
+
+.time {
+  font-size: 3.5rem;
+  font-weight: 200;
+  letter-spacing: -0.02em;
+}
+
+.date {
+  font-size: 0.9rem;
+  font-weight: 500;
+  margin-top: 4px;
+}
+
+.widgets-grid {
+  display: flex;
+  gap: 16px;
+  margin-top: -120px;
+}
+
+.widget {
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 12px 18px;
+  border-radius: 16px;
+  color: var(--text-white);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.unlock-prompt {
+  color: var(--text-white);
+  font-size: 0.85rem;
+  font-weight: 500;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.swipe-bar {
+  width: 120px;
+  height: 5px;
+  background: var(--text-white);
+  border-radius: 999px;
+  opacity: 0.8;
+  animation: bounceBar 2s ease-in-out infinite;
+}
+
+/* ============================================================
+   Keyframe Declarations
+   ============================================================ */
+
+@keyframes fillProgress {
+  0% { width: 0%; }
+  30% { width: 40%; }
+  50% { width: 45%; }
+  75% { width: 85%; }
+  100% { width: 100%; }
+}
+
+@keyframes logoPulse {
+  0%, 100% { transform: scale(1); filter: brightness(1); }
+  50% { transform: scale(1.03); filter: brightness(1.1); }
+}
+
+@keyframes messageSequence {
+  0% { content: "Loading system resources..."; }
+  25% { opacity: 0; }
+  26% { opacity: 1; text-shadow: 0 0 0; }
+  50% { opacity: 0; }
+  51% { opacity: 1; }
+  100% { opacity: 1; }
+}
+
+@keyframes fadeOutBoot {
+  to {
+    opacity: 0;
+    visibility: hidden;
+  }
+}
+
+@keyframes fadeInLock {
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes bounceBar {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-4px); }
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .progress-bar {
+    animation-duration: 0.1s !important;
+  }
+  .boot-screen {
+    animation-delay: 0.2s !important;
+  }
+  .lock-screen {
+    animation-delay: 0.3s !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-ios-boot` showcase. It demonstrates a high-fidelity iOS startup sequence utilizing pure HTML/CSS animations (cycling progress bars, apple logo pulses, and fades) transitioning into a fully widgeted lock screen.

## Root Cause
No startup boot animations or iOS system simulation layouts existed in EaseMotion CSS.

## Changes Made
- `submissions/examples/ios-boot-33643-ag/demo.html`: Device mockup, Apple SVG logo, loader rails, lock screen widgets, time display, and swipe-up prompts.
- `submissions/examples/ios-boot-33643-ag/style.css`: Mobile frame dimensions, linear gradients, progress fill curves, blur filters, keyframe translations, and scale bounces.
- `submissions/examples/ios-boot-33643-ag/README.md`: Explains sequence keyframes, layout assets, and manual testing.

## How to Test
1. Open `demo.html` in a browser.
2. Confirm the loading bar finishes loading and fades into the simulated iOS interface.

## Related Issue
Closes #33643