### PR TITLE
feat: add kanban column focus transition example

### DIFF
--- a/submissions/examples/kanban-focus-transition-mnsvi/README.md
+++ b/submissions/examples/kanban-focus-transition-mnsvi/README.md
@@ -1,0 +1,41 @@
+# Kanban Column Focus Transition
+
+A sleek, responsive Kanban board that elegantly highlights the active column while softly fading and blurring the surrounding columns to maintain user focus.
+
+### 1. What does this do?
+It demonstrates a smooth focus and de-emphasis motion for Kanban columns using only CSS hover states and transitions, guiding the user's attention to the active workflow without losing the overall board context.
+
+### 2. How is it used?
+Apply the hover logic to the parent container (`.kanban-board`) and the individual items (`.kanban-column`). 
+
+```html
+<main class="kanban-board">
+    <section class="kanban-column">
+        <!-- Column content -->
+    </section>
+    <section class="kanban-column">
+        <!-- Column content -->
+    </section>
+</main>
+```
+
+```css
+/* Fade all columns when the board is hovered */
+.kanban-board:hover .kanban-column {
+    opacity: 0.4;
+    filter: blur(2px) grayscale(50%);
+    transform: scale(0.98);
+}
+
+/* Bring the hovered column back to full focus and elevate it */
+.kanban-board .kanban-column:hover {
+    opacity: 1;
+    filter: blur(0) grayscale(0);
+    transform: scale(1.02) translateY(-4px);
+    box-shadow: 0 20px 25px -5px rgba(0,0,0,0.5);
+    z-index: 10;
+}
+```
+
+### 3. Why is it useful?
+In complex dashboard interfaces or task management apps, having many columns can be visually overwhelming. This micro-interaction reduces cognitive load by emphasizing the current interaction area while keeping the peripheral context visible but unobtrusive.

--- a/submissions/examples/kanban-focus-transition-mnsvi/demo.html
+++ b/submissions/examples/kanban-focus-transition-mnsvi/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kanban Column Focus Transition</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="kanban-container">
+        <header class="kanban-header">
+            <h1>Project Roadmap</h1>
+            <p>Hover over a column to focus on the active workflow.</p>
+        </header>
+        
+        <main class="kanban-board">
+            <section class="kanban-column">
+                <div class="column-header">
+                    <h2>To Do</h2>
+                    <span class="task-count">3</span>
+                </div>
+                <div class="task-list">
+                    <div class="task-card">Research target audience</div>
+                    <div class="task-card">Draft initial wireframes</div>
+                    <div class="task-card">Set up project repository</div>
+                </div>
+            </section>
+            
+            <section class="kanban-column">
+                <div class="column-header">
+                    <h2>In Progress</h2>
+                    <span class="task-count">2</span>
+                </div>
+                <div class="task-list">
+                    <div class="task-card">Design login page</div>
+                    <div class="task-card">Implement authentication API</div>
+                </div>
+            </section>
+            
+            <section class="kanban-column">
+                <div class="column-header">
+                    <h2>Review</h2>
+                    <span class="task-count">1</span>
+                </div>
+                <div class="task-list">
+                    <div class="task-card">Code review for PR #42</div>
+                </div>
+            </section>
+
+            <section class="kanban-column">
+                <div class="column-header">
+                    <h2>Done</h2>
+                    <span class="task-count">2</span>
+                </div>
+                <div class="task-list">
+                    <div class="task-card">Initial project setup</div>
+                    <div class="task-card">Create database schema</div>
+                </div>
+            </section>
+        </main>
+    </div>
+</body>
+</html>

--- a/submissions/examples/kanban-focus-transition-mnsvi/style.css
+++ b/submissions/examples/kanban-focus-transition-mnsvi/style.css
@@ -1,0 +1,134 @@
+/* Base styles and variables */
+:root {
+    --bg-color: #0f172a;
+    --text-color: #f8fafc;
+    --col-bg: #1e293b;
+    --col-border: #334155;
+    --card-text: #0f172a;
+    --transition-speed: 0.4s;
+}
+
+body {
+    margin: 0;
+    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+}
+
+.kanban-container {
+    width: 100%;
+    max-width: 1200px;
+    padding: 2rem;
+}
+
+.kanban-header {
+    margin-bottom: 2rem;
+    text-align: center;
+}
+
+.kanban-header h1 {
+    margin: 0 0 0.5rem 0;
+    font-size: 2.5rem;
+    background: linear-gradient(to right, #2dd4bf, #3b82f6);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.kanban-header p {
+    color: #94a3b8;
+}
+
+/* Kanban Board Layout */
+.kanban-board {
+    display: flex;
+    gap: 1.5rem;
+    overflow-x: auto;
+    padding-bottom: 1rem;
+    /* This parent is the key for targeting children when hovered */
+}
+
+.kanban-column {
+    flex: 1;
+    min-width: 250px;
+    background-color: var(--col-bg);
+    border: 1px solid var(--col-border);
+    border-radius: 0.75rem;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    /* Smooth transitions for all changing properties */
+    transition: transform var(--transition-speed) cubic-bezier(0.4, 0, 0.2, 1),
+                opacity var(--transition-speed) ease,
+                filter var(--transition-speed) ease,
+                box-shadow var(--transition-speed) ease;
+}
+
+.column-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid var(--col-border);
+    padding-bottom: 0.75rem;
+}
+
+.column-header h2 {
+    margin: 0;
+    font-size: 1.125rem;
+    font-weight: 600;
+}
+
+.task-count {
+    background-color: #3b82f6;
+    color: white;
+    padding: 0.25rem 0.6rem;
+    border-radius: 999px;
+    font-size: 0.875rem;
+    font-weight: 700;
+}
+
+.task-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.task-card {
+    background-color: white;
+    color: var(--card-text);
+    padding: 1rem;
+    border-radius: 0.5rem;
+    font-size: 0.9rem;
+    font-weight: 500;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.task-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.15);
+}
+
+/* The Magic: Focus and De-emphasis Transitions */
+
+/* 1. Fade out and blur all columns when the entire board is hovered */
+.kanban-board:hover .kanban-column {
+    opacity: 0.4;
+    filter: blur(2px) grayscale(50%);
+    transform: scale(0.98);
+}
+
+/* 2. Bring the specifically hovered column back to full focus and elevate it */
+.kanban-board .kanban-column:hover {
+    opacity: 1;
+    filter: blur(0) grayscale(0);
+    transform: scale(1.02) translateY(-4px);
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.5), 0 8px 10px -6px rgba(0, 0, 0, 0.3);
+    z-index: 10;
+    border-color: #3b82f6;
+}


### PR DESCRIPTION
## Pull Request Description

Added a Kanban column focus transition example to demonstrate highlighting active workflows while blurring and de-emphasizing surrounding columns using pure CSS hover states and transitions.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It demonstrates a smooth focus and de-emphasis motion for Kanban columns using only CSS hover states and transitions.

**How does a developer use it?**

```html
<main class="kanban-board">
    <section class="kanban-column">
        <!-- Column content -->
    </section>
</main>
