### PR TITLE
feat: add React rating star bar with burst effect component

### DIFF
--- a/submissions/react/react-rating-star-bar-with-interactive-burst-effect/README.md
+++ b/submissions/react/react-rating-star-bar-with-interactive-burst-effect/README.md
@@ -1,0 +1,42 @@
+# React Rating Star Bar with Interactive Burst Effect
+
+## Description
+A modular, copy-paste ready React rating component. Clicking a star sets the rating and triggers a small radiating "burst" particle animation from that star. Hovering previews the rating before committing on click.
+
+## Files
+- `RatingStarBar.jsx` — the component
+- `style.css` — required styling (burst animation, star fill states)
+- `README.md` — this file
+
+## Installation
+Copy `RatingStarBar.jsx` and `style.css` into your project, then import both:
+```jsx
+import RatingStarBar from "./RatingStarBar";
+import "./style.css";
+```
+
+## Usage
+```jsx
+<RatingStarBar
+  totalStars={5}
+  initialRating={3}
+  size={36}
+  color="#facc15"
+  onRate={(rating) => console.log("User rated:", rating)}
+/>
+```
+
+## Props
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `totalStars` | `number` | `5` | Number of stars rendered |
+| `initialRating` | `number` | `0` | Starting rating value |
+| `size` | `number` | `32` | Star size in pixels |
+| `color` | `string` | `"#facc15"` | Color of filled stars and burst particles |
+| `onRate` | `(rating: number) => void` | `undefined` | Callback fired with the new rating when a star is clicked |
+
+## Accessibility
+Implemented as a `radiogroup`/`radio` pattern with `aria-checked`, keyboard-focusable stars, and visible `:focus-visible` outlines. Respects `prefers-reduced-motion` by disabling the burst animation entirely.
+
+## Dependencies
+None beyond React itself — no external animation or icon libraries.

--- a/submissions/react/react-rating-star-bar-with-interactive-burst-effect/RatingStarBar.jsx
+++ b/submissions/react/react-rating-star-bar-with-interactive-burst-effect/RatingStarBar.jsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+
+/**
+ * RatingStarBar
+ * A star rating component with an animated "burst" effect
+ * (small radiating particles) when a star is clicked/selected.
+ *
+ * Props:
+ * @param {number} totalStars - number of stars to render (default 5)
+ * @param {number} initialRating - starting rating value (default 0)
+ * @param {(rating: number) => void} onRate - callback fired with the new rating on click
+ * @param {number} size - star size in px (default 32)
+ * @param {string} color - filled star / burst color (default "#facc15")
+ */
+export default function RatingStarBar({
+  totalStars = 5,
+  initialRating = 0,
+  onRate,
+  size = 32,
+  color = "#facc15",
+}) {
+  const [rating, setRating] = useState(initialRating);
+  const [hovered, setHovered] = useState(0);
+  const [burstKey, setBurstKey] = useState(null); // tracks which star is currently bursting
+
+  function handleClick(index) {
+    setRating(index);
+    setBurstKey(index + "-" + Date.now()); // unique key forces re-mount, replaying the animation
+    onRate?.(index);
+  }
+
+  const displayValue = hovered || rating;
+
+  return (
+    <div
+      className="ease-rating-bar"
+      style={{ "--rating-star-size": `${size}px`, "--rating-color": color }}
+      role="radiogroup"
+      aria-label={`Rating: ${rating} out of ${totalStars} stars`}
+    >
+      {Array.from({ length: totalStars }, (_, i) => i + 1).map((starIndex) => {
+        const filled = starIndex <= displayValue;
+        const isBursting = burstKey && burstKey.startsWith(starIndex + "-");
+
+        return (
+          <button
+            key={starIndex}
+            type="button"
+            className={`rating-star ${filled ? "is-filled" : ""}`}
+            role="radio"
+            aria-checked={starIndex === rating}
+            aria-label={`${starIndex} star${starIndex > 1 ? "s" : ""}`}
+            onMouseEnter={() => setHovered(starIndex)}
+            onMouseLeave={() => setHovered(0)}
+            onFocus={() => setHovered(starIndex)}
+            onBlur={() => setHovered(0)}
+            onClick={() => handleClick(starIndex)}
+          >
+            <svg viewBox="0 0 24 24" className="star-icon" aria-hidden="true">
+              <path d="M12 2l3.09 6.26L22 9.27l-5 4.87L18.18 21 12 17.77 5.82 21 7 14.14l-5-4.87 6.91-1.01L12 2z" />
+            </svg>
+
+            {isBursting && (
+              <span className="star-burst" key={burstKey} aria-hidden="true">
+                {Array.from({ length: 8 }, (_, p) => (
+                  <span
+                    className="burst-particle"
+                    key={p}
+                    style={{ "--angle": `${p * 45}deg` }}
+                  />
+                ))}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/submissions/react/react-rating-star-bar-with-interactive-burst-effect/style.css
+++ b/submissions/react/react-rating-star-bar-with-interactive-burst-effect/style.css
@@ -1,0 +1,83 @@
+/* Ease Rating Star Bar with Interactive Burst Effect */
+
+.ease-rating-bar {
+  display: inline-flex;
+  gap: 4px;
+}
+
+.rating-star {
+  position: relative;
+  background: none;
+  border: none;
+  padding: 4px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.rating-star:focus-visible {
+  outline: 2px solid var(--rating-color, #facc15);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+.star-icon {
+  width: var(--rating-star-size, 32px);
+  height: var(--rating-star-size, 32px);
+  fill: none;
+  stroke: #6b7280;
+  stroke-width: 1.5;
+  transition: fill 0.2s ease, stroke 0.2s ease, transform 0.2s ease;
+}
+
+.rating-star:hover .star-icon {
+  transform: scale(1.12);
+}
+
+.rating-star.is-filled .star-icon {
+  fill: var(--rating-color, #facc15);
+  stroke: var(--rating-color, #facc15);
+}
+
+.rating-star:active .star-icon {
+  transform: scale(0.9);
+}
+
+/* Burst effect */
+.star-burst {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.burst-particle {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--rating-color, #facc15);
+  transform: rotate(var(--angle)) translate(0, 0) scale(1);
+  opacity: 1;
+  animation: burst-fly 0.5s ease-out forwards;
+}
+
+@keyframes burst-fly {
+  to {
+    transform: rotate(var(--angle)) translate(22px, 0) scale(0);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .star-icon,
+  .burst-particle {
+    animation: none !important;
+    transition: none !important;
+  }
+  .star-burst {
+    display: none;
+  }
+}


### PR DESCRIPTION
Closes #27544 

## Pull Request Description
Adds a modular, copy-paste ready React rating star bar component with an interactive "burst" particle effect that fires when a star is clicked. Includes hover-preview behavior, keyboard accessibility, and full customization via props.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/react/react-rating-star-bar-with-interactive-burst-effect/`)
- [x] Includes `.jsx` file with clean, structured React component code (`RatingStarBar.jsx`)
- [x] Includes `README.md` — props, installation, and usage examples
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)
- [x] Zero external dependencies outside React and standard EaseMotion CSS styles

---

## Feature Description

**What does this add?**
A React star-rating component where clicking a star sets the rating and triggers a small radiating burst-particle animation from that star, with hover-based rating preview.

**How does a developer use it?**
```jsx
import RatingStarBar from "./RatingStarBar";
import "./style.css";

<RatingStarBar
  totalStars={5}
  initialRating={3}
  size={36}
  color="#facc15"
  onRate={(rating) => console.log("User rated:", rating)}
/>
```

**Why does it fit EaseMotion CSS?**
Uses only React hooks (`useState`) and plain CSS keyframe animations for the burst effect — no external animation or icon libraries — consistent with the framework's zero-dependency, animation-first philosophy. Implements a `radiogroup`/`radio` ARIA pattern with keyboard focus support and respects `prefers-reduced-motion` by disabling the burst animation entirely.

---

## Demo
- [x] Demo added *(component tested locally via a Vite React scaffold; no `demo.html` included since this is a `.jsx` component requiring a React build step, per the React submissions category)*

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Tested locally via a temporary Vite + React scaffold since this component requires JSX compilation. Rating is controlled via internal state (`useState`) but exposes `initialRating` and `onRate` for parent components to sync/control externally if needed.