### PR TITLE
feat: add GitHub repository link to demo navbar (#30747)

### DIFF
--- a/docs/demo.html
+++ b/docs/demo.html
@@ -306,6 +306,15 @@
         <li><a href="#layout">Layout</a></li>
         <li><a href="./">Docs</a></li>
         <li>
+      <a
+        href="https://github.com/saptarshi-coder/easemotion-css"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        GitHub ↗
+      </a>
+    </li>
+        <li>
           <button
             id="theme-toggle"
             class="theme-toggle-btn ease-hover-grow"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "easemotion-css",
       "version": "1.1.0",
       "license": "MIT",
+      "dependencies": {
+        "easemotion-css": "^1.0.0"
+      },
       "devDependencies": {
         "jsdom": "^29.1.1",
         "prettier": "^3.8.3",
@@ -1528,6 +1531,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/easemotion-css": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/easemotion-css/-/easemotion-css-1.0.0.tgz",
+      "integrity": "sha512-2t037jVVFxcZ9P3q19wsQ5DHOwYMPAECHb21aIHjF8VGCJtit6V0fzG/lHr8+4lGWAUzGV1jwbgqRX/8Cvyl4Q==",
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -61,5 +61,8 @@
     "stylelint": "^17.12.0",
     "stylelint-config-standard": "^40.0.0",
     "vitest": "^4.1.8"
+  },
+  "dependencies": {
+    "easemotion-css": "^1.0.0"
   }
 }


### PR DESCRIPTION
Related Issue

Closes #30747

**Description**
What does this PR do?
Added a GitHub Repository link to the demo page navigation bar.
Configured the link to open the repository in a new browser tab using target="_blank" and rel="noopener noreferrer".
Kept the new navigation item consistent with the existing navbar styling and layout.

**Testing**
Verified the GitHub link is visible in the navbar.
Confirmed it opens the repository in a new tab.
Ensured existing navigation links and the theme toggle continue to work correctly.