### PR TITLE
feat: add reusable React command palette component

### DIFF
--- a/submissions/react/35318-command-palette-dp/CommandPalette.jsx
+++ b/submissions/react/35318-command-palette-dp/CommandPalette.jsx
@@ -1,0 +1,324 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+const DEFAULT_COMMANDS = [
+  { id: "new-file", label: "New File", group: "General", shortcut: "Ctrl N" },
+  {
+    id: "new-window",
+    label: "New Window",
+    group: "General",
+    shortcut: "Ctrl Shift N",
+  },
+  {
+    id: "open-settings",
+    label: "Open Settings",
+    group: "General",
+    shortcut: "Ctrl ,",
+  },
+  { id: "toggle-theme", label: "Toggle Theme", group: "Appearance" },
+  { id: "zoom-in", label: "Zoom In", group: "Appearance", shortcut: "Ctrl +" },
+  {
+    id: "zoom-out",
+    label: "Zoom Out",
+    group: "Appearance",
+    shortcut: "Ctrl -",
+  },
+  {
+    id: "go-to-file",
+    label: "Go to File...",
+    group: "Navigation",
+    shortcut: "Ctrl P",
+  },
+  {
+    id: "go-to-line",
+    label: "Go to Line...",
+    group: "Navigation",
+    shortcut: "Ctrl G",
+  },
+];
+
+function groupCommands(commands) {
+  const groups = new Map();
+  commands.forEach((command) => {
+    const groupName = command.group || "Other";
+    if (!groups.has(groupName)) groups.set(groupName, []);
+    groups.get(groupName).push(command);
+  });
+  return groups;
+}
+
+function matchesQuery(command, query) {
+  if (!query) return true;
+  const haystack = [command.label, command.group, ...(command.keywords || [])]
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes(query.toLowerCase());
+}
+
+export default function CommandPalette({
+  commands = DEFAULT_COMMANDS,
+  placeholder = "Search commands...",
+  title = "Command Palette",
+  emptyMessage = "No matching commands found.",
+  shortcutEnabled = true,
+  onSelect = () => {},
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isClosing, setIsClosing] = useState(false);
+  const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const triggerRef = useRef(null);
+  const inputRef = useRef(null);
+  const listRef = useRef(null);
+
+  const baseId = useId();
+  const dialogId = `${baseId}-dialog`;
+  const dialogTitleId = `${baseId}-title`;
+  const listboxId = `${baseId}-listbox`;
+
+  const filteredCommands = useMemo(
+    () => commands.filter((command) => matchesQuery(command, query)),
+    [commands, query]
+  );
+
+  const groupedCommands = useMemo(
+    () => groupCommands(filteredCommands),
+    [filteredCommands]
+  );
+
+  const activeCommand = filteredCommands[activeIndex] || null;
+
+  const openPalette = useCallback(() => {
+    setQuery("");
+    setActiveIndex(0);
+    setIsClosing(false);
+    setIsOpen(true);
+  }, []);
+
+  const closePalette = useCallback(() => {
+    setIsClosing(true);
+  }, []);
+
+  const handleOverlayAnimationEnd = useCallback(
+    (event) => {
+      if (event.target !== event.currentTarget) return;
+      if (isClosing) {
+        setIsOpen(false);
+        setIsClosing(false);
+        triggerRef.current?.focus();
+      }
+    },
+    [isClosing]
+  );
+
+  useEffect(() => {
+    if (isOpen && !isClosing) {
+      inputRef.current?.focus();
+    }
+  }, [isOpen, isClosing]);
+
+  useEffect(() => {
+    if (!shortcutEnabled) return undefined;
+
+    function handleGlobalKeyDown(event) {
+      const isShortcut =
+        (event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k";
+      if (isShortcut) {
+        event.preventDefault();
+        setIsOpen((current) => {
+          if (current) return current;
+          openPalette();
+          return true;
+        });
+      }
+    }
+
+    window.addEventListener("keydown", handleGlobalKeyDown);
+    return () => window.removeEventListener("keydown", handleGlobalKeyDown);
+  }, [shortcutEnabled, openPalette]);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [query]);
+
+  useEffect(() => {
+    if (!activeCommand || !listRef.current) return;
+    const activeEl = listRef.current.querySelector(
+      `[data-command-id="${activeCommand.id}"]`
+    );
+    activeEl?.scrollIntoView({ block: "nearest" });
+  }, [activeCommand]);
+
+  function moveActiveIndex(direction) {
+    if (filteredCommands.length === 0) return;
+    setActiveIndex((current) => {
+      const next =
+        (current + direction + filteredCommands.length) %
+        filteredCommands.length;
+      return next;
+    });
+  }
+
+  function handleSelect(command) {
+    if (!command) return;
+    onSelect(command);
+    closePalette();
+  }
+
+  function handleKeyDown(event) {
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        moveActiveIndex(1);
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        moveActiveIndex(-1);
+        break;
+      case "Tab":
+        event.preventDefault();
+        moveActiveIndex(event.shiftKey ? -1 : 1);
+        break;
+      case "Enter":
+        event.preventDefault();
+        handleSelect(activeCommand);
+        break;
+      case "Escape":
+        event.preventDefault();
+        closePalette();
+        break;
+      default:
+        break;
+    }
+  }
+
+  let renderedIndex = -1;
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        className="command-palette-trigger"
+        aria-haspopup="dialog"
+        aria-expanded={isOpen}
+        aria-controls={isOpen ? dialogId : undefined}
+        onClick={openPalette}
+      >
+        <span>Open Command Palette</span>
+        {shortcutEnabled && (
+          <span className="command-palette-trigger-hint" aria-hidden="true">
+            Ctrl K
+          </span>
+        )}
+      </button>
+
+      {(isOpen || isClosing) && (
+        <div
+          className={`command-palette-overlay${isClosing ? " is-closing" : ""}`}
+          onAnimationEnd={handleOverlayAnimationEnd}
+          onMouseDown={(event) => {
+            if (event.target === event.currentTarget) closePalette();
+          }}
+        >
+          <div
+            id={dialogId}
+            className={`command-palette${isClosing ? " is-closing" : ""}`}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={dialogTitleId}
+          >
+            <h2 id={dialogTitleId} className="command-palette-title">
+              {title}
+            </h2>
+
+            <div className="command-palette-search">
+              <input
+                ref={inputRef}
+                type="text"
+                className="command-palette-input"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder={placeholder}
+                role="combobox"
+                aria-expanded={isOpen}
+                aria-controls={listboxId}
+                aria-autocomplete="list"
+                aria-activedescendant={
+                  activeCommand
+                    ? `${listboxId}-option-${activeCommand.id}`
+                    : undefined
+                }
+                autoComplete="off"
+                spellCheck="false"
+              />
+            </div>
+
+            <div
+              id={listboxId}
+              ref={listRef}
+              role="listbox"
+              aria-label={title}
+              className="command-palette-list"
+            >
+              {filteredCommands.length === 0 && (
+                <p className="command-palette-empty">{emptyMessage}</p>
+              )}
+
+              {Array.from(groupedCommands.entries()).map(
+                ([groupName, items]) => (
+                  <div
+                    className="command-palette-group"
+                    role="group"
+                    aria-label={groupName}
+                    key={groupName}
+                  >
+                    <p className="command-palette-group-label">{groupName}</p>
+                    {items.map((command) => {
+                      renderedIndex += 1;
+                      const optionIndex = renderedIndex;
+                      const isActive = optionIndex === activeIndex;
+                      return (
+                        <div
+                          key={command.id}
+                          id={`${listboxId}-option-${command.id}`}
+                          data-command-id={command.id}
+                          role="option"
+                          aria-selected={isActive}
+                          tabIndex={-1}
+                          className={`command-palette-option${isActive ? " is-active" : ""}`}
+                          onMouseEnter={() => setActiveIndex(optionIndex)}
+                          onClick={() => handleSelect(command)}
+                        >
+                          <span className="command-palette-option-label">
+                            {command.label}
+                          </span>
+                          {command.shortcut && (
+                            <span
+                              className="command-palette-option-shortcut"
+                              aria-hidden="true"
+                            >
+                              {command.shortcut}
+                            </span>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                )
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/submissions/react/35318-command-palette-dp/README.md
+++ b/submissions/react/35318-command-palette-dp/README.md
@@ -1,0 +1,55 @@
+# Command Palette
+
+## 1. What does this do?
+
+This submission provides a reusable React Command Palette component inspired by modern productivity applications such as VS Code, GitHub, and Linear. It features searchable commands, grouped results, keyboard-first navigation, smooth animations, and accessible interactions, making it easy to integrate into a wide range of React applications.
+
+---
+
+## 2. How is it used?
+
+Import the component and its stylesheet into your React project, then pass a list of commands through the `commands` prop. Configure optional props such as the title, placeholder text, keyboard shortcut support, and command selection handler. The component automatically manages searching, filtering, keyboard navigation, focus management, and command selection.
+
+```jsx
+import CommandPalette from "./CommandPalette";
+import "./style.css";
+
+const commands = [
+  {
+    id: "dashboard",
+    label: "Go to Dashboard",
+    group: "Navigation",
+    shortcut: "Ctrl + D",
+  },
+  {
+    id: "settings",
+    label: "Open Settings",
+    group: "General",
+  },
+  {
+    id: "theme",
+    label: "Toggle Theme",
+    group: "Appearance",
+  },
+];
+
+export default function App() {
+  return (
+    <CommandPalette
+      commands={commands}
+      title="Quick Actions"
+      placeholder="Search commands..."
+      shortcutEnabled
+      onSelect={(command) => console.log(command.id)}
+    />
+  );
+}
+```
+
+The component supports real-time search, grouped commands, keyboard shortcuts (`Ctrl + K` / `⌘ + K`), arrow key navigation, Enter to execute commands, Escape to close the palette, responsive layouts, and customizable styling through the accompanying `style.css`.
+
+---
+
+## 3. Why is it useful?
+
+Command palettes have become a standard interaction pattern in modern applications because they allow users to quickly search and execute actions without navigating through multiple menus. This component demonstrates a lightweight, accessible, and reusable implementation built with React and CSS only, making it suitable for dashboards, developer tools, admin panels, documentation sites, and other productivity-focused interfaces while aligning with EaseMotion CSS's goal of providing modern, practical, and reusable UI components.

--- a/submissions/react/35318-command-palette-dp/style.css
+++ b/submissions/react/35318-command-palette-dp/style.css
@@ -1,0 +1,266 @@
+:root {
+  --command-palette-bg: rgba(20, 22, 34, 0.75);
+  --command-palette-border: rgba(255, 255, 255, 0.14);
+  --command-palette-shadow: rgba(0, 0, 0, 0.5);
+
+  --command-palette-text: #f5f6fb;
+  --command-palette-text-secondary: rgba(245, 246, 251, 0.62);
+  --command-palette-text-muted: rgba(245, 246, 251, 0.4);
+
+  --command-palette-accent: #7c9cff;
+  --command-palette-active-bg: rgba(124, 156, 255, 0.16);
+
+  --command-palette-radius-lg: 16px;
+  --command-palette-radius-md: 10px;
+
+  --command-palette-duration: 180ms;
+}
+
+.command-palette-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
+    Arial, sans-serif;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--command-palette-text);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--command-palette-border);
+  border-radius: 999px;
+  padding: 10px 18px;
+  cursor: pointer;
+  transition:
+    background var(--command-palette-duration) ease,
+    transform var(--command-palette-duration) ease;
+}
+
+.command-palette-trigger:hover {
+  background: rgba(255, 255, 255, 0.1);
+  transform: translateY(-1px);
+}
+
+.command-palette-trigger:focus {
+  outline: none;
+}
+
+.command-palette-trigger:focus-visible {
+  outline: 3px solid var(--command-palette-accent);
+  outline-offset: 3px;
+}
+
+.command-palette-trigger-hint {
+  font-size: 0.75rem;
+  padding: 2px 8px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--command-palette-text-secondary);
+}
+
+.command-palette-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 12vh 20px 20px;
+  background: rgba(5, 6, 12, 0.55);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  z-index: 1000;
+  animation: command-palette-overlay-in var(--command-palette-duration) ease
+    forwards;
+}
+
+.command-palette-overlay.is-closing {
+  animation: command-palette-overlay-out var(--command-palette-duration) ease
+    forwards;
+}
+
+.command-palette {
+  width: 100%;
+  max-width: 560px;
+  max-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--command-palette-bg);
+  border: 1px solid var(--command-palette-border);
+  border-radius: var(--command-palette-radius-lg);
+  box-shadow: 0 24px 60px var(--command-palette-shadow);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
+    Arial, sans-serif;
+  color: var(--command-palette-text);
+  overflow: hidden;
+  animation: command-palette-panel-in var(--command-palette-duration)
+    cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.command-palette.is-closing {
+  animation: command-palette-panel-out var(--command-palette-duration) ease
+    forwards;
+}
+
+.command-palette-title {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.command-palette-search {
+  border-bottom: 1px solid var(--command-palette-border);
+  padding: 4px 6px;
+}
+
+.command-palette-input {
+  width: 100%;
+  background: transparent;
+  border: none;
+  color: var(--command-palette-text);
+  font-size: 1.05rem;
+  padding: 16px 14px;
+  font-family: inherit;
+}
+
+.command-palette-input::placeholder {
+  color: var(--command-palette-text-muted);
+}
+
+.command-palette-input:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.command-palette-input:focus-visible {
+  outline: 2px solid var(--command-palette-accent);
+  outline-offset: 2px;
+}
+
+.command-palette-list {
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.command-palette-group {
+  margin-bottom: 6px;
+}
+
+.command-palette-group-label {
+  margin: 10px 10px 6px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--command-palette-text-muted);
+}
+
+.command-palette-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: var(--command-palette-radius-md);
+  font-size: 0.92rem;
+  cursor: pointer;
+  transition: background var(--command-palette-duration) ease;
+}
+
+.command-palette-option.is-active {
+  background: var(--command-palette-active-bg);
+}
+
+.command-palette-option-label {
+  color: var(--command-palette-text);
+}
+
+.command-palette-option-shortcut {
+  font-size: 0.75rem;
+  color: var(--command-palette-text-muted);
+  padding: 2px 8px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.06);
+  white-space: nowrap;
+}
+
+.command-palette-empty {
+  padding: 32px 16px;
+  text-align: center;
+  color: var(--command-palette-text-secondary);
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+@keyframes command-palette-overlay-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes command-palette-overlay-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes command-palette-panel-in {
+  from {
+    opacity: 0;
+    transform: translateY(-12px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes command-palette-panel-out {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-8px) scale(0.98);
+  }
+}
+
+@media (max-width: 480px) {
+  .command-palette-overlay {
+    padding: 6vh 12px 12px;
+  }
+
+  .command-palette {
+    max-height: 80vh;
+  }
+
+  .command-palette-input {
+    font-size: 1rem;
+    padding: 14px 12px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .command-palette-overlay,
+  .command-palette,
+  .command-palette-trigger,
+  .command-palette-option {
+    animation: none !important;
+    transition: none !important;
+  }
+
+  .command-palette-trigger:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a reusable React Command Palette component under the React submissions track. The component is designed to provide a modern, keyboard-first command interface inspired by applications such as VS Code, GitHub, and Linear while remaining lightweight, accessible, and dependency-free.

### Type of Change

- [x] New React component
- [x] Documentation improvement
- [ ] Bug fix
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/react/`
- [x] Includes `CommandPalette.jsx`
- [x] Includes `README.md`
- [x] Includes `style.css`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] No unrelated files modified
- [x] One feature per PR

---

## Feature Overview

This submission provides a reusable React Command Palette component with:

- Searchable and grouped command list
- Keyboard shortcuts (`Ctrl + K` / `⌘ + K`)
- Arrow key and Tab navigation
- Enter to execute commands
- Escape to close the palette
- Accessible ARIA roles and focus management
- Responsive layout
- Smooth open and close animations
- Glassmorphism-inspired UI
- CSS variables for easy customization
- No external dependencies

---

## Files Added

```text
submissions/react/command-palette-dp/
├── CommandPalette.jsx
├── style.css
└── README.md
```

---

## Why is this useful?

Command palettes have become a common interaction pattern in modern applications because they allow users to quickly search and execute actions from a single interface. This reusable React component demonstrates an accessible, customizable, and lightweight implementation that can be integrated into dashboards, admin panels, documentation sites, developer tools, and other productivity-focused applications.

---

Closes #35318 