### PR TITLE
feat: add animated login/signup form with tab switch

### DIFF
--- a/submissions/examples/u-animated-login-signup-gb/README.md
+++ b/submissions/examples/u-animated-login-signup-gb/README.md
@@ -1,0 +1,17 @@
+﻿# Animated Login / Signup Form
+
+A responsive login/signup card with a smooth sliding tab toggle between the two forms.
+
+## Features
+- Toggle between Login and Sign Up using animated tab buttons
+- Sliding pill indicator that moves behind the active tab
+- Fade + slide-in transition when switching forms
+- Clean gradient theme with hover effects on the submit button
+- Fully responsive, no external dependencies
+
+## Files
+- `demo.html` — Markup and tab-switching logic
+- `style.css` — Styling and animations
+
+## Author
+GeethaBurigalla

--- a/submissions/examples/u-animated-login-signup-gb/demo.html
+++ b/submissions/examples/u-animated-login-signup-gb/demo.html
@@ -1,0 +1,57 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Animated Login / Signup Form</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="auth-container">
+    <div class="tab-toggle">
+      <button class="tab-btn active" id="loginTab" onclick="switchTab('login')">Login</button>
+      <button class="tab-btn" id="signupTab" onclick="switchTab('signup')">Sign Up</button>
+      <div class="tab-slider" id="tabSlider"></div>
+    </div>
+
+    <form class="auth-form active" id="loginForm">
+      <h2>Welcome Back</h2>
+      <input type="email" placeholder="Email" required>
+      <input type="password" placeholder="Password" required>
+      <button type="submit" class="submit-btn">Login</button>
+    </form>
+
+    <form class="auth-form" id="signupForm">
+      <h2>Create Account</h2>
+      <input type="text" placeholder="Full Name" required>
+      <input type="email" placeholder="Email" required>
+      <input type="password" placeholder="Password" required>
+      <button type="submit" class="submit-btn">Sign Up</button>
+    </form>
+  </div>
+
+  <script>
+    function switchTab(tab) {
+      const loginTab = document.getElementById('loginTab');
+      const signupTab = document.getElementById('signupTab');
+      const loginForm = document.getElementById('loginForm');
+      const signupForm = document.getElementById('signupForm');
+      const slider = document.getElementById('tabSlider');
+
+      if (tab === 'login') {
+        loginTab.classList.add('active');
+        signupTab.classList.remove('active');
+        loginForm.classList.add('active');
+        signupForm.classList.remove('active');
+        slider.classList.remove('right');
+      } else {
+        signupTab.classList.add('active');
+        loginTab.classList.remove('active');
+        signupForm.classList.add('active');
+        loginForm.classList.remove('active');
+        slider.classList.add('right');
+      }
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/u-animated-login-signup-gb/style.css
+++ b/submissions/examples/u-animated-login-signup-gb/style.css
@@ -1,0 +1,119 @@
+﻿* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Segoe UI', sans-serif;
+  background: linear-gradient(135deg, #667eea, #764ba2);
+}
+
+.auth-container {
+  position: relative;
+  width: 360px;
+  background: #fff;
+  border-radius: 16px;
+  padding: 40px 30px 30px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+  overflow: hidden;
+}
+
+.tab-toggle {
+  position: relative;
+  display: flex;
+  background: #f0f0f5;
+  border-radius: 30px;
+  margin-bottom: 30px;
+  height: 46px;
+}
+
+.tab-btn {
+  flex: 1;
+  border: none;
+  background: transparent;
+  z-index: 1;
+  font-weight: 600;
+  cursor: pointer;
+  color: #666;
+  transition: color 0.3s ease;
+}
+
+.tab-btn.active {
+  color: #fff;
+}
+
+.tab-slider {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: calc(50% - 3px);
+  height: calc(100% - 6px);
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  border-radius: 30px;
+  transition: transform 0.35s ease;
+}
+
+.tab-slider.right {
+  transform: translateX(100%);
+}
+
+.auth-form {
+  display: none;
+  flex-direction: column;
+  gap: 14px;
+  animation: fadeSlide 0.4s ease;
+}
+
+.auth-form.active {
+  display: flex;
+}
+
+.auth-form h2 {
+  text-align: center;
+  margin-bottom: 10px;
+  color: #333;
+}
+
+.auth-form input {
+  padding: 12px 14px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  font-size: 14px;
+  outline: none;
+  transition: border-color 0.3s ease;
+}
+
+.auth-form input:focus {
+  border-color: #764ba2;
+}
+
+.submit-btn {
+  padding: 12px;
+  border: none;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.3s ease;
+}
+
+.submit-btn:hover {
+  opacity: 0.9;
+}
+
+@keyframes fadeSlide {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a new example: an animated login/signup card with a sliding tab toggle between the two forms, a fading transition on switch, and a gradient theme.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/u-animated-login-signup-gb/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A login/signup card with an animated pill-style tab toggle that slides between "Login" and "Sign Up," swapping forms with a fade-in transition.

**How does a developer use it?**
```html
<div class="auth-container">
  <div class="tab-toggle">
    <button class="tab-btn active" id="loginTab" onclick="switchTab('login')">Login</button>
    <button class="tab-btn" id="signupTab" onclick="switchTab('signup')">Sign Up</button>
    <div class="tab-slider" id="tabSlider"></div>
  </div>
  <form class="auth-form active">...</form>
  <form class="auth-form">...</form>
</div>
```

**Why does it fit EaseMotion CSS?**
It's a common, human-readable UI pattern (auth forms) built with plain CSS transitions and transforms — no libraries, no build step — matching the animation-first, copy-paste-friendly philosophy of this project.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Edge

---

## Notes for Maintainer
Straightforward CSS-only tab switch using a sliding indicator (`transform: translateX`) and a fade+slide keyframe on form change. Happy to adjust timing/colors if it doesn't match the repo's existing palette conventions.

---

##Screenshots
<img width="655" height="787" alt="Screenshot 2026-07-04 110445" src="https://github.com/user-attachments/assets/57036c74-5db7-4431-b1ef-a77c153759cb" />
<img width="545" height="852" alt="Screenshot 2026-07-04 110450" src="https://github.com/user-attachments/assets/21f8715b-86a5-4260-a4b8-e645334125ac" />
