### PR TITLE
feat: add reusable MotionGroup React component

### DIFF
--- a/submissions/react/36317-motion-group-dp/MotionGroup.jsx
+++ b/submissions/react/36317-motion-group-dp/MotionGroup.jsx
@@ -1,0 +1,34 @@
+import { Children, cloneElement, isValidElement } from "react";
+
+export default function MotionGroup({
+  children,
+  animationClass,
+  stagger = 100,
+  delay = 0,
+  className = "",
+  as: Wrapper = "div",
+}) {
+  const items = Children.toArray(children);
+
+  return (
+    <Wrapper className={["motion-group", className].filter(Boolean).join(" ")}>
+      {Children.map(items, (child, index) => {
+        if (!isValidElement(child)) return child;
+
+        const itemDelay = delay + index * stagger;
+        const existingClassName = child.props.className || "";
+        const existingStyle = child.props.style || {};
+
+        return cloneElement(child, {
+          className: [existingClassName, animationClass]
+            .filter(Boolean)
+            .join(" "),
+          style: {
+            ...existingStyle,
+            animationDelay: `${itemDelay}ms`,
+          },
+        });
+      })}
+    </Wrapper>
+  );
+}

--- a/submissions/react/36317-motion-group-dp/README.md
+++ b/submissions/react/36317-motion-group-dp/README.md
@@ -1,0 +1,60 @@
+# MotionGroup
+
+A lightweight React component that automatically applies staggered animation delays to grouped child elements using existing EaseMotion CSS animation classes.
+
+---
+
+## Overview
+
+`MotionGroup` simplifies staggered animations by automatically assigning incremental `animation-delay` values to each child element. It works as a thin React wrapper around existing CSS animations, keeping the implementation lightweight, reusable, and CSS-first.
+
+---
+
+## Props
+
+| Prop             | Type        | Default | Description                                     |
+| ---------------- | ----------- | ------- | ----------------------------------------------- |
+| `children`       | `ReactNode` | —       | Child elements to animate.                      |
+| `animationClass` | `string`    | —       | CSS animation class applied to each child.      |
+| `stagger`        | `number`    | `100`   | Delay (ms) added between consecutive children.  |
+| `delay`          | `number`    | `0`     | Base delay before staggering begins.            |
+| `className`      | `string`    | `""`    | Additional class name for the wrapper element.  |
+| `as`             | `string`    | `"div"` | Wrapper element (`div`, `section`, `ul`, etc.). |
+
+---
+
+## Example Usage
+
+```jsx
+import MotionGroup from "./MotionGroup";
+import "./style.css";
+
+export default function CardGrid() {
+  return (
+    <MotionGroup
+      animationClass="fade-up"
+      stagger={120}
+      as="ul"
+      className="motion-group-list"
+    >
+      <li className="motion-group-card">Card One</li>
+      <li className="motion-group-card">Card Two</li>
+      <li className="motion-group-card">Card Three</li>
+      <li className="motion-group-card">Card Four</li>
+    </MotionGroup>
+  );
+}
+```
+
+Each child automatically receives an increasing animation delay while preserving its existing props, styles, and class names.
+
+---
+
+## Why MotionGroup?
+
+- Automatically applies staggered animation timing.
+- Reduces repetitive animation-delay calculations.
+- Works with any existing EaseMotion CSS animation class.
+- Preserves existing child props and class names.
+- Lightweight, reusable, and dependency-free.
+- Follows EaseMotion CSS's CSS-first philosophy.

--- a/submissions/react/36317-motion-group-dp/style.css
+++ b/submissions/react/36317-motion-group-dp/style.css
@@ -1,0 +1,162 @@
+:root {
+  --motion-group-bg: #f8fafc;
+  --motion-group-card-bg: #ffffff;
+  --motion-group-primary: #2563eb;
+  --motion-group-accent: #7c3aed;
+  --motion-group-border: #e2e8f0;
+  --motion-group-text: #0f172a;
+  --motion-group-muted: #64748b;
+
+  --motion-group-radius: 10px;
+  --motion-group-gap: 20px;
+}
+
+.motion-group {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--motion-group-gap);
+  background: var(--motion-group-bg);
+  padding: 24px;
+  border-radius: var(--motion-group-radius);
+}
+
+.motion-group-card {
+  background: var(--motion-group-card-bg);
+  border: 1px solid var(--motion-group-border);
+  border-radius: var(--motion-group-radius);
+  padding: 20px;
+  color: var(--motion-group-text);
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
+    Arial, sans-serif;
+  transition:
+    border-color 0.2s ease,
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.motion-group-card:hover {
+  border-color: var(--motion-group-primary);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
+}
+
+.motion-group-card__title {
+  margin: 0 0 6px;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--motion-group-text);
+}
+
+.motion-group-card__description {
+  margin: 0;
+  font-size: 0.88rem;
+  line-height: 1.5;
+  color: var(--motion-group-muted);
+}
+
+.motion-group-card a,
+.motion-group-card button {
+  color: var(--motion-group-primary);
+}
+
+.motion-group-card a:focus,
+.motion-group-card button:focus,
+.motion-group-card:focus {
+  outline: none;
+}
+
+.motion-group-card a:focus-visible,
+.motion-group-card button:focus-visible,
+.motion-group-card:focus-visible {
+  outline: 3px solid var(--motion-group-accent);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+.fade-up {
+  animation-name: motion-group-fade-up;
+  animation-duration: 500ms;
+  animation-timing-function: ease-out;
+  animation-fill-mode: both;
+}
+
+.fade-in {
+  animation-name: motion-group-fade-in;
+  animation-duration: 500ms;
+  animation-timing-function: ease-out;
+  animation-fill-mode: both;
+}
+
+.slide-in {
+  animation-name: motion-group-slide-in;
+  animation-duration: 500ms;
+  animation-timing-function: ease-out;
+  animation-fill-mode: both;
+}
+
+.scale-in {
+  animation-name: motion-group-scale-in;
+  animation-duration: 500ms;
+  animation-timing-function: ease-out;
+  animation-fill-mode: both;
+}
+
+@keyframes motion-group-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes motion-group-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes motion-group-slide-in {
+  from {
+    opacity: 0;
+    transform: translateX(-24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes motion-group-scale-in {
+  from {
+    opacity: 0;
+    transform: scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@media (max-width: 480px) {
+  .motion-group {
+    grid-template-columns: 1fr;
+    padding: 16px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fade-up,
+  .fade-in,
+  .slide-in,
+  .scale-in {
+    animation-duration: 1ms !important;
+    animation-delay: 0ms !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a **reusable MotionGroup React component** under the `submissions/react/` track.

The component automatically applies staggered animation delays to grouped React children while leveraging existing EaseMotion CSS animation classes. It reduces repetitive animation logic and provides a lightweight, reusable API that aligns with the framework's CSS-first philosophy.

Closes #36317 

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `MotionGroup.jsx`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

A reusable `MotionGroup` React component that automatically applies staggered animation delays to child elements using existing EaseMotion CSS animation classes.

### How does a developer use it?

```jsx
<MotionGroup
  animationClass="fade-up"
  stagger={120}
>
  <Card />
  <Card />
  <Card />
  <Card />
</MotionGroup>
```

### Why does it fit EaseMotion CSS?

The component extends EaseMotion CSS into React without introducing a new animation engine or external dependencies. It follows the framework's CSS-first philosophy by providing a lightweight wrapper that makes staggered animations easier to implement while remaining reusable and maintainable.

---

## Demo

- [x] Example usage included within the component documentation

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional)*