### PR TITLE
feat: add traffic shift slider demo

### DIFF
--- a/submissions/examples/traffic-shift-slider/README.md
+++ b/submissions/examples/traffic-shift-slider/README.md
@@ -1,0 +1,15 @@
+# Traffic Shift Slider
+
+Traffic Shift Slider is a responsive progressive delivery panel that visualizes how much production traffic is assigned to a canary release. It pairs the allocation slider with route summaries and a guardrail note.
+
+## Features
+
+- Static traffic allocation slider
+- Stable and canary route summaries
+- Guardrail callout for rollout safety
+- Responsive layout for smaller screens
+
+## Files
+
+- `demo.html` contains the rollout allocation content.
+- `style.css` contains the slider visuals and responsive styling.

--- a/submissions/examples/traffic-shift-slider/demo.html
+++ b/submissions/examples/traffic-shift-slider/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Traffic Shift Slider</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="shift">
+    <section class="copy">
+      <p>Progressive Delivery</p>
+      <h1>Traffic Shift Slider</h1>
+      <span>Production canary at 35%</span>
+    </section>
+
+    <section class="console" aria-label="Traffic allocation console">
+      <div class="track">
+        <span class="fill"></span>
+        <span class="thumb">35%</span>
+      </div>
+      <div class="labels">
+        <span>Stable 65%</span>
+        <span>Canary 35%</span>
+      </div>
+      <article class="route stable">
+        <strong>Stable pool</strong>
+        <p>1.8M requests per hour</p>
+      </article>
+      <article class="route canary">
+        <strong>Canary pool</strong>
+        <p>969K requests per hour</p>
+      </article>
+      <article class="guard">
+        <strong>Guardrail</strong>
+        <p>Pause shift if error rate exceeds 1.4% for five minutes.</p>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/traffic-shift-slider/style.css
+++ b/submissions/examples/traffic-shift-slider/style.css
@@ -1,0 +1,143 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #edf1f7;
+  color: #162236;
+  font-family: Inter, Arial, sans-serif;
+}
+
+.shift {
+  width: min(1040px, 92vw);
+  display: grid;
+  grid-template-columns: 0.85fr 1.15fr;
+  gap: 22px;
+  align-items: center;
+}
+
+.copy {
+  padding: 34px;
+  background: #ffffff;
+  border: 1px solid #dce3ee;
+  border-radius: 8px;
+  box-shadow: 0 18px 42px rgba(41, 60, 89, 0.12);
+}
+
+.copy p {
+  margin: 0 0 14px;
+  color: #3d72b8;
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.copy h1 {
+  margin: 0 0 24px;
+  font-size: clamp(2.4rem, 6vw, 4.8rem);
+  line-height: 0.95;
+}
+
+.copy span {
+  display: inline-block;
+  padding: 12px 14px;
+  background: #e6f0ff;
+  color: #255a9b;
+  border-radius: 8px;
+  font-weight: 800;
+}
+
+.console {
+  padding: 30px;
+  background: #172236;
+  color: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 22px 50px rgba(18, 31, 52, 0.26);
+}
+
+.track {
+  position: relative;
+  height: 22px;
+  margin: 24px 8px 34px;
+  background: #314258;
+  border-radius: 999px;
+}
+
+.fill {
+  display: block;
+  width: 35%;
+  height: 100%;
+  background: linear-gradient(90deg, #64d3b2, #75a7ff);
+  border-radius: inherit;
+}
+
+.thumb {
+  position: absolute;
+  top: 50%;
+  left: 35%;
+  transform: translate(-50%, -50%);
+  display: grid;
+  place-items: center;
+  width: 62px;
+  height: 62px;
+  background: #ffffff;
+  color: #172236;
+  border: 6px solid #75a7ff;
+  border-radius: 50%;
+  font-weight: 900;
+}
+
+.labels {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 22px;
+  color: #cbd8eb;
+  font-weight: 800;
+}
+
+.route,
+.guard {
+  padding: 18px;
+  margin-top: 12px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+}
+
+.route strong,
+.guard strong {
+  display: block;
+  margin-bottom: 8px;
+}
+
+.route p,
+.guard p {
+  margin: 0;
+  color: #cbd8eb;
+}
+
+.stable {
+  border-left: 5px solid #64d3b2;
+}
+
+.canary {
+  border-left: 5px solid #75a7ff;
+}
+
+.guard {
+  border-left: 5px solid #f0b35a;
+}
+
+@media (max-width: 780px) {
+  body {
+    padding: 28px 0;
+  }
+
+  .shift {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a responsive Traffic Shift Slider example
- include stable and canary allocation states plus rollout guardrail copy

## Validation
- git diff --check