### PR TITLE
feat: add CSS Spring Physics Accordion for Interactive Interface Layouts

### DIFF
--- a/submissions/examples/spring-physics-accordion-interactive-interface/README.md
+++ b/submissions/examples/spring-physics-accordion-interactive-interface/README.md
@@ -1,0 +1,44 @@
+﻿# CSS Spring Physics Accordion — Interactive Interface Layout
+
+A pure CSS accordion where the expand/collapse animation uses an overshoot easing curve to mimic spring physics damping — no JavaScript animation logic required.
+
+## CSS Custom Properties
+
+| Property                          | Default   | Description                          |
+|--------------------------------------|-----------|------------------------------------------|
+| `--ease-accordion-spring-duration`   | `0.55s`   | Expand/collapse transition duration        |
+| `--ease-accordion-spring-easing`     | `cubic-bezier(0.34, 1.56, 0.64, 1)` | Overshoot easing curve simulating spring damping |
+| `--ease-accordion-bg`                | `#ffffff` | Item background color                      |
+| `--ease-accordion-accent`            | `#4f46e5` | Icon and focus ring color                  |
+| `--ease-accordion-radius`            | `12px`    | Item corner radius                         |
+
+## Usage
+
+```html
+<div class="ease-accordion">
+  <div class="ease-accordion__item">
+    <button class="ease-accordion__header" aria-expanded="false">
+      Question
+      <svg class="ease-accordion__icon">...</svg>
+    </button>
+    <div class="ease-accordion__panel">
+      <div class="ease-accordion__panel-inner">
+        <div class="ease-accordion__body">Answer content</div>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+Toggle `ease-accordion__item--open` and `aria-expanded` on the header (see `demo.html`). The panel expands via `grid-template-rows: 0fr → 1fr`, and the body content fades/slides in with the same spring easing.
+
+## Accessibility
+
+- Native `<button>` headers with `aria-expanded` reflecting state.
+- Fully keyboard operable.
+- Visible `:focus-visible` outline.
+- `prefers-reduced-motion: reduce` swaps the overshoot spring curve for a fast, simple `ease` transition — no bounce.
+
+## Why it fits EaseMotion CSS
+
+Uses `ease-` prefixed classes and CSS custom properties for spring-curve/timing theming, consistent with the framework's zero-dependency philosophy. Demonstrates that convincing "physics-based" motion doesn't require JS spring libraries — a well-chosen `cubic-bezier()` overshoot curve gets remarkably close.

--- a/submissions/examples/spring-physics-accordion-interactive-interface/demo.html
+++ b/submissions/examples/spring-physics-accordion-interactive-interface/demo.html
@@ -1,0 +1,88 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Spring Physics Accordion Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: -apple-system, sans-serif; background: #f9fafb; padding: 60px; }
+  </style>
+</head>
+<body>
+  <h2>CSS Spring Physics Accordion — Interactive Interface Layout</h2>
+
+  <div class="ease-accordion" id="accordion">
+    <div class="ease-accordion__item">
+      <button class="ease-accordion__header" aria-expanded="false">
+        What makes this "spring physics"?
+        <svg class="ease-accordion__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M6 9l6 6 6-6" />
+        </svg>
+      </button>
+      <div class="ease-accordion__panel">
+        <div class="ease-accordion__panel-inner">
+          <div class="ease-accordion__body">
+            It uses an overshoot cubic-bezier curve so the panel slightly overshoots
+            its final height and settles back, mimicking spring damping.
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="ease-accordion__item">
+      <button class="ease-accordion__header" aria-expanded="false">
+        Does it need JavaScript for the animation?
+        <svg class="ease-accordion__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M6 9l6 6 6-6" />
+        </svg>
+      </button>
+      <div class="ease-accordion__panel">
+        <div class="ease-accordion__panel-inner">
+          <div class="ease-accordion__body">
+            No — the spring feel is achieved purely with CSS `cubic-bezier()` easing on
+            a grid-template-rows transition. JS is only used to toggle the open class.
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="ease-accordion__item">
+      <button class="ease-accordion__header" aria-expanded="false">
+        Is it accessible?
+        <svg class="ease-accordion__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M6 9l6 6 6-6" />
+        </svg>
+      </button>
+      <div class="ease-accordion__panel">
+        <div class="ease-accordion__panel-inner">
+          <div class="ease-accordion__body">
+            Yes — native buttons, aria-expanded state, and a reduced-motion fallback
+            that swaps the springy overshoot for a simple linear ease.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const items = document.querySelectorAll('.ease-accordion__item');
+
+    items.forEach((item) => {
+      const header = item.querySelector('.ease-accordion__header');
+      header.addEventListener('click', () => {
+        const isOpen = item.classList.contains('ease-accordion__item--open');
+
+        items.forEach((other) => {
+          other.classList.remove('ease-accordion__item--open');
+          other.querySelector('.ease-accordion__header').setAttribute('aria-expanded', 'false');
+        });
+
+        if (!isOpen) {
+          item.classList.add('ease-accordion__item--open');
+          header.setAttribute('aria-expanded', 'true');
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/spring-physics-accordion-interactive-interface/style.css
+++ b/submissions/examples/spring-physics-accordion-interactive-interface/style.css
@@ -1,0 +1,104 @@
+﻿:root {
+  --ease-accordion-spring-duration: 0.55s;
+  --ease-accordion-spring-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-accordion-bg: #ffffff;
+  --ease-accordion-accent: #4f46e5;
+  --ease-accordion-radius: 12px;
+}
+
+.ease-accordion {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 520px;
+}
+
+.ease-accordion__item {
+  border: 1px solid #e5e7eb;
+  border-radius: var(--ease-accordion-radius);
+  background: var(--ease-accordion-bg);
+  overflow: hidden;
+  transition: box-shadow 0.3s ease, border-color 0.3s ease;
+}
+
+.ease-accordion__item--open {
+  border-color: rgba(79, 70, 229, 0.35);
+  box-shadow: 0 8px 24px rgba(79, 70, 229, 0.12);
+}
+
+.ease-accordion__header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 15px;
+  font-weight: 600;
+  color: #111827;
+  text-align: left;
+}
+
+.ease-accordion__header:focus-visible {
+  outline: 3px solid var(--ease-accordion-accent);
+  outline-offset: -3px;
+}
+
+.ease-accordion__icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  color: var(--ease-accordion-accent);
+  transition: transform var(--ease-accordion-spring-duration) var(--ease-accordion-spring-easing);
+}
+
+.ease-accordion__item--open .ease-accordion__icon {
+  transform: rotate(180deg) scale(1.1);
+}
+
+/* The spring-physics feel comes from the overshoot easing curve applied
+   to the grid-row expansion — it overshoots slightly past 1fr and settles
+   back, mimicking spring damping without JS or @property interpolation. */
+.ease-accordion__panel {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows var(--ease-accordion-spring-duration) var(--ease-accordion-spring-easing);
+}
+
+.ease-accordion__item--open .ease-accordion__panel {
+  grid-template-rows: 1fr;
+}
+
+.ease-accordion__panel-inner {
+  overflow: hidden;
+}
+
+.ease-accordion__body {
+  padding: 0 20px 18px;
+  color: #4b5563;
+  font-size: 14px;
+  line-height: 1.6;
+  transform: translateY(-6px);
+  opacity: 0;
+  transition: transform var(--ease-accordion-spring-duration) var(--ease-accordion-spring-easing),
+    opacity 0.3s ease;
+}
+
+.ease-accordion__item--open .ease-accordion__body {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-accordion__icon,
+  .ease-accordion__panel,
+  .ease-accordion__body {
+    transition-duration: 0.15s;
+    transition-timing-function: ease;
+  }
+  .ease-accordion__item--open .ease-accordion__icon {
+    transform: rotate(180deg);
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS accordion with a spring-physics-style expand/collapse animation using an overshoot easing curve, styled for interactive interface layouts. Resolves #33132

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/spring-physics-accordion-interactive-interface/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS accordion whose expand/collapse transition uses an overshoot `cubic-bezier()` curve to mimic spring physics damping — the panel slightly overshoots its final height and settles back, with no JavaScript animation logic.

**How does a developer use it?**
```html
<div class="ease-accordion">
  <div class="ease-accordion__item">
    <button class="ease-accordion__header" aria-expanded="false">
      Question
      <svg class="ease-accordion__icon">...</svg>
    </button>
    <div class="ease-accordion__panel">
      <div class="ease-accordion__panel-inner">
        <div class="ease-accordion__body">Answer content</div>
      </div>
    </div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Uses `ease-` prefixed classes and CSS custom properties for spring-curve/timing theming, consistent with the framework's zero-dependency philosophy. Demonstrates that convincing physics-based motion doesn't require a JS spring library.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome

---

## Notes for Maintainer
Panel expands via `grid-template-rows: 0fr → 1fr` with the overshoot easing applied directly to that transition; body content also fades/slides with the same curve for a cohesive spring feel. `prefers-reduced-motion` swaps to a fast linear ease with no overshoot. Happy to adjust the bounce intensity if preferred.