### PR TITLE
fix: add border-style to border-image utilities

### DIFF
--- a/core/utilities.css
+++ b/core/utilities.css
@@ -1072,14 +1072,17 @@
 /* ── Issue #9865: Core Changes — Issue #9865: Add Border Image Utility Classes ── */
   .ease-border-gradient-primary {
     border-image: linear-gradient(135deg, var(--ease-color-primary), var(--ease-color-secondary)) 1 !important;
+    border-style: solid !important;
   }
   
   .ease-border-gradient-success {
     border-image: linear-gradient(135deg, var(--ease-color-success), var(--ease-color-success-dark)) 1 !important;
+    border-style: solid !important;
   }
   
   .ease-border-gradient-danger {
     border-image: linear-gradient(135deg, var(--ease-color-danger), var(--ease-color-danger-dark)) 1 !important;
+    border-style: solid !important;
   }
   
   .ease-border-slice-1 { border-image-slice: 1 !important; }


### PR DESCRIPTION
Closes #35671

For `border-image` to render, the element must have a `border-style` other than `none`. Adds `border-style: solid` to the gradient border utility classes.