### PR TITLE
feat: add incident cost meter demo

### DIFF
--- a/submissions/examples/incident-cost-meter/README.md
+++ b/submissions/examples/incident-cost-meter/README.md
@@ -1,0 +1,15 @@
+# Incident Cost Meter
+
+Incident Cost Meter is a responsive dashboard card set for estimating the business cost of an active service incident. It combines a high-level projected impact panel with focused cards for revenue, support, recovery, and trust exposure.
+
+## Features
+
+- Prominent projected impact summary
+- Four metric cards for incident cost categories
+- Distinct color markers for quick scanning
+- Responsive single-column mobile layout
+
+## Files
+
+- `demo.html` defines the incident cost dashboard content.
+- `style.css` defines the layout, metrics, colors, and breakpoints.

--- a/submissions/examples/incident-cost-meter/demo.html
+++ b/submissions/examples/incident-cost-meter/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Incident Cost Meter</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="meter">
+    <section class="panel intro">
+      <p class="label">Incident Finance</p>
+      <h1>Incident Cost Meter</h1>
+      <p class="copy">Estimate live customer impact, recovery spend, and operational exposure while an incident is still active.</p>
+      <div class="total">
+        <span>Projected impact</span>
+        <strong>$18.4k</strong>
+      </div>
+    </section>
+
+    <section class="panel metrics" aria-label="Incident cost metrics">
+      <article>
+        <span class="dot revenue"></span>
+        <p>Revenue at risk</p>
+        <strong>$9.8k</strong>
+        <small>42% of active impact</small>
+      </article>
+      <article>
+        <span class="dot support"></span>
+        <p>Support load</p>
+        <strong>312</strong>
+        <small>new tickets expected</small>
+      </article>
+      <article>
+        <span class="dot recovery"></span>
+        <p>Recovery spend</p>
+        <strong>$3.1k</strong>
+        <small>infra and staffing</small>
+      </article>
+      <article>
+        <span class="dot trust"></span>
+        <p>Trust exposure</p>
+        <strong>High</strong>
+        <small>public status page active</small>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/incident-cost-meter/style.css
+++ b/submissions/examples/incident-cost-meter/style.css
@@ -1,0 +1,133 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #f8f3ec;
+  color: #1f2630;
+  font-family: Inter, Arial, sans-serif;
+}
+
+.meter {
+  width: min(1060px, 92vw);
+  display: grid;
+  grid-template-columns: 0.8fr 1.2fr;
+  gap: 20px;
+}
+
+.panel {
+  background: #ffffff;
+  border: 1px solid #eaded0;
+  border-radius: 8px;
+  box-shadow: 0 18px 42px rgba(76, 55, 36, 0.12);
+}
+
+.intro {
+  padding: 34px;
+}
+
+.label {
+  margin: 0 0 14px;
+  color: #b35432;
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 18px;
+  font-size: clamp(2.4rem, 6vw, 4.7rem);
+  line-height: 0.95;
+}
+
+.copy {
+  color: #6f6257;
+  line-height: 1.7;
+}
+
+.total {
+  margin-top: 34px;
+  padding: 24px;
+  background: #1f2630;
+  color: #ffffff;
+  border-radius: 8px;
+}
+
+.total span {
+  display: block;
+  margin-bottom: 8px;
+  color: #f1b07f;
+  font-weight: 800;
+}
+
+.total strong {
+  font-size: 2.9rem;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1px;
+  overflow: hidden;
+}
+
+.metrics article {
+  min-height: 210px;
+  padding: 28px;
+  background: #fffaf5;
+}
+
+.dot {
+  display: block;
+  width: 18px;
+  height: 18px;
+  margin-bottom: 32px;
+  border-radius: 50%;
+}
+
+.revenue {
+  background: #d95f43;
+}
+
+.support {
+  background: #3d7f9f;
+}
+
+.recovery {
+  background: #d99f2b;
+}
+
+.trust {
+  background: #5b6f48;
+}
+
+.metrics p {
+  margin: 0 0 10px;
+  color: #6f6257;
+  font-weight: 700;
+}
+
+.metrics strong {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 2.2rem;
+}
+
+.metrics small {
+  color: #8d8175;
+}
+
+@media (max-width: 780px) {
+  body {
+    padding: 28px 0;
+  }
+
+  .meter,
+  .metrics {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a responsive Incident Cost Meter example
- include projected impact, support load, recovery spend, and trust exposure cards

## Validation
- git diff --check