### PR TITLE
fix(range): add moz-range-thumb and cross-browser track styles for Firefox/Safari

### DIFF
--- a/submissions/examples/fix-range-thumb-cross-browser-ag/README.md
+++ b/submissions/examples/fix-range-thumb-cross-browser-ag/README.md
@@ -1,0 +1,15 @@
+# Fix ease-range Thumb Cross-Browser Consistency
+
+## What does this do?
+Adds `::-moz-range-thumb` and `::-moz-range-track` rules so the range
+slider thumb looks identical in Firefox, Chrome, and Safari.
+
+## How is it used?
+```html
+<input class="ease-range" type="range" min="0" max="100" value="50">
+```
+
+## Why is it useful?
+Without Firefox-specific vendor prefix selectors, the slider thumb
+uses the OS default in Firefox — visually inconsistent with Chrome/Safari.
+Fixes: #35785

--- a/submissions/examples/fix-range-thumb-cross-browser-ag/demo.html
+++ b/submissions/examples/fix-range-thumb-cross-browser-ag/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Range Thumb Cross-Browser Fix – EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h2>ease-range – Cross-Browser Thumb Fix</h2>
+  <div class="demo-stack">
+    <div>
+      <label for="r1">Volume</label>
+      <input class="ease-range" type="range" id="r1" min="0" max="100" value="60">
+    </div>
+    <div>
+      <label for="r2">Brightness</label>
+      <input class="ease-range" type="range" id="r2" min="0" max="100" value="30">
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-range-thumb-cross-browser-ag/style.css
+++ b/submissions/examples/fix-range-thumb-cross-browser-ag/style.css
@@ -1,0 +1,67 @@
+/* EaseMotion CSS – Range thumb cross-browser fix. Fixes: #35785 */
+:root {
+  --ease-range-thumb-size: 18px;
+  --ease-range-thumb-color: #4361ee;
+  --ease-range-track-height: 4px;
+  --ease-range-track-color: #dee2e6;
+  --ease-range-track-fill-color: #4361ee;
+  --ease-range-thumb-shadow: 0 1px 4px rgba(67,97,238,0.4);
+}
+/* Reset */
+.ease-range {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  width: 100%;
+  max-width: 400px;
+  height: var(--ease-range-track-height);
+  background: var(--ease-range-track-color);
+  border-radius: 999px;
+  outline: none;
+  cursor: pointer;
+  border: none;
+}
+/* Chrome/Safari/Edge track */
+.ease-range::-webkit-slider-runnable-track {
+  height: var(--ease-range-track-height);
+  background: var(--ease-range-track-color);
+  border-radius: 999px;
+}
+/* Firefox track — KEY FIX: appearance reset required */
+.ease-range::-moz-range-track {
+  height: var(--ease-range-track-height);
+  background: var(--ease-range-track-color);
+  border-radius: 999px;
+  border: none;
+}
+/* Chrome/Safari/Edge thumb */
+.ease-range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: var(--ease-range-thumb-size);
+  height: var(--ease-range-thumb-size);
+  border-radius: 50%;
+  background: var(--ease-range-thumb-color);
+  box-shadow: var(--ease-range-thumb-shadow);
+  cursor: pointer;
+  margin-top: calc((var(--ease-range-thumb-size) / -2) + (var(--ease-range-track-height) / 2));
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.ease-range::-webkit-slider-thumb:hover { transform: scale(1.15); box-shadow: 0 2px 8px rgba(67,97,238,0.5); }
+/* KEY FIX: Firefox thumb */
+.ease-range::-moz-range-thumb {
+  width: var(--ease-range-thumb-size);
+  height: var(--ease-range-thumb-size);
+  border-radius: 50%;
+  background: var(--ease-range-thumb-color);
+  border: none;
+  box-shadow: var(--ease-range-thumb-shadow);
+  cursor: pointer;
+  transition: transform 0.15s ease;
+}
+.ease-range::-moz-range-thumb:hover { transform: scale(1.15); }
+.ease-range:focus-visible::-webkit-slider-thumb { outline: 3px solid rgba(67,97,238,0.5); outline-offset: 2px; }
+.ease-range:focus-visible::-moz-range-thumb { outline: 3px solid rgba(67,97,238,0.5); outline-offset: 2px; }
+body { font-family: system-ui, sans-serif; padding: 2rem; background: #f0f2f5; }
+h2 { font-size: 1rem; margin-bottom: 1.5rem; }
+.demo-stack { display: flex; flex-direction: column; gap: 1.5rem; max-width: 420px; }
+label { font-size: 0.9rem; color: #495057; display: block; margin-bottom: 0.5rem; }


### PR DESCRIPTION
Fixes #35785.\n\n## Changes\n- `style.css` — original CSS fix (well over 5 lines)\n- `demo.html` — interactive demo with full HTML5 boilerplate\n- `README.md` — describes the fix and usage\n\n## Validation Checklist\n- [x] `demo.html` has `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` tags\n- [x] `style.css` has original, meaningful CSS (50+ lines)\n- [x] `README.md` included\n- [x] Files placed in `submissions/examples/fix-range-thumb-cross-browser-ag/`\n- [x] No edits to `core/` or `components/`\n- [x] Single squashed commit — conventional-commit format