### PR TITLE
fix(dropdown): raise menu z-index above sticky header to prevent clipping

### DIFF
--- a/submissions/examples/fix-dropdown-zindex-sticky-header-ag/README.md
+++ b/submissions/examples/fix-dropdown-zindex-sticky-header-ag/README.md
@@ -1,0 +1,20 @@
+# Fix ease-dropdown Z-Index Behind Sticky Header
+
+## What does this do?
+Raises `.ease-dropdown__menu` z-index to `1100` so it appears above
+sticky/fixed navigation headers that commonly use `z-index: 1000`.
+
+## How is it used?
+```html
+<div class="ease-dropdown">
+  <button class="ease-dropdown__trigger">Options ▾</button>
+  <div class="ease-dropdown__menu" role="menu">
+    <button class="ease-dropdown__item" role="menuitem">Edit</button>
+  </div>
+</div>
+```
+
+## Why is it useful?
+A dropdown appearing behind the site header is completely unusable.
+The z-index hierarchy (header: 1000, dropdown: 1100, modal: 10000) ensures
+correct stacking. Fixes: #35799

--- a/submissions/examples/fix-dropdown-zindex-sticky-header-ag/demo.html
+++ b/submissions/examples/fix-dropdown-zindex-sticky-header-ag/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dropdown Z-Index Fix – EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="demo-header">Sticky Header (z-index: 1000)</header>
+  <div class="demo-body">
+    <h2>ease-dropdown – Z-Index Sticky Header Fix</h2>
+    <div class="ease-dropdown" id="dd1">
+      <button class="ease-dropdown__trigger"
+              aria-haspopup="true"
+              aria-expanded="false"
+              onclick="this.closest('.ease-dropdown').classList.toggle('is-open'); this.setAttribute('aria-expanded', this.closest('.ease-dropdown').classList.contains('is-open'))">
+        Options ▾
+      </button>
+      <div class="ease-dropdown__menu" role="menu">
+        <button class="ease-dropdown__item" role="menuitem">Edit</button>
+        <button class="ease-dropdown__item" role="menuitem">Duplicate</button>
+        <div class="ease-dropdown__divider" role="separator"></div>
+        <button class="ease-dropdown__item" role="menuitem">Delete</button>
+      </div>
+    </div>
+    <p class="note">Menu appears above the sticky header — scroll up to see it overlapping.</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-dropdown-zindex-sticky-header-ag/style.css
+++ b/submissions/examples/fix-dropdown-zindex-sticky-header-ag/style.css
@@ -1,0 +1,51 @@
+/* EaseMotion CSS – Dropdown z-index sticky header fix. Fixes: #35799 */
+:root {
+  --ease-dropdown-z: 1100;
+  --ease-dropdown-shadow: 0 4px 16px rgba(0,0,0,0.12);
+  --ease-dropdown-border: #dee2e6;
+  --ease-dropdown-radius: 8px;
+  --ease-dropdown-item-hover: #f0f2ff;
+}
+.ease-dropdown { position: relative; display: inline-block; }
+.ease-dropdown__trigger {
+  padding: 0.5rem 1rem; border: 1px solid var(--ease-dropdown-border);
+  border-radius: 6px; background: #fff; cursor: pointer;
+  font-size: 0.9rem; display: inline-flex; align-items: center; gap: 0.4rem;
+}
+.ease-dropdown__trigger:focus-visible { outline: 3px solid rgba(67,97,238,0.4); outline-offset: 2px; }
+.ease-dropdown__menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  min-width: 200px;
+  background: #fff;
+  border: 1px solid var(--ease-dropdown-border);
+  border-radius: var(--ease-dropdown-radius);
+  box-shadow: var(--ease-dropdown-shadow);
+  /* KEY FIX: z-index above sticky headers (typically 1000) */
+  z-index: var(--ease-dropdown-z);
+  padding: 0.4rem 0;
+  display: none;
+  animation: ease-dropdown-in 150ms ease-out;
+}
+.ease-dropdown.is-open .ease-dropdown__menu { display: block; }
+@keyframes ease-dropdown-in { from { opacity: 0; transform: translateY(-6px); } to { opacity: 1; transform: translateY(0); } }
+@media (prefers-reduced-motion: reduce) { .ease-dropdown__menu { animation: none; } }
+.ease-dropdown__item {
+  display: block; width: 100%; padding: 0.5rem 1rem;
+  font-size: 0.9rem; color: #212529; text-align: left;
+  background: none; border: none; cursor: pointer;
+  transition: background 0.15s ease;
+}
+.ease-dropdown__item:hover { background: var(--ease-dropdown-item-hover); }
+.ease-dropdown__item:focus-visible { outline: 2px solid #4361ee; outline-offset: -2px; }
+.ease-dropdown__divider { height: 1px; background: var(--ease-dropdown-border); margin: 0.4rem 0; }
+/* Sticky header for demo */
+.demo-header {
+  position: sticky; top: 0; background: #4361ee; color: #fff;
+  padding: 1rem 2rem; z-index: 1000; font-size: 0.9rem;
+}
+body { font-family: system-ui, sans-serif; background: #f0f2f5; }
+.demo-body { padding: 2rem; }
+h2 { font-size: 1rem; margin-bottom: 1.5rem; }
+.note { margin-top: 1rem; font-size: 0.8rem; color: #6c757d; }


### PR DESCRIPTION
Fixes #35799.\n\n## Changes\n- `style.css` — original CSS fix (well over 5 lines)\n- `demo.html` — interactive demo with full HTML5 boilerplate\n- `README.md` — describes the fix and usage\n\n## Validation Checklist\n- [x] `demo.html` has `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` tags\n- [x] `style.css` has original, meaningful CSS (50+ lines)\n- [x] `README.md` included\n- [x] Files placed in `submissions/examples/fix-dropdown-zindex-sticky-header-ag/`\n- [x] No edits to `core/` or `components/`\n- [x] Single squashed commit — conventional-commit format