### PR TITLE
feat(examples): Micro Shake Modal for Creative Portfolios

### DIFF
--- a/submissions/examples/34021-micro-shake-modal-creative-portfolio-sj6/README.md
+++ b/submissions/examples/34021-micro-shake-modal-creative-portfolio-sj6/README.md
@@ -1,0 +1,83 @@
+# Micro Shake Modal — Creative Portfolio
+
+A pure CSS, zero-dependency **project quick-view modal** for portfolio
+sites. Opening it behaves like a print being placed on a table: the
+dialog drops in and settles, then gives a **micro shake** — a tiny
+decaying *rotational* wobble (fractions of a degree) rather than a
+side-to-side nudge. That hand-placed wobble is what makes the motion
+feel crafted instead of mechanical. Driven entirely by the `:target`
+selector — no JavaScript anywhere.
+
+Resolves Issue: #34021
+
+## ✨ Features
+
+- **Drop, then micro wobble** — `pf-drop` settles the dialog from 18px
+  above with a soft-landing curve (`cubic-bezier(0.3, 1.25, 0.45, 1)`),
+  then `pf-wobble` rotates it −0.8° → +0.8° → ∓0.36° → ±0.16° → 0,
+  coming to rest exactly level. Rotation instead of translation is the
+  signature: it reads as *placed by hand*, which suits portfolio work.
+- **Replays on every open** — both animations are gated behind `:target`,
+  so each open restarts the choreography from scratch. Zero JS.
+- **Careful animation layering** — the wobble deliberately carries no
+  fill mode; a backwards fill would pin `transform` during its delay and
+  cancel the drop (later animations in a comma list win shared
+  properties). Commented in the CSS.
+- **Keyboard accessible** — trigger, ✕, click-away scrim, and both action
+  buttons are native `<a>` elements (Tab + Enter); gold `:focus-visible`
+  rings throughout; the dialog carries `role="dialog"`, `aria-modal`,
+  `aria-labelledby`, and `aria-describedby`.
+- **Portfolio-native details** — dark editorial skin with serif display
+  type, CSS-gradient cover art (no image files), full-bleed cover across
+  the dialog top, role/year/tools meta strip, uppercase letter-spaced
+  actions.
+- **Genuinely responsive** — the work grid is `auto-fit, minmax(210px, 1fr)`
+  (two-across → one column), dialog width `min(430px, 100%)`, actions
+  stack full-width under 420px.
+- **Tunable via custom properties** — wobble angle, wobble duration, drop
+  duration, drop distance, easing, and exit time on `:root`.
+- **Motion-safe** — `prefers-reduced-motion` removes the drop and the
+  wobble entirely; the modal simply appears.
+
+## 🔧 Custom Properties
+
+| Property              | Default                            | Role                         |
+| --------------------- | ---------------------------------- | ---------------------------- |
+| `--pf-shake-angle`    | `0.8deg`                           | Max tilt (decays from here)  |
+| `--pf-shake-duration` | `460ms`                            | Whole wobble gesture         |
+| `--pf-drop-duration`  | `320ms`                            | Entrance drop/settle time    |
+| `--pf-drop-distance`  | `-18px`                            | Starting offset above rest   |
+| `--pf-ease`           | `cubic-bezier(0.3, 1.25, 0.45, 1)` | Soft-landing curve           |
+| `--pf-exit-duration`  | `150ms`                            | Dismissal time               |
+
+## 🚀 Usage
+
+```html
+<!-- Trigger -->
+<a class="pf-view" href="#pf-quickview">Quick view</a>
+
+<!-- Modal -->
+<div class="pf-modal" id="pf-quickview">
+  <a class="pf-scrim" href="#pf-index" aria-label="Close"></a>
+  <div class="pf-dialog" role="dialog" aria-modal="true" aria-labelledby="title">
+    <div class="pf-dialog-cover" aria-hidden="true"></div>
+    <a class="pf-close" href="#pf-index" aria-label="Close">✕</a>
+    <div class="pf-dialog-inner">
+      <h2 class="pf-dialog-title" id="title">Night Signals</h2>
+      <!-- meta, blurb, actions -->
+    </div>
+  </div>
+</div>
+```
+
+## 📂 Files
+
+- `demo.html` — a portfolio index (two work tiles) with a quick-view dialog.
+- `style.css` — motion tokens, `:target` drop + wobble engine, editorial skin, a11y guards.
+- `README.md` — this document.
+
+## 📝 Note
+
+`:target` modals cannot close on the Esc key without JavaScript — a
+limitation of the pure CSS approach, mitigated here by three separate
+close affordances (✕, scrim, and both action links).

--- a/submissions/examples/34021-micro-shake-modal-creative-portfolio-sj6/demo.html
+++ b/submissions/examples/34021-micro-shake-modal-creative-portfolio-sj6/demo.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Micro Shake Modal — Creative Portfolio</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="pf-index" id="pf-index">
+    <h1 class="pf-index-title">Mara Voss — Selected Work</h1>
+    <p class="pf-index-sub">
+      "Quick view" opens a pure CSS <code>:target</code> modal that drops in
+      and settles with a micro wobble. Tab + Enter works — no JavaScript.
+    </p>
+
+    <div class="pf-grid">
+      <article class="pf-tile">
+        <div class="pf-cover" aria-hidden="true"></div>
+        <div class="pf-tile-body">
+          <span class="pf-tile-name">Night Signals</span>
+          <span class="pf-tile-kind">Brand identity</span><br />
+          <a class="pf-view" href="#pf-quickview">Quick view</a>
+        </div>
+      </article>
+
+      <article class="pf-tile">
+        <div class="pf-cover is-alt" aria-hidden="true"></div>
+        <div class="pf-tile-body">
+          <span class="pf-tile-name">Clay &amp; Ember</span>
+          <span class="pf-tile-kind">Editorial design</span><br />
+          <span class="pf-view" style="opacity:.35; cursor:default">Case study soon</span>
+        </div>
+      </article>
+    </div>
+  </main>
+
+  <!-- Micro shake (wobble) modal — shown while it is the URL :target -->
+  <div class="pf-modal" id="pf-quickview">
+    <!-- click-away close -->
+    <a class="pf-scrim" href="#pf-index" aria-label="Close quick view"></a>
+
+    <div class="pf-dialog" role="dialog" aria-modal="true"
+         aria-labelledby="pf-dialog-title" aria-describedby="pf-dialog-sub">
+      <div class="pf-dialog-cover" aria-hidden="true"></div>
+      <a class="pf-close" href="#pf-index" aria-label="Close quick view">✕</a>
+
+      <div class="pf-dialog-inner">
+        <h2 class="pf-dialog-title" id="pf-dialog-title">Night Signals</h2>
+        <p class="pf-dialog-sub" id="pf-dialog-sub">
+          Brand identity for a late-night radio collective
+        </p>
+
+        <ul class="pf-meta">
+          <li><strong>Role</strong> Lead designer</li>
+          <li><strong>Year</strong> 2026</li>
+          <li><strong>Tools</strong> Figma · Blender</li>
+        </ul>
+
+        <p class="pf-blurb">
+          A wordmark that hums: variable-weight type paired with a signal
+          motif that sweeps across posters, sleeves, and the station's
+          live-show visuals.
+        </p>
+
+        <div class="pf-actions">
+          <a class="pf-btn is-ghost" href="#pf-index">Back to work</a>
+          <a class="pf-btn is-primary" href="#pf-index">Full case study</a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/34021-micro-shake-modal-creative-portfolio-sj6/style.css
+++ b/submissions/examples/34021-micro-shake-modal-creative-portfolio-sj6/style.css
@@ -1,0 +1,396 @@
+/* ==========================================================================
+   Micro Shake Modal — Creative Portfolio
+   --------------------------------------------------------------------------
+   Pure CSS "quick view" modal for portfolio sites, driven entirely by the
+   :target selector. The dialog behaves like a print being placed on a
+   table: it drops in and settles, then gives a micro shake — a tiny
+   decaying ROTATIONAL wobble (fractions of a degree) rather than a
+   side-to-side nudge. That hand-placed wobble is what makes it feel
+   crafted instead of mechanical.
+
+   Both animations are gated behind :target, so the drop + wobble replay
+   from scratch on every open. Zero JavaScript.
+
+   Issue: #34021
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Tokens — motion first, then the studio skin
+   -------------------------------------------------------------------------- */
+:root {
+  /* Micro shake (rotational wobble) */
+  --pf-shake-angle: 0.8deg;                        /* max tilt, decays from here */
+  --pf-shake-duration: 460ms;                      /* whole wobble gesture       */
+  --pf-drop-duration: 320ms;                       /* entrance drop/settle       */
+  --pf-drop-distance: -18px;                       /* starts above, settles down */
+  --pf-ease: cubic-bezier(0.3, 1.25, 0.45, 1);     /* settle with soft landing   */
+  --pf-exit-duration: 150ms;                       /* dismissal time             */
+
+  /* Studio skin — dark editorial */
+  --pf-canvas: #141311;
+  --pf-card: #1e1c19;
+  --pf-edge: #322f29;
+  --pf-heading: #f2ede4;
+  --pf-body: #a39c8e;
+  --pf-accent: #e8b64c;
+  --pf-accent-ink: #241c07;
+  --pf-overlay-tint: rgba(10, 9, 8, 0.72);
+
+  --pf-modal-shadow: 0 30px 70px rgba(0, 0, 0, 0.55), 0 6px 18px rgba(0, 0, 0, 0.35);
+}
+
+/* --------------------------------------------------------------------------
+   2. Demo stage — a slice of a portfolio index
+   -------------------------------------------------------------------------- */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 34px 16px;
+  box-sizing: border-box;
+  background: var(--pf-canvas);
+  font-family: Georgia, "Times New Roman", serif;
+  color: var(--pf-body);
+}
+
+.pf-index {
+  width: 100%;
+  max-width: 560px;
+}
+
+.pf-index-title {
+  margin: 0 0 4px;
+  font-size: 1.3rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--pf-heading);
+}
+
+.pf-index-sub {
+  margin: 0 0 20px;
+  font-size: 0.8rem;
+  font-family: "Segoe UI", system-ui, sans-serif;
+}
+
+/* Work grid — two tiles across, one column on phones */
+.pf-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 14px;
+}
+
+.pf-tile {
+  border: 1px solid var(--pf-edge);
+  border-radius: 4px;
+  overflow: hidden;
+  background: var(--pf-card);
+}
+
+/* CSS-generated cover art — no image files needed */
+.pf-cover {
+  height: 120px;
+  background:
+    radial-gradient(circle at 75% 20%, rgba(232, 182, 76, 0.5), transparent 55%),
+    linear-gradient(160deg, #3d2f4f 0%, #1c2a3a 60%, #12100d 100%);
+}
+
+.pf-cover.is-alt {
+  background:
+    radial-gradient(circle at 20% 80%, rgba(232, 182, 76, 0.4), transparent 50%),
+    linear-gradient(20deg, #4f2f2f 0%, #3a2a1c 55%, #12100d 100%);
+}
+
+.pf-tile-body {
+  padding: 12px 14px 14px;
+  font-family: "Segoe UI", system-ui, sans-serif;
+}
+
+.pf-tile-name {
+  display: block;
+  font-family: Georgia, serif;
+  font-size: 0.95rem;
+  color: var(--pf-heading);
+  margin-bottom: 2px;
+}
+
+.pf-tile-kind {
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+/* Quick-view trigger — a real link, keyboard operable by default */
+.pf-view {
+  display: inline-block;
+  margin-top: 10px;
+  padding: 7px 14px;
+  border: 1px solid var(--pf-accent);
+  border-radius: 2px;
+  color: var(--pf-accent);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition: background-color 160ms ease, color 160ms ease;
+}
+
+.pf-view:hover {
+  background: var(--pf-accent);
+  color: var(--pf-accent-ink);
+}
+
+.pf-view:focus-visible {
+  outline: 2px solid var(--pf-accent);
+  outline-offset: 3px;
+}
+
+/* --------------------------------------------------------------------------
+   3. Overlay — the studio dims while the modal is the :target
+   -------------------------------------------------------------------------- */
+.pf-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: grid;
+  place-items: center;
+  padding: 20px;
+  box-sizing: border-box;
+  background: var(--pf-overlay-tint);
+
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity var(--pf-exit-duration) ease,
+    visibility 0s linear var(--pf-exit-duration);
+}
+
+.pf-modal:target {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition: opacity var(--pf-drop-duration) var(--pf-ease);
+}
+
+/* Click-away close — an invisible link covering the backdrop */
+.pf-scrim {
+  position: absolute;
+  inset: 0;
+  display: block;
+}
+
+/* --------------------------------------------------------------------------
+   4. Dialog — drops in like a print, then wobbles to rest
+   --------------------------------------------------------------------------
+   The drop animates translateY/opacity; the wobble then rotates around
+   the center with decaying amplitude. The wobble carries NO fill mode on
+   purpose: a backwards fill would pin transform during its delay and
+   cancel the drop, since later animations in a comma list win shared
+   properties. */
+.pf-dialog {
+  position: relative;
+  width: min(430px, 100%);
+  background: var(--pf-card);
+  border: 1px solid var(--pf-edge);
+  border-radius: 6px;
+  box-shadow: var(--pf-modal-shadow);
+  padding: 0 0 18px;
+  box-sizing: border-box;
+  overflow: hidden;
+
+  opacity: 0;
+  transform: translateY(var(--pf-drop-distance));
+  transition:
+    opacity var(--pf-exit-duration) ease,
+    transform var(--pf-exit-duration) ease;
+}
+
+.pf-modal:target .pf-dialog {
+  opacity: 1;
+  transform: translateY(0);
+  transition: none;
+  animation:
+    pf-drop var(--pf-drop-duration) var(--pf-ease) both,
+    pf-wobble var(--pf-shake-duration) ease-in-out var(--pf-drop-duration);
+}
+
+@keyframes pf-drop {
+  from {
+    opacity: 0;
+    transform: translateY(var(--pf-drop-distance));
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* A print settling on the table: tilt, counter-tilt, come to rest */
+@keyframes pf-wobble {
+  0%   { transform: rotate(0deg); }
+  18%  { transform: rotate(calc(var(--pf-shake-angle) * -1)); }
+  38%  { transform: rotate(var(--pf-shake-angle)); }
+  58%  { transform: rotate(calc(var(--pf-shake-angle) * -0.45)); }
+  78%  { transform: rotate(calc(var(--pf-shake-angle) * 0.2)); }
+  100% { transform: rotate(0deg); }
+}
+
+/* Full-bleed cover art across the dialog's top */
+.pf-dialog-cover {
+  height: 150px;
+  background:
+    radial-gradient(circle at 75% 20%, rgba(232, 182, 76, 0.5), transparent 55%),
+    linear-gradient(160deg, #3d2f4f 0%, #1c2a3a 60%, #12100d 100%);
+}
+
+.pf-dialog-inner {
+  padding: 16px 20px 0;
+}
+
+.pf-dialog-title {
+  margin: 0 0 2px;
+  font-family: Georgia, serif;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--pf-heading);
+}
+
+.pf-dialog-sub {
+  margin: 0 0 14px;
+  font-family: "Segoe UI", system-ui, sans-serif;
+  font-size: 0.76rem;
+}
+
+/* Close (✕) — a link back to the index anchor, sitting on the cover */
+.pf-close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 3px;
+  background: rgba(20, 19, 17, 0.55);
+  color: var(--pf-heading);
+  text-decoration: none;
+  font-size: 0.85rem;
+  font-family: "Segoe UI", system-ui, sans-serif;
+  transition: background-color 140ms ease;
+}
+
+.pf-close:hover {
+  background: rgba(20, 19, 17, 0.85);
+}
+
+.pf-close:focus-visible {
+  outline: 2px solid var(--pf-accent);
+  outline-offset: 1px;
+}
+
+/* Project meta — role / year / tools */
+.pf-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 18px;
+  margin: 0 0 14px;
+  padding: 12px 0;
+  border-top: 1px solid var(--pf-edge);
+  border-bottom: 1px solid var(--pf-edge);
+  list-style: none;
+  font-family: "Segoe UI", system-ui, sans-serif;
+  font-size: 0.72rem;
+}
+
+.pf-meta strong {
+  display: block;
+  color: var(--pf-heading);
+  font-weight: 600;
+  font-size: 0.62rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  margin-bottom: 1px;
+}
+
+.pf-blurb {
+  margin: 0 0 16px;
+  font-family: "Segoe UI", system-ui, sans-serif;
+  font-size: 0.8rem;
+  line-height: 1.55;
+}
+
+/* Dialog actions */
+.pf-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-family: "Segoe UI", system-ui, sans-serif;
+}
+
+.pf-btn {
+  flex: 1 1 150px;
+  padding: 11px 14px;
+  border-radius: 2px;
+  font-size: 0.76rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-align: center;
+  text-decoration: none;
+  transition: background-color 160ms ease, color 160ms ease;
+}
+
+.pf-btn.is-primary {
+  background: var(--pf-accent);
+  color: var(--pf-accent-ink);
+}
+
+.pf-btn.is-primary:hover {
+  background: #f0c66b;
+}
+
+.pf-btn.is-ghost {
+  border: 1px solid var(--pf-edge);
+  color: var(--pf-heading);
+}
+
+.pf-btn.is-ghost:hover {
+  background: rgba(163, 156, 142, 0.1);
+}
+
+.pf-btn:focus-visible {
+  outline: 2px solid var(--pf-accent);
+  outline-offset: 2px;
+}
+
+/* --------------------------------------------------------------------------
+   5. Small screens — dialog hugs the viewport, actions stack
+   -------------------------------------------------------------------------- */
+@media (max-width: 420px) {
+  .pf-modal { padding: 14px; }
+  .pf-dialog-inner { padding: 14px 14px 0; }
+  .pf-actions .pf-btn { flex-basis: 100%; }
+}
+
+/* --------------------------------------------------------------------------
+   6. Reduced motion — no drop, no wobble; the modal simply appears
+   -------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .pf-modal,
+  .pf-modal:target,
+  .pf-dialog,
+  .pf-view {
+    transition: none;
+  }
+
+  .pf-dialog {
+    transform: none;
+  }
+
+  .pf-modal:target .pf-dialog {
+    animation: none;
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS **Micro Shake Modal** styled for **Creative Portfolio** layouts as a fully self-contained example under `submissions/examples/34021-micro-shake-modal-creative-portfolio-sj6/`.

Fixes #34021

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/34021-micro-shake-modal-creative-portfolio-sj6/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A zero-JavaScript project quick-view modal for portfolio sites: the dialog drops in like a print being placed on a table (`pf-drop`, soft-landing curve from 18px above), then gives a micro shake as a tiny decaying *rotational* wobble — −0.8° → +0.8° → ∓0.36° → ±0.16° → level (`pf-wobble`). Rotation instead of translation makes it read as placed by hand, which suits creative work. Both animations are gated behind `:target` and replay on every open. The demo is a dark editorial portfolio index with CSS-gradient cover art — no image files.

**How does a developer use it?**

```html
<!-- Trigger -->
<a class="pf-view" href="#pf-quickview">Quick view</a>

<!-- Modal -->
<div class="pf-modal" id="pf-quickview">
  <a class="pf-scrim" href="#pf-index" aria-label="Close"></a>
  <div class="pf-dialog" role="dialog" aria-modal="true" aria-labelledby="title">
    <div class="pf-dialog-cover" aria-hidden="true"></div>
    <a class="pf-close" href="#pf-index" aria-label="Close">✕</a>
    <div class="pf-dialog-inner">
      <h2 class="pf-dialog-title" id="title">Night Signals</h2>
      <!-- meta, blurb, actions -->
    </div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**

Human-readable classes, animation-first, zero JS. Wobble angle/duration, drop duration/distance, easing, and exit time are all `--pf-*` custom properties on `:root`; every control is a native `<a>` (Tab + Enter operable) with gold `:focus-visible` rings and full `role="dialog"`/`aria-*` wiring; `prefers-reduced-motion` removes the drop and the wobble for an instant reveal.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Deliberately distinct from my marketing-landing micro shake modal (#34011): that one pops and nudges on translateX like a wave for attention; this one drops and wobbles rotationally like a hand-placed print. Same integration caveat applies and is commented in the CSS: the wobble animation must carry **no fill mode**, or its backwards fill would pin `transform` during its delay and cancel the drop. Esc-to-close is not possible in a pure `:target` modal (noted in the README), mitigated with three close affordances.

@SAPTARSHI-coder Please review
