### PR TITLE
feat: add SVG stroke-dashoffset path draw animation showcase

### DIFF
--- a/submissions/examples/svg-stroke-draw/README.md
+++ b/submissions/examples/svg-stroke-draw/README.md
@@ -1,0 +1,34 @@
+# SVG Stroke Draw Showcase
+
+## What does this do?
+
+Demonstrates three common SVG stroke draw animations (a signature reveal, a success checkmark, and a multi-path icon) using pure CSS `stroke-dashoffset`.
+
+## How is it used?
+
+```html
+<svg viewBox="0 0 100 100">
+  <path 
+    class="draw-path" 
+    style="--path-length: 283" 
+    d="..." 
+  />
+</svg>
+```
+
+```css
+@keyframes draw-stroke {
+  from { stroke-dashoffset: var(--path-length); }
+  to   { stroke-dashoffset: 0; }
+}
+
+.draw-path {
+  stroke-dasharray: var(--path-length);
+  stroke-dashoffset: var(--path-length);
+  animation: draw-stroke 1.2s ease-in-out forwards;
+}
+```
+
+## Why is it useful?
+
+Drawing SVG paths is a classic animation effect, but developers frequently reach for heavy JavaScript libraries (like GSAP's DrawSVGPlugin) to achieve it because hardcoding path lengths in CSS is tedious. By setting the path length as an inline custom property (`--path-length`), we can use a single reusable `@keyframes` definition for *any* SVG path. This submission consolidates three common use-cases into one reference implementation, entirely in CSS.

--- a/submissions/examples/svg-stroke-draw/demo.html
+++ b/submissions/examples/svg-stroke-draw/demo.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EaseMotion CSS - SVG Stroke Draw</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      body {
+        font-family: system-ui, -apple-system, sans-serif;
+        background: #0d1117;
+        color: #e6edf3;
+        margin: 0;
+        padding: 4rem 2rem;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 2rem;
+      }
+
+      h1 {
+        margin: 0;
+        background: linear-gradient(135deg, #a78bfa, #3b82f6);
+        -webkit-background-clip: text;
+        background-clip: text;
+        color: transparent;
+      }
+
+      p {
+        color: #8b949e;
+        margin-bottom: 2rem;
+      }
+
+      .demo-grid {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 2rem;
+      }
+
+      .replay-btn {
+        background: transparent;
+        color: #8b949e;
+        border: 1px solid #484f58;
+        padding: 0.5rem 1rem;
+        border-radius: 6px;
+        cursor: pointer;
+        font-size: 0.85rem;
+        transition: all 0.2s;
+        margin-top: 1rem;
+      }
+
+      .replay-btn:hover {
+        background: #21262d;
+        color: #e6edf3;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>SVG Stroke Draw</h1>
+    <p>Using <code>stroke-dashoffset</code> to draw paths purely via CSS.</p>
+
+    <div class="demo-grid">
+      <!-- Section 1: Signature -->
+      <div class="demo-section signature">
+        <h3>Signature</h3>
+        <svg class="demo-svg" viewBox="0 0 200 80">
+          <path
+            class="draw-path"
+            style="--path-length: 300"
+            stroke-width="3"
+            d="M 20,60 C 20,60 40,-20 60,60 C 80,-20 100,80 120,40 C 140,0 160,80 180,20"
+          />
+        </svg>
+        <button class="replay-btn" onclick="replay(this)">Replay</button>
+      </div>
+
+      <!-- Section 2: Checkmark -->
+      <div class="demo-section checkmark">
+        <h3>Success Checkmark</h3>
+        <svg class="demo-svg" viewBox="0 0 100 100">
+          <circle
+            class="draw-path"
+            style="--path-length: 283"
+            cx="50"
+            cy="50"
+            r="45"
+            stroke-width="5"
+          />
+          <polyline
+            class="draw-path"
+            style="--path-length: 75"
+            points="25,50 45,70 75,30"
+            stroke-width="5"
+          />
+        </svg>
+        <button class="replay-btn" onclick="replay(this)">Replay</button>
+      </div>
+
+      <!-- Section 3: Multi-path Icon -->
+      <div class="demo-section multi-path">
+        <h3>Multi-path Icon</h3>
+        <!-- Cloud outline with a lightning bolt -->
+        <svg class="demo-svg" viewBox="0 0 100 100">
+          <path
+            class="draw-path"
+            style="--path-length: 230"
+            stroke-width="5"
+            d="M 30,70 A 20,20 0 0,1 30,30 A 25,25 0 0,1 80,40 A 20,20 0 0,1 70,80 Z"
+          />
+          <polyline
+            class="draw-path"
+            style="--path-length: 70"
+            points="55,35 45,55 60,55 45,85"
+            stroke-width="4"
+          />
+        </svg>
+        <button class="replay-btn" onclick="replay(this)">Replay</button>
+      </div>
+    </div>
+
+    <script>
+      function replay(btn) {
+        const section = btn.closest(".demo-section");
+        // Force reflow to restart CSS animation
+        section.classList.add("is-drawing");
+        void section.offsetWidth; // trigger reflow
+        section.classList.remove("is-drawing");
+      }
+    </script>
+  </body>
+</html>

--- a/submissions/examples/svg-stroke-draw/style.css
+++ b/submissions/examples/svg-stroke-draw/style.css
@@ -1,0 +1,94 @@
+/* SVG Stroke Draw Animation
+   Uses stroke-dashoffset to draw SVG paths.
+   The path length must be provided via the --path-length inline style variable. */
+
+@keyframes draw-stroke {
+  from {
+    stroke-dashoffset: var(--path-length, 600);
+  }
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+.draw-path {
+  fill: none;
+  stroke: currentColor;
+  /* Setup dash array and offset to the exact path length */
+  stroke-dasharray: var(--path-length, 600);
+  stroke-dashoffset: var(--path-length, 600);
+  animation: draw-stroke 1.2s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+/* Base styles for demo containers */
+.demo-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  background: #161b22;
+  border: 1px solid #21262d;
+  border-radius: 12px;
+  padding: 3rem;
+  min-width: 280px;
+}
+
+.demo-svg {
+  width: 120px;
+  height: 120px;
+  color: #c9d1d9;
+}
+
+/* Section 1: Signature */
+.signature .demo-svg {
+  width: 200px;
+  height: 80px;
+  color: #a78bfa;
+}
+.signature .draw-path {
+  animation-duration: 2s;
+  animation-timing-function: ease-in-out;
+}
+
+/* Section 2: Checkmark */
+.checkmark .demo-svg {
+  color: #10b981;
+}
+.checkmark .draw-path:nth-child(1) {
+  /* Circle */
+  animation-duration: 0.8s;
+}
+.checkmark .draw-path:nth-child(2) {
+  /* Check */
+  animation-duration: 0.5s;
+  animation-delay: 0.8s;
+}
+
+/* Section 3: Multi-path Icon */
+.multi-path .demo-svg {
+  color: #3b82f6;
+}
+.multi-path .draw-path:nth-child(1) {
+  animation-delay: 0s;
+}
+.multi-path .draw-path:nth-child(2) {
+  animation-delay: 0.4s;
+}
+.multi-path .draw-path:nth-child(3) {
+  animation-delay: 0.8s;
+}
+
+/* Replay functionality via class toggle */
+.is-drawing .draw-path {
+  animation: none;
+}
+/* A tiny delay before reapplying the animation class */
+
+@media (prefers-reduced-motion: reduce) {
+  .draw-path {
+    animation: none !important;
+    stroke-dashoffset: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Three practical `stroke-dashoffset` demos in one submission: signature reveal, success checkmark, and multi-path staggered icon. `--path-length` is set inline on each element so the keyframe can reference it via `var()`. Replaces common JS/SMIL stroke animation patterns with pure CSS.

Closes #35503

---

## Type of Change

- [x] New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/svg-stroke-draw/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Demonstrates three common SVG stroke draw animations (a signature reveal, a success checkmark, and a multi-path icon) using pure CSS `stroke-dashoffset`.

**How does a developer use it?**

```html
<svg viewBox="0 0 100 100">
  <path class="draw-path" style="--path-length: 283" d="..." />
</svg>
```

**Why does it fit EaseMotion CSS?**

Drawing SVG paths is a classic animation effect, but developers frequently reach for heavy JavaScript libraries to achieve it because hardcoding path lengths in CSS is tedious. By setting the path length as an inline custom property (`--path-length`), we can use a single reusable `@keyframes` definition for *any* SVG path.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer

Uses a tiny inline script in the demo merely to toggle a class to replay the animation.