### PR TITLE
feat: add ease-color-picker-palette-ij component (#34718)

### DIFF
--- a/submissions/examples/ease-color-picker-palette-ij/README.md
+++ b/submissions/examples/ease-color-picker-palette-ij/README.md
@@ -1,0 +1,93 @@
+# ease-color-picker-palette-ij
+
+Color picker palette that reveals with a staggered swatch expansion animation.
+
+Resolves: #34718
+
+## Overview
+
+A color swatch picker where the palette panel reveals on interaction and each
+swatch pops in with a staggered scale/fade animation (spring-style easing).
+Two interaction variants are included — a click-to-open dropdown panel and a
+hover-to-expand inline strip — plus a CSS-variable customization example.
+
+## Markup
+
+Click-triggered dropdown:
+
+```html
+<div class="ease-color-picker-palette-ij">
+  <button class="ecpp-trigger" aria-haspopup="true" aria-expanded="false" aria-controls="panelId">
+    <span class="ecpp-trigger__swatch" style="--ecpp-swatch: #7c5cff;"></span>
+    <span class="ecpp-trigger__label">Violet</span>
+    <svg class="ecpp-trigger__chevron">...</svg>
+  </button>
+
+  <div class="ecpp-panel" id="panelId" role="listbox">
+    <button class="ecpp-swatch" role="option" data-color="#7c5cff" style="--ecpp-swatch: #7c5cff; --ecpp-i: 0;"></button>
+    <button class="ecpp-swatch" role="option" data-color="#22d3ee" style="--ecpp-swatch: #22d3ee; --ecpp-i: 1;"></button>
+    <!-- ...more swatches, incrementing --ecpp-i for stagger order -->
+  </div>
+</div>
+```
+
+Toggle `.ecpp-panel`'s `is-open` class via JS to reveal it (see `demo.html`
+for the full click/keyboard handling).
+
+## CSS Variables
+
+| Variable             | Default | Description                                   |
+|------------------------|---------|-------------------------------------------------|
+| `--ecpp-swatch-size`  | `28px`  | Diameter of each color swatch                    |
+| `--ecpp-gap`          | `8px`   | Gap between swatches in the panel/strip          |
+| `--ecpp-speed`        | `0.35s` | Duration of the expand/scale-in animation         |
+| `--ecpp-swatch`       | —       | Set per-swatch inline; the color that swatch represents |
+| `--ecpp-i`            | —       | Set per-swatch inline (0, 1, 2…); controls stagger order |
+
+## How the Stagger Works
+
+Each `.ecpp-swatch` starts at `scale(0)` / `opacity: 0` and transitions to
+`scale(1)` / `opacity: 1` with a spring-like `cubic-bezier(0.34, 1.56, 0.64, 1)`
+easing. The `transition-delay` is computed from `--ecpp-i` (`calc(var(--ecpp-i) * 0.045s)`),
+so swatches with a higher index pop in slightly after the ones before them,
+producing the staggered reveal.
+
+## Interactive Triggers (Acceptance Criteria)
+
+Two full variants are demonstrated in `demo.html`:
+
+1. **Click** — a trigger button toggles `aria-expanded` and an `is-open`
+   class on the panel; swatches stagger-expand in. Selecting a swatch
+   updates the trigger's displayed color/label and closes the panel.
+   Supports closing via outside-click and `Escape`.
+2. **Hover / focus** — an inline anchor swatch expands a horizontal strip of
+   mini swatches on `:hover`/`:focus-within`, each staggering in.
+
+A third section shows the panel statically with larger swatches, wider gaps,
+and a faster stagger via CSS variable overrides.
+
+## Responsive Design
+
+- The dropdown panel wraps to fewer columns and anchors to the right edge on
+  narrow viewports (≤560px) to avoid overflowing the screen.
+- The hover strip's max expansion width shrinks and wraps on small screens
+  so it doesn't get clipped.
+
+## Accessibility
+
+- The click variant uses `aria-haspopup`, `aria-expanded` on the trigger, and
+  `role="listbox"` / `role="option"` / `aria-selected` on the panel and
+  swatches.
+- Fully keyboard operable: trigger is a real `<button>`, swatches are real
+  `<button>`s, `Escape` closes the panel and returns focus to the trigger.
+- Visible `:focus-visible` outlines on the trigger and every swatch.
+- Respects `prefers-reduced-motion: reduce` by collapsing all transition
+  durations/delays to near-zero.
+
+## Files
+
+- `demo.html` — click-triggered dropdown, hover-triggered strip, and a
+  CSS-variable customization example.
+- `style.css` — component styles, staggered expansion animation, both
+  interaction variants, responsive rules, and reduced-motion handling.
+- `README.md` — this file.

--- a/submissions/examples/ease-color-picker-palette-ij/demo.html
+++ b/submissions/examples/ease-color-picker-palette-ij/demo.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>ease-color-picker-palette-ij — Color Picker Palette with Swatch Expansion</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="page">
+    <h1>ease-color-picker-palette-ij</h1>
+    <p class="subtitle">Color picker palette that reveals with a staggered swatch expansion animation.</p>
+
+    <!-- ============ CLICK-TRIGGERED PALETTE ============ -->
+    <section class="showcase">
+      <h2>Click to open palette</h2>
+
+      <div class="ease-color-picker-palette-ij" id="colorPicker">
+        <button
+          type="button"
+          class="ecpp-trigger"
+          id="ecppTrigger"
+          aria-haspopup="true"
+          aria-expanded="false"
+          aria-controls="ecppSwatchPanel"
+        >
+          <span class="ecpp-trigger__swatch" id="ecppSelectedSwatch" style="--ecpp-swatch: #7c5cff;"></span>
+          <span class="ecpp-trigger__label" id="ecppSelectedLabel">Violet</span>
+          <svg class="ecpp-trigger__chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <path d="M6 9l6 6 6-6"/>
+          </svg>
+        </button>
+
+        <div class="ecpp-panel" id="ecppSwatchPanel" role="listbox" aria-label="Color palette">
+          <button type="button" class="ecpp-swatch" role="option" aria-selected="true"  data-color="#7c5cff" data-label="Violet"  style="--ecpp-swatch: #7c5cff; --ecpp-i: 0;"></button>
+          <button type="button" class="ecpp-swatch" role="option" aria-selected="false" data-color="#22d3ee" data-label="Cyan"    style="--ecpp-swatch: #22d3ee; --ecpp-i: 1;"></button>
+          <button type="button" class="ecpp-swatch" role="option" aria-selected="false" data-color="#4ade80" data-label="Mint"    style="--ecpp-swatch: #4ade80; --ecpp-i: 2;"></button>
+          <button type="button" class="ecpp-swatch" role="option" aria-selected="false" data-color="#fbbf24" data-label="Amber"   style="--ecpp-swatch: #fbbf24; --ecpp-i: 3;"></button>
+          <button type="button" class="ecpp-swatch" role="option" aria-selected="false" data-color="#f472b6" data-label="Pink"    style="--ecpp-swatch: #f472b6; --ecpp-i: 4;"></button>
+          <button type="button" class="ecpp-swatch" role="option" aria-selected="false" data-color="#f87171" data-label="Coral"   style="--ecpp-swatch: #f87171; --ecpp-i: 5;"></button>
+          <button type="button" class="ecpp-swatch" role="option" aria-selected="false" data-color="#60a5fa" data-label="Sky"     style="--ecpp-swatch: #60a5fa; --ecpp-i: 6;"></button>
+          <button type="button" class="ecpp-swatch" role="option" aria-selected="false" data-color="#a3e635" data-label="Lime"    style="--ecpp-swatch: #a3e635; --ecpp-i: 7;"></button>
+        </div>
+      </div>
+
+      <p class="hint">Click the swatch trigger to reveal the palette — each swatch expands in with a staggered delay. Click a swatch to select it.</p>
+    </section>
+
+    <!-- ============ HOVER-TRIGGERED PALETTE STRIP ============ -->
+    <section class="showcase">
+      <h2>Hover to expand palette strip</h2>
+
+      <div class="ease-color-picker-palette-ij ease-color-picker-palette-ij--hover" tabindex="0">
+        <span class="ecpp-trigger__swatch ecpp-hover-anchor" style="--ecpp-swatch: #22d3ee;"></span>
+        <div class="ecpp-strip" aria-label="Color palette strip">
+          <span class="ecpp-swatch ecpp-swatch--mini" style="--ecpp-swatch: #7c5cff; --ecpp-i: 0;"></span>
+          <span class="ecpp-swatch ecpp-swatch--mini" style="--ecpp-swatch: #22d3ee; --ecpp-i: 1;"></span>
+          <span class="ecpp-swatch ecpp-swatch--mini" style="--ecpp-swatch: #4ade80; --ecpp-i: 2;"></span>
+          <span class="ecpp-swatch ecpp-swatch--mini" style="--ecpp-swatch: #fbbf24; --ecpp-i: 3;"></span>
+          <span class="ecpp-swatch ecpp-swatch--mini" style="--ecpp-swatch: #f472b6; --ecpp-i: 4;"></span>
+          <span class="ecpp-swatch ecpp-swatch--mini" style="--ecpp-swatch: #f87171; --ecpp-i: 5;"></span>
+        </div>
+      </div>
+
+      <p class="hint">Hover or focus the swatch anchor — the strip expands and swatches pop in one after another.</p>
+    </section>
+
+    <!-- ============ CUSTOMIZATION VIA CSS VARIABLES ============ -->
+    <section class="showcase">
+      <h2>Customized via CSS variables</h2>
+
+      <div class="ease-color-picker-palette-ij ease-color-picker-palette-ij--open-demo" style="--ecpp-swatch-size: 44px; --ecpp-gap: 10px; --ecpp-speed: 0.25s;">
+        <div class="ecpp-panel ecpp-panel--static" aria-label="Large swatch palette example">
+          <span class="ecpp-swatch" style="--ecpp-swatch: #7c5cff; --ecpp-i: 0;"></span>
+          <span class="ecpp-swatch" style="--ecpp-swatch: #22d3ee; --ecpp-i: 1;"></span>
+          <span class="ecpp-swatch" style="--ecpp-swatch: #4ade80; --ecpp-i: 2;"></span>
+          <span class="ecpp-swatch" style="--ecpp-swatch: #fbbf24; --ecpp-i: 3;"></span>
+        </div>
+      </div>
+      <p class="hint">Larger swatches, wider gap, faster expansion — all via <code>--ecpp-swatch-size</code>, <code>--ecpp-gap</code>, <code>--ecpp-speed</code>.</p>
+    </section>
+  </main>
+
+  <script>
+    // ---------- Click-triggered palette ----------
+    const trigger = document.getElementById('ecppTrigger');
+    const panel = document.getElementById('ecppSwatchPanel');
+    const selectedSwatch = document.getElementById('ecppSelectedSwatch');
+    const selectedLabel = document.getElementById('ecppSelectedLabel');
+    const picker = document.getElementById('colorPicker');
+
+    function togglePanel(open) {
+      const isOpen = open ?? !panel.classList.contains('is-open');
+      panel.classList.toggle('is-open', isOpen);
+      trigger.setAttribute('aria-expanded', String(isOpen));
+    }
+
+    trigger.addEventListener('click', () => togglePanel());
+
+    panel.querySelectorAll('.ecpp-swatch').forEach((swatch) => {
+      swatch.addEventListener('click', () => {
+        const color = swatch.dataset.color;
+        const label = swatch.dataset.label;
+
+        selectedSwatch.style.setProperty('--ecpp-swatch', color);
+        selectedLabel.textContent = label;
+
+        panel.querySelectorAll('.ecpp-swatch').forEach((s) => s.setAttribute('aria-selected', 'false'));
+        swatch.setAttribute('aria-selected', 'true');
+
+        togglePanel(false);
+        trigger.focus();
+      });
+    });
+
+    // Close panel on outside click
+    document.addEventListener('click', (e) => {
+      if (!picker.contains(e.target)) {
+        togglePanel(false);
+      }
+    });
+
+    // Close panel on Escape
+    picker.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {
+        togglePanel(false);
+        trigger.focus();
+      }
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-color-picker-palette-ij/style.css
+++ b/submissions/examples/ease-color-picker-palette-ij/style.css
@@ -1,0 +1,295 @@
+/* ==========================================================================
+   ease-color-picker-palette-ij
+   Color picker palette that reveals with staggered swatch expansion
+   ========================================================================== */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: #0f1115;
+  color: #edeef2;
+  padding: 3rem 1.5rem;
+}
+
+.page {
+  max-width: 880px;
+  margin: 0 auto;
+}
+
+.page h1 {
+  margin-bottom: 0.25rem;
+  font-size: 1.9rem;
+}
+
+.subtitle {
+  color: #a3a7b7;
+  margin-bottom: 2.5rem;
+}
+
+.showcase {
+  margin-bottom: 3rem;
+}
+
+.showcase h2 {
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #a3a7b7;
+  margin-bottom: 1.25rem;
+}
+
+.hint {
+  margin-top: 1rem;
+  font-size: 0.85rem;
+  color: #7a7f92;
+  max-width: 60ch;
+}
+
+code {
+  background: #1b1e27;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+
+/* ==========================================================================
+   COMPONENT: ease-color-picker-palette-ij
+   Customizable via CSS variables:
+     --ecpp-swatch-size : diameter/side of each swatch (default 28px)
+     --ecpp-gap         : gap between swatches (default 8px)
+     --ecpp-speed       : expansion animation duration (default 0.35s)
+   ========================================================================== */
+
+.ease-color-picker-palette-ij {
+  --ecpp-swatch-size: 28px;
+  --ecpp-gap: 8px;
+  --ecpp-speed: 0.35s;
+
+  position: relative;
+  display: inline-block;
+}
+
+/* ---------- Trigger button (click variant) ---------- */
+.ecpp-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  background: #1b1e27;
+  border: 1px solid #2a2d38;
+  color: #edeef2;
+  padding: 0.55rem 1rem;
+  border-radius: 999px;
+  font-size: 0.92rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.ecpp-trigger:hover {
+  border-color: #4a4f61;
+}
+
+.ecpp-trigger:focus-visible {
+  outline: 2px solid #7c5cff;
+  outline-offset: 3px;
+}
+
+.ecpp-trigger__swatch {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--ecpp-swatch, #7c5cff);
+  border: 2px solid rgba(255, 255, 255, 0.25);
+  flex-shrink: 0;
+}
+
+.ecpp-trigger__chevron {
+  transition: transform 0.25s ease;
+  color: #a3a7b7;
+}
+
+.ecpp-trigger[aria-expanded="true"] .ecpp-trigger__chevron {
+  transform: rotate(180deg);
+}
+
+/* ---------- Expandable panel (click variant) ---------- */
+.ecpp-panel {
+  position: absolute;
+  top: calc(100% + 0.6rem);
+  left: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ecpp-gap);
+  max-width: calc((var(--ecpp-swatch-size) + var(--ecpp-gap)) * 4 + var(--ecpp-gap));
+  padding: 0.85rem;
+  background: #1b1e27;
+  border: 1px solid #2a2d38;
+  border-radius: 12px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
+  z-index: 10;
+
+  /* Hidden by default */
+  visibility: hidden;
+  opacity: 0;
+  transform: translateY(-6px);
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0s linear var(--ecpp-speed);
+}
+
+.ecpp-panel.is-open {
+  visibility: visible;
+  opacity: 1;
+  transform: translateY(0);
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0s linear 0s;
+}
+
+/* Static panel used purely for the CSS-variable customization showcase */
+.ecpp-panel--static {
+  position: static;
+  visibility: visible;
+  opacity: 1;
+  transform: none;
+  box-shadow: none;
+  display: inline-flex;
+}
+
+/* ---------- Individual swatch: expansion + staggered delay ---------- */
+.ecpp-swatch {
+  width: var(--ecpp-swatch-size);
+  height: var(--ecpp-swatch-size);
+  border-radius: 50%;
+  background: var(--ecpp-swatch, #ffffff);
+  border: 2px solid rgba(255, 255, 255, 0.15);
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+
+  transform: scale(0);
+  opacity: 0;
+  transition:
+    transform var(--ecpp-speed) cubic-bezier(0.34, 1.56, 0.64, 1),
+    opacity var(--ecpp-speed) ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+  transition-delay: calc(var(--ecpp-i, 0) * 0.045s);
+}
+
+.ecpp-panel.is-open .ecpp-swatch,
+.ecpp-panel--static .ecpp-swatch,
+.ecpp-strip.is-open .ecpp-swatch--mini {
+  transform: scale(1);
+  opacity: 1;
+}
+
+.ecpp-swatch:hover,
+.ecpp-swatch:focus-visible {
+  border-color: #ffffff;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ecpp-swatch) 40%, transparent);
+  transform: scale(1.12);
+}
+
+.ecpp-swatch:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
+}
+
+.ecpp-swatch[aria-selected="true"] {
+  border-color: #ffffff;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ecpp-swatch) 55%, transparent);
+}
+
+/* ==========================================================================
+   HOVER VARIANT — expanding strip anchored to a swatch
+   ========================================================================== */
+
+.ease-color-picker-palette-ij--hover {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  cursor: pointer;
+  padding: 0.5rem;
+  border-radius: 999px;
+}
+
+.ecpp-hover-anchor {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.25);
+  flex-shrink: 0;
+}
+
+.ease-color-picker-palette-ij--hover:focus-visible {
+  outline: 2px solid #7c5cff;
+  outline-offset: 3px;
+  border-radius: 999px;
+}
+
+.ecpp-strip {
+  display: flex;
+  gap: var(--ecpp-gap);
+  max-width: 0;
+  overflow: hidden;
+  transition: max-width var(--ecpp-speed) ease;
+}
+
+.ease-color-picker-palette-ij--hover:hover .ecpp-strip,
+.ease-color-picker-palette-ij--hover:focus-visible .ecpp-strip,
+.ease-color-picker-palette-ij--hover:focus-within .ecpp-strip {
+  max-width: 400px;
+}
+
+.ecpp-swatch--mini {
+  width: calc(var(--ecpp-swatch-size) * 0.7);
+  height: calc(var(--ecpp-swatch-size) * 0.7);
+  border-radius: 50%;
+  background: var(--ecpp-swatch, #ffffff);
+  border: 2px solid rgba(255, 255, 255, 0.15);
+  flex-shrink: 0;
+
+  transform: scale(0);
+  opacity: 0;
+  transition:
+    transform var(--ecpp-speed) cubic-bezier(0.34, 1.56, 0.64, 1),
+    opacity var(--ecpp-speed) ease;
+  transition-delay: calc(var(--ecpp-i, 0) * 0.05s);
+}
+
+.ease-color-picker-palette-ij--hover:hover .ecpp-swatch--mini,
+.ease-color-picker-palette-ij--hover:focus-visible .ecpp-swatch--mini,
+.ease-color-picker-palette-ij--hover:focus-within .ecpp-swatch--mini {
+  transform: scale(1);
+  opacity: 1;
+}
+
+/* ==========================================================================
+   RESPONSIVE
+   ========================================================================== */
+
+@media (max-width: 560px) {
+  .ecpp-panel {
+    max-width: calc((var(--ecpp-swatch-size) + var(--ecpp-gap)) * 3 + var(--ecpp-gap));
+    left: auto;
+    right: 0;
+  }
+
+  .ease-color-picker-palette-ij--hover:hover .ecpp-strip,
+  .ease-color-picker-palette-ij--hover:focus-visible .ecpp-strip,
+  .ease-color-picker-palette-ij--hover:focus-within .ecpp-strip {
+    max-width: 220px;
+    flex-wrap: wrap;
+  }
+}
+
+/* ---------- Reduced motion support ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .ecpp-swatch,
+  .ecpp-swatch--mini,
+  .ecpp-panel,
+  .ecpp-strip {
+    transition-duration: 0.01ms !important;
+    transition-delay: 0s !important;
+  }
+}


### PR DESCRIPTION
## Description

Adds `ease-color-picker-palette-ij` — a color picker palette that reveals
with a staggered swatch expansion animation. Closes #34718.

## Changes

- Added `submissions/examples/ease-color-picker-palette-ij/demo.html` —
  click-to-open dropdown panel, hover-to-expand inline strip, and a
  CSS-variable customization example.
- Added `submissions/examples/ease-color-picker-palette-ij/style.css` —
  the component itself: staggered scale/fade swatch expansion, both
  interaction variants, responsive rules, and `prefers-reduced-motion`
  support.
- Added `submissions/examples/ease-color-picker-palette-ij/README.md` —
  usage docs, variable table, stagger mechanism explanation, and
  accessibility notes.

## Acceptance Criteria Coverage

- ✅ Smooth CSS transition — each swatch animates from `scale(0)`/`opacity: 0`
  to `scale(1)`/`opacity: 1` with a spring-like `cubic-bezier(0.34, 1.56, 0.64, 1)`
  easing, staggered via a per-swatch `--ecpp-i`-driven `transition-delay`.
- ✅ Interactive trigger — two patterns included:
  - **Click** — a trigger button toggles the panel open/closed
    (`aria-expanded`, outside-click and `Escape` to close); selecting a
    swatch updates the trigger's color/label.
  - **Hover / focus** — an inline anchor swatch expands a horizontal strip
    of mini swatches on `:hover`/`:focus-within`.
- ✅ Customizable via CSS variables — `--ecpp-swatch-size`, `--ecpp-gap`,
  and `--ecpp-speed` control swatch size, spacing, and animation speed.
- ✅ Responsive design — the dropdown panel reflows to fewer columns and
  anchors to the right edge below 560px; the hover strip's expansion width
  shrinks and wraps on narrow viewports.

## Accessibility

- `aria-haspopup`, `aria-expanded` on the trigger; `role="listbox"` /
  `role="option"` / `aria-selected` on the panel and swatches.
- Fully keyboard operable — real `<button>` elements throughout, `Escape`
  closes the panel and returns focus to the trigger.
- Visible `:focus-visible` outlines on the trigger and every swatch.
- Respects `prefers-reduced-motion: reduce` by collapsing transition