### PR TITLE
fix: add ease- prefix to skeleton-card-header selector

### DIFF
--- a/components/skeleton.css
+++ b/components/skeleton.css
@@ -37,11 +37,11 @@
   border-radius: 0.5rem;
 }
 
-.skeleton-card-header .ease-skeleton-text {
+.ease-skeleton-card-header .ease-skeleton-text {
   flex: 1;
 }
 
-.skeleton-card-header .ease-skeleton-text:first-child {
+.ease-skeleton-card-header .ease-skeleton-text:first-child {
   width: 40%;
 }
 }


### PR DESCRIPTION
Closes #35670

The class `.skeleton-card-header` in `skeleton.css` is missing the required `ease-` prefix used by all other framework classes.