### PR TITLE
feat(examples): Cyberpunk Neon Slide-Up Tooltip

### DIFF
--- a/submissions/examples/34270-cyberpunk-neon-slide-up-tooltip-sj6/README.md
+++ b/submissions/examples/34270-cyberpunk-neon-slide-up-tooltip-sj6/README.md
@@ -1,0 +1,55 @@
+# Cyberpunk Neon Slide-Up Tooltip
+
+A zero-dependency, pure CSS tooltip that glides **upward** into place with a
+soft neon bloom — built to sit naturally inside cyberpunk / tech-noir dark
+interfaces. No JavaScript: the reveal is driven entirely by `:hover` and
+`:focus-visible`, so it works for mouse and keyboard users alike.
+
+Resolves Issue: #34270
+
+## ✨ Features
+
+- **Slide-Up motion** — the tooltip rests below its final position and
+  travels up by a configurable distance (`--nx-tt-rise`) while fading in,
+  on a decelerating `cubic-bezier` glide.
+- **Zero JavaScript** — visibility, motion, and delay are handled with CSS
+  transitions on sibling selectors (`.nx-chip:hover + .nx-tip`).
+- **Keyboard accessible** — triggers are real `<button>` elements wired with
+  `aria-describedby` → `role="tooltip"`, revealed on `:focus-visible`, with a
+  high-contrast lime focus ring that stays distinct from the hover style.
+- **Tunable via custom properties** — duration, easing curve, travel
+  distance, and hover-intent delay are all exposed on `:root`.
+- **Cyberpunk Neon skin** — clipped-corner chips, magenta/cyan glow recipes,
+  CRT scanline overlay, and a dark HUD grid backdrop.
+- **Responsive & motion-safe** — trigger row wraps on narrow screens, the
+  tooltip caps its width at `min(240px, 82vw)`, and a
+  `prefers-reduced-motion` guard removes all travel for users who request it.
+
+## 🔧 Custom Properties
+
+| Property           | Default                            | Role                          |
+| ------------------ | ---------------------------------- | ----------------------------- |
+| `--nx-tt-duration` | `340ms`                            | Slide + fade time             |
+| `--nx-tt-ease`     | `cubic-bezier(0.22, 1, 0.36, 1)`   | Motion curve                  |
+| `--nx-tt-rise`     | `14px`                             | Distance travelled upward     |
+| `--nx-tt-delay`    | `60ms`                             | Hover-intent delay before show|
+
+## 🚀 Usage
+
+```html
+<span class="nx-tip-anchor">
+  <button class="nx-chip" type="button" aria-describedby="my-tip">
+    TRIGGER
+  </button>
+  <span class="nx-tip" id="my-tip" role="tooltip">
+    <span class="nx-tip-label">Label strip</span>
+    Tooltip body copy slides up from below.
+  </span>
+</span>
+```
+
+## 📂 Files
+
+- `demo.html` — augment-market console demo with three tooltip triggers.
+- `style.css` — tokens, neon theme, slide-up interaction engine, a11y guards.
+- `README.md` — this document.

--- a/submissions/examples/34270-cyberpunk-neon-slide-up-tooltip-sj6/demo.html
+++ b/submissions/examples/34270-cyberpunk-neon-slide-up-tooltip-sj6/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cyberpunk Neon Slide-Up Tooltip — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="nx-console" aria-label="Augment market console demo">
+    <h1 class="nx-console-title">Augment Market // Bay 07</h1>
+    <p class="nx-console-sub">
+      Hover any module — or Tab onto it with the keyboard — and its spec sheet
+      slides up from the chrome below.
+    </p>
+
+    <div class="nx-augment-row">
+      <span class="nx-tip-anchor">
+        <button class="nx-chip" type="button" aria-describedby="tip-optics">
+          KIROSHI OPTICS
+        </button>
+        <span class="nx-tip" id="tip-optics" role="tooltip">
+          <span class="nx-tip-label">Ocular // Tier 3</span>
+          Zoom-threat overlay with low-light bloom compensation. Draws 0.4u
+          from the neural rail.
+        </span>
+      </span>
+
+      <span class="nx-tip-anchor">
+        <button class="nx-chip" type="button" aria-describedby="tip-deck">
+          CYBERDECK MK-II
+        </button>
+        <span class="nx-tip" id="tip-deck" role="tooltip">
+          <span class="nx-tip-label">Netrunning // Tier 4</span>
+          Six quickhack slots, ICE-pick buffer ×2. Ships with a burned-in
+          daemon library.
+        </span>
+      </span>
+
+      <span class="nx-tip-anchor">
+        <button class="nx-chip" type="button" aria-describedby="tip-reflex">
+          REFLEX TUNER
+        </button>
+        <span class="nx-tip" id="tip-reflex" role="tooltip">
+          <span class="nx-tip-label">Nervous // Tier 2</span>
+          Sandevistan-lite time dilation burst. Cooldown 18s, chrome fatigue
+          minimal.
+        </span>
+      </span>
+    </div>
+  </main>
+</body>
+
+</html>

--- a/submissions/examples/34270-cyberpunk-neon-slide-up-tooltip-sj6/style.css
+++ b/submissions/examples/34270-cyberpunk-neon-slide-up-tooltip-sj6/style.css
@@ -1,0 +1,233 @@
+/* ==========================================================================
+   Cyberpunk Neon Slide-Up Tooltip
+   --------------------------------------------------------------------------
+   Pure CSS tooltip that rises from beneath its final resting point with a
+   soft neon bloom. Zero JavaScript — driven entirely by :hover and
+   :focus-visible so it stays keyboard accessible.
+
+   Issue: #34270
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Tunable parameters — override these to re-time or re-skin the tooltip
+   -------------------------------------------------------------------------- */
+:root {
+  /* Motion controls */
+  --nx-tt-duration: 340ms;                        /* slide + fade time      */
+  --nx-tt-ease: cubic-bezier(0.22, 1, 0.36, 1);   /* decelerating glide     */
+  --nx-tt-rise: 14px;                             /* distance travelled up  */
+  --nx-tt-delay: 60ms;                            /* hover intent debounce  */
+
+  /* Neon palette */
+  --nx-ink: #05060a;
+  --nx-panel: #0b0e17;
+  --nx-line: #232a3d;
+  --nx-cyan: #22e4f2;
+  --nx-magenta: #f22bb3;
+  --nx-lime: #b8f135;
+  --nx-dim: #7787a3;
+
+  /* Glow recipes */
+  --nx-glow-cyan: 0 0 8px rgba(34, 228, 242, 0.55), 0 0 22px rgba(34, 228, 242, 0.25);
+  --nx-glow-magenta: 0 0 8px rgba(242, 43, 179, 0.55), 0 0 22px rgba(242, 43, 179, 0.25);
+}
+
+/* --------------------------------------------------------------------------
+   2. Demo stage — dark grid backdrop typical of neon HUD interfaces
+   -------------------------------------------------------------------------- */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 32px 16px;
+  box-sizing: border-box;
+  background-color: var(--nx-ink);
+  background-image:
+    radial-gradient(ellipse at 50% -20%, rgba(242, 43, 179, 0.12), transparent 55%),
+    linear-gradient(rgba(35, 42, 61, 0.35) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(35, 42, 61, 0.35) 1px, transparent 1px);
+  background-size: 100% 100%, 26px 26px, 26px 26px;
+  font-family: "Lucida Console", Monaco, monospace;
+  color: var(--nx-dim);
+}
+
+.nx-console {
+  width: 100%;
+  max-width: 520px;
+  border: 1px solid var(--nx-line);
+  border-top: 3px solid var(--nx-magenta);
+  background: var(--nx-panel);
+  padding: 26px 26px 84px;
+  position: relative;
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.7);
+}
+
+/* Faint CRT scanlines over the whole console */
+.nx-console::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(255, 255, 255, 0.025) 0 1px,
+    transparent 1px 3px
+  );
+}
+
+.nx-console-title {
+  margin: 0 0 6px;
+  font-size: 1rem;
+  letter-spacing: 0.18em;
+  color: var(--nx-cyan);
+  text-shadow: var(--nx-glow-cyan);
+  text-transform: uppercase;
+}
+
+.nx-console-sub {
+  margin: 0 0 26px;
+  font-size: 0.78rem;
+  line-height: 1.6;
+}
+
+/* Trigger row wraps on narrow screens — tooltips stay anchored per trigger */
+.nx-augment-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+
+/* --------------------------------------------------------------------------
+   3. Tooltip anchor + trigger chip
+   -------------------------------------------------------------------------- */
+.nx-tip-anchor {
+  position: relative;
+  display: inline-block;
+}
+
+.nx-chip {
+  font: inherit;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  padding: 11px 18px;
+  color: var(--nx-cyan);
+  background: transparent;
+  border: 1px solid var(--nx-cyan);
+  clip-path: polygon(8px 0, 100% 0, 100% calc(100% - 8px), calc(100% - 8px) 100%, 0 100%, 0 8px);
+  cursor: pointer;
+  transition: color 180ms ease, background-color 180ms ease, box-shadow 180ms ease;
+}
+
+.nx-chip:hover {
+  color: var(--nx-ink);
+  background: var(--nx-cyan);
+  box-shadow: var(--nx-glow-cyan);
+}
+
+/* Visible keyboard focus ring, distinct from hover styling */
+.nx-chip:focus-visible {
+  outline: 2px solid var(--nx-lime);
+  outline-offset: 3px;
+}
+
+/* --------------------------------------------------------------------------
+   4. The slide-up tooltip itself
+   --------------------------------------------------------------------------
+   Rest state: parked below its final position, invisible.
+   Active state: glides up by --nx-tt-rise while fading in.
+   -------------------------------------------------------------------------- */
+.nx-tip {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  z-index: 20;
+  width: max-content;
+  max-width: min(240px, 82vw);
+  padding: 12px 14px;
+  box-sizing: border-box;
+  background: linear-gradient(160deg, #131829, #0b0e17 70%);
+  border: 1px solid var(--nx-magenta);
+  box-shadow: var(--nx-glow-magenta);
+  color: #c5d2e8;
+  font-size: 0.72rem;
+  line-height: 1.5;
+  text-align: left;
+  pointer-events: none;
+
+  /* Rest state: shifted DOWN by the rise distance, fully transparent */
+  opacity: 0;
+  visibility: hidden;
+  transform: translate(-50%, var(--nx-tt-rise));
+  transition:
+    opacity var(--nx-tt-duration) var(--nx-tt-ease),
+    transform var(--nx-tt-duration) var(--nx-tt-ease),
+    visibility 0s linear calc(var(--nx-tt-duration) + var(--nx-tt-delay));
+}
+
+/* Neon jack-in port: small triangle pointing back at the trigger */
+.nx-tip::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-top-color: var(--nx-magenta);
+  filter: drop-shadow(0 2px 4px rgba(242, 43, 179, 0.5));
+}
+
+/* Data-label strip across the tooltip head */
+.nx-tip-label {
+  display: block;
+  margin-bottom: 5px;
+  font-size: 0.68rem;
+  font-weight: bold;
+  letter-spacing: 0.14em;
+  color: var(--nx-lime);
+  text-transform: uppercase;
+  text-shadow: 0 0 6px rgba(184, 241, 53, 0.45);
+}
+
+/* --------------------------------------------------------------------------
+   5. Interaction engine — hover OR keyboard focus fires the slide-up
+   -------------------------------------------------------------------------- */
+.nx-chip:hover + .nx-tip,
+.nx-chip:focus-visible + .nx-tip {
+  opacity: 1;
+  visibility: visible;
+  transform: translate(-50%, 0);
+  transition:
+    opacity var(--nx-tt-duration) var(--nx-tt-ease) var(--nx-tt-delay),
+    transform var(--nx-tt-duration) var(--nx-tt-ease) var(--nx-tt-delay),
+    visibility 0s linear var(--nx-tt-delay);
+}
+
+/* --------------------------------------------------------------------------
+   6. Responsive + accessibility guards
+   -------------------------------------------------------------------------- */
+@media (max-width: 480px) {
+  .nx-console {
+    padding: 20px 16px 72px;
+  }
+
+  .nx-augment-row {
+    gap: 10px;
+  }
+
+  .nx-chip {
+    padding: 10px 14px;
+    font-size: 0.74rem;
+  }
+}
+
+/* Honor system-level reduced-motion: reveal instantly, no travel */
+@media (prefers-reduced-motion: reduce) {
+  .nx-tip,
+  .nx-chip:hover + .nx-tip,
+  .nx-chip:focus-visible + .nx-tip {
+    transition-duration: 1ms;
+    transition-delay: 0s;
+    transform: translate(-50%, 0);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS **Slide-Up Tooltip** styled for **Cyberpunk Neon** layouts as a fully self-contained example under `submissions/examples/34270-cyberpunk-neon-slide-up-tooltip-sj6/`.

Closes #34270

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/34270-cyberpunk-neon-slide-up-tooltip-sj6/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A zero-JavaScript tooltip that glides upward into place with a neon bloom, revealed by `:hover` and `:focus-visible`, themed for cyberpunk/tech-noir dark interfaces.

**How does a developer use it?**

```html
<span class="nx-tip-anchor">
  <button class="nx-chip" type="button" aria-describedby="my-tip">TRIGGER</button>
  <span class="nx-tip" id="my-tip" role="tooltip">
    <span class="nx-tip-label">Label strip</span>
    Tooltip body copy slides up from below.
  </span>
</span>
```

**Why does it fit EaseMotion CSS?**

Human-readable classes, animation-first, zero JS. Motion is fully tunable via CSS custom properties (`--nx-tt-duration`, `--nx-tt-ease`, `--nx-tt-rise`, `--nx-tt-delay`), triggers are real `<button>` elements wired with `aria-describedby`/`role="tooltip"` for keyboard users, and a `prefers-reduced-motion` guard removes all travel for users who request it.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The demo is a small "augment market" console with three tooltip triggers so responsiveness (flex-wrap on narrow screens) is visible. All motion parameters are exposed on `:root` — feel free to adjust the default timing.

@SAPTARSHI-coder please review this pr 
