### PR TITLE
feat(examples): Cyberpunk Neon Zoom-In Tooltip

### DIFF
--- a/submissions/examples/34284-cyberpunk-neon-zoom-in-tooltip-sj6/README.md
+++ b/submissions/examples/34284-cyberpunk-neon-zoom-in-tooltip-sj6/README.md
@@ -1,0 +1,60 @@
+# Cyberpunk Neon Zoom-In Tooltip
+
+A pure CSS, zero-dependency tooltip that **zooms into focus** like a
+holo-projection: it grows from a collapsed point anchored at its trigger,
+overshoots slightly on a spring curve, and settles crisp and readable.
+Styled for cyberpunk neon dark UIs, revealed by both `:hover` and
+`:focus-visible` — no JavaScript anywhere.
+
+Resolves Issue: #34284
+
+## ✨ Features
+
+- **Zoom-In motion with overshoot** — scales from `--cz-tt-scale-from`
+  (default `0.4`) to full size on a springy
+  `cubic-bezier(0.34, 1.56, 0.64, 1)`; the shrink-away uses a separate,
+  faster exit curve so hide never feels laggy.
+- **Anchored growth** — `transform-origin` is pinned to the arrow tip, so
+  the tooltip visibly "projects" out of its trigger instead of inflating in
+  place.
+- **Zero JavaScript** — sibling-selector interaction engine
+  (`.cz-node-btn:hover + .cz-holo`), CSS transitions only.
+- **Keyboard accessible** — real `<button>` triggers with
+  `aria-describedby` → `role="tooltip"`, plus a dashed acid-green
+  `:focus-visible` ring that never collides with the violet hover glow.
+- **Tunable via custom properties** — start scale, duration, and both
+  easing curves are exposed on `:root`.
+- **Cyberpunk Neon skin** — acid-green / violet / ember palette, HUD corner
+  brackets, radial glow washes, and an inner phosphor bloom on the tooltip.
+- **Responsive & motion-safe** — node tiles wrap on narrow screens, tooltip
+  width caps at `min(230px, 80vw)`, and `prefers-reduced-motion` collapses
+  the zoom into an instant reveal.
+
+## 🔧 Custom Properties
+
+| Property             | Default                              | Role                       |
+| -------------------- | ------------------------------------ | -------------------------- |
+| `--cz-tt-scale-from` | `0.4`                                | Collapsed starting scale   |
+| `--cz-tt-duration`   | `280ms`                              | Grow time                  |
+| `--cz-tt-ease`       | `cubic-bezier(0.34, 1.56, 0.64, 1)`  | Overshoot spring (show)    |
+| `--cz-tt-ease-out`   | `cubic-bezier(0.4, 0, 1, 1)`         | Exit curve (hide)          |
+
+## 🚀 Usage
+
+```html
+<span class="cz-node">
+  <button class="cz-node-btn" type="button" aria-describedby="my-holo">
+    NODE 09-A
+  </button>
+  <span class="cz-holo" id="my-holo" role="tooltip">
+    <span class="cz-holo-head">Header <small>TAG</small></span>
+    Body copy zooms into focus above the trigger.
+  </span>
+</span>
+```
+
+## 📂 Files
+
+- `demo.html` — NetWatch security-grid demo with three tooltip nodes.
+- `style.css` — theme tokens, zoom interaction engine, responsive + a11y guards.
+- `README.md` — this document.

--- a/submissions/examples/34284-cyberpunk-neon-zoom-in-tooltip-sj6/demo.html
+++ b/submissions/examples/34284-cyberpunk-neon-zoom-in-tooltip-sj6/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cyberpunk Neon Zoom-In Tooltip — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="cz-terminal" aria-label="Security grid terminal demo">
+    <h1 class="cz-heading">NetWatch // Grid Sector 9</h1>
+    <p class="cz-tagline">
+      Three intrusion nodes are live on this subnet. Hover a node — or reach
+      it with Tab — and its threat dossier zooms into focus like a
+      holo-projection.
+    </p>
+
+    <div class="cz-node-row">
+      <span class="cz-node">
+        <button class="cz-node-btn" type="button" aria-describedby="holo-brute">
+          NODE 09-A
+        </button>
+        <span class="cz-holo" id="holo-brute" role="tooltip">
+          <span class="cz-holo-head">Brute-Force <small>SEV 2</small></span>
+          Credential hammering from a rotating proxy pool. Lockout rules are
+          absorbing 97% of attempts.
+        </span>
+      </span>
+
+      <span class="cz-node">
+        <button class="cz-node-btn" type="button" aria-describedby="holo-worm">
+          NODE 09-B
+        </button>
+        <span class="cz-holo" id="holo-worm" role="tooltip">
+          <span class="cz-holo-head">Worm Signature <small>SEV 4</small></span>
+          Self-replicating payload knocking on legacy ports. Quarantine mesh
+          raised, spread contained to one rack.
+        </span>
+      </span>
+
+      <span class="cz-node">
+        <button class="cz-node-btn" type="button" aria-describedby="holo-ghost">
+          NODE 09-C
+        </button>
+        <span class="cz-holo" id="holo-ghost" role="tooltip">
+          <span class="cz-holo-head">Ghost Login <small>SEV 1</small></span>
+          Session token replayed from two cities at once. Probably a roaming
+          VPN — flagged for human review.
+        </span>
+      </span>
+    </div>
+  </main>
+</body>
+
+</html>

--- a/submissions/examples/34284-cyberpunk-neon-zoom-in-tooltip-sj6/style.css
+++ b/submissions/examples/34284-cyberpunk-neon-zoom-in-tooltip-sj6/style.css
@@ -1,0 +1,246 @@
+/* ==========================================================================
+   Cyberpunk Neon Zoom-In Tooltip
+   --------------------------------------------------------------------------
+   Pure CSS tooltip that materialises with a punchy zoom: it scales up from a
+   collapsed point directly above its trigger, overshooting slightly before
+   settling — like a holo-projection snapping into focus. No JavaScript;
+   :hover and :focus-visible drive everything.
+
+   Issue: #34284
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Control panel — every motion + theme knob lives here
+   -------------------------------------------------------------------------- */
+:root {
+  /* Zoom motion */
+  --cz-tt-scale-from: 0.4;                                /* collapsed size   */
+  --cz-tt-duration: 280ms;                                /* grow time        */
+  --cz-tt-ease: cubic-bezier(0.34, 1.56, 0.64, 1);        /* overshoot pop    */
+  --cz-tt-ease-out: cubic-bezier(0.4, 0, 1, 1);           /* shrink-away      */
+
+  /* Night-grid palette */
+  --cz-void: #070312;
+  --cz-slab: #120a24;
+  --cz-seam: #2b1d4d;
+  --cz-acid: #9dff00;
+  --cz-violet: #a05cff;
+  --cz-ember: #ff6b1a;
+  --cz-fog: #8f86ad;
+
+  /* Bloom stacks */
+  --cz-bloom-acid: 0 0 9px rgba(157, 255, 0, 0.5), 0 0 24px rgba(157, 255, 0, 0.22);
+  --cz-bloom-violet: 0 0 9px rgba(160, 92, 255, 0.55), 0 0 26px rgba(160, 92, 255, 0.28);
+}
+
+/* --------------------------------------------------------------------------
+   2. Demo stage — NetWatch security grid terminal
+   -------------------------------------------------------------------------- */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 18px;
+  box-sizing: border-box;
+  background:
+    radial-gradient(circle at 15% 110%, rgba(160, 92, 255, 0.16), transparent 45%),
+    radial-gradient(circle at 85% -10%, rgba(157, 255, 0, 0.07), transparent 40%),
+    var(--cz-void);
+  font-family: Consolas, "Andale Mono", monospace;
+  color: var(--cz-fog);
+}
+
+.cz-terminal {
+  width: 100%;
+  max-width: 560px;
+  background: var(--cz-slab);
+  border: 1px solid var(--cz-seam);
+  outline: 1px solid rgba(157, 255, 0, 0.12);
+  outline-offset: 5px;
+  padding: 28px 28px 96px;
+  position: relative;
+}
+
+/* Corner brackets — classic HUD framing, drawn with two gradients */
+.cz-terminal::after {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  pointer-events: none;
+  background:
+    linear-gradient(var(--cz-acid), var(--cz-acid)) top left / 22px 2px,
+    linear-gradient(var(--cz-acid), var(--cz-acid)) top left / 2px 22px,
+    linear-gradient(var(--cz-acid), var(--cz-acid)) bottom right / 22px 2px,
+    linear-gradient(var(--cz-acid), var(--cz-acid)) bottom right / 2px 22px;
+  background-repeat: no-repeat;
+}
+
+.cz-heading {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--cz-acid);
+  text-shadow: var(--cz-bloom-acid);
+}
+
+.cz-tagline {
+  margin: 8px 0 30px;
+  font-size: 0.76rem;
+  line-height: 1.65;
+}
+
+/* Node tiles sit in a wrapping row — layout survives any viewport width */
+.cz-node-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+/* --------------------------------------------------------------------------
+   3. Anchor + node tile trigger
+   -------------------------------------------------------------------------- */
+.cz-node {
+  position: relative;
+  display: inline-flex;
+}
+
+.cz-node-btn {
+  font: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  padding: 12px 16px;
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  color: var(--cz-violet);
+  background: rgba(160, 92, 255, 0.06);
+  border: 1px solid var(--cz-violet);
+  border-radius: 3px;
+  cursor: pointer;
+  transition: background-color 160ms ease, box-shadow 160ms ease, color 160ms ease;
+}
+
+.cz-node-btn::before {
+  content: "◈";
+  font-size: 0.9em;
+}
+
+.cz-node-btn:hover {
+  background: rgba(160, 92, 255, 0.18);
+  box-shadow: var(--cz-bloom-violet);
+}
+
+/* Keyboard ring stays readable against the violet hover state */
+.cz-node-btn:focus-visible {
+  outline: 2px dashed var(--cz-acid);
+  outline-offset: 3px;
+}
+
+/* --------------------------------------------------------------------------
+   4. The zoom-in tooltip
+   --------------------------------------------------------------------------
+   Rest: collapsed to --cz-tt-scale-from at the anchor point, transparent.
+   Active: scales to 1 with an overshooting spring curve. transform-origin
+   pins the growth to the arrow tip so it reads as "projected" from the tile.
+   -------------------------------------------------------------------------- */
+.cz-holo {
+  position: absolute;
+  bottom: calc(100% + 12px);
+  left: 50%;
+  z-index: 30;
+  width: max-content;
+  max-width: min(230px, 80vw);
+  padding: 12px 15px;
+  box-sizing: border-box;
+  background: rgba(7, 3, 18, 0.96);
+  border: 1px solid var(--cz-acid);
+  border-radius: 3px;
+  box-shadow: var(--cz-bloom-acid), inset 0 0 18px rgba(157, 255, 0, 0.06);
+  color: #d6cfec;
+  font-size: 0.71rem;
+  line-height: 1.55;
+  pointer-events: none;
+  transform-origin: 50% calc(100% + 12px);
+
+  opacity: 0;
+  visibility: hidden;
+  transform: translateX(-50%) scale(var(--cz-tt-scale-from));
+  transition:
+    opacity var(--cz-tt-duration) var(--cz-tt-ease-out),
+    transform var(--cz-tt-duration) var(--cz-tt-ease-out),
+    visibility 0s linear var(--cz-tt-duration);
+}
+
+/* Projection beam: thin triangle linking holo to its node */
+.cz-holo::before {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 7px solid transparent;
+  border-top-color: var(--cz-acid);
+}
+
+.cz-holo-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 6px;
+  font-size: 0.66rem;
+  font-weight: bold;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--cz-ember);
+  text-shadow: 0 0 7px rgba(255, 107, 26, 0.5);
+}
+
+.cz-holo-head small {
+  font-weight: normal;
+  color: var(--cz-acid);
+}
+
+/* --------------------------------------------------------------------------
+   5. Trigger wiring — pointer or keyboard, same zoom
+   -------------------------------------------------------------------------- */
+.cz-node-btn:hover + .cz-holo,
+.cz-node-btn:focus-visible + .cz-holo {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) scale(1);
+  transition:
+    opacity calc(var(--cz-tt-duration) * 0.6) ease-out,
+    transform var(--cz-tt-duration) var(--cz-tt-ease),
+    visibility 0s;
+}
+
+/* --------------------------------------------------------------------------
+   6. Small screens + motion preferences
+   -------------------------------------------------------------------------- */
+@media (max-width: 520px) {
+  .cz-terminal {
+    padding: 22px 18px 84px;
+  }
+
+  .cz-node-row {
+    gap: 12px;
+  }
+
+  .cz-node-btn {
+    padding: 10px 13px;
+    font-size: 0.73rem;
+  }
+}
+
+/* Reduced motion: no scaling journey, instant legible reveal */
+@media (prefers-reduced-motion: reduce) {
+  .cz-holo,
+  .cz-node-btn:hover + .cz-holo,
+  .cz-node-btn:focus-visible + .cz-holo {
+    transition-duration: 1ms;
+    transform: translateX(-50%) scale(1);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS **Zoom-In Tooltip** styled for **Cyberpunk Neon** layouts as a fully self-contained example under `submissions/examples/34284-cyberpunk-neon-zoom-in-tooltip-sj6/`.

Fixes #34284

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/34284-cyberpunk-neon-zoom-in-tooltip-sj6/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A zero-JavaScript tooltip that zooms into focus like a holo-projection — scaling up from a collapsed point anchored at its trigger with a spring overshoot, revealed by `:hover` and `:focus-visible`.

**How does a developer use it?**

```html
<span class="cz-node">
  <button class="cz-node-btn" type="button" aria-describedby="my-holo">
    NODE 09-A
  </button>
  <span class="cz-holo" id="my-holo" role="tooltip">
    <span class="cz-holo-head">Header <small>TAG</small></span>
    Body copy zooms into focus above the trigger.
  </span>
</span>
```

**Why does it fit EaseMotion CSS?**

Human-readable classes, animation-first, zero JS. The zoom is fully tunable via CSS custom properties (`--cz-tt-scale-from`, `--cz-tt-duration`, `--cz-tt-ease`, `--cz-tt-ease-out`), `transform-origin` is pinned to the arrow tip so the growth reads as "projected" from the trigger, triggers are real `<button>` elements with `aria-describedby`/`role="tooltip"`, and a `prefers-reduced-motion` guard collapses the zoom into an instant reveal.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The demo is a "NetWatch security grid" console with three tooltip nodes so wrap behavior on narrow screens is visible. Show and hide use separate easing curves — the exit is deliberately faster so dismissal never feels laggy. All knobs are on `:root`.

@SAPTARSHI-coder  Please review this pr 
