### PR TITLE
fix(select): preserve custom arrow in forced-colors high-contrast mode

### DIFF
--- a/submissions/examples/fix-select-forced-colors-arrow-ag/README.md
+++ b/submissions/examples/fix-select-forced-colors-arrow-ag/README.md
@@ -1,0 +1,18 @@
+# Fix ease-select Arrow in Forced-Colors Mode
+
+## What does this do?
+Adds a `@media (forced-colors: active)` block so the custom dropdown arrow
+remains visible in Windows High Contrast / forced-colors mode.
+
+## How is it used?
+```html
+<select class="ease-select">
+  <option>Option 1</option>
+</select>
+```
+
+## Why is it useful?
+CSS `background-image` SVGs are stripped in forced-colors mode.
+Without a fallback, the select looks like a plain text box with no affordance
+that it is interactive. `forced-color-adjust: none` + system color keywords
+(`ButtonText`, `Field`) restore the visual correctly. Fixes: #35778

--- a/submissions/examples/fix-select-forced-colors-arrow-ag/demo.html
+++ b/submissions/examples/fix-select-forced-colors-arrow-ag/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Select Forced-Colors Fix – EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h2>ease-select – Forced-Colors Arrow Fix</h2>
+  <div class="demo-stack">
+    <div>
+      <label for="s1">Country</label>
+      <select class="ease-select" id="s1">
+        <option>United States</option>
+        <option>United Kingdom</option>
+        <option>India</option>
+      </select>
+    </div>
+    <div>
+      <label for="s2">Disabled select</label>
+      <select class="ease-select" id="s2" disabled>
+        <option>Unavailable</option>
+      </select>
+    </div>
+  </div>
+  <p class="note">Enable Windows High Contrast or DevTools forced-colors emulation — the arrow remains visible.</p>
+</body>
+</html>

--- a/submissions/examples/fix-select-forced-colors-arrow-ag/style.css
+++ b/submissions/examples/fix-select-forced-colors-arrow-ag/style.css
@@ -1,0 +1,58 @@
+/* EaseMotion CSS – Select forced-colors arrow fix. Fixes: #35778 */
+:root {
+  --ease-select-arrow-color: #495057;
+  --ease-select-border: #ced4da;
+  --ease-select-bg: #ffffff;
+  --ease-select-color: #212529;
+  --ease-select-radius: 6px;
+  --ease-select-padding: 0.55rem 2.5rem 0.55rem 0.875rem;
+}
+.ease-select {
+  display: block;
+  width: 100%;
+  max-width: 360px;
+  padding: var(--ease-select-padding);
+  font-size: 1rem;
+  line-height: 1.5;
+  color: var(--ease-select-color);
+  background-color: var(--ease-select-bg);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23495057' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  background-size: 12px;
+  border: 1px solid var(--ease-select-border);
+  border-radius: var(--ease-select-radius);
+  appearance: none;
+  -webkit-appearance: none;
+  outline: none;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  box-sizing: border-box;
+}
+.ease-select:focus {
+  border-color: #4361ee;
+  box-shadow: 0 0 0 3px rgba(67, 97, 238, 0.2);
+}
+.ease-select:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+/* KEY FIX: restore arrow in forced-colors mode */
+@media (forced-colors: active) {
+  .ease-select {
+    forced-color-adjust: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='ButtonText' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+    border: 2px solid ButtonText;
+    background-color: Field;
+    color: FieldText;
+  }
+  .ease-select:focus {
+    outline: 3px solid Highlight;
+    box-shadow: none;
+  }
+}
+body { font-family: system-ui, sans-serif; padding: 2rem; background: #f0f2f5; }
+h2 { font-size: 1rem; margin-bottom: 1rem; }
+.demo-stack { display: flex; flex-direction: column; gap: 1rem; max-width: 380px; }
+label { font-size: 0.9rem; color: #495057; display: block; margin-bottom: 0.3rem; }
+.note { margin-top: 1.5rem; font-size: 0.85rem; color: #6c757d; }


### PR DESCRIPTION
Fixes #35778.\n\n## Changes\n- `style.css` — original CSS fix (well over 5 lines)\n- `demo.html` — interactive demo with full HTML5 boilerplate\n- `README.md` — describes the fix and usage\n\n## Validation Checklist\n- [x] `demo.html` has `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` tags\n- [x] `style.css` has original, meaningful CSS (50+ lines)\n- [x] `README.md` included\n- [x] Files placed in `submissions/examples/fix-select-forced-colors-arrow-ag/`\n- [x] No edits to `core/` or `components/`\n- [x] Single squashed commit — conventional-commit format