### PR TITLE
feat: add animated background patterns showcase (#35281)

### DIFF
--- a/submissions/examples/animated-bg-patterns-gb/README.md
+++ b/submissions/examples/animated-bg-patterns-gb/README.md
@@ -1,0 +1,29 @@
+# Animated Background Patterns Showcase
+
+Resolves: #35281 — Feature Request: Add an Animated Background Patterns Showcase
+
+## What does this do?
+
+Provides five lightweight, CSS-only animated background patterns — gradient shift, floating blobs, moving grid, glow particles, and mesh glow — that can be used as section or card backgrounds.
+
+## How is it used?
+
+Apply any one pattern class to a container element:
+
+```html
+<div class="gradient-shift"></div>
+<div class="floating-blobs">
+  <span class="blob blob-1"></span>
+  <span class="blob blob-2"></span>
+  <span class="blob blob-3"></span>
+</div>
+<div class="moving-grid"></div>
+<div class="glow-particles"></div>
+<div class="mesh-glow"></div>
+```
+
+Each pattern only needs the container to have a defined height (e.g. `height: 200px` or `min-height: 100vh` for a full section background). Open `demo.html` to see all five side by side.
+
+## Why is it useful?
+
+Animated backgrounds are a common request for hero sections, cards, and landing pages, but hand-rolling them usually means picking between heavy JS particle libraries or static images. These five patterns are pure CSS (`background`, `linear-gradient`, `radial-gradient`, `filter: blur`, and `@keyframes`), so they add virtually no weight and fit EaseMotion CSS's animation-first, dependency-free philosophy. All animations pause automatically under `prefers-reduced-motion: reduce` for accessibility.

--- a/submissions/examples/animated-bg-patterns-gb/demo.html
+++ b/submissions/examples/animated-bg-patterns-gb/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Animated Background Patterns — Showcase</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="showcase-header">
+    <h1>Animated Background Patterns</h1>
+    <p>Five lightweight, CSS-only background effects. No images, no JS, no external libraries.</p>
+  </header>
+
+  <main class="showcase-grid">
+
+    <section class="pattern-card">
+      <div class="pattern gradient-shift"></div>
+      <h2>Gradient Shift</h2>
+      <code>.gradient-shift</code>
+    </section>
+
+    <section class="pattern-card">
+      <div class="pattern floating-blobs">
+        <span class="blob blob-1"></span>
+        <span class="blob blob-2"></span>
+        <span class="blob blob-3"></span>
+      </div>
+      <h2>Floating Blobs</h2>
+      <code>.floating-blobs</code>
+    </section>
+
+    <section class="pattern-card">
+      <div class="pattern moving-grid"></div>
+      <h2>Moving Grid</h2>
+      <code>.moving-grid</code>
+    </section>
+
+    <section class="pattern-card">
+      <div class="pattern glow-particles"></div>
+      <h2>Glow Particles</h2>
+      <code>.glow-particles</code>
+    </section>
+
+    <section class="pattern-card">
+      <div class="pattern mesh-glow"></div>
+      <h2>Mesh Glow</h2>
+      <code>.mesh-glow</code>
+    </section>
+
+  </main>
+
+  <p class="showcase-note">
+    All animations respect <code>prefers-reduced-motion</code> and pause automatically for users who have that setting enabled.
+  </p>
+
+</body>
+</html>

--- a/submissions/examples/animated-bg-patterns-gb/style.css
+++ b/submissions/examples/animated-bg-patterns-gb/style.css
@@ -1,0 +1,196 @@
+/* Animated Background Patterns — showcase styles
+   Five self-contained, CSS-only background effects.
+*/
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2.5rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #0f0e17;
+  color: #fffffe;
+}
+
+.showcase-header {
+  text-align: center;
+  max-width: 640px;
+  margin: 0 auto 2.5rem;
+}
+
+.showcase-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.75rem;
+}
+
+.showcase-header p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.65);
+  font-size: 0.95rem;
+}
+
+.showcase-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.75rem;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.pattern-card {
+  text-align: center;
+}
+
+.pattern-card h2 {
+  font-size: 1rem;
+  margin: 0.9rem 0 0.25rem;
+}
+
+.pattern-card code {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.pattern {
+  height: 200px;
+  border-radius: 14px;
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.showcase-note {
+  text-align: center;
+  max-width: 560px;
+  margin: 2.5rem auto 0;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+/* ── 1. Gradient Shift ────────────────────────────────────────── */
+.gradient-shift {
+  background: linear-gradient(
+    -45deg,
+    #6c63ff,
+    #ff6b9d,
+    #22d3ee,
+    #a78bfa
+  );
+  background-size: 300% 300%;
+  animation: gradientShift 8s ease infinite;
+}
+
+@keyframes gradientShift {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+
+/* ── 2. Floating Blobs ────────────────────────────────────────── */
+.floating-blobs {
+  background: #15131f;
+}
+
+.blob {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(30px);
+  opacity: 0.55;
+}
+
+.blob-1 {
+  width: 140px;
+  height: 140px;
+  background: #6c63ff;
+  top: -30px;
+  left: -20px;
+  animation: floatBlob 9s ease-in-out infinite;
+}
+
+.blob-2 {
+  width: 110px;
+  height: 110px;
+  background: #ff6b9d;
+  bottom: -20px;
+  right: 10px;
+  animation: floatBlob 11s ease-in-out infinite reverse;
+}
+
+.blob-3 {
+  width: 90px;
+  height: 90px;
+  background: #22d3ee;
+  bottom: 30px;
+  left: 40%;
+  animation: floatBlob 7s ease-in-out infinite;
+}
+
+@keyframes floatBlob {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  33% { transform: translate(30px, 20px) scale(1.1); }
+  66% { transform: translate(-20px, -15px) scale(0.95); }
+}
+
+/* ── 3. Moving Grid ───────────────────────────────────────────── */
+.moving-grid {
+  background-color: #0f0e17;
+  background-image:
+    linear-gradient(rgba(108, 99, 255, 0.35) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(108, 99, 255, 0.35) 1px, transparent 1px);
+  background-size: 32px 32px;
+  animation: gridPan 6s linear infinite;
+}
+
+@keyframes gridPan {
+  0% { background-position: 0 0; }
+  100% { background-position: 32px 32px; }
+}
+
+/* ── 4. Glow Particles ────────────────────────────────────────── */
+.glow-particles {
+  background: #0f0e17;
+  background-image:
+    radial-gradient(2px 2px at 20% 30%, #a78bfa, transparent),
+    radial-gradient(2px 2px at 70% 20%, #22d3ee, transparent),
+    radial-gradient(2px 2px at 40% 70%, #ff6b9d, transparent),
+    radial-gradient(2px 2px at 85% 65%, #6c63ff, transparent),
+    radial-gradient(2px 2px at 55% 45%, #ffffff, transparent),
+    radial-gradient(2px 2px at 10% 80%, #22d3ee, transparent);
+  background-repeat: repeat;
+  background-size: 200% 200%;
+  animation: particleDrift 14s linear infinite;
+}
+
+@keyframes particleDrift {
+  0% { background-position: 0% 0%; }
+  100% { background-position: 100% 100%; }
+}
+
+/* ── 5. Mesh Glow ─────────────────────────────────────────────── */
+.mesh-glow {
+  background-color: #0f0e17;
+  background-image:
+    radial-gradient(at 20% 30%, rgba(108, 99, 255, 0.55) 0px, transparent 50%),
+    radial-gradient(at 80% 20%, rgba(255, 107, 157, 0.5) 0px, transparent 50%),
+    radial-gradient(at 50% 80%, rgba(34, 211, 238, 0.5) 0px, transparent 50%);
+  background-size: 160% 160%;
+  animation: meshMove 10s ease-in-out infinite;
+}
+
+@keyframes meshMove {
+  0%, 100% { background-position: 0% 0%; }
+  50% { background-position: 60% 40%; }
+}
+
+/* ── Accessibility: respect reduced motion ───────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .gradient-shift,
+  .blob,
+  .moving-grid,
+  .glow-particles,
+  .mesh-glow {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
This adds a showcase for issue #35281 — five lightweight, CSS-only animated background patterns: gradient shift, floating blobs, moving grid, glow particles, and mesh glow.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Five pure-CSS animated background patterns for hero sections, cards, or full-page backgrounds.

**How does a developer use it?**
```html
<div class="gradient-shift"></div>
<div class="floating-blobs">
  <span class="blob blob-1"></span>
  <span class="blob blob-2"></span>
  <span class="blob blob-3"></span>
</div>
<div class="moving-grid"></div>
<div class="glow-particles"></div>
<div class="mesh-glow"></div>
```

**Why does it fit EaseMotion CSS?**
No JS, no images, no external libraries — just CSS gradients, blur, and keyframes, in line with the framework's animation-first, dependency-free philosophy. All animations pause under `prefers-reduced-motion`.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
All five patterns are self-contained in demo.html for easy side-by-side review.