### PR TITLE
fix(avatar): add CSS initials fallback when image src fails to load

### DIFF
--- a/submissions/examples/fix-avatar-broken-image-ag/README.md
+++ b/submissions/examples/fix-avatar-broken-image-ag/README.md
@@ -1,0 +1,17 @@
+# Fix ease-avatar Broken Image Fallback
+
+## What does this do?
+Adds a CSS `::after` pseudo-element that displays `data-initials` text
+when the `<img>` fails to load (using `onerror` to add an `.error` class
+that hides the broken img).
+
+## How is it used?
+```html
+<div class="ease-avatar ease-avatar--blue" data-initials="AJ">
+  <img src="photo.jpg" alt="Alice Johnson" onerror="this.classList.add('error')">
+</div>
+```
+
+## Why is it useful?
+Broken avatar images look unprofessional and confuse users. A styled
+initials fallback provides a consistent, graceful degradation. Fixes: #35812

--- a/submissions/examples/fix-avatar-broken-image-ag/demo.html
+++ b/submissions/examples/fix-avatar-broken-image-ag/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Avatar Broken Image Fallback – EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h2>ease-avatar – Broken Image Fallback Fix</h2>
+  <div class="flex-row">
+    <div>
+      <div class="ease-avatar ease-avatar--blue" data-initials="AJ">
+        <img src="https://this-url-will-fail.invalid/photo.jpg"
+             alt="Alice Johnson"
+             onerror="this.classList.add('error')">
+      </div>
+      <p class="item-label">Broken src → "AJ"</p>
+    </div>
+    <div>
+      <div class="ease-avatar ease-avatar--green" data-initials="BS">
+        <img src="https://another-broken.invalid/photo.jpg"
+             alt="Bob Smith"
+             onerror="this.classList.add('error')">
+      </div>
+      <p class="item-label">Broken src → "BS"</p>
+    </div>
+    <div>
+      <div class="ease-avatar ease-avatar--purple ease-avatar--lg" data-initials="CD">
+        <img src="https://broken.invalid/photo.jpg"
+             alt="Carol Davis"
+             onerror="this.classList.add('error')">
+      </div>
+      <p class="item-label">Large — broken src</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-avatar-broken-image-ag/style.css
+++ b/submissions/examples/fix-avatar-broken-image-ag/style.css
@@ -1,0 +1,54 @@
+/* EaseMotion CSS – Avatar broken image fallback. Fixes: #35812 */
+:root {
+  --ease-avatar-size: 48px;
+  --ease-avatar-font-size: 1.1rem;
+  --ease-avatar-radius: 50%;
+}
+.ease-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--ease-avatar-size);
+  height: var(--ease-avatar-size);
+  border-radius: var(--ease-avatar-radius);
+  overflow: hidden;
+  position: relative;
+  background: #ddd;
+  color: #555;
+  font-weight: 700;
+  font-size: var(--ease-avatar-font-size);
+  user-select: none;
+  flex-shrink: 0;
+}
+.ease-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  display: block;
+  border-radius: inherit;
+}
+/* KEY FIX: show initials from data-initials when img fails */
+.ease-avatar img[data-error="true"],
+.ease-avatar img.error {
+  display: none;
+}
+.ease-avatar::after {
+  content: attr(data-initials);
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.ease-avatar--sm { --ease-avatar-size: 32px; --ease-avatar-font-size: 0.75rem; }
+.ease-avatar--lg { --ease-avatar-size: 64px; --ease-avatar-font-size: 1.4rem; }
+.ease-avatar--xl { --ease-avatar-size: 96px; --ease-avatar-font-size: 2rem; }
+.ease-avatar--blue { background: #dbeafe; color: #1d4ed8; }
+.ease-avatar--green { background: #d1fae5; color: #065f46; }
+.ease-avatar--purple { background: #ede9fe; color: #6d28d9; }
+.ease-avatar--orange { background: #ffedd5; color: #c2410c; }
+body { font-family: system-ui, sans-serif; padding: 2rem; background: #f0f2f5; }
+h2 { font-size: 1rem; margin-bottom: 1.5rem; }
+.flex-row { display: flex; gap: 1.5rem; align-items: center; flex-wrap: wrap; }
+.item-label { font-size: 0.75rem; color: #6c757d; margin-top: 0.4rem; text-align: center; }


### PR DESCRIPTION
Fixes #35812.\n\n## Changes\n- `style.css` — original CSS fix (well over 5 lines)\n- `demo.html` — interactive demo with full HTML5 boilerplate\n- `README.md` — describes the fix and usage\n\n## Validation Checklist\n- [x] `demo.html` has `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` tags\n- [x] `style.css` has original, meaningful CSS (50+ lines)\n- [x] `README.md` included\n- [x] Files placed in `submissions/examples/fix-avatar-broken-image-ag/`\n- [x] No edits to `core/` or `components/`\n- [x] Single squashed commit — conventional-commit format