### PR TITLE
feat: add image comparison slider component

### DIFF
--- a/submissions/examples/image-comparison-slider/README.md
+++ b/submissions/examples/image-comparison-slider/README.md
@@ -1,0 +1,27 @@
+# Image Comparison Slider
+
+A component showing two overlapping layers with a draggable divider — sliding it left/right reveals more or less of the "before" layer over the "after" layer. Uses colored placeholder blocks in the demo; swap `.compare-after` and `.compare-before` backgrounds for real images in production.
+
+## Usage
+```html
+<div class="compare-slider">
+  <div class="compare-layer compare-after">After content</div>
+  <div class="compare-before-wrap">
+    <div class="compare-layer compare-before">Before content</div>
+  </div>
+  <div class="compare-handle"></div>
+</div>
+```
+
+Attach the pointer event listeners shown in `demo.html` to the handle to drive the drag interaction.
+
+## How it works
+- The `.compare-before-wrap` clips the "before" layer to a percentage width
+- Dragging the handle updates that width based on cursor position relative to the slider's bounding box
+- Uses Pointer Events (`pointerdown`/`pointermove`/`pointerup`) so it works on both mouse and touch
+
+## Browser support
+Pointer Events are supported in all modern browsers, including touch devices.
+
+## Notes
+No external libraries required. To use with real images instead of color blocks, replace the `.compare-after`/`.compare-before` background gradients with `background-image` or nested `<img>` tags sized to the container.

--- a/submissions/examples/image-comparison-slider/demo.html
+++ b/submissions/examples/image-comparison-slider/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Image Comparison Slider Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body
+    style="display:flex; justify-content:center; align-items:center; min-height:100vh; margin:0; background:#f4f4f4; font-family:sans-serif;">
+
+    <div class="compare-slider" id="compareSlider">
+        <div class="compare-layer compare-after">After</div>
+        <div class="compare-before-wrap" id="beforeWrap">
+            <div class="compare-layer compare-before">Before</div>
+        </div>
+        <div class="compare-handle" id="compareHandle"></div>
+    </div>
+
+    <script>
+        var slider = document.getElementById('compareSlider');
+        var beforeWrap = document.getElementById('beforeWrap');
+        var handle = document.getElementById('compareHandle');
+        var dragging = false;
+
+        function updateSlider(clientX) {
+            var rect = slider.getBoundingClientRect();
+            var x = clientX - rect.left;
+            var percent = Math.min(Math.max((x / rect.width) * 100, 0), 100);
+            beforeWrap.style.width = percent + '%';
+            handle.style.left = percent + '%';
+        }
+
+        handle.addEventListener('pointerdown', function (e) {
+            dragging = true;
+            handle.setPointerCapture(e.pointerId);
+        });
+
+        handle.addEventListener('pointermove', function (e) {
+            if (!dragging) return;
+            updateSlider(e.clientX);
+        });
+
+        handle.addEventListener('pointerup', function () {
+            dragging = false;
+        });
+    </script>
+
+</body>
+
+</html>

--- a/submissions/examples/image-comparison-slider/style.css
+++ b/submissions/examples/image-comparison-slider/style.css
@@ -1,0 +1,72 @@
+.compare-slider {
+    position: relative;
+    width: 400px;
+    max-width: 100%;
+    aspect-ratio: 4 / 3;
+    overflow: hidden;
+    border-radius: 12px;
+    user-select: none;
+}
+
+.compare-slider .compare-layer {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #ffffff;
+    font-family: sans-serif;
+    font-weight: 600;
+    font-size: 20px;
+}
+
+.compare-after {
+    background: linear-gradient(135deg, #2b5876, #4e4376);
+}
+
+.compare-before-wrap {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 50%;
+    height: 100%;
+    overflow: hidden;
+}
+
+.compare-before {
+    width: 400px;
+    max-width: none;
+    background: linear-gradient(135deg, #f7971e, #ffd200);
+}
+
+.compare-handle {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 50%;
+    width: 4px;
+    background: #ffffff;
+    cursor: ew-resize;
+    transform: translateX(-50%);
+}
+
+.compare-handle::after {
+    content: '⇔';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 32px;
+    height: 32px;
+    background: #ffffff;
+    color: #333;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transform: translate(-50%, -50%);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+    font-size: 16px;
+}


### PR DESCRIPTION
## Pull Request Description
Adds an image comparison slider — two overlapping layers with a draggable divider that reveals more or less of the "before" layer over the "after" layer as it's dragged.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/image-comparison-slider/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A draggable before/after comparison slider — dragging the handle reveals more or less of the top layer over the bottom layer.

**How does a developer use it?**
```html
<div class="compare-slider">
  <div class="compare-layer compare-after">After content</div>
  <div class="compare-before-wrap">
    <div class="compare-layer compare-before">Before content</div>
  </div>
  <div class="compare-handle"></div>
</div>
```

**Why does it fit EaseMotion CSS?**
Comparison sliders are a common pattern for before/after showcases (photo editing, renovations, design revisions, product changes). It's a strong intermediate interaction — a continuous drag mapped in real time to a clip width — that's visually striking and demonstrates motion driven directly by pointer position, fitting the animation-first philosophy well.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Edge

---

## Notes for Maintainer
Uses Pointer Events (not just mouse events) so the drag works on both desktop and touch devices. Demo uses colored placeholder layers instead of real images — swap the `.compare-after`/`.compare-before` backgrounds for actual `background-image` or `<img>` content in production use. Closes #36288.