### PR TITLE
feat: add physical-to-logical property transpiler utility

### DIFF
--- a/submissions/scss/37052-physical-logical-property-transpiler-dp/README.md
+++ b/submissions/scss/37052-physical-logical-property-transpiler-dp/README.md
@@ -1,0 +1,28 @@
+# Physical-to-Logical Property Transpiler
+
+## 1. What does this do?
+
+Converts physical CSS properties (`margin-left`, `right`, etc.) into their logical property equivalents (`margin-inline-start`, `inset-inline-end`, etc.) using a configurable mapping, passing through anything with no equivalent.
+
+## 2. How is it used?
+
+```scss
+@include emit-logical-properties(
+  (
+    margin-left: 1rem,
+    padding-right: 2rem,
+    display: flex,
+  ),
+  $selector: ".card"
+);
+```
+
+Applied in markup as:
+
+```html
+<div class="card"></div>
+```
+
+## 3. Why is it useful?
+
+One declaration map compiles to direction-aware CSS, so layouts adapt automatically to RTL and multilingual contexts without duplicated rules — matching EaseMotion CSS's philosophy of small, declarative, compile-time-only utilities.

--- a/submissions/scss/37052-physical-logical-property-transpiler-dp/_physical-logical-property-transpiler.scss
+++ b/submissions/scss/37052-physical-logical-property-transpiler-dp/_physical-logical-property-transpiler.scss
@@ -1,0 +1,92 @@
+$plt-logical-properties: (
+  margin-left: margin-inline-start,
+  margin-right: margin-inline-end,
+  padding-left: padding-inline-start,
+  padding-right: padding-inline-end,
+  left: inset-inline-start,
+  right: inset-inline-end,
+  border-left: border-inline-start,
+  border-right: border-inline-end,
+) !default;
+
+@function plt-check-mapping($mapping) {
+  @if type-of($mapping) != "map" {
+    @error "logical-property: $mapping must be a map.";
+  }
+
+  @if length($mapping) == 0 {
+    @warn "logical-property: mapping is empty, no properties will be transpiled.";
+  }
+
+  $seen: ();
+
+  @each $physical, $logical in $mapping {
+    @if type-of($logical) != "string" {
+      @error "logical-property: invalid mapping value for `#{$physical}` - expected a string, got `#{type-of($logical)}`.";
+    }
+
+    @if index($seen, $logical) {
+      @warn "logical-property: duplicate logical property target `#{$logical}` mapped from multiple physical properties.";
+    }
+
+    $seen: append($seen, $logical);
+  }
+
+  @return $mapping;
+}
+
+@function logical-property($property, $mapping: $plt-logical-properties) {
+  $mapping: plt-check-mapping($mapping);
+  $logical: map-get($mapping, $property);
+
+  @return if($logical, $logical, $property);
+}
+
+@function transpile-logical-properties(
+  $declarations,
+  $mapping: $plt-logical-properties
+) {
+  @if type-of($declarations) != "map" {
+    @error "transpile-logical-properties: $declarations must be a map.";
+  }
+
+  @if length($declarations) == 0 {
+    @warn "transpile-logical-properties: $declarations map is empty.";
+  }
+
+  $mapping: plt-check-mapping($mapping);
+  $result: ();
+
+  @each $property, $value in $declarations {
+    $target: map-get($mapping, $property);
+    $key: if($target, $target, $property);
+    $result: map-merge(
+      $result,
+      (
+        $key: $value,
+      )
+    );
+  }
+
+  @return $result;
+}
+
+@mixin emit-logical-properties(
+  $declarations,
+  $mapping: $plt-logical-properties,
+  $selector: null
+) {
+  $transpiled: transpile-logical-properties($declarations, $mapping);
+
+  @if $selector {
+    #{$selector} {
+      @each $property, $value in $transpiled {
+        #{$property}: #{$value};
+      }
+    }
+  } @else {
+    @each $property, $value in $transpiled {
+      #{$property}: #{$value};
+    }
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a **Physical-to-Logical Property Transpiler** utility under the `submissions/scss/` track.

The utility provides a reusable compile-time SCSS solution for converting physical CSS properties into their logical equivalents using configurable property mappings. It helps developers build RTL-friendly and internationalized styles while reducing repetitive property conversions.

Closes #37052

---

## Type of Change

- [x] 🧩 New SCSS utility submission
- [ ] ✨ New animation
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/scss/`
- [x] Includes `_physical-logical-property-transpiler.scss`
- [x] Includes `README.md`
- [x] Uses SCSS only
- [x] No HTML
- [x] No CSS
- [x] No JavaScript
- [x] No external dependencies
- [x] Framework agnostic
- [x] Compiles to reusable CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

A reusable compile-time SCSS utility that converts physical CSS properties such as `margin-left`, `padding-right`, and `left` into their logical equivalents using configurable mappings, while preserving unsupported properties through pass-through behavior.

### Key Features

- Configurable property mapping
- Automatic logical property generation
- Pass-through support for unsupported properties
- Compile-time validation using `@warn` and `@error`
- Framework-agnostic API
- Reusable compile-time architecture

### Why does it fit EaseMotion CSS?

Modern applications increasingly require RTL support and logical CSS authoring. This utility simplifies that workflow by providing a reusable compile-time transpiler that improves maintainability while remaining completely framework agnostic.

---

## Browser Testing

Not applicable (SCSS utility)

---

## Notes for Maintainer

- Fully self-contained under `submissions/scss/37052-physical-logical-property-transpiler-dp/`
- Contains only:
  - `_physical-logical-property-transpiler.scss`
  - `README.md`
- Uses SCSS only
- Framework agnostic
- Generates reusable CSS at compile time
- Includes configurable property mappings, pass-through support, and compile-time validation