### PR TITLE
feat: add dial-code-dropdown component (#36612)

### DIFF
--- a/submissions/examples/ease-dial-code-dropdown-ij/README.md
+++ b/submissions/examples/ease-dial-code-dropdown-ij/README.md
@@ -1,0 +1,34 @@
+# Ease Dial Code Dropdown
+
+## What does this do?
+A country dial code picker dropdown with search filtering. Displays the selected country flag, name, and code in the trigger. Features a smooth fade+slide expand animation, real-time search filtering, and hover highlight on items.
+
+## How is it used?
+```html
+<div class="ease-dial-dropdown">
+  <div class="ease-dial-dropdown__trigger" data-trigger>
+    <span class="ease-dial-dropdown__flag"> </span>
+    <span data-trigger-name>United States</span>
+    <span class="ease-dial-dropdown__code" data-trigger-code>+1</span>
+    <svg class="ease-dial-dropdown__arrow">▾</svg>
+  </div>
+  <div class="ease-dial-dropdown__menu" data-menu>
+    <input class="ease-dial-dropdown__search" type="text" placeholder="Search...">
+    <div data-items>
+      <div class="ease-dial-dropdown__item" data-code="+1" data-name="United States">...</div>
+    </div>
+  </div>
+</div>
+```
+Toggle `is-open` on the container to show/hide. Set `is-selected` on the active item. The demo JS handles search filtering and selection sync.
+
+## CSS Custom Properties
+| Prop | Default | Description |
+|------|---------|-------------|
+| `--dropdown-bg` | `#1e293b` | Background of trigger and menu |
+| `--flag-size` | `22px` | Width of flag elements |
+| `--item-hover-bg` | `#334155` | Hover/selected item background |
+| `--expand-duration` | `0.3s` | Dropdown expand animation speed |
+
+## Why is it useful?
+Dial code pickers are essential in international phone input forms, sign-up flows, and contact forms. The search filter makes it easy to find countries from a long list, and the flag + code display provides clear feedback on the current selection.

--- a/submissions/examples/ease-dial-code-dropdown-ij/demo.html
+++ b/submissions/examples/ease-dial-code-dropdown-ij/demo.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Ease Dial Code Dropdown</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: #0f172a;
+    padding: 80px 40px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 60px;
+    min-height: 100vh;
+    margin: 0;
+  }
+  h2 { color: #e2e8f0; margin: 0 0 20px; font-weight: 500; font-size: 18px; }
+  .demo-card {
+    background: #1e293b;
+    border-radius: 12px;
+    padding: 32px;
+    width: 340px;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.4);
+  }
+  .demo-row {
+    display: flex;
+    gap: 24px;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+  .demo-dial-code {
+    display: flex;
+    gap: 10px;
+    margin-top: 16px;
+    align-items: center;
+  }
+  .demo-phone-input {
+    flex: 1;
+    padding: 10px 14px;
+    border-radius: 8px;
+    border: 1px solid #334155;
+    background: #0f172a;
+    color: #e2e8f0;
+    font-size: 14px;
+    outline: none;
+    transition: border-color 0.2s;
+    box-sizing: border-box;
+  }
+  .demo-phone-input:focus {
+    border-color: #6366f1;
+  }
+</style>
+</head>
+<body>
+
+  <div class="demo-row">
+    <div class="demo-card">
+      <h2>Country Dial Code</h2>
+      <div class="ease-dial-dropdown" data-dial>
+        <div class="ease-dial-dropdown__trigger" data-trigger>
+          <span class="ease-dial-dropdown__flag" data-trigger-flag style="background: #6366f1;"> </span>
+          <span data-trigger-name>United States</span>
+          <span class="ease-dial-dropdown__code" data-trigger-code>+1</span>
+          <svg class="ease-dial-dropdown__arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
+        </div>
+        <div class="ease-dial-dropdown__menu" data-menu>
+          <input class="ease-dial-dropdown__search" type="text" placeholder="Search country..." data-search>
+          <div data-items>
+            <div class="ease-dial-dropdown__item is-selected" data-code="+1" data-name="United States">
+              <span class="ease-dial-dropdown__item-flag" style="background: #6366f1;"> </span>
+              <span class="ease-dial-dropdown__item-name">United States</span>
+              <span class="ease-dial-dropdown__item-code">+1</span>
+            </div>
+            <div class="ease-dial-dropdown__item" data-code="+44" data-name="United Kingdom">
+              <span class="ease-dial-dropdown__item-flag" style="background: #3b82f6;"> </span>
+              <span class="ease-dial-dropdown__item-name">United Kingdom</span>
+              <span class="ease-dial-dropdown__item-code">+44</span>
+            </div>
+            <div class="ease-dial-dropdown__item" data-code="+91" data-name="India">
+              <span class="ease-dial-dropdown__item-flag" style="background: #f97316;"> </span>
+              <span class="ease-dial-dropdown__item-name">India</span>
+              <span class="ease-dial-dropdown__item-code">+91</span>
+            </div>
+            <div class="ease-dial-dropdown__item" data-code="+81" data-name="Japan">
+              <span class="ease-dial-dropdown__item-flag" style="background: #ef4444;"> </span>
+              <span class="ease-dial-dropdown__item-name">Japan</span>
+              <span class="ease-dial-dropdown__item-code">+81</span>
+            </div>
+            <div class="ease-dial-dropdown__item" data-code="+61" data-name="Australia">
+              <span class="ease-dial-dropdown__item-flag" style="background: #22c55e;"> </span>
+              <span class="ease-dial-dropdown__item-name">Australia</span>
+              <span class="ease-dial-dropdown__item-code">+61</span>
+            </div>
+            <div class="ease-dial-dropdown__item" data-code="+49" data-name="Germany">
+              <span class="ease-dial-dropdown__item-flag" style="background: #eab308;"> </span>
+              <span class="ease-dial-dropdown__item-name">Germany</span>
+              <span class="ease-dial-dropdown__item-code">+49</span>
+            </div>
+            <div class="ease-dial-dropdown__item" data-code="+33" data-name="France">
+              <span class="ease-dial-dropdown__item-flag" style="background: #6366f1;"> </span>
+              <span class="ease-dial-dropdown__item-name">France</span>
+              <span class="ease-dial-dropdown__item-code">+33</span>
+            </div>
+            <div class="ease-dial-dropdown__item" data-code="+55" data-name="Brazil">
+              <span class="ease-dial-dropdown__item-flag" style="background: #22c55e;"> </span>
+              <span class="ease-dial-dropdown__item-name">Brazil</span>
+              <span class="ease-dial-dropdown__item-code">+55</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="demo-dial-code">
+        <span style="color:#64748b; font-size:14px;">Phone</span>
+        <input class="demo-phone-input" type="text" placeholder="(555) 123-4567">
+      </div>
+    </div>
+
+    <div class="demo-card" style="--dropdown-bg: #1a1a2e; --item-hover-bg: #16213e; --flag-size: 28px;">
+      <h2>Large Flags</h2>
+      <div class="ease-dial-dropdown" data-dial style="--dropdown-bg: #1a1a2e; --item-hover-bg: #16213e; --flag-size: 28px;">
+        <div class="ease-dial-dropdown__trigger" data-trigger>
+          <span class="ease-dial-dropdown__flag" data-trigger-flag style="background: #f97316;"> </span>
+          <span data-trigger-name>India</span>
+          <span class="ease-dial-dropdown__code" data-trigger-code>+91</span>
+          <svg class="ease-dial-dropdown__arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
+        </div>
+        <div class="ease-dial-dropdown__menu" data-menu>
+          <input class="ease-dial-dropdown__search" type="text" placeholder="Search country..." data-search>
+          <div data-items>
+            <div class="ease-dial-dropdown__item" data-code="+1" data-name="United States">
+              <span class="ease-dial-dropdown__item-flag" style="background: #6366f1;"> </span>
+              <span class="ease-dial-dropdown__item-name">United States</span>
+              <span class="ease-dial-dropdown__item-code">+1</span>
+            </div>
+            <div class="ease-dial-dropdown__item is-selected" data-code="+91" data-name="India">
+              <span class="ease-dial-dropdown__item-flag" style="background: #f97316;"> </span>
+              <span class="ease-dial-dropdown__item-name">India</span>
+              <span class="ease-dial-dropdown__item-code">+91</span>
+            </div>
+            <div class="ease-dial-dropdown__item" data-code="+81" data-name="Japan">
+              <span class="ease-dial-dropdown__item-flag" style="background: #ef4444;"> </span>
+              <span class="ease-dial-dropdown__item-name">Japan</span>
+              <span class="ease-dial-dropdown__item-code">+81</span>
+            </div>
+            <div class="ease-dial-dropdown__item" data-code="+61" data-name="Australia">
+              <span class="ease-dial-dropdown__item-flag" style="background: #22c55e;"> </span>
+              <span class="ease-dial-dropdown__item-name">Australia</span>
+              <span class="ease-dial-dropdown__item-code">+61</span>
+            </div>
+            <div class="ease-dial-dropdown__item" data-code="+49" data-name="Germany">
+              <span class="ease-dial-dropdown__item-flag" style="background: #eab308;"> </span>
+              <span class="ease-dial-dropdown__item-name">Germany</span>
+              <span class="ease-dial-dropdown__item-code">+49</span>
+            </div>
+            <div class="ease-dial-dropdown__item" data-code="+44" data-name="United Kingdom">
+              <span class="ease-dial-dropdown__item-flag" style="background: #3b82f6;"> </span>
+              <span class="ease-dial-dropdown__item-name">United Kingdom</span>
+              <span class="ease-dial-dropdown__item-code">+44</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+<script>
+  document.querySelectorAll('[data-dial]').forEach(dropdown => {
+    const trigger = dropdown.querySelector('[data-trigger]');
+    const menu = dropdown.querySelector('[data-menu]');
+    const search = dropdown.querySelector('[data-search]');
+    const itemsContainer = dropdown.querySelector('[data-items]');
+    const items = itemsContainer.querySelectorAll('[data-code]');
+    const triggerName = dropdown.querySelector('[data-trigger-name]');
+    const triggerCode = dropdown.querySelector('[data-trigger-code]');
+    const triggerFlag = dropdown.querySelector('[data-trigger-flag]');
+
+    trigger.addEventListener('click', (e) => {
+      e.stopPropagation();
+      dropdown.classList.toggle('is-open');
+      if (dropdown.classList.contains('is-open')) {
+        setTimeout(() => search?.focus(), 100);
+      }
+    });
+
+    items.forEach(item => {
+      item.addEventListener('click', () => {
+        items.forEach(i => i.classList.remove('is-selected'));
+        item.classList.add('is-selected');
+        triggerName.textContent = item.dataset.name;
+        triggerCode.textContent = item.dataset.code;
+        const itemFlag = item.querySelector('.ease-dial-dropdown__item-flag');
+        triggerFlag.style.background = itemFlag.style.background;
+        dropdown.classList.remove('is-open');
+      });
+    });
+
+    if (search) {
+      search.addEventListener('input', () => {
+        const q = search.value.toLowerCase();
+        let hasResults = false;
+        items.forEach(item => {
+          const name = item.dataset.name.toLowerCase();
+          const code = item.dataset.code;
+          if (name.includes(q) || code.includes(q)) {
+            item.style.display = 'flex';
+            hasResults = true;
+          } else {
+            item.style.display = 'none';
+          }
+        });
+        let empty = itemsContainer.querySelector('.ease-dial-dropdown__empty');
+        if (!hasResults) {
+          if (!empty) {
+            empty = document.createElement('div');
+            empty.className = 'ease-dial-dropdown__empty';
+            empty.textContent = 'No countries found';
+            itemsContainer.appendChild(empty);
+          }
+        } else if (empty) {
+          empty.remove();
+        }
+      });
+    }
+
+    document.addEventListener('click', (e) => {
+      if (!dropdown.contains(e.target)) {
+        dropdown.classList.remove('is-open');
+      }
+    });
+  });
+</script>
+
+</body>
+</html>

--- a/submissions/examples/ease-dial-code-dropdown-ij/style.css
+++ b/submissions/examples/ease-dial-code-dropdown-ij/style.css
@@ -1,0 +1,163 @@
+/* Ease Dial Code Dropdown */
+
+.ease-dial-dropdown {
+  --dropdown-bg: #1e293b;
+  --flag-size: 22px;
+  --item-hover-bg: #334155;
+  --expand-duration: 0.3s;
+  position: relative;
+  width: 280px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.ease-dial-dropdown__trigger {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 10px 14px;
+  background: var(--dropdown-bg);
+  border: 1px solid #334155;
+  border-radius: 8px;
+  color: #e2e8f0;
+  font-size: 14px;
+  cursor: pointer;
+  transition: border-color 0.2s;
+  box-sizing: border-box;
+}
+
+.ease-dial-dropdown__trigger:hover {
+  border-color: #475569;
+}
+
+.ease-dial-dropdown__flag {
+  width: var(--flag-size);
+  height: calc(var(--flag-size) * 0.75);
+  border-radius: 2px;
+  flex-shrink: 0;
+  object-fit: cover;
+  background: #475569;
+}
+
+.ease-dial-dropdown__code {
+  color: #94a3b8;
+  margin-left: auto;
+}
+
+.ease-dial-dropdown__arrow {
+  width: 14px;
+  height: 14px;
+  transition: transform var(--expand-duration) ease;
+  flex-shrink: 0;
+  color: #64748b;
+}
+
+.ease-dial-dropdown.is-open .ease-dial-dropdown__arrow {
+  transform: rotate(180deg);
+}
+
+.ease-dial-dropdown__menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  background: var(--dropdown-bg);
+  border: 1px solid #334155;
+  border-radius: 8px;
+  padding: 6px;
+  opacity: 0;
+  transform: translateY(-8px);
+  pointer-events: none;
+  transition: opacity var(--expand-duration) ease,
+              transform var(--expand-duration) ease;
+  z-index: 100;
+  max-height: 260px;
+  overflow-y: auto;
+  box-sizing: border-box;
+}
+
+.ease-dial-dropdown.is-open .ease-dial-dropdown__menu {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.ease-dial-dropdown__search {
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 6px;
+  border: 1px solid #334155;
+  background: #0f172a;
+  color: #e2e8f0;
+  font-size: 13px;
+  margin-bottom: 6px;
+  box-sizing: border-box;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.ease-dial-dropdown__search:focus {
+  border-color: #6366f1;
+}
+
+.ease-dial-dropdown__search::placeholder {
+  color: #475569;
+}
+
+.ease-dial-dropdown__item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  color: #94a3b8;
+  font-size: 14px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.ease-dial-dropdown__item:hover {
+  background: var(--item-hover-bg);
+  color: #e2e8f0;
+}
+
+.ease-dial-dropdown__item.is-selected {
+  background: var(--item-hover-bg);
+  color: #fff;
+}
+
+.ease-dial-dropdown__item-flag {
+  width: var(--flag-size);
+  height: calc(var(--flag-size) * 0.75);
+  border-radius: 2px;
+  flex-shrink: 0;
+  object-fit: cover;
+  background: #475569;
+}
+
+.ease-dial-dropdown__item-name {
+  flex: 1;
+}
+
+.ease-dial-dropdown__item-code {
+  color: #64748b;
+  font-size: 13px;
+}
+
+.ease-dial-dropdown__item.is-selected .ease-dial-dropdown__item-code {
+  color: #94a3b8;
+}
+
+.ease-dial-dropdown__empty {
+  padding: 16px;
+  text-align: center;
+  color: #475569;
+  font-size: 13px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-dial-dropdown__menu,
+  .ease-dial-dropdown__arrow {
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Component: ease-dial-code-dropdown - Dial code dropdown with country code picker

**Closes #36612**

### Acceptance Criteria
- [x] CSS-only animated component with @keyframes
- [x] Custom properties via CSS variables
- [x] Interactive demo page
- [x] README with documentation

### Files
- submissions/examples/ease-dial-code-dropdown-ij/demo.html
- submissions/examples/ease-dial-code-dropdown-ij/style.css
- submissions/examples/ease-dial-code-dropdown-ij/README.md

### Review Instructions
Open demo.html in a browser and verify the animation works. Check that CSS variables can be customized.
