### PR TITLE
feat: add reusable MotionDeferred React component

### DIFF
--- a/submissions/react/36976-motion-deferred-dp/MotionDeffred.jsx
+++ b/submissions/react/36976-motion-deferred-dp/MotionDeffred.jsx
@@ -1,0 +1,52 @@
+import { cloneElement, isValidElement, useEffect, useState } from "react";
+
+export default function MotionDeferred({
+  children,
+  animationClass,
+  delay = 300,
+  disabled = false,
+  className = "",
+  as: Wrapper = "div",
+  onDeferredStart,
+}) {
+  const [isActive, setIsActive] = useState(disabled);
+
+  useEffect(() => {
+    if (disabled) {
+      setIsActive(true);
+      return undefined;
+    }
+
+    setIsActive(false);
+    const timerId = setTimeout(() => {
+      setIsActive(true);
+      if (typeof onDeferredStart === "function") onDeferredStart();
+    }, delay);
+
+    return () => {
+      clearTimeout(timerId);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [disabled, delay]);
+
+  if (!isValidElement(children)) {
+    return children ?? null;
+  }
+
+  const existingClassName = children.props.className || "";
+  const combinedClassName = [existingClassName, isActive ? animationClass : ""]
+    .filter(Boolean)
+    .join(" ");
+
+  const clonedChild = cloneElement(children, {
+    className: combinedClassName,
+  });
+
+  return (
+    <Wrapper
+      className={["motion-deferred", className].filter(Boolean).join(" ")}
+    >
+      {clonedChild}
+    </Wrapper>
+  );
+}

--- a/submissions/react/36976-motion-deferred-dp/README.md
+++ b/submissions/react/36976-motion-deferred-dp/README.md
@@ -1,0 +1,114 @@
+# MotionDeferred
+
+## Overview
+
+MotionDeferred is a lightweight React component that delays applying
+an existing EaseMotion CSS animation class until a configurable amount
+of time has passed after the component first renders. The child
+content itself renders immediately and is fully visible right away —
+only the animation class is withheld and applied later, once the
+delay has elapsed.
+
+The problem it solves is competing priorities at initial render: when
+several animated elements all start animating the moment a page loads,
+they compete with critical rendering work like layout, paint, and
+data fetching, and the result often looks like visual noise rather
+than a deliberate sequence. Non-critical, decorative animations
+frequently don't need to start immediately, but most components have
+no built-in way to postpone them without manual `setTimeout` wiring
+scattered throughout the codebase.
+
+MotionDeferred coordinates existing EaseMotion CSS animation classes
+only — it applies whatever `animationClass` is provided after the
+delay, without generating, inspecting, or modifying any keyframes
+itself. This keeps the approach fully CSS-first: the animation's
+appearance and timing remain owned entirely by CSS, while the
+component only decides when that class is switched on.
+
+## Props
+
+| Prop              | Type       | Default | Description                                                              |
+| ----------------- | ---------- | ------- | ------------------------------------------------------------------------ |
+| `children`        | `element`  | —       | A single valid React element that receives the deferred animation class. |
+| `animationClass`  | `string`   | —       | CSS animation class applied once the delay elapses.                      |
+| `delay`           | `number`   | `300`   | Milliseconds to wait after mount before applying the animation class.    |
+| `disabled`        | `bool`     | `false` | If `true`, applies the animation class immediately, skipping the delay.  |
+| `className`       | `string`   | `""`    | Additional class name(s) applied to the wrapper element.                 |
+| `as`              | `string`   | `"div"` | Element type used for the wrapper.                                       |
+| `onDeferredStart` | `function` | —       | Called once the deferred animation class is applied.                     |
+
+## Example Usage
+
+```jsx
+import { useState } from "react";
+import MotionDeferred from "./component";
+import "./style.css";
+
+export default function App() {
+  const [status, setStatus] = useState("waiting");
+
+  return (
+    <div className="motion-deferred-page">
+      <div className="motion-deferred-demo">
+        <span className="motion-deferred-badge">
+          {status === "waiting" ? "Deferred: waiting" : "Deferred: started"}
+        </span>
+
+        <div className="motion-deferred-info-card">
+          <h3 className="motion-deferred-info-card__title">Motion Deferred</h3>
+          <p className="motion-deferred-info-card__description">
+            This card below renders immediately, but its animation is delayed by
+            800ms.
+          </p>
+        </div>
+
+        <div className="motion-deferred-grid">
+          <MotionDeferred
+            animationClass="fade-up"
+            delay={800}
+            disabled={false}
+            onDeferredStart={() => setStatus("started")}
+          >
+            <div className="motion-deferred-card">
+              <h3 className="motion-deferred-card__title">Secondary Content</h3>
+              <p className="motion-deferred-card__description">
+                Animates in after the deferred delay.
+              </p>
+            </div>
+          </MotionDeferred>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+## Why MotionDeferred?
+
+Not every animation on a page needs to start the instant it renders.
+Secondary or decorative content — a supplementary card, a promotional
+banner, a non-essential widget — often benefits more from appearing a
+beat after the primary content has settled, so the user's attention
+is drawn to what matters first instead of everything animating in at
+once. Delaying that motion deliberately, rather than letting it fire
+immediately by default, is a small but meaningful improvement to
+perceived hierarchy and polish.
+
+Without a reusable mechanism, achieving this means writing a
+`setTimeout` and a piece of local state in every component that needs
+a deferred animation, then remembering to clear that timer on unmount
+to avoid updating state after the component is gone. That logic is
+identical everywhere it's needed, which makes it a good candidate for
+centralization rather than repetition.
+
+MotionDeferred centralizes exactly that: one small component tracks
+the delay, applies the animation class when it elapses, exposes an
+`onDeferredStart` callback for coordinating other logic, and cleans up
+its timer automatically on unmount or when props change. Any element
+that needs delayed motion can be wrapped once instead of re-implementing
+the same timer logic by hand.
+
+MotionDeferred fits EaseMotion CSS's philosophy directly: it defines no
+animation, generates no CSS, and inspects no stylesheets. It only
+decides _when_ an existing CSS animation class is switched on, leaving
+all actual motion to CSS and keeping the whole system CSS-first.

--- a/submissions/react/36976-motion-deferred-dp/style.css
+++ b/submissions/react/36976-motion-deferred-dp/style.css
@@ -1,0 +1,163 @@
+:root {
+  --md-bg: #f8fafc;
+  --md-surface: #ffffff;
+  --md-primary: #2563eb;
+  --md-accent: #7c3aed;
+  --md-border: #e2e8f0;
+  --md-text: #0f172a;
+  --md-muted: #64748b;
+
+  --md-radius: 10px;
+  --md-spacing: 24px;
+}
+
+.motion-deferred-page {
+  min-height: 100vh;
+  background: var(--md-bg);
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
+    Arial, sans-serif;
+  color: var(--md-text);
+  padding: 48px 24px;
+}
+
+.motion-deferred-demo {
+  max-width: 720px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.motion-deferred {
+  display: block;
+}
+
+.motion-deferred-info-card {
+  background: var(--md-surface);
+  border: 1px solid var(--md-border);
+  border-radius: var(--md-radius);
+  padding: var(--md-spacing);
+}
+
+.motion-deferred-info-card__title {
+  margin: 0 0 8px;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--md-text);
+}
+
+.motion-deferred-info-card__description {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: var(--md-muted);
+}
+
+.motion-deferred-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  align-self: flex-start;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: var(--md-surface);
+  border: 1px solid var(--md-border);
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--md-accent);
+}
+
+.motion-deferred-trigger {
+  appearance: none;
+  align-self: flex-start;
+  border: 1px solid var(--md-border);
+  background: var(--md-surface);
+  color: var(--md-text);
+  font: inherit;
+  font-weight: 600;
+  font-size: 0.9rem;
+  padding: 10px 20px;
+  border-radius: var(--md-radius);
+  cursor: pointer;
+  transition:
+    border-color 0.2s ease,
+    background 0.2s ease;
+}
+
+.motion-deferred-trigger:hover {
+  border-color: var(--md-primary);
+  background: #eef2ff;
+}
+
+.motion-deferred-trigger:focus {
+  outline: none;
+}
+
+.motion-deferred-trigger:focus-visible {
+  outline: 3px solid var(--md-accent);
+  outline-offset: 2px;
+}
+
+.motion-deferred-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.motion-deferred-card {
+  background: var(--md-surface);
+  border: 1px solid var(--md-border);
+  border-radius: var(--md-radius);
+  padding: 18px;
+}
+
+.motion-deferred-card__title {
+  margin: 0 0 6px;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--md-text);
+}
+
+.motion-deferred-card__description {
+  margin: 0;
+  font-size: 0.86rem;
+  line-height: 1.55;
+  color: var(--md-muted);
+}
+
+.fade-up {
+  animation-name: motion-deferred-fade-up;
+  animation-duration: 450ms;
+  animation-timing-function: ease-out;
+  animation-fill-mode: both;
+}
+
+@keyframes motion-deferred-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 480px) {
+  .motion-deferred-page {
+    padding: 32px 16px;
+  }
+
+  .motion-deferred-info-card,
+  .motion-deferred-card {
+    padding: 16px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fade-up {
+    animation-duration: 1ms !important;
+    animation-delay: 0ms !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a **reusable MotionDeferred React component** under the `submissions/react/` track.

`MotionDeferred` provides a lightweight, CSS-first wrapper that defers applying existing EaseMotion CSS animation classes until after the initial render. It helps developers delay non-critical animations, reducing repetitive coordination logic while continuing to rely entirely on existing CSS animations without introducing any animation engine or external dependencies.

Closes #36976

---

## Type of Change

- [x] 🧩 New React submission
- [ ] ✨ New animation
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/react/`
- [x] Includes `component.jsx`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Uses React only
- [x] No external dependencies
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

A reusable `MotionDeferred` component that delays applying an existing EaseMotion CSS animation class until after the initial render, allowing non-critical animations to start later in a clean, reusable way.

### Key Features

- Defers animation until after the initial render
- Configurable delay duration
- Optional disable flag
- Callback when the deferred animation begins
- Preserves existing child props and class names
- Lightweight and CSS-first
- No external animation libraries

### Example Usage

```jsx
<MotionDeferred
  animationClass="fade-up"
  delay={300}
  onDeferredStart={() => console.log("Animation started")}
>
  <Card />
</MotionDeferred>
```

### Why does it fit EaseMotion CSS?

`MotionDeferred` improves coordination of non-critical animations while continuing to use existing EaseMotion CSS animation classes. It introduces no new animation logic, remains lightweight, and provides a reusable scheduling utility that aligns with the repository's CSS-first philosophy.

---

## Demo

- [x] Responsive example included in `style.css`
- [x] Usage example documented in `README.md`

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge