### PR TITLE
fix: redirect navbar logo to landing page from docs

### DIFF
--- a/docs/demo.html
+++ b/docs/demo.html
@@ -296,7 +296,7 @@
   ══════════════════════════════════════════════════════════ -->
   <nav class="demo-nav" style="padding-left: 10px;">
     <div class="ease-container demo-nav-inner">
-      <a href="index.html" class="demo-logo" style="text-decoration: none; display: flex; align-items: center;">
+      <a href="demo.html" class="demo-logo" style="text-decoration: none; display: flex; align-items: center;">
         <img src="assets/logo.svg" alt="EaseMotion CSS" style="height: 36px; width: auto; display: block;" />
       </a>
       <ul class="demo-nav-links">

--- a/docs/index.html
+++ b/docs/index.html
@@ -91,7 +91,7 @@
 
     <!-- ── Header ───────────────────────────────────────────── -->
     <header class="docs-header">
-      <a href="index.html" class="docs-logo">
+      <a href="demo.html" class="docs-logo">
         <img src="assets/logo.svg" alt="EaseMotion CSS" class="docs-logo-img" />
       </a>
 


### PR DESCRIPTION
## Pull Request Description

This PR resolves a navigation inconsistency on the **Demo** page by updating the **EaseMotion CSS** logo to redirect users to the project's **Landing/Home** page instead of the **Documentation** page.

This change aligns the navigation with standard web UX conventions, where clicking the project logo typically returns users to the homepage, while preserving the existing **Docs** navigation link for accessing the documentation.

---

## Type of Change


- [x] 🐛 Bug fix in an existing submission

---

## Feature Description

**What does this add?**

Improves the Demo page's navigation by redirecting the navbar logo to the project's Landing/Home page.

**How does a developer use it?**

No additional configuration is required. The change only updates the navigation behavior of the project logo.

**Why does it fit EaseMotion CSS?**

This enhancement improves usability by following common web navigation standards. Users can intuitively return to the Landing/Home page by clicking the project logo, while the dedicated **Docs** link continues to provide access to the documentation.

---

## Demo

- [x] Verified that clicking the navbar logo redirects to the Landing/Home page.
- [x] Verified that the **Docs** navigation link continues to redirect to the Documentation page.

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge

---

## Notes for Maintainer

- Updated only the navigation target of the navbar logo.
- No changes were made to animations, components, styles, or core functionality.
- This is a UX-focused improvement that ensures consistent and intuitive navigation across the project.

---

>**Fixes:** #<35242>