### PR TITLE
feat : add image-colour-reveal-k553 submission

### DIFF
--- a/submissions/examples/image-colour-reveal-k553/README.md
+++ b/submissions/examples/image-colour-reveal-k553/README.md
@@ -1,0 +1,18 @@
+# Image Color Reveal
+
+**EaseMotion Submission** · Contributor: kavin553
+
+---
+
+## 1. What does this do?
+
+Displays an image in grayscale by default, smoothly transitioning to full color on hover or keyboard focus.
+
+## 2. How is it used?
+
+```html
+<img
+  class="image-color-reveal"
+  src="team-member.jpg"
+  alt="Team member portrait"
+/>

--- a/submissions/examples/image-colour-reveal-k553/demo.html
+++ b/submissions/examples/image-colour-reveal-k553/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Image Color Reveal Demo</title>
+  <link rel="stylesheet" href="./style.css" />
+  <style>
+    body {
+      font-family: sans-serif;
+      background: #f4f4f7;
+      display: flex;
+      gap: 1.5rem;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      flex-wrap: wrap;
+      padding: 2rem;
+    }
+
+    img {
+      width: 220px;
+      height: 220px;
+      object-fit: cover;
+    }
+
+    p.hint {
+      width: 100%;
+      text-align: center;
+      color: #888;
+      font-size: 0.85rem;
+    }
+  </style>
+</head>
+<body>
+
+  <img
+    class="image-color-reveal"
+    src="https://picsum.photos/220/220?random=1"
+    alt="Team member portrait"
+    tabindex="0"
+  />
+  <img
+    class="image-color-reveal"
+    src="https://picsum.photos/220/220?random=2"
+    alt="Product photo"
+    tabindex="0"
+  />
+
+  <p class="hint">Hover or Tab-focus each image to reveal color.</p>
+
+</body>
+</html>

--- a/submissions/examples/image-colour-reveal-k553/style.css
+++ b/submissions/examples/image-colour-reveal-k553/style.css
@@ -1,0 +1,25 @@
+/*
+  Image Color Reveal — grayscale to full color on hover.
+  Contributor: kavin553 (submission id: k553)
+
+  No "ease-" prefix used, per submission guidelines.
+*/
+
+.image-color-reveal {
+  filter: grayscale(100%);
+  transition: filter 0.4s ease;
+  display: block;
+  max-width: 100%;
+  border-radius: 8px;
+}
+
+.image-color-reveal:hover,
+.image-color-reveal:focus-visible {
+  filter: grayscale(0%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .image-color-reveal {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a new self-contained submission — `image-color-reveal-k553` — implementing an image that displays in grayscale by default and smoothly transitions to full color on hover, as requested in issue #36430.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (`submissions/examples/image-color-reveal-k553/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An image that displays in grayscale by default and transitions smoothly to full color on hover or keyboard focus.

**How does a developer use it?**

```html
<img
  class="image-color-reveal"
  src="team-member.jpg"
  alt="Team member portrait"
/>

Why does it fit EaseMotion CSS?
Pure CSS filter transition, zero dependencies, and pairs :focus-visible with :hover for keyboard accessibility — matching the animation-first philosophy while covering a widely used real-world pattern for team pages, product galleries, and portfolios.
Demo
[x] Demo added (demo.html works by opening directly in a browser)
Browser Testing
[x] Chrome
[x] Firefox
[x] Edge
[ ] Safari (optional but appreciated)
Notes for Maintainer
I checked submissions/examples/ for existing grayscale/color-reveal submissions before starting. grayscale-animation was the closest name match, but its README turned out to describe an unrelated rotating conic-gradient border effect, not an image color reveal — so I confirmed no duplicate exists. Added :focus-visible alongside :hover for keyboard accessibility, matching the pattern used in a few of my other submissions. Suffix -k553 added per naming policy.
Reminder: Only the repository maintainer may merge pull requests.
Do not self-merge, even if you have write access.
Maximum 25 active assigned issues per contributor — unassign extras before opening a PR.
Tip: Once you open your PR, feel free to showcase your design or component in the #showcase channel on our official Discord Server!