### PR TITLE
feat: add pure CSS spring physics modal component #34176

### DIFF
--- a/submissions/examples/spring-physics-modal/README.md
+++ b/submissions/examples/spring-physics-modal/README.md
@@ -1,0 +1,8 @@
+# Pure CSS Spring Physics Modal
+
+A highly tactile interaction pattern mimicking kinetic spring/elastic mechanics entirely within CSS variables and cubic-bezier boundary acceleration limits. Optimized for Creative Editorial Portfolios.
+
+## Features
+- **Elastic Kinematics without JS:** Exploits overshoot bezier definitions (`cubic-bezier(0.43, 1.62, 0.6, 0.93)`) to emulate physical mass bounce behaviors.
+- **Configurable System Variables:** Change target elasticity or timing properties dynamically across breakpoints.
+- **Responsive Layout Architecture:** Smoothly translates from single column blocks on mobile viewports into asymmetric grid patterns on large-scale environments.

--- a/submissions/examples/spring-physics-modal/demo.html
+++ b/submissions/examples/spring-physics-modal/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Spring Physics Modal - EaseMotion</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <nav class="portfolio-nav">
+        <div class="logo">STUDIO_M</div>
+    </nav>
+
+    <main class="portfolio-grid">
+        <div class="project-card">
+            <div class="project-thumb"></div>
+            <div class="project-info">
+                <span>Interaction Design</span>
+                <h3>Kinetic Typography System</h3>
+                <label for="modal-spring-toggle" class="btn-view-project" role="button" tabindex="0">
+                    View Project Case Study
+                </label>
+            </div>
+        </div>
+    </main>
+
+    <input type="checkbox" id="modal-spring-toggle" class="modal-state-checkbox" aria-hidden="true">
+
+    <div class="modal-overlay">
+        <label for="modal-spring-toggle" class="modal-backdrop-closer"></label>
+        
+        <div class="modal-card" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+            <label for="modal-spring-toggle" class="modal-btn-close" aria-label="Close modal" role="button" tabindex="0">&times;</label>
+            
+            <div class="modal-grid-layout">
+                <div class="modal-visual-side"></div>
+                <div class="modal-content-side">
+                    <span class="project-meta">Case Study / 2026</span>
+                    <h2 id="modal-title">Kinetic Typography System</h2>
+                    <p>An investigation into variable typography interacting with user viewport speed. Built leveraging localized math transformations to mimic biological structural dampening weight scales.</p>
+                    
+                    <div class="tech-stack">
+                        <span>WebGL</span>
+                        <span>CSS Variables</span>
+                        <span>OpenType.js</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        // Keyboard accessibility handler for labels
+        document.querySelectorAll('label[role="button"]').forEach(label => {
+            label.addEventListener('keydown', (e) => {
+                if (e.key === ' ' || e.key === 'Enter') {
+                    e.preventDefault();
+                    document.getElementById(label.getAttribute('for')).click();
+                }
+            });
+        });
+    </script>
+</body>
+</html>

--- a/submissions/examples/spring-physics-modal/style.css
+++ b/submissions/examples/spring-physics-modal/style.css
@@ -1,0 +1,242 @@
+/* ==========================================================================
+   Spring Physics Parameter Design Tokens
+   ========================================================================== */
+:root {
+    /* Custom Timing Parameters */
+    --spring-duration: 0.68s;
+    /* This specialized cubic-bezier creates the essential "overshoot" peak mimicking a spring tension release */
+    --spring-physics-curve: cubic-bezier(0.43, 1.62, 0.6, 0.93);
+    
+    /* Configurable Scale Factor States */
+    --spring-initial-scale: 0.75;
+    --spring-target-scale: 1;
+
+    /* Theme Layout Color Space (Minimalist Editorial Portfolio) */
+    --studio-bg: #0a0a0a;
+    --studio-surface: #121212;
+    --studio-border: rgba(255, 255, 255, 0.1);
+    --accent-color: #ff3e55;
+    --text-white: #ffffff;
+    --text-gray: #888888;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    background-color: var(--studio-bg);
+    color: var(--text-white);
+    -webkit-font-smoothing: antialiased;
+}
+
+/* ==========================================================================
+   Portfolio Interface Layout Mockup
+   ========================================================================== */
+.portfolio-nav {
+    padding: 2rem;
+    font-weight: 700;
+    letter-spacing: 2px;
+}
+
+.portfolio-grid {
+    max-width: 1200px;
+    margin: 4rem auto;
+    padding: 0 2rem;
+}
+
+.project-card {
+    max-width: 450px;
+    background: var(--studio-surface);
+    border: 1px solid var(--studio-border);
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.project-thumb {
+    height: 300px;
+    background: linear-gradient(45deg, #161616, #262626);
+}
+
+.project-info {
+    padding: 1.5rem;
+}
+
+.project-info span {
+    font-size: 0.8rem;
+    color: var(--text-gray);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.project-info h3 {
+    margin: 0.5rem 0 1.5rem 0;
+    font-size: 1.4rem;
+}
+
+.btn-view-project {
+    display: inline-block;
+    padding: 0.75rem 1.2rem;
+    border: 1px solid var(--text-white);
+    font-size: 0.85rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.3s, color 0.3s;
+}
+
+.btn-view-project:hover {
+    background: var(--text-white);
+    color: var(--studio-bg);
+}
+
+/* ==========================================================================
+   Pure CSS Spring Physics Modal System
+   ========================================================================== */
+.modal-state-checkbox {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+
+/* Modal Overlay Layer */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+    opacity: 0;
+    pointer-events: none;
+    background-color: rgba(0, 0, 0, 0.85);
+    transition: opacity 0.3s linear;
+}
+
+.modal-backdrop-closer {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    z-index: 1;
+}
+
+/* Spring Elastic Structural Modal Box */
+.modal-card {
+    position: relative;
+    z-index: 2;
+    width: 100%;
+    max-width: 800px;
+    background: var(--studio-surface);
+    border: 1px solid var(--studio-border);
+    border-radius: 8px;
+    overflow: hidden;
+    
+    /* Outward spring initialization vectors */
+    transform: scale(var(--spring-initial-scale)) translateY(60px);
+    opacity: 0;
+    
+    /* Snappy exit duration transition configuration */
+    transition: transform 0.25s cubic-bezier(0.25, 1, 0.5, 1), opacity 0.25s linear;
+}
+
+/* ==========================================================================
+   State Activation Mapping (Overshoot Injection)
+   ========================================================================== */
+.modal-state-checkbox:checked + .modal-overlay {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.modal-state-checkbox:checked + .modal-overlay .modal-card {
+    opacity: 1;
+    transform: scale(var(--spring-target-scale)) translateY(0);
+    
+    /* Using custom properties inside transition to snap modal forward with spring physics curve */
+    transition: transform var(--spring-duration) var(--spring-physics-curve), 
+                opacity var(--spring-duration) linear;
+}
+
+/* ==========================================================================
+   Inner Content Framework Structures
+   ========================================================================== */
+.modal-grid-layout {
+    display: grid;
+    grid-template-columns: 1fr;
+}
+
+@media(min-width: 768px) {
+    .modal-grid-layout {
+        grid-template-columns: 1fr 1.2fr;
+    }
+}
+
+.modal-visual-side {
+    background: linear-gradient(135deg, var(--accent-color), #bc1328);
+    min-height: 250px;
+}
+
+.modal-content-side {
+    padding: 3rem 2.5rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.project-meta {
+    font-size: 0.8rem;
+    color: var(--accent-color);
+    font-weight: 600;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    margin-bottom: 0.5rem;
+}
+
+.modal-content-side h2 {
+    font-size: 2rem;
+    margin-bottom: 1rem;
+    line-height: 1.2;
+}
+
+.modal-content-side p {
+    color: var(--text-gray);
+    font-size: 0.95rem;
+    line-height: 1.7;
+    margin-bottom: 2rem;
+}
+
+.tech-stack {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.tech-stack span {
+    font-size: 0.75rem;
+    border: 1px solid var(--studio-border);
+    padding: 0.35rem 0.75rem;
+    border-radius: 3px;
+    color: var(--text-gray);
+}
+
+.modal-btn-close {
+    position: absolute;
+    top: 1rem;
+    right: 1.5rem;
+    font-size: 2rem;
+    color: var(--text-gray);
+    cursor: pointer;
+    z-index: 10;
+    transition: color 0.2s;
+}
+
+.modal-btn-close:hover {
+    color: var(--text-white);
+}


### PR DESCRIPTION
## 🎯 Description
Resolves issue #34176 by adding an elastic **Spring Physics Modal** asset targeting creative folio styles into the `EaseMotion` core submissions space.

## 🛠️ Changes Implemented
- 📁 Added directory: `submissions/examples/spring-physics-modal/`
- 📄 **`demo.html`**: Standard modular creative layout containing clean markup using accessible checkbox hooks to drive structural rendering updates without JS engines.
- 🎨 **`style.css`**: Configured custom mathematical curve boundaries inside standard transforms to mimic physical structural dampening weight scales (`cubic-bezier(0.43, 1.62, 0.6, 0.93)`).
- 📝 **`README.md`**: Provided variable integration mapping data and usage instructions.

## ⚙️ Design Tokens & Custom Properties Exposed
* `--spring-duration`: Total kinetic animation timeline length.
* `--spring-physics-curve`: Controls structural bounce and acceleration peaks.
* `--spring-initial-scale`: Base size variable prior to modal scaling.

## 📌 Related Issue
Closes #34176