### PR TITLE
feat: add split view comparison panel transition example

### DIFF
--- a/submissions/examples/37016-split-view-comparison-transition-dp/README.md
+++ b/submissions/examples/37016-split-view-comparison-transition-dp/README.md
@@ -1,0 +1,43 @@
+# Split View Comparison Panel Transition
+
+## Overview
+
+A code review style split view comparing a "Before" and "After" version of a function, where focusing either side smoothly resizes both panels instead of snapping between layouts. It solves the production problem of comparing two related pieces of content, code, specs, or document versions, without losing sight of the other side. Coordinated panel transitions preserve context by keeping both panels visible and readable throughout the resize, so users never lose their place mid-comparison. Implemented entirely with HTML and CSS, no JavaScript.
+
+## Features
+
+- Responsive split view with left ("Before") and right ("After") panels
+- Realistic code comparison content with added/removed line highlighting
+- Three CSS-only view states: balanced, left-focused, right-focused
+- Radio-button controlled focus with clearly highlighted active control
+- Animated width, spacing, opacity and shadow emphasis on focus change
+- De-emphasized inactive panel without hiding its content
+- Layout stays stable and both panels remain readable during transitions
+- CSS custom properties for spacing, duration, easing and color
+- Fully responsive with a stacked, single-column mobile layout
+
+## File Structure
+
+- demo.html
+- style.css
+- README.md
+
+## How It Works
+
+- **Split layout**: two flex panels of equal width by default, separated by a thin divider
+- **Focus controls**: three hidden radio inputs sharing a `name`, paired with labels styled as a segmented control
+- **Panel transitions**: `:checked` on a given radio, combined with sibling combinators, increases the matching panel's `flex-grow` while shrinking, dimming and slightly scaling down the other
+- **CSS-only interaction**: radios and labels handle all state changes, no scripting involved
+- **Responsive behavior**: below the split breakpoint, panels stack vertically and focus states reset to equal size so content stays fully readable on small screens
+
+## Example Use Cases
+
+- Code review platforms
+- File comparison tools
+- Product comparison pages
+- Analytics dashboards
+- Document comparison interfaces
+
+## Why This Example?
+
+Abrupt layout changes, panels that jump to a new size with no transition, make it hard to track what changed and where to look next. Smooth panel transitions keep both sides visually connected as focus shifts, which directly improves comparison workflows where users move back and forth between two versions. This fits EaseMotion CSS as a focused example of coordinated, context-preserving motion across two regions, and it is production-inspired because focus-driven split views are a common pattern in code review and comparison tooling.

--- a/submissions/examples/37016-split-view-comparison-transition-dp/demo.html
+++ b/submissions/examples/37016-split-view-comparison-transition-dp/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Split View Comparison Panel Transition</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+    <header class="page-header">
+        <h1>Split View Comparison Panel Transition</h1>
+        <p class="page-description">
+            A code review style split view comparing two versions of a function.
+            Switch focus between the panels and watch width, spacing, opacity and
+            emphasis animate together while both versions stay readable throughout.
+        </p>
+    </header>
+
+    <main class="page-main">
+
+        <input type="radio" name="view-mode" id="view-balanced" class="view-toggle" checked>
+        <input type="radio" name="view-mode" id="view-left" class="view-toggle">
+        <input type="radio" name="view-mode" id="view-right" class="view-toggle">
+
+        <div class="view-controls" role="group" aria-label="Panel focus controls">
+            <label for="view-left" class="control-btn">Focus Before</label>
+            <label for="view-balanced" class="control-btn">Balanced</label>
+            <label for="view-right" class="control-btn">Focus After</label>
+        </div>
+
+        <div class="split-view">
+
+            <section class="panel panel-left" aria-label="Before version">
+                <header class="panel-header">
+                    <span class="panel-tag tag-before">Before</span>
+                    <span class="panel-file">discount.js · v1.2</span>
+                </header>
+                <pre class="code-block"><code><span class="line">function applyDiscount(price, code) {</span>
+<span class="line line-removed">  if (code === "SAVE10") {</span>
+<span class="line line-removed">    return price - price * 0.10;</span>
+<span class="line line-removed">  }</span>
+<span class="line">  return price;</span>
+<span class="line">}</span></code></pre>
+                <p class="panel-note">Single hard-coded discount code with no validation or logging.</p>
+            </section>
+
+            <div class="divider" aria-hidden="true"></div>
+
+            <section class="panel panel-right" aria-label="After version">
+                <header class="panel-header">
+                    <span class="panel-tag tag-after">After</span>
+                    <span class="panel-file">discount.js · v2.0</span>
+                </header>
+                <pre class="code-block"><code><span class="line">function applyDiscount(price, code) {</span>
+<span class="line line-added">  const rate = discountTable[code];</span>
+<span class="line line-added">  if (!rate) return price;</span>
+<span class="line line-added">  const finalPrice = price - price * rate;</span>
+<span class="line line-added">  logDiscountUsage(code, finalPrice);</span>
+<span class="line line-added">  return finalPrice;</span>
+<span class="line">}</span></code></pre>
+                <p class="panel-note">Table-driven discount lookup with graceful fallback and usage logging.</p>
+            </section>
+
+        </div>
+
+    </main>
+
+    <footer class="page-footer">
+        <p>Built with CSS-only radio inputs and sibling combinators — no JavaScript, no SCSS, no external libraries.</p>
+    </footer>
+
+</body>
+
+</html>

--- a/submissions/examples/37016-split-view-comparison-transition-dp/style.css
+++ b/submissions/examples/37016-split-view-comparison-transition-dp/style.css
@@ -1,0 +1,283 @@
+:root {
+  --space-xs: 0.4rem;
+  --space-sm: 0.8rem;
+  --space-md: 1.2rem;
+  --space-lg: 2rem;
+
+  --radius-sm: 6px;
+  --radius-md: 12px;
+
+  --duration-base: 380ms;
+  --easing: cubic-bezier(0.22, 1, 0.36, 1);
+
+  --color-bg: #f3f4f8;
+  --color-surface: #ffffff;
+  --color-code-bg: #161822;
+  --color-border: #e4e6f0;
+  --color-text: #1c1e2b;
+  --color-text-muted: #676b80;
+  --color-primary: #6f5bff;
+  --color-primary-soft: #efecff;
+
+  --color-before: #c02f2f;
+  --color-before-bg: #ffe6e6;
+  --color-after: #1f9d5f;
+  --color-after-bg: #e8f9ef;
+
+  --focus-grow: 2.4;
+  --unfocus-shrink: 0.55;
+  --unfocus-opacity: 0.5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: var(--space-lg);
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
+    sans-serif;
+  line-height: 1.5;
+}
+
+.page-header {
+  max-width: 820px;
+  margin: 0 auto var(--space-lg);
+  text-align: center;
+}
+
+.page-header h1 {
+  margin: 0 0 var(--space-sm);
+  font-size: clamp(1.4rem, 2.2vw, 2rem);
+  letter-spacing: -0.02em;
+}
+
+.page-description {
+  margin: 0 auto;
+  max-width: 640px;
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+}
+
+.page-main {
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
+.view-toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  border: 0;
+}
+
+.view-controls {
+  display: flex;
+  justify-content: center;
+  gap: var(--space-xs);
+  margin-bottom: var(--space-md);
+}
+
+.control-btn {
+  padding: 0.55rem 1.1rem;
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background var(--duration-base) var(--easing),
+    color var(--duration-base) var(--easing),
+    border-color var(--duration-base) var(--easing),
+    transform var(--duration-base) var(--easing);
+}
+
+.control-btn:hover {
+  transform: translateY(-1px);
+}
+
+#view-left:focus-visible ~ .view-controls label[for="view-left"],
+#view-balanced:focus-visible ~ .view-controls label[for="view-balanced"],
+#view-right:focus-visible ~ .view-controls label[for="view-right"] {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+#view-left:checked ~ .view-controls label[for="view-left"],
+#view-balanced:checked ~ .view-controls label[for="view-balanced"],
+#view-right:checked ~ .view-controls label[for="view-right"] {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #ffffff;
+}
+
+.split-view {
+  display: flex;
+  align-items: stretch;
+  gap: var(--space-md);
+}
+
+.panel {
+  flex: 1 1 50%;
+  min-width: 0;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  opacity: 1;
+  transform: scale(1);
+  transition:
+    flex-grow var(--duration-base) var(--easing),
+    opacity var(--duration-base) var(--easing),
+    transform var(--duration-base) var(--easing),
+    box-shadow var(--duration-base) var(--easing);
+}
+
+.divider {
+  width: 1px;
+  background: var(--color-border);
+  flex: 0 0 1px;
+  transition: opacity var(--duration-base) var(--easing);
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.panel-tag {
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.tag-before {
+  background: var(--color-before-bg);
+  color: var(--color-before);
+}
+
+.tag-after {
+  background: var(--color-after-bg);
+  color: var(--color-after);
+}
+
+.panel-file {
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+}
+
+.code-block {
+  margin: 0;
+  padding: var(--space-md);
+  background: var(--color-code-bg);
+  color: #e6e8f2;
+  font-family: "SFMono-Regular", Consolas, Menlo, monospace;
+  font-size: 0.85rem;
+  overflow-x: auto;
+  flex: 1;
+}
+
+.code-block .line {
+  display: block;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+}
+
+.line-removed {
+  background: rgba(192, 47, 47, 0.22);
+}
+
+.line-added {
+  background: rgba(31, 157, 95, 0.22);
+}
+
+.panel-note {
+  margin: 0;
+  padding: var(--space-sm) var(--space-md);
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  border-top: 1px solid var(--color-border);
+}
+
+#view-left:checked ~ .split-view .panel-left {
+  flex-grow: var(--focus-grow);
+  box-shadow: 0 14px 30px rgba(31, 34, 63, 0.12);
+}
+
+#view-left:checked ~ .split-view .panel-right {
+  flex-grow: var(--unfocus-shrink);
+  opacity: var(--unfocus-opacity);
+  transform: scale(0.98);
+}
+
+#view-right:checked ~ .split-view .panel-right {
+  flex-grow: var(--focus-grow);
+  box-shadow: 0 14px 30px rgba(31, 34, 63, 0.12);
+}
+
+#view-right:checked ~ .split-view .panel-left {
+  flex-grow: var(--unfocus-shrink);
+  opacity: var(--unfocus-opacity);
+  transform: scale(0.98);
+}
+
+.page-footer {
+  max-width: 1080px;
+  margin: var(--space-lg) auto 0;
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: 0.82rem;
+}
+
+@media (max-width: 780px) {
+  .split-view {
+    flex-direction: column;
+  }
+
+  .divider {
+    width: auto;
+    height: 1px;
+  }
+
+  #view-left:checked ~ .split-view .panel-right,
+  #view-right:checked ~ .split-view .panel-left {
+    flex-grow: 1;
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  .view-controls {
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: var(--space-md);
+  }
+
+  .code-block {
+    font-size: 0.78rem;
+  }
+
+  .panel-header {
+    flex-wrap: wrap;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a **Split View Comparison Panel Transition** example under the `submissions/examples/` track.

The example demonstrates a production-inspired split-view interface where two comparison panels smoothly transition between balanced and focused layouts. Motion is used to resize panels, emphasize the active comparison, and preserve visual continuity during layout changes. The implementation is built entirely with HTML and CSS, without JavaScript or external libraries.

Closes #37016

---

## Type of Change

- [x] 🧩 New example submission
- [ ] ✨ New animation
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Uses HTML and CSS only
- [x] No JavaScript
- [x] No external dependencies
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

A reusable example demonstrating smooth transitions between comparison panels in a split-view layout, allowing users to focus on one panel while maintaining awareness of the other.

### Key Features

- Responsive split-view layout
- Balanced and focused panel states
- CSS-only interaction
- Smooth panel resizing and emphasis transitions
- Responsive design
- Production-inspired comparison interface

### Why does it fit EaseMotion CSS?

This example showcases a practical interaction pattern used in code review tools, file comparison applications, analytics dashboards, and product comparison pages. It demonstrates how CSS motion can improve comparison workflows and preserve user context while remaining lightweight and entirely HTML/CSS based.

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge