### PR TITLE
feat: add code-block-copy component (#36558)

### DIFF
--- a/submissions/examples/ease-code-block-copy-ij/README.md
+++ b/submissions/examples/ease-code-block-copy-ij/README.md
@@ -1,0 +1,36 @@
+# ease-code-block-copy
+
+> Issue #36558 — Code block with copy-to-clipboard feedback animation.
+
+A styled code-block component that reveals a copy button on hover and animates a "Copied!" feedback badge when text is copied.
+
+## CSS Custom Properties
+
+| Property               | Default   | Description                            |
+| ---------------------- | --------- | -------------------------------------- |
+| `--code-bg`            | `#1e1e2e` | Background of the code block           |
+| `--copy-btn-bg`        | `#313244` | Background of the copy button          |
+| `--copy-feedback-color`| `#a6e3a1` | Background of the feedback popup       |
+| `--feedback-duration`  | `1.5s`    | Duration of the copy feedback animation|
+
+## Usage
+
+```html
+<link rel="stylesheet" href="https://unpkg.com/easemotion/css/code-block-copy.css" />
+
+<div class="code-block-copy">
+  <pre>const msg = "Hello!";</pre>
+  <button class="copy-btn" aria-label="Copy code">…</button>
+  <div class="copy-feedback">Copied</div>
+</div>
+```
+
+Trigger the feedback by adding class `copied` to `.copy-feedback`:
+
+```js
+feedback.classList.add('copied');
+```
+
+## Animation
+
+The feedback element scales in, holds visible for most of the animation, then fades and scales out using the `copyFeedbackPop` keyframes. Timing is controlled entirely by `--feedback-duration`.

--- a/submissions/examples/ease-code-block-copy-ij/demo.html
+++ b/submissions/examples/ease-code-block-copy-ij/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-code-block-copy / Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      background: #11111b;
+      font-family: system-ui, -apple-system, sans-serif;
+      padding: 2rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="code-block-copy" style="width: 100%; max-width: 680px;">
+    <pre><span style="color:#89b4fa;">const</span> <span style="color:#fab387;">greet</span> <span style="color:#89b4fa;">=</span> <span style="color:#a6e3a1;">(</span><span style="color:#f38ba8;">name</span><span style="color:#a6e3a1;">)</span> <span style="color:#89b4fa;">=&gt;</span> <span style="color:#a6e3a1;">{</span>
+  <span style="color:#cba6f7;">console</span><span style="color:#89b4fa;">.log</span><span style="color:#a6e3a1;">(</span><span style="color:#a6adc8;">`Hello,</span> <span style="color:#f5c2e7;">${</span><span style="color:#f38ba8;">name</span><span style="color:#f5c2e7;">}</span><span style="color:#a6adc8;">!`</span><span style="color:#a6e3a1;">);</span>
+<span style="color:#a6e3a1;">};</span>
+
+<span style="color:#89b4fa;">const</span> <span style="color:#fab387;">users</span> <span style="color:#89b4fa;">=</span> <span style="color:#a6e3a1;">[</span><span style="color:#a6adc8;">'Alice'</span><span style="color:#a6e3a1;">,</span> <span style="color:#a6adc8;">'Bob'</span><span style="color:#a6e3a1;">,</span> <span style="color:#a6adc8;">'Charlie'</span><span style="color:#a6e3a1;">];</span>
+<span style="color:#fab387;">users</span><span style="color:#89b4fa;">.</span><span style="color:#cba6f7;">forEach</span><span style="color:#a6e3a1;">(</span><span style="color:#fab387;">greet</span><span style="color:#a6e3a1;">);</span></pre>
+    <button class="copy-btn" aria-label="Copy code" onclick="handleCopy(this)">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+        <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+      </svg>
+    </button>
+    <div class="copy-feedback" id="feedback">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+      Copied
+    </div>
+  </div>
+
+  <script>
+    function handleCopy(btn) {
+      const block = btn.closest('.code-block-copy');
+      const code = block.querySelector('pre').textContent;
+      navigator.clipboard.writeText(code).then(() => {
+        const feedback = block.querySelector('.copy-feedback');
+        feedback.classList.remove('copied');
+        void feedback.offsetWidth;
+        feedback.classList.add('copied');
+      });
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-code-block-copy-ij/style.css
+++ b/submissions/examples/ease-code-block-copy-ij/style.css
@@ -1,0 +1,90 @@
+.code-block-copy {
+  --code-bg: #1e1e2e;
+  --copy-btn-bg: #313244;
+  --copy-feedback-color: #a6e3a1;
+  --feedback-duration: 1.5s;
+
+  position: relative;
+  background: var(--code-bg);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.code-block-copy pre {
+  margin: 0;
+  padding: 1.25rem 1rem;
+  overflow-x: auto;
+  font-family: 'Cascadia Code', 'Fira Code', 'JetBrains Mono', monospace;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  color: #cdd6f4;
+}
+
+.code-block-copy .copy-btn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: var(--copy-btn-bg);
+  color: #a6adc8;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.code-block-copy:hover .copy-btn {
+  opacity: 1;
+}
+
+.code-block-copy .copy-btn svg {
+  width: 16px;
+  height: 16px;
+}
+
+.code-block-copy .copy-feedback {
+  position: absolute;
+  top: 0.5rem;
+  right: 3rem;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: 6px;
+  background: var(--copy-feedback-color);
+  color: #1e1e2e;
+  font-size: 0.75rem;
+  font-weight: 600;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(-4px);
+}
+
+.code-block-copy .copy-feedback.copied {
+  animation: copyFeedbackPop var(--feedback-duration) ease forwards;
+}
+
+@keyframes copyFeedbackPop {
+  0% {
+    opacity: 0;
+    transform: translateY(-4px) scale(0.9);
+  }
+  15% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  70% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-4px) scale(0.9);
+  }
+}


### PR DESCRIPTION
## Component: ease-code-block-copy - Code block with copy-to-clipboard feedback animation

**Closes #36558**

### Acceptance Criteria
- [x] CSS-only animated component with @keyframes
- [x] Custom properties via CSS variables
- [x] Interactive demo page
- [x] README with documentation

### Files
- submissions/examples/ease-code-block-copy-ij/demo.html
- submissions/examples/ease-code-block-copy-ij/style.css
- submissions/examples/ease-code-block-copy-ij/README.md

### Review Instructions
Open demo.html in a browser and verify the animation works. Check that CSS variables can be customized.
