### PR TITLE
feat: add offset-path non-circular orbital spinners

### DIFF
--- a/submissions/examples/offset-path-custom-orbit/README.md
+++ b/submissions/examples/offset-path-custom-orbit/README.md
@@ -1,0 +1,24 @@
+# `offset-path` Custom Orbital Spinners
+
+## What does this do?
+
+Demonstrates three loading spinners where dots travel along non-circular SVG paths via `offset-path: path()`.
+
+## How is it used?
+
+```css
+@keyframes follow-path {
+  from { offset-distance: 0%; }
+  to   { offset-distance: 100%; }
+}
+
+.orbit-dot {
+  /* An infinity symbol path */
+  offset-path: path("M 100,100 C 100,100 100,50 150,50 C 200,50 200,150 150,150 C 100,150 100,50 50,50 C 0,50 0,150 50,150 C 100,150 100,100 100,100 Z");
+  animation: follow-path 3s linear infinite;
+}
+```
+
+## Why is it useful?
+
+Most CSS "orbital" loaders use the `transform: rotate()` hack combined with an offset `transform-origin` to spin dots around a center point. However, this technique *only* works for perfect circles. The `offset-path` (CSS Motion Path) specification allows you to send an HTML element along any vector path imaginable. This submission includes a figure-eight, a sharp-cornered pentagon (using `offset-rotate: auto` so the elements face their direction of travel), and an ellipse demonstrating non-linear speed via `ease-in-out`.

--- a/submissions/examples/offset-path-custom-orbit/demo.html
+++ b/submissions/examples/offset-path-custom-orbit/demo.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EaseMotion CSS - offset-path Custom Orbit Spinners</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      body {
+        font-family: system-ui, -apple-system, sans-serif;
+        background: #0d1117;
+        color: #e6edf3;
+        margin: 0;
+        padding: 4rem 2rem;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 3rem;
+      }
+
+      h1 {
+        margin: 0;
+        background: linear-gradient(135deg, #a78bfa, #3b82f6);
+        -webkit-background-clip: text;
+        background-clip: text;
+        color: transparent;
+        text-align: center;
+      }
+
+      p.desc {
+        color: #8b949e;
+        text-align: center;
+        max-width: 600px;
+        line-height: 1.6;
+        margin-bottom: 2rem;
+      }
+
+      .demo-grid {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 2rem;
+        width: 100%;
+        max-width: 900px;
+      }
+
+      .demo-card {
+        background: #161b22;
+        border: 1px solid #21262d;
+        border-radius: 16px;
+        padding: 2.5rem 2rem;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 1.5rem;
+        flex: 1;
+        min-width: 250px;
+      }
+
+      .demo-card h3 {
+        margin: 0;
+        font-size: 1rem;
+        color: #c9d1d9;
+      }
+
+      .path-svg {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        top: 0;
+        left: 0;
+        pointer-events: none;
+      }
+
+      .path-svg path {
+        fill: none;
+        stroke: #21262d;
+        stroke-width: 2;
+        stroke-dasharray: 4 4;
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      <h1>Custom SVG Orbital Spinners</h1>
+      <p class="desc">
+        Unlike <code>transform: rotate()</code> which is limited to perfect
+        circles, <code>offset-path</code> lets you animate elements along any
+        arbitrary SVG path vector.
+      </p>
+    </div>
+
+    <div class="demo-grid">
+      <!-- Demo 1: Figure-Eight -->
+      <div class="demo-card">
+        <h3>Figure-Eight (3 Dots)</h3>
+        <div class="orbit-stage figure-eight">
+          <!-- Background SVG just to visualize the invisible offset-path -->
+          <svg class="path-svg" viewBox="0 0 200 200">
+            <path
+              d="M 100,100 C 100,100 100,50 150,50 C 200,50 200,150 150,150 C 100,150 100,50 50,50 C 0,50 0,150 50,150 C 100,150 100,100 100,100 Z"
+            />
+          </svg>
+          <div class="orbit-dot"></div>
+          <div class="orbit-dot"></div>
+          <div class="orbit-dot"></div>
+        </div>
+      </div>
+
+      <!-- Demo 2: Pentagon -->
+      <div class="demo-card">
+        <h3>Pentagon (auto-rotate)</h3>
+        <div class="orbit-stage pentagon">
+          <svg class="path-svg" viewBox="0 0 200 200">
+            <path d="M 100,20 L 176,75 L 147,165 L 53,165 L 24,75 Z" />
+          </svg>
+          <div class="orbit-dot"></div>
+          <div class="orbit-dot"></div>
+          <div class="orbit-dot"></div>
+          <div class="orbit-dot"></div>
+          <div class="orbit-dot"></div>
+        </div>
+      </div>
+
+      <!-- Demo 3: Ellipse with ease-in-out -->
+      <div class="demo-card">
+        <h3>Ellipse (ease-in-out speed)</h3>
+        <div class="orbit-stage ellipse">
+          <svg class="path-svg" viewBox="0 0 200 200">
+            <path d="M 100,40 A 80,60 0 1,1 99.9,40" />
+          </svg>
+          <div class="orbit-dot"></div>
+          <div class="orbit-dot"></div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/offset-path-custom-orbit/style.css
+++ b/submissions/examples/offset-path-custom-orbit/style.css
@@ -1,0 +1,119 @@
+/* offset-path Non-Circular Orbital Spinners
+   Moves elements along an arbitrary SVG path.
+   Unlike transform: rotate(), which is strictly circular, 
+   offset-path supports any shape (figure-eight, pentagon, ellipse, etc). */
+
+@keyframes follow-path {
+  from {
+    offset-distance: 0%;
+  }
+  to {
+    offset-distance: 100%;
+  }
+}
+
+.orbit-stage {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Base dot style */
+.orbit-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #a78bfa;
+  position: absolute;
+  top: 0;
+  left: 0;
+  /* Elements travel the path using offset-distance 0 -> 100% */
+  animation: follow-path 2s linear infinite;
+}
+
+/* Shared colors for multiple dots */
+.orbit-dot:nth-child(2) {
+  background: #ec4899;
+}
+.orbit-dot:nth-child(3) {
+  background: #06b6d4;
+}
+.orbit-dot:nth-child(4) {
+  background: #10b981;
+}
+.orbit-dot:nth-child(5) {
+  background: #f59e0b;
+}
+
+/* ── 1. Figure-Eight Path (Infinity symbol) ── */
+.figure-eight .orbit-dot {
+  offset-path: path(
+    "M 100,100 C 100,100 100,50 150,50 C 200,50 200,150 150,150 C 100,150 100,50 50,50 C 0,50 0,150 50,150 C 100,150 100,100 100,100 Z"
+  );
+  animation-duration: 3s;
+}
+/* Stagger 3 dots evenly across 3 seconds (-1s, -2s) */
+.figure-eight .orbit-dot:nth-child(2) {
+  animation-delay: -1s;
+}
+.figure-eight .orbit-dot:nth-child(3) {
+  animation-delay: -2s;
+}
+
+/* ── 2. Pentagon Path ── */
+.pentagon .orbit-dot {
+  /* Replace the dot with an arrow shape so we can see it rotating */
+  border-radius: 0;
+  clip-path: polygon(0 0, 100% 50%, 0 100%);
+  width: 18px;
+  height: 18px;
+  background: #e6edf3;
+  
+  offset-path: path("M 100,20 L 176,75 L 147,165 L 53,165 L 24,75 Z");
+  /* offset-rotate: auto ensures the element faces its direction of travel */
+  offset-rotate: auto;
+  animation-duration: 4s;
+}
+/* Stagger 5 arrows evenly across 4 seconds */
+.pentagon .orbit-dot:nth-child(1) { animation-delay: 0s; }
+.pentagon .orbit-dot:nth-child(2) { animation-delay: -0.8s; }
+.pentagon .orbit-dot:nth-child(3) { animation-delay: -1.6s; }
+.pentagon .orbit-dot:nth-child(4) { animation-delay: -2.4s; }
+.pentagon .orbit-dot:nth-child(5) { animation-delay: -3.2s; }
+
+/* ── 3. Ellipse Path (Variable speed) ── */
+.ellipse .orbit-dot {
+  offset-path: path("M 100,40 A 80,60 0 1,1 99.9,40");
+  /* ease-in-out causes the dots to accelerate/decelerate around the path */
+  animation-timing-function: ease-in-out;
+  animation-duration: 2.5s;
+}
+.ellipse .orbit-dot:nth-child(2) {
+  animation-delay: -1.25s;
+}
+
+/* Fallback for browsers that don't support offset-path: path() */
+@supports not (offset-path: path("M 0,0")) {
+  .orbit-stage {
+    border: 4px solid #21262d;
+    border-top-color: #a78bfa;
+    border-radius: 50%;
+    animation: follow-path 1s linear infinite;
+  }
+  .orbit-dot {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .orbit-dot {
+    animation-play-state: paused;
+  }
+  /* Fallback border spinner */
+  .orbit-stage {
+    animation-play-state: paused;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Three loading spinners where dots travel non-circular SVG paths via `offset-path: path()`. Unlike the existing orbital loaders that use `transform: rotate()` (circular-only hack), `offset-path` sends elements along any SVG shape. Figure-eight (3 dots), pentagon with `offset-rotate: auto` (5 dots facing direction of travel), and ellipse with `ease-in-out` variable speed (2 dots). `@supports` guard falls back to a standard border spinner.

Closes #35511

---

## Type of Change

- [x] New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/offset-path-custom-orbit/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Demonstrates three loading spinners where dots travel along non-circular SVG paths via `offset-path: path()`.

**How does a developer use it?**

```css
@keyframes follow-path {
  from { offset-distance: 0%; }
  to   { offset-distance: 100%; }
}

.orbit-dot {
  /* An infinity symbol path */
  offset-path: path("M 100,100 C 100,100 100,50 150,50 C 200,50 200,150 150,150 C 100,150 100,50 50,50 C 0,50 0,150 50,150 C 100,150 100,100 100,100 Z");
  animation: follow-path 3s linear infinite;
}
```

**Why does it fit EaseMotion CSS?**

Most CSS "orbital" loaders use the `transform: rotate()` hack combined with an offset `transform-origin` to spin dots around a center point. However, this technique *only* works for perfect circles. The `offset-path` (CSS Motion Path) specification allows you to send an HTML element along any vector path imaginable. This submission bridges that gap.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---

## Notes for Maintainer

`offset-path` is supported in all modern browsers.