### PR TITLE
fix: add mobile overflow fix to submissions/docs

### DIFF
--- a/submissions/docs/mobile-overflow-fix/README.md
+++ b/submissions/docs/mobile-overflow-fix/README.md
@@ -1,0 +1,16 @@
+# Mobile Overflow Fix
+
+## What does this do?
+This adds `.ease-overflow-x-hidden` and `.ease-overflow-y-hidden` utility classes to prevent horizontal scrolling on mobile devices when using slide-in animations.
+
+## How is it used?
+```html
+<div class="ease-overflow-x-hidden">
+  <div class="ease-slide-in-right">
+    Content animating from the right
+  </div>
+</div>
+```
+
+## Why is it useful?
+When elements translate off-screen before animating in, they can expand the browser's viewport width on mobile, causing an unwanted horizontal scrollbar. Having native utility classes to hide overflow solves this problem effortlessly, fitting perfectly with EaseMotion's utility-first approach.

--- a/submissions/docs/mobile-overflow-fix/demo.html
+++ b/submissions/docs/mobile-overflow-fix/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mobile Overflow Fix Demo</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.css">
+  <style>
+    body { padding: 2rem; font-family: sans-serif; }
+    .card { background: #eee; padding: 1rem; margin-top: 1rem; }
+  </style>
+</head>
+<body>
+  <h2>Overflow Bug Demo</h2>
+  <div class="ease-overflow-x-hidden">
+    <div class="ease-slide-in-right card">
+      I slide in from the right, but thanks to the wrapper class, I do not cause a horizontal scrollbar!
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/docs/mobile-overflow-fix/style.css
+++ b/submissions/docs/mobile-overflow-fix/style.css
@@ -1,0 +1,7 @@
+/* Core framework bug fix submission */
+.ease-overflow-x-hidden { 
+    overflow-x: hidden !important; 
+}
+.ease-overflow-y-hidden { 
+    overflow-y: hidden !important; 
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes a bug where `ease-slide-in-*` animations cause a horizontal scrollbar on mobile devices because the element's off-screen starting position expands the viewport width. 

Following the contribution guidelines, I have submitted this fix (`.ease-overflow-x-hidden`) inside the `submissions/docs/mobile-overflow-fix/` folder so it can be safely reviewed and integrated by the maintainer.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds `.ease-overflow-x-hidden` and `.ease-overflow-y-hidden` utility classes to prevent unwanted scrollbars during slide animations.

**How does a developer use it?**

```html
<div class="ease-overflow-x-hidden">
  <div class="ease-slide-in-right">
    This element slides in without causing horizontal scroll!
  </div>
</div>
```
## Why does it fit EaseMotion CSS?

It perfectly aligns with the utility-first, zero-dependency philosophy by giving developers a simple wrapper class to contain animations that might temporarily bleed off-screen.