### PR TITLE
feat: add reusable MotionTrigger React component

### DIFF
--- a/submissions/react/36337-motion-trigger-dp/MotionTrigger.jsx
+++ b/submissions/react/36337-motion-trigger-dp/MotionTrigger.jsx
@@ -1,0 +1,121 @@
+import {
+  cloneElement,
+  isValidElement,
+  useCallback,
+  useRef,
+  useState,
+} from "react";
+
+const EVENT_PROP_MAP = {
+  click: ["onClick"],
+  hover: ["onMouseEnter"],
+  focus: ["onFocus"],
+  blur: ["onBlur"],
+  keydown: ["onKeyDown"],
+};
+
+export default function MotionTrigger({
+  children,
+  trigger = "click",
+  animationClass,
+  replay = false,
+  disabled = false,
+  className = "",
+  as: Wrapper = "span",
+  onTrigger,
+  onAnimationStart,
+  onAnimationEnd,
+}) {
+  const [isAnimating, setIsAnimating] = useState(false);
+  const nodeRef = useRef(null);
+
+  const fireAnimation = useCallback(
+    (event) => {
+      if (disabled) return;
+
+      if (typeof onTrigger === "function") onTrigger(event);
+
+      if (replay && isAnimating) {
+        setIsAnimating(false);
+        requestAnimationFrame(() => {
+          setIsAnimating(true);
+          if (typeof onAnimationStart === "function") onAnimationStart(event);
+        });
+        return;
+      }
+
+      setIsAnimating(true);
+      if (typeof onAnimationStart === "function") onAnimationStart(event);
+    },
+    [disabled, replay, isAnimating, onTrigger, onAnimationStart]
+  );
+
+  const handleAnimationEnd = useCallback(
+    (event) => {
+      setIsAnimating(false);
+      if (typeof onAnimationEnd === "function") onAnimationEnd(event);
+    },
+    [onAnimationEnd]
+  );
+
+  const handleKeyDown = useCallback(
+    (event) => {
+      if (trigger !== "keydown") return;
+      if (event.key === "Enter" || event.key === " ") {
+        fireAnimation(event);
+      }
+    },
+    [trigger, fireAnimation]
+  );
+
+  if (!isValidElement(children)) {
+    return children ?? null;
+  }
+
+  const existingClassName = children.props.className || "";
+  const combinedClassName = [
+    existingClassName,
+    isAnimating ? animationClass : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const eventProps = {};
+  const eventNames = EVENT_PROP_MAP[trigger] || [];
+
+  eventNames.forEach((eventName) => {
+    const existingHandler = children.props[eventName];
+    eventProps[eventName] = (event) => {
+      if (typeof existingHandler === "function") existingHandler(event);
+      fireAnimation(event);
+    };
+  });
+
+  if (trigger === "keydown") {
+    const existingKeyDown = children.props.onKeyDown;
+    eventProps.onKeyDown = (event) => {
+      if (typeof existingKeyDown === "function") existingKeyDown(event);
+      handleKeyDown(event);
+    };
+  }
+
+  const clonedChild = cloneElement(children, {
+    ...eventProps,
+    className: combinedClassName,
+    onAnimationEnd: (event) => {
+      if (typeof children.props.onAnimationEnd === "function") {
+        children.props.onAnimationEnd(event);
+      }
+      handleAnimationEnd(event);
+    },
+  });
+
+  return (
+    <Wrapper
+      ref={nodeRef}
+      className={["motion-trigger", className].filter(Boolean).join(" ")}
+    >
+      {clonedChild}
+    </Wrapper>
+  );
+}

--- a/submissions/react/36337-motion-trigger-dp/README.md
+++ b/submissions/react/36337-motion-trigger-dp/README.md
@@ -1,0 +1,60 @@
+# MotionTrigger
+
+A lightweight React component that applies existing EaseMotion CSS animation classes in response to configurable user interactions.
+
+---
+
+## Overview
+
+`MotionTrigger` simplifies interaction-driven animations by automatically applying a CSS animation class when a specified user event occurs. It supports common interaction types such as click, hover, focus, blur, and keyboard events while preserving existing props, styles, and event handlers. The component remains lightweight, reusable, and CSS-first.
+
+---
+
+## Props
+
+| Prop               | Type           | Default   | Description                                                                       |
+| ------------------ | -------------- | --------- | --------------------------------------------------------------------------------- |
+| `children`         | `ReactElement` | —         | Child element that receives the animation.                                        |
+| `trigger`          | `string`       | `"click"` | Event that triggers the animation (`click`, `hover`, `focus`, `blur`, `keydown`). |
+| `animationClass`   | `string`       | —         | CSS animation class applied when triggered.                                       |
+| `replay`           | `boolean`      | `false`   | Allows the animation to restart on repeated interactions.                         |
+| `disabled`         | `boolean`      | `false`   | Disables animation triggering.                                                    |
+| `className`        | `string`       | `""`      | Additional class name for the wrapper element.                                    |
+| `as`               | `string`       | `"span"`  | Wrapper element (`span`, `div`, `button`, etc.).                                  |
+| `onTrigger`        | `function`     | —         | Callback fired when the configured trigger occurs.                                |
+| `onAnimationStart` | `function`     | —         | Callback fired when the animation begins.                                         |
+| `onAnimationEnd`   | `function`     | —         | Callback fired when the animation completes.                                      |
+
+For `trigger="keydown"`, the component responds to both **Enter** and **Space** to support standard keyboard interactions.
+
+---
+
+## Example Usage
+
+```jsx
+import MotionTrigger from "./MotionTrigger";
+import "./style.css";
+
+export default function App() {
+  return (
+    <MotionTrigger trigger="click" animationClass="bounce" replay>
+      <button className="motion-trigger-button">Animate Me</button>
+    </MotionTrigger>
+  );
+}
+```
+
+The child element retains its existing props, event handlers, and class names while receiving the configured animation class whenever the selected interaction occurs.
+
+---
+
+## Why MotionTrigger?
+
+- Simplifies interaction-driven animations.
+- Eliminates repetitive event handling logic.
+- Supports click, hover, focus, blur, and keyboard interactions.
+- Works seamlessly with existing EaseMotion CSS animation classes.
+- Preserves existing child props, event handlers, and class names.
+- Supports replayable animations and lifecycle callbacks.
+- Lightweight, reusable, and dependency-free.
+- Follows EaseMotion CSS's CSS-first philosophy.

--- a/submissions/react/36337-motion-trigger-dp/style.css
+++ b/submissions/react/36337-motion-trigger-dp/style.css
@@ -1,0 +1,150 @@
+:root {
+  --mt-bg: #f8fafc;
+  --mt-surface: #ffffff;
+  --mt-primary: #2563eb;
+  --mt-accent: #f97316;
+  --mt-border: #e2e8f0;
+  --mt-text: #0f172a;
+  --mt-muted: #64748b;
+
+  --mt-radius: 10px;
+  --mt-spacing: 24px;
+}
+
+.motion-trigger {
+  display: inline-block;
+}
+
+.motion-trigger-demo {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 20px;
+  background: var(--mt-bg);
+  padding: var(--mt-spacing);
+  border-radius: var(--mt-radius);
+}
+
+.motion-trigger-button {
+  appearance: none;
+  border: 1px solid var(--mt-border);
+  background: var(--mt-surface);
+  color: var(--mt-text);
+  font: inherit;
+  font-weight: 600;
+  font-size: 0.9rem;
+  padding: 10px 20px;
+  border-radius: var(--mt-radius);
+  cursor: pointer;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.motion-trigger-button:hover {
+  border-color: var(--mt-primary);
+}
+
+.motion-trigger-button:focus {
+  outline: none;
+}
+
+.motion-trigger-button:focus-visible {
+  outline: 3px solid var(--mt-accent);
+  outline-offset: 2px;
+}
+
+.motion-trigger-card {
+  background: var(--mt-surface);
+  border: 1px solid var(--mt-border);
+  border-radius: var(--mt-radius);
+  padding: 20px;
+  color: var(--mt-text);
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
+    Arial, sans-serif;
+}
+
+.motion-trigger-card__title {
+  margin: 0 0 8px;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.motion-trigger-card__description {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: var(--mt-muted);
+}
+
+.bounce {
+  animation-name: motion-trigger-bounce;
+  animation-duration: 500ms;
+  animation-timing-function: ease-out;
+}
+
+.pulse {
+  animation-name: motion-trigger-pulse;
+  animation-duration: 400ms;
+  animation-timing-function: ease-in-out;
+}
+
+.shake {
+  animation-name: motion-trigger-shake;
+  animation-duration: 400ms;
+  animation-timing-function: ease-in-out;
+}
+
+@keyframes motion-trigger-bounce {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  30% {
+    transform: translateY(-14px);
+  }
+  60% {
+    transform: translateY(0);
+  }
+  80% {
+    transform: translateY(-6px);
+  }
+}
+
+@keyframes motion-trigger-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.08);
+  }
+}
+
+@keyframes motion-trigger-shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-6px);
+  }
+  75% {
+    transform: translateX(6px);
+  }
+}
+
+@media (max-width: 480px) {
+  .motion-trigger-demo {
+    padding: 16px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bounce,
+  .pulse,
+  .shake {
+    animation-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a **reusable MotionTrigger React component** under the `submissions/react/` track.

`MotionTrigger` provides a lightweight, CSS-first utility for triggering existing EaseMotion CSS animation classes in response to configurable user interactions such as click, hover, focus, blur, and keyboard events. It minimizes repetitive event-handling logic while preserving existing child props, styles, and event handlers.

Closes #36337

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `MotionTrigger.jsx`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

A reusable `MotionTrigger` React component that applies existing EaseMotion CSS animation classes in response to configurable user interactions such as click, hover, focus, blur, and keyboard events.

### How does a developer use it?

```jsx
<MotionTrigger
  trigger="click"
  animationClass="bounce"
  replay
>
  <button>Animate Me</button>
</MotionTrigger>
```

### Why does it fit EaseMotion CSS?

`MotionTrigger` extends EaseMotion CSS into React without introducing a custom animation engine or external dependencies. It provides a reusable abstraction for interaction-driven animations while continuing to rely entirely on existing EaseMotion CSS animation classes, reinforcing the framework's CSS-first philosophy.

---

## Demo

- [x] Example usage included in the README

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional)*