### PR TITLE
fix: remove top-level comma from var() fallback in navbar.css

### DIFF
--- a/components/navbar.css
+++ b/components/navbar.css
@@ -18,11 +18,7 @@
     background: var(--ease-glass-bg, rgba(255, 255, 255, 0.18));
     border: 1px solid var(--ease-glass-border, rgba(255, 255, 255, 0.24));
     border-radius: var(--ease-radius-xl, 1.5rem);
-    box-shadow: var(
-      --ease-shadow-md,
-      0 4px 6px -1px rgba(0, 0, 0, 0.35),
-      0 2px 4px -1px rgba(0, 0, 0, 0.25)
-    );
+    box-shadow: var(--ease-shadow-md);
     color: var(--ease-color-neutral-900, #0f172a);
     backdrop-filter: blur(var(--ease-navbar-glass-blur, 16px));
     -webkit-backdrop-filter: blur(var(--ease-navbar-glass-blur, 16px));
@@ -88,11 +84,7 @@
 
     background: var(--ease-glass-bg, rgba(255, 255, 255, 0.14));
     border-color: var(--ease-glass-border, rgba(255, 255, 255, 0.2));
-    box-shadow: var(
-      --ease-shadow-xl,
-      0 20px 25px -5px rgba(0, 0, 0, 0.45),
-      0 10px 10px -5px rgba(0, 0, 0, 0.3)
-    );
+    box-shadow: var(--ease-shadow-xl);
   }
 
   @supports not (backdrop-filter: blur(0)) {


### PR DESCRIPTION
Closes #35681

Per CSS spec, a top-level comma terminates the fallback value of `var()`. The shadow fallbacks in navbar.css contain top-level commas in the shadow lists.