### PR TITLE
feat: add pure CSS spotlight hover card using @property and radial-gradient

### DIFF
--- a/submissions/examples/css-spotlight-card/README.md
+++ b/submissions/examples/css-spotlight-card/README.md
@@ -1,0 +1,53 @@
+# CSS Spotlight Card
+
+## What does this add?
+
+A pure-CSS spotlight hover effect for cards. When the user hovers over a card,
+a soft radial-gradient glow blooms from the top-center of the card surface and
+the border color shifts to match. No JavaScript is involved — the effect is
+driven entirely by `@property --spotlight-opacity` and a `::before` pseudo-element.
+
+## How does a developer use it?
+
+Add the base class plus one color-variant modifier:
+
+```html
+<!-- Purple glow -->
+<div class="spotlight-card spotlight-card--purple">
+  <h3>Card Title</h3>
+  <p>Card description goes here.</p>
+</div>
+
+<!-- Cyan glow -->
+<div class="spotlight-card spotlight-card--cyan">
+  <h3>Card Title</h3>
+  <p>Card description goes here.</p>
+</div>
+
+<!-- Amber glow -->
+<div class="spotlight-card spotlight-card--amber">…</div>
+
+<!-- Pink glow -->
+<div class="spotlight-card spotlight-card--pink">…</div>
+```
+
+Available variants: `--purple`, `--cyan`, `--amber`, `--pink`.
+
+Custom colors can be added by setting `--spotlight-rgb` to an RGB triplet:
+
+```css
+.spotlight-card--brand {
+  --spotlight-rgb: 34, 197, 94;
+}
+```
+
+## Why does it fit EaseMotion CSS?
+
+The existing spotlight-card submission in this repo relies on a `mousemove`
+JavaScript listener to update `--x` and `--y` custom properties so the glow
+follows the cursor. This submission is the CSS-only baseline: it uses
+`@property --spotlight-opacity` (a registered, interpolatable `<number>`) to
+animate the glow opacity on `:hover` via a standard CSS transition. No JS event
+listeners are needed, making it suitable for static sites, server-rendered pages,
+and environments where JS is disabled. The `::before` radial-gradient is hidden
+entirely under `prefers-reduced-motion`, keeping the component accessible.

--- a/submissions/examples/css-spotlight-card/demo.html
+++ b/submissions/examples/css-spotlight-card/demo.html
@@ -1,0 +1,109 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CSS Spotlight Card — EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: #010409;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        font-family:
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          sans-serif;
+        gap: 2rem;
+      }
+
+      .demo-heading {
+        text-align: center;
+        color: #e6edf3;
+      }
+
+      .demo-heading h1 {
+        margin: 0 0 0.5rem;
+        font-size: 1.75rem;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+      }
+
+      .demo-heading p {
+        margin: 0;
+        color: #8b949e;
+        font-size: 0.9rem;
+      }
+
+      .card-grid {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 1.25rem;
+        width: 100%;
+        max-width: 680px;
+      }
+
+      @media (max-width: 540px) {
+        .card-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="demo-heading">
+      <h1>CSS Spotlight Card</h1>
+      <p>Hover each card to see the pure-CSS spotlight glow effect</p>
+    </div>
+
+    <div class="card-grid">
+      <!-- Purple variant -->
+      <div class="spotlight-card spotlight-card--purple">
+        <h3>Purple Spotlight</h3>
+        <p>
+          A radial gradient centered at 50% 20% fades in via an animatable
+          @property custom property — no JavaScript required.
+        </p>
+      </div>
+
+      <!-- Cyan variant -->
+      <div class="spotlight-card spotlight-card--cyan">
+        <h3>Cyan Spotlight</h3>
+        <p>
+          Four color presets are available via --spotlight-rgb. Swap or extend
+          them freely in your own design system.
+        </p>
+      </div>
+
+      <!-- Amber variant -->
+      <div class="spotlight-card spotlight-card--amber">
+        <h3>Amber Spotlight</h3>
+        <p>
+          The border color also transitions on hover, matching the glow hue for
+          a cohesive illuminated look.
+        </p>
+      </div>
+
+      <!-- Pink variant -->
+      <div class="spotlight-card spotlight-card--pink">
+        <h3>Pink Spotlight</h3>
+        <p>
+          All transitions are suppressed under prefers-reduced-motion and the
+          ::before layer is hidden entirely.
+        </p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/css-spotlight-card/style.css
+++ b/submissions/examples/css-spotlight-card/style.css
@@ -1,0 +1,96 @@
+/* CSS Spotlight Card — pure CSS, no JavaScript required */
+/* Uses @property for animatable custom property and ::before radial-gradient */
+
+@property --spotlight-opacity {
+  syntax: "<number>";
+  inherits: false;
+  initial-value: 0;
+}
+
+/* ── Base Layout ─────────────────────────────────────────────── */
+.spotlight-card {
+  position: relative;
+  background: #0d1117;
+  border: 1px solid #21262d;
+  border-radius: 16px;
+  overflow: hidden;
+  padding: 2rem;
+  cursor: pointer;
+  transition:
+    --spotlight-opacity 0.4s ease,
+    border-color 0.3s ease;
+}
+
+/* ── Spotlight Glow Layer ────────────────────────────────────── */
+.spotlight-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(
+    circle 220px at 50% 20%,
+    rgba(var(--spotlight-rgb), calc(var(--spotlight-opacity) * 0.18)),
+    transparent 70%
+  );
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* Ensure card content sits above the glow layer */
+.spotlight-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+/* ── Hover State ─────────────────────────────────────────────── */
+.spotlight-card:hover {
+  --spotlight-opacity: 1;
+  border-color: rgba(var(--spotlight-rgb), 0.5);
+}
+
+/* ── Color Variants ──────────────────────────────────────────── */
+/* Purple: #6c63ff */
+.spotlight-card--purple {
+  --spotlight-rgb: 108, 99, 255;
+}
+
+/* Cyan: #06b6d4 */
+.spotlight-card--cyan {
+  --spotlight-rgb: 6, 182, 212;
+}
+
+/* Amber: #f59e0b */
+.spotlight-card--amber {
+  --spotlight-rgb: 245, 158, 11;
+}
+
+/* Pink: #ec4899 */
+.spotlight-card--pink {
+  --spotlight-rgb: 236, 72, 153;
+}
+
+/* ── Typography ──────────────────────────────────────────────── */
+.spotlight-card h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #e6edf3;
+}
+
+.spotlight-card p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #8b949e;
+  line-height: 1.6;
+}
+
+/* ── Accessibility: Reduced Motion ───────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .spotlight-card {
+    transition: border-color 0.3s ease;
+  }
+
+  .spotlight-card::before {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

The existing spotlight card submission uses JS mousemove to update --x/--y. This is the CSS-only baseline using @property --spotlight-opacity and a ::before radial-gradient centered at 50% 20%. Four color variants via --spotlight-rgb. Closes #35492

---

## Type of Change

- [x] ✨ New animation / hover effect

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A pure-CSS spotlight hover card that blooms a radial-gradient glow on hover using @property --spotlight-opacity — no JavaScript required.

**How does a developer use it?**

```html
<div class="spotlight-card spotlight-card--purple">
  <h3>Card Title</h3>
  <p>Description text here.</p>
</div>
```

**Why does it fit EaseMotion CSS?**

The @property registration makes --spotlight-opacity an interpolatable `<number>`, enabling a smooth CSS transition on the radial-gradient opacity. Four color variants (purple, cyan, amber, pink) are provided via --spotlight-rgb. The ::before glow layer is hidden under prefers-reduced-motion.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

@property and transition on custom properties are supported in Chrome 85+, Edge 85+, and Safari 15.4+. Firefox support for @property landed in Firefox 128. A graceful fallback (no glow, just a static card) is provided for older browsers.