### PR TITLE
fix: correct animation name in connection-status.css

### DIFF
--- a/components/connection-status.css
+++ b/components/connection-status.css
@@ -17,7 +17,7 @@
     transform: translateY(0);
     background: #ef4444;
     color: #fff;
-    animation: ease-pulse 2s infinite;
+    animation: ease-kf-pulse 2s infinite;
   }
   
   .ease-connection-status.is-online {


### PR DESCRIPTION
Closes #35641

Changes `ease-pulse` to `ease-kf-pulse` in `connection-status.css` since the keyframe is defined with the `-kf-` infix.