### PR TITLE
feat: add SaaS showcase fade-in tooltip (closes #34253)

### DIFF
--- a/submissions/examples/saas-fade-tooltip/README.md
+++ b/submissions/examples/saas-fade-tooltip/README.md
@@ -1,0 +1,22 @@
+# SaaS Showcase Fade-In Tooltip (Pure CSS)
+
+A zero-JS tooltip with a clean fade + scale-in transition, styled for modern SaaS product UIs.
+
+## Usage
+Wrap your trigger element and tooltip text as shown in `demo.html`.
+
+## Customization (CSS variables)
+| Variable | Purpose | Default |
+|---|---|---|
+| --tooltip-duration | Fade/scale transition speed | 200ms |
+| --tooltip-easing | Transition easing | ease-out |
+| --tooltip-scale-from | Starting scale before fade-in | 0.95 |
+| --tooltip-bg | Tooltip background | #1e293b |
+| --tooltip-text | Tooltip text color | #f8fafc |
+| --tooltip-accent | Brand/button accent color | #6366f1 |
+| --tooltip-offset | Gap between trigger and tooltip | 10px |
+
+## Accessibility
+- Tooltip shows on `:hover`, `:focus`, and `:focus-within` (keyboard support)
+- Uses `role="tooltip"` and `aria-describedby`
+- Visible focus ring via `:focus-visible`

--- a/submissions/examples/saas-fade-tooltip/demo.html
+++ b/submissions/examples/saas-fade-tooltip/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>SaaS Showcase Fade Tooltip</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-wrap">
+    <button class="tooltip-trigger" aria-describedby="tip1">
+      Hover or Tab to me
+      <span class="tooltip" id="tip1" role="tooltip">
+        Upgrade to Pro for unlimited exports 🚀
+      </span>
+    </button>
+  </main>
+</body>
+</html>

--- a/submissions/examples/saas-fade-tooltip/style.css
+++ b/submissions/examples/saas-fade-tooltip/style.css
@@ -1,0 +1,90 @@
+:root {
+  --tooltip-bg: #1e293b;
+  --tooltip-text: #f8fafc;
+  --tooltip-accent: #6366f1;
+  --tooltip-radius: 8px;
+  --tooltip-duration: 200ms;
+  --tooltip-easing: ease-out;
+  --tooltip-scale-from: 0.95;
+  --tooltip-offset: 10px;
+  --tooltip-shadow: 0 10px 25px rgba(15, 23, 42, 0.25);
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f1f5f9;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.tooltip-trigger {
+  position: relative;
+  padding: 12px 24px;
+  border-radius: 8px;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 500;
+  background: var(--tooltip-accent);
+  color: #fff;
+  box-shadow: 0 4px 12px rgba(99, 102, 241, 0.3);
+}
+
+.tooltip {
+  position: absolute;
+  bottom: calc(100% + var(--tooltip-offset));
+  left: 50%;
+  transform: translate(-50%, 4px) scale(var(--tooltip-scale-from));
+  min-width: 200px;
+  padding: 10px 14px;
+  border-radius: var(--tooltip-radius);
+  background: var(--tooltip-bg);
+  color: var(--tooltip-text);
+  font-size: 0.85rem;
+  font-weight: 400;
+  text-align: center;
+  box-shadow: var(--tooltip-shadow);
+
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity var(--tooltip-duration) var(--tooltip-easing),
+    transform var(--tooltip-duration) var(--tooltip-easing),
+    visibility var(--tooltip-duration);
+}
+
+/* little arrow pointer */
+.tooltip::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 6px;
+  border-style: solid;
+  border-color: var(--tooltip-bg) transparent transparent transparent;
+}
+
+.tooltip-trigger:hover .tooltip,
+.tooltip-trigger:focus .tooltip,
+.tooltip-trigger:focus-within .tooltip {
+  opacity: 1;
+  visibility: visible;
+  transform: translate(-50%, 0) scale(1);
+  pointer-events: auto;
+}
+
+.tooltip-trigger:focus-visible {
+  outline: 2px solid var(--tooltip-accent);
+  outline-offset: 3px;
+}
+
+@media (max-width: 480px) {
+  .tooltip {
+    min-width: 160px;
+    font-size: 0.8rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Added a pure CSS tooltip with a smooth fade-in and scale-in transition, styled for modern SaaS product interfaces.
- Keyboard accessible (`:focus`, `:focus-within`, `:focus-visible`)
- Customizable via CSS variables (duration, easing, scale, colors, offset)
- Includes a small arrow pointer for a polished SaaS look
- Fully responsive
- Zero JavaScript

Closes #34253

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component