### PR TITLE
feat: add glassmorphism fade-in tooltip (closes #34254)

### DIFF
--- a/submissions/examples/glass-fade-tooltip/README.md
+++ b/submissions/examples/glass-fade-tooltip/README.md
@@ -1,0 +1,21 @@
+# Glassmorphism Fade-In Tooltip (Pure CSS)
+
+A zero-JS tooltip with a smooth fade + scale-in transition, styled with a frosted-glass aesthetic.
+
+## Usage
+Wrap your trigger element and tooltip text as shown in `demo.html`.
+
+## Customization (CSS variables)
+| Variable | Purpose | Default |
+|---|---|---|
+| --tooltip-duration | Fade/scale transition speed | 250ms |
+| --tooltip-easing | Transition easing | ease-out |
+| --tooltip-scale-from | Starting scale before fade-in | 0.9 |
+| --tooltip-blur | Glass blur intensity | 12px |
+| --tooltip-bg / --tooltip-border | Glass color/border | see style.css |
+| --tooltip-offset | Gap between trigger and tooltip | 10px |
+
+## Accessibility
+- Tooltip shows on `:hover`, `:focus`, and `:focus-within` (keyboard support)
+- Uses `role="tooltip"` and `aria-describedby`
+- Visible focus ring via `:focus-visible`

--- a/submissions/examples/glass-fade-tooltip/demo.html
+++ b/submissions/examples/glass-fade-tooltip/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Glassmorphism Fade Tooltip</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-wrap">
+    <button class="tooltip-trigger" aria-describedby="tip1">
+      Hover or Tab to me
+      <span class="tooltip" id="tip1" role="tooltip">
+        This is a glassmorphism tooltip ✨
+      </span>
+    </button>
+  </main>
+</body>
+</html>

--- a/submissions/examples/glass-fade-tooltip/style.css
+++ b/submissions/examples/glass-fade-tooltip/style.css
@@ -1,0 +1,77 @@
+:root {
+  --tooltip-bg: rgba(255, 255, 255, 0.15);
+  --tooltip-border: rgba(255, 255, 255, 0.3);
+  --tooltip-blur: 12px;
+  --tooltip-radius: 10px;
+  --tooltip-duration: 250ms;
+  --tooltip-easing: ease-out;
+  --tooltip-scale-from: 0.9;
+  --tooltip-offset: 10px;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  font-family: system-ui, sans-serif;
+}
+
+.tooltip-trigger {
+  position: relative;
+  padding: 12px 20px;
+  border-radius: 8px;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  background: rgba(255,255,255,0.2);
+  color: #fff;
+}
+
+.tooltip {
+  position: absolute;
+  bottom: calc(100% + var(--tooltip-offset));
+  left: 50%;
+  transform: translate(-50%, 4px) scale(var(--tooltip-scale-from));
+  min-width: 180px;
+  padding: 10px 14px;
+  border-radius: var(--tooltip-radius);
+  background: var(--tooltip-bg);
+  border: 1px solid var(--tooltip-border);
+  backdrop-filter: blur(var(--tooltip-blur));
+  -webkit-backdrop-filter: blur(var(--tooltip-blur));
+  color: #fff;
+  font-size: 0.85rem;
+  text-align: center;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.2);
+
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity var(--tooltip-duration) var(--tooltip-easing),
+    transform var(--tooltip-duration) var(--tooltip-easing),
+    visibility var(--tooltip-duration);
+}
+
+.tooltip-trigger:hover .tooltip,
+.tooltip-trigger:focus .tooltip,
+.tooltip-trigger:focus-within .tooltip {
+  opacity: 1;
+  visibility: visible;
+  transform: translate(-50%, 0) scale(1);
+  pointer-events: auto;
+}
+
+.tooltip-trigger:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 3px;
+}
+
+@media (max-width: 480px) {
+  .tooltip {
+    min-width: 140px;
+    font-size: 0.8rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Added a pure CSS glassmorphism tooltip with a smooth fade-in and scale-in transition.
- Keyboard accessible (`:focus`, `:focus-within`, `:focus-visible`)
- Customizable via CSS variables (duration, easing, blur, scale, offset, colors)
- Fully responsive on smaller screens
- Zero JavaScript

Closes #34254

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component