### PR TITLE
feat: add reusable MotionSwitch React component

### DIFF
--- a/submissions/react/36335-motion-switch-dp/MotionSwitch.jsx
+++ b/submissions/react/36335-motion-switch-dp/MotionSwitch.jsx
@@ -1,0 +1,80 @@
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  useEffect,
+  useRef,
+} from "react";
+
+export default function MotionSwitch({
+  children,
+  activeKey,
+  animationClass,
+  duration = "400ms",
+  className = "",
+  as: Wrapper = "div",
+  onTransitionStart,
+  onTransitionEnd,
+}) {
+  const wrapperRef = useRef(null);
+  const previousKeyRef = useRef(activeKey);
+  const timeoutRef = useRef(null);
+
+  useEffect(() => {
+    const node = wrapperRef.current;
+    if (!node) return undefined;
+
+    if (previousKeyRef.current === activeKey) {
+      return undefined;
+    }
+
+    previousKeyRef.current = activeKey;
+
+    clearTimeout(timeoutRef.current);
+    node.classList.remove(animationClass);
+    // eslint-disable-next-line no-unused-expressions
+    node.offsetWidth;
+    node.classList.add(animationClass);
+
+    if (typeof onTransitionStart === "function") {
+      onTransitionStart(activeKey);
+    }
+
+    const durationMs =
+      parseFloat(duration) * (String(duration).includes("ms") ? 1 : 1000);
+
+    timeoutRef.current = setTimeout(() => {
+      node.classList.remove(animationClass);
+      if (typeof onTransitionEnd === "function") {
+        onTransitionEnd(activeKey);
+      }
+    }, durationMs);
+
+    return () => {
+      clearTimeout(timeoutRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeKey, animationClass, duration]);
+
+  useEffect(() => {
+    return () => clearTimeout(timeoutRef.current);
+  }, []);
+
+  const items = Children.toArray(children).filter(Boolean);
+
+  return (
+    <Wrapper
+      ref={wrapperRef}
+      className={["motion-switch", className].filter(Boolean).join(" ")}
+    >
+      {items.map((child, index) => {
+        if (!isValidElement(child)) return child;
+        const existingClassName = child.props.className || "";
+        return cloneElement(child, {
+          key: child.key ?? index,
+          className: existingClassName,
+        });
+      })}
+    </Wrapper>
+  );
+}

--- a/submissions/react/36335-motion-switch-dp/README.md
+++ b/submissions/react/36335-motion-switch-dp/README.md
@@ -1,0 +1,76 @@
+# MotionSwitch
+
+A lightweight React component that applies existing EaseMotion CSS animation classes whenever the active UI state changes.
+
+---
+
+## Overview
+
+`MotionSwitch` simplifies transitions between conditionally rendered content by automatically applying an animation class whenever the `activeKey` changes. It works as a lightweight React wrapper around existing EaseMotion CSS animations, making state transitions smoother while remaining reusable, dependency-free, and CSS-first.
+
+---
+
+## Props
+
+| Prop                | Type        | Default   | Description                                                                     |
+| ------------------- | ----------- | --------- | ------------------------------------------------------------------------------- |
+| `children`          | `ReactNode` | —         | The currently active content to render.                                         |
+| `activeKey`         | `any`       | —         | Unique value representing the active state. Changing it triggers the animation. |
+| `animationClass`    | `string`    | —         | CSS animation class applied during state transitions.                           |
+| `duration`          | `string`    | `"400ms"` | Duration for which the animation class remains active.                          |
+| `className`         | `string`    | `""`      | Additional class name for the wrapper element.                                  |
+| `as`                | `string`    | `"div"`   | Wrapper element (`div`, `section`, `main`, etc.).                               |
+| `onTransitionStart` | `function`  | —         | Callback fired when a transition begins.                                        |
+| `onTransitionEnd`   | `function`  | —         | Callback fired when a transition completes.                                     |
+
+---
+
+## Example Usage
+
+```jsx
+import { useState } from "react";
+import MotionSwitch from "./MotionSwitch";
+import "./style.css";
+
+export default function App() {
+  const [currentView, setCurrentView] = useState("home");
+
+  return (
+    <>
+      <MotionSwitch
+        activeKey={currentView}
+        animationClass="fade-up"
+        duration="500ms"
+      >
+        {currentView === "home" && (
+          <div className="motion-switch-card">Home</div>
+        )}
+
+        {currentView === "about" && (
+          <div className="motion-switch-card">About</div>
+        )}
+
+        {currentView === "contact" && (
+          <div className="motion-switch-card">Contact</div>
+        )}
+      </MotionSwitch>
+
+      <button onClick={() => setCurrentView("about")}>Switch View</button>
+    </>
+  );
+}
+```
+
+Whenever `activeKey` changes, the specified animation class is applied automatically while preserving the existing props, styles, and class names of the rendered content.
+
+---
+
+## Why MotionSwitch?
+
+- Automatically animates transitions between UI states.
+- Eliminates repetitive class-toggle logic.
+- Works with existing EaseMotion CSS animation classes.
+- Preserves existing child props and class names.
+- Supports transition lifecycle callbacks.
+- Lightweight, reusable, and dependency-free.
+- Follows EaseMotion CSS's CSS-first philosophy.

--- a/submissions/react/36335-motion-switch-dp/style.css
+++ b/submissions/react/36335-motion-switch-dp/style.css
@@ -1,0 +1,136 @@
+:root {
+  --msw-bg: #f8fafc;
+  --msw-surface: #ffffff;
+  --msw-primary: #2563eb;
+  --msw-accent: #0ea5e9;
+  --msw-border: #e2e8f0;
+  --msw-text: #0f172a;
+  --msw-muted: #64748b;
+
+  --msw-radius: 10px;
+  --msw-spacing: 24px;
+}
+
+.motion-switch {
+  display: block;
+  background: var(--msw-bg);
+  border-radius: var(--msw-radius);
+  padding: var(--msw-spacing);
+}
+
+.motion-switch-card {
+  background: var(--msw-surface);
+  border: 1px solid var(--msw-border);
+  border-radius: var(--msw-radius);
+  padding: 20px;
+  color: var(--msw-text);
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
+    Arial, sans-serif;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.motion-switch-card:hover {
+  border-color: var(--msw-primary);
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.06);
+}
+
+.motion-switch-card__title {
+  margin: 0 0 8px;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--msw-text);
+}
+
+.motion-switch-card__description {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: var(--msw-muted);
+}
+
+.motion-switch-card a,
+.motion-switch-card button {
+  color: var(--msw-primary);
+}
+
+.motion-switch-card a:focus,
+.motion-switch-card button:focus {
+  outline: none;
+}
+
+.motion-switch-card a:focus-visible,
+.motion-switch-card button:focus-visible {
+  outline: 3px solid var(--msw-accent);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+.fade-up {
+  animation-name: motion-switch-fade-up;
+  animation-duration: 400ms;
+  animation-timing-function: ease-out;
+  animation-fill-mode: both;
+}
+
+.fade-in {
+  animation-name: motion-switch-fade-in;
+  animation-duration: 400ms;
+  animation-timing-function: ease-out;
+  animation-fill-mode: both;
+}
+
+.slide-in {
+  animation-name: motion-switch-slide-in;
+  animation-duration: 400ms;
+  animation-timing-function: ease-out;
+  animation-fill-mode: both;
+}
+
+@keyframes motion-switch-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes motion-switch-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes motion-switch-slide-in {
+  from {
+    opacity: 0;
+    transform: translateX(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@media (max-width: 480px) {
+  .motion-switch {
+    padding: 16px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fade-up,
+  .fade-in,
+  .slide-in {
+    animation-duration: 1ms !important;
+    animation-delay: 0ms !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a **reusable MotionSwitch React component** under the `submissions/react/` track.

`MotionSwitch` provides a lightweight, CSS-first utility for animating transitions between different UI states using existing EaseMotion CSS animation classes. It simplifies state-based animations while remaining dependency-free and fully reusable across React applications.

Closes #36335 

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `MotionSwitch.jsx`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

A reusable `MotionSwitch` React component that applies existing EaseMotion CSS animation classes whenever the active UI state changes, making transitions between conditional views smooth and consistent.

### How does a developer use it?

```jsx
<MotionSwitch
  activeKey={currentView}
  animationClass="fade-up"
  duration="500ms"
>
  {currentView === "home" && <Home />}
  {currentView === "about" && <About />}
  {currentView === "contact" && <Contact />}
</MotionSwitch>
```

### Why does it fit EaseMotion CSS?

`MotionSwitch` extends EaseMotion CSS into React without introducing a custom animation engine or external dependencies. It simply coordinates the application of existing CSS animation classes during state changes, reinforcing the framework's CSS-first philosophy while providing a clean, reusable developer utility.

---

## Demo

- [x] Example usage included in the README

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional)*