### PR TITLE
feat: add CSS Magnetic Pull Modal for Minimalist Tech Layouts

### DIFF
--- a/submissions/examples/magnetic-pull-modal-minimalist-tech/README.md
+++ b/submissions/examples/magnetic-pull-modal-minimalist-tech/README.md
@@ -1,0 +1,45 @@
+﻿# CSS Magnetic Pull Modal — Minimalist Tech Layout
+
+A pure CSS modal that enters with a restrained magnetic-pull motion — drawn in and settling with a light elastic snap — styled with a clean, minimal aesthetic.
+
+## CSS Custom Properties
+
+| Property                     | Default                              | Description                                |
+|-------------------------------|-----------------------------------------|--------------------------------------------|
+| `--ease-modal-pull-duration`  | `0.45s`                                 | Duration of the pull-in entrance animation  |
+| `--ease-modal-pull-easing`    | `cubic-bezier(0.34, 1.56, 0.64, 1)`    | Overshoot easing curve for the pull effect  |
+| `--ease-modal-pull-distance`  | `32px`                                   | Distance the modal travels on entrance      |
+| `--ease-modal-backdrop-color` | `rgba(20, 20, 22, 0.5)`                | Overlay backdrop color                      |
+| `--ease-modal-bg`             | `#ffffff`                                | Modal background color                      |
+| `--ease-modal-border-color`   | `#e5e5e7`                                | Modal border color                          |
+| `--ease-modal-accent`         | `#111111`                                | Primary accent color (buttons, title)       |
+| `--ease-modal-radius`         | `10px`                                   | Modal corner radius                         |
+| `--ease-modal-max-width`      | `420px`                                  | Maximum modal width                         |
+| `--ease-modal-focus-ring`     | `#111111`                                | Focus outline color                         |
+
+## Usage
+
+```html
+<button class="ease-modal-trigger" id="openModalBtn">Open Modal</button>
+
+<div class="ease-modal-overlay" id="modalOverlay" role="dialog" aria-modal="true">
+  <div class="ease-modal" tabindex="-1">
+    <!-- modal content -->
+  </div>
+</div>
+```
+
+Toggle `ease-modal-overlay--open` on the overlay to open/close. The magnetic-pull entrance is driven purely by a CSS `transform`/`opacity` transition — no JS animation logic required.
+
+## Accessibility
+
+- `role="dialog"`, `aria-modal="true"`, `aria-labelledby` pointing to the title.
+- Full focus trap while open (Tab/Shift+Tab cycle within the modal).
+- Focus moves to the close button on open, returns to the trigger on close.
+- `Escape` key and backdrop click both close the modal.
+- Visible `:focus-visible` outlines on every interactive element.
+- `prefers-reduced-motion: reduce` disables all transform/transition animations.
+
+## Why it fits EaseMotion CSS
+
+Uses `ease-` prefixed classes and exposes timing, easing, and pull distance through CSS custom properties, matching the framework's zero-dependency, animation-first philosophy. Minimal JS handles only the class toggle and accessibility — not the animation itself.

--- a/submissions/examples/magnetic-pull-modal-minimalist-tech/demo.html
+++ b/submissions/examples/magnetic-pull-modal-minimalist-tech/demo.html
@@ -1,0 +1,90 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Magnetic Pull Modal Demo — Minimalist Tech</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: -apple-system, "Segoe UI", sans-serif; min-height: 100vh; display: flex; align-items: center; justify-content: center; background: #fafafa; }
+    .wrap { text-align: center; }
+    h2 { color: #111; font-weight: 600; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h2>CSS Magnetic Pull Modal — Minimalist Tech</h2>
+    <button class="ease-modal-trigger" id="openModalBtn">Open Modal</button>
+  </div>
+
+  <div class="ease-modal-overlay" id="modalOverlay" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+    <div class="ease-modal" tabindex="-1">
+      <div class="ease-modal__header">
+        <span class="ease-modal__title" id="modalTitle">Confirm Action</span>
+        <button class="ease-modal__close" id="closeModalBtn" aria-label="Close modal">✕</button>
+      </div>
+      <div class="ease-modal__body">
+        This modal enters with a subtle magnetic-pull motion — settling in with a light
+        elastic snap, kept restrained to match a clean, minimal tech aesthetic.
+        Fully keyboard accessible with focus trapping and Escape-to-close.
+      </div>
+      <div class="ease-modal__footer">
+        <button class="ease-modal__btn ease-modal__btn--ghost" id="cancelBtn">Cancel</button>
+        <button class="ease-modal__btn ease-modal__btn--primary" id="confirmBtn">Confirm</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const overlay = document.getElementById('modalOverlay');
+    const modal = overlay.querySelector('.ease-modal');
+    const openBtn = document.getElementById('openModalBtn');
+    const closeBtn = document.getElementById('closeModalBtn');
+    const cancelBtn = document.getElementById('cancelBtn');
+    const confirmBtn = document.getElementById('confirmBtn');
+
+    function getFocusable() {
+      return modal.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+    }
+
+    function openModal() {
+      overlay.classList.add('ease-modal-overlay--open');
+      closeBtn.focus();
+      document.addEventListener('keydown', handleKeydown);
+    }
+
+    function closeModal() {
+      overlay.classList.remove('ease-modal-overlay--open');
+      openBtn.focus();
+      document.removeEventListener('keydown', handleKeydown);
+    }
+
+    function handleKeydown(e) {
+      if (e.key === 'Escape') {
+        closeModal();
+        return;
+      }
+      if (e.key === 'Tab') {
+        const focusable = getFocusable();
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    openBtn.addEventListener('click', openModal);
+    closeBtn.addEventListener('click', closeModal);
+    cancelBtn.addEventListener('click', closeModal);
+    confirmBtn.addEventListener('click', closeModal);
+
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) closeModal();
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/magnetic-pull-modal-minimalist-tech/style.css
+++ b/submissions/examples/magnetic-pull-modal-minimalist-tech/style.css
@@ -1,0 +1,168 @@
+﻿:root {
+  --ease-modal-pull-duration: 0.45s;
+  --ease-modal-pull-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-modal-backdrop-color: rgba(20, 20, 22, 0.5);
+  --ease-modal-bg: #ffffff;
+  --ease-modal-border-color: #e5e5e7;
+  --ease-modal-accent: #111111;
+  --ease-modal-radius: 10px;
+  --ease-modal-max-width: 420px;
+  --ease-modal-focus-ring: #111111;
+  --ease-modal-pull-distance: 32px;
+}
+
+.ease-modal-trigger {
+  padding: 11px 22px;
+  border-radius: 6px;
+  border: 1px solid var(--ease-modal-accent);
+  background: var(--ease-modal-accent);
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 0.2px;
+  cursor: pointer;
+  transition: transform 0.25s var(--ease-modal-pull-easing), opacity 0.2s ease;
+}
+
+.ease-modal-trigger:hover {
+  opacity: 0.85;
+  transform: translateY(-1px);
+}
+
+.ease-modal-trigger:focus-visible {
+  outline: 2px solid var(--ease-modal-focus-ring);
+  outline-offset: 2px;
+}
+
+.ease-modal-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--ease-modal-backdrop-color);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.25s ease, visibility 0s linear 0.25s;
+  z-index: 999;
+}
+
+.ease-modal-overlay.ease-modal-overlay--open {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition: opacity 0.25s ease, visibility 0s linear 0s;
+}
+
+/* Magnetic Pull: modal is drawn in from a slight distance and snaps into
+   place with a subtle elastic settle, kept understated for a minimal aesthetic. */
+.ease-modal {
+  width: 100%;
+  max-width: var(--ease-modal-max-width);
+  margin: 20px;
+  padding: 28px;
+  border-radius: var(--ease-modal-radius);
+  background: var(--ease-modal-bg);
+  border: 1px solid var(--ease-modal-border-color);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.12);
+  outline: none;
+  transform: translateY(calc(-1 * var(--ease-modal-pull-distance))) scale(0.94);
+  opacity: 0;
+  transition: transform var(--ease-modal-pull-duration) var(--ease-modal-pull-easing),
+              opacity var(--ease-modal-pull-duration) ease;
+}
+
+.ease-modal-overlay--open .ease-modal {
+  transform: translateY(0) scale(1);
+  opacity: 1;
+}
+
+.ease-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 14px;
+}
+
+.ease-modal__title {
+  font-size: 17px;
+  font-weight: 600;
+  color: #111111;
+}
+
+.ease-modal__close {
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 50%;
+  background: #f2f2f3;
+  color: #55555a;
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  transition: transform 0.25s var(--ease-modal-pull-easing), background-color 0.2s ease;
+}
+
+.ease-modal__close:hover {
+  transform: scale(1.1);
+  background: #e5e5e7;
+}
+
+.ease-modal__close:focus-visible {
+  outline: 2px solid var(--ease-modal-focus-ring);
+  outline-offset: 2px;
+}
+
+.ease-modal__body {
+  color: #444448;
+  font-size: 14px;
+  line-height: 1.65;
+}
+
+.ease-modal__footer {
+  margin-top: 22px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.ease-modal__btn {
+  padding: 8px 18px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  font-size: 13.5px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: transform 0.2s var(--ease-modal-pull-easing), opacity 0.2s ease;
+}
+
+.ease-modal__btn--primary {
+  background: var(--ease-modal-accent);
+  color: #ffffff;
+}
+
+.ease-modal__btn--ghost {
+  background: transparent;
+  color: #444448;
+  border-color: #d8d8da;
+}
+
+.ease-modal__btn:hover {
+  opacity: 0.85;
+}
+
+.ease-modal__btn:focus-visible {
+  outline: 2px solid var(--ease-modal-focus-ring);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-modal,
+  .ease-modal-trigger,
+  .ease-modal__close,
+  .ease-modal__btn {
+    transition: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS animated modal with a restrained magnetic-pull entrance effect, styled for minimalist tech layouts. Resolves #34185

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/magnetic-pull-modal-minimalist-tech/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS modal that enters with a restrained magnetic-pull motion — drawn in and settling with a light elastic snap — styled with a clean, minimal tech aesthetic.

**How does a developer use it?**
```html
<button class="ease-modal-trigger" id="openModalBtn">Open Modal</button>

<div class="ease-modal-overlay" id="modalOverlay" role="dialog" aria-modal="true">
  <div class="ease-modal" tabindex="-1">
    <!-- modal content -->
  </div>
</div>
```
Toggling the `ease-modal-overlay--open` class drives the entire pull-in animation via CSS transform/opacity transitions.

**Why does it fit EaseMotion CSS?**
Uses `ease-` prefixed class names and exposes timing, easing, and pull distance via CSS custom properties for easy theming, matching the framework's zero-JS-overhead, animation-first philosophy. The minimal JS included only handles the class toggle and accessibility (focus trap, Escape key) — not the animation itself.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome

---

## Notes for Maintainer
Kept the pull distance and overshoot subtle (32px, lighter scale delta) compared to the Cyberpunk Neon variant, to match a restrained minimal aesthetic rather than a dramatic snap. Includes basic accessibility: `role="dialog"`, `aria-modal`, focus trap on open/close, and Escape-to-close. `prefers-reduced-motion` disables all transforms/transitions. Happy to adjust timing/scale if preferred.