### PR TITLE
fix / 36379 add theme previw switcher

### DIFF
--- a/submissions/examples/theme-preview-switcher-tj/README.md
+++ b/submissions/examples/theme-preview-switcher-tj/README.md
@@ -1,0 +1,23 @@
+# Interactive Documentation Theme Preview Switcher
+
+## What does this do?
+Adds a Light / Dark / System theme switcher for the documentation preview, letting visitors instantly see how components, buttons, forms, and animations look across themes, with the choice remembered via `localStorage`.
+
+## How is it used?
+```html
+<div class="theme-preview-switcher" role="group" aria-label="Theme switcher">
+  <button data-theme="light" class="theme-btn">☀️ Light</button>
+  <button data-theme="dark" class="theme-btn">🌙 Dark</button>
+  <button data-theme="system" class="theme-btn">💻 System</button>
+</div>
+```
+Each button sets a `data-doc-theme` attribute (`light` or `dark`) on `<html>`. Selecting `system` follows `prefers-color-scheme` and updates live if the OS setting changes. The selection is saved to `localStorage` under the key `easemotion-doc-theme` and restored on page load, with a safe fallback to `system` if storage is unavailable (e.g. private browsing).
+
+All demo components (buttons, card, form inputs, animation box) are built entirely on CSS custom properties (`--doc-bg`, `--doc-surface`, `--doc-text`, `--doc-accent`, etc.) that get reassigned per theme, so no component markup needs to change when the theme switches.
+
+## Why is it useful?
+EaseMotion CSS already ships dark-mode-capable CSS variables, but there was no quick way to preview that support while browsing the docs. This switcher:
+- Lets contributors and users verify component appearance in both themes instantly, without changing OS settings.
+- Demonstrates EaseMotion's theming approach in a concrete, interactive way (rather than just documenting it in prose).
+- Persists the user's preferred docs appearance across visits, improving the browsing experience.
+- Is scoped entirely to the documentation preview — it doesn't alter any core animation classes or generated component HTML.

--- a/submissions/examples/theme-preview-switcher-tj/demo.html
+++ b/submissions/examples/theme-preview-switcher-tj/demo.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <title>Interactive Documentation Theme Preview Switcher</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+    <header class="doc-header">
+        <h1>EaseMotion CSS — Docs Preview</h1>
+        <div class="theme-preview-switcher" role="group" aria-label="Theme switcher">
+            <button data-theme="light" class="theme-btn" aria-pressed="false">☀️ Light</button>
+            <button data-theme="dark" class="theme-btn" aria-pressed="false">🌙 Dark</button>
+            <button data-theme="system" class="theme-btn" aria-pressed="true">💻 System</button>
+        </div>
+    </header>
+
+    <main class="doc-preview">
+        <section class="preview-card">
+            <h2>Buttons</h2>
+            <div class="preview-row">
+                <button class="demo-btn demo-btn-primary">Primary</button>
+                <button class="demo-btn demo-btn-secondary">Secondary</button>
+                <button class="demo-btn demo-btn-outline">Outline</button>
+            </div>
+        </section>
+
+        <section class="preview-card">
+            <h2>Card Component</h2>
+            <div class="demo-component-card">
+                <h3>Sample Card</h3>
+                <p>This card shows how surfaces, borders, and text adapt to the selected theme.</p>
+            </div>
+        </section>
+
+        <section class="preview-card">
+            <h2>Form Elements</h2>
+            <div class="preview-row preview-row-form">
+                <input type="text" class="demo-input" placeholder="Type something...">
+                <select class="demo-select">
+                    <option>Option A</option>
+                    <option>Option B</option>
+                </select>
+            </div>
+        </section>
+
+        <section class="preview-card">
+            <h2>Animation Utility</h2>
+            <div class="demo-animate-box" id="animateBox"></div>
+            <button class="demo-btn demo-btn-outline" id="replayBtn">Replay Animation</button>
+        </section>
+    </main>
+
+    <footer class="doc-footer">
+        <p>Theme choice is saved locally and restored on your next visit.</p>
+    </footer>
+
+    <script>
+        (function () {
+            const STORAGE_KEY = 'easemotion-doc-theme';
+            const root = document.documentElement;
+            const buttons = document.querySelectorAll('.theme-btn');
+            const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+            function applyTheme(mode) {
+                if (mode === 'system') {
+                    root.setAttribute('data-doc-theme', mediaQuery.matches ? 'dark' : 'light');
+                } else {
+                    root.setAttribute('data-doc-theme', mode);
+                }
+
+                buttons.forEach(btn => {
+                    const isActive = btn.dataset.theme === mode;
+                    btn.classList.toggle('is-active', isActive);
+                    btn.setAttribute('aria-pressed', String(isActive));
+                });
+            }
+
+            function setTheme(mode) {
+                try {
+                    localStorage.setItem(STORAGE_KEY, mode);
+                } catch (e) {
+                    // localStorage unavailable (private browsing, etc.) — theme just won't persist
+                }
+                applyTheme(mode);
+            }
+
+            buttons.forEach(btn => {
+                btn.addEventListener('click', () => setTheme(btn.dataset.theme));
+            });
+
+            mediaQuery.addEventListener('change', () => {
+                const saved = localStorage.getItem(STORAGE_KEY) || 'system';
+                if (saved === 'system') applyTheme('system');
+            });
+
+            const saved = (function () {
+                try {
+                    return localStorage.getItem(STORAGE_KEY);
+                } catch (e) {
+                    return null;
+                }
+            })() || 'system';
+
+            applyTheme(saved);
+
+            document.getElementById('replayBtn').addEventListener('click', () => {
+                const box = document.getElementById('animateBox');
+                box.classList.remove('replay');
+                void box.offsetWidth;
+                box.classList.add('replay');
+            });
+        })();
+    </script>
+
+</body>
+
+</html>

--- a/submissions/examples/theme-preview-switcher-tj/style.css
+++ b/submissions/examples/theme-preview-switcher-tj/style.css
@@ -1,0 +1,194 @@
+/* ============================================
+   Theme tokens — swapped via [data-doc-theme]
+   ============================================ */
+:root {
+    --doc-bg: #f7f8fa;
+    --doc-surface: #ffffff;
+    --doc-border: #e2e4e9;
+    --doc-text: #1f2430;
+    --doc-text-muted: #6b7280;
+    --doc-accent: #6366f1;
+    --doc-accent-contrast: #ffffff;
+}
+
+html[data-doc-theme="dark"] {
+    --doc-bg: #14161c;
+    --doc-surface: #1e2129;
+    --doc-border: #2c3038;
+    --doc-text: #f1f2f6;
+    --doc-text-muted: #9aa0ab;
+    --doc-accent: #818cf8;
+    --doc-accent-contrast: #14161c;
+}
+
+/* ============================================
+   Base layout
+   ============================================ */
+body {
+    margin: 0;
+    font-family: system-ui, -apple-system, sans-serif;
+    background: var(--doc-bg);
+    color: var(--doc-text);
+    transition: background 0.25s ease, color 0.25s ease;
+}
+
+.doc-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    padding: 1.5rem 2rem;
+    border-bottom: 1px solid var(--doc-border);
+}
+
+.doc-header h1 {
+    font-size: 1.25rem;
+    margin: 0;
+}
+
+.doc-preview {
+    padding: 2rem;
+    display: grid;
+    gap: 1.5rem;
+    max-width: 720px;
+    margin: 0 auto;
+}
+
+.doc-footer {
+    padding: 1.5rem 2rem;
+    text-align: center;
+    color: var(--doc-text-muted);
+    font-size: 0.85rem;
+}
+
+/* ============================================
+   Theme switcher
+   ============================================ */
+.theme-preview-switcher {
+    display: flex;
+    gap: 0.75rem;
+}
+
+.theme-btn {
+    cursor: pointer;
+    padding: 0.5rem 1rem;
+    border-radius: 8px;
+    border: 1px solid var(--doc-border);
+    background: var(--doc-surface);
+    color: var(--doc-text);
+    font-size: 0.9rem;
+    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.theme-btn:hover {
+    border-color: var(--doc-accent);
+}
+
+.theme-btn.is-active {
+    background: var(--doc-accent);
+    border-color: var(--doc-accent);
+    color: var(--doc-accent-contrast);
+}
+
+/* ============================================
+   Preview cards
+   ============================================ */
+.preview-card {
+    background: var(--doc-surface);
+    border: 1px solid var(--doc-border);
+    border-radius: 12px;
+    padding: 1.5rem;
+}
+
+.preview-card h2 {
+    margin-top: 0;
+    font-size: 1rem;
+    color: var(--doc-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.preview-row {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+/* ============================================
+   Demo components (theme-aware)
+   ============================================ */
+.demo-btn {
+    cursor: pointer;
+    padding: 0.6rem 1.2rem;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    border: 1px solid transparent;
+    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.demo-btn-primary {
+    background: var(--doc-accent);
+    color: var(--doc-accent-contrast);
+}
+
+.demo-btn-secondary {
+    background: var(--doc-border);
+    color: var(--doc-text);
+}
+
+.demo-btn-outline {
+    background: transparent;
+    border-color: var(--doc-accent);
+    color: var(--doc-accent);
+}
+
+.demo-component-card {
+    background: var(--doc-bg);
+    border: 1px solid var(--doc-border);
+    border-radius: 10px;
+    padding: 1rem 1.25rem;
+}
+
+.demo-component-card h3 {
+    margin-top: 0;
+}
+
+.demo-input,
+.demo-select {
+    padding: 0.55rem 0.8rem;
+    border-radius: 8px;
+    border: 1px solid var(--doc-border);
+    background: var(--doc-surface);
+    color: var(--doc-text);
+    font-size: 0.9rem;
+}
+
+.demo-animate-box {
+    width: 60px;
+    height: 60px;
+    border-radius: 10px;
+    background: linear-gradient(135deg, var(--doc-accent), #ec4899);
+    margin-bottom: 1rem;
+    animation: doc-pop 0.8s ease;
+}
+
+.demo-animate-box.replay {
+    animation: doc-pop 0.8s ease;
+}
+
+@keyframes doc-pop {
+    0% {
+        transform: scale(0.5);
+        opacity: 0;
+    }
+
+    70% {
+        transform: scale(1.05);
+        opacity: 1;
+    }
+
+    100% {
+        transform: scale(1);
+    }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a self-contained demo for an Interactive Documentation Theme Preview Switcher, as requested in #36379. Lets visitors toggle between Light, Dark, and System themes to preview how components and animations appear, with the choice persisted via `localStorage`.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/theme-preview-switcher-tj/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A Light / Dark / System theme switcher for previewing documentation components across themes.

**How does a developer use it?**
```html
<div class="theme-preview-switcher">
  <button data-theme="light">Light</button>
  <button data-theme="dark">Dark</button>
  <button data-theme="system">System</button>
</div>
```

**Why does it fit EaseMotion CSS?**
It showcases EaseMotion's existing CSS-variable-based dark mode support in an interactive, hands-on way, improving how contributors and users evaluate component appearance — without touching any core animation classes.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Theme persistence uses `localStorage` with a try/catch fallback for environments where it's unavailable. Happy to adjust the token names (`--doc-*`) if you'd like these unified with EaseMotion's core variable naming when this gets promoted.