### PR TITLE
feat: add uptime signal stack demo

### DIFF
--- a/submissions/examples/uptime-signal-stack/README.md
+++ b/submissions/examples/uptime-signal-stack/README.md
@@ -1,0 +1,12 @@
+# Uptime Signal Stack
+
+A responsive service health demo with pulsing status signals, hover lift cards, and keyboard focus states.
+
+## Files
+
+- `demo.html` contains the uptime signal stack markup.
+- `style.css` contains the signal pulse animation, card interactions, and responsive layout.
+
+## Usage
+
+Open `demo.html` in a browser. Hover or focus each service card to see the lift effect and pulsing signal state.

--- a/submissions/examples/uptime-signal-stack/demo.html
+++ b/submissions/examples/uptime-signal-stack/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Uptime Signal Stack</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="uptime-page" aria-labelledby="uptime-title">
+    <section class="intro">
+      <p class="eyebrow">Service health</p>
+      <h1 id="uptime-title">Uptime signal stack</h1>
+      <p>A responsive service health stack with pulsing signal dots, hover lift cards, and focus-visible states.</p>
+    </section>
+
+    <section class="signal-stack" aria-label="Service uptime signals">
+      <article class="signal-card healthy" tabindex="0">
+        <span class="signal" aria-hidden="true"></span>
+        <div>
+          <h2>API gateway</h2>
+          <p>99.99% uptime across all production regions.</p>
+        </div>
+        <strong>Live</strong>
+      </article>
+
+      <article class="signal-card watch" tabindex="0">
+        <span class="signal" aria-hidden="true"></span>
+        <div>
+          <h2>Worker queue</h2>
+          <p>Processing is normal with a slightly elevated retry rate.</p>
+        </div>
+        <strong>Watch</strong>
+      </article>
+
+      <article class="signal-card healthy" tabindex="0">
+        <span class="signal" aria-hidden="true"></span>
+        <div>
+          <h2>Search index</h2>
+          <p>Index freshness is within the configured service target.</p>
+        </div>
+        <strong>Live</strong>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/uptime-signal-stack/style.css
+++ b/submissions/examples/uptime-signal-stack/style.css
@@ -1,0 +1,173 @@
+:root {
+  --page: #f3f8f6;
+  --ink: #172033;
+  --muted: #667085;
+  --surface: #ffffff;
+  --line: #d8e5df;
+  --green: #16a34a;
+  --amber: #d97706;
+  --blue: #2563eb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background:
+    linear-gradient(135deg, rgba(22, 163, 74, 0.14), transparent 38%),
+    linear-gradient(315deg, rgba(37, 99, 235, 0.12), transparent 34%),
+    var(--page);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.uptime-page {
+  width: min(1040px, calc(100% - 32px));
+  display: grid;
+  grid-template-columns: minmax(260px, 0.85fr) minmax(320px, 1.15fr);
+  gap: 42px;
+  align-items: center;
+  padding: 48px 0;
+}
+
+.intro {
+  max-width: 460px;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--green);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 16px;
+  font-size: clamp(2.15rem, 5vw, 3.8rem);
+  line-height: 1;
+}
+
+.intro p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.06rem;
+  line-height: 1.65;
+}
+
+.signal-stack {
+  display: grid;
+  gap: 16px;
+  padding: 18px;
+  border: 1px solid var(--line);
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: 0 22px 64px rgba(23, 32, 51, 0.12);
+}
+
+.signal-card {
+  --accent: var(--green);
+  min-height: 126px;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 16px;
+  align-items: start;
+  padding: 22px;
+  border: 1px solid rgba(23, 32, 51, 0.1);
+  border-radius: 18px;
+  background: var(--surface);
+  box-shadow: 0 14px 32px rgba(23, 32, 51, 0.08);
+  transition: transform 220ms ease, border-color 220ms ease, box-shadow 220ms ease;
+}
+
+.signal-card:hover,
+.signal-card:focus-visible {
+  transform: translateY(-8px);
+  border-color: color-mix(in srgb, var(--accent) 46%, transparent);
+  box-shadow: 0 26px 54px color-mix(in srgb, var(--accent) 18%, transparent);
+  outline: none;
+}
+
+.signal-card:focus-visible {
+  outline: 4px solid rgba(37, 99, 235, 0.3);
+  outline-offset: 4px;
+}
+
+.watch {
+  --accent: var(--amber);
+}
+
+.signal {
+  width: 15px;
+  height: 15px;
+  margin-top: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 32%, transparent);
+  animation: signal-pulse 1.8s ease-out infinite;
+}
+
+h2 {
+  margin-bottom: 8px;
+  font-size: 1.26rem;
+}
+
+.signal-card p {
+  margin-bottom: 0;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.signal-card strong {
+  color: var(--accent);
+  font-size: 0.86rem;
+  text-transform: uppercase;
+}
+
+@keyframes signal-pulse {
+  0% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, currentColor 24%, transparent);
+  }
+
+  70% {
+    box-shadow: 0 0 0 12px transparent;
+  }
+
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+}
+
+@media (max-width: 820px) {
+  .uptime-page {
+    grid-template-columns: 1fr;
+    gap: 28px;
+  }
+
+  .intro {
+    max-width: none;
+    text-align: center;
+  }
+}
+
+@media (max-width: 520px) {
+  .signal-card {
+    grid-template-columns: auto 1fr;
+  }
+
+  .signal-card strong {
+    grid-column: 2;
+  }
+}


### PR DESCRIPTION
## Summary
- add a responsive uptime signal stack demo
- include pulsing service signals, hover lift, and focus-visible states
- document files and usage

## Testing
- git diff --cached --check