### PR TITLE
feat(examples): Glassmorphism 3D Flip Tooltip

### DIFF
--- a/submissions/examples/34296-glassmorphism-3d-flip-tooltip-sj6/README.md
+++ b/submissions/examples/34296-glassmorphism-3d-flip-tooltip-sj6/README.md
@@ -1,0 +1,68 @@
+# Glassmorphism 3D Flip Tooltip
+
+A pure CSS **frosted-glass tooltip that pivots into view around its
+vertical axis** (`rotateY`) — like a pane of glass turning to face you,
+blurring whatever sits behind it. Real glassmorphism (backdrop blur +
+saturation, translucent fill, hairline highlight border) with zero
+JavaScript: the turn is driven by `:hover` and `:focus-visible`.
+
+Resolves Issue: #34296
+
+## ✨ Features
+
+- **Y-axis 3D flip** — the pane rests turned edge-on to the viewer
+  (`rotateY(-86deg)`) and pivots to flat around its vertical center line,
+  inside a `perspective()` baked into the transform. Settles on a gentle
+  `cubic-bezier(0.32, 1.15, 0.44, 1)`; exits faster than it enters.
+- **Real glass, not painted glass** — `backdrop-filter: blur() saturate()`
+  on the tooltip, the chips, and the main sheet, so the sunset gradient
+  genuinely smears behind each surface; a faint diagonal "sun-catch" streak
+  adds the classic glassmorphism light edge.
+- **Contrast-audited smoked glass** — every text-bearing surface uses a
+  dark-tinted fill instead of white-tinted glass. Ratios were computed with
+  all translucent layers composited over the *lightest* stop of the
+  gradient: worst case 5.26:1 for body copy, 10.9:1+ inside the tooltip
+  (WCAG AA everywhere, AAA in the tooltip). Chip hover deepens the smoke
+  rather than lightening it, so hovering never costs contrast.
+- **Graceful degradation** — an `@supports not (backdrop-filter…)` block
+  swaps translucent fills for a solid tint on browsers without blur.
+- **Zero JavaScript** — sibling-selector engine
+  (`.gl-chip:hover + .gl-tip`), CSS transitions only.
+- **Keyboard accessible** — real `<button>` triggers with
+  `aria-describedby` → `role="tooltip"` and a warm-gold `:focus-visible`
+  ring that reads clearly on the translucent chips.
+- **Tunable via custom properties** — pivot angle, camera distance,
+  duration, easing, and blur radius all live on `:root`.
+- **Responsive & motion-safe** — chips wrap on narrow screens, tooltip
+  width caps at `min(235px, 80vw)`, and `prefers-reduced-motion` removes
+  the rotation entirely.
+
+## 🔧 Custom Properties
+
+| Property              | Default                              | Role                    |
+| --------------------- | ------------------------------------ | ----------------------- |
+| `--gl-tt-angle`       | `-86deg`                             | Resting pivot angle     |
+| `--gl-tt-perspective` | `640px`                              | 3D camera distance      |
+| `--gl-tt-duration`    | `380ms`                              | Turn time               |
+| `--gl-tt-ease`        | `cubic-bezier(0.32, 1.15, 0.44, 1)`  | Settling curve          |
+| `--gl-blur`           | `16px`                               | Glass blur radius       |
+
+## 🚀 Usage
+
+```html
+<span class="gl-anchor">
+  <button class="gl-chip" type="button" aria-describedby="my-tip">
+    ✈ Lisbon
+  </button>
+  <span class="gl-tip" id="my-tip" role="tooltip">
+    <span class="gl-tip-place">Lisbon, PT <span class="gl-tip-temp">24°C</span></span>
+    Detail copy pivots into view on a frosted pane.
+  </span>
+</span>
+```
+
+## 📂 Files
+
+- `demo.html` — "golden hour getaways" travel picker with three destinations.
+- `style.css` — glass recipe, Y-axis pivot engine, fallback + a11y guards.
+- `README.md` — this document.

--- a/submissions/examples/34296-glassmorphism-3d-flip-tooltip-sj6/demo.html
+++ b/submissions/examples/34296-glassmorphism-3d-flip-tooltip-sj6/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Glassmorphism 3D Flip Tooltip — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="gl-pane" aria-label="Travel destinations demo">
+    <h1 class="gl-title">Golden Hour Getaways</h1>
+    <p class="gl-sub">
+      Hover a destination — or Tab to it — and a frosted glass pane pivots
+      around its vertical axis to face you, blurring the sunset behind it.
+    </p>
+
+    <div class="gl-row">
+      <span class="gl-anchor">
+        <button class="gl-chip" type="button" aria-describedby="gl-lisbon">
+          ✈ Lisbon
+        </button>
+        <span class="gl-tip" id="gl-lisbon" role="tooltip">
+          <span class="gl-tip-place">Lisbon, PT <span class="gl-tip-temp">24°C</span></span>
+          Tram bells, tiled alleys, and pastel sunsets over the Tagus.
+          Direct flights from $410 round trip.
+        </span>
+      </span>
+
+      <span class="gl-anchor">
+        <button class="gl-chip" type="button" aria-describedby="gl-kyoto">
+          ✈ Kyoto
+        </button>
+        <span class="gl-tip" id="gl-kyoto" role="tooltip">
+          <span class="gl-tip-place">Kyoto, JP <span class="gl-tip-temp">19°C</span></span>
+          Lantern-lit lanes and maple gardens at peak color. One stop,
+          from $780 round trip.
+        </span>
+      </span>
+
+      <span class="gl-anchor">
+        <button class="gl-chip" type="button" aria-describedby="gl-oaxaca">
+          ✈ Oaxaca
+        </button>
+        <span class="gl-tip" id="gl-oaxaca" role="tooltip">
+          <span class="gl-tip-place">Oaxaca, MX <span class="gl-tip-temp">27°C</span></span>
+          Mercado mornings and mezcal evenings in the high valley.
+          Direct from $350 round trip.
+        </span>
+      </span>
+    </div>
+  </main>
+</body>
+
+</html>

--- a/submissions/examples/34296-glassmorphism-3d-flip-tooltip-sj6/style.css
+++ b/submissions/examples/34296-glassmorphism-3d-flip-tooltip-sj6/style.css
@@ -1,0 +1,253 @@
+/* ==========================================================================
+   Glassmorphism 3D Flip Tooltip
+   --------------------------------------------------------------------------
+   Pure CSS frosted-glass tooltip that turns into view around its VERTICAL
+   axis (rotateY) — like a pane of glass pivoting to face you. The pane is
+   real glassmorphism: backdrop blur + saturation, translucent fill, hairline
+   highlight border. Zero JavaScript — :hover and :focus-visible only.
+
+   Issue: #34296
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Tokens — pivot physics, then the glass recipe
+   -------------------------------------------------------------------------- */
+:root {
+  /* Flip motion (Y-axis pivot) */
+  --gl-tt-angle: -86deg;                             /* resting pivot angle */
+  --gl-tt-perspective: 640px;                        /* camera distance     */
+  --gl-tt-duration: 380ms;                           /* turn time           */
+  --gl-tt-ease: cubic-bezier(0.32, 1.15, 0.44, 1);   /* settles gently      */
+
+  /* Glass recipe — smoked (dark-tinted) glass so white text keeps WCAG
+     contrast over every stop of the sunset gradient. Audited worst case
+     (lightest backdrop, all layers composited) stays above 5.2:1. */
+  --gl-blur: 16px;
+  --gl-fill: rgba(29, 18, 64, 0.55);          /* main sheet   */
+  --gl-fill-chip: rgba(29, 18, 64, 0.45);     /* trigger chips */
+  --gl-fill-chip-hover: rgba(20, 12, 48, 0.62); /* hover deepens the smoke */
+  --gl-fill-tip: rgba(20, 12, 48, 0.72);      /* tooltip pane  */
+  --gl-edge: rgba(255, 255, 255, 0.38);
+  --gl-text: #f4f7ff;
+  --gl-text-dim: rgba(244, 247, 255, 0.78);
+
+  /* Scenery gradient behind the glass */
+  --gl-sky-a: #3d2f8f;
+  --gl-sky-b: #b13c8b;
+  --gl-sky-c: #e8794a;
+}
+
+/* --------------------------------------------------------------------------
+   2. Demo stage — sunset gradient with soft light orbs
+   -------------------------------------------------------------------------- */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 34px 16px;
+  box-sizing: border-box;
+  background:
+    radial-gradient(circle at 18% 22%, rgba(255, 255, 255, 0.22), transparent 26%),
+    radial-gradient(circle at 82% 70%, rgba(255, 255, 255, 0.14), transparent 30%),
+    linear-gradient(135deg, var(--gl-sky-a), var(--gl-sky-b) 55%, var(--gl-sky-c));
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  color: var(--gl-text);
+}
+
+/* The main glass sheet everything sits on */
+.gl-pane {
+  width: 100%;
+  max-width: 540px;
+  padding: 30px 30px 116px;
+  border-radius: 22px;
+  background: var(--gl-fill);
+  border: 1px solid var(--gl-edge);
+  box-shadow: 0 18px 44px rgba(20, 12, 48, 0.35);
+  backdrop-filter: blur(var(--gl-blur)) saturate(150%);
+  -webkit-backdrop-filter: blur(var(--gl-blur)) saturate(150%);
+}
+
+.gl-title {
+  margin: 0 0 6px;
+  font-size: 1.25rem;
+  font-weight: 650;
+  letter-spacing: 0.01em;
+  text-shadow: 0 1px 8px rgba(20, 12, 48, 0.35);
+}
+
+.gl-sub {
+  margin: 0 0 26px;
+  font-size: 0.82rem;
+  line-height: 1.65;
+  color: var(--gl-text-dim);
+}
+
+/* Destination chips wrap on narrow screens */
+.gl-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 13px;
+}
+
+/* --------------------------------------------------------------------------
+   3. Anchor + glass chip trigger
+   -------------------------------------------------------------------------- */
+.gl-anchor {
+  position: relative;
+  display: inline-flex;
+}
+
+.gl-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 42px;
+  padding: 9px 17px;
+  font: 600 0.8rem/1.2 inherit;
+  font-family: inherit;
+  color: var(--gl-text);
+  background: var(--gl-fill-chip);
+  border: 1px solid var(--gl-edge);
+  border-radius: 999px;
+  cursor: pointer;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  transition: background-color 170ms ease, box-shadow 170ms ease;
+}
+
+.gl-chip:hover {
+  background: var(--gl-fill-chip-hover);
+  box-shadow: 0 6px 20px rgba(20, 12, 48, 0.3), inset 0 0 0 1px rgba(255, 255, 255, 0.25);
+}
+
+.gl-chip:focus-visible {
+  outline: 2px solid #ffe9a8;
+  outline-offset: 3px;
+}
+
+/* --------------------------------------------------------------------------
+   4. The frosted pane tooltip, pivoting on its vertical center line
+   --------------------------------------------------------------------------
+   Rest: turned edge-on to the viewer (rotateY), nearly invisible — a pane
+   of glass seen from the side. Active: pivots to face the viewer.
+   -------------------------------------------------------------------------- */
+.gl-tip {
+  position: absolute;
+  bottom: calc(100% + 12px);
+  left: 50%;
+  z-index: 30;
+  width: max-content;
+  max-width: min(235px, 80vw);
+  padding: 13px 16px;
+  box-sizing: border-box;
+  background: var(--gl-fill-tip);
+  border: 1px solid var(--gl-edge);
+  border-radius: 14px;
+  box-shadow: 0 14px 34px rgba(20, 12, 48, 0.4);
+  backdrop-filter: blur(var(--gl-blur)) saturate(160%);
+  -webkit-backdrop-filter: blur(var(--gl-blur)) saturate(160%);
+  color: var(--gl-text);
+  font-size: 0.74rem;
+  line-height: 1.55;
+  text-align: left;
+  pointer-events: none;
+  transform-origin: 50% 50%;
+
+  opacity: 0;
+  visibility: hidden;
+  transform: translateX(-50%)
+    perspective(var(--gl-tt-perspective))
+    rotateY(var(--gl-tt-angle));
+  transition:
+    opacity calc(var(--gl-tt-duration) * 0.5) ease-in,
+    transform calc(var(--gl-tt-duration) * 0.5) ease-in,
+    visibility 0s linear calc(var(--gl-tt-duration) * 0.5);
+}
+
+/* Sun-catch: a faint diagonal light streak — kept dim (0.10 alpha) so the
+   text above it never drops below the audited contrast floor */
+.gl-tip::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: linear-gradient(115deg, rgba(255, 255, 255, 0.1) 0%, transparent 34%);
+}
+
+.gl-tip::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 7px solid transparent;
+  border-top-color: var(--gl-edge);
+}
+
+.gl-tip-place {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 4px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.gl-tip-temp {
+  font-weight: 600;
+  color: #ffe9a8;
+}
+
+/* --------------------------------------------------------------------------
+   5. Reveal wiring — the pane pivots for mouse and keyboard alike
+   -------------------------------------------------------------------------- */
+.gl-chip:hover + .gl-tip,
+.gl-chip:focus-visible + .gl-tip {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%)
+    perspective(var(--gl-tt-perspective))
+    rotateY(0deg);
+  transition:
+    opacity calc(var(--gl-tt-duration) * 0.55) ease-out,
+    transform var(--gl-tt-duration) var(--gl-tt-ease),
+    visibility 0s;
+}
+
+/* --------------------------------------------------------------------------
+   6. Small screens, reduced motion, and no-blur fallback
+   -------------------------------------------------------------------------- */
+@media (max-width: 480px) {
+  .gl-pane {
+    padding: 24px 20px 104px;
+    border-radius: 18px;
+  }
+
+  .gl-row {
+    gap: 10px;
+  }
+}
+
+/* Browsers without backdrop-filter get a near-solid dark pane instead */
+@supports not (backdrop-filter: blur(1px)) {
+  .gl-pane,
+  .gl-chip,
+  .gl-tip {
+    background: rgba(30, 19, 70, 0.95);
+  }
+}
+
+/* Reduced motion: the pane simply appears, already facing the viewer */
+@media (prefers-reduced-motion: reduce) {
+  .gl-tip,
+  .gl-chip:hover + .gl-tip,
+  .gl-chip:focus-visible + .gl-tip {
+    transition-duration: 1ms;
+    transform: translateX(-50%) perspective(var(--gl-tt-perspective)) rotateY(0deg);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS **3D Flip Tooltip** styled for **Glassmorphism UI** layouts as a fully self-contained example under `submissions/examples/34296-glassmorphism-3d-flip-tooltip-sj6/`.

Fixes #34296

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/34296-glassmorphism-3d-flip-tooltip-sj6/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A frosted-glass tooltip that pivots into view around its **vertical axis** (`rotateY(-86deg)` → flat) with real `perspective()` — like a pane of glass turning to face you. Genuine glassmorphism: `backdrop-filter: blur() saturate()` so the sunset gradient smears behind every surface, hairline highlight border, and a faint sun-catch streak. Zero JavaScript.

**How does a developer use it?**

```html
<span class="gl-anchor">
  <button class="gl-chip" type="button" aria-describedby="my-tip">
    ✈ Lisbon
  </button>
  <span class="gl-tip" id="my-tip" role="tooltip">
    <span class="gl-tip-place">Lisbon, PT <span class="gl-tip-temp">24°C</span></span>
    Detail copy pivots into view on a frosted pane.
  </span>
</span>
```

**Why does it fit EaseMotion CSS?**

Human-readable classes, animation-first, zero JS. Pivot angle, perspective, duration, easing, and blur radius are all `--gl-*` custom properties; triggers are real `<button>` elements with `aria-describedby`/`role="tooltip"`; `prefers-reduced-motion` removes the rotation and `@supports not (backdrop-filter…)` provides a near-solid fallback.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Contrast was audited numerically, not by eye: all translucent layers were composited over the **lightest** stop of the background gradient and checked against WCAG. That is why the glass is smoked (dark-tinted) rather than white-tinted — worst-case body text lands at 5.26:1 and tooltip text at 10.9:1+, and the chip hover deepens the tint rather than lightening it so hovering never costs contrast.

@SAPTARSHI-coder Please review the pr
