### PR TITLE
feat: add CSS Jello-Hover Accordion for SaaS Showcase Layouts

### DIFF
--- a/submissions/examples/jello-hover-accordion-saas-showcase/README.md
+++ b/submissions/examples/jello-hover-accordion-saas-showcase/README.md
@@ -1,0 +1,46 @@
+﻿# CSS Jello-Hover Accordion — SaaS Showcase Layout
+
+A pure CSS accordion where each header wobbles playfully on hover, styled with a clean purple-accented SaaS product aesthetic — ideal for FAQ sections.
+
+## CSS Custom Properties
+
+| Property                          | Default                                   | Description                              |
+|-------------------------------------|-----------------------------------------------|-------------------------------------------|
+| `--ease-accordion-jello-duration`  | `0.45s`                                       | Duration of the expand/collapse transition |
+| `--ease-accordion-jello-easing`    | `cubic-bezier(0.68, -0.55, 0.27, 1.55)`      | Overshoot easing curve for the jello wobble|
+| `--ease-accordion-bg`              | `#ffffff`                                     | Panel background color                     |
+| `--ease-accordion-border`          | `#e5e7eb`                                     | Panel border color                         |
+| `--ease-accordion-accent`          | `#6d28d9`                                     | Accent color (icon, hover background)      |
+| `--ease-accordion-accent-soft`     | `#ede9fe`                                     | Soft accent background on header hover     |
+| `--ease-accordion-radius`          | `12px`                                        | Panel corner radius                        |
+| `--ease-accordion-max-width`       | `480px`                                       | Maximum accordion width                    |
+| `--ease-accordion-focus-ring`      | `#6d28d9`                                     | Focus outline color                        |
+
+## Usage
+
+```html
+<div class="ease-accordion">
+  <div class="ease-accordion__item" data-open="false">
+    <button class="ease-accordion__header" aria-expanded="false">
+      <span>Question</span>
+      <svg class="ease-accordion__icon">...</svg>
+    </button>
+    <div class="ease-accordion__panel">
+      <div class="ease-accordion__body">Answer content</div>
+    </div>
+  </div>
+</div>
+```
+
+Toggle `data-open="true"` on `.ease-accordion__item` (and `aria-expanded` on the header) to expand/collapse. The jello wobble triggers automatically on header `:hover` via a CSS keyframe.
+
+## Accessibility
+
+- Each header is a real `<button>` with `aria-expanded` reflecting open state.
+- Fully keyboard operable — headers are natively focusable and clickable via Enter/Space.
+- Visible `:focus-visible` outline on headers.
+- `prefers-reduced-motion: reduce` disables the wobble animation and collapse transition.
+
+## Why it fits EaseMotion CSS
+
+Uses `ease-` prefixed class names and exposes timing/easing via CSS custom properties for easy theming, matching the framework's zero-JS-overhead, animation-first philosophy. The minimal JS included only toggles the open/closed data attribute — not the animation itself.

--- a/submissions/examples/jello-hover-accordion-saas-showcase/demo.html
+++ b/submissions/examples/jello-hover-accordion-saas-showcase/demo.html
@@ -1,0 +1,70 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Jello-Hover Accordion Demo — SaaS Showcase</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: -apple-system, "Segoe UI", sans-serif; min-height: 100vh; padding: 60px 20px; margin: 0; background: #f8fafc; }
+    h2 { color: #1e1b2e; text-align: center; }
+  </style>
+</head>
+<body>
+  <h2>CSS Jello-Hover Accordion — SaaS Showcase</h2>
+
+  <div class="ease-accordion">
+    <div class="ease-accordion__item" data-open="true">
+      <button class="ease-accordion__header" aria-expanded="true">
+        <span>What plans do you offer?</span>
+        <svg class="ease-accordion__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M6 9l6 6 6-6" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+      <div class="ease-accordion__panel">
+        <div class="ease-accordion__body">
+          We offer Starter, Pro, and Enterprise plans, each scaling with your team size and feature needs.
+        </div>
+      </div>
+    </div>
+
+    <div class="ease-accordion__item" data-open="false">
+      <button class="ease-accordion__header" aria-expanded="false">
+        <span>Can I cancel anytime?</span>
+        <svg class="ease-accordion__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M6 9l6 6 6-6" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+      <div class="ease-accordion__panel">
+        <div class="ease-accordion__body">
+          Yes — all plans are month-to-month with no long-term contracts required.
+        </div>
+      </div>
+    </div>
+
+    <div class="ease-accordion__item" data-open="false">
+      <button class="ease-accordion__header" aria-expanded="false">
+        <span>Do you offer a free trial?</span>
+        <svg class="ease-accordion__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M6 9l6 6 6-6" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+      <div class="ease-accordion__panel">
+        <div class="ease-accordion__body">
+          Yes, every plan includes a 14-day free trial with full feature access.
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    document.querySelectorAll('.ease-accordion__header').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const item = btn.closest('.ease-accordion__item');
+        const isOpen = item.getAttribute('data-open') === 'true';
+        item.setAttribute('data-open', String(!isOpen));
+        btn.setAttribute('aria-expanded', String(!isOpen));
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/jello-hover-accordion-saas-showcase/style.css
+++ b/submissions/examples/jello-hover-accordion-saas-showcase/style.css
@@ -1,0 +1,100 @@
+﻿:root {
+  --ease-accordion-jello-duration: 0.45s;
+  --ease-accordion-jello-easing: cubic-bezier(0.68, -0.55, 0.27, 1.55);
+  --ease-accordion-bg: #ffffff;
+  --ease-accordion-border: #e5e7eb;
+  --ease-accordion-accent: #6d28d9;
+  --ease-accordion-accent-soft: #ede9fe;
+  --ease-accordion-radius: 12px;
+  --ease-accordion-max-width: 480px;
+  --ease-accordion-focus-ring: #6d28d9;
+}
+
+.ease-accordion {
+  max-width: var(--ease-accordion-max-width);
+  margin: 20px auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ease-accordion__item {
+  background: var(--ease-accordion-bg);
+  border: 1px solid var(--ease-accordion-border);
+  border-radius: var(--ease-accordion-radius);
+  overflow: hidden;
+  box-shadow: 0 4px 14px rgba(15, 23, 42, 0.06);
+}
+
+.ease-accordion__header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  background: transparent;
+  border: none;
+  color: #1e1b2e;
+  font-size: 15.5px;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: left;
+  transition: transform 0.3s var(--ease-accordion-jello-easing);
+}
+
+/* Jello-Hover: header wobbles playfully on hover, giving tactile feedback
+   before the accordion body expands. */
+.ease-accordion__header:hover {
+  animation: ease-jello-wobble 0.6s var(--ease-accordion-jello-easing);
+  background: var(--ease-accordion-accent-soft);
+}
+
+@keyframes ease-jello-wobble {
+  0%, 100% { transform: scale(1, 1); }
+  30% { transform: scale(1.05, 0.95); }
+  50% { transform: scale(0.97, 1.04); }
+  70% { transform: scale(1.02, 0.99); }
+}
+
+.ease-accordion__header:focus-visible {
+  outline: 3px solid var(--ease-accordion-focus-ring);
+  outline-offset: -3px;
+}
+
+.ease-accordion__icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  color: var(--ease-accordion-accent);
+  transition: transform var(--ease-accordion-jello-duration) var(--ease-accordion-jello-easing);
+}
+
+.ease-accordion__item[data-open="true"] .ease-accordion__icon {
+  transform: rotate(180deg);
+}
+
+.ease-accordion__panel {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height var(--ease-accordion-jello-duration) var(--ease-accordion-jello-easing);
+}
+
+.ease-accordion__item[data-open="true"] .ease-accordion__panel {
+  max-height: 300px;
+}
+
+.ease-accordion__body {
+  padding: 0 20px 18px;
+  color: #4b5563;
+  font-size: 14.5px;
+  line-height: 1.65;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-accordion__header,
+  .ease-accordion__icon,
+  .ease-accordion__panel {
+    transition: none !important;
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS accordion with a jello-hover interaction effect on the header, styled for SaaS showcase layouts. Resolves #33040

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/jello-hover-accordion-saas-showcase/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS accordion where each header wobbles playfully on hover, styled with a clean purple-accented SaaS product aesthetic — ideal for FAQ sections.

**How does a developer use it?**
```html
<div class="ease-accordion">
  <div class="ease-accordion__item" data-open="false">
    <button class="ease-accordion__header" aria-expanded="false">
      <span>Question</span>
      <svg class="ease-accordion__icon">...</svg>
    </button>
    <div class="ease-accordion__panel">
      <div class="ease-accordion__body">Answer content</div>
    </div>
  </div>
</div>
```
Toggling `data-open` on the item (and `aria-expanded` on the header) drives the expand/collapse transition; the jello wobble triggers automatically on header hover.

**Why does it fit EaseMotion CSS?**
Uses `ease-` prefixed class names and exposes timing/easing via CSS custom properties for easy theming, matching the framework's zero-JS-overhead, animation-first philosophy. Minimal JS only toggles the open/closed state — not the animation itself.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome

---

## Notes for Maintainer
FAQ-style demo content to match the SaaS showcase use case, with a soft purple hover background on the header alongside the jello wobble. Includes accessibility: real `<button>` headers with `aria-expanded`, keyboard operable, `:focus-visible` outline. `prefers-reduced-motion` disables both the wobble and the collapse transition.
