### PR TITLE
fix: remove duplicate prefers-reduced-motion block from easemotion.css

### DIFF
--- a/easemotion.css
+++ b/easemotion.css
@@ -61,21 +61,3 @@
 @import "./components/toast.css";
 @import "./components/view-transitions.css";
 @import "./components/forms.css";
-
-
-/* Accessibility: Respect user's reduced motion preference */
-@media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-    scroll-behavior: auto !important;
-  }
-}
-
-
-
-
-


### PR DESCRIPTION
Closes #35631

The `@media (prefers-reduced-motion: reduce)` block in `easemotion.css` duplicates the one already in `core/animations.css` (which is imported by `easemotion.css`).