### PR TITLE
feat: add motion preset inheritance SCSS utility

### DIFF
--- a/submissions/scss/motion-preset-inheritance-mp/README.md
+++ b/submissions/scss/motion-preset-inheritance-mp/README.md
@@ -1,0 +1,87 @@
+# Motion Preset Inheritance Utility
+
+## What does this do?
+
+A framework-agnostic SCSS utility for defining hierarchical motion presets, where specialized presets can inherit, extend, and override a shared base preset at compile time, eliminating duplicated transition/animation definitions.
+
+## How is it used?
+
+Import the partial, define a base preset, extend it for specific components, then output the resolved CSS with `use-motion-preset`.
+
+```scss
+@import "motion-preset-inheritance";
+
+// 1. Define a base preset
+@include define-motion-preset("base-fade", (
+  transition-property: opacity, transform,
+  transition-duration: 0.3s,
+  transition-timing-function: ease-in-out
+));
+
+// 2. Extend the base preset, overriding only what's needed
+@include extend-motion-preset("base-fade", "card-fade", (
+  transition-duration: 0.5s
+));
+
+// 3. Nested inheritance — extend an already-extended preset
+@include extend-motion-preset("card-fade", "modal-fade", (
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1)
+));
+
+// 4. Output resolved CSS wherever you need it
+.ease-card {
+  @include use-motion-preset("card-fade");
+}
+
+.ease-modal {
+  @include use-motion-preset("modal-fade");
+}
+
+// 5. One-off override without creating a new named preset
+.ease-card--slow {
+  @include use-motion-preset("card-fade", (
+    transition-duration: 1s
+  ));
+}
+```
+
+Compiles to:
+
+```css
+.ease-card {
+  transition-property: opacity, transform;
+  transition-duration: 0.5s;
+  transition-timing-function: ease-in-out;
+}
+
+.ease-modal {
+  transition-property: opacity, transform;
+  transition-duration: 0.5s;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.ease-card--slow {
+  transition-property: opacity, transform;
+  transition-duration: 1s;
+  transition-timing-function: ease-in-out;
+}
+```
+
+### API Reference
+
+| Mixin / Function | Parameters | Description |
+|---|---|---|
+| `define-motion-preset($name, $properties, $extends: null)` | `$name`: preset identifier · `$properties`: map of CSS property => value · `$extends`: (optional) parent preset name, or list of parent names | Registers a new preset, optionally merging in one or more parent presets first |
+| `extend-motion-preset($base-name, $new-name, $overrides: ())` | `$base-name`: preset to inherit from · `$new-name`: new preset identifier · `$overrides`: map of properties to override | Shorthand for creating a new preset that inherits from `$base-name` |
+| `use-motion-preset($name, $overrides: ())` | `$name`: preset to output · `$overrides`: map of properties to override at the call site | Outputs the fully resolved CSS declarations for a preset, without mutating the registry |
+| `motion-preset-get($name)` | `$name`: preset identifier | Function that returns the resolved property map for a preset |
+| `motion-preset-exists($name)` | `$name`: preset identifier | Function that returns `true`/`false` |
+
+## Why is this useful?
+
+EaseMotion CSS already offers reusable motion utilities, but there was no compile-time way to build a *hierarchy* of motion behaviors. Design systems commonly need a base preset (e.g. a standard fade/slide) that specialized components extend and tweak — cards, modals, tooltips, toasts — without redefining the same transition properties over and over. This utility:
+
+- Eliminates duplicated preset definitions across components.
+- Supports unlimited nested inheritance (presets can extend presets that extend presets).
+- Allows per-usage overrides without creating throwaway presets.
+- Is pure SCSS — framework agnostic, no dependency on EaseMotion's core or any other library — and compiles down to plain, reusable CSS.

--- a/submissions/scss/motion-preset-inheritance-mp/_motion-preset-inheritance.scss
+++ b/submissions/scss/motion-preset-inheritance-mp/_motion-preset-inheritance.scss
@@ -1,0 +1,89 @@
+// =============================================================================
+// Motion Preset Inheritance Utility
+// -----------------------------------------------------------------------------
+// A framework-agnostic SCSS utility that lets you define hierarchical motion
+// presets, extend them, override individual properties, and output the fully
+// resolved CSS at compile time. Presets can extend one or more parent presets,
+// and extended presets can themselves be extended, giving unlimited nesting.
+// =============================================================================
+
+// Internal registry. Holds every defined preset as a fully-resolved map of
+// CSS property => value. Not intended to be used directly by consumers.
+$__motion-presets: () !default;
+
+// -----------------------------------------------------------------------------
+// motion-preset-exists($name)
+// Returns true if a preset with the given name has already been defined.
+// -----------------------------------------------------------------------------
+@function motion-preset-exists($name) {
+  @return map-has-key($__motion-presets, $name);
+}
+
+// -----------------------------------------------------------------------------
+// motion-preset-get($name)
+// Returns the fully-resolved property map for a defined preset.
+// Errors at compile time if the preset has not been defined yet.
+// -----------------------------------------------------------------------------
+@function motion-preset-get($name) {
+  @if not motion-preset-exists($name) {
+    @error "Motion preset `#{$name}` does not exist. Define it first using define-motion-preset().";
+  }
+  @return map-get($__motion-presets, $name);
+}
+
+// -----------------------------------------------------------------------------
+// define-motion-preset($name, $properties, $extends: null)
+// Registers a new motion preset.
+//
+// $name       : Unique identifier for the preset (string).
+// $properties : Map of CSS property => value for this preset.
+// $extends    : (optional) Name of a single parent preset, or a list of
+//               parent preset names to merge from (later parents win ties).
+//               Parents must already be defined.
+//
+// The resulting preset is stored fully-resolved, so presets that extend an
+// already-extended preset automatically inherit the entire chain.
+// -----------------------------------------------------------------------------
+@mixin define-motion-preset($name, $properties: (), $extends: null) {
+  $resolved: ();
+
+  @if $extends != null {
+    @if type-of($extends) == "list" {
+      @each $parent in $extends {
+        $resolved: map-merge($resolved, motion-preset-get($parent));
+      }
+    } @else {
+      $resolved: map-merge($resolved, motion-preset-get($extends));
+    }
+  }
+
+  $resolved: map-merge($resolved, $properties);
+
+  $__motion-presets: map-merge($__motion-presets, ($name: $resolved)) !global;
+}
+
+// -----------------------------------------------------------------------------
+// extend-motion-preset($base-name, $new-name, $overrides: ())
+// Convenience mixin for creating a new named preset that inherits everything
+// from $base-name, with $overrides layered on top. Equivalent to calling
+// define-motion-preset($new-name, $overrides, $extends: $base-name).
+// Because the new preset is stored fully-resolved, it can be extended again,
+// supporting unlimited nested inheritance chains.
+// -----------------------------------------------------------------------------
+@mixin extend-motion-preset($base-name, $new-name, $overrides: ()) {
+  @include define-motion-preset($new-name, $overrides, $extends: $base-name);
+}
+
+// -----------------------------------------------------------------------------
+// use-motion-preset($name, $overrides: ())
+// Outputs the resolved CSS declarations for a preset. Optional $overrides
+// are applied on top of the stored preset without mutating the registry,
+// letting you tweak a preset per-usage without creating a new named preset.
+// -----------------------------------------------------------------------------
+@mixin use-motion-preset($name, $overrides: ()) {
+  $final: map-merge(motion-preset-get($name), $overrides);
+
+  @each $property, $value in $final {
+    #{$property}: #{$value};
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a framework-agnostic SCSS utility (`_motion-preset-inheritance.scss`) that lets developers define hierarchical motion presets, extend a base preset for specialized components, override individual properties, and compile everything to reusable CSS. Solves duplicated transition/animation definitions across related components (e.g. card → modal → tooltip all sharing a base fade).

Closes #37063

---
## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (describe below)

**Other:** New SCSS utility submission (per the SCSS Integration track in CONTRIBUTING.md), not an HTML/CSS example.

---
## Submission Checklist
- [x] All changes are inside `submissions/` — specifically `submissions/scss/motion-preset-inheritance-mp/`
- [ ] Includes `demo.html` — **N/A**: this is an SCSS-track submission, which requires `_your-mixin.scss` + `README.md` only, no `demo.html`
- [ ] Includes `style.css` — **N/A** for the same reason; see `_motion-preset-inheritance.scss` instead
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A compile-time SCSS mixin system for defining, extending, and overriding hierarchical motion presets, so specialized component presets can inherit from a shared base without duplicating transition/animation properties.

**How does a developer use it?**
```scss
@import "motion-preset-inheritance";

@include define-motion-preset("base-fade", (
  transition-property: opacity, transform,
  transition-duration: 0.3s
));

@include extend-motion-preset("base-fade", "card-fade", (
  transition-duration: 0.5s
));

.ease-card {
  @include use-motion-preset("card-fade");
}
```

**Why does it fit EaseMotion CSS?**
It extends EaseMotion's animation-first philosophy into the SCSS layer: instead of hand-copying transition properties between related components, developers declare intent once and inherit/override cleanly, keeping motion definitions human-readable and DRY while still compiling to plain, framework-agnostic CSS.

---
## Demo
- [ ] Demo added (`demo.html` works by opening directly in a browser) — **N/A**, SCSS-track submissions don't include a `demo.html`; usage is demonstrated via SCSS code samples in the README.

---
## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

N/A — this is a compile-time SCSS utility with no runtime browser-specific behavior; it produces plain CSS output that inherits whatever browser support the consuming project already targets.

---
## Notes for Maintainer
This follows the SCSS Integration track (`submissions/scss/`), so only `_motion-preset-inheritance.scss` and `README.md` are included, per CONTRIBUTING.md — the demo.html/style.css/browser-testing sections above are marked N/A rather than left silently unchecked. Happy to add a companion `demo.html` if you'd prefer visual verification alongside the SCSS output.

---
> **Reminder:** Only the repository maintainer may merge pull requests.