### PR TITLE
feat: add markdown-preview-tab component (#36807)

### DIFF
--- a/submissions/examples/ease-markdown-preview-tab-ij/README.md
+++ b/submissions/examples/ease-markdown-preview-tab-ij/README.md
@@ -1,0 +1,16 @@
+# Markdown Preview Tab (#36807)
+
+A tabbed interface that toggles between a Markdown editor and rendered preview. The active tab slides with an elastic indicator, and the content pane fades in.
+
+## CSS Custom Properties
+
+| Property           | Default   | Description                            |
+| ------------------ | --------- | -------------------------------------- |
+| `--tab-bg`         | `#2c2c2e` | Inactive tab bar background            |
+| `--tab-active-bg`  | `#3a3a3c` | Active tab indicator background        |
+| `--preview-bg`     | `#1c1c1e` | Editor / preview pane background       |
+| `--switch-duration`| `0.3s`    | Duration of tab and pane transitions   |
+
+## Interactive Controls
+
+Click the tab buttons to switch views. Use the variable panel to customize all backgrounds and transition speed.

--- a/submissions/examples/ease-markdown-preview-tab-ij/demo.html
+++ b/submissions/examples/ease-markdown-preview-tab-ij/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Markdown Preview Tab — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="component-card">
+    <h2 class="card-title">Markdown Preview Tab</h2>
+    <p class="card-desc">Switch between edit and preview with a smooth tab transition.</p>
+    <div class="tabs-container">
+      <div class="tab-bar">
+        <button class="tab-btn active" data-tab="edit">Edit</button>
+        <button class="tab-btn" data-tab="preview">Preview</button>
+        <span class="tab-indicator"></span>
+      </div>
+      <div class="tab-content">
+        <div class="tab-pane active" id="pane-edit">
+          <textarea class="md-editor"># Hello World
+
+This is a **markdown** preview.
+
+- Item one
+- Item two
+- Item three</textarea>
+        </div>
+        <div class="tab-pane" id="pane-preview">
+          <div class="md-preview">
+            <h1>Hello World</h1>
+            <p>This is a <strong>markdown</strong> preview.</p>
+            <ul>
+              <li>Item one</li>
+              <li>Item two</li>
+              <li>Item three</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="vars-panel">
+      <label>--tab-bg <input type="color" value="#2c2c2e" data-var="--tab-bg"></label>
+      <label>--tab-active-bg <input type="color" value="#3a3a3c" data-var="--tab-active-bg"></label>
+      <label>--preview-bg <input type="color" value="#1c1c1e" data-var="--preview-bg"></label>
+      <label>--switch-duration <input type="range" min="0.1" max="0.8" step="0.05" value="0.3" data-var="--switch-duration"> <span class="val">0.3s</span></label>
+    </div>
+  </div>
+  <script>
+    const tabs = document.querySelectorAll('.tab-btn');
+    const panes = {
+      edit: document.getElementById('pane-edit'),
+      preview: document.getElementById('pane-preview'),
+    };
+    const indicator = document.querySelector('.tab-indicator');
+
+    tabs.forEach(btn => {
+      btn.addEventListener('click', () => {
+        tabs.forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        Object.values(panes).forEach(p => p.classList.remove('active'));
+        panes[btn.dataset.tab].classList.add('active');
+        const idx = Array.from(tabs).indexOf(btn);
+        indicator.style.transform = `translateX(${idx * 100}%)`;
+      });
+    });
+
+    document.querySelectorAll('.vars-panel input[data-var]').forEach(el => {
+      el.addEventListener('input', () => {
+        const val = el.type === 'color' ? el.value : el.value + 's';
+        document.querySelector('.tabs-container').style.setProperty(el.dataset.var, val);
+        if (el.type === 'range') el.nextElementSibling.textContent = val;
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-markdown-preview-tab-ij/style.css
+++ b/submissions/examples/ease-markdown-preview-tab-ij/style.css
@@ -1,0 +1,190 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #1c1c1e;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  padding: 1rem;
+}
+
+.component-card {
+  background: #2c2c2e;
+  border-radius: 1.25rem;
+  padding: 2rem;
+  max-width: 600px;
+  width: 100%;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+}
+
+.card-title {
+  color: #f5f5f7;
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.card-desc {
+  color: #98989d;
+  font-size: 0.875rem;
+  margin-bottom: 1.5rem;
+}
+
+.tabs-container {
+  --tab-bg: #2c2c2e;
+  --tab-active-bg: #3a3a3c;
+  --preview-bg: #1c1c1e;
+  --switch-duration: 0.3s;
+}
+
+.tab-bar {
+  position: relative;
+  display: flex;
+  background: var(--tab-bg);
+  border-radius: 0.5rem;
+  overflow: hidden;
+  margin-bottom: 0.75rem;
+}
+
+.tab-btn {
+  flex: 1;
+  padding: 0.6rem 1rem;
+  background: none;
+  border: none;
+  color: #98989d;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color var(--switch-duration) ease;
+  position: relative;
+  z-index: 1;
+}
+
+.tab-btn.active {
+  color: #f5f5f7;
+}
+
+.tab-indicator {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 50%;
+  height: 100%;
+  background: var(--tab-active-bg);
+  border-radius: 0.5rem;
+  transition: transform var(--switch-duration) cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.tab-content {
+  position: relative;
+  overflow: hidden;
+}
+
+.tab-pane {
+  display: none;
+}
+
+.tab-pane.active {
+  display: block;
+  animation: paneIn var(--switch-duration) ease;
+}
+
+@keyframes paneIn {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.md-editor {
+  width: 100%;
+  min-height: 180px;
+  padding: 0.75rem;
+  background: var(--preview-bg);
+  border: 1px solid #3a3a3c;
+  border-radius: 0.5rem;
+  color: #f5f5f7;
+  font-family: "SF Mono", "Cascadia Code", monospace;
+  font-size: 0.8125rem;
+  resize: vertical;
+  outline: none;
+}
+
+.md-editor:focus {
+  border-color: #0a84ff;
+}
+
+.md-preview {
+  background: var(--preview-bg);
+  border-radius: 0.5rem;
+  padding: 0.75rem 1rem;
+  color: #f5f5f7;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  min-height: 180px;
+}
+
+.md-preview h1 {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.md-preview p {
+  margin-bottom: 0.5rem;
+}
+
+.md-preview ul {
+  padding-left: 1.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.md-preview strong {
+  color: #ff9f0a;
+}
+
+.vars-panel {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid #3a3a3c;
+}
+
+.vars-panel label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  color: #98989d;
+  font-family: "SF Mono", "Cascadia Code", monospace;
+}
+
+.vars-panel input[type="range"] {
+  width: 80px;
+  accent-color: #0a84ff;
+}
+
+.vars-panel input[type="color"] {
+  width: 32px;
+  height: 24px;
+  border: 1px solid #3a3a3c;
+  border-radius: 4px;
+  background: none;
+  cursor: pointer;
+}
+
+.vars-panel .val {
+  color: #f5f5f7;
+  min-width: 2.5rem;
+}


### PR DESCRIPTION
## Component: ease-markdown-preview-tab - Markdown preview tab with switch animation

**Closes #36807**

### Acceptance Criteria
- [x] CSS-only animated component with @keyframes
- [x] Custom properties via CSS variables
- [x] Interactive demo page
- [x] README with documentation

### Files
- submissions/examples/ease-markdown-preview-tab-ij/demo.html
- submissions/examples/ease-markdown-preview-tab-ij/style.css
- submissions/examples/ease-markdown-preview-tab-ij/README.md

### Review Instructions
Open demo.html in a browser and verify the animation works.
