### PR TITLE
feat: add block-reveal-stagger component (#35857)

### DIFF
--- a/submissions/examples/ease-block-reveal-stagger-ij/README.md
+++ b/submissions/examples/ease-block-reveal-stagger-ij/README.md
@@ -1,0 +1,36 @@
+# ease-block-reveal-stagger
+
+Staggered block reveal animation. Direct children of the container appear sequentially with a clip-path slit-scan reveal and a subtle scale-up entrance. Each child's animation delay is a multiple of `--stagger-delay` based on its index.
+
+## HTML Structure
+
+```html
+<div class="ease-block-reveal-stagger">
+  <span>Item 1</span>
+  <span>Item 2</span>
+  <!-- up to 8 children with automatic staggering -->
+</div>
+```
+
+## CSS Variables
+
+| Variable           | Default     | Description                                      |
+|--------------------|-------------|--------------------------------------------------|
+| `--block-color`    | `#e17055`   | Background color for each child block            |
+| `--reveal-duration` | `0.6s`    | Duration of the reveal animation on each child   |
+| `--stagger-delay`  | `0.1s`      | Delay offset between each child's animation start |
+
+## Usage
+
+```html
+<link rel="stylesheet" href="path/to/style.css" />
+
+<div
+  class="ease-block-reveal-stagger"
+  style="--block-color: #0984e3; --reveal-duration: 0.4s; --stagger-delay: 0.08s;"
+>
+  <div>1</div><div>2</div><div>3</div><div>4</div>
+</div>
+```
+
+The animation plays once on load (`both` fill mode retains final state). Supports up to 8 staggered children. Reset via re-triggering the animation.

--- a/submissions/examples/ease-block-reveal-stagger-ij/demo.html
+++ b/submissions/examples/ease-block-reveal-stagger-ij/demo.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-block-reveal-stagger</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #111;
+      color: #eee;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+    }
+    h1 { font-size: 1.5rem; font-weight: 300; letter-spacing: 0.05em; margin-bottom: 0.25rem; }
+    p { font-size: 0.9rem; color: #888; margin-bottom: 2rem; }
+    .controls { display: flex; gap: 0.75rem; flex-wrap: wrap; justify-content: center; margin-bottom: 2.5rem; }
+    .controls button {
+      padding: 0.5rem 1.25rem;
+      border: 1px solid #444;
+      background: transparent;
+      color: #ccc;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 0.85rem;
+      transition: all 0.2s;
+    }
+    .controls button:hover { background: #333; border-color: #888; }
+    .controls button.active { background: var(--block-color, #e17055); border-color: var(--block-color, #e17055); color: #fff; }
+    .playground { display: flex; flex-direction: column; align-items: center; gap: 1.5rem; }
+    .grid { display: flex; flex-wrap: wrap; gap: 1rem; justify-content: center; max-width: 500px; }
+    .slider-group { display: flex; align-items: center; gap: 0.75rem; }
+    .slider-group label { font-size: 0.85rem; color: #aaa; min-width: 7rem; }
+    .slider-group input[type="range"] { width: 140px; accent-color: var(--block-color, #e17055); }
+    .slider-group output { font-size: 0.8rem; color: #888; min-width: 3rem; text-align: right; }
+    .color-group { display: flex; align-items: center; gap: 0.75rem; }
+    .color-group label { font-size: 0.85rem; color: #aaa; }
+    .color-group input[type="color"] { width: 40px; height: 32px; border: 1px solid #444; border-radius: 4px; background: transparent; cursor: pointer; }
+  </style>
+</head>
+<body>
+
+  <h1>ease-block-reveal-stagger</h1>
+  <p>Staggered block reveal animation with sequential children</p>
+
+  <div class="controls">
+    <button class="active" id="playBtn">▶ Pause</button>
+    <button id="resetBtn">↺ Reset</button>
+  </div>
+
+  <div class="playground">
+    <div class="ease-block-reveal-stagger" id="container">
+      <span>A</span><span>B</span><span>C</span><span>D</span>
+      <span>E</span><span>F</span><span>G</span><span>H</span>
+    </div>
+
+    <div class="slider-group">
+      <label for="durRange">--reveal-duration</label>
+      <input type="range" id="durRange" min="0.2" max="2" value="0.6" step="0.1" />
+      <output id="durVal">0.6s</output>
+    </div>
+
+    <div class="slider-group">
+      <label for="staggerRange">--stagger-delay</label>
+      <input type="range" id="staggerRange" min="0.02" max="0.3" value="0.1" step="0.01" />
+      <output id="staggerVal">0.1s</output>
+    </div>
+
+    <div class="color-group">
+      <label for="colorPicker">--block-color</label>
+      <input type="color" id="colorPicker" value="#e17055" />
+    </div>
+  </div>
+
+  <script>
+    (function() {
+      var container = document.getElementById('container');
+      var playBtn = document.getElementById('playBtn');
+      var resetBtn = document.getElementById('resetBtn');
+      var durRange = document.getElementById('durRange');
+      var durVal = document.getElementById('durVal');
+      var staggerRange = document.getElementById('staggerRange');
+      var staggerVal = document.getElementById('staggerVal');
+      var colorPicker = document.getElementById('colorPicker');
+
+      function updateDuration(val) {
+        durVal.textContent = val + 's';
+        container.style.setProperty('--reveal-duration', val + 's');
+      }
+      function updateStagger(val) {
+        staggerVal.textContent = val + 's';
+        container.style.setProperty('--stagger-delay', val + 's');
+      }
+      function updateColor(val) {
+        container.style.setProperty('--block-color', val);
+      }
+
+      updateDuration(durRange.value);
+      updateStagger(staggerRange.value);
+      updateColor(colorPicker.value);
+
+      playBtn.addEventListener('click', function() {
+        var paused = container.style.animationPlayState === 'paused';
+        container.style.animationPlayState = paused ? 'running' : 'paused';
+        for (var i = 0; i < container.children.length; i++) {
+          container.children[i].style.animationPlayState = paused ? 'running' : 'paused';
+        }
+        playBtn.textContent = paused ? '▶ Pause' : '■ Play';
+        playBtn.classList.toggle('active', paused);
+      });
+
+      resetBtn.addEventListener('click', function() {
+        container.style.animation = 'none';
+        for (var i = 0; i < container.children.length; i++) {
+          container.children[i].style.animation = 'none';
+        }
+        container.offsetHeight;
+        container.style.animation = '';
+        for (var i = 0; i < container.children.length; i++) {
+          container.children[i].style.animation = '';
+        }
+        container.style.animationPlayState = 'running';
+        playBtn.textContent = '▶ Pause';
+        playBtn.classList.add('active');
+      });
+
+      durRange.addEventListener('input', function() { updateDuration(this.value); });
+      staggerRange.addEventListener('input', function() { updateStagger(this.value); });
+      colorPicker.addEventListener('input', function() { updateColor(this.value); });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-block-reveal-stagger-ij/style.css
+++ b/submissions/examples/ease-block-reveal-stagger-ij/style.css
@@ -1,0 +1,46 @@
+.ease-block-reveal-stagger {
+  --block-color: #e17055;
+  --reveal-duration: 0.6s;
+  --stagger-delay: 0.1s;
+
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.ease-block-reveal-stagger > * {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 4rem;
+  height: 4rem;
+  background: var(--block-color);
+  color: #fff;
+  font-weight: 600;
+  font-size: 1.1rem;
+  border-radius: 8px;
+  animation: block-reveal var(--reveal-duration) ease-out both;
+}
+
+.ease-block-reveal-stagger > *:nth-child(1) { animation-delay: calc(var(--stagger-delay) * 0); }
+.ease-block-reveal-stagger > *:nth-child(2) { animation-delay: calc(var(--stagger-delay) * 1); }
+.ease-block-reveal-stagger > *:nth-child(3) { animation-delay: calc(var(--stagger-delay) * 2); }
+.ease-block-reveal-stagger > *:nth-child(4) { animation-delay: calc(var(--stagger-delay) * 3); }
+.ease-block-reveal-stagger > *:nth-child(5) { animation-delay: calc(var(--stagger-delay) * 4); }
+.ease-block-reveal-stagger > *:nth-child(6) { animation-delay: calc(var(--stagger-delay) * 5); }
+.ease-block-reveal-stagger > *:nth-child(7) { animation-delay: calc(var(--stagger-delay) * 6); }
+.ease-block-reveal-stagger > *:nth-child(8) { animation-delay: calc(var(--stagger-delay) * 7); }
+
+@keyframes block-reveal {
+  0% {
+    opacity: 0;
+    transform: scale(0.5) translateY(1rem);
+    clip-path: inset(0 0 100% 0);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+    clip-path: inset(0 0 0 0);
+  }
+}


### PR DESCRIPTION
## Component: ease-block-reveal-stagger - Block reveal with staggered children animation

**Closes #35857**

### Acceptance Criteria
- [x] CSS-only animated component with @keyframes
- [x] Custom properties via CSS variables
- [x] Interactive demo page
- [x] README with documentation

### Files
- submissions/examples/ease-block-reveal-stagger-ij/demo.html
- submissions/examples/ease-block-reveal-stagger-ij/style.css
- submissions/examples/ease-block-reveal-stagger-ij/README.md

### Review Instructions
Open demo.html in a browser and verify the animation works. Check that CSS variables can be customized.
