### PR TITLE
fix(input-group): add :focus-within highlight border to wrapper when child input is focused

### DIFF
--- a/submissions/examples/fix-focus-within-group-highlight-ag/README.md
+++ b/submissions/examples/fix-focus-within-group-highlight-ag/README.md
@@ -1,0 +1,18 @@
+# Fix ease-input-group :focus-within Border Highlight
+
+## What does this do?
+Adds a `:focus-within` rule to `.ease-input-group` that highlights the
+wrapper border and applies a focus ring when any child input receives focus.
+
+## How is it used?
+```html
+<div class="ease-input-group">
+  <span class="ease-input-group__addon">https://</span>
+  <input class="ease-input-group__input" type="text" placeholder="example.com">
+</div>
+```
+
+## Why is it useful?
+Without `:focus-within`, only the `<input>` itself gets a focus ring.
+The outer wrapper stays visually disconnected, making it unclear where
+the focus boundary is. Fixes: #35837

--- a/submissions/examples/fix-focus-within-group-highlight-ag/demo.html
+++ b/submissions/examples/fix-focus-within-group-highlight-ag/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Input Group Focus-Within Fix – EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h2>ease-input-group – :focus-within Highlight Fix</h2>
+  <div class="demo-stack">
+    <div>
+      <label for="url">Website URL</label>
+      <div class="ease-input-group">
+        <span class="ease-input-group__addon" aria-hidden="true">https://</span>
+        <input class="ease-input-group__input" id="url" type="text" placeholder="example.com">
+      </div>
+    </div>
+    <div>
+      <label for="search">Search</label>
+      <div class="ease-input-group">
+        <input class="ease-input-group__input" id="search" type="search" placeholder="Search components…">
+        <button class="ease-input-group__btn" type="submit" aria-label="Submit search">→</button>
+      </div>
+    </div>
+    <div>
+      <label for="amount">Amount</label>
+      <div class="ease-input-group">
+        <span class="ease-input-group__addon" aria-hidden="true">$</span>
+        <input class="ease-input-group__input" id="amount" type="number" placeholder="0.00">
+        <span class="ease-input-group__addon" aria-hidden="true">USD</span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-focus-within-group-highlight-ag/style.css
+++ b/submissions/examples/fix-focus-within-group-highlight-ag/style.css
@@ -1,0 +1,69 @@
+/* EaseMotion CSS – Input-group focus-within fix. Fixes: #35837 */
+:root {
+  --ease-ig-border: #ced4da;
+  --ease-ig-radius: 8px;
+  --ease-ig-bg: #fff;
+  --ease-ig-focus-border: #4361ee;
+  --ease-ig-focus-ring: rgba(67,97,238,0.2);
+  --ease-ig-addon-bg: #f8f9fa;
+  --ease-ig-addon-color: #6c757d;
+}
+.ease-input-group {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  max-width: 420px;
+  border: 1.5px solid var(--ease-ig-border);
+  border-radius: var(--ease-ig-radius);
+  overflow: hidden;
+  background: var(--ease-ig-bg);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+/* KEY FIX: highlight wrapper when any child is focused */
+.ease-input-group:focus-within {
+  border-color: var(--ease-ig-focus-border);
+  box-shadow: 0 0 0 3px var(--ease-ig-focus-ring);
+}
+.ease-input-group__input {
+  flex: 1;
+  padding: 0.6rem 0.875rem;
+  font-size: 1rem;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: #212529;
+}
+.ease-input-group__input::placeholder { color: #adb5bd; opacity: 1; }
+.ease-input-group__addon {
+  display: flex;
+  align-items: center;
+  padding: 0 0.875rem;
+  background: var(--ease-ig-addon-bg);
+  color: var(--ease-ig-addon-color);
+  font-size: 0.9rem;
+  border-inline-start: 1.5px solid var(--ease-ig-border);
+  user-select: none;
+  flex-shrink: 0;
+}
+.ease-input-group__addon:first-child {
+  border-inline-start: none;
+  border-inline-end: 1.5px solid var(--ease-ig-border);
+}
+.ease-input-group__btn {
+  padding: 0 1rem;
+  background: #4361ee;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border-inline-start: 1.5px solid var(--ease-ig-border);
+  transition: background 0.15s ease;
+  flex-shrink: 0;
+}
+.ease-input-group__btn:hover { background: #3451d4; }
+.ease-input-group__btn:focus-visible { outline: 3px solid rgba(67,97,238,0.5); outline-offset: -3px; }
+body { font-family: system-ui, sans-serif; padding: 2rem; background: #f0f2f5; }
+h2 { font-size: 1rem; margin-bottom: 1.5rem; }
+.demo-stack { display: flex; flex-direction: column; gap: 1.25rem; max-width: 440px; }
+label { font-size: 0.85rem; font-weight: 600; color: #495057; display: block; margin-bottom: 0.4rem; }


### PR DESCRIPTION
Fixes #35837.\n\n## Changes\n- `style.css` — original CSS fix (well over 5 lines)\n- `demo.html` — interactive demo with full HTML5 boilerplate\n- `README.md` — describes the fix and usage\n\n## Validation Checklist\n- [x] `demo.html` has `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` tags\n- [x] `style.css` has original, meaningful CSS (50+ lines)\n- [x] `README.md` included\n- [x] Files placed in `submissions/examples/fix-focus-within-group-highlight-ag/`\n- [x] No edits to `core/` or `components/`\n- [x] Single squashed commit — conventional-commit format