### PR TITLE
feat: add product catalog blur entrance tooltip

### DIFF
--- a/submissions/examples/css-blur-entrance-tooltip-product-catalog/README.md
+++ b/submissions/examples/css-blur-entrance-tooltip-product-catalog/README.md
@@ -1,0 +1,35 @@
+# CSS Submissions Examples: Product Catalog Layout Blur-Entrance Tooltip
+
+A performance-first pure CSS interactive component example featuring a cinematic backdrop-blur entrance animation sequence, styled specifically to integrate seamlessly with modern luxury e-commerce interfaces and clean product catalogs.
+
+## Property Parameter Tokens API
+
+Downstream developers can customize catalog theme configurations fluidly inside the `.ease-catalog-tooltip-wrapper` block:
+
+| Custom CSS Property Variable      | Default Value | Purpose                                                                 |
+| :-------------------------------- | :------------ | :---------------------------------------------------------------------- |
+| `--ease-catalog-bg`               | `rgba(...)`   | Frosted glass backing color profile utilizing alpha transparent meshes. |
+| `--ease-catalog-text`             | `#1e293b`     | Deep slate typography fill color node token.                             |
+| `--ease-catalog-border`           | `rgba(...)`   | Semi-transparent boundary highlight line asset.                          |
+| `--ease-catalog-duration`         | `0.4s`        | Cinematic fading and de-blurring timeline velocity lifespan.            |
+| `--ease-catalog-initial-blur`     | `12px`        | Baseline starting filter blur value mapping structural entrance keys.   |
+| `--ease-catalog-accent`           | `#d97706`     | Premium amber luxury catalog interface highlight color focus indicator.  |
+
+---
+
+## Technical Integration Blueprint
+
+```html
+<link rel="stylesheet" href="style.css">
+
+<div class="ease-catalog-tooltip-wrapper">
+  <button class="ease-catalog-tooltip-target" aria-describedby="specs-bubble">
+    View Product Details
+  </button>
+  <div id="specs-bubble" class="ease-catalog-tooltip-content" role="tooltip">
+    Limited Edition • Hand-numbered 01/50
+  </div>
+</div>
+```
+---
+Crafted with 💜 by **[pari-dubey1](https://github.com/pari-dubey1)**

--- a/submissions/examples/css-blur-entrance-tooltip-product-catalog/demo.html
+++ b/submissions/examples/css-blur-entrance-tooltip-product-catalog/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Product Catalog Tooltip // Pure CSS Blur Entrance Showcase</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+      min-height: 100vh;
+      background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%); /* Clean luxury studio background */
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="ease-catalog-tooltip-wrapper">
+    <button class="ease-catalog-tooltip-target" aria-describedby="product-spec-tooltip">
+      View Specifications
+    </button>
+
+    <div id="product-spec-tooltip" class="ease-catalog-tooltip-content" role="tooltip">
+      Material: 100% Organic Merino Wool • Premium Grade
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-blur-entrance-tooltip-product-catalog/style.css
+++ b/submissions/examples/css-blur-entrance-tooltip-product-catalog/style.css
@@ -1,0 +1,111 @@
+/* ─── 🎛️ PRODUCT CATALOG DESIGN CONFIGURABLE VARIABLES ─── */
+.ease-catalog-tooltip-wrapper {
+  --ease-catalog-bg: rgba(255, 255, 255, 0.85); /* High-end frosted glass appearance */
+  --ease-catalog-text: #1e293b;                 /* Deep slate premium text contrast */
+  --ease-catalog-border: rgba(255, 255, 255, 0.4);
+  --ease-catalog-duration: 0.4s;                 /* Smooth cinematic cinematic window */
+  --ease-catalog-easing: cubic-bezier(0.25, 1, 0.5, 1); /* Out-quart fluid ease */
+  --ease-catalog-initial-blur: 12px;             /* Target entrance blur radius */
+  --ease-catalog-initial-scale: 0.95;            /* Micro scaling offset parameter */
+  --ease-catalog-accent: #d97706;                /* Elegant gold/amber catalog tint */
+
+  position: relative;
+  display: inline-block;
+}
+
+/* ─── 🌀 HARDWARE-ACCELERATED BLUR ENTRANCE KEYFRAMES ─── */
+@keyframes ease-catalog-blur-entrance {
+  0% {
+    transform: translateX(-50%) translateY(4px) scale(var(--ease-catalog-initial-scale));
+    filter: blur(var(--ease-catalog-initial-blur));
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(-50%) translateY(0) scale(1);
+    filter: blur(0);
+    opacity: 1;
+  }
+}
+
+/* ─── 🏗️ STRUCTURAL CATALOG TOOLTIP PANEL ARCHITECTURE ─── */
+.ease-catalog-tooltip-content {
+  position: absolute;
+  bottom: 140%;
+  left: 50%;
+  transform: translateX(-50%) scale(var(--ease-catalog-initial-scale));
+  transform-origin: bottom center;
+
+  /* Applying Frosted E-Commerce Core Parameters */
+  background-color: var(--ease-catalog-bg);
+  color: var(--ease-catalog-text);
+  border: 1px solid var(--ease-catalog-border);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  padding: 0.6rem 1.2rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  border-radius: 20px; /* High-end rounded chip catalog aesthetic */
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.05), 
+              0 8px 10px -6px rgba(0, 0, 0, 0.05);
+
+  /* Basic state transitions fallback */
+  transition: opacity var(--ease-catalog-duration) var(--ease-catalog-easing),
+              visibility var(--ease-catalog-duration) var(--ease-catalog-easing),
+              filter var(--ease-catalog-duration) var(--ease-catalog-easing);
+}
+
+/* Rounded Frosted Bottom Pointer Arrow Indicator */
+.ease-catalog-tooltip-content::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 6px;
+  border-style: solid;
+  border-color: var(--ease-catalog-bg) transparent transparent transparent;
+}
+
+/* ─── ♿ ACCESSIBLE DUAL STATE MOUSE + KEYBOARD TRIGGERS ─── */
+.ease-catalog-tooltip-wrapper:hover .ease-catalog-tooltip-content,
+.ease-catalog-tooltip-wrapper:focus-within .ease-catalog-tooltip-content {
+  opacity: 1;
+  visibility: visible;
+
+  /* Executes clean blur scales transitions smoothly over GPU layer configurations */
+  animation: ease-catalog-blur-entrance var(--ease-catalog-duration) var(--ease-catalog-easing) forwards;
+}
+
+/* Premium Minimal E-Commerce Catalog Card Button Container */
+.ease-catalog-tooltip-target {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  padding: 0.75rem 1.5rem;
+  font-family: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--ease-catalog-text);
+  cursor: pointer;
+  border-radius: 30px;
+  outline: none;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.02);
+  transition: border-color 0.3s ease, color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.ease-catalog-tooltip-target:hover,
+.ease-catalog-tooltip-target:focus-visible {
+  border-color: var(--ease-catalog-accent);
+  color: var(--ease-catalog-accent);
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.04);
+}
+
+.ease-catalog-tooltip-target:focus-visible {
+  outline: 2px solid var(--ease-catalog-accent);
+  outline-offset: 3px;
+}


### PR DESCRIPTION
## Pull Request Description

This pull request introduces a highly modular, responsive, and hardware-accelerated **CSS Blur-Entrance Tooltip Module for Product Catalog Layouts** engineered entirely within the correct target **`submissions/examples/css-blur-entrance-tooltip-product-catalog/`** nested subdirectory.

Fixes #34350

---

## Type of Change

- [x] 📂 Submissions Examples Library Feature
- [x] ✨ New animation / micro-interaction state
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are isolated exclusively inside the `submissions/examples/css-blur-entrance-tooltip-product-catalog/` trajectory folder
- [x] Includes `style.css` — containing advanced backdrop-filter parameters, frosted glass container models, and e-commerce aesthetic variables
- [x] Includes `demo.html` — compiling clean standalone luxury product components showcase
- [x] Includes `README.md` — listing parametric tokens API guidelines and technical usability features
- [x] Fully compliant with automated merge validation scripts nested paths placement rules

---

## Feature Description

- **Correct Submissions/Examples Path Mapping:** Settled perfectly into the `submissions/examples/` hierarchy system to conform strictly to repository tracking automation engines.
- **Parametric Cinematic UI Matrix:** Exposes core configurations via native CSS custom properties (`--ease-catalog-*`), allowing developers to control animation velocities or backdrop blur levels fluidly.
- **Zero JS Layer Overheads:** Employs GPU-composited scaling modifications combined with fluid de-blurring `@keyframes`, bypassing document repaint loops to execute a clean cinematic backdrop entrance at 60fps upon mouse hovers or keyboard tab focus captures.