### PR TITLE
feat: add fade out modal exafeat: add fade out modal examplemple

### DIFF
--- a/submissions/examples/fade-out-modal/README.md
+++ b/submissions/examples/fade-out-modal/README.md
@@ -1,0 +1,92 @@
+# CSS Fade-Out Modal
+
+A simple CSS-only modal component with a smooth fade-out transition. It is designed for SaaS landing pages, dashboards, and modern web interfaces without using JavaScript.
+
+## Features
+
+- Pure HTML and CSS
+- Smooth fade-in and fade-out transition
+- Uses CSS custom properties for easy customization
+- Responsive design
+- No JavaScript required
+- Easy to reuse in different projects
+
+## File Structure
+
+```
+fade-out-modal/
+│── demo.html
+│── style.css
+└── README.md
+```
+
+## How to Use
+
+1. Include the stylesheet in your HTML file.
+
+```html
+<link rel="stylesheet" href="style.css">
+```
+
+2. Add a button or link to open the modal.
+
+```html
+<a href="#modal" class="open-btn">Open Modal</a>
+```
+
+3. Add the modal structure.
+
+```html
+<div id="modal" class="modal">
+    <div class="modal-box">
+        <h2>Upgrade to Pro</h2>
+
+        <p>
+            Unlock advanced analytics, unlimited projects and premium support.
+        </p>
+
+        <div class="buttons">
+            <a href="#" class="close-btn">Cancel</a>
+            <button>Upgrade</button>
+        </div>
+    </div>
+</div>
+```
+
+Opening the modal changes the URL target, and clicking **Cancel** removes the target, creating a smooth fade-out effect using only CSS.
+
+## Customization
+
+The component uses CSS variables, so changing the animation is straightforward.
+
+```css
+:root {
+    --modal-duration: 0.35s;
+    --modal-easing: ease;
+    --modal-scale: 0.95;
+
+    --primary-color: #4f46e5;
+    --overlay-color: rgba(0, 0, 0, 0.55);
+}
+```
+
+You can modify these values to change the animation speed, easing, scale, or colors.
+
+## Browser Support
+
+Works in all modern browsers that support:
+
+- CSS Variables
+- CSS Transitions
+- `:target` selector
+
+## Demo
+
+Open **demo.html** in your browser to see the component in action.
+
+## Tech Stack
+
+- HTML5
+- CSS3
+- No JavaScript
+**Note:** This example uses the CSS `:target` selector for opening and closing the modal, so no JavaScript is required.

--- a/submissions/examples/fade-out-modal/demo.html
+++ b/submissions/examples/fade-out-modal/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Fade Out Modal</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="page">
+    <h1>SaaS Dashboard</h1>
+    <p>Click the button below to open the modal.</p>
+
+    <a href="#modal" class="open-btn">Open Modal</a>
+</div>
+
+<div id="modal" class="modal">
+    <div class="modal-box">
+
+        <h2>Upgrade to Pro</h2>
+
+        <p>
+            Unlock advanced analytics, unlimited projects and premium support.
+        </p>
+
+        <div class="buttons">
+            <a href="#" class="close-btn">Cancel</a>
+            <button>Upgrade</button>
+        </div>
+
+    </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/fade-out-modal/style.css
+++ b/submissions/examples/fade-out-modal/style.css
@@ -1,0 +1,172 @@
+:root {
+    --modal-duration: 0.35s;
+    --modal-easing: ease;
+    --modal-scale: 0.95;
+
+    --primary-color: #4f46e5;
+    --primary-hover: #4338ca;
+    --overlay-color: rgba(15, 23, 42, 0.55);
+    --background-color: #f5f7fb;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: Arial, Helvetica, sans-serif;
+    background: var(--background-color);
+    color: #222;
+}
+
+.page {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    padding: 20px;
+}
+
+.page h1 {
+    font-size: 2.6rem;
+    margin-bottom: 12px;
+}
+
+.page p {
+    color: #666;
+    margin-bottom: 24px;
+}
+
+.open-btn {
+    display: inline-block;
+    text-decoration: none;
+    background: var(--primary-color);
+    color: white;
+    padding: 12px 28px;
+    border-radius: 8px;
+    transition: background .3s ease, transform .3s ease;
+}
+
+.open-btn:hover {
+    background: var(--primary-hover);
+    transform: translateY(-2px);
+}
+
+.open-btn:focus,
+.close-btn:focus,
+.buttons button:focus {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 3px;
+}
+
+.modal {
+    position: fixed;
+    inset: 0;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    background: var(--overlay-color);
+    backdrop-filter: blur(4px);
+
+    opacity: 0;
+    visibility: hidden;
+
+    transition:
+        opacity var(--modal-duration) var(--modal-easing),
+        visibility var(--modal-duration) var(--modal-easing);
+}
+
+.modal-box {
+    background: white;
+    width: 90%;
+    max-width: 430px;
+
+    padding: 30px;
+    border-radius: 14px;
+
+    text-align: center;
+
+    transform: scale(var(--modal-scale));
+
+    box-shadow: 0 18px 40px rgba(0,0,0,.18);
+
+    transition:
+        transform var(--modal-duration) var(--modal-easing);
+}
+
+.modal-box h2 {
+    margin-bottom: 14px;
+}
+
+.modal-box p {
+    color: #666;
+    line-height: 1.6;
+}
+
+.buttons {
+    display: flex;
+    justify-content: center;
+    gap: 14px;
+    margin-top: 28px;
+}
+
+.buttons a,
+.buttons button {
+    padding: 10px 24px;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 15px;
+    text-decoration: none;
+    transition: .3s ease;
+}
+
+.close-btn {
+    background: #e5e7eb;
+    color: #222;
+}
+
+.close-btn:hover {
+    background: #d1d5db;
+}
+
+.buttons button {
+    background: var(--primary-color);
+    color: white;
+}
+
+.buttons button:hover {
+    background: var(--primary-hover);
+    transform: translateY(-2px);
+}
+
+.modal:target {
+    opacity: 1;
+    visibility: visible;
+}
+
+.modal:target .modal-box {
+    transform: scale(1);
+}
+
+@media (max-width: 500px) {
+
+    .modal-box {
+        padding: 22px;
+    }
+
+    .buttons {
+        flex-direction: column;
+    }
+
+    .buttons a,
+    .buttons button {
+        width: 100%;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

Added a CSS-only fade-out modal example for SaaS showcase layouts. The component uses a smooth fade-out transition, is responsive, and can be customized with CSS variables.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/fade-out-modal/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

A reusable CSS-only fade-out modal with a clean SaaS-inspired design.

### How does a developer use it?

```html
<a href="#modal" class="open-btn">Open Modal</a>
```

### Why does it fit EaseMotion CSS?

It demonstrates a lightweight animation using only HTML and CSS while keeping the code simple, reusable, and easy to customize.

---

## Demo

- [x] Demo added (`demo.html` opens directly in the browser)

---

## Browser Testing

- [x] Chrome
- [x] Edge
- [ ] Firefox
- [ ] Safari

---

## Notes for Maintainer

The modal is built using pure HTML and CSS with no JavaScript. Animation timing and scaling can be adjusted through CSS variables.