### PR TITLE
feat: add per-element scroll reveal grid using animation-timeline: view()

### DIFF
--- a/submissions/examples/view-timeline-stagger-grid/README.md
+++ b/submissions/examples/view-timeline-stagger-grid/README.md
@@ -1,0 +1,30 @@
+# Per-Element Scroll-Reveal Grid (`animation-timeline: view()`)
+
+## What does this do?
+
+A card grid where each individual card fires its own entrance animation at the moment it enters the viewport — using `animation-timeline: view()`.
+
+## How is it used?
+
+```html
+<div class="reveal-grid">
+  <div class="grid-card">
+    <h3>Title</h3>
+    <p>Content</p>
+  </div>
+</div>
+```
+
+```css
+@supports (animation-timeline: view()) {
+  .grid-card {
+    animation: card-enter linear both;
+    animation-timeline: view();
+    animation-range: entry 0% entry 35%;
+  }
+}
+```
+
+## Why is it useful?
+
+Intersection Observer is the current standard for scroll-reveal. `animation-timeline: view()` replaces it entirely for visual entrance effects with no JS and no event listeners. The existing scroll-driven submissions in EaseMotion use `scroll(root)` which ties the animation to the root scroll container — not the element's own viewport entry. The `view()` approach is per-element, composable, and requires no wrapper logic. This is the missing bridge between EaseMotion's scroll-animation utilities and real-world landing page builds.

--- a/submissions/examples/view-timeline-stagger-grid/demo.html
+++ b/submissions/examples/view-timeline-stagger-grid/demo.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EaseMotion CSS - view() Timeline Stagger Grid</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      body {
+        font-family: system-ui, -apple-system, sans-serif;
+        background: #0d1117;
+        color: #e6edf3;
+        margin: 0;
+        padding: 0;
+      }
+
+      .hero {
+        height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        border-bottom: 1px solid #21262d;
+      }
+
+      .hero h1 {
+        font-size: 3rem;
+        margin: 0 0 1rem;
+        background: linear-gradient(135deg, #6c63ff, #ec4899);
+        -webkit-background-clip: text;
+        background-clip: text;
+        color: transparent;
+      }
+
+      .hero p {
+        color: #8b949e;
+        font-size: 1.1rem;
+        max-width: 500px;
+        line-height: 1.6;
+      }
+
+      .section {
+        padding: 6rem 2rem;
+        border-bottom: 1px solid #21262d;
+      }
+
+      .section-header {
+        text-align: center;
+        margin-bottom: 4rem;
+      }
+
+      .section-header h2 {
+        font-size: 2rem;
+        margin: 0 0 0.5rem;
+      }
+
+      .section-header p {
+        color: #8b949e;
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="hero">
+      <h1>Scroll to Reveal</h1>
+      <p>
+        These grids use <code>animation-timeline: view()</code>. Each card fires
+        its entrance animation the moment it enters the viewport. No JS.
+      </p>
+    </div>
+
+    <div class="section">
+      <div class="section-header">
+        <h2>Features</h2>
+        <p>First grid section</p>
+      </div>
+
+      <div class="reveal-grid">
+        <div class="grid-card">
+          <h3>Performance</h3>
+          <p>GPU-accelerated, zero layout thrashing.</p>
+        </div>
+        <div class="grid-card">
+          <h3>Composable</h3>
+          <p>Works alongside any CSS framework.</p>
+        </div>
+        <div class="grid-card">
+          <h3>Accessible</h3>
+          <p>Respects prefers-reduced-motion.</p>
+        </div>
+        <div class="grid-card">
+          <h3>Per-Element</h3>
+          <p>Timeline attached to the card, not the root.</p>
+        </div>
+        <div class="grid-card">
+          <h3>Staggered</h3>
+          <p>Columns offset via animation-range.</p>
+        </div>
+        <div class="grid-card">
+          <h3>No JS</h3>
+          <p>Replaces Intersection Observer entirely.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="section">
+      <div class="section-header">
+        <h2>More Features</h2>
+        <p>Keep scrolling for the second grid</p>
+      </div>
+
+      <div class="reveal-grid">
+        <div class="grid-card">
+          <h3>Declarative</h3>
+          <p>Animation logic stays in CSS.</p>
+        </div>
+        <div class="grid-card">
+          <h3>Responsive</h3>
+          <p>Adapts to any viewport size.</p>
+        </div>
+        <div class="grid-card">
+          <h3>Fallback</h3>
+          <p>Graceful degradation built-in.</p>
+        </div>
+        <div class="grid-card">
+          <h3>Reusable</h3>
+          <p>Apply the class anywhere.</p>
+        </div>
+        <div class="grid-card">
+          <h3>Smooth</h3>
+          <p>Tied directly to scroll velocity.</p>
+        </div>
+        <div class="grid-card">
+          <h3>Modern</h3>
+          <p>Uses the latest CSS standards.</p>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/view-timeline-stagger-grid/style.css
+++ b/submissions/examples/view-timeline-stagger-grid/style.css
@@ -1,0 +1,84 @@
+/* Per-Element Scroll-Reveal using animation-timeline: view()
+   Each element tracks its own scroll intersection. */
+
+@keyframes card-enter {
+  from {
+    opacity: 0;
+    translate: 0 40px;
+    scale: 0.96;
+  }
+  to {
+    opacity: 1;
+    translate: 0 0;
+    scale: 1;
+  }
+}
+
+.reveal-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+/* Base card styling */
+.grid-card {
+  background: #161b22;
+  border: 1px solid #21262d;
+  border-radius: 12px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.grid-card h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #e6edf3;
+}
+
+.grid-card p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #8b949e;
+  line-height: 1.5;
+}
+
+/* Scroll animation applied to each card individually */
+@supports (animation-timeline: view()) {
+  .grid-card {
+    animation: card-enter linear both;
+    animation-timeline: view();
+    /* Default: animate as element enters bottom 35% of viewport */
+    animation-range: entry 0% entry 35%;
+  }
+
+  /* Stagger across columns */
+  .grid-card:nth-child(3n + 2) {
+    animation-range: entry 5% entry 40%;
+  }
+  
+  .grid-card:nth-child(3n + 3) {
+    animation-range: entry 10% entry 45%;
+  }
+}
+
+/* Static fallback for unsupported browsers */
+@supports not (animation-timeline: view()) {
+  .grid-card {
+    opacity: 1;
+    translate: none;
+    scale: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .grid-card {
+    animation: none;
+    opacity: 1;
+    translate: none;
+    scale: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Each `.grid-card` fires its own entrance animation (opacity + translate + scale) the moment it enters the viewport via `animation-timeline: view()`. This is distinct from `scroll(root)` used in other scroll-driven submissions — `view()` attaches to the element itself, not the root container. `@supports` guard for static fallback.

Closes #35501

---

## Type of Change

- [x] New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/view-timeline-stagger-grid/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A card grid where each individual card fires its own entrance animation at the moment it enters the viewport — using `animation-timeline: view()`.

**How does a developer use it?**

```html
<div class="reveal-grid">
  <div class="grid-card">
    <h3>Title</h3>
    <p>Content</p>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**

Intersection Observer is the current standard for scroll-reveal. `animation-timeline: view()` replaces it entirely for visual entrance effects with no JS and no event listeners. The existing scroll-driven submissions in EaseMotion use `scroll(root)` which ties the animation to the root scroll container — not the element's own viewport entry. The `view()` approach is per-element, composable, and requires no wrapper logic.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer

`animation-range: entry 0% entry 35%` provides a smooth, progressive reveal as cards enter the viewport from the bottom.