### PR TITLE
feat: add reusable Motion Validator SCSS mixin

### DIFF
--- a/submissions/scss/36437-motion-validator-dp/README.md
+++ b/submissions/scss/36437-motion-validator-dp/README.md
@@ -1,0 +1,51 @@
+# Motion Validator
+
+## Overview
+
+Motion Validator provides a reusable SCSS mixin, `motion-validate`, for validating common animation configuration values at compile time. It does not emit CSS declarations; it only raises helpful Sass errors when invalid values are supplied.
+
+## Parameters
+
+| Parameter          | Type                 | Default | Description                            |
+| ------------------ | -------------------- | ------- | -------------------------------------- |
+| `$duration`        | Time                 | `null`  | Animation duration to validate.        |
+| `$delay`           | Time                 | `null`  | Animation delay to validate.           |
+| `$iteration-count` | Number or `infinite` | `null`  | Animation iteration count to validate. |
+| `$direction`       | Keyword              | `null`  | Animation direction to validate.       |
+| `$fill-mode`       | Keyword              | `null`  | Animation fill mode to validate.       |
+
+## Validation Rules
+
+- `$duration` must be a time value and cannot be negative.
+- `$delay` must be a time value and cannot be negative.
+- `$iteration-count` must be a positive number or `infinite`; zero, negative numbers, and non-numeric values are rejected.
+- `$direction` must be one of `normal`, `reverse`, `alternate`, or `alternate-reverse`.
+- `$fill-mode` must be one of `none`, `forwards`, `backwards`, or `both`.
+
+## Example Usage
+
+```scss
+@use "motion-validator" as *;
+
+@include motion-validate(
+  $duration: 400ms,
+  $delay: 100ms,
+  $iteration-count: 2,
+  $direction: alternate,
+  $fill-mode: both
+);
+```
+
+```scss
+@include motion-validate($duration: -200ms);
+```
+
+Produces:
+
+```scss
+error: Animation duration cannot be negative.;
+```
+
+## Why Motion Validator?
+
+Compile-time validation catches invalid animation values before CSS is generated, giving developers faster feedback and clearer failure messages. This helps prevent subtle motion bugs from reaching production stylesheets while keeping animation utilities focused and reusable.

--- a/submissions/scss/36437-motion-validator-dp/_motion-validator.scss
+++ b/submissions/scss/36437-motion-validator-dp/_motion-validator.scss
@@ -1,0 +1,68 @@
+@use "sass:list";
+@use "sass:math";
+@use "sass:meta";
+
+@mixin _validate-time($value, $name) {
+  @if $value != null {
+    @if meta.type-of($value) !=
+      "number" or not
+      list.index("s" "ms", math.unit($value))
+    {
+      @error "Animation #{$name} must be a time value.";
+    }
+
+    @if $value < 0s {
+      @if $name == "duration" {
+        @error "Animation duration cannot be negative.";
+      }
+
+      @if $name == "delay" {
+        @error "Animation delay cannot be negative.";
+      }
+    }
+  }
+}
+
+@mixin _validate-option($value, $name, $allowed-values) {
+  @if $value != null and not list.index($allowed-values, $value) {
+    @error "Invalid animation #{$name}: #{$value}. Allowed values are: #{$allowed-values}.";
+  }
+}
+
+@mixin motion-validate(
+  $duration: null,
+  $delay: null,
+  $iteration-count: null,
+  $direction: null,
+  $fill-mode: null
+) {
+  @include _validate-time($duration, "duration");
+  @include _validate-time($delay, "delay");
+
+  @if $iteration-count != null {
+    @if $iteration-count != infinite {
+      @if meta.type-of($iteration-count) != "number" {
+        @error "Animation iteration count must be a positive number or infinite.";
+      }
+
+      @if math.unit($iteration-count) != "" {
+        @error "Animation iteration count must be unitless.";
+      }
+
+      @if $iteration-count <= 0 {
+        @error "Animation iteration count must be greater than zero.";
+      }
+    }
+  }
+
+  @include _validate-option(
+    $direction,
+    "direction",
+    normal reverse alternate alternate-reverse
+  );
+  @include _validate-option(
+    $fill-mode,
+    "fill mode",
+    none forwards backwards both
+  );
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a **reusable Motion Validator SCSS mixin** under the `submissions/scss/` track.

`motion-validate` provides compile-time validation for common animation configuration values using SCSS's built-in `@error` and `@warn` directives. It helps developers detect invalid animation settings early, reducing debugging time while keeping motion configurations consistent and fully aligned with EaseMotion CSS's CSS-first philosophy.

Closes #36437

---

## Type of Change

- [x] 🧩 New SCSS utility
- [ ] ✨ New animation
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `_motion-validator.scss`
- [x] Includes `README.md`
- [x] Uses SCSS only
- [x] No JavaScript
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

A reusable `motion-validate` SCSS mixin that performs compile-time validation for animation configuration values such as duration, delay, iteration count, direction, and fill mode using SCSS validation directives.

### Example Usage

```scss
@include motion-validate(
  $duration: 400ms,
  $delay: 100ms,
  $iteration-count: 2,
  $direction: alternate,
  $fill-mode: both
);
```

### Invalid Example

```scss
@include motion-validate(
  $duration: -400ms
);
```

Produces:

```scss
Error: Animation duration cannot be negative.
```

### Why does it fit EaseMotion CSS?

`motion-validate` enhances the developer experience by validating animation configurations during SCSS compilation without generating additional CSS or introducing runtime logic. It complements existing EaseMotion CSS utilities while remaining lightweight, reusable, and fully CSS-first.

---

## Demo

- [x] Example usage included in the README

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional)*