### PR TITLE
feat: Add React Notification Center Drawer with Slide-In (#28156)

### DIFF
--- a/submissions/react/react-notification-center-drawer-with-slide-in-realtushartyagi-28156/NotificationDrawer.jsx
+++ b/submissions/react/react-notification-center-drawer-with-slide-in-realtushartyagi-28156/NotificationDrawer.jsx
@@ -1,0 +1,72 @@
+import React, { useState, useEffect } from 'react';
+
+/**
+ * NotificationDrawer
+ * A sliding off-canvas notification center drawer with smooth EaseMotion CSS
+ * slide-in and slide-out transitions.
+ *
+ * Props:
+ * - isOpen: boolean - Controls the visibility of the drawer.
+ * - onClose: () => void - Callback to close the drawer.
+ * - notifications: Array<{ id, title, message, time, read }> - List of notifications.
+ */
+export default function NotificationDrawer({ isOpen, onClose, notifications = [] }) {
+  const [isVisible, setIsVisible] = useState(false);
+  const [renderDrawer, setRenderDrawer] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setRenderDrawer(true);
+      setTimeout(() => setIsVisible(true), 10);
+      document.body.style.overflow = 'hidden';
+    } else {
+      setIsVisible(false);
+      const timer = setTimeout(() => {
+        setRenderDrawer(false);
+        document.body.style.overflow = '';
+      }, 300);
+      return () => clearTimeout(timer);
+    }
+  }, [isOpen]);
+
+  const unreadCount = notifications.filter((n) => !n.read).length;
+
+  if (!renderDrawer) return null;
+
+  return (
+    <div className="ease-nd-backdrop" onClick={onClose}>
+      <div
+        className={`ease-nd-panel ${isVisible ? 'ease-nd-panel--open' : ''}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="ease-nd-header">
+          <div className="ease-nd-title-wrap">
+            <h2 className="ease-nd-title">Notifications</h2>
+            {unreadCount > 0 && (
+              <span className="ease-nd-badge">{unreadCount}</span>
+            )}
+          </div>
+          <button className="ease-nd-close" onClick={onClose} aria-label="Close">×</button>
+        </div>
+
+        <div className="ease-nd-body">
+          {notifications.length === 0 ? (
+            <p className="ease-nd-empty">You're all caught up!</p>
+          ) : (
+            <ul className="ease-nd-list">
+              {notifications.map((n) => (
+                <li key={n.id} className={`ease-nd-item ${n.read ? '' : 'ease-nd-item--unread'}`}>
+                  <div className="ease-nd-item-header">
+                    <span className="ease-nd-item-title">{n.title}</span>
+                    <span className="ease-nd-item-time">{n.time}</span>
+                  </div>
+                  <p className="ease-nd-item-msg">{n.message}</p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/submissions/react/react-notification-center-drawer-with-slide-in-realtushartyagi-28156/README.md
+++ b/submissions/react/react-notification-center-drawer-with-slide-in-realtushartyagi-28156/README.md
@@ -1,0 +1,57 @@
+# React Notification Center Drawer with Slide-In
+
+A modular, copy-paste ready React component providing an off-canvas notification center drawer with a smooth slide-in animation and backdrop fade, powered by **EaseMotion CSS**.
+
+## Files
+- `NotificationDrawer.jsx` – Core React component managing mount/unmount timing and notification rendering.
+- `style.css` – EaseMotion CSS styles: `translateX` slide-in, `cubic-bezier` timing, backdrop fade, and unread accent styling.
+- `demo.html` – Standalone HTML demo using Babel and React CDNs — no server required.
+
+## Installation
+1. Copy the folder into your project.
+2. Import the component:
+   ```jsx
+   import NotificationDrawer from "./NotificationDrawer.jsx";
+   ```
+3. Link the stylesheet:
+   ```html
+   <link rel="stylesheet" href="./style.css" />
+   ```
+
+## Usage
+```jsx
+import React, { useState } from 'react';
+import NotificationDrawer from './NotificationDrawer';
+
+const notifications = [
+  { id: "1", title: "New Message", message: "You have a new DM.", time: "2m ago", read: false },
+  { id: "2", title: "Weekly Report", message: "Your report is ready.", time: "1h ago", read: true },
+];
+
+function App() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Notifications</button>
+      <NotificationDrawer isOpen={open} onClose={() => setOpen(false)} notifications={notifications} />
+    </>
+  );
+}
+```
+
+## Props
+| Prop | Type | Description |
+|------|------|-------------|
+| `isOpen` | `boolean` | Controls whether the drawer is visible. |
+| `onClose` | `() => void` | Callback fired on backdrop click or close button. |
+| `notifications` | `Array` | Items: `{ id, title, message, time, read }`. |
+
+## Why it fits EaseMotion CSS
+All motion is CSS-first: the panel uses `transform: translateX(100%)` → `translateX(0)` with a `cubic-bezier(0.16, 1, 0.3, 1)` transition. The backdrop fades via a CSS `@keyframes` animation. React handles only the mount timing and state — no JS animation libraries.
+
+## Demo
+Open `demo.html` directly in a browser — no server needed.
+
+---
+
+> **Note:** PR modifies only files inside `submissions/react/react-notification-center-drawer-with-slide-in-realtushartyagi-28156/`. No changes to `core/` or `components/`.

--- a/submissions/react/react-notification-center-drawer-with-slide-in-realtushartyagi-28156/demo.html
+++ b/submissions/react/react-notification-center-drawer-with-slide-in-realtushartyagi-28156/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Notification Center Drawer with Slide-In</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="./style.css" />
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      margin: 0; padding: 40px;
+      background: #f3f4f6;
+      display: flex; justify-content: center; align-items: flex-start; min-height: 100vh;
+    }
+    .trigger-btn {
+      background: #3b82f6; color: #fff; border: none;
+      padding: 12px 24px; font-size: 1rem; border-radius: 8px;
+      cursor: pointer; transition: background 0.2s;
+    }
+    .trigger-btn:hover { background: #2563eb; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" data-type="module">
+    import NotificationDrawer from "./NotificationDrawer.jsx";
+
+    const demoNotifications = [
+      { id: "1", title: "New Message", message: "Sarah sent you a direct message.", time: "2m ago", read: false },
+      { id: "2", title: "Deployment Success", message: "Your build was deployed to production.", time: "15m ago", read: false },
+      { id: "3", title: "Weekly Summary", message: "Your analytics report for the week is ready.", time: "2h ago", read: true },
+      { id: "4", title: "Comment on PR #42", message: "Alex left a review on your pull request.", time: "1d ago", read: true },
+    ];
+
+    function Demo() {
+      const [open, setOpen] = React.useState(false);
+      return (
+        <div>
+          <button className="trigger-btn" onClick={() => setOpen(true)}>
+            Open Notifications (2 unread)
+          </button>
+          <NotificationDrawer
+            isOpen={open}
+            onClose={() => setOpen(false)}
+            notifications={demoNotifications}
+          />
+        </div>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById("root")).render(<Demo />);
+  </script>
+</body>
+</html>

--- a/submissions/react/react-notification-center-drawer-with-slide-in-realtushartyagi-28156/style.css
+++ b/submissions/react/react-notification-center-drawer-with-slide-in-realtushartyagi-28156/style.css
@@ -1,0 +1,147 @@
+/*
+  style.css
+  EaseMotion CSS – Notification Center Drawer with Slide-In (#28156)
+*/
+
+:root {
+  --nd-width: 380px;
+  --nd-bg: #ffffff;
+  --nd-backdrop: rgba(0, 0, 0, 0.45);
+  --nd-border: #e5e7eb;
+  --nd-text: #111827;
+  --nd-muted: #6b7280;
+  --nd-unread-bg: #eff6ff;
+  --nd-unread-accent: #3b82f6;
+  --nd-speed: 0.3s;
+}
+
+.ease-nd-backdrop {
+  position: fixed;
+  inset: 0;
+  background: var(--nd-backdrop);
+  z-index: 9999;
+  display: flex;
+  justify-content: flex-end;
+  animation: easeNdFadeIn var(--nd-speed) ease forwards;
+}
+
+.ease-nd-panel {
+  width: var(--nd-width);
+  max-width: 100vw;
+  height: 100%;
+  background: var(--nd-bg);
+  box-shadow: -4px 0 20px rgba(0, 0, 0, 0.12);
+  display: flex;
+  flex-direction: column;
+  transform: translateX(100%);
+  transition: transform var(--nd-speed) cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.ease-nd-panel--open {
+  transform: translateX(0);
+}
+
+.ease-nd-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 24px;
+  border-bottom: 1px solid var(--nd-border);
+}
+
+.ease-nd-title-wrap {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.ease-nd-title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--nd-text);
+}
+
+.ease-nd-badge {
+  background: var(--nd-unread-accent);
+  color: #fff;
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 2px 7px;
+  border-radius: 9999px;
+}
+
+.ease-nd-close {
+  background: transparent;
+  border: none;
+  font-size: 1.6rem;
+  line-height: 1;
+  color: var(--nd-muted);
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.ease-nd-close:hover {
+  color: var(--nd-text);
+}
+
+.ease-nd-body {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.ease-nd-empty {
+  text-align: center;
+  color: var(--nd-muted);
+  margin-top: 48px;
+}
+
+.ease-nd-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.ease-nd-item {
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--nd-border);
+  transition: background 0.2s;
+}
+
+.ease-nd-item:hover {
+  background: #f9fafb;
+}
+
+.ease-nd-item--unread {
+  background: var(--nd-unread-bg);
+  border-left: 4px solid var(--nd-unread-accent);
+}
+
+.ease-nd-item-header {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+
+.ease-nd-item-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--nd-text);
+}
+
+.ease-nd-item-time {
+  font-size: 0.78rem;
+  color: var(--nd-muted);
+}
+
+.ease-nd-item-msg {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--nd-muted);
+  line-height: 1.5;
+}
+
+@keyframes easeNdFadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a modular, copy-paste ready React component: **Notification Center Drawer with Slide-In**.  
This component provides an off-canvas side drawer for displaying notifications with a smooth CSS slide-in animation and a fading backdrop, resolving issue #28156. Zero external JS animation dependencies.

Fixes #28156

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/react/react-notification-center-drawer-with-slide-in-realtushartyagi-28156/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A reusable React off-canvas notification drawer component that supports sliding in from the right side, fading backdrops, closing on click outside, and dynamic rendering of unread/read states.

**How does a developer use it?**

```html
<!-- Include the component stylesheet -->
<link rel="stylesheet" href="style.css" />

<!-- In your React application: -->
<NotificationDrawer 
  isOpen={isOpen} 
  onClose={() => setIsOpen(false)} 
  notifications={myNotificationsArray} 
/>
