### PR TITLE
feat: add skeleton loader with shimmer sweep submission

### DIFF
--- a/submissions/examples/skeleton-loader-sup/README.md
+++ b/submissions/examples/skeleton-loader-sup/README.md
@@ -1,0 +1,20 @@
+# Skeleton Loader
+
+1. **What does this do?** Shows a content-shaped placeholder with a shimmer sweep while real data is still loading, instead of a generic spinner.
+
+2. **How is it used?** Wrap placeholder blocks in a container with `.skeleton-loader-sup`, and give each shape (avatar, title line, text line) the `.skeleton-loader-sup__block` class plus a size modifier:
+
+```html
+<div class="skeleton-loader-sup" role="status" aria-live="polite" aria-label="Loading content">
+  <div class="skeleton-loader-sup__avatar-row">
+    <div class="skeleton-loader-sup__block skeleton-loader-sup__avatar"></div>
+    <div class="skeleton-loader-sup__text-lines">
+      <div class="skeleton-loader-sup__block skeleton-loader-sup__line skeleton-loader-sup__line--title"></div>
+      <div class="skeleton-loader-sup__block skeleton-loader-sup__line skeleton-loader-sup__line--short"></div>
+    </div>
+  </div>
+  <div class="skeleton-loader-sup__block skeleton-loader-sup__line skeleton-loader-sup__line--full"></div>
+</div>
+```
+
+3. **Why is it useful?** A shimmering, content-shaped skeleton gives users a clearer sense of *what* is loading and roughly how it will be laid out, which feels faster than a blank screen or a spinner — the same pattern used by GitHub, LinkedIn, and YouTube. It also respects `prefers-reduced-motion` (the shimmer animation is dropped, leaving a static placeholder) and adapts its colors under `prefers-color-scheme: dark`, matching EaseMotion CSS's accessibility-first philosophy.

--- a/submissions/examples/skeleton-loader-sup/demo.html
+++ b/submissions/examples/skeleton-loader-sup/demo.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Skeleton Loader Demo</title>
+<link rel="stylesheet" href="./style.css">
+<style>
+  body {
+    font-family: system-ui, sans-serif;
+    background: #ffffff;
+    color: #1a1a1a;
+    padding: 2rem;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    body {
+      background: #121212;
+      color: #eaeaea;
+    }
+  }
+
+  h1 {
+    font-size: 1.1rem;
+    margin-bottom: 1.5rem;
+  }
+</style>
+</head>
+<body>
+  <h1>Skeleton loading placeholder</h1>
+
+  <div class="skeleton-loader-sup" role="status" aria-live="polite" aria-label="Loading content">
+    <div class="skeleton-loader-sup__avatar-row">
+      <div class="skeleton-loader-sup__block skeleton-loader-sup__avatar"></div>
+      <div class="skeleton-loader-sup__text-lines">
+        <div class="skeleton-loader-sup__block skeleton-loader-sup__line skeleton-loader-sup__line--title"></div>
+        <div class="skeleton-loader-sup__block skeleton-loader-sup__line skeleton-loader-sup__line--short"></div>
+      </div>
+    </div>
+    <div class="skeleton-loader-sup__block skeleton-loader-sup__line skeleton-loader-sup__line--full"></div>
+    <div class="skeleton-loader-sup__block skeleton-loader-sup__line skeleton-loader-sup__line--full"></div>
+    <div class="skeleton-loader-sup__block skeleton-loader-sup__line skeleton-loader-sup__line--short"></div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/skeleton-loader-sup/style.css
+++ b/submissions/examples/skeleton-loader-sup/style.css
@@ -1,0 +1,90 @@
+/* Skeleton loading placeholder with a shimmer sweep.
+   Communicates "content is loading" without a spinner, matching the
+   shape of the content that will appear once it's ready. */
+
+.skeleton-loader-sup {
+  --skeleton-base: #e2e2e2;
+  --skeleton-highlight: #f4f4f4;
+  --skeleton-radius: 8px;
+  --skeleton-duration: 1.4s;
+
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 320px;
+}
+
+.skeleton-loader-sup__avatar-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.skeleton-loader-sup__block {
+  background: linear-gradient(
+    100deg,
+    var(--skeleton-base) 30%,
+    var(--skeleton-highlight) 50%,
+    var(--skeleton-base) 70%
+  );
+  background-size: 200% 100%;
+  border-radius: var(--skeleton-radius);
+  animation: skeleton-loader-sup-shimmer var(--skeleton-duration) ease-in-out infinite;
+}
+
+.skeleton-loader-sup__avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.skeleton-loader-sup__line {
+  height: 12px;
+}
+
+.skeleton-loader-sup__line--title {
+  width: 60%;
+  height: 14px;
+}
+
+.skeleton-loader-sup__line--short {
+  width: 40%;
+}
+
+.skeleton-loader-sup__line--full {
+  width: 100%;
+}
+
+.skeleton-loader-sup__text-lines {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  flex: 1;
+}
+
+@keyframes skeleton-loader-sup-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+/* Respect users who've asked for less motion: keep the placeholder
+   shape visible, but drop the sweeping animation. */
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-loader-sup__block {
+    animation: none;
+    background: var(--skeleton-base);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .skeleton-loader-sup {
+    --skeleton-base: #2a2a2a;
+    --skeleton-highlight: #3a3a3a;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained skeleton loading placeholder (avatar + text lines) with a shimmer sweep animation, as a Standard Track submission.

## Type of Change

New component.

## Submission Checklist

All boxes below are satisfied: changes are only inside submissions/examples/skeleton-loader-sup/, includes demo.html (self-contained, opens with no server), style.css (raw CSS), and README.md (what/how/why). No changes to core/ or components/. One feature per PR.

## Feature Description

What it does: shows a content-shaped placeholder while real data is still loading, instead of a generic spinner.

Accessibility: respects prefers-reduced-motion (drops the shimmer animation, keeps a static placeholder shape) and adapts colors under prefers-color-scheme: dark. Uses role="status" and aria-live="polite" so screen readers announce the loading state.

Tested by opening demo.html directly in a browser (no server or build step needed).