### PR TITLE
feat: add reusable Motion Tokens SCSS functions

### DIFF
--- a/submissions/scss/36348-motion-tokens-dp/README.md
+++ b/submissions/scss/36348-motion-tokens-dp/README.md
@@ -1,0 +1,76 @@
+# Motion Tokens
+
+## Overview
+
+Motion Tokens is a lightweight SCSS utility for retrieving standardized animation values from reusable token maps. It provides CSS-first functions for durations, delays, easing functions, and distances without generating CSS automatically.
+
+## Available Functions
+
+| Function                  | Description                                                        |
+| ------------------------- | ------------------------------------------------------------------ |
+| `motion-duration($token)` | Returns a duration token value for animation or transition timing. |
+| `motion-delay($token)`    | Returns a delay token value for staggered or deferred motion.      |
+| `motion-easing($token)`   | Returns an easing token value for animation or transition curves.  |
+| `motion-distance($token)` | Returns a distance token value for movement-based transforms.      |
+
+Unknown tokens raise a meaningful SCSS `@error`.
+
+## Available Tokens
+
+| Duration Token | Value   |
+| -------------- | ------- |
+| `instant`      | `0ms`   |
+| `fast`         | `200ms` |
+| `normal`       | `400ms` |
+| `slow`         | `700ms` |
+
+| Delay Token | Value   |
+| ----------- | ------- |
+| `none`      | `0ms`   |
+| `xs`        | `50ms`  |
+| `sm`        | `100ms` |
+| `md`        | `150ms` |
+| `lg`        | `250ms` |
+
+| Easing Token | Value                            |
+| ------------ | -------------------------------- |
+| `linear`     | `linear`                         |
+| `smooth`     | `ease-out`                       |
+| `standard`   | `ease`                           |
+| `emphasized` | `cubic-bezier(0.22, 1, 0.36, 1)` |
+
+| Distance Token | Value  |
+| -------------- | ------ |
+| `xs`           | `4px`  |
+| `sm`           | `8px`  |
+| `md`           | `16px` |
+| `lg`           | `24px` |
+| `xl`           | `40px` |
+
+## Example Usage
+
+```scss
+@use "motion-tokens" as *;
+
+.button {
+  animation-duration: motion-duration(fast);
+  animation-delay: motion-delay(md);
+  animation-timing-function: motion-easing(smooth);
+  transform: translateY(motion-distance(sm));
+}
+```
+
+Generated CSS:
+
+```css
+.button {
+  animation-duration: 200ms;
+  animation-delay: 150ms;
+  animation-timing-function: ease-out;
+  transform: translateY(8px);
+}
+```
+
+## Why Motion Tokens?
+
+Motion token functions replace hardcoded animation values with shared, named tokens. This keeps motion choices consistent across a project, makes timing and movement easier to update, and improves maintainability while staying SCSS-only with no JavaScript, HTML, generated CSS, React, external libraries, or additional files.

--- a/submissions/scss/36348-motion-tokens-dp/_motion-tokens.scss
+++ b/submissions/scss/36348-motion-tokens-dp/_motion-tokens.scss
@@ -1,0 +1,61 @@
+$motion-durations: (
+  instant: 0ms,
+  fast: 200ms,
+  normal: 400ms,
+  slow: 700ms,
+);
+
+$motion-delays: (
+  none: 0ms,
+  xs: 50ms,
+  sm: 100ms,
+  md: 150ms,
+  lg: 250ms,
+);
+
+$motion-easings: (
+  linear: linear,
+  smooth: ease-out,
+  standard: ease,
+  emphasized: cubic-bezier(0.22, 1, 0.36, 1),
+);
+
+$motion-distances: (
+  xs: 4px,
+  sm: 8px,
+  md: 16px,
+  lg: 24px,
+  xl: 40px,
+);
+
+@function motion-duration($token) {
+  @if not map-has-key($motion-durations, $token) {
+    @error 'Unknown duration token "#{$token}".';
+  }
+
+  @return map-get($motion-durations, $token);
+}
+
+@function motion-delay($token) {
+  @if not map-has-key($motion-delays, $token) {
+    @error 'Unknown delay token "#{$token}".';
+  }
+
+  @return map-get($motion-delays, $token);
+}
+
+@function motion-easing($token) {
+  @if not map-has-key($motion-easings, $token) {
+    @error 'Unknown easing token "#{$token}".';
+  }
+
+  @return map-get($motion-easings, $token);
+}
+
+@function motion-distance($token) {
+  @if not map-has-key($motion-distances, $token) {
+    @error 'Unknown distance token "#{$token}".';
+  }
+
+  @return map-get($motion-distances, $token);
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a **reusable Motion Tokens SCSS utility** under the `submissions/scss/` track.

`motion-tokens` provides a centralized set of SCSS functions for retrieving standardized motion-related values such as durations, delays, easing functions, and distances. By replacing hardcoded values with reusable tokens, it improves consistency, maintainability, and scalability while remaining lightweight and fully aligned with EaseMotion CSS's CSS-first philosophy.

Closes #36438

---

## Type of Change

- [x] 🧩 New SCSS utility
- [ ] ✨ New animation
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `_motion-tokens.scss`
- [x] Includes `README.md`
- [x] Uses SCSS only
- [x] No JavaScript
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

A reusable SCSS utility that exposes standardized motion token functions for durations, delays, easing functions, and distances, allowing developers to replace hardcoded animation values with consistent reusable tokens.

### Example Usage

```scss
.button {
  animation-duration: motion-duration(fast);
  animation-delay: motion-delay(md);
  animation-timing-function: motion-easing(smooth);
  transform: translateY(motion-distance(sm));
}
```

### Example Generated CSS

```css
.button {
  animation-duration: 200ms;
  animation-delay: 150ms;
  animation-timing-function: ease-out;
  transform: translateY(8px);
}
```

### Why does it fit EaseMotion CSS?

`motion-tokens` provides a reusable, centralized token system for motion-related values without introducing runtime logic or external dependencies. It promotes consistent animation values across projects while remaining lightweight, maintainable, and fully CSS-first.

---

## Demo

- [x] Example usage included in the README

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional)*