### PR TITLE
feat: add ease-page-loader component (#35214)

### DIFF
--- a/submissions/examples/ease-page-loader/README.md
+++ b/submissions/examples/ease-page-loader/README.md
@@ -1,0 +1,65 @@
+# ease-page-loader
+
+A full-screen animated page loader / splash screen that displays while content loads, then smoothly fades out to reveal the page. Features a pulsing branded logo, an animated progress bar, and a smooth exit transition.
+
+## Features
+
+- 🎨 Pulsing logo animation (customizable — emoji, text, or SVG)
+- 📊 Animated progress bar that fills over a configurable duration
+- ✨ Smooth fade-out exit transition when loading completes
+- 🔁 Self-hides automatically when the progress animation ends (with a `window.load` fallback), or can be dismissed manually by toggling `.is-hidden`
+- 🎨 Fully customizable via CSS custom properties
+- 🌗 Light/dark mode support via `[data-theme]`
+- 📱 Responsive: logo size and bar width scale down on small screens
+- ♿ Accessible: `role="alert"` + `aria-live="assertive"` + `aria-label` so assistive tech announces the loading state; logo is `aria-hidden` (decorative)
+- 🧠 Respects `prefers-reduced-motion` — loader skips animation and hides immediately
+
+## Usage
+
+```html
+<div class="ease-page-loader" id="pageLoader" role="alert" aria-live="assertive" aria-label="Page is loading">
+  <div class="ease-page-loader__content">
+    <div class="ease-page-loader__logo" aria-hidden="true">⚡</div>
+    <div class="ease-page-loader__bar">
+      <div class="ease-page-loader__progress"></div>
+    </div>
+    <p class="ease-page-loader__text">Loading...</p>
+  </div>
+</div>
+```
+
+To hide the loader once your page/assets are ready, add the `.is-hidden` class:
+
+```js
+document.getElementById('pageLoader').classList.add('is-hidden');
+```
+
+The included demo automatically hides the loader when the progress-bar fill animation finishes (`animationend`), with a `window.load` timeout as a fallback in case the tab was backgrounded.
+
+## CSS Variables
+
+| Variable                        | Default    | Description                          |
+|-----------------------------------|------------|-----------------------------------------|
+| `--ease-loader-bg`                 | `#0f0f1a`  | Full-screen background color          |
+| `--ease-loader-text`               | `#f1f5f9`  | Primary text color                    |
+| `--ease-loader-muted`              | `#94a3b8`  | "Loading..." text color               |
+| `--ease-loader-accent-start`       | `#6366f1`  | Progress bar gradient start           |
+| `--ease-loader-accent-end`         | `#3b82f6`  | Progress bar gradient end             |
+| `--ease-loader-bar-track`          | `rgba(255,255,255,0.1)` | Progress bar track color |
+| `--ease-loader-bar-width`          | `200px`    | Progress bar width                    |
+| `--ease-loader-bar-height`         | `4px`      | Progress bar height                   |
+| `--ease-loader-logo-size`          | `4rem`     | Logo font size                        |
+| `--ease-loader-pulse-duration`     | `1s`       | Logo pulse animation duration          |
+| `--ease-loader-fill-duration`      | `2s`       | Progress bar fill duration            |
+| `--ease-loader-exit-duration`      | `0.5s`     | Fade-out exit transition duration      |
+
+## Accessibility
+
+- The loader uses `role="alert"` and `aria-live="assertive"` so screen readers immediately announce that the page is loading.
+- `aria-label="Page is loading"` gives a clear description independent of the decorative logo.
+- The logo is marked `aria-hidden="true"` since it conveys no essential information beyond branding.
+- Under `prefers-reduced-motion: reduce`, the loader skips its animations and hides immediately rather than forcing users to wait through a pulse/fill they can't perceive as motion.
+
+## Browser Support
+
+Works in all modern browsers supporting CSS custom properties and `@keyframes` (Chrome, Firefox, Safari, Edge).

--- a/submissions/examples/ease-page-loader/demo.html
+++ b/submissions/examples/ease-page-loader/demo.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>ease-page-loader Demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body data-theme="dark">
+
+<!-- The page's real content, revealed once the loader fades out -->
+<main class="ease-loader-demo-page">
+  <button class="ease-loader-replay-btn" id="easeLoaderReplay" type="button">
+    Replay Loader
+  </button>
+</main>
+
+<!-- The loader itself. role="alert" + aria-live announce it to assistive
+     tech; it self-hides after the progress bar completes, or can be
+     dismissed early by toggling .is-hidden via JS. -->
+<div class="ease-page-loader" id="pageLoader" role="alert" aria-live="assertive" aria-label="Page is loading">
+  <div class="ease-page-loader__content">
+    <div class="ease-page-loader__logo" aria-hidden="true">⚡</div>
+    <div class="ease-page-loader__bar">
+      <div class="ease-page-loader__progress" id="pageLoaderProgress"></div>
+    </div>
+    <p class="ease-page-loader__text">Loading...</p>
+  </div>
+</div>
+
+<script>
+  // Minimal JS: hides the loader once the progress-fill animation
+  // completes (or immediately, if reduced motion is preferred), and
+  // lets the demo replay it. All visuals are pure CSS.
+  (function () {
+    var loader = document.getElementById('pageLoader');
+    var progress = document.getElementById('pageLoaderProgress');
+    var replayBtn = document.getElementById('easeLoaderReplay');
+    var prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    function hideLoader() {
+      loader.classList.add('is-hidden');
+    }
+
+    function showLoader() {
+      loader.classList.remove('is-hidden');
+      // Restart the progress-fill animation
+      progress.style.animation = 'none';
+      void progress.offsetWidth;
+      progress.style.animation = '';
+    }
+
+    if (prefersReducedMotion) {
+      hideLoader();
+    } else {
+      // Fires when the CSS fill animation finishes
+      progress.addEventListener('animationend', hideLoader);
+      // Fallback in case animationend doesn't fire (e.g. tab backgrounded)
+      window.addEventListener('load', function () {
+        setTimeout(hideLoader, 2500);
+      });
+    }
+
+    replayBtn.addEventListener('click', showLoader);
+  })();
+</script>
+
+</body>
+</html>

--- a/submissions/examples/ease-page-loader/style.css
+++ b/submissions/examples/ease-page-loader/style.css
@@ -1,0 +1,166 @@
+/* ==========================================================================
+   ease-page-loader
+   A full-screen animated page loader / splash screen with a pulsing logo,
+   an animated progress bar, and a smooth fade-out exit transition.
+   ========================================================================== */
+
+:root {
+  --ease-loader-bg: #0f0f1a;
+  --ease-loader-text: #f1f5f9;
+  --ease-loader-muted: #94a3b8;
+  --ease-loader-accent-start: #6366f1;
+  --ease-loader-accent-end: #3b82f6;
+  --ease-loader-bar-track: rgba(255, 255, 255, 0.1);
+  --ease-loader-bar-width: 200px;
+  --ease-loader-bar-height: 4px;
+  --ease-loader-logo-size: 4rem;
+  --ease-loader-pulse-duration: 1s;
+  --ease-loader-fill-duration: 2s;
+  --ease-loader-exit-duration: 0.5s;
+}
+
+[data-theme="light"] {
+  --ease-loader-bg: #f8fafc;
+  --ease-loader-text: #0f172a;
+  --ease-loader-muted: #64748b;
+  --ease-loader-bar-track: rgba(15, 23, 42, 0.08);
+}
+
+.ease-page-loader {
+  position: fixed;
+  inset: 0;
+  background: var(--ease-loader-bg);
+  color: var(--ease-loader-text);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 99999;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  transition: opacity var(--ease-loader-exit-duration) ease,
+              visibility var(--ease-loader-exit-duration) ease;
+}
+
+/* Toggle this class (e.g. via JS once the page/assets finish loading)
+   to trigger the exit transition. */
+.ease-page-loader.is-hidden {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.ease-page-loader__content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.ease-page-loader__logo {
+  font-size: var(--ease-loader-logo-size);
+  margin-bottom: 2rem;
+  animation: ease-loader-pulse var(--ease-loader-pulse-duration) ease-in-out infinite;
+}
+
+@keyframes ease-loader-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.2);
+    opacity: 0.8;
+  }
+}
+
+.ease-page-loader__bar {
+  width: var(--ease-loader-bar-width);
+  height: var(--ease-loader-bar-height);
+  background: var(--ease-loader-bar-track);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.ease-page-loader__progress {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, var(--ease-loader-accent-start), var(--ease-loader-accent-end));
+  border-radius: 999px;
+  animation: ease-loader-fill var(--ease-loader-fill-duration) ease forwards;
+}
+
+@keyframes ease-loader-fill {
+  from {
+    width: 0%;
+  }
+  to {
+    width: 100%;
+  }
+}
+
+.ease-page-loader__text {
+  margin: 1rem 0 0;
+  font-size: 0.9rem;
+  color: var(--ease-loader-muted);
+  letter-spacing: 0.02em;
+}
+
+/* Demo page content revealed behind the loader */
+.ease-loader-demo-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--ease-loader-bg);
+  color: var(--ease-loader-text);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.ease-loader-replay-btn {
+  padding: 0.7rem 1.4rem;
+  border: none;
+  border-radius: 0.6rem;
+  background: var(--ease-loader-accent-start);
+  color: #ffffff;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s ease, transform 0.15s ease;
+}
+
+.ease-loader-replay-btn:hover {
+  opacity: 0.88;
+}
+
+.ease-loader-replay-btn:active {
+  transform: scale(0.97);
+}
+
+.ease-loader-replay-btn:focus-visible {
+  outline: 2px solid var(--ease-loader-accent-start);
+  outline-offset: 3px;
+}
+
+/* Responsive */
+@media (max-width: 480px) {
+  :root {
+    --ease-loader-logo-size: 3rem;
+    --ease-loader-bar-width: 160px;
+  }
+}
+
+/* Reduced motion support */
+@media (prefers-reduced-motion: reduce) {
+  .ease-page-loader__logo {
+    animation: none;
+  }
+
+  .ease-page-loader__progress {
+    animation: none;
+    width: 100%;
+  }
+
+  .ease-page-loader {
+    transition: opacity 0.15s linear, visibility 0.15s linear;
+  }
+}


### PR DESCRIPTION
## Description
Adds `ease-page-loader` — a full-screen animated page loader / splash screen with a pulsing branded logo, an animated progress bar, and a smooth fade-out exit transition. Auto-hides when loading completes, or can be dismissed manually.

Closes #35214

## Changes
- `submissions/examples/ease-page-loader/demo.html` — Full working loader with auto-hide + replay button
- `submissions/examples/ease-page-loader/style.css` — Logo pulse, progress fill, exit transition, theming
- `submissions/examples/ease-page-loader/README.md` — Usage docs, CSS variables, accessibility notes

## Acceptance Criteria
- [x] Full-screen loader with branded logo animation
- [x] Loading progress bar animation
- [x] Smooth exit transition (fade + visibility) on hide
- [x] Auto-hides after progress completes, or via class toggle
- [x] Fully customizable via CSS custom properties (`--ease-loader-*`)
- [x] Responsive (logo/bar sizing scales down under 480px)
- [x] Light/dark mode via `[data-theme]`
- [x] `prefers-reduced-motion` respected (skips animation, hides immediately)
- [x] Accessible: `role="alert"`, `aria-live="assertive"`, `aria-label`, decorative logo hidden from AT

## Testing
- Verified logo pulse and progress-bar fill animate correctly
- Verified loader auto-hides on `animationend`, with `window.load` fallback
- Verified manual toggle via `.is-hidden` class works independently
- Verified reduced-motion skips animation and hides immediately
- Verified responsive sizing at mobile widths