### PR TITLE
feat: add cyberpunk neon 3D perspective tilt modal

### DIFF
--- a/submissions/examples/cyberpunk-neon-tilt-modal/README.md
+++ b/submissions/examples/cyberpunk-neon-tilt-modal/README.md
@@ -1,0 +1,47 @@
+# Cyberpunk Neon 3D Perspective Tilt Modal
+
+## Description
+A pure CSS modal with a cyberpunk/neon aesthetic and a 3D perspective tilt entrance animation. Opens/closes entirely via a hidden checkbox and the `:checked` pseudo-class — zero JavaScript.
+
+## Features
+- 3D `rotateX` tilt + scale entrance, powered by CSS `perspective` and `transform-style: preserve-3d`
+- Neon glow styling (text-shadow, box-shadow, gradient border)
+- Fully keyboard accessible: `<label>` triggers are focusable and toggle via Enter/Space since they're bound to the checkbox
+- Customizable via CSS custom properties (timing, easing, tilt angle, scale, colors)
+- Respects `prefers-reduced-motion`
+
+## Usage
+```html
+<div class="ease-modal">
+  <input type="checkbox" id="modal1" class="modal-toggle" />
+  <label for="modal1" class="modal-open-btn">Open Terminal</label>
+
+  <div class="modal-overlay">
+    <div class="modal-box" role="dialog" aria-modal="true">
+      <h2 class="modal-title">Title</h2>
+      <p class="modal-body">Content goes here.</p>
+      <label for="modal1" class="modal-close-btn">Close</label>
+    </div>
+  </div>
+</div>
+```
+
+## Customization (CSS custom properties)
+| Property | Default | Description |
+|---|---|---|
+| `--modal-duration` | `0.5s` | Animation duration |
+| `--modal-easing` | `cubic-bezier(0.34, 1.56, 0.64, 1)` | Timing function |
+| `--modal-tilt-angle` | `18deg` | Starting 3D tilt rotation |
+| `--modal-scale-start` | `0.85` | Starting scale before entrance |
+| `--modal-neon` | `#00f0ff` | Primary neon accent color |
+| `--modal-neon-secondary` | `#ff00c8` | Secondary neon accent color |
+| `--modal-bg` | `#0a0a12` | Base background tone |
+| `--modal-overlay` | `rgba(5,5,15,0.75)` | Backdrop overlay color |
+
+## Why zero JavaScript?
+The modal's open/closed state lives entirely in a hidden `<input type="checkbox">`. Both the trigger and close button are `<label>` elements pointing at the same checkbox `id`, so clicking either toggles the state via native HTML behavior — no event listeners needed.
+
+## Files
+- `demo.html` — live working example
+- `style.css` — component styles
+- `README.md` — this file

--- a/submissions/examples/cyberpunk-neon-tilt-modal/demo.html
+++ b/submissions/examples/cyberpunk-neon-tilt-modal/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cyberpunk Neon Tilt Modal — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #05050a;
+      font-family: system-ui, sans-serif;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="ease-modal">
+    <input type="checkbox" id="modal1" class="modal-toggle" />
+
+    <label for="modal1" class="modal-open-btn" role="button" tabindex="0">
+      Open Terminal
+    </label>
+
+    <div class="modal-overlay">
+      <div class="modal-box" role="dialog" aria-modal="true" aria-labelledby="modal1-title">
+        <h2 class="modal-title" id="modal1-title">SYSTEM ACCESS GRANTED</h2>
+        <p class="modal-body">
+          Pure CSS modal with a 3D perspective tilt entrance — no JavaScript required.
+          Toggle driven entirely by a hidden checkbox and the <code>:checked</code> selector.
+        </p>
+        <label for="modal1" class="modal-close-btn" role="button" tabindex="0">
+          Close
+        </label>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/cyberpunk-neon-tilt-modal/style.css
+++ b/submissions/examples/cyberpunk-neon-tilt-modal/style.css
@@ -1,0 +1,150 @@
+/* Cyberpunk Neon 3D Perspective Tilt Modal — pure CSS, zero JS */
+
+.ease-modal {
+  --modal-duration: 0.5s;
+  --modal-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --modal-tilt-angle: 18deg;
+  --modal-scale-start: 0.85;
+  --modal-neon: #00f0ff;
+  --modal-neon-secondary: #ff00c8;
+  --modal-bg: #0a0a12;
+  --modal-fg: #e8f9ff;
+  --modal-overlay: rgba(5, 5, 15, 0.75);
+}
+
+/* Hidden checkbox drives open/close state — no JS needed */
+.ease-modal .modal-toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.ease-modal .modal-open-btn {
+  background: transparent;
+  border: 2px solid var(--modal-neon);
+  color: var(--modal-neon);
+  font-family: inherit;
+  font-weight: 600;
+  padding: 10px 22px;
+  border-radius: 8px;
+  cursor: pointer;
+  text-shadow: 0 0 8px var(--modal-neon);
+  box-shadow: 0 0 12px rgba(0, 240, 255, 0.4);
+  transition: all 0.25s ease;
+}
+.ease-modal .modal-open-btn:hover {
+  background: rgba(0, 240, 255, 0.1);
+  box-shadow: 0 0 20px rgba(0, 240, 255, 0.7);
+}
+
+.ease-modal .modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--modal-overlay);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  perspective: 1200px;
+
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity var(--modal-duration) ease, visibility var(--modal-duration);
+  z-index: 1000;
+}
+
+.ease-modal .modal-toggle:checked ~ .modal-overlay {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.ease-modal .modal-box {
+  position: relative;
+  width: min(420px, 90vw);
+  background: linear-gradient(160deg, #0f0f1a 0%, #1a0f24 100%);
+  border: 1px solid var(--modal-neon);
+  border-radius: 16px;
+  padding: 32px;
+  color: var(--modal-fg);
+  box-shadow:
+    0 0 30px rgba(0, 240, 255, 0.25),
+    0 0 60px rgba(255, 0, 200, 0.15),
+    inset 0 0 40px rgba(0, 240, 255, 0.05);
+
+  transform: rotateX(var(--modal-tilt-angle)) scale(var(--modal-scale-start));
+  opacity: 0;
+  transition: transform var(--modal-duration) var(--modal-easing),
+              opacity var(--modal-duration) ease;
+  transform-style: preserve-3d;
+}
+
+.ease-modal .modal-toggle:checked ~ .modal-overlay .modal-box {
+  transform: rotateX(0deg) scale(1);
+  opacity: 1;
+}
+
+.ease-modal .modal-box::before {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  border-radius: 16px;
+  padding: 1px;
+  background: linear-gradient(135deg, var(--modal-neon), var(--modal-neon-secondary));
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.ease-modal .modal-title {
+  margin: 0 0 12px;
+  font-size: 1.4rem;
+  font-weight: 800;
+  color: var(--modal-neon);
+  text-shadow: 0 0 10px rgba(0, 240, 255, 0.6);
+  letter-spacing: 0.03em;
+}
+
+.ease-modal .modal-body {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: #b8c5d6;
+  margin-bottom: 24px;
+}
+
+.ease-modal .modal-close-btn {
+  display: inline-block;
+  background: transparent;
+  border: 1px solid var(--modal-neon-secondary);
+  color: var(--modal-neon-secondary);
+  font-family: inherit;
+  font-weight: 600;
+  padding: 8px 20px;
+  border-radius: 8px;
+  cursor: pointer;
+  text-decoration: none;
+  transition: all 0.25s ease;
+}
+.ease-modal .modal-close-btn:hover {
+  background: rgba(255, 0, 200, 0.12);
+  box-shadow: 0 0 16px rgba(255, 0, 200, 0.5);
+}
+
+.ease-modal .modal-close-btn:focus-visible,
+.ease-modal .modal-open-btn:focus-visible {
+  outline: 2px solid var(--modal-neon);
+  outline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-modal .modal-overlay,
+  .ease-modal .modal-box {
+    transition: opacity 0.2s ease;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
Closes #34200 

## Pull Request Description
Adds a pure CSS modal with a cyberpunk/neon aesthetic, opened via a smooth 3D perspective tilt entrance animation. The modal's open/close state is driven entirely by a hidden checkbox and the `:checked` selector — zero JavaScript.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/cyberpunk-neon-tilt-modal/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A cyberpunk/neon-styled modal that opens with a 3D perspective tilt (`rotateX` + scale) entrance animation, built with pure CSS and zero JavaScript.

**How does a developer use it?**
```html
<div class="ease-modal">
  <input type="checkbox" id="modal1" class="modal-toggle" />
  <label for="modal1" class="modal-open-btn">Open Terminal</label>

  <div class="modal-overlay">
    <div class="modal-box" role="dialog" aria-modal="true">
      <h2 class="modal-title">Title</h2>
      <p class="modal-body">Content goes here.</p>
      <label for="modal1" class="modal-close-btn">Close</label>
    </div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Zero-JavaScript state management using the checkbox `:checked` toggle pattern, with `perspective`/`transform-style: preserve-3d` for the 3D tilt effect — fully driven by CSS custom properties for timing, easing, tilt angle, scale, and color, consistent with the framework's animation-first, zero-dependency philosophy. Keyboard accessible since both trigger and close controls are native `<label>`/`<input>` pairs, and respects `prefers-reduced-motion`.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Open/close state uses the classic hidden-checkbox + `:checked` sibling-selector pattern rather than a native `<dialog>` element, to keep the demo maximally portable (works in any browser without polyfills) and fully CSS-driven per the "zero JavaScript overhead" requirement in the issue.