### PR TITLE
feat(examples): Cyberpunk Neon 3D Flip Tooltip

### DIFF
--- a/submissions/examples/34298-cyberpunk-neon-3d-flip-tooltip-sj6/README.md
+++ b/submissions/examples/34298-cyberpunk-neon-3d-flip-tooltip-sj6/README.md
@@ -1,0 +1,62 @@
+# Cyberpunk Neon 3D Flip Tooltip — "Hatch Drop"
+
+A pure CSS tooltip that **drops open like a maintenance hatch**: hinged on
+its top edge, it swings down through real 3D perspective and lands with a
+brief neon-tube flicker, like a strip light striking. Styled for cyberpunk
+neon garage/industrial UIs. Zero JavaScript — the hinge is driven entirely
+by `:hover` and `:focus-visible`.
+
+Resolves Issue: #34298
+
+## ✨ Features
+
+- **Top-hinge 3D flip** — `transform-origin: 50% 0` with
+  `rotateX(-84deg → 0)` inside a `perspective()` baked into the transform;
+  the tooltip opens *downward* below its trigger like a dropped hatch, and
+  the landing curve (`cubic-bezier(0.3, 1.2, 0.5, 1)`) gives it a
+  mechanical clunk.
+- **Strike-light flicker** — a short `@keyframes` pass dips opacity three
+  times before holding steady, selling the "neon tube igniting" moment.
+  Runs once per reveal, fully disabled under `prefers-reduced-motion`.
+- **Zero JavaScript** — sibling-selector engine
+  (`.hx-part-btn:hover + .hx-hatch`), transitions + one keyframe animation.
+- **Keyboard accessible** — real `<button>` triggers with
+  `aria-describedby` → `role="tooltip"` and a teal `:focus-visible` ring
+  that stays distinct from the red hover fill.
+- **Tunable via custom properties** — hinge angle, perspective, drop
+  duration, landing curve, and flicker length all live on `:root`.
+- **Cyberpunk garage skin** — hot-red part slots, teal-edged hatch, amber
+  hazard stripes, monospace HUD type, radial glow from the pit floor.
+- **Responsive & motion-safe** — slots wrap on narrow screens, hatch width
+  caps at `min(240px, 80vw)`, reduced-motion swaps hinge + flicker for an
+  instant reveal.
+
+## 🔧 Custom Properties
+
+| Property              | Default                            | Role                    |
+| --------------------- | ---------------------------------- | ----------------------- |
+| `--hx-tt-angle`       | `-84deg`                           | Folded-away hinge angle |
+| `--hx-tt-perspective` | `560px`                            | 3D camera distance      |
+| `--hx-tt-duration`    | `300ms`                            | Drop time               |
+| `--hx-tt-ease`        | `cubic-bezier(0.3, 1.2, 0.5, 1)`   | Landing curve           |
+| `--hx-flicker`        | `460ms`                            | Strike-light length     |
+
+## 🚀 Usage
+
+```html
+<span class="hx-slot">
+  <button class="hx-part-btn" type="button" aria-describedby="my-hatch">
+    NITRO CELL
+  </button>
+  <span class="hx-hatch" id="my-hatch" role="tooltip">
+    <span class="hx-hatch-tag">Propulsion <small>SLOT A</small></span>
+    Spec copy drops open below the trigger.
+  </span>
+</span>
+```
+
+## 📂 Files
+
+- `demo.html` — "Mod Bay 03" vehicle-upgrade console with three part slots.
+- `style.css` — garage tokens, top-hinge engine, strike flicker, a11y guards.
+- `README.md` — this document.

--- a/submissions/examples/34298-cyberpunk-neon-3d-flip-tooltip-sj6/demo.html
+++ b/submissions/examples/34298-cyberpunk-neon-3d-flip-tooltip-sj6/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cyberpunk Neon 3D Flip Tooltip — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="hx-bay" aria-label="Vehicle mod bay demo">
+    <h1 class="hx-bay-title">Mod Bay 03 // Chrome Garage</h1>
+    <p class="hx-bay-sub">
+      Hover a part slot — or Tab onto it — and its spec hatch drops open on a
+      top hinge, neon tube flickering as it strikes.
+    </p>
+
+    <div class="hx-slots">
+      <span class="hx-slot">
+        <button class="hx-part-btn" type="button" aria-describedby="hx-nitro">
+          NITRO CELL
+        </button>
+        <span class="hx-hatch" id="hx-nitro" role="tooltip">
+          <span class="hx-hatch-tag">Propulsion <small>SLOT A</small></span>
+          Twin-stage boost injector. 4.2s burn, 90s recharge off the main
+          coil. Street-legal in two districts.
+        </span>
+      </span>
+
+      <span class="hx-slot">
+        <button class="hx-part-btn" type="button" aria-describedby="hx-plasma">
+          PLASMA COIL
+        </button>
+        <span class="hx-hatch" id="hx-plasma" role="tooltip">
+          <span class="hx-hatch-tag">Power Core <small>SLOT B</small></span>
+          Salvaged reactor winding, re-shielded. Feeds the rig and both
+          rail chargers without browning out the cab.
+        </span>
+      </span>
+
+      <span class="hx-slot">
+        <button class="hx-part-btn" type="button" aria-describedby="hx-hover">
+          HOVER RIG
+        </button>
+        <span class="hx-hatch" id="hx-hover" role="tooltip">
+          <span class="hx-hatch-tag">Suspension <small>SLOT C</small></span>
+          Quad mag-lift pods rated to 2.1 tonnes. Whisper mode trades 30%
+          lift for near-silent running.
+        </span>
+      </span>
+    </div>
+  </main>
+</body>
+
+</html>

--- a/submissions/examples/34298-cyberpunk-neon-3d-flip-tooltip-sj6/style.css
+++ b/submissions/examples/34298-cyberpunk-neon-3d-flip-tooltip-sj6/style.css
@@ -1,0 +1,256 @@
+/* ==========================================================================
+   Cyberpunk Neon 3D Flip Tooltip — "Hatch Drop"
+   --------------------------------------------------------------------------
+   Pure CSS tooltip that drops open like a maintenance hatch: hinged on its
+   TOP edge, it swings down through real perspective and lands with a brief
+   neon flicker, as if its tube-light just struck. Zero JavaScript —
+   :hover and :focus-visible drive the hinge.
+
+   Issue: #34298
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Rig parameters — hinge physics + neon supply
+   -------------------------------------------------------------------------- */
+:root {
+  /* Hatch motion */
+  --hx-tt-angle: -84deg;                            /* folded-away angle   */
+  --hx-tt-perspective: 560px;                       /* camera distance     */
+  --hx-tt-duration: 300ms;                          /* drop time           */
+  --hx-tt-ease: cubic-bezier(0.3, 1.2, 0.5, 1);     /* clunks into place   */
+  --hx-flicker: 460ms;                              /* strike-light length */
+
+  /* Garage-bay palette */
+  --hx-pit: #0c0507;
+  --hx-plate: #160b10;
+  --hx-seam: #3a1b26;
+  --hx-red: #ff2d55;
+  --hx-teal: #00ffd0;
+  --hx-amber: #ffb300;
+  --hx-zinc: #a08e96;
+
+  --hx-red-glow: 0 0 9px rgba(255, 45, 85, 0.55), 0 0 24px rgba(255, 45, 85, 0.25);
+  --hx-teal-glow: 0 0 9px rgba(0, 255, 208, 0.5), 0 0 22px rgba(0, 255, 208, 0.22);
+}
+
+/* --------------------------------------------------------------------------
+   2. Demo stage — vehicle mod bay, hazard stripes and all
+   -------------------------------------------------------------------------- */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 36px 16px;
+  box-sizing: border-box;
+  background:
+    radial-gradient(ellipse at 50% 120%, rgba(255, 45, 85, 0.12), transparent 55%),
+    var(--hx-pit);
+  font-family: "Cascadia Mono", Consolas, monospace;
+  color: var(--hx-zinc);
+}
+
+.hx-bay {
+  width: 100%;
+  max-width: 540px;
+  position: relative;
+  background: var(--hx-plate);
+  border: 1px solid var(--hx-seam);
+  padding: 30px 28px 110px;
+}
+
+/* Hazard strip across the top of the bay panel */
+.hx-bay::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 8px;
+  background: repeating-linear-gradient(
+    -45deg,
+    var(--hx-amber) 0 12px,
+    var(--hx-pit) 12px 24px
+  );
+}
+
+.hx-bay-title {
+  margin: 6px 0 4px;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--hx-teal);
+  text-shadow: var(--hx-teal-glow);
+}
+
+.hx-bay-sub {
+  margin: 0 0 28px;
+  font-size: 0.76rem;
+  line-height: 1.65;
+}
+
+/* Part-slot row wraps cleanly at any width */
+.hx-slots {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+
+/* --------------------------------------------------------------------------
+   3. Anchor + part-slot trigger
+   -------------------------------------------------------------------------- */
+.hx-slot {
+  position: relative;
+  display: inline-flex;
+}
+
+.hx-part-btn {
+  font: 700 0.78rem/1.2 inherit;
+  font-family: inherit;
+  letter-spacing: 0.09em;
+  min-height: 42px;
+  padding: 10px 16px;
+  color: var(--hx-red);
+  background: transparent;
+  border: 1px solid var(--hx-red);
+  border-left-width: 4px;
+  cursor: pointer;
+  transition: color 160ms ease, background-color 160ms ease, box-shadow 160ms ease;
+}
+
+.hx-part-btn:hover {
+  color: var(--hx-pit);
+  background: var(--hx-red);
+  box-shadow: var(--hx-red-glow);
+}
+
+.hx-part-btn:focus-visible {
+  outline: 2px solid var(--hx-teal);
+  outline-offset: 3px;
+}
+
+/* --------------------------------------------------------------------------
+   4. The hatch tooltip — hinged on its TOP edge
+   --------------------------------------------------------------------------
+   Rest: folded up and away (rotateX toward the screen), dark.
+   Active: swings down through perspective and strikes its neon tube.
+   -------------------------------------------------------------------------- */
+.hx-hatch {
+  position: absolute;
+  top: calc(100% + 12px);
+  left: 50%;
+  z-index: 30;
+  width: max-content;
+  max-width: min(240px, 80vw);
+  padding: 12px 15px;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #1d0e15, #120810);
+  border: 1px solid var(--hx-teal);
+  border-top-width: 3px;
+  box-shadow: var(--hx-teal-glow);
+  color: #e8dce2;
+  font-size: 0.72rem;
+  line-height: 1.55;
+  text-align: left;
+  pointer-events: none;
+  transform-origin: 50% 0;
+
+  opacity: 0;
+  visibility: hidden;
+  transform: translateX(-50%)
+    perspective(var(--hx-tt-perspective))
+    rotateX(var(--hx-tt-angle));
+  transition:
+    opacity calc(var(--hx-tt-duration) * 0.5) ease-in,
+    transform calc(var(--hx-tt-duration) * 0.5) ease-in,
+    visibility 0s linear calc(var(--hx-tt-duration) * 0.5);
+}
+
+/* Feed line: small triangle pointing UP at the part slot */
+.hx-hatch::before {
+  content: "";
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-bottom-color: var(--hx-teal);
+}
+
+.hx-hatch-tag {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 5px;
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--hx-amber);
+  text-shadow: 0 0 6px rgba(255, 179, 0, 0.4);
+}
+
+.hx-hatch-tag small {
+  font-weight: 400;
+  color: var(--hx-teal);
+}
+
+/* --------------------------------------------------------------------------
+   5. Reveal wiring + strike-light flicker
+   -------------------------------------------------------------------------- */
+.hx-part-btn:hover + .hx-hatch,
+.hx-part-btn:focus-visible + .hx-hatch {
+  visibility: visible;
+  transform: translateX(-50%)
+    perspective(var(--hx-tt-perspective))
+    rotateX(0deg);
+  transition:
+    transform var(--hx-tt-duration) var(--hx-tt-ease),
+    visibility 0s;
+  /* Neon tube striking: three quick dips, then steady */
+  animation: hx-strike var(--hx-flicker) linear forwards;
+}
+
+@keyframes hx-strike {
+  0%   { opacity: 0.2; }
+  22%  { opacity: 1; }
+  34%  { opacity: 0.55; }
+  46%  { opacity: 1; }
+  58%  { opacity: 0.75; }
+  70%, 100% { opacity: 1; }
+}
+
+/* --------------------------------------------------------------------------
+   6. Small screens + reduced motion
+   -------------------------------------------------------------------------- */
+@media (max-width: 480px) {
+  .hx-bay {
+    padding: 26px 18px 100px;
+  }
+
+  .hx-slots {
+    gap: 10px;
+  }
+
+  .hx-part-btn {
+    min-height: 40px;
+    padding: 9px 13px;
+    font-size: 0.73rem;
+  }
+}
+
+/* Reduced motion: no hinge, no flicker — the hatch simply appears */
+@media (prefers-reduced-motion: reduce) {
+  .hx-hatch {
+    transition-duration: 1ms;
+    transform: translateX(-50%) perspective(var(--hx-tt-perspective)) rotateX(0deg);
+  }
+
+  .hx-part-btn:hover + .hx-hatch,
+  .hx-part-btn:focus-visible + .hx-hatch {
+    transition-duration: 1ms;
+    animation: none;
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS **3D Flip Tooltip** styled for **Cyberpunk Neon** layouts as a fully self-contained example under `submissions/examples/34298-cyberpunk-neon-3d-flip-tooltip-sj6/`.

Fixes #34298

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/34298-cyberpunk-neon-3d-flip-tooltip-sj6/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A "hatch drop" tooltip: hinged on its **top edge** (`transform-origin: 50% 0`), it swings open downward through real `perspective()` from `rotateX(-84deg)` and lands with a one-shot neon strike-light flicker (a short `@keyframes` pass that dips opacity three times before holding steady). Zero JavaScript — `:hover` and `:focus-visible` drive the hinge.

**How does a developer use it?**

```html
<span class="hx-slot">
  <button class="hx-part-btn" type="button" aria-describedby="my-hatch">
    NITRO CELL
  </button>
  <span class="hx-hatch" id="my-hatch" role="tooltip">
    <span class="hx-hatch-tag">Propulsion <small>SLOT A</small></span>
    Spec copy drops open below the trigger.
  </span>
</span>
```

**Why does it fit EaseMotion CSS?**

Human-readable classes, animation-first, zero JS. Hinge angle, perspective, drop duration, landing curve, and flicker length are all `--hx-*` custom properties; triggers are real `<button>` elements with `aria-describedby`/`role="tooltip"`; `prefers-reduced-motion` disables both the hinge and the flicker for an instant reveal. Color pairs were contrast-checked (worst pair 5.29:1, tooltip text 14:1).

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This completes a trio of 3D flip tooltips with deliberately different hinges: bottom-edge swing (Modern SaaS, #34290), vertical-axis pivot (Glassmorphism, #34296), and this top-edge hatch drop. The strike-light flicker runs once per reveal via `animation … forwards` so it never loops.

@SAPTARSHI-coder please review this pr 

