### PR TITLE
feat: add ease-badge-dot-pulse-xk status indicator component (#35124)

### DIFF
--- a/submissions/examples/ease-badge-dot-pulse-xk/README.md
+++ b/submissions/examples/ease-badge-dot-pulse-xk/README.md
@@ -1,0 +1,82 @@
+# ease-badge-dot-pulse-xk
+
+Status indicator dot with concentric pulse rings for **online**, **away**,
+and **offline** states.
+
+Resolves: #35124
+
+## Overview
+
+A small, self-contained status badge component. A solid core dot represents
+the current state, with two staggered expanding-and-fading rings layered
+behind it to create a "radar ping" pulse effect for active states. Fully
+customizable via CSS variables and includes multiple interactive trigger
+patterns.
+
+## Markup
+
+```html
+<span class="ease-badge-dot-pulse-xk is-online" role="status" aria-label="Online">
+  <span class="ease-badge-dot-pulse-xk__ring"></span>
+  <span class="ease-badge-dot-pulse-xk__ring ease-badge-dot-pulse-xk__ring--delay"></span>
+  <span class="ease-badge-dot-pulse-xk__dot"></span>
+</span>
+```
+
+Swap `is-online` for `is-away` or `is-offline` to change state. For the
+offline state, the two `__ring` elements can be omitted entirely since there's
+no pulse — see `demo.html` for the exact markup used per state.
+
+## CSS Variables
+
+| Variable        | Default   | Description                              |
+|------------------|-----------|-------------------------------------------|
+| `--ebdp-size`    | `12px`    | Diameter of the core dot                  |
+| `--ebdp-color`   | `#22c55e`| Base color (auto-set per state class, or override inline) |
+| `--ebdp-speed`   | `1.8s`    | Duration of one pulse ring animation cycle |
+
+Example override:
+
+```html
+<span class="ease-badge-dot-pulse-xk is-online"
+      style="--ebdp-size: 22px; --ebdp-color: #ff5cad; --ebdp-speed: 0.9s;">
+  ...
+</span>
+```
+
+## States
+
+- **Online** (`is-online`) — green, active pulsing rings.
+- **Away** (`is-away`) — amber, pulsing rings at a slower/gentler cadence.
+- **Offline** (`is-offline`) — grey, static dot, no rings/animation.
+
+## Interactive Triggers (Acceptance Criteria)
+
+Three interaction patterns are demonstrated in `demo.html`:
+
+1. **Static showcase** — all three states side by side.
+2. **Click trigger** — a button cycles the badge through
+   Online → Away → Offline on each click, updating the label and
+   `aria-label` accordingly.
+3. **Hover / focus trigger** — a variant (`--hover-trigger` modifier) where
+   the pulse rings stay paused and invisible until the badge is hovered or
+   keyboard-focused, then animate in.
+
+## Accessibility
+
+- Each badge has `role="status"` and a descriptive `aria-label` reflecting
+  the current state.
+- The click-cycling demo uses `aria-live="polite"` so state changes are
+  announced.
+- The hover-trigger variant is keyboard-reachable (`tabindex="0"`) with a
+  visible `:focus-visible` outline.
+- Respects `prefers-reduced-motion: reduce` by disabling the ring animation
+  entirely for users who've opted out of motion.
+
+## Files
+
+- `demo.html` — all four showcase sections (static states, click trigger,
+  hover trigger, CSS variable customization).
+- `style.css` — component styles, keyframes, interactive states, and
+  reduced-motion handling.
+- `README.md` — this file.

--- a/submissions/examples/ease-badge-dot-pulse-xk/demo.html
+++ b/submissions/examples/ease-badge-dot-pulse-xk/demo.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>ease-badge-dot-pulse-xk — Status Indicator with Pulse Rings</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="page">
+    <h1>ease-badge-dot-pulse-xk</h1>
+    <p class="subtitle">Status indicator dot with concentric pulse rings for online / offline / away states.</p>
+
+    <!-- ============ STATIC STATE SHOWCASE ============ -->
+    <section class="showcase">
+      <h2>States</h2>
+      <div class="badge-row">
+
+        <div class="badge-demo">
+          <span class="ease-badge-dot-pulse-xk is-online" role="status" aria-label="Online">
+            <span class="ease-badge-dot-pulse-xk__ring"></span>
+            <span class="ease-badge-dot-pulse-xk__ring ease-badge-dot-pulse-xk__ring--delay"></span>
+            <span class="ease-badge-dot-pulse-xk__dot"></span>
+          </span>
+          <span class="badge-label">Online</span>
+        </div>
+
+        <div class="badge-demo">
+          <span class="ease-badge-dot-pulse-xk is-away" role="status" aria-label="Away">
+            <span class="ease-badge-dot-pulse-xk__ring"></span>
+            <span class="ease-badge-dot-pulse-xk__ring ease-badge-dot-pulse-xk__ring--delay"></span>
+            <span class="ease-badge-dot-pulse-xk__dot"></span>
+          </span>
+          <span class="badge-label">Away</span>
+        </div>
+
+        <div class="badge-demo">
+          <span class="ease-badge-dot-pulse-xk is-offline" role="status" aria-label="Offline">
+            <span class="ease-badge-dot-pulse-xk__dot"></span>
+          </span>
+          <span class="badge-label">Offline</span>
+        </div>
+
+      </div>
+    </section>
+
+    <!-- ============ INTERACTIVE TRIGGER: CLICK TO CYCLE STATE ============ -->
+    <section class="showcase">
+      <h2>Interactive — click to cycle state</h2>
+      <button type="button" id="statusToggle" class="status-toggle-btn">
+        <span class="ease-badge-dot-pulse-xk is-online" id="interactiveBadge" role="status" aria-live="polite" aria-label="Online">
+          <span class="ease-badge-dot-pulse-xk__ring"></span>
+          <span class="ease-badge-dot-pulse-xk__ring ease-badge-dot-pulse-xk__ring--delay"></span>
+          <span class="ease-badge-dot-pulse-xk__dot"></span>
+        </span>
+        <span id="statusText">Online</span>
+      </button>
+      <p class="hint">Click the pill to cycle through Online → Away → Offline.</p>
+    </section>
+
+    <!-- ============ INTERACTIVE TRIGGER: HOVER TO PULSE ============ -->
+    <section class="showcase">
+      <h2>Interactive — hover to activate pulse</h2>
+      <div class="badge-row">
+        <div class="badge-demo">
+          <span class="ease-badge-dot-pulse-xk ease-badge-dot-pulse-xk--hover-trigger is-online" tabindex="0" role="status" aria-label="Online, hover or focus to see pulse">
+            <span class="ease-badge-dot-pulse-xk__ring"></span>
+            <span class="ease-badge-dot-pulse-xk__ring ease-badge-dot-pulse-xk__ring--delay"></span>
+            <span class="ease-badge-dot-pulse-xk__dot"></span>
+          </span>
+          <span class="badge-label">Hover / focus me</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============ CUSTOMIZATION VIA CSS VARIABLES ============ -->
+    <section class="showcase">
+      <h2>Customized via CSS variables</h2>
+      <div class="badge-row">
+        <div class="badge-demo">
+          <span class="ease-badge-dot-pulse-xk is-online" style="--ebdp-size: 22px; --ebdp-color: #ff5cad;" role="status" aria-label="Online, custom pink, large">
+            <span class="ease-badge-dot-pulse-xk__ring"></span>
+            <span class="ease-badge-dot-pulse-xk__ring ease-badge-dot-pulse-xk__ring--delay"></span>
+            <span class="ease-badge-dot-pulse-xk__dot"></span>
+          </span>
+          <span class="badge-label">Large + pink</span>
+        </div>
+
+        <div class="badge-demo">
+          <span class="ease-badge-dot-pulse-xk is-online" style="--ebdp-size: 8px; --ebdp-color: #ffc23c; --ebdp-speed: 0.9s;" role="status" aria-label="Online, custom amber, small, fast">
+            <span class="ease-badge-dot-pulse-xk__ring"></span>
+            <span class="ease-badge-dot-pulse-xk__ring ease-badge-dot-pulse-xk__ring--delay"></span>
+            <span class="ease-badge-dot-pulse-xk__dot"></span>
+          </span>
+          <span class="badge-label">Small + fast + amber</span>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    // Click-to-cycle interactive trigger
+    const states = ['online', 'away', 'offline'];
+    const labels = { online: 'Online', away: 'Away', offline: 'Offline' };
+    let stateIndex = 0;
+
+    const toggleBtn = document.getElementById('statusToggle');
+    const badge = document.getElementById('interactiveBadge');
+    const text = document.getElementById('statusText');
+
+    toggleBtn.addEventListener('click', () => {
+      stateIndex = (stateIndex + 1) % states.length;
+      const next = states[stateIndex];
+
+      badge.classList.remove('is-online', 'is-away', 'is-offline');
+      badge.classList.add('is-' + next);
+      badge.setAttribute('aria-label', labels[next]);
+      text.textContent = labels[next];
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-badge-dot-pulse-xk/style.css
+++ b/submissions/examples/ease-badge-dot-pulse-xk/style.css
@@ -1,0 +1,199 @@
+/* ==========================================================================
+   ease-badge-dot-pulse-xk
+   Status indicator dot with concentric pulse rings (online/away/offline)
+   ========================================================================== */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: #0f1115;
+  color: #edeef2;
+  padding: 3rem 1.5rem;
+}
+
+.page {
+  max-width: 880px;
+  margin: 0 auto;
+}
+
+.page h1 {
+  margin-bottom: 0.25rem;
+  font-size: 1.9rem;
+}
+
+.subtitle {
+  color: #a3a7b7;
+  margin-bottom: 2.5rem;
+}
+
+.showcase {
+  margin-bottom: 2.75rem;
+}
+
+.showcase h2 {
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #a3a7b7;
+  margin-bottom: 1.25rem;
+}
+
+.badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2.5rem;
+}
+
+.badge-demo {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.badge-label {
+  font-size: 0.9rem;
+  color: #c7c9d6;
+}
+
+.hint {
+  margin-top: 0.75rem;
+  font-size: 0.85rem;
+  color: #7a7f92;
+}
+
+/* ==========================================================================
+   COMPONENT: ease-badge-dot-pulse-xk
+   Customizable via CSS variables:
+     --ebdp-size   : diameter of the core dot (default 12px)
+     --ebdp-color  : base color, overridden per-state below
+     --ebdp-speed  : pulse animation duration (default 1.8s)
+   ========================================================================== */
+
+.ease-badge-dot-pulse-xk {
+  --ebdp-size: 12px;
+  --ebdp-color: #22c55e;
+  --ebdp-speed: 1.8s;
+
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: calc(var(--ebdp-size) * 2.6);
+  height: calc(var(--ebdp-size) * 2.6);
+  border-radius: 50%;
+}
+
+/* State color mapping (used when no inline --ebdp-color override is set) */
+.ease-badge-dot-pulse-xk.is-online { --ebdp-color: #22c55e; }
+.ease-badge-dot-pulse-xk.is-away   { --ebdp-color: #f5a524; }
+.ease-badge-dot-pulse-xk.is-offline { --ebdp-color: #6b7280; }
+
+/* Core solid dot */
+.ease-badge-dot-pulse-xk__dot {
+  position: absolute;
+  width: var(--ebdp-size);
+  height: var(--ebdp-size);
+  border-radius: 50%;
+  background: var(--ebdp-color);
+  box-shadow: 0 0 6px color-mix(in srgb, var(--ebdp-color) 70%, transparent);
+  z-index: 2;
+  transition: background-color 0.25s ease;
+}
+
+/* Concentric pulse rings — hidden by default for offline state (no rings in markup) */
+.ease-badge-dot-pulse-xk__ring {
+  position: absolute;
+  width: var(--ebdp-size);
+  height: var(--ebdp-size);
+  border-radius: 50%;
+  background: var(--ebdp-color);
+  opacity: 0.6;
+  animation: ebdp-pulse var(--ebdp-speed) cubic-bezier(0.2, 0.6, 0.4, 1) infinite;
+}
+
+.ease-badge-dot-pulse-xk__ring--delay {
+  animation-delay: calc(var(--ebdp-speed) / 2);
+}
+
+/* Offline state: no motion, rings not present in markup, dot dimmed slightly */
+.ease-badge-dot-pulse-xk.is-offline .ease-badge-dot-pulse-xk__dot {
+  box-shadow: none;
+}
+
+/* Away state: slower, gentler pulse */
+.ease-badge-dot-pulse-xk.is-away .ease-badge-dot-pulse-xk__ring {
+  animation-duration: calc(var(--ebdp-speed) * 1.3);
+}
+
+@keyframes ebdp-pulse {
+  0% {
+    transform: scale(1);
+    opacity: 0.55;
+  }
+  70% {
+    transform: scale(2.6);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(2.6);
+    opacity: 0;
+  }
+}
+
+/* ---------- Interactive trigger variant: hover / focus activates pulse ---------- */
+.ease-badge-dot-pulse-xk--hover-trigger .ease-badge-dot-pulse-xk__ring {
+  animation-play-state: paused;
+  opacity: 0;
+}
+
+.ease-badge-dot-pulse-xk--hover-trigger:hover .ease-badge-dot-pulse-xk__ring,
+.ease-badge-dot-pulse-xk--hover-trigger:focus-visible .ease-badge-dot-pulse-xk__ring {
+  animation-play-state: running;
+  opacity: 0.6;
+}
+
+.ease-badge-dot-pulse-xk--hover-trigger {
+  cursor: pointer;
+  outline-offset: 4px;
+}
+
+.ease-badge-dot-pulse-xk--hover-trigger:focus-visible {
+  outline: 2px solid var(--ebdp-color);
+  border-radius: 50%;
+}
+
+/* ---------- Click-to-cycle toggle button (demo-level, not part of the core component) ---------- */
+.status-toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: #1b1e27;
+  border: 1px solid #2a2d38;
+  color: #edeef2;
+  padding: 0.6rem 1.1rem;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease;
+}
+
+.status-toggle-btn:hover {
+  border-color: var(--ebdp-color, #7c5cff);
+}
+
+.status-toggle-btn:focus-visible {
+  outline: 2px solid #7c5cff;
+  outline-offset: 3px;
+}
+
+/* ---------- Reduced motion support ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .ease-badge-dot-pulse-xk__ring {
+    animation: none;
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Description

Adds `ease-badge-dot-pulse-xk` — a status indicator dot with concentric
pulse rings for online, away, and offline states. Closes #35124.

## Changes

- Added `submissions/examples/ease-badge-dot-pulse-xk/demo.html` — static
  showcase of all three states, a click-to-cycle interactive trigger, a
  hover/focus-activated pulse variant, and CSS-variable customization
  examples.
- Added `submissions/examples/ease-badge-dot-pulse-xk/style.css` — the
  component itself: `@keyframes` pulse animation, CSS-variable-driven
  sizing/color/speed, per-state color mapping, and `prefers-reduced-motion`
  support.
- Added `submissions/examples/ease-badge-dot-pulse-xk/README.md` — usage
  docs, variable table, and accessibility notes.

## Acceptance Criteria Coverage

- ✅ Smooth `@keyframes` animation — concentric rings expand and fade via
  `ebdp-pulse`, staggered with an animation-delay for a layered ripple effect.
- ✅ Interactive trigger — two patterns included:
  - **Click** — a toggle button cycles Online → Away → Offline.
  - **Hover / focus** — a `--hover-trigger` modifier pauses the pulse until
    the badge is hovered or keyboard-focused.
- ✅ Customizable via CSS variables — `--ebdp-size`, `--ebdp-color`, and
  `--ebdp-speed` control dot size, color, and animation speed independently
  of the state classes.

## States

- **Online** — green, active pulse.
- **Away** — amber, slower/gentler pulse cadence.
- **Offline** — grey, static, no animation.

## Accessibility

- `role="status"` with descriptive `aria-label` per state.
- `aria-live="polite"` on the click-cycling demo so state changes are announced.
- Hover-trigger variant is keyboard-reachable (`tabindex="0"`) with a visible
  `:focus-visible` outline.
- Respects `prefers-reduced-motion: reduce` by disabling ring animation.

## Testing

- Verified all three states render correctly with correct colors.
- Verified click-cycle updates label, `aria-label`, and visual state in sync.
- Verified hover/focus trigger activates and pauses the pulse correctly.
- Verified CSS variable overrides (size, color, speed) work independently.
- Verified keyboard focus is visible and reduced-motion preference is respected.

## Screenshots

_(Add screenshots/GIF of the pulse animation and each state here)_