### PR TITLE
fix: add overflow hidden to .ease-ping animation

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -925,6 +925,7 @@
 
 .ease-ping {
   animation: ease-kf-ping 1s var(--ease-ease-out) var(--ease-animation-iterations, infinite);
+  overflow: hidden;
 }
 
 .ease-shake {


### PR DESCRIPTION
Closes #35637

Adds `overflow: hidden` to the `.ease-ping` class to prevent unwanted scrollbars during the scale-up animation.