### PR TITLE
fix(tabs): use in-flow border-bottom indicator to prevent overflow in scrollable tab bar

### DIFF
--- a/submissions/examples/fix-tabs-scrollable-indicator-ag/README.md
+++ b/submissions/examples/fix-tabs-scrollable-indicator-ag/README.md
@@ -1,0 +1,19 @@
+# Fix ease-tabs Scrollable Active Indicator
+
+## What does this do?
+Replaces the absolute-positioned underline indicator with an in-flow
+`border-bottom` on the active tab button, preventing overflow in
+horizontally scrollable tab bars on mobile.
+
+## How is it used?
+```html
+<div class="ease-tabs">
+  <ul class="ease-tabs__list" role="tablist">
+    <li><button class="ease-tabs__tab is-active" role="tab" aria-selected="true">Tab 1</button></li>
+  </ul>
+</div>
+```
+
+## Why is it useful?
+Absolute-positioned indicators ignore the scroll container's bounds.
+An in-flow border naturally scrolls with its tab. Fixes: #35833

--- a/submissions/examples/fix-tabs-scrollable-indicator-ag/demo.html
+++ b/submissions/examples/fix-tabs-scrollable-indicator-ag/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tabs Scrollable Indicator Fix – EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h2>ease-tabs – Scrollable Indicator Fix</h2>
+  <div class="ease-tabs">
+    <ul class="ease-tabs__list" role="tablist" aria-label="Component tabs">
+      <li role="presentation">
+        <button class="ease-tabs__tab is-active" role="tab" aria-selected="true" aria-controls="panel-overview" id="tab-overview" onclick="switchTab(this,'panel-overview')">Overview</button>
+      </li>
+      <li role="presentation"><button class="ease-tabs__tab" role="tab" aria-selected="false" aria-controls="panel-props" id="tab-props" onclick="switchTab(this,'panel-props')">Properties</button></li>
+      <li role="presentation"><button class="ease-tabs__tab" role="tab" aria-selected="false" aria-controls="panel-events" id="tab-events" onclick="switchTab(this,'panel-events')">Events</button></li>
+      <li role="presentation"><button class="ease-tabs__tab" role="tab" aria-selected="false" aria-controls="panel-slots" id="tab-slots" onclick="switchTab(this,'panel-slots')">Slots</button></li>
+      <li role="presentation"><button class="ease-tabs__tab" role="tab" aria-selected="false" aria-controls="panel-examples" id="tab-examples" onclick="switchTab(this,'panel-examples')">Examples</button></li>
+      <li role="presentation"><button class="ease-tabs__tab" role="tab" aria-selected="false" aria-controls="panel-changelog" id="tab-changelog" onclick="switchTab(this,'panel-changelog')">Changelog</button></li>
+      <li role="presentation"><button class="ease-tabs__tab" role="tab" aria-selected="false" aria-controls="panel-faq" id="tab-faq" onclick="switchTab(this,'panel-faq')">FAQ</button></li>
+      <li role="presentation"><button class="ease-tabs__tab" role="tab" aria-selected="false" aria-controls="panel-a11y" id="tab-a11y" onclick="switchTab(this,'panel-a11y')">Accessibility</button></li>
+    </ul>
+    <div class="ease-tabs__panels">
+      <div class="ease-tabs__panel is-active" id="panel-overview" role="tabpanel" aria-labelledby="tab-overview"><p class="panel-content">Overview content — component description and usage summary.</p></div>
+      <div class="ease-tabs__panel" id="panel-props" role="tabpanel" aria-labelledby="tab-props"><p class="panel-content">Properties / API reference table.</p></div>
+      <div class="ease-tabs__panel" id="panel-events" role="tabpanel" aria-labelledby="tab-events"><p class="panel-content">Events emitted by the component.</p></div>
+      <div class="ease-tabs__panel" id="panel-slots" role="tabpanel" aria-labelledby="tab-slots"><p class="panel-content">Named slots and their expected content.</p></div>
+      <div class="ease-tabs__panel" id="panel-examples" role="tabpanel" aria-labelledby="tab-examples"><p class="panel-content">Live usage examples.</p></div>
+      <div class="ease-tabs__panel" id="panel-changelog" role="tabpanel" aria-labelledby="tab-changelog"><p class="panel-content">Version history and changelog entries.</p></div>
+      <div class="ease-tabs__panel" id="panel-faq" role="tabpanel" aria-labelledby="tab-faq"><p class="panel-content">Frequently asked questions.</p></div>
+      <div class="ease-tabs__panel" id="panel-a11y" role="tabpanel" aria-labelledby="tab-a11y"><p class="panel-content">Accessibility notes and keyboard interactions.</p></div>
+    </div>
+  </div>
+  <script>
+    function switchTab(tab, panelId) {
+      document.querySelectorAll('.ease-tabs__tab').forEach(t => { t.setAttribute('aria-selected','false'); t.classList.remove('is-active'); });
+      document.querySelectorAll('.ease-tabs__panel').forEach(p => p.classList.remove('is-active'));
+      tab.setAttribute('aria-selected','true'); tab.classList.add('is-active');
+      document.getElementById(panelId).classList.add('is-active');
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/fix-tabs-scrollable-indicator-ag/style.css
+++ b/submissions/examples/fix-tabs-scrollable-indicator-ag/style.css
@@ -1,0 +1,61 @@
+/* EaseMotion CSS – Tabs scrollable indicator fix. Fixes: #35833 */
+:root {
+  --ease-tabs-indicator-color: #4361ee;
+  --ease-tabs-indicator-height: 3px;
+  --ease-tabs-border: #dee2e6;
+  --ease-tabs-active-color: #4361ee;
+  --ease-tabs-inactive-color: #6c757d;
+}
+.ease-tabs {
+  width: 100%;
+  border-bottom: 1px solid var(--ease-tabs-border);
+}
+/* KEY FIX: scrollable list with in-flow indicator */
+.ease-tabs__list {
+  display: flex;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior-x: contain;
+  scrollbar-width: none; /* Firefox */
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  /* Scroll snapping so tabs snap into position */
+  scroll-snap-type: x mandatory;
+}
+.ease-tabs__list::-webkit-scrollbar { display: none; }
+.ease-tabs__tab {
+  flex-shrink: 0;
+  padding: 0.75rem 1.25rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--ease-tabs-inactive-color);
+  background: none;
+  border: none;
+  cursor: pointer;
+  white-space: nowrap;
+  position: relative;
+  scroll-snap-align: start;
+  /* KEY FIX: in-flow border-bottom replaces absolute indicator */
+  border-bottom: var(--ease-tabs-indicator-height) solid transparent;
+  margin-bottom: -1px; /* aligns with container border */
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+.ease-tabs__tab:hover { color: #495057; }
+.ease-tabs__tab[aria-selected="true"],
+.ease-tabs__tab.is-active {
+  color: var(--ease-tabs-active-color);
+  border-bottom-color: var(--ease-tabs-indicator-color);
+}
+.ease-tabs__tab:focus-visible {
+  outline: 3px solid rgba(67,97,238,0.4);
+  outline-offset: -3px;
+  border-radius: 4px 4px 0 0;
+}
+.ease-tabs__panels { padding: 1.25rem 0; }
+.ease-tabs__panel { display: none; }
+.ease-tabs__panel.is-active { display: block; }
+body { font-family: system-ui, sans-serif; padding: 1.5rem; background: #f0f2f5; max-width: 600px; }
+h2 { font-size: 1rem; margin-bottom: 1.25rem; }
+.panel-content { font-size: 0.9rem; color: #495057; line-height: 1.6; }


### PR DESCRIPTION
Fixes #35833.\n\n## Changes\n- `style.css` — original CSS fix (well over 5 lines)\n- `demo.html` — interactive demo with full HTML5 boilerplate\n- `README.md` — describes the fix and usage\n\n## Validation Checklist\n- [x] `demo.html` has `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` tags\n- [x] `style.css` has original, meaningful CSS (50+ lines)\n- [x] `README.md` included\n- [x] Files placed in `submissions/examples/fix-tabs-scrollable-indicator-ag/`\n- [x] No edits to `core/` or `components/`\n- [x] Single squashed commit — conventional-commit format