### PR TITLE
feat(examples): Micro Shake Modal for Marketing Landing Pages

### DIFF
--- a/submissions/examples/34011-micro-shake-modal-marketing-landing-sj6/README.md
+++ b/submissions/examples/34011-micro-shake-modal-marketing-landing-sj6/README.md
@@ -1,0 +1,78 @@
+# Micro Shake Modal — Marketing Landing Page
+
+A pure CSS, zero-dependency **promo modal** for landing pages. "Claim 20%
+off" pops a discount dialog in with a soft overshoot, then delivers a
+**micro shake** — three quick, decaying horizontal nudges of a couple of
+pixels, ending dead center. It's the UI-scale version of waving for
+attention: big enough to catch the eye, small enough not to read as an
+error. Driven entirely by the `:target` selector — no JavaScript.
+
+Resolves Issue: #34011
+
+## ✨ Features
+
+- **Pop, then micro shake** — `mk-pop` scales the dialog in with a gentle
+  overshoot (`cubic-bezier(0.34, 1.4, 0.5, 1)`), then `mk-shake` runs a
+  decaying translateX gesture (−3px → +3px → ∓1.8px → ∓0.75px → 0).
+  Keeping the shake on translateX only — no rotation — is what keeps it
+  "micro": it reads as a wave, not a validation failure.
+- **Replays on every open** — both animations are gated behind `:target`,
+  so each open restarts the choreography from scratch. Zero JS.
+- **Careful animation layering** — the shake deliberately carries no fill
+  mode; a backwards fill would pin `transform` during its delay and
+  cancel the pop (later animations in the list win shared properties).
+- **Keyboard accessible** — trigger, ✕, click-away scrim, and both action
+  buttons are native `<a>` elements: Tab reaches them, Enter activates;
+  3px brand `:focus-visible` rings throughout; the dialog carries
+  `role="dialog"`, `aria-modal`, `aria-labelledby`, `aria-describedby`.
+- **Landing-page-native details** — gradient headline and CTA, floating
+  "Limited · 48h" badge bridging the dialog edge, dashed monospace
+  discount code block, checkmark perk list, primary vs. ghost actions.
+- **Genuinely responsive** — fluid hero type via `clamp()`, dialog width
+  `min(420px, 100%)`, actions stack full-width under 420px.
+- **Tunable via custom properties** — shake distance, shake duration,
+  pop duration, easing, starting scale, and exit time on `:root`.
+- **Motion-safe** — `prefers-reduced-motion` removes the pop and the
+  shake entirely; the modal simply appears.
+
+## 🔧 Custom Properties
+
+| Property               | Default                            | Role                        |
+| ---------------------- | ---------------------------------- | --------------------------- |
+| `--mk-shake-distance`  | `3px`                              | Max nudge (decays from here)|
+| `--mk-shake-duration`  | `420ms`                            | Whole shake gesture         |
+| `--mk-pop-duration`    | `300ms`                            | Entrance pop time           |
+| `--mk-ease`            | `cubic-bezier(0.34, 1.4, 0.5, 1)`  | Pop overshoot curve         |
+| `--mk-scale-from`      | `0.9`                              | Dialog starting scale       |
+| `--mk-exit-duration`   | `150ms`                            | Dismissal time              |
+
+## 🚀 Usage
+
+```html
+<!-- Trigger -->
+<a class="mk-cta" href="#mk-offer-modal">Claim 20% off</a>
+
+<!-- Modal -->
+<div class="mk-modal" id="mk-offer-modal">
+  <a class="mk-scrim" href="#mk-hero" aria-label="Close"></a>
+  <div class="mk-dialog" role="dialog" aria-modal="true" aria-labelledby="title">
+    <span class="mk-badge">Limited · 48h only</span>
+    <a class="mk-close" href="#mk-hero" aria-label="Close">✕</a>
+    <h2 class="mk-dialog-title" id="title">Here's your 20% off</h2>
+    <span class="mk-code">SUMMER-20</span>
+    <!-- perks, actions -->
+  </div>
+</div>
+```
+
+## 📂 Files
+
+- `demo.html` — a landing-page hero with a limited-offer discount dialog.
+- `style.css` — motion tokens, `:target` pop + shake engine, landing skin, a11y guards.
+- `README.md` — this document.
+
+## 📝 Note
+
+`:target` modals cannot close on the Esc key without JavaScript — a
+limitation of the pure CSS approach, mitigated here by three separate
+close affordances (✕, scrim, and both action links).

--- a/submissions/examples/34011-micro-shake-modal-marketing-landing-sj6/demo.html
+++ b/submissions/examples/34011-micro-shake-modal-marketing-landing-sj6/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Micro Shake Modal — Marketing Landing Page</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="mk-hero" id="mk-hero">
+    <span class="mk-eyebrow">Summer drop</span>
+    <h1 class="mk-hero-title">Design tools that <em>sell themselves</em></h1>
+    <p class="mk-hero-sub">
+      Everything you need to launch your next campaign — templates,
+      analytics, and a checkout that converts.
+    </p>
+
+    <a class="mk-cta" href="#mk-offer-modal">Claim 20% off</a>
+
+    <p class="mk-hint">
+      The button opens a pure CSS <code>:target</code> modal that pops in,
+      then gives a micro shake. Tab + Enter works — no JavaScript.
+    </p>
+  </main>
+
+  <!-- Micro shake modal — shown while it is the URL :target -->
+  <div class="mk-modal" id="mk-offer-modal">
+    <!-- click-away close -->
+    <a class="mk-scrim" href="#mk-hero" aria-label="Close offer"></a>
+
+    <div class="mk-dialog" role="dialog" aria-modal="true"
+         aria-labelledby="mk-dialog-title" aria-describedby="mk-dialog-sub">
+      <span class="mk-badge">Limited · 48h only</span>
+      <a class="mk-close" href="#mk-hero" aria-label="Close offer">✕</a>
+
+      <h2 class="mk-dialog-title" id="mk-dialog-title">Here's your 20% off</h2>
+      <p class="mk-dialog-sub" id="mk-dialog-sub">
+        Use the code at checkout on any plan — yearly plans stack with the
+        launch discount.
+      </p>
+
+      <span class="mk-code">SUMMER-20</span>
+
+      <ul class="mk-perks">
+        <li>All templates</li>
+        <li>Cancel anytime</li>
+        <li>Free migration</li>
+      </ul>
+
+      <div class="mk-actions">
+        <a class="mk-btn is-ghost" href="#mk-hero">Maybe later</a>
+        <a class="mk-btn is-primary" href="#mk-hero">Shop the sale</a>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/34011-micro-shake-modal-marketing-landing-sj6/style.css
+++ b/submissions/examples/34011-micro-shake-modal-marketing-landing-sj6/style.css
@@ -1,0 +1,384 @@
+/* ==========================================================================
+   Micro Shake Modal — Marketing Landing Page
+   --------------------------------------------------------------------------
+   Pure CSS promo modal for landing pages, driven entirely by the :target
+   selector. The dialog pops in with a soft overshoot, then delivers a
+   "micro shake" — three quick, decaying horizontal nudges of a couple of
+   pixels — the same gesture a hand makes waving for attention, scaled
+   down to UI size. Big enough to catch the eye, small enough not to feel
+   like an error.
+
+   Both animations are gated behind :target, so the pop + shake replay
+   from scratch on every open. Zero JavaScript.
+
+   Issue: #34011
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Tokens — motion first, then the landing-page skin
+   -------------------------------------------------------------------------- */
+:root {
+  /* Micro shake */
+  --mk-shake-distance: 3px;                        /* max nudge, decays from here */
+  --mk-shake-duration: 420ms;                      /* whole shake gesture         */
+  --mk-pop-duration: 300ms;                        /* entrance pop                */
+  --mk-ease: cubic-bezier(0.34, 1.4, 0.5, 1);      /* pop overshoot               */
+  --mk-scale-from: 0.9;                            /* dialog starting scale       */
+  --mk-exit-duration: 150ms;                       /* dismissal time              */
+
+  /* Landing-page skin */
+  --mk-canvas: #fdf9f4;
+  --mk-card: #ffffff;
+  --mk-border: #efe6da;
+  --mk-heading: #251d33;
+  --mk-body: #6f6581;
+  --mk-brand-a: #7c3aed;
+  --mk-brand-b: #f97362;
+  --mk-brand-soft: #f3ecff;
+  --mk-overlay-tint: rgba(37, 29, 51, 0.45);
+
+  --mk-card-shadow: 0 1px 3px rgba(37, 29, 51, 0.06);
+  --mk-modal-shadow: 0 24px 60px rgba(37, 29, 51, 0.28), 0 4px 14px rgba(37, 29, 51, 0.14);
+}
+
+/* --------------------------------------------------------------------------
+   2. Demo stage — a slice of a marketing landing page
+   -------------------------------------------------------------------------- */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 34px 16px;
+  box-sizing: border-box;
+  background: var(--mk-canvas);
+  font-family: "Segoe UI", system-ui, -apple-system, Arial, sans-serif;
+  color: var(--mk-body);
+}
+
+.mk-hero {
+  width: 100%;
+  max-width: 520px;
+  text-align: center;
+}
+
+.mk-eyebrow {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: var(--mk-brand-soft);
+  color: var(--mk-brand-a);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 14px;
+}
+
+.mk-hero-title {
+  margin: 0 0 10px;
+  font-size: clamp(1.5rem, 5vw, 2.1rem);
+  line-height: 1.15;
+  font-weight: 750;
+  color: var(--mk-heading);
+}
+
+.mk-hero-title em {
+  font-style: normal;
+  background: linear-gradient(100deg, var(--mk-brand-a), var(--mk-brand-b));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.mk-hero-sub {
+  margin: 0 auto 22px;
+  max-width: 38ch;
+  font-size: 0.86rem;
+  line-height: 1.55;
+}
+
+/* Primary CTA — a real link, keyboard operable by default */
+.mk-cta {
+  display: inline-block;
+  padding: 13px 26px;
+  border-radius: 999px;
+  background: linear-gradient(100deg, var(--mk-brand-a), var(--mk-brand-b));
+  color: #fff;
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-decoration: none;
+  box-shadow: 0 8px 22px rgba(124, 58, 237, 0.3);
+  transition: transform 180ms var(--mk-ease), box-shadow 180ms ease;
+}
+
+.mk-cta:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 28px rgba(124, 58, 237, 0.38);
+}
+
+.mk-cta:focus-visible {
+  outline: 3px solid var(--mk-brand-a);
+  outline-offset: 3px;
+}
+
+.mk-hint {
+  margin-top: 12px;
+  font-size: 0.72rem;
+}
+
+/* --------------------------------------------------------------------------
+   3. Overlay — dims the page while the modal is the :target
+   -------------------------------------------------------------------------- */
+.mk-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: grid;
+  place-items: center;
+  padding: 20px;
+  box-sizing: border-box;
+  background: var(--mk-overlay-tint);
+
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity var(--mk-exit-duration) ease,
+    visibility 0s linear var(--mk-exit-duration);
+}
+
+.mk-modal:target {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition: opacity var(--mk-pop-duration) ease;
+}
+
+/* Click-away close — an invisible link covering the backdrop */
+.mk-scrim {
+  position: absolute;
+  inset: 0;
+  display: block;
+}
+
+/* --------------------------------------------------------------------------
+   4. Dialog — pops in, then gives the micro shake
+   --------------------------------------------------------------------------
+   The pop animates scale/opacity; the shake then nudges translateX with a
+   decaying amplitude. Keeping the shake on translateX only (no rotation)
+   is what keeps it "micro" — it reads as a wave, not an error. */
+.mk-dialog {
+  position: relative;
+  width: min(420px, 100%);
+  background: var(--mk-card);
+  border-radius: 16px;
+  box-shadow: var(--mk-modal-shadow);
+  padding: 24px 22px 20px;
+  box-sizing: border-box;
+  text-align: center;
+
+  opacity: 0;
+  transform: scale(var(--mk-scale-from));
+  transition:
+    opacity var(--mk-exit-duration) ease,
+    transform var(--mk-exit-duration) ease;
+}
+
+.mk-modal:target .mk-dialog {
+  opacity: 1;
+  transform: scale(1);
+  transition: none;
+  /* No fill mode on the shake: with one, its backwards fill would pin
+     transform to translateX(0) during its delay and cancel the pop
+     (later animations win shared properties). Without it, the pop owns
+     transform first, then the shake takes over and hands back to the
+     base scale(1) when done. */
+  animation:
+    mk-pop var(--mk-pop-duration) var(--mk-ease) both,
+    mk-shake var(--mk-shake-duration) ease-in-out var(--mk-pop-duration);
+}
+
+@keyframes mk-pop {
+  from {
+    opacity: 0;
+    transform: scale(var(--mk-scale-from));
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* Three nudges, each smaller than the last, ending dead center */
+@keyframes mk-shake {
+  0%   { transform: translateX(0); }
+  16%  { transform: translateX(calc(var(--mk-shake-distance) * -1)); }
+  33%  { transform: translateX(var(--mk-shake-distance)); }
+  50%  { transform: translateX(calc(var(--mk-shake-distance) * -0.6)); }
+  66%  { transform: translateX(calc(var(--mk-shake-distance) * 0.6)); }
+  83%  { transform: translateX(calc(var(--mk-shake-distance) * -0.25)); }
+  100% { transform: translateX(0); }
+}
+
+/* Offer badge that bridges the dialog's top edge */
+.mk-badge {
+  position: absolute;
+  top: -13px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 5px 14px;
+  border-radius: 999px;
+  background: linear-gradient(100deg, var(--mk-brand-a), var(--mk-brand-b));
+  color: #fff;
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.mk-dialog-title {
+  margin: 10px 0 6px;
+  font-size: 1.25rem;
+  font-weight: 750;
+  color: var(--mk-heading);
+}
+
+.mk-dialog-sub {
+  margin: 0 auto 16px;
+  max-width: 34ch;
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+/* Close (✕) — a link back to the hero anchor */
+.mk-close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  color: var(--mk-body);
+  text-decoration: none;
+  font-size: 0.85rem;
+  transition: background-color 140ms ease, color 140ms ease;
+}
+
+.mk-close:hover {
+  background: var(--mk-brand-soft);
+  color: var(--mk-heading);
+}
+
+.mk-close:focus-visible {
+  outline: 2px solid var(--mk-brand-a);
+  outline-offset: 1px;
+}
+
+/* Discount code block */
+.mk-code {
+  display: block;
+  margin: 0 auto 16px;
+  padding: 12px 16px;
+  max-width: 240px;
+  border: 2px dashed var(--mk-brand-a);
+  border-radius: 10px;
+  background: var(--mk-brand-soft);
+  color: var(--mk-brand-a);
+  font-family: Consolas, "Courier New", monospace;
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+}
+
+/* Perk list */
+.mk-perks {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 6px 16px;
+  margin: 0 0 18px;
+  padding: 0;
+  list-style: none;
+  font-size: 0.74rem;
+}
+
+.mk-perks li::before {
+  content: "✓ ";
+  color: var(--mk-brand-a);
+  font-weight: 700;
+}
+
+/* Dialog actions */
+.mk-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.mk-btn {
+  flex: 1 1 140px;
+  padding: 12px 14px;
+  border-radius: 999px;
+  font-size: 0.84rem;
+  font-weight: 700;
+  text-align: center;
+  text-decoration: none;
+  transition: box-shadow 160ms ease, background-color 160ms ease;
+}
+
+.mk-btn.is-primary {
+  background: linear-gradient(100deg, var(--mk-brand-a), var(--mk-brand-b));
+  color: #fff;
+}
+
+.mk-btn.is-primary:hover {
+  box-shadow: 0 8px 20px rgba(124, 58, 237, 0.35);
+}
+
+.mk-btn.is-ghost {
+  border: 1px solid var(--mk-border);
+  color: var(--mk-heading);
+}
+
+.mk-btn.is-ghost:hover {
+  background: var(--mk-brand-soft);
+}
+
+.mk-btn:focus-visible {
+  outline: 3px solid var(--mk-brand-a);
+  outline-offset: 2px;
+}
+
+/* --------------------------------------------------------------------------
+   5. Small screens — dialog hugs the viewport, actions stack
+   -------------------------------------------------------------------------- */
+@media (max-width: 420px) {
+  .mk-modal { padding: 14px; }
+  .mk-dialog { padding: 20px 16px 16px; }
+  .mk-actions .mk-btn { flex-basis: 100%; }
+}
+
+/* --------------------------------------------------------------------------
+   6. Reduced motion — no pop, no shake; the modal simply appears
+   -------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .mk-modal,
+  .mk-modal:target,
+  .mk-dialog,
+  .mk-cta {
+    transition: none;
+  }
+
+  .mk-dialog {
+    transform: none;
+  }
+
+  .mk-modal:target .mk-dialog {
+    animation: none;
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS **Micro Shake Modal** styled for **Marketing Landing Page** layouts as a fully self-contained example under `submissions/examples/34011-micro-shake-modal-marketing-landing-sj6/`.

Fixes #34011

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/34011-micro-shake-modal-marketing-landing-sj6/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A zero-JavaScript promo modal for landing pages: the discount dialog pops in with a soft overshoot (`mk-pop`), then delivers a micro shake — three quick, decaying horizontal nudges (−3px → +3px → ∓1.8px → ∓0.75px → 0) that end dead center (`mk-shake`). TranslateX only, no rotation, so it reads as a wave for attention rather than a validation error. Both animations are gated behind `:target` and replay on every open.

**How does a developer use it?**

```html
<!-- Trigger -->
<a class="mk-cta" href="#mk-offer-modal">Claim 20% off</a>

<!-- Modal -->
<div class="mk-modal" id="mk-offer-modal">
  <a class="mk-scrim" href="#mk-hero" aria-label="Close"></a>
  <div class="mk-dialog" role="dialog" aria-modal="true" aria-labelledby="title">
    <span class="mk-badge">Limited · 48h only</span>
    <a class="mk-close" href="#mk-hero" aria-label="Close">✕</a>
    <h2 class="mk-dialog-title" id="title">Here's your 20% off</h2>
    <span class="mk-code">SUMMER-20</span>
    <!-- perks, actions -->
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**

Human-readable classes, animation-first, zero JS. Shake distance/duration, pop duration, overshoot curve, starting scale, and exit time are all `--mk-*` custom properties on `:root`; every control is a native `<a>` (Tab + Enter operable) with brand `:focus-visible` rings and full `role="dialog"`/`aria-*` wiring; `prefers-reduced-motion` removes both the pop and the shake for an instant reveal.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

One deliberate detail worth keeping through integration: the shake animation carries **no fill mode** — with `both`, its backwards fill would pin `transform` to `translateX(0)` during its delay and cancel the pop, since later animations in a comma list win shared properties (commented in the CSS). Esc-to-close is not possible in a pure `:target` modal (noted in the README), mitigated with three separate close affordances.

@SAPTARSHI-coder Please review this pr