### PR TITLE
feat: add ease-image-color-reveal hover effect

### DIFF
--- a/submissions/examples/ease-image-color-reveal-36430/README.md
+++ b/submissions/examples/ease-image-color-reveal-36430/README.md
@@ -1,0 +1,58 @@
+\# ease-image-color-reveal
+
+
+
+A hover effect utility that reveals full color on a grayscale image. Great for team cards, product galleries, portfolios, and photography pages.
+
+
+
+\## Usage
+
+
+
+```html
+
+<img class="ease-image-color-reveal" src="image.jpg" alt="Demo">
+
+```
+
+
+
+\## Speed Variants
+
+
+
+| Class | Transition speed |
+
+|---|---|
+
+| `ease-image-color-reveal--fast` | 0.2s |
+
+| (default) | 0.4s |
+
+| `ease-image-color-reveal--slow` | 0.8s |
+
+
+
+\## How It Works
+
+
+
+\- Base class applies `filter: grayscale(100%)` with a transition.
+
+\- On hover/focus, grayscale is removed, revealing color.
+
+\- Respects `prefers-reduced-motion`.
+
+
+
+\## Files
+
+
+
+\- `demo.html` — live demo
+
+\- `style.css` — component styles
+
+\- `README.md` — this file
+

--- a/submissions/examples/ease-image-color-reveal-36430/demo.html
+++ b/submissions/examples/ease-image-color-reveal-36430/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-image-color-reveal Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: system-ui, sans-serif; background: #f7f7f8; padding: 40px; }
+    h1 { margin-bottom: 30px; }
+    .demo-row { display: flex; gap: 24px; flex-wrap: wrap; }
+    .demo-block { display: flex; flex-direction: column; align-items: flex-start; }
+    .demo-label { font-size: 14px; color: #666; margin-bottom: 8px; }
+    .demo-block img { width: 220px; border-radius: 8px; }
+  </style>
+</head>
+<body>
+  <h1>ease-image-color-reveal</h1>
+  <p>Hover over each image to reveal color.</p>
+
+  <div class="demo-row">
+    <div class="demo-block">
+      <span class="demo-label">Default</span>
+      <div class="ease-image-color-reveal-wrapper">
+        <img class="ease-image-color-reveal" src="https://picsum.photos/id/1015/300/300" alt="Mountain landscape">
+      </div>
+    </div>
+    <div class="demo-block">
+      <span class="demo-label">Fast transition</span>
+      <div class="ease-image-color-reveal-wrapper">
+        <img class="ease-image-color-reveal ease-image-color-reveal--fast" src="https://picsum.photos/id/1025/300/300" alt="Dog portrait">
+      </div>
+    </div>
+    <div class="demo-block">
+      <span class="demo-label">Slow transition</span>
+      <div class="ease-image-color-reveal-wrapper">
+        <img class="ease-image-color-reveal ease-image-color-reveal--slow" src="https://picsum.photos/id/1035/300/300" alt="Forest path">
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-image-color-reveal-36430/style.css
+++ b/submissions/examples/ease-image-color-reveal-36430/style.css
@@ -1,0 +1,32 @@
+.ease-image-color-reveal {
+  filter: grayscale(100%);
+  transition: filter 0.4s ease;
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+.ease-image-color-reveal:hover,
+.ease-image-color-reveal:focus-visible {
+  filter: grayscale(0%);
+}
+
+.ease-image-color-reveal-wrapper {
+  overflow: hidden;
+  border-radius: 8px;
+  display: inline-block;
+}
+
+.ease-image-color-reveal--fast {
+  transition-duration: 0.2s;
+}
+
+.ease-image-color-reveal--slow {
+  transition-duration: 0.8s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-image-color-reveal {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #36430

Adds `ease-image-color-reveal` hover effect utility — grayscale to full color transition. Useful for team cards, product galleries, portfolios, photography pages.

Files:
- submissions/examples/ease-image-color-reveal-36430/demo.html
- submissions/examples/ease-image-color-reveal-36430/style.css
- submissions/examples/ease-image-color-reveal-36430/README.md