### PR TITLE
fix: remove top-level comma from var() fallback in buttons.css

### DIFF
--- a/components/buttons.css
+++ b/components/buttons.css
@@ -277,8 +277,7 @@
 @media (hover: hover) and (pointer: fine) {
   .ease-btn-hover:hover {
     transform: translate3d(0, -3px, 0); /* GPU path: replaces translateY(-3px) */
-    box-shadow: var(--ease-shadow-lg, 0 10px 15px -3px rgba(0, 0, 0, 0.40),
-                       0 4px 6px -2px rgba(0, 0, 0, 0.25)), var(--ease-btn-glow, var(--ease-glow-primary, 0 0 16px rgba(108, 99, 255, 0.45)));
+    box-shadow: var(--ease-shadow-lg), var(--ease-btn-glow, var(--ease-glow-primary, 0 0 16px rgba(108, 99, 255, 0.45)));
   }
 }
 


### PR DESCRIPTION
Closes #35677

Per CSS spec, a top-level comma terminates the fallback value of `var()`. The shadow fallback in buttons.css contains a top-level comma.