### PR TITLE
feat: add CSS Wobble-Focus Accordion for Interactive Interface Layouts

### DIFF
--- a/submissions/examples/wobble-focus-accordion-interactive-interface/README.md
+++ b/submissions/examples/wobble-focus-accordion-interactive-interface/README.md
@@ -1,0 +1,47 @@
+﻿# CSS Wobble-Focus Accordion — Interactive Interface Layout
+
+A pure CSS accordion where each header rocks with a subtle wobble on keyboard focus, drawing clear attention to the currently active control.
+
+## CSS Custom Properties
+
+| Property                            | Default                              | Description                                |
+|----------------------------------------|-------------------------------------------|-----------------------------------------------|
+| `--ease-accordion-wobble-duration`   | `0.5s`                                    | Duration of the focus wobble animation        |
+| `--ease-accordion-wobble-easing`     | `cubic-bezier(0.34, 1.56, 0.64, 1)`      | Easing curve for the wobble                   |
+| `--ease-accordion-wobble-angle`      | `3deg`                                    | Maximum rotation angle of the wobble          |
+| `--ease-accordion-bg`                | `#ffffff`                                 | Panel background color                        |
+| `--ease-accordion-border`            | `#e2e8f0`                                 | Panel border color                            |
+| `--ease-accordion-accent`            | `#4f46e5`                                 | Accent color (icon)                           |
+| `--ease-accordion-accent-soft`       | `#e0e7ff`                                 | Soft accent background on hover/focus         |
+| `--ease-accordion-radius`            | `12px`                                    | Panel corner radius                           |
+| `--ease-accordion-max-width`         | `500px`                                   | Maximum accordion width                       |
+| `--ease-accordion-focus-ring`        | `#4f46e5`                                 | Focus outline color                           |
+
+## Usage
+
+```html
+<div class="ease-accordion">
+  <div class="ease-accordion__item" data-open="false">
+    <button class="ease-accordion__header" aria-expanded="false">
+      <span>Question</span>
+      <svg class="ease-accordion__icon">...</svg>
+    </button>
+    <div class="ease-accordion__panel">
+      <div class="ease-accordion__body">Answer content</div>
+    </div>
+  </div>
+</div>
+```
+
+Toggle `data-open="true"` on `.ease-accordion__item` (and `aria-expanded` on the header) to expand/collapse. The wobble triggers automatically on header `:focus-visible` via a CSS keyframe.
+
+## Accessibility
+
+- Each header is a real `<button>` with `aria-expanded` reflecting open state.
+- Fully keyboard operable — headers are natively focusable and clickable via Enter/Space.
+- The wobble animation itself reinforces focus visibility, in addition to a visible outline.
+- `prefers-reduced-motion: reduce` disables the wobble animation and collapse transition.
+
+## Why it fits EaseMotion CSS
+
+Uses `ease-` prefixed class names and exposes timing, easing, and wobble angle via CSS custom properties for easy theming, matching the framework's zero-JS-overhead, animation-first philosophy. The minimal JS included only toggles the open/closed data attribute — not the animation itself.

--- a/submissions/examples/wobble-focus-accordion-interactive-interface/demo.html
+++ b/submissions/examples/wobble-focus-accordion-interactive-interface/demo.html
@@ -1,0 +1,72 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Wobble-Focus Accordion Demo — Interactive Interface</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: -apple-system, "Segoe UI", sans-serif; min-height: 100vh; padding: 60px 20px; margin: 0; background: #f8fafc; }
+    h2 { color: #1e293b; text-align: center; }
+    p.hint { text-align: center; color: #64748b; font-size: 13.5px; }
+  </style>
+</head>
+<body>
+  <h2>CSS Wobble-Focus Accordion — Interactive Interface</h2>
+  <p class="hint">Tab through the headers below to see the wobble-focus effect.</p>
+
+  <div class="ease-accordion">
+    <div class="ease-accordion__item" data-open="true">
+      <button class="ease-accordion__header" aria-expanded="true">
+        <span>Keyboard Navigation</span>
+        <svg class="ease-accordion__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M6 9l6 6 6-6" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+      <div class="ease-accordion__panel">
+        <div class="ease-accordion__body">
+          This accordion is fully operable via Tab and Enter/Space, with a wobble animation drawing attention to the focused header.
+        </div>
+      </div>
+    </div>
+
+    <div class="ease-accordion__item" data-open="false">
+      <button class="ease-accordion__header" aria-expanded="false">
+        <span>Interactive States</span>
+        <svg class="ease-accordion__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M6 9l6 6 6-6" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+      <div class="ease-accordion__panel">
+        <div class="ease-accordion__body">
+          Hover and focus states are both styled distinctly for clear visual feedback.
+        </div>
+      </div>
+    </div>
+
+    <div class="ease-accordion__item" data-open="false">
+      <button class="ease-accordion__header" aria-expanded="false">
+        <span>Customization</span>
+        <svg class="ease-accordion__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M6 9l6 6 6-6" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+      <div class="ease-accordion__panel">
+        <div class="ease-accordion__body">
+          Adjust the wobble angle and timing via CSS custom properties.
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    document.querySelectorAll('.ease-accordion__header').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const item = btn.closest('.ease-accordion__item');
+        const isOpen = item.getAttribute('data-open') === 'true';
+        item.setAttribute('data-open', String(!isOpen));
+        btn.setAttribute('aria-expanded', String(!isOpen));
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/wobble-focus-accordion-interactive-interface/style.css
+++ b/submissions/examples/wobble-focus-accordion-interactive-interface/style.css
@@ -1,0 +1,101 @@
+﻿:root {
+  --ease-accordion-wobble-duration: 0.5s;
+  --ease-accordion-wobble-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-accordion-bg: #ffffff;
+  --ease-accordion-border: #e2e8f0;
+  --ease-accordion-accent: #4f46e5;
+  --ease-accordion-accent-soft: #e0e7ff;
+  --ease-accordion-radius: 12px;
+  --ease-accordion-max-width: 500px;
+  --ease-accordion-focus-ring: #4f46e5;
+  --ease-accordion-wobble-angle: 3deg;
+}
+
+.ease-accordion {
+  max-width: var(--ease-accordion-max-width);
+  margin: 20px auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ease-accordion__item {
+  background: var(--ease-accordion-bg);
+  border: 1px solid var(--ease-accordion-border);
+  border-radius: var(--ease-accordion-radius);
+  overflow: hidden;
+  box-shadow: 0 4px 16px rgba(15, 23, 42, 0.06);
+}
+
+.ease-accordion__header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  background: transparent;
+  border: none;
+  color: #1e293b;
+  font-size: 15.5px;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: left;
+}
+
+/* Wobble-Focus: the header rocks side-to-side on keyboard focus,
+   drawing clear attention to the currently focused control. */
+.ease-accordion__header:focus-visible {
+  outline: 3px solid var(--ease-accordion-focus-ring);
+  outline-offset: -3px;
+  animation: ease-wobble-focus var(--ease-accordion-wobble-duration) var(--ease-accordion-wobble-easing);
+  background: var(--ease-accordion-accent-soft);
+}
+
+@keyframes ease-wobble-focus {
+  0%, 100% { transform: rotate(0deg); }
+  25% { transform: rotate(calc(-1 * var(--ease-accordion-wobble-angle))); }
+  50% { transform: rotate(var(--ease-accordion-wobble-angle)); }
+  75% { transform: rotate(calc(-0.5 * var(--ease-accordion-wobble-angle))); }
+}
+
+.ease-accordion__header:hover {
+  background: var(--ease-accordion-accent-soft);
+}
+
+.ease-accordion__icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  color: var(--ease-accordion-accent);
+  transition: transform 0.3s var(--ease-accordion-wobble-easing);
+}
+
+.ease-accordion__item[data-open="true"] .ease-accordion__icon {
+  transform: rotate(180deg);
+}
+
+.ease-accordion__panel {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.35s ease;
+}
+
+.ease-accordion__item[data-open="true"] .ease-accordion__panel {
+  max-height: 300px;
+}
+
+.ease-accordion__body {
+  padding: 0 20px 18px;
+  color: #475569;
+  font-size: 14.5px;
+  line-height: 1.65;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-accordion__header,
+  .ease-accordion__icon,
+  .ease-accordion__panel {
+    transition: none !important;
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS accordion with a wobble-focus interaction effect on keyboard focus, styled for interactive interface layouts. Resolves #33034

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/wobble-focus-accordion-interactive-interface/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS accordion where each header rocks with a subtle wobble on keyboard focus, drawing clear attention to the currently active control.

**How does a developer use it?**
```html
<div class="ease-accordion">
  <div class="ease-accordion__item" data-open="false">
    <button class="ease-accordion__header" aria-expanded="false">
      <span>Question</span>
      <svg class="ease-accordion__icon">...</svg>
    </button>
    <div class="ease-accordion__panel">
      <div class="ease-accordion__body">Answer content</div>
    </div>
  </div>
</div>
```
Toggling `data-open` on the item (and `aria-expanded` on the header) drives the expand/collapse transition; the wobble triggers automatically on header `:focus-visible`.

**Why does it fit EaseMotion CSS?**
Uses `ease-` prefixed class names and exposes timing, easing, and wobble angle via CSS custom properties for easy theming, matching the framework's zero-JS-overhead, animation-first philosophy. Minimal JS only toggles the open/closed state — not the animation itself.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome

---

## Notes for Maintainer
The wobble is triggered on `:focus-visible` rather than hover, since this variant is themed around keyboard/interactive-state visibility rather than mouse interaction. Includes accessibility: real `<button>` headers with `aria-expanded`, keyboard operable, wobble reinforces (doesn't replace) the visible focus outline. `prefers-reduced-motion` disables both the wobble and the collapse transition.