### PR TITLE
feat: Add CSS Fade-In Tooltip for Cyberpunk Neon Layouts (#34256)

### DIFF
--- a/submissions/examples/css-fade-in-tooltip-for-cyberpunk-neon-layouts-realtushartyagi-34256/README.md
+++ b/submissions/examples/css-fade-in-tooltip-for-cyberpunk-neon-layouts-realtushartyagi-34256/README.md
@@ -1,0 +1,50 @@
+# CSS Fade-In Tooltip for Cyberpunk Neon Layouts
+
+A pure CSS tooltip component featuring a smooth fade-in and slide-up transition, styled specifically for **Cyberpunk Neon** interface aesthetics.
+
+## Files
+- `style.css` – Contains all the EaseMotion CSS variables, wrapper mechanics, and the glowing neon tooltip transition styles.
+- `demo.html` – A standalone HTML file demonstrating the tooltip with a cyberpunk button trigger.
+
+## Installation
+1. Copy the folder into your project's `examples` directory.
+2. Link the stylesheet in your HTML file:
+   ```html
+   <link rel="stylesheet" href="./style.css" />
+   ```
+
+## Usage
+Wrap your trigger element (e.g., a button) and the tooltip content inside a container with the `.ease-tooltip-wrapper` class.
+
+```html
+<div class="ease-tooltip-wrapper">
+  <!-- Trigger Element -->
+  <button class="ease-cp-btn" aria-describedby="my-tooltip">
+    Hover Me
+  </button>
+  
+  <!-- Tooltip Element -->
+  <div id="my-tooltip" class="ease-tooltip-content" role="tooltip">
+    System Online
+  </div>
+</div>
+```
+
+## CSS Custom Properties
+You can easily adjust the animation timing and offset by overriding the CSS variables defined in `:root`:
+
+| Property | Default Value | Description |
+|----------|---------------|-------------|
+| `--ease-tt-transition-duration` | `0.3s` | The speed of the fade and slide transition. |
+| `--ease-tt-transition-easing` | `cubic-bezier(...)` | The timing function for the transition. |
+| `--ease-tt-offset-y` | `-10px` | How far the tooltip translates vertically upon hover. |
+
+## Why it fits EaseMotion CSS
+This component adheres to the **zero JavaScript overhead** philosophy of EaseMotion CSS. The interactive states (`:hover`, `:focus-within`) on the wrapper gracefully trigger the `opacity`, `visibility`, and `transform` CSS properties on the tooltip content, providing a 60fps, performant micro-interaction without any event listeners.
+
+## Accessibility
+The implementation utilizes standard ARIA attributes (`aria-describedby`, `role="tooltip"`) and respects keyboard navigation via the `:focus-within` pseudo-class.
+
+---
+
+> **Note:** PR modifies only files inside `submissions/examples/css-fade-in-tooltip-for-cyberpunk-neon-layouts-realtushartyagi-34256/`.

--- a/submissions/examples/css-fade-in-tooltip-for-cyberpunk-neon-layouts-realtushartyagi-34256/demo.html
+++ b/submissions/examples/css-fade-in-tooltip-for-cyberpunk-neon-layouts-realtushartyagi-34256/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>CSS Fade-In Tooltip (Cyberpunk Neon)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="./style.css" />
+  <style>
+    body {
+      background-color: #1a1a2e; /* Deep dark bg for cyberpunk contrast */
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+      margin: 0;
+      font-family: 'Courier New', Courier, monospace;
+    }
+    
+    .container {
+      text-align: center;
+    }
+    
+    .title {
+      color: #0ff;
+      text-shadow: 0 0 10px #0ff;
+      margin-bottom: 60px;
+      text-transform: uppercase;
+      letter-spacing: 2px;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h2 class="title">System Initialization</h2>
+    
+    <!-- Tooltip Wrapper -->
+    <div class="ease-tooltip-wrapper">
+      <button class="ease-cp-btn" aria-describedby="cyber-tooltip">
+        Engage Protocol
+      </button>
+      
+      <!-- Tooltip Content -->
+      <div id="cyber-tooltip" class="ease-tooltip-content" role="tooltip">
+        Data Linked
+      </div>
+    </div>
+    
+  </div>
+</body>
+</html>

--- a/submissions/examples/css-fade-in-tooltip-for-cyberpunk-neon-layouts-realtushartyagi-34256/style.css
+++ b/submissions/examples/css-fade-in-tooltip-for-cyberpunk-neon-layouts-realtushartyagi-34256/style.css
@@ -1,0 +1,108 @@
+/* 
+  style.css
+  EaseMotion CSS – Cyberpunk Neon Fade-In Tooltip
+*/
+
+:root {
+  /* Cyberpunk Variables */
+  --ease-cp-neon-cyan: #0ff;
+  --ease-cp-neon-magenta: #f0f;
+  --ease-cp-dark-bg: #0a0a0a;
+  --ease-cp-text: #fff;
+  
+  /* Tooltip Variables */
+  --ease-tt-transition-duration: 0.3s;
+  --ease-tt-transition-easing: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-tt-offset-y: -10px;
+}
+
+/* The wrapper containing the trigger element */
+.ease-tooltip-wrapper {
+  position: relative;
+  display: inline-flex;
+  justify-content: center;
+}
+
+/* The actual tooltip element */
+.ease-tooltip-content {
+  position: absolute;
+  bottom: 100%;
+  margin-bottom: 12px;
+  min-width: 140px;
+  padding: 10px 14px;
+  background-color: var(--ease-cp-dark-bg);
+  color: var(--ease-cp-text);
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 0.85rem;
+  font-weight: bold;
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  white-space: nowrap;
+  
+  /* Cyberpunk Neon Styling */
+  border: 1px solid var(--ease-cp-neon-cyan);
+  box-shadow: 
+    0 0 5px var(--ease-cp-neon-cyan),
+    inset 0 0 5px var(--ease-cp-neon-cyan);
+  border-radius: 2px;
+  
+  /* Animation initial state */
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(0);
+  pointer-events: none;
+  z-index: 10;
+  
+  /* Smooth Fade-In Transition */
+  transition: 
+    opacity var(--ease-tt-transition-duration) var(--ease-tt-transition-easing),
+    visibility var(--ease-tt-transition-duration) var(--ease-tt-transition-easing),
+    transform var(--ease-tt-transition-duration) var(--ease-tt-transition-easing);
+}
+
+/* The glowing arrow pointer */
+.ease-tooltip-content::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 6px;
+  border-style: solid;
+  border-color: var(--ease-cp-neon-cyan) transparent transparent transparent;
+  /* Faint glow for the arrow */
+  filter: drop-shadow(0 3px 2px var(--ease-cp-neon-cyan));
+}
+
+/* Show tooltip on hover and focus within the wrapper */
+.ease-tooltip-wrapper:hover .ease-tooltip-content,
+.ease-tooltip-wrapper:focus-within .ease-tooltip-content {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(var(--ease-tt-offset-y));
+}
+
+/* Cyberpunk Button (just for the demo trigger) */
+.ease-cp-btn {
+  background: var(--ease-cp-dark-bg);
+  color: var(--ease-cp-neon-magenta);
+  border: 2px solid var(--ease-cp-neon-magenta);
+  padding: 12px 24px;
+  font-family: 'Courier New', Courier, monospace;
+  font-weight: bold;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  cursor: pointer;
+  outline: none;
+  box-shadow: 0 0 8px var(--ease-cp-neon-magenta);
+  transition: all 0.2s ease-in-out;
+}
+
+.ease-cp-btn:hover,
+.ease-cp-btn:focus-visible {
+  background: var(--ease-cp-neon-magenta);
+  color: var(--ease-cp-dark-bg);
+  box-shadow: 0 0 16px var(--ease-cp-neon-magenta);
+}


### PR DESCRIPTION
## Pull Request Description

Adds a new pure CSS component: **CSS Fade-In Tooltip for Cyberpunk Neon Layouts**.  
This component implements a glowing, neon-styled tooltip that smoothly fades in and translates upwards on hover or focus, utilizing zero JavaScript. Resolves issue #34256.

Fixes #34256

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/css-fade-in-tooltip-for-cyberpunk-neon-layouts-realtushartyagi-34256/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A pure CSS tooltip wrapped around an interactive element, featuring cyberpunk aesthetics (cyan/magenta glows, dark backgrounds, monospace fonts) and a highly performant CSS fade/transform transition.

**How does a developer use it?**

```html
<div class="ease-tooltip-wrapper">
  <button class="ease-cp-btn" aria-describedby="cyber-tooltip">Engage</button>
  <div id="cyber-tooltip" class="ease-tooltip-content" role="tooltip">System Online</div>
</div>
