### PR TITLE
feat: add CSS Wobble-Focus Accordion for Creative Portfolio Layouts

### DIFF
--- a/submissions/examples/wobble-focus-accordion-creative-portfolio/README.md
+++ b/submissions/examples/wobble-focus-accordion-creative-portfolio/README.md
@@ -1,0 +1,47 @@
+﻿# CSS Wobble-Focus Accordion — Creative Portfolio Layout
+
+A pure CSS accordion where each header rocks with a subtle wobble on keyboard focus, styled with a warm, editorial aesthetic suited to an artist portfolio.
+
+## CSS Custom Properties
+
+| Property                            | Default                              | Description                                |
+|----------------------------------------|-------------------------------------------|-----------------------------------------------|
+| `--ease-accordion-wobble-duration`   | `0.5s`                                    | Duration of the focus wobble animation        |
+| `--ease-accordion-wobble-easing`     | `cubic-bezier(0.34, 1.56, 0.64, 1)`      | Easing curve for the wobble                   |
+| `--ease-accordion-wobble-angle`      | `3deg`                                    | Maximum rotation angle of the wobble          |
+| `--ease-accordion-bg`                | `#fffdf9`                                 | Panel background color                        |
+| `--ease-accordion-border`            | `#ede4d3`                                 | Panel border color                            |
+| `--ease-accordion-accent`            | `#b45309`                                 | Accent color (icon)                           |
+| `--ease-accordion-accent-soft`       | `#fef3c7`                                 | Soft accent background on hover/focus         |
+| `--ease-accordion-radius`            | `14px`                                    | Panel corner radius                           |
+| `--ease-accordion-max-width`         | `520px`                                   | Maximum accordion width                       |
+| `--ease-accordion-focus-ring`        | `#b45309`                                 | Focus outline color                           |
+
+## Usage
+
+```html
+<div class="ease-accordion">
+  <div class="ease-accordion__item" data-open="false">
+    <button class="ease-accordion__header" aria-expanded="false">
+      <span>About the Artist</span>
+      <svg class="ease-accordion__icon">...</svg>
+    </button>
+    <div class="ease-accordion__panel">
+      <div class="ease-accordion__body">Content</div>
+    </div>
+  </div>
+</div>
+```
+
+Toggle `data-open="true"` on `.ease-accordion__item` (and `aria-expanded` on the header) to expand/collapse. The wobble triggers automatically on header `:focus-visible` via a CSS keyframe.
+
+## Accessibility
+
+- Each header is a real `<button>` with `aria-expanded` reflecting open state.
+- Fully keyboard operable — headers are natively focusable and clickable via Enter/Space.
+- The wobble animation reinforces (not replaces) a visible focus outline.
+- `prefers-reduced-motion: reduce` disables the wobble animation and collapse transition.
+
+## Why it fits EaseMotion CSS
+
+Uses `ease-` prefixed class names and exposes timing, easing, and wobble angle via CSS custom properties for easy theming, matching the framework's zero-JS-overhead, animation-first philosophy. The minimal JS included only toggles the open/closed data attribute — not the animation itself.

--- a/submissions/examples/wobble-focus-accordion-creative-portfolio/demo.html
+++ b/submissions/examples/wobble-focus-accordion-creative-portfolio/demo.html
@@ -1,0 +1,72 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Wobble-Focus Accordion Demo — Creative Portfolio</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: Georgia, serif; min-height: 100vh; padding: 60px 20px; margin: 0; background: #fdf6ec; }
+    h2 { color: #451a03; text-align: center; }
+    p.hint { text-align: center; color: #92400e; font-size: 13.5px; }
+  </style>
+</head>
+<body>
+  <h2>CSS Wobble-Focus Accordion — Creative Portfolio</h2>
+  <p class="hint">Tab through the headers below to see the wobble-focus effect.</p>
+
+  <div class="ease-accordion">
+    <div class="ease-accordion__item" data-open="true">
+      <button class="ease-accordion__header" aria-expanded="true">
+        <span>About the Artist</span>
+        <svg class="ease-accordion__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M6 9l6 6 6-6" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+      <div class="ease-accordion__panel">
+        <div class="ease-accordion__body">
+          A visual artist working across illustration, mixed media, and digital design, inspired by nature and negative space.
+        </div>
+      </div>
+    </div>
+
+    <div class="ease-accordion__item" data-open="false">
+      <button class="ease-accordion__header" aria-expanded="false">
+        <span>Featured Projects</span>
+        <svg class="ease-accordion__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M6 9l6 6 6-6" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+      <div class="ease-accordion__panel">
+        <div class="ease-accordion__body">
+          A curated selection of gallery exhibitions, brand collaborations, and personal series.
+        </div>
+      </div>
+    </div>
+
+    <div class="ease-accordion__item" data-open="false">
+      <button class="ease-accordion__header" aria-expanded="false">
+        <span>Get in Touch</span>
+        <svg class="ease-accordion__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M6 9l6 6 6-6" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+      <div class="ease-accordion__panel">
+        <div class="ease-accordion__body">
+          Available for commissions and collaborations — reach out via the contact page.
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    document.querySelectorAll('.ease-accordion__header').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const item = btn.closest('.ease-accordion__item');
+        const isOpen = item.getAttribute('data-open') === 'true';
+        item.setAttribute('data-open', String(!isOpen));
+        btn.setAttribute('aria-expanded', String(!isOpen));
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/wobble-focus-accordion-creative-portfolio/style.css
+++ b/submissions/examples/wobble-focus-accordion-creative-portfolio/style.css
@@ -1,0 +1,102 @@
+﻿:root {
+  --ease-accordion-wobble-duration: 0.5s;
+  --ease-accordion-wobble-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-accordion-bg: #fffdf9;
+  --ease-accordion-border: #ede4d3;
+  --ease-accordion-accent: #b45309;
+  --ease-accordion-accent-soft: #fef3c7;
+  --ease-accordion-radius: 14px;
+  --ease-accordion-max-width: 520px;
+  --ease-accordion-focus-ring: #b45309;
+  --ease-accordion-wobble-angle: 3deg;
+}
+
+.ease-accordion {
+  max-width: var(--ease-accordion-max-width);
+  margin: 20px auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ease-accordion__item {
+  background: var(--ease-accordion-bg);
+  border: 1px solid var(--ease-accordion-border);
+  border-radius: var(--ease-accordion-radius);
+  overflow: hidden;
+  box-shadow: 0 6px 18px rgba(120, 80, 30, 0.08);
+}
+
+.ease-accordion__header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 22px;
+  background: transparent;
+  border: none;
+  color: #451a03;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: left;
+  font-family: Georgia, "Times New Roman", serif;
+}
+
+/* Wobble-Focus: the header rocks side-to-side on keyboard focus,
+   drawing clear attention to the currently focused control. */
+.ease-accordion__header:focus-visible {
+  outline: 3px solid var(--ease-accordion-focus-ring);
+  outline-offset: -3px;
+  animation: ease-wobble-focus var(--ease-accordion-wobble-duration) var(--ease-accordion-wobble-easing);
+  background: var(--ease-accordion-accent-soft);
+}
+
+@keyframes ease-wobble-focus {
+  0%, 100% { transform: rotate(0deg); }
+  25% { transform: rotate(calc(-1 * var(--ease-accordion-wobble-angle))); }
+  50% { transform: rotate(var(--ease-accordion-wobble-angle)); }
+  75% { transform: rotate(calc(-0.5 * var(--ease-accordion-wobble-angle))); }
+}
+
+.ease-accordion__header:hover {
+  background: var(--ease-accordion-accent-soft);
+}
+
+.ease-accordion__icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  color: var(--ease-accordion-accent);
+  transition: transform 0.3s var(--ease-accordion-wobble-easing);
+}
+
+.ease-accordion__item[data-open="true"] .ease-accordion__icon {
+  transform: rotate(180deg);
+}
+
+.ease-accordion__panel {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.35s ease;
+}
+
+.ease-accordion__item[data-open="true"] .ease-accordion__panel {
+  max-height: 300px;
+}
+
+.ease-accordion__body {
+  padding: 0 22px 20px;
+  color: #78350f;
+  font-size: 15px;
+  line-height: 1.7;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-accordion__header,
+  .ease-accordion__icon,
+  .ease-accordion__panel {
+    transition: none !important;
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS accordion with a wobble-focus interaction effect on keyboard focus, styled for creative portfolio layouts. Resolves #33033

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/wobble-focus-accordion-creative-portfolio/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS accordion where each header rocks with a subtle wobble on keyboard focus, styled with a warm, editorial aesthetic suited to an artist portfolio.

**How does a developer use it?**
```html
<div class="ease-accordion">
  <div class="ease-accordion__item" data-open="false">
    <button class="ease-accordion__header" aria-expanded="false">
      <span>About the Artist</span>
      <svg class="ease-accordion__icon">...</svg>
    </button>
    <div class="ease-accordion__panel">
      <div class="ease-accordion__body">Content</div>
    </div>
  </div>
</div>
```
Toggling `data-open` on the item (and `aria-expanded` on the header) drives the expand/collapse transition; the wobble triggers automatically on header `:focus-visible`.

**Why does it fit EaseMotion CSS?**
Uses `ease-` prefixed class names and exposes timing, easing, and wobble angle via CSS custom properties for easy theming, matching the framework's zero-JS-overhead, animation-first philosophy. Minimal JS only toggles the open/closed state — not the animation itself.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome

---

## Notes for Maintainer
Uses a serif typeface and warm amber palette to match a creative-portfolio aesthetic, distinct from the Interactive Interface variant. Includes accessibility: real `<button>` headers with `aria-expanded`, keyboard operable, wobble reinforces the visible focus outline. `prefers-reduced-motion` disables both the wobble and the collapse transition.