### PR TITLE
feat(examples): Neumorphic Soft Zoom-In Tooltip

### DIFF
--- a/submissions/examples/34285-neumorphic-soft-zoom-in-tooltip-sj6/README.md
+++ b/submissions/examples/34285-neumorphic-soft-zoom-in-tooltip-sj6/README.md
@@ -1,0 +1,59 @@
+# Neumorphic Soft Zoom-In Tooltip
+
+A pure CSS, zero-dependency tooltip built for **soft-UI (neumorphism)**
+surfaces. The tooltip is a raised card cut from the same clay as the page —
+it *breathes in* with a small, calm zoom and floats above the surface on a
+deeper dual shadow. Reveal is driven entirely by `:hover` and
+`:focus-visible`, so mouse and keyboard users get the same experience with
+zero JavaScript.
+
+Resolves Issue: #34285
+
+## ✨ Features
+
+- **Gentle Zoom-In** — scales from `--nm-tt-scale-from` (default `0.72`) to
+  full size with a faint overshoot; deliberately restrained motion that
+  matches the calm of neumorphic design. Hide uses a quicker `ease-in` exit.
+- **True soft-UI material** — one `--nm-surface` color everywhere; depth
+  comes only from paired light/dark shadows (`--nm-raised`,
+  `--nm-floating`, `--nm-pressed`). The trigger key *presses into* the clay
+  on hover — classic neumorphic feedback.
+- **Soft diamond pointer** — the arrow is a rotated, shadow-matched square
+  of the same surface, so the tooltip stays arrow-consistent with the theme
+  (no hard CSS-border triangles).
+- **Zero JavaScript** — sibling-selector engine
+  (`.nm-key:hover + .nm-tip`), CSS transitions only.
+- **Keyboard accessible** — real `<button>` triggers with `aria-describedby`
+  → `role="tooltip"` and a crisp 3px accent `:focus-visible` halo.
+- **Tunable via custom properties** — start scale, duration, show curve,
+  and exit curve are all exposed on `:root`.
+- **Responsive & motion-safe** — keys wrap on narrow screens, tooltip width
+  caps at `min(220px, 78vw)`, and `prefers-reduced-motion` replaces the
+  zoom with an instant reveal.
+
+## 🔧 Custom Properties
+
+| Property             | Default                            | Role                     |
+| -------------------- | ---------------------------------- | ------------------------ |
+| `--nm-tt-scale-from` | `0.72`                             | Starting scale           |
+| `--nm-tt-duration`   | `260ms`                            | Breathe-in time          |
+| `--nm-tt-ease`       | `cubic-bezier(0.3, 1.24, 0.6, 1)`  | Show curve (soft pop)    |
+| `--nm-tt-ease-exit`  | `ease-in`                          | Hide curve               |
+
+## 🚀 Usage
+
+```html
+<span class="nm-anchor">
+  <button class="nm-key" type="button" aria-describedby="my-tip">☾</button>
+  <span class="nm-tip" id="my-tip" role="tooltip">
+    <span class="nm-tip-title">Card title</span>
+    Explanation copy zooms in gently above the key.
+  </span>
+</span>
+```
+
+## 📂 Files
+
+- `demo.html` — "evening wind-down" smart-home panel with four tooltip keys.
+- `style.css` — clay tokens, shadow recipes, zoom engine, a11y guards.
+- `README.md` — this document.

--- a/submissions/examples/34285-neumorphic-soft-zoom-in-tooltip-sj6/demo.html
+++ b/submissions/examples/34285-neumorphic-soft-zoom-in-tooltip-sj6/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Neumorphic Soft Zoom-In Tooltip — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="nm-panel" aria-label="Wellness control panel demo">
+    <h1 class="nm-title">Evening Wind-Down</h1>
+    <p class="nm-caption">
+      Hover a control — or Tab to it — and its explanation card breathes in
+      with a gentle zoom, floating just above the surface.
+    </p>
+
+    <div class="nm-keys">
+      <span class="nm-anchor">
+        <button class="nm-key" type="button" aria-describedby="tip-dim">
+          ☾
+        </button>
+        <span class="nm-tip" id="tip-dim" role="tooltip">
+          <span class="nm-tip-title">Dim Lights</span>
+          Fades every connected lamp to 20% warmth over five minutes.
+        </span>
+      </span>
+
+      <span class="nm-anchor">
+        <button class="nm-key" type="button" aria-describedby="tip-sound">
+          ♫
+        </button>
+        <span class="nm-tip" id="tip-sound" role="tooltip">
+          <span class="nm-tip-title">Rain Sounds</span>
+          Plays a soft rain loop in the bedroom speakers, off at midnight.
+        </span>
+      </span>
+
+      <span class="nm-anchor">
+        <button class="nm-key" type="button" aria-describedby="tip-air">
+          ❆
+        </button>
+        <span class="nm-tip" id="tip-air" role="tooltip">
+          <span class="nm-tip-title">Cool Air</span>
+          Drops the thermostat two degrees for deeper sleep cycles.
+        </span>
+      </span>
+
+      <span class="nm-anchor">
+        <button class="nm-key" type="button" aria-describedby="tip-lock">
+          ⌂
+        </button>
+        <span class="nm-tip" id="tip-lock" role="tooltip">
+          <span class="nm-tip-title">Secure Home</span>
+          Locks both doors and arms the porch sensor until sunrise.
+        </span>
+      </span>
+    </div>
+  </main>
+</body>
+
+</html>

--- a/submissions/examples/34285-neumorphic-soft-zoom-in-tooltip-sj6/style.css
+++ b/submissions/examples/34285-neumorphic-soft-zoom-in-tooltip-sj6/style.css
@@ -1,0 +1,219 @@
+/* ==========================================================================
+   Neumorphic Soft Zoom-In Tooltip
+   --------------------------------------------------------------------------
+   Pure CSS tooltip for soft-UI (neumorphism) surfaces. The tooltip is a
+   gently raised card cut from the same clay as the page: it breathes in
+   with a small, calm zoom — no hard edges, no harsh motion, no JavaScript.
+
+   Interaction is driven by :hover and :focus-visible only, so keyboard
+   users get the identical experience.
+
+   Issue: #34285
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Design tokens — motion knobs first, then the soft-clay material
+   -------------------------------------------------------------------------- */
+:root {
+  /* Zoom motion (kept gentle on purpose — soft UI dislikes violence) */
+  --nm-tt-scale-from: 0.72;                            /* starting size     */
+  --nm-tt-duration: 260ms;                             /* breathe-in time   */
+  --nm-tt-ease: cubic-bezier(0.3, 1.24, 0.6, 1);       /* faint overshoot   */
+  --nm-tt-ease-exit: ease-in;                          /* quick, quiet hide */
+
+  /* Clay material */
+  --nm-surface: #e4e9f2;
+  --nm-ink: #4c566e;
+  --nm-muted: #8b95ab;
+  --nm-accent: #6d7ff2;
+
+  /* The two lights every neumorphic surface lives between */
+  --nm-shadow-dark: rgba(163, 177, 198, 0.65);
+  --nm-shadow-light: rgba(255, 255, 255, 0.95);
+
+  /* Shadow recipes: raised, hovering, and pressed-in */
+  --nm-raised: 7px 7px 14px var(--nm-shadow-dark), -7px -7px 14px var(--nm-shadow-light);
+  --nm-floating: 10px 10px 22px var(--nm-shadow-dark), -10px -10px 22px var(--nm-shadow-light);
+  --nm-pressed: inset 5px 5px 10px var(--nm-shadow-dark), inset -5px -5px 10px var(--nm-shadow-light);
+}
+
+/* --------------------------------------------------------------------------
+   2. Demo stage — one continuous soft surface
+   -------------------------------------------------------------------------- */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 36px 18px;
+  box-sizing: border-box;
+  background: var(--nm-surface);
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  color: var(--nm-ink);
+}
+
+.nm-panel {
+  width: 100%;
+  max-width: 480px;
+  padding: 34px 34px 110px;
+  border-radius: 28px;
+  background: var(--nm-surface);
+  box-shadow: var(--nm-raised);
+}
+
+.nm-title {
+  margin: 0 0 4px;
+  font-size: 1.15rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.nm-caption {
+  margin: 0 0 30px;
+  font-size: 0.83rem;
+  line-height: 1.6;
+  color: var(--nm-muted);
+}
+
+/* Wrapping row of round keys — stays tidy at any width */
+.nm-keys {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 22px;
+}
+
+/* --------------------------------------------------------------------------
+   3. Anchor + round soft key
+   -------------------------------------------------------------------------- */
+.nm-anchor {
+  position: relative;
+  display: inline-flex;
+}
+
+.nm-key {
+  width: 58px;
+  height: 58px;
+  display: grid;
+  place-items: center;
+  font-size: 1.25rem;
+  color: var(--nm-accent);
+  background: var(--nm-surface);
+  border: none;
+  border-radius: 50%;
+  box-shadow: var(--nm-raised);
+  cursor: pointer;
+  transition: box-shadow 200ms ease, color 200ms ease, transform 200ms ease;
+}
+
+/* Classic soft-UI feedback: the key presses INTO the clay on hover */
+.nm-key:hover {
+  box-shadow: var(--nm-pressed);
+  transform: scale(0.97);
+}
+
+/* Keyboard ring: crisp accent halo that reads on the pale surface */
+.nm-key:focus-visible {
+  outline: 3px solid var(--nm-accent);
+  outline-offset: 4px;
+}
+
+/* --------------------------------------------------------------------------
+   4. The zoom-in tooltip card
+   --------------------------------------------------------------------------
+   Rest: shrunk to --nm-tt-scale-from at its anchor, invisible.
+   Active: breathes up to full size, floating on a deeper shadow.
+   -------------------------------------------------------------------------- */
+.nm-tip {
+  position: absolute;
+  bottom: calc(100% + 16px);
+  left: 50%;
+  z-index: 10;
+  width: max-content;
+  max-width: min(220px, 78vw);
+  padding: 13px 16px;
+  box-sizing: border-box;
+  background: var(--nm-surface);
+  border-radius: 16px;
+  box-shadow: var(--nm-floating);
+  font-size: 0.76rem;
+  line-height: 1.55;
+  color: var(--nm-ink);
+  text-align: left;
+  pointer-events: none;
+  transform-origin: 50% 100%;
+
+  opacity: 0;
+  visibility: hidden;
+  transform: translateX(-50%) scale(var(--nm-tt-scale-from));
+  transition:
+    opacity calc(var(--nm-tt-duration) * 0.7) var(--nm-tt-ease-exit),
+    transform calc(var(--nm-tt-duration) * 0.7) var(--nm-tt-ease-exit),
+    visibility 0s linear calc(var(--nm-tt-duration) * 0.7);
+}
+
+/* Soft diamond pointer — a rotated square of the same clay */
+.nm-tip::after {
+  content: "";
+  position: absolute;
+  top: calc(100% - 7px);
+  left: 50%;
+  width: 14px;
+  height: 14px;
+  background: var(--nm-surface);
+  border-radius: 3px;
+  transform: translateX(-50%) rotate(45deg);
+  box-shadow: 4px 4px 8px var(--nm-shadow-dark);
+}
+
+.nm-tip-title {
+  display: block;
+  margin-bottom: 3px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--nm-accent);
+}
+
+/* --------------------------------------------------------------------------
+   5. Reveal wiring — pointer and keyboard share one path
+   -------------------------------------------------------------------------- */
+.nm-key:hover + .nm-tip,
+.nm-key:focus-visible + .nm-tip {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) scale(1);
+  transition:
+    opacity var(--nm-tt-duration) var(--nm-tt-ease),
+    transform var(--nm-tt-duration) var(--nm-tt-ease),
+    visibility 0s;
+}
+
+/* --------------------------------------------------------------------------
+   6. Narrow screens + reduced motion
+   -------------------------------------------------------------------------- */
+@media (max-width: 460px) {
+  .nm-panel {
+    padding: 26px 22px 96px;
+    border-radius: 22px;
+  }
+
+  .nm-keys {
+    gap: 16px;
+  }
+
+  .nm-key {
+    width: 52px;
+    height: 52px;
+    font-size: 1.1rem;
+  }
+}
+
+/* Reduced motion: the card simply appears, already full size */
+@media (prefers-reduced-motion: reduce) {
+  .nm-tip,
+  .nm-key:hover + .nm-tip,
+  .nm-key:focus-visible + .nm-tip {
+    transition-duration: 1ms;
+    transform: translateX(-50%) scale(1);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS **Zoom-In Tooltip** styled for **Neumorphic Soft** layouts as a fully self-contained example under `submissions/examples/34285-neumorphic-soft-zoom-in-tooltip-sj6/`.

Fixes #34285

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/34285-neumorphic-soft-zoom-in-tooltip-sj6/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A zero-JavaScript soft-UI tooltip that "breathes in" with a gentle zoom and floats above the clay surface on a deeper dual shadow, revealed by `:hover` and `:focus-visible`. The trigger keys press into the surface on hover — classic neumorphic feedback.

**How does a developer use it?**

```html
<span class="nm-anchor">
  <button class="nm-key" type="button" aria-describedby="my-tip">☾</button>
  <span class="nm-tip" id="my-tip" role="tooltip">
    <span class="nm-tip-title">Card title</span>
    Explanation copy zooms in gently above the key.
  </span>
</span>
```

**Why does it fit EaseMotion CSS?**

Human-readable classes, animation-first, zero JS. Motion is tunable via CSS custom properties (`--nm-tt-scale-from`, `--nm-tt-duration`, `--nm-tt-ease`, `--nm-tt-ease-exit`); depth comes exclusively from paired light/dark shadow tokens so the whole theme can be re-skinned from `:root`; triggers are real `<button>` elements with `aria-describedby`/`role="tooltip"`; `prefers-reduced-motion` replaces the zoom with an instant reveal.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The arrow is a rotated, shadow-matched square of the same surface color rather than a CSS-border triangle — hard triangles break the soft-UI illusion. The demo is a small smart-home "wind-down" panel with four keys so wrap behavior is visible on narrow screens.

@SAPTARSHI-coder Please review this pr