### PR TITLE
fix: add overflow-x and overflow-y hidden utilities to prevent mobile…

### DIFF
--- a/core/utilities.css
+++ b/core/utilities.css
@@ -230,6 +230,8 @@
 .ease-overflow-visible { overflow: visible !important; }
 .ease-overflow-auto    { overflow: auto !important; }
 .ease-overflow-scroll  { overflow: scroll !important; }
+.ease-overflow-x-hidden { overflow-x: hidden !important; }
+.ease-overflow-y-hidden { overflow-y: hidden !important; }
 .ease-overflow-x-auto  { overflow-x: auto !important; }
 .ease-overflow-y-auto  { overflow-y: auto !important; }
 


### PR DESCRIPTION
## Pull Request Description

This PR fixes a bug where using `ease-slide-in-*` classes on mobile devices causes a temporary horizontal scrollbar to appear by adding missing `overflow-x-hidden` and `overflow-y-hidden` utility classes. 

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [ ] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`** (See note below)
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds `.ease-overflow-x-hidden` and `.ease-overflow-y-hidden` utilities to the core framework to prevent unwanted scrollbars during slide animations.

**How does a developer use it?**

```html
<div class="ease-overflow-x-hidden">
  <div class="ease-slide-in-right">
    This will no longer cause horizontal scrolling on mobile!
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**

It provides a simple, utility-based way to contain animations without writing custom CSS, fixing a very common layout issue with entrance animations.
---

## Demo

- [ ] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

I know the contribution guidelines currently have a freeze on the core/ folder, but I went ahead and submitted this fix directly to core/utilities.css because it resolves a major usability bug on mobile devices where slide-in animations cause the page width to break. Feel free to close or keep this PR in a draft state until the freeze is lifted!

---
