### PR TITLE
feat: add 3D flip card component

### DIFF
--- a/submissions/examples/flip-card-component/demo.html
+++ b/submissions/examples/flip-card-component/demo.html
@@ -1,0 +1,31 @@
+@'
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>3D Flip Card Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body
+    style="display:flex; justify-content:center; align-items:center; min-height:100vh; margin:0; background:#f4f4f4; font-family:sans-serif;">
+
+    <div class="flip-card" onclick="this.classList.toggle(&apos;is-flipped&apos;)">
+        <div class="flip-card-inner">
+            <div class="flip-card-front">
+                <h3>Gunvanth Kandula</h3>
+                <p>Hover or tap to flip</p>
+            </div>
+            <div class="flip-card-back">
+                <h3>B.Tech AI &amp; DS</h3>
+                <p>SVIT Hyderabad &middot; 2027</p>
+            </div>
+        </div>
+    </div>
+
+</body>
+
+</html>
+'@ | Out-File -FilePath demo.html -Encoding utf8

--- a/submissions/examples/flip-card-component/style.css
+++ b/submissions/examples/flip-card-component/style.css
@@ -1,0 +1,45 @@
+.flip-card {
+    width: 280px;
+    height: 180px;
+    perspective: 1000px;
+}
+
+.flip-card-inner {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    transition: transform 0.6s;
+    transform-style: preserve-3d;
+}
+
+.flip-card:hover .flip-card-inner,
+.flip-card.is-flipped .flip-card-inner {
+    transform: rotateY(180deg);
+}
+
+.flip-card-front,
+.flip-card-back {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    backface-visibility: hidden;
+    border-radius: 12px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding: 1rem;
+    box-sizing: border-box;
+    text-align: center;
+}
+
+.flip-card-front {
+    background: #ffffff;
+    border: 1px solid #e0e0e0;
+}
+
+.flip-card-back {
+    background: #1a1a2e;
+    color: #ffffff;
+    transform: rotateY(180deg);
+}


### PR DESCRIPTION
## Feature Name
3D Flip Card Component

## Description
A pure CSS card component that flips in 3D to reveal a hidden back face.
- **Desktop:** flips on hover
- **Mobile/touch:** flips on tap, via a toggled `is-flipped` class
- Front and back share the same card space, so it feels like a real card turning over rather than a fade or swap

## Why this fits EaseMotion CSS
The framework currently has no component demonstrating true 3D transforms — most existing effects are 2D (fades, slides, hovers). This fills that gap with a genuinely common UI pattern (profile cards, product cards, team bios) while staying zero-dependency and pure CSS — no JavaScript required for the core flip effect.

## Files Added
- `submissions/examples/flip-card-component/demo.html`
- `submissions/examples/flip-card-component/style.css`
- `submissions/examples/flip-card-component/README.md`

## How to test
Open `demo.html` directly in a browser (no build step needed):
- Hover over the card on desktop → it flips to show the back
- Tap the card on mobile/touch devices → it flips via the `is-flipped` class toggle

**Tested on:**
- [x] Chrome
- [x] Edge

## Checklist
- [x] Demo added (demo.html works by opening directly in a browser)
- [x] Code is inside `submissions/` only — not `core/` or `components/`
- [x] Does not duplicate an existing EaseMotion CSS class
- [x] Naming may be standardized by the maintainer

Closes #36202 