### PR TITLE
fix(modal): lock body scroll when modal is open using overflow:hidden and iOS safe fallback

### DIFF
--- a/submissions/examples/fix-modal-body-scroll-lock-ag/README.md
+++ b/submissions/examples/fix-modal-body-scroll-lock-ag/README.md
@@ -1,0 +1,22 @@
+# Fix ease-modal Body Scroll Lock
+
+## What does this do?
+Adds `body.ease-modal-open` CSS class that sets `overflow: hidden` and
+`position: fixed` (for iOS Safari) to prevent background scroll when
+a modal is open. JS preserves the scroll position via `body.style.top`.
+
+## How is it used?
+```js
+// Open
+document.body.style.top = `-${window.scrollY}px`;
+document.body.classList.add('ease-modal-open');
+// Close
+document.body.classList.remove('ease-modal-open');
+document.body.style.top = '';
+window.scrollTo(0, savedScrollY);
+```
+
+## Why is it useful?
+Without scroll lock, background page content scrolls while the modal
+is open, which is confusing UX. On iOS, `overflow: hidden` alone is
+insufficient — `position: fixed` is required. Fixes: #35821

--- a/submissions/examples/fix-modal-body-scroll-lock-ag/demo.html
+++ b/submissions/examples/fix-modal-body-scroll-lock-ag/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Modal Body Scroll Lock Fix – EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h2>ease-modal – Body Scroll Lock Fix</h2>
+  <button class="btn btn-primary" onclick="openModal()">Open Modal</button>
+  <p style="margin-top:2rem;font-size:0.9rem;color:#6c757d">
+    Scroll this page content — when the modal is open, the page behind it stays fixed.
+  </p>
+  <div style="height:200vh;padding-top:3rem;font-size:0.85rem;color:#aaa">
+    (Long page content to demonstrate scroll lock)
+  </div>
+  <!-- Modal -->
+  <div class="ease-modal-overlay" id="modalOverlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+    <div class="ease-modal">
+      <div class="ease-modal__header">
+        <h2 class="ease-modal__title" id="modalTitle">Confirm Action</h2>
+        <button class="ease-modal__close" aria-label="Close modal" onclick="closeModal()">✕</button>
+      </div>
+      <div class="ease-modal__body">
+        <p>Are you sure you want to delete this item? This action cannot be undone.</p>
+      </div>
+      <div class="ease-modal__footer">
+        <button class="btn btn-secondary" onclick="closeModal()">Cancel</button>
+        <button class="btn btn-primary">Delete</button>
+      </div>
+    </div>
+  </div>
+  <script>
+    let scrollY = 0;
+    function openModal() {
+      scrollY = window.scrollY;
+      document.body.style.top = `-${scrollY}px`;
+      document.body.classList.add('ease-modal-open');
+      document.getElementById('modalOverlay').style.display = 'flex';
+    }
+    function closeModal() {
+      document.body.classList.remove('ease-modal-open');
+      document.body.style.top = '';
+      window.scrollTo(0, scrollY);
+      document.getElementById('modalOverlay').style.display = 'none';
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/fix-modal-body-scroll-lock-ag/style.css
+++ b/submissions/examples/fix-modal-body-scroll-lock-ag/style.css
@@ -1,0 +1,54 @@
+/* EaseMotion CSS – Modal body scroll lock fix. Fixes: #35821 */
+/* KEY FIX: body class toggled by JS when modal opens/closes */
+body.ease-modal-open {
+  overflow: hidden;
+  /* iOS Safari needs position:fixed to fully prevent scroll */
+  position: fixed;
+  width: 100%;
+  /* Preserve scroll position via top offset (set by JS) */
+}
+.ease-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  backdrop-filter: blur(2px);
+  padding: 1rem;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+.ease-modal {
+  background: #fff;
+  border-radius: 12px;
+  width: 100%;
+  max-width: 520px;
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.2);
+  display: flex;
+  flex-direction: column;
+  z-index: 10001;
+}
+.ease-modal__header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 1.25rem 1.5rem; border-bottom: 1px solid #e9ecef;
+}
+.ease-modal__title { font-size: 1.1rem; font-weight: 600; margin: 0; }
+.ease-modal__close {
+  background: none; border: none; cursor: pointer;
+  color: #6c757d; padding: 0.35rem; border-radius: 6px; font-size: 1.2rem;
+  transition: color 0.15s ease;
+}
+.ease-modal__close:hover { color: #212529; }
+.ease-modal__close:focus-visible { outline: 3px solid rgba(67,97,238,0.5); outline-offset: 2px; }
+.ease-modal__body { padding: 1.25rem 1.5rem; flex: 1; }
+.ease-modal__footer { padding: 1rem 1.5rem; border-top: 1px solid #e9ecef; display: flex; gap: 0.75rem; justify-content: flex-end; }
+.btn { padding: 0.5rem 1.25rem; border-radius: 6px; font-size: 0.9rem; border: 1px solid transparent; cursor: pointer; font-weight: 500; }
+.btn-primary { background: #4361ee; color: #fff; border-color: #4361ee; }
+.btn-secondary { background: #f8f9fa; color: #495057; border-color: #dee2e6; }
+body { font-family: system-ui, sans-serif; padding: 2rem; background: #f0f2f5; }
+h2 { font-size: 1rem; margin-bottom: 1.5rem; }


### PR DESCRIPTION
Fixes #35821.\n\n## Changes\n- `style.css` — original CSS fix (well over 5 lines)\n- `demo.html` — interactive demo with full HTML5 boilerplate\n- `README.md` — describes the fix and usage\n\n## Validation Checklist\n- [x] `demo.html` has `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` tags\n- [x] `style.css` has original, meaningful CSS (50+ lines)\n- [x] `README.md` included\n- [x] Files placed in `submissions/examples/fix-modal-body-scroll-lock-ag/`\n- [x] No edits to `core/` or `components/`\n- [x] Single squashed commit — conventional-commit format