### PR TITLE
feat: add animated login/signup form with tab switch (#35239)

### DIFF
--- a/submissions/examples-v1/u-animated-login-signup-35239/index.html
+++ b/submissions/examples-v1/u-animated-login-signup-35239/index.html
@@ -1,0 +1,298 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Animated Login/Signup Form</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
+      font-family: 'Segoe UI', sans-serif;
+    }
+
+    .card {
+      width: 380px;
+      background: rgba(255, 255, 255, 0.05);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: 20px;
+      padding: 40px 36px;
+      backdrop-filter: blur(16px);
+      box-shadow: 0 24px 60px rgba(0,0,0,0.4);
+    }
+
+    /* Tab Switch */
+    .tabs {
+      display: flex;
+      background: rgba(255,255,255,0.05);
+      border-radius: 12px;
+      padding: 4px;
+      margin-bottom: 32px;
+      position: relative;
+    }
+
+    .tab-btn {
+      flex: 1;
+      padding: 10px;
+      border: none;
+      background: transparent;
+      color: rgba(255,255,255,0.5);
+      font-size: 14px;
+      font-weight: 600;
+      cursor: pointer;
+      border-radius: 10px;
+      position: relative;
+      z-index: 1;
+      transition: color 0.3s ease;
+    }
+
+    .tab-btn.active { color: #fff; }
+
+    .tab-indicator {
+      position: absolute;
+      top: 4px;
+      left: 4px;
+      width: calc(50% - 4px);
+      height: calc(100% - 8px);
+      background: linear-gradient(135deg, #6c63ff, #3ecf8e);
+      border-radius: 8px;
+      transition: transform 0.35s cubic-bezier(0.68, -0.55, 0.27, 1.55);
+      z-index: 0;
+    }
+
+    .tab-indicator.signup { transform: translateX(100%); }
+
+    /* Form panels */
+    .form-panel {
+      display: none;
+      animation: fadeSlideIn 0.4s ease forwards;
+    }
+    .form-panel.active { display: block; }
+
+    @keyframes fadeSlideIn {
+      from { opacity: 0; transform: translateY(12px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+
+    h2 {
+      color: #fff;
+      font-size: 22px;
+      margin-bottom: 6px;
+    }
+
+    .subtitle {
+      color: rgba(255,255,255,0.4);
+      font-size: 13px;
+      margin-bottom: 24px;
+    }
+
+    .input-group {
+      margin-bottom: 18px;
+    }
+
+    label {
+      display: block;
+      color: rgba(255,255,255,0.6);
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.5px;
+      margin-bottom: 8px;
+      text-transform: uppercase;
+    }
+
+    input {
+      width: 100%;
+      padding: 12px 16px;
+      background: rgba(255,255,255,0.07);
+      border: 1px solid rgba(255,255,255,0.1);
+      border-radius: 10px;
+      color: #fff;
+      font-size: 14px;
+      outline: none;
+      transition: border-color 0.3s, box-shadow 0.3s;
+    }
+
+    input::placeholder { color: rgba(255,255,255,0.25); }
+
+    input:focus {
+      border-color: #6c63ff;
+      box-shadow: 0 0 0 3px rgba(108,99,255,0.2);
+    }
+
+    .btn {
+      width: 100%;
+      padding: 13px;
+      background: linear-gradient(135deg, #6c63ff, #3ecf8e);
+      border: none;
+      border-radius: 10px;
+      color: #fff;
+      font-size: 15px;
+      font-weight: 700;
+      cursor: pointer;
+      margin-top: 8px;
+      letter-spacing: 0.5px;
+      transition: transform 0.2s, box-shadow 0.2s;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .btn:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 8px 24px rgba(108,99,255,0.4);
+    }
+
+    .btn:active { transform: translateY(0); }
+
+    /* Ripple */
+    .btn .ripple {
+      position: absolute;
+      border-radius: 50%;
+      background: rgba(255,255,255,0.3);
+      transform: scale(0);
+      animation: ripple-anim 0.6s linear;
+      pointer-events: none;
+    }
+
+    @keyframes ripple-anim {
+      to { transform: scale(4); opacity: 0; }
+    }
+
+    .divider {
+      text-align: center;
+      color: rgba(255,255,255,0.25);
+      font-size: 12px;
+      margin: 20px 0;
+      position: relative;
+    }
+
+    .divider::before, .divider::after {
+      content: '';
+      position: absolute;
+      top: 50%;
+      width: 40%;
+      height: 1px;
+      background: rgba(255,255,255,0.1);
+    }
+
+    .divider::before { left: 0; }
+    .divider::after  { right: 0; }
+
+    .social-btn {
+      width: 100%;
+      padding: 11px;
+      background: rgba(255,255,255,0.05);
+      border: 1px solid rgba(255,255,255,0.1);
+      border-radius: 10px;
+      color: rgba(255,255,255,0.7);
+      font-size: 13px;
+      cursor: pointer;
+      transition: background 0.2s, border-color 0.2s;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+    }
+
+    .social-btn:hover {
+      background: rgba(255,255,255,0.1);
+      border-color: rgba(255,255,255,0.2);
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <!-- Tab Switch -->
+    <div class="tabs">
+      <div class="tab-indicator" id="indicator"></div>
+      <button class="tab-btn active" id="loginTab" onclick="switchTab('login')">Login</button>
+      <button class="tab-btn" id="signupTab" onclick="switchTab('signup')">Sign Up</button>
+    </div>
+
+    <!-- Login Panel -->
+    <div class="form-panel active" id="loginPanel">
+      <h2>Welcome back 👋</h2>
+      <p class="subtitle">Sign in to your account</p>
+
+      <div class="input-group">
+        <label>Email</label>
+        <input type="email" placeholder="you@example.com" />
+      </div>
+      <div class="input-group">
+        <label>Password</label>
+        <input type="password" placeholder="••••••••" />
+      </div>
+
+      <button class="btn" onclick="rippleEffect(event)">Sign In</button>
+
+      <div class="divider">or continue with</div>
+      <button class="social-btn">🌐 Continue with Google</button>
+    </div>
+
+    <!-- Signup Panel -->
+    <div class="form-panel" id="signupPanel">
+      <h2>Create account ✨</h2>
+      <p class="subtitle">Join us today, it's free</p>
+
+      <div class="input-group">
+        <label>Full Name</label>
+        <input type="text" placeholder="Geetha Burigalla" />
+      </div>
+      <div class="input-group">
+        <label>Email</label>
+        <input type="email" placeholder="you@example.com" />
+      </div>
+      <div class="input-group">
+        <label>Password</label>
+        <input type="password" placeholder="••••••••" />
+      </div>
+
+      <button class="btn" onclick="rippleEffect(event)">Create Account</button>
+
+      <div class="divider">or continue with</div>
+      <button class="social-btn">🌐 Continue with Google</button>
+    </div>
+  </div>
+
+  <script>
+    function switchTab(tab) {
+      const indicator = document.getElementById('indicator');
+      const loginTab = document.getElementById('loginTab');
+      const signupTab = document.getElementById('signupTab');
+      const loginPanel = document.getElementById('loginPanel');
+      const signupPanel = document.getElementById('signupPanel');
+
+      if (tab === 'login') {
+        indicator.classList.remove('signup');
+        loginTab.classList.add('active');
+        signupTab.classList.remove('active');
+        loginPanel.classList.add('active');
+        signupPanel.classList.remove('active');
+      } else {
+        indicator.classList.add('signup');
+        signupTab.classList.add('active');
+        loginTab.classList.remove('active');
+        signupPanel.classList.add('active');
+        loginPanel.classList.remove('active');
+      }
+    }
+
+    function rippleEffect(e) {
+      const btn = e.currentTarget;
+      const ripple = document.createElement('span');
+      const rect = btn.getBoundingClientRect();
+      const size = Math.max(rect.width, rect.height);
+      ripple.classList.add('ripple');
+      ripple.style.width = ripple.style.height = size + 'px';
+      ripple.style.left = (e.clientX - rect.left - size / 2) + 'px';
+      ripple.style.top = (e.clientY - rect.top - size / 2) + 'px';
+      btn.appendChild(ripple);
+      setTimeout(() => ripple.remove(), 600);
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Closes #35239

## What's added
- Animated login/signup form with smooth tab switch indicator
- CSS `transform` + `transition` for sliding pill indicator between tabs
- `fadeSlideIn` keyframe animation on panel switch
- Ripple effect on submit button click
- Glassmorphism card design with focus states on inputs
- Fully self-contained single `index.html` file

## Preview
Tab switching works smoothly between Login and Signup panels with animated indicator slide.

##Screenshots
<img width="655" height="787" alt="Screenshot 2026-07-04 110445" src="https://github.com/user-attachments/assets/212b5ecf-40ab-40dc-a387-1bec3b6a3b8c" />
<img width="545" height="852" alt="Screenshot 2026-07-04 110450" src="https://github.com/user-attachments/assets/a5a64587-a31d-4241-bc8b-66c1badb96de" />
