### PR TITLE
feat: Add React Context Menu Popup with Scale & Fade Entrance (#28180)

### DIFF
--- a/submissions/react/react-context-menu-popup-with-scale-fade-entrance-realtushartyagi-28180/ContextMenuPopup.jsx
+++ b/submissions/react/react-context-menu-popup-with-scale-fade-entrance-realtushartyagi-28180/ContextMenuPopup.jsx
@@ -1,0 +1,70 @@
+import React, { useState, useEffect, useRef } from 'react';
+
+/**
+ * ContextMenuPopup
+ * A right-click (or trigger button) context menu with a CSS scale & fade
+ * entrance animation powered by EaseMotion CSS.
+ *
+ * Props:
+ * - items: Array<{ label: string, icon?: string, onClick: () => void, danger?: boolean }>
+ * - children: ReactNode - The target element that triggers the context menu on right-click.
+ */
+export default function ContextMenuPopup({ items = [], children }) {
+  const [visible, setVisible] = useState(false);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const menuRef = useRef(null);
+
+  const handleContextMenu = (e) => {
+    e.preventDefault();
+    setVisible(true);
+    setPosition({ x: e.clientX, y: e.clientY });
+  };
+
+  const handleClose = () => setVisible(false);
+
+  useEffect(() => {
+    const onClickOutside = (e) => {
+      if (menuRef.current && !menuRef.current.contains(e.target)) {
+        handleClose();
+      }
+    };
+    if (visible) {
+      document.addEventListener('mousedown', onClickOutside);
+      document.addEventListener('scroll', handleClose, true);
+    }
+    return () => {
+      document.removeEventListener('mousedown', onClickOutside);
+      document.removeEventListener('scroll', handleClose, true);
+    };
+  }, [visible]);
+
+  return (
+    <>
+      <div onContextMenu={handleContextMenu} className="ease-ctx-target">
+        {children}
+      </div>
+
+      {visible && (
+        <ul
+          ref={menuRef}
+          className="ease-ctx-menu"
+          style={{ top: position.y, left: position.x }}
+        >
+          {items.map((item, idx) => (
+            <li
+              key={idx}
+              className={`ease-ctx-item ${item.danger ? 'ease-ctx-item--danger' : ''}`}
+              onClick={() => {
+                item.onClick?.();
+                handleClose();
+              }}
+            >
+              {item.icon && <span className="ease-ctx-icon">{item.icon}</span>}
+              {item.label}
+            </li>
+          ))}
+        </ul>
+      )}
+    </>
+  );
+}

--- a/submissions/react/react-context-menu-popup-with-scale-fade-entrance-realtushartyagi-28180/README.md
+++ b/submissions/react/react-context-menu-popup-with-scale-fade-entrance-realtushartyagi-28180/README.md
@@ -1,0 +1,64 @@
+# React Context Menu Popup with Scale & Fade Entrance
+
+A modular, copy-paste ready React component that renders a right-click context menu with a smooth CSS scale and fade entrance animation using **EaseMotion CSS**.
+
+## Files
+- `ContextMenuPopup.jsx` – Core React component handling right-click positioning, outside-click dismissal, and item rendering.
+- `style.css` – EaseMotion CSS styles with the `easeCtxScaleFadeIn` keyframe (`scale(0.92)` → `scale(1)` + `opacity`) and hover states.
+- `demo.html` – Standalone HTML demo using Babel and React CDNs — no server required.
+
+## Installation
+1. Copy the folder into your project.
+2. Import the component:
+   ```jsx
+   import ContextMenuPopup from "./ContextMenuPopup.jsx";
+   ```
+3. Link the stylesheet:
+   ```html
+   <link rel="stylesheet" href="./style.css" />
+   ```
+
+## Usage
+```jsx
+import React from 'react';
+import ContextMenuPopup from './ContextMenuPopup';
+
+const menuItems = [
+  { label: "Edit",   icon: "✏️", onClick: () => console.log("edit") },
+  { label: "Delete", icon: "🗑️", onClick: () => console.log("delete"), danger: true },
+];
+
+function App() {
+  return (
+    <ContextMenuPopup items={menuItems}>
+      <div style={{ padding: 40, border: "2px dashed #ccc" }}>
+        Right-click me
+      </div>
+    </ContextMenuPopup>
+  );
+}
+```
+
+## Props
+| Prop | Type | Description |
+|------|------|-------------|
+| `items` | `Array` | Menu items: `{ label, icon?, onClick, danger? }`. |
+| `children` | `ReactNode` | The wrapped element that listens for right-click events. |
+
+## Item Shape
+| Field | Type | Description |
+|-------|------|-------------|
+| `label` | `string` | Text shown in the menu item. |
+| `icon` | `string` | Optional emoji or character icon. |
+| `onClick` | `() => void` | Callback when item is clicked. |
+| `danger` | `boolean` | Renders the item in red for destructive actions. |
+
+## Why it fits EaseMotion CSS
+The entrance animation is driven entirely by a CSS `@keyframes` rule (`easeCtxScaleFadeIn`) using `transform: scale()` and `opacity`. React only manages the menu's visibility state and DOM position — no JS animation libraries needed.
+
+## Demo
+Open `demo.html` directly in a browser — no server needed.
+
+---
+
+> **Note:** PR modifies only files inside `submissions/react/react-context-menu-popup-with-scale-fade-entrance-realtushartyagi-28180/`. No changes to `core/` or `components/`.

--- a/submissions/react/react-context-menu-popup-with-scale-fade-entrance-realtushartyagi-28180/demo.html
+++ b/submissions/react/react-context-menu-popup-with-scale-fade-entrance-realtushartyagi-28180/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Context Menu Popup with Scale & Fade Entrance</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="./style.css" />
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      margin: 0; padding: 60px;
+      background: #f3f4f6;
+      display: flex; justify-content: center; align-items: flex-start; min-height: 100vh;
+    }
+    .demo-area {
+      width: 400px; height: 220px;
+      background: #fff;
+      border: 2px dashed #d1d5db;
+      border-radius: 12px;
+      display: flex; align-items: center; justify-content: center;
+      color: #6b7280; font-size: 0.95rem; user-select: none;
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" data-type="module">
+    import ContextMenuPopup from "./ContextMenuPopup.jsx";
+
+    const menuItems = [
+      { label: "Edit",     icon: "✏️", onClick: () => alert("Edit clicked") },
+      { label: "Duplicate",icon: "📋", onClick: () => alert("Duplicate clicked") },
+      { label: "Share",    icon: "🔗", onClick: () => alert("Share clicked") },
+      { label: "Delete",   icon: "🗑️", onClick: () => alert("Delete clicked"), danger: true },
+    ];
+
+    function Demo() {
+      return (
+        <ContextMenuPopup items={menuItems}>
+          <div className="demo-area">
+            🖱️ Right-click anywhere here to open the context menu
+          </div>
+        </ContextMenuPopup>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById("root")).render(<Demo />);
+  </script>
+</body>
+</html>

--- a/submissions/react/react-context-menu-popup-with-scale-fade-entrance-realtushartyagi-28180/style.css
+++ b/submissions/react/react-context-menu-popup-with-scale-fade-entrance-realtushartyagi-28180/style.css
@@ -1,0 +1,78 @@
+/*
+  style.css
+  EaseMotion CSS – Context Menu Popup with Scale & Fade Entrance (#28180)
+*/
+
+:root {
+  --ctx-bg: #ffffff;
+  --ctx-border: #e5e7eb;
+  --ctx-shadow: 0 8px 24px rgba(0, 0, 0, 0.12), 0 2px 6px rgba(0, 0, 0, 0.06);
+  --ctx-text: #1f2937;
+  --ctx-hover-bg: #f3f4f6;
+  --ctx-danger: #ef4444;
+  --ctx-danger-bg: #fef2f2;
+  --ctx-radius: 8px;
+  --ctx-speed: 0.18s;
+}
+
+.ease-ctx-target {
+  display: inline-block;
+}
+
+.ease-ctx-menu {
+  position: fixed;
+  z-index: 9999;
+  list-style: none;
+  margin: 0;
+  padding: 6px;
+  background: var(--ctx-bg);
+  border: 1px solid var(--ctx-border);
+  border-radius: var(--ctx-radius);
+  box-shadow: var(--ctx-shadow);
+  min-width: 180px;
+  /* Scale & Fade entrance */
+  transform-origin: top left;
+  animation: easeCtxScaleFadeIn var(--ctx-speed) cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+.ease-ctx-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 14px;
+  font-size: 0.9rem;
+  color: var(--ctx-text);
+  border-radius: 6px;
+  cursor: pointer;
+  user-select: none;
+  transition: background var(--ctx-speed) ease;
+}
+
+.ease-ctx-item:hover {
+  background: var(--ctx-hover-bg);
+}
+
+.ease-ctx-item--danger {
+  color: var(--ctx-danger);
+}
+
+.ease-ctx-item--danger:hover {
+  background: var(--ctx-danger-bg);
+}
+
+.ease-ctx-icon {
+  font-size: 1rem;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+@keyframes easeCtxScaleFadeIn {
+  from {
+    opacity: 0;
+    transform: scale(0.92);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a modular, copy-paste ready React component: **Context Menu Popup with Scale & Fade Entrance**.  
This component renders a right-click context menu that appears with a smooth CSS scale and fade entrance animation, resolving issue #28180. Supports custom items, icons, and danger styling — zero external JS animation dependencies.

Fixes #28180

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/react/react-context-menu-popup-with-scale-fade-entrance-realtushartyagi-28180/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A reusable React context menu component that appears on right-click with a smooth scale and fade entrance animation, supporting configurable menu items with optional icons and danger states.

**How does a developer use it?**

```html
<!-- Include the component stylesheet -->
<link rel="stylesheet" href="style.css" />

<!-- In your React application: -->
<ContextMenuPopup items={[
  { label: "Edit",   icon: "✏️", onClick: () => {} },
  { label: "Delete", icon: "🗑️", onClick: () => {}, danger: true },
]}>
  <div>Right-click me</div>
</ContextMenuPopup>
