### PR TITLE
feat: add connection-line-draw component (#36566)

### DIFF
--- a/submissions/examples/ease-connection-line-draw-ij/README.md
+++ b/submissions/examples/ease-connection-line-draw-ij/README.md
@@ -1,0 +1,18 @@
+# Connection Line Draw
+
+**Issue:** #36566
+
+Connection line drawing between nodes using SVG `stroke-dasharray` / `stroke-dashoffset` animation.
+
+## CSS Custom Properties
+
+| Variable         | Default    | Description                     |
+|------------------|------------|---------------------------------|
+| `--line-color`   | `#89b4fa`  | Color of connection lines       |
+| `--node-color`   | `#cba6f7`  | Fill color of graph nodes       |
+| `--stroke-width` | `2.5`      | Stroke width of lines           |
+| `--draw-duration`| `1.2s`     | Duration of the line draw anim  |
+
+## Usage
+
+Place SVG lines with class `.conn-line` and circles with class `.graph-node` inside a container. Add `.drawn` class to lines to trigger the draw animation. Use the Redraw button or call `redrawLines()` to replay.

--- a/submissions/examples/ease-connection-line-draw-ij/demo.html
+++ b/submissions/examples/ease-connection-line-draw-ij/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Connection Line Draw</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="graph-container">
+    <svg class="connection-svg" viewBox="0 0 600 350" preserveAspectRatio="xMidYMid meet">
+      <line class="conn-line" x1="100" y1="80" x2="300" y2="80" />
+      <line class="conn-line" x1="300" y1="80" x2="300" y2="230" />
+      <line class="conn-line" x1="300" y1="230" x2="500" y2="230" />
+      <line class="conn-line" x1="300" y1="230" x2="300" y2="290" />
+      <line class="conn-line" x1="100" y1="80" x2="100" y2="290" />
+      <line class="conn-line" x1="100" y1="290" x2="300" y2="290" />
+
+      <circle class="graph-node" cx="100" cy="80" r="18" />
+      <circle class="graph-node" cx="300" cy="80" r="18" />
+      <circle class="graph-node" cx="300" cy="230" r="18" />
+      <circle class="graph-node" cx="500" cy="230" r="18" />
+      <circle class="graph-node" cx="100" cy="290" r="18" />
+      <circle class="graph-node" cx="300" cy="290" r="18" />
+    </svg>
+
+    <button class="redraw-btn" onclick="redrawLines()">Redraw</button>
+  </div>
+
+  <script>
+    function redrawLines() {
+      const lines = document.querySelectorAll('.conn-line');
+      lines.forEach((line) => {
+        line.classList.remove('drawn');
+        void line.offsetWidth;
+        line.classList.add('drawn');
+      });
+    }
+
+    document.addEventListener('DOMContentLoaded', redrawLines);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-connection-line-draw-ij/style.css
+++ b/submissions/examples/ease-connection-line-draw-ij/style.css
@@ -1,0 +1,96 @@
+:root {
+  --line-color: #89b4fa;
+  --node-color: #cba6f7;
+  --stroke-width: 2.5;
+  --draw-duration: 1.2s;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background: #11111b;
+}
+
+.graph-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
+
+.connection-svg {
+  width: 600px;
+  max-width: 90vw;
+  height: auto;
+}
+
+.conn-line {
+  stroke: var(--line-color);
+  stroke-width: var(--stroke-width);
+  stroke-linecap: round;
+  fill: none;
+  stroke-dasharray: 600;
+  stroke-dashoffset: 600;
+}
+
+.conn-line.drawn {
+  animation: draw-line var(--draw-duration) ease-out forwards;
+}
+
+.conn-line.drawn:nth-child(1) { animation-delay: 0.0s; }
+.conn-line.drawn:nth-child(2) { animation-delay: 0.2s; }
+.conn-line.drawn:nth-child(3) { animation-delay: 0.4s; }
+.conn-line.drawn:nth-child(4) { animation-delay: 0.6s; }
+.conn-line.drawn:nth-child(5) { animation-delay: 0.8s; }
+.conn-line.drawn:nth-child(6) { animation-delay: 1.0s; }
+
+@keyframes draw-line {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+.graph-node {
+  fill: var(--node-color);
+  stroke: #1e1e2e;
+  stroke-width: 3;
+  opacity: 0;
+  animation: fade-in 0.3s ease-out forwards;
+}
+
+.graph-node:nth-child(7)  { animation-delay: 0.1s; }
+.graph-node:nth-child(8)  { animation-delay: 0.3s; }
+.graph-node:nth-child(9)  { animation-delay: 0.5s; }
+.graph-node:nth-child(10) { animation-delay: 0.7s; }
+.graph-node:nth-child(11) { animation-delay: 0.9s; }
+.graph-node:nth-child(12) { animation-delay: 1.1s; }
+
+@keyframes fade-in {
+  to {
+    opacity: 1;
+  }
+}
+
+.redraw-btn {
+  padding: 10px 24px;
+  font-size: 0.9rem;
+  background: #45475a;
+  color: #cdd6f4;
+  border: none;
+  border-radius: 7px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.redraw-btn:hover {
+  background: #585b70;
+}


### PR DESCRIPTION
## Component: ease-connection-line-draw - Connection line drawing between nodes

**Closes #36566**

### Acceptance Criteria
- [x] CSS-only animated component with @keyframes
- [x] Custom properties via CSS variables
- [x] Interactive demo page
- [x] README with documentation

### Files
- submissions/examples/ease-connection-line-draw-ij/demo.html
- submissions/examples/ease-connection-line-draw-ij/style.css
- submissions/examples/ease-connection-line-draw-ij/README.md

### Review Instructions
Open demo.html in a browser and verify the animation works. Check that CSS variables can be customized.
