### PR TITLE
feat: add tab slide indicator example

### DIFF
--- a/submissions/examples/tab-slide-indicator-ak/README.md
+++ b/submissions/examples/tab-slide-indicator-ak/README.md
@@ -1,0 +1,40 @@
+# Tab Slide Indicator
+
+## What does this do?
+
+A pure CSS tabbed content panel where the active tab indicator slides smoothly between tabs using the radio-button hack. No JavaScript needed.
+
+## How is it used?
+
+Radio inputs with the same `name` drive tab selection. Each tab's content is shown/hidden via the `:checked` pseudo-class.
+
+```html
+<div class="tabs-wrapper-ak">
+  <input type="radio" name="tabs-ak" id="tab1-ak" checked hidden>
+  <input type="radio" name="tabs-ak" id="tab2-ak" hidden>
+  <input type="radio" name="tabs-ak" id="tab3-ak" hidden>
+
+  <nav class="tabs-bar-ak">
+    <label for="tab1-ak" class="tab-label-ak" data-tab="Features">Features</label>
+    <label for="tab2-ak" class="tab-label-ak" data-tab="Pricing">Pricing</label>
+    <label for="tab3-ak" class="tab-label-ak" data-tab="About">About</label>
+    <span class="tab-indicator-ak"></span>
+  </nav>
+
+  <div class="tab-panel-ak" data-panel="tab1-ak">...</div>
+  <div class="tab-panel-ak" data-panel="tab2-ak">...</div>
+  <div class="tab-panel-ak" data-panel="tab3-ak">...</div>
+</div>
+```
+
+### Custom Properties
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `--tab-indicator-color-ak` | `#6c63ff` | Color of the sliding underline |
+| `--tab-radius-ak` | `8px` | Border radius of tab labels |
+| `--tab-duration-ak` | `0.3s` | Slide transition speed |
+
+## Why is it useful?
+
+Provides a fully accessible, animated tab component with zero JavaScript. Ideal for documentation pages, feature showcases, pricing tables, and any content that needs organized switching without framework overhead.

--- a/submissions/examples/tab-slide-indicator-ak/demo.html
+++ b/submissions/examples/tab-slide-indicator-ak/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tab Slide Indicator</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="tabs-wrapper-ak">
+    <input type="radio" name="tabs-ak" id="tab1-ak" checked hidden>
+    <input type="radio" name="tabs-ak" id="tab2-ak" hidden>
+    <input type="radio" name="tabs-ak" id="tab3-ak" hidden>
+
+    <nav class="tabs-bar-ak" role="tablist">
+      <label for="tab1-ak" class="tab-label-ak" role="tab" aria-selected="true" tabindex="0">Features</label>
+      <label for="tab2-ak" class="tab-label-ak" role="tab" aria-selected="false" tabindex="0">Pricing</label>
+      <label for="tab3-ak" class="tab-label-ak" role="tab" aria-selected="false" tabindex="0">About</label>
+      <span class="tab-indicator-ak"></span>
+    </nav>
+
+    <div class="tab-panel-ak" data-panel="tab1-ak" role="tabpanel">
+      <h3>Core Features</h3>
+      <ul>
+        <li>Zero-dependency CSS components</li>
+        <li>Custom property theming</li>
+        <li>Reduced-motion support</li>
+        <li>Responsive by default</li>
+      </ul>
+    </div>
+
+    <div class="tab-panel-ak" data-panel="tab2-ak" role="tabpanel">
+      <h3>Simple Pricing</h3>
+      <p><strong>Free</strong> — All components open source under MIT license.</p>
+      <p>Use in personal and commercial projects with no attribution required.</p>
+    </div>
+
+    <div class="tab-panel-ak" data-panel="tab3-ak" role="tabpanel">
+      <h3>About This Project</h3>
+      <p>EaseMotion CSS is a curated CSS animation framework built by the open-source community. Every component is hand-reviewed for quality, performance, and naming consistency.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/tab-slide-indicator-ak/style.css
+++ b/submissions/examples/tab-slide-indicator-ak/style.css
@@ -1,0 +1,145 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #0f0f1a;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.tabs-wrapper-ak {
+  --tab-indicator-color-ak: #6c63ff;
+  --tab-radius-ak: 8px;
+  --tab-duration-ak: 0.3s;
+
+  width: 540px;
+  max-width: 90vw;
+  background: #1a1a2e;
+  border-radius: 12px;
+  padding: 24px;
+}
+
+.tabs-bar-ak {
+  position: relative;
+  display: flex;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: var(--tab-radius-ak);
+  padding: 4px;
+}
+
+.tab-label-ak {
+  flex: 1;
+  padding: 10px 16px;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  border-radius: calc(var(--tab-radius-ak) - 2px);
+  transition: color var(--tab-duration-ak) ease;
+  z-index: 2;
+  position: relative;
+}
+
+.tab-label-ak:focus-visible {
+  outline: 2px solid var(--tab-indicator-color-ak);
+  outline-offset: 2px;
+}
+
+.tab-indicator-ak {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  height: calc(100% - 8px);
+  width: calc(33.33% - 4px);
+  background: rgba(108, 99, 255, 0.15);
+  border-radius: calc(var(--tab-radius-ak) - 2px);
+  transition: transform var(--tab-duration-ak) cubic-bezier(0.34, 1.56, 0.64, 1);
+  z-index: 1;
+}
+
+#tab1-ak:checked ~ .tabs-bar-ak .tab-indicator-ak {
+  transform: translateX(0);
+}
+
+#tab2-ak:checked ~ .tabs-bar-ak .tab-indicator-ak {
+  transform: translateX(calc(100% + 4px));
+}
+
+#tab3-ak:checked ~ .tabs-bar-ak .tab-indicator-ak {
+  transform: translateX(calc(200% + 8px));
+}
+
+#tab1-ak:checked ~ .tabs-bar-ak .tab-label-ak[for="tab1-ak"],
+#tab2-ak:checked ~ .tabs-bar-ak .tab-label-ak[for="tab2-ak"],
+#tab3-ak:checked ~ .tabs-bar-ak .tab-label-ak[for="tab3-ak"] {
+  color: #fff;
+}
+
+.tab-panel-ak {
+  display: none;
+  margin-top: 20px;
+  padding: 8px 4px;
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 14px;
+  line-height: 1.7;
+}
+
+.tab-panel-ak h3 {
+  color: #fff;
+  font-size: 18px;
+  margin-bottom: 8px;
+}
+
+.tab-panel-ak p {
+  margin-bottom: 10px;
+}
+
+.tab-panel-ak ul {
+  list-style: none;
+  padding: 0;
+}
+
+.tab-panel-ak li {
+  padding: 6px 0 6px 20px;
+  position: relative;
+}
+
+.tab-panel-ak li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 12px;
+  width: 8px;
+  height: 8px;
+  background: var(--tab-indicator-color-ak);
+  border-radius: 50%;
+  opacity: 0.6;
+}
+
+#tab1-ak:checked ~ .tab-panel-ak[data-panel="tab1-ak"],
+#tab2-ak:checked ~ .tab-panel-ak[data-panel="tab2-ak"],
+#tab3-ak:checked ~ .tab-panel-ak[data-panel="tab3-ak"] {
+  display: block;
+  animation: tab-fade-in-ak var(--tab-duration-ak) ease;
+}
+
+@keyframes tab-fade-in-ak {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tab-indicator-ak,
+  .tab-label-ak,
+  .tab-panel-ak {
+    transition: none !important;
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
A pure CSS tabbed content panel with sliding underline indicator using the radio-button hack. Zero JavaScript, accessible, and responsive.