### PR TITLE
fix: h1–h6 and th nearly invisible in dark mode — use --ease-color-text instead of --ease-color-neutral-900

### DIFF
--- a/submissions/examples/toast-stacking-16393/README.md
+++ b/submissions/examples/toast-stacking-16393/README.md
@@ -1,0 +1,53 @@
+# Toast Notification Stacking & Positioning
+
+**Fixes:** Issue #16393 — Toast notifications overlap when triggered simultaneously
+
+## Problem
+
+The original toast component had no stacking or positioning system.
+Multiple toasts triggered at the same time would render on top of each
+other instead of stacking vertically.
+
+## Solution
+
+A complete toast notification system with:
+
+- **Stacking** — multiple toasts stack vertically, never overlapping
+- **5 position variants** — top-right, top-left, top-center, bottom-right, bottom-left
+- **4 types** — success, error, warning, info (colored left border + icon)
+- **Auto-dismiss** with a visual progress bar countdown
+- **Sticky toasts** — set `duration: 0` to disable auto-dismiss
+- **Manual close** via × button (keyboard accessible)
+- **Entrance / exit animations** — smooth slide + fade
+- **`prefers-reduced-motion`** respected
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `style.css` | Container and toast card styles |
+| `toast.js`  | `showToast()` function — zero dependencies |
+| `demo.html` | Interactive demo |
+| `README.md` | This file |
+
+## Usage
+
+```html
+<script src="toast.js"></script>
+<link rel="stylesheet" href="style.css" />
+```
+
+```js
+showToast({
+  title:    'Changes saved',
+  message:  'Your work has been saved.',
+  type:     'success',      // success | error | warning | info
+  duration: 4000,           // ms; 0 = sticky
+  position: 'top-right'     // top-right | top-left | top-center
+                            // bottom-right | bottom-left
+});
+```
+
+## No existing files modified
+
+All files are new under `submissions/examples/toast-stacking-16393/`.

--- a/submissions/examples/toast-stacking-16393/demo.html
+++ b/submissions/examples/toast-stacking-16393/demo.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>EaseMotion CSS — Toast Stacking Demo (#16393)</title>
+  <link rel="stylesheet" href="style.css"/>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background: #0b0f19;
+      color: #f1f5f9;
+      font-family: system-ui, -apple-system, sans-serif;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 40px 20px;
+      gap: 32px;
+    }
+    .header { text-align: center; }
+    .badge {
+      display: inline-block;
+      background: rgba(56,189,248,.12);
+      color: #38bdf8;
+      border: 1px solid rgba(56,189,248,.3);
+      border-radius: 999px;
+      font-size: 0.7rem;
+      font-weight: 700;
+      letter-spacing: .07em;
+      text-transform: uppercase;
+      padding: 3px 12px;
+      margin-bottom: 10px;
+    }
+    h1 { font-size: clamp(1.2rem, 3vw, 1.8rem); font-weight: 700; }
+    p.sub { color: #94a3b8; font-size: 0.875rem; margin-top: 6px; }
+
+    .panels {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 16px;
+      width: 100%;
+      max-width: 820px;
+    }
+    .panel {
+      background: #111827;
+      border: 1px solid #1f2937;
+      border-radius: 12px;
+      padding: 20px;
+    }
+    .panel h2 {
+      font-size: 0.75rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: .08em;
+      color: #94a3b8;
+      margin-bottom: 12px;
+    }
+    .btn-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 8px;
+    }
+    .btn-grid.cols-1 { grid-template-columns: 1fr; }
+    button {
+      padding: 9px 14px;
+      border: 1px solid #1f2937;
+      border-radius: 8px;
+      background: #1e293b;
+      color: #f1f5f9;
+      font-size: 0.8rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.15s, transform 0.1s;
+      text-align: left;
+    }
+    button:hover  { background: #243044; }
+    button:active { transform: scale(0.97); }
+    button.success { border-left: 3px solid #4ade80; }
+    button.error   { border-left: 3px solid #f87171; }
+    button.warning { border-left: 3px solid #fbbf24; }
+    button.info    { border-left: 3px solid #38bdf8; }
+
+    .divider { height: 1px; background: #1f2937; margin: 12px 0; }
+
+    .pos-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 6px;
+    }
+    .pos-btn {
+      font-size: 0.7rem;
+      padding: 8px 4px;
+      text-align: center;
+      border-radius: 6px;
+    }
+    .pos-btn.active {
+      background: rgba(56,189,248,.15);
+      border-color: #38bdf8;
+      color: #38bdf8;
+    }
+    .row { display: flex; gap: 8px; }
+    .row button { flex: 1; }
+  </style>
+</head>
+<body>
+
+  <div class="header">
+    <div class="badge">Fix · Issue #16393</div>
+    <h1>Toast Notification Stacking</h1>
+    <p class="sub">Toasts stack properly — no overlapping. 5 position options.</p>
+  </div>
+
+  <div class="panels">
+
+    <div class="panel">
+      <h2>📢 Toast Types</h2>
+      <div class="btn-grid">
+        <button class="success" onclick="fireToast('success')">✓ Success</button>
+        <button class="error"   onclick="fireToast('error')">✕ Error</button>
+        <button class="warning" onclick="fireToast('warning')">⚠ Warning</button>
+        <button class="info"    onclick="fireToast('info')">ℹ Info</button>
+      </div>
+      <div class="divider"></div>
+      <h2>📦 Stack Test</h2>
+      <div class="row">
+        <button onclick="fireStack(3)">Stack 3</button>
+        <button onclick="fireStack(5)">Stack 5</button>
+      </div>
+      <div class="divider"></div>
+      <h2>📌 Sticky</h2>
+      <div class="btn-grid cols-1">
+        <button class="info" onclick="fireSticky()">ℹ Sticky (manual close only)</button>
+      </div>
+    </div>
+
+    <div class="panel">
+      <h2>📍 Position</h2>
+      <div class="pos-grid">
+        <button class="pos-btn" data-pos="top-left"     onclick="setPos(this)">↖ Top Left</button>
+        <button class="pos-btn active" data-pos="top-center" onclick="setPos(this)">↑ Top Center</button>
+        <button class="pos-btn" data-pos="top-right"    onclick="setPos(this)">↗ Top Right</button>
+        <button class="pos-btn" data-pos="bottom-left"  onclick="setPos(this)">↙ Bot Left</button>
+        <div></div>
+        <button class="pos-btn" data-pos="bottom-right" onclick="setPos(this)">↘ Bot Right</button>
+      </div>
+      <div class="divider"></div>
+      <h2>⏱ Duration</h2>
+      <div class="btn-grid">
+        <button onclick="setDur(2000,this)">2 sec</button>
+        <button onclick="setDur(4000,this)" id="active-dur" style="border-color:#38bdf8;color:#38bdf8">4 sec ✓</button>
+        <button onclick="setDur(6000,this)">6 sec</button>
+        <button onclick="setDur(8000,this)">8 sec</button>
+      </div>
+    </div>
+
+  </div>
+
+  <script src="toast.js"></script>
+  <script>
+    var currentPos = 'top-center';
+    var currentDur = 4000;
+
+    var MESSAGES = {
+      success: { title: 'Changes saved',        message: 'Your work has been saved successfully.' },
+      error:   { title: 'Something went wrong', message: 'Could not connect. Please try again.' },
+      warning: { title: 'Heads up',             message: 'Your session will expire in 5 minutes.' },
+      info:    { title: 'Update available',      message: 'Refresh the page to get the latest version.' }
+    };
+
+    function fireToast(type) {
+      showToast({ title: MESSAGES[type].title, message: MESSAGES[type].message,
+                  type: type, position: currentPos, duration: currentDur });
+    }
+
+    function fireStack(n) {
+      var types = ['success','error','warning','info'];
+      for (var i = 0; i < n; i++) {
+        (function(idx) {
+          setTimeout(function() {
+            showToast({ type: types[idx % 4], title: 'Notification ' + (idx+1),
+                        message: 'Stacked toast #' + (idx+1) + ' — no overlap!',
+                        position: currentPos, duration: currentDur });
+          }, idx * 120);
+        })(i);
+      }
+    }
+
+    function fireSticky() {
+      showToast({ type: 'info', title: 'Sticky Toast',
+                  message: "Won't auto-dismiss. Click × to close.",
+                  position: currentPos, duration: 0 });
+    }
+
+    function setPos(btn) {
+      document.querySelectorAll('.pos-btn').forEach(function(b) { b.classList.remove('active'); });
+      btn.classList.add('active');
+      currentPos = btn.dataset.pos;
+    }
+
+    function setDur(ms, btn) {
+      currentDur = ms;
+      document.querySelectorAll('.btn-grid button').forEach(function(b) {
+        b.style.borderColor = ''; b.style.color = '';
+      });
+      btn.style.borderColor = '#38bdf8';
+      btn.style.color = '#38bdf8';
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/toast-stacking-16393/style.css
+++ b/submissions/examples/toast-stacking-16393/style.css
@@ -1,0 +1,202 @@
+/* ============================================================
+   EaseMotion CSS — Toast Notification Stacking & Positioning
+   Submission for Issue #16393
+   New file: submissions/examples/toast-stacking-16393/style.css
+============================================================ */
+
+:root {
+  --ease-toast-gap:        10px;
+  --ease-toast-width:      340px;
+  --ease-toast-radius:     10px;
+  --ease-toast-padding:    14px 16px;
+  --ease-toast-bg:         #1e293b;
+  --ease-toast-border:     #334155;
+  --ease-toast-text:       #f1f5f9;
+  --ease-toast-muted:      #94a3b8;
+  --ease-toast-shadow:     0 8px 24px rgba(0,0,0,0.45);
+  --ease-toast-duration:   300ms;
+  --ease-toast-offset:     20px;
+  --ease-toast-success:    #4ade80;
+  --ease-toast-error:      #f87171;
+  --ease-toast-warning:    #fbbf24;
+  --ease-toast-info:       #38bdf8;
+}
+
+/* Container */
+.ease-toast-container {
+  position: fixed;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-toast-gap);
+  pointer-events: none;
+  max-width: var(--ease-toast-width);
+  width: calc(100% - 32px);
+}
+
+/* Position variants */
+.ease-toast-container--top-right {
+  top: var(--ease-toast-offset);
+  right: var(--ease-toast-offset);
+  align-items: flex-end;
+}
+.ease-toast-container--top-left {
+  top: var(--ease-toast-offset);
+  left: var(--ease-toast-offset);
+  align-items: flex-start;
+}
+.ease-toast-container--top-center {
+  top: var(--ease-toast-offset);
+  left: 50%;
+  transform: translateX(-50%);
+  align-items: center;
+}
+.ease-toast-container--bottom-right {
+  bottom: var(--ease-toast-offset);
+  right: var(--ease-toast-offset);
+  flex-direction: column-reverse;
+  align-items: flex-end;
+}
+.ease-toast-container--bottom-left {
+  bottom: var(--ease-toast-offset);
+  left: var(--ease-toast-offset);
+  flex-direction: column-reverse;
+  align-items: flex-start;
+}
+
+/* Toast card */
+.ease-toast {
+  pointer-events: all;
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  width: 100%;
+  max-width: var(--ease-toast-width);
+  padding: var(--ease-toast-padding);
+  background: var(--ease-toast-bg);
+  border: 1px solid var(--ease-toast-border);
+  border-left: 4px solid var(--ease-toast-info);
+  border-radius: var(--ease-toast-radius);
+  box-shadow: var(--ease-toast-shadow);
+  color: var(--ease-toast-text);
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  position: relative;
+  overflow: hidden;
+  animation: ease-toast-in var(--ease-toast-duration) cubic-bezier(0.22,1,0.36,1) forwards;
+}
+
+.ease-toast--dismissing {
+  animation: ease-toast-out var(--ease-toast-duration) ease-in forwards;
+}
+
+/* Type variants */
+.ease-toast--success { border-left-color: var(--ease-toast-success); }
+.ease-toast--error   { border-left-color: var(--ease-toast-error);   }
+.ease-toast--warning { border-left-color: var(--ease-toast-warning); }
+.ease-toast--info    { border-left-color: var(--ease-toast-info);    }
+
+/* Icon */
+.ease-toast__icon {
+  font-size: 1.1rem;
+  line-height: 1;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+.ease-toast--success .ease-toast__icon { color: var(--ease-toast-success); }
+.ease-toast--error   .ease-toast__icon { color: var(--ease-toast-error);   }
+.ease-toast--warning .ease-toast__icon { color: var(--ease-toast-warning); }
+.ease-toast--info    .ease-toast__icon { color: var(--ease-toast-info);    }
+
+/* Body */
+.ease-toast__body { flex: 1; min-width: 0; }
+
+.ease-toast__title {
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: var(--ease-toast-text);
+  margin-bottom: 2px;
+}
+
+.ease-toast__message {
+  font-size: 0.8rem;
+  color: var(--ease-toast-muted);
+  word-break: break-word;
+}
+
+/* Close button */
+.ease-toast__close {
+  background: none;
+  border: none;
+  color: var(--ease-toast-muted);
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0;
+  flex-shrink: 0;
+  margin-top: 1px;
+  transition: color 0.2s ease;
+}
+.ease-toast__close:hover { color: var(--ease-toast-text); }
+.ease-toast__close:focus-visible {
+  outline: 2px solid var(--ease-toast-info);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
+/* Progress bar */
+.ease-toast__progress {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 3px;
+  width: 100%;
+  background: currentColor;
+  opacity: 0.25;
+  transform-origin: left;
+  animation: ease-toast-progress linear forwards;
+}
+.ease-toast--success .ease-toast__progress { color: var(--ease-toast-success); }
+.ease-toast--error   .ease-toast__progress { color: var(--ease-toast-error);   }
+.ease-toast--warning .ease-toast__progress { color: var(--ease-toast-warning); }
+.ease-toast--info    .ease-toast__progress { color: var(--ease-toast-info);    }
+
+/* Keyframes */
+@keyframes ease-toast-in {
+  from { opacity: 0; transform: translateX(40px) scale(0.95); }
+  to   { opacity: 1; transform: translateX(0) scale(1); }
+}
+
+@keyframes ease-toast-out {
+  from {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+    max-height: 120px;
+    margin-bottom: 0;
+  }
+  to {
+    opacity: 0;
+    transform: translateX(40px) scale(0.92);
+    max-height: 0;
+    margin-bottom: calc(var(--ease-toast-gap) * -1);
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+}
+
+@keyframes ease-toast-progress {
+  from { transform: scaleX(1); }
+  to   { transform: scaleX(0); }
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .ease-toast,
+  .ease-toast--dismissing,
+  .ease-toast__progress {
+    animation: none;
+    transition: none;
+  }
+  .ease-toast--dismissing { opacity: 0; }
+}

--- a/submissions/examples/toast-stacking-16393/toast.js
+++ b/submissions/examples/toast-stacking-16393/toast.js
@@ -1,0 +1,118 @@
+/**
+ * EaseMotion CSS — Toast Notification Manager
+ * Submission for Issue #16393
+ *
+ * Usage:
+ *   showToast({ message, title, type, duration, position })
+ */
+
+;(function (global) {
+  'use strict';
+
+  const ICONS = {
+    success: '✓',
+    error:   '✕',
+    warning: '⚠',
+    info:    'ℹ',
+  };
+
+  const containers = {};
+
+  function getContainer(position) {
+    if (containers[position]) return containers[position];
+    const el = document.createElement('div');
+    el.className = 'ease-toast-container ease-toast-container--' + position;
+    el.setAttribute('aria-live', 'polite');
+    el.setAttribute('aria-atomic', 'false');
+    el.setAttribute('role', 'region');
+    el.setAttribute('aria-label', 'Notifications');
+    document.body.appendChild(el);
+    containers[position] = el;
+    return el;
+  }
+
+  function dismiss(toastEl) {
+    if (toastEl.dataset.dismissed) return;
+    toastEl.dataset.dismissed = '1';
+    toastEl.classList.add('ease-toast--dismissing');
+    const duration = parseFloat(
+      getComputedStyle(toastEl)
+        .getPropertyValue('--ease-toast-duration') || '300'
+    ) || 300;
+    setTimeout(function () {
+      if (toastEl.parentNode) toastEl.parentNode.removeChild(toastEl);
+    }, duration);
+  }
+
+  function showToast(options) {
+    const opts = Object.assign(
+      { type: 'info', duration: 4000, position: 'top-right' },
+      options || {}
+    );
+
+    if (!opts.message) {
+      console.warn('[EaseMotion Toast] "message" is required.');
+      return;
+    }
+
+    const container = getContainer(opts.position);
+    const type = ['success','error','warning','info'].includes(opts.type)
+                   ? opts.type : 'info';
+
+    const toast = document.createElement('div');
+    toast.className = 'ease-toast ease-toast--' + type;
+    toast.setAttribute('role', 'alert');
+    toast.setAttribute('aria-live', 'assertive');
+
+    /* Icon */
+    const icon = document.createElement('span');
+    icon.className   = 'ease-toast__icon';
+    icon.textContent = ICONS[type];
+    icon.setAttribute('aria-hidden', 'true');
+    toast.appendChild(icon);
+
+    /* Body */
+    const body = document.createElement('div');
+    body.className = 'ease-toast__body';
+
+    if (opts.title) {
+      const title = document.createElement('div');
+      title.className   = 'ease-toast__title';
+      title.textContent = opts.title;
+      body.appendChild(title);
+    }
+
+    const msg = document.createElement('div');
+    msg.className   = 'ease-toast__message';
+    msg.textContent = opts.message;
+    body.appendChild(msg);
+    toast.appendChild(body);
+
+    /* Close button */
+    const closeBtn = document.createElement('button');
+    closeBtn.className   = 'ease-toast__close';
+    closeBtn.textContent = '×';
+    closeBtn.setAttribute('aria-label', 'Close notification');
+    closeBtn.addEventListener('click', function () { dismiss(toast); });
+    toast.appendChild(closeBtn);
+
+    /* Progress bar */
+    if (opts.duration > 0) {
+      const progress = document.createElement('div');
+      progress.className = 'ease-toast__progress';
+      progress.style.animationDuration = opts.duration + 'ms';
+      toast.appendChild(progress);
+    }
+
+    container.appendChild(toast);
+
+    if (opts.duration > 0) {
+      setTimeout(function () { dismiss(toast); }, opts.duration);
+    }
+
+    return toast;
+  }
+
+  global.showToast = showToast;
+
+}(typeof window !== 'undefined' ? window : this));


### PR DESCRIPTION
## 🐛 Bug Fixed
Headings (h1–h6) and table headers (th) in `core/base.css` were hardcoded 
to `--ease-color-neutral-900` (#0f172a), which never changes in dark mode — 
making them virtually unreadable on the dark background (#0b1121).

## ✅ Fix
Replaced the hardcoded token with the theme-aware `--ease-color-text`:

- color: var(--ease-color-neutral-900);
+ color: var(--ease-color-text);

`--ease-color-text` already resolves to a light value (#e2e8f0) in dark mode,
so no new tokens or variables were needed — just using the right existing one.

## 📁 Submission
- `submissions/bug-fixes/dark-mode-heading-fix/demo.html` — live Before/After 
   comparison with a dark mode toggle
- `submissions/bug-fixes/dark-mode-heading-fix/style.css` — fix with comments
- `submissions/bug-fixes/dark-mode-heading-fix/README.md` — explanation

## 🧪 Tested
- [x] Light mode — no visual change, headings look identical
- [x] Dark mode via `data-theme="dark"` — headings and th now legible
- [x] Dark mode via `prefers-color-scheme: dark` — same result