### PR TITLE
feat: add @property-powered animatable gradient button

### DIFF
--- a/submissions/examples/registered-property-gradient-btn/README.md
+++ b/submissions/examples/registered-property-gradient-btn/README.md
@@ -1,0 +1,22 @@
+# @property Gradient Button
+
+## What does this do?
+
+Animates gradient colors and rotation natively in CSS using `@property` typed custom properties — no JavaScript, no background-position hacks.
+
+## How is it used?
+
+```html
+<!-- Spinning conic gradient -->
+<button class="grad-btn grad-btn--spin">Get Started</button>
+
+<!-- Hue-shifting linear gradient -->
+<button class="grad-btn grad-btn--hue">Learn More</button>
+
+<!-- Animated border ring -->
+<button class="grad-btn grad-btn--ring">Contact Us</button>
+```
+
+## Why is it useful?
+
+Without `@property`, CSS cannot interpolate custom properties used as gradient stops — the browser treats them as discrete switches. Declaring `--grad-angle` as `<angle>` and `--grad-color-start` as `<color>` gives the browser the type information it needs to animate them smoothly inside `@keyframes`. This produces a continuously rotating conic gradient and cross-hue color shift that is impossible with `transition` or `background-position` alone. Requires Chrome 85+, Firefox 128+, Safari 16.4+. A `@supports` fallback targets older browsers gracefully.

--- a/submissions/examples/registered-property-gradient-btn/demo.html
+++ b/submissions/examples/registered-property-gradient-btn/demo.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EaseMotion CSS - @property Gradient Button</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      body {
+        font-family: system-ui, -apple-system, sans-serif;
+        background: #0d1117;
+        min-height: 100vh;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        margin: 0;
+        padding: 2rem;
+        box-sizing: border-box;
+      }
+
+      .container {
+        text-align: center;
+        max-width: 800px;
+        width: 100%;
+      }
+
+      h1 {
+        font-size: 2rem;
+        font-weight: 800;
+        background: linear-gradient(135deg, #6c63ff, #ec4899);
+        -webkit-background-clip: text;
+        background-clip: text;
+        color: transparent;
+        margin: 0 0 0.5rem;
+      }
+
+      .subtitle {
+        color: #64748b;
+        font-size: 0.9rem;
+        margin: 0 0 3rem;
+      }
+
+      .demo-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 2.5rem;
+        margin-bottom: 2.5rem;
+      }
+
+      .demo-item {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 1rem;
+      }
+
+      .demo-item span {
+        color: #94a3b8;
+        font-size: 0.8rem;
+        font-family: ui-monospace, monospace;
+      }
+
+      .note {
+        background: #161b22;
+        border: 1px solid #21262d;
+        border-radius: 10px;
+        padding: 1rem 1.5rem;
+        font-size: 0.8rem;
+        color: #8b949e;
+        line-height: 1.6;
+      }
+
+      .note code {
+        color: #c9d1d9;
+        background: #0d1117;
+        padding: 0.1em 0.4em;
+        border-radius: 4px;
+        font-family: ui-monospace, monospace;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>@property Gradient Button</h1>
+      <p class="subtitle">
+        True CSS gradient interpolation via registered typed custom properties
+      </p>
+
+      <div class="demo-grid">
+        <div class="demo-item">
+          <button class="grad-btn grad-btn--spin">Get Started</button>
+          <span>conic spin — --grad-angle</span>
+        </div>
+
+        <div class="demo-item">
+          <button class="grad-btn grad-btn--hue">Learn More</button>
+          <span>hue shift — --grad-color-start</span>
+        </div>
+
+        <div class="demo-item">
+          <button class="grad-btn grad-btn--ring">Contact Us</button>
+          <span>border ring — --border-hue</span>
+        </div>
+      </div>
+
+      <div class="note">
+        <code>@property</code> registers typed custom properties (
+        <code>&lt;angle&gt;</code>, <code>&lt;color&gt;</code>) that the browser
+        can interpolate inside <code>@keyframes</code>. Without it, gradient
+        stops cannot be animated natively. Requires Chrome 85+, Firefox 128+,
+        Safari 16.4+.
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/registered-property-gradient-btn/style.css
+++ b/submissions/examples/registered-property-gradient-btn/style.css
@@ -1,0 +1,153 @@
+/* @property declarations — typed custom properties enable true CSS interpolation */
+@property --grad-angle {
+  syntax: "<angle>";
+  inherits: false;
+  initial-value: 0deg;
+}
+
+@property --grad-color-start {
+  syntax: "<color>";
+  inherits: false;
+  initial-value: #6c63ff;
+}
+
+@property --grad-color-mid {
+  syntax: "<color>";
+  inherits: false;
+  initial-value: #06b6d4;
+}
+
+@property --border-hue {
+  syntax: "<angle>";
+  inherits: false;
+  initial-value: 0deg;
+}
+
+/* Keyframes — animate the registered properties directly */
+@keyframes spin-gradient {
+  to {
+    --grad-angle: 360deg;
+  }
+}
+
+@keyframes shift-color {
+  0%,
+  100% {
+    --grad-color-start: #6c63ff;
+    --grad-color-mid: #06b6d4;
+  }
+  33% {
+    --grad-color-start: #ec4899;
+    --grad-color-mid: #f59e0b;
+  }
+  66% {
+    --grad-color-start: #10b981;
+    --grad-color-mid: #6c63ff;
+  }
+}
+
+@keyframes spin-border {
+  to {
+    --border-hue: 360deg;
+  }
+}
+
+/* Base button styles */
+.grad-btn {
+  position: relative;
+  padding: 0.8rem 2rem;
+  border: none;
+  border-radius: 10px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  color: #fff;
+  letter-spacing: 0.01em;
+  transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1),
+    box-shadow 0.2s ease;
+}
+
+.grad-btn:hover {
+  transform: scale(1.04) translateY(-1px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+}
+
+.grad-btn:active {
+  transform: scale(0.98) translateY(0);
+}
+
+/* Variant 1 — Spinning conic gradient */
+.grad-btn--spin {
+  background: conic-gradient(
+    from var(--grad-angle),
+    #6c63ff,
+    #06b6d4,
+    #ec4899,
+    #f59e0b,
+    #6c63ff
+  );
+  animation: spin-gradient 3s linear infinite;
+}
+
+/* Variant 2 — Hue-shifting linear gradient */
+.grad-btn--hue {
+  background: linear-gradient(
+    135deg,
+    var(--grad-color-start),
+    var(--grad-color-mid)
+  );
+  animation: shift-color 5s ease-in-out infinite;
+}
+
+/* Variant 3 — Animated border ring via pseudo-element */
+.grad-btn--ring {
+  background: #0d1117;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+  z-index: 0;
+}
+
+.grad-btn--ring::before {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  border-radius: inherit;
+  background: conic-gradient(
+    from var(--border-hue),
+    #6c63ff,
+    #ec4899,
+    #06b6d4,
+    #6c63ff
+  );
+  z-index: -1;
+  animation: spin-border 2.5s linear infinite;
+}
+
+/* Graceful degradation — browsers without conic-gradient support */
+@supports not (background: conic-gradient(from 0deg, red, blue)) {
+  .grad-btn--spin {
+    background: linear-gradient(135deg, #6c63ff, #06b6d4);
+    animation: none;
+  }
+  .grad-btn--ring::before {
+    background: linear-gradient(135deg, #6c63ff, #ec4899);
+    animation: none;
+  }
+}
+
+/* Graceful degradation — browsers without @property support */
+@supports not (background: paint(something)) {
+  .grad-btn--hue {
+    background: linear-gradient(135deg, #6c63ff, #06b6d4);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .grad-btn {
+    animation: none;
+    transition: none;
+  }
+  .grad-btn--ring::before {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a button component with three gradient animation variants, each using CSS `@property` registered typed custom properties to achieve real gradient interpolation inside `@keyframes`. Without `@property`, CSS cannot animate custom properties used as gradient stops. This uses `--grad-angle: <angle>`, `--grad-color-start: <color>`, and `--border-hue: <angle>` to drive a conic spin, hue-shift, and animated border ring respectively.

Closes #35483

---

## Type of Change

- [x] New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/registered-property-gradient-btn/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Three button variants (conic spin, hue-shift, animated border ring) animated via `@property` typed custom properties — Chrome 85+, Firefox 128+, Safari 16.4+, with `@supports` fallbacks for older browsers.

**How does a developer use it?**

```html
<button class="grad-btn grad-btn--spin">Get Started</button>
<button class="grad-btn grad-btn--hue">Learn More</button>
<button class="grad-btn grad-btn--ring">Contact Us</button>
```

**Why does it fit EaseMotion CSS?**

Gradients are a first-class visual primitive in modern UI but have historically required JS to animate. `@property` makes this a pure CSS concern. The technique is distinct from background-position hacks and produces smoother, GPU-interpolated results.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer

`@supports not (background: conic-gradient(from 0deg, red, blue))` guard handles older browsers. The `--ring` variant uses a `::before` pseudo-element positioned `inset: -2px` so the animated gradient sits behind the button background via `z-index: -1`.