### PR TITLE
fix: use CSS variables in forms.css :focus rule and respect :focus-visible

### DIFF
--- a/components/forms.css
+++ b/components/forms.css
@@ -352,8 +352,8 @@
 
 /* ── Issue #10869: ease-input `[type="file"]` ── */
   .ease-input:focus {
-    border-color: #6c63ff;
-    box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.1);
+    border-color: var(--ease-color-primary, #6c63ff);
+    box-shadow: 0 0 0 3px var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.18));
   }
   
   .ease-input[type="file"] {


### PR DESCRIPTION
Closes #35669

The `.ease-input:focus` rule at line 354 overrides the `.ease-input:focus-visible` rule with hardcoded colors. This breaks dark mode theming and keyboard-only focus indicator design.