### PR TITLE
feat: add conic-gradient progress ring animated via @property --progress

### DIFF
--- a/submissions/examples/conic-gradient-progress-clock/README.md
+++ b/submissions/examples/conic-gradient-progress-clock/README.md
@@ -1,0 +1,35 @@
+# Conic Gradient Progress Ring
+
+## What does this do?
+
+Animates a donut-style progress ring by driving a `conic-gradient()` with a `@property`-registered custom property (`--progress`).
+
+## How is it used?
+
+```css
+@property --progress {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 0%;
+}
+
+@keyframes progress-fill {
+  to { --progress: var(--target); }
+}
+
+.progress-ring {
+  background: conic-gradient(
+    blue var(--progress), 
+    transparent var(--progress)
+  );
+  animation: progress-fill 1.5s ease-out forwards;
+}
+```
+
+```html
+<div class="progress-ring" style="--target: 75%"></div>
+```
+
+## Why is it useful?
+
+Progress rings are traditionally built using SVG `<circle>` and `stroke-dasharray` math. CSS `conic-gradient()` is a much simpler layout primitive, but gradients cannot natively animate color stop positions. By registering `--progress` as a `<percentage>` via `@property`, the browser's engine knows how to mathematically interpolate the value during a `@keyframes` animation, allowing the gradient to sweep smoothly. This demo provides three variants: a linear countdown, a spring-eased skill fill, and a nested system monitor cluster.

--- a/submissions/examples/conic-gradient-progress-clock/demo.html
+++ b/submissions/examples/conic-gradient-progress-clock/demo.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EaseMotion CSS - Conic Gradient Progress Ring</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      body {
+        font-family: system-ui, -apple-system, sans-serif;
+        background: #0d1117;
+        color: #e6edf3;
+        margin: 0;
+        padding: 4rem 2rem;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 3rem;
+      }
+
+      h1 {
+        margin: 0 0 0.5rem;
+        background: linear-gradient(135deg, #a78bfa, #f472b6);
+        -webkit-background-clip: text;
+        background-clip: text;
+        color: transparent;
+        text-align: center;
+      }
+
+      p.desc {
+        color: #8b949e;
+        text-align: center;
+        margin-bottom: 3rem;
+      }
+
+      .demo-grid {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 2rem;
+        width: 100%;
+        max-width: 900px;
+      }
+
+      .demo-card {
+        background: #161b22;
+        border: 1px solid #21262d;
+        border-radius: 16px;
+        padding: 2.5rem 2rem;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 1.5rem;
+        flex: 1;
+        min-width: 250px;
+      }
+
+      .demo-card h3 {
+        margin: 0;
+        font-size: 1rem;
+        color: #c9d1d9;
+      }
+
+      .note {
+        background: rgba(167, 139, 250, 0.1);
+        border: 1px solid rgba(167, 139, 250, 0.3);
+        color: #a78bfa;
+        padding: 1rem;
+        border-radius: 8px;
+        font-size: 0.85rem;
+        max-width: 600px;
+        text-align: center;
+        line-height: 1.5;
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      <h1>@property Conic Progress</h1>
+      <p class="desc">
+        Real CSS gradient interpolation, no SVG `stroke-dasharray` required.
+      </p>
+    </div>
+
+    <div class="demo-grid">
+      <!-- Demo 1: Countdown -->
+      <div class="demo-card">
+        <h3>15s Countdown</h3>
+        <div
+          class="progress-ring progress-ring--countdown"
+          style="--duration: 15s; --accent: #ef4444"
+        >
+          <div class="ring-label">
+            Timer
+            <span>running</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Demo 2: Skill Fill -->
+      <div class="demo-card">
+        <h3>Skill Completion</h3>
+        <div
+          class="progress-ring progress-ring--fill"
+          style="--target: 78%; --accent: #3b82f6"
+        >
+          <div class="ring-label" style="font-size: 1.5rem">78%</div>
+        </div>
+      </div>
+
+      <!-- Demo 3: Concentric Monitor -->
+      <div class="demo-card">
+        <h3>System Monitor</h3>
+        <div class="ring-cluster">
+          <!-- Outer: CPU -->
+          <div
+            class="progress-ring progress-ring--fill"
+            style="
+              --ring-size: 180px;
+              --ring-thickness: 10px;
+              --target: 85%;
+              --accent: #ec4899;
+              animation-delay: 0s;
+            "
+          ></div>
+          <!-- Middle: RAM -->
+          <div
+            class="progress-ring progress-ring--fill"
+            style="
+              --ring-size: 140px;
+              --ring-thickness: 10px;
+              --target: 62%;
+              --accent: #a855f7;
+              animation-delay: 0.2s;
+            "
+          ></div>
+          <!-- Inner: Disk -->
+          <div
+            class="progress-ring progress-ring--fill"
+            style="
+              --ring-size: 100px;
+              --ring-thickness: 10px;
+              --target: 40%;
+              --accent: #06b6d4;
+              animation-delay: 0.4s;
+            "
+          ></div>
+          <div class="ring-label" style="z-index: 10">Sys</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="note">
+      Requires <code>@property</code> support (Chrome 85+, Firefox 128+, Safari
+      16.4+). Without typing <code>--progress</code> as a
+      <code>&lt;percentage&gt;</code>, CSS engines treat the custom property as
+      a string and fall back to a discrete 0-to-100 jump instead of smooth
+      interpolation.
+    </div>
+  </body>
+</html>

--- a/submissions/examples/conic-gradient-progress-clock/style.css
+++ b/submissions/examples/conic-gradient-progress-clock/style.css
@@ -1,0 +1,108 @@
+/* @property allows --progress to be animated like a real number/percentage
+   Without this, browsers treat custom properties as strings and can't interpolate them. */
+@property --progress {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 0%;
+}
+
+/* Countdown: from 100% down to 0% */
+@keyframes countdown-fill {
+  from {
+    --progress: 100%;
+  }
+  to {
+    --progress: 0%;
+  }
+}
+
+/* Fill up to a target percentage */
+@keyframes progress-fill {
+  from {
+    --progress: 0%;
+  }
+  to {
+    --progress: var(--target, 75%);
+  }
+}
+
+.progress-ring {
+  position: relative;
+  width: var(--ring-size, 140px);
+  height: var(--ring-size, 140px);
+  border-radius: 50%;
+  /* The conic gradient uses --progress to determine where the accent color stops */
+  background: conic-gradient(
+    from -90deg,
+    var(--accent, #6c63ff) var(--progress),
+    #1e293b var(--progress)
+  );
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Donut hole cutout */
+.progress-ring::before {
+  content: "";
+  position: absolute;
+  inset: var(--ring-thickness, 12px);
+  background: #0d1117;
+  border-radius: 50%;
+}
+
+/* Label inside the ring */
+.ring-label {
+  position: relative;
+  z-index: 1;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: #e6edf3;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  line-height: 1.2;
+}
+
+.ring-label span {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: #8b949e;
+}
+
+/* Modifiers */
+.progress-ring--countdown {
+  /* Use linear for smooth clock-like ticks */
+  animation: countdown-fill var(--duration, 10s) linear forwards;
+}
+
+.progress-ring--fill {
+  /* Use cubic-bezier for a springy fill effect */
+  animation: progress-fill 1.5s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+/* Concentric rings monitor setup */
+.ring-cluster {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ring-cluster .progress-ring {
+  position: absolute;
+}
+/* Ensure the cutout matches the background of the cluster */
+.ring-cluster .progress-ring::before {
+  background: #161b22;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .progress-ring {
+    animation: none !important;
+    /* Static fallback to the target or 100% */
+    --progress: var(--target, 100%);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

A donut-style progress ring where the arc is driven by animating `--progress`, a `@property`-registered `<percentage>`. Without the type registration the browser treats custom properties as strings and can't interpolate them inside `conic-gradient()`. Three variants: countdown, skill fill, concentric system monitor.

Closes #35507

---

## Type of Change

- [x] New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/conic-gradient-progress-clock/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Animates a donut-style progress ring by driving a `conic-gradient()` with a `@property`-registered custom property (`--progress`).

**How does a developer use it?**

```css
@property --progress {
  syntax: "<percentage>";
  inherits: false;
  initial-value: 0%;
}
```
```html
<div class="progress-ring" style="--target: 75%"></div>
```

**Why does it fit EaseMotion CSS?**

Progress rings are traditionally built using SVG `<circle>` and `stroke-dasharray` math. CSS `conic-gradient()` is a much simpler layout primitive, but gradients cannot natively animate color stop positions. By registering `--progress` as a `<percentage>` via `@property`, the browser's engine knows how to mathematically interpolate the value during a `@keyframes` animation, allowing the gradient to sweep smoothly.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---

## Notes for Maintainer

Requires Chrome 85+, Firefox 128+, Safari 16.4+ for `@property` support.