### PR TITLE
feat(examples): Jello-Hover Accordion for Responsive Dashboards

### DIFF
--- a/submissions/examples/33045-jello-hover-accordion-responsive-dashboard-sj6/README.md
+++ b/submissions/examples/33045-jello-hover-accordion-responsive-dashboard-sj6/README.md
@@ -1,0 +1,73 @@
+# Jello-Hover Accordion — Responsive Dashboard
+
+A pure CSS, zero-dependency **accordion** for dashboard panels whose
+closed sections **jello on hover** — a squash-and-stretch wiggle that
+decays back to rest, with the whole gesture driven by a single amplitude
+token. Built on native `<details>`/`<summary>`, so keyboard support and
+exclusive-open behavior come from the browser, not JavaScript.
+
+Resolves Issue: #33045
+
+## ✨ Features
+
+- **One-token jello** — the keyframes compute every squash and stretch
+  from `--jl-squash` via `calc()` (±5% → ∓4% → ±2.25% → ∓1% → ±0.4% → 0),
+  so a single number makes the whole gesture subtler or bouncier. No
+  hand-tuned keyframe soup.
+- **Closed sections only** — the wiggle applies via
+  `.jl-item:not([open]):hover`, so an open section holds perfectly still
+  while its content is being read. Motion invites interaction; it never
+  interferes with reading.
+- **Keyboard parity** — `:focus-within` triggers the same jello + accent
+  highlight when the summary takes keyboard focus, so Tab users get the
+  identical affordance; Enter/Space toggles natively; 2px accent
+  `:focus-visible` ring on the header.
+- **Native accordion semantics** — `<details name="jl-demo">` makes the
+  group exclusive (opening one closes the rest) with zero JS; remove the
+  `name` to allow multiple open sections.
+- **Replaying reveal** — content inside a closed `<details>` isn't
+  rendered, so the body's fade-rise replays naturally on every open.
+- **Dashboard-native details** — analytics workspace skin, icon chips,
+  headline stat visible on each closed header, green/red trend deltas,
+  tabular numerals.
+- **Genuinely responsive** — fluid panel up to 540px; under 420px values
+  wrap onto their own line so rows stay readable on phones.
+- **Motion-safe** — `prefers-reduced-motion` removes the jello and the
+  reveal but keeps the border/shadow hover affordance, so the interaction
+  cue survives without any movement.
+
+## 🔧 Custom Properties
+
+| Property               | Default                          | Role                          |
+| ---------------------- | -------------------------------- | ----------------------------- |
+| `--jl-squash`          | `0.05`                           | Jello amplitude (0.05 = ±5%)  |
+| `--jl-duration`        | `560ms`                          | Whole wiggle gesture          |
+| `--jl-open-duration`   | `260ms`                          | Body fade-rise on open        |
+| `--jl-ease`            | `cubic-bezier(0.22, 1, 0.36, 1)` | Reveal curve                  |
+| `--jl-toggle-duration` | `220ms`                          | Chevron rotation              |
+
+## 🚀 Usage
+
+```html
+<details class="jl-item" name="my-accordion">
+  <summary class="jl-head">
+    <span class="jl-head-icon" aria-hidden="true">⚡</span>
+    Section Title
+    <span class="jl-head-stat">42 pts</span>
+    <span class="jl-chevron" aria-hidden="true"></span>
+  </summary>
+  <div class="jl-body">
+    <div class="jl-row">
+      <span class="jl-row-label">Metric name</span>
+      <span class="jl-delta is-up">▲ 8%</span>
+      <span class="jl-row-value">46 pts</span>
+    </div>
+  </div>
+</details>
+```
+
+## 📂 Files
+
+- `demo.html` — a "Team Performance" panel (velocity / review turnaround / deploys).
+- `style.css` — motion tokens, calc()-driven jello engine, analytics skin, a11y guards.
+- `README.md` — this document.

--- a/submissions/examples/33045-jello-hover-accordion-responsive-dashboard-sj6/demo.html
+++ b/submissions/examples/33045-jello-hover-accordion-responsive-dashboard-sj6/demo.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Jello-Hover Accordion — Responsive Dashboard</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <section class="jl-panel" aria-label="Team performance">
+    <h1 class="jl-panel-title">Team Performance</h1>
+    <p class="jl-panel-sub">
+      Hover (or Tab to) a closed section — it jellos. Open sections hold
+      still while you read. Enter toggles. No JavaScript.
+    </p>
+
+    <!-- name="jl-demo" makes the accordion exclusive: opening one section
+         closes the others, natively. Remove it to allow multiple open. -->
+    <details class="jl-item" name="jl-demo" open>
+      <summary class="jl-head">
+        <span class="jl-head-icon" aria-hidden="true">⚡</span>
+        Sprint velocity
+        <span class="jl-head-stat">42 pts</span>
+        <span class="jl-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="jl-body">
+        <div class="jl-row">
+          <span class="jl-row-label">Committed</span>
+          <span class="jl-delta is-up">▲ 8%</span>
+          <span class="jl-row-value">46 pts</span>
+        </div>
+        <div class="jl-row">
+          <span class="jl-row-label">Completed</span>
+          <span class="jl-delta is-up">▲ 12%</span>
+          <span class="jl-row-value">42 pts</span>
+        </div>
+        <div class="jl-row">
+          <span class="jl-row-label">Carry-over</span>
+          <span class="jl-delta is-down">▼ 3 pts</span>
+          <span class="jl-row-value">4 pts</span>
+        </div>
+      </div>
+    </details>
+
+    <details class="jl-item" name="jl-demo">
+      <summary class="jl-head">
+        <span class="jl-head-icon" aria-hidden="true">⏱</span>
+        Review turnaround
+        <span class="jl-head-stat">6.1 h</span>
+        <span class="jl-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="jl-body">
+        <div class="jl-row">
+          <span class="jl-row-label">First response</span>
+          <span class="jl-delta is-up">▲ faster</span>
+          <span class="jl-row-value">1.8 h</span>
+        </div>
+        <div class="jl-row">
+          <span class="jl-row-label">Approval time</span>
+          <span class="jl-delta is-down">▼ slower</span>
+          <span class="jl-row-value">4.3 h</span>
+        </div>
+        <div class="jl-row">
+          <span class="jl-row-label">Reviews per PR</span>
+          <span class="jl-row-value">2.2</span>
+        </div>
+      </div>
+    </details>
+
+    <details class="jl-item" name="jl-demo">
+      <summary class="jl-head">
+        <span class="jl-head-icon" aria-hidden="true">🚀</span>
+        Deploy frequency
+        <span class="jl-head-stat">9 / wk</span>
+        <span class="jl-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="jl-body">
+        <div class="jl-row">
+          <span class="jl-row-label">Production</span>
+          <span class="jl-delta is-up">▲ 2</span>
+          <span class="jl-row-value">9 this week</span>
+        </div>
+        <div class="jl-row">
+          <span class="jl-row-label">Rollbacks</span>
+          <span class="jl-delta is-up">▲ none</span>
+          <span class="jl-row-value">0</span>
+        </div>
+        <div class="jl-row">
+          <span class="jl-row-label">Lead time</span>
+          <span class="jl-row-value">2.4 days</span>
+        </div>
+      </div>
+    </details>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/33045-jello-hover-accordion-responsive-dashboard-sj6/style.css
+++ b/submissions/examples/33045-jello-hover-accordion-responsive-dashboard-sj6/style.css
@@ -1,0 +1,259 @@
+/* ==========================================================================
+   Jello-Hover Accordion — Responsive Dashboard
+   --------------------------------------------------------------------------
+   Pure CSS accordion for dashboard panels, built on native
+   <details>/<summary> so keyboard support and exclusive-open behavior
+   (the `name` attribute) come from the browser, not JavaScript.
+
+   The signature interaction: hovering a CLOSED section makes the whole
+   card "jello" — a squash-and-stretch wiggle that decays back to rest.
+   The amplitude is a single custom property (--jl-squash) fed through
+   calc() in the keyframes, so the entire gesture can be made subtler or
+   bouncier with one number. Open sections never wiggle: content that is
+   being read stays still.
+
+   Issue: #33045
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Tokens — motion first, then the analytics skin
+   -------------------------------------------------------------------------- */
+:root {
+  /* Jello gesture */
+  --jl-squash: 0.05;                               /* amplitude: 0.05 = ±5%  */
+  --jl-duration: 560ms;                            /* whole wiggle           */
+  --jl-open-duration: 260ms;                       /* body reveal            */
+  --jl-ease: cubic-bezier(0.22, 1, 0.36, 1);       /* reveal curve           */
+  --jl-toggle-duration: 220ms;                     /* chevron rotation       */
+
+  /* Analytics workspace skin */
+  --jl-canvas: #f4f3fa;
+  --jl-card: #ffffff;
+  --jl-border: #e4e1f0;
+  --jl-heading: #241f3d;
+  --jl-body: #6b6488;
+  --jl-accent: #7048e8;
+  --jl-accent-soft: #efeafc;
+  --jl-up: #14804a;
+  --jl-down: #c2374b;
+
+  --jl-card-shadow: 0 1px 3px rgba(36, 31, 61, 0.07);
+  --jl-card-shadow-hover: 0 6px 18px rgba(112, 72, 232, 0.16);
+}
+
+/* --------------------------------------------------------------------------
+   2. Demo stage — a team-performance panel
+   -------------------------------------------------------------------------- */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 34px 16px;
+  box-sizing: border-box;
+  background: var(--jl-canvas);
+  font-family: "Segoe UI", system-ui, -apple-system, Arial, sans-serif;
+  color: var(--jl-body);
+}
+
+.jl-panel {
+  width: 100%;
+  max-width: 540px;
+}
+
+.jl-panel-title {
+  margin: 0 0 3px;
+  font-size: 1.05rem;
+  font-weight: 650;
+  color: var(--jl-heading);
+}
+
+.jl-panel-sub {
+  margin: 0 0 18px;
+  font-size: 0.78rem;
+}
+
+/* --------------------------------------------------------------------------
+   3. Sections — closed cards jello on hover (and on keyboard focus)
+   -------------------------------------------------------------------------- */
+.jl-item {
+  background: var(--jl-card);
+  border: 1px solid var(--jl-border);
+  border-radius: 12px;
+  box-shadow: var(--jl-card-shadow);
+  transition: box-shadow 180ms ease, border-color 180ms ease;
+}
+
+.jl-item + .jl-item {
+  margin-top: 10px;
+}
+
+/* The wiggle: only while CLOSED — an open section holds still so the
+   content being read never moves. :focus-within gives keyboard users the
+   same feedback when the summary takes focus. */
+.jl-item:not([open]):hover,
+.jl-item:not([open]):focus-within {
+  border-color: var(--jl-accent);
+  box-shadow: var(--jl-card-shadow-hover);
+  animation: jl-jello var(--jl-duration) ease-in-out;
+}
+
+/* Squash-and-stretch with decaying amplitude — one token drives it all */
+@keyframes jl-jello {
+  0%   { transform: scale3d(1, 1, 1); }
+  25%  { transform: scale3d(calc(1 + var(--jl-squash)), calc(1 - var(--jl-squash)), 1); }
+  40%  { transform: scale3d(calc(1 - var(--jl-squash) * 0.8), calc(1 + var(--jl-squash) * 0.8), 1); }
+  55%  { transform: scale3d(calc(1 + var(--jl-squash) * 0.45), calc(1 - var(--jl-squash) * 0.45), 1); }
+  70%  { transform: scale3d(calc(1 - var(--jl-squash) * 0.2), calc(1 + var(--jl-squash) * 0.2), 1); }
+  85%  { transform: scale3d(calc(1 + var(--jl-squash) * 0.08), calc(1 - var(--jl-squash) * 0.08), 1); }
+  100% { transform: scale3d(1, 1, 1); }
+}
+
+/* --------------------------------------------------------------------------
+   4. Summary — the clickable header row (real disclosure semantics)
+   -------------------------------------------------------------------------- */
+.jl-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 13px 15px;
+  cursor: pointer;
+  list-style: none;                 /* hide default marker (Firefox) */
+  user-select: none;
+  color: var(--jl-heading);
+  font-size: 0.86rem;
+  font-weight: 600;
+  border-radius: 12px;
+}
+
+.jl-head::-webkit-details-marker { display: none; }
+
+.jl-head:focus-visible {
+  outline: 2px solid var(--jl-accent);
+  outline-offset: -2px;
+}
+
+.jl-head-icon {
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  flex: none;
+  border-radius: 8px;
+  background: var(--jl-accent-soft);
+  color: var(--jl-accent);
+  font-size: 0.78rem;
+}
+
+/* Headline stat visible while the section is closed */
+.jl-head-stat {
+  margin-left: auto;
+  font-size: 0.8rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--jl-accent);
+}
+
+/* Chevron rotates as the section opens */
+.jl-chevron {
+  flex: none;
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid var(--jl-body);
+  border-bottom: 2px solid var(--jl-body);
+  transform: rotate(45deg);
+  transition: transform var(--jl-toggle-duration) var(--jl-ease);
+}
+
+.jl-item[open] > .jl-head .jl-chevron {
+  transform: rotate(225deg);
+}
+
+.jl-item[open] > .jl-head {
+  border-bottom: 1px solid var(--jl-border);
+  border-radius: 12px 12px 0 0;
+}
+
+/* --------------------------------------------------------------------------
+   5. Body — soft fade-rise each time a section opens
+   --------------------------------------------------------------------------
+   Content inside a closed <details> is not rendered, so this animation
+   replays naturally on every open. */
+.jl-body {
+  padding: 6px 15px 12px;
+  animation: jl-body-in var(--jl-open-duration) var(--jl-ease);
+}
+
+@keyframes jl-body-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.jl-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  padding: 9px 2px;
+  font-size: 0.8rem;
+}
+
+.jl-row + .jl-row {
+  border-top: 1px dashed var(--jl-border);
+}
+
+.jl-row-label {
+  color: var(--jl-heading);
+  font-weight: 600;
+}
+
+.jl-row-value {
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Trend deltas */
+.jl-delta {
+  flex: none;
+  font-size: 0.72rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.jl-delta.is-up   { color: var(--jl-up); }
+.jl-delta.is-down { color: var(--jl-down); }
+
+/* --------------------------------------------------------------------------
+   6. Small screens — tighten the panel, keep rows readable
+   -------------------------------------------------------------------------- */
+@media (max-width: 420px) {
+  .jl-panel { max-width: none; }
+  .jl-head { padding: 12px 12px; }
+  .jl-body { padding: 4px 12px 10px; }
+  .jl-head-stat { font-size: 0.74rem; }
+  .jl-row-value { flex-basis: 100%; margin-left: 0; }
+}
+
+/* --------------------------------------------------------------------------
+   7. Reduced motion — hover still highlights, nothing wiggles
+   -------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .jl-item:not([open]):hover,
+  .jl-item:not([open]):focus-within {
+    animation: none;               /* keep the border/shadow affordance */
+  }
+
+  .jl-body {
+    animation: none;
+  }
+
+  .jl-chevron {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS **Jello-Hover Accordion** styled for **Responsive Dashboard** layouts as a fully self-contained example under `submissions/examples/33045-jello-hover-accordion-responsive-dashboard-sj6/`.

Fixes #33045

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/33045-jello-hover-accordion-responsive-dashboard-sj6/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A zero-JavaScript dashboard accordion whose closed sections jello on hover — a decaying squash-and-stretch wiggle where every keyframe is computed from a single amplitude token (`--jl-squash`) via `calc()`, so one number tunes the whole gesture. The wiggle only applies to closed sections (`:not([open])`): content being read holds perfectly still. Built on native `<details>`/`<summary>` with the `name` attribute for exclusive-open behavior.

**How does a developer use it?**

```html
<details class="jl-item" name="my-accordion">
  <summary class="jl-head">
    <span class="jl-head-icon" aria-hidden="true">⚡</span>
    Section Title
    <span class="jl-head-stat">42 pts</span>
    <span class="jl-chevron" aria-hidden="true"></span>
  </summary>
  <div class="jl-body">
    <div class="jl-row">
      <span class="jl-row-label">Metric name</span>
      <span class="jl-delta is-up">▲ 8%</span>
      <span class="jl-row-value">46 pts</span>
    </div>
  </div>
</details>
```

**Why does it fit EaseMotion CSS?**

Human-readable classes, animation-first, zero JS. The jello amplitude, wiggle duration, reveal timing/curve, and chevron rotation are all `--jl-*` custom properties on `:root`; `:focus-within` gives keyboard users the identical jello + accent affordance that mouse users get on hover, and Enter/Space toggling comes free from `<summary>`; body content fade-rises on every open because closed `<details>` content isn't rendered; `prefers-reduced-motion` removes the wiggle but keeps the border/shadow hover cue, so the affordance survives without movement.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Design decision worth keeping: the jello is gated to `:not([open])` on purpose — wiggling an expanded section moves the text someone is reading. Under `prefers-reduced-motion` the hover still changes border/shadow so the interactivity cue isn't lost. The `calc()`-driven keyframes mean integration only needs to expose `--jl-squash` rather than six hand-tuned keyframe values.

@SAPTARSHI-coder Please review this pr 
