### PR TITLE
feat: add reusable motion timeline SCSS mixin

### DIFF
--- a/submissions/scss/36379-motion-timeline-mixin-dp/README.md
+++ b/submissions/scss/36379-motion-timeline-mixin-dp/README.md
@@ -1,0 +1,71 @@
+# Motion Timeline
+
+## Overview
+
+Motion Timeline is a lightweight SCSS mixin for generating sequential `animation-delay` values across repeated elements. It helps build staggered motion patterns without writing repetitive delay declarations by hand.
+
+The mixin is fully CSS-first: it compiles to plain CSS, requires no JavaScript, and adds no runtime logic.
+
+## Parameters
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `$count` | `5` | Number of sequential `:nth-child()` rules to generate. |
+| `$delay` | `120ms` | Delay increment added between each generated element. |
+| `$start` | `0ms` | Starting delay for the first generated element. |
+| `$selector` | `"&"` | Target selector for the generated timeline. Supports explicit selectors like `".card"` and nested selectors using `"&"`. |
+
+## Example Usage
+
+```scss
+@use "motion-timeline" as *;
+
+@include motion-timeline(
+  $count: 6,
+  $delay: 100ms,
+  $start: 50ms,
+  $selector: ".card"
+);
+```
+
+Nested usage with the default selector:
+
+```scss
+.list-item {
+  @include motion-timeline;
+}
+```
+
+## Generated Output
+
+```css
+.card:nth-child(1) {
+  animation-delay: 50ms;
+}
+
+.card:nth-child(2) {
+  animation-delay: 150ms;
+}
+
+.card:nth-child(3) {
+  animation-delay: 250ms;
+}
+
+.card:nth-child(4) {
+  animation-delay: 350ms;
+}
+
+.card:nth-child(5) {
+  animation-delay: 450ms;
+}
+
+.card:nth-child(6) {
+  animation-delay: 550ms;
+}
+```
+
+## Why Motion Timeline?
+
+Staggered motion often requires many repeated `animation-delay` declarations that differ only by a small increment. Motion Timeline centralizes that pattern in a reusable mixin, reducing copy-paste code while keeping the final CSS clean and predictable.
+
+This aligns with EaseMotion CSS by making expressive motion easier to author without adding JavaScript, external dependencies, or runtime complexity. Designers and developers can configure the item count, timing interval, starting delay, and selector while preserving a lightweight CSS-first workflow.

--- a/submissions/scss/36379-motion-timeline-mixin-dp/_motion-timeline.scss
+++ b/submissions/scss/36379-motion-timeline-mixin-dp/_motion-timeline.scss
@@ -1,0 +1,72 @@
+/// Generate a sequential animation-delay timeline for repeated elements.
+///
+/// @param {Number} $count - Number of child rules to generate.
+/// @param {Time} $delay - Delay increment between each generated item.
+/// @param {Time} $start - Initial delay applied to the first item.
+/// @param {String} $selector - Selector to target; supports "&" in nested usage.
+///
+/// @example scss
+///   @include motion-timeline(
+///     $count: 6,
+///     $delay: 100ms,
+///     $start: 50ms,
+///     $selector: ".card"
+///   );
+@mixin motion-timeline(
+  $count: 5,
+  $delay: 120ms,
+  $start: 0ms,
+  $selector: "&"
+) {
+  @for $index from 1 through $count {
+    $animation-delay: $start + (($index - 1) * $delay);
+
+    #{$selector}:nth-child(#{$index}) {
+      animation-delay: $animation-delay;
+    }
+  }
+}
+/// Generate a sequential animation-delay timeline for repeated elements.
+///
+/// @param {Number} $count - Number of child rules to generate.
+/// @param {Time} $delay - Delay increment between each generated item.
+/// @param {Time} $start - Initial delay applied to the first item.
+/// @param {String} $selector - Selector to target; supports "&" in nested usage.
+///
+/// @example scss
+///   @include motion-timeline(
+///     $count: 6,
+///     $delay: 100ms,
+///     $start: 50ms,
+///     $selector: ".card"
+///   );
+@mixin motion-timeline(
+  $count: 5,
+  $delay: 120ms,
+  $start: 0ms,
+  $selector: "&"
+) {
+  @for $index from 1 through $count {
+    $animation-delay: $start + (($index - 1) * $delay);
+
+    #{$selector}:nth-child(#{$index}) {
+      animation-delay: $animation-delay;
+    }
+  }
+}
+@mixin motion-timeline(
+  $count: 5,
+  $delay: 120ms,
+  $start: 0ms,
+  $selector: "&"
+) {
+  @if $count < 1 {
+    @return;
+  }
+
+  @for $index from 1 through $count {
+    #{$selector}:nth-child(#{$index}) {
+      animation-delay: $start + (($index - 1) * $delay);
+    }
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a **reusable Motion Timeline SCSS mixin** under the `submissions/scss/` track.

The mixin provides a configurable way to generate sequential `animation-delay` values for repeated elements, eliminating repetitive delay declarations while keeping the implementation lightweight, reusable, and fully CSS-first.

Closes #36397 

---

## Type of Change

- [x] 🧩 New SCSS utility
- [ ] ✨ New animation
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `_motion-timeline.scss`
- [x] Includes `README.md`
- [x] No JavaScript
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

A reusable `motion-timeline` SCSS mixin that automatically generates sequential `animation-delay` values for collections of elements.

### Example Usage

```scss
@include motion-timeline(
  $count: 5,
  $delay: 120ms,
  $start: 0ms,
  $selector: ".card"
);
```

### Example Generated Output

```css
.card:nth-child(1) {
  animation-delay: 0ms;
}

.card:nth-child(2) {
  animation-delay: 120ms;
}

.card:nth-child(3) {
  animation-delay: 240ms;
}

.card:nth-child(4) {
  animation-delay: 360ms;
}

.card:nth-child(5) {
  animation-delay: 480ms;
}
```

### Why does it fit EaseMotion CSS?

This utility enhances EaseMotion CSS by providing a reusable SCSS mixin for generating consistent animation timelines without introducing JavaScript or runtime logic. It follows the framework's CSS-first philosophy while reducing repetitive code and improving maintainability.

---

## Demo

- [x] Example usage included in the README

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional)*