### PR TITLE
feat : add skeleton-content-swap-k553 submission

### DIFF
--- a/submissions/examples/skeleton-content-swap-k553/README.md
+++ b/submissions/examples/skeleton-content-swap-k553/README.md
@@ -1,0 +1,24 @@
+# Skeleton-to-Content Swap Transition
+
+**EaseMotion Submission** · Contributor: kavin553
+
+---
+
+## 1. What does this do?
+
+Provides a crossfade transition between a shimmer skeleton placeholder and the real content once it loads, avoiding a jarring instant pop-in.
+
+## 2. How is it used?
+
+```html
+<div class="skeleton-swap" id="myCard">
+  <div class="skeleton-layer card-shape"></div>
+  <div class="content-layer">
+    <!-- real content goes here -->
+  </div>
+</div>
+
+<script>
+  // Toggle this once your data has actually loaded
+  document.getElementById('myCard').classList.add('is-loaded');
+</script>

--- a/submissions/examples/skeleton-content-swap-k553/demo.html
+++ b/submissions/examples/skeleton-content-swap-k553/demo.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Skeleton-to-Content Swap Demo</title>
+  <link rel="stylesheet" href="./style.css" />
+  <style>
+    body {
+      font-family: sans-serif;
+      background: #f4f4f7;
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+    }
+
+    .card-demo {
+      width: 280px;
+      height: 100px;
+    }
+
+    .skeleton-layer.card-shape {
+      width: 100%;
+      height: 100%;
+    }
+
+    .content-layer {
+      background: white;
+      padding: 1rem;
+      border-radius: 6px;
+      width: 100%;
+      box-sizing: border-box;
+    }
+
+    button {
+      padding: 0.7rem 1.4rem;
+      border: none;
+      border-radius: 8px;
+      background: #3b82f6;
+      color: white;
+      cursor: pointer;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="card-demo skeleton-swap" id="demoCard">
+    <div class="skeleton-layer card-shape"></div>
+    <div class="content-layer">
+      <strong>Real content loaded!</strong>
+      <p>This replaces the shimmer smoothly.</p>
+    </div>
+  </div>
+
+  <button onclick="document.getElementById('demoCard').classList.add('is-loaded')">
+    Simulate content loaded
+  </button>
+
+  <p style="color:#888; font-size:0.85rem;">
+    Click the button to see the skeleton crossfade into real content.
+  </p>
+
+</body>
+</html>

--- a/submissions/examples/skeleton-content-swap-k553/style.css
+++ b/submissions/examples/skeleton-content-swap-k553/style.css
@@ -1,0 +1,60 @@
+/*
+  Skeleton-to-Content Swap Transition
+  Contributor: kavin553 (submission id: k553)
+
+  Distinct from existing loading-states and text-shimmer-loading
+  submissions: those provide the shimmer placeholder visual itself,
+  but neither documents the transition when real content arrives.
+  This submission solves that specific gap - a crossfade between
+  the skeleton and the loaded content, avoiding a jarring pop-in.
+
+  No "ease-" prefix used, per submission guidelines.
+*/
+
+.skeleton-swap {
+  position: relative;
+}
+
+.skeleton-swap .skeleton-layer,
+.skeleton-swap .content-layer {
+  transition: opacity 0.4s ease;
+}
+
+.skeleton-swap .content-layer {
+  opacity: 0;
+  position: absolute;
+  inset: 0;
+}
+
+.skeleton-swap.is-loaded .skeleton-layer {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.skeleton-swap.is-loaded .content-layer {
+  opacity: 1;
+  position: static;
+}
+
+/* The shimmer visual itself, reusable for any placeholder shape */
+.skeleton-layer {
+  background: linear-gradient(90deg, #eee 25%, #ddd 50%, #eee 75%);
+  background-size: 200% 100%;
+  animation: skeleton-swap-shimmer-k553 1.4s infinite;
+  border-radius: 6px;
+}
+
+@keyframes skeleton-swap-shimmer-k553 {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-layer {
+    animation: none;
+  }
+  .skeleton-swap .skeleton-layer,
+  .skeleton-swap .content-layer {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a new self-contained submission — `skeleton-content-swap-k553` — providing a crossfade transition between a shimmer skeleton placeholder and real content once it loads, addressing an integration gap not covered by the existing shimmer submissions relative to issue #36436.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (`submissions/examples/skeleton-content-swap-k553/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A crossfade transition between a shimmer skeleton placeholder and the real content once it loads, toggled via a single `is-loaded` class.

**How does a developer use it?**

```html
<div class="skeleton-swap" id="myCard">
  <div class="skeleton-layer card-shape"></div>
  <div class="content-layer">
    <!-- real content goes here -->
  </div>
</div>

Why does it fit EaseMotion CSS?
Pure CSS transition logic, zero dependencies, and closes a real integration gap — the shimmer visual itself is already well-covered elsewhere, but the actual swap-to-content behavior developers need in practice wasn't documented anywhere yet.
Demo
[x] Demo added (demo.html works by opening directly in a browser)
Browser Testing
[x] Chrome
[x] Firefox
[x] Edge
[ ] Safari (optional but appreciated)
Notes for Maintainer
I checked submissions/examples/ before starting and found this issue is largely covered by two existing submissions: loading-states (full skeleton system — cards, avatars, buttons, text) and text-shimmer-loading (text-specific shimmer with variants). Both provide excellent placeholder visuals, but neither documents what happens once real content actually arrives. This submission fills that specific gap: a crossfade transition triggered by toggling one class, avoiding a jarring instant pop-in. Happy for this to be treated as a complement to the existing shimmer submissions, or closed if you feel the issue is already resolved by them. The demo's button is only for interactive testing — the transition logic itself is pure CSS. Suffix -k553 added per naming policy.
Reminder: Only the repository maintainer may merge pull requests.
Do not self-merge, even if you have write access.
Maximum 25 active assigned issues per contributor — unassign extras before opening a PR.
Tip: Once you open your PR, feel free to showcase your design or component in the #showcase channel on our official Discord Server!