### PR TITLE
feat: add shimmer sweep modal for SaaS layouts (closes #34234)

### DIFF
--- a/submissions/examples/shimmer-sweep-modal/README.md
+++ b/submissions/examples/shimmer-sweep-modal/README.md
@@ -1,0 +1,21 @@
+# Shimmer Sweep Modal (SaaS style)
+
+A modal dialog with a one-time shimmer light sweep on open, styled for modern SaaS product UIs.
+
+## Usage
+Include the markup and script from `demo.html`. The open/close logic is minimal vanilla JS; the shimmer sweep and modal entrance transition are pure CSS.
+
+## Customization (CSS variables)
+| Variable | Purpose | Default |
+|---|---|---|
+| --modal-duration | Modal open/close transition speed | 280ms |
+| --modal-easing | Transition easing | cubic-bezier(0.16, 1, 0.3, 1) |
+| --modal-scale-from | Starting scale before entrance | 0.92 |
+| --shimmer-color | Color of the light sweep | rgba(255,255,255,0.6) |
+| --accent | Brand/button accent color | #6366f1 |
+
+## Accessibility
+- `role="dialog"`, `aria-modal="true"`, `aria-labelledby`
+- Focus moves to modal on open, returns to trigger on close
+- Closes on `Escape` key or clicking the overlay
+- Visible focus rings via `:focus-visible`

--- a/submissions/examples/shimmer-sweep-modal/demo.html
+++ b/submissions/examples/shimmer-sweep-modal/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Shimmer Sweep Modal</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-wrap">
+    <button class="open-btn" id="openBtn" aria-haspopup="dialog" aria-controls="myModal">
+      Open Modal
+    </button>
+
+    <div class="modal-overlay" id="overlay">
+      <div class="modal" id="myModal" role="dialog" aria-modal="true" aria-labelledby="modalTitle" tabindex="-1">
+        <div class="modal-shimmer"></div>
+        <button class="close-btn" id="closeBtn" aria-label="Close modal">&times;</button>
+        <h2 id="modalTitle">Upgrade your plan</h2>
+        <p>Unlock unlimited projects, priority support, and more with Pro.</p>
+        <button class="cta-btn">Upgrade now</button>
+      </div>
+    </div>
+  </main>
+
+  <script>
+    const openBtn = document.getElementById('openBtn');
+    const closeBtn = document.getElementById('closeBtn');
+    const overlay = document.getElementById('overlay');
+    const modal = document.getElementById('myModal');
+
+    function openModal() {
+      overlay.classList.add('active');
+      modal.focus();
+      document.addEventListener('keydown', onKeydown);
+    }
+    function closeModal() {
+      overlay.classList.remove('active');
+      openBtn.focus();
+      document.removeEventListener('keydown', onKeydown);
+    }
+    function onKeydown(e) {
+      if (e.key === 'Escape') closeModal();
+    }
+
+    openBtn.addEventListener('click', openModal);
+    closeBtn.addEventListener('click', closeModal);
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) closeModal();
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/shimmer-sweep-modal/style.css
+++ b/submissions/examples/shimmer-sweep-modal/style.css
@@ -1,0 +1,135 @@
+:root {
+  --modal-bg: #ffffff;
+  --modal-radius: 14px;
+  --modal-duration: 280ms;
+  --modal-easing: cubic-bezier(0.16, 1, 0.3, 1);
+  --modal-scale-from: 0.92;
+  --shimmer-color: rgba(255, 255, 255, 0.6);
+  --accent: #6366f1;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f1f5f9;
+  font-family: system-ui, sans-serif;
+}
+
+.open-btn {
+  padding: 12px 24px;
+  border-radius: 8px;
+  border: none;
+  background: var(--accent);
+  color: #fff;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--modal-duration) var(--modal-easing), visibility var(--modal-duration);
+  z-index: 100;
+}
+
+.modal-overlay.active {
+  opacity: 1;
+  visibility: visible;
+}
+
+.modal {
+  position: relative;
+  background: var(--modal-bg);
+  border-radius: var(--modal-radius);
+  padding: 32px;
+  max-width: 380px;
+  width: 90%;
+  box-shadow: 0 25px 50px rgba(0,0,0,0.25);
+  transform: scale(var(--modal-scale-from)) translateY(10px);
+  transition: transform var(--modal-duration) var(--modal-easing);
+  overflow: hidden;
+}
+
+.modal-overlay.active .modal {
+  transform: scale(1) translateY(0);
+}
+
+/* Shimmer sweep effect */
+.modal-shimmer {
+  position: absolute;
+  top: 0;
+  left: -150%;
+  width: 60%;
+  height: 100%;
+  background: linear-gradient(
+    100deg,
+    transparent,
+    var(--shimmer-color),
+    transparent
+  );
+  pointer-events: none;
+}
+
+.modal-overlay.active .modal-shimmer {
+  animation: shimmerSweep 1000ms ease-out 150ms 1;
+}
+
+@keyframes shimmerSweep {
+  from { left: -150%; }
+  to { left: 150%; }
+}
+
+.close-btn {
+  position: absolute;
+  top: 12px;
+  right: 14px;
+  border: none;
+  background: transparent;
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+  color: #64748b;
+}
+
+.close-btn:focus-visible,
+.cta-btn:focus-visible,
+.open-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.modal h2 {
+  margin: 0 0 10px;
+  font-size: 1.25rem;
+  color: #111;
+}
+
+.modal p {
+  margin: 0 0 20px;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.cta-btn {
+  padding: 10px 20px;
+  border-radius: 8px;
+  border: none;
+  background: var(--accent);
+  color: #fff;
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+
+@media (max-width: 480px) {
+  .modal {
+    padding: 24px;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Added a shimmer sweep modal component styled for modern SaaS product interfaces. The modal fades and scales in on open, with a one-time light sweep animation across its surface.
- Keyboard accessible: focus moves into the modal on open, returns to the trigger on close, and `Escape` closes it
- Customizable via CSS variables (duration, easing, scale, shimmer color, accent color)
- Fully responsive
- Minimal JS only for open/close and focus handling; the shimmer sweep and entrance transition are pure CSS

Closes #34234

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)