### PR TITLE
feat: add @starting-style enter/exit animation for dialog and details

### DIFF
--- a/submissions/examples/starting-style-dialog-details/README.md
+++ b/submissions/examples/starting-style-dialog-details/README.md
@@ -1,0 +1,39 @@
+# `@starting-style` Dialog and Details Animation
+
+## What does this do?
+
+Demonstrates the three-ingredient recipe required to animate elements transitioning to and from `display: none` natively in CSS:
+1. `@starting-style` to define the initial state.
+2. `transition: display allow-discrete` to keep the element painted while animating out.
+3. `transition: overlay allow-discrete` (for top-layer elements like `<dialog>`).
+
+## How is it used?
+
+```css
+/* 1. Define the normal open state */
+details[open] .faq-body {
+  opacity: 1;
+  translate: 0 0;
+}
+
+/* 2. Define the starting state (when opening) */
+@starting-style {
+  details[open] .faq-body {
+    opacity: 0;
+    translate: 0 -8px;
+  }
+}
+
+/* 3. Define the closed state and the transition with allow-discrete */
+.faq-body {
+  opacity: 0;
+  translate: 0 -8px;
+  transition: opacity 0.3s ease, 
+              translate 0.3s ease, 
+              display 0.3s allow-discrete;
+}
+```
+
+## Why is it useful?
+
+Historically, animating elements in and out of the DOM (or `display: none`) required complex JavaScript to wait for the animation to finish before removing the element, or hacky workarounds like animating `max-height: 1000px`. `@starting-style` allows pure CSS entry/exit animations for natively toggled elements. This submission provides two practical templates: a `<dialog>` with a backdrop fade, and a pure HTML `<details>` accordion — a pattern that previously had no clean CSS-only animation solution. Chrome 117+, Firefox (in development), Safari 17.5+.

--- a/submissions/examples/starting-style-dialog-details/demo.html
+++ b/submissions/examples/starting-style-dialog-details/demo.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EaseMotion CSS - @starting-style Enter/Exit Animations</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      body {
+        font-family: system-ui, -apple-system, sans-serif;
+        background: #0d1117;
+        color: #e6edf3;
+        margin: 0;
+        padding: 4rem 2rem;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 4rem;
+      }
+
+      .container {
+        max-width: 600px;
+        width: 100%;
+      }
+
+      h1 {
+        text-align: center;
+        font-size: 2rem;
+        background: linear-gradient(135deg, #a78bfa, #3b82f6);
+        -webkit-background-clip: text;
+        background-clip: text;
+        color: transparent;
+        margin-bottom: 2rem;
+      }
+
+      .section-title {
+        font-size: 1.25rem;
+        color: #8b949e;
+        margin-bottom: 1.5rem;
+        border-bottom: 1px solid #21262d;
+        padding-bottom: 0.5rem;
+      }
+
+      .btn {
+        background: #7c3aed;
+        color: white;
+        border: none;
+        padding: 0.75rem 1.5rem;
+        border-radius: 8px;
+        font-size: 1rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background 0.2s;
+      }
+
+      .btn:hover {
+        background: #6d28d9;
+      }
+
+      .btn-outline {
+        background: transparent;
+        border: 1px solid #484f58;
+        color: #c9d1d9;
+      }
+
+      .btn-outline:hover {
+        background: #21262d;
+      }
+
+      .dialog-header {
+        margin-top: 0;
+        margin-bottom: 1rem;
+        color: #c9d1d9;
+      }
+
+      .dialog-text {
+        color: #8b949e;
+        line-height: 1.6;
+        margin-bottom: 2rem;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>@starting-style Animations</h1>
+
+      <!-- Dialog Section -->
+      <section>
+        <h2 class="section-title">Part 1: Dialog Modal</h2>
+        <button id="open-dialog" class="btn">Open Animated Dialog</button>
+
+        <dialog id="demo-dialog">
+          <h2 class="dialog-header">Animated Dialog</h2>
+          <p class="dialog-text">
+            This dialog fades and scales in/out using
+            <code>@starting-style</code>. The backdrop dims smoothly. There is
+            no animation code in the JavaScript — it only calls
+            <code>showModal()</code> and <code>close()</code>.
+          </p>
+          <button id="close-dialog" class="btn btn-outline">Close</button>
+        </dialog>
+      </section>
+
+      <!-- Details/Accordion Section -->
+      <section style="margin-top: 3rem">
+        <h2 class="section-title">Part 2: Pure CSS Accordion</h2>
+
+        <details class="faq-item">
+          <summary class="faq-question">What is @starting-style?</summary>
+          <div class="faq-body">
+            <p>
+              It defines the initial visual state of an element the moment it
+              becomes visible (transitions from <code>display: none</code> to
+              <code>block</code>).
+            </p>
+          </div>
+        </details>
+
+        <details class="faq-item">
+          <summary class="faq-question">Why use allow-discrete?</summary>
+          <div class="faq-body">
+            <p>
+              Because <code>display</code> is a discrete property, it can't be
+              interpolated normally. <code>allow-discrete</code> tells the
+              browser to flip the display value at the <em>end</em> of the exit
+              transition, keeping the element painted while it fades out.
+            </p>
+          </div>
+        </details>
+
+        <details class="faq-item">
+          <summary class="faq-question">Any JavaScript needed here?</summary>
+          <div class="faq-body">
+            <p>
+              Zero JavaScript. This uses the native HTML
+              <code>&lt;details&gt;</code> element's built-in toggle behavior,
+              enhanced purely by CSS transitions. No
+              <code>max-height</code> hacks required!
+            </p>
+          </div>
+        </details>
+      </section>
+    </div>
+
+    <!-- Minimal script just to open/close the dialog natively -->
+    <script>
+      const dialog = document.getElementById("demo-dialog");
+      const openBtn = document.getElementById("open-dialog");
+      const closeBtn = document.getElementById("close-dialog");
+
+      openBtn.addEventListener("click", () => dialog.showModal());
+      closeBtn.addEventListener("click", () => dialog.close());
+    </script>
+  </body>
+</html>

--- a/submissions/examples/starting-style-dialog-details/style.css
+++ b/submissions/examples/starting-style-dialog-details/style.css
@@ -1,0 +1,120 @@
+/* @starting-style Enter/Exit Animations
+   Requires the three-ingredient recipe for display:none elements:
+   1. @starting-style block
+   2. transition: ... allow-discrete
+   3. overlay ... allow-discrete (for top-layer elements) */
+
+/* ── Dialog enter/exit ── */
+dialog[open] {
+  opacity: 1;
+  scale: 1;
+  transition: opacity 0.3s ease,
+    scale 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
+    display 0.3s allow-discrete,
+    overlay 0.3s allow-discrete;
+}
+
+@starting-style {
+  dialog[open] {
+    opacity: 0;
+    scale: 0.9;
+  }
+}
+
+/* Backdrop animation */
+dialog[open]::backdrop {
+  background: rgba(0, 0, 0, 0.6);
+  transition: background 0.3s,
+    display 0.3s allow-discrete,
+    overlay 0.3s allow-discrete;
+}
+
+@starting-style {
+  dialog[open]::backdrop {
+    background: rgba(0, 0, 0, 0);
+  }
+}
+
+/* Dialog base styling */
+dialog {
+  margin: auto;
+  max-width: 500px;
+  width: 90%;
+  border-radius: 16px;
+  padding: 2rem;
+  border: 1px solid #21262d;
+  background: #161b22;
+  color: #e6edf3;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+}
+
+/* ── Details accordion (pure CSS, no JS) ── */
+.faq-body {
+  opacity: 0;
+  translate: 0 -8px;
+  /* Allow-discrete opts display into the transition lifecycle */
+  transition: opacity 0.3s ease,
+    translate 0.3s ease,
+    display 0.3s allow-discrete;
+}
+
+details[open] .faq-body {
+  opacity: 1;
+  translate: 0 0;
+}
+
+@starting-style {
+  details[open] .faq-body {
+    opacity: 0;
+    translate: 0 -8px;
+  }
+}
+
+/* Details base styling */
+.faq-item {
+  background: #0d1117;
+  border: 1px solid #21262d;
+  border-radius: 12px;
+  margin-bottom: 1rem;
+  overflow: hidden;
+}
+
+.faq-question {
+  cursor: pointer;
+  list-style: none; /* Hide default arrow */
+  padding: 1.25rem 1.5rem;
+  font-weight: 600;
+  color: #c9d1d9;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+/* Custom arrow */
+.faq-question::after {
+  content: "↓";
+  transition: transform 0.3s ease;
+}
+
+details[open] .faq-question::after {
+  transform: rotate(180deg);
+}
+
+details[open] .faq-question {
+  border-bottom: 1px solid #21262d;
+}
+
+.faq-body p {
+  padding: 1.25rem 1.5rem;
+  margin: 0;
+  color: #8b949e;
+  line-height: 1.6;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  dialog[open],
+  dialog[open]::backdrop,
+  .faq-body {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Demonstrates the three-ingredient recipe for animating `display:none` elements: `@starting-style` + `transition: allow-discrete` + `overlay allow-discrete`. Part 1 covers `<dialog>` with backdrop fade. Part 2 covers `<details>` accordion — pure CSS animated open/close, no JS, no max-height hack. The `<details>` + `@starting-style` combination specifically is absent from existing submissions.

Closes #35502

---

## Type of Change

- [x] New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/starting-style-dialog-details/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Two practical templates for animating elements transitioning to and from `display: none` natively in CSS using `@starting-style`: a `<dialog>` modal and a `<details>` accordion.

**How does a developer use it?**

```css
.faq-body {
  transition: opacity 0.3s ease, display 0.3s allow-discrete;
}

@starting-style {
  details[open] .faq-body {
    opacity: 0;
  }
}
```

**Why does it fit EaseMotion CSS?**

Historically, animating elements in and out of the DOM required complex JavaScript or hacky workarounds like animating `max-height: 1000px`. `@starting-style` allows pure CSS entry/exit animations for natively toggled elements. This pattern previously had no clean CSS-only animation solution in the repository.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [x] Safari

---

## Notes for Maintainer

`@starting-style` is supported in Chrome 117+, Edge 117+, Safari 17.5+, and Firefox 129+.