### PR TITLE
feat: add code-snippet-fade component (#36559)

### DIFF
--- a/submissions/examples/ease-code-snippet-fade-ij/README.md
+++ b/submissions/examples/ease-code-snippet-fade-ij/README.md
@@ -1,0 +1,31 @@
+# ease-code-snippet-fade
+
+> Issue #36559 — Code snippet with fade-in line reveals.
+
+Lines of code fade and slide in sequentially, creating a smooth typewriter-like reveal effect.
+
+## CSS Custom Properties
+
+| Property          | Default    | Description                                |
+| ----------------- | ---------- | ------------------------------------------ |
+| `--snippet-bg`    | `#1e1e2e`  | Background of the snippet container        |
+| `--line-color`    | `#cdd6f4`  | Text colour of each line                   |
+| `--fade-duration` | `0.5s`     | Duration of the fade-in animation per line |
+| `--line-delay`    | `0.08s`    | Stagger delay between each line            |
+
+## Usage
+
+```html
+<link rel="stylesheet" href="https://unpkg.com/easemotion/css/code-snippet-fade.css" />
+
+<div class="code-snippet-fade">
+  <span class="snippet-line">const x = 1;</span>
+  <span class="snippet-line">const y = 2;</span>
+</div>
+```
+
+Each line must be wrapped in a `<span class="snippet-line">`. Lines animate on page load. To replay, remove and re-add the `snippetFadeIn` animation.
+
+## Animation
+
+`snippetFadeIn` fades from `opacity: 0; translateY(6px)` to `opacity: 1; translateY(0)`. Lines target up to the 10th child with incremental `animation-delay` using `--line-delay`.

--- a/submissions/examples/ease-code-snippet-fade-ij/demo.html
+++ b/submissions/examples/ease-code-snippet-fade-ij/demo.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-code-snippet-fade / Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      background: #11111b;
+      font-family: system-ui, -apple-system, sans-serif;
+      padding: 2rem;
+    }
+    .controls {
+      position: fixed;
+      bottom: 2rem;
+      left: 50%;
+      transform: translateX(-50%);
+      display: flex;
+      gap: 0.75rem;
+    }
+    .controls button {
+      padding: 0.5rem 1.25rem;
+      border: none;
+      border-radius: 6px;
+      background: #313244;
+      color: #cdd6f4;
+      font-size: 0.875rem;
+      cursor: pointer;
+    }
+    .controls button:hover { background: #45475a; }
+  </style>
+</head>
+<body>
+  <div class="code-snippet-fade" style="width: 100%; max-width: 620px;" id="snippet">
+    <span class="snippet-line"><span style="color:#89b4fa;">import</span> <span style="color:#a6e3a1;">{</span> <span style="color:#fab387;">useState</span> <span style="color:#a6e3a1;">}</span> <span style="color:#89b4fa;">from</span> <span style="color:#a6adc8;">'react'</span><span style="color:#89b4fa;">;</span></span>
+    <span class="snippet-line"></span>
+    <span class="snippet-line"><span style="color:#89b4fa;">const</span> <span style="color:#fab387;">Counter</span> <span style="color:#89b4fa;">=</span> <span style="color:#a6e3a1;">()</span> <span style="color:#89b4fa;">=&gt;</span> <span style="color:#a6e3a1;">{</span></span>
+    <span class="snippet-line">  <span style="color:#89b4fa;">const</span> <span style="color:#a6e3a1;">[</span><span style="color:#f38ba8;">count</span><span style="color:#a6e3a1;">,</span> <span style="color:#f38ba8;">setCount</span><span style="color:#a6e3a1;">]</span> <span style="color:#89b4fa;">=</span> <span style="color:#fab387;">useState</span><span style="color:#a6e3a1;">(</span><span style="color:#fab387;">0</span><span style="color:#a6e3a1;">);</span></span>
+    <span class="snippet-line">  <span style="color:#89b4fa;">const</span> <span style="color:#fab387;">increment</span> <span style="color:#89b4fa;">=</span> <span style="color:#a6e3a1;">()</span> <span style="color:#89b4fa;">=&gt;</span> <span style="color:#a6e3a1;">{</span></span>
+    <span class="snippet-line">    <span style="color:#fab387;">setCount</span><span style="color:#a6e3a1;">(</span><span style="color:#f38ba8;">prev</span> <span style="color:#89b4fa;">=&gt;</span> <span style="color:#f38ba8;">prev</span> <span style="color:#89b4fa;">+</span> <span style="color:#fab387;">1</span><span style="color:#a6e3a1;">);</span></span>
+    <span class="snippet-line">  <span style="color:#a6e3a1;">};</span></span>
+    <span class="snippet-line">  <span style="color:#89b4fa;">return</span> <span style="color:#a6e3a1;">&lt;</span><span style="color:#cba6f7;">button</span> <span style="color:#89b4fa;">onClick=</span><span style="color:#a6e3a1;">{</span><span style="color:#fab387;">increment</span><span style="color:#a6e3a1;">}&gt;{</span><span style="color:#fab387;">count</span><span style="color:#a6e3a1;">}&lt;/</span><span style="color:#cba6f7;">button</span><span style="color:#a6e3a1;">&gt;;</span></span>
+    <span class="snippet-line"><span style="color:#a6e3a1;">};</span></span>
+    <span class="snippet-line"></span>
+    <span class="snippet-line"><span style="color:#89b4fa;">export</span> <span style="color:#89b4fa;">default</span> <span style="color:#fab387;">Counter</span><span style="color:#89b4fa;">;</span></span>
+  </div>
+
+  <div class="controls">
+    <button onclick="replay()">Replay</button>
+  </div>
+
+  <script>
+    function replay() {
+      const snippet = document.getElementById('snippet');
+      const lines = snippet.querySelectorAll('.snippet-line');
+      lines.forEach(line => {
+        line.style.animation = 'none';
+        void line.offsetWidth;
+        line.style.animation = '';
+      });
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-code-snippet-fade-ij/style.css
+++ b/submissions/examples/ease-code-snippet-fade-ij/style.css
@@ -1,0 +1,40 @@
+.code-snippet-fade {
+  --snippet-bg: #1e1e2e;
+  --line-color: #cdd6f4;
+  --fade-duration: 0.5s;
+  --line-delay: 0.08s;
+
+  background: var(--snippet-bg);
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  font-family: 'Cascadia Code', 'Fira Code', 'JetBrains Mono', monospace;
+  font-size: 0.875rem;
+  line-height: 1.7;
+  overflow-x: auto;
+}
+
+.code-snippet-fade .snippet-line {
+  display: block;
+  color: var(--line-color);
+  opacity: 0;
+  transform: translateY(6px);
+  animation: snippetFadeIn var(--fade-duration) ease forwards;
+}
+
+.code-snippet-fade .snippet-line:nth-child(1) { animation-delay: calc(var(--line-delay) * 1); }
+.code-snippet-fade .snippet-line:nth-child(2) { animation-delay: calc(var(--line-delay) * 2); }
+.code-snippet-fade .snippet-line:nth-child(3) { animation-delay: calc(var(--line-delay) * 3); }
+.code-snippet-fade .snippet-line:nth-child(4) { animation-delay: calc(var(--line-delay) * 4); }
+.code-snippet-fade .snippet-line:nth-child(5) { animation-delay: calc(var(--line-delay) * 5); }
+.code-snippet-fade .snippet-line:nth-child(6) { animation-delay: calc(var(--line-delay) * 6); }
+.code-snippet-fade .snippet-line:nth-child(7) { animation-delay: calc(var(--line-delay) * 7); }
+.code-snippet-fade .snippet-line:nth-child(8) { animation-delay: calc(var(--line-delay) * 8); }
+.code-snippet-fade .snippet-line:nth-child(9) { animation-delay: calc(var(--line-delay) * 9); }
+.code-snippet-fade .snippet-line:nth-child(10) { animation-delay: calc(var(--line-delay) * 10); }
+
+@keyframes snippetFadeIn {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION
## Component: ease-code-snippet-fade - Code snippet with fade-in line reveals

**Closes #36559**

### Acceptance Criteria
- [x] CSS-only animated component with @keyframes
- [x] Custom properties via CSS variables
- [x] Interactive demo page
- [x] README with documentation

### Files
- submissions/examples/ease-code-snippet-fade-ij/demo.html
- submissions/examples/ease-code-snippet-fade-ij/style.css
- submissions/examples/ease-code-snippet-fade-ij/README.md

### Review Instructions
Open demo.html in a browser and verify the animation works. Check that CSS variables can be customized.
