### PR TITLE
Add glassmorphism fade-in modal example

### DIFF
--- a/submissions/examples/33218-glassmorphism-fade-in-modal-lekhanpro/README.md
+++ b/submissions/examples/33218-glassmorphism-fade-in-modal-lekhanpro/README.md
@@ -1,0 +1,22 @@
+# Glassmorphism Fade-In Modal
+
+A pure CSS modal pattern for glassmorphism interfaces. The demo uses a hidden checkbox and semantic labels to open and close the dialog without JavaScript.
+
+## Files
+
+- `demo.html` - Standalone modal preview with keyboard reachable controls.
+- `style.css` - Scoped modal styles with configurable CSS custom properties.
+- `README.md` - Usage notes for the component.
+
+## Custom Properties
+
+```css
+.glass-fade-modal-demo {
+  --gfm-duration: 260ms;
+  --gfm-easing: cubic-bezier(0.22, 1, 0.36, 1);
+  --gfm-scale-start: 0.96;
+  --gfm-panel-bg: rgba(255, 255, 255, 0.14);
+}
+```
+
+The modal honors `prefers-reduced-motion` and stacks its action buttons on narrow screens.

--- a/submissions/examples/33218-glassmorphism-fade-in-modal-lekhanpro/demo.html
+++ b/submissions/examples/33218-glassmorphism-fade-in-modal-lekhanpro/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS - Glassmorphism Fade-In Modal</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="glass-fade-modal-demo">
+    <section class="gfm-hero" aria-labelledby="gfm-title">
+      <p class="gfm-eyebrow">Pure CSS component</p>
+      <h1 id="gfm-title">Glassmorphism fade-in modal</h1>
+      <p class="gfm-copy">A responsive, keyboard reachable dialog pattern with configurable timing, easing, scale, blur, and surface tokens.</p>
+      <a class="gfm-open-button" href="#glass-fade-modal">Open modal</a>
+    </section>
+
+    <div class="gfm-overlay" id="glass-fade-modal" role="presentation">
+      <a class="gfm-backdrop" href="#" aria-label="Close modal"></a>
+      <section class="gfm-dialog" role="dialog" aria-modal="true" aria-labelledby="gfm-dialog-title" aria-describedby="gfm-dialog-copy">
+        <div class="gfm-dialog-header">
+          <span class="gfm-status">Live preview</span>
+          <a class="gfm-close-button" href="#" aria-label="Close modal">x</a>
+        </div>
+        <h2 id="gfm-dialog-title">Glass panel ready</h2>
+        <p id="gfm-dialog-copy">The modal fades and scales into place using only CSS. Update the custom properties in the wrapper to tune the animation for dashboards, portfolios, and product previews.</p>
+        <div class="gfm-feature-grid" aria-label="Modal features">
+          <span>Responsive sizing</span>
+          <span>Focus outlines</span>
+          <span>Reduced motion</span>
+          <span>Backdrop close</span>
+        </div>
+        <div class="gfm-actions">
+          <a class="gfm-secondary-button" href="#">Cancel</a>
+          <a class="gfm-primary-button" href="#">Confirm</a>
+        </div>
+      </section>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/33218-glassmorphism-fade-in-modal-lekhanpro/style.css
+++ b/submissions/examples/33218-glassmorphism-fade-in-modal-lekhanpro/style.css
@@ -1,0 +1,243 @@
+@import "../../../core/variables.css";
+@import "../../../core/utilities.css";
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: var(--ease-font-sans, Inter, system-ui, sans-serif);
+  color: #f8fafc;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(56, 189, 248, 0.3), transparent 30rem),
+    radial-gradient(circle at 82% 18%, rgba(168, 85, 247, 0.28), transparent 26rem),
+    linear-gradient(135deg, #07111f 0%, #111827 52%, #1e1b4b 100%);
+}
+
+.glass-fade-modal-demo {
+  --gfm-duration: 260ms;
+  --gfm-easing: cubic-bezier(0.22, 1, 0.36, 1);
+  --gfm-scale-start: 0.96;
+  --gfm-backdrop-bg: rgba(2, 6, 23, 0.62);
+  --gfm-panel-bg: rgba(255, 255, 255, 0.14);
+  --gfm-panel-border: rgba(255, 255, 255, 0.24);
+  --gfm-panel-shadow: 0 28px 90px rgba(2, 6, 23, 0.48);
+  --gfm-radius: 1.35rem;
+  --gfm-blur: 22px;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: clamp(1rem, 4vw, 3rem);
+}
+
+.gfm-hero {
+  width: min(100%, 42rem);
+  text-align: center;
+}
+
+.gfm-eyebrow {
+  margin: 0 0 0.7rem;
+  color: #67e8f9;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.gfm-hero h1 {
+  margin: 0;
+  font-size: clamp(2.2rem, 8vw, 5.6rem);
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+.gfm-copy {
+  width: min(100%, 35rem);
+  margin: 1rem auto 1.5rem;
+  color: #cbd5e1;
+  line-height: 1.7;
+}
+
+.gfm-open-button,
+.gfm-primary-button,
+.gfm-secondary-button,
+.gfm-close-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  cursor: pointer;
+  text-decoration: none;
+  user-select: none;
+}
+
+.gfm-open-button,
+.gfm-primary-button {
+  min-height: 2.75rem;
+  padding: 0 1.1rem;
+  border-radius: 999px;
+  background: #f8fafc;
+  color: #0f172a;
+  font-weight: 800;
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.28);
+}
+
+.gfm-secondary-button {
+  min-height: 2.75rem;
+  padding: 0 1.1rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.1);
+  color: #e2e8f0;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+
+.gfm-overlay {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: clamp(1rem, 4vw, 2rem);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity var(--gfm-duration) var(--gfm-easing),
+    visibility var(--gfm-duration) var(--gfm-easing);
+}
+
+.gfm-backdrop {
+  position: absolute;
+  inset: 0;
+  background: var(--gfm-backdrop-bg);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  cursor: pointer;
+}
+
+.gfm-dialog {
+  position: relative;
+  width: min(100%, 34rem);
+  max-height: min(82vh, 44rem);
+  overflow: auto;
+  padding: clamp(1.15rem, 4vw, 1.6rem);
+  border-radius: var(--gfm-radius);
+  border: 1px solid var(--gfm-panel-border);
+  background: var(--gfm-panel-bg);
+  box-shadow: var(--gfm-panel-shadow);
+  backdrop-filter: blur(var(--gfm-blur));
+  -webkit-backdrop-filter: blur(var(--gfm-blur));
+  transform: translateY(1rem) scale(var(--gfm-scale-start));
+  opacity: 0;
+  transition:
+    transform var(--gfm-duration) var(--gfm-easing),
+    opacity var(--gfm-duration) var(--gfm-easing);
+}
+
+.gfm-overlay:target {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.gfm-overlay:target .gfm-dialog {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.gfm-dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.2rem;
+}
+
+.gfm-status {
+  color: #bae6fd;
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.gfm-close-button {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.gfm-dialog h2 {
+  margin: 0;
+  font-size: clamp(1.6rem, 5vw, 2.35rem);
+  letter-spacing: 0;
+}
+
+.gfm-dialog p {
+  margin: 0.75rem 0 1.1rem;
+  color: #dbeafe;
+  line-height: 1.65;
+}
+
+.gfm-feature-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.7rem;
+  margin: 1rem 0 1.3rem;
+}
+
+.gfm-feature-grid span {
+  padding: 0.75rem;
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: #e0f2fe;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.gfm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.7rem;
+}
+
+.gfm-open-button:focus-visible,
+.gfm-primary-button:focus-visible,
+.gfm-secondary-button:focus-visible,
+.gfm-close-button:focus-visible {
+  outline: 3px solid #67e8f9;
+  outline-offset: 4px;
+}
+
+@media (max-width: 520px) {
+  .gfm-feature-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .gfm-actions {
+    flex-direction: column-reverse;
+  }
+
+  .gfm-primary-button,
+  .gfm-secondary-button {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gfm-overlay,
+  .gfm-dialog {
+    transition: none;
+  }
+
+  .gfm-dialog {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a self-contained glassmorphism fade-in modal example under submissions/examples
- Uses CSS custom properties for duration, easing, scale, blur, and surface styling
- Uses a JavaScript-free :target interaction with responsive layout and reduced-motion support

Closes #33218

## Tests
- npm run validate:pack