### PR TITLE
fix: correct animation name in announce-bar.css

### DIFF
--- a/components/announce-bar.css
+++ b/components/announce-bar.css
@@ -6,7 +6,7 @@
     color: #fff;
     text-align: center;
     font-size: 0.875rem;
-    animation: ease-slide-down 0.3s ease;
+    animation: ease-kf-slide-down 0.3s ease;
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
Closes #35645

Changes `ease-slide-down` to `ease-kf-slide-down` in `announce-bar.css` since the keyframe is defined with the `-kf-` infix.