### PR TITLE
fix(tooltip): disable scale/translate animation under prefers-reduced-motion

### DIFF
--- a/submissions/examples/fix-tooltip-reduced-motion-ag/README.md
+++ b/submissions/examples/fix-tooltip-reduced-motion-ag/README.md
@@ -1,0 +1,32 @@
+# Fix Tooltip prefers-reduced-motion
+
+## What does this do?
+
+Adds a `@media (prefers-reduced-motion: reduce)` block to `.ease-tooltip` so
+the scale and translate animation is disabled for users who have enabled
+**Reduce Motion** in their OS accessibility settings.
+
+## How is it used?
+
+```html
+<span class="ease-tooltip" data-tooltip="Helpful hint text">
+  Hover me
+</span>
+```
+
+No change to the HTML API. The fix is CSS-only and activates automatically
+when the user's OS reports `prefers-reduced-motion: reduce`.
+
+## Why is it useful?
+
+CSS animations involving `scale()` and `translateY()` can trigger vestibular
+symptoms (dizziness, nausea) in users with vestibular disorders. WCAG 2.1
+Success Criterion 2.3.3 (Animation from Interactions, AAA) requires that
+motion animation triggered by interaction can be disabled.
+
+The fix removes the `scale` + `translateY` transform entirely under
+`prefers-reduced-motion: reduce`, keeping only a short opacity crossfade
+(which is considered acceptable per WCAG guidance since it does not involve
+spatial movement).
+
+Fixes: #35724

--- a/submissions/examples/fix-tooltip-reduced-motion-ag/demo.html
+++ b/submissions/examples/fix-tooltip-reduced-motion-ag/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tooltip Reduced-Motion Fix – EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Tooltip — Reduced Motion Fix Demo</h1>
+  <p class="subtitle">
+    Enable <strong>Reduce Motion</strong> in your OS settings, then hover the tooltips below.
+    With the fix, no scale/translate animation plays — only a quick opacity crossfade.
+  </p>
+
+  <!-- Normal motion -->
+  <div class="demo-row">
+    <span class="demo-label">Default (top):</span>
+    <span class="ease-tooltip" data-tooltip="Tooltip appears above with scale animation in normal motion mode">
+      Hover for top tooltip
+    </span>
+  </div>
+
+  <!-- Bottom placement -->
+  <div class="demo-row">
+    <span class="demo-label">Bottom placement:</span>
+    <span class="ease-tooltip" data-position="bottom" data-tooltip="This tooltip appears below the trigger element">
+      Hover for bottom tooltip
+    </span>
+  </div>
+
+  <!-- Keyboard accessible -->
+  <div class="demo-row">
+    <span class="demo-label">Keyboard accessible:</span>
+    <button
+      class="ease-tooltip"
+      data-tooltip="This tooltip also shows on :focus-visible for keyboard users"
+      style="padding: 0.45rem 1rem; border: 1px solid #ced4da; border-radius: 6px;
+             background: #f8f9fa; cursor: pointer; font-size: 1rem;">
+      Focus me (Tab key)
+    </button>
+  </div>
+
+  <p class="note">
+    <strong>Testing tip:</strong> On macOS, go to
+    <em>System Settings → Accessibility → Display → Reduce Motion</em> and toggle it on.
+    Then hover the tooltips above — the scale/translate animation will be gone,
+    replaced by a simple opacity crossfade only.
+  </p>
+</body>
+</html>

--- a/submissions/examples/fix-tooltip-reduced-motion-ag/style.css
+++ b/submissions/examples/fix-tooltip-reduced-motion-ag/style.css
@@ -1,0 +1,180 @@
+/* =====================================================
+   EaseMotion CSS – Tooltip prefers-reduced-motion Fix
+   Disables scale/fade animation for users who prefer
+   reduced motion, per WCAG 2.1 SC 2.3.3
+   Fixes: #35724
+   ===================================================== */
+
+/* ── CSS Custom Properties ──────────────────────────── */
+:root {
+  --ease-tooltip-bg: #1e1e2e;
+  --ease-tooltip-color: #e0e0f0;
+  --ease-tooltip-border-radius: 5px;
+  --ease-tooltip-padding: 0.4rem 0.75rem;
+  --ease-tooltip-font-size: 0.8125rem;
+  --ease-tooltip-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  --ease-tooltip-arrow-size: 6px;
+  --ease-tooltip-offset: 10px;
+  --ease-tooltip-transition-duration: 180ms;
+  --ease-tooltip-transition-easing: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* ── Tooltip Trigger ─────────────────────────────────── */
+.ease-tooltip {
+  position: relative;
+  display: inline-block;
+  cursor: default;
+  /* Underline hint that element has a tooltip */
+  text-decoration: underline dotted;
+  text-underline-offset: 3px;
+}
+
+/* ── Tooltip Bubble (::before = text, ::after = arrow) ─ */
+.ease-tooltip::before {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + var(--ease-tooltip-offset));
+  left: 50%;
+
+  /* Layout */
+  padding: var(--ease-tooltip-padding);
+  max-width: 220px;
+  width: max-content;
+  white-space: normal;
+
+  /* Visuals */
+  background: var(--ease-tooltip-bg);
+  color: var(--ease-tooltip-color);
+  border-radius: var(--ease-tooltip-border-radius);
+  font-size: var(--ease-tooltip-font-size);
+  line-height: 1.4;
+  box-shadow: var(--ease-tooltip-shadow);
+  z-index: 9999;
+  pointer-events: none;
+
+  /* Hidden by default */
+  opacity: 0;
+  transform: translateX(-50%) translateY(4px) scale(0.92);
+
+  /* Standard transition — animates on hover */
+  transition:
+    opacity var(--ease-tooltip-transition-duration) var(--ease-tooltip-transition-easing),
+    transform var(--ease-tooltip-transition-duration) var(--ease-tooltip-transition-easing);
+}
+
+/* Arrow */
+.ease-tooltip::after {
+  content: "";
+  position: absolute;
+  bottom: calc(100% + var(--ease-tooltip-offset) - var(--ease-tooltip-arrow-size));
+  left: 50%;
+  transform: translateX(-50%);
+  border: var(--ease-tooltip-arrow-size) solid transparent;
+  border-top-color: var(--ease-tooltip-bg);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--ease-tooltip-transition-duration) ease;
+  z-index: 9999;
+}
+
+/* ── Visible State ───────────────────────────────────── */
+.ease-tooltip:hover::before,
+.ease-tooltip:focus-visible::before {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0) scale(1);
+}
+
+.ease-tooltip:hover::after,
+.ease-tooltip:focus-visible::after {
+  opacity: 1;
+}
+
+/* ── KEY FIX: Respect prefers-reduced-motion ─────────── */
+/*
+ * When the user has enabled Reduce Motion, skip all scale/translate
+ * animations. We still allow a simple opacity fade (acceptable per
+ * WCAG 2.1 guidance — "animation" refers to decorative motion).
+ */
+@media (prefers-reduced-motion: reduce) {
+  .ease-tooltip::before {
+    /* Remove scale + translate — keep opacity crossfade only */
+    transform: translateX(-50%) translateY(0) scale(1);
+    transition: opacity 80ms linear;
+  }
+
+  .ease-tooltip::after {
+    transition: opacity 80ms linear;
+  }
+}
+
+/* ── Bottom placement variant ────────────────────────── */
+.ease-tooltip[data-position="bottom"]::before {
+  bottom: auto;
+  top: calc(100% + var(--ease-tooltip-offset));
+  transform: translateX(-50%) translateY(-4px) scale(0.92);
+}
+
+.ease-tooltip[data-position="bottom"]:hover::before,
+.ease-tooltip[data-position="bottom"]:focus-visible::before {
+  transform: translateX(-50%) translateY(0) scale(1);
+}
+
+.ease-tooltip[data-position="bottom"]::after {
+  bottom: auto;
+  top: calc(100% + var(--ease-tooltip-offset) - var(--ease-tooltip-arrow-size));
+  border-top-color: transparent;
+  border-bottom-color: var(--ease-tooltip-bg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-tooltip[data-position="bottom"]::before {
+    transform: translateX(-50%) translateY(0) scale(1);
+    transition: opacity 80ms linear;
+  }
+}
+
+/* ── Demo page layout ────────────────────────────────── */
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  padding: 3rem 2rem;
+  background: #f0f2f5;
+  color: #212529;
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+h1 {
+  font-size: 1.25rem;
+  margin-bottom: 0.25rem;
+}
+
+.subtitle {
+  font-size: 0.9rem;
+  color: #6c757d;
+  margin-bottom: 2.5rem;
+}
+
+.demo-row {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  flex-wrap: wrap;
+  margin-bottom: 2.5rem;
+}
+
+.demo-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #495057;
+  min-width: 160px;
+}
+
+.note {
+  margin-top: 2rem;
+  padding: 1rem 1.25rem;
+  background: #fff3cd;
+  border-left: 4px solid #ffc107;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  color: #664d03;
+}


### PR DESCRIPTION
Fixes #35724.

## What
Adds a `@media (prefers-reduced-motion: reduce)` block to `.ease-tooltip` that removes the `scale()` and `translateY()` entrance animation. A minimal `opacity`-only crossfade (80ms) is retained as it does not involve spatial movement.

## Why
Tooltips currently animate with a scale + translate effect even when the user has enabled **Reduce Motion** in OS accessibility settings. This can trigger vestibular symptoms (dizziness, nausea) in affected users and fails WCAG 2.1 SC 2.3.3 (Animation from Interactions).

## Changes
- `style.css` — full tooltip implementation with `@media (prefers-reduced-motion: reduce)` override for top and bottom placements, keyboard focus support, CSS custom properties
- `demo.html` — three interactive examples (top, bottom, keyboard focus), with a testing tip for enabling Reduce Motion
- `README.md` — documents the fix, usage, and WCAG rationale

## Validation Checklist
- [x] `demo.html` has `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` tags
- [x] `style.css` has original, meaningful CSS (160+ lines)
- [x] `README.md` included with clear description
- [x] Files placed in `submissions/examples/fix-tooltip-reduced-motion-ag/`
- [x] No edits to `core/` or `components/`
- [x] **Single squashed commit** with conventional-commit message: `fix(tooltip): disable scale/translate animation under prefers-reduced-motion`