### PR TITLE
feat: add token delta theming engine utility

### DIFF
--- a/submissions/scss/37054-token-delta-theming-engine-dp/README.md
+++ b/submissions/scss/37054-token-delta-theming-engine-dp/README.md
@@ -1,0 +1,28 @@
+# Physical-to-Logical Property Transpiler
+
+## 1. What does this do?
+
+Converts physical CSS properties (`margin-left`, `right`, etc.) into their logical property equivalents (`margin-inline-start`, `inset-inline-end`, etc.) using a configurable mapping, passing through anything with no equivalent.
+
+## 2. How is it used?
+
+```scss
+@include emit-logical-properties(
+  (
+    margin-left: 1rem,
+    padding-right: 2rem,
+    display: flex,
+  ),
+  $selector: ".card"
+);
+```
+
+Applied in markup as:
+
+```html
+<div class="card"></div>
+```
+
+## 3. Why is it useful?
+
+One declaration map compiles to direction-aware CSS, so layouts adapt automatically to RTL and multilingual contexts without duplicated rules — matching EaseMotion CSS's philosophy of small, declarative, compile-time-only utilities.

--- a/submissions/scss/37054-token-delta-theming-engine-dp/_token-delta-theming-engine.scss
+++ b/submissions/scss/37054-token-delta-theming-engine-dp/_token-delta-theming-engine.scss
@@ -1,0 +1,117 @@
+$td-property-prefix: "--" !default;
+$td-key-separator: "-" !default;
+
+@function td-is-map($value) {
+  @return type-of($value) == "map";
+}
+
+@function td-flatten($map, $prefix: null, $separator: $td-key-separator) {
+  $flat: ();
+
+  @each $key, $value in $map {
+    $current-key: if($prefix, "#{$prefix}#{$separator}#{$key}", "#{$key}");
+
+    @if td-is-map($value) {
+      $flat: map-merge($flat, td-flatten($value, $current-key, $separator));
+    } @else {
+      $flat: map-merge(
+        $flat,
+        (
+          $current-key: $value,
+        )
+      );
+    }
+  }
+
+  @return $flat;
+}
+
+@function token-delta($base, $theme) {
+  @if not td-is-map($base) or not td-is-map($theme) {
+    @error "token-delta: both $base and $theme arguments must be maps.";
+  }
+
+  @if length($base) == 0 {
+    @warn "token-delta: $base token map is empty.";
+  }
+
+  @if length($theme) == 0 {
+    @warn "token-delta: $theme token map is empty.";
+  }
+
+  $delta: ();
+
+  @each $key, $theme-value in $theme {
+    $base-value: map-get($base, $key);
+
+    @if td-is-map($theme-value) {
+      @if td-is-map($base-value) {
+        $nested-delta: token-delta($base-value, $theme-value);
+
+        @if length($nested-delta) > 0 {
+          $delta: map-merge(
+            $delta,
+            (
+              $key: $nested-delta,
+            )
+          );
+        }
+      } @else {
+        @if $base-value != null {
+          @warn "token-delta: type mismatch for `#{$key}` - base value is a scalar, theme value is a map.";
+        }
+        $delta: map-merge(
+          $delta,
+          (
+            $key: $theme-value,
+          )
+        );
+      }
+    } @else if td-is-map($base-value) {
+      @warn "token-delta: type mismatch for `#{$key}` - base value is a map, theme value is a scalar.";
+      $delta: map-merge(
+        $delta,
+        (
+          $key: $theme-value,
+        )
+      );
+    } @else if $base-value != $theme-value {
+      $delta: map-merge(
+        $delta,
+        (
+          $key: $theme-value,
+        )
+      );
+    }
+  }
+
+  @return $delta;
+}
+
+@mixin emit-token-delta(
+  $base,
+  $theme,
+  $selector: null,
+  $prefix: $td-property-prefix,
+  $separator: $td-key-separator
+) {
+  $delta: token-delta($base, $theme);
+
+  @if length($delta) == 0 {
+    @warn "emit-token-delta: no differing tokens found between $base and $theme.";
+  } @else {
+    $flat: td-flatten($delta, null, $separator);
+
+    @if $selector {
+      #{$selector} {
+        @each $key, $value in $flat {
+          #{$prefix}#{$key}: #{$value};
+        }
+      }
+    } @else {
+      @each $key, $value in $flat {
+        #{$prefix}#{$key}: #{$value};
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a **Token Delta Theming Engine** utility under the `submissions/scss/` track.

The utility provides a reusable compile-time SCSS solution for comparing a base theme with a target theme and generating only the token differences. It enables scalable theme management while minimizing duplicated token definitions and CSS output.

Closes #37054 

---

## Type of Change

- [x] 🧩 New SCSS utility submission
- [ ] ✨ New animation
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/scss/`
- [x] Includes `_token-delta-theming-engine.scss`
- [x] Includes `README.md`
- [x] Uses SCSS only
- [x] No HTML
- [x] No CSS
- [x] No JavaScript
- [x] No external dependencies
- [x] Framework agnostic
- [x] Compiles to reusable CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

A reusable compile-time SCSS utility that compares two token maps, computes only the differences, and emits scoped CSS custom properties for theme overrides.

### Key Features

- Base and target theme comparison
- Recursive nested map support
- Delta token generation
- Scoped custom property output
- Compile-time validation using `@warn` and `@error`
- Framework-agnostic API
- Optimized CSS generation

### Why does it fit EaseMotion CSS?

Large design systems frequently maintain multiple themes that differ only slightly. This utility minimizes duplicated token definitions, improves maintainability, and generates cleaner CSS while remaining fully compile-time and framework agnostic.

---

## Browser Testing

Not applicable (SCSS utility)

---

## Notes for Maintainer

- Fully self-contained under `submissions/scss/37054-token-delta-theming-engine-dp/`
- Contains only:
  - `_token-delta-theming-engine.scss`
  - `README.md`
- Uses SCSS only
- Framework agnostic
- Generates reusable CSS at compile time
- Includes recursive token comparison and scoped delta generation