### PR TITLE
feat: add ease-command-palette component (#35137)

### DIFF
--- a/submissions/examples/ease-command-palette/README.md
+++ b/submissions/examples/ease-command-palette/README.md
@@ -1,0 +1,69 @@
+# ease-command-palette
+
+A `Ctrl+K` / `Cmd+K` style command palette with a smooth fade + scale entrance animation, animated search input, and a searchable command list with hover/focus states — the kind of interface pattern found in developer tools, docs sites, and admin dashboards.
+
+## Features
+
+- 🎨 Smooth fade + scale entrance/exit animation on the palette
+- ⌨️ Keyboard-friendly: `Ctrl+K` / `Cmd+K` toggles it open, `Esc` closes it, `↑`/`↓` navigate the list
+- 🔍 Animated, focus-styled search input
+- 📋 Grouped, searchable command list with hover and focus-visible states
+- 🌙 Light and dark theme support via `[data-theme]`
+- 📱 Fully responsive layout
+- ⚡ Lightweight — minimal JS only for open/close/keyboard logic; all visuals are CSS
+- ♿ Accessible: `role="dialog"` + `aria-modal`, `role="listbox"`/`role="option"` with `aria-selected`, focus is moved into the search input on open and returned to the launcher on close
+- 🧠 Respects `prefers-reduced-motion`
+
+## Usage
+
+```html
+<button class="ease-cmdp-launcher" id="myLauncher" type="button" aria-haspopup="dialog">
+  Search commands…
+  <span class="ease-cmdp-kbd">Ctrl</span>
+  <span class="ease-cmdp-kbd">K</span>
+</button>
+
+<div class="ease-cmdp-overlay" id="myOverlay">
+  <div class="ease-cmdp-palette" role="dialog" aria-modal="true" aria-label="Command palette">
+    <div class="ease-cmdp-search-wrap">
+      <input class="ease-cmdp-search-input" type="text" placeholder="Type a command…" />
+    </div>
+    <ul class="ease-cmdp-list" role="listbox">
+      <li class="ease-cmdp-item" role="option" tabindex="0">
+        <span class="ease-cmdp-item-label">Go to Dashboard</span>
+        <span class="ease-cmdp-item-shortcut">G D</span>
+      </li>
+    </ul>
+  </div>
+</div>
+```
+
+Toggle the `.is-open` class on `.ease-cmdp-overlay` to open/close the palette — see `demo.html` for a complete working example including keyboard shortcut wiring.
+
+## CSS Variables
+
+| Variable                  | Default    | Description                          |
+|----------------------------|------------|-----------------------------------------|
+| `--ease-cmdp-overlay`       | `rgba(15,23,42,0.5)` | Backdrop overlay color       |
+| `--ease-cmdp-bg`            | `#ffffff`  | Palette background                     |
+| `--ease-cmdp-border`        | `#e2e8f0`  | Border color                           |
+| `--ease-cmdp-text`          | `#0f172a`  | Primary text color                     |
+| `--ease-cmdp-muted`         | `#64748b`  | Secondary/placeholder text color       |
+| `--ease-cmdp-accent`        | `#6366f1`  | Icon accent color                      |
+| `--ease-cmdp-hover-bg`      | `#eef2ff`  | Item hover/active background           |
+| `--ease-cmdp-radius`        | `0.9rem`   | Palette corner radius                  |
+| `--ease-cmdp-duration`      | `0.2s`     | Entrance/exit animation duration        |
+| `--ease-cmdp-easing`        | `cubic-bezier(0.16, 1, 0.3, 1)` | Entrance animation easing |
+| `--ease-cmdp-max-width`     | `480px`    | Max palette width                       |
+
+## Accessibility
+
+- The palette uses `role="dialog"` with `aria-modal="true"` and an `aria-label`.
+- The command list uses `role="listbox"` with each command as `role="option"` and `aria-selected` reflecting the active item.
+- Opening the palette moves focus into the search input; closing it returns focus to the launcher button, preserving keyboard flow.
+- `Esc` closes the palette; `↑`/`↓` move the active selection.
+- All entrance/exit and hover transitions are disabled under `prefers-reduced-motion: reduce`.
+
+## Browser Support
+
+Works in all modern browsers supporting CSS custom properties and CSS transitions (Chrome, Firefox, Safari, Edge). No experimental CSS features used.

--- a/submissions/examples/ease-command-palette/demo.html
+++ b/submissions/examples/ease-command-palette/demo.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>ease-command-palette Demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body data-theme="light">
+
+<div class="ease-cmdp-launcher-wrap">
+  <button class="ease-cmdp-launcher" id="easeCmdpLauncher" type="button" aria-haspopup="dialog">
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8" /><path d="m21 21-4.3-4.3" /></svg>
+    Search commands…
+    <span class="ease-cmdp-kbd">Ctrl</span>
+    <span class="ease-cmdp-kbd">K</span>
+  </button>
+</div>
+
+<div class="ease-cmdp-overlay" id="easeCmdpOverlay" role="presentation">
+  <div class="ease-cmdp-palette" role="dialog" aria-modal="true" aria-label="Command palette">
+
+    <div class="ease-cmdp-search-wrap">
+      <svg class="ease-cmdp-search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="11" cy="11" r="8" /><path d="m21 21-4.3-4.3" /></svg>
+      <input
+        class="ease-cmdp-search-input"
+        id="easeCmdpSearchInput"
+        type="text"
+        placeholder="Type a command or search…"
+        aria-label="Search commands"
+        autocomplete="off"
+      />
+      <button class="ease-cmdp-close" id="easeCmdpClose" type="button" aria-label="Close command palette">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18" /><path d="m6 6 12 12" /></svg>
+      </button>
+    </div>
+
+    <ul class="ease-cmdp-list" id="easeCmdpList" role="listbox" aria-label="Commands">
+      <li class="ease-cmdp-group-label" role="presentation">Navigation</li>
+      <li class="ease-cmdp-item is-active" role="option" tabindex="0" aria-selected="true">
+        <svg class="ease-cmdp-item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 9.5 12 3l9 6.5" /><path d="M5 10v10h14V10" /></svg>
+        <span class="ease-cmdp-item-label">Go to Dashboard</span>
+        <span class="ease-cmdp-item-shortcut">G D</span>
+      </li>
+      <li class="ease-cmdp-item" role="option" tabindex="0" aria-selected="false">
+        <svg class="ease-cmdp-item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="4" width="18" height="16" rx="2" /><path d="M3 10h18" /></svg>
+        <span class="ease-cmdp-item-label">Open Calendar</span>
+        <span class="ease-cmdp-item-shortcut">G C</span>
+      </li>
+
+      <li class="ease-cmdp-group-label" role="presentation">Actions</li>
+      <li class="ease-cmdp-item" role="option" tabindex="0" aria-selected="false">
+        <svg class="ease-cmdp-item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 5v14M5 12h14" /></svg>
+        <span class="ease-cmdp-item-label">Create New Project</span>
+        <span class="ease-cmdp-item-shortcut">N</span>
+      </li>
+      <li class="ease-cmdp-item" role="option" tabindex="0" aria-selected="false">
+        <svg class="ease-cmdp-item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.7 1.7 0 0 0 .3 1.9l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.9-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1-1.6 1.7 1.7 0 0 0-1.9.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.9 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.6-1 1.7 1.7 0 0 0-.3-1.9l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.9.3H9a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.9-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.9V9a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1Z" /></svg>
+        <span class="ease-cmdp-item-label">Open Settings</span>
+        <span class="ease-cmdp-item-shortcut">G S</span>
+      </li>
+    </ul>
+
+  </div>
+</div>
+
+<script>
+  // Minimal JS to open/close the palette and support Ctrl+K / Cmd+K.
+  // All visual transitions (fade, scale, hover) are pure CSS.
+  (function () {
+    var launcher = document.getElementById('easeCmdpLauncher');
+    var overlay = document.getElementById('easeCmdpOverlay');
+    var closeBtn = document.getElementById('easeCmdpClose');
+    var searchInput = document.getElementById('easeCmdpSearchInput');
+    var items = Array.prototype.slice.call(document.querySelectorAll('.ease-cmdp-item'));
+    var activeIndex = 0;
+
+    function openPalette() {
+      overlay.classList.add('is-open');
+      searchInput.value = '';
+      searchInput.focus();
+    }
+
+    function closePalette() {
+      overlay.classList.remove('is-open');
+      launcher.focus();
+    }
+
+    function setActive(index) {
+      items.forEach(function (item, i) {
+        var isActive = i === index;
+        item.classList.toggle('is-active', isActive);
+        item.setAttribute('aria-selected', isActive ? 'true' : 'false');
+      });
+      activeIndex = index;
+    }
+
+    launcher.addEventListener('click', openPalette);
+    closeBtn.addEventListener('click', closePalette);
+
+    overlay.addEventListener('click', function (e) {
+      if (e.target === overlay) closePalette();
+    });
+
+    document.addEventListener('keydown', function (e) {
+      var isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+      var modifier = isMac ? e.metaKey : e.ctrlKey;
+
+      if (modifier && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        overlay.classList.contains('is-open') ? closePalette() : openPalette();
+      }
+
+      if (overlay.classList.contains('is-open')) {
+        if (e.key === 'Escape') {
+          closePalette();
+        } else if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          setActive((activeIndex + 1) % items.length);
+        } else if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          setActive((activeIndex - 1 + items.length) % items.length);
+        }
+      }
+    });
+
+    items.forEach(function (item, i) {
+      item.addEventListener('click', function () {
+        setActive(i);
+        closePalette();
+      });
+    });
+  })();
+</script>
+
+</body>
+</html>

--- a/submissions/examples/ease-command-palette/style.css
+++ b/submissions/examples/ease-command-palette/style.css
@@ -1,0 +1,227 @@
+/* ==========================================================================
+   ease-command-palette
+   A Ctrl+K / Cmd+K style command palette with a fade+scale entrance
+   animation, animated search input, and hover/focus command list states.
+   ========================================================================== */
+
+:root {
+  --ease-cmdp-overlay: rgba(15, 23, 42, 0.5);
+  --ease-cmdp-bg: #ffffff;
+  --ease-cmdp-border: #e2e8f0;
+  --ease-cmdp-text: #0f172a;
+  --ease-cmdp-muted: #64748b;
+  --ease-cmdp-accent: #6366f1;
+  --ease-cmdp-hover-bg: #eef2ff;
+  --ease-cmdp-radius: 0.9rem;
+  --ease-cmdp-duration: 0.2s;
+  --ease-cmdp-easing: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-cmdp-max-width: 480px;
+}
+
+[data-theme="dark"] {
+  --ease-cmdp-overlay: rgba(0, 0, 0, 0.6);
+  --ease-cmdp-bg: #111827;
+  --ease-cmdp-border: #1f2937;
+  --ease-cmdp-text: #f1f5f9;
+  --ease-cmdp-muted: #94a3b8;
+  --ease-cmdp-hover-bg: #1e1b4b;
+}
+
+.ease-cmdp-launcher-wrap {
+  display: flex;
+  justify-content: center;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.ease-cmdp-launcher {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1rem;
+  border: 1px solid var(--ease-cmdp-border);
+  border-radius: 0.6rem;
+  background: var(--ease-cmdp-bg);
+  color: var(--ease-cmdp-muted);
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: border-color var(--ease-cmdp-duration) ease;
+}
+
+.ease-cmdp-launcher:hover,
+.ease-cmdp-launcher:focus-visible {
+  border-color: var(--ease-cmdp-accent);
+  outline: none;
+}
+
+.ease-cmdp-kbd {
+  padding: 0.15rem 0.4rem;
+  border: 1px solid var(--ease-cmdp-border);
+  border-radius: 0.35rem;
+  font-size: 0.75rem;
+  font-family: inherit;
+}
+
+/* Overlay + palette */
+.ease-cmdp-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--ease-cmdp-overlay);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 12vh;
+  z-index: 1000;
+
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--ease-cmdp-duration) ease, visibility 0s linear var(--ease-cmdp-duration);
+}
+
+.ease-cmdp-overlay.is-open {
+  opacity: 1;
+  visibility: visible;
+  transition: opacity var(--ease-cmdp-duration) ease;
+}
+
+.ease-cmdp-palette {
+  width: 100%;
+  max-width: var(--ease-cmdp-max-width);
+  background: var(--ease-cmdp-bg);
+  border: 1px solid var(--ease-cmdp-border);
+  border-radius: var(--ease-cmdp-radius);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.25);
+  overflow: hidden;
+
+  /* Entrance animation */
+  transform: scale(0.95) translateY(-8px);
+  opacity: 0;
+  transition: transform var(--ease-cmdp-duration) var(--ease-cmdp-easing),
+              opacity var(--ease-cmdp-duration) var(--ease-cmdp-easing);
+}
+
+.ease-cmdp-overlay.is-open .ease-cmdp-palette {
+  transform: scale(1) translateY(0);
+  opacity: 1;
+}
+
+.ease-cmdp-search-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 1rem 1.1rem;
+  border-bottom: 1px solid var(--ease-cmdp-border);
+}
+
+.ease-cmdp-search-icon {
+  width: 1.1rem;
+  height: 1.1rem;
+  color: var(--ease-cmdp-muted);
+  flex-shrink: 0;
+}
+
+.ease-cmdp-search-input {
+  flex: 1;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--ease-cmdp-text);
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+.ease-cmdp-search-input::placeholder {
+  color: var(--ease-cmdp-muted);
+}
+
+.ease-cmdp-close {
+  border: none;
+  background: transparent;
+  color: var(--ease-cmdp-muted);
+  cursor: pointer;
+  padding: 0.2rem;
+  border-radius: 0.3rem;
+  transition: background var(--ease-cmdp-duration) ease;
+}
+
+.ease-cmdp-close:hover {
+  background: var(--ease-cmdp-hover-bg);
+}
+
+.ease-cmdp-list {
+  list-style: none;
+  margin: 0;
+  padding: 0.5rem;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.ease-cmdp-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.7rem 0.75rem;
+  border-radius: 0.55rem;
+  color: var(--ease-cmdp-text);
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background var(--ease-cmdp-duration) ease, transform 0.15s ease;
+}
+
+.ease-cmdp-item:hover,
+.ease-cmdp-item:focus-visible,
+.ease-cmdp-item.is-active {
+  background: var(--ease-cmdp-hover-bg);
+  outline: none;
+  transform: translateX(2px);
+}
+
+.ease-cmdp-item-icon {
+  width: 1.1rem;
+  height: 1.1rem;
+  color: var(--ease-cmdp-accent);
+  flex-shrink: 0;
+}
+
+.ease-cmdp-item-label {
+  flex: 1;
+}
+
+.ease-cmdp-item-shortcut {
+  font-size: 0.75rem;
+  color: var(--ease-cmdp-muted);
+  padding: 0.1rem 0.4rem;
+  border: 1px solid var(--ease-cmdp-border);
+  border-radius: 0.3rem;
+}
+
+.ease-cmdp-group-label {
+  padding: 0.5rem 0.75rem 0.25rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--ease-cmdp-muted);
+}
+
+/* Responsive */
+@media (max-width: 560px) {
+  .ease-cmdp-overlay {
+    padding-top: 4vh;
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .ease-cmdp-palette {
+    max-width: 100%;
+  }
+}
+
+/* Reduced motion support */
+@media (prefers-reduced-motion: reduce) {
+  .ease-cmdp-overlay,
+  .ease-cmdp-palette,
+  .ease-cmdp-item {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Description
Adds `ease-command-palette` — a Ctrl+K / Cmd+K style command palette with a smooth fade + scale entrance animation, animated search input, and a searchable, keyboard-navigable command list.

Closes #35137

## Changes
- `submissions/examples/ease-command-palette/demo.html` — Full working palette with launcher button, search, grouped commands, and keyboard shortcuts
- `submissions/examples/ease-command-palette/style.css` — Entrance/exit animation, hover/focus states, theming, responsive layout
- `submissions/examples/ease-command-palette/README.md` — Usage docs, CSS variables, accessibility notes

## Acceptance Criteria
- [x] Reusable `ease-command-palette` component
- [x] Smooth open/close animation (fade + scale)
- [x] Responsive layout (full-width on small screens)
- [x] Hover and focus animation states on command list items
- [x] Compatible with modern browsers (standard CSS transitions only)
- [x] Documentation with usage examples and CSS variable customization options
- [x] Ctrl+K / Cmd+K keyboard shortcut, Esc to close, arrow-key navigation
- [x] `prefers-reduced-motion` respected

## Testing
- Verified Ctrl+K / Cmd+K opens and closes the palette
- Verified fade + scale entrance/exit animation
- Verified arrow-key navigation and Esc close behavior
- Verified focus moves to search input on open and back to launcher on close
- Verified reduced-motion disables all transitions
- Verified responsive layout at mobile widths