### PR TITLE
feat: add pure CSS spring physics analytics modal #34165

### DIFF
--- a/submissions/examples/spring-physics-modals-365/README.md
+++ b/submissions/examples/spring-physics-modals-365/README.md
@@ -1,0 +1,15 @@
+# Analytics Spring Physics Modal (Pure CSS)
+
+A metric fluid animation model using custom cubicbezier overshooting physics parameters to process animations natively.
+
+## Features
+* ⚡ **Zero JavaScript Animation States:** Models snappy elastic spring vectors purely over the URL native browser `:target` system.
+* 📊 **Clean Enterprise Layout System:** Complements clean SaaS dashboards, featuring clean layouts, precise custom inputs, and soft shadow backdrops.
+* 🎛️ **Exposed Configuration Nodes:** Modify the bounce profile elasticity and speed values globally via localized variables.
+
+## Configuration Profiles
+| Custom Property | Description | Default Value |
+| :--- | :--- | :--- |
+| `--spring-duration` | Determines velocity/speed boundaries of the mass execution. | `0.55s` |
+| `--spring-curve` | Overshooting cubic-bezier values modeling mass spring variables. | `cubic-bezier(0.68, -0.6, 0.32, 1.4)` |
+| `--spring-scale-start` | Setting target scale values prior to layout expansion triggers. | `0.75` |

--- a/submissions/examples/spring-physics-modals-365/demo.html
+++ b/submissions/examples/spring-physics-modals-365/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dashboard Analytics - Spring Physics Modal</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="dashboard-root">
+    <header class="dash-navbar">
+      <div class="dash-title">Analytics_Hub // v2.0</div>
+      <a href="#spring-modal" class="btn btn-primary" role="button">Export Reports</a>
+    </header>
+
+    <main class="dash-grid">
+      <div class="dash-card">
+        <span class="card-title">Conversion Rate</span>
+        <div class="card-metric">3.42% <span class="trend-up">▲ 1.2%</span></div>
+      </div>
+      <div class="dash-card">
+        <span class="card-title">Active Sessions</span>
+        <div class="card-metric">1,842 <span class="trend-neutral">Stable</span></div>
+      </div>
+    </main>
+  </div>
+
+  <div id="spring-modal" class="modal-overlay" aria-hidden="true" role="dialog" aria-labelledby="modal-title">
+    <a href="#" class="modal-close-overlay" aria-label="Close modal window"></a>
+    
+    <div class="modal-container">
+      <div class="modal-header">
+        <h3 id="modal-title">Export Dataset Options</h3>
+        <a href="#" class="modal-close-x" aria-label="Close modal window">&times;</a>
+      </div>
+      
+      <div class="modal-body">
+        <p>Select your target optimization parameters. This panel models realistic spring mass mechanics using a custom overshooting cubic-bezier curve profile.</p>
+        
+        <div class="options-group">
+          <label class="radio-option">
+            <input type="radio" name="format" checked>
+            <span>Raw Analytics Payload (.JSON)</span>
+          </label>
+          <label class="radio-option">
+            <input type="radio" name="format">
+            <span>Executive Overview Spreadsheet (.CSV)</span>
+          </label>
+        </div>
+      </div>
+      
+      <div class="modal-footer">
+        <a href="#" class="btn btn-link">Close</a>
+        <a href="#" class="btn btn-primary">Generate Stream</a>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/spring-physics-modals-365/style.css
+++ b/submissions/examples/spring-physics-modals-365/style.css
@@ -1,0 +1,127 @@
+/* ==========================================================================
+   Analytics Dashboard Custom Spring Variables
+   ========================================================================== */
+:root {
+  --bg-dash: #f8fafc;
+  --text-dark: #0f172a;
+  --text-slate: #64748b;
+  --primary-accent: #2563eb;
+  --border-light: #e2e8f0;
+  
+  /* Spring Physics Framework - The 1.35 and 1.4 values create the dynamic bounce */
+  --spring-duration: 0.55s;
+  --spring-curve: cubic-bezier(0.68, -0.6, 0.32, 1.4);
+  --spring-scale-start: 0.75;
+}
+
+/* Base System Typography & Rules */
+body {
+  background-color: var(--bg-dash);
+  color: var(--text-dark);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  margin: 0;
+  padding: 2rem;
+}
+
+.dashboard-root { max-width: 900px; margin: 0 auto; }
+.dash-navbar { display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid var(--border-light); padding-bottom: 1.25rem; }
+.dash-title { font-weight: 700; color: var(--text-dark); letter-spacing: -0.3px; }
+
+.dash-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.5rem; margin-top: 2rem; }
+.dash-card { background: #ffffff; border: 1px solid var(--border-light); padding: 1.5rem; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,0.02); }
+.card-title { font-size: 0.85rem; color: var(--text-slate); font-weight: 500; }
+.card-metric { font-size: 1.75rem; font-weight: 700; margin-top: 0.5rem; display: flex; align-items: center; gap: 10px; }
+
+.trend-up { font-size: 0.85rem; color: #16a34a; font-weight: 600; }
+.trend-neutral { font-size: 0.85rem; color: var(--text-slate); font-weight: 500; }
+
+/* Interactive Interface Tokens */
+.btn {
+  display: inline-block;
+  text-decoration: none;
+  font-size: 0.875rem;
+  font-weight: 600;
+  padding: 0.625rem 1.25rem;
+  border-radius: 8px;
+  transition: opacity 0.2s;
+}
+.btn-primary { background: var(--primary-accent); color: #ffffff; }
+.btn-primary:hover { opacity: 0.9; }
+.btn-link { color: var(--text-slate); }
+.btn-link:hover { color: var(--text-dark); }
+
+.options-group { margin-top: 1.25rem; display: flex; flex-direction: column; gap: 0.75rem; }
+.radio-option { display: flex; align-items: center; gap: 10px; font-size: 0.9rem; cursor: pointer; color: #334155; }
+
+/* ==========================================================================
+   Pure CSS Spring Physics Modal Overlay
+   ========================================================================== */
+.modal-overlay {
+  position: fixed;
+  top: 0; left: 0; width: 100%; height: 100%;
+  background: rgba(15, 23, 42, 0.3);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  box-sizing: border-box;
+  z-index: 9999;
+  
+  /* Smooth standard fade loop for backdrop */
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+
+.modal-close-overlay { position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 1; }
+
+.modal-container {
+  position: relative;
+  background: #ffffff;
+  border: 1px solid var(--border-light);
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.08);
+  width: 100%;
+  max-width: 480px;
+  border-radius: 14px;
+  z-index: 2;
+  box-sizing: border-box;
+  
+  /* Initial Scale/Transform Position */
+  transform: scale(var(--spring-scale-start));
+  transition: transform var(--spring-duration) var(--spring-curve);
+}
+
+/* Open Anchor Trigger Pipeline via URL Target Route pointer */
+.modal-overlay:target {
+  opacity: 1;
+  visibility: visible;
+}
+.modal-overlay:target .modal-container {
+  transform: scale(1);
+}
+
+/* Inside Layout Segment Specs */
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid var(--border-light);
+}
+.modal-header h3 { margin: 0; font-size: 1.1rem; font-weight: 700; color: var(--text-dark); }
+.modal-close-x { text-decoration: none; color: var(--text-slate); font-size: 1.4rem; line-height: 1; }
+.modal-close-x:hover { color: var(--text-dark); }
+
+.modal-body { padding: 1.5rem; font-size: 0.925rem; line-height: 1.6; color: #475569; }
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 1rem 1.5rem;
+  border-top: 1px solid var(--border-light);
+  background: #f8fafc;
+  border-bottom-left-radius: 14px;
+  border-bottom-right-radius: 14px;
+}


### PR DESCRIPTION
## 🚀 Description
This PR answers issue #34165 by shipping a **Pure CSS Spring Physics Modal** component explicitly styled for Dashboard Analytics user interfaces. The expansion transition mimics fluid spring-mass metrics natively with zero JavaScript dependency layers.

Fixes #34165

## 🛠️ Changes Proposed
* **Dashboard Component Submission:** Added all target layout assets inside `submissions/examples/spring-physics-modal/`.
* **Zero-JS Elastic Animation:** Engineered high-fidelity overshooting snap actions purely by matching the structural `:target` hook selector with custom animation math.
* **Modern Clean System Architecture:** Styled explicitly with standard layout attributes, soft metric dashboards, custom option states, and accessible semantics.
* **Exposed Parametric Physics Framework:** Leveraged standard custom variables to cleanly fine-tune elastic curve indices (`--spring-curve`) and timing limits (`--spring-duration`) from the root scope.

## 📁 Submission Structure
* `submissions/examples/spring-physics-modal/demo.html`
* `submissions/examples/spring-physics-modal/style.css`
* `submissions/examples/spring-physics-modal/README.md`

## ✅ Checklist
- [x] My files are placed exclusively inside the `submissions/` directory.
- [x] I have included `demo.html`, `style.css`, and `README.md` in my folder.
- [x] The code matches responsive rulesets and accessibility standards cleanly.