### PR TITLE
feat(examples): Fade-Out Accordion for Marketing Landing Pages

### DIFF
--- a/submissions/examples/33065-fade-out-accordion-marketing-landing-sj6/README.md
+++ b/submissions/examples/33065-fade-out-accordion-marketing-landing-sj6/README.md
@@ -1,0 +1,77 @@
+# Fade-Out Accordion — Marketing Landing Page
+
+A pure CSS, zero-dependency **FAQ accordion** for landing pages where
+"fade-out" works on two layers: while you move through the list, the
+questions you're *not* on fade back so the one you're considering stands
+out (spotlight dim); and in modern browsers, answers **fade out and
+collapse smoothly** when a section closes, using the new
+`::details-content` animation pattern. Built on native
+`<details>`/`<summary>` — no JavaScript anywhere.
+
+Resolves Issue: #33065
+
+## ✨ Features
+
+- **Spotlight dim (all browsers)** — while the pointer or keyboard focus
+  is inside the list, closed items you're not on ease to
+  `opacity: var(--fo-dim)`. At rest, everything is fully legible; open
+  answers never dim, so nothing fades while being read.
+- **Fading close (modern browsers)** — the answer fades and its
+  `block-size` collapses to zero on close via `::details-content`,
+  `interpolate-size: allow-keywords`, and
+  `transition-behavior: allow-discrete` (so `content-visibility` waits
+  for the fade to finish). Browsers without support simply drop the rule
+  and close instantly — graceful degradation, not breakage.
+- **Keyboard parity** — the spotlight is also driven by `:focus-within`,
+  so Tab users get the same fade-out choreography; Enter/Space toggles
+  natively; 2px accent `:focus-visible` ring on each question.
+- **Native accordion semantics** — `<details name="fo-faq">` gives
+  exclusive-open behavior (one answer at a time) with zero JS.
+- **Landing-page-native details** — FAQ eyebrow badge, fluid `clamp()`
+  headline, plus-to-minus marker drawn with two pseudo-element bars and
+  rotated 135° on open, accent border on the active card.
+- **Genuinely responsive** — fluid column up to 540px, fluid type,
+  tightened paddings under 420px.
+- **Tunable via custom properties** — dim level, dim duration, collapse
+  duration, easing, and marker rotation time on `:root`.
+- **Motion-safe** — `prefers-reduced-motion` removes the dim transition,
+  the collapse animation, and the marker rotation.
+
+## 🔧 Custom Properties
+
+| Property                 | Default                          | Role                            |
+| ------------------------ | -------------------------------- | ------------------------------- |
+| `--fo-dim`               | `0.42`                           | Rest opacity of faded questions |
+| `--fo-dim-duration`      | `220ms`                          | Spotlight fade time             |
+| `--fo-collapse-duration` | `300ms`                          | Answer fade + collapse time     |
+| `--fo-ease`              | `cubic-bezier(0.22, 1, 0.36, 1)` | Collapse curve                  |
+| `--fo-toggle-duration`   | `220ms`                          | Marker rotation time            |
+
+## 🚀 Usage
+
+```html
+<div class="fo-list">
+  <details class="fo-item" name="my-faq">
+    <summary class="fo-head">
+      How does the free trial work?
+      <span class="fo-marker" aria-hidden="true"></span>
+    </summary>
+    <p class="fo-answer">Every plan starts with 14 days free…</p>
+  </details>
+  <!-- more items -->
+</div>
+```
+
+## 📂 Files
+
+- `demo.html` — a landing-page FAQ block (four pricing/support questions).
+- `style.css` — motion tokens, spotlight dim, `::details-content` collapse, a11y guards.
+- `README.md` — this document.
+
+## 📝 Note
+
+The fading close uses `::details-content` + `interpolate-size`, currently
+shipping in Chromium-based browsers (Chrome/Edge 131+) and progressing
+elsewhere. The component is designed so that everything else — spotlight
+fade-out, exclusive open, keyboard support — works identically in every
+browser; only the close animation is an enhancement.

--- a/submissions/examples/33065-fade-out-accordion-marketing-landing-sj6/demo.html
+++ b/submissions/examples/33065-fade-out-accordion-marketing-landing-sj6/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fade-Out Accordion — Marketing Landing Page</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <section class="fo-section" aria-label="Frequently asked questions">
+    <span class="fo-eyebrow">FAQ</span>
+    <h1 class="fo-section-title">Questions, answered</h1>
+    <p class="fo-section-sub">
+      Move through the list — the questions you're not on fade out, and
+      answers fade closed in modern browsers. Tab + Enter works — no
+      JavaScript.
+    </p>
+
+    <div class="fo-list">
+      <!-- name="fo-faq" makes the accordion exclusive: opening one
+           question closes the others, natively. -->
+      <details class="fo-item" name="fo-faq" open>
+        <summary class="fo-head">
+          How does the free trial work?
+          <span class="fo-marker" aria-hidden="true"></span>
+        </summary>
+        <p class="fo-answer">
+          Every plan starts with 14 days free — full features, no card
+          required. When the trial ends, pick a plan or your workspace
+          simply pauses; nothing is deleted.
+        </p>
+      </details>
+
+      <details class="fo-item" name="fo-faq">
+        <summary class="fo-head">
+          Can I change plans later?
+          <span class="fo-marker" aria-hidden="true"></span>
+        </summary>
+        <p class="fo-answer">
+          Anytime. Upgrades apply immediately and are prorated; downgrades
+          take effect at the next billing cycle so you never lose paid time.
+        </p>
+      </details>
+
+      <details class="fo-item" name="fo-faq">
+        <summary class="fo-head">
+          What happens to my data if I cancel?
+          <span class="fo-marker" aria-hidden="true"></span>
+        </summary>
+        <p class="fo-answer">
+          Your workspace goes read-only for 90 days, during which you can
+          export everything with one click. After that, data is permanently
+          removed from our servers.
+        </p>
+      </details>
+
+      <details class="fo-item" name="fo-faq">
+        <summary class="fo-head">
+          Do you offer support on the starter plan?
+          <span class="fo-marker" aria-hidden="true"></span>
+        </summary>
+        <p class="fo-answer">
+          Yes — every plan includes email support with a one-business-day
+          response time. Priority chat is part of the Growth plan and above.
+        </p>
+      </details>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/33065-fade-out-accordion-marketing-landing-sj6/style.css
+++ b/submissions/examples/33065-fade-out-accordion-marketing-landing-sj6/style.css
@@ -1,0 +1,233 @@
+/* ==========================================================================
+   Fade-Out Accordion — Marketing Landing Page
+   --------------------------------------------------------------------------
+   Pure CSS FAQ accordion for landing pages, built on native
+   <details>/<summary>. "Fade-out" works on two layers:
+
+     1. Spotlight dim (all browsers): while the pointer — or keyboard
+        focus — is inside the list, every closed question you are NOT on
+        fades back, so the one you're considering stands out.
+
+     2. Fading close (modern browsers): answers fade out and collapse
+        smoothly when a section closes, via ::details-content +
+        interpolate-size + transition-behavior: allow-discrete. Where
+        unsupported, the rule is simply dropped and close is instant —
+        a graceful degradation, not a breakage.
+
+   Zero JavaScript anywhere.
+
+   Issue: #33065
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Tokens — motion first, then the landing-page skin
+   -------------------------------------------------------------------------- */
+:root {
+  /* Fade-out layers */
+  --fo-dim: 0.42;                                  /* rest opacity of faded items */
+  --fo-dim-duration: 220ms;                        /* spotlight fade              */
+  --fo-collapse-duration: 300ms;                   /* answer fade+collapse        */
+  --fo-ease: cubic-bezier(0.22, 1, 0.36, 1);       /* collapse curve              */
+  --fo-toggle-duration: 220ms;                     /* marker rotation             */
+
+  /* Landing-page skin */
+  --fo-canvas: #f7f8f4;
+  --fo-card: #ffffff;
+  --fo-border: #e3e7dc;
+  --fo-heading: #1e2a22;
+  --fo-body: #64705f;
+  --fo-accent: #0e9f6e;
+  --fo-accent-soft: #e4f5ec;
+
+  --fo-card-shadow: 0 1px 3px rgba(30, 42, 34, 0.06);
+
+  /* Opt in to animating block-size to/from auto (modern browsers) */
+  interpolate-size: allow-keywords;
+}
+
+/* --------------------------------------------------------------------------
+   2. Demo stage — the FAQ block of a landing page
+   -------------------------------------------------------------------------- */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 34px 16px;
+  box-sizing: border-box;
+  background: var(--fo-canvas);
+  font-family: "Segoe UI", system-ui, -apple-system, Arial, sans-serif;
+  color: var(--fo-body);
+}
+
+.fo-section {
+  width: 100%;
+  max-width: 540px;
+}
+
+.fo-eyebrow {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: var(--fo-accent-soft);
+  color: var(--fo-accent);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 12px;
+}
+
+.fo-section-title {
+  margin: 0 0 6px;
+  font-size: clamp(1.3rem, 4.5vw, 1.7rem);
+  font-weight: 750;
+  color: var(--fo-heading);
+  line-height: 1.2;
+}
+
+.fo-section-sub {
+  margin: 0 0 20px;
+  font-size: 0.84rem;
+  line-height: 1.55;
+  max-width: 46ch;
+}
+
+/* --------------------------------------------------------------------------
+   3. Spotlight dim — fade out the questions you're not on
+   --------------------------------------------------------------------------
+   Gated on hover/focus INSIDE the list, so at rest everything is fully
+   legible. Open items never dim: an answer being read stays at full
+   strength. :focus-within gives keyboard users the same spotlight. */
+.fo-list .fo-item {
+  transition: opacity var(--fo-dim-duration) ease;
+}
+
+.fo-list:hover .fo-item:not(:hover):not([open]),
+.fo-list:focus-within .fo-item:not(:focus-within):not([open]) {
+  opacity: var(--fo-dim);
+}
+
+/* --------------------------------------------------------------------------
+   4. Items — native disclosure cards
+   -------------------------------------------------------------------------- */
+.fo-item {
+  background: var(--fo-card);
+  border: 1px solid var(--fo-border);
+  border-radius: 12px;
+  box-shadow: var(--fo-card-shadow);
+}
+
+.fo-item + .fo-item {
+  margin-top: 10px;
+}
+
+.fo-item[open] {
+  border-color: var(--fo-accent);
+}
+
+.fo-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  cursor: pointer;
+  list-style: none;                 /* hide default marker (Firefox) */
+  user-select: none;
+  color: var(--fo-heading);
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.fo-head::-webkit-details-marker { display: none; }
+
+.fo-head:focus-visible {
+  outline: 2px solid var(--fo-accent);
+  outline-offset: -2px;
+  border-radius: 10px;
+}
+
+/* Plus-to-minus marker, rotated by the open state */
+.fo-marker {
+  position: relative;
+  flex: none;
+  margin-left: auto;
+  width: 16px;
+  height: 16px;
+  transition: transform var(--fo-toggle-duration) var(--fo-ease);
+}
+
+.fo-marker::before,
+.fo-marker::after {
+  content: "";
+  position: absolute;
+  inset: 50% auto auto 50%;
+  translate: -50% -50%;
+  background: var(--fo-accent);
+  border-radius: 2px;
+}
+
+.fo-marker::before { width: 14px; height: 2px; }
+.fo-marker::after  { width: 2px;  height: 14px; }
+
+.fo-item[open] > .fo-head .fo-marker {
+  transform: rotate(135deg);        /* + becomes ×→− as it turns */
+}
+
+/* --------------------------------------------------------------------------
+   5. Fading close — answers fade out and collapse (modern browsers)
+   --------------------------------------------------------------------------
+   ::details-content is the element browsers wrap the answer in.
+   content-visibility needs allow-discrete to wait for the fade before
+   hiding; block-size animates to/from auto thanks to interpolate-size.
+   Browsers without support drop this rule and close instantly. */
+.fo-item::details-content {
+  opacity: 0;
+  block-size: 0;
+  overflow: clip;
+  transition:
+    content-visibility var(--fo-collapse-duration) allow-discrete,
+    opacity var(--fo-collapse-duration) ease,
+    block-size var(--fo-collapse-duration) var(--fo-ease);
+}
+
+.fo-item[open]::details-content {
+  opacity: 1;
+  block-size: auto;
+}
+
+.fo-answer {
+  padding: 2px 16px 15px;
+  font-size: 0.82rem;
+  line-height: 1.6;
+}
+
+.fo-answer a {
+  color: var(--fo-accent);
+  font-weight: 600;
+}
+
+/* --------------------------------------------------------------------------
+   6. Small screens — tighten paddings, keep type fluid
+   -------------------------------------------------------------------------- */
+@media (max-width: 420px) {
+  .fo-head { padding: 13px 13px; }
+  .fo-answer { padding: 2px 13px 13px; }
+}
+
+/* --------------------------------------------------------------------------
+   7. Reduced motion — no dimming choreography, no collapse animation
+   -------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .fo-list .fo-item {
+    transition: none;
+  }
+
+  .fo-item::details-content {
+    transition: none;
+  }
+
+  .fo-marker {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS **Fade-Out Accordion** styled for **Marketing Landing Page** layouts as a fully self-contained example under `submissions/examples/33065-fade-out-accordion-marketing-landing-sj6/`.

Fixes #33065

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/33065-fade-out-accordion-marketing-landing-sj6/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A zero-JavaScript landing-page FAQ accordion where fade-out works on two layers: (1) spotlight dim — while the pointer or keyboard focus is inside the list, closed questions you're not on ease back to a configurable opacity, so the one you're considering stands out (works in every browser); (2) fading close — answers fade out and collapse smoothly on close via the modern `::details-content` + `interpolate-size: allow-keywords` + `transition-behavior: allow-discrete` pattern, degrading gracefully to an instant close where unsupported. Native `<details name>` gives exclusive-open behavior.

**How does a developer use it?**

```html
<div class="fo-list">
  <details class="fo-item" name="my-faq">
    <summary class="fo-head">
      How does the free trial work?
      <span class="fo-marker" aria-hidden="true"></span>
    </summary>
    <p class="fo-answer">Every plan starts with 14 days free…</p>
  </details>
  <!-- more items -->
</div>
```

**Why does it fit EaseMotion CSS?**

Human-readable classes, animation-first, zero JS. Dim level, dim duration, collapse duration, easing, and marker rotation are all `--fo-*` custom properties on `:root`; the spotlight is driven by `:focus-within` as well as `:hover`, so keyboard users get the identical choreography; open answers never dim (content being read stays at full strength); `prefers-reduced-motion` removes the dim transition, the collapse animation, and the marker rotation.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The fading close relies on `::details-content`/`interpolate-size` (Chromium 131+; progressing elsewhere) — it is deliberately layered as a progressive enhancement: spotlight fade-out, exclusive open, and keyboard support are identical in every browser, only the close animation upgrades. The plus-to-minus marker is drawn with two pseudo-element bars and rotated 135°, no icon assets.

@SAPTARSHI-coder Please review the pr