### PR TITLE
feat: add reusable MotionCascade React component

### DIFF
--- a/submissions/react/36353-motion-cascade-dp/MotionCascade.jsx
+++ b/submissions/react/36353-motion-cascade-dp/MotionCascade.jsx
@@ -1,0 +1,76 @@
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+export default function MotionCascade({
+  children,
+  animationClass,
+  cascadeDelay = 150,
+  direction = "vertical",
+  replay,
+  className = "",
+  as: Wrapper = "div",
+  onCascadeStart,
+  onCascadeEnd,
+}) {
+  const items = useMemo(() => Children.toArray(children), [children]);
+  const [activeCount, setActiveCount] = useState(0);
+
+  useEffect(() => {
+    setActiveCount(0);
+
+    if (items.length === 0) return undefined;
+
+    if (typeof onCascadeStart === "function") onCascadeStart();
+
+    const timers = items.map((_, index) =>
+      setTimeout(() => {
+        setActiveCount((count) => {
+          const next = Math.max(count, index + 1);
+          if (next === items.length && typeof onCascadeEnd === "function") {
+            onCascadeEnd();
+          }
+          return next;
+        });
+      }, index * cascadeDelay)
+    );
+
+    return () => {
+      timers.forEach(clearTimeout);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [items.length, cascadeDelay, replay]);
+
+  return (
+    <Wrapper
+      className={[
+        "motion-cascade",
+        direction === "horizontal"
+          ? "motion-cascade--horizontal"
+          : "motion-cascade--vertical",
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {items.map((child, index) => {
+        if (!isValidElement(child)) return child;
+
+        const isActive = index < activeCount;
+        const existingClassName = child.props.className || "";
+
+        return cloneElement(child, {
+          key: child.key ?? index,
+          className: [existingClassName, isActive ? animationClass : ""]
+            .filter(Boolean)
+            .join(" "),
+        });
+      })}
+    </Wrapper>
+  );
+}

--- a/submissions/react/36353-motion-cascade-dp/README.md
+++ b/submissions/react/36353-motion-cascade-dp/README.md
@@ -1,0 +1,75 @@
+# MotionCascade
+
+A lightweight React component that progressively reveals grouped layout sections using existing EaseMotion CSS animation classes.
+
+---
+
+## Overview
+
+`MotionCascade` coordinates cascading animations across direct child elements, allowing sections of a page to appear progressively rather than all at once. It is designed for layouts such as landing pages, dashboards, onboarding flows, documentation, and feature showcases while remaining lightweight, reusable, and CSS-first.
+
+---
+
+## Props
+
+| Prop             | Type        | Default      | Description                                               |
+| ---------------- | ----------- | ------------ | --------------------------------------------------------- |
+| `children`       | `ReactNode` | —            | Direct child elements to animate in sequence.             |
+| `animationClass` | `string`    | —            | CSS animation class applied to each child.                |
+| `cascadeDelay`   | `number`    | `150`        | Delay (ms) between consecutive child animations.          |
+| `direction`      | `string`    | `"vertical"` | Cascade direction (`"vertical"` or `"horizontal"`).       |
+| `replay`         | `any`       | —            | Restarts the cascade whenever the value changes.          |
+| `className`      | `string`    | `""`         | Additional class name for the wrapper element.            |
+| `as`             | `string`    | `"div"`      | Wrapper element (`div`, `section`, `main`, etc.).         |
+| `onCascadeStart` | `function`  | —            | Callback fired when the cascade begins.                   |
+| `onCascadeEnd`   | `function`  | —            | Callback fired after the final child animation completes. |
+
+---
+
+## Example Usage
+
+```jsx
+import { useState } from "react";
+import MotionCascade from "./MotionCascade";
+import "./style.css";
+
+export default function LandingPage() {
+  const [replay, setReplay] = useState(0);
+
+  return (
+    <>
+      <MotionCascade
+        animationClass="fade-up"
+        cascadeDelay={180}
+        direction="vertical"
+        replay={replay}
+      >
+        <section className="motion-cascade-section">Hero</section>
+        <section className="motion-cascade-section">Features</section>
+        <section className="motion-cascade-section">Pricing</section>
+        <section className="motion-cascade-section">Testimonials</section>
+      </MotionCascade>
+
+      <button onClick={() => setReplay((value) => value + 1)}>
+        Replay Cascade
+      </button>
+    </>
+  );
+}
+```
+
+Each direct child is revealed progressively while preserving its existing props, styles, and class names.
+
+---
+
+## Why MotionCascade?
+
+- Creates progressive section-by-section layout animations.
+- Ideal for landing pages, dashboards, onboarding flows, and documentation.
+- Eliminates repetitive cascade timing logic.
+- Supports configurable cascade direction and delay.
+- Preserves existing child props and class names.
+- Supports replayable animations and lifecycle callbacks.
+- Works seamlessly with existing EaseMotion CSS animation classes.
+- Lightweight, reusable, and dependency-free.
+- Follows EaseMotion CSS's CSS-first philosophy.

--- a/submissions/react/36353-motion-cascade-dp/style.css
+++ b/submissions/react/36353-motion-cascade-dp/style.css
@@ -1,0 +1,158 @@
+:root {
+  --mc-bg: #f8fafc;
+  --mc-surface: #ffffff;
+  --mc-primary: #2563eb;
+  --mc-accent: #8b5cf6;
+  --mc-border: #e2e8f0;
+  --mc-text: #0f172a;
+  --mc-muted: #64748b;
+
+  --mc-radius: 10px;
+  --mc-gap: 20px;
+}
+
+.motion-cascade {
+  display: flex;
+  gap: var(--mc-gap);
+  background: var(--mc-bg);
+  padding: 24px;
+  border-radius: var(--mc-radius);
+}
+
+.motion-cascade--vertical {
+  flex-direction: column;
+}
+
+.motion-cascade--horizontal {
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+
+.motion-cascade-section {
+  background: var(--mc-surface);
+  border: 1px solid var(--mc-border);
+  border-radius: var(--mc-radius);
+  padding: 24px;
+  color: var(--mc-text);
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
+    Arial, sans-serif;
+  opacity: 0;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.motion-cascade--horizontal .motion-cascade-section {
+  flex: 1;
+  min-width: 200px;
+}
+
+.motion-cascade-section:hover {
+  border-color: var(--mc-primary);
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.06);
+}
+
+.motion-cascade-section__title {
+  margin: 0 0 8px;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--mc-text);
+}
+
+.motion-cascade-section__description {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: var(--mc-muted);
+}
+
+.motion-cascade-section a,
+.motion-cascade-section button {
+  color: var(--mc-primary);
+}
+
+.motion-cascade-section a:focus,
+.motion-cascade-section button:focus {
+  outline: none;
+}
+
+.motion-cascade-section a:focus-visible,
+.motion-cascade-section button:focus-visible {
+  outline: 3px solid var(--mc-accent);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+.fade-up {
+  animation-name: motion-cascade-fade-up;
+  animation-duration: 500ms;
+  animation-timing-function: ease-out;
+  animation-fill-mode: both;
+}
+
+.fade-in {
+  animation-name: motion-cascade-fade-in;
+  animation-duration: 500ms;
+  animation-timing-function: ease-out;
+  animation-fill-mode: both;
+}
+
+.slide-in {
+  animation-name: motion-cascade-slide-in;
+  animation-duration: 500ms;
+  animation-timing-function: ease-out;
+  animation-fill-mode: both;
+}
+
+@keyframes motion-cascade-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes motion-cascade-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes motion-cascade-slide-in {
+  from {
+    opacity: 0;
+    transform: translateX(-24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@media (max-width: 640px) {
+  .motion-cascade--horizontal {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 480px) {
+  .motion-cascade {
+    padding: 16px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fade-up,
+  .fade-in,
+  .slide-in {
+    animation-duration: 1ms !important;
+    animation-delay: 0ms !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a **reusable MotionCascade React component** under the `submissions/react/` track.

`MotionCascade` provides a lightweight, CSS-first utility for progressively revealing grouped layout sections using existing EaseMotion CSS animation classes. It coordinates cascading animations across direct child elements, making it well-suited for landing pages, dashboards, onboarding flows, feature showcases, and documentation layouts while remaining reusable and dependency-free.

Closes #36353 

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `MotionCascade.jsx`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

A reusable `MotionCascade` React component that progressively applies existing EaseMotion CSS animation classes to grouped layout sections, creating structured cascading animations with configurable timing and direction.

### How does a developer use it?

```jsx
<MotionCascade
  animationClass="fade-up"
  cascadeDelay={180}
  direction="vertical"
  replay={replay}
>
  <section>Hero</section>
  <section>Features</section>
  <section>Pricing</section>
  <section>Testimonials</section>
</MotionCascade>
```

### Why does it fit EaseMotion CSS?

`MotionCascade` extends EaseMotion CSS into React by providing a reusable layout-level animation utility without introducing a custom animation engine or external dependencies. It coordinates when existing CSS animation classes are applied, reinforcing the framework's CSS-first philosophy while encouraging structured, reusable motion patterns.

---

## Demo

- [x] Example usage included in the README

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional)*