### PR TITLE
feat: add CSS Blur-Entrance Modal for Interactive Interface Layouts

### DIFF
--- a/submissions/examples/blur-entrance-modal-interactive-interface/README.md
+++ b/submissions/examples/blur-entrance-modal-interactive-interface/README.md
@@ -1,0 +1,40 @@
+﻿# CSS Blur-Entrance Modal — Interactive Interface Layout
+
+A pure CSS modal that enters with a blur-to-focus transition: the modal starts fully out-of-focus (via `filter: blur()`) and sharpens into place, while the backdrop simultaneously gains a frosted blur.
+
+## CSS Custom Properties
+
+| Property                     | Default   | Description                          |
+|--------------------------------|-----------|------------------------------------------|
+| `--ease-modal-blur-amount`     | `16px`    | Starting blur radius of the modal box       |
+| `--ease-modal-blur-duration`   | `0.45s`   | Open/close transition duration              |
+| `--ease-modal-blur-easing`     | `cubic-bezier(0.16, 1, 0.3, 1)` | Transition easing curve |
+| `--ease-modal-bg`              | `#ffffff` | Modal background color                     |
+| `--ease-modal-radius`          | `14px`    | Modal corner radius                        |
+| `--ease-modal-max-width`       | `440px`   | Maximum modal width                        |
+
+## Usage
+
+```html
+<button class="ease-modal-trigger" id="openModalBtn">Open Modal</button>
+
+<div class="ease-modal-overlay" id="modalOverlay" role="dialog" aria-modal="true">
+  <div class="ease-modal" tabindex="-1">
+    <!-- modal content -->
+  </div>
+</div>
+```
+
+Toggle `ease-modal-overlay--open` on the overlay to open/close. Both the modal's own blur-to-focus and the overlay's backdrop blur animate together.
+
+## Accessibility
+
+- `role="dialog"`, `aria-modal="true"`, `aria-labelledby` on the overlay.
+- Full focus trap while open (Tab/Shift+Tab cycles within the modal).
+- Focus moves to close button on open, returns to trigger on close.
+- `Escape` key and backdrop click both close the modal.
+- `prefers-reduced-motion: reduce` collapses all transitions to near-instant.
+
+## Why it fits EaseMotion CSS
+
+Uses `ease-` prefixed classes and CSS custom properties for full blur/timing theming, consistent with the framework's zero-dependency, animation-first philosophy. Demonstrates a distinct animation technique (CSS `filter: blur()`) from opacity/transform-only entrance patterns already in the library.

--- a/submissions/examples/blur-entrance-modal-interactive-interface/demo.html
+++ b/submissions/examples/blur-entrance-modal-interactive-interface/demo.html
@@ -1,0 +1,81 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Blur-Entrance Modal Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: -apple-system, sans-serif; background: #f9fafb; padding: 60px; }
+  </style>
+</head>
+<body>
+  <h2>CSS Blur-Entrance Modal — Interactive Interface Layout</h2>
+
+  <button class="ease-modal-trigger" id="openModalBtn">Open Modal</button>
+
+  <div class="ease-modal-overlay" id="modalOverlay" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+    <div class="ease-modal" tabindex="-1">
+      <div class="ease-modal__header">
+        <span class="ease-modal__title" id="modalTitle">Blur Entrance</span>
+        <button class="ease-modal__close" id="closeModalBtn" aria-label="Close modal">✕</button>
+      </div>
+      <div class="ease-modal__body">
+        This modal enters with a blur-to-focus transition — starting fully blurred
+        and out of focus, then sharpening into view — built with the CSS `filter`
+        property and a backdrop blur on the overlay.
+      </div>
+      <div class="ease-modal__footer">
+        <button class="ease-modal__btn ease-modal__btn--ghost" id="cancelBtn">Cancel</button>
+        <button class="ease-modal__btn ease-modal__btn--primary" id="confirmBtn">Confirm</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const overlay = document.getElementById('modalOverlay');
+    const modal = overlay.querySelector('.ease-modal');
+    const openBtn = document.getElementById('openModalBtn');
+    const closeBtn = document.getElementById('closeModalBtn');
+    const cancelBtn = document.getElementById('cancelBtn');
+    const confirmBtn = document.getElementById('confirmBtn');
+
+    function getFocusable() {
+      return modal.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+    }
+
+    function openModal() {
+      overlay.classList.add('ease-modal-overlay--open');
+      closeBtn.focus();
+      document.addEventListener('keydown', handleKeydown);
+    }
+
+    function closeModal() {
+      overlay.classList.remove('ease-modal-overlay--open');
+      openBtn.focus();
+      document.removeEventListener('keydown', handleKeydown);
+    }
+
+    function handleKeydown(e) {
+      if (e.key === 'Escape') { closeModal(); return; }
+      if (e.key === 'Tab') {
+        const focusable = getFocusable();
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    openBtn.addEventListener('click', openModal);
+    closeBtn.addEventListener('click', closeModal);
+    cancelBtn.addEventListener('click', closeModal);
+    confirmBtn.addEventListener('click', closeModal);
+    overlay.addEventListener('click', (e) => { if (e.target === overlay) closeModal(); });
+  </script>
+</body>
+</html>

--- a/submissions/examples/blur-entrance-modal-interactive-interface/style.css
+++ b/submissions/examples/blur-entrance-modal-interactive-interface/style.css
@@ -1,0 +1,166 @@
+﻿:root {
+  --ease-modal-blur-amount: 16px;
+  --ease-modal-blur-duration: 0.45s;
+  --ease-modal-blur-easing: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-modal-bg: #ffffff;
+  --ease-modal-radius: 14px;
+  --ease-modal-max-width: 440px;
+  --ease-modal-backdrop-color: rgba(17, 24, 39, 0.55);
+  --ease-modal-focus-ring: #4f46e5;
+}
+
+.ease-modal-trigger {
+  padding: 10px 20px;
+  border-radius: 8px;
+  border: none;
+  background: #4f46e5;
+  color: #ffffff;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.ease-modal-trigger:hover {
+  background: #4338ca;
+  transform: translateY(-1px);
+}
+
+.ease-modal-trigger:focus-visible {
+  outline: 3px solid var(--ease-modal-focus-ring);
+  outline-offset: 2px;
+}
+
+.ease-modal-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--ease-modal-backdrop-color);
+  backdrop-filter: blur(0px);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity var(--ease-modal-blur-duration) var(--ease-modal-blur-easing),
+    backdrop-filter var(--ease-modal-blur-duration) var(--ease-modal-blur-easing),
+    visibility 0s linear var(--ease-modal-blur-duration);
+  z-index: 999;
+}
+
+.ease-modal-overlay.ease-modal-overlay--open {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  backdrop-filter: blur(4px);
+  transition: opacity var(--ease-modal-blur-duration) var(--ease-modal-blur-easing),
+    backdrop-filter var(--ease-modal-blur-duration) var(--ease-modal-blur-easing),
+    visibility 0s linear 0s;
+}
+
+.ease-modal {
+  width: 100%;
+  max-width: var(--ease-modal-max-width);
+  margin: 20px;
+  padding: 30px;
+  border-radius: var(--ease-modal-radius);
+  background: var(--ease-modal-bg);
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.25);
+  filter: blur(var(--ease-modal-blur-amount));
+  opacity: 0;
+  transform: scale(0.96);
+  transition: filter var(--ease-modal-blur-duration) var(--ease-modal-blur-easing),
+    opacity var(--ease-modal-blur-duration) var(--ease-modal-blur-easing),
+    transform var(--ease-modal-blur-duration) var(--ease-modal-blur-easing);
+}
+
+.ease-modal-overlay--open .ease-modal {
+  filter: blur(0px);
+  opacity: 1;
+  transform: scale(1);
+}
+
+.ease-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 14px;
+}
+
+.ease-modal__title {
+  font-size: 19px;
+  font-weight: 700;
+  color: #111827;
+}
+
+.ease-modal__close {
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 50%;
+  background: #f3f4f6;
+  color: #4b5563;
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.ease-modal__close:hover {
+  background: #e5e7eb;
+  transform: rotate(90deg);
+}
+
+.ease-modal__close:focus-visible {
+  outline: 3px solid var(--ease-modal-focus-ring);
+  outline-offset: 2px;
+}
+
+.ease-modal__body {
+  color: #4b5563;
+  font-size: 15px;
+  line-height: 1.7;
+}
+
+.ease-modal__footer {
+  margin-top: 22px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.ease-modal__btn {
+  padding: 9px 18px;
+  border-radius: 8px;
+  border: none;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.ease-modal__btn--primary {
+  background: #4f46e5;
+  color: #ffffff;
+}
+
+.ease-modal__btn--ghost {
+  background: transparent;
+  color: #4b5563;
+  border: 2px solid #e5e7eb;
+}
+
+.ease-modal__btn--ghost:hover {
+  background: #f3f4f6;
+}
+
+.ease-modal__btn:focus-visible {
+  outline: 3px solid var(--ease-modal-focus-ring);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-modal,
+  .ease-modal-overlay {
+    transition-duration: 0.01s !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS animated modal that enters with a blur-to-focus transition, styled for interactive interface layouts. Resolves #33980

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/blur-entrance-modal-interactive-interface/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS modal that enters with a blur-to-focus transition — starting fully out-of-focus via `filter: blur()` and sharpening into view — while the backdrop simultaneously gains a frosted `backdrop-filter` blur.

**How does a developer use it?**
```html
<button class="ease-modal-trigger" id="openModalBtn">Open Modal</button>

<div class="ease-modal-overlay" id="modalOverlay" role="dialog" aria-modal="true">
  <div class="ease-modal" tabindex="-1">
    <!-- modal content -->
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Uses `ease-` prefixed classes and CSS custom properties for full blur/timing theming, consistent with the framework's zero-dependency, animation-first philosophy. Demonstrates a distinct CSS technique (`filter: blur()`) rather than the more common opacity/transform-only entrance patterns.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome

---

## Notes for Maintainer
Both the modal's own blur and the overlay's `backdrop-filter` blur animate together for a cohesive "coming into focus" effect. Includes full focus trap, Escape-to-close, and `prefers-reduced-motion` support (collapses transitions to near-instant rather than removing the blur entirely, to avoid an abrupt pop-in). Happy to adjust default blur amount if preferred.