### PR TITLE
fix: guard .ease-hover-glow dual filter with @supports

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -1013,12 +1013,20 @@
   transition: filter var(--ease-speed-medium) var(--ease-ease);
 }
 
-.ease-hover-glow:hover {
-  filter: drop-shadow(0 0 8px rgba(108, 99, 255, 0.45))
-          drop-shadow(0 0 20px rgba(108, 99, 255, 0.30));
-  filter: drop-shadow(0 0 8px color-mix(in srgb, var(--ease-color-primary) 45%, transparent))
-          drop-shadow(0 0 20px color-mix(in srgb, var(--ease-color-primary) 30%, transparent));
-  box-shadow: none;
+@supports (color: color-mix(in srgb, red 50%, transparent)) {
+  .ease-hover-glow:hover {
+    filter: drop-shadow(0 0 8px color-mix(in srgb, var(--ease-color-primary) 45%, transparent))
+            drop-shadow(0 0 20px color-mix(in srgb, var(--ease-color-primary) 30%, transparent));
+    box-shadow: none;
+  }
+}
+
+@supports not (color: color-mix(in srgb, red 50%, transparent)) {
+  .ease-hover-glow:hover {
+    filter: drop-shadow(0 0 8px rgba(108, 99, 255, 0.45))
+            drop-shadow(0 0 20px rgba(108, 99, 255, 0.30));
+    box-shadow: none;
+  }
 }
 
 /* Lift (shadow depth) on hover */


### PR DESCRIPTION
Closes #35673

The `.ease-hover-glow:hover` has two `filter` declarations. The second always overrides the first. If the browser does not support `color-mix()`, the entire second `filter` becomes invalid and no filter is applied.