### PR TITLE
feat: add CSS 3D Perspective Tilt Accordion for Interactive Interface Layouts

### DIFF
--- a/submissions/examples/3d-perspective-tilt-accordion-interactive-interface/README.md
+++ b/submissions/examples/3d-perspective-tilt-accordion-interactive-interface/README.md
@@ -1,0 +1,46 @@
+﻿# CSS 3D Perspective Tilt Accordion — Interactive Interface Layout
+
+A pure CSS accordion where each item subtly tilts in 3D space on hover using `perspective` and `rotateX`, flattening back to neutral when expanded.
+
+## CSS Custom Properties
+
+| Property                        | Default   | Description                          |
+|------------------------------------|-----------|------------------------------------------|
+| `--ease-accordion-tilt-angle`      | `6deg`    | Hover tilt rotation angle                  |
+| `--ease-accordion-perspective`     | `800px`   | 3D perspective depth for the container      |
+| `--ease-accordion-duration`        | `0.4s`    | Transition duration                        |
+| `--ease-accordion-easing`          | `cubic-bezier(0.4, 0, 0.2, 1)` | Transition easing curve |
+| `--ease-accordion-bg`              | `#ffffff` | Item background color                      |
+| `--ease-accordion-accent`          | `#4f46e5` | Icon and focus ring color                  |
+| `--ease-accordion-radius`          | `12px`    | Item corner radius                         |
+
+## Usage
+
+```html
+<div class="ease-accordion">
+  <div class="ease-accordion__item">
+    <button class="ease-accordion__header" aria-expanded="false">
+      Question
+      <svg class="ease-accordion__icon">...</svg>
+    </button>
+    <div class="ease-accordion__panel">
+      <div class="ease-accordion__panel-inner">
+        <div class="ease-accordion__body">Answer content</div>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+Toggle the `ease-accordion__item--open` class on an item and `aria-expanded` on its header (see `demo.html` for the toggle logic). The expand/collapse itself uses a `grid-template-rows: 0fr → 1fr` technique for smooth height animation without JS-measured heights.
+
+## Accessibility
+
+- Each header is a real `<button>` with `aria-expanded` reflecting state.
+- Fully keyboard operable (native button focus/Enter/Space).
+- Visible `:focus-visible` outline on headers.
+- `prefers-reduced-motion: reduce` disables the tilt transform, keeping only a subtle shadow change.
+
+## Why it fits EaseMotion CSS
+
+Uses `ease-` prefixed classes and CSS custom properties for tilt/timing theming, consistent with the framework's zero-dependency philosophy. The `grid-template-rows` expand technique avoids the common `max-height` hack, giving a smoother, content-agnostic collapse animation.

--- a/submissions/examples/3d-perspective-tilt-accordion-interactive-interface/demo.html
+++ b/submissions/examples/3d-perspective-tilt-accordion-interactive-interface/demo.html
@@ -1,0 +1,85 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>3D Perspective Tilt Accordion Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: -apple-system, sans-serif; background: #f9fafb; padding: 60px; }
+  </style>
+</head>
+<body>
+  <h2>CSS 3D Perspective Tilt Accordion — Interactive Interface Layout</h2>
+
+  <div class="ease-accordion" id="accordion">
+    <div class="ease-accordion__item">
+      <button class="ease-accordion__header" aria-expanded="false">
+        What is EaseMotion CSS?
+        <svg class="ease-accordion__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M6 9l6 6 6-6" />
+        </svg>
+      </button>
+      <div class="ease-accordion__panel">
+        <div class="ease-accordion__panel-inner">
+          <div class="ease-accordion__body">
+            An animation-first CSS framework with zero-dependency, copy-paste ready components.
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="ease-accordion__item">
+      <button class="ease-accordion__header" aria-expanded="false">
+        How does the tilt effect work?
+        <svg class="ease-accordion__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M6 9l6 6 6-6" />
+        </svg>
+      </button>
+      <div class="ease-accordion__panel">
+        <div class="ease-accordion__panel-inner">
+          <div class="ease-accordion__body">
+            Each item subtly rotates on the X-axis on hover using CSS `perspective` and `rotateX`, then flattens back on open.
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="ease-accordion__item">
+      <button class="ease-accordion__header" aria-expanded="false">
+        Is it accessible?
+        <svg class="ease-accordion__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M6 9l6 6 6-6" />
+        </svg>
+      </button>
+      <div class="ease-accordion__panel">
+        <div class="ease-accordion__panel-inner">
+          <div class="ease-accordion__body">
+            Yes — full keyboard support, aria-expanded state, and reduced-motion fallback.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const items = document.querySelectorAll('.ease-accordion__item');
+
+    items.forEach((item) => {
+      const header = item.querySelector('.ease-accordion__header');
+      header.addEventListener('click', () => {
+        const isOpen = item.classList.contains('ease-accordion__item--open');
+
+        items.forEach((other) => {
+          other.classList.remove('ease-accordion__item--open');
+          other.querySelector('.ease-accordion__header').setAttribute('aria-expanded', 'false');
+        });
+
+        if (!isOpen) {
+          item.classList.add('ease-accordion__item--open');
+          header.setAttribute('aria-expanded', 'true');
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/3d-perspective-tilt-accordion-interactive-interface/style.css
+++ b/submissions/examples/3d-perspective-tilt-accordion-interactive-interface/style.css
@@ -1,0 +1,100 @@
+﻿:root {
+  --ease-accordion-tilt-angle: 6deg;
+  --ease-accordion-perspective: 800px;
+  --ease-accordion-duration: 0.4s;
+  --ease-accordion-easing: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-accordion-bg: #ffffff;
+  --ease-accordion-accent: #4f46e5;
+  --ease-accordion-radius: 12px;
+}
+
+.ease-accordion {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 520px;
+  perspective: var(--ease-accordion-perspective);
+}
+
+.ease-accordion__item {
+  border: 1px solid #e5e7eb;
+  border-radius: var(--ease-accordion-radius);
+  background: var(--ease-accordion-bg);
+  overflow: hidden;
+  transform-style: preserve-3d;
+  transition: transform var(--ease-accordion-duration) var(--ease-accordion-easing),
+    box-shadow var(--ease-accordion-duration) var(--ease-accordion-easing);
+}
+
+.ease-accordion__item:hover {
+  transform: rotateX(var(--ease-accordion-tilt-angle)) scale(1.01);
+  box-shadow: 0 12px 30px rgba(79, 70, 229, 0.15);
+}
+
+.ease-accordion__item--open {
+  transform: rotateX(0deg);
+  box-shadow: 0 8px 24px rgba(79, 70, 229, 0.12);
+}
+
+.ease-accordion__header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 15px;
+  font-weight: 600;
+  color: #111827;
+  text-align: left;
+}
+
+.ease-accordion__header:focus-visible {
+  outline: 3px solid var(--ease-accordion-accent);
+  outline-offset: -3px;
+}
+
+.ease-accordion__icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  transition: transform var(--ease-accordion-duration) var(--ease-accordion-easing);
+  color: var(--ease-accordion-accent);
+}
+
+.ease-accordion__item--open .ease-accordion__icon {
+  transform: rotate(180deg);
+}
+
+.ease-accordion__panel {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows var(--ease-accordion-duration) var(--ease-accordion-easing);
+}
+
+.ease-accordion__item--open .ease-accordion__panel {
+  grid-template-rows: 1fr;
+}
+
+.ease-accordion__panel-inner {
+  overflow: hidden;
+}
+
+.ease-accordion__body {
+  padding: 0 20px 18px;
+  color: #4b5563;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-accordion__item {
+    transition: box-shadow var(--ease-accordion-duration) ease;
+  }
+  .ease-accordion__item:hover,
+  .ease-accordion__item--open {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS accordion component with a 3D perspective tilt hover effect, styled for interactive interface layouts. Resolves #33167

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/3d-perspective-tilt-accordion-interactive-interface/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS accordion where each item subtly tilts in 3D space on hover via `perspective` and `rotateX`, flattening back to neutral when expanded, with a smooth `grid-template-rows` expand/collapse animation.

**How does a developer use it?**
```html
<div class="ease-accordion">
  <div class="ease-accordion__item">
    <button class="ease-accordion__header" aria-expanded="false">
      Question
      <svg class="ease-accordion__icon">...</svg>
    </button>
    <div class="ease-accordion__panel">
      <div class="ease-accordion__panel-inner">
        <div class="ease-accordion__body">Answer content</div>
      </div>
    </div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Uses `ease-` prefixed classes and CSS custom properties for tilt angle/timing theming, consistent with the framework's zero-dependency, animation-first philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome

---

## Notes for Maintainer
Uses `grid-template-rows: 0fr → 1fr` for the expand/collapse instead of a `max-height` hack, so it works cleanly regardless of content length. Includes native `<button>` headers with `aria-expanded`, full keyboard support, and `prefers-reduced-motion` fallback (disables the tilt transform, keeps only a subtle shadow change). Happy to adjust the tilt angle if preferred.