### PR TITLE
fix: add prefers-reduced-motion support for ease-loader animations

### DIFF
--- a/submissions/examples/fix-loaders-reduced-motion-gb/README.md
+++ b/submissions/examples/fix-loaders-reduced-motion-gb/README.md
@@ -1,0 +1,11 @@
+# Fix ease-loader Reduced Motion Support
+
+## What does this do?
+Adds a `prefers-reduced-motion` fallback for the `ease-loader-spin`, `ease-loader-pulse`, `ease-loader-ping`, and `ease-loader-dot` animations so they stop spinning/pulsing/bouncing when the user's OS has motion reduction enabled.
+
+## How is it used?
+Include the component as usual. The media query automatically disables the animation for users with reduced-motion preferences enabled — no markup changes needed.
+
+## Why is it useful?
+Prevents forced continuous motion for users with vestibular disorders or motion sensitivity, per WCAG 2.1 SC 2.3.3.
+Fixes: #36262

--- a/submissions/examples/fix-loaders-reduced-motion-gb/demo.html
+++ b/submissions/examples/fix-loaders-reduced-motion-gb/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Loader Reduced Motion Fix - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h2>ease-loader Reduced Motion Fix</h2>
+  <div class="ease-loader ease-loader-spin" aria-label="Loading" aria-busy="true"></div>
+  <div class="ease-loader ease-loader-pulse" aria-label="Loading" aria-busy="true"></div>
+  <div class="ease-loader ease-loader-ping" aria-label="Loading" aria-busy="true"></div>
+  <div class="ease-loader-dots" aria-label="Loading" aria-busy="true">
+    <span class="ease-loader-dot"></span>
+    <span class="ease-loader-dot"></span>
+    <span class="ease-loader-dot"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-loaders-reduced-motion-gb/style.css
+++ b/submissions/examples/fix-loaders-reduced-motion-gb/style.css
@@ -1,0 +1,77 @@
+/* Base ease-loader styles (mirrors components/loaders.css) */
+.ease-loader {
+  display: inline-block;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  margin: 12px;
+}
+
+.ease-loader-spin {
+  border: 3px solid #e5e7eb;
+  border-top-color: #3b82f6;
+  animation: ease-kf-rotate 0.8s linear infinite;
+}
+
+.ease-loader-pulse {
+  background-color: #3b82f6;
+  animation: ease-kf-pulse 1.2s ease-in-out infinite;
+}
+
+.ease-loader-ping {
+  background-color: #93c5fd;
+  animation: ease-kf-ping 1s ease-out infinite;
+}
+
+.ease-loader-dots {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 12px;
+  margin: 12px;
+}
+
+.ease-loader-dot {
+  width: 8px;
+  height: 8px;
+  background-color: #3b82f6;
+  border-radius: 50%;
+  animation: ease-kf-bounce 1s infinite alternate;
+}
+
+.ease-loader-dot:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.ease-loader-dot:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes ease-kf-rotate {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes ease-kf-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.5; transform: scale(0.9); }
+}
+
+@keyframes ease-kf-ping {
+  0% { transform: scale(1); opacity: 1; }
+  100% { transform: scale(1.8); opacity: 0; }
+}
+
+@keyframes ease-kf-bounce {
+  from { transform: translateY(0); }
+  to { transform: translateY(-6px); }
+}
+
+/* --- The actual fix for this submission --- */
+@media (prefers-reduced-motion: reduce) {
+  .ease-loader-spin,
+  .ease-loader-pulse,
+  .ease-loader-ping,
+  .ease-loader-dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
Fixes #36262 (partial — addressing ease-loader as the first of 19 identified components)

Adds a `prefers-reduced-motion` fallback for the `ease-loader-spin`, `ease-loader-pulse`, `ease-loader-ping`, and `ease-loader-dot` animations. When the user's OS has reduced motion enabled, these loaders now stay static instead of continuously spinning/pulsing/bouncing.

Tested manually by toggling "Animation effects" off in Windows Accessibility settings and confirming all four loader variants stop animating.

Files added:
- `submissions/examples/fix-loaders-reduced-motion-gb/demo.html`
- `submissions/examples/fix-loaders-reduced-motion-gb/style.css`
- `submissions/examples/fix-loaders-reduced-motion-gb/README.md`