### PR TITLE
feat: add draw-border line modal for product catalog layouts (closes …

### DIFF
--- a/submissions/examples/draw-border-catalog-modal/README.md
+++ b/submissions/examples/draw-border-catalog-modal/README.md
@@ -1,0 +1,21 @@
+# Draw-Border Line Modal (Product Catalog style)
+
+A "Quick View" product modal where the border draws itself in with an SVG stroke animation on open.
+
+## Usage
+Include the markup and script from `demo.html`. Open/close logic is minimal vanilla JS; the border-draw animation and modal entrance transition are pure CSS/SVG.
+
+## Customization (CSS variables)
+| Variable | Purpose | Default |
+|---|---|---|
+| --modal-duration | Modal fade/scale transition speed | 260ms |
+| --border-draw-duration | Border line draw animation speed | 900ms |
+| --border-color | Color of the drawn border line | #d97706 |
+| --accent | Brand/button accent color | #d97706 |
+| --modal-scale-from | Starting scale before entrance | 0.94 |
+
+## Accessibility
+- `role="dialog"`, `aria-modal="true"`, `aria-labelledby`
+- Focus moves to modal on open, returns to trigger on close
+- Closes on `Escape` key or clicking the overlay
+- Visible focus rings via `:focus-visible`

--- a/submissions/examples/draw-border-catalog-modal/demo.html
+++ b/submissions/examples/draw-border-catalog-modal/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Draw-Border Line Modal - Product Catalog</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-wrap">
+    <button class="open-btn" id="openBtn" aria-haspopup="dialog" aria-controls="myModal">
+      Quick View
+    </button>
+
+    <div class="modal-overlay" id="overlay">
+      <div class="modal" id="myModal" role="dialog" aria-modal="true" aria-labelledby="modalTitle" tabindex="-1">
+        <svg class="border-line" viewBox="0 0 400 280" preserveAspectRatio="none">
+          <rect x="2" y="2" width="396" height="276" rx="12" ry="12" />
+        </svg>
+        <button class="close-btn" id="closeBtn" aria-label="Close modal">&times;</button>
+        <h2 id="modalTitle">Classic Canvas Sneakers</h2>
+        <p>$59.00 — Available in 5 colors. Free shipping on orders over $50.</p>
+        <button class="cta-btn">Add to Cart</button>
+      </div>
+    </div>
+  </main>
+
+  <script>
+    const openBtn = document.getElementById('openBtn');
+    const closeBtn = document.getElementById('closeBtn');
+    const overlay = document.getElementById('overlay');
+    const modal = document.getElementById('myModal');
+
+    function openModal() {
+      overlay.classList.add('active');
+      modal.focus();
+      document.addEventListener('keydown', onKeydown);
+    }
+    function closeModal() {
+      overlay.classList.remove('active');
+      openBtn.focus();
+      document.removeEventListener('keydown', onKeydown);
+    }
+    function onKeydown(e) {
+      if (e.key === 'Escape') closeModal();
+    }
+
+    openBtn.addEventListener('click', openModal);
+    closeBtn.addEventListener('click', closeModal);
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) closeModal();
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/draw-border-catalog-modal/style.css
+++ b/submissions/examples/draw-border-catalog-modal/style.css
@@ -1,0 +1,134 @@
+:root {
+  --modal-bg: #ffffff;
+  --modal-radius: 12px;
+  --modal-duration: 260ms;
+  --border-draw-duration: 900ms;
+  --border-color: #d97706;
+  --accent: #d97706;
+  --modal-scale-from: 0.94;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f8fafc;
+  font-family: system-ui, sans-serif;
+}
+
+.open-btn {
+  padding: 12px 24px;
+  border-radius: 8px;
+  border: none;
+  background: var(--accent);
+  color: #fff;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--modal-duration) ease, visibility var(--modal-duration);
+  z-index: 100;
+}
+
+.modal-overlay.active {
+  opacity: 1;
+  visibility: visible;
+}
+
+.modal {
+  position: relative;
+  background: var(--modal-bg);
+  border-radius: var(--modal-radius);
+  padding: 32px;
+  max-width: 380px;
+  width: 90%;
+  box-shadow: 0 20px 40px rgba(0,0,0,0.15);
+  transform: scale(var(--modal-scale-from));
+  transition: transform var(--modal-duration) ease;
+}
+
+.modal-overlay.active .modal {
+  transform: scale(1);
+}
+
+.border-line {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.border-line rect {
+  fill: none;
+  stroke: var(--border-color);
+  stroke-width: 2;
+  stroke-dasharray: 1350;
+  stroke-dashoffset: 1350;
+}
+
+.modal-overlay.active .border-line rect {
+  animation: drawBorder var(--border-draw-duration) ease-out forwards;
+}
+
+@keyframes drawBorder {
+  to { stroke-dashoffset: 0; }
+}
+
+.close-btn {
+  position: absolute;
+  top: 12px;
+  right: 14px;
+  border: none;
+  background: transparent;
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+  color: #64748b;
+}
+
+.close-btn:focus-visible,
+.cta-btn:focus-visible,
+.open-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.modal h2 {
+  margin: 0 0 10px;
+  font-size: 1.25rem;
+  color: #111;
+}
+
+.modal p {
+  margin: 0 0 20px;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.cta-btn {
+  padding: 10px 20px;
+  border-radius: 8px;
+  border: none;
+  background: var(--accent);
+  color: #fff;
+  font-size: 0.95rem;
+  cursor: pointer;
+  width: 100%;
+}
+
+@media (max-width: 480px) {
+  .modal {
+    padding: 24px;
+  }
+}


### PR DESCRIPTION
Closes #34223

## Pull Request Description

Added a draw-border-line modal styled for product catalog "Quick View" interactions. The modal's border draws itself in with an SVG stroke animation on open, alongside a fade + scale entrance.
- Keyboard accessible: focus moves into the modal on open, returns to the trigger on close, and `Escape` closes it
- Customizable via CSS variables (durations, border color, accent color, scale)
- Fully responsive
- Minimal JS only for open/close and focus handling; the border-draw and entrance animations are pure CSS/SVG

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component