### PR TITLE
fix: add lint-staged to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "sass": "^1.77.0",
     "stylelint": "^17.12.0",
     "stylelint-config-standard": "^40.0.0",
-    "vitest": "^4.1.8"
+    "vitest": "^4.1.8",
+    "lint-staged": "^15.2.0"
   }
 }


### PR DESCRIPTION
Closes #35623

Adds `lint-staged` to `devDependencies` in `package.json` so the pre-commit hook works on fresh clones.