### PR TITLE
docs: add footer light-mode contrast fix demo for issue 35414

### DIFF
--- a/submissions/docs/core_changes-issue-35414/README.md
+++ b/submissions/docs/core_changes-issue-35414/README.md
@@ -1,0 +1,30 @@
+# Footer Contrast & Theme Toggle Fix
+
+## Issue #35414
+
+Fixes contrast and readability issues in the footer component (`.ease-footer`) when the application is toggled to Light Theme.
+
+## Problem
+
+When the application's theme was toggled to Light Theme (which sets `data-theme="light"` on the root document `html` element), the light mode rules defined inside the media query `@media (prefers-color-scheme: light)` did not activate unless the user's OS also preferred light mode.
+
+This caused two critical issues:
+
+1. **Low Contrast / Invisible Text**: Default dark theme text variables and hardcoded backgrounds remained active, causing elements like `.ease-footer-logo`, `.ease-footer-description`, and `.ease-footer-newsletter-text` to retain light colors (such as `#9ca3af` and `#f3f4f6`) against the light background.
+2. **Theme Incoherence**: The footer background remained dark while the rest of the application changed to light background, causing visual inconsistency.
+
+## Solution
+
+We added explicit selectors for `[data-theme="light"]` and properly aligned the media query to target `:root:not([data-theme="dark"])`. This ensures the footer correctly switches to the light background and uses high-contrast text and link colors.
+
+Specifically, the following elements adapt dynamically to the theme:
+
+- `.ease-footer` (uses light-mode background and borders)
+- `.ease-footer-logo`, `.ease-footer-col-title`, and `.ease-footer-newsletter-title` (shift to high-contrast dark slate color)
+- `.ease-footer-description`, `.ease-footer-newsletter-text`, and links (shift to readable neutral slate color)
+- Social icons (`.ease-footer-social a`) and Newsletter input (`.ease-footer-newsletter-input`) (use high-opacity white background with dark border and text)
+
+## Files Included
+
+- `demo.html` — Interactive demonstration showcasing the footer theme toggle and the contrast fix.
+- `style.css` — CSS stylesheet containing the high-contrast light mode overrides.

--- a/submissions/docs/core_changes-issue-35414/demo.html
+++ b/submissions/docs/core_changes-issue-35414/demo.html
@@ -1,0 +1,258 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EaseMotion CSS — Footer Contrast Fix</title>
+    <!-- Import Core Variables and Styles -->
+    <link rel="stylesheet" href="../../../core/variables.css" />
+    <link rel="stylesheet" href="../../../components/footer.css" />
+    <!-- Link the contrast override styling -->
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      :root {
+        --ease-font-sans: "Inter", system-ui, -apple-system, sans-serif;
+      }
+
+      body {
+        background-color: var(--ease-color-bg, #0b1121);
+        color: var(--ease-color-text, #e2e8f0);
+        font-family: var(--ease-font-sans);
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        transition:
+          background-color var(--ease-speed-medium, 300ms) var(--ease-ease),
+          color var(--ease-speed-medium, 300ms) var(--ease-ease);
+      }
+
+      .demo-header {
+        padding: 4rem 2rem;
+        text-align: center;
+        max-width: 800px;
+        margin: 0 auto;
+      }
+
+      .demo-title {
+        font-size: 2.5rem;
+        font-weight: 800;
+        background: linear-gradient(135deg, #6c63ff 0%, #8b5cf6 100%);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        margin-bottom: 1rem;
+      }
+
+      .demo-description {
+        font-size: 1.1rem;
+        line-height: 1.6;
+        color: var(--ease-color-muted, #94a3b8);
+        margin-bottom: 2rem;
+      }
+
+      .theme-toggle-container {
+        display: flex;
+        justify-content: center;
+        gap: 1rem;
+        margin-bottom: 2rem;
+      }
+
+      .btn-toggle {
+        background: var(--ease-color-primary, #6c63ff);
+        color: #ffffff;
+        border: none;
+        padding: 0.75rem 1.5rem;
+        font-size: 1rem;
+        font-weight: 600;
+        border-radius: 8px;
+        cursor: pointer;
+        transition: all 0.2s ease;
+        box-shadow: 0 4px 14px rgba(108, 99, 255, 0.4);
+      }
+
+      .btn-toggle:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 6px 20px rgba(108, 99, 255, 0.6);
+      }
+
+      .btn-toggle:active {
+        transform: translateY(0);
+      }
+
+      /* Indicator to show if data-theme or media queries are active */
+      .theme-indicator {
+        display: inline-block;
+        padding: 0.35rem 0.75rem;
+        background: var(--ease-glass-bg, rgba(255, 255, 255, 0.05));
+        border: 1px solid var(--ease-glass-border, rgba(255, 255, 255, 0.1));
+        border-radius: 20px;
+        font-size: 0.85rem;
+        font-weight: 500;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="demo-header">
+      <h1 class="demo-title">Footer Contrast & Theme Toggle Fix</h1>
+      <p class="demo-description">
+        This demo showcases the fix for <strong>Issue #35414</strong>. When
+        switching to <strong>Light Theme</strong>
+        (either via OS settings or the explicit JS toggle button below), the
+        footer components automatically adapt with high contrast, ensuring all
+        text links, descriptions, and headings are fully readable.
+      </p>
+
+      <div class="theme-toggle-container">
+        <button class="btn-toggle" onclick="toggleTheme()">
+          Toggle Light/Dark Theme
+        </button>
+      </div>
+      <div>
+        <span class="theme-indicator" id="theme-status"
+          >Active State: Dark Theme</span
+        >
+      </div>
+    </header>
+
+    <!-- EaseMotion Premium Footer Component -->
+    <footer class="ease-footer">
+      <div class="ease-footer-container">
+        <div class="ease-footer-grid">
+          <!-- Brand Column -->
+          <div class="ease-footer-brand">
+            <a href="#" class="ease-footer-logo">
+              <span class="ease-footer-logo-icon">EM</span>
+              EaseMotion CSS
+            </a>
+            <p class="ease-footer-description">
+              A premium, human-readable, animation-first CSS framework for
+              crafting stunning responsive user interfaces with glassmorphism.
+            </p>
+            <div class="ease-footer-social">
+              <a href="#" aria-label="Github">
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path
+                    d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"
+                  ></path>
+                </svg>
+              </a>
+              <a href="#" aria-label="Twitter">
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path
+                    d="M23 3a10.9 10.9 0 0 1-3.14 1.53 4.48 4.48 0 0 0-7.86 3v1A10.66 10.66 0 0 1 3 4s-4 9 5 13a11.64 11.64 0 0 1-7 2c9 5 20 0 20-11.5a4.5 4.5 0 0 0-.08-.83A7.72 7.72 0 0 0 23 3z"
+                  ></path>
+                </svg>
+              </a>
+              <a href="#" aria-label="Discord">
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"></path>
+                  <path d="M13.73 21a2 2 0 0 1-3.46 0"></path>
+                </svg>
+              </a>
+            </div>
+          </div>
+
+          <!-- Quick Links -->
+          <div class="ease-footer-col">
+            <h3 class="ease-footer-col-title">Resources</h3>
+            <ul class="ease-footer-links">
+              <li><a href="#">Documentation</a></li>
+              <li><a href="#">Components</a></li>
+              <li><a href="#">Animations</a></li>
+              <li><a href="#">Examples</a></li>
+            </ul>
+          </div>
+
+          <!-- Community -->
+          <div class="ease-footer-col">
+            <h3 class="ease-footer-col-title">Community</h3>
+            <ul class="ease-footer-links">
+              <li><a href="#">Discord Server</a></li>
+              <li><a href="#">GitHub Issues</a></li>
+              <li><a href="#">Code of Conduct</a></li>
+              <li><a href="#">Contributing Guide</a></li>
+            </ul>
+          </div>
+
+          <!-- Newsletter Column -->
+          <div class="ease-footer-col">
+            <h3 class="ease-footer-col-title">Newsletter</h3>
+            <div class="ease-footer-newsletter">
+              <h4 class="ease-footer-newsletter-title">Stay Updated</h4>
+              <p class="ease-footer-newsletter-text">
+                Subscribe to get notified about new animation presets and
+                features.
+              </p>
+              <form
+                class="ease-footer-newsletter-form"
+                onsubmit="
+                  event.preventDefault();
+                  alert('Subscribed!');
+                "
+              >
+                <input
+                  class="ease-footer-newsletter-input"
+                  type="email"
+                  placeholder="email@example.com"
+                  required
+                  aria-label="Email address"
+                />
+                <button class="ease-footer-newsletter-btn" type="submit">
+                  Join
+                </button>
+              </form>
+            </div>
+          </div>
+        </div>
+
+        <!-- Bottom Copyright -->
+        <div class="ease-footer-bottom">
+          <div class="ease-footer-copyright">
+            © 2026 EaseMotion CSS. Open-source under MIT License.
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      function toggleTheme() {
+        const html = document.documentElement;
+        const current = html.getAttribute("data-theme") || "dark";
+        const target = current === "dark" ? "light" : "dark";
+        html.setAttribute("data-theme", target);
+
+        // Update indicator text
+        const indicator = document.getElementById("theme-status");
+        indicator.textContent = `Active State: ${target.charAt(0).toUpperCase() + target.slice(1)} Theme`;
+      }
+    </script>
+  </body>
+</html>

--- a/submissions/docs/core_changes-issue-35414/style.css
+++ b/submissions/docs/core_changes-issue-35414/style.css
@@ -1,0 +1,138 @@
+/* ============================================================
+   EaseMotion CSS — Footer Contrast Fix style.css
+   Addresses contrast issues when toggled to Light Theme
+   ============================================================ */
+
+/* Light mode overrides for data-theme="light" */
+[data-theme="light"] .ease-footer {
+  background: var(--ease-footer-bg-light);
+  border-top-color: var(--ease-footer-border-light);
+  color: var(--ease-footer-text-light);
+}
+
+[data-theme="light"] .ease-footer-logo {
+  color: var(--ease-footer-heading-light);
+}
+
+[data-theme="light"] .ease-footer-description {
+  color: var(--ease-footer-text-light);
+}
+
+[data-theme="light"] .ease-footer-col-title {
+  color: var(--ease-footer-heading-light);
+}
+
+[data-theme="light"] .ease-footer-links a {
+  color: var(--ease-footer-text-light);
+}
+
+[data-theme="light"] .ease-footer-links a:hover {
+  color: var(--ease-footer-accent);
+}
+
+[data-theme="light"] .ease-footer-newsletter-title {
+  color: var(--ease-footer-heading-light);
+}
+
+[data-theme="light"] .ease-footer-newsletter-text {
+  color: var(--ease-footer-text-light);
+}
+
+[data-theme="light"] .ease-footer-social a {
+  background: rgba(255, 255, 255, 0.8);
+  color: var(--ease-footer-heading-light);
+  border: 1px solid var(--ease-footer-border-light);
+}
+
+[data-theme="light"] .ease-footer-social a:hover {
+  background: var(--ease-footer-accent-gradient);
+  color: #fff;
+  border-color: transparent;
+}
+
+[data-theme="light"] .ease-footer-bottom {
+  border-top-color: var(--ease-footer-border-light);
+  color: var(--ease-footer-text-light);
+}
+
+[data-theme="light"] .ease-footer-newsletter-input {
+  background: rgba(255, 255, 255, 0.9);
+  border-color: var(--ease-footer-border-light);
+  color: var(--ease-footer-heading-light);
+}
+
+[data-theme="light"] .ease-footer-newsletter-input::placeholder {
+  color: var(--ease-footer-text-light);
+}
+
+[data-theme="light"] .ease-footer-newsletter-btn {
+  background: var(--ease-footer-accent-gradient);
+}
+
+/* Light mode overrides for prefers-color-scheme when not explicitly dark */
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme="dark"]) .ease-footer {
+    background: var(--ease-footer-bg-light);
+    border-top-color: var(--ease-footer-border-light);
+    color: var(--ease-footer-text-light);
+  }
+
+  :root:not([data-theme="dark"]) .ease-footer-logo {
+    color: var(--ease-footer-heading-light);
+  }
+
+  :root:not([data-theme="dark"]) .ease-footer-description {
+    color: var(--ease-footer-text-light);
+  }
+
+  :root:not([data-theme="dark"]) .ease-footer-col-title {
+    color: var(--ease-footer-heading-light);
+  }
+
+  :root:not([data-theme="dark"]) .ease-footer-links a {
+    color: var(--ease-footer-text-light);
+  }
+
+  :root:not([data-theme="dark"]) .ease-footer-links a:hover {
+    color: var(--ease-footer-accent);
+  }
+
+  :root:not([data-theme="dark"]) .ease-footer-newsletter-title {
+    color: var(--ease-footer-heading-light);
+  }
+
+  :root:not([data-theme="dark"]) .ease-footer-newsletter-text {
+    color: var(--ease-footer-text-light);
+  }
+
+  :root:not([data-theme="dark"]) .ease-footer-social a {
+    background: rgba(255, 255, 255, 0.8);
+    color: var(--ease-footer-heading-light);
+    border: 1px solid var(--ease-footer-border-light);
+  }
+
+  :root:not([data-theme="dark"]) .ease-footer-social a:hover {
+    background: var(--ease-footer-accent-gradient);
+    color: #fff;
+    border-color: transparent;
+  }
+
+  :root:not([data-theme="dark"]) .ease-footer-bottom {
+    border-top-color: var(--ease-footer-border-light);
+    color: var(--ease-footer-text-light);
+  }
+
+  :root:not([data-theme="dark"]) .ease-footer-newsletter-input {
+    background: rgba(255, 255, 255, 0.9);
+    border-color: var(--ease-footer-border-light);
+    color: var(--ease-footer-heading-light);
+  }
+
+  :root:not([data-theme="dark"]) .ease-footer-newsletter-input::placeholder {
+    color: var(--ease-footer-text-light);
+  }
+
+  :root:not([data-theme="dark"]) .ease-footer-newsletter-btn {
+    background: var(--ease-footer-accent-gradient);
+  }
+}


### PR DESCRIPTION
## Description
Fixes footer text visibility in Light Mode (Issue #35414).

The `.ease-footer` component originally relied on `@media (prefers-color-scheme: light)`, which only reacts to the OS-level theme preference. The site's actual theme toggle sets `data-theme="light"` on `<html>` — so when a user manually toggles to light mode while their OS is still dark, the footer never received the light-mode overrides, leaving text like the logo, description, and newsletter copy washed out against the light background.

This submission adds a self-contained demo (`submissions/docs/core_changes-issue-35414/`) with an override stylesheet targeting `[data-theme="light"]` directly, alongside a corrected `:root:not([data-theme="dark"])` media query fallback — following the same accepted pattern used in the prior footer contrast fix (#33457).

## Related Issue
Closes #35414

## How to Test
1. Open `submissions/docs/core_changes-issue-35414/demo.html`
2. Click "Toggle Light/Dark Theme"
3. Verify footer heading, description, links, newsletter input, and bottom bar are all clearly readable in light mode

## Checklist
- [x] Tested in browser
- [x] Linked related issue
- [x] Only files inside `submissions/` are modified
- [x] No new dependencies