### PR TITLE
feat: add CSS-only macOS style magnification dock #36114

### DIFF
--- a/submissions/examples/macos-magnification-dock/README.md
+++ b/submissions/examples/macos-magnification-dock/README.md
@@ -1,0 +1,17 @@
+# macOS Style Magnification Dock (CSS-Only)
+
+A seamless, hardware-accelerated fluid magnification navigation menu mimicking the iconic macOS dock layout.
+
+## How It Works
+Instead of heavy JavaScript window listeners or distance formula bounding-box tracking, this utility leverages modern relational layout states:
+* Uses CSS **Adjacent Sibling Combinators (`+`)** to scale immediate elements moving downstream.
+* Uses relational pseudo-class **`:has()` selectors** to look backward up the DOM tree and scale upstream preceding elements safely.
+* Avoids dynamic layout margins, completely eliminating mouse-tracking layout reflow loops (jitter).
+
+## Component Schema
+
+| Class Target | Implementation Layer | Function |
+| :--- | :--- | :--- |
+| `.ease-dock-container` | Structure Wrapper | Handles contextual positioning inside target viewports. |
+| `.ease-dock` | Parent Node | Acts as the track container; adjusts item gaps dynamically on element focus. |
+| `.dock-item` | Target Node | Independent component layer that transforms size from a locked base origin. |

--- a/submissions/examples/macos-magnification-dock/demo.html
+++ b/submissions/examples/macos-magnification-dock/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>macOS Style Magnification Dock - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    /* Demo Page Staging Only */
+    body {
+      margin: 0;
+      height: 100vh;
+      background: linear-gradient(135deg, #0f172a, #1e1b4b);
+      display: flex;
+      justify-content: center;
+      align-items: flex-end;
+      padding-bottom: 40px;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="ease-dock-container">
+    <ul class="ease-dock">
+      <li class="dock-item"><span class="dock-icon">📁</span></li>
+      <li class="dock-item"><span class="dock-icon">💬</span></li>
+      <li class="dock-item"><span class="dock-icon">🌐</span></li>
+      <li class="dock-item"><span class="dock-icon">🎵</span></li>
+      <li class="dock-item"><span class="dock-icon">⚙️</span></li>
+    </ul>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/macos-magnification-dock/style.css
+++ b/submissions/examples/macos-magnification-dock/style.css
@@ -1,0 +1,68 @@
+/* ==========================================================================
+   EaseMotion CSS - macOS Magnification Dock Feature
+   ========================================================================== */
+
+.ease-dock {
+  display: flex;
+  gap: 12px;
+  padding: 12px 24px;
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 24px;
+  margin: 0;
+  list-style: none;
+  align-items: flex-end;
+  height: 80px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+  transition: gap 0.3s cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+.dock-item {
+  width: 48px;
+  height: 48px;
+  background: #334155;
+  border-radius: 12px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 24px;
+  cursor: pointer;
+  user-select: none;
+  
+  /* Performance & Smoothness Architecture */
+  will-change: transform;
+  transform-origin: bottom center;
+  transition: transform 0.3s cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+/* Base hover (Largest) */
+.dock-item:hover {
+  transform: scale(1.6);
+}
+
+/* Immediate sibling right */
+.dock-item:hover + .dock-item {
+  transform: scale(1.3);
+}
+
+/* Immediate sibling left */
+.ease-dock:has(.dock-item:hover) .dock-item:has(+ .dock-item:hover) {
+  transform: scale(1.3);
+}
+
+/* Outer sibling right */
+.dock-item:hover + .dock-item + .dock-item {
+  transform: scale(1.1);
+}
+
+/* Outer sibling left */
+.ease-dock:has(.dock-item:hover) .dock-item:has(+ .dock-item + .dock-item:hover) {
+  transform: scale(1.1);
+}
+
+/* Dynamic track expansion to prevent child overflow clipping */
+.ease-dock:has(.dock-item:hover) {
+  gap: 18px;
+}


### PR DESCRIPTION
## 🚀 Feature: CSS-Only macOS Style Magnification Dock

### 📋 Overview
Closes #36114

This PR introduces a pure-CSS, hardware-accelerated macOS-style magnification dock utility. It removes the traditional dependency on heavy JavaScript window listeners or bounding-box distance formulas by utilizing advanced relational pseudo-classes (`:has()`) paired with adjacent sibling combinators (`+`).

### 🛠️ Technical Implementation Details
* **Zero Jitter & Reflow Prevention:** The implementation strictly avoids dynamic margin shifts on hover, which traditionally trigger continuous layout reflows and mouse-tracking flickering loops. Sizing is offloaded completely to the GPU using `transform: scale()` paired with `will-change: transform`.
* **Proportional Proximity Scaling:** Implements clean stepped transitions cascading outward from the cursor focus point ($1.6 \rightarrow 1.3 \rightarrow 1.1$).
* **Dynamic Containment:** The parent container scales its flex-gap safely (`.ease-dock:has(.dock-item:hover)`) to accommodate the expanded elements without layout shifting or edge clipping.

### 📂 Directory Structure Added
As per the contribution guidelines, all code lives inside the isolated submission tree:
```text
submissions/examples/macos-magnification-dock/
├── demo.html
├── style.css
└── README.md