### PR TITLE
feat(examples): Fade-In Accordion for Responsive Dashboards

### DIFF
--- a/submissions/examples/32821-fade-in-accordion-responsive-dashboard-sj6/README.md
+++ b/submissions/examples/32821-fade-in-accordion-responsive-dashboard-sj6/README.md
@@ -1,0 +1,72 @@
+# Fade-In Accordion — Responsive Dashboard
+
+A pure CSS, zero-dependency **service-status accordion** for dashboard
+panels whose signature is a **summary ⇄ detail crossfade**: every closed
+header carries a compact headline metric ("142 ms", "78% storage");
+opening the section fades that metric out exactly while the detail rows
+fade in, so the same number never shows twice — and closing fades the
+metric back. Built on native `<details>`/`<summary>`; no JavaScript
+anywhere.
+
+Resolves Issue: #32821
+
+## ✨ Features
+
+- **Crossfade, not just fade-in** — the headline metric lives in the
+  always-rendered header, so a plain `transition` fades it both ways:
+  out on open, back in on close (a genuine animated close, no tricks).
+  The detail rows live inside the `<details>` content, so their fade-in
+  replays on every open. Two mechanisms, one seamless gesture.
+- **Opacity only** — no translate, no scale; dashboards want data, not
+  drama.
+- **Native accordion semantics** — `<details name="fd-status">` gives
+  exclusive-open behavior (one section at a time) straight from the
+  browser; remove the `name` to allow multiple open.
+- **Keyboard accessible** — `<summary>` is natively focusable and toggles
+  with Enter/Space; 2px accent `:focus-visible` ring; the open card is
+  additionally marked by an accent border, a cue that survives with
+  animations disabled.
+- **Dashboard-native details** — green/amber/red status dots on each
+  header, tabular numerals, status pills, dashed row separators.
+- **Genuinely responsive** — fluid panel up to 540px; under 420px the
+  row values wrap onto their own line so rows stay readable on phones.
+- **Tunable via custom properties** — detail fade duration, metric fade
+  duration, easing, and chevron rotation on `:root`.
+- **Motion-safe** — `prefers-reduced-motion` removes both fades and all
+  transitions; the metric swaps instantly and the accent border still
+  marks the open section.
+
+## 🔧 Custom Properties
+
+| Property               | Default    | Role                            |
+| ---------------------- | ---------- | ------------------------------- |
+| `--fd-duration`        | `300ms`    | Detail rows fade-in             |
+| `--fd-stat-duration`   | `240ms`    | Headline metric fade (both ways)|
+| `--fd-ease`            | `ease-out` | Fade curve                      |
+| `--fd-toggle-duration` | `220ms`    | Chevron rotation time           |
+
+## 🚀 Usage
+
+```html
+<details class="fd-item" name="my-status">
+  <summary class="fd-head">
+    <span class="fd-dot" aria-hidden="true"></span>
+    API
+    <span class="fd-head-stat">142 ms</span>
+    <span class="fd-chevron" aria-hidden="true"></span>
+  </summary>
+  <div class="fd-body">
+    <div class="fd-row">
+      <span class="fd-row-label">P50 latency</span>
+      <span class="fd-pill is-ok">Healthy</span>
+      <span class="fd-row-value">142 ms</span>
+    </div>
+  </div>
+</details>
+```
+
+## 📂 Files
+
+- `demo.html` — a "Service Status" panel (API / database / CDN).
+- `style.css` — motion tokens, crossfade engine, dashboard skin, a11y guards.
+- `README.md` — this document.

--- a/submissions/examples/32821-fade-in-accordion-responsive-dashboard-sj6/demo.html
+++ b/submissions/examples/32821-fade-in-accordion-responsive-dashboard-sj6/demo.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fade-In Accordion — Responsive Dashboard</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <section class="fd-panel" aria-label="Service status">
+    <h1 class="fd-panel-title">Service Status</h1>
+    <p class="fd-panel-sub">
+      Each closed header shows a headline metric. Open a section — the
+      metric fades out exactly as the detail fades in, and fades back on
+      close. Tab + Enter works — no JavaScript.
+    </p>
+
+    <!-- name="fd-status" makes the accordion exclusive: opening one
+         section closes the others, natively. -->
+    <details class="fd-item" name="fd-status" open>
+      <summary class="fd-head">
+        <span class="fd-dot" aria-hidden="true"></span>
+        API
+        <span class="fd-head-stat">142 ms</span>
+        <span class="fd-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="fd-body">
+        <div class="fd-row">
+          <span class="fd-row-label">P50 latency</span>
+          <span class="fd-pill is-ok">Healthy</span>
+          <span class="fd-row-value">142 ms</span>
+        </div>
+        <div class="fd-row">
+          <span class="fd-row-label">P99 latency</span>
+          <span class="fd-pill is-ok">Healthy</span>
+          <span class="fd-row-value">480 ms</span>
+        </div>
+        <div class="fd-row">
+          <span class="fd-row-label">Error rate</span>
+          <span class="fd-pill is-ok">0.02%</span>
+          <span class="fd-row-value">last hour</span>
+        </div>
+      </div>
+    </details>
+
+    <details class="fd-item" name="fd-status">
+      <summary class="fd-head">
+        <span class="fd-dot is-warn" aria-hidden="true"></span>
+        Database
+        <span class="fd-head-stat">78% storage</span>
+        <span class="fd-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="fd-body">
+        <div class="fd-row">
+          <span class="fd-row-label">Storage used</span>
+          <span class="fd-pill is-warn">Watch</span>
+          <span class="fd-row-value">78% of 2 TB</span>
+        </div>
+        <div class="fd-row">
+          <span class="fd-row-label">Replication lag</span>
+          <span class="fd-pill is-ok">Healthy</span>
+          <span class="fd-row-value">0.3 s</span>
+        </div>
+        <div class="fd-row">
+          <span class="fd-row-label">Slow queries</span>
+          <span class="fd-pill is-warn">12 today</span>
+          <span class="fd-row-value">&gt; 500 ms</span>
+        </div>
+      </div>
+    </details>
+
+    <details class="fd-item" name="fd-status">
+      <summary class="fd-head">
+        <span class="fd-dot" aria-hidden="true"></span>
+        CDN
+        <span class="fd-head-stat">98.6% hit</span>
+        <span class="fd-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="fd-body">
+        <div class="fd-row">
+          <span class="fd-row-label">Cache hit ratio</span>
+          <span class="fd-pill is-ok">Healthy</span>
+          <span class="fd-row-value">98.6%</span>
+        </div>
+        <div class="fd-row">
+          <span class="fd-row-label">Edge regions</span>
+          <span class="fd-pill is-ok">All up</span>
+          <span class="fd-row-value">28 / 28</span>
+        </div>
+        <div class="fd-row">
+          <span class="fd-row-label">Bandwidth</span>
+          <span class="fd-row-value">1.9 TB today</span>
+        </div>
+      </div>
+    </details>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/32821-fade-in-accordion-responsive-dashboard-sj6/style.css
+++ b/submissions/examples/32821-fade-in-accordion-responsive-dashboard-sj6/style.css
@@ -1,0 +1,238 @@
+/* ==========================================================================
+   Fade-In Accordion — Responsive Dashboard
+   --------------------------------------------------------------------------
+   Pure CSS accordion for dashboard panels, built on native
+   <details>/<summary>. The signature is a SUMMARY ⇄ DETAIL CROSSFADE:
+   every closed header carries a compact headline metric; opening the
+   section fades that metric out exactly while the detail rows fade in —
+   the same number never shows twice. Closing fades the headline metric
+   back (a genuine fade on close, since the header is always rendered
+   and can transition both ways).
+
+   Zero JavaScript.
+
+   Issue: #32821
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Tokens — motion first, then the dashboard skin
+   -------------------------------------------------------------------------- */
+:root {
+  /* Crossfade */
+  --fd-duration: 300ms;                            /* detail fade-in         */
+  --fd-stat-duration: 240ms;                       /* headline metric fade   */
+  --fd-ease: ease-out;                             /* pure fades like it     */
+  --fd-toggle-duration: 220ms;                     /* chevron rotation       */
+
+  /* Dashboard skin */
+  --fd-canvas: #f2f6f5;
+  --fd-card: #ffffff;
+  --fd-border: #dde7e4;
+  --fd-heading: #16302b;
+  --fd-body: #5c7570;
+  --fd-accent: #0d9488;
+  --fd-accent-soft: #e0f2f0;
+  --fd-ok: #12855f;
+  --fd-warn: #b26a10;
+  --fd-crit: #c43a4e;
+
+  --fd-card-shadow: 0 1px 3px rgba(22, 48, 43, 0.06);
+}
+
+/* --------------------------------------------------------------------------
+   2. Demo stage — a service-status panel
+   -------------------------------------------------------------------------- */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 34px 16px;
+  box-sizing: border-box;
+  background: var(--fd-canvas);
+  font-family: "Segoe UI", system-ui, -apple-system, Arial, sans-serif;
+  color: var(--fd-body);
+}
+
+.fd-panel {
+  width: 100%;
+  max-width: 540px;
+}
+
+.fd-panel-title {
+  margin: 0 0 3px;
+  font-size: 1.05rem;
+  font-weight: 650;
+  color: var(--fd-heading);
+}
+
+.fd-panel-sub {
+  margin: 0 0 18px;
+  font-size: 0.78rem;
+}
+
+/* --------------------------------------------------------------------------
+   3. Sections — native disclosure cards
+   -------------------------------------------------------------------------- */
+.fd-item {
+  background: var(--fd-card);
+  border: 1px solid var(--fd-border);
+  border-radius: 12px;
+  box-shadow: var(--fd-card-shadow);
+  transition: border-color 200ms ease;
+}
+
+.fd-item + .fd-item {
+  margin-top: 10px;
+}
+
+.fd-item[open] {
+  border-color: var(--fd-accent);
+}
+
+.fd-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 13px 15px;
+  cursor: pointer;
+  list-style: none;                 /* hide default marker (Firefox) */
+  user-select: none;
+  color: var(--fd-heading);
+  font-size: 0.86rem;
+  font-weight: 600;
+}
+
+.fd-head::-webkit-details-marker { display: none; }
+
+.fd-head:focus-visible {
+  outline: 2px solid var(--fd-accent);
+  outline-offset: -2px;
+  border-radius: 10px;
+}
+
+/* Status dot on each header */
+.fd-dot {
+  flex: none;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--fd-ok);
+}
+
+.fd-dot.is-warn { background: var(--fd-warn); }
+.fd-dot.is-crit { background: var(--fd-crit); }
+
+/* --------------------------------------------------------------------------
+   4. The crossfade — headline metric out, detail in
+   --------------------------------------------------------------------------
+   The metric lives in the always-rendered header, so a plain transition
+   fades it BOTH ways: out on open, back in on close. The detail rows
+   live inside <details> content, so their fade-in replays on every open. */
+.fd-head-stat {
+  margin-left: auto;
+  font-size: 0.8rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--fd-accent);
+  opacity: 1;
+  transition: opacity var(--fd-stat-duration) var(--fd-ease);
+}
+
+.fd-item[open] > .fd-head .fd-head-stat {
+  opacity: 0;
+}
+
+/* Chevron rotates as the section opens */
+.fd-chevron {
+  flex: none;
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid var(--fd-body);
+  border-bottom: 2px solid var(--fd-body);
+  transform: rotate(45deg);
+  transition: transform var(--fd-toggle-duration) var(--fd-ease);
+}
+
+.fd-item[open] > .fd-head .fd-chevron {
+  transform: rotate(225deg);
+}
+
+/* Detail body fades in each time the section opens */
+.fd-body {
+  padding: 2px 15px 12px;
+  animation: fd-fade var(--fd-duration) var(--fd-ease) both;
+}
+
+@keyframes fd-fade {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.fd-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  padding: 9px 2px;
+  font-size: 0.8rem;
+}
+
+.fd-row + .fd-row {
+  border-top: 1px dashed var(--fd-border);
+}
+
+.fd-row-label {
+  color: var(--fd-heading);
+  font-weight: 600;
+}
+
+.fd-row-value {
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Status pills */
+.fd-pill {
+  flex: none;
+  padding: 2px 9px;
+  border-radius: 999px;
+  font-size: 0.64rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.fd-pill.is-ok   { background: #e2f5ec; color: var(--fd-ok); }
+.fd-pill.is-warn { background: #fbf0dd; color: var(--fd-warn); }
+.fd-pill.is-crit { background: #fce9ec; color: var(--fd-crit); }
+
+/* --------------------------------------------------------------------------
+   5. Small screens — tighten paddings, keep rows readable
+   -------------------------------------------------------------------------- */
+@media (max-width: 420px) {
+  .fd-head { padding: 12px 12px; }
+  .fd-body { padding: 2px 12px 10px; }
+  .fd-row-value { flex-basis: 100%; margin-left: 0; }
+}
+
+/* --------------------------------------------------------------------------
+   6. Reduced motion — no fades; the border still marks the open card
+   -------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .fd-head-stat {
+    transition: none;
+  }
+
+  .fd-body {
+    animation: none;
+  }
+
+  .fd-chevron {
+    transition: none;
+  }
+
+  .fd-item {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS **Fade-In Accordion** styled for **Responsive Dashboard** layouts as a fully self-contained example under `submissions/examples/32821-fade-in-accordion-responsive-dashboard-sj6/`.

Fixes #32821

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/32821-fade-in-accordion-responsive-dashboard-sj6/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A zero-JavaScript service-status accordion whose fade-in is a summary ⇄ detail crossfade: each closed header shows a compact headline metric ("142 ms", "78% storage"); opening fades the metric out exactly while the detail rows fade in, so the same number never shows twice — and closing fades the metric back. The metric sits in the always-rendered header (plain two-way `transition`), while the detail rows sit in `<details>` content (fade-in animation that replays every open). Opacity only, no movement.

**How does a developer use it?**

```html
<details class="fd-item" name="my-status">
  <summary class="fd-head">
    <span class="fd-dot" aria-hidden="true"></span>
    API
    <span class="fd-head-stat">142 ms</span>
    <span class="fd-chevron" aria-hidden="true"></span>
  </summary>
  <div class="fd-body">
    <div class="fd-row">
      <span class="fd-row-label">P50 latency</span>
      <span class="fd-pill is-ok">Healthy</span>
      <span class="fd-row-value">142 ms</span>
    </div>
  </div>
</details>
```

**Why does it fit EaseMotion CSS?**

Human-readable classes, animation-first, zero JS. Detail fade, metric fade, easing, and chevron rotation are `--fd-*` custom properties on `:root`; `<summary>` gives native Tab/Enter operation with an accent `:focus-visible` ring; `<details name>` provides exclusive-open with zero scripting; the open card also gets an accent border so the state cue survives with animations disabled; `prefers-reduced-motion` removes both fades entirely.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Distinct from my Modern SaaS fade-in accordion (#32809): that one is a two-stage fade of the panel then its rows; this one crossfades the header's headline metric against the incoming detail — including a genuinely animated fade on close, which pure `<details>` accordions usually can't offer (possible here because the fading element lives in the always-rendered header).

@SAPTARSHI-coder Please review
