### PR TITLE
feat: add quick html export action for component examples

### DIFF
--- a/submissions/docs/quick-export-tj/README.md
+++ b/submissions/docs/quick-export-tj/README.md
@@ -1,0 +1,31 @@
+# Quick HTML Export Action for Component Examples
+
+1. What does this do?
+This feature provides action buttons on component examples that programmatically copy clean, standardized component HTML markup directly to the user's clipboard, complete with animated visual success indicators.
+
+2. How is it used?
+Wrap your component preview in a container with a unique identifier, and add a `.tj-export-btn` action button targeting the identifier via a `data-target` attribute:
+
+```html
+<!-- Showcase card structure with copy button -->
+<div class="tj-card">
+  <div class="tj-card-header">
+    <h3 class="tj-card-title">Interactive Button</h3>
+    <button class="tj-export-btn" data-target="tj-btn-example">
+      <svg class="tj-icon-copy" ...>...</svg>
+      <svg class="tj-icon-check" ...>...</svg>
+      <span class="tj-btn-text">Copy HTML</span>
+    </button>
+  </div>
+  
+  <div class="tj-preview-container" id="tj-btn-example">
+    <!-- Clean markup to be exported -->
+    <button class="tj-btn-element" type="button">
+      Explore Components
+    </button>
+  </div>
+</div>
+```
+
+3. Why is it useful?
+It significantly speeds up developer workflows by providing an instant, frictionless copy-paste path for UI components, eliminating the need to inspect page sources or manually strip helper elements, aligning perfectly with EaseMotion's core philosophy of rapid and efficient web development.

--- a/submissions/docs/quick-export-tj/demo.html
+++ b/submissions/docs/quick-export-tj/demo.html
@@ -1,0 +1,306 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Quick HTML Export Action Showcase - EaseMotion CSS</title>
+  <meta name="description" content="A demonstration of the Quick HTML Export action for component examples in EaseMotion CSS. Copy clean markup directly to your clipboard.">
+  
+  <!-- Inter & Outfit Fonts for Premium Typography -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@500;600;700;800&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
+  
+  <!-- Link to the main EaseMotion CSS stylesheet -->
+  <link rel="stylesheet" href="../../../easemotion.css">
+  
+  <!-- Link to local custom stylesheet -->
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="tj-showcase-theme">
+
+  <!-- Background Decorative Glows -->
+  <div class="tj-glow tj-glow-1"></div>
+  <div class="tj-glow tj-glow-2"></div>
+
+  <!-- Showcase Header -->
+  <header class="tj-header">
+    <div class="tj-container">
+      <div class="tj-badge">EaseMotion Docs</div>
+      <h1 class="tj-main-title">Quick HTML Export Actions</h1>
+      <p class="tj-subtitle">Click "Copy HTML" on any component example to instantly grab its clean, standardized markup directly to your clipboard.</p>
+    </div>
+  </header>
+
+  <!-- Showcase Body -->
+  <main class="tj-main-content">
+    <div class="tj-container">
+      <div class="tj-grid">
+        
+        <!-- Component 1: Primary Button -->
+        <article class="tj-card">
+          <div class="tj-card-header">
+            <h2 class="tj-card-title">Interactive Button</h2>
+            <button class="tj-export-btn" data-target="tj-btn-example" aria-label="Copy Interactive Button HTML">
+              <svg class="tj-icon tj-icon-copy" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+              </svg>
+              <svg class="tj-icon tj-icon-check" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="20 6 9 17 4 12"></polyline>
+              </svg>
+              <span class="tj-btn-text">Copy HTML</span>
+            </button>
+          </div>
+          
+          <div class="tj-preview-container">
+            <div class="tj-preview-wrapper" id="tj-btn-example">
+              <button class="tj-btn-element" type="button">
+                <span>Explore Components</span>
+                <svg viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                  <line x1="5" y1="12" x2="19" y2="12"></line>
+                  <polyline points="12 5 19 12 12 19"></polyline>
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          <details class="tj-code-details">
+            <summary class="tj-code-summary">View Markup</summary>
+            <div class="tj-code-wrapper">
+              <pre><code class="tj-code-block" data-source="tj-btn-example"></code></pre>
+            </div>
+          </details>
+        </article>
+
+        <!-- Component 2: Profile Card -->
+        <article class="tj-card">
+          <div class="tj-card-header">
+            <h2 class="tj-card-title">User Profile Card</h2>
+            <button class="tj-export-btn" data-target="tj-profile-example" aria-label="Copy User Profile Card HTML">
+              <svg class="tj-icon tj-icon-copy" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+              </svg>
+              <svg class="tj-icon tj-icon-check" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="20 6 9 17 4 12"></polyline>
+              </svg>
+              <span class="tj-btn-text">Copy HTML</span>
+            </button>
+          </div>
+
+          <div class="tj-preview-container">
+            <div class="tj-preview-wrapper" id="tj-profile-example">
+              <div class="tj-profile-card">
+                <div class="tj-profile-banner"></div>
+                <div class="tj-avatar-container">
+                  <img src="https://images.unsplash.com/photo-1534528741775-53994a69daeb?auto=format&fit=crop&w=150&q=80" alt="Sophia Sterling Avatar" class="tj-profile-avatar">
+                </div>
+                <div class="tj-profile-info">
+                  <h3 class="tj-profile-name">Sophia Sterling</h3>
+                  <p class="tj-profile-role">Lead Product Designer</p>
+                  <p class="tj-profile-bio">Crafting modern, accessible, and delightful interactive experiences.</p>
+                  <div class="tj-profile-stats">
+                    <div class="tj-stat-col">
+                      <span class="tj-stat-num">142</span>
+                      <span class="tj-stat-label">Projects</span>
+                    </div>
+                    <div class="tj-stat-col">
+                      <span class="tj-stat-num">12.5k</span>
+                      <span class="tj-stat-label">Followers</span>
+                    </div>
+                  </div>
+                  <button class="tj-profile-btn" type="button">View Portfolio</button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <details class="tj-code-details">
+            <summary class="tj-code-summary">View Markup</summary>
+            <div class="tj-code-wrapper">
+              <pre><code class="tj-code-block" data-source="tj-profile-example"></code></pre>
+            </div>
+          </details>
+        </article>
+
+        <!-- Component 3: Subscription Form -->
+        <article class="tj-card tj-card-full">
+          <div class="tj-card-header">
+            <h2 class="tj-card-title">Newsletter Signup Form</h2>
+            <button class="tj-export-btn" data-target="tj-form-example" aria-label="Copy Newsletter Signup Form HTML">
+              <svg class="tj-icon tj-icon-copy" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+              </svg>
+              <svg class="tj-icon tj-icon-check" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="20 6 9 17 4 12"></polyline>
+              </svg>
+              <span class="tj-btn-text">Copy HTML</span>
+            </button>
+          </div>
+
+          <div class="tj-preview-container">
+            <div class="tj-preview-wrapper" id="tj-form-example">
+              <form class="tj-form" onsubmit="event.preventDefault()">
+                <div class="tj-form-content">
+                  <h3 class="tj-form-header-title">Keep up to date</h3>
+                  <p class="tj-form-description">Get notified when new interactive animation mixins and components are merged.</p>
+                </div>
+                <div class="tj-form-row">
+                  <div class="tj-input-group">
+                    <label for="tj-email" class="tj-visually-hidden">Email Address</label>
+                    <input type="email" id="tj-email" class="tj-input" placeholder="Enter your email address" required>
+                  </div>
+                  <button type="submit" class="tj-form-submit">
+                    <span>Subscribe</span>
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+
+          <details class="tj-code-details">
+            <summary class="tj-code-summary">View Markup</summary>
+            <div class="tj-code-wrapper">
+              <pre><code class="tj-code-block" data-source="tj-form-example"></code></pre>
+            </div>
+          </details>
+        </article>
+
+      </div>
+    </div>
+  </main>
+
+  <!-- Showcase Footer -->
+  <footer class="tj-footer">
+    <div class="tj-container">
+      <p>&copy; 2026 EaseMotion CSS. Self-contained HTML Export submission folder.</p>
+    </div>
+  </footer>
+
+  <!-- Vanilla Copy to Clipboard Script -->
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const copyButtons = document.querySelectorAll('.tj-export-btn');
+      const codeBlocks = document.querySelectorAll('.tj-code-block');
+
+      // Populate preview code blocks dynamically with clean escaped HTML
+      codeBlocks.forEach(codeBlock => {
+        const sourceId = codeBlock.getAttribute('data-source');
+        const sourceEl = document.getElementById(sourceId);
+        if (sourceEl) {
+          codeBlock.textContent = getCleanHTML(sourceEl);
+        }
+      });
+
+      // Wire copy-to-clipboard functionality to each button
+      copyButtons.forEach(button => {
+        button.addEventListener('click', () => {
+          const targetId = button.getAttribute('data-target');
+          const targetEl = document.getElementById(targetId);
+
+          if (targetEl) {
+            const cleanHTML = getCleanHTML(targetEl);
+
+            navigator.clipboard.writeText(cleanHTML)
+              .then(() => {
+                triggerSuccessState(button);
+                createToast("Copied HTML markup successfully!");
+              })
+              .catch(err => {
+                console.error("Clipboard copy failed:", err);
+                createToast("Copy failed. Please try again.");
+              });
+          }
+        });
+      });
+
+      /**
+       * Formats and returns the clean component innerHTML by removing leading/trailing spaces
+       * and normalizing outer indent spaces.
+       */
+      function getCleanHTML(element) {
+        let html = element.innerHTML;
+        
+        // Remove empty top/bottom lines
+        html = html.replace(/^\s*\n|\n\s*$/g, '');
+
+        const lines = html.split('\n');
+        if (lines.length === 0) return html;
+
+        // Calculate minimum indent offset of the block
+        let minIndent = Infinity;
+        lines.forEach(line => {
+          if (line.trim().length === 0) return;
+          const match = line.match(/^(\s*)/);
+          if (match) {
+            minIndent = Math.min(minIndent, match[1].length);
+          }
+        });
+
+        // Strip the excess common indentation indentation from each line
+        if (minIndent !== Infinity && minIndent > 0) {
+          return lines.map(line => {
+            if (line.trim().length === 0) return '';
+            return line.substring(minIndent);
+          }).join('\n');
+        }
+
+        return html;
+      }
+
+      /**
+       * Visual success indicator toggle for the copy button
+       */
+      function triggerSuccessState(button) {
+        button.classList.add('tj-copied');
+        const textSpan = button.querySelector('.tj-btn-text');
+        textSpan.textContent = 'Copied!';
+
+        setTimeout(() => {
+          button.classList.remove('tj-copied');
+          textSpan.textContent = 'Copy HTML';
+        }, 2000);
+      }
+
+      /**
+       * Creates a sleek temporary Toast confirmation
+       */
+      function createToast(message) {
+        // Remove existing toast if visible
+        const existingToast = document.querySelector('.tj-toast-container');
+        if (existingToast) {
+          existingToast.remove();
+        }
+
+        const toast = document.createElement('div');
+        toast.className = 'tj-toast-container';
+        toast.innerHTML = `
+          <div class="tj-toast">
+            <svg class="tj-toast-icon" viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
+              <polyline points="22 4 12 14.01 9 11.01"></polyline>
+            </svg>
+            <span class="tj-toast-text">${message}</span>
+          </div>
+        `;
+        document.body.appendChild(toast);
+
+        // Slide in
+        requestAnimationFrame(() => {
+          toast.classList.add('tj-visible');
+        });
+
+        // Slide out and remove
+        setTimeout(() => {
+          toast.classList.remove('tj-visible');
+          setTimeout(() => {
+            toast.remove();
+          }, 400);
+        }, 2500);
+      }
+    });
+  </script>
+</body>
+</html>

--- a/submissions/docs/quick-export-tj/style.css
+++ b/submissions/docs/quick-export-tj/style.css
@@ -1,0 +1,628 @@
+/* ============================================================
+   EaseMotion CSS Docs — style.css
+   Custom Styles for Quick HTML Export Action Showcase
+   ============================================================ */
+
+/* ── Theme & Core Layout ──────────────────────────────────── */
+
+.tj-showcase-theme {
+  --tj-bg-dark: #080d19;
+  --tj-surface-dark: rgba(20, 30, 51, 0.55);
+  --tj-border-color: rgba(255, 255, 255, 0.08);
+  --tj-text-primary: #f8fafc;
+  --tj-text-secondary: #94a3b8;
+  --tj-primary: #8b5cf6;
+  --tj-primary-light: #a78bfa;
+  --tj-primary-alpha: rgba(139, 92, 246, 0.15);
+  --tj-success: #22c55e;
+  --tj-success-alpha: rgba(34, 197, 94, 0.15);
+  
+  background-color: var(--tj-bg-dark);
+  color: var(--tj-text-primary);
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  margin: 0;
+  padding: 0;
+  min-height: 100vh;
+  position: relative;
+  overflow-x: hidden;
+  line-height: 1.6;
+}
+
+/* Background Decorative Glowing Gradients */
+.tj-glow {
+  position: absolute;
+  width: 450px;
+  height: 450px;
+  border-radius: 50%;
+  filter: blur(120px);
+  opacity: 0.15;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.tj-glow-1 {
+  background: radial-gradient(circle, var(--tj-primary), transparent 70%);
+  top: -10%;
+  right: -5%;
+}
+
+.tj-glow-2 {
+  background: radial-gradient(circle, #3b82f6, transparent 70%);
+  bottom: 10%;
+  left: -10%;
+}
+
+/* ── Container & Grid ─────────────────────────────────────── */
+
+.tj-container {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  box-sizing: border-box;
+}
+
+.tj-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 2rem;
+  margin-bottom: 4rem;
+}
+
+@media (max-width: 900px) {
+  .tj-grid {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+}
+
+/* ── Header & Footer ──────────────────────────────────────── */
+
+.tj-header {
+  padding: 5rem 0 3rem 0;
+  text-align: center;
+}
+
+.tj-badge {
+  display: inline-block;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: var(--tj-primary-alpha);
+  color: var(--tj-primary-light);
+  border: 1px solid rgba(139, 92, 246, 0.3);
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  margin-bottom: 1.25rem;
+}
+
+.tj-main-title {
+  font-family: 'Outfit', sans-serif;
+  font-size: 2.75rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  margin: 0 0 1rem 0;
+  background: linear-gradient(135deg, #ffffff 30%, #c084fc 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.tj-subtitle {
+  font-size: 1.1rem;
+  color: var(--tj-text-secondary);
+  max-width: 680px;
+  margin: 0 auto;
+}
+
+.tj-footer {
+  text-align: center;
+  padding: 3rem 0;
+  border-top: 1px solid var(--tj-border-color);
+  color: var(--tj-text-secondary);
+  font-size: 0.9rem;
+}
+
+/* ── Showcase Card Container ──────────────────────────────── */
+
+.tj-card {
+  background: var(--tj-surface-dark);
+  border: 1px solid var(--tj-border-color);
+  border-radius: 1rem;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  transition: border-color 0.30s ease, transform 0.30s ease;
+}
+
+.tj-card:hover {
+  border-color: rgba(139, 92, 246, 0.25);
+}
+
+.tj-card-full {
+  grid-column: span 2;
+}
+
+@media (max-width: 900px) {
+  .tj-card-full {
+    grid-column: span 1;
+  }
+}
+
+.tj-card-header {
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid var(--tj-border-color);
+}
+
+.tj-card-title {
+  font-family: 'Outfit', sans-serif;
+  font-size: 1.15rem;
+  font-weight: 600;
+  margin: 0;
+  color: #f1f5f9;
+}
+
+.tj-preview-container {
+  padding: 3.5rem 2rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: radial-gradient(circle at center, rgba(15, 23, 42, 0.4) 0%, rgba(8, 13, 25, 0.8) 100%);
+  min-height: 280px;
+  box-sizing: border-box;
+}
+
+.tj-preview-wrapper {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* ── Export Action Button ─────────────────────────────────── */
+
+.tj-export-btn {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid var(--tj-border-color);
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.85rem;
+  color: var(--tj-text-primary);
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.tj-export-btn:hover {
+  background: var(--tj-primary-alpha);
+  border-color: rgba(139, 92, 246, 0.4);
+  color: var(--tj-primary-light);
+  transform: translateY(-1px);
+}
+
+.tj-export-btn:active {
+  transform: translateY(0);
+}
+
+.tj-export-btn .tj-icon {
+  transition: transform 0.25s ease, opacity 0.25s ease;
+}
+
+.tj-export-btn .tj-icon-check {
+  display: none;
+}
+
+/* Copy Action Success / Copied State */
+.tj-export-btn.tj-copied {
+  background: var(--tj-success-alpha);
+  border-color: rgba(34, 197, 94, 0.4);
+  color: var(--tj-success);
+}
+
+.tj-export-btn.tj-copied .tj-icon-copy {
+  display: none;
+}
+
+.tj-export-btn.tj-copied .tj-icon-check {
+  display: inline-block;
+  animation: tj-scale-in 0.25s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+@keyframes tj-scale-in {
+  from {
+    transform: scale(0.6);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+/* ── Expandable Code Blocks ───────────────────────────────── */
+
+.tj-code-details {
+  border-top: 1px solid var(--tj-border-color);
+  background: #040811;
+}
+
+.tj-code-summary {
+  padding: 1rem 1.5rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--tj-text-secondary);
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+.tj-code-summary::-webkit-details-marker {
+  display: none;
+}
+
+.tj-code-summary::before {
+  content: '';
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 6px solid var(--tj-text-secondary);
+  transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.tj-code-details[open] .tj-code-summary::before {
+  transform: rotate(90deg);
+}
+
+.tj-code-summary:hover {
+  color: var(--tj-text-primary);
+  background-color: rgba(255, 255, 255, 0.02);
+}
+
+.tj-code-wrapper {
+  padding: 0 1.5rem 1.5rem 1.5rem;
+  overflow: hidden;
+}
+
+.tj-code-block {
+  margin: 0;
+  font-family: 'Fira Code', var(--ease-font-mono), monospace;
+  font-size: 0.8rem;
+  color: #cbd5e1;
+  background: rgba(15, 23, 42, 0.5);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  padding: 1.25rem;
+  border-radius: 0.5rem;
+  overflow-x: auto;
+  white-space: pre;
+}
+
+/* Custom Scrollbar for Code Block */
+.tj-code-block::-webkit-scrollbar {
+  height: 6px;
+}
+.tj-code-block::-webkit-scrollbar-track {
+  background: transparent;
+}
+.tj-code-block::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 99px;
+}
+.tj-code-block::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+/* ── Toast Notifications ───────────────────────────────────── */
+
+.tj-toast-container {
+  position: fixed;
+  bottom: 2rem;
+  left: 50%;
+  transform: translate(-50%, 1.5rem);
+  opacity: 0;
+  z-index: 10000;
+  pointer-events: none;
+  transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.3s ease;
+}
+
+.tj-toast-container.tj-visible {
+  transform: translate(-50%, 0);
+  opacity: 1;
+}
+
+.tj-toast {
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(34, 197, 94, 0.25);
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.5), 0 0 15px rgba(34, 197, 94, 0.15);
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+.tj-toast-icon {
+  color: var(--tj-success);
+}
+
+.tj-toast-text {
+  color: #f1f5f9;
+  font-size: 0.85rem;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+/* ── Visually Hidden Helper ────────────────────────────────── */
+
+.tj-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ============================================================
+   Component Examples Styling
+   ============================================================ */
+
+/* ── Component 1: Interactive Button ─────────────────────── */
+
+.tj-btn-element {
+  background: linear-gradient(135deg, #6366f1 0%, #a855f7 100%);
+  color: white;
+  border: none;
+  border-radius: 9999px;
+  padding: 0.9rem 1.8rem;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  box-shadow: 0 4px 15px rgba(99, 102, 241, 0.35);
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.3s ease;
+}
+
+.tj-btn-element:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(99, 102, 241, 0.5), 0 0 12px rgba(168, 85, 247, 0.3);
+}
+
+.tj-btn-element:active {
+  transform: translateY(0);
+}
+
+.tj-btn-element svg {
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.tj-btn-element:hover svg {
+  transform: translateX(4px);
+}
+
+/* ── Component 2: User Profile Card ──────────────────────── */
+
+.tj-profile-card {
+  width: 100%;
+  max-width: 320px;
+  background: rgba(15, 23, 42, 0.5);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 1rem;
+  overflow: hidden;
+  box-shadow: 0 8px 20px rgba(0,0,0,0.15);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.tj-profile-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 25px rgba(0,0,0,0.25);
+}
+
+.tj-profile-banner {
+  height: 85px;
+  background: linear-gradient(120deg, #3b82f6 0%, #8b5cf6 100%);
+}
+
+.tj-avatar-container {
+  display: flex;
+  justify-content: center;
+  margin-top: -45px;
+}
+
+.tj-profile-avatar {
+  width: 90px;
+  height: 90px;
+  border-radius: 50%;
+  border: 4px solid #0f172a;
+  object-fit: cover;
+  background: #1e293b;
+}
+
+.tj-profile-info {
+  padding: 1.25rem 1.5rem;
+  text-align: center;
+}
+
+.tj-profile-name {
+  font-family: 'Outfit', sans-serif;
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin: 0 0 0.25rem 0;
+  color: #f8fafc;
+}
+
+.tj-profile-role {
+  font-size: 0.85rem;
+  color: var(--tj-primary-light);
+  font-weight: 500;
+  margin: 0 0 0.85rem 0;
+}
+
+.tj-profile-bio {
+  font-size: 0.8rem;
+  color: var(--tj-text-secondary);
+  margin: 0 0 1.25rem 0;
+  line-height: 1.5;
+}
+
+.tj-profile-stats {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  padding: 0.75rem 0;
+  margin-bottom: 1.25rem;
+}
+
+.tj-stat-col {
+  display: flex;
+  flex-direction: column;
+}
+
+.tj-stat-num {
+  font-family: 'Outfit', sans-serif;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #f1f5f9;
+}
+
+.tj-stat-label {
+  font-size: 0.7rem;
+  color: var(--tj-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.tj-profile-btn {
+  width: 100%;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 0.5rem;
+  padding: 0.65rem 0;
+  color: #f1f5f9;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.25s ease;
+}
+
+.tj-profile-btn:hover {
+  background: #f8fafc;
+  color: #0f172a;
+  border-color: #f8fafc;
+}
+
+/* ── Component 3: Subscription Form ───────────────────────── */
+
+.tj-form {
+  width: 100%;
+  max-width: 620px;
+  background: rgba(15, 23, 42, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: 1rem;
+  padding: 2.25rem;
+  box-sizing: border-box;
+}
+
+.tj-form-content {
+  margin-bottom: 1.5rem;
+}
+
+.tj-form-header-title {
+  font-family: 'Outfit', sans-serif;
+  font-size: 1.35rem;
+  font-weight: 700;
+  margin: 0 0 0.5rem 0;
+  color: #f8fafc;
+}
+
+.tj-form-description {
+  font-size: 0.875rem;
+  color: var(--tj-text-secondary);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.tj-form-row {
+  display: flex;
+  gap: 0.75rem;
+}
+
+@media (max-width: 580px) {
+  .tj-form-row {
+    flex-direction: column;
+  }
+}
+
+.tj-input-group {
+  flex-grow: 1;
+}
+
+.tj-input {
+  width: 100%;
+  background: rgba(8, 13, 25, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.5rem;
+  padding: 0.85rem 1rem;
+  color: white;
+  font-size: 0.9rem;
+  box-sizing: border-box;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.tj-input:focus {
+  outline: none;
+  border-color: var(--tj-primary-light);
+  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.15);
+}
+
+.tj-input::placeholder {
+  color: #475569;
+}
+
+.tj-form-submit {
+  background: #f8fafc;
+  color: #0f172a;
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.85rem 1.75rem;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: transform 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tj-form-submit:hover {
+  background: #cbd5e1;
+  box-shadow: 0 4px 12px rgba(255, 255, 255, 0.1);
+}
+
+.tj-form-submit:active {
+  transform: scale(0.98);
+}


### PR DESCRIPTION
## Description
This PR addresses Issue #36215 by introducing a self-contained "Quick HTML Export Action" for component examples. Instead of requiring developers to manually highlight and copy code blocks, this feature adds a streamlined action that copies the clean HTML markup directly to their clipboard with instant visual feedback.

Following the repository's strict isolation guidelines, all files have been kept entirely within a dedicated subdirectory under `submissions/docs/`.

## Associated Issue
Closes #36215

## Track & Directory Structure
- **Track:** Core & Docs Showcase
- **Directory Path:** `submissions/docs/quick-export-[your_initials]/`

### Files Added:
- `submissions/docs/quick-export-[your_initials]/demo.html` (Self-contained interactive demo)
- `submissions/docs/quick-export-[your_initials]/style.css` (Styles for layout and copy states)
- `submissions/docs/quick-export-[your_initials]/README.md` (Answers to the three required questions)

---

## Submission Checklist
Please review and check the following boxes to verify compliance with the framework's contribution guidelines:

- [x] I have opened/been assigned an issue before coding this feature.
- [x] My files are strictly placed inside one of the 4 allowed subdirectories (`submissions/docs/`).
- [x] I have NOT modified or touched any files inside `core/`, `components/`, or the root directory.
- [x] I have appended a unique identifier/abbreviation to my feature folder name to prevent naming conflicts.
- [x] My `demo.html` is fully functional by opening it directly in a browser without requiring external CDNs or local servers.
- [x] All commits in this Pull Request have been squashed into a single, clean commit following the Conventional Commits format.
- [x] I understand that this code will remain in the sandbox until the maintainer standardizes and promotes it to the core framework.