### PR TITLE
feat: add ease-user-activity-card component (#34674)

### DIFF
--- a/submissions/examples/ease-user-activity-card/README.md
+++ b/submissions/examples/ease-user-activity-card/README.md
@@ -1,0 +1,68 @@
+# ease-user-activity-card
+
+A user activity card showing an avatar, name, and live status — with an animated "active now" pulse ring and a typing indicator, built entirely in CSS.
+
+## Features
+
+- 🟢 Animated pulse ring for "active now" status (pure CSS `@keyframes`)
+- 💬 Animated typing indicator (three bouncing dots)
+- 🖱️ Interactive hover: card lifts with elevated shadow
+- 🎨 Fully customizable via CSS custom properties
+- 🌗 Light/dark mode support via `[data-theme]`
+- 📱 Responsive: avatar and padding scale down on small screens
+- ♿ Accessible: status dots are `aria-hidden` (decorative), typing text uses `aria-live="polite"` so screen readers announce it, text truncates gracefully with ellipsis instead of breaking layout
+- 🧠 Respects `prefers-reduced-motion`
+
+## Usage
+
+```html
+<div class="ease-activity-card">
+  <div class="ease-activity-avatar-wrap">
+    <img class="ease-activity-avatar" src="avatar.jpg" alt="User name" />
+    <span class="ease-activity-status-dot is-online" aria-hidden="true"></span>
+  </div>
+  <div class="ease-activity-info">
+    <p class="ease-activity-name">User Name</p>
+    <p class="ease-activity-status-text">Active now</p>
+  </div>
+</div>
+```
+
+### Status variants
+
+| Class          | Meaning                     |
+|----------------|------------------------------|
+| `.is-online`   | Active now (pulsing green dot) |
+| `.is-away`     | Away (solid amber dot)       |
+| `.is-offline`  | Offline (solid gray dot)     |
+
+### Typing indicator
+
+Add `.is-typing` to `.ease-activity-status-text` and include three `<span class="ease-activity-typing-dot"></span>` elements before the label text.
+
+## CSS Variables
+
+| Variable                          | Default    | Description                        |
+|-------------------------------------|------------|--------------------------------------|
+| `--ease-activity-bg`                | `#ffffff`  | Card background                      |
+| `--ease-activity-border`            | `#e2e8f0`  | Card border color                    |
+| `--ease-activity-text`              | `#0f172a`  | Name text color                      |
+| `--ease-activity-muted`             | `#64748b`  | Status text color                    |
+| `--ease-activity-accent`            | `#22c55e`  | "Online" dot + pulse color           |
+| `--ease-activity-away`              | `#f59e0b`  | "Away" dot color                     |
+| `--ease-activity-offline`           | `#94a3b8`  | "Offline" dot color                  |
+| `--ease-activity-radius`            | `0.9rem`   | Card corner radius                   |
+| `--ease-activity-duration`          | `0.25s`    | Hover transition duration            |
+| `--ease-activity-avatar-size`       | `3rem`     | Avatar diameter                      |
+| `--ease-activity-pulse-duration`    | `1.8s`     | Online pulse ring animation duration |
+| `--ease-activity-max-width`         | `320px`    | Max card width                       |
+
+## Accessibility
+
+- Status dots are purely decorative (`aria-hidden="true"`); status is always conveyed via visible text too.
+- The typing indicator's container uses `aria-live="polite"` so screen reader users are notified when someone starts typing.
+- All animations are disabled under `prefers-reduced-motion: reduce`, including the pulse ring, typing dots, and hover lift.
+
+## Browser Support
+
+Works in all modern browsers supporting CSS custom properties and `@keyframes` (Chrome, Firefox, Safari, Edge).

--- a/submissions/examples/ease-user-activity-card/demo.html
+++ b/submissions/examples/ease-user-activity-card/demo.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>ease-user-activity-card Demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<div class="ease-activity-demo" data-theme="light">
+
+  <!-- Online / active now -->
+  <div class="ease-activity-card">
+    <div class="ease-activity-avatar-wrap">
+      <img
+        class="ease-activity-avatar"
+        src="https://i.pravatar.cc/100?img=12"
+        alt="Ayesha Khan"
+      />
+      <span class="ease-activity-status-dot is-online" aria-hidden="true"></span>
+    </div>
+    <div class="ease-activity-info">
+      <p class="ease-activity-name">Ayesha Khan</p>
+      <p class="ease-activity-status-text">Active now</p>
+    </div>
+  </div>
+
+  <!-- Typing -->
+  <div class="ease-activity-card">
+    <div class="ease-activity-avatar-wrap">
+      <img
+        class="ease-activity-avatar"
+        src="https://i.pravatar.cc/100?img=32"
+        alt="Rohan Mehta"
+      />
+      <span class="ease-activity-status-dot is-online" aria-hidden="true"></span>
+    </div>
+    <div class="ease-activity-info">
+      <p class="ease-activity-name">Rohan Mehta</p>
+      <p class="ease-activity-status-text is-typing" aria-live="polite">
+        <span class="ease-activity-typing-dot"></span>
+        <span class="ease-activity-typing-dot"></span>
+        <span class="ease-activity-typing-dot"></span>
+        typing
+      </p>
+    </div>
+  </div>
+
+  <!-- Away -->
+  <div class="ease-activity-card">
+    <div class="ease-activity-avatar-wrap">
+      <img
+        class="ease-activity-avatar"
+        src="https://i.pravatar.cc/100?img=45"
+        alt="Sofia Torres"
+      />
+      <span class="ease-activity-status-dot is-away" aria-hidden="true"></span>
+    </div>
+    <div class="ease-activity-info">
+      <p class="ease-activity-name">Sofia Torres</p>
+      <p class="ease-activity-status-text">Away · back in 10m</p>
+    </div>
+  </div>
+
+  <!-- Offline -->
+  <div class="ease-activity-card">
+    <div class="ease-activity-avatar-wrap">
+      <img
+        class="ease-activity-avatar"
+        src="https://i.pravatar.cc/100?img=5"
+        alt="Daniel Osei"
+      />
+      <span class="ease-activity-status-dot is-offline" aria-hidden="true"></span>
+    </div>
+    <div class="ease-activity-info">
+      <p class="ease-activity-name">Daniel Osei</p>
+      <p class="ease-activity-status-text">Last seen 2h ago</p>
+    </div>
+  </div>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/ease-user-activity-card/style.css
+++ b/submissions/examples/ease-user-activity-card/style.css
@@ -1,0 +1,194 @@
+/* ==========================================================================
+   ease-user-activity-card
+   A user activity card showing avatar, name, status text, and an animated
+   "active now" pulse indicator. Card lifts and reveals detail on hover.
+   ========================================================================== */
+
+:root {
+  --ease-activity-bg: #ffffff;
+  --ease-activity-border: #e2e8f0;
+  --ease-activity-text: #0f172a;
+  --ease-activity-muted: #64748b;
+  --ease-activity-accent: #22c55e;
+  --ease-activity-away: #f59e0b;
+  --ease-activity-offline: #94a3b8;
+  --ease-activity-radius: 0.9rem;
+  --ease-activity-duration: 0.25s;
+  --ease-activity-easing: ease;
+  --ease-activity-avatar-size: 3rem;
+  --ease-activity-pulse-duration: 1.8s;
+  --ease-activity-max-width: 320px;
+}
+
+[data-theme="dark"] {
+  --ease-activity-bg: #111827;
+  --ease-activity-border: #1f2937;
+  --ease-activity-text: #f1f5f9;
+  --ease-activity-muted: #94a3b8;
+}
+
+.ease-activity-demo {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  padding: 2rem;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.ease-activity-card {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  width: 100%;
+  max-width: var(--ease-activity-max-width);
+  padding: 1rem 1.15rem;
+  background: var(--ease-activity-bg);
+  border: 1px solid var(--ease-activity-border);
+  border-radius: var(--ease-activity-radius);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  transition: transform var(--ease-activity-duration) var(--ease-activity-easing),
+              box-shadow var(--ease-activity-duration) var(--ease-activity-easing);
+}
+
+.ease-activity-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.1);
+}
+
+.ease-activity-avatar-wrap {
+  position: relative;
+  flex-shrink: 0;
+  width: var(--ease-activity-avatar-size);
+  height: var(--ease-activity-avatar-size);
+}
+
+.ease-activity-avatar {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+  display: block;
+}
+
+.ease-activity-status-dot {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 50%;
+  background: var(--ease-activity-accent);
+  border: 2px solid var(--ease-activity-bg);
+}
+
+/* Animated pulse ring for "active now" status */
+.ease-activity-status-dot.is-online::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: var(--ease-activity-accent);
+  animation: ease-activity-ping var(--ease-activity-pulse-duration) cubic-bezier(0, 0, 0.2, 1) infinite;
+}
+
+@keyframes ease-activity-ping {
+  0% {
+    transform: scale(1);
+    opacity: 0.7;
+  }
+  75%,
+  100% {
+    transform: scale(2.2);
+    opacity: 0;
+  }
+}
+
+.ease-activity-status-dot.is-away {
+  background: var(--ease-activity-away);
+}
+
+.ease-activity-status-dot.is-offline {
+  background: var(--ease-activity-offline);
+}
+
+.ease-activity-info {
+  min-width: 0;
+  flex: 1;
+}
+
+.ease-activity-name {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--ease-activity-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ease-activity-status-text {
+  margin: 0.15rem 0 0;
+  font-size: 0.8rem;
+  color: var(--ease-activity-muted);
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Typing indicator dots, shown when status-text has .is-typing */
+.ease-activity-status-text.is-typing .ease-activity-typing-dot {
+  display: inline-block;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: currentColor;
+  margin-right: 2px;
+  animation: ease-activity-typing 1.2s infinite ease-in-out;
+}
+
+.ease-activity-status-text.is-typing .ease-activity-typing-dot:nth-child(2) {
+  animation-delay: 0.15s;
+}
+.ease-activity-status-text.is-typing .ease-activity-typing-dot:nth-child(3) {
+  animation-delay: 0.3s;
+}
+
+@keyframes ease-activity-typing {
+  0%,
+  60%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.5;
+  }
+  30% {
+    transform: translateY(-3px);
+    opacity: 1;
+  }
+}
+
+/* Responsive */
+@media (max-width: 480px) {
+  :root {
+    --ease-activity-avatar-size: 2.5rem;
+  }
+
+  .ease-activity-card {
+    max-width: 100%;
+    padding: 0.85rem;
+  }
+}
+
+/* Reduced motion support */
+@media (prefers-reduced-motion: reduce) {
+  .ease-activity-status-dot.is-online::after,
+  .ease-activity-status-text.is-typing .ease-activity-typing-dot {
+    animation: none;
+  }
+
+  .ease-activity-card:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Description
Adds the `ease-user-activity-card` component — a user card displaying avatar, name, and live status, with a pulsing "active now" indicator and an animated typing indicator, built entirely with CSS.

Closes #34674

## Changes
- `submissions/examples/ease-user-activity-card/demo.html` — Four card variants (online, typing, away, offline)
- `submissions/examples/ease-user-activity-card/style.css` — Pulse ring, typing dots, hover lift, theming
- `submissions/examples/ease-user-activity-card/README.md` — Usage docs, status variants, CSS variables

## Acceptance Criteria
- [x] Smooth CSS `@keyframes` animation (pulse ring + typing dots)
- [x] Interactive trigger: hover lift on card
- [x] Fully customizable via CSS custom properties (`--ease-activity-*`)
- [x] Responsive (avatar/padding scale down under 480px)
- [x] Light/dark mode via `[data-theme]`
- [x] `prefers-reduced-motion` respected
- [x] Accessible: decorative dots hidden from AT, `aria-live` on typing status

## Testing
- Verified pulse ring animates correctly on "online" status
- Verified typing dots bounce with staggered delays
- Verified reduced-motion disables all animation
- Verified responsive layout at mobile widths