### PR TITLE
feat: add framework-aware installation guide with dynamic command gen…

### DIFF
--- a/submissions/examples/framework-installation-tj/README.md
+++ b/submissions/examples/framework-installation-tj/README.md
@@ -1,0 +1,10 @@
+# Framework-Aware Installation Guide with Dynamic Command Generator
+
+## What does this do?
+This component introduces an interactive framework selector tool to the "Getting Started" documentation, updating recommended command line instructions, configuration setups, and import code-blocks dynamically depending on the developer's project tech stack.
+
+## How is it used?
+Developers use a clean `<select>` HTML element containing core modern environments (such as React, Vue, HTML/CDN). Upon selection change, an event handler modifies the DOM elements inside `#installation-output` with context-specific setups instantly.
+
+## Why is it useful?
+It heavily reduces cognitive load and text scanning fatigue for newcomers browsing EaseMotion CSS documentation. Rather than sorting through long, scrolling blocks of configuration variants (NPM, granular, or CDN methods simultaneously), a developer is served only the codebase-specific requirements relevant to their framework layout.

--- a/submissions/examples/framework-installation-tj/demo.html
+++ b/submissions/examples/framework-installation-tj/demo.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Framework-Aware Installation Guide | EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+    <div class="installation-container">
+        <h2>Getting Started</h2>
+        <p class="subtitle">Choose your preferred framework environment to view the optimized installation steps.</p>
+
+        <!-- Framework Selector -->
+        <div class="installation-selector">
+            <label for="framework">Choose your framework</label>
+            <select id="framework" onchange="updateInstallationGuide()">
+                <option value="html">HTML / CDN</option>
+                <option value="react">React</option>
+                <option value="nextjs">Next.js</option>
+                <option value="vue">Vue.js</option>
+                <option value="vite">Vite</option>
+                <option value="angular">Angular</option>
+            </select>
+        </div>
+
+        <!-- Dynamic Output Box -->
+        <div id="installation-output" class="installation-output">
+            <!-- Populated dynamically via JS -->
+        </div>
+    </div>
+
+    <script>
+        const data = {
+            html: {
+                command: `<!-- Include via Content Delivery Network (CDN) -->\n<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">`,
+                importStr: `<!-- Include inside your <head> tags -->`,
+                lang: "html"
+            },
+            react: {
+                command: "npm install easemotion-css",
+                importStr: `import "easemotion-css/easemotion.min.css";\n\n// Place inside your App.jsx or main.jsx root file`,
+                lang: "javascript"
+            },
+            nextjs: {
+                command: "npm install easemotion-css",
+                importStr: `import "easemotion-css/easemotion.min.css";\n\n// Place at the very top of your app/layout.js file`,
+                lang: "javascript"
+            },
+            vue: {
+                command: "npm install easemotion-css",
+                importStr: `import 'easemotion-css/easemotion.min.css';\n\n// Place inside your src/main.js entry point`,
+                lang: "javascript"
+            },
+            vite: {
+                command: "npm install easemotion-css",
+                importStr: `import 'easemotion-css/easemotion.min.css';\n\n// Add to your main entry JavaScript or TypeScript file`,
+                lang: "javascript"
+            },
+            angular: {
+                command: "npm install easemotion-css",
+                importStr: `"styles": [\n  "node_modules/easemotion-css/easemotion.min.css"\n]\n\n// Add to the styles array configuration inside angular.json`,
+                lang: "json"
+            }
+        };
+
+        function updateInstallationGuide() {
+            const framework = document.getElementById('framework').value;
+            const targetData = data[framework];
+            const outputDiv = document.getElementById('installation-output');
+
+            outputDiv.innerHTML = `
+        <div class="step">
+          <h3>1. Recommended Installation</h3>
+          <div class="code-block">
+            <pre><code>${targetData.command}</code></pre>
+          </div>
+        </div>
+        <div class="step">
+          <h3>2. Usage & Imports</h3>
+          <div class="code-block">
+            <pre><code>${targetData.importStr}</code></pre>
+          </div>
+        </div>
+      `;
+        }
+
+        // Initialize with default framework
+        document.addEventListener("DOMContentLoaded", updateInstallationGuide);
+    </script>
+</body>
+
+</html>

--- a/submissions/examples/framework-installation-tj/style.css
+++ b/submissions/examples/framework-installation-tj/style.css
@@ -1,0 +1,95 @@
+/* Base styles & UI container setup */
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background-color: #f8fafc;
+    color: #0f172a;
+    padding: 2rem;
+    display: flex;
+    justify-content: center;
+}
+
+.installation-container {
+    background-color: #ffffff;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    padding: 2rem;
+    max-width: 600px;
+    width: 100%;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+}
+
+h2 {
+    margin-top: 0;
+    font-size: 1.5rem;
+    color: #1e293b;
+}
+
+.subtitle {
+    color: #64748b;
+    font-size: 0.95rem;
+    margin-bottom: 1.5rem;
+}
+
+/* Feature selector styling */
+.installation-selector {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    max-width: 320px;
+    margin-bottom: 2rem;
+}
+
+.installation-selector label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #475569;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.installation-selector select {
+    padding: 0.6rem 0.8rem;
+    border: 1px solid #cbd5e1;
+    border-radius: 8px;
+    background-color: #fff;
+    font-size: 1rem;
+    color: #334155;
+    outline: none;
+    cursor: pointer;
+    transition: border-color 0.2s;
+}
+
+.installation-selector select:focus {
+    border-color: #6366f1;
+}
+
+/* Dynamic code output styling */
+.installation-output {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.step h3 {
+    font-size: 1rem;
+    color: #334155;
+    margin: 0 0 0.5rem 0;
+}
+
+.code-block {
+    background-color: #0f172a;
+    border-radius: 8px;
+    padding: 1rem;
+    overflow-x: auto;
+}
+
+.code-block pre {
+    margin: 0;
+}
+
+.code-block code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 0.9rem;
+    color: #38bdf8;
+    white-space: pre-wrap;
+}


### PR DESCRIPTION
## Pull Request Description
Adds a self-contained documentation showcase for a Framework-Aware Installation Guide with a Dynamic Command Generator, as requested in #36381. It introduces an interactive environment selector that dynamically switches installation steps and import statements based on the developer's tech stack (HTML, React, Next.js, etc.).

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/docs/framework-installation-tj/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
An interactive framework selector tool to the "Getting Started" documentation that filters out unrelated configuration variants and displays ecosystem-specific setup steps instantly.

**How does a developer use it?**
```html
<div class="installation-selector">
  <label for="framework">Choose your framework</label>
  <select id="framework" onchange="updateInstallationGuide()">
    <option value="html">HTML / CDN</option>
    <option value="react">React</option>
    <!-- Additional options -->
  </select>
</div>
<div id="installation-output" class="installation-output"></div>