### PR TITLE
fix: remove duplicate translate from ease-kf-btn-spin keyframes

### DIFF
--- a/components/buttons.css
+++ b/components/buttons.css
@@ -250,11 +250,11 @@
 
 @keyframes ease-kf-btn-spin {
   from {
-    transform: translate(-50%, -50%) rotate(0deg);
+    transform: rotate(0deg);
   }
 
   to {
-    transform: translate(-50%, -50%) rotate(360deg);
+    transform: rotate(360deg);
   }
 }
 


### PR DESCRIPTION
Closes #35667

The standalone `translate` property and `transform` property stack in modern CSS. The spinner's centering is already handled by `translate: -50% -50%`, so the keyframes should only apply rotation.