### PR TITLE
feat(submissions): add sidebar active text contrast showcase

### DIFF
--- a/submissions/sidebar-active-text-contrast/README.md
+++ b/submissions/sidebar-active-text-contrast/README.md
@@ -1,0 +1,57 @@
+﻿# Sidebar Active Text Contrast
+
+## Overview
+
+This submission showcases an improved active sidebar navigation style for documentation interfaces. It demonstrates how increasing the contrast of the active navigation item improves readability while preserving the clean, modern appearance of the original design.
+
+## Problem
+
+The original active sidebar item used a very light text color on a light purple background, resulting in poor contrast and making the selected navigation item difficult to read in light mode.
+
+## Solution
+
+This showcase demonstrates an accessible alternative by:
+
+- Preserving the existing light purple active background.
+- Using a darker text color for the active navigation item.
+- Maintaining the original layout and visual hierarchy.
+- Improving readability without changing the overall design language.
+
+## Features
+
+- Side-by-side **Before** and **After** comparison.
+- Improved active navigation contrast.
+- Lightweight and responsive design.
+- Pure HTML and CSS.
+- No JavaScript or external dependencies.
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+Example:
+
+```html
+<nav class="sidebar-nav">
+  <a href="#overview">Overview</a>
+  <a href="#getting-started" class="active">Getting Started</a>
+  <a href="#components">Components</a>
+</nav>
+```
+
+## Files
+
+- `demo.html` — Interactive showcase
+- `style.css` — Component styling
+- `README.md` — Documentation
+
+## Browser Support
+
+- Chrome
+- Edge
+- Firefox
+- Safari
+
+## Why it fits EaseMotion CSS
+
+This example aligns with EaseMotion CSS's lightweight and human-readable philosophy by demonstrating a practical UI enhancement that improves accessibility while keeping the implementation simple, reusable, and dependency-free.

--- a/submissions/sidebar-active-text-contrast/demo.html
+++ b/submissions/sidebar-active-text-contrast/demo.html
@@ -1,0 +1,86 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sidebar Active Text Contrast</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="showcase-shell">
+    <header class="hero">
+      <div>
+        <span class="eyebrow">EaseMotion CSS showcase</span>
+        <h1>Sidebar Active Text Contrast</h1>
+        <p>Improve documentation sidebar readability with a polished light-mode active link state that preserves the soft purple aesthetic.</p>
+      </div>
+      <div class="hero-badge">Accessibility improvement</div>
+    </header>
+
+    <section class="overview">
+      <article class="feature-card">
+        <h2>What changed</h2>
+        <p>The active sidebar item now uses a darker text color with a stronger accent while keeping the light purple background. This preserves the design language and improves legibility for users in bright themes.</p>
+      </article>
+      <article class="feature-card">
+        <h2>Why it matters</h2>
+        <p>Low-contrast active text can disappear in a documentation sidebar. A clearer active state helps users quickly identify their current section without relying on hover or extra cues.</p>
+      </article>
+    </section>
+
+    <section class="layout">
+      <aside class="sidebar sidebar--live">
+        <div class="sidebar-header">
+          <span class="brand">EaseMotion Docs</span>
+          <p>Primary documentation navigation with the improved active state.</p>
+        </div>
+        <nav class="sidebar-nav">
+          <a href="#overview">Overview</a>
+          <a href="#getting-started" class="active">Getting Started</a>
+          <a href="#components">Components</a>
+          <a href="#utilities">Utilities</a>
+          <a href="#accessibility">Accessibility</a>
+        </nav>
+      </aside>
+
+      <main class="content-shell">
+        <section class="comparison">
+          <h2>Before / After</h2>
+          <div class="comparison-grid">
+            <article class="comparison-card">
+              <div class="comparison-label">Before</div>
+              <nav class="sidebar-nav example--before">
+                <a href="#overview">Overview</a>
+                <a href="#getting-started" class="active">Getting Started</a>
+                <a href="#components">Components</a>
+                <a href="#utilities">Utilities</a>
+                <a href="#accessibility">Accessibility</a>
+              </nav>
+            </article>
+            <article class="comparison-card">
+              <div class="comparison-label">After</div>
+              <nav class="sidebar-nav example--after">
+                <a href="#overview">Overview</a>
+                <a href="#getting-started" class="active">Getting Started</a>
+                <a href="#components">Components</a>
+                <a href="#utilities">Utilities</a>
+                <a href="#accessibility">Accessibility</a>
+              </nav>
+            </article>
+          </div>
+        </section>
+
+        <section class="note-panel">
+          <h2>Accessibility Improvement</h2>
+          <p>The improved active state uses a deep indigo text color with a subtle purple highlight. This creates a stronger contrast ratio while maintaining the soft, approachable look of the sidebar.</p>
+          <ul>
+            <li>Better readability for active navigation labels</li>
+            <li>Stronger visual hierarchy in the sidebar</li>
+            <li>Preserves a lightweight, documentation-style layout</li>
+          </ul>
+        </section>
+      </main>
+    </section>
+  </div>
+</body>
+</html>

--- a/submissions/sidebar-active-text-contrast/style.css
+++ b/submissions/sidebar-active-text-contrast/style.css
@@ -1,0 +1,237 @@
+﻿:root {
+  color-scheme: light;
+  font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #eef2fb;
+  color: #172133;
+}
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #eef2fb;
+}
+img, picture, video, canvas, svg {
+  max-width: 100%;
+}
+.showcase-shell {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 32px 24px 48px;
+}
+.hero {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  padding: 32px;
+  border-radius: 28px;
+  background: #ffffff;
+  box-shadow: 0 24px 60px rgba(25, 41, 76, 0.08);
+}
+.eyebrow {
+  display: inline-block;
+  margin-bottom: 12px;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #6f7ea2;
+}
+.hero h1 {
+  margin: 0;
+  font-size: clamp(2.3rem, 3vw, 3.4rem);
+  line-height: 1.03;
+}
+.hero p {
+  max-width: 56ch;
+  margin: 18px 0 0;
+  color: #4b5677;
+  line-height: 1.75;
+}
+.hero-badge {
+  align-self: start;
+  padding: 12px 18px;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  font-weight: 700;
+  background: #f3f6ff;
+  color: #3c4b9f;
+}
+.overview {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+  margin: 32px 0;
+}
+.feature-card {
+  padding: 24px;
+  border-radius: 24px;
+  background: #ffffff;
+  border: 1px solid #e3e7f1;
+  box-shadow: 0 12px 35px rgba(25, 41, 76, 0.06);
+}
+.feature-card h2 {
+  margin-top: 0;
+}
+.feature-card p {
+  margin: 14px 0 0;
+  color: #495476;
+  line-height: 1.8;
+}
+.layout {
+  display: grid;
+  grid-template-columns: 320px minmax(0, 1fr);
+  gap: 28px;
+}
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 28px;
+  border-radius: 28px;
+  background: #ffffff;
+  border: 1px solid #e8edf7;
+  box-shadow: 0 24px 70px rgba(25, 41, 76, 0.08);
+}
+.sidebar-header {
+  margin-bottom: 24px;
+}
+.brand {
+  display: block;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #1b2640;
+}
+.sidebar-header p {
+  margin: 12px 0 0;
+  color: #5f6d8b;
+  line-height: 1.7;
+}
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.sidebar-nav a {
+  display: block;
+  padding: 16px 18px;
+  border-radius: 16px;
+  text-decoration: none;
+  color: #4d5e80;
+  background: #f6f8ff;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+.sidebar-nav a:hover {
+  background: #e9efff;
+  color: #27334f;
+  transform: translateX(2px);
+}
+.sidebar-nav a.active {
+  background: #edefff;
+  color: #0f2340;
+  font-weight: 700;
+  border-left: 4px solid #5c6cff;
+  padding-left: 14px;
+}
+.comparison {
+  padding: 28px;
+  border-radius: 28px;
+  background: #ffffff;
+  border: 1px solid #e3e7f1;
+  box-shadow: 0 18px 45px rgba(25, 41, 76, 0.06);
+}
+.comparison h2 {
+  margin-top: 0;
+}
+.comparison-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+  margin-top: 24px;
+}
+.comparison-card {
+  background: #f7f9ff;
+  border-radius: 22px;
+  border: 1px solid #dde2ed;
+  padding: 20px;
+}
+.comparison-label {
+  display: inline-flex;
+  margin-bottom: 18px;
+  padding: 10px 14px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #46588f;
+  background: #eef2ff;
+}
+.example--before a.active {
+  background: linear-gradient(
+    90deg,
+    rgba(108, 99, 255, 0.15),
+    rgba(108, 99, 255, 0.05)
+  );
+  color: #ffffff;          /* Original issue */
+  border-left: 2px solid #6c63ff;
+  font-weight: 600;
+}
+.example--after a.active {
+  background: linear-gradient(
+    90deg,
+    rgba(108, 99, 255, 0.15),
+    rgba(108, 99, 255, 0.05)
+  );
+  color: #0f2340;
+  border-left: 2px solid #6c63ff;
+  font-weight: 700;
+}
+.example--before a,
+.example--after a {
+  padding: 14px 16px;
+  margin-bottom: 10px;
+  border-radius: 14px;
+  display: block;
+  text-decoration: none;
+  color: #4d5e80;
+  background: #f6f8ff;
+}
+.example--before a:hover,
+.example--after a:hover {
+  background: #e9efff;
+}
+.note-panel {
+  margin-top: 24px;
+  padding: 24px;
+  border-radius: 24px;
+  background: #f7f8ff;
+  border: 1px solid #dde2ee;
+}
+.note-panel h2 {
+  margin-top: 0;
+}
+.note-panel p {
+  color: #4b5570;
+  line-height: 1.85;
+}
+.note-panel ul {
+  margin: 18px 0 0;
+  padding-left: 20px;
+  color: #4b5570;
+}
+.note-panel li {
+  margin-bottom: 10px;
+}
+@media (max-width: 980px) {
+  .hero {
+    grid-template-columns: 1fr;
+  }
+  .overview,
+  .layout,
+  .comparison-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a standalone showcase demonstrating an improved active sidebar text contrast for documentation navigation.

### Type of Change

- [x] 📝 Documentation improvement

### Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

### Feature Description

**What does this add?**

A standalone documentation sidebar showcase demonstrating improved active text contrast using a before/after comparison.

**How does a developer use it?**

Open `demo.html` directly in a browser.

**Why does it fit EaseMotion CSS?**

It demonstrates an accessibility-focused documentation UI improvement using only HTML and CSS while remaining lightweight and easy to understand.

### Demo

- [x] Demo added (`demo.html` opens directly in a browser)

### Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

### Notes for Maintainer

This submission is completely self-contained and does not modify any framework or documentation source files.

Related to #35265