### PR TITLE
feat: add pure CSS tada-click modal example

### DIFF
--- a/submissions/examples/Tada-click-animation/README.md
+++ b/submissions/examples/Tada-click-animation/README.md
@@ -1,0 +1,38 @@
+# Tada-Click Modal
+
+Pure CSS modal that opens with a "tada" pop animation. No JavaScript.
+
+## Usage
+
+Copy `style.css` into your project and link it, then drop in the markup from `index.html`.
+
+```html
+<link rel="stylesheet" href="style.css">
+```
+
+## Customization
+
+Override these custom properties on `.tada-modal` (or a parent) to change behavior:
+
+| Property | Default | Description |
+|---|---|---|
+| `--tada-duration` | `0.6s` | Animation length |
+| `--tada-easing` | `cubic-bezier(.36, .07, .19, 1.07)` | Timing function |
+| `--tada-scale-max` | `1.1` | Peak overshoot scale |
+| `--tada-scale-min` | `0.9` | Undershoot scale before settling |
+| `--tada-overlay-bg` | `rgba(0, 0, 0, 0.55)` | Backdrop color |
+
+## How it works
+
+Checkbox hack. A hidden `<input type="checkbox">` is toggled by clicking the trigger `<label>`. CSS sibling combinators (`~`) show the overlay and run the keyframe animation when the checkbox is `:checked`. Clicking the backdrop or the close `<label>` (also bound to the same checkbox) closes it.
+
+## Accessibility — read this before claiming "fully accessible" in your PR
+
+- Trigger, close button, and backdrop are all keyboard-reachable and toggle via native checkbox behavior (Space/Enter). That part is solid.
+- `prefers-reduced-motion` is respected — animation is skipped for users who've asked for it.
+- **Escape key does not close the modal.** There is no CSS mechanism to bind a specific key. If you need Escape-to-close or a real focus trap, that requires JavaScript. Don't oversell this in the issue/PR description — say it's keyboard-operable, not that it fully matches WAI-ARIA modal dialog pattern requirements.
+- `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` are included, but screen readers may still let users tab/read content behind the modal since there's no real focus containment without JS.
+
+## Browser support
+
+Requires `:has()`-free sibling selectors, CSS custom properties, and `:focus-visible` — works in all current evergreen browsers. No IE11 support, not that anyone should care in 2026.

--- a/submissions/examples/Tada-click-animation/demo.html
+++ b/submissions/examples/Tada-click-animation/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Tada-Click Modal</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="tada-modal">
+    <input type="checkbox" id="modal-toggle" class="tada-modal__toggle">
+    <label for="modal-toggle" class="tada-modal__trigger" tabindex="0" role="button" aria-haspopup="dialog">
+      Open Modal
+    </label>
+
+    <div class="tada-modal__overlay">
+      <label for="modal-toggle" class="tada-modal__backdrop" aria-hidden="true"></label>
+      <div class="tada-modal__box" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+        <label for="modal-toggle" class="tada-modal__close" tabindex="0" role="button" aria-label="Close modal">&times;</label>
+        <h2 id="modal-title">Tada Modal</h2>
+        <p>Pure CSS, opens with a tada-style pop. Tab to the trigger and press Enter/Space — no mouse needed.</p>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/Tada-click-animation/style.css
+++ b/submissions/examples/Tada-click-animation/style.css
@@ -1,0 +1,101 @@
+.tada-modal {
+  --tada-duration: 0.6s;
+  --tada-easing: cubic-bezier(.36, .07, .19, 1.07);
+  --tada-scale-max: 1.1;
+  --tada-scale-min: 0.9;
+  --tada-overlay-bg: rgba(0, 0, 0, 0.55);
+}
+
+.tada-modal__toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  overflow: hidden;
+}
+
+.tada-modal__trigger {
+  display: inline-block;
+  padding: 0.6em 1.2em;
+  background: #4f46e5;
+  color: #fff;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.tada-modal__trigger:focus-visible,
+.tada-modal__toggle:focus-visible ~ .tada-modal__trigger {
+  outline: 3px solid #f59e0b;
+  outline-offset: 2px;
+}
+
+.tada-modal__overlay {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: transparent;
+  opacity: 0;
+  pointer-events: none;
+  transition: background var(--tada-duration) ease, opacity var(--tada-duration) ease;
+  z-index: 1000;
+}
+
+.tada-modal__toggle:checked ~ .tada-modal__overlay {
+  background: var(--tada-overlay-bg);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.tada-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  cursor: pointer;
+}
+
+.tada-modal__box {
+  position: relative;
+  background: #fff;
+  border-radius: 10px;
+  padding: 2rem;
+  max-width: min(90vw, 420px);
+  transform: scale(0);
+  opacity: 0;
+}
+
+.tada-modal__toggle:checked ~ .tada-modal__overlay .tada-modal__box {
+  animation: tada-pop var(--tada-duration) var(--tada-easing) forwards;
+}
+
+@keyframes tada-pop {
+  0%   { transform: scale(0);                    opacity: 0; }
+  50%  { transform: scale(var(--tada-scale-max)); opacity: 1; }
+  70%  { transform: scale(var(--tada-scale-min)); }
+  85%  { transform: scale(1.03); }
+  100% { transform: scale(1); }
+}
+
+.tada-modal__close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.75rem;
+  font-size: 1.4rem;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.tada-modal__close:focus-visible {
+  outline: 3px solid #f59e0b;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tada-modal__toggle:checked ~ .tada-modal__overlay .tada-modal__box {
+    animation: none;
+    transform: scale(1);
+    opacity: 1;
+  }
+  .tada-modal__overlay {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS "tada-click" modal to the examples library. Clicking a trigger opens a modal with a bouncy tada-style pop-in animation, fully driven by CSS custom properties, no JavaScript

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A pure CSS modal component that opens with a "tada" pop animation (scale overshoot/undershoot), triggered by a checkbox-hack
**How does a developer use it?**

```html


  
  
    Open Modal
  
  
    
    
      &times;
      Tada Modal
   
    
  

```

**Why does it fit EaseMotion CSS?**

It's a self-contained, readable CSS pattern (BEM-style class names, custom properties for `--tada-duration`, `--tada-easing`, `--tada-scale-max`/`--tada-scale-min`) that demonstrates a common UI pattern (modal) with zero JS dependency, matching the animation-first, human-readable philosophy of the library.


---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

<!-- Anything the maintainer should know when reviewing or integrating.
     e.g. "I wasn't sure about the timing — feel free to adjust."
     e.g. "Inspired by Material UI's shimmer effect." -->

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
