### PR TITLE
feat: add ease-card-shimmer-load component (#34713)

### DIFF
--- a/submissions/examples/ease-card-shimmer-load-ij/README.md
+++ b/submissions/examples/ease-card-shimmer-load-ij/README.md
@@ -1,0 +1,59 @@
+# ease-card-shimmer-load
+
+A card skeleton loader with an animated shimmer sweep, used as a placeholder while real content loads. Click the toggle button to see the skeleton swap for loaded content.
+
+## Features
+
+- 🎯 Smooth CSS keyframe shimmer sweep across skeleton blocks
+- 🖱️ Interactive trigger: click toggle to switch between loading/loaded states
+- 🎨 Fully customizable via CSS custom properties
+- 🌗 Light/dark mode support via `[data-theme]`
+- 📱 Responsive: thumbnail height scales down on small screens
+- ♿ Accessible: `role="status"` + `aria-live="polite"` + `aria-busy` on the card so assistive tech is notified when loading completes; skeleton is `aria-hidden` with a visually-hidden "Loading content…" text as a fallback
+- 🧠 Respects `prefers-reduced-motion`
+
+## Usage
+
+```html
+<div class="ease-shimmer-card" role="status" aria-live="polite" aria-busy="true">
+  <div class="ease-shimmer-skeleton" aria-hidden="true">
+    <div class="ease-shimmer-block ease-shimmer-thumb"></div>
+    <div class="ease-shimmer-block ease-shimmer-line ease-shimmer-line--title"></div>
+    <div class="ease-shimmer-block ease-shimmer-line"></div>
+    <div class="ease-shimmer-block ease-shimmer-line ease-shimmer-line--short"></div>
+  </div>
+
+  <div class="ease-shimmer-content">
+    <img src="photo.jpg" alt="Description" />
+    <h3>Real Title</h3>
+    <p>Real loaded content.</p>
+  </div>
+</div>
+```
+
+Toggle to the loaded state by adding the `.is-loaded` class to `.ease-shimmer-card` (and updating `aria-busy="false"`) once your real data arrives — this hides the skeleton and reveals `.ease-shimmer-content` with a subtle fade-in.
+
+## CSS Variables
+
+| Variable                     | Default   | Description                          |
+|-------------------------------|-----------|-----------------------------------------|
+| `--ease-shimmer-bg`            | `#ffffff` | Card background                        |
+| `--ease-shimmer-border`        | `#e2e8f0` | Card border color                      |
+| `--ease-shimmer-base`          | `#e5e7eb` | Skeleton block base color              |
+| `--ease-shimmer-highlight`     | `#f8fafc` | Shimmer sweep highlight color          |
+| `--ease-shimmer-radius`        | `0.9rem`  | Card corner radius                     |
+| `--ease-shimmer-duration`      | `1.6s`    | Shimmer sweep animation duration        |
+| `--ease-shimmer-text`          | `#0f172a` | Loaded content title color             |
+| `--ease-shimmer-muted`         | `#64748b` | Loaded content body text color         |
+| `--ease-shimmer-max-width`     | `320px`   | Max card width                         |
+
+## Accessibility
+
+- The card uses `role="status"` and `aria-live="polite"` so screen readers announce when content finishes loading.
+- `aria-busy` reflects the current loading state and is toggled by the demo script.
+- The skeleton itself is `aria-hidden="true"` (purely decorative) with a visually-hidden "Loading content…" text as a redundant cue for assistive tech that doesn't process `aria-busy`.
+- All shimmer and fade-in animations are disabled under `prefers-reduced-motion: reduce`.
+
+## Browser Support
+
+Works in all modern browsers supporting CSS custom properties and `@keyframes` (Chrome, Firefox, Safari, Edge).

--- a/submissions/examples/ease-card-shimmer-load-ij/demo.html
+++ b/submissions/examples/ease-card-shimmer-load-ij/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>ease-card-shimmer-load Demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<div class="ease-shimmer-demo" data-theme="light">
+
+  <div class="ease-shimmer-card" id="easeShimmerCard" role="status" aria-live="polite" aria-busy="true">
+
+    <div class="ease-shimmer-skeleton" aria-hidden="true">
+      <div class="ease-shimmer-block ease-shimmer-thumb"></div>
+      <div class="ease-shimmer-block ease-shimmer-line ease-shimmer-line--title"></div>
+      <div class="ease-shimmer-block ease-shimmer-line"></div>
+      <div class="ease-shimmer-block ease-shimmer-line ease-shimmer-line--short"></div>
+      <span class="ease-shimmer-sr-text" style="position:absolute;left:-9999px;">Loading content…</span>
+    </div>
+
+    <div class="ease-shimmer-content">
+      <img src="https://picsum.photos/seed/ease-shimmer/400/300" alt="Mountain landscape at sunrise" />
+      <h3>Article Loaded</h3>
+      <p>This is the real content that replaces the shimmer placeholder once loading completes.</p>
+    </div>
+
+  </div>
+
+  <button class="ease-shimmer-toggle" id="easeShimmerToggle" type="button">
+    Toggle Load State
+  </button>
+
+</div>
+
+<script>
+  // Minimal JS only to demonstrate toggling loading -> loaded.
+  // All shimmer visuals/animation are pure CSS.
+  (function () {
+    var card = document.getElementById('easeShimmerCard');
+    var btn = document.getElementById('easeShimmerToggle');
+
+    btn.addEventListener('click', function () {
+      var isLoaded = card.classList.toggle('is-loaded');
+      card.setAttribute('aria-busy', isLoaded ? 'false' : 'true');
+    });
+  })();
+</script>
+
+</body>
+</html>

--- a/submissions/examples/ease-card-shimmer-load-ij/style.css
+++ b/submissions/examples/ease-card-shimmer-load-ij/style.css
@@ -1,0 +1,187 @@
+/* ==========================================================================
+   ease-card-shimmer-load
+   A card skeleton with an animated shimmer sweep, used as a loading
+   placeholder. Click the button to toggle between loading and loaded state.
+   ========================================================================== */
+
+:root {
+  --ease-shimmer-bg: #ffffff;
+  --ease-shimmer-border: #e2e8f0;
+  --ease-shimmer-base: #e5e7eb;
+  --ease-shimmer-highlight: #f8fafc;
+  --ease-shimmer-radius: 0.9rem;
+  --ease-shimmer-duration: 1.6s;
+  --ease-shimmer-text: #0f172a;
+  --ease-shimmer-muted: #64748b;
+  --ease-shimmer-max-width: 320px;
+}
+
+[data-theme="dark"] {
+  --ease-shimmer-bg: #111827;
+  --ease-shimmer-border: #1f2937;
+  --ease-shimmer-base: #1f2937;
+  --ease-shimmer-highlight: #334155;
+  --ease-shimmer-text: #f1f5f9;
+  --ease-shimmer-muted: #94a3b8;
+}
+
+.ease-shimmer-demo {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.25rem;
+  padding: 2rem;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.ease-shimmer-card {
+  width: 100%;
+  max-width: var(--ease-shimmer-max-width);
+  padding: 1.1rem;
+  background: var(--ease-shimmer-bg);
+  border: 1px solid var(--ease-shimmer-border);
+  border-radius: var(--ease-shimmer-radius);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.ease-shimmer-block {
+  position: relative;
+  overflow: hidden;
+  background: var(--ease-shimmer-base);
+  border-radius: 0.5rem;
+}
+
+.ease-shimmer-block::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--ease-shimmer-highlight) 50%,
+    transparent 100%
+  );
+  animation: ease-shimmer-sweep var(--ease-shimmer-duration) infinite;
+}
+
+@keyframes ease-shimmer-sweep {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+.ease-shimmer-thumb {
+  width: 100%;
+  height: 140px;
+  margin-bottom: 1rem;
+}
+
+.ease-shimmer-line {
+  height: 0.8rem;
+  margin-bottom: 0.6rem;
+}
+
+.ease-shimmer-line--title {
+  width: 70%;
+  height: 1rem;
+}
+
+.ease-shimmer-line--short {
+  width: 45%;
+  margin-bottom: 0;
+}
+
+/* Loaded content, hidden while in loading state */
+.ease-shimmer-content {
+  display: none;
+}
+
+.ease-shimmer-card.is-loaded .ease-shimmer-skeleton {
+  display: none;
+}
+
+.ease-shimmer-card.is-loaded .ease-shimmer-content {
+  display: block;
+  animation: ease-shimmer-fade-in 0.4s ease;
+}
+
+@keyframes ease-shimmer-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.ease-shimmer-content img {
+  width: 100%;
+  height: 140px;
+  object-fit: cover;
+  border-radius: 0.5rem;
+  margin-bottom: 1rem;
+  display: block;
+}
+
+.ease-shimmer-content h3 {
+  margin: 0 0 0.4rem;
+  font-size: 1rem;
+  color: var(--ease-shimmer-text);
+}
+
+.ease-shimmer-content p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--ease-shimmer-muted);
+}
+
+.ease-shimmer-toggle {
+  padding: 0.5rem 1.1rem;
+  border: none;
+  border-radius: 0.5rem;
+  background: var(--ease-shimmer-text);
+  color: var(--ease-shimmer-bg);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s ease, transform 0.15s ease;
+}
+
+.ease-shimmer-toggle:hover {
+  opacity: 0.85;
+}
+
+.ease-shimmer-toggle:active {
+  transform: scale(0.96);
+}
+
+.ease-shimmer-toggle:focus-visible {
+  outline: 2px solid var(--ease-shimmer-text);
+  outline-offset: 2px;
+}
+
+/* Responsive */
+@media (max-width: 480px) {
+  .ease-shimmer-card {
+    max-width: 100%;
+  }
+
+  .ease-shimmer-thumb,
+  .ease-shimmer-content img {
+    height: 110px;
+  }
+}
+
+/* Reduced motion support */
+@media (prefers-reduced-motion: reduce) {
+  .ease-shimmer-block::after {
+    animation: none;
+  }
+
+  .ease-shimmer-content {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Description
Adds the `ease-card-shimmer-load` component — a card skeleton loader with an animated shimmer sweep, used as a placeholder while real content loads. Toggling loaded state swaps the skeleton for actual content with a subtle fade-in.

Closes #34713

## Changes
- `submissions/examples/ease-card-shimmer-load-ij/demo.html` — Skeleton + loaded content toggle demo
- `submissions/examples/ease-card-shimmer-load-ij/style.css` — Shimmer sweep animation, fade-in, theming
- `submissions/examples/ease-card-shimmer-load-ij/README.md` — Usage docs, accessibility notes, CSS variables

## Acceptance Criteria
- [x] Smooth CSS `@keyframes` shimmer sweep animation
- [x] Interactive trigger: click toggle between loading/loaded states
- [x] Fully customizable via CSS custom properties (`--ease-shimmer-*`)
- [x] Responsive (thumbnail height adjusts under 480px)
- [x] Light/dark mode via `[data-theme]`
- [x] `prefers-reduced-motion` respected
- [x] Accessible: `role="status"`, `aria-live`, `aria-busy`, hidden skeleton with SR fallback text

## Testing
- Verified shimmer sweep loops smoothly across all skeleton blocks
- Verified toggle correctly swaps skeleton for loaded content with fade-in
- Verified reduced-motion disables shimmer and fade animations
- Verified responsive layout at mobile widths