### PR TITLE
feat: add compact status timeline demo

### DIFF
--- a/submissions/examples/compact-status-timeline/README.md
+++ b/submissions/examples/compact-status-timeline/README.md
@@ -1,0 +1,12 @@
+# Compact Status Timeline
+
+A responsive release timeline demo with animated markers, hover elevation, and keyboard focus states.
+
+## Files
+
+- `demo.html` contains the timeline milestone markup.
+- `style.css` contains the timeline rail, marker animation, card lift, and responsive layout.
+
+## Usage
+
+Open `demo.html` in a browser. Hover or focus a timeline card to see the marker pulse and card lift.

--- a/submissions/examples/compact-status-timeline/demo.html
+++ b/submissions/examples/compact-status-timeline/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Compact Status Timeline</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="timeline-page" aria-labelledby="timeline-title">
+    <section class="intro">
+      <p class="eyebrow">Release tracker</p>
+      <h1 id="timeline-title">Compact status timeline</h1>
+      <p>A compact milestone list with animated markers, hover elevation, and accessible focus states.</p>
+    </section>
+
+    <section class="timeline" aria-label="Release status timeline">
+      <article class="timeline-card done" tabindex="0">
+        <span class="marker" aria-hidden="true"></span>
+        <div>
+          <p class="stage">Completed</p>
+          <h2>Design approved</h2>
+          <p>Layout tokens and interaction states were reviewed by the product team.</p>
+        </div>
+      </article>
+
+      <article class="timeline-card current" tabindex="0">
+        <span class="marker" aria-hidden="true"></span>
+        <div>
+          <p class="stage">In progress</p>
+          <h2>Implementation check</h2>
+          <p>Final UI states are being verified across desktop and mobile breakpoints.</p>
+        </div>
+      </article>
+
+      <article class="timeline-card next" tabindex="0">
+        <span class="marker" aria-hidden="true"></span>
+        <div>
+          <p class="stage">Next</p>
+          <h2>Launch handoff</h2>
+          <p>Release notes and QA notes will be bundled after the last smoke pass.</p>
+        </div>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/compact-status-timeline/style.css
+++ b/submissions/examples/compact-status-timeline/style.css
@@ -1,0 +1,195 @@
+:root {
+  --page: #f7f4ef;
+  --ink: #172033;
+  --muted: #667085;
+  --surface: #ffffff;
+  --line: #ded7cc;
+  --green: #16a34a;
+  --blue: #2563eb;
+  --orange: #ea580c;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background:
+    linear-gradient(145deg, rgba(37, 99, 235, 0.14), transparent 38%),
+    linear-gradient(315deg, rgba(234, 88, 12, 0.13), transparent 35%),
+    var(--page);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.timeline-page {
+  width: min(1040px, calc(100% - 32px));
+  display: grid;
+  grid-template-columns: minmax(260px, 0.82fr) minmax(330px, 1.18fr);
+  gap: 44px;
+  align-items: center;
+  padding: 48px 0;
+}
+
+.intro {
+  max-width: 450px;
+}
+
+.eyebrow,
+.stage {
+  margin: 0 0 9px;
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.eyebrow {
+  color: var(--blue);
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 16px;
+  font-size: clamp(2.1rem, 5vw, 3.7rem);
+  line-height: 1;
+}
+
+.intro p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.06rem;
+  line-height: 1.65;
+}
+
+.timeline {
+  position: relative;
+  display: grid;
+  gap: 16px;
+  padding-left: 34px;
+}
+
+.timeline::before {
+  content: "";
+  position: absolute;
+  top: 26px;
+  bottom: 26px;
+  left: 13px;
+  width: 4px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, var(--green), var(--blue), var(--orange));
+}
+
+.timeline-card {
+  --accent: var(--blue);
+  position: relative;
+  min-height: 138px;
+  padding: 24px;
+  border: 1px solid rgba(23, 32, 51, 0.11);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 16px 36px rgba(23, 32, 51, 0.09);
+  transition: transform 220ms ease, border-color 220ms ease, box-shadow 220ms ease;
+}
+
+.timeline-card:hover,
+.timeline-card:focus-visible {
+  transform: translateY(-8px) translateX(8px);
+  border-color: color-mix(in srgb, var(--accent) 45%, transparent);
+  box-shadow: 0 28px 56px color-mix(in srgb, var(--accent) 18%, transparent);
+  outline: none;
+}
+
+.timeline-card:focus-visible {
+  outline: 4px solid rgba(234, 88, 12, 0.32);
+  outline-offset: 4px;
+}
+
+.done {
+  --accent: var(--green);
+}
+
+.current {
+  --accent: var(--blue);
+}
+
+.next {
+  --accent: var(--orange);
+}
+
+.marker {
+  position: absolute;
+  top: 28px;
+  left: -34px;
+  width: 28px;
+  height: 28px;
+  border: 5px solid var(--page);
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 28%, transparent);
+  animation: marker-pulse 1.9s ease-out infinite;
+}
+
+.stage {
+  color: var(--accent);
+}
+
+h2 {
+  margin-bottom: 8px;
+  font-size: 1.28rem;
+}
+
+.timeline-card p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+@keyframes marker-pulse {
+  0% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, currentColor 24%, transparent);
+  }
+
+  70% {
+    box-shadow: 0 0 0 12px transparent;
+  }
+
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+}
+
+@media (max-width: 820px) {
+  .timeline-page {
+    grid-template-columns: 1fr;
+    gap: 30px;
+  }
+
+  .intro {
+    max-width: none;
+    text-align: center;
+  }
+}
+
+@media (max-width: 520px) {
+  .timeline {
+    padding-left: 28px;
+  }
+
+  .timeline::before {
+    left: 10px;
+  }
+
+  .marker {
+    left: -30px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a responsive compact status timeline demo
- include animated markers, hover lift, and focus-visible states
- document files and usage

## Testing
- git diff --cached --check