### PR TITLE
feat : add hover-focus-glow-status-k553 submission

### DIFF
--- a/submissions/examples/hover-focus-glow-status-k553/README.md
+++ b/submissions/examples/hover-focus-glow-status-k553/README.md
@@ -1,0 +1,17 @@
+# Hover/Focus Glow — Status Variants
+
+**EaseMotion Submission** · Contributor: kavin553
+
+---
+
+## 1. What does this do?
+
+Adds a `box-shadow` glow that triggers on both hover **and** keyboard focus, with semantic status modifiers (default, success, error, warning) as a single composable system.
+
+## 2. How is it used?
+
+```html
+<button class="glow-status">Default</button>
+<button class="glow-status glow-success">Success</button>
+<button class="glow-status glow-error">Error</button>
+<input class="glow-status glow-warning" placeholder="Focus me" />

--- a/submissions/examples/hover-focus-glow-status-k553/demo.html
+++ b/submissions/examples/hover-focus-glow-status-k553/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Hover/Focus Glow Status Demo</title>
+  <link rel="stylesheet" href="./style.css" />
+  <style>
+    body {
+      font-family: sans-serif;
+      background: #f4f4f7;
+      display: flex;
+      gap: 1.5rem;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      flex-wrap: wrap;
+      padding: 2rem;
+    }
+
+    input, button {
+      padding: 0.8rem 1.2rem;
+      font-size: 1rem;
+      border-radius: 8px;
+      border: 1px solid #ddd;
+    }
+
+    button {
+      background: #3b82f6;
+      color: white;
+      border: none;
+      cursor: pointer;
+    }
+  </style>
+</head>
+<body>
+
+  <button class="glow-status">Default</button>
+  <button class="glow-status glow-success">Success</button>
+  <button class="glow-status glow-error">Error</button>
+  <input class="glow-status glow-warning" placeholder="Focus me (warning)" />
+
+</body>
+</html>

--- a/submissions/examples/hover-focus-glow-status-k553/style.css
+++ b/submissions/examples/hover-focus-glow-status-k553/style.css
@@ -1,0 +1,46 @@
+/*
+  Hover/Focus Glow — Status Variants
+  Contributor: kavin553 (submission id: k553)
+
+  Distinct from existing glow submissions (glow-button-emphasis,
+  glow-card-emphasis, glow-icon-hover-v1, glow-text-utility,
+  glow-warning-token): those are hover-only, per-component decorative
+  glows. This submission adds:
+    - :focus-visible support (keyboard accessibility gap none of the
+      existing glow submissions address)
+    - A semantic status system (default/success/error/warning) as
+      swappable modifier classes on one base class, rather than a
+      single fixed color per component
+
+  No "ease-" prefix used, per submission guidelines.
+*/
+
+.glow-status {
+  transition: box-shadow 0.3s ease;
+}
+
+.glow-status:hover,
+.glow-status:focus-visible {
+  box-shadow: 0 0 18px rgba(59, 130, 246, 0.45); /* default: blue */
+}
+
+.glow-status.glow-success:hover,
+.glow-status.glow-success:focus-visible {
+  box-shadow: 0 0 18px rgba(34, 197, 94, 0.45); /* green */
+}
+
+.glow-status.glow-error:hover,
+.glow-status.glow-error:focus-visible {
+  box-shadow: 0 0 18px rgba(239, 68, 68, 0.45); /* red */
+}
+
+.glow-status.glow-warning:hover,
+.glow-status.glow-warning:focus-visible {
+  box-shadow: 0 0 18px rgba(234, 179, 8, 0.45); /* amber */
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glow-status {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a new self-contained submission — `hover-focus-glow-status-k553` — implementing a `box-shadow` glow that triggers on both hover and keyboard focus, with semantic status modifiers (success/error/warning), addressing issue #36189 from an angle not yet covered by existing glow submissions.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (`submissions/examples/hover-focus-glow-status-k553/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A `box-shadow` glow triggered on both `:hover` and `:focus-visible`, with semantic status modifiers (`glow-success`, `glow-error`, `glow-warning`) layered on a single reusable base class.

**How does a developer use it?**

```html
<button class="glow-status">Default</button>
<button class="glow-status glow-success">Success</button>
<button class="glow-status glow-error">Error</button>
<input class="glow-status glow-warning" placeholder="Focus me" />

Why does it fit EaseMotion CSS?
Pure CSS, zero dependencies, composable via modifier classes rather than one-off hardcoded colors per component — matching the animation-first, reusable-utility philosophy while closing a keyboard-accessibility gap.
Demo
[x] Demo added (demo.html works by opening directly in a browser)
Browser Testing
[x] Chrome
[x] Firefox
[x] Edge
[ ] Safari (optional but appreciated)
Notes for Maintainer
I checked submissions/examples/ before starting and found several existing glow submissions: glow-button-emphasis, glow-card-emphasis, glow-icon-hover-v1, glow-text-utility, and glow-warning-token. All are hover-only, per-component, single-color decorative glows. Rather than adding a sixth near-duplicate, this submission covers two gaps none of them address: :focus-visible support for keyboard accessibility, and a semantic status system (success/error/warning) as composable modifiers on one base class. Happy to have this merged as a complement to the existing set, or adjusted if you'd rather consolidate the glow submissions differently. Suffix -k553 added per naming policy.
Reminder: Only the repository maintainer may merge pull requests.
Do not self-merge, even if you have write access.
Maximum 25 active assigned issues per contributor — unassign extras before opening a PR.
Tip: Once you open your PR, feel free to showcase your design or component in the #showcase channel on our official Discord Server!