### PR TITLE
fix: replace undefined --ease-shadow-2xl with --ease-shadow-xl in modals.css

### DIFF
--- a/components/modals.css
+++ b/components/modals.css
@@ -42,7 +42,7 @@
   .ease-modal {
     background: var(--ease-color-bg, #ffffff);
     border-radius: var(--ease-radius-lg, 1rem);
-    box-shadow: var(--ease-shadow-2xl, 0 25px 50px -12px rgba(0, 0, 0, 0.25));
+    box-shadow: var(--ease-shadow-xl, 0 20px 25px -5px rgba(0, 0, 0, 0.45), 0 10px 10px -5px rgba(0, 0, 0, 0.30));
     max-width: 500px;
     width: 90%;
     max-height: 90vh;


### PR DESCRIPTION
Closes #35668

`--ease-shadow-2xl` is not defined anywhere in the framework. Replaced with `--ease-shadow-xl` which is the largest defined shadow token.