### PR TITLE
fix(input): override webkit autofill background to preserve dark mode surface

### DIFF
--- a/submissions/examples/fix-input-autofill-dark-ag/README.md
+++ b/submissions/examples/fix-input-autofill-dark-ag/README.md
@@ -1,0 +1,16 @@
+# Fix Input Autofill Dark Mode Background
+
+## What does this do?
+Overrides the browser autofill yellow/white background on `.ease-input`
+in dark mode using `-webkit-autofill` + `box-shadow: inset 0 0 0 1000px` trick.
+
+## How is it used?
+```html
+<input class="ease-input" type="email" autocomplete="email" placeholder="Email">
+```
+
+## Why is it useful?
+Browsers inject their own background for autofilled fields that cannot
+be overridden with `background-color`. The only reliable cross-browser fix
+is the inset box-shadow trick combined with `-webkit-text-fill-color`.
+Without this, dark mode UIs break visually on autofill. Fixes: #35781

--- a/submissions/examples/fix-input-autofill-dark-ag/demo.html
+++ b/submissions/examples/fix-input-autofill-dark-ag/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Input Autofill Dark Mode Fix – EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h2>ease-input – Autofill Dark Mode Fix</h2>
+  <div class="dark-section">
+    <label for="email">Email</label>
+    <input class="ease-input" id="email" type="email" placeholder="you@example.com" autocomplete="email">
+    <br><br>
+    <label for="pass">Password</label>
+    <input class="ease-input" id="pass" type="password" placeholder="••••••••" autocomplete="current-password">
+  </div>
+  <p class="note">Enable dark mode and trigger browser autofill — input background stays dark.</p>
+</body>
+</html>

--- a/submissions/examples/fix-input-autofill-dark-ag/style.css
+++ b/submissions/examples/fix-input-autofill-dark-ag/style.css
@@ -1,0 +1,56 @@
+/* EaseMotion CSS – Input autofill dark mode fix. Fixes: #35781 */
+:root {
+  --ease-input-bg: #ffffff;
+  --ease-input-color: #212529;
+  --ease-input-border: #ced4da;
+  --ease-input-placeholder: #6c757d;
+  --ease-input-radius: 6px;
+  --ease-input-autofill-bg-light: #fffde7;
+  --ease-input-autofill-bg-dark: #1e1e2e;
+  --ease-input-autofill-color-dark: #e0e0f0;
+}
+.ease-input {
+  display: block;
+  width: 100%;
+  max-width: 400px;
+  padding: 0.6rem 0.875rem;
+  font-size: 1rem;
+  border: 1px solid var(--ease-input-border);
+  border-radius: var(--ease-input-radius);
+  background-color: var(--ease-input-bg);
+  color: var(--ease-input-color);
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  box-sizing: border-box;
+}
+.ease-input::placeholder { color: var(--ease-input-placeholder); opacity: 1; }
+.ease-input:focus { border-color: #4361ee; box-shadow: 0 0 0 3px rgba(67,97,238,0.2); }
+/* KEY FIX: override autofill background in dark mode */
+@media (prefers-color-scheme: dark) {
+  .ease-input {
+    background-color: #1e1e2e;
+    color: #e0e0f0;
+    border-color: #444466;
+  }
+  .ease-input::placeholder { color: #8888aa; }
+  .ease-input:-webkit-autofill,
+  .ease-input:-webkit-autofill:hover,
+  .ease-input:-webkit-autofill:focus {
+    -webkit-text-fill-color: var(--ease-input-autofill-color-dark);
+    box-shadow: inset 0 0 0 1000px var(--ease-input-autofill-bg-dark);
+    caret-color: var(--ease-input-autofill-color-dark);
+    border-color: #555577;
+  }
+}
+.dark .ease-input:-webkit-autofill,
+.dark .ease-input:-webkit-autofill:hover,
+.dark .ease-input:-webkit-autofill:focus {
+  -webkit-text-fill-color: #e0e0f0;
+  box-shadow: inset 0 0 0 1000px #1e1e2e;
+  caret-color: #e0e0f0;
+}
+body { font-family: system-ui, sans-serif; padding: 2rem; background: #f0f2f5; }
+.dark-section { background: #1e1e2e; padding: 1.5rem; border-radius: 10px; max-width: 440px; margin-top: 1rem; }
+.dark-section label { color: #ccc; display: block; margin-bottom: 0.4rem; font-size: 0.9rem; }
+h2 { font-size: 1rem; margin-bottom: 1rem; }
+.note { margin-top: 1rem; font-size: 0.8rem; color: #6c757d; }


### PR DESCRIPTION
Fixes #35781.\n\n## Changes\n- `style.css` — original CSS fix (well over 5 lines)\n- `demo.html` — interactive demo with full HTML5 boilerplate\n- `README.md` — describes the fix and usage\n\n## Validation Checklist\n- [x] `demo.html` has `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` tags\n- [x] `style.css` has original, meaningful CSS (50+ lines)\n- [x] `README.md` included\n- [x] Files placed in `submissions/examples/fix-input-autofill-dark-ag/`\n- [x] No edits to `core/` or `components/`\n- [x] Single squashed commit — conventional-commit format