### PR TITLE
feat: add CSS Wobble-Focus Accordion for Neumorphic Soft Layouts

### DIFF
--- a/submissions/examples/wobble-focus-accordion-neumorphic-soft/README.md
+++ b/submissions/examples/wobble-focus-accordion-neumorphic-soft/README.md
@@ -1,0 +1,47 @@
+﻿# CSS Wobble-Focus Accordion — Neumorphic Soft Layout
+
+A pure CSS accordion where each header rocks with a subtle wobble on keyboard focus, styled with a soft neumorphic surface using dual-tone shadows.
+
+## CSS Custom Properties
+
+| Property                            | Default                              | Description                                |
+|----------------------------------------|-------------------------------------------|-----------------------------------------------|
+| `--ease-accordion-wobble-duration`   | `0.5s`                                    | Duration of the focus wobble animation        |
+| `--ease-accordion-wobble-easing`     | `cubic-bezier(0.34, 1.56, 0.64, 1)`      | Easing curve for the wobble                   |
+| `--ease-accordion-wobble-angle`      | `2.5deg`                                  | Maximum rotation angle of the wobble          |
+| `--ease-accordion-bg`                | `#e6e9ef`                                 | Panel/page background (neumorphic base)       |
+| `--ease-accordion-accent`            | `#6366f1`                                 | Accent color (icon)                           |
+| `--ease-accordion-shadow-light`      | `#ffffff`                                 | Light-side neumorphic shadow                  |
+| `--ease-accordion-shadow-dark`       | `#b8bcc7`                                 | Dark-side neumorphic shadow                   |
+| `--ease-accordion-radius`            | `16px`                                    | Panel corner radius                           |
+| `--ease-accordion-max-width`         | `500px`                                   | Maximum accordion width                       |
+| `--ease-accordion-focus-ring`        | `#6366f1`                                 | Focus outline color                           |
+
+## Usage
+
+```html
+<div class="ease-accordion">
+  <div class="ease-accordion__item" data-open="false">
+    <button class="ease-accordion__header" aria-expanded="false">
+      <span>Notification Preferences</span>
+      <svg class="ease-accordion__icon">...</svg>
+    </button>
+    <div class="ease-accordion__panel">
+      <div class="ease-accordion__body">Content</div>
+    </div>
+  </div>
+</div>
+```
+
+Toggle `data-open="true"` on `.ease-accordion__item` (and `aria-expanded` on the header) to expand/collapse. The wobble triggers automatically on header `:focus-visible` via a CSS keyframe.
+
+## Accessibility
+
+- Each header is a real `<button>` with `aria-expanded` reflecting open state.
+- Fully keyboard operable — headers are natively focusable and clickable via Enter/Space.
+- Neumorphic surfaces are famously low-contrast, so the wobble adds a motion-based focus cue beyond just the outline.
+- `prefers-reduced-motion: reduce` disables the wobble animation and collapse transition.
+
+## Why it fits EaseMotion CSS
+
+Uses `ease-` prefixed class names and exposes timing, easing, and wobble angle via CSS custom properties for easy theming, matching the framework's zero-JS-overhead, animation-first philosophy. The minimal JS included only toggles the open/closed data attribute — not the animation itself.

--- a/submissions/examples/wobble-focus-accordion-neumorphic-soft/demo.html
+++ b/submissions/examples/wobble-focus-accordion-neumorphic-soft/demo.html
@@ -1,0 +1,72 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Wobble-Focus Accordion Demo — Neumorphic Soft</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: -apple-system, "Segoe UI", sans-serif; min-height: 100vh; padding: 60px 20px; margin: 0; }
+    h2 { color: #374151; text-align: center; }
+    p.hint { text-align: center; color: #6b7280; font-size: 13.5px; }
+  </style>
+</head>
+<body>
+  <h2>CSS Wobble-Focus Accordion — Neumorphic Soft</h2>
+  <p class="hint">Tab through the headers below to see the wobble-focus effect.</p>
+
+  <div class="ease-accordion">
+    <div class="ease-accordion__item" data-open="true">
+      <button class="ease-accordion__header" aria-expanded="true">
+        <span>Notification Preferences</span>
+        <svg class="ease-accordion__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M6 9l6 6 6-6" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+      <div class="ease-accordion__panel">
+        <div class="ease-accordion__body">
+          Choose how you'd like to receive updates — email, push, or both.
+        </div>
+      </div>
+    </div>
+
+    <div class="ease-accordion__item" data-open="false">
+      <button class="ease-accordion__header" aria-expanded="false">
+        <span>Privacy Settings</span>
+        <svg class="ease-accordion__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M6 9l6 6 6-6" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+      <div class="ease-accordion__panel">
+        <div class="ease-accordion__body">
+          Control who can see your profile and activity.
+        </div>
+      </div>
+    </div>
+
+    <div class="ease-accordion__item" data-open="false">
+      <button class="ease-accordion__header" aria-expanded="false">
+        <span>Account Security</span>
+        <svg class="ease-accordion__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M6 9l6 6 6-6" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+      <div class="ease-accordion__panel">
+        <div class="ease-accordion__body">
+          Manage two-factor authentication and connected devices.
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    document.querySelectorAll('.ease-accordion__header').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const item = btn.closest('.ease-accordion__item');
+        const isOpen = item.getAttribute('data-open') === 'true';
+        item.setAttribute('data-open', String(!isOpen));
+        btn.setAttribute('aria-expanded', String(!isOpen));
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/wobble-focus-accordion-neumorphic-soft/style.css
+++ b/submissions/examples/wobble-focus-accordion-neumorphic-soft/style.css
@@ -1,0 +1,101 @@
+﻿:root {
+  --ease-accordion-wobble-duration: 0.5s;
+  --ease-accordion-wobble-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-accordion-bg: #e6e9ef;
+  --ease-accordion-accent: #6366f1;
+  --ease-accordion-accent-soft: #eef0fb;
+  --ease-accordion-radius: 16px;
+  --ease-accordion-max-width: 500px;
+  --ease-accordion-focus-ring: #6366f1;
+  --ease-accordion-wobble-angle: 2.5deg;
+  --ease-accordion-shadow-light: #ffffff;
+  --ease-accordion-shadow-dark: #b8bcc7;
+}
+
+body {
+  background: var(--ease-accordion-bg);
+}
+
+.ease-accordion {
+  max-width: var(--ease-accordion-max-width);
+  margin: 20px auto;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.ease-accordion__item {
+  background: var(--ease-accordion-bg);
+  border-radius: var(--ease-accordion-radius);
+  overflow: hidden;
+  box-shadow: 8px 8px 16px var(--ease-accordion-shadow-dark),
+              -8px -8px 16px var(--ease-accordion-shadow-light);
+}
+
+.ease-accordion__header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 22px;
+  background: transparent;
+  border: none;
+  color: #374151;
+  font-size: 15.5px;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: left;
+}
+
+/* Wobble-Focus: the header rocks side-to-side on keyboard focus,
+   giving a tactile focus cue against the soft, low-contrast neumorphic surface. */
+.ease-accordion__header:focus-visible {
+  outline: 3px solid var(--ease-accordion-focus-ring);
+  outline-offset: -3px;
+  animation: ease-wobble-focus var(--ease-accordion-wobble-duration) var(--ease-accordion-wobble-easing);
+}
+
+@keyframes ease-wobble-focus {
+  0%, 100% { transform: rotate(0deg); }
+  25% { transform: rotate(calc(-1 * var(--ease-accordion-wobble-angle))); }
+  50% { transform: rotate(var(--ease-accordion-wobble-angle)); }
+  75% { transform: rotate(calc(-0.5 * var(--ease-accordion-wobble-angle))); }
+}
+
+.ease-accordion__icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  color: var(--ease-accordion-accent);
+  transition: transform 0.3s var(--ease-accordion-wobble-easing);
+}
+
+.ease-accordion__item[data-open="true"] .ease-accordion__icon {
+  transform: rotate(180deg);
+}
+
+.ease-accordion__panel {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.35s ease;
+}
+
+.ease-accordion__item[data-open="true"] .ease-accordion__panel {
+  max-height: 300px;
+}
+
+.ease-accordion__body {
+  padding: 0 22px 20px;
+  color: #4b5563;
+  font-size: 14.5px;
+  line-height: 1.7;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-accordion__header,
+  .ease-accordion__icon,
+  .ease-accordion__panel {
+    transition: none !important;
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS accordion with a wobble-focus interaction effect on keyboard focus, styled for neumorphic soft layouts. Resolves #33030

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/wobble-focus-accordion-neumorphic-soft/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS accordion where each header rocks with a subtle wobble on keyboard focus, styled with a soft neumorphic surface using dual-tone shadows.

**How does a developer use it?**
```html
<div class="ease-accordion">
  <div class="ease-accordion__item" data-open="false">
    <button class="ease-accordion__header" aria-expanded="false">
      <span>Notification Preferences</span>
      <svg class="ease-accordion__icon">...</svg>
    </button>
    <div class="ease-accordion__panel">
      <div class="ease-accordion__body">Content</div>
    </div>
  </div>
</div>
```
Toggling `data-open` on the item (and `aria-expanded` on the header) drives the expand/collapse transition; the wobble triggers automatically on header `:focus-visible`.

**Why does it fit EaseMotion CSS?**
Uses `ease-` prefixed class names and exposes timing, easing, and wobble angle via CSS custom properties for easy theming, matching the framework's zero-JS-overhead, animation-first philosophy. Minimal JS only toggles the open/closed state — not the animation itself.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome

---

## Notes for Maintainer
Uses dual-tone box-shadows (light + dark) for the classic neumorphic "soft UI" surface rather than a border. Given neumorphism's typically low contrast, the wobble adds a motion-based focus cue beyond the outline alone. Includes accessibility: real `<button>` headers with `aria-expanded`, keyboard operable. `prefers-reduced-motion` disables both the wobble and the collapse transition.
