### PR TITLE
feat: add ease-badge-count-pop component (#34710)

### DIFF
--- a/submissions/examples/ease-badge-count-pop-ij/README.md
+++ b/submissions/examples/ease-badge-count-pop-ij/README.md
@@ -1,0 +1,58 @@
+# ease-badge-count-pop
+
+A notification badge component that **pops with a scale animation whenever its count updates**. Includes a secondary hover pulse trigger, full CSS-variable theming, light/dark mode, and responsive sizing.
+
+## Features
+
+- 🎯 Smooth CSS keyframe "pop" animation on count update
+- 🖱️ Interactive triggers: click (Add/Reset) and hover pulse
+- 🎨 Fully customizable via CSS custom properties
+- 🌗 Light/dark mode support via `[data-theme]`
+- 📱 Responsive sizing on smaller screens
+- ♿ Accessible: `aria-live="polite"` announces count changes, visible focus states on controls
+- 🧠 Respects `prefers-reduced-motion`
+
+## Usage
+
+```html
+<div class="ease-badge-wrapper">
+  <svg class="ease-badge-icon">...</svg>
+  <span class="ease-badge-count" id="easeBadgeCount">0</span>
+</div>
+```
+
+To trigger the pop animation on update (e.g. after changing the count via JS):
+
+```js
+countEl.classList.remove('ease-badge-pop');
+void countEl.offsetWidth; // force reflow
+countEl.classList.add('ease-badge-pop');
+```
+
+The animation itself is 100% CSS — the class toggle above simply replays it.
+
+## CSS Variables
+
+| Variable                     | Default   | Description                          |
+|-------------------------------|-----------|---------------------------------------|
+| `--ease-badge-bg`              | `#ef4444` | Badge background color                |
+| `--ease-badge-text`            | `#ffffff` | Badge text color                      |
+| `--ease-badge-icon-bg`         | `#f1f5f9` | Icon circle background                |
+| `--ease-badge-icon-color`      | `#1e293b` | Icon color                            |
+| `--ease-badge-size`            | `1.5rem`  | Badge diameter                        |
+| `--ease-badge-font-size`       | `0.75rem` | Badge count font size                 |
+| `--ease-badge-pop-scale`       | `1.35`    | Peak scale during the pop animation   |
+| `--ease-badge-duration`        | `0.35s`   | Pop animation duration                |
+| `--ease-badge-easing`          | `cubic-bezier(0.34, 1.56, 0.64, 1)` | Animation easing |
+| `--ease-badge-icon-diameter`   | `3.5rem`  | Icon circle diameter                  |
+| `--ease-badge-gap`             | `2rem`    | Gap between icon and controls in demo |
+
+## Accessibility
+
+- The count uses `aria-live="polite"` so screen readers announce updates.
+- All interactive buttons have visible `:focus-visible` outlines.
+- Animation is disabled entirely under `prefers-reduced-motion: reduce`.
+
+## Browser Support
+
+Works in all modern browsers supporting CSS custom properties and `@keyframes` (Chrome, Firefox, Safari, Edge).

--- a/submissions/examples/ease-badge-count-pop-ij/demo.html
+++ b/submissions/examples/ease-badge-count-pop-ij/demo.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>ease-badge-count-pop Demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<div class="ease-badge-demo" data-theme="light">
+
+  <div class="ease-badge-wrapper" aria-label="Notifications">
+    <svg class="ease-badge-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9"></path>
+      <path d="M13.73 21a2 2 0 0 1-3.46 0"></path>
+    </svg>
+    <span class="ease-badge-count" id="easeBadgeCount" aria-live="polite">0</span>
+  </div>
+
+  <div class="ease-badge-controls">
+    <button class="ease-badge-btn" id="easeBadgeAdd" type="button">Add</button>
+    <button class="ease-badge-btn" id="easeBadgeReset" type="button">Reset</button>
+    <button class="ease-badge-btn" id="easeBadgeTheme" type="button">Toggle Theme</button>
+  </div>
+
+</div>
+
+<script>
+  // Minimal JS only to drive the demo count — all animation/visual
+  // logic lives entirely in CSS (ease-badge-pop keyframes).
+  (function () {
+    var countEl = document.getElementById('easeBadgeCount');
+    var addBtn = document.getElementById('easeBadgeAdd');
+    var resetBtn = document.getElementById('easeBadgeReset');
+    var themeBtn = document.getElementById('easeBadgeTheme');
+    var demo = document.querySelector('.ease-badge-demo');
+    var count = 0;
+
+    function triggerPop() {
+      countEl.classList.remove('ease-badge-pop');
+      // force reflow so the animation can replay
+      void countEl.offsetWidth;
+      countEl.classList.add('ease-badge-pop');
+    }
+
+    addBtn.addEventListener('click', function () {
+      count++;
+      countEl.textContent = count;
+      triggerPop();
+    });
+
+    resetBtn.addEventListener('click', function () {
+      count = 0;
+      countEl.textContent = count;
+      triggerPop();
+    });
+
+    themeBtn.addEventListener('click', function () {
+      var isDark = demo.getAttribute('data-theme') === 'dark';
+      demo.setAttribute('data-theme', isDark ? 'light' : 'dark');
+    });
+  })();
+</script>
+
+</body>
+</html>

--- a/submissions/examples/ease-badge-count-pop-ij/style.css
+++ b/submissions/examples/ease-badge-count-pop-ij/style.css
@@ -1,0 +1,165 @@
+/* ==========================================================================
+   ease-badge-count-pop
+   A notification badge that "pops" with a scale animation whenever its
+   count updates. Includes hover pulse as a secondary interactive trigger.
+   ========================================================================== */
+
+:root {
+  --ease-badge-bg: #ef4444;
+  --ease-badge-text: #ffffff;
+  --ease-badge-icon-bg: #f1f5f9;
+  --ease-badge-icon-color: #1e293b;
+  --ease-badge-size: 1.5rem;
+  --ease-badge-font-size: 0.75rem;
+  --ease-badge-pop-scale: 1.35;
+  --ease-badge-duration: 0.35s;
+  --ease-badge-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-badge-icon-diameter: 3.5rem;
+  --ease-badge-gap: 2rem;
+}
+
+[data-theme="dark"] {
+  --ease-badge-icon-bg: #1e293b;
+  --ease-badge-icon-color: #f1f5f9;
+  --ease-badge-bg: #f87171;
+  --ease-badge-text: #1e1b1b;
+}
+
+.ease-badge-demo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--ease-badge-gap);
+  padding: 2rem;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.ease-badge-wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--ease-badge-icon-diameter);
+  height: var(--ease-badge-icon-diameter);
+  background: var(--ease-badge-icon-bg);
+  color: var(--ease-badge-icon-color);
+  border-radius: 50%;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  transition: transform 0.2s ease;
+}
+
+.ease-badge-wrapper:hover {
+  transform: translateY(-2px);
+}
+
+.ease-badge-icon {
+  width: 1.75rem;
+  height: 1.75rem;
+}
+
+.ease-badge-count {
+  position: absolute;
+  top: -0.25rem;
+  right: -0.25rem;
+  min-width: var(--ease-badge-size);
+  height: var(--ease-badge-size);
+  padding: 0 0.35rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--ease-badge-bg);
+  color: var(--ease-badge-text);
+  font-size: var(--ease-badge-font-size);
+  font-weight: 700;
+  line-height: 1;
+  border-radius: 999px;
+  border: 2px solid var(--ease-badge-icon-bg);
+  box-sizing: border-box;
+}
+
+/* Pop animation, triggered by adding this class on count update */
+.ease-badge-count.ease-badge-pop {
+  animation: ease-badge-pop-keyframes var(--ease-badge-duration) var(--ease-badge-easing);
+}
+
+@keyframes ease-badge-pop-keyframes {
+  0% {
+    transform: scale(1);
+  }
+  45% {
+    transform: scale(var(--ease-badge-pop-scale));
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+/* Secondary interactive trigger: hover pulse, no JS required */
+.ease-badge-wrapper:hover .ease-badge-count {
+  animation: ease-badge-pulse-keyframes 0.6s var(--ease-badge-easing);
+}
+
+@keyframes ease-badge-pulse-keyframes {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.5);
+  }
+  50% {
+    box-shadow: 0 0 0 6px rgba(239, 68, 68, 0);
+  }
+}
+
+.ease-badge-controls {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.ease-badge-btn {
+  padding: 0.5rem 1.1rem;
+  border: none;
+  border-radius: 0.5rem;
+  background: var(--ease-badge-icon-color);
+  color: var(--ease-badge-icon-bg);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s ease, transform 0.15s ease;
+}
+
+.ease-badge-btn:hover {
+  opacity: 0.85;
+}
+
+.ease-badge-btn:active {
+  transform: scale(0.95);
+}
+
+.ease-badge-btn:focus-visible {
+  outline: 2px solid var(--ease-badge-bg);
+  outline-offset: 2px;
+}
+
+/* Responsive */
+@media (max-width: 480px) {
+  :root {
+    --ease-badge-icon-diameter: 3rem;
+    --ease-badge-size: 1.3rem;
+    --ease-badge-font-size: 0.7rem;
+  }
+
+  .ease-badge-demo {
+    padding: 1.25rem;
+  }
+}
+
+/* Reduced motion support */
+@media (prefers-reduced-motion: reduce) {
+  .ease-badge-count.ease-badge-pop,
+  .ease-badge-wrapper:hover .ease-badge-count {
+    animation: none;
+  }
+
+  .ease-badge-wrapper:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Description
Adds the `ease-badge-count-pop` component — a notification badge that pops with a smooth CSS scale animation whenever its count updates. Includes a secondary hover-pulse interaction as an additional trigger.

Closes #34710

## Changes
- `submissions/examples/ease-badge-count-pop-ij/demo.html` — Badge UI with Add/Reset/Theme controls
- `submissions/examples/ease-badge-count-pop-ij/style.css` — Pop keyframe animation, hover pulse, theming
- `submissions/examples/ease-badge-count-pop-ij/README.md` — Usage docs, CSS variables, accessibility notes

## Acceptance Criteria
- [x] Smooth CSS `@keyframes` pop animation on count update
- [x] Interactive triggers: click (Add/Reset) + hover pulse
- [x] Fully customizable via CSS custom properties (`--ease-badge-*`)
- [x] Responsive design (adjusted sizing at `max-width: 480px`)
- [x] Light/dark mode via `[data-theme]`
- [x] `prefers-reduced-motion` respected
- [x] Accessible: `aria-live="polite"` on count, visible focus states on buttons

## Screenshots / Demo
_(Add a screenshot or short screen recording of the badge popping on "Add" click here)_

## Testing
- Verified pop animation replays correctly on repeated clicks (via forced reflow)
- Verified reduced-motion disables all animation
- Verified light/dark theme toggle updates all colors via CSS variables
- Tested responsiveness at mobile viewport widths