### PR TITLE
feat: Add React Notification Center Drawer with Slide-In (#28216)

### DIFF
--- a/submissions/react/react-notification-center-drawer-with-slide-in-realtushartyagi/NotificationCenterDrawer.jsx
+++ b/submissions/react/react-notification-center-drawer-with-slide-in-realtushartyagi/NotificationCenterDrawer.jsx
@@ -1,0 +1,65 @@
+import React, { useState, useEffect } from 'react';
+
+/**
+ * NotificationCenterDrawer
+ * A sliding drawer component to display notifications using EaseMotion CSS animations.
+ *
+ * Props:
+ * - isOpen: boolean - Controls the visibility of the drawer
+ * - onClose: () => void - Callback triggered to close the drawer
+ * - notifications: Array<{ id: string, title: string, message: string, time: string, read: boolean }>
+ */
+export default function NotificationCenterDrawer({ isOpen, onClose, notifications = [] }) {
+  const [isVisible, setIsVisible] = useState(isOpen);
+  const [renderDrawer, setRenderDrawer] = useState(isOpen);
+
+  useEffect(() => {
+    if (isOpen) {
+      setRenderDrawer(true);
+      // Small delay to ensure the component is rendered before applying the slide-in class
+      setTimeout(() => setIsVisible(true), 10);
+      document.body.style.overflow = 'hidden';
+    } else {
+      setIsVisible(false);
+      // Wait for the slide-out animation to finish before unmounting
+      const timer = setTimeout(() => {
+        setRenderDrawer(false);
+        document.body.style.overflow = '';
+      }, 300);
+      return () => clearTimeout(timer);
+    }
+  }, [isOpen]);
+
+  if (!renderDrawer) return null;
+
+  return (
+    <div className="ease-drawer-backdrop" onClick={onClose}>
+      <div 
+        className={`ease-drawer-content ${isVisible ? 'ease-drawer-open' : 'ease-drawer-closed'}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="ease-drawer-header">
+          <h2>Notifications</h2>
+          <button className="ease-drawer-close-btn" onClick={onClose}>×</button>
+        </div>
+        <div className="ease-drawer-body">
+          {notifications.length === 0 ? (
+            <p className="ease-empty-state">No new notifications.</p>
+          ) : (
+            <ul className="ease-notification-list">
+              {notifications.map((notif) => (
+                <li key={notif.id} className={`ease-notification-item ${notif.read ? 'read' : 'unread'}`}>
+                  <div className="ease-notification-meta">
+                    <span className="ease-notification-title">{notif.title}</span>
+                    <span className="ease-notification-time">{notif.time}</span>
+                  </div>
+                  <p className="ease-notification-message">{notif.message}</p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/submissions/react/react-notification-center-drawer-with-slide-in-realtushartyagi/README.md
+++ b/submissions/react/react-notification-center-drawer-with-slide-in-realtushartyagi/README.md
@@ -1,0 +1,61 @@
+# React Notification Center Drawer with Slide-In
+
+A modular, copy-paste ready React component that provides a sleek off-canvas notification drawer with a smooth slide-in animation using **EaseMotion CSS**.
+
+## Files
+- `NotificationCenterDrawer.jsx` – The core React component handling state, mounting delays for animation, and rendering the notification list.
+- `style.css` – Custom EaseMotion CSS styles defining the slide-in transform, cubic-bezier timing functions, and backdrop fade.
+- `demo.html` – A standalone HTML file demonstrating the notification drawer using Babel and React CDNs.
+
+## Installation
+1. Copy the `react-notification-center-drawer-with-slide-in-realtushartyagi` folder into your project's `submissions/react/` directory.
+2. Import the component:
+   ```jsx
+   import NotificationCenterDrawer from "./NotificationCenterDrawer.jsx";
+   ```
+3. Include the stylesheet in your HTML or import it in your bundler:
+   ```html
+   <link rel="stylesheet" href="./style.css" />
+   ```
+
+## Usage
+```jsx
+import React, { useState } from 'react';
+import NotificationCenterDrawer from './NotificationCenterDrawer';
+
+function App() {
+  const [isOpen, setIsOpen] = useState(false);
+  const notifications = [
+    { id: '1', title: 'New Message', message: 'Hello there!', time: 'Now', read: false }
+  ];
+
+  return (
+    <div>
+      <button onClick={() => setIsOpen(true)}>Notifications</button>
+      
+      <NotificationCenterDrawer 
+        isOpen={isOpen} 
+        onClose={() => setIsOpen(false)}
+        notifications={notifications}
+      />
+    </div>
+  );
+}
+```
+
+## Props
+| Prop | Type | Description |
+|------|------|-------------|
+| `isOpen` | `boolean` | Determines if the drawer is visible. |
+| `onClose` | `() => void` | Callback fired when clicking the backdrop or close button. |
+| `notifications` | `Array` | Array of notification objects `{id, title, message, time, read}`. |
+
+## Why it fits EaseMotion CSS
+This component perfectly aligns with the EaseMotion philosophy by using pure CSS `transform: translateX()` and hardware-accelerated transitions to handle the heavy lifting of the slide-in animation. React is only responsible for toggling the class state and unmounting the DOM node after the transition completes, keeping the motion buttery smooth without any JS animation bloat.
+
+## Demo
+Open `demo.html` directly in a web browser—no server needed.
+
+---
+
+> **Note:** The PR should only modify files inside `submissions/react/react-notification-center-drawer-with-slide-in-realtushartyagi/`. No changes to `core/` or `components/`.

--- a/submissions/react/react-notification-center-drawer-with-slide-in-realtushartyagi/demo.html
+++ b/submissions/react/react-notification-center-drawer-with-slide-in-realtushartyagi/demo.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Notification Center Drawer with Slide-In</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="./style.css" />
+  <!-- React and Babel CDN -->
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      margin: 0;
+      padding: 40px;
+      background-color: #f3f4f6;
+      display: flex;
+      justify-content: center;
+      align-items: flex-start;
+      min-height: 100vh;
+    }
+    .trigger-btn {
+      background: #3b82f6;
+      color: white;
+      border: none;
+      padding: 12px 24px;
+      font-size: 16px;
+      border-radius: 8px;
+      cursor: pointer;
+      box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1);
+      transition: background 0.2s;
+    }
+    .trigger-btn:hover {
+      background: #2563eb;
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" data-type="module">
+    import NotificationCenterDrawer from "./NotificationCenterDrawer.jsx";
+
+    const dummyNotifications = [
+      {
+        id: "1",
+        title: "New Follower",
+        message: "Alice started following you.",
+        time: "5m ago",
+        read: false
+      },
+      {
+        id: "2",
+        title: "System Update",
+        message: "EaseMotion v2.0 is now available. Restart to apply changes.",
+        time: "1h ago",
+        read: false
+      },
+      {
+        id: "3",
+        title: "Weekly Report",
+        message: "Your weekly analytics report is ready to view.",
+        time: "2d ago",
+        read: true
+      }
+    ];
+
+    function Demo() {
+      const [isOpen, setIsOpen] = React.useState(false);
+
+      return (
+        <div>
+          <button className="trigger-btn" onClick={() => setIsOpen(true)}>
+            Open Notifications
+          </button>
+          
+          <NotificationCenterDrawer 
+            isOpen={isOpen} 
+            onClose={() => setIsOpen(false)}
+            notifications={dummyNotifications}
+          />
+        </div>
+      );
+    }
+    ReactDOM.createRoot(document.getElementById("root")).render(<Demo />);
+  </script>
+</body>
+</html>

--- a/submissions/react/react-notification-center-drawer-with-slide-in-realtushartyagi/style.css
+++ b/submissions/react/react-notification-center-drawer-with-slide-in-realtushartyagi/style.css
@@ -1,0 +1,141 @@
+/*
+  style.css
+  EaseMotion CSS – Notification Center Drawer with Slide-In
+*/
+
+:root {
+  --drawer-width: 380px;
+  --drawer-bg: #ffffff;
+  --drawer-backdrop: rgba(0, 0, 0, 0.5);
+  --text-main: #111827;
+  --text-muted: #6b7280;
+  --border-color: #e5e7eb;
+  --unread-bg: #eff6ff;
+  --unread-border: #3b82f6;
+  --transition-speed: 0.3s;
+}
+
+.ease-drawer-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: var(--drawer-backdrop);
+  z-index: 9999;
+  display: flex;
+  justify-content: flex-end;
+  /* Simple fade in for the backdrop */
+  animation: easeBackdropFadeIn var(--transition-speed) ease forwards;
+}
+
+.ease-drawer-content {
+  width: var(--drawer-width);
+  max-width: 100vw;
+  height: 100%;
+  background-color: var(--drawer-bg);
+  box-shadow: -4px 0 15px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  transform: translateX(100%);
+  transition: transform var(--transition-speed) cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.ease-drawer-open {
+  transform: translateX(0);
+}
+
+.ease-drawer-closed {
+  transform: translateX(100%);
+}
+
+.ease-drawer-header {
+  padding: 20px 24px;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.ease-drawer-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: var(--text-main);
+}
+
+.ease-drawer-close-btn {
+  background: transparent;
+  border: none;
+  font-size: 1.5rem;
+  line-height: 1;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.ease-drawer-close-btn:hover {
+  color: var(--text-main);
+}
+
+.ease-drawer-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0;
+  margin: 0;
+}
+
+.ease-empty-state {
+  padding: 40px 24px;
+  text-align: center;
+  color: var(--text-muted);
+}
+
+.ease-notification-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.ease-notification-item {
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--border-color);
+  transition: background-color 0.2s ease;
+}
+
+.ease-notification-item:hover {
+  background-color: #f9fafb;
+}
+
+.ease-notification-item.unread {
+  background-color: var(--unread-bg);
+  border-left: 4px solid var(--unread-border);
+}
+
+.ease-notification-meta {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.ease-notification-title {
+  font-weight: 600;
+  color: var(--text-main);
+  font-size: 0.95rem;
+}
+
+.ease-notification-time {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.ease-notification-message {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+@keyframes easeBackdropFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a modular, copy-paste ready React component: **Notification Center Drawer with Slide-In**. 
This component provides a sleek off-canvas notification drawer with a smooth slide-in animation from the right and a faded backdrop. It resolves issue #28216 and adheres completely to the EaseMotion CSS animation-first philosophy without relying on external JS animation libraries.

Fixes #28216

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/react/react-notification-center-drawer-with-slide-in-realtushartyagi/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A reusable React off-canvas notification drawer component with a smooth slide-in transition and backdrop fade, designed to handle dynamic lists of notifications.

**How does a developer use it?**

```html
<!-- Include the component stylesheet -->
<link rel="stylesheet" href="style.css" />

<!-- In your React application: -->
<NotificationCenterDrawer 
  isOpen={isOpen} 
  onClose={() => setIsOpen(false)}
  notifications={notificationsList}
/>
