### PR TITLE
feat: add animated toggle switch component

### DIFF
--- a/submissions/examples/animated-toggle-switch/README.md
+++ b/submissions/examples/animated-toggle-switch/README.md
@@ -1,0 +1,15 @@
+# Animated Toggle Switch
+
+An iOS-style toggle switch built on a native checkbox for accessibility, styled entirely with CSS.
+
+## Usage
+Wrap a checkbox input inside `.toggle-switch > .toggle-track > .toggle-thumb`. The `:checked` state drives the track color and thumb position via CSS sibling selectors.
+
+## Accessibility
+Uses a real `<input type="checkbox">` under the hood, so it's keyboard-navigable and screen-reader friendly. Includes a `:focus-visible` outline for keyboard users.
+
+## Browser support
+Works in all modern browsers — uses `transform`, `transition`, and the `~` sibling selector.
+
+## Notes
+No JavaScript required.

--- a/submissions/examples/animated-toggle-switch/demo.html
+++ b/submissions/examples/animated-toggle-switch/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Animated Toggle Switch Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body
+    style="display:flex; justify-content:center; align-items:center; min-height:100vh; margin:0; background:#f4f4f4; font-family:sans-serif;">
+
+    <label class="toggle-switch">
+        <input type="checkbox">
+        <span class="toggle-track">
+            <span class="toggle-thumb"></span>
+        </span>
+    </label>
+
+</body>
+
+</html>

--- a/submissions/examples/animated-toggle-switch/style.css
+++ b/submissions/examples/animated-toggle-switch/style.css
@@ -1,0 +1,46 @@
+.toggle-switch {
+    display: inline-block;
+    position: relative;
+    width: 52px;
+    height: 28px;
+    cursor: pointer;
+}
+
+.toggle-switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.toggle-track {
+    position: absolute;
+    inset: 0;
+    background: #ccc;
+    border-radius: 999px;
+    transition: background-color 0.3s ease;
+}
+
+.toggle-thumb {
+    position: absolute;
+    top: 3px;
+    left: 3px;
+    width: 22px;
+    height: 22px;
+    background: #ffffff;
+    border-radius: 50%;
+    transition: transform 0.3s ease;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}
+
+.toggle-switch input:checked~.toggle-track {
+    background: #4caf50;
+}
+
+.toggle-switch input:checked~.toggle-track .toggle-thumb {
+    transform: translateX(24px);
+}
+
+.toggle-switch input:focus-visible~.toggle-track {
+    outline: 2px solid #4caf50;
+    outline-offset: 2px;
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS animated toggle switch — an iOS-style switch with a smoothly sliding thumb and track color transition, built on a native checkbox for accessibility.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/animated-toggle-switch/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
An animated toggle switch component with a sliding thumb and a track that transitions color when toggled on/off.

**How does a developer use it?**
```html
<label class="toggle-switch">
  <input type="checkbox">
  <span class="toggle-track">
    <span class="toggle-thumb"></span>
  </span>
</label>
```

**Why does it fit EaseMotion CSS?**
The framework has no dedicated toggle/switch component yet, despite it being one of the most common interactive UI elements (settings pages, preference panels, feature flags). It's built on a native `<input type="checkbox">` for accessibility — keyboard-navigable and screen-reader friendly — and styled entirely with CSS, keeping it zero-dependency and fully composable, in line with the animation-first philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Edge

---

## Notes for Maintainer
Includes a `:focus-visible` outline for keyboard accessibility. Happy to adjust the transition timing or colors if you'd prefer something different from the defaults. Closes #36239.