### PR TITLE
[Feat] #33629 — Add Fedora startup animation component (unique folder)

### DIFF
--- a/submissions/examples/fedora-boot-33629-ag/README.md
+++ b/submissions/examples/fedora-boot-33629-ag/README.md
@@ -1,0 +1,18 @@
+# Pure CSS Fedora Startup Animation
+
+A complete Fedora Linux boot and login screen transition component built using only HTML/CSS.
+
+---
+
+## What is Included
+
+1. **`demo.html`**: A monitor-style simulated screen containing the Fedora Infinity branding logo, spinning loader, terminal log lines, and a GDM User Login screen.
+2. **`style.css`**: Monitor boundaries, infinite spins, log line entrance timings, GDM layouts.
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a web browser.
+2. Observe the Fedora logo, spinning loader, and terminal log entries compiling sequentially.
+3. Verify that after 4.8 seconds, the terminal logs fade into the Fedora GDM Sign-in screen.

--- a/submissions/examples/fedora-boot-33629-ag/demo.html
+++ b/submissions/examples/fedora-boot-33629-ag/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fedora Startup Animation — EaseMotion CSS</title>
+  <meta name="description" content="Visual showcase of a pure CSS Fedora Linux boot sequence, scrolling systemd log rails, and GDM login screen.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="monitor-frame">
+    <!-- Boot Screen Layer -->
+    <div class="boot-screen">
+      <div class="logo-container">
+        <!-- Fedora Infinity Logo SVG -->
+        <svg class="fedora-logo" viewBox="0 0 100 100" width="100" height="100">
+          <circle cx="50" cy="50" r="46" fill="#3c6eb4"/>
+          <path fill="#ffffff" d="M54.5 35.8c-2.3-2.3-6.1-2.3-8.4 0l-10.3 10.3c-2.3 2.3-2.3 6.1 0 8.4s6.1 2.3 8.4 0l10.3-10.3c2.3-2.3 2.3-6.1 0-8.4z"/>
+          <path fill="#ffffff" d="M45.5 64.2c2.3 2.3 6.1 2.3 8.4 0l10.3-10.3c2.3-2.3 2.3-6.1 0-8.4s-6.1-2.3-8.4 0L45.5 55.8c-2.3 2.3-2.3 6.1 0 8.4z"/>
+          <path fill="#ffffff" d="M37.5 50h25v5h-25z" transform="rotate(45 50 50)"/>
+        </svg>
+      </div>
+
+      <div class="spinner"></div>
+
+      <!-- Scrolling systemd logs -->
+      <div class="systemd-logs">
+        <p class="log-line l-1">[  OK  ] Started LVM event activation on device 253:0.</p>
+        <p class="log-line l-2">[  OK  ] Reached target Local File Systems (Pre).</p>
+        <p class="log-line l-3">[  OK  ] Mount Network File System.</p>
+        <p class="log-line l-4">[  OK  ] Started GNOME Display Manager.</p>
+      </div>
+    </div>
+
+    <!-- GDM Login Screen Layer -->
+    <div class="gdm-screen">
+      <div class="avatar-wrap">
+        <div class="avatar">👤</div>
+        <div class="username">Fedora User</div>
+      </div>
+
+      <div class="password-box">
+        <input type="password" placeholder="Password" disabled>
+        <button class="sign-in-btn">➔</button>
+      </div>
+
+      <div class="bottom-bar">
+        <span>Fedora Linux 40</span>
+        <span>Accessibility</span>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/fedora-boot-33629-ag/style.css
+++ b/submissions/examples/fedora-boot-33629-ag/style.css
@@ -1,0 +1,229 @@
+/* ============================================================
+   Fedora Boot & Startup Animation — style.css
+   Submission for EaseMotion CSS Issue #33629
+   Fedora blues, systemd text lists, loading wheels, login screens
+   ============================================================ */
+
+:root {
+  --fedora-blue: #3c6eb4;
+  --fedora-dark: #0b1a30;
+  --text-light: #e6effa;
+  --text-ok: #2ecc71;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  background: #111827;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  overflow: hidden;
+}
+
+/* ── Screen Frame ── */
+.monitor-frame {
+  width: 500px;
+  height: 350px;
+  background: #000;
+  border: 14px solid #1f2937;
+  border-radius: 20px;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.6);
+}
+
+/* ============================================================
+   Fedora Boot Animation Layers
+   ============================================================ */
+
+.boot-screen {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: #000000;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 10;
+  animation: fadeOutBoot 0.6s ease 4.8s forwards;
+}
+
+.logo-container {
+  margin-bottom: 32px;
+  animation: floatLogo 3s ease-in-out infinite;
+}
+
+.spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid rgba(60, 110, 180, 0.2);
+  border-top-color: var(--fedora-blue);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-bottom: 24px;
+}
+
+.systemd-logs {
+  width: 80%;
+  max-height: 80px;
+  overflow: hidden;
+  font-family: monospace;
+  font-size: 0.72rem;
+  color: #9ca3af;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.log-line {
+  opacity: 0;
+  transform: translateY(10px);
+}
+
+.log-line::before {
+  content: '';
+}
+
+.l-1 { animation: showLog 0.3s ease 0.6s forwards; }
+.l-2 { animation: showLog 0.3s ease 1.5s forwards; }
+.l-3 { animation: showLog 0.3s ease 2.6s forwards; }
+.l-4 { animation: showLog 0.3s ease 3.8s forwards; }
+
+/* ============================================================
+   GDM Login Screen Layer (Fades In)
+   ============================================================ */
+
+.gdm-screen {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, var(--fedora-dark) 0%, #152d4e 100%);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 32px;
+  opacity: 0;
+  transform: scale(0.97);
+  animation: fadeInGdm 0.6s cubic-bezier(0.16, 1, 0.3, 1) 5.0s forwards;
+}
+
+.avatar-wrap {
+  text-align: center;
+  color: var(--text-light);
+}
+
+.avatar {
+  width: 72px;
+  height: 72px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  margin: 0 auto 12px;
+}
+
+.username {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.password-box {
+  display: flex;
+  background: rgba(0, 0, 0, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 4px;
+}
+
+.password-box input {
+  background: transparent;
+  border: none;
+  color: #fff;
+  padding: 10px 14px;
+  font-size: 0.85rem;
+  outline: none;
+}
+
+.sign-in-btn {
+  background: var(--fedora-blue);
+  border: none;
+  color: #fff;
+  width: 36px;
+  height: 36px;
+  border-radius: 6px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.bottom-bar {
+  position: absolute;
+  bottom: 16px;
+  left: 0;
+  width: 100%;
+  padding: 0 24px;
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.72rem;
+  color: rgba(255, 255, 255, 0.4);
+}
+
+/* ============================================================
+   Keyframes
+   ============================================================ */
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes floatLogo {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-3px); }
+}
+
+@keyframes showLog {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fadeOutBoot {
+  to {
+    opacity: 0;
+    visibility: hidden;
+  }
+}
+
+@keyframes fadeInGdm {
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation: none !important;
+  }
+  .boot-screen {
+    animation-delay: 0.2s !important;
+  }
+  .gdm-screen {
+    animation-delay: 0.3s !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-fedora-boot` showcase. It demonstrates Fedora boot configurations generated using pure CSS animations (featuring rotating infinite spin loops, scrolling systemd log lines, and logo floating offsets) transitioning into the Fedora GDM login dashboard.

## Root Cause
No Linux boot screen animations or scrolling system boot loaders existed in the codebase.

## Changes Made
- `submissions/examples/fedora-boot-33629-ag/demo.html`: Container monitor framework, Fedora Infinity vector graphics, spinning loader, terminal log lines, and user avatar sign-ins.
- `submissions/examples/fedora-boot-33629-ag/style.css`: Monitor boundaries, spin timings, delay offsets, GDM gradients, password overlays, and accessibility panels.
- `submissions/examples/fedora-boot-33629-ag/README.md`: Explains sequence delay triggers, rotation keyframes, and manual validation.

## How to Test
1. Open `demo.html` in a browser.
2. Confirm the boot loaders finish compiling logs and reveal the login fields.

## Related Issue
Closes #33629