### PR TITLE
feat(examples): Slide-Up Accordion for Glassmorphism UI

### DIFF
--- a/submissions/examples/32832-slide-up-accordion-glassmorphism-sj6/README.md
+++ b/submissions/examples/32832-slide-up-accordion-glassmorphism-sj6/README.md
@@ -1,0 +1,78 @@
+# Slide-Up Accordion — Glassmorphism UI
+
+A pure CSS, zero-dependency **accordion of frosted-glass cards** over a
+vivid gradient scene. On open, the panel content **slides up out of the
+glass**: the card clips its content, so the rows rise from below the
+header's frost line and settle into place — like a sheet of glass
+revealing what was underneath. Built on native `<details>`/`<summary>`;
+no JavaScript anywhere.
+
+Resolves Issue: #32832
+
+## ✨ Features
+
+- **Clipped slide-up** — `overflow: hidden` on the card means the rising
+  content (`translateY(22px) → 0` + fade) emerges from inside the glass
+  instead of floating in from open space; the start of the rise is
+  physically clipped by the card edge.
+- **Replays on every open** — content inside a closed `<details>` is not
+  rendered, so the slide-up restarts naturally each time. Zero JS.
+- **Real glass recipe** — `backdrop-filter: blur(16px) saturate(1.4)`
+  (with `-webkit-` twin), translucent fill and border, a 1px gradient
+  highlight along the top edge, and a deeper open-state tint. An
+  `@supports not (backdrop-filter…)` fallback swaps in a deeper opaque
+  tint so text stays readable where frost is unsupported.
+- **Native accordion semantics** — `<details name="gl-cc">` gives
+  exclusive-open behavior (one card at a time) straight from the
+  browser; remove the `name` to allow multiple open.
+- **Keyboard accessible** — `<summary>` is natively focusable and toggles
+  with Enter/Space; 2px gold `:focus-visible` ring tuned to stay visible
+  against the frost.
+- **Control-center details** — icon chips in glass squares, state chips
+  (on-state filled gold), hairline translucent row separators, tabular
+  numerals.
+- **Genuinely responsive** — fluid stack up to 520px; under 420px row
+  values wrap onto their own line; the gradient scene is fixed-attached
+  so the frost has something to blur at every size.
+- **Tunable via custom properties** — rise distance, duration, easing,
+  chevron time, blur radius, and all glass tints on `:root`.
+- **Motion-safe** — `prefers-reduced-motion` removes the slide and all
+  transitions; cards simply open with the frost intact.
+
+## 🔧 Custom Properties
+
+| Property               | Default                          | Role                       |
+| ---------------------- | -------------------------------- | -------------------------- |
+| `--gl-rise`            | `22px`                           | Slide-up distance          |
+| `--gl-duration`        | `360ms`                          | Slide-up time              |
+| `--gl-ease`            | `cubic-bezier(0.22, 1, 0.36, 1)` | Glide-out curve            |
+| `--gl-toggle-duration` | `240ms`                          | Chevron rotation           |
+| `--gl-blur`            | `16px`                           | Backdrop frost radius      |
+| `--gl-tint`            | `rgba(255, 255, 255, 0.14)`      | Card fill                  |
+| `--gl-tint-open`       | `rgba(255, 255, 255, 0.2)`       | Open card fill             |
+| `--gl-edge`            | `rgba(255, 255, 255, 0.35)`      | Card border                |
+
+## 🚀 Usage
+
+```html
+<details class="gl-item" name="my-glass">
+  <summary class="gl-head">
+    <span class="gl-head-icon" aria-hidden="true">🎧</span>
+    Now playing
+    <span class="gl-head-meta">Bedroom mix</span>
+    <span class="gl-chevron" aria-hidden="true"></span>
+  </summary>
+  <div class="gl-body">
+    <div class="gl-row">
+      <span class="gl-row-label">Track</span>
+      <span class="gl-row-value">Glass Hours — Mirea</span>
+    </div>
+  </div>
+</details>
+```
+
+## 📂 Files
+
+- `demo.html` — a "Control Center" stack (now playing / notifications / connectivity).
+- `style.css` — motion tokens, clipped slide-up engine, glass recipe + fallback, a11y guards.
+- `README.md` — this document.

--- a/submissions/examples/32832-slide-up-accordion-glassmorphism-sj6/demo.html
+++ b/submissions/examples/32832-slide-up-accordion-glassmorphism-sj6/demo.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Slide-Up Accordion — Glassmorphism UI</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <section class="gl-stack" aria-label="Control center">
+    <h1 class="gl-stack-title">Control Center</h1>
+    <p class="gl-stack-sub">
+      Open a glass card — its content slides up out of the frost. Tab +
+      Enter works throughout — no JavaScript.
+    </p>
+
+    <!-- name="gl-cc" makes the accordion exclusive: opening one card
+         closes the others, natively. -->
+    <details class="gl-item" name="gl-cc" open>
+      <summary class="gl-head">
+        <span class="gl-head-icon" aria-hidden="true">🎧</span>
+        Now playing
+        <span class="gl-head-meta">Bedroom mix</span>
+        <span class="gl-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="gl-body">
+        <div class="gl-row">
+          <span class="gl-row-label">Track</span>
+          <span class="gl-row-value">Glass Hours — Mirea</span>
+        </div>
+        <div class="gl-row">
+          <span class="gl-row-label">Output</span>
+          <span class="gl-chip is-on">AirBuds</span>
+          <span class="gl-row-value">64%</span>
+        </div>
+        <div class="gl-row">
+          <span class="gl-row-label">Equalizer</span>
+          <span class="gl-chip">Warm</span>
+          <span class="gl-row-value">custom</span>
+        </div>
+      </div>
+    </details>
+
+    <details class="gl-item" name="gl-cc">
+      <summary class="gl-head">
+        <span class="gl-head-icon" aria-hidden="true">🔔</span>
+        Notifications
+        <span class="gl-head-meta">3 apps</span>
+        <span class="gl-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="gl-body">
+        <div class="gl-row">
+          <span class="gl-row-label">Focus mode</span>
+          <span class="gl-chip is-on">On</span>
+          <span class="gl-row-value">until 18:00</span>
+        </div>
+        <div class="gl-row">
+          <span class="gl-row-label">Allowed</span>
+          <span class="gl-row-value">Calls · Calendar · Mail</span>
+        </div>
+        <div class="gl-row">
+          <span class="gl-row-label">Summary</span>
+          <span class="gl-chip">Daily</span>
+          <span class="gl-row-value">08:30</span>
+        </div>
+      </div>
+    </details>
+
+    <details class="gl-item" name="gl-cc">
+      <summary class="gl-head">
+        <span class="gl-head-icon" aria-hidden="true">🛰</span>
+        Connectivity
+        <span class="gl-head-meta">Wi-Fi · BT</span>
+        <span class="gl-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="gl-body">
+        <div class="gl-row">
+          <span class="gl-row-label">Wi-Fi</span>
+          <span class="gl-chip is-on">Studio-5G</span>
+          <span class="gl-row-value">−48 dBm</span>
+        </div>
+        <div class="gl-row">
+          <span class="gl-row-label">Bluetooth</span>
+          <span class="gl-chip is-on">2 devices</span>
+          <span class="gl-row-value">buds · deck</span>
+        </div>
+        <div class="gl-row">
+          <span class="gl-row-label">Hotspot</span>
+          <span class="gl-chip">Off</span>
+          <span class="gl-row-value">—</span>
+        </div>
+      </div>
+    </details>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/32832-slide-up-accordion-glassmorphism-sj6/style.css
+++ b/submissions/examples/32832-slide-up-accordion-glassmorphism-sj6/style.css
@@ -1,0 +1,259 @@
+/* ==========================================================================
+   Slide-Up Accordion — Glassmorphism UI
+   --------------------------------------------------------------------------
+   Pure CSS accordion of frosted-glass cards over a vivid gradient scene,
+   built on native <details>/<summary>. On open, the panel content SLIDES
+   UP out of the glass: the card clips its content (overflow hidden), so
+   the rows rise from below the header's frost line and settle — like a
+   sheet of glass revealing what was underneath it.
+
+   Content inside a closed <details> is not rendered, so the slide-up
+   replays naturally on every open. Zero JavaScript.
+
+   Issue: #32832
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Tokens — motion first, then the glass recipe
+   -------------------------------------------------------------------------- */
+:root {
+  /* Slide-up */
+  --gl-rise: 22px;                                 /* distance rows rise     */
+  --gl-duration: 360ms;                            /* one slide-up           */
+  --gl-ease: cubic-bezier(0.22, 1, 0.36, 1);       /* decisive glide-out     */
+  --gl-toggle-duration: 240ms;                     /* chevron rotation       */
+
+  /* Glass recipe */
+  --gl-blur: 16px;                                 /* backdrop frost         */
+  --gl-tint: rgba(255, 255, 255, 0.14);            /* card fill              */
+  --gl-tint-open: rgba(255, 255, 255, 0.2);        /* open card fill         */
+  --gl-edge: rgba(255, 255, 255, 0.35);            /* card border            */
+  --gl-heading: #ffffff;
+  --gl-body: rgba(255, 255, 255, 0.78);
+  --gl-accent: #ffd166;
+
+  --gl-card-shadow: 0 8px 32px rgba(12, 8, 40, 0.25);
+}
+
+/* --------------------------------------------------------------------------
+   2. Demo stage — a gradient scene for the glass to frost
+   -------------------------------------------------------------------------- */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 34px 16px;
+  box-sizing: border-box;
+  background:
+    radial-gradient(600px 420px at 15% 12%, rgba(255, 209, 102, 0.5), transparent 60%),
+    radial-gradient(520px 480px at 88% 30%, rgba(239, 111, 156, 0.55), transparent 62%),
+    radial-gradient(640px 520px at 45% 95%, rgba(94, 96, 235, 0.6), transparent 65%),
+    linear-gradient(150deg, #3b2a68 0%, #4a2f7d 45%, #2b2258 100%);
+  background-attachment: fixed;
+  font-family: "Segoe UI", system-ui, -apple-system, Arial, sans-serif;
+  color: var(--gl-body);
+}
+
+.gl-stack {
+  width: 100%;
+  max-width: 520px;
+}
+
+.gl-stack-title {
+  margin: 0 0 3px;
+  font-size: 1.1rem;
+  font-weight: 650;
+  color: var(--gl-heading);
+  text-shadow: 0 1px 8px rgba(12, 8, 40, 0.3);
+}
+
+.gl-stack-sub {
+  margin: 0 0 18px;
+  font-size: 0.78rem;
+}
+
+/* --------------------------------------------------------------------------
+   3. Glass cards — native disclosure elements
+   -------------------------------------------------------------------------- */
+.gl-item {
+  background: var(--gl-tint);
+  -webkit-backdrop-filter: blur(var(--gl-blur)) saturate(1.4);
+  backdrop-filter: blur(var(--gl-blur)) saturate(1.4);
+  border: 1px solid var(--gl-edge);
+  border-radius: 16px;
+  box-shadow: var(--gl-card-shadow);
+  overflow: hidden;                 /* clips the rising content */
+  transition: background-color 220ms ease;
+}
+
+/* Glass highlight along the top edge */
+.gl-item::before {
+  content: "";
+  display: block;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.7), transparent);
+}
+
+.gl-item + .gl-item {
+  margin-top: 12px;
+}
+
+.gl-item[open] {
+  background: var(--gl-tint-open);
+}
+
+/* Fallback: where backdrop-filter is unsupported, deepen the tint so
+   text stays readable without the frost */
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .gl-item {
+    background: rgba(46, 34, 92, 0.82);
+  }
+  .gl-item[open] {
+    background: rgba(46, 34, 92, 0.92);
+  }
+}
+
+.gl-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 15px 17px;
+  cursor: pointer;
+  list-style: none;                 /* hide default marker (Firefox) */
+  user-select: none;
+  color: var(--gl-heading);
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.gl-head::-webkit-details-marker { display: none; }
+
+.gl-head:focus-visible {
+  outline: 2px solid var(--gl-accent);
+  outline-offset: -2px;
+  border-radius: 14px;
+}
+
+.gl-head-icon {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  flex: none;
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  font-size: 0.8rem;
+}
+
+.gl-head-meta {
+  margin-left: auto;
+  font-size: 0.72rem;
+  color: var(--gl-body);
+}
+
+/* Chevron rotates as the card opens */
+.gl-chevron {
+  flex: none;
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid var(--gl-body);
+  border-bottom: 2px solid var(--gl-body);
+  transform: rotate(45deg);
+  transition: transform var(--gl-toggle-duration) var(--gl-ease);
+}
+
+.gl-item[open] > .gl-head .gl-chevron {
+  transform: rotate(225deg);
+}
+
+/* --------------------------------------------------------------------------
+   4. Slide-up — rows rise from below the frost line
+   --------------------------------------------------------------------------
+   The card's overflow:hidden clips the start of the rise, so content
+   appears to emerge from inside the glass rather than fading in place. */
+.gl-body {
+  padding: 2px 17px 14px;
+  animation: gl-slide-up var(--gl-duration) var(--gl-ease) both;
+}
+
+@keyframes gl-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(var(--gl-rise));
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.gl-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  padding: 10px 2px;
+  font-size: 0.8rem;
+}
+
+.gl-row + .gl-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+.gl-row-label {
+  color: var(--gl-heading);
+  font-weight: 600;
+}
+
+.gl-row-value {
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+}
+
+/* State chips */
+.gl-chip {
+  flex: none;
+  padding: 2px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  background: rgba(255, 255, 255, 0.12);
+  font-size: 0.64rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--gl-heading);
+}
+
+.gl-chip.is-on {
+  background: var(--gl-accent);
+  border-color: var(--gl-accent);
+  color: #3a2c09;
+}
+
+/* --------------------------------------------------------------------------
+   5. Small screens — tighten paddings, keep rows readable
+   -------------------------------------------------------------------------- */
+@media (max-width: 420px) {
+  .gl-head { padding: 13px 13px; }
+  .gl-body { padding: 2px 13px 12px; }
+  .gl-row-value { flex-basis: 100%; margin-left: 0; }
+}
+
+/* --------------------------------------------------------------------------
+   6. Reduced motion — content appears in place; frost stays
+   -------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .gl-body {
+    animation: none;
+  }
+
+  .gl-chevron {
+    transition: none;
+  }
+
+  .gl-item {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS **Slide-Up Accordion** styled for **Glassmorphism UI** layouts as a fully self-contained example under `submissions/examples/32832-slide-up-accordion-glassmorphism-sj6/`.

Fixes #32832

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/32832-slide-up-accordion-glassmorphism-sj6/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A zero-JavaScript accordion of frosted-glass cards ("Control Center": now playing / notifications / connectivity) over a vivid gradient scene. On open, the panel content slides up out of the glass — `overflow: hidden` on the card clips the start of the rise (`translateY(22px) → 0` + fade), so rows emerge from below the header's frost line instead of floating in from open space. The slide replays on every open because closed `<details>` content isn't rendered.

**How does a developer use it?**

```html
<details class="gl-item" name="my-glass">
  <summary class="gl-head">
    <span class="gl-head-icon" aria-hidden="true">🎧</span>
    Now playing
    <span class="gl-head-meta">Bedroom mix</span>
    <span class="gl-chevron" aria-hidden="true"></span>
  </summary>
  <div class="gl-body">
    <div class="gl-row">
      <span class="gl-row-label">Track</span>
      <span class="gl-row-value">Glass Hours — Mirea</span>
    </div>
  </div>
</details>
```

**Why does it fit EaseMotion CSS?**

Human-readable classes, animation-first, zero JS. Rise distance, duration, easing, chevron time, blur radius, and all glass tints are `--gl-*` custom properties on `:root`; `<details name>` provides exclusive-open natively and `<summary>` gives Tab/Enter operation with a gold `:focus-visible` ring tuned for visibility against frost; an `@supports not (backdrop-filter…)` fallback deepens the card tint so text stays readable where frost is unsupported; `prefers-reduced-motion` removes the slide entirely.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The glass recipe includes the `-webkit-backdrop-filter` twin for Safari and a 1px gradient highlight along each card's top edge — small, but it's what sells the glass. The background gradient is `background-attachment: fixed` so the frost always has something to blur while scrolling.

@SAPTARSHI-coder Please review
