### PR TITLE
feat: add CSS Wobble-Focus Accordion for Accessible Web Layouts

### DIFF
--- a/submissions/examples/wobble-focus-accordion-accessible-web/README.md
+++ b/submissions/examples/wobble-focus-accordion-accessible-web/README.md
@@ -1,0 +1,48 @@
+﻿# CSS Wobble-Focus Accordion — Accessible Web Layout
+
+A pure CSS accordion where each header rocks with a subtle wobble on keyboard focus, providing a strong, non-color-dependent focus cue in addition to a visible outline.
+
+## CSS Custom Properties
+
+| Property                            | Default                              | Description                                |
+|----------------------------------------|-------------------------------------------|-----------------------------------------------|
+| `--ease-accordion-wobble-duration`   | `0.5s`                                    | Duration of the focus wobble animation        |
+| `--ease-accordion-wobble-easing`     | `cubic-bezier(0.34, 1.56, 0.64, 1)`      | Easing curve for the wobble                   |
+| `--ease-accordion-wobble-angle`      | `2.5deg`                                  | Maximum rotation angle of the wobble          |
+| `--ease-accordion-bg`                | `#ffffff`                                 | Panel background color                        |
+| `--ease-accordion-border`            | `#d1d5db`                                 | Panel border color                            |
+| `--ease-accordion-accent`            | `#1d4ed8`                                 | Accent color (icon)                           |
+| `--ease-accordion-accent-soft`       | `#dbeafe`                                 | Soft accent background on hover/focus         |
+| `--ease-accordion-radius`            | `10px`                                    | Panel corner radius                           |
+| `--ease-accordion-max-width`         | `520px`                                   | Maximum accordion width                       |
+| `--ease-accordion-focus-ring`        | `#1d4ed8`                                 | Focus outline color                           |
+
+## Usage
+
+```html
+<div class="ease-accordion">
+  <div class="ease-accordion__item" data-open="false">
+    <button class="ease-accordion__header" aria-expanded="false">
+      <span>Question</span>
+      <svg class="ease-accordion__icon">...</svg>
+    </button>
+    <div class="ease-accordion__panel">
+      <div class="ease-accordion__body">Answer content</div>
+    </div>
+  </div>
+</div>
+```
+
+Toggle `data-open="true"` on `.ease-accordion__item` (and `aria-expanded` on the header) to expand/collapse. The wobble triggers automatically on header `:focus-visible` via a CSS keyframe.
+
+## Accessibility
+
+- Each header is a real `<button>` with `aria-expanded` reflecting open state.
+- Fully keyboard operable — headers are natively focusable and clickable via Enter/Space.
+- Uses a bold 2px border and strong outline so state is never conveyed by color alone.
+- The wobble reinforces (doesn't replace) the visible focus outline, giving a motion-based cue as well.
+- `prefers-reduced-motion: reduce` disables the wobble animation and collapse transition.
+
+## Why it fits EaseMotion CSS
+
+Uses `ease-` prefixed class names and exposes timing, easing, and wobble angle via CSS custom properties for easy theming, matching the framework's zero-JS-overhead, animation-first philosophy. The minimal JS included only toggles the open/closed data attribute — not the animation itself.

--- a/submissions/examples/wobble-focus-accordion-accessible-web/demo.html
+++ b/submissions/examples/wobble-focus-accordion-accessible-web/demo.html
@@ -1,0 +1,72 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Wobble-Focus Accordion Demo — Accessible Web</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: -apple-system, "Segoe UI", sans-serif; min-height: 100vh; padding: 60px 20px; margin: 0; background: #f9fafb; }
+    h2 { color: #111827; text-align: center; }
+    p.hint { text-align: center; color: #4b5563; font-size: 14px; }
+  </style>
+</head>
+<body>
+  <h2>CSS Wobble-Focus Accordion — Accessible Web</h2>
+  <p class="hint">Tab through the headers below to see the wobble-focus effect.</p>
+
+  <div class="ease-accordion">
+    <div class="ease-accordion__item" data-open="true">
+      <button class="ease-accordion__header" aria-expanded="true">
+        <span>Why does focus matter?</span>
+        <svg class="ease-accordion__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M6 9l6 6 6-6" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+      <div class="ease-accordion__panel">
+        <div class="ease-accordion__body">
+          Keyboard users rely on visible focus indicators to navigate. This component pairs a strong outline with a motion cue for extra clarity.
+        </div>
+      </div>
+    </div>
+
+    <div class="ease-accordion__item" data-open="false">
+      <button class="ease-accordion__header" aria-expanded="false">
+        <span>Is it screen reader friendly?</span>
+        <svg class="ease-accordion__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M6 9l6 6 6-6" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+      <div class="ease-accordion__panel">
+        <div class="ease-accordion__body">
+          Yes — headers use real buttons with aria-expanded, announced correctly by assistive tech.
+        </div>
+      </div>
+    </div>
+
+    <div class="ease-accordion__item" data-open="false">
+      <button class="ease-accordion__header" aria-expanded="false">
+        <span>Does motion cause issues?</span>
+        <svg class="ease-accordion__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M6 9l6 6 6-6" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+      <div class="ease-accordion__panel">
+        <div class="ease-accordion__body">
+          Not for most users, and prefers-reduced-motion is fully respected for those who are sensitive to it.
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    document.querySelectorAll('.ease-accordion__header').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const item = btn.closest('.ease-accordion__item');
+        const isOpen = item.getAttribute('data-open') === 'true';
+        item.setAttribute('data-open', String(!isOpen));
+        btn.setAttribute('aria-expanded', String(!isOpen));
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/wobble-focus-accordion-accessible-web/style.css
+++ b/submissions/examples/wobble-focus-accordion-accessible-web/style.css
@@ -1,0 +1,100 @@
+﻿:root {
+  --ease-accordion-wobble-duration: 0.5s;
+  --ease-accordion-wobble-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-accordion-bg: #ffffff;
+  --ease-accordion-border: #d1d5db;
+  --ease-accordion-accent: #1d4ed8;
+  --ease-accordion-accent-soft: #dbeafe;
+  --ease-accordion-radius: 10px;
+  --ease-accordion-max-width: 520px;
+  --ease-accordion-focus-ring: #1d4ed8;
+  --ease-accordion-wobble-angle: 2.5deg;
+}
+
+.ease-accordion {
+  max-width: var(--ease-accordion-max-width);
+  margin: 20px auto;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.ease-accordion__item {
+  background: var(--ease-accordion-bg);
+  border: 2px solid var(--ease-accordion-border);
+  border-radius: var(--ease-accordion-radius);
+  overflow: hidden;
+}
+
+.ease-accordion__header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 17px 20px;
+  background: transparent;
+  border: none;
+  color: #111827;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: left;
+}
+
+/* Wobble-Focus: the header rocks side-to-side on keyboard focus,
+   providing a strong, non-color-dependent focus cue for accessibility. */
+.ease-accordion__header:focus-visible {
+  outline: 3px solid var(--ease-accordion-focus-ring);
+  outline-offset: -3px;
+  animation: ease-wobble-focus var(--ease-accordion-wobble-duration) var(--ease-accordion-wobble-easing);
+  background: var(--ease-accordion-accent-soft);
+}
+
+@keyframes ease-wobble-focus {
+  0%, 100% { transform: rotate(0deg); }
+  25% { transform: rotate(calc(-1 * var(--ease-accordion-wobble-angle))); }
+  50% { transform: rotate(var(--ease-accordion-wobble-angle)); }
+  75% { transform: rotate(calc(-0.5 * var(--ease-accordion-wobble-angle))); }
+}
+
+.ease-accordion__header:hover {
+  background: var(--ease-accordion-accent-soft);
+}
+
+.ease-accordion__icon {
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+  color: var(--ease-accordion-accent);
+  transition: transform 0.3s var(--ease-accordion-wobble-easing);
+}
+
+.ease-accordion__item[data-open="true"] .ease-accordion__icon {
+  transform: rotate(180deg);
+}
+
+.ease-accordion__panel {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.35s ease;
+}
+
+.ease-accordion__item[data-open="true"] .ease-accordion__panel {
+  max-height: 320px;
+}
+
+.ease-accordion__body {
+  padding: 0 20px 18px;
+  color: #374151;
+  font-size: 15px;
+  line-height: 1.7;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-accordion__header,
+  .ease-accordion__icon,
+  .ease-accordion__panel {
+    transition: none !important;
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS accordion with a wobble-focus interaction effect on keyboard focus, styled for accessible web layouts with extra emphasis on non-color-dependent state indicators. Resolves #33032

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/wobble-focus-accordion-accessible-web/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS accordion where each header rocks with a subtle wobble on keyboard focus, providing a strong, non-color-dependent focus cue in addition to a visible outline.

**How does a developer use it?**
```html
<div class="ease-accordion">
  <div class="ease-accordion__item" data-open="false">
    <button class="ease-accordion__header" aria-expanded="false">
      <span>Question</span>
      <svg class="ease-accordion__icon">...</svg>
    </button>
    <div class="ease-accordion__panel">
      <div class="ease-accordion__body">Answer content</div>
    </div>
  </div>
</div>
```
Toggling `data-open` on the item (and `aria-expanded` on the header) drives the expand/collapse transition; the wobble triggers automatically on header `:focus-visible`.

**Why does it fit EaseMotion CSS?**
Uses `ease-` prefixed class names and exposes timing, easing, and wobble angle via CSS custom properties for easy theming, matching the framework's zero-JS-overhead, animation-first philosophy. Minimal JS only toggles the open/closed state — not the animation itself.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome

---

## Notes for Maintainer
Bolder 2px border and stronger outline than other variants, in keeping with the accessible-web theme — motion is an accessibility enhancement here, not decoration. Includes: real `<button>` headers with `aria-expanded`, keyboard operable, wobble reinforces the visible focus outline. `prefers-reduced-motion` disables both the wobble and the collapse transition.