### PR TITLE
feat: add release health strip demo

### DIFF
--- a/submissions/examples/release-health-strip/README.md
+++ b/submissions/examples/release-health-strip/README.md
@@ -1,0 +1,12 @@
+# Release Health Strip
+
+A responsive release readiness demo with animated health bars, hover lift cards, and keyboard focus states.
+
+## Files
+
+- `demo.html` contains the release health metric markup.
+- `style.css` contains the metric strip layout, bar animation, and card interaction states.
+
+## Usage
+
+Open `demo.html` in a browser. Hover or focus each metric card to see the lift state and animated health bar.

--- a/submissions/examples/release-health-strip/demo.html
+++ b/submissions/examples/release-health-strip/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Release Health Strip</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="health-page" aria-labelledby="health-title">
+    <section class="health-copy">
+      <p class="eyebrow">Release guard</p>
+      <h1 id="health-title">Release health strip</h1>
+      <p>A compact release readiness strip with animated score bars, hover lift cards, and focus states.</p>
+    </section>
+
+    <section class="health-strip" aria-label="Release health metrics">
+      <article class="health-card tests" tabindex="0">
+        <span>Tests</span>
+        <strong>98%</strong>
+        <div class="bar" aria-hidden="true"><i></i></div>
+        <p>Regression suite passed with two quarantine skips.</p>
+      </article>
+
+      <article class="health-card risk" tabindex="0">
+        <span>Risk</span>
+        <strong>Low</strong>
+        <div class="bar" aria-hidden="true"><i></i></div>
+        <p>No open blockers remain in the release checklist.</p>
+      </article>
+
+      <article class="health-card rollout" tabindex="0">
+        <span>Rollout</span>
+        <strong>75%</strong>
+        <div class="bar" aria-hidden="true"><i></i></div>
+        <p>Gradual rollout is active for three production segments.</p>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/release-health-strip/style.css
+++ b/submissions/examples/release-health-strip/style.css
@@ -1,0 +1,164 @@
+:root {
+  --page: #f6f7fb;
+  --ink: #172033;
+  --muted: #667085;
+  --surface: #ffffff;
+  --line: #dce3ed;
+  --green: #16a34a;
+  --blue: #2563eb;
+  --violet: #7c3aed;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background:
+    linear-gradient(135deg, rgba(22, 163, 74, 0.13), transparent 38%),
+    linear-gradient(315deg, rgba(124, 58, 237, 0.12), transparent 34%),
+    var(--page);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.health-page {
+  width: min(1100px, calc(100% - 32px));
+  padding: 48px 0;
+}
+
+.health-copy {
+  max-width: 650px;
+  margin: 0 auto 30px;
+  text-align: center;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--green);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 14px;
+  font-size: clamp(2.15rem, 5vw, 3.8rem);
+  line-height: 1;
+}
+
+.health-copy p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.06rem;
+  line-height: 1.65;
+}
+
+.health-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.health-card {
+  --accent: var(--green);
+  --fill: 98%;
+  min-height: 238px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 24px;
+  border: 1px solid rgba(23, 32, 51, 0.1);
+  border-radius: 20px;
+  background: var(--surface);
+  box-shadow: 0 18px 44px rgba(23, 32, 51, 0.1);
+  transition: transform 220ms ease, border-color 220ms ease, box-shadow 220ms ease;
+}
+
+.health-card:hover,
+.health-card:focus-visible {
+  transform: translateY(-8px);
+  border-color: color-mix(in srgb, var(--accent) 46%, transparent);
+  box-shadow: 0 28px 58px color-mix(in srgb, var(--accent) 18%, transparent);
+  outline: none;
+}
+
+.health-card:focus-visible {
+  outline: 4px solid rgba(37, 99, 235, 0.3);
+  outline-offset: 4px;
+}
+
+.risk {
+  --accent: var(--blue);
+  --fill: 62%;
+}
+
+.rollout {
+  --accent: var(--violet);
+  --fill: 75%;
+}
+
+.health-card span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.health-card strong {
+  color: var(--accent);
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
+  line-height: 1;
+}
+
+.bar {
+  height: 12px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e6edf4;
+}
+
+.bar i {
+  display: block;
+  width: var(--fill);
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), color-mix(in srgb, var(--accent) 64%, #ffffff));
+  animation: health-fill 900ms ease both;
+}
+
+.health-card p {
+  margin-bottom: 0;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+@keyframes health-fill {
+  from {
+    width: 0;
+  }
+
+  to {
+    width: var(--fill);
+  }
+}
+
+@media (max-width: 860px) {
+  .health-strip {
+    grid-template-columns: 1fr;
+  }
+
+  .health-card {
+    min-height: 210px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a responsive release health strip demo
- include animated health bars, hover lift, and focus-visible states
- document files and usage

## Testing
- git diff --cached --check