### PR TITLE
feat: add CSS Fade-In Tooltip for creative portfolio layouts #34260

### DIFF
--- a/submissions/examples/css-fade-in-portfolio-tooltip/README.md
+++ b/submissions/examples/css-fade-in-portfolio-tooltip/README.md
@@ -1,0 +1,14 @@
+# CSS Fade-In Tooltip (Creative Portfolio Layouts)
+
+A pure CSS, lightweight animated tooltip styled to complement high-end creative portfolio layouts, galleries, and showcase sites. It implements smooth hardware-accelerated opacity changes alongside subtle directional translation vectors to display project credits, context metadata, or category details on demand with zero JavaScript overhead.
+
+## Features
+- **Portfolio Minimalist Aesthetic:** Features deep premium charcoal backdrops with elegant typographic layout properties perfectly optimized for dark/light creative interfaces.
+- **Pure CSS Fade-In Mechanics:** Employs hardware-accelerated opacity layers paired with localized structural offsets to prevent animation stutters.
+- **Zero-JS Focus Management:** Integrates standard `:focus-within` triggers and explicit `tabindex="0"` constraints to ensure robust, accessible keyboard tab routing.
+
+## Custom Properties
+Configure or modify these parameters inside `style.css`:
+- `--tooltip-speed`: Transition duration window for the visibility fade (default: `0.3s`).
+- `--tooltip-easing`: Custom acceleration bezier applied to the interaction layout (default: `cubic-bezier(0.22, 1, 0.36, 1)`).
+- `--tooltip-lift`: Vertical translation pixel distance applied during the fade lifecycle (default: `-8px`).

--- a/submissions/examples/css-fade-in-portfolio-tooltip/demo.html
+++ b/submissions/examples/css-fade-in-portfolio-tooltip/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Fade-In Portfolio Tooltip</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="portfolio-workspace">
+    <div class="portfolio-grid">
+      
+      <article class="portfolio-card">
+        <div class="card-image-wrapper">
+          <div class="dummy-image"></div>
+          
+          <div class="tooltip-container">
+            <span class="tooltip-trigger" tabindex="0" aria-describedby="project-info-metadata">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="16" x2="12" y2="12"></line><line x1="12" y1="8" x2="12.01" y2="8"></line></svg>
+            </span>
+            
+            <div id="project-info-metadata" class="tooltip-bubble" role="tooltip">
+              Creative Direction / UI / 3D Asset Render
+              <div class="tooltip-arrow"></div>
+            </div>
+          </div>
+        </div>
+        
+        <div class="card-footer">
+          <h3>Ethereal Forms</h3>
+          <p>Exhibition Architecture Project</p>
+        </div>
+      </article>
+
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-fade-in-portfolio-tooltip/style.css
+++ b/submissions/examples/css-fade-in-portfolio-tooltip/style.css
@@ -1,0 +1,182 @@
+/* ==========================================================================
+   Config & Custom Properties (Creative Layout Architecture)
+   ========================================================================== */
+:root {
+  /* Tooltip Motion Parameters */
+  --tooltip-speed: 0.3s;
+  --tooltip-easing: cubic-bezier(0.22, 1, 0.36, 1);
+  --tooltip-lift: -8px;
+
+  /* Portfolio Aesthetic UI Colors */
+  --portfolio-bg: #0b0c10;
+  --card-bg: #1f2833;
+  --text-main: #f8fafc;
+  --text-sub: #c5a880; /* Elegant gold/bronze secondary accent token */
+  
+  /* Tooltip Theme Settings */
+  --tooltip-bg: #ffffff;
+  --tooltip-text: #0b0c10;
+}
+
+/* ==========================================================================
+   Base Structure Reset & Universal Layout Safeguards
+   ========================================================================== */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background-color: var(--portfolio-bg);
+  color: var(--text-main);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 24px;
+}
+
+.portfolio-workspace {
+  width: 100%;
+  max-width: 400px;
+}
+
+.portfolio-grid {
+  display: flex;
+  flex-direction: column;
+}
+
+.portfolio-card {
+  background-color: var(--card-bg);
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+}
+
+.card-image-wrapper {
+  position: relative;
+  height: 280px;
+  width: 100%;
+  background: linear-gradient(135deg, #2c3e50, #000000); /* Stylized mock image placeholder */
+}
+
+.dummy-image {
+  width: 100%;
+  height: 100%;
+  opacity: 0.4;
+  background-image: radial-gradient(circle at 50% 50%, var(--text-sub) 1px, transparent 1px);
+  background-size: 16px 16px;
+}
+
+.card-footer {
+  padding: 24px;
+}
+
+.card-footer h3 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin-bottom: 4px;
+}
+
+.card-footer p {
+  font-size: 0.85rem;
+  color: var(--text-sub);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* ==========================================================================
+   Core Component: Portfolio Fade-In Tooltip Mechanics
+   ========================================================================== */
+.tooltip-container {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  display: inline-flex;
+}
+
+.tooltip-trigger {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background-color: rgba(11, 12, 16, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text-main);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  outline: none;
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  transition: background-color 0.2s, border-color 0.2s;
+}
+
+.tooltip-trigger:hover,
+.tooltip-trigger:focus-visible {
+  background-color: var(--portfolio-bg);
+  border-color: var(--text-sub);
+  color: var(--text-sub);
+}
+
+/* Base Collapsed Frame Setup with Directional Offsets */
+.tooltip-bubble {
+  position: absolute;
+  bottom: calc(100% + 12px);
+  right: 50%;
+  transform: translateX(50%) translateY(0); /* Default centered offset base layer */
+  
+  width: 220px;
+  background-color: var(--tooltip-bg);
+  color: var(--tooltip-text);
+  padding: 10px 14px;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.3;
+  text-align: center;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
+  
+  /* Controlled entry transition layer states */
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  will-change: transform, opacity;
+  transition: transform var(--tooltip-speed) var(--tooltip-easing),
+              opacity var(--tooltip-speed) ease-out,
+              visibility var(--tooltip-speed);
+  z-index: 50;
+}
+
+/* Minimalist Triangular Base Indicator Arrow */
+.tooltip-arrow {
+  position: absolute;
+  top: 100%;
+  right: 24px; /* Right-aligned tracking balance offset */
+  border-width: 6px;
+  border-style: solid;
+  border-color: var(--tooltip-bg) transparent transparent transparent;
+}
+
+/* ==========================================================================
+   Activation Cascades (Hover & Focus States)
+   ========================================================================== */
+.tooltip-container:hover .tooltip-bubble,
+.tooltip-container:focus-within .tooltip-bubble {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  /* Multi-value transformation combining positional reset alongside structural variable translation lift */
+  transform: translateX(50%) translateY(var(--tooltip-lift));
+}
+
+/* Motion system bypass loop targeting assistive preferences */
+@media (prefers-reduced-motion: reduce) {
+  .tooltip-bubble {
+    transition: none !important;
+    transform: translateX(50%) translateY(var(--tooltip-lift)) !important;
+  }
+}


### PR DESCRIPTION
### 🛠️ Description
This PR resolves #34260 by adding a pure-CSS, hardware-accelerated **Fade-In Tooltip** element styled to blend cleanly with modern creative portfolio designs, artist catalogs, and high-end agency layouts.

The component pairs micro-opacity shifts with a parameterized layout height lift parameter (`translateY`) mapped entirely across GPU-bound threads, operating seamlessly with zero JS file bloat.

### 🚀 Features Included
- **Premium Creative UI Aesthetic:** Implements deep typography styles combined with light neutral container elements to elevate dark portfolio asset containers.
- **Micro-Lift Translation Physics:** Employs explicit structural transitions via `will-change: transform, opacity` layer isolations to support smooth 60fps frame rates.
- **Zero-JS Focus Mapping:** Fully complies with standard web access models, executing visibility toggles via native text `:focus-within` and mouse `:hover` vectors.
- **Reduced Motion Fallbacks:** Incorporates explicit `prefers-reduced-motion` safety bindings to immediately disable micro-translations for users with visual tracking preferences.

### 📂 Directory Layout
- `submissions/examples/css-fade-in-portfolio-tooltip/demo.html`
- `submissions/examples/css-fade-in-portfolio-tooltip/style.css`
- `submissions/examples/css-fade-in-portfolio-tooltip/README.md`

### 📝 Checklist
- [x] All file assets reside strictly beneath the targeted `submissions/` project branch tree.
- [x] No supplementary scripts or heavy presentation dependencies brought into scope.
- [x] Inspected fluid focus-ring outlines to ensure error-free sequential keyboard document traversal.