### PR TITLE
feat: add reusable Motion Blueprint SCSS mixin

### DIFF
--- a/submissions/scss/36409-motion-blueprint-mixin-dp/README.md
+++ b/submissions/scss/36409-motion-blueprint-mixin-dp/README.md
@@ -1,0 +1,55 @@
+# Motion Blueprint Mixin
+
+## Overview
+
+`motion-blueprint` is a reusable SCSS mixin that turns a single animation configuration map into CSS animation declarations. It validates the required animation fields, outputs only keys that are present, and keeps animation setup readable across components.
+
+## Blueprint Keys
+
+Required keys:
+
+- `animation` -> `animation-name`
+- `duration` -> `animation-duration`
+
+Optional keys:
+
+- `delay` -> `animation-delay`
+- `timing-function` -> `animation-timing-function`
+- `fill-mode` -> `animation-fill-mode`
+- `direction` -> `animation-direction`
+- `iteration-count` -> `animation-iteration-count`
+- `play-state` -> `animation-play-state`
+
+## Example Usage
+
+```scss
+@use "motion-blueprint" as *;
+
+$hero: (
+  animation: fade-up,
+  duration: 600ms,
+  delay: 150ms,
+  timing-function: ease-out,
+  fill-mode: both,
+);
+
+.hero {
+  @include motion-blueprint($hero);
+}
+```
+
+## Generated Output
+
+```css
+.hero {
+  animation-name: fade-up;
+  animation-duration: 600ms;
+  animation-delay: 150ms;
+  animation-timing-function: ease-out;
+  animation-fill-mode: both;
+}
+```
+
+## Why Motion Blueprint?
+
+Animation declarations often repeat the same group of properties with small variations. A map-based blueprint keeps those values together, makes required animation settings explicit, and avoids generating unused or empty CSS. This helps teams define motion patterns once and apply them consistently wherever animation behavior is needed.

--- a/submissions/scss/36409-motion-blueprint-mixin-dp/_motion-blueprint.scss
+++ b/submissions/scss/36409-motion-blueprint-mixin-dp/_motion-blueprint.scss
@@ -1,0 +1,25 @@
+@mixin motion-blueprint($blueprint) {
+  $required-keys: animation, duration;
+  $animation-properties: (
+    animation: animation-name,
+    duration: animation-duration,
+    delay: animation-delay,
+    timing-function: animation-timing-function,
+    fill-mode: animation-fill-mode,
+    direction: animation-direction,
+    iteration-count: animation-iteration-count,
+    play-state: animation-play-state,
+  );
+
+  @each $key in $required-keys {
+    @if not map-has-key($blueprint, $key) {
+      @error "motion-blueprint requires `#{$key}`.";
+    }
+  }
+
+  @each $key, $property in $animation-properties {
+    @if map-has-key($blueprint, $key) {
+      #{$property}: map-get($blueprint, $key);
+    }
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a **reusable Motion Blueprint SCSS mixin** under the `submissions/scss/` track.

`motion-blueprint` allows developers to define complete animation configurations using a single SCSS map and generate the corresponding CSS animation properties. By centralizing animation settings into reusable blueprints, it reduces repetitive declarations while remaining lightweight, configurable, and fully aligned with EaseMotion CSS's CSS-first philosophy.

Closes #36409 

---

## Type of Change

- [x] 🧩 New SCSS utility
- [ ] ✨ New animation
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `_motion-blueprint.scss`
- [x] Includes `README.md`
- [x] Uses SCSS only
- [x] No JavaScript
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

A reusable `motion-blueprint` SCSS mixin that converts a motion configuration map into standard CSS animation properties, allowing developers to reuse complete animation configurations across components.

### Example Usage

```scss
$hero: (
  animation: fade-up,
  duration: 600ms,
  delay: 150ms,
  timing-function: ease-out,
  fill-mode: both
);

.hero {
  @include motion-blueprint($hero);
}
```

### Example Generated Output

```css
.hero {
  animation-name: fade-up;
  animation-duration: 600ms;
  animation-delay: 150ms;
  animation-timing-function: ease-out;
  animation-fill-mode: both;
}
```

### Why does it fit EaseMotion CSS?

`motion-blueprint` improves developer experience by making animation configurations reusable through SCSS maps while continuing to rely entirely on existing CSS animation capabilities. It introduces no runtime logic or JavaScript, reinforcing EaseMotion CSS's CSS-first approach.

---

## Demo

- [x] Example usage included in the README

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional)*

---

## Notes for Maintainer

- Fully self-contained under `submissions/scss/`.
- Pure SCSS implementation with no external dependencies.
- Uses SCSS maps to define reusable animation blueprints.
- Supports required and optional animation properties.
- Validates required blueprint keys using SCSS compile-time checks.
- Designed as a lightweight developer utility that promotes reusable, maintainable motion configurations while remaining fully CSS-first.