### PR TITLE
feat: add animated underline tabs component

### DIFF
--- a/submissions/examples/animated-underline-tabs/README.md
+++ b/submissions/examples/animated-underline-tabs/README.md
@@ -1,0 +1,20 @@
+# Animated Underline Tabs
+
+A tab navigation component with a sliding underline indicator that smoothly moves to whichever tab is clicked.
+
+## Usage
+Wrap `.tab` buttons and a `.tab-underline` span inside a `.tabs` container. Call `setActiveTab(this)` on each tab's `onclick` to switch the active state and animate the underline.
+
+```html
+<div class="tabs">
+  <button class="tab active" onclick="setActiveTab(this)">Home</button>
+  <button class="tab" onclick="setActiveTab(this)">Profile</button>
+  <span class="tab-underline"></span>
+</div>
+```
+
+## Browser support
+Works in all modern browsers — uses `offsetWidth`/`offsetLeft` and CSS transitions on `transform`/`width`.
+
+## Notes
+Requires a small amount of JavaScript to measure the clicked tab's position and width; the sliding motion itself is a pure CSS transition.

--- a/submissions/examples/animated-underline-tabs/demo.html
+++ b/submissions/examples/animated-underline-tabs/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Animated Underline Tabs Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body
+    style="display:flex; justify-content:center; align-items:center; min-height:100vh; margin:0; background:#f4f4f4; font-family:sans-serif;">
+
+    <div class="tabs">
+        <button class="tab active" onclick="setActiveTab(this)">Home</button>
+        <button class="tab" onclick="setActiveTab(this)">Profile</button>
+        <button class="tab" onclick="setActiveTab(this)">Settings</button>
+        <span class="tab-underline"></span>
+    </div>
+
+    <script>
+        function moveUnderline(tab) {
+            var tabs = tab.parentElement;
+            var underline = tabs.querySelector('.tab-underline');
+            underline.style.width = tab.offsetWidth + 'px';
+            underline.style.transform = 'translateX(' + tab.offsetLeft + 'px)';
+        }
+
+        function setActiveTab(tab) {
+            var tabs = tab.parentElement.querySelectorAll('.tab');
+            tabs.forEach(function (t) {
+                t.classList.remove('active');
+            });
+            tab.classList.add('active');
+            moveUnderline(tab);
+        }
+
+        window.addEventListener('load', function () {
+            var activeTab = document.querySelector('.tab.active');
+            if (activeTab) moveUnderline(activeTab);
+        });
+    </script>
+
+</body>
+
+</html>

--- a/submissions/examples/animated-underline-tabs/style.css
+++ b/submissions/examples/animated-underline-tabs/style.css
@@ -1,0 +1,29 @@
+.tabs {
+    position: relative;
+    display: inline-flex;
+    border-bottom: 1px solid #e0e0e0;
+}
+
+.tab {
+    padding: 10px 20px;
+    border: none;
+    background: none;
+    cursor: pointer;
+    font-size: 14px;
+    color: #666;
+    transition: color 0.2s ease;
+}
+
+.tab.active {
+    color: #1a1a2e;
+    font-weight: 600;
+}
+
+.tab-underline {
+    position: absolute;
+    bottom: -1px;
+    left: 0;
+    height: 2px;
+    background: #4caf50;
+    transition: transform 0.3s ease, width 0.3s ease;
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS + minimal JS animated underline tabs component — a tab navigation where the underline indicator smoothly slides and resizes to match whichever tab is clicked.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/animated-underline-tabs/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A tab navigation component with a sliding underline indicator that animates between tabs on click.

**How does a developer use it?**
```html
<div class="tabs">
  <button class="tab active" onclick="setActiveTab(this)">Home</button>
  <button class="tab" onclick="setActiveTab(this)">Profile</button>
  <span class="tab-underline"></span>
</div>
```

**Why does it fit EaseMotion CSS?**
Tabs are a near-universal navigation pattern (settings pages, dashboards, content sections), and the framework has no tab component yet. The sliding underline is a small but highly visible animation that makes a UI feel considerably more polished — a strong showcase of the animation-first philosophy. Requires minimal JavaScript (just measuring the clicked tab's position and width); the actual motion is a CSS `transition` on `transform` and `width`.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Edge

---

## Notes for Maintainer
Requires a small inline script to calculate the clicked tab's `offsetLeft`/`offsetWidth`; the sliding motion itself is a pure CSS transition. Happy to adjust the underline color or transition timing if preferred. Closes #36273.