### PR TITLE
fix(docs): improve active sidebar text contrast in light theme

### DIFF
--- a/docs/docs.css
+++ b/docs/docs.css
@@ -676,7 +676,7 @@ a.sidebar-group-label:hover {
   }
 
   .sidebar-nav a:hover:not(.active) {
-    color: rgba(255, 255, 255, 0.6);
+    color: var(--nav-link-active-text);
     background: transparent;
   }
 }
@@ -1001,7 +1001,7 @@ body > .docs-shell {
 .sidebar-nav a:hover {
   background: rgba(108, 99, 255, 0.08);
   border-left-color: rgba(108, 99, 255, 0.4);
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--nav-link-active-text);
   padding-left: 14px;
 }
 
@@ -1012,7 +1012,7 @@ body > .docs-shell {
     rgba(108, 99, 255, 0.05)
   );
   border-left: 2px solid #6c63ff;
-  color: #ffffff;
+  color: var(--nav-link-active-text);
   padding-left: 14px;
 }
 


### PR DESCRIPTION
## Description

This PR fixes the low-contrast active sidebar text in the documentation when using the light theme.

### Changes Made
- Replaced hardcoded text color overrides with the existing `--nav-link-active-text` theme variable.
- Improved readability of active and hover sidebar items in the light theme.
- Preserved the existing dark theme behavior and sidebar styling.

### Screenshots
<img width="296" height="142" alt="image" src="https://github.com/user-attachments/assets/86aa0f9c-71d3-47df-851a-0d49dc0634db" />
<br/>
<img width="297" height="132" alt="image" src="https://github.com/user-attachments/assets/0eed6da6-4577-4d92-a103-8446ee4f2e57" />


Closes #35265