### PR TITLE
feat: add runtime drift timeline demo

### DIFF
--- a/submissions/examples/runtime-drift-timeline/README.md
+++ b/submissions/examples/runtime-drift-timeline/README.md
@@ -1,0 +1,15 @@
+# Runtime Drift Timeline
+
+Runtime Drift Timeline is a responsive status panel for release and platform teams. It highlights the most important drift events across a deployment window and separates stable, warning, and danger states with clear visual markers.
+
+## Features
+
+- Two-column release summary and timeline layout
+- Drift risk callout with strong contrast
+- Status-colored timeline events
+- Mobile-friendly single-column view
+
+## Files
+
+- `demo.html` contains the semantic timeline markup.
+- `style.css` contains the responsive layout and visual states.

--- a/submissions/examples/runtime-drift-timeline/demo.html
+++ b/submissions/examples/runtime-drift-timeline/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Runtime Drift Timeline</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="drift-shell">
+    <section class="summary">
+      <p class="eyebrow">Release Observability</p>
+      <h1>Runtime Drift Timeline</h1>
+      <p>Track config, dependency, and latency drift before a deployment moves beyond the recovery window.</p>
+      <div class="score">
+        <span>Drift risk</span>
+        <strong>42%</strong>
+      </div>
+    </section>
+
+    <section class="timeline" aria-label="Runtime drift timeline">
+      <article class="event stable">
+        <span class="time">08:15</span>
+        <div>
+          <h2>Baseline locked</h2>
+          <p>All production nodes matched the approved release manifest.</p>
+        </div>
+      </article>
+      <article class="event warning">
+        <span class="time">10:40</span>
+        <div>
+          <h2>Config variance</h2>
+          <p>Two edge services reported timeout values outside the release profile.</p>
+        </div>
+      </article>
+      <article class="event danger">
+        <span class="time">12:05</span>
+        <div>
+          <h2>Latency drift</h2>
+          <p>P95 response time moved 18% above the last healthy deployment.</p>
+        </div>
+      </article>
+      <article class="event stable">
+        <span class="time">13:20</span>
+        <div>
+          <h2>Rollback guard armed</h2>
+          <p>Traffic can be shifted back within eight minutes if drift expands.</p>
+        </div>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/runtime-drift-timeline/style.css
+++ b/submissions/examples/runtime-drift-timeline/style.css
@@ -1,0 +1,158 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #f5f7fb;
+  color: #172033;
+  font-family: Inter, Arial, sans-serif;
+}
+
+.drift-shell {
+  width: min(1040px, 92vw);
+  display: grid;
+  grid-template-columns: 0.9fr 1.1fr;
+  gap: 28px;
+  align-items: stretch;
+}
+
+.summary,
+.timeline {
+  background: #ffffff;
+  border: 1px solid #dde4f0;
+  border-radius: 8px;
+  box-shadow: 0 18px 40px rgba(54, 71, 105, 0.12);
+}
+
+.summary {
+  padding: 34px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.eyebrow {
+  margin: 0 0 14px;
+  color: #2a7f62;
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 11ch;
+  margin-bottom: 18px;
+  font-size: clamp(2.5rem, 6vw, 4.8rem);
+  line-height: 0.94;
+}
+
+.summary p:not(.eyebrow) {
+  color: #5c677d;
+  line-height: 1.7;
+}
+
+.score {
+  margin-top: 36px;
+  padding: 20px;
+  border-left: 5px solid #ec8f35;
+  background: #fff7ed;
+}
+
+.score span {
+  display: block;
+  margin-bottom: 8px;
+  color: #83521d;
+  font-weight: 700;
+}
+
+.score strong {
+  font-size: 2.6rem;
+}
+
+.timeline {
+  position: relative;
+  padding: 28px;
+}
+
+.timeline::before {
+  content: "";
+  position: absolute;
+  top: 44px;
+  bottom: 44px;
+  left: 106px;
+  width: 3px;
+  background: #d8e1ee;
+}
+
+.event {
+  position: relative;
+  display: grid;
+  grid-template-columns: 70px 1fr;
+  gap: 28px;
+  padding: 18px 0;
+}
+
+.event::before {
+  content: "";
+  position: absolute;
+  top: 25px;
+  left: 72px;
+  width: 16px;
+  height: 16px;
+  border: 4px solid #ffffff;
+  border-radius: 50%;
+  box-shadow: 0 0 0 2px currentColor;
+}
+
+.stable {
+  color: #2a7f62;
+}
+
+.warning {
+  color: #d47a1d;
+}
+
+.danger {
+  color: #c94848;
+}
+
+.time {
+  color: #697489;
+  font-weight: 800;
+}
+
+.event h2 {
+  margin-bottom: 8px;
+  color: #192235;
+  font-size: 1rem;
+}
+
+.event p {
+  margin-bottom: 0;
+  color: #697489;
+  line-height: 1.5;
+}
+
+@media (max-width: 760px) {
+  body {
+    padding: 28px 0;
+  }
+
+  .drift-shell {
+    grid-template-columns: 1fr;
+  }
+
+  h1 {
+    max-width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add a responsive Runtime Drift Timeline example
- include release drift states, risk summary, and mobile layout

## Validation
- git diff --check