### PR TITLE
fix: demonstrate broken button markup fix

### DIFF
--- a/submissions/docs/fix-broken-button-mnsvi/README.md
+++ b/submissions/docs/fix-broken-button-mnsvi/README.md
@@ -1,0 +1,17 @@
+# Fix: Broken Button Markup in docs/demo.html
+
+This submission demonstrates a bug in `docs/demo.html` where an unclosed style attribute swallows the button label and breaks the subsequent button's markup.
+
+### 1. What does this do?
+It provides a visual side-by-side comparison of the broken HTML markup currently present in `docs/demo.html` and the corrected markup.
+
+### 2. How is it used?
+The maintainer can review `demo.html` to clearly see the parsing issue caused by the missing `"` and `>`. To fix the core framework, the maintainer should apply the following change in `docs/demo.html`:
+
+```diff
+- <button class="ease-btn ease-btn-outline ease-btn-hover" style="border-color:rgba(255,255,255,0.3); color: var(--page-text);Hover me 🚀</button>
++ <button class="ease-btn ease-btn-outline ease-btn-hover" style="border-color:rgba(255,255,255,0.3); color: var(--page-text);">Hover me 🚀</button>
+```
+
+### 3. Why is it useful?
+Because contributors are restricted from editing files in `core/` or `docs/` directly, this submission in `submissions/docs/` strictly follows the contribution guidelines while providing the exact solution to fix the bug.

--- a/submissions/docs/fix-broken-button-mnsvi/demo.html
+++ b/submissions/docs/fix-broken-button-mnsvi/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Broken Button Markup Fix</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Button Markup Fix Demonstration</h1>
+        <p>This demo shows the broken markup currently in <code>docs/demo.html</code> and the corrected markup.</p>
+        
+        <div class="section">
+            <h2>Before (Broken Markup)</h2>
+            <p>The first button's style attribute and tag are unclosed, swallowing the label and breaking the next button.</p>
+            <div class="preview broken">
+                <!-- Exact broken markup from docs/demo.html -->
+                <button class="ease-btn ease-btn-outline ease-btn-hover"
+                  style="border-color:rgba(255,255,255,0.3); color: var(--page-text);Hover me 🚀</button>
+                <button class="ease-btn ease-btn-success ease-btn-hover">Hover me 🌿</button>
+            </div>
+        </div>
+
+        <div class="section">
+            <h2>After (Fixed Markup)</h2>
+            <p>Added the missing closing quote and angle bracket.</p>
+            <div class="preview fixed">
+                <!-- Corrected markup -->
+                <button class="ease-btn ease-btn-outline ease-btn-hover"
+                  style="border-color:rgba(255,255,255,0.3); color: var(--page-text);">Hover me 🚀</button>
+                <button class="ease-btn ease-btn-success ease-btn-hover">Hover me 🌿</button>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/docs/fix-broken-button-mnsvi/style.css
+++ b/submissions/docs/fix-broken-button-mnsvi/style.css
@@ -1,0 +1,72 @@
+:root {
+    --bg-color: #0f172a;
+    --text-color: #f8fafc;
+    --page-text: #f8fafc;
+    --border-color: #334155;
+}
+
+body {
+    margin: 0;
+    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    padding: 2rem;
+}
+
+.container {
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+h1 {
+    font-size: 2rem;
+    margin-bottom: 0.5rem;
+}
+
+.section {
+    margin-top: 2rem;
+    padding: 1.5rem;
+    background-color: #1e293b;
+    border: 1px solid var(--border-color);
+    border-radius: 0.5rem;
+}
+
+.section h2 {
+    margin-top: 0;
+    font-size: 1.25rem;
+    color: #38bdf8;
+}
+
+.preview {
+    margin-top: 1.5rem;
+    padding: 1.5rem;
+    background-color: #0f172a;
+    border-radius: 0.5rem;
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+}
+
+/* Base button styles to make the demo visible */
+.ease-btn {
+    padding: 0.5rem 1rem;
+    border-radius: 0.25rem;
+    font-size: 1rem;
+    cursor: pointer;
+    border: 1px solid transparent;
+    transition: all 0.2s ease;
+}
+
+.ease-btn-outline {
+    background: transparent;
+}
+
+.ease-btn-success {
+    background-color: #22c55e;
+    color: white;
+}
+
+.ease-btn-hover:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+}


### PR DESCRIPTION
## Pull Request Description

This PR provides a demonstration of the broken button markup found in `docs/demo.html` and the corrected markup, fulfilling the requirement for issue #37025. The unclosed style attribute swallows the button label and breaks the subsequent button's rendering.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It provides a visual side-by-side comparison of the broken HTML markup currently present in `docs/demo.html` and the corrected markup.

**How does a developer use it?**

```html
<!-- Corrected markup for docs/demo.html -->
<button class="ease-btn ease-btn-outline ease-btn-hover" style="border-color:rgba(255,255,255,0.3); color: var(--page-text);">Hover me 🚀</button>

Why does it fit EaseMotion CSS?

Because contributors are restricted from editing files in core/ or docs/ directly, this submission in submissions/docs/ strictly follows the contribution guidelines while providing the exact solution to fix the bug in the core docs.

Notes for Maintainer
This submission demonstrates the bug and fix for docs/demo.html. The actual one-line correction needed in docs/demo.html is on the ease-btn-outline ease-btn-hover button under the "With ease-btn-hover" section (adding the missing " and >).

Closes #37025
