### PR TITLE
#35252 fixed moon icon issue in light mode

### DIFF
--- a/submissions/docs/fix-theme-toggle-contrast-jy/README.md
+++ b/submissions/docs/fix-theme-toggle-contrast-jy/README.md
@@ -1,0 +1,16 @@
+# What does this do?
+This submission fixes the low visibility of the theme switcher's Moon icon in Light Mode by applying `fill: currentColor` to the SVG path, ensuring a solid dark crescent moon shape with high contrast against the header background.
+
+# How is it used?
+Apply the `.theme-toggle-btn` class to the toggle button, housing the SVG moon icon. In the CSS stylesheet, update the light mode state selector to fill the moon icon:
+
+```css
+[data-theme="light"] .theme-toggle-btn .moon-icon {
+  opacity: 1;
+  transform: rotate(0deg) scale(1);
+  fill: currentColor;
+}
+```
+
+# Why is it useful?
+It ensures that the theme switcher remains highly visible and accessible to all users in Light Mode, complying with standard WCAG visual contrast ratios and improving the overall usability of the framework's documentation pages.

--- a/submissions/docs/fix-theme-toggle-contrast-jy/demo.html
+++ b/submissions/docs/fix-theme-toggle-contrast-jy/demo.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bug Fix: Theme Toggle Contrast in Light Mode — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="docs-header">
+    <div class="header-container">
+      <span class="docs-logo">EaseMotion Docs</span>
+      <button class="theme-toggle-btn" id="theme-toggle" aria-label="Toggle dark/light theme">
+        <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="5"></circle>
+          <line x1="12" y1="1" x2="12" y2="3"></line>
+          <line x1="12" y1="21" x2="12" y2="23"></line>
+          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+          <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+          <line x1="1" y1="12" x2="3" y2="12"></line>
+          <line x1="21" y1="12" x2="23" y2="12"></line>
+          <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+          <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+        </svg>
+        <svg class="moon-icon" viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+        </svg>
+      </button>
+    </div>
+  </nav>
+
+  <!-- Showcase Content -->
+  <main class="docs-shell">
+    <div class="content-box">
+      <h2>Theme Toggle Moon Icon Contrast Fix</h2>
+      <p>This demo resolves the issue where the theme switcher button's Moon icon is difficult to see when Light Mode is active.</p>
+      
+      <div class="status-indicator">
+        <p>Current Theme: <strong id="themeStatus">Light Mode</strong></p>
+        <p>Click the circular toggle button in the top-right corner of the nav bar to switch themes. Observe how the Moon icon renders clearly with solid fill in Light Mode to ensure high contrast against the header background.</p>
+      </div>
+    </div>
+  </main>
+
+  <script>
+    const themeBtn = document.getElementById("theme-toggle");
+    const htmlEl = document.documentElement;
+    const statusText = document.getElementById("themeStatus");
+
+    function updateStatusText(theme) {
+      statusText.textContent = theme === 'light' ? 'Light Mode' : 'Dark Mode';
+    }
+
+    themeBtn.addEventListener("click", () => {
+      const currentTheme = htmlEl.getAttribute("data-theme") || "dark";
+      const targetTheme = currentTheme === "light" ? "dark" : "light";
+      htmlEl.setAttribute("data-theme", targetTheme);
+      updateStatusText(targetTheme);
+    });
+
+    // Set initial status text
+    updateStatusText(htmlEl.getAttribute("data-theme") || "light");
+  </script>
+</body>
+</html>

--- a/submissions/docs/fix-theme-toggle-contrast-jy/style.css
+++ b/submissions/docs/fix-theme-toggle-contrast-jy/style.css
@@ -1,0 +1,156 @@
+:root {
+  --docs-header-h: 60px;
+  --page-bg: #0f0e17;
+  --page-text: #fffffe;
+  --border-color: rgba(255, 255, 255, 0.07);
+  --header-bg: rgba(15, 14, 23, 0.9);
+  --ease-color-primary: #6c63ff;
+  --ease-radius-full: 9999px;
+  --ease-speed-fast: 150ms;
+  --ease-ease: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+[data-theme="light"] {
+  --page-bg: #f8fafc;
+  --page-text: #0f172a;
+  --border-color: rgba(15, 23, 42, 0.08);
+  --header-bg: rgba(248, 250, 252, 0.9);
+}
+
+body {
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  margin: 0;
+  background: var(--page-bg);
+  color: var(--page-text);
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+/* ── Header ── */
+.docs-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--docs-header-h);
+  z-index: 200;
+  background: var(--header-bg);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  align-items: center;
+  transition: background 0.3s ease, border-color 0.3s ease;
+}
+
+.header-container {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.docs-logo {
+  font-size: 1.25rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #6c63ff, #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.docs-shell {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  box-sizing: border-box;
+}
+
+.content-box {
+  text-align: center;
+  max-width: 600px;
+  margin-top: var(--docs-header-h);
+}
+
+.content-box h2 {
+  font-size: 1.8rem;
+  margin-bottom: 1rem;
+}
+
+.content-box p {
+  color: var(--page-text);
+  opacity: 0.8;
+  line-height: 1.6;
+}
+
+.status-indicator {
+  margin-top: 2rem;
+  padding: 1.5rem;
+  background: rgba(108, 99, 255, 0.08);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+}
+
+/* ── Theme Toggle Button ── */
+.theme-toggle-btn {
+  background: none;
+  border: 1px solid var(--border-color);
+  color: var(--page-text);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: var(--ease-radius-full);
+  position: relative;
+  overflow: hidden;
+  transition:
+    background var(--ease-speed-fast) var(--ease-ease),
+    color var(--ease-speed-fast) var(--ease-ease),
+    border-color var(--ease-speed-fast) var(--ease-ease);
+}
+
+.theme-toggle-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: var(--ease-color-primary);
+}
+
+[data-theme="light"] .theme-toggle-btn:hover {
+  background: rgba(15, 23, 42, 0.08);
+}
+
+.theme-toggle-btn svg {
+  position: absolute;
+  transition:
+    transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1),
+    opacity 0.3s;
+}
+
+/* Sun Icon Default (Dark Mode active) */
+.theme-toggle-btn .sun-icon {
+  opacity: 1;
+  transform: rotate(0deg) scale(1);
+}
+
+/* Moon Icon Default (Dark Mode active) */
+.theme-toggle-btn .moon-icon {
+  opacity: 0;
+  transform: rotate(90deg) scale(0);
+}
+
+/* Active State Styles (Light Mode active) */
+[data-theme="light"] .theme-toggle-btn .sun-icon {
+  opacity: 0;
+  transform: rotate(-90deg) scale(0);
+}
+
+[data-theme="light"] .theme-toggle-btn .moon-icon {
+  opacity: 1;
+  transform: rotate(0deg) scale(1);
+  fill: currentColor; /* RESOLVES THE VISIBILITY CONTRAST ISSUE */
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes the low visibility/contrast of the theme toggle switcher's Moon icon in Light Mode by filling it with the current text color (`currentColor`) when active.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (specifically `submissions/docs/fix-theme-toggle-contrast-jy/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It makes the Moon icon clearly visible in Light Mode by rendering it as a solid crescent moon shape with high contrast against the header background.

**How does a developer use it?**

```css
[data-theme="light"] .theme-toggle-btn .moon-icon {
  opacity: 1;
  transform: rotate(0deg) scale(1);
  fill: currentColor;
}
