### PR TITLE
 feat : add border-draw-a11y-reverse-k553 submission

### DIFF
--- a/submissions/examples/border-draw-a11y-reverse-k553/README.md
+++ b/submissions/examples/border-draw-a11y-reverse-k553/README.md
@@ -1,0 +1,14 @@
+# Border Draw — Accessible + Reverse Exit
+
+**EaseMotion Submission** · Contributor: kavin553
+
+---
+
+## 1. What does this do?
+
+Draws a border around an element on hover **or keyboard focus**, then retracts it in reverse sequence on mouse-leave/blur instead of simply disappearing.
+
+## 2. How is it used?
+
+```html
+<a href="#" class="border-draw-a11y">Hover or Tab-focus me</a>

--- a/submissions/examples/border-draw-a11y-reverse-k553/demo.html
+++ b/submissions/examples/border-draw-a11y-reverse-k553/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Border Draw (Accessible + Reverse) Demo</title>
+  <link rel="stylesheet" href="./style.css" />
+  <style>
+    body {
+      font-family: sans-serif;
+      background: #f4f4f7;
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+    }
+
+    a.border-draw-a11y {
+      color: #333;
+      text-decoration: none;
+      font-weight: 600;
+      background: white;
+      border-radius: 4px;
+    }
+
+    p.hint {
+      color: #888;
+      font-size: 0.85rem;
+      max-width: 320px;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+
+  <a href="#" class="border-draw-a11y">Hover or Tab-focus me</a>
+
+  <p class="hint">
+    Try hovering, then moving the mouse away — the border retracts in
+    reverse sequence. Also try Tab key navigation for keyboard focus.
+  </p>
+
+</body>
+</html>

--- a/submissions/examples/border-draw-a11y-reverse-k553/style.css
+++ b/submissions/examples/border-draw-a11y-reverse-k553/style.css
@@ -1,0 +1,86 @@
+/*
+  Border Draw — Accessible + Reverse Exit
+  Contributor: kavin553 (submission id: k553)
+
+  Distinct from submissions/examples/hover-border-draw/: that
+  submission is hover-only and doesn't specify exit behavior. This
+  submission adds two gaps it doesn't cover:
+    1. :focus-visible support, so keyboard users get the same border
+       draw as mouse users (accessibility gap)
+    2. An explicit reverse-sequence retraction on mouse-leave/blur,
+       so the border draws back out in reverse order instead of
+       simply disappearing - a smoother, more intentional exit
+
+  No "ease-" prefix used, per submission guidelines.
+*/
+
+.border-draw-a11y {
+  position: relative;
+  display: inline-block;
+  padding: 1rem 2rem;
+}
+
+.border-draw-a11y::before,
+.border-draw-a11y::after {
+  content: "";
+  position: absolute;
+  background: #6366f1;
+  transition: transform 0.3s ease;
+}
+
+/* Top + bottom lines */
+.border-draw-a11y::before {
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  transform: scaleX(0);
+  transform-origin: left;
+}
+
+/* Left + right lines via box-shadow trick keeps this to 2 pseudo-elements */
+.border-draw-a11y::after {
+  bottom: 0;
+  right: 0;
+  width: 100%;
+  height: 2px;
+  transform: scaleX(0);
+  transform-origin: right;
+  transition-delay: 0.15s;
+}
+
+/* Draw on hover OR keyboard focus */
+.border-draw-a11y:hover::before,
+.border-draw-a11y:focus-visible::before,
+.border-draw-a11y:hover::after,
+.border-draw-a11y:focus-visible::after {
+  transform: scaleX(1);
+}
+
+/* Reverse the delay order on the way out, so the second line to
+   appear is the first to retract - an intentional reverse sequence
+   rather than an instant disappearance. */
+.border-draw-a11y::before {
+  transition-delay: 0.15s;
+}
+
+.border-draw-a11y:hover::before,
+.border-draw-a11y:focus-visible::before {
+  transition-delay: 0s;
+}
+
+.border-draw-a11y::after {
+  transition-delay: 0s;
+}
+
+.border-draw-a11y:hover::after,
+.border-draw-a11y:focus-visible::after {
+  transition-delay: 0.15s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .border-draw-a11y::before,
+  .border-draw-a11y::after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a new self-contained submission — `border-draw-a11y-reverse-k553` — extending the border-draw-on-hover concept with keyboard focus support and an intentional reverse-sequence exit animation, addressing gaps in the existing `hover-border-draw` submission relative to issue #36429.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/border-draw-a11y-reverse-k553/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A border-draw hover/focus effect that retracts in reverse sequence on exit, rather than disappearing instantly.

**How does a developer use it?**

```html
<a href="#" class="border-draw-a11y">Hover or Tab-focus me</a>

Why does it fit EaseMotion CSS?
Pure CSS, zero dependencies, closes a keyboard-accessibility gap and adds a more intentional exit animation than the existing border-draw submission.
Demo
[x] Demo added (demo.html works by opening directly in a browser)
Browser Testing
[x] Chrome
[x] Firefox
[x] Edge
[ ] Safari (optional but appreciated)
Notes for Maintainer
I checked submissions/examples/hover-border-draw/ first — it's a polished, hover-only sequential border draw with customizable color/speed via CSS variables, and honestly already covers most of issue #36429's request very well. Rather than duplicating it, this submission specifically adds two things its README doesn't mention: :focus-visible support for keyboard users, and an explicit reverse-order retraction on mouse-leave/blur. Happy for this to be treated as a complementary variant, merged as a replacement, or closed if you feel hover-border-draw already fully resolves the issue — your call. Suffix -k553 added per naming policy.
Reminder: Only the repository maintainer may merge pull requests.
Do not self-merge, even if you have write access.
Maximum 25 active assigned issues per contributor — unassign extras before opening a PR.