### PR TITLE
feat: add CSS Staggered Entrance Accordion for Interactive Interface Layouts

### DIFF
--- a/submissions/examples/staggered-entrance-accordion-interactive-interface/README.md
+++ b/submissions/examples/staggered-entrance-accordion-interactive-interface/README.md
@@ -1,0 +1,41 @@
+﻿# CSS Staggered Entrance Accordion — Interactive Interface Layout
+
+A pure CSS accordion where items animate into view one after another on page load, using incremental `:nth-child()` animation delays.
+
+## CSS Custom Properties
+
+| Property                            | Default   | Description                          |
+|----------------------------------------|-----------|------------------------------------------|
+| `--ease-accordion-stagger-delay`       | `80ms`    | Base delay multiplied per item index       |
+| `--ease-accordion-entrance-duration`   | `0.5s`    | Entrance animation duration                |
+| `--ease-accordion-entrance-easing`     | `cubic-bezier(0.16, 1, 0.3, 1)` | Entrance easing curve |
+| `--ease-accordion-bg`                  | `#ffffff` | Item background color                      |
+| `--ease-accordion-accent`              | `#4f46e5` | Icon and focus ring color                  |
+| `--ease-accordion-radius`              | `12px`    | Item corner radius                         |
+
+## Usage
+
+```html
+<div class="ease-accordion">
+  <div class="ease-accordion__item"> <!-- 1st item, no extra delay needed -->
+    <button class="ease-accordion__header" aria-expanded="false">Question 1</button>
+    <div class="ease-accordion__panel">...</div>
+  </div>
+  <div class="ease-accordion__item"> <!-- 2nd item, delayed automatically -->
+    <button class="ease-accordion__header" aria-expanded="false">Question 2</button>
+    <div class="ease-accordion__panel">...</div>
+  </div>
+</div>
+```
+
+Stagger delays are wired via `:nth-child(1)` through `:nth-child(5)` by default — extend the CSS with more `:nth-child` rules for longer lists.
+
+## Accessibility
+
+- Entrance animation is purely visual and doesn't affect interactivity — accordion items are immediately clickable even mid-animation.
+- Native `<button>` headers with `aria-expanded`.
+- `prefers-reduced-motion: reduce` disables the entrance animation entirely (items render fully visible immediately).
+
+## Why it fits EaseMotion CSS
+
+Uses `ease-` prefixed classes and a CSS custom property for stagger timing, consistent with the framework's zero-dependency philosophy. Demonstrates a common "cascading reveal" pattern achievable with pure CSS `:nth-child` delays, no JS orchestration needed.

--- a/submissions/examples/staggered-entrance-accordion-interactive-interface/demo.html
+++ b/submissions/examples/staggered-entrance-accordion-interactive-interface/demo.html
@@ -1,0 +1,86 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Staggered Entrance Accordion Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: -apple-system, sans-serif; background: #f9fafb; padding: 60px; }
+  </style>
+</head>
+<body>
+  <h2>CSS Staggered Entrance Accordion — Interactive Interface Layout</h2>
+  <p>Refresh the page to see items animate in one after another.</p>
+
+  <div class="ease-accordion" id="accordion">
+    <div class="ease-accordion__item">
+      <button class="ease-accordion__header" aria-expanded="false">
+        What is staggered entrance?
+        <svg class="ease-accordion__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M6 9l6 6 6-6" />
+        </svg>
+      </button>
+      <div class="ease-accordion__panel">
+        <div class="ease-accordion__panel-inner">
+          <div class="ease-accordion__body">
+            Each item fades and slides in with an incremental delay based on its position, creating a cascading reveal.
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="ease-accordion__item">
+      <button class="ease-accordion__header" aria-expanded="false">
+        How is the delay calculated?
+        <svg class="ease-accordion__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M6 9l6 6 6-6" />
+        </svg>
+      </button>
+      <div class="ease-accordion__panel">
+        <div class="ease-accordion__panel-inner">
+          <div class="ease-accordion__body">
+            Using `:nth-child()` selectors multiplied against a base `--ease-accordion-stagger-delay` custom property.
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="ease-accordion__item">
+      <button class="ease-accordion__header" aria-expanded="false">
+        Is it accessible?
+        <svg class="ease-accordion__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M6 9l6 6 6-6" />
+        </svg>
+      </button>
+      <div class="ease-accordion__panel">
+        <div class="ease-accordion__panel-inner">
+          <div class="ease-accordion__body">
+            Yes — the entrance animation is purely visual; `aria-expanded` and keyboard support are unaffected, and `prefers-reduced-motion` disables the stagger entirely.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const items = document.querySelectorAll('.ease-accordion__item');
+
+    items.forEach((item) => {
+      const header = item.querySelector('.ease-accordion__header');
+      header.addEventListener('click', () => {
+        const isOpen = item.classList.contains('ease-accordion__item--open');
+
+        items.forEach((other) => {
+          other.classList.remove('ease-accordion__item--open');
+          other.querySelector('.ease-accordion__header').setAttribute('aria-expanded', 'false');
+        });
+
+        if (!isOpen) {
+          item.classList.add('ease-accordion__item--open');
+          header.setAttribute('aria-expanded', 'true');
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/staggered-entrance-accordion-interactive-interface/style.css
+++ b/submissions/examples/staggered-entrance-accordion-interactive-interface/style.css
@@ -1,0 +1,105 @@
+﻿:root {
+  --ease-accordion-stagger-delay: 80ms;
+  --ease-accordion-entrance-duration: 0.5s;
+  --ease-accordion-entrance-easing: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-accordion-bg: #ffffff;
+  --ease-accordion-accent: #4f46e5;
+  --ease-accordion-radius: 12px;
+}
+
+.ease-accordion {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 520px;
+}
+
+.ease-accordion__item {
+  border: 1px solid #e5e7eb;
+  border-radius: var(--ease-accordion-radius);
+  background: var(--ease-accordion-bg);
+  overflow: hidden;
+  opacity: 0;
+  transform: translateY(16px);
+  animation: ease-stagger-in var(--ease-accordion-entrance-duration) var(--ease-accordion-entrance-easing) forwards;
+}
+
+/* Stagger delay per item, set via inline style or nth-child fallback */
+.ease-accordion__item:nth-child(1) { animation-delay: calc(var(--ease-accordion-stagger-delay) * 1); }
+.ease-accordion__item:nth-child(2) { animation-delay: calc(var(--ease-accordion-stagger-delay) * 2); }
+.ease-accordion__item:nth-child(3) { animation-delay: calc(var(--ease-accordion-stagger-delay) * 3); }
+.ease-accordion__item:nth-child(4) { animation-delay: calc(var(--ease-accordion-stagger-delay) * 4); }
+.ease-accordion__item:nth-child(5) { animation-delay: calc(var(--ease-accordion-stagger-delay) * 5); }
+
+@keyframes ease-stagger-in {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.ease-accordion__item--open {
+  border-color: rgba(79, 70, 229, 0.35);
+  box-shadow: 0 8px 24px rgba(79, 70, 229, 0.12);
+}
+
+.ease-accordion__header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 15px;
+  font-weight: 600;
+  color: #111827;
+  text-align: left;
+}
+
+.ease-accordion__header:focus-visible {
+  outline: 3px solid var(--ease-accordion-accent);
+  outline-offset: -3px;
+}
+
+.ease-accordion__icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  color: var(--ease-accordion-accent);
+  transition: transform 0.3s ease;
+}
+
+.ease-accordion__item--open .ease-accordion__icon {
+  transform: rotate(180deg);
+}
+
+.ease-accordion__panel {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.35s ease;
+}
+
+.ease-accordion__item--open .ease-accordion__panel {
+  grid-template-rows: 1fr;
+}
+
+.ease-accordion__panel-inner {
+  overflow: hidden;
+}
+
+.ease-accordion__body {
+  padding: 0 20px 18px;
+  color: #4b5563;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-accordion__item {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS accordion where items animate into view one after another using incremental entrance delays, styled for interactive interface layouts. Resolves #33118

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/staggered-entrance-accordion-interactive-interface/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS accordion where each item fades and slides into view on page load with an incremental delay based on its position, creating a cascading "staggered" reveal effect.

**How does a developer use it?**
```html
<div class="ease-accordion">
  <div class="ease-accordion__item"> <!-- animates first -->
    <button class="ease-accordion__header" aria-expanded="false">Question 1</button>
    <div class="ease-accordion__panel">...</div>
  </div>
  <div class="ease-accordion__item"> <!-- animates with a slight delay -->
    <button class="ease-accordion__header" aria-expanded="false">Question 2</button>
    <div class="ease-accordion__panel">...</div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Uses `ease-` prefixed classes and a CSS custom property for stagger timing, consistent with the framework's zero-dependency philosophy. Demonstrates the cascading reveal pattern purely via `:nth-child` animation delays, no JS orchestration.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome

---

## Notes for Maintainer
Stagger delays are wired via `:nth-child(1)` through `:nth-child(5)`; extend with more rules for longer lists. Entrance animation is purely visual — items remain fully clickable mid-animation. `prefers-reduced-motion` disables the entrance animation entirely. Happy to adjust the base delay if preferred.