### PR TITLE
feat: add animated skeleton loading shimmer component

### DIFF
--- a/submissions/examples/animated-skeleton-shimmer/README.md
+++ b/submissions/examples/animated-skeleton-shimmer/README.md
@@ -1,0 +1,17 @@
+# Animated Skeleton Loading Shimmer
+
+A loading placeholder component with an animated shimmer sweep, used to indicate content is loading (text lines, avatars, cards).
+
+## Usage
+Apply `.skeleton` alongside a shape modifier class:
+- `.skeleton-avatar` — circular avatar placeholder
+- `.skeleton-text` — text line placeholder
+- `.skeleton-text-short` — shorter text line variant
+
+Combine inside a `.skeleton-card` wrapper to build a full loading card layout.
+
+## Browser support
+Works in all modern browsers — uses CSS gradients and keyframe animations only.
+
+## Notes
+No JavaScript required. Swap the `.skeleton` elements for real content once data has loaded.

--- a/submissions/examples/animated-skeleton-shimmer/demo.html
+++ b/submissions/examples/animated-skeleton-shimmer/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Skeleton Loading Shimmer Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body
+    style="display:flex; justify-content:center; align-items:center; min-height:100vh; margin:0; background:#f4f4f4; font-family:sans-serif;">
+
+    <div class="skeleton-card" style="background:#ffffff; border-radius:12px; box-shadow:0 1px 4px rgba(0,0,0,0.1);">
+        <div class="skeleton-card-row">
+            <div class="skeleton skeleton-avatar"></div>
+            <div style="flex:1;">
+                <div class="skeleton skeleton-text skeleton-text-short"></div>
+            </div>
+        </div>
+        <div class="skeleton skeleton-text"></div>
+        <div class="skeleton skeleton-text"></div>
+        <div class="skeleton skeleton-text skeleton-text-short"></div>
+    </div>
+
+</body>
+
+</html>

--- a/submissions/examples/animated-skeleton-shimmer/style.css
+++ b/submissions/examples/animated-skeleton-shimmer/style.css
@@ -1,0 +1,49 @@
+.skeleton {
+    background: linear-gradient(90deg,
+            #e0e0e0 25%,
+            #f0f0f0 37%,
+            #e0e0e0 63%);
+    background-size: 400% 100%;
+    animation: skeleton-shimmer 1.4s ease-in-out infinite;
+    border-radius: 4px;
+}
+
+@keyframes skeleton-shimmer {
+    0% {
+        background-position: 100% 50%;
+    }
+
+    100% {
+        background-position: 0% 50%;
+    }
+}
+
+.skeleton-avatar {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+}
+
+.skeleton-text {
+    width: 100%;
+    height: 14px;
+    margin-top: 8px;
+}
+
+.skeleton-text-short {
+    width: 60%;
+}
+
+.skeleton-card {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 16px;
+    max-width: 280px;
+}
+
+.skeleton-card-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS animated skeleton loading shimmer component — a placeholder UI that mimics content (avatar circles, text lines) with an animated gradient sweep while real content is loading.

Note: named `animated-skeleton-shimmer` since `skeleton-loading-shimmer` already exists in the repo — this is a distinct implementation.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/animated-skeleton-shimmer/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A skeleton loading placeholder with an animated shimmer sweep, used to indicate content is loading.

**How does a developer use it?**
```html
<div class="skeleton skeleton-avatar"></div>
<div class="skeleton skeleton-text"></div>
<div class="skeleton skeleton-text skeleton-text-short"></div>
```

**Why does it fit EaseMotion CSS?**
Skeleton loaders are a near-universal pattern in modern UIs (social feeds, dashboards, product grids), and the shimmer motion is the entire value of the component — a perfect fit for the animation-first philosophy. Pure CSS, zero dependencies, using only a gradient and a `background-position` keyframe animation.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Edge

---

## Notes for Maintainer
Named this submission `animated-skeleton-shimmer` to avoid colliding with the existing `skeleton-loading-shimmer` folder already merged in `main`. Happy to adjust naming, shimmer speed, or gradient colors if preferred. Closes #36247.