### PR TITLE
feat: add finite-state selector generator utility

### DIFF
--- a/submissions/scss/37051-finite-state-selector-generator-dp/README.md
+++ b/submissions/scss/37051-finite-state-selector-generator-dp/README.md
@@ -1,0 +1,29 @@
+# Finite-State Selector Generator
+
+## 1. What does this do?
+
+Generates `[data-state]` / `[data-next]` CSS selectors from a declarative list of states and transitions, instead of hand-writing each one.
+
+## 2. How is it used?
+
+```scss
+$states: (idle, loading, success, error);
+
+.button {
+  @include finite-state($states: $states) using ($state) {
+    @if $state == loading {
+      pointer-events: none;
+    }
+  }
+}
+```
+
+Applied in markup as:
+
+```html
+<button class="button" data-state="loading">Save</button>
+```
+
+## 3. Why is it useful?
+
+States are declared once and selectors are derived automatically, keeping state-driven styling consistent, DRY, and compile-time only — in line with EaseMotion CSS's philosophy of generating plain, framework-agnostic CSS from small, declarative SCSS utilities.

--- a/submissions/scss/37051-finite-state-selector-generator-dp/_finite-state-selector-generator.scss
+++ b/submissions/scss/37051-finite-state-selector-generator-dp/_finite-state-selector-generator.scss
@@ -1,0 +1,106 @@
+$fs-states: () !default;
+$fs-transitions: () !default;
+$fs-state-attribute: "data-state" !default;
+$fs-next-attribute: "data-next" !default;
+
+@function fs-list-contains($list, $value) {
+  @return index($list, $value) != null;
+}
+
+@function fs-has-duplicate-states($states) {
+  $seen: ();
+
+  @each $state in $states {
+    @if fs-list-contains($seen, $state) {
+      @return true;
+    }
+    $seen: append($seen, $state);
+  }
+
+  @return false;
+}
+
+@function fs-transition-key($transition) {
+  @return "#{nth($transition, 1)}->#{nth($transition, 2)}";
+}
+
+@function fs-has-duplicate-transitions($transitions) {
+  $seen: ();
+
+  @each $transition in $transitions {
+    $key: fs-transition-key($transition);
+
+    @if fs-list-contains($seen, $key) {
+      @return true;
+    }
+    $seen: append($seen, $key);
+  }
+
+  @return false;
+}
+
+@mixin fs-validate-states($states) {
+  @if length($states) == 0 {
+    @error "finite-state: the state list is empty. Provide at least one state.";
+  }
+
+  @if fs-has-duplicate-states($states) {
+    @warn "finite-state: duplicate states detected in the provided state list.";
+  }
+}
+
+@mixin fs-validate-transitions($transitions, $states) {
+  @if length($transitions) == 0 {
+    @warn "finite-state-transitions: no transitions were provided, nothing will be generated.";
+  }
+
+  @each $transition in $transitions {
+    @if length($transition) != 2 {
+      @error "finite-state-transitions: each transition must be a (from, to) pair, got `#{$transition}`.";
+    }
+
+    $from: nth($transition, 1);
+    $to: nth($transition, 2);
+
+    @if not fs-list-contains($states, $from) {
+      @error "finite-state-transitions: transition references unknown state `#{$from}`.";
+    }
+
+    @if not fs-list-contains($states, $to) {
+      @error "finite-state-transitions: transition references unknown state `#{$to}`.";
+    }
+  }
+
+  @if fs-has-duplicate-transitions($transitions) {
+    @warn "finite-state-transitions: duplicate transitions detected in the provided transition list.";
+  }
+}
+
+@mixin finite-state($states: $fs-states, $attribute: $fs-state-attribute) {
+  @include fs-validate-states($states);
+
+  @each $state in $states {
+    &[#{$attribute}="#{$state}"] {
+      @content ($state);
+    }
+  }
+}
+
+@mixin finite-state-transitions(
+  $transitions: $fs-transitions,
+  $states: $fs-states,
+  $state-attribute: $fs-state-attribute,
+  $next-attribute: $fs-next-attribute
+) {
+  @include fs-validate-states($states);
+  @include fs-validate-transitions($transitions, $states);
+
+  @each $transition in $transitions {
+    $from: nth($transition, 1);
+    $to: nth($transition, 2);
+
+    &[#{$state-attribute}="#{$from}"][#{$next-attribute}="#{$to}"] {
+      @content ($from, $to);
+    }
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a **Finite-State Selector Generator** utility under the `submissions/scss/` track.

The utility provides a reusable compile-time SCSS solution for generating state-based selectors and valid transition selectors from declarative state definitions. It helps eliminate repetitive selector boilerplate while encouraging scalable, state-driven styling in component libraries and design systems.

Closes #37051

---

## Type of Change

- [x] 🧩 New SCSS utility submission
- [ ] ✨ New animation
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/scss/`
- [x] Includes `_finite-state-selector-generator.scss`
- [x] Includes `README.md`
- [x] Uses SCSS only
- [x] No HTML
- [x] No CSS
- [x] No JavaScript
- [x] No external dependencies
- [x] Framework agnostic
- [x] Compiles to reusable CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

A reusable SCSS utility that generates state selectors and valid transition selectors from declarative state definitions, reducing repetitive selector authoring while improving consistency across components.

### Key Features

- Configurable finite state definitions
- Automatic attribute selector generation
- Optional transition selector generation
- Nested selector support
- Compile-time validation using `@warn` and `@error`
- Framework-agnostic API
- Reusable compile-time architecture

### Why does it fit EaseMotion CSS?

Modern interfaces commonly rely on state-driven styling for components such as buttons, dialogs, forms, notifications, and loading indicators. This utility introduces a reusable compile-time approach for generating state selectors, reducing boilerplate while remaining completely CSS-first and framework agnostic.

---

## Browser Testing

Not applicable (SCSS utility)

---

## Notes for Maintainer

- Fully self-contained under `submissions/scss/37051-finite-state-selector-generator-dp/`
- Contains only:
  - `_finite-state-selector-generator.scss`
  - `README.md`
- Uses SCSS only
- Framework agnostic
- Generates reusable CSS at compile time
- Includes configurable state definitions, transition generation, and compile-time validation