### PR TITLE
feat(examples): Responsive Dashboard Zoom-In Tooltip

### DIFF
--- a/submissions/examples/34286-responsive-dashboard-zoom-in-tooltip-sj6/README.md
+++ b/submissions/examples/34286-responsive-dashboard-zoom-in-tooltip-sj6/README.md
@@ -1,0 +1,59 @@
+# Responsive Dashboard Zoom-In Tooltip
+
+A pure CSS, zero-dependency **metric-definition tooltip** for analytics
+dashboards. Each KPI card carries a quiet "i" chip; hovering it — or
+reaching it with the keyboard — zooms a small definition card into view,
+complete with the metric's formula. Brisk, professional motion with no
+JavaScript anywhere.
+
+Resolves Issue: #34286
+
+## ✨ Features
+
+- **Zoom-In from the corner** — `transform-origin` sits on the info chip,
+  so the tooltip grows out of the corner it belongs to and never drifts
+  over the number it explains. Show uses a barely-there overshoot
+  (`cubic-bezier(0.25, 1.1, 0.45, 1)`); hide is a faster `ease-in`.
+- **Genuinely responsive demo** — the KPI strip is a
+  `repeat(auto-fit, minmax(170px, 1fr))` grid: three-across on desktop,
+  single column on phones, tooltip width capped at `min(215px, 76vw)`.
+- **Zero JavaScript** — sibling-selector reveal
+  (`.db-info-btn:hover + .db-tip`), CSS transitions only.
+- **Keyboard accessible** — the chip is a real `<button>` with
+  `aria-describedby` → `role="tooltip"` and a clear 2px accent
+  `:focus-visible` ring; `cursor: help` signals the affordance to mouse
+  users.
+- **Tunable via custom properties** — start scale, show duration, easing,
+  and exit duration are exposed on `:root`, as is the whole dashboard skin.
+- **Dashboard-native details** — white cards on a cool canvas, accent top
+  border on the tooltip, monospace formula strip, green/red delta badges.
+- **Motion-safe** — `prefers-reduced-motion` swaps the zoom for an instant
+  reveal.
+
+## 🔧 Custom Properties
+
+| Property                 | Default                             | Role                    |
+| ------------------------ | ----------------------------------- | ----------------------- |
+| `--db-tt-scale-from`     | `0.55`                              | Starting scale          |
+| `--db-tt-duration`       | `190ms`                             | Show (zoom-in) time     |
+| `--db-tt-ease`           | `cubic-bezier(0.25, 1.1, 0.45, 1)`  | Show curve              |
+| `--db-tt-exit-duration`  | `130ms`                             | Hide time               |
+
+## 🚀 Usage
+
+```html
+<span class="db-info-slot">
+  <button class="db-info-btn" type="button" aria-describedby="def-metric">i</button>
+  <span class="db-tip" id="def-metric" role="tooltip">
+    <span class="db-tip-term">Metric Name</span>
+    Plain-language definition of the metric.
+    <span class="db-tip-formula">numerator ÷ denominator</span>
+  </span>
+</span>
+```
+
+## 📂 Files
+
+- `demo.html` — storefront KPI strip (revenue / conversion / cart abandonment).
+- `style.css` — dashboard tokens, corner-anchored zoom engine, a11y guards.
+- `README.md` — this document.

--- a/submissions/examples/34286-responsive-dashboard-zoom-in-tooltip-sj6/demo.html
+++ b/submissions/examples/34286-responsive-dashboard-zoom-in-tooltip-sj6/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Responsive Dashboard Zoom-In Tooltip — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="db-board" aria-label="Analytics dashboard demo">
+    <h1 class="db-board-title">Storefront Overview</h1>
+    <p class="db-board-sub">
+      Hover the <em>i</em> chip on any card — or Tab to it — and the metric's
+      definition zooms in. Resize the window to watch the grid reflow.
+    </p>
+
+    <div class="db-grid">
+      <section class="db-card">
+        <span class="db-metric-label">Net Revenue</span>
+        <span class="db-metric-value">$48.2k<span class="db-delta is-up">▲ 6.1%</span></span>
+        <span class="db-info-slot">
+          <button class="db-info-btn" type="button" aria-describedby="def-revenue">i</button>
+          <span class="db-tip" id="def-revenue" role="tooltip">
+            <span class="db-tip-term">Net Revenue</span>
+            Gross sales for the period minus refunds, discounts, and processor fees.
+            <span class="db-tip-formula">gross − refunds − fees</span>
+          </span>
+        </span>
+      </section>
+
+      <section class="db-card">
+        <span class="db-metric-label">Conversion</span>
+        <span class="db-metric-value">3.4%<span class="db-delta is-up">▲ 0.3</span></span>
+        <span class="db-info-slot">
+          <button class="db-info-btn" type="button" aria-describedby="def-conversion">i</button>
+          <span class="db-tip" id="def-conversion" role="tooltip">
+            <span class="db-tip-term">Conversion Rate</span>
+            Share of unique visitors who completed checkout at least once.
+            <span class="db-tip-formula">orders ÷ visitors × 100</span>
+          </span>
+        </span>
+      </section>
+
+      <section class="db-card">
+        <span class="db-metric-label">Cart Abandon</span>
+        <span class="db-metric-value">61%<span class="db-delta is-down">▼ 2.2</span></span>
+        <span class="db-info-slot">
+          <button class="db-info-btn" type="button" aria-describedby="def-abandon">i</button>
+          <span class="db-tip" id="def-abandon" role="tooltip">
+            <span class="db-tip-term">Cart Abandonment</span>
+            Carts created but never checked out within the session window.
+            <span class="db-tip-formula">1 − (orders ÷ carts)</span>
+          </span>
+        </span>
+      </section>
+    </div>
+  </main>
+</body>
+
+</html>

--- a/submissions/examples/34286-responsive-dashboard-zoom-in-tooltip-sj6/style.css
+++ b/submissions/examples/34286-responsive-dashboard-zoom-in-tooltip-sj6/style.css
@@ -1,0 +1,254 @@
+/* ==========================================================================
+   Responsive Dashboard Zoom-In Tooltip
+   --------------------------------------------------------------------------
+   Pure CSS metric-info tooltip for analytics dashboards. Each KPI card
+   carries a small "i" affordance; hovering or keyboard-focusing it zooms a
+   definition card into view — quick, professional, zero JavaScript.
+
+   The KPI row itself is a fluid auto-fit grid, so the same markup works
+   from a phone column to a wide desktop strip.
+
+   Issue: #34286
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Tokens — motion first, then the dashboard skin
+   -------------------------------------------------------------------------- */
+:root {
+  /* Zoom motion: brisk and businesslike, barely-there overshoot */
+  --db-tt-scale-from: 0.55;
+  --db-tt-duration: 190ms;
+  --db-tt-ease: cubic-bezier(0.25, 1.1, 0.45, 1);
+  --db-tt-exit-duration: 130ms;
+
+  /* Dashboard skin */
+  --db-canvas: #f2f5fa;
+  --db-card: #ffffff;
+  --db-border: #e2e8f2;
+  --db-heading: #1d2b45;
+  --db-body: #5c6b85;
+  --db-accent: #2f6fed;
+  --db-up: #12855f;
+  --db-down: #c93a4c;
+
+  /* Depth */
+  --db-card-shadow: 0 1px 3px rgba(29, 43, 69, 0.08);
+  --db-tip-shadow: 0 10px 30px rgba(29, 43, 69, 0.18), 0 2px 6px rgba(29, 43, 69, 0.1);
+}
+
+/* --------------------------------------------------------------------------
+   2. Demo stage — a slice of an analytics dashboard
+   -------------------------------------------------------------------------- */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 30px 16px;
+  box-sizing: border-box;
+  background: var(--db-canvas);
+  font-family: "Segoe UI", system-ui, -apple-system, Arial, sans-serif;
+  color: var(--db-body);
+}
+
+.db-board {
+  width: 100%;
+  max-width: 640px;
+}
+
+.db-board-title {
+  margin: 0 0 3px;
+  font-size: 1.05rem;
+  font-weight: 650;
+  color: var(--db-heading);
+}
+
+.db-board-sub {
+  margin: 0 0 22px;
+  font-size: 0.8rem;
+}
+
+/* Fluid KPI strip: cards reflow from 3-across to a single column */
+.db-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 14px;
+}
+
+/* --------------------------------------------------------------------------
+   3. KPI card with an info affordance in its corner
+   -------------------------------------------------------------------------- */
+.db-card {
+  position: relative;
+  background: var(--db-card);
+  border: 1px solid var(--db-border);
+  border-radius: 10px;
+  padding: 16px 16px 14px;
+  box-shadow: var(--db-card-shadow);
+}
+
+.db-metric-label {
+  display: block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--db-body);
+  margin-bottom: 8px;
+}
+
+.db-metric-value {
+  font-size: 1.45rem;
+  font-weight: 700;
+  color: var(--db-heading);
+  line-height: 1.1;
+}
+
+.db-delta {
+  font-size: 0.72rem;
+  font-weight: 600;
+  margin-left: 6px;
+}
+
+.db-delta.is-up { color: var(--db-up); }
+.db-delta.is-down { color: var(--db-down); }
+
+/* --------------------------------------------------------------------------
+   4. Info trigger — a quiet "i" chip that wakes on approach
+   -------------------------------------------------------------------------- */
+.db-info-slot {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  display: inline-flex;
+}
+
+.db-info-btn {
+  width: 22px;
+  height: 22px;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  font: 700 0.68rem/1 Georgia, serif;
+  font-style: italic;
+  color: var(--db-body);
+  background: var(--db-canvas);
+  border: 1px solid var(--db-border);
+  border-radius: 50%;
+  cursor: help;
+  transition: color 140ms ease, border-color 140ms ease, background-color 140ms ease;
+}
+
+.db-info-btn:hover {
+  color: #fff;
+  background: var(--db-accent);
+  border-color: var(--db-accent);
+}
+
+.db-info-btn:focus-visible {
+  outline: 2px solid var(--db-accent);
+  outline-offset: 2px;
+}
+
+/* --------------------------------------------------------------------------
+   5. The zoom-in definition tooltip
+   --------------------------------------------------------------------------
+   Anchored to the info chip's top-right corner and growing from it, so the
+   tooltip never drifts over the metric number it explains.
+   -------------------------------------------------------------------------- */
+.db-tip {
+  position: absolute;
+  bottom: calc(100% + 9px);
+  right: -6px;
+  z-index: 40;
+  width: max-content;
+  max-width: min(215px, 76vw);
+  padding: 11px 13px;
+  box-sizing: border-box;
+  background: var(--db-card);
+  border: 1px solid var(--db-border);
+  border-top: 3px solid var(--db-accent);
+  border-radius: 8px;
+  box-shadow: var(--db-tip-shadow);
+  font-size: 0.73rem;
+  line-height: 1.5;
+  color: var(--db-body);
+  text-align: left;
+  pointer-events: none;
+  transform-origin: calc(100% - 14px) 100%;
+
+  opacity: 0;
+  visibility: hidden;
+  transform: scale(var(--db-tt-scale-from));
+  transition:
+    opacity var(--db-tt-exit-duration) ease-in,
+    transform var(--db-tt-exit-duration) ease-in,
+    visibility 0s linear var(--db-tt-exit-duration);
+}
+
+/* Notch pointing back at the chip */
+.db-tip::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  right: 12px;
+  border: 6px solid transparent;
+  border-top-color: var(--db-card);
+  filter: drop-shadow(0 1px 0 var(--db-border));
+}
+
+.db-tip-term {
+  display: block;
+  margin-bottom: 3px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: var(--db-heading);
+}
+
+.db-tip-formula {
+  display: block;
+  margin-top: 5px;
+  padding: 4px 7px;
+  font-family: Consolas, monospace;
+  font-size: 0.66rem;
+  background: var(--db-canvas);
+  border-radius: 4px;
+  color: var(--db-accent);
+}
+
+/* --------------------------------------------------------------------------
+   6. Reveal wiring — hover or keyboard focus, one behavior
+   -------------------------------------------------------------------------- */
+.db-info-btn:hover + .db-tip,
+.db-info-btn:focus-visible + .db-tip {
+  opacity: 1;
+  visibility: visible;
+  transform: scale(1);
+  transition:
+    opacity var(--db-tt-duration) var(--db-tt-ease),
+    transform var(--db-tt-duration) var(--db-tt-ease),
+    visibility 0s;
+}
+
+/* --------------------------------------------------------------------------
+   7. Small screens + reduced motion
+   -------------------------------------------------------------------------- */
+@media (max-width: 420px) {
+  .db-metric-value {
+    font-size: 1.25rem;
+  }
+
+  .db-tip {
+    max-width: 72vw;
+  }
+}
+
+/* Reduced motion: definitions appear instantly at full size */
+@media (prefers-reduced-motion: reduce) {
+  .db-tip,
+  .db-info-btn:hover + .db-tip,
+  .db-info-btn:focus-visible + .db-tip {
+    transition-duration: 1ms;
+    transform: scale(1);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS **Zoom-In Tooltip** styled for **Responsive Dashboard** layouts as a fully self-contained example under `submissions/examples/34286-responsive-dashboard-zoom-in-tooltip-sj6/`.

Fixes #34286

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/34286-responsive-dashboard-zoom-in-tooltip-sj6/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A zero-JavaScript metric-definition tooltip for analytics dashboards: an "i" chip on each KPI card zooms a definition card (with the metric's formula) out of the card corner on `:hover` / `:focus-visible`. The KPI strip itself is an `auto-fit` CSS grid, so the demo reflows from three-across to a single phone column.

**How does a developer use it?**

```html
<span class="db-info-slot">
  <button class="db-info-btn" type="button" aria-describedby="def-metric">i</button>
  <span class="db-tip" id="def-metric" role="tooltip">
    <span class="db-tip-term">Metric Name</span>
    Plain-language definition of the metric.
    <span class="db-tip-formula">numerator ÷ denominator</span>
  </span>
</span>
```

**Why does it fit EaseMotion CSS?**

Human-readable classes, animation-first, zero JS. `transform-origin` is anchored to the info chip so the tooltip grows out of its corner and never covers the number it explains; motion (start scale, duration, curve, exit time) is tunable via `--db-tt-*` custom properties; triggers are real `<button>` elements with `aria-describedby`/`role="tooltip"`; `prefers-reduced-motion` swaps the zoom for an instant reveal.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The show/hide use asymmetric timing (190ms in, 130ms out) — dashboards feel snappier when dismissal is faster than reveal. Resizing the demo window shows the responsive grid behavior the issue asks for.

@SAPTARSHI-coder  Please review this review 