### PR TITLE
feat: add neumorphic soft fade-in tooltip (closes #34257)

### DIFF
--- a/submissions/examples/neumorphic-fade-tooltip/README.md
+++ b/submissions/examples/neumorphic-fade-tooltip/README.md
@@ -1,0 +1,22 @@
+# Neumorphic Soft Fade-In Tooltip (Pure CSS)
+
+A zero-JS tooltip with a soft fade + scale-in transition, styled with a neumorphic (soft UI) aesthetic using dual-direction shadows.
+
+## Usage
+Wrap your trigger element and tooltip text as shown in `demo.html`.
+
+## Customization (CSS variables)
+| Variable | Purpose | Default |
+|---|---|---|
+| --tooltip-duration | Fade/scale transition speed | 220ms |
+| --tooltip-easing | Transition easing | ease-out |
+| --tooltip-scale-from | Starting scale before fade-in | 0.94 |
+| --tooltip-bg | Base surface color | #e0e5ec |
+| --shadow-light | Light-direction shadow | #ffffff |
+| --shadow-dark | Dark-direction shadow | #a3b1c6 |
+| --tooltip-offset | Gap between trigger and tooltip | 12px |
+
+## Accessibility
+- Tooltip shows on `:hover`, `:focus`, and `:focus-within` (keyboard support)
+- Uses `role="tooltip"` and `aria-describedby`
+- Visible focus ring via `:focus-visible`

--- a/submissions/examples/neumorphic-fade-tooltip/demo.html
+++ b/submissions/examples/neumorphic-fade-tooltip/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Neumorphic Soft Fade Tooltip</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-wrap">
+    <button class="tooltip-trigger" aria-describedby="tip1">
+      Hover or Tab to me
+      <span class="tooltip" id="tip1" role="tooltip">
+        Soft shadows, smooth feel.
+      </span>
+    </button>
+  </main>
+</body>
+</html>

--- a/submissions/examples/neumorphic-fade-tooltip/style.css
+++ b/submissions/examples/neumorphic-fade-tooltip/style.css
@@ -1,0 +1,87 @@
+:root {
+  --tooltip-bg: #e0e5ec;
+  --tooltip-text: #4a5568;
+  --tooltip-radius: 12px;
+  --tooltip-duration: 220ms;
+  --tooltip-easing: ease-out;
+  --tooltip-scale-from: 0.94;
+  --tooltip-offset: 12px;
+  --shadow-light: #ffffff;
+  --shadow-dark: #a3b1c6;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #e0e5ec;
+  font-family: system-ui, sans-serif;
+}
+
+.tooltip-trigger {
+  position: relative;
+  padding: 14px 26px;
+  border-radius: 12px;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  background: var(--tooltip-bg);
+  color: var(--tooltip-text);
+  box-shadow:
+    6px 6px 12px var(--shadow-dark),
+    -6px -6px 12px var(--shadow-light);
+  transition: box-shadow 150ms ease;
+}
+
+.tooltip-trigger:active {
+  box-shadow:
+    inset 4px 4px 8px var(--shadow-dark),
+    inset -4px -4px 8px var(--shadow-light);
+}
+
+.tooltip {
+  position: absolute;
+  bottom: calc(100% + var(--tooltip-offset));
+  left: 50%;
+  transform: translate(-50%, 4px) scale(var(--tooltip-scale-from));
+  min-width: 190px;
+  padding: 10px 14px;
+  border-radius: var(--tooltip-radius);
+  background: var(--tooltip-bg);
+  color: var(--tooltip-text);
+  font-size: 0.85rem;
+  text-align: center;
+  box-shadow:
+    5px 5px 10px var(--shadow-dark),
+    -5px -5px 10px var(--shadow-light);
+
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity var(--tooltip-duration) var(--tooltip-easing),
+    transform var(--tooltip-duration) var(--tooltip-easing),
+    visibility var(--tooltip-duration);
+}
+
+.tooltip-trigger:hover .tooltip,
+.tooltip-trigger:focus .tooltip,
+.tooltip-trigger:focus-within .tooltip {
+  opacity: 1;
+  visibility: visible;
+  transform: translate(-50%, 0) scale(1);
+  pointer-events: auto;
+}
+
+.tooltip-trigger:focus-visible {
+  outline: 2px solid var(--shadow-dark);
+  outline-offset: 3px;
+}
+
+@media (max-width: 480px) {
+  .tooltip {
+    min-width: 150px;
+    font-size: 0.8rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Added a pure CSS tooltip with a soft fade-in and scale-in transition, styled with a neumorphic (soft UI) aesthetic using dual-direction shadows.
- Keyboard accessible (`:focus`, `:focus-within`, `:focus-visible`)
- Customizable via CSS variables (duration, easing, scale, shadow colors, offset)
- Includes a pressed/inset shadow state on the trigger button
- Fully responsive
- Zero JavaScript

Closes #34257

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist