### PR TITLE
feat: add kanban column focus transition example

### DIFF
--- a/submissions/examples/37018-kanban-column-focus-transition-dp/README.md
+++ b/submissions/examples/37018-kanban-column-focus-transition-dp/README.md
@@ -1,0 +1,43 @@
+# Kanban Column Focus Transition
+
+## Overview
+
+A four-column sprint board where focusing one column, Backlog, In Progress, Review or Done, smoothly expands it while the others compress, dim and settle back. It solves the production problem of reviewing one workflow stage in depth without losing sight of the rest of the board. Focus transitions improve readability by giving the active column more room and visual weight while keeping every other column present, just quieter. Implemented entirely with HTML and CSS, no JavaScript.
+
+## Features
+
+- Responsive Kanban board with Backlog, In Progress, Review and Done columns
+- Realistic task cards with priority tags, owner and due date metadata
+- CSS-only column focus using radio inputs and labels
+- Animated width, scale, brightness, opacity and elevation on focus change
+- Expanding active column paired with compressed, de-emphasized inactive columns
+- All columns remain visible at every focus state
+- Subtle lift and shadow animation on task card hover
+- CSS custom properties for spacing, duration, easing and color
+- Fully responsive, wrapping to a grid and then a single column on smaller screens
+
+## File Structure
+
+- demo.html
+- style.css
+- README.md
+
+## How It Works
+
+- **Kanban board layout**: a flex row of four equal-width columns, each with a header, count badge, and a scrollable list of task cards
+- **Column focus controls**: five hidden radio inputs sharing a `name`, `All Columns` plus one per column, paired with labels styled as a control bar
+- **Animated emphasis transitions**: `:checked` combined with sibling combinators grows the matching column's `flex-grow` and scale while shrinking, dimming and desaturating the rest via `filter` and `opacity`
+- **CSS-only interaction**: radios and labels alone drive every focus change, no scripting involved
+- **Responsive behavior**: columns wrap into a two-column grid on medium screens and stack into a single column on small screens, where focus scaling and dimming are relaxed so all content stays legible
+
+## Example Use Cases
+
+- Project management platforms
+- Agile boards
+- Issue trackers
+- Sprint planning tools
+- Workflow dashboards
+
+## Why This Example?
+
+Highlighting one workflow stage at a time makes it easier to scan a busy column's cards without the rest of the board competing for attention. Motion preserves awareness of the surrounding columns by shrinking and dimming them instead of hiding them, so the overall workflow stays visible even while one stage is emphasized. This fits EaseMotion CSS as a focused example of proportional, board-wide motion driven by a single interaction, and it is production-inspired because focus-driven Kanban and sprint boards are a standard pattern in agile project tooling.

--- a/submissions/examples/37018-kanban-column-focus-transition-dp/demo.html
+++ b/submissions/examples/37018-kanban-column-focus-transition-dp/demo.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kanban Column Focus Transition</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+    <header class="page-header">
+        <h1>Kanban Column Focus Transition</h1>
+        <p class="page-description">
+            A sprint board where focusing a single column smoothly expands it while
+            the remaining columns compress, dim and settle back, keeping the whole
+            workflow visible without any JavaScript.
+        </p>
+    </header>
+
+    <main class="app">
+
+        <input type="radio" name="column-focus" id="focus-all" class="focus-toggle" checked>
+        <input type="radio" name="column-focus" id="focus-backlog" class="focus-toggle">
+        <input type="radio" name="column-focus" id="focus-progress" class="focus-toggle">
+        <input type="radio" name="column-focus" id="focus-review" class="focus-toggle">
+        <input type="radio" name="column-focus" id="focus-done" class="focus-toggle">
+
+        <nav class="focus-controls" aria-label="Column focus controls">
+            <label for="focus-all" class="focus-btn">All Columns</label>
+            <label for="focus-backlog" class="focus-btn">Backlog</label>
+            <label for="focus-progress" class="focus-btn">In Progress</label>
+            <label for="focus-review" class="focus-btn">Review</label>
+            <label for="focus-done" class="focus-btn">Done</label>
+        </nav>
+
+        <div class="board">
+
+            <section class="column" data-col="backlog">
+                <header class="column-header">
+                    <h2>Backlog</h2>
+                    <span class="count-badge">4</span>
+                </header>
+                <div class="card-list">
+                    <article class="card">
+                        <span class="tag tag-low">Low</span>
+                        <h3>Audit unused CSS across marketing pages</h3>
+                        <p class="card-meta">Frontend · No due date</p>
+                    </article>
+                    <article class="card">
+                        <span class="tag tag-medium">Medium</span>
+                        <h3>Draft onboarding checklist for new admins</h3>
+                        <p class="card-meta">Product · No due date</p>
+                    </article>
+                    <article class="card">
+                        <span class="tag tag-low">Low</span>
+                        <h3>Research alternative charting library</h3>
+                        <p class="card-meta">Engineering · No due date</p>
+                    </article>
+                    <article class="card">
+                        <span class="tag tag-medium">Medium</span>
+                        <h3>Collect feedback on new pricing page</h3>
+                        <p class="card-meta">Growth · No due date</p>
+                    </article>
+                </div>
+            </section>
+
+            <section class="column" data-col="progress">
+                <header class="column-header">
+                    <h2>In Progress</h2>
+                    <span class="count-badge">3</span>
+                </header>
+                <div class="card-list">
+                    <article class="card">
+                        <span class="tag tag-high">High</span>
+                        <h3>Migrate authentication to new session store</h3>
+                        <p class="card-meta">Amara Musa · Due Fri</p>
+                    </article>
+                    <article class="card">
+                        <span class="tag tag-medium">Medium</span>
+                        <h3>Build responsive layout for billing settings</h3>
+                        <p class="card-meta">Diego Lorca · Due Mon</p>
+                    </article>
+                    <article class="card">
+                        <span class="tag tag-high">High</span>
+                        <h3>Fix pagination bug on search results</h3>
+                        <p class="card-meta">Nia Kessler · Due Thu</p>
+                    </article>
+                </div>
+            </section>
+
+            <section class="column" data-col="review">
+                <header class="column-header">
+                    <h2>Review</h2>
+                    <span class="count-badge">2</span>
+                </header>
+                <div class="card-list">
+                    <article class="card">
+                        <span class="tag tag-medium">Medium</span>
+                        <h3>Add empty states to notifications panel</h3>
+                        <p class="card-meta">Tomasz Redl · Awaiting review</p>
+                    </article>
+                    <article class="card">
+                        <span class="tag tag-high">High</span>
+                        <h3>Harden API rate limiting on public endpoints</h3>
+                        <p class="card-meta">Sara Pham · Awaiting review</p>
+                    </article>
+                </div>
+            </section>
+
+            <section class="column" data-col="done">
+                <header class="column-header">
+                    <h2>Done</h2>
+                    <span class="count-badge">3</span>
+                </header>
+                <div class="card-list">
+                    <article class="card card-done">
+                        <span class="tag tag-done">Done</span>
+                        <h3>Ship dark mode toggle in account settings</h3>
+                        <p class="card-meta">Amara Musa · Merged</p>
+                    </article>
+                    <article class="card card-done">
+                        <span class="tag tag-done">Done</span>
+                        <h3>Upgrade build pipeline to new runner image</h3>
+                        <p class="card-meta">Diego Lorca · Merged</p>
+                    </article>
+                    <article class="card card-done">
+                        <span class="tag tag-done">Done</span>
+                        <h3>Write release notes for version 3.4</h3>
+                        <p class="card-meta">Nia Kessler · Published</p>
+                    </article>
+                </div>
+            </section>
+
+        </div>
+
+    </main>
+
+    <footer class="page-footer">
+        <p>Built with CSS-only radio inputs and sibling combinators — no JavaScript, no SCSS, no external libraries.</p>
+    </footer>
+
+</body>
+
+</html>

--- a/submissions/examples/37018-kanban-column-focus-transition-dp/style.css
+++ b/submissions/examples/37018-kanban-column-focus-transition-dp/style.css
@@ -1,0 +1,321 @@
+:root {
+  --space-xs: 0.4rem;
+  --space-sm: 0.8rem;
+  --space-md: 1.2rem;
+  --space-lg: 2rem;
+
+  --radius-sm: 6px;
+  --radius-md: 12px;
+
+  --duration-base: 380ms;
+  --easing: cubic-bezier(0.22, 1, 0.36, 1);
+
+  --color-bg: #f3f4f8;
+  --color-surface: #ffffff;
+  --color-border: #e4e6f0;
+  --color-text: #1c1e2b;
+  --color-text-muted: #676b80;
+  --color-primary: #6f5bff;
+  --color-primary-soft: #efecff;
+
+  --tag-low-bg: #e8f9ef;
+  --tag-low-fg: #1f9d5f;
+  --tag-medium-bg: #fff3e0;
+  --tag-medium-fg: #b3660a;
+  --tag-high-bg: #ffe6e6;
+  --tag-high-fg: #c02f2f;
+  --tag-done-bg: #ececf4;
+  --tag-done-fg: #55596b;
+
+  --focus-grow: 2.1;
+  --unfocus-shrink: 0.72;
+  --unfocus-opacity: 0.85;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: var(--space-lg);
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
+    sans-serif;
+  line-height: 1.5;
+}
+
+.page-header {
+  max-width: 820px;
+  margin: 0 auto var(--space-lg);
+  text-align: center;
+}
+
+.page-header h1 {
+  margin: 0 0 var(--space-sm);
+  font-size: clamp(1.4rem, 2.2vw, 2rem);
+  letter-spacing: -0.02em;
+}
+
+.page-description {
+  margin: 0 auto;
+  max-width: 640px;
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+}
+
+.app {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.focus-toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  border: 0;
+}
+
+.focus-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  margin-bottom: var(--space-md);
+}
+
+.focus-btn {
+  padding: 0.55rem 1rem;
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  font-size: 0.84rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background var(--duration-base) var(--easing),
+    color var(--duration-base) var(--easing),
+    border-color var(--duration-base) var(--easing),
+    transform var(--duration-base) var(--easing);
+}
+
+.focus-btn:hover {
+  transform: translateY(-1px);
+}
+
+#focus-all:checked ~ .focus-controls label[for="focus-all"],
+#focus-backlog:checked ~ .focus-controls label[for="focus-backlog"],
+#focus-progress:checked ~ .focus-controls label[for="focus-progress"],
+#focus-review:checked ~ .focus-controls label[for="focus-review"],
+#focus-done:checked ~ .focus-controls label[for="focus-done"] {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #ffffff;
+}
+
+.board {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-md);
+  overflow-x: auto;
+  padding-bottom: var(--space-xs);
+}
+
+.column {
+  flex: 1 1 0;
+  min-width: 240px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  transform: scale(1);
+  filter: brightness(1) saturate(1);
+  opacity: 1;
+  transition:
+    flex-grow var(--duration-base) var(--easing),
+    transform var(--duration-base) var(--easing),
+    filter var(--duration-base) var(--easing),
+    opacity var(--duration-base) var(--easing),
+    box-shadow var(--duration-base) var(--easing);
+}
+
+.column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-sm) var(--space-md);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.column-header h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.count-badge {
+  font-size: 0.74rem;
+  font-weight: 700;
+  color: var(--color-primary);
+  background: var(--color-primary-soft);
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+}
+
+.card-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md) var(--space-md);
+  overflow-y: auto;
+}
+
+.card {
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  transition:
+    transform var(--duration-base) var(--easing),
+    box-shadow var(--duration-base) var(--easing),
+    border-color var(--duration-base) var(--easing);
+}
+
+.card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 10px 22px rgba(31, 34, 63, 0.12);
+  border-color: var(--color-primary);
+}
+
+.card h3 {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.card-meta {
+  margin: 0;
+  font-size: 0.76rem;
+  color: var(--color-text-muted);
+}
+
+.card-done {
+  opacity: 0.85;
+}
+
+.tag {
+  align-self: flex-start;
+  font-size: 0.68rem;
+  font-weight: 700;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+}
+
+.tag-low {
+  background: var(--tag-low-bg);
+  color: var(--tag-low-fg);
+}
+.tag-medium {
+  background: var(--tag-medium-bg);
+  color: var(--tag-medium-fg);
+}
+.tag-high {
+  background: var(--tag-high-bg);
+  color: var(--tag-high-fg);
+}
+.tag-done {
+  background: var(--tag-done-bg);
+  color: var(--tag-done-fg);
+}
+
+#focus-backlog:checked ~ .board .column[data-col="backlog"],
+#focus-progress:checked ~ .board .column[data-col="progress"],
+#focus-review:checked ~ .board .column[data-col="review"],
+#focus-done:checked ~ .board .column[data-col="done"] {
+  flex-grow: var(--focus-grow);
+  transform: scale(1.02);
+  box-shadow: 0 18px 34px rgba(31, 34, 63, 0.16);
+  z-index: 1;
+}
+
+#focus-backlog:checked ~ .board .column:not([data-col="backlog"]),
+#focus-progress:checked ~ .board .column:not([data-col="progress"]),
+#focus-review:checked ~ .board .column:not([data-col="review"]),
+#focus-done:checked ~ .board .column:not([data-col="done"]) {
+  flex-grow: var(--unfocus-shrink);
+  transform: scale(0.97);
+  filter: brightness(0.94) saturate(0.85);
+  opacity: var(--unfocus-opacity);
+}
+
+.page-footer {
+  max-width: 1200px;
+  margin: var(--space-lg) auto 0;
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: 0.82rem;
+}
+
+@media (max-width: 900px) {
+  .board {
+    flex-wrap: wrap;
+  }
+
+  .column {
+    flex: 1 1 calc(50% - var(--space-md));
+    min-width: 220px;
+  }
+
+  #focus-backlog:checked ~ .board .column:not([data-col="backlog"]),
+  #focus-progress:checked ~ .board .column:not([data-col="progress"]),
+  #focus-review:checked ~ .board .column:not([data-col="review"]),
+  #focus-done:checked ~ .board .column:not([data-col="done"]) {
+    flex-grow: 1;
+  }
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: var(--space-md);
+  }
+
+  .board {
+    flex-direction: column;
+  }
+
+  .column {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  #focus-backlog:checked ~ .board .column[data-col="backlog"],
+  #focus-progress:checked ~ .board .column[data-col="progress"],
+  #focus-review:checked ~ .board .column[data-col="review"],
+  #focus-done:checked ~ .board .column[data-col="done"] {
+    transform: scale(1);
+  }
+
+  #focus-backlog:checked ~ .board .column:not([data-col="backlog"]),
+  #focus-progress:checked ~ .board .column:not([data-col="progress"]),
+  #focus-review:checked ~ .board .column:not([data-col="review"]),
+  #focus-done:checked ~ .board .column:not([data-col="done"]) {
+    transform: scale(1);
+    filter: none;
+    opacity: 0.9;
+  }
+
+  .focus-controls {
+    justify-content: center;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a **Kanban Column Focus Transition** example under the `submissions/examples/` track.

The example demonstrates a production-inspired Kanban board where users can smoothly shift focus between workflow columns while preserving visibility of the overall board. Motion is used to emphasize the active workflow stage through animated resizing, elevation, and opacity changes, improving readability without disrupting context. The implementation is built entirely with HTML and CSS, requiring no JavaScript or external libraries.

Closes #37018

---

## Type of Change

- [x] 🧩 New example submission
- [ ] ✨ New animation
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Uses HTML and CSS only
- [x] No JavaScript
- [x] No external dependencies
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

A reusable example demonstrating smooth focus transitions between Kanban board columns while preserving awareness of the complete workflow.

### Key Features

- Responsive multi-column Kanban board
- CSS-only column focus controls
- Animated column emphasis and de-emphasis
- Smooth resizing, opacity, and elevation transitions
- Interactive task cards
- Production-inspired workflow interface

### Why does it fit EaseMotion CSS?

This example reflects a common interaction pattern found in agile project management tools, issue trackers, workflow dashboards, and sprint planning applications. It demonstrates how CSS motion can improve workflow clarity and navigation while remaining lightweight, responsive, and entirely HTML/CSS based.

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge