### PR TITLE
 feat : add loading-dots-button-k553 submission

### DIFF
--- a/submissions/examples/loading-dots-button-k553/README.md
+++ b/submissions/examples/loading-dots-button-k553/README.md
@@ -1,0 +1,25 @@
+# Loading Dots Button
+
+**EaseMotion Submission** · Contributor: kavin553
+
+---
+
+## 1. What does this do?
+
+Solves the button loading-state transition problem: when a button's label is replaced by a loading indicator, the button's width stays fixed instead of jumping/resizing, and the three dots animate in place using the exact bounce animation requested in issue #36188.
+
+## 2. How is it used?
+
+```html
+<button class="loading-dots-btn" id="submitBtn">
+  <span class="btn-label">Submit</span>
+  <span class="btn-dots">
+    <span></span><span></span><span></span>
+  </span>
+</button>
+
+<script>
+  // Toggle from your own app logic (e.g. on form submit / API call)
+  submitBtn.classList.add('is-loading');
+  submitBtn.disabled = true;
+</script>

--- a/submissions/examples/loading-dots-button-k553/demo.html
+++ b/submissions/examples/loading-dots-button-k553/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Loading Dots Button Demo</title>
+  <link rel="stylesheet" href="./style.css" />
+  <style>
+    body {
+      font-family: sans-serif;
+      background: #f4f4f7;
+      display: flex;
+      gap: 1.5rem;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      flex-direction: column;
+    }
+
+    p {
+      color: #666;
+      font-size: 0.9rem;
+    }
+  </style>
+</head>
+<body>
+
+  <button class="loading-dots-btn" id="demoBtn" onclick="toggleLoading()">
+    <span class="btn-label">Submit</span>
+    <span class="btn-dots">
+      <span></span><span></span><span></span>
+    </span>
+  </button>
+
+  <p>Click the button — width stays fixed while the label swaps to loading dots.</p>
+
+  <script>
+    function toggleLoading() {
+      const btn = document.getElementById('demoBtn');
+      btn.classList.add('is-loading');
+      btn.disabled = true;
+
+      // Simulate an async action (e.g. API request)
+      setTimeout(() => {
+        btn.classList.remove('is-loading');
+        btn.disabled = false;
+      }, 2000);
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/loading-dots-button-k553/style.css
+++ b/submissions/examples/loading-dots-button-k553/style.css
@@ -1,0 +1,85 @@
+/*
+  Loading Dots Button — button loading-state transition with no width jump.
+  Contributor: kavin553 (submission id: k553)
+
+  Distinct from submissions/examples/loading-states/: that submission
+  provides a standalone ease-spinner-dots element placed inside a static
+  button, but doesn't solve the transition itself. This submission
+  handles the actual UX problem: a button's width jumping when its
+  label is replaced by a loading indicator.
+
+  No "ease-" prefix used, per submission guidelines.
+*/
+
+.loading-dots-btn {
+  position: relative;
+  min-width: 140px; /* reserves space so width never jumps on state change */
+  padding: 0.9rem 1.8rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: white;
+  background: #007bff;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.loading-dots-btn:disabled {
+  cursor: not-allowed;
+  background: #4d94ff;
+}
+
+/* Label fades out, dots fade in — same position, no reflow */
+.loading-dots-btn .btn-label,
+.loading-dots-btn .btn-dots {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  transition: opacity 0.2s ease;
+}
+
+.loading-dots-btn .btn-dots {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.loading-dots-btn.is-loading .btn-label {
+  opacity: 0;
+}
+
+.loading-dots-btn.is-loading .btn-dots {
+  opacity: 1;
+}
+
+.btn-dots span {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: white;
+  animation: loading-dots-bounce-k553 0.8s infinite alternate;
+}
+
+.btn-dots span:nth-child(2) {
+  animation-delay: 0.15s;
+}
+
+.btn-dots span:nth-child(3) {
+  animation-delay: 0.3s;
+}
+
+@keyframes loading-dots-bounce-k553 {
+  to {
+    transform: translateY(-6px);
+    opacity: 0.5;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .btn-dots span {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a new self-contained submission — `loading-dots-button-k553` — solving the button loading-state transition problem: a fixed-width button that smoothly swaps its label for a 3-dot bounce indicator with zero layout jump, addressing issue #36188's request for a loading dots utility from a real-world integration angle.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (`submissions/examples/loading-dots-button-k553/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A button loading-state pattern that reserves width up front and cross-fades its label into a 3-dot bounce indicator, so the button never resizes or jumps when entering/exiting a loading state.

**How does a developer use it?**

```html
<button class="loading-dots-btn" id="submitBtn">
  <span class="btn-label">Submit</span>
  <span class="btn-dots">
    <span></span><span></span><span></span>
  </span>
</button>

Why does it fit EaseMotion CSS?
Pure CSS animation, zero dependencies, solves a real everyday UX problem (button width jumping during loading states) using the same bounce timing requested in the issue — matching the animation-first, human-readable philosophy while covering a practical integration gap.
Demo
[x] Demo added (demo.html works by opening directly in a browser)
Browser Testing
[x] Chrome
[x] Firefox
[x] Edge
[ ] Safari (optional but appreciated)
Notes for Maintainer
I checked submissions/examples/loading-states/ before starting — it already provides a comprehensive ease-spinner-dots element (plus 5 other spinner types and skeleton loaders), and places it inside a static button in its usage example. However, it doesn't solve the transition itself: buttons commonly jump/resize when their label is swapped for a loading indicator. This submission solves that specific integration gap using a fixed min-width and cross-fade, reusing the same bounce keyframe timing from the issue. The demo includes a small local <script> purely to toggle the .is-loading class interactively for review — the CSS itself has zero JS dependency. Suffix -k553 added per naming policy.
Reminder: Only the repository maintainer may merge pull requests.
Do not self-merge, even if you have write access.
Maximum 25 active assigned issues per contributor — unassign extras before opening a PR.
Tip: Once you open your PR, feel free to showcase your design or component in the #showcase channel on our official Discord Server!