### PR TITLE
feat: add ease-card-zoom-xk card zoom component (#35126)

### DIFF
--- a/submissions/examples/ease-card-zoom-xk/README.md
+++ b/submissions/examples/ease-card-zoom-xk/README.md
@@ -1,0 +1,82 @@
+# ease-card-zoom-xk
+
+Card component with a zoom-in image effect and overlay content reveal on hover.
+
+Resolves: #35126
+
+## Overview
+
+An image card where hovering (or clicking, for touch devices) smoothly
+zooms the background image and slides/fades in a gradient overlay containing
+a title, description, and call-to-action link.
+
+## Markup
+
+```html
+<article class="ease-card-zoom-xk">
+  <div class="ecz-media">
+    <img src="..." alt="..." />
+  </div>
+  <div class="ecz-overlay">
+    <h3 class="ecz-title">Card Title</h3>
+    <p class="ecz-desc">Short supporting description text.</p>
+    <a class="ecz-cta" href="#">Explore &rarr;</a>
+  </div>
+</article>
+```
+
+For the touch-friendly click variant, add `ease-card-zoom-xk--click`,
+`tabindex="0"`, `role="button"`, and `aria-pressed="false"` to the root
+element, then toggle an `is-active` class via JS on click/Enter/Space
+(see `demo.html` for the exact script).
+
+## CSS Variables
+
+| Variable                | Default   | Description                                       |
+|---------------------------|-----------|------------------------------------------------------|
+| `--ecz-zoom`             | `1.15`    | Scale applied to the image on hover/active           |
+| `--ecz-speed`            | `0.45s`   | Duration of the zoom and overlay transitions          |
+| `--ecz-radius`           | `14px`    | Corner radius of the card                             |
+| `--ecz-overlay-color`    | `0, 0, 0` | RGB triplet (no `rgb()` wrapper) used to tint the overlay gradient — override per card, e.g. `124, 92, 255` for a violet tint |
+
+Example override:
+
+```html
+<article class="ease-card-zoom-xk" style="--ecz-zoom: 1.25; --ecz-speed: 0.6s; --ecz-radius: 4px; --ecz-overlay-color: 251, 191, 36;">
+  ...
+</article>
+```
+
+## Interactive Triggers (Acceptance Criteria)
+
+Two variants are demonstrated in `demo.html`:
+
+1. **Hover / focus** (default) — the image scales up via
+   `transform: scale(var(--ecz-zoom))` and the overlay fades in while
+   sliding up from `translateY(12px)` to `translateY(0)`. Works with both
+   mouse hover and keyboard `:focus-visible`.
+2. **Click** (`--click` modifier) — since hover doesn't exist on touch
+   devices, this variant toggles an `is-active` class on tap/click (and on
+   `Enter`/`Space` for keyboard users), producing the same zoom + overlay
+   reveal without relying on `:hover`.
+
+## Accessibility
+
+- Card root uses `role="button"`, `tabindex="0"`, and `aria-pressed` for the
+  click variant so screen readers and keyboard users get correct semantics.
+- `:focus-visible` triggers the same zoom/overlay reveal as hover, so
+  keyboard-only users see the same content.
+- The CTA link inside the overlay is a real `<a>`, independently focusable
+  and operable.
+- Respects `prefers-reduced-motion: reduce` by collapsing transition
+  durations to near-zero.
+
+## Files
+
+- `demo.html` — hover-triggered card grid (3 color-tinted examples), a
+  click-toggle touch-friendly variant, and a CSS-variable customization
+  example.
+- `style.css` — component styles, zoom/overlay transitions, both
+  interaction variants, responsive grid breakpoints, and reduced-motion
+  handling.
+- `README.md` — this file.

--- a/submissions/examples/ease-card-zoom-xk/demo.html
+++ b/submissions/examples/ease-card-zoom-xk/demo.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>ease-card-zoom-xk — Card Zoom with Overlay Reveal</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="page">
+    <h1>ease-card-zoom-xk</h1>
+    <p class="subtitle">Card component with a zoom-in image effect and overlay content reveal on hover.</p>
+
+    <!-- ============ HOVER-TRIGGERED CARDS ============ -->
+    <section class="showcase">
+      <h2>Hover to zoom + reveal overlay</h2>
+
+      <div class="card-grid">
+
+        <article class="ease-card-zoom-xk">
+          <div class="ecz-media">
+            <img src="https://images.unsplash.com/photo-1506744038136-46273834b3fb?w=600&h=400&fit=crop" alt="Mountain landscape at sunrise" />
+          </div>
+          <div class="ecz-overlay">
+            <h3 class="ecz-title">Mountain Escape</h3>
+            <p class="ecz-desc">A quiet trail through alpine ridgelines, best hiked at first light.</p>
+            <a class="ecz-cta" href="#">Explore &rarr;</a>
+          </div>
+        </article>
+
+        <article class="ease-card-zoom-xk" style="--ecz-overlay-color: 124, 92, 255;">
+          <div class="ecz-media">
+            <img src="https://images.unsplash.com/photo-1519681393784-d120267933ba?w=600&h=400&fit=crop" alt="City skyline at night" />
+          </div>
+          <div class="ecz-overlay">
+            <h3 class="ecz-title">Night City</h3>
+            <p class="ecz-desc">Neon-lit streets and rooftop views across the downtown skyline.</p>
+            <a class="ecz-cta" href="#">Explore &rarr;</a>
+          </div>
+        </article>
+
+        <article class="ease-card-zoom-xk" style="--ecz-overlay-color: 34, 197, 94;">
+          <div class="ecz-media">
+            <img src="https://images.unsplash.com/photo-1441974231531-c6227db76b6e?w=600&h=400&fit=crop" alt="Forest path in autumn" />
+          </div>
+          <div class="ecz-overlay">
+            <h3 class="ecz-title">Autumn Trail</h3>
+            <p class="ecz-desc">A winding forest path carpeted in fallen leaves.</p>
+            <a class="ecz-cta" href="#">Explore &rarr;</a>
+          </div>
+        </article>
+
+      </div>
+
+      <p class="hint">Hover any card — the image zooms in and the overlay content slides up and fades in.</p>
+    </section>
+
+    <!-- ============ CLICK TRIGGER: TOUCH-FRIENDLY TOGGLE ============ -->
+    <section class="showcase">
+      <h2>Interactive — click to toggle overlay (touch-friendly)</h2>
+
+      <div class="card-grid card-grid--single">
+        <article class="ease-card-zoom-xk ease-card-zoom-xk--click" id="clickCard" tabindex="0" role="button" aria-pressed="false">
+          <div class="ecz-media">
+            <img src="https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=600&h=400&fit=crop" alt="Starry night sky over mountains" />
+          </div>
+          <div class="ecz-overlay">
+            <h3 class="ecz-title">Starlit Peaks</h3>
+            <p class="ecz-desc">Tap again to close. Ideal pattern for touch devices where hover isn't available.</p>
+            <a class="ecz-cta" href="#">Explore &rarr;</a>
+          </div>
+        </article>
+      </div>
+      <p class="hint">On touch devices hover doesn't exist, so this variant toggles the zoom/overlay reveal on click/tap instead.</p>
+    </section>
+
+    <!-- ============ CUSTOMIZATION VIA CSS VARIABLES ============ -->
+    <section class="showcase">
+      <h2>Customized via CSS variables</h2>
+
+      <div class="card-grid card-grid--single">
+        <article class="ease-card-zoom-xk" style="--ecz-zoom: 1.25; --ecz-speed: 0.6s; --ecz-radius: 4px; --ecz-overlay-color: 251, 191, 36;">
+          <div class="ecz-media">
+            <img src="https://images.unsplash.com/photo-1500534623283-312aade485b7?w=600&h=400&fit=crop" alt="Desert dunes at sunset" />
+          </div>
+          <div class="ecz-overlay">
+            <h3 class="ecz-title">Desert Dunes</h3>
+            <p class="ecz-desc">Stronger zoom, slower transition, sharper corners, amber overlay tint.</p>
+            <a class="ecz-cta" href="#">Explore &rarr;</a>
+          </div>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    // Click-to-toggle variant (touch-friendly alternative to hover)
+    const clickCard = document.getElementById('clickCard');
+
+    function toggleCard() {
+      const isActive = clickCard.classList.toggle('is-active');
+      clickCard.setAttribute('aria-pressed', String(isActive));
+    }
+
+    clickCard.addEventListener('click', toggleCard);
+    clickCard.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        toggleCard();
+      }
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-card-zoom-xk/style.css
+++ b/submissions/examples/ease-card-zoom-xk/style.css
@@ -1,0 +1,202 @@
+/* ==========================================================================
+   ease-card-zoom-xk
+   Card component with zoom-in effect and overlay content reveal on hover
+   ========================================================================== */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: #0f1115;
+  color: #edeef2;
+  padding: 3rem 1.5rem;
+}
+
+.page {
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+.page h1 {
+  margin-bottom: 0.25rem;
+  font-size: 1.9rem;
+}
+
+.subtitle {
+  color: #a3a7b7;
+  margin-bottom: 2.5rem;
+}
+
+.showcase {
+  margin-bottom: 3rem;
+}
+
+.showcase h2 {
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #a3a7b7;
+  margin-bottom: 1.25rem;
+}
+
+.hint {
+  margin-top: 1rem;
+  font-size: 0.85rem;
+  color: #7a7f92;
+  max-width: 60ch;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+}
+
+.card-grid--single {
+  grid-template-columns: minmax(0, 340px);
+}
+
+/* ==========================================================================
+   COMPONENT: ease-card-zoom-xk
+   Customizable via CSS variables:
+     --ecz-zoom          : image zoom scale on hover/active (default 1.15)
+     --ecz-speed         : transition duration (default 0.45s)
+     --ecz-radius        : card corner radius (default 14px)
+     --ecz-overlay-color : RGB triplet used for the overlay gradient tint (default 0, 0, 0)
+   ========================================================================== */
+
+.ease-card-zoom-xk {
+  --ecz-zoom: 1.15;
+  --ecz-speed: 0.45s;
+  --ecz-radius: 14px;
+  --ecz-overlay-color: 0, 0, 0;
+
+  position: relative;
+  border-radius: var(--ecz-radius);
+  overflow: hidden;
+  background: #14151c;
+  cursor: pointer;
+  isolation: isolate;
+}
+
+.ecz-media {
+  position: relative;
+  aspect-ratio: 3 / 2;
+  overflow: hidden;
+  border-radius: inherit;
+}
+
+.ecz-media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transform: scale(1);
+  transition: transform var(--ecz-speed) cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* Overlay: gradient scrim + text content, hidden until hover/active */
+.ecz-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 1.25rem;
+  background: linear-gradient(
+    to top,
+    rgba(var(--ecz-overlay-color), 0.92) 0%,
+    rgba(var(--ecz-overlay-color), 0.55) 45%,
+    rgba(var(--ecz-overlay-color), 0) 100%
+  );
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity var(--ecz-speed) ease, transform var(--ecz-speed) cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.ecz-title {
+  margin: 0 0 0.35rem;
+  font-size: 1.15rem;
+  color: #ffffff;
+}
+
+.ecz-desc {
+  margin: 0 0 0.75rem;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.85);
+  line-height: 1.45;
+}
+
+.ecz-cta {
+  align-self: flex-start;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #ffffff;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.5);
+  padding-bottom: 2px;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.ecz-cta:hover {
+  border-color: #ffffff;
+  transform: translateX(2px);
+}
+
+/* ---------- Hover trigger (default variant) ---------- */
+.ease-card-zoom-xk:hover .ecz-media img,
+.ease-card-zoom-xk:focus-visible .ecz-media img {
+  transform: scale(var(--ecz-zoom));
+}
+
+.ease-card-zoom-xk:hover .ecz-overlay,
+.ease-card-zoom-xk:focus-visible .ecz-overlay {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.ease-card-zoom-xk:focus-visible {
+  outline: 2px solid #7c5cff;
+  outline-offset: 3px;
+}
+
+/* ---------- Click trigger (touch-friendly variant) ---------- */
+.ease-card-zoom-xk--click.is-active .ecz-media img {
+  transform: scale(var(--ecz-zoom));
+}
+
+.ease-card-zoom-xk--click.is-active .ecz-overlay {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* ==========================================================================
+   RESPONSIVE
+   ========================================================================== */
+
+@media (max-width: 900px) {
+  .card-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 600px) {
+  .card-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .card-grid--single {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ---------- Reduced motion support ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .ecz-media img,
+  .ecz-overlay {
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Description

Adds `ease-card-zoom-xk` — a card component with a zoom-in image effect
and overlay content reveal on hover. Closes #35126.

## Changes

- Added `submissions/examples/ease-card-zoom-xk/demo.html` — a 3-card
  hover grid with color-tinted overlays, a touch-friendly click-toggle
  variant, and a CSS-variable customization example.
- Added `submissions/examples/ease-card-zoom-xk/style.css` — the
  component itself: image zoom transition, gradient overlay slide/fade-in,
  both interaction variants, responsive grid breakpoints, and
  `prefers-reduced-motion` support.
- Added `submissions/examples/ease-card-zoom-xk/README.md` — usage docs,
  variable table, and accessibility notes.

## Acceptance Criteria Coverage

- ✅ Smooth CSS transition — the image scales via
  `transform: scale(var(--ecz-zoom))` with a `cubic-bezier(0.22, 1, 0.36, 1)`
  easing, while the overlay fades in and slides up from `translateY(12px)`
  to `translateY(0)`.
- ✅ Interactive trigger — two patterns included:
  - **Hover / focus** — default variant, triggers on `:hover` and
    `:focus-visible`.
  - **Click** — a `--click` modifier toggles an `is-active` class for
    touch devices where hover isn't available, with full keyboard support
    (`Enter`/`Space`).
- ✅ Customizable via CSS variables — `--ecz-zoom`, `--ecz-speed`,
  `--ecz-radius`, and `--ecz-overlay-color` control zoom intensity,
  transition speed, corner radius, and overlay tint independently.

## Accessibility

- Click variant uses `role="button"`, `tabindex="0"`, and `aria-pressed`
  for correct semantics.
- `:focus-visible` triggers the same zoom/overlay reveal as hover.
- CTA link inside the overlay is a real, independently focusable `<a>`.
- Respects `prefers-reduced-motion: reduce` by collapsing transitions to
  near-zero duration.

## Testing

- Verified hover zoom + overlay reveal across all three grid cards.
- Verified click-toggle variant works via mouse, tap, and keyboard
  (`Enter`/`Space`).
- Verified CSS variable overrides (zoom, speed, radius, overlay color)
  work independently.
- Verified responsive grid collapses 3 → 2 → 1 columns at 900px/600px.
- Verified reduced-motion preference disables transitions.

## Screenshots

_(Add screenshots/GIF of the hover zoom effect and click-toggle variant here)_