### PR TITLE
feat: add inline to fullscreen media expansion example

### DIFF
--- a/submissions/examples/37007-inline-fullscreen-media-expansion-dp/README.md
+++ b/submissions/examples/37007-inline-fullscreen-media-expansion-dp/README.md
@@ -1,0 +1,51 @@
+# Context-Preserving Inline-to-Fullscreen Media Expansion
+
+## Overview
+
+A fullscreen media expansion built entirely with HTML and CSS using
+the `:target` pseudo-class instead of JavaScript. Clicking a media
+card transitions it into an overlay that scales and fades in from the
+same position, so expanding a thumbnail feels like a continuation of
+the card rather than an abrupt jump to a new screen. Implemented using
+only HTML and CSS — no JavaScript, no libraries.
+
+## Features
+
+- Responsive media gallery with six cards
+- CSS-only fullscreen expansion using `:target`
+- Smooth scale, translate, and opacity transition
+- Dimmed, blurred backdrop while expanded
+- Close button plus click-outside-to-close
+- Fully responsive layout
+- CSS custom properties for timing and color
+
+## File Structure
+
+- `demo.html`
+- `style.css`
+- `README.md`
+
+## How It Works
+
+Each media card is an anchor linking to a unique `id` (e.g.
+`#media-1`). The matching overlay is hidden by default and revealed
+when its `id` matches the URL fragment via `:target`, triggering a
+CSS transition from a scaled-down state to full size. The backdrop and
+close button link back to `#`, un-matching `:target` and reversing the
+transition. No JavaScript is involved — only anchor navigation and CSS.
+
+## Example Use Cases
+
+- Photo galleries and portfolio websites
+- Social media feeds with expandable posts
+- Media dashboards
+- Product galleries
+
+## Why This Example?
+
+An abrupt cut to fullscreen breaks the user's sense of where content
+came from. A short, connected transition communicates continuity
+instead. This fits EaseMotion CSS's CSS-first philosophy by achieving
+a typically JavaScript-driven pattern with only anchors, `:target`,
+and CSS transitions — a production-inspired technique with no script
+required.

--- a/submissions/examples/37007-inline-fullscreen-media-expansion-dp/demo.html
+++ b/submissions/examples/37007-inline-fullscreen-media-expansion-dp/demo.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Inline-to-Fullscreen Media Expansion — EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+    <header class="page-header">
+        <p class="page-header__eyebrow">EaseMotion CSS · Examples</p>
+        <h1 class="page-header__title">Inline-to-Fullscreen Media Expansion</h1>
+        <p class="page-header__description">
+            A context-preserving transition between an inline media card and an
+            expanded fullscreen view, built entirely with HTML and CSS using the
+            <code>:target</code> technique.
+        </p>
+    </header>
+
+    <main class="gallery-wrapper">
+        <section class="media-gallery" aria-label="Media gallery">
+
+            <a href="#media-1" class="media-card" id="card-media-1">
+                <span class="media-card__surface media-card__surface--one">
+                    <span class="media-card__label">Aurora</span>
+                </span>
+            </a>
+
+            <a href="#media-2" class="media-card" id="card-media-2">
+                <span class="media-card__surface media-card__surface--two">
+                    <span class="media-card__label">Canyon</span>
+                </span>
+            </a>
+
+            <a href="#media-3" class="media-card" id="card-media-3">
+                <span class="media-card__surface media-card__surface--three">
+                    <span class="media-card__label">Harbor</span>
+                </span>
+            </a>
+
+            <a href="#media-4" class="media-card" id="card-media-4">
+                <span class="media-card__surface media-card__surface--four">
+                    <span class="media-card__label">Meadow</span>
+                </span>
+            </a>
+
+            <a href="#media-5" class="media-card" id="card-media-5">
+                <span class="media-card__surface media-card__surface--five">
+                    <span class="media-card__label">Skyline</span>
+                </span>
+            </a>
+
+            <a href="#media-6" class="media-card" id="card-media-6">
+                <span class="media-card__surface media-card__surface--six">
+                    <span class="media-card__label">Reef</span>
+                </span>
+            </a>
+
+        </section>
+    </main>
+
+    <div class="media-overlay" id="media-1">
+        <a href="#" class="media-overlay__backdrop" aria-label="Close expanded media"></a>
+        <div class="media-overlay__stage">
+            <span class="media-overlay__surface media-overlay__surface--one">
+                <span class="media-overlay__label">Aurora</span>
+            </span>
+            <a href="#" class="media-overlay__close" aria-label="Close expanded media">&times;</a>
+        </div>
+    </div>
+
+    <div class="media-overlay" id="media-2">
+        <a href="#" class="media-overlay__backdrop" aria-label="Close expanded media"></a>
+        <div class="media-overlay__stage">
+            <span class="media-overlay__surface media-overlay__surface--two">
+                <span class="media-overlay__label">Canyon</span>
+            </span>
+            <a href="#" class="media-overlay__close" aria-label="Close expanded media">&times;</a>
+        </div>
+    </div>
+
+    <div class="media-overlay" id="media-3">
+        <a href="#" class="media-overlay__backdrop" aria-label="Close expanded media"></a>
+        <div class="media-overlay__stage">
+            <span class="media-overlay__surface media-overlay__surface--three">
+                <span class="media-overlay__label">Harbor</span>
+            </span>
+            <a href="#" class="media-overlay__close" aria-label="Close expanded media">&times;</a>
+        </div>
+    </div>
+
+    <div class="media-overlay" id="media-4">
+        <a href="#" class="media-overlay__backdrop" aria-label="Close expanded media"></a>
+        <div class="media-overlay__stage">
+            <span class="media-overlay__surface media-overlay__surface--four">
+                <span class="media-overlay__label">Meadow</span>
+            </span>
+            <a href="#" class="media-overlay__close" aria-label="Close expanded media">&times;</a>
+        </div>
+    </div>
+
+    <div class="media-overlay" id="media-5">
+        <a href="#" class="media-overlay__backdrop" aria-label="Close expanded media"></a>
+        <div class="media-overlay__stage">
+            <span class="media-overlay__surface media-overlay__surface--five">
+                <span class="media-overlay__label">Skyline</span>
+            </span>
+            <a href="#" class="media-overlay__close" aria-label="Close expanded media">&times;</a>
+        </div>
+    </div>
+
+    <div class="media-overlay" id="media-6">
+        <a href="#" class="media-overlay__backdrop" aria-label="Close expanded media"></a>
+        <div class="media-overlay__stage">
+            <span class="media-overlay__surface media-overlay__surface--six">
+                <span class="media-overlay__label">Reef</span>
+            </span>
+            <a href="#" class="media-overlay__close" aria-label="Close expanded media">&times;</a>
+        </div>
+    </div>
+
+    <footer class="page-footer">
+        <p>Pure HTML &amp; CSS. No JavaScript, no dependencies, no build step.</p>
+    </footer>
+
+</body>
+
+</html>

--- a/submissions/examples/37007-inline-fullscreen-media-expansion-dp/style.css
+++ b/submissions/examples/37007-inline-fullscreen-media-expansion-dp/style.css
@@ -1,0 +1,296 @@
+:root {
+  --surface-bg: #0f1117;
+  --card-bg: #171a22;
+  --card-border: #2a2e38;
+  --text-primary: #f5f6fb;
+  --text-secondary: rgba(245, 246, 251, 0.68);
+  --text-muted: rgba(245, 246, 251, 0.45);
+
+  --overlay-dim: rgba(5, 6, 10, 0.88);
+
+  --radius-lg: 18px;
+  --radius-md: 12px;
+
+  --transition-duration: 420ms;
+  --transition-ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
+    Arial, sans-serif;
+  color: var(--text-primary);
+  background: var(--surface-bg);
+}
+
+code {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 0.9em;
+  background: rgba(255, 255, 255, 0.08);
+  padding: 1px 6px;
+  border-radius: 4px;
+}
+
+.page-header {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 64px 24px 8px;
+  text-align: center;
+}
+
+.page-header__eyebrow {
+  margin: 0 0 12px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.page-header__title {
+  margin: 0 0 16px;
+  font-size: clamp(1.8rem, 3.6vw, 2.4rem);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.page-header__description {
+  margin: 0 auto;
+  max-width: 560px;
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.gallery-wrapper {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 40px 24px 60px;
+}
+
+.media-gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.media-card {
+  display: block;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  text-decoration: none;
+  outline-offset: 4px;
+}
+
+.media-card__surface {
+  position: relative;
+  display: flex;
+  align-items: flex-end;
+  height: 220px;
+  border-radius: var(--radius-lg);
+  transition:
+    transform var(--transition-duration) var(--transition-ease),
+    box-shadow var(--transition-duration) var(--transition-ease);
+}
+
+.media-card:hover .media-card__surface,
+.media-card:focus-visible .media-card__surface {
+  transform: scale(1.02);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+}
+
+.media-card__label {
+  padding: 16px 18px;
+  font-weight: 700;
+  font-size: 1rem;
+  color: #ffffff;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+}
+
+.media-card__surface--one {
+  background: linear-gradient(135deg, #4facfe, #6a5bff);
+}
+.media-card__surface--two {
+  background: linear-gradient(135deg, #ff9966, #ff5e62);
+}
+.media-card__surface--three {
+  background: linear-gradient(135deg, #43cea2, #185a9d);
+}
+.media-card__surface--four {
+  background: linear-gradient(135deg, #f7971e, #ffd200);
+}
+.media-card__surface--five {
+  background: linear-gradient(135deg, #8e2de2, #4a00e0);
+}
+.media-card__surface--six {
+  background: linear-gradient(135deg, #11998e, #38ef7d);
+}
+
+.media-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  z-index: 100;
+  transition:
+    opacity var(--transition-duration) var(--transition-ease),
+    visibility 0s linear var(--transition-duration);
+}
+
+.media-overlay:target {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition:
+    opacity var(--transition-duration) var(--transition-ease),
+    visibility 0s linear 0s;
+}
+
+.media-overlay__backdrop {
+  position: absolute;
+  inset: 0;
+  background: var(--overlay-dim);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+}
+
+.media-overlay__stage {
+  position: relative;
+  width: min(90vw, 780px);
+  height: min(80vh, 520px);
+  transform: scale(0.85) translateY(24px);
+  opacity: 0;
+  transition:
+    transform var(--transition-duration) var(--transition-ease),
+    opacity var(--transition-duration) var(--transition-ease);
+}
+
+.media-overlay:target .media-overlay__stage {
+  transform: scale(1) translateY(0);
+  opacity: 1;
+}
+
+.media-overlay__surface {
+  display: flex;
+  align-items: flex-end;
+  width: 100%;
+  height: 100%;
+  border-radius: var(--radius-lg);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.5);
+}
+
+.media-overlay__surface--one {
+  background: linear-gradient(135deg, #4facfe, #6a5bff);
+}
+.media-overlay__surface--two {
+  background: linear-gradient(135deg, #ff9966, #ff5e62);
+}
+.media-overlay__surface--three {
+  background: linear-gradient(135deg, #43cea2, #185a9d);
+}
+.media-overlay__surface--four {
+  background: linear-gradient(135deg, #f7971e, #ffd200);
+}
+.media-overlay__surface--five {
+  background: linear-gradient(135deg, #8e2de2, #4a00e0);
+}
+.media-overlay__surface--six {
+  background: linear-gradient(135deg, #11998e, #38ef7d);
+}
+
+.media-overlay__label {
+  padding: 24px 28px;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #ffffff;
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+}
+
+.media-overlay__close {
+  position: absolute;
+  top: -18px;
+  right: -18px;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  color: var(--text-primary);
+  font-size: 1.4rem;
+  line-height: 1;
+  text-decoration: none;
+  transition:
+    background 0.2s ease,
+    transform 0.2s ease;
+}
+
+.media-overlay__close:hover,
+.media-overlay__close:focus-visible {
+  background: #232733;
+  transform: scale(1.08);
+}
+
+.page-footer {
+  text-align: center;
+  padding: 0 24px 56px;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+a:focus {
+  outline: none;
+}
+
+a:focus-visible {
+  outline: 3px solid #7cc4ff;
+  outline-offset: 3px;
+  border-radius: 6px;
+}
+
+@media (max-width: 640px) {
+  .media-overlay__stage {
+    width: 92vw;
+    height: 70vh;
+  }
+
+  .media-overlay__close {
+    top: 12px;
+    right: 12px;
+  }
+}
+
+@media (max-width: 480px) {
+  .page-header {
+    padding: 44px 20px 4px;
+  }
+
+  .gallery-wrapper {
+    padding: 28px 18px 48px;
+  }
+
+  .media-card__surface {
+    height: 180px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .media-card__surface,
+  .media-overlay,
+  .media-overlay__stage,
+  .media-overlay__close {
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a **Context-Preserving Inline-to-Fullscreen Media Expansion** example under the `submissions/examples/` track.

The example demonstrates a production-inspired media interaction where an inline media card smoothly expands into a fullscreen view while preserving spatial context. The implementation relies entirely on HTML and CSS, providing a lightweight and reusable motion pattern without JavaScript.

Closes #37007

---

## Type of Change

- [x] 🧩 New example submission
- [ ] ✨ New animation
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Uses HTML and CSS only
- [x] No JavaScript
- [x] No external dependencies
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

A reusable example demonstrating how an inline media element can smoothly transition into a fullscreen presentation while preserving visual continuity and user orientation.

### Key Features

- Responsive media gallery
- CSS-only fullscreen interaction
- Smooth scale and opacity transitions
- Background dimming
- Responsive layout
- Production-inspired motion pattern

### Why does it fit EaseMotion CSS?

This example demonstrates a practical interaction commonly found in galleries, media dashboards, portfolios, and social applications. It showcases how CSS motion can preserve spatial context without relying on JavaScript, aligning with the repository's HTML/CSS-first philosophy.

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional)*