### PR TITLE
feat: add minimalist tech fade-in tooltip (closes #34255)

### DIFF
--- a/submissions/examples/minimal-fade-tooltip/README.md
+++ b/submissions/examples/minimal-fade-tooltip/README.md
@@ -1,0 +1,22 @@
+# Minimalist Tech Fade-In Tooltip (Pure CSS)
+
+A zero-JS tooltip with a subtle fade + scale transition, styled for clean, minimalist tech interfaces.
+
+## Usage
+Wrap your trigger element and tooltip text as shown in `demo.html`.
+
+## Customization (CSS variables)
+| Variable | Purpose | Default |
+|---|---|---|
+| --tooltip-duration | Fade/scale transition speed | 180ms |
+| --tooltip-easing | Transition easing | cubic-bezier(0.4, 0, 0.2, 1) |
+| --tooltip-scale-from | Starting scale before fade-in | 0.97 |
+| --tooltip-bg | Tooltip background | #0a0a0a |
+| --tooltip-text | Tooltip text color | #fafafa |
+| --tooltip-border | Tooltip border color | #262626 |
+| --tooltip-offset | Gap between trigger and tooltip | 8px |
+
+## Accessibility
+- Tooltip shows on `:hover`, `:focus`, and `:focus-within` (keyboard support)
+- Uses `role="tooltip"` and `aria-describedby`
+- Visible focus ring via `:focus-visible`

--- a/submissions/examples/minimal-fade-tooltip/demo.html
+++ b/submissions/examples/minimal-fade-tooltip/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Minimalist Tech Fade Tooltip</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-wrap">
+    <button class="tooltip-trigger" aria-describedby="tip1">
+      Hover or Tab to me
+      <span class="tooltip" id="tip1" role="tooltip">
+        Build faster with less noise.
+      </span>
+    </button>
+  </main>
+</body>
+</html>

--- a/submissions/examples/minimal-fade-tooltip/style.css
+++ b/submissions/examples/minimal-fade-tooltip/style.css
@@ -1,0 +1,82 @@
+:root {
+  --tooltip-bg: #0a0a0a;
+  --tooltip-text: #fafafa;
+  --tooltip-border: #262626;
+  --tooltip-radius: 4px;
+  --tooltip-duration: 180ms;
+  --tooltip-easing: cubic-bezier(0.4, 0, 0.2, 1);
+  --tooltip-scale-from: 0.97;
+  --tooltip-offset: 8px;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #ffffff;
+  font-family: -apple-system, "Inter", sans-serif;
+}
+
+.tooltip-trigger {
+  position: relative;
+  padding: 10px 20px;
+  border-radius: 4px;
+  border: 1px solid #e5e5e5;
+  cursor: pointer;
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+  background: #fff;
+  color: #111;
+  transition: border-color 150ms ease;
+}
+
+.tooltip-trigger:hover {
+  border-color: #111;
+}
+
+.tooltip {
+  position: absolute;
+  bottom: calc(100% + var(--tooltip-offset));
+  left: 50%;
+  transform: translate(-50%, 3px) scale(var(--tooltip-scale-from));
+  min-width: 180px;
+  padding: 8px 12px;
+  border-radius: var(--tooltip-radius);
+  background: var(--tooltip-bg);
+  border: 1px solid var(--tooltip-border);
+  color: var(--tooltip-text);
+  font-size: 0.78rem;
+  font-weight: 400;
+  letter-spacing: 0.01em;
+  text-align: center;
+
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity var(--tooltip-duration) var(--tooltip-easing),
+    transform var(--tooltip-duration) var(--tooltip-easing),
+    visibility var(--tooltip-duration);
+}
+
+.tooltip-trigger:hover .tooltip,
+.tooltip-trigger:focus .tooltip,
+.tooltip-trigger:focus-within .tooltip {
+  opacity: 1;
+  visibility: visible;
+  transform: translate(-50%, 0) scale(1);
+  pointer-events: auto;
+}
+
+.tooltip-trigger:focus-visible {
+  outline: 1px solid #111;
+  outline-offset: 3px;
+}
+
+@media (max-width: 480px) {
+  .tooltip {
+    min-width: 140px;
+    font-size: 0.72rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Added a pure CSS tooltip with a subtle fade-in and scale-in transition, styled for clean, minimalist tech interfaces.
- Keyboard accessible (`:focus`, `:focus-within`, `:focus-visible`)
- Customizable via CSS variables (duration, easing, scale, colors, offset)
- Monochrome palette with thin borders for a minimal aesthetic
- Fully responsive
- Zero JavaScript

Closes #34255

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)