### PR TITLE
Add CSS statistics dashboard cards (Basic, Glassmorphism, Gradient va…

### DIFF
--- a/submissions/examples/statistics-dashboard-cards-GeethaBurigalla/README.md
+++ b/submissions/examples/statistics-dashboard-cards-GeethaBurigalla/README.md
@@ -1,0 +1,23 @@
+﻿# CSS Statistics Dashboard Cards
+
+A responsive, CSS-only statistics dashboard component built for issue #36332.
+
+## Variants Included
+1. **Basic** - clean white cards with colored labels and subtle shadow
+2. **Glassmorphism** - frosted-glass cards over a gradient background
+3. **Gradient** - bold gradient-filled cards, one gradient per stat
+
+## Features
+- KPI cards for Users, Revenue, Orders, and Rating
+- Trend indicators (up/down) with color coding
+- Animated progress bars
+- Staggered entrance animation on load
+- Hover lift effect on all cards
+- Fully responsive grid (auto-fit, minmax)
+- Respects prefers-reduced-motion
+
+## How to View
+Open demo.html directly in a browser - no build step needed.
+
+## Author
+Geetha Burigalla ([@GeethaBurigalla](https://github.com/GeethaBurigalla))

--- a/submissions/examples/statistics-dashboard-cards-GeethaBurigalla/demo.html
+++ b/submissions/examples/statistics-dashboard-cards-GeethaBurigalla/demo.html
@@ -1,0 +1,158 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CSS Statistics Dashboard Cards</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <h1 class="page-title">CSS Statistics Dashboard Cards</h1>
+
+  <!-- Variant 1: Basic -->
+  <section class="variant-section">
+    <h2 class="variant-title">Basic</h2>
+    <div class="dashboard-grid">
+
+      <div class="stat-card basic" style="--delay: 0">
+        <div class="stat-icon">Users</div>
+        <div class="stat-info">
+          <p class="stat-label">Total Users</p>
+          <h3 class="stat-value">12,450</h3>
+          <span class="stat-trend up">Up 8.2%</span>
+        </div>
+        <div class="progress-bar"><div class="progress-fill" style="width:72%"></div></div>
+      </div>
+
+      <div class="stat-card basic" style="--delay: 1">
+        <div class="stat-icon">Revenue</div>
+        <div class="stat-info">
+          <p class="stat-label">Revenue</p>
+          <h3 class="stat-value">$48,200</h3>
+          <span class="stat-trend up">Up 12.5%</span>
+        </div>
+        <div class="progress-bar"><div class="progress-fill" style="width:85%"></div></div>
+      </div>
+
+      <div class="stat-card basic" style="--delay: 2">
+        <div class="stat-icon">Orders</div>
+        <div class="stat-info">
+          <p class="stat-label">Orders</p>
+          <h3 class="stat-value">1,204</h3>
+          <span class="stat-trend down">Down 3.1%</span>
+        </div>
+        <div class="progress-bar"><div class="progress-fill" style="width:54%"></div></div>
+      </div>
+
+      <div class="stat-card basic" style="--delay: 3">
+        <div class="stat-icon">Rating</div>
+        <div class="stat-info">
+          <p class="stat-label">Rating</p>
+          <h3 class="stat-value">4.8/5</h3>
+          <span class="stat-trend up">Up 0.3</span>
+        </div>
+        <div class="progress-bar"><div class="progress-fill" style="width:96%"></div></div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- Variant 2: Glassmorphism -->
+  <section class="variant-section glass-bg">
+    <h2 class="variant-title light">Glassmorphism</h2>
+    <div class="dashboard-grid">
+
+      <div class="stat-card glass" style="--delay: 0">
+        <div class="stat-icon">Users</div>
+        <div class="stat-info">
+          <p class="stat-label">Total Users</p>
+          <h3 class="stat-value">12,450</h3>
+          <span class="stat-trend up">Up 8.2%</span>
+        </div>
+        <div class="progress-bar"><div class="progress-fill" style="width:72%"></div></div>
+      </div>
+
+      <div class="stat-card glass" style="--delay: 1">
+        <div class="stat-icon">Revenue</div>
+        <div class="stat-info">
+          <p class="stat-label">Revenue</p>
+          <h3 class="stat-value">$48,200</h3>
+          <span class="stat-trend up">Up 12.5%</span>
+        </div>
+        <div class="progress-bar"><div class="progress-fill" style="width:85%"></div></div>
+      </div>
+
+      <div class="stat-card glass" style="--delay: 2">
+        <div class="stat-icon">Orders</div>
+        <div class="stat-info">
+          <p class="stat-label">Orders</p>
+          <h3 class="stat-value">1,204</h3>
+          <span class="stat-trend down">Down 3.1%</span>
+        </div>
+        <div class="progress-bar"><div class="progress-fill" style="width:54%"></div></div>
+      </div>
+
+      <div class="stat-card glass" style="--delay: 3">
+        <div class="stat-icon">Rating</div>
+        <div class="stat-info">
+          <p class="stat-label">Rating</p>
+          <h3 class="stat-value">4.8/5</h3>
+          <span class="stat-trend up">Up 0.3</span>
+        </div>
+        <div class="progress-bar"><div class="progress-fill" style="width:96%"></div></div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- Variant 3: Gradient -->
+  <section class="variant-section">
+    <h2 class="variant-title">Gradient</h2>
+    <div class="dashboard-grid">
+
+      <div class="stat-card gradient grad-1" style="--delay: 0">
+        <div class="stat-icon">Users</div>
+        <div class="stat-info">
+          <p class="stat-label">Total Users</p>
+          <h3 class="stat-value">12,450</h3>
+          <span class="stat-trend up">Up 8.2%</span>
+        </div>
+        <div class="progress-bar"><div class="progress-fill" style="width:72%"></div></div>
+      </div>
+
+      <div class="stat-card gradient grad-2" style="--delay: 1">
+        <div class="stat-icon">Revenue</div>
+        <div class="stat-info">
+          <p class="stat-label">Revenue</p>
+          <h3 class="stat-value">$48,200</h3>
+          <span class="stat-trend up">Up 12.5%</span>
+        </div>
+        <div class="progress-bar"><div class="progress-fill" style="width:85%"></div></div>
+      </div>
+
+      <div class="stat-card gradient grad-3" style="--delay: 2">
+        <div class="stat-icon">Orders</div>
+        <div class="stat-info">
+          <p class="stat-label">Orders</p>
+          <h3 class="stat-value">1,204</h3>
+          <span class="stat-trend down">Down 3.1%</span>
+        </div>
+        <div class="progress-bar"><div class="progress-fill" style="width:54%"></div></div>
+      </div>
+
+      <div class="stat-card gradient grad-4" style="--delay: 3">
+        <div class="stat-icon">Rating</div>
+        <div class="stat-info">
+          <p class="stat-label">Rating</p>
+          <h3 class="stat-value">4.8/5</h3>
+          <span class="stat-trend up">Up 0.3</span>
+        </div>
+        <div class="progress-bar"><div class="progress-fill" style="width:96%"></div></div>
+      </div>
+
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/statistics-dashboard-cards-GeethaBurigalla/style.css
+++ b/submissions/examples/statistics-dashboard-cards-GeethaBurigalla/style.css
@@ -1,0 +1,178 @@
+﻿* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: "Segoe UI", Arial, sans-serif;
+  margin: 0;
+  padding: 40px 20px;
+  background: #f4f5f7;
+}
+
+.page-title {
+  text-align: center;
+  margin-bottom: 30px;
+  color: #222;
+}
+
+.variant-section {
+  padding: 40px 20px;
+  margin-bottom: 20px;
+  border-radius: 16px;
+}
+
+.variant-title {
+  text-align: center;
+  margin-bottom: 24px;
+  font-size: 1.4rem;
+  color: #333;
+}
+
+.variant-title.light {
+  color: #fff;
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.stat-card {
+  padding: 22px;
+  border-radius: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  opacity: 0;
+  transform: translateY(20px);
+  animation: cardEnter 0.5s ease forwards;
+  animation-delay: calc(var(--delay) * 0.12s);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.stat-card:hover {
+  transform: translateY(-6px);
+}
+
+.stat-icon {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  opacity: 0.6;
+  letter-spacing: 0.05em;
+}
+
+.stat-label {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.75;
+}
+
+.stat-value {
+  margin: 2px 0 4px;
+  font-size: 1.6rem;
+}
+
+.stat-trend {
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 20px;
+  width: fit-content;
+}
+
+.stat-trend.up {
+  color: #16a34a;
+  background: rgba(22, 163, 74, 0.12);
+}
+
+.stat-trend.down {
+  color: #dc2626;
+  background: rgba(220, 38, 38, 0.12);
+}
+
+.progress-bar {
+  height: 6px;
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  border-radius: 10px;
+  background: currentColor;
+  animation: fillGrow 1s ease forwards;
+  animation-delay: calc(var(--delay) * 0.12s + 0.3s);
+}
+
+.stat-card.basic {
+  background: #ffffff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  color: #4f46e5;
+}
+
+.stat-card.basic:hover {
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.12);
+}
+
+.glass-bg {
+  background: linear-gradient(135deg, #667eea, #764ba2);
+}
+
+.stat-card.glass {
+  background: rgba(255, 255, 255, 0.15);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  color: #fff;
+}
+
+.stat-card.glass .stat-label {
+  color: #f1f1f1;
+}
+
+.stat-card.glass:hover {
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.25);
+}
+
+.stat-card.gradient {
+  color: #fff;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.15);
+}
+
+.stat-card.gradient:hover {
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+}
+
+.grad-1 { background: linear-gradient(135deg, #ff9a9e, #fad0c4); }
+.grad-2 { background: linear-gradient(135deg, #43e97b, #38f9d7); }
+.grad-3 { background: linear-gradient(135deg, #4facfe, #00f2fe); }
+.grad-4 { background: linear-gradient(135deg, #f6d365, #fda085); }
+
+@keyframes cardEnter {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fillGrow {
+  from { width: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stat-card, .progress-fill {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .stat-value {
+    font-size: 1.3rem;
+  }
+}


### PR DESCRIPTION
Closes #36332

Added a CSS-only statistics dashboard cards component with three variants:
- Basic
- Glassmorphism
- Gradient

Each includes KPI cards (Users, Revenue, Orders, Rating), trend indicators, animated progress bars, staggered entrance animation, and hover effects. Fully responsive and respects prefers-reduced-motion.