### PR TITLE
feat: add squircle morphing avatar with clip-path keyframes

### DIFF
--- a/submissions/examples/squircle-morph-avatar/README.md
+++ b/submissions/examples/squircle-morph-avatar/README.md
@@ -1,0 +1,30 @@
+# Squircle Morphing Avatar
+
+## What does this do?
+
+Continuously morphs an avatar container between circle, squircle, and diamond shapes using `@keyframes` that animate `clip-path: path()` — the image fill is unchanged, only the clip mask morphs.
+
+## How is it used?
+
+```html
+<!-- Default morph -->
+<div class="avatar-morph">
+  <img src="photo.jpg" alt="User avatar" />
+</div>
+
+<!-- Slow status pulse with online ring -->
+<div class="avatar-morph avatar-morph--slow avatar-morph--online" style="--delay: 0s">
+  <img src="photo.jpg" alt="User avatar" />
+</div>
+
+<!-- Staggered group -->
+<div class="avatar-pile">
+  <div class="avatar-morph" style="--delay: 0s"><img src="u1.jpg" alt="" /></div>
+  <div class="avatar-morph" style="--delay: -1.25s"><img src="u2.jpg" alt="" /></div>
+  <div class="avatar-morph" style="--delay: -2.5s"><img src="u3.jpg" alt="" /></div>
+</div>
+```
+
+## Why is it useful?
+
+`border-radius` only produces ellipses — it cannot generate the squircle (superellipse) shape used in Apple's iOS icons, Linear, Figma, and Loom. `clip-path: path()` supports arbitrary shapes, and CSS can interpolate between paths when they share identical point counts. This fills a real gap: a CSS-native animated shape morph for avatars and profile images. Includes `prefers-reduced-motion` compliance and size/speed modifier classes.

--- a/submissions/examples/squircle-morph-avatar/demo.html
+++ b/submissions/examples/squircle-morph-avatar/demo.html
@@ -1,0 +1,227 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EaseMotion CSS - Squircle Morphing Avatar</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        font-family: system-ui, -apple-system, sans-serif;
+        background: #0d1117;
+        color: #e6edf3;
+        min-height: 100vh;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding: 3rem 2rem;
+      }
+
+      .container {
+        max-width: 700px;
+        width: 100%;
+        text-align: center;
+      }
+
+      h1 {
+        font-size: 2rem;
+        font-weight: 800;
+        background: linear-gradient(135deg, #a78bfa, #ec4899);
+        -webkit-background-clip: text;
+        background-clip: text;
+        color: transparent;
+        margin-bottom: 0.5rem;
+      }
+
+      .subtitle {
+        color: #64748b;
+        font-size: 0.875rem;
+        margin-bottom: 3rem;
+      }
+
+      .demo-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 2.5rem;
+        margin-bottom: 3rem;
+      }
+
+      .demo-card {
+        background: #161b22;
+        border: 1px solid #21262d;
+        border-radius: 16px;
+        padding: 2rem 1.5rem;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 1rem;
+      }
+
+      .demo-card h3 {
+        font-size: 0.875rem;
+        font-weight: 600;
+        color: #8b949e;
+      }
+
+      /* Placeholder gradient images (no external deps) */
+      .avatar-img {
+        width: 100%;
+        height: 100%;
+        display: block;
+      }
+
+      .avatar-img--1 {
+        background: linear-gradient(135deg, #7c3aed, #2563eb);
+      }
+
+      .avatar-img--2 {
+        background: linear-gradient(135deg, #0891b2, #10b981);
+      }
+
+      .avatar-img--3 {
+        background: linear-gradient(135deg, #be185d, #dc2626);
+      }
+
+      .avatar-img--4 {
+        background: linear-gradient(135deg, #d97706, #b45309);
+      }
+
+      /* Profile row layout */
+      .profile-row {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        background: #161b22;
+        border: 1px solid #21262d;
+        border-radius: 12px;
+        padding: 1.25rem 1.5rem;
+        margin-bottom: 1rem;
+        text-align: left;
+      }
+
+      .profile-row .user-info h4 {
+        font-size: 0.95rem;
+        font-weight: 600;
+        margin-bottom: 0.2rem;
+      }
+
+      .profile-row .user-info span {
+        font-size: 0.8rem;
+        color: #8b949e;
+      }
+
+      .note {
+        background: #161b22;
+        border: 1px solid #21262d;
+        border-radius: 10px;
+        padding: 1rem 1.5rem;
+        font-size: 0.8rem;
+        color: #8b949e;
+        line-height: 1.6;
+        text-align: left;
+        margin-top: 2rem;
+      }
+
+      .note code {
+        color: #c9d1d9;
+        background: #0d1117;
+        padding: 0.1em 0.4em;
+        border-radius: 4px;
+        font-family: ui-monospace, monospace;
+        font-size: 0.85em;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>Squircle Morphing Avatar</h1>
+      <p class="subtitle">
+        clip-path: path() morphs between circle, squircle, and diamond — same
+        point count required
+      </p>
+
+      <!-- Variant grid -->
+      <div class="demo-grid">
+        <!-- Slow status pulse -->
+        <div class="demo-card">
+          <div class="avatar-morph avatar-morph--lg avatar-morph--slow avatar-morph--online">
+            <div class="avatar-img avatar-img--1"></div>
+          </div>
+          <h3>Status pulse (slow)</h3>
+        </div>
+
+        <!-- Default speed -->
+        <div class="demo-card">
+          <div class="avatar-morph avatar-morph--lg">
+            <div class="avatar-img avatar-img--2"></div>
+          </div>
+          <h3>Default (5s)</h3>
+        </div>
+
+        <!-- Fast -->
+        <div class="demo-card">
+          <div class="avatar-morph avatar-morph--lg avatar-morph--fast">
+            <div class="avatar-img avatar-img--3"></div>
+          </div>
+          <h3>Fast (2.5s)</h3>
+        </div>
+      </div>
+
+      <!-- Staggered avatar pile -->
+      <div class="demo-card" style="margin-bottom: 2rem">
+        <h3 style="margin-bottom: 1.5rem">Staggered group</h3>
+        <div class="avatar-pile">
+          <div class="avatar-morph" style="--delay: 0s">
+            <div class="avatar-img avatar-img--1"></div>
+          </div>
+          <div class="avatar-morph" style="--delay: -1.25s">
+            <div class="avatar-img avatar-img--2"></div>
+          </div>
+          <div class="avatar-morph" style="--delay: -2.5s">
+            <div class="avatar-img avatar-img--3"></div>
+          </div>
+          <div class="avatar-morph avatar-morph--sm" style="--delay: -3.75s">
+            <div class="avatar-img avatar-img--4"></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Profile card use-case -->
+      <div class="profile-row">
+        <div class="avatar-morph avatar-morph--online" style="--delay: -0.5s">
+          <div class="avatar-img avatar-img--1"></div>
+        </div>
+        <div class="user-info">
+          <h4>Alex Kim</h4>
+          <span>Online</span>
+        </div>
+      </div>
+
+      <div class="profile-row">
+        <div class="avatar-morph avatar-morph--slow" style="--delay: -2s">
+          <div class="avatar-img avatar-img--2"></div>
+        </div>
+        <div class="user-info">
+          <h4>Taylor Chen</h4>
+          <span>Away</span>
+        </div>
+      </div>
+
+      <div class="note">
+        All four path strings in each <code>@keyframes</code> use the same
+        number of cubic bezier segments. This is required for browser
+        interpolation — mismatched point counts fall back to a discrete switch.
+        Replace the gradient divs with <code>&lt;img&gt;</code> elements for
+        real photos.
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/squircle-morph-avatar/style.css
+++ b/submissions/examples/squircle-morph-avatar/style.css
@@ -1,0 +1,122 @@
+/* Squircle Morphing Avatar
+   Animates clip-path: path() between shapes with identical point counts.
+   All four path strings use the same number of cubic bezier segments
+   so the browser can interpolate smoothly between them.
+   The image fill is unaffected — only the clipping mask morphs. */
+
+@keyframes shape-morph-slow {
+  0%,
+  100% {
+    /* Circle — 4 cubic bezier segments */
+    clip-path: path(
+      "M 50,0 C 77.6,0 100,22.4 100,50 C 100,77.6 77.6,100 50,100 C 22.4,100 0,77.6 0,50 C 0,22.4 22.4,0 50,0 Z"
+    );
+  }
+  33% {
+    /* Squircle — same 4 segments, corners pulled inward */
+    clip-path: path(
+      "M 50,4 C 79,4 96,21 96,50 C 96,79 79,96 50,96 C 21,96 4,79 4,50 C 4,21 21,4 50,4 Z"
+    );
+  }
+  66% {
+    /* Diamond — same segment count, corners at edge midpoints */
+    clip-path: path(
+      "M 50,2 C 50,2 98,50 98,50 C 98,50 50,98 50,98 C 50,98 2,50 2,50 C 2,50 50,2 50,2 Z"
+    );
+  }
+}
+
+@keyframes shape-morph-fast {
+  0%,
+  100% {
+    clip-path: path(
+      "M 50,0 C 77.6,0 100,22.4 100,50 C 100,77.6 77.6,100 50,100 C 22.4,100 0,77.6 0,50 C 0,22.4 22.4,0 50,0 Z"
+    );
+  }
+  33% {
+    clip-path: path(
+      "M 50,4 C 79,4 96,21 96,50 C 96,79 79,96 50,96 C 21,96 4,79 4,50 C 4,21 21,4 50,4 Z"
+    );
+  }
+  66% {
+    clip-path: path(
+      "M 50,2 C 50,2 98,50 98,50 C 98,50 50,98 50,98 C 50,98 2,50 2,50 C 2,50 50,2 50,2 Z"
+    );
+  }
+}
+
+/* Base avatar container */
+.avatar-morph {
+  position: relative;
+  display: inline-flex;
+  width: 80px;
+  height: 80px;
+  overflow: hidden;
+  animation: shape-morph-slow 5s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+  animation-delay: var(--delay, 0s);
+}
+
+.avatar-morph img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  /* Slight scale prevents sub-pixel edge bleed during clip-path morph */
+  transform: scale(1.02);
+}
+
+/* Size variants */
+.avatar-morph--sm {
+  width: 52px;
+  height: 52px;
+}
+
+.avatar-morph--lg {
+  width: 112px;
+  height: 112px;
+}
+
+/* Speed variants */
+.avatar-morph--slow {
+  animation-duration: 7s;
+}
+
+.avatar-morph--fast {
+  animation-name: shape-morph-fast;
+  animation-duration: 2.5s;
+}
+
+/* Status ring — glows around the avatar */
+.avatar-morph--online::after {
+  content: "";
+  position: absolute;
+  inset: -3px;
+  border-radius: 50%;
+  background: conic-gradient(#10b981, #06b6d4, #10b981);
+  z-index: -1;
+  animation: shape-morph-slow 5s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+  animation-delay: var(--delay, 0s);
+}
+
+/* Stagger group layout */
+.avatar-pile {
+  display: flex;
+  align-items: center;
+}
+
+.avatar-pile .avatar-morph + .avatar-morph {
+  margin-left: -14px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .avatar-morph {
+    animation: none;
+    /* Fall back to a plain circle */
+    clip-path: path(
+      "M 50,0 C 77.6,0 100,22.4 100,50 C 100,77.6 77.6,100 50,100 C 22.4,100 0,77.6 0,50 C 0,22.4 22.4,0 50,0 Z"
+    );
+  }
+  .avatar-morph--online::after {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an avatar component that continuously morphs between circle, squircle, and diamond using `@keyframes` animating `clip-path: path()`. The key constraint is that all four path strings use identical cubic bezier segment counts — without this, browsers fall back to a discrete jump instead of interpolating. Uses gradient divs as placeholder images (no external assets). Includes `--delay` custom property for stagger groups, size modifiers (`--sm`, `--lg`), speed modifiers (`--slow`, `--fast`), and an online status ring variant.

Closes #35487

---

## Type of Change

- [x] New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/squircle-morph-avatar/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

CSS shape morphing for avatars using `clip-path: path()` — circle → squircle → diamond → circle loop.

**How does a developer use it?**

```html
<div class="avatar-morph avatar-morph--slow avatar-morph--online" style="--delay: 0s">
  <img src="photo.jpg" alt="User avatar" />
</div>
```

**Why does it fit EaseMotion CSS?**

`border-radius` only produces ellipses. `clip-path: path()` morphing is the CSS-native way to animate between arbitrary shapes. The squircle specifically is the dominant shape in modern design systems (iOS, Linear, Figma) but has no pure CSS animation coverage in EaseMotion.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer

The `scale(1.02)` on the inner image prevents sub-pixel edge bleed that appears during `clip-path` transitions at certain zoom levels. The `--online` variant uses a `::after` conic gradient ring that mirrors the same morph animation.