### PR TITLE
feat: add reusable MotionVariant React component

### DIFF
--- a/submissions/react/36384-motion-variant-dp/MotionVariant.jsx
+++ b/submissions/react/36384-motion-variant-dp/MotionVariant.jsx
@@ -1,0 +1,212 @@
+import React, {
+  Children,
+  cloneElement,
+  isValidElement,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
+
+const FORWARD_REF_TYPE = Symbol.for("react.forward_ref");
+const MEMO_TYPE = Symbol.for("react.memo");
+
+function cx(...values) {
+  const classes = new Set();
+
+  values
+    .filter(Boolean)
+    .join(" ")
+    .split(/\s+/)
+    .filter(Boolean)
+    .forEach((className) => classes.add(className));
+
+  return Array.from(classes).join(" ");
+}
+
+function composeRefs(...refs) {
+  return (node) => {
+    refs.forEach((ref) => {
+      if (!ref) return;
+
+      if (typeof ref === "function") {
+        ref(node);
+        return;
+      }
+
+      ref.current = node;
+    });
+  };
+}
+
+function callAll(...handlers) {
+  return (event) => {
+    handlers.forEach((handler) => {
+      if (typeof handler === "function") {
+        handler(event);
+      }
+    });
+  };
+}
+
+function canReceiveRef(element) {
+  return canReceiveRefType(element.type);
+}
+
+function canReceiveRefType(type) {
+  if (typeof type === "string") return true;
+  if (
+    typeof type === "function" &&
+    type.prototype &&
+    type.prototype.isReactComponent
+  )
+    return true;
+  if (type && type.$$typeof === FORWARD_REF_TYPE) return true;
+  if (
+    type &&
+    type.$$typeof === MEMO_TYPE &&
+    type.type &&
+    type.type.$$typeof === FORWARD_REF_TYPE
+  )
+    return true;
+
+  return false;
+}
+
+export default function MotionVariant({
+  children,
+  state,
+  variants = {},
+  fallback = "",
+  replay = false,
+  className = "",
+  as: Component,
+  onVariantChange,
+  onAnimationStart,
+  onAnimationEnd,
+}) {
+  const child = Children.only(children);
+
+  if (!isValidElement(child)) {
+    throw new Error(
+      "MotionVariant expects exactly one valid React element child."
+    );
+  }
+
+  const targetRef = useRef(null);
+  const previousVariantRef = useRef();
+  const previousReplayRef = useRef(replay);
+  const hasMountedRef = useRef(false);
+
+  const variantClass = useMemo(() => {
+    if (variants && Object.prototype.hasOwnProperty.call(variants, state)) {
+      return variants[state] || "";
+    }
+
+    return fallback || "";
+  }, [fallback, state, variants]);
+
+  const resolvedClassName = useMemo(
+    () => cx(child.props.className, className, variantClass),
+    [child.props.className, className, variantClass]
+  );
+
+  useEffect(() => {
+    if (previousVariantRef.current === variantClass) return;
+
+    previousVariantRef.current = variantClass;
+
+    if (typeof onVariantChange === "function") {
+      onVariantChange({
+        state,
+        variant: variantClass,
+        isFallback: !(
+          variants && Object.prototype.hasOwnProperty.call(variants, state)
+        ),
+      });
+    }
+  }, [onVariantChange, state, variantClass, variants]);
+
+  useEffect(() => {
+    const node = targetRef.current;
+    const classes = variantClass.split(/\s+/).filter(Boolean);
+
+    if (!node || classes.length === 0) {
+      hasMountedRef.current = true;
+      previousReplayRef.current = replay;
+      return undefined;
+    }
+
+    const shouldReplay =
+      hasMountedRef.current &&
+      (replay === true || previousReplayRef.current !== replay);
+
+    hasMountedRef.current = true;
+    previousReplayRef.current = replay;
+
+    if (!shouldReplay) return undefined;
+
+    classes.forEach((name) => node.classList.remove(name));
+
+    const frame = window.requestAnimationFrame(() => {
+      void node.offsetWidth;
+      classes.forEach((name) => node.classList.add(name));
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
+  }, [replay, state, variantClass]);
+
+  const animationHandlers = {
+    onAnimationStart: (event) => {
+      if (event.currentTarget !== event.target) return;
+      callAll(child.props.onAnimationStart, onAnimationStart)(event);
+    },
+    onAnimationEnd: (event) => {
+      if (event.currentTarget !== event.target) return;
+      callAll(child.props.onAnimationEnd, onAnimationEnd)(event);
+    },
+  };
+
+  if (Component) {
+    const wrapperHandlers = {
+      onAnimationStart: (event) => {
+        if (
+          event.currentTarget === event.target &&
+          typeof onAnimationStart === "function"
+        ) {
+          onAnimationStart(event);
+        }
+      },
+      onAnimationEnd: (event) => {
+        if (
+          event.currentTarget === event.target &&
+          typeof onAnimationEnd === "function"
+        ) {
+          onAnimationEnd(event);
+        }
+      },
+    };
+    const wrapperProps = {
+      className: cx(className, variantClass),
+      ...wrapperHandlers,
+    };
+
+    if (canReceiveRefType(Component)) {
+      wrapperProps.ref = targetRef;
+    }
+
+    return <Component {...wrapperProps}>{child}</Component>;
+  }
+
+  const childProps = {
+    ...animationHandlers,
+    className: resolvedClassName,
+  };
+
+  if (canReceiveRef(child)) {
+    childProps.ref = composeRefs(child.ref, targetRef);
+  }
+
+  return cloneElement(child, childProps);
+}

--- a/submissions/react/36384-motion-variant-dp/README.md
+++ b/submissions/react/36384-motion-variant-dp/README.md
@@ -1,0 +1,54 @@
+# MotionVariant
+
+## Overview
+
+`MotionVariant` is a lightweight React utility that maps application state to existing EaseMotion CSS animation classes. It stays CSS-first: no generated keyframes, no animation engine, and no runtime animation definitions.
+
+## Props
+
+| Prop               | Type               | Default     | Description                                                                     |
+| ------------------ | ------------------ | ----------- | ------------------------------------------------------------------------------- |
+| `children`         | React element      | Required    | Exactly one valid React element to receive the animation behavior.              |
+| `state`            | `string`           | Required    | Current application state used to select a variant.                             |
+| `variants`         | `object`           | `{}`        | Map of state values to existing EaseMotion CSS class names.                     |
+| `fallback`         | `string`           | `""`        | Animation class used when `state` is not present in `variants`.                 |
+| `replay`           | `boolean` or token | `false`     | Restarts the active animation when enabled or when the token changes.           |
+| `className`        | `string`           | `""`        | Additional class names merged with the child and selected animation class.      |
+| `as`               | React element type | `undefined` | Optional wrapper element or component used as the animation target.             |
+| `onVariantChange`  | `function`         | `undefined` | Called with `{ state, variant, isFallback }` when the selected variant changes. |
+| `onAnimationStart` | `function`         | `undefined` | Called when the applied animation starts.                                       |
+| `onAnimationEnd`   | `function`         | `undefined` | Called when the applied animation ends.                                         |
+
+## Example Usage
+
+```jsx
+import MotionVariant from "./MotionVariant";
+
+function StatusAlert({ status }) {
+  return (
+    <MotionVariant
+      state={status}
+      variants={{
+        success: "fade-up",
+        warning: "pulse",
+        error: "shake",
+        loading: "scale-in",
+        idle: "fade",
+      }}
+      fallback="fade"
+      replay
+      onVariantChange={({ state, variant }) => {
+        console.log(`State ${state} is using ${variant}`);
+      }}
+    >
+      <section className="alert" aria-live="polite">
+        Current status: {status}
+      </section>
+    </MotionVariant>
+  );
+}
+```
+
+## Why MotionVariant?
+
+State-driven interfaces often need animation changes without moving animation logic into JavaScript. `MotionVariant` keeps React responsible for selection and keeps EaseMotion CSS responsible for motion, making the result predictable, reusable, accessible, and easy to compose in production applications.

--- a/submissions/react/36384-motion-variant-dp/style.css
+++ b/submissions/react/36384-motion-variant-dp/style.css
@@ -1,0 +1,251 @@
+:root {
+  color-scheme: dark;
+  --mv-bg: #0f172a;
+  --mv-surface: #1e293b;
+  --mv-primary: #22c55e;
+  --mv-warning: #f59e0b;
+  --mv-danger: #ef4444;
+  --mv-info: #3b82f6;
+  --mv-border: #334155;
+  --mv-text: #f8fafc;
+  --mv-muted: #94a3b8;
+  --mv-shadow: 0 18px 44px rgba(2, 6, 23, 0.32);
+}
+
+.motion-variant-docs {
+  min-height: 100vh;
+  margin: 0;
+  background: var(--mv-bg);
+  color: var(--mv-text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  line-height: 1.5;
+}
+
+.motion-variant-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 56px 0;
+}
+
+.motion-variant-header {
+  display: grid;
+  gap: 14px;
+  margin-bottom: 28px;
+}
+
+.motion-variant-kicker {
+  width: fit-content;
+  border: 1px solid rgba(34, 197, 94, 0.42);
+  border-radius: 999px;
+  padding: 5px 10px;
+  color: var(--mv-primary);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.motion-variant-title {
+  margin: 0;
+  max-width: 760px;
+  font-size: clamp(2rem, 4vw, 4rem);
+  line-height: 1.05;
+}
+
+.motion-variant-copy {
+  max-width: 680px;
+  margin: 0;
+  color: var(--mv-muted);
+  font-size: 1rem;
+}
+
+.motion-variant-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+  gap: 20px;
+  align-items: start;
+}
+
+.motion-variant-card,
+.motion-variant-panel {
+  border: 1px solid var(--mv-border);
+  border-radius: 8px;
+  background: var(--mv-surface);
+  box-shadow: var(--mv-shadow);
+}
+
+.motion-variant-card {
+  padding: 22px;
+}
+
+.motion-variant-card:hover,
+.motion-variant-panel:hover {
+  border-color: rgba(148, 163, 184, 0.6);
+  transform: translateY(-2px);
+}
+
+.motion-variant-card,
+.motion-variant-panel,
+.motion-variant-button {
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease,
+    background-color 180ms ease;
+}
+
+.motion-variant-panel {
+  overflow: hidden;
+}
+
+.motion-variant-panel-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--mv-border);
+  padding: 16px 18px;
+}
+
+.motion-variant-panel-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.motion-variant-panel-body {
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+}
+
+.motion-variant-status-list {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.motion-variant-status-item {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid var(--mv-border);
+  border-radius: 8px;
+  padding: 12px;
+  background: rgba(15, 23, 42, 0.42);
+}
+
+.motion-variant-status-label {
+  color: var(--mv-text);
+  font-weight: 650;
+}
+
+.motion-variant-status-meta {
+  color: var(--mv-muted);
+  font-size: 0.88rem;
+}
+
+.motion-variant-chip {
+  display: inline-flex;
+  min-height: 28px;
+  align-items: center;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 0.78rem;
+  font-weight: 750;
+}
+
+.motion-variant-chip[data-status="success"] {
+  color: var(--mv-primary);
+}
+
+.motion-variant-chip[data-status="warning"] {
+  color: var(--mv-warning);
+}
+
+.motion-variant-chip[data-status="error"] {
+  color: var(--mv-danger);
+}
+
+.motion-variant-chip[data-status="loading"] {
+  color: var(--mv-info);
+}
+
+.motion-variant-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.motion-variant-button {
+  border: 1px solid var(--mv-border);
+  border-radius: 8px;
+  padding: 9px 13px;
+  background: #111827;
+  color: var(--mv-text);
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.motion-variant-button:hover {
+  border-color: var(--mv-primary);
+  background: #162033;
+}
+
+.motion-variant-button:focus-visible,
+.motion-variant-card:focus-within,
+.motion-variant-status-item:focus-within {
+  outline: 3px solid rgba(59, 130, 246, 0.72);
+  outline-offset: 3px;
+}
+
+.motion-variant-code {
+  overflow-x: auto;
+  border: 1px solid var(--mv-border);
+  border-radius: 8px;
+  padding: 16px;
+  background: #020617;
+  color: var(--mv-text);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 820px) {
+  .motion-variant-shell {
+    width: min(100% - 24px, 680px);
+    padding: 36px 0;
+  }
+
+  .motion-variant-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .motion-variant-status-item {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a **reusable MotionVariant React component** under the `submissions/react/` track.

`MotionVariant` provides a lightweight, CSS-first utility that maps application states to existing EaseMotion CSS animation classes. By centralizing state-to-animation mapping, it eliminates repetitive conditional logic while preserving existing props, styles, and class names. The component remains dependency-free and relies entirely on existing EaseMotion CSS animations.

Closes #36384 

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `MotionVariant.jsx`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

A reusable `MotionVariant` React component that declaratively maps application states to existing EaseMotion CSS animation classes, making state-driven animations consistent, reusable, and easy to maintain.

### How does a developer use it?

```jsx
<MotionVariant
  state={status}
  variants={{
    success: "fade-up",
    warning: "pulse",
    error: "shake",
    loading: "scale-in",
    idle: "fade"
  }}
  fallback="fade"
  replay
>
  <Alert />
</MotionVariant>
```

### Why does it fit EaseMotion CSS?

`MotionVariant` extends EaseMotion CSS by providing a declarative way to select existing animation classes based on application state. It introduces no custom animation engine or external dependencies, instead enhancing the framework's CSS-first philosophy through reusable state-driven motion patterns.

---

## Demo

- [x] Example usage included in the README

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*