### PR TITLE
feat(examples): Fade-In Accordion for Modern SaaS

### DIFF
--- a/submissions/examples/32809-fade-in-accordion-modern-saas-sj6/README.md
+++ b/submissions/examples/32809-fade-in-accordion-modern-saas-sj6/README.md
@@ -1,0 +1,79 @@
+# Fade-In Accordion — Modern SaaS
+
+A pure CSS, zero-dependency **feature accordion** for SaaS pricing and
+marketing pages with a **two-stage fade-in**: when a section opens, the
+tinted panel surface fades up first, then the feature rows bloom in a
+beat later. Opacity only — no translate, no scale — which keeps the
+motion calm and product-page appropriate. Built on native
+`<details>`/`<summary>`; no JavaScript anywhere.
+
+Resolves Issue: #32809
+
+## ✨ Features
+
+- **Two-stage fade** — one keyframe (`fi-fade`), two elements: the body
+  surface animates immediately, the rows repeat the same fade after
+  `--fi-content-delay` with `both` fill so they hold invisible during
+  the delay. The layering reads as depth without a single pixel moving.
+- **Replays on every open** — content inside a closed `<details>` is not
+  rendered, so both stages restart naturally each time a section opens.
+  Zero JS.
+- **Native accordion semantics** — `<details name="fi-features">` gives
+  exclusive-open behavior (one section at a time) straight from the
+  browser; remove the `name` to allow multiple open.
+- **Keyboard accessible** — `<summary>` is natively focusable and
+  toggles with Enter/Space; 2px accent `:focus-visible` ring; the open
+  card is additionally marked by an accent border + soft shadow, a cue
+  that survives with animations disabled.
+- **SaaS-native details** — eyebrow badge, fluid `clamp()` headline,
+  icon chips, plan-availability pills on each header, checkmark feature
+  rows with muted right-hand notes.
+- **Genuinely responsive** — fluid column up to 540px; under 420px the
+  row notes wrap to their own line so features stay readable on phones.
+- **Tunable via custom properties** — stage duration, content delay,
+  easing, and chevron rotation on `:root`.
+- **Motion-safe** — `prefers-reduced-motion` removes both fade stages
+  and all transitions; content simply appears, and the accent border
+  still marks the open section.
+
+## 🔧 Custom Properties
+
+| Property               | Default    | Role                                |
+| ---------------------- | ---------- | ----------------------------------- |
+| `--fi-duration`        | `320ms`    | Each fade stage                     |
+| `--fi-content-delay`   | `140ms`    | Delay before the rows' fade begins  |
+| `--fi-ease`            | `ease-out` | Fade curve                          |
+| `--fi-toggle-duration` | `220ms`    | Chevron rotation time               |
+
+## 🚀 Usage
+
+```html
+<details class="fi-item" name="my-features">
+  <summary class="fi-head">
+    <span class="fi-head-icon" aria-hidden="true">👥</span>
+    Collaboration
+    <span class="fi-plan">All plans</span>
+    <span class="fi-chevron" aria-hidden="true"></span>
+  </summary>
+  <div class="fi-body">
+    <div class="fi-rows">
+      <div class="fi-row">
+        <span class="fi-row-label">Unlimited shared workspaces</span>
+        <span class="fi-row-note">no seat minimum</span>
+      </div>
+    </div>
+  </div>
+</details>
+```
+
+## 📂 Files
+
+- `demo.html` — a pricing-page "what's included" block (collaboration / automation / security).
+- `style.css` — motion tokens, two-stage fade engine, SaaS skin, a11y guards.
+- `README.md` — this document.
+
+## 📝 Note
+
+The body surface tint uses `color-mix()` (supported in all evergreen
+browsers); if unavailable, the panel simply renders without the tint —
+the fades are unaffected.

--- a/submissions/examples/32809-fade-in-accordion-modern-saas-sj6/demo.html
+++ b/submissions/examples/32809-fade-in-accordion-modern-saas-sj6/demo.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fade-In Accordion — Modern SaaS</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <section class="fi-block" aria-label="What's included">
+    <span class="fi-eyebrow">What's included</span>
+    <h1 class="fi-block-title">Every plan, unpacked</h1>
+    <p class="fi-block-sub">
+      Open a category — the panel fades up first, then the features bloom
+      in a beat later. Opacity only, no movement. Tab + Enter works —
+      no JavaScript.
+    </p>
+
+    <!-- name="fi-features" makes the accordion exclusive: opening one
+         section closes the others, natively. -->
+    <details class="fi-item" name="fi-features" open>
+      <summary class="fi-head">
+        <span class="fi-head-icon" aria-hidden="true">👥</span>
+        Collaboration
+        <span class="fi-plan">All plans</span>
+        <span class="fi-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="fi-body">
+        <div class="fi-rows">
+          <div class="fi-row">
+            <span class="fi-row-label">Unlimited shared workspaces</span>
+            <span class="fi-row-note">no seat minimum</span>
+          </div>
+          <div class="fi-row">
+            <span class="fi-row-label">Real-time co-editing</span>
+            <span class="fi-row-note">with presence</span>
+          </div>
+          <div class="fi-row">
+            <span class="fi-row-label">Comments &amp; mentions</span>
+            <span class="fi-row-note">threaded</span>
+          </div>
+        </div>
+      </div>
+    </details>
+
+    <details class="fi-item" name="fi-features">
+      <summary class="fi-head">
+        <span class="fi-head-icon" aria-hidden="true">⚙️</span>
+        Automation
+        <span class="fi-plan">Growth +</span>
+        <span class="fi-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="fi-body">
+        <div class="fi-rows">
+          <div class="fi-row">
+            <span class="fi-row-label">Workflow builder</span>
+            <span class="fi-row-note">50+ triggers</span>
+          </div>
+          <div class="fi-row">
+            <span class="fi-row-label">Scheduled reports</span>
+            <span class="fi-row-note">email &amp; webhook</span>
+          </div>
+          <div class="fi-row">
+            <span class="fi-row-label">API access</span>
+            <span class="fi-row-note">10k calls/day</span>
+          </div>
+        </div>
+      </div>
+    </details>
+
+    <details class="fi-item" name="fi-features">
+      <summary class="fi-head">
+        <span class="fi-head-icon" aria-hidden="true">🛡</span>
+        Security &amp; compliance
+        <span class="fi-plan">Business +</span>
+        <span class="fi-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="fi-body">
+        <div class="fi-rows">
+          <div class="fi-row">
+            <span class="fi-row-label">SSO / SAML</span>
+            <span class="fi-row-note">Okta, Entra, Google</span>
+          </div>
+          <div class="fi-row">
+            <span class="fi-row-label">Audit log</span>
+            <span class="fi-row-note">18-month retention</span>
+          </div>
+          <div class="fi-row">
+            <span class="fi-row-label">SOC 2 Type II</span>
+            <span class="fi-row-note">report on request</span>
+          </div>
+        </div>
+      </div>
+    </details>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/32809-fade-in-accordion-modern-saas-sj6/style.css
+++ b/submissions/examples/32809-fade-in-accordion-modern-saas-sj6/style.css
@@ -1,0 +1,249 @@
+/* ==========================================================================
+   Fade-In Accordion — Modern SaaS
+   --------------------------------------------------------------------------
+   Pure CSS feature accordion for SaaS marketing/pricing pages, built on
+   native <details>/<summary>. The signature is a TWO-STAGE fade-in: when
+   a section opens, the panel surface fades up first, then the feature
+   rows bloom in a beat later. No movement at all — opacity only — which
+   is what keeps it calm and product-page appropriate.
+
+   Content inside a closed <details> is not rendered, so both fade stages
+   replay naturally on every open. Zero JavaScript.
+
+   Issue: #32809
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Tokens — motion first, then the SaaS skin
+   -------------------------------------------------------------------------- */
+:root {
+  /* Two-stage fade */
+  --fi-duration: 320ms;                            /* each fade stage        */
+  --fi-content-delay: 140ms;                       /* rows start after panel */
+  --fi-ease: ease-out;                             /* pure fades like it     */
+  --fi-toggle-duration: 220ms;                     /* chevron rotation       */
+
+  /* Modern SaaS skin */
+  --fi-canvas: #f6f7fb;
+  --fi-card: #ffffff;
+  --fi-border: #e5e8f2;
+  --fi-heading: #1d2433;
+  --fi-body: #5f6b83;
+  --fi-accent: #4c62e9;
+  --fi-accent-soft: #eceffd;
+  --fi-check: #14804a;
+
+  --fi-card-shadow: 0 1px 3px rgba(29, 36, 51, 0.06);
+  --fi-card-shadow-open: 0 10px 30px rgba(76, 98, 233, 0.12);
+}
+
+/* --------------------------------------------------------------------------
+   2. Demo stage — a pricing-page feature block
+   -------------------------------------------------------------------------- */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 34px 16px;
+  box-sizing: border-box;
+  background: var(--fi-canvas);
+  font-family: "Segoe UI", system-ui, -apple-system, Arial, sans-serif;
+  color: var(--fi-body);
+}
+
+.fi-block {
+  width: 100%;
+  max-width: 540px;
+}
+
+.fi-eyebrow {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: var(--fi-accent-soft);
+  color: var(--fi-accent);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 12px;
+}
+
+.fi-block-title {
+  margin: 0 0 6px;
+  font-size: clamp(1.3rem, 4.5vw, 1.7rem);
+  font-weight: 750;
+  color: var(--fi-heading);
+  line-height: 1.2;
+}
+
+.fi-block-sub {
+  margin: 0 0 20px;
+  font-size: 0.84rem;
+  line-height: 1.55;
+  max-width: 48ch;
+}
+
+/* --------------------------------------------------------------------------
+   3. Sections — native disclosure cards
+   -------------------------------------------------------------------------- */
+.fi-item {
+  background: var(--fi-card);
+  border: 1px solid var(--fi-border);
+  border-radius: 12px;
+  box-shadow: var(--fi-card-shadow);
+  transition: box-shadow 200ms ease, border-color 200ms ease;
+}
+
+.fi-item + .fi-item {
+  margin-top: 10px;
+}
+
+.fi-item[open] {
+  border-color: var(--fi-accent);
+  box-shadow: var(--fi-card-shadow-open);
+}
+
+.fi-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  cursor: pointer;
+  list-style: none;                 /* hide default marker (Firefox) */
+  user-select: none;
+  color: var(--fi-heading);
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.fi-head::-webkit-details-marker { display: none; }
+
+.fi-head:focus-visible {
+  outline: 2px solid var(--fi-accent);
+  outline-offset: -2px;
+  border-radius: 10px;
+}
+
+.fi-head-icon {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  flex: none;
+  border-radius: 8px;
+  background: var(--fi-accent-soft);
+  color: var(--fi-accent);
+  font-size: 0.8rem;
+}
+
+/* Plan availability pill on the header */
+.fi-plan {
+  margin-left: auto;
+  flex: none;
+  padding: 3px 10px;
+  border-radius: 999px;
+  background: var(--fi-accent-soft);
+  color: var(--fi-accent);
+  font-size: 0.64rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+/* Chevron rotates as the section opens */
+.fi-chevron {
+  flex: none;
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid var(--fi-body);
+  border-bottom: 2px solid var(--fi-body);
+  transform: rotate(45deg);
+  transition: transform var(--fi-toggle-duration) var(--fi-ease);
+}
+
+.fi-item[open] > .fi-head .fi-chevron {
+  transform: rotate(225deg);
+}
+
+/* --------------------------------------------------------------------------
+   4. Two-stage fade-in — surface first, then the rows bloom
+   --------------------------------------------------------------------------
+   Stage 1: the body surface (tinted panel) fades up.
+   Stage 2: the feature rows fade in a beat later (--fi-content-delay),
+   with fill-mode both so they hold invisible during the delay.
+   Opacity only — no translate, no scale. Replays on every open. */
+.fi-body {
+  margin: 0 10px 10px;
+  padding: 6px 14px 10px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--fi-accent-soft) 45%, transparent);
+  animation: fi-fade var(--fi-duration) var(--fi-ease) both;
+}
+
+.fi-rows {
+  animation: fi-fade var(--fi-duration) var(--fi-ease) var(--fi-content-delay) both;
+}
+
+@keyframes fi-fade {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.fi-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  padding: 9px 2px;
+  font-size: 0.8rem;
+}
+
+.fi-row + .fi-row {
+  border-top: 1px dashed var(--fi-border);
+}
+
+.fi-row::before {
+  content: "✓";
+  flex: none;
+  color: var(--fi-check);
+  font-weight: 700;
+}
+
+.fi-row-label {
+  color: var(--fi-heading);
+  font-weight: 600;
+}
+
+.fi-row-note {
+  margin-left: auto;
+  font-size: 0.72rem;
+}
+
+/* --------------------------------------------------------------------------
+   5. Small screens — tighten paddings, keep rows readable
+   -------------------------------------------------------------------------- */
+@media (max-width: 420px) {
+  .fi-head { padding: 13px 13px; }
+  .fi-body { margin: 0 8px 8px; padding: 4px 11px 8px; }
+  .fi-row-note { flex-basis: 100%; margin-left: 22px; }
+}
+
+/* --------------------------------------------------------------------------
+   6. Reduced motion — content simply appears; highlight cues remain
+   -------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .fi-body,
+  .fi-rows {
+    animation: none;
+  }
+
+  .fi-chevron {
+    transition: none;
+  }
+
+  .fi-item {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS **Fade-In Accordion** styled for **Modern SaaS** layouts as a fully self-contained example under `submissions/examples/32809-fade-in-accordion-modern-saas-sj6/`.

Fixes #32809

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/32809-fade-in-accordion-modern-saas-sj6/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A zero-JavaScript SaaS feature accordion with a two-stage fade-in: on open, the tinted panel surface fades up first, then the checkmark feature rows bloom in a beat later (`--fi-content-delay`, `both` fill so they hold invisible during the delay). Opacity only — no translate, no scale — deliberately calm for pricing/marketing pages. Both stages replay on every open because closed `<details>` content isn't rendered. Native `<details name>` provides exclusive-open behavior.

**How does a developer use it?**

```html
<details class="fi-item" name="my-features">
  <summary class="fi-head">
    <span class="fi-head-icon" aria-hidden="true">👥</span>
    Collaboration
    <span class="fi-plan">All plans</span>
    <span class="fi-chevron" aria-hidden="true"></span>
  </summary>
  <div class="fi-body">
    <div class="fi-rows">
      <div class="fi-row">
        <span class="fi-row-label">Unlimited shared workspaces</span>
        <span class="fi-row-note">no seat minimum</span>
      </div>
    </div>
  </div>
</details>
```

**Why does it fit EaseMotion CSS?**

Human-readable classes, animation-first, zero JS. Stage duration, content delay, easing, and chevron rotation are `--fi-*` custom properties on `:root`; `<summary>` gives native Tab/Enter operation with a 2px accent `:focus-visible` ring; the open card is also marked by an accent border + shadow, so the state cue survives with animations disabled; `prefers-reduced-motion` removes both fade stages for an instant reveal.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The two stages reuse a single `fi-fade` keyframe — only the delay differs — so integration stays tiny. The body tint uses `color-mix()`; where unsupported the panel renders untinted and the fades are unaffected.

@SAPTARSHI-coder Please review this pr
