### PR TITLE
feat: add CSS Magnetic Pull Modal for Cyberpunk Neon Layouts

### DIFF
--- a/submissions/examples/magnetic-pull-modal-cyberpunk-neon/README.md
+++ b/submissions/examples/magnetic-pull-modal-cyberpunk-neon/README.md
@@ -1,0 +1,45 @@
+﻿# CSS Magnetic Pull Modal — Cyberpunk Neon Layout
+
+A pure CSS modal that snaps into view with a magnetic-pull entrance — drawn in from above and settling with an elastic overshoot — styled with a glowing neon cyberpunk aesthetic.
+
+## CSS Custom Properties
+
+| Property                     | Default                                   | Description                                |
+|-------------------------------|---------------------------------------------|--------------------------------------------|
+| `--ease-modal-pull-duration`  | `0.5s`                                       | Duration of the pull-in entrance animation  |
+| `--ease-modal-pull-easing`    | `cubic-bezier(0.34, 1.56, 0.64, 1)`         | Overshoot easing curve for the pull effect  |
+| `--ease-modal-pull-distance`  | `40px`                                        | Distance the modal travels on entrance      |
+| `--ease-modal-backdrop-color` | `rgba(5, 0, 15, 0.75)`                       | Overlay backdrop color                      |
+| `--ease-modal-bg`             | `#0d0b1e`                                     | Modal background color                      |
+| `--ease-modal-border-glow`    | `#ff2ec4`                                     | Neon border/glow accent color               |
+| `--ease-modal-accent`         | `#00eaff`                                     | Secondary neon accent color                 |
+| `--ease-modal-radius`         | `12px`                                        | Modal corner radius                         |
+| `--ease-modal-max-width`      | `440px`                                       | Maximum modal width                         |
+| `--ease-modal-focus-ring`     | `#00eaff`                                     | Focus outline color                         |
+
+## Usage
+
+```html
+<button class="ease-modal-trigger" id="openModalBtn">Open Modal</button>
+
+<div class="ease-modal-overlay" id="modalOverlay" role="dialog" aria-modal="true">
+  <div class="ease-modal" tabindex="-1">
+    <!-- modal content -->
+  </div>
+</div>
+```
+
+Toggle `ease-modal-overlay--open` on the overlay to open/close. The magnetic-pull entrance is driven purely by a CSS `transform`/`opacity` transition — no JS animation logic required.
+
+## Accessibility
+
+- `role="dialog"`, `aria-modal="true"`, `aria-labelledby` pointing to the title.
+- Full focus trap while open (Tab/Shift+Tab cycle within the modal).
+- Focus moves to the close button on open, returns to the trigger on close.
+- `Escape` key and backdrop click both close the modal.
+- Visible `:focus-visible` outlines on every interactive element.
+- `prefers-reduced-motion: reduce` disables all transform/transition animations.
+
+## Why it fits EaseMotion CSS
+
+Uses `ease-` prefixed classes and exposes timing, easing, and distance through CSS custom properties, matching the framework's zero-dependency, animation-first philosophy. Minimal JS handles only the class toggle and accessibility — not the animation itself.

--- a/submissions/examples/magnetic-pull-modal-cyberpunk-neon/demo.html
+++ b/submissions/examples/magnetic-pull-modal-cyberpunk-neon/demo.html
@@ -1,0 +1,90 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Magnetic Pull Modal Demo — Cyberpunk Neon</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: "Segoe UI", sans-serif; min-height: 100vh; display: flex; align-items: center; justify-content: center; }
+    h2 { color: #00eaff; text-shadow: 0 0 10px rgba(0,234,255,0.5); }
+    .wrap { text-align: center; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h2>CSS Magnetic Pull Modal — Cyberpunk Neon</h2>
+    <button class="ease-modal-trigger" id="openModalBtn">Open Modal</button>
+  </div>
+
+  <div class="ease-modal-overlay" id="modalOverlay" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+    <div class="ease-modal" tabindex="-1">
+      <div class="ease-modal__header">
+        <span class="ease-modal__title" id="modalTitle">System Alert</span>
+        <button class="ease-modal__close" id="closeModalBtn" aria-label="Close modal">✕</button>
+      </div>
+      <div class="ease-modal__body">
+        This modal snaps into view with a magnetic-pull entrance — drawn in from
+        above and settling with an elastic overshoot, styled for a neon cyberpunk aesthetic.
+        Fully keyboard accessible with focus trapping and Escape-to-close.
+      </div>
+      <div class="ease-modal__footer">
+        <button class="ease-modal__btn ease-modal__btn--ghost" id="cancelBtn">Cancel</button>
+        <button class="ease-modal__btn ease-modal__btn--primary" id="confirmBtn">Confirm</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const overlay = document.getElementById('modalOverlay');
+    const modal = overlay.querySelector('.ease-modal');
+    const openBtn = document.getElementById('openModalBtn');
+    const closeBtn = document.getElementById('closeModalBtn');
+    const cancelBtn = document.getElementById('cancelBtn');
+    const confirmBtn = document.getElementById('confirmBtn');
+
+    function getFocusable() {
+      return modal.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+    }
+
+    function openModal() {
+      overlay.classList.add('ease-modal-overlay--open');
+      closeBtn.focus();
+      document.addEventListener('keydown', handleKeydown);
+    }
+
+    function closeModal() {
+      overlay.classList.remove('ease-modal-overlay--open');
+      openBtn.focus();
+      document.removeEventListener('keydown', handleKeydown);
+    }
+
+    function handleKeydown(e) {
+      if (e.key === 'Escape') {
+        closeModal();
+        return;
+      }
+      if (e.key === 'Tab') {
+        const focusable = getFocusable();
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    openBtn.addEventListener('click', openModal);
+    closeBtn.addEventListener('click', closeModal);
+    cancelBtn.addEventListener('click', closeModal);
+    confirmBtn.addEventListener('click', closeModal);
+
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) closeModal();
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/magnetic-pull-modal-cyberpunk-neon/style.css
+++ b/submissions/examples/magnetic-pull-modal-cyberpunk-neon/style.css
@@ -1,0 +1,179 @@
+﻿:root {
+  --ease-modal-pull-duration: 0.5s;
+  --ease-modal-pull-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-modal-backdrop-color: rgba(5, 0, 15, 0.75);
+  --ease-modal-bg: #0d0b1e;
+  --ease-modal-border-glow: #ff2ec4;
+  --ease-modal-accent: #00eaff;
+  --ease-modal-radius: 12px;
+  --ease-modal-max-width: 440px;
+  --ease-modal-focus-ring: #00eaff;
+  --ease-modal-pull-distance: 40px;
+}
+
+body {
+  background: #0a0714;
+}
+
+.ease-modal-trigger {
+  padding: 12px 24px;
+  border-radius: 8px;
+  border: 2px solid var(--ease-modal-accent);
+  background: transparent;
+  color: var(--ease-modal-accent);
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  cursor: pointer;
+  text-shadow: 0 0 8px var(--ease-modal-accent);
+  box-shadow: 0 0 12px rgba(0, 234, 255, 0.4), inset 0 0 12px rgba(0, 234, 255, 0.1);
+  transition: transform 0.3s var(--ease-modal-pull-easing), box-shadow 0.3s ease;
+}
+
+.ease-modal-trigger:hover {
+  transform: scale(1.05);
+  box-shadow: 0 0 20px rgba(0, 234, 255, 0.7), inset 0 0 20px rgba(0, 234, 255, 0.2);
+}
+
+.ease-modal-trigger:focus-visible {
+  outline: 3px solid var(--ease-modal-focus-ring);
+  outline-offset: 3px;
+}
+
+.ease-modal-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--ease-modal-backdrop-color);
+  backdrop-filter: blur(4px);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.3s ease, visibility 0s linear 0.3s;
+  z-index: 999;
+}
+
+.ease-modal-overlay.ease-modal-overlay--open {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition: opacity 0.3s ease, visibility 0s linear 0s;
+}
+
+/* Magnetic Pull: modal appears drawn in from a distance, snapping into place
+   with an elastic overshoot, evoking a magnetic attraction effect. */
+.ease-modal {
+  width: 100%;
+  max-width: var(--ease-modal-max-width);
+  margin: 20px;
+  padding: 32px;
+  border-radius: var(--ease-modal-radius);
+  background: var(--ease-modal-bg);
+  border: 1px solid var(--ease-modal-border-glow);
+  box-shadow: 0 0 30px rgba(255, 46, 196, 0.35), 0 0 60px rgba(0, 234, 255, 0.15);
+  outline: none;
+  transform: translateY(calc(-1 * var(--ease-modal-pull-distance))) scale(0.85);
+  opacity: 0;
+  transition: transform var(--ease-modal-pull-duration) var(--ease-modal-pull-easing),
+              opacity var(--ease-modal-pull-duration) ease;
+}
+
+.ease-modal-overlay--open .ease-modal {
+  transform: translateY(0) scale(1);
+  opacity: 1;
+}
+
+.ease-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+  border-bottom: 1px solid rgba(0, 234, 255, 0.2);
+  padding-bottom: 12px;
+}
+
+.ease-modal__title {
+  font-size: 19px;
+  font-weight: 700;
+  color: var(--ease-modal-accent);
+  text-shadow: 0 0 8px rgba(0, 234, 255, 0.6);
+}
+
+.ease-modal__close {
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--ease-modal-border-glow);
+  border-radius: 50%;
+  background: transparent;
+  color: var(--ease-modal-border-glow);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  transition: transform 0.3s var(--ease-modal-pull-easing), background-color 0.2s ease;
+}
+
+.ease-modal__close:hover {
+  transform: scale(1.15) rotate(90deg);
+  background: rgba(255, 46, 196, 0.15);
+}
+
+.ease-modal__close:focus-visible {
+  outline: 3px solid var(--ease-modal-focus-ring);
+  outline-offset: 2px;
+}
+
+.ease-modal__body {
+  color: #c9c4e0;
+  font-size: 15px;
+  line-height: 1.7;
+}
+
+.ease-modal__footer {
+  margin-top: 24px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.ease-modal__btn {
+  padding: 9px 20px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.25s var(--ease-modal-pull-easing);
+}
+
+.ease-modal__btn--primary {
+  background: var(--ease-modal-accent);
+  color: #0a0714;
+  box-shadow: 0 0 12px rgba(0, 234, 255, 0.5);
+}
+
+.ease-modal__btn--ghost {
+  background: transparent;
+  color: #c9c4e0;
+  border-color: rgba(201, 196, 224, 0.3);
+}
+
+.ease-modal__btn:hover {
+  transform: translateY(-2px);
+}
+
+.ease-modal__btn:focus-visible {
+  outline: 3px solid var(--ease-modal-focus-ring);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-modal,
+  .ease-modal-trigger,
+  .ease-modal__close,
+  .ease-modal__btn {
+    transition: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS animated modal with a magnetic-pull entrance effect (drawn in and settling with an elastic overshoot), styled for cyberpunk neon layouts. Resolves #34186

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist
> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (`submissions/examples/magnetic-pull-modal-cyberpunk-neon/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS modal that snaps into view with a magnetic-pull entrance — translating in from above and settling with an elastic overshoot — wrapped in a glowing neon cyberpunk visual style.

**How does a developer use it?**
```html
<button class="ease-modal-trigger" id="openModalBtn">Open Modal</button>

<div class="ease-modal-overlay" id="modalOverlay" role="dialog" aria-modal="true">
  <div class="ease-modal" tabindex="-1">
    <!-- modal content -->
  </div>
</div>
```
Toggling the `ease-modal-overlay--open` class drives the entire pull-in animation via CSS transform/opacity transitions.

**Why does it fit EaseMotion CSS?**
Uses `ease-` prefixed class names and exposes timing, easing, and pull distance via CSS custom properties for easy theming, matching the framework's zero-JS-overhead, animation-first philosophy. The minimal JS included only handles the class toggle and accessibility (focus trap, Escape key) — not the animation itself.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome

---

## Notes for Maintainer
The modal uses `transform: translateY() scale()` combined with `opacity` for the pull-in effect, driven by `--ease-modal-pull-easing` (an overshoot cubic-bezier) for the "magnetic snap" feel. Includes basic accessibility: `role="dialog"`, `aria-modal`, focus trap on open/close, and Escape-to-close. `prefers-reduced-motion` disables all transforms/transitions. Happy to adjust default glow colors/timing if preferred.