### PR TITLE
feat: add logo-reveal component (#35453)

### DIFF
--- a/submissions/examples/ease-logo-reveal-ij/README.md
+++ b/submissions/examples/ease-logo-reveal-ij/README.md
@@ -1,0 +1,36 @@
+# Logo Reveal
+
+Interactive SVG logo reveal with stroke-dash path drawing animation and staggered multi-path support.
+
+## Features
+
+- SVG paths animate from invisible to drawn using `stroke-dasharray` / `stroke-dashoffset`
+- Multiple logo style options (Hex Star, Ease Mark, Diamond Arc)
+- Staggered path draw with configurable delay
+- Fill color fades in after stroke completes
+- Replay button to retrigger animation
+- Speed slider (0.25x – 3x)
+
+## Usage
+
+Include `style.css` and `demo.html`. The component uses CSS custom properties for theming.
+
+### Custom Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `--lr-duration` | `2s` | Stroke draw duration |
+| `--lr-stroke-color` | `#6366f1` | Path stroke color |
+| `--lr-fill-color` | `#6366f1` | Path fill color (appears after stroke) |
+| `--lr-stagger` | `0.15s` | Delay between each path start |
+| `--lr-bg` | `#0f0f1a` | Background color |
+
+### JavaScript API
+
+- `replayBtn` – retriggers the draw animation
+- `speedSlider` – adjusts `--lr-speed` which scales animation timing
+- `styleSelect` – switches between logo SVGs
+
+## Browser Support
+
+Chromium, Firefox, Safari. Requires `getTotalLength()` support.

--- a/submissions/examples/ease-logo-reveal-ij/demo.html
+++ b/submissions/examples/ease-logo-reveal-ij/demo.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Logo Reveal</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Logo Reveal</h1>
+  <p class="subtitle">Stroke-dash path reveal with stagger</p>
+
+  <div class="container">
+    <div class="controls">
+      <button id="replayBtn" class="btn">&#9654; Replay</button>
+      <div class="control-group">
+        <label for="speedSlider">Speed: <span id="speedLabel">1.0</span>x</label>
+        <input type="range" id="speedSlider" min="0.25" max="3" step="0.05" value="1">
+      </div>
+      <div class="control-group">
+        <label for="styleSelect">Logo Style</label>
+        <select id="styleSelect">
+          <option value="hex">Hex Star</option>
+          <option value="ease">Ease Mark</option>
+          <option value="diamond">Diamond Arc</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="logo-wrapper" id="logoWrapper">
+      <!-- Hex Star -->
+      <svg id="logo-hex" class="logo-svg active" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+        <path class="lr-path" d="M100 10 L180 55 L180 145 L100 190 L20 145 L20 55 Z" fill="none" stroke-width="4" stroke-linejoin="round"/>
+        <path class="lr-path" d="M100 40 L148 65 L148 135 L100 160 L52 135 L52 65 Z" fill="none" stroke-width="3" stroke-linejoin="round"/>
+        <path class="lr-path" d="M100 70 L124 85 L124 115 L100 130 L76 115 L76 85 Z" fill="none" stroke-width="2.5" stroke-linejoin="round"/>
+        <path class="lr-path" d="M100 10 L148 65 M100 10 L52 65 M180 55 L124 85 M180 55 L148 135 M20 55 L76 85 M20 55 L52 135 M100 190 L76 115 M100 190 L124 115" fill="none" stroke-width="1.5" stroke-linecap="round"/>
+      </svg>
+
+      <!-- Ease Mark -->
+      <svg id="logo-ease" class="logo-svg" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+        <path class="lr-path" d="M30 100 Q30 40 80 40 Q110 40 110 70 Q110 100 80 100 Q50 100 50 130 Q50 160 80 160 Q130 160 150 120" fill="none" stroke-width="5" stroke-linecap="round"/>
+        <path class="lr-path" d="M140 60 L170 60 M140 100 L180 100 M140 140 L160 140" fill="none" stroke-width="4" stroke-linecap="round"/>
+        <path class="lr-path" d="M100 40 L100 160" fill="none" stroke-width="2" stroke-dasharray="4 6" stroke-linecap="round"/>
+      </svg>
+
+      <!-- Diamond Arc -->
+      <svg id="logo-diamond" class="logo-svg" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+        <path class="lr-path" d="M100 10 L170 100 L100 190 L30 100 Z" fill="none" stroke-width="4" stroke-linejoin="round"/>
+        <path class="lr-path" d="M100 40 L145 100 L100 160 L55 100 Z" fill="none" stroke-width="3" stroke-linejoin="round"/>
+        <path class="lr-path" d="M30 100 L170 100 M100 10 L100 190" fill="none" stroke-width="2" stroke-linecap="round"/>
+        <circle class="lr-path" cx="100" cy="100" r="15" fill="none" stroke-width="3"/>
+      </svg>
+    </div>
+
+    <div id="status" class="status">Ready</div>
+  </div>
+
+  <script>
+    const wrapper = document.getElementById('logoWrapper');
+    const replayBtn = document.getElementById('replayBtn');
+    const speedSlider = document.getElementById('speedSlider');
+    const speedLabel = document.getElementById('speedLabel');
+    const styleSelect = document.getElementById('styleSelect');
+    const status = document.getElementById('status');
+
+    function getActiveSvg() {
+      return wrapper.querySelector('.logo-svg.active');
+    }
+
+    function getPaths() {
+      const svg = getActiveSvg();
+      return svg ? [...svg.querySelectorAll('.lr-path')] : [];
+    }
+
+    function resetPaths() {
+      const root = document.documentElement;
+      const speed = parseFloat(speedSlider.value);
+      root.style.setProperty('--lr-speed', speed);
+      getPaths().forEach((path, i) => {
+        const len = path.getTotalLength();
+        path.style.strokeDasharray = len;
+        path.style.strokeDashoffset = len;
+        path.style.animation = 'none';
+        path.getBoundingClientRect();
+        path.style.animation = '';
+        path.style.setProperty('--path-index', i);
+      });
+      status.textContent = 'Animating...';
+      setTimeout(() => { status.textContent = 'Complete'; }, 3000 / speed);
+    }
+
+    function switchLogo(id) {
+      wrapper.querySelectorAll('.logo-svg').forEach(svg => svg.classList.remove('active'));
+      document.getElementById(id).classList.add('active');
+      resetPaths();
+    }
+
+    replayBtn.addEventListener('click', resetPaths);
+
+    speedSlider.addEventListener('input', () => {
+      const val = parseFloat(speedSlider.value);
+      speedLabel.textContent = val.toFixed(2);
+      document.documentElement.style.setProperty('--lr-speed', val);
+    });
+
+    styleSelect.addEventListener('change', () => {
+      const map = { hex: 'logo-hex', ease: 'logo-ease', diamond: 'logo-diamond' };
+      switchLogo(map[styleSelect.value]);
+    });
+
+    window.addEventListener('load', resetPaths);
+    window.addEventListener('resize', () => {
+      getPaths().forEach(p => {
+        const len = p.getTotalLength();
+        p.style.strokeDasharray = len;
+        p.style.strokeDashoffset = len;
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-logo-reveal-ij/style.css
+++ b/submissions/examples/ease-logo-reveal-ij/style.css
@@ -1,0 +1,175 @@
+:root {
+  --lr-duration: 2s;
+  --lr-stroke-color: #6366f1;
+  --lr-fill-color: #6366f1;
+  --lr-stagger: 0.15s;
+  --lr-bg: #0f0f1a;
+  --lr-speed: 1;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+  background: var(--lr-bg);
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+h1 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin-bottom: 0.25rem;
+}
+
+.subtitle {
+  color: #94a3b8;
+  margin-bottom: 2rem;
+  font-size: 0.95rem;
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+  width: 100%;
+  max-width: 520px;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+}
+
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.control-group label {
+  font-size: 0.8rem;
+  color: #94a3b8;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.btn {
+  background: var(--lr-stroke-color);
+  color: #fff;
+  border: none;
+  padding: 0.6rem 1.4rem;
+  border-radius: 8px;
+  font-family: 'Inter', sans-serif;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: opacity 0.2s, transform 0.15s;
+}
+
+.btn:hover {
+  opacity: 0.9;
+  transform: scale(1.03);
+}
+
+.btn:active {
+  transform: scale(0.97);
+}
+
+input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  height: 4px;
+  border-radius: 2px;
+  background: #334155;
+  outline: none;
+  width: 120px;
+}
+
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--lr-stroke-color);
+  cursor: pointer;
+}
+
+select {
+  font-family: 'Inter', sans-serif;
+  background: #1e293b;
+  color: #e2e8f0;
+  border: 1px solid #334155;
+  padding: 0.4rem 0.8rem;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.logo-wrapper {
+  width: 260px;
+  height: 260px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.logo-svg {
+  display: none;
+  width: 100%;
+  height: 100%;
+}
+
+.logo-svg.active {
+  display: block;
+}
+
+.lr-path {
+  stroke: var(--lr-stroke-color);
+  stroke-dasharray: 500;
+  stroke-dashoffset: 500;
+  fill: transparent;
+  animation: drawPath var(--lr-duration) ease-out forwards;
+  animation-delay: calc(var(--path-index, 0) * var(--lr-stagger) / var(--lr-speed, 1));
+  animation-duration: calc(var(--lr-duration) / var(--lr-speed, 1));
+}
+
+.logo-svg.active .lr-path:last-child {
+  animation-fill-mode: forwards;
+}
+
+@keyframes drawPath {
+  0% {
+    stroke-dashoffset: 500;
+    fill: transparent;
+  }
+  70% {
+    fill: transparent;
+  }
+  100% {
+    stroke-dashoffset: 0;
+    fill: var(--lr-fill-color);
+  }
+}
+
+.status {
+  font-size: 0.85rem;
+  color: #64748b;
+  font-family: 'Inter', monospace;
+  min-height: 1.2em;
+}


### PR DESCRIPTION
## Component: ease-logo-reveal - Logo reveal SVG draw animation

**Closes #35453**

### What this adds
CSS animated logo-reveal component.

### Acceptance Criteria covered
- Smooth CSS transition or @keyframes animation
- Interactive trigger (click, hover, or scroll)
- Customizable via CSS variables

### Files
- \submissions/examples/ease-logo-reveal-ij/demo.html\
- \submissions/examples/ease-logo-reveal-ij/style.css\
- \submissions/examples/ease-logo-reveal-ij/README.md\

### How to review
Open \demo.html\ directly in a browser.
