### PR TITLE
feat(examples): Modern SaaS 3D Flip Tooltip

### DIFF
--- a/submissions/examples/34290-modern-saas-3d-flip-tooltip-sj6/README.md
+++ b/submissions/examples/34290-modern-saas-3d-flip-tooltip-sj6/README.md
@@ -1,0 +1,61 @@
+# Modern SaaS 3D Flip Tooltip
+
+A pure CSS tooltip that **swings into view on a 3D hinge**: at rest it lies
+flipped back into the page (`rotateX`), and on hover or keyboard focus it
+rotates down to face the viewer with real perspective — like a badge
+turning over. Clean product-UI styling (indigo accents, soft shadows,
+rounded corners) and zero JavaScript.
+
+Resolves Issue: #34290
+
+## ✨ Features
+
+- **True 3D flip** — the tooltip is hinged on its bottom edge
+  (`transform-origin: 50% 100%`) and rotates from `--ss-tt-angle`
+  (default `-78deg`) to flat, inside a `perspective()` baked into the
+  transform — no extra wrapper element needed.
+- **Lands with a nudge** — the show curve
+  (`cubic-bezier(0.2, 0.9, 0.3, 1.15)`) overshoots the hinge slightly so
+  the card "settles"; the hide path is a faster, plain `ease-in`.
+- **Zero JavaScript** — sibling-selector engine
+  (`.ss-chip:hover + .ss-tip`), CSS transitions only.
+- **Keyboard accessible** — triggers are real `<button>` elements with
+  `aria-describedby` → `role="tooltip"` and a clear indigo
+  `:focus-visible` outline.
+- **Tunable via custom properties** — hinge angle, camera distance
+  (perspective), duration, and easing all live on `:root`.
+- **SaaS-native content pattern** — each tooltip carries a status line
+  (Connected / Action needed) with a colored dot, the kind of glanceable
+  detail integration pickers actually need.
+- **Responsive & motion-safe** — chips wrap on narrow screens, tooltip
+  width caps at `min(240px, 80vw)`, and `prefers-reduced-motion` removes
+  the rotation entirely.
+
+## 🔧 Custom Properties
+
+| Property              | Default                              | Role                     |
+| --------------------- | ------------------------------------ | ------------------------ |
+| `--ss-tt-angle`       | `-78deg`                             | Resting hinge angle      |
+| `--ss-tt-perspective` | `520px`                              | 3D camera distance       |
+| `--ss-tt-duration`    | `320ms`                              | Swing time               |
+| `--ss-tt-ease`        | `cubic-bezier(0.2, 0.9, 0.3, 1.15)`  | Landing curve            |
+
+## 🚀 Usage
+
+```html
+<span class="ss-anchor">
+  <button class="ss-chip" type="button" aria-describedby="my-tip">
+    <span class="ss-chip-logo">CS</span> CodeSync
+  </button>
+  <span class="ss-tip" id="my-tip" role="tooltip">
+    <span class="ss-tip-status is-ok"><span class="ss-dot"></span> Connected</span>
+    Status detail flips down to face the viewer.
+  </span>
+</span>
+```
+
+## 📂 Files
+
+- `demo.html` — workspace-settings card with three integration chips.
+- `style.css` — product-UI tokens, 3D hinge engine, responsive + a11y guards.
+- `README.md` — this document.

--- a/submissions/examples/34290-modern-saas-3d-flip-tooltip-sj6/demo.html
+++ b/submissions/examples/34290-modern-saas-3d-flip-tooltip-sj6/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Modern SaaS 3D Flip Tooltip — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="ss-card" aria-label="Workspace integrations demo">
+    <span class="ss-eyebrow">Workspace Settings</span>
+    <h1 class="ss-title">Connected Integrations</h1>
+    <p class="ss-sub">
+      Hover an integration — or Tab onto it — and its status card flips down
+      on a 3D hinge, like a badge turning to face you.
+    </p>
+
+    <div class="ss-integrations">
+      <span class="ss-anchor">
+        <button class="ss-chip" type="button" aria-describedby="tip-codesync">
+          <span class="ss-chip-logo">CS</span> CodeSync
+        </button>
+        <span class="ss-tip" id="tip-codesync" role="tooltip">
+          <span class="ss-tip-status is-ok"><span class="ss-dot"></span> Connected</span>
+          Pull requests and deploy previews post to your team channel.
+          Last sync 2 minutes ago.
+        </span>
+      </span>
+
+      <span class="ss-anchor">
+        <button class="ss-chip" type="button" aria-describedby="tip-chatops">
+          <span class="ss-chip-logo">CO</span> ChatOps
+        </button>
+        <span class="ss-tip" id="tip-chatops" role="tooltip">
+          <span class="ss-tip-status is-ok"><span class="ss-dot"></span> Connected</span>
+          Incident alerts route to the on-call rotation with one-tap
+          acknowledge.
+        </span>
+      </span>
+
+      <span class="ss-anchor">
+        <button class="ss-chip" type="button" aria-describedby="tip-designhub">
+          <span class="ss-chip-logo">DH</span> DesignHub
+        </button>
+        <span class="ss-tip" id="tip-designhub" role="tooltip">
+          <span class="ss-tip-status is-warn"><span class="ss-dot"></span> Action needed</span>
+          Token expires in 3 days — reauthorize to keep file previews live.
+        </span>
+      </span>
+    </div>
+  </main>
+</body>
+
+</html>

--- a/submissions/examples/34290-modern-saas-3d-flip-tooltip-sj6/style.css
+++ b/submissions/examples/34290-modern-saas-3d-flip-tooltip-sj6/style.css
@@ -1,0 +1,255 @@
+/* ==========================================================================
+   Modern SaaS 3D Flip Tooltip
+   --------------------------------------------------------------------------
+   Pure CSS tooltip that swings into view like a card on a hinge: it starts
+   flipped back on its bottom edge (rotateX) and rotates down to face the
+   viewer, with real perspective. Clean product-UI styling — indigo accents,
+   soft shadow, rounded corners. Zero JavaScript: :hover + :focus-visible.
+
+   Issue: #34290
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Tokens — hinge physics first, then the product skin
+   -------------------------------------------------------------------------- */
+:root {
+  /* Flip motion */
+  --ss-tt-angle: -78deg;                            /* resting hinge angle  */
+  --ss-tt-perspective: 520px;                       /* camera distance      */
+  --ss-tt-duration: 320ms;                          /* swing time           */
+  --ss-tt-ease: cubic-bezier(0.2, 0.9, 0.3, 1.15);  /* lands with a nudge   */
+
+  /* SaaS skin */
+  --ss-bg: #f7f8fc;
+  --ss-card: #ffffff;
+  --ss-border: #e4e7f2;
+  --ss-heading: #16192c;
+  --ss-body: #5a6178;
+  --ss-indigo: #5b5bd6;
+  --ss-indigo-soft: #eeeefb;
+  --ss-ok: #1e9e6a;
+  --ss-warn: #d97706;
+
+  --ss-shadow-card: 0 1px 2px rgba(22, 25, 44, 0.06), 0 8px 24px rgba(22, 25, 44, 0.06);
+  --ss-shadow-tip: 0 12px 32px rgba(22, 25, 44, 0.16), 0 2px 8px rgba(22, 25, 44, 0.08);
+}
+
+/* --------------------------------------------------------------------------
+   2. Demo stage — a workspace-settings card
+   -------------------------------------------------------------------------- */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 32px 16px;
+  box-sizing: border-box;
+  background: var(--ss-bg);
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  color: var(--ss-body);
+}
+
+.ss-card {
+  width: 100%;
+  max-width: 560px;
+  background: var(--ss-card);
+  border: 1px solid var(--ss-border);
+  border-radius: 14px;
+  box-shadow: var(--ss-shadow-card);
+  padding: 28px 28px 112px;
+}
+
+.ss-eyebrow {
+  display: inline-block;
+  margin: 0 0 10px;
+  padding: 3px 10px;
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ss-indigo);
+  background: var(--ss-indigo-soft);
+  border-radius: 999px;
+}
+
+.ss-title {
+  margin: 0 0 5px;
+  font-size: 1.2rem;
+  font-weight: 650;
+  color: var(--ss-heading);
+}
+
+.ss-sub {
+  margin: 0 0 26px;
+  font-size: 0.82rem;
+  line-height: 1.65;
+}
+
+/* Integration chips wrap on small screens */
+.ss-integrations {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+/* --------------------------------------------------------------------------
+   3. Anchor + integration chip
+   -------------------------------------------------------------------------- */
+.ss-anchor {
+  position: relative;
+  display: inline-flex;
+}
+
+.ss-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  min-height: 42px;
+  padding: 9px 16px;
+  font: 600 0.8rem/1.2 inherit;
+  font-family: inherit;
+  color: var(--ss-heading);
+  background: var(--ss-card);
+  border: 1px solid var(--ss-border);
+  border-radius: 10px;
+  cursor: pointer;
+  transition: border-color 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+}
+
+/* Little brand square standing in for a product logo */
+.ss-chip-logo {
+  width: 20px;
+  height: 20px;
+  display: grid;
+  place-items: center;
+  font-size: 0.62rem;
+  font-weight: 800;
+  color: #fff;
+  border-radius: 6px;
+  background: linear-gradient(135deg, var(--ss-indigo), #8b5bd6);
+}
+
+.ss-chip:hover {
+  border-color: var(--ss-indigo);
+  box-shadow: 0 4px 14px rgba(91, 91, 214, 0.18);
+  transform: translateY(-1px);
+}
+
+.ss-chip:focus-visible {
+  outline: 2px solid var(--ss-indigo);
+  outline-offset: 3px;
+}
+
+/* --------------------------------------------------------------------------
+   4. The 3D flip tooltip
+   --------------------------------------------------------------------------
+   Hinged on its bottom edge (the edge facing the trigger). At rest it lies
+   flipped back into the page; on reveal it swings down into the viewer's
+   plane. Perspective lives inside the transform so no wrapper is needed.
+   -------------------------------------------------------------------------- */
+.ss-tip {
+  position: absolute;
+  bottom: calc(100% + 11px);
+  left: 50%;
+  z-index: 30;
+  width: max-content;
+  max-width: min(240px, 80vw);
+  padding: 13px 15px;
+  box-sizing: border-box;
+  background: var(--ss-heading);
+  border-radius: 10px;
+  box-shadow: var(--ss-shadow-tip);
+  color: #eef0f8;
+  font-size: 0.74rem;
+  line-height: 1.55;
+  text-align: left;
+  pointer-events: none;
+  transform-origin: 50% 100%;
+
+  opacity: 0;
+  visibility: hidden;
+  transform: translateX(-50%)
+    perspective(var(--ss-tt-perspective))
+    rotateX(var(--ss-tt-angle));
+  transition:
+    opacity calc(var(--ss-tt-duration) * 0.55) ease-in,
+    transform calc(var(--ss-tt-duration) * 0.55) ease-in,
+    visibility 0s linear calc(var(--ss-tt-duration) * 0.55);
+}
+
+.ss-tip::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-top-color: var(--ss-heading);
+}
+
+/* Status line inside the tooltip */
+.ss-tip-status {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 5px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.ss-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+}
+
+.ss-tip-status.is-ok { color: #7ee2b8; }
+.ss-tip-status.is-ok .ss-dot { background: var(--ss-ok); }
+.ss-tip-status.is-warn { color: #fbbf74; }
+.ss-tip-status.is-warn .ss-dot { background: var(--ss-warn); }
+
+/* --------------------------------------------------------------------------
+   5. Reveal wiring — the hinge swings for pointer and keyboard alike
+   -------------------------------------------------------------------------- */
+.ss-chip:hover + .ss-tip,
+.ss-chip:focus-visible + .ss-tip {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%)
+    perspective(var(--ss-tt-perspective))
+    rotateX(0deg);
+  transition:
+    opacity calc(var(--ss-tt-duration) * 0.6) ease-out,
+    transform var(--ss-tt-duration) var(--ss-tt-ease),
+    visibility 0s;
+}
+
+/* --------------------------------------------------------------------------
+   6. Small screens + reduced motion
+   -------------------------------------------------------------------------- */
+@media (max-width: 480px) {
+  .ss-card {
+    padding: 22px 18px 100px;
+  }
+
+  .ss-integrations {
+    gap: 10px;
+  }
+
+  .ss-chip {
+    min-height: 40px;
+    padding: 8px 13px;
+  }
+}
+
+/* Reduced motion: no rotation in 3D space, a plain instant reveal */
+@media (prefers-reduced-motion: reduce) {
+  .ss-tip,
+  .ss-chip:hover + .ss-tip,
+  .ss-chip:focus-visible + .ss-tip {
+    transition-duration: 1ms;
+    transform: translateX(-50%) perspective(var(--ss-tt-perspective)) rotateX(0deg);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS **3D Flip Tooltip** styled for **Modern SaaS** layouts as a fully self-contained example under `submissions/examples/34290-modern-saas-3d-flip-tooltip-sj6/`.

Fixes #34290

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/34290-modern-saas-3d-flip-tooltip-sj6/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A zero-JavaScript tooltip that swings into view on a 3D hinge: it rests flipped back into the page (`rotateX(-78deg)`) and rotates down to face the viewer with real `perspective()`, landing with a slight settle. Demo styled as a SaaS "Connected Integrations" panel with status-dot tooltips.

**How does a developer use it?**

```html
<span class="ss-anchor">
  <button class="ss-chip" type="button" aria-describedby="my-tip">
    <span class="ss-chip-logo">CS</span> CodeSync
  </button>
  <span class="ss-tip" id="my-tip" role="tooltip">
    <span class="ss-tip-status is-ok"><span class="ss-dot"></span> Connected</span>
    Status detail flips down to face the viewer.
  </span>
</span>
```

**Why does it fit EaseMotion CSS?**

Human-readable classes, animation-first, zero JS. Hinge angle, perspective distance, duration, and easing are all exposed as `--ss-tt-*` custom properties; perspective is baked into the transform so no wrapper element is needed; triggers are real `<button>` elements with `aria-describedby`/`role="tooltip"`; `prefers-reduced-motion` removes the rotation entirely.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Show and hide are asymmetric: the swing-in runs the full 320ms with the landing curve, the swing-out is a faster plain ease-in so dismissal feels crisp. All knobs live on `:root`.

@SAPTARSHI-coder please review the pr 
