### PR TITLE
feat: add copy-to-clipboard button component #36267

### DIFF
--- a/submissions/examples/copy-to-clipboard-btn/README.md
+++ b/submissions/examples/copy-to-clipboard-btn/README.md
@@ -1,0 +1,15 @@
+# Copy-to-Clipboard Component with Morphing Check Pulse
+
+An intuitive micro-interaction utility built for **EaseMotion CSS** that visually morphs an active utility element upon successful completion of clipboard data copies.
+
+## 🚀 Component Advantages
+- **Fluid Morph States:** Uses CSS scaling keyframes to transition the standard action sheets icon cleanly into a success confirmation checkmark.
+- **Micro-Impact Physics:** Includes an implicit elastic overshoot timing curve (`cubic-bezier(0.34, 1.56, 0.64, 1)`) to make the success trigger look snappy and premium.
+- **Minimal Main Thread Scripting:** Uses only JavaScript to access native browser background processes (`navigator.clipboard`), keeping layout alterations pure CSS.
+
+## 📂 Submission Directory Layout
+```text
+submissions/examples/copy-to-clipboard-btn/
+├── demo.html   # Sandbox code frame workspace with sample copy target text
+├── style.css   # Implementation of transition logic, structural button tokens, and pulse mechanics
+└── README.md   # Setup documentation and guidance manually

--- a/submissions/examples/copy-to-clipboard-btn/demo.html
+++ b/submissions/examples/copy-to-clipboard-btn/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Copy-to-Clipboard Button - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="sandbox-container">
+    <div class="snippet-card">
+      <div class="snippet-header">
+        <span class="file-label">api-endpoint.sh</span>
+        
+        <button class="copy-btn" id="copyBtn" data-copy-text="https://api.easemotioncss.org/v1/animate" aria-label="Copy API Endpoint">
+          <svg class="copy-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+          </svg>
+          <svg class="check-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="20 6 9 17 4 12"></polyline>
+          </svg>
+          <span class="btn-text">Copy</span>
+        </button>
+      </div>
+      <div class="snippet-body">
+        <code>https://api.easemotioncss.org/v1/animate</code>
+      </div>
+    </div>
+  </main>
+
+  <script>
+    const copyBtn = document.getElementById('copyBtn');
+    const btnText = copyBtn.querySelector('.btn-text');
+    let isResetting = false;
+
+    copyBtn.addEventListener('click', async () => {
+      if (isResetting) return;
+      
+      const textToCopy = copyBtn.getAttribute('data-copy-text');
+      
+      try {
+        await navigator.clipboard.writeText(textToCopy);
+        
+        // Trigger Animated State Classes
+        copyBtn.classList.add('copied');
+        btnText.textContent = 'Copied!';
+        isResetting = true;
+        
+        // Revert back to original state after 2 seconds
+        setTimeout(() => {
+          copyBtn.classList.remove('copied');
+          btnText.textContent = 'Copy';
+          isResetting = false;
+        }, 2000);
+        
+      } catch (err) {
+        console.error('Failed to copy text: ', err);
+      }
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/copy-to-clipboard-btn/style.css
+++ b/submissions/examples/copy-to-clipboard-btn/style.css
@@ -1,0 +1,120 @@
+/* --- Sandbox Presentation Layout --- */
+body {
+  margin: 0;
+  padding: 0;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background-color: #0f172a;
+  color: #f8fafc;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.sandbox-container {
+  width: 100%;
+  max-width: 500px;
+  padding: 1rem;
+}
+
+.snippet-card {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.3);
+}
+
+.snippet-header {
+  background: #0f172a;
+  padding: 0.75rem 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid #334155;
+}
+
+.file-label {
+  font-family: monospace;
+  font-size: 0.85rem;
+  color: #94a3b8;
+}
+
+.snippet-body {
+  padding: 1.25rem;
+  background: #111827;
+}
+
+.snippet-body code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.95rem;
+  color: #38bdf8;
+  word-break: break-all;
+}
+
+/* --- Core Feature: Animated Copy Button Component --- */
+.copy-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 1px solid #475569;
+  border-radius: 6px;
+  background: #1e293b;
+  color: #94a3b8;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.1s ease;
+}
+
+.copy-btn:hover {
+  background: #334155;
+  border-color: #64748b;
+  color: #f1f5f9;
+}
+
+.copy-btn:active {
+  transform: scale(0.96);
+}
+
+.copy-btn svg {
+  width: 14px;
+  height: 14px;
+}
+
+/* Icon visibility routing rules */
+.copy-btn .check-icon {
+  display: none;
+}
+
+/* Active copied status overrides */
+.copy-btn.copied {
+  background: rgba(16, 185, 129, 0.1);
+  border-color: #10b981;
+  color: #34d399;
+}
+
+.copy-btn.copied .copy-icon {
+  display: none;
+}
+
+.copy-btn.copied .check-icon {
+  display: inline-block;
+  animation: check-pulse 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* Smooth morph scaling keyframe pulse sequence */
+@keyframes check-pulse {
+  0% {
+    transform: scale(0.5);
+    opacity: 0;
+  }
+  60% {
+    transform: scale(1.25);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+  }
+}


### PR DESCRIPTION
## 🚀 Proposed Changes

This PR addresses issue #36267 by establishing an interactive, performance-friendly **Copy-to-Clipboard Button** within the submissions framework.

The workflow uses an asynchronous JavaScript navigator fallback to securely set system clipboard buffers on click, while handling the rest of the layout transitions natively via CSS. When activated, the component swaps the default document icon for an animated checkmark that uses an elastic scale-up keyframe rule (`@keyframes check-pulse`) to clearly signal a successful operation to the user.

## 📂 Submissions Checklist
- [x] Created `submissions/examples/copy-to-clipboard-btn/`
- [x] Included `demo.html` (Complete mock inline command dashboard sandboxing layout strings)
- [x] Included `style.css` (Micro-state animations, active scaling logic, and SVG color variations)
- [x] Included `README.md` (Integration manuals and functional breakdown details)

## 🛠️ Technical Specifications
- **Snappy Curve Transitions:** Utilizes an overshoot timing curve (`cubic-bezier(0.34, 1.56, 0.64, 1)`) to provide clean visual feedback.
- **Performance Optimized:** Uses discrete state toggles (`.copied`) to cleanly change display nodes on demand without causing layout thrashing or repetitive rendering cycles.

## 🔗 Closes Issue
Closes #36267