### PR TITLE
feat: add draw-svg-path-animate component (#36608)

### DIFF
--- a/submissions/examples/ease-draw-svg-path-animate-ij/README.md
+++ b/submissions/examples/ease-draw-svg-path-animate-ij/README.md
@@ -1,0 +1,24 @@
+# ease-draw-svg-path-animate
+
+**Issue #36608** — Animated SVG path drawing using `stroke-dasharray` / `stroke-dashoffset`.
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `--stroke-color` | `#a29bfe` | Color of the drawn path stroke |
+| `--stroke-width` | `3` | Width of the stroke |
+| `--draw-duration` | `2s` | Duration of the draw animation |
+| `--path-bg` | `#1a1a2e` | Background of the SVG container |
+
+## Usage
+
+```html
+<div class="ease-draw-svg">
+  <svg class="ease-draw-svg__svg" viewBox="0 0 200 200">
+    <path class="ease-draw-svg__path" d="..." style="--path-length: 360"/>
+  </svg>
+</div>
+```
+
+Each `<path>` needs a `--path-length` custom property equal to its total length (use `path.getTotalLength()` in JS). The CSS animation reduces `stroke-dashoffset` from `--path-length` to `0`.

--- a/submissions/examples/ease-draw-svg-path-animate-ij/demo.html
+++ b/submissions/examples/ease-draw-svg-path-animate-ij/demo.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion — Draw SVG Path Animate</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      background: #0f0f1a;
+      color: #e0e0e0;
+      font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .card {
+      background: #16162a;
+      border-radius: 1.25rem;
+      padding: 2rem;
+      max-width: 620px;
+      width: 100%;
+      margin: 2rem;
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+      text-align: center;
+    }
+    .card__title {
+      font-size: 1.5rem;
+      font-weight: 700;
+      margin-bottom: 0.25rem;
+      color: #fff;
+    }
+    .card__subtitle {
+      font-size: 0.875rem;
+      opacity: 0.6;
+      margin-bottom: 1.5rem;
+    }
+    .controls {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+      justify-content: center;
+      margin-bottom: 1.5rem;
+    }
+    .controls label {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+      font-size: 0.75rem;
+      opacity: 0.7;
+    }
+    .controls input[type="color"],
+    .controls input[type="range"] {
+      cursor: pointer;
+      background: #2d2d3d;
+      border: 1px solid #3d3d5c;
+      border-radius: 0.375rem;
+      padding: 0.25rem;
+    }
+    .btn {
+      background: #2d2d3d;
+      border: none;
+      color: #e0e0e0;
+      padding: 0.5rem 1.25rem;
+      border-radius: 0.5rem;
+      cursor: pointer;
+      font-size: 0.875rem;
+      transition: background 0.2s;
+      margin-top: 1rem;
+    }
+    .btn:hover { background: #3d3d5c; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1 class="card__title">✏️ Draw SVG Path Animate</h1>
+    <p class="card__subtitle">Issue #36608 — line-drawing stroke animation on SVG paths</p>
+
+    <div class="controls">
+      <label>Stroke Color
+        <input type="color" id="strokeColor" value="#a29bfe">
+      </label>
+      <label>Path BG
+        <input type="color" id="pathBg" value="#1a1a2e">
+      </label>
+      <label>Stroke Width
+        <input type="range" id="strokeWidth" min="1" max="8" step="0.5" value="3">
+        <span id="swVal">3</span>
+      </label>
+      <label>Draw Duration
+        <input type="range" id="drawDuration" min="0.5" max="6" step="0.25" value="2">
+        <span id="durVal">2s</span>
+      </label>
+    </div>
+
+    <div class="ease-draw-svg" id="svgContainer">
+      <svg class="ease-draw-svg__svg" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+        <path class="ease-draw-svg__path" id="svgPath"
+              d="M20 100 Q50 20 100 100 T180 100"
+              style="--path-length: 360"/>
+      </svg>
+    </div>
+
+    <button class="btn" id="replayBtn">↻ Replay Drawing</button>
+  </div>
+
+  <script>
+    const container = document.getElementById('svgContainer');
+    const path = document.getElementById('svgPath');
+
+    function replay() {
+      path.style.animation = 'none';
+      void path.offsetWidth;
+      path.style.animation = '';
+    }
+
+    document.getElementById('replayBtn').addEventListener('click', replay);
+
+    document.getElementById('strokeColor').addEventListener('input', e => {
+      container.style.setProperty('--stroke-color', e.target.value);
+    });
+    document.getElementById('pathBg').addEventListener('input', e => {
+      container.style.setProperty('--path-bg', e.target.value);
+    });
+    document.getElementById('strokeWidth').addEventListener('input', e => {
+      const v = e.target.value;
+      container.style.setProperty('--stroke-width', v);
+      document.getElementById('swVal').textContent = v;
+      replay();
+    });
+    document.getElementById('drawDuration').addEventListener('input', e => {
+      const v = e.target.value + 's';
+      container.style.setProperty('--draw-duration', v);
+      document.getElementById('durVal').textContent = v;
+      replay();
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-draw-svg-path-animate-ij/style.css
+++ b/submissions/examples/ease-draw-svg-path-animate-ij/style.css
@@ -1,0 +1,52 @@
+.ease-draw-svg {
+  --stroke-color: #a29bfe;
+  --stroke-width: 3;
+  --draw-duration: 2s;
+  --path-bg: #1a1a2e;
+
+  position: relative;
+  width: 100%;
+  max-width: 500px;
+  aspect-ratio: 1 / 1;
+  background: var(--path-bg);
+  border-radius: 1rem;
+  overflow: hidden;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ease-draw-svg__svg {
+  width: 80%;
+  height: 80%;
+  display: block;
+}
+
+.ease-draw-svg__path {
+  fill: none;
+  stroke: var(--stroke-color);
+  stroke-width: var(--stroke-width);
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-dasharray: var(--path-length, 1000);
+  stroke-dashoffset: var(--path-length, 1000);
+  animation: ease-svg-draw var(--draw-duration) ease-in-out forwards;
+}
+
+.ease-draw-svg__path.fade-in {
+  animation: ease-svg-draw var(--draw-duration) ease-in-out forwards,
+             ease-svg-fade 0.5s ease forwards;
+}
+
+@keyframes ease-svg-draw {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+@keyframes ease-svg-fade {
+  to {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Component: ease-draw-svg-path-animate - Draw SVG path animate with line-drawing stroke

**Closes #36608**

### Acceptance Criteria
- [x] CSS-only animated component with @keyframes
- [x] Custom properties via CSS variables
- [x] Interactive demo page
- [x] README with documentation

### Files
- submissions/examples/ease-draw-svg-path-animate-ij/demo.html
- submissions/examples/ease-draw-svg-path-animate-ij/style.css
- submissions/examples/ease-draw-svg-path-animate-ij/README.md

### Review Instructions
Open demo.html in a browser and verify the animation works. Check that CSS variables can be customized.
