### PR TITLE
feat: add error budget heatmap demo

### DIFF
--- a/submissions/examples/error-budget-heatmap/README.md
+++ b/submissions/examples/error-budget-heatmap/README.md
@@ -1,0 +1,12 @@
+# Error Budget Heatmap
+
+An intermediate EaseMotion CSS example for reliability dashboards. Service tiles animate into a compact heatmap with stable, watch, and alert states.
+
+## Files
+
+- `demo.html` - Accessible service burn-rate tile markup.
+- `style.css` - Responsive heatmap layout, delayed tile entrance, and glow motion states.
+
+## Usage
+
+Open `demo.html` in a browser to preview the animated error budget component.

--- a/submissions/examples/error-budget-heatmap/demo.html
+++ b/submissions/examples/error-budget-heatmap/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Error Budget Heatmap</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="budget-shell" aria-labelledby="budget-title">
+    <section class="budget-card">
+      <div class="budget-heading">
+        <p class="eyebrow">sre overview</p>
+        <h1 id="budget-title">Error budget heatmap</h1>
+        <p>Service tiles pulse into view with burn-rate status so operators can spot risk before a release window.</p>
+      </div>
+
+      <div class="heatmap" role="list" aria-label="Service error budget burn rates">
+        <article class="tile stable" role="listitem">
+          <span>API</span>
+          <strong>18%</strong>
+        </article>
+        <article class="tile stable" role="listitem">
+          <span>Auth</span>
+          <strong>22%</strong>
+        </article>
+        <article class="tile watch" role="listitem">
+          <span>Sync</span>
+          <strong>48%</strong>
+        </article>
+        <article class="tile alert" role="listitem">
+          <span>Search</span>
+          <strong>73%</strong>
+        </article>
+        <article class="tile watch" role="listitem">
+          <span>Billing</span>
+          <strong>51%</strong>
+        </article>
+        <article class="tile stable" role="listitem">
+          <span>CDN</span>
+          <strong>15%</strong>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/error-budget-heatmap/style.css
+++ b/submissions/examples/error-budget-heatmap/style.css
@@ -1,0 +1,139 @@
+:root {
+  color-scheme: dark;
+  --bg: #0c111d;
+  --panel: #151c2b;
+  --text: #f9fafb;
+  --muted: #a7b0c0;
+  --stable: #22c55e;
+  --watch: #f59e0b;
+  --alert: #ef4444;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    linear-gradient(120deg, rgba(34, 197, 94, 0.14), transparent 36%),
+    linear-gradient(300deg, rgba(239, 68, 68, 0.16), transparent 42%),
+    var(--bg);
+  color: var(--text);
+}
+
+.budget-shell {
+  width: min(960px, calc(100vw - 32px));
+}
+
+.budget-card {
+  display: grid;
+  grid-template-columns: minmax(240px, 0.78fr) minmax(340px, 1.22fr);
+  gap: 28px;
+  align-items: center;
+  padding: 32px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 16px;
+  background: rgba(21, 28, 43, 0.88);
+  box-shadow: 0 32px 90px rgba(2, 6, 23, 0.48);
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: #67e8f9;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  max-width: 8ch;
+  font-size: clamp(2.4rem, 6vw, 4.8rem);
+  line-height: 0.94;
+}
+
+.budget-heading p:last-child {
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.heatmap {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.tile {
+  min-height: 132px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 14px;
+  opacity: 0;
+  transform: translateY(16px) scale(0.96);
+  animation: tileIn 0.68s cubic-bezier(.2,.8,.2,1) forwards, glow 3.2s ease-in-out infinite;
+}
+
+.tile:nth-child(1) { animation-delay: 0.06s, 0.9s; }
+.tile:nth-child(2) { animation-delay: 0.14s, 1.1s; }
+.tile:nth-child(3) { animation-delay: 0.22s, 1.3s; }
+.tile:nth-child(4) { animation-delay: 0.3s, 1.5s; }
+.tile:nth-child(5) { animation-delay: 0.38s, 1.7s; }
+.tile:nth-child(6) { animation-delay: 0.46s, 1.9s; }
+
+.tile span {
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 0.86rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.tile strong {
+  font-size: clamp(2rem, 6vw, 3.4rem);
+  line-height: 1;
+}
+
+.stable {
+  background: linear-gradient(145deg, rgba(34, 197, 94, 0.88), rgba(21, 128, 61, 0.62));
+}
+
+.watch {
+  background: linear-gradient(145deg, rgba(245, 158, 11, 0.9), rgba(180, 83, 9, 0.64));
+}
+
+.alert {
+  background: linear-gradient(145deg, rgba(239, 68, 68, 0.92), rgba(153, 27, 27, 0.68));
+}
+
+@keyframes tileIn {
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes glow {
+  50% {
+    box-shadow: 0 0 26px rgba(255, 255, 255, 0.14);
+  }
+}
+
+@media (max-width: 760px) {
+  .budget-card {
+    grid-template-columns: 1fr;
+    padding: 24px;
+  }
+
+  .heatmap {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}


### PR DESCRIPTION
## Summary
- add an animated error budget heatmap example
- show stable, watch, and alert burn-rate tiles
- document the demo files and usage

## Validation
- git diff --check