### PR TITLE
feat: add CSS Tada-Click Accordion for Accessible Web Layouts

### DIFF
--- a/submissions/examples/tada-click-accordion-accessible-web/README.md
+++ b/submissions/examples/tada-click-accordion-accessible-web/README.md
@@ -1,0 +1,46 @@
+﻿# CSS Tada-Click Accordion — Accessible Web Layout
+
+A pure CSS accordion where each header plays a quick "tada" scale-and-rotate burst on click, giving a strong, non-color-dependent confirmation that the action registered.
+
+## CSS Custom Properties
+
+| Property                          | Default        | Description                              |
+|-------------------------------------|-------------------|---------------------------------------------|
+| `--ease-accordion-tada-duration`  | `0.6s`             | Duration of the tada click animation        |
+| `--ease-accordion-tada-easing`    | `ease-in-out`      | Easing curve for the tada burst             |
+| `--ease-accordion-bg`             | `#ffffff`          | Panel background color                      |
+| `--ease-accordion-border`         | `#d1d5db`          | Panel border color                          |
+| `--ease-accordion-accent`         | `#1d4ed8`          | Accent color (icon)                         |
+| `--ease-accordion-accent-soft`    | `#dbeafe`          | Soft accent background on hover             |
+| `--ease-accordion-radius`         | `10px`             | Panel corner radius                         |
+| `--ease-accordion-max-width`      | `520px`            | Maximum accordion width                     |
+| `--ease-accordion-focus-ring`     | `#1d4ed8`          | Focus outline color                         |
+
+## Usage
+
+```html
+<div class="ease-accordion">
+  <div class="ease-accordion__item" data-open="false">
+    <button class="ease-accordion__header" aria-expanded="false">
+      <span>Question</span>
+      <svg class="ease-accordion__icon">...</svg>
+    </button>
+    <div class="ease-accordion__panel">
+      <div class="ease-accordion__body">Answer content</div>
+    </div>
+  </div>
+</div>
+```
+
+Add the `is-tada` class on click (removing it on `animationend`) to replay the tada burst; toggle `data-open`/`aria-expanded` to expand/collapse.
+
+## Accessibility
+
+- Each header is a real `<button>` with `aria-expanded` reflecting open state.
+- Fully keyboard operable — Enter/Space both trigger the same click handler and tada animation.
+- Bold 2px border and strong focus outline ensure state is never conveyed by color alone.
+- `prefers-reduced-motion: reduce` disables the tada animation and collapse transition.
+
+## Why it fits EaseMotion CSS
+
+Uses `ease-` prefixed class names and exposes timing/easing via CSS custom properties for easy theming, matching the framework's zero-JS-overhead, animation-first philosophy. The minimal JS included only toggles classes/attributes — not the animation itself.

--- a/submissions/examples/tada-click-accordion-accessible-web/demo.html
+++ b/submissions/examples/tada-click-accordion-accessible-web/demo.html
@@ -1,0 +1,79 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Tada-Click Accordion Demo — Accessible Web</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: -apple-system, "Segoe UI", sans-serif; min-height: 100vh; padding: 60px 20px; margin: 0; background: #f9fafb; }
+    h2 { color: #111827; text-align: center; }
+    p.hint { text-align: center; color: #4b5563; font-size: 14px; }
+  </style>
+</head>
+<body>
+  <h2>CSS Tada-Click Accordion — Accessible Web</h2>
+  <p class="hint">Click a header to see the tada confirmation burst.</p>
+
+  <div class="ease-accordion">
+    <div class="ease-accordion__item" data-open="true">
+      <button class="ease-accordion__header" aria-expanded="true">
+        <span>What does "tada-click" mean?</span>
+        <svg class="ease-accordion__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M6 9l6 6 6-6" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+      <div class="ease-accordion__panel">
+        <div class="ease-accordion__body">
+          A quick scale-and-rotate burst plays on click, confirming your action registered — helpful for users who may miss subtler feedback.
+        </div>
+      </div>
+    </div>
+
+    <div class="ease-accordion__item" data-open="false">
+      <button class="ease-accordion__header" aria-expanded="false">
+        <span>Does this replace focus styles?</span>
+        <svg class="ease-accordion__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M6 9l6 6 6-6" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+      <div class="ease-accordion__panel">
+        <div class="ease-accordion__body">
+          No — a strong focus outline is always present separately from the click animation.
+        </div>
+      </div>
+    </div>
+
+    <div class="ease-accordion__item" data-open="false">
+      <button class="ease-accordion__header" aria-expanded="false">
+        <span>Can I trigger this with Enter/Space?</span>
+        <svg class="ease-accordion__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M6 9l6 6 6-6" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+      <div class="ease-accordion__panel">
+        <div class="ease-accordion__body">
+          Yes — since headers are real buttons, both keyboard activation methods trigger the same tada effect.
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    document.querySelectorAll('.ease-accordion__header').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const item = btn.closest('.ease-accordion__item');
+        const isOpen = item.getAttribute('data-open') === 'true';
+        item.setAttribute('data-open', String(!isOpen));
+        btn.setAttribute('aria-expanded', String(!isOpen));
+
+        btn.classList.remove('is-tada');
+        void btn.offsetWidth;
+        btn.classList.add('is-tada');
+      });
+      btn.addEventListener('animationend', () => {
+        btn.classList.remove('is-tada');
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/tada-click-accordion-accessible-web/style.css
+++ b/submissions/examples/tada-click-accordion-accessible-web/style.css
@@ -1,0 +1,102 @@
+﻿:root {
+  --ease-accordion-tada-duration: 0.6s;
+  --ease-accordion-tada-easing: ease-in-out;
+  --ease-accordion-bg: #ffffff;
+  --ease-accordion-border: #d1d5db;
+  --ease-accordion-accent: #1d4ed8;
+  --ease-accordion-accent-soft: #dbeafe;
+  --ease-accordion-radius: 10px;
+  --ease-accordion-max-width: 520px;
+  --ease-accordion-focus-ring: #1d4ed8;
+}
+
+.ease-accordion {
+  max-width: var(--ease-accordion-max-width);
+  margin: 20px auto;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.ease-accordion__item {
+  background: var(--ease-accordion-bg);
+  border: 2px solid var(--ease-accordion-border);
+  border-radius: var(--ease-accordion-radius);
+  overflow: hidden;
+}
+
+.ease-accordion__header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 17px 20px;
+  background: transparent;
+  border: none;
+  color: #111827;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: left;
+}
+
+/* Tada-Click: header pulses with a scale-up "tada" burst when clicked,
+   confirming the click registered — a strong, non-color-dependent cue. */
+.ease-accordion__header.is-tada {
+  animation: ease-tada var(--ease-accordion-tada-duration) var(--ease-accordion-tada-easing);
+}
+
+@keyframes ease-tada {
+  0% { transform: scale(1); }
+  10%, 20% { transform: scale(0.94) rotate(-2deg); }
+  30%, 50%, 70%, 90% { transform: scale(1.08) rotate(2deg); }
+  40%, 60%, 80% { transform: scale(1.08) rotate(-2deg); }
+  100% { transform: scale(1) rotate(0); }
+}
+
+.ease-accordion__header:hover {
+  background: var(--ease-accordion-accent-soft);
+}
+
+.ease-accordion__header:focus-visible {
+  outline: 3px solid var(--ease-accordion-focus-ring);
+  outline-offset: -3px;
+}
+
+.ease-accordion__icon {
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+  color: var(--ease-accordion-accent);
+  transition: transform 0.3s ease;
+}
+
+.ease-accordion__item[data-open="true"] .ease-accordion__icon {
+  transform: rotate(180deg);
+}
+
+.ease-accordion__panel {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.35s ease;
+}
+
+.ease-accordion__item[data-open="true"] .ease-accordion__panel {
+  max-height: 320px;
+}
+
+.ease-accordion__body {
+  padding: 0 20px 18px;
+  color: #374151;
+  font-size: 15px;
+  line-height: 1.7;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-accordion__header,
+  .ease-accordion__icon,
+  .ease-accordion__panel {
+    transition: none !important;
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS accordion with a tada-click confirmation burst on header click, styled for accessible web layouts. Resolves #33016

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/tada-click-accordion-accessible-web/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS accordion where each header plays a quick "tada" scale-and-rotate burst on click, giving a strong, non-color-dependent confirmation that the action registered.

**How does a developer use it?**
```html
<div class="ease-accordion">
  <div class="ease-accordion__item" data-open="false">
    <button class="ease-accordion__header" aria-expanded="false">
      <span>Question</span>
      <svg class="ease-accordion__icon">...</svg>
    </button>
    <div class="ease-accordion__panel">
      <div class="ease-accordion__body">Answer content</div>
    </div>
  </div>
</div>
```
Add the `is-tada` class on click (removed on `animationend`) to replay the burst; toggle `data-open`/`aria-expanded` to expand/collapse.

**Why does it fit EaseMotion CSS?**
Uses `ease-` prefixed class names and exposes timing/easing via CSS custom properties for easy theming, matching the framework's zero-JS-overhead, animation-first philosophy. Minimal JS only toggles classes/attributes — not the animation itself.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome

---

## Notes for Maintainer
The tada class is added/removed via JS on click and `animationend` so it can replay on every click, not just the first. Bold border + strong focus outline reinforce the accessible-web theme. `prefers-reduced-motion` disables both the tada burst and the collapse transition.