### PR TITLE
feat: add ease-filter-blur-xk blur-to-clear reveal (#35128)

### DIFF
--- a/submissions/examples/ease-filter-blur-xk/README.md
+++ b/submissions/examples/ease-filter-blur-xk/README.md
@@ -1,0 +1,97 @@
+# ease-filter-blur-xk
+
+Blur-to-clear reveal effect for images or text, on hover or click.
+
+Resolves: #35128
+
+## Overview
+
+A reveal effect built entirely on the CSS `filter: blur()` property.
+Content starts heavily blurred and smoothly clears to full focus on
+interaction. Three variants are included: an image gallery (hover to
+reveal), inline spoiler text (click to reveal), and a scroll-triggered
+image reveal.
+
+## Markup
+
+**Image (hover variant, default):**
+
+```html
+<figure class="ease-filter-blur-xk">
+  <img src="..." alt="..." />
+  <figcaption>Hover to clear</figcaption>
+</figure>
+```
+
+**Text (click variant):**
+
+```html
+<span class="ease-filter-blur-xk ease-filter-blur-xk--click ease-filter-blur-xk--text"
+      tabindex="0" role="button" aria-pressed="false" aria-label="Hidden spoiler, click to reveal">
+  the narrator was the culprit all along
+</span>
+```
+
+**Image (scroll variant):**
+
+```html
+<figure class="ease-filter-blur-xk ease-filter-blur-xk--scroll" id="scrollImage">
+  <img src="..." alt="..." />
+  <figcaption>Revealed on scroll</figcaption>
+</figure>
+```
+
+Toggle `.is-revealed` via JS (click or `IntersectionObserver`, depending on
+variant) — see `demo.html` for the exact handlers.
+
+## CSS Variables
+
+| Variable      | Default | Description                              |
+|-----------------|---------|---------------------------------------------|
+| `--efb-blur`  | `14px`  | Blur radius applied in the hidden state        |
+| `--efb-speed` | `0.45s` | Duration of the blur-to-clear transition        |
+
+Example override:
+
+```html
+<figure class="ease-filter-blur-xk" style="--efb-blur: 24px; --efb-speed: 0.8s;">
+  ...
+</figure>
+```
+
+## Interactive Triggers (Acceptance Criteria)
+
+Three patterns are demonstrated in `demo.html`:
+
+1. **Hover** (default, image variant) — `filter: blur(var(--efb-blur))`
+   transitions to `blur(0)` on `:hover` / `:focus-within`, paired with a
+   subtle `scale(1.05) → scale(1)` zoom-out for added depth.
+2. **Click** (text variant) — an inline spoiler phrase toggles an
+   `is-revealed` class on click or `Enter`/`Space` when focused, clearing
+   the blur; clicking again re-blurs it.
+3. **Scroll** (image variant) — a `--scroll` modifier keeps the image
+   blurred until it enters the viewport, then adds `is-revealed` via
+   `IntersectionObserver` (threshold 0.4).
+
+## Accessibility
+
+- The text spoiler variant uses `role="button"`, `tabindex="0"`, and
+  `aria-pressed` so its toggle state is announced correctly, plus a
+  descriptive `aria-label` since the visible text itself is intentionally
+  obscured.
+- `user-select` is disabled while the spoiler is blurred (to prevent
+  copying hidden text) and re-enabled once revealed.
+- Image variant uses `:focus-within` so keyboard users tabbing to a link
+  or control inside the figure also trigger the reveal.
+- Respects `prefers-reduced-motion: reduce` by collapsing the blur
+  transition duration to near-zero, so content still becomes readable
+  without the animated effect.
+
+## Files
+
+- `demo.html` — hover image reveal (2 examples), click-to-reveal spoiler
+  text, scroll-triggered image reveal, and a CSS-variable customization
+  example.
+- `style.css` — component styles for all three variants (image/hover,
+  text/click, image/scroll), plus reduced-motion and responsive handling.
+- `README.md` — this file.

--- a/submissions/examples/ease-filter-blur-xk/demo.html
+++ b/submissions/examples/ease-filter-blur-xk/demo.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>ease-filter-blur-xk — Blur-to-Clear Reveal</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="page">
+    <h1>ease-filter-blur-xk</h1>
+    <p class="subtitle">Blur-to-clear reveal effect for images or text, on hover or click.</p>
+
+    <!-- ============ HOVER TRIGGER: IMAGE ============ -->
+    <section class="showcase">
+      <h2>Hover to reveal — image</h2>
+
+      <div class="efb-grid">
+        <figure class="ease-filter-blur-xk">
+          <img src="https://images.unsplash.com/photo-1441974231531-c6227db76b6e?w=600&h=400&fit=crop" alt="Forest path in autumn" />
+          <figcaption>Hover to clear</figcaption>
+        </figure>
+
+        <figure class="ease-filter-blur-xk" style="--efb-blur: 24px; --efb-speed: 0.8s;">
+          <img src="https://images.unsplash.com/photo-1506744038136-46273834b3fb?w=600&h=400&fit=crop" alt="Mountain landscape at sunrise" />
+          <figcaption>Stronger blur, slower clear</figcaption>
+        </figure>
+      </div>
+
+      <p class="hint">Hover either image — it transitions smoothly from a heavy blur to fully in focus.</p>
+    </section>
+
+    <!-- ============ CLICK TRIGGER: SPOILER TEXT ============ -->
+    <section class="showcase">
+      <h2>Click to reveal — spoiler text</h2>
+
+      <p class="spoiler-line">
+        The final twist is that
+        <span class="ease-filter-blur-xk ease-filter-blur-xk--click ease-filter-blur-xk--text" tabindex="0" role="button" aria-pressed="false" aria-label="Hidden spoiler, click to reveal">
+          the narrator was the culprit all along
+        </span>.
+      </p>
+
+      <p class="hint">Click (or press Enter/Space while focused on) the blurred phrase to reveal it. Click again to re-blur.</p>
+    </section>
+
+    <!-- ============ SCROLL TRIGGER ============ -->
+    <section class="showcase">
+      <h2>Scroll to reveal</h2>
+      <p class="hint">Scroll down — the image below clears automatically once it enters the viewport.</p>
+
+      <div class="scroll-spacer"></div>
+
+      <figure class="ease-filter-blur-xk ease-filter-blur-xk--scroll" id="scrollImage">
+        <img src="https://images.unsplash.com/photo-1519681393784-d120267933ba?w=600&h=400&fit=crop" alt="City skyline at night" />
+        <figcaption>Revealed on scroll</figcaption>
+      </figure>
+
+      <div class="scroll-spacer"></div>
+    </section>
+
+    <!-- ============ CUSTOMIZATION VIA CSS VARIABLES ============ -->
+    <section class="showcase">
+      <h2>Customized via CSS variables</h2>
+
+      <div class="efb-grid">
+        <figure class="ease-filter-blur-xk" style="--efb-blur: 6px; --efb-speed: 0.2s;">
+          <img src="https://images.unsplash.com/photo-1500534623283-312aade485b7?w=600&h=400&fit=crop" alt="Desert dunes at sunset" />
+          <figcaption>Subtle blur, snappy speed</figcaption>
+        </figure>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    // ---------- Click trigger (spoiler text) ----------
+    document.querySelectorAll('.ease-filter-blur-xk--click').forEach((el) => {
+      function toggle() {
+        const isRevealed = el.classList.toggle('is-revealed');
+        el.setAttribute('aria-pressed', String(isRevealed));
+      }
+
+      el.addEventListener('click', toggle);
+      el.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          toggle();
+        }
+      });
+    });
+
+    // ---------- Scroll trigger ----------
+    const scrollImage = document.getElementById('scrollImage');
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          scrollImage.classList.add('is-revealed');
+        }
+      });
+    }, { threshold: 0.4 });
+
+    observer.observe(scrollImage);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-filter-blur-xk/style.css
+++ b/submissions/examples/ease-filter-blur-xk/style.css
@@ -1,0 +1,177 @@
+/* ==========================================================================
+   ease-filter-blur-xk
+   Blur-to-clear reveal effect for images or text, on hover, click, or scroll
+   ========================================================================== */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: #0f1115;
+  color: #edeef2;
+  padding: 3rem 1.5rem;
+}
+
+.page {
+  max-width: 880px;
+  margin: 0 auto;
+}
+
+.page h1 {
+  margin-bottom: 0.25rem;
+  font-size: 1.9rem;
+}
+
+.subtitle {
+  color: #a3a7b7;
+  margin-bottom: 2.5rem;
+}
+
+.showcase {
+  margin-bottom: 3rem;
+}
+
+.showcase h2 {
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #a3a7b7;
+  margin-bottom: 1.25rem;
+}
+
+.hint {
+  margin-top: 1rem;
+  font-size: 0.85rem;
+  color: #7a7f92;
+  max-width: 60ch;
+}
+
+.efb-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.scroll-spacer {
+  height: 55vh;
+}
+
+.spoiler-line {
+  font-size: 1.05rem;
+  line-height: 1.6;
+  max-width: 60ch;
+}
+
+/* ==========================================================================
+   COMPONENT: ease-filter-blur-xk
+   Customizable via CSS variables:
+     --efb-blur  : blur amount in the hidden state (default 14px)
+     --efb-speed : transition duration (default 0.45s)
+   ========================================================================== */
+
+.ease-filter-blur-xk {
+  --efb-blur: 14px;
+  --efb-speed: 0.45s;
+
+  margin: 0;
+  position: relative;
+}
+
+/* ---------- Image variant (default) ---------- */
+figure.ease-filter-blur-xk {
+  overflow: hidden;
+  border-radius: 12px;
+  background: #14151c;
+}
+
+figure.ease-filter-blur-xk img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  aspect-ratio: 3 / 2;
+  object-fit: cover;
+  filter: blur(var(--efb-blur));
+  transform: scale(1.05);
+  transition: filter var(--efb-speed) ease, transform var(--efb-speed) ease;
+}
+
+figure.ease-filter-blur-xk figcaption {
+  padding: 0.6rem 0.85rem;
+  font-size: 0.82rem;
+  color: #a3a7b7;
+  background: #14151c;
+}
+
+/* Hover reveal (default trigger for the image variant) */
+figure.ease-filter-blur-xk:hover img,
+figure.ease-filter-blur-xk:focus-within img {
+  filter: blur(0);
+  transform: scale(1);
+}
+
+/* Class-driven reveal (used by scroll trigger) */
+figure.ease-filter-blur-xk.is-revealed img {
+  filter: blur(0);
+  transform: scale(1);
+}
+
+figure.ease-filter-blur-xk:focus-within {
+  outline: 2px solid #7c5cff;
+  outline-offset: 3px;
+}
+
+/* ---------- Text variant ---------- */
+.ease-filter-blur-xk--text {
+  display: inline;
+  filter: blur(var(--efb-blur));
+  transition: filter var(--efb-speed) ease;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.ease-filter-blur-xk--text.is-revealed {
+  filter: blur(0);
+}
+
+.ease-filter-blur-xk--text:focus-visible {
+  outline: 2px solid #7c5cff;
+  outline-offset: 2px;
+}
+
+/* ---------- Click variant modifier (used on the text spoiler) ---------- */
+.ease-filter-blur-xk--click {
+  user-select: none;
+}
+
+.ease-filter-blur-xk--click.is-revealed {
+  user-select: text;
+}
+
+/* ---------- Scroll variant: image stays blurred until .is-revealed is added ---------- */
+.ease-filter-blur-xk--scroll img {
+  filter: blur(var(--efb-blur));
+  transform: scale(1.05);
+}
+
+.ease-filter-blur-xk--scroll.is-revealed img {
+  filter: blur(0);
+  transform: scale(1);
+}
+
+/* ---------- Reduced motion support ---------- */
+@media (prefers-reduced-motion: reduce) {
+  figure.ease-filter-blur-xk img,
+  .ease-filter-blur-xk--text {
+    transition-duration: 0.01ms !important;
+  }
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 560px) {
+  .efb-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Description

Adds `ease-filter-blur-xk` — a blur-to-clear reveal effect for images or
text, triggered by hover, click, or scroll. Closes #35128.

## Changes

- Added `submissions/examples/ease-filter-blur-xk/demo.html` —
  hover-to-reveal image gallery, click-to-reveal spoiler text, a
  scroll-triggered image reveal, and a CSS-variable customization example.
- Added `submissions/examples/ease-filter-blur-xk/style.css` — the
  component styles for all three variants (image/hover, text/click,
  image/scroll), plus reduced-motion and responsive handling.
- Added `submissions/examples/ease-filter-blur-xk/README.md` — usage docs
  for each variant, variable table, and accessibility notes.

## Acceptance Criteria Coverage

- ✅ Smooth CSS transition — `filter: blur(var(--efb-blur))` transitions
  to `blur(0)`, paired with a subtle `scale(1.05) → scale(1)` zoom-out on
  the image variant for added depth.
- ✅ Interactive trigger — three patterns included:
  - **Hover** — default image variant, triggers on `:hover` /
    `:focus-within`.
  - **Click** — inline spoiler text toggles `is-revealed` on click or
    `Enter`/`Space` when focused; clicking again re-blurs it.
  - **Scroll** — a `--scroll` modifier reveals the image once it enters
    the viewport via `IntersectionObserver` (threshold 0.4).
- ✅ Customizable via CSS variables — `--efb-blur` and `--efb-speed`
  control blur intensity and transition speed independently.

## Accessibility

- Spoiler text uses `role="button"`, `tabindex="0"`, `aria-pressed`, and a
  descriptive `aria-label` since the visible text is intentionally obscured.
- `user-select` disabled while blurred (prevents copying hidden text),
  re-enabled once revealed.
- Image variant uses `:focus-within` so keyboard focus on nested controls
  also triggers the reveal.
- Respects `prefers-reduced-motion: reduce` by collapsing the blur
  transition to near-zero duration.

## Testing

- Verified hover reveal on both image examples.
- Verified click-to-reveal spoiler text via mouse, tap, and keyboard
  (`Enter`/`Space`), and re-blur on second click.
- Verified scroll-triggered reveal at 40% viewport visibility.
- Verified CSS variable overrides (blur amount, speed) work independently.
- Verified reduced-motion preference disables the transition.

## Screenshots

_(Add screenshots/GIF of the blur-to-clear effect for image, text, and scroll variants here)_