### PR TITLE
feat: Add React Context Menu Popup with Scale & Fade Entrance (#28150)

### DIFF
--- a/submissions/react/react-context-menu-popup-with-scale-fade-entrance-realtushartyagi-28150/ContextMenu.jsx
+++ b/submissions/react/react-context-menu-popup-with-scale-fade-entrance-realtushartyagi-28150/ContextMenu.jsx
@@ -1,0 +1,82 @@
+import React, { useState, useEffect, useRef } from 'react';
+
+/**
+ * ContextMenu
+ * A scale-and-fade animated popup menu that positions itself at the cursor,
+ * using EaseMotion CSS for the entrance animation.
+ *
+ * Props:
+ * - isOpen: boolean - visibility state of the menu
+ * - position: { x: number, y: number } - coordinates to spawn the menu
+ * - onClose: () => void - callback to close menu on outside click or item selection
+ * - items: Array<{ id, label, icon, onClick, danger }> - menu actions
+ */
+export default function ContextMenu({ isOpen, position, onClose, items = [] }) {
+  const [renderMenu, setRenderMenu] = useState(false);
+  const menuRef = useRef(null);
+
+  // Mount/Unmount tracking to allow CSS animations
+  useEffect(() => {
+    if (isOpen) {
+      setRenderMenu(true);
+    } else {
+      const timer = setTimeout(() => {
+        setRenderMenu(false);
+      }, 200); // Wait for potential exit animation, though we primarily animate in
+      return () => clearTimeout(timer);
+    }
+  }, [isOpen]);
+
+  // Handle outside click
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleClickOutside = (e) => {
+      if (menuRef.current && !menuRef.current.contains(e.target)) {
+        onClose();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    // Prevent context menu from closing if right-clicking again
+    const handleContextMenu = (e) => {
+      if (menuRef.current && !menuRef.current.contains(e.target)) {
+        onClose();
+      }
+    };
+    document.addEventListener('contextmenu', handleContextMenu);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('contextmenu', handleContextMenu);
+    };
+  }, [isOpen, onClose]);
+
+  if (!renderMenu) return null;
+
+  return (
+    <div
+      ref={menuRef}
+      className={`ease-cm-popup ${isOpen ? 'ease-cm-popup--open' : ''}`}
+      style={{ top: position.y, left: position.x }}
+    >
+      <ul className="ease-cm-list">
+        {items.map((item) => (
+          <li key={item.id} className="ease-cm-item">
+            <button
+              className={`ease-cm-btn ${item.danger ? 'ease-cm-btn--danger' : ''}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                item.onClick();
+                onClose();
+              }}
+            >
+              {item.icon && <span className="ease-cm-icon">{item.icon}</span>}
+              <span className="ease-cm-label">{item.label}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/submissions/react/react-context-menu-popup-with-scale-fade-entrance-realtushartyagi-28150/README.md
+++ b/submissions/react/react-context-menu-popup-with-scale-fade-entrance-realtushartyagi-28150/README.md
@@ -1,0 +1,67 @@
+# React Context Menu Popup with Scale & Fade Entrance
+
+A modular, copy-paste ready React component that provides a custom context menu (right-click menu) with a smooth scale and fade entrance animation, powered by **EaseMotion CSS**.
+
+## Files
+- `ContextMenu.jsx` – Core React component managing coordinates, mount timing, and outside click / re-trigger handling.
+- `style.css` – EaseMotion CSS styles: `easeCmScaleFadeIn` `@keyframes` scaling up from a top-left origin.
+- `demo.html` – Standalone HTML demo using Babel and React CDNs — no server required.
+
+## Installation
+1. Copy the folder into your project.
+2. Import the component:
+   ```jsx
+   import ContextMenu from "./ContextMenu.jsx";
+   ```
+3. Link the stylesheet:
+   ```html
+   <link rel="stylesheet" href="./style.css" />
+   ```
+
+## Usage
+```jsx
+import React, { useState } from 'react';
+import ContextMenu from './ContextMenu';
+
+function App() {
+  const [menu, setMenu] = useState({ isOpen: false, x: 0, y: 0 });
+
+  return (
+    <div 
+      onContextMenu={(e) => {
+        e.preventDefault();
+        setMenu({ isOpen: true, x: e.clientX, y: e.clientY });
+      }}
+      style={{ height: '100vh', background: '#f3f4f6' }}
+    >
+      <ContextMenu 
+        isOpen={menu.isOpen} 
+        position={{ x: menu.x, y: menu.y }}
+        onClose={() => setMenu(m => ({ ...m, isOpen: false }))}
+        items={[
+          { id: '1', label: 'Copy', onClick: () => console.log('Copy') },
+          { id: '2', label: 'Delete', danger: true, onClick: () => console.log('Delete') }
+        ]}
+      />
+    </div>
+  );
+}
+```
+
+## Props
+| Prop | Type | Description |
+|------|------|-------------|
+| `isOpen` | `boolean` | Controls whether the popup is rendered. |
+| `position` | `{ x, y }` | Page coordinates to spawn the menu. |
+| `onClose` | `() => void` | Callback to close the menu. Handles clicks outside the menu automatically. |
+| `items` | `Array` | Menu items: `{ id, label, icon, onClick, danger }`. |
+
+## Why it fits EaseMotion CSS
+All animations are completely decoupled from React state updates. The popup scales from `0.95` to `1` and fades from opacity `0` to `1` using a pure CSS `cubic-bezier` keyframe animation (`easeCmScaleFadeIn`). React only sets the top/left style properties based on the mouse event coordinate and delegates the actual rendering motion to the browser's compositor.
+
+## Demo
+Open `demo.html` directly in a browser — no server needed.
+
+---
+
+> **Note:** PR modifies only files inside `submissions/react/react-context-menu-popup-with-scale-fade-entrance-realtushartyagi-28150/`. No changes to `core/` or `components/`.

--- a/submissions/react/react-context-menu-popup-with-scale-fade-entrance-realtushartyagi-28150/demo.html
+++ b/submissions/react/react-context-menu-popup-with-scale-fade-entrance-realtushartyagi-28150/demo.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Context Menu Popup with Scale & Fade Entrance</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="./style.css" />
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      margin: 0; 
+      min-height: 100vh;
+      background: #f3f4f6;
+      display: flex; justify-content: center; align-items: center;
+    }
+    .trigger-area {
+      width: 400px;
+      height: 300px;
+      background: #e5e7eb;
+      border: 2px dashed #9ca3af;
+      border-radius: 12px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      color: #6b7280;
+      user-select: none;
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" data-type="module">
+    import ContextMenu from "./ContextMenu.jsx";
+
+    function Demo() {
+      const [menuState, setMenuState] = React.useState({ isOpen: false, x: 0, y: 0 });
+
+      const handleContextMenu = (e) => {
+        e.preventDefault();
+        setMenuState({
+          isOpen: true,
+          x: e.clientX,
+          y: e.clientY
+        });
+      };
+
+      const closeMenu = () => setMenuState(prev => ({ ...prev, isOpen: false }));
+
+      const menuItems = [
+        { id: '1', label: 'Copy link', icon: '🔗', onClick: () => console.log('Copied') },
+        { id: '2', label: 'Duplicate item', icon: '📑', onClick: () => console.log('Duplicated') },
+        { id: '3', label: 'Share...', icon: '📤', onClick: () => console.log('Share opened') },
+        { id: '4', label: 'Delete completely', icon: '🗑️', danger: true, onClick: () => console.log('Deleted') }
+      ];
+
+      return (
+        <div 
+          className="trigger-area" 
+          onContextMenu={handleContextMenu}
+        >
+          <p>Right-click inside this area</p>
+          <ContextMenu 
+            isOpen={menuState.isOpen} 
+            position={{ x: menuState.x, y: menuState.y }}
+            onClose={closeMenu}
+            items={menuItems}
+          />
+        </div>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById("root")).render(<Demo />);
+  </script>
+</body>
+</html>

--- a/submissions/react/react-context-menu-popup-with-scale-fade-entrance-realtushartyagi-28150/style.css
+++ b/submissions/react/react-context-menu-popup-with-scale-fade-entrance-realtushartyagi-28150/style.css
@@ -1,0 +1,100 @@
+/*
+  style.css
+  EaseMotion CSS – Context Menu Popup with Scale & Fade Entrance (#28150)
+*/
+
+:root {
+  --cm-bg: #ffffff;
+  --cm-border: #e5e7eb;
+  --cm-text: #374151;
+  --cm-hover-bg: #f3f4f6;
+  --cm-danger: #dc2626;
+  --cm-danger-bg: #fef2f2;
+  --cm-radius: 8px;
+  --cm-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
+  --cm-speed: 0.2s;
+}
+
+.ease-cm-popup {
+  position: fixed;
+  background: var(--cm-bg);
+  border: 1px solid var(--cm-border);
+  border-radius: var(--cm-radius);
+  box-shadow: var(--cm-shadow);
+  padding: 6px;
+  min-width: 180px;
+  z-index: 9999;
+  
+  /* Initial state for animation */
+  opacity: 0;
+  transform: scale(0.95);
+  pointer-events: none;
+  transform-origin: top left;
+}
+
+.ease-cm-popup--open {
+  animation: easeCmScaleFadeIn var(--cm-speed) cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  pointer-events: auto;
+}
+
+.ease-cm-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.ease-cm-item {
+  margin: 0;
+  padding: 0;
+}
+
+.ease-cm-btn {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  color: var(--cm-text);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  text-align: left;
+}
+
+.ease-cm-btn:hover {
+  background: var(--cm-hover-bg);
+}
+
+.ease-cm-btn--danger {
+  color: var(--cm-danger);
+}
+
+.ease-cm-btn--danger:hover {
+  background: var(--cm-danger-bg);
+}
+
+.ease-cm-icon {
+  font-size: 1.1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  opacity: 0.8;
+}
+
+/* Entrance Keyframes */
+@keyframes easeCmScaleFadeIn {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a modular, copy-paste ready React component: **Context Menu Popup with Scale & Fade Entrance**.  
This component implements a custom right-click context menu that spawns precisely at the cursor location with a smooth, native-feeling scale-and-fade animation, resolving issue #28150. Zero external JS animation dependencies.

Fixes #28150

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/react/react-context-menu-popup-with-scale-fade-entrance-realtushartyagi-28150/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A custom React right-click context menu component that tracks mouse coordinates, handles "click outside" and "right-click outside" closures, and animates its entrance cleanly without heavy JavaScript math.

**How does a developer use it?**

```html
<!-- Include the component stylesheet -->
<link rel="stylesheet" href="style.css" />

<!-- In your React application: -->
<div onContextMenu={(e) => { e.preventDefault(); openMenu(e.clientX, e.clientY); }}>
  <ContextMenu 
    isOpen={isOpen} 
    position={{ x, y }} 
    onClose={closeMenu} 
    items={[
      { id: '1', label: 'Copy', icon: '🔗', onClick: () => copyAction() }
    ]}
  />
</div>
