### PR TITLE
feat: add motion recipe composer SCSS utility

### DIFF
--- a/submissions/scss/motion-recipe-composer-mp/README.md
+++ b/submissions/scss/motion-recipe-composer-mp/README.md
@@ -1,0 +1,86 @@
+# Motion Recipe Composer
+
+## What does this do?
+
+A framework-agnostic SCSS utility for declaratively defining reusable "motion recipes" — named combinations of animation steps with their own duration, delay, easing, and fill-mode — then composing recipes together and outputting a single resolved `animation` shorthand at compile time.
+
+## How is it used?
+
+Define your `@keyframes` as usual, define recipes referencing them, optionally compose multiple recipes into a new one, then apply a recipe to any selector.
+
+```scss
+@import "motion-recipe-composer";
+
+// Your own keyframes — this utility stays framework agnostic
+@keyframes fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes slide-up {
+  from { transform: translateY(12px); }
+  to   { transform: translateY(0); }
+}
+
+// 1. Define individual recipes
+@include define-motion-recipe("fade-in", (
+  (name: fade-in, duration: 0.25s, easing: ease-out)
+));
+
+@include define-motion-recipe("slide-up", (
+  (name: slide-up, duration: 0.3s, delay: 0.05s, easing: ease-out)
+));
+
+// 2. Compose them into a single interaction pattern
+@include compose-motion-recipe("toast-enter", ("fade-in", "slide-up"));
+
+// 3. Apply the composed recipe
+.ease-toast {
+  @include use-motion-recipe("toast-enter");
+}
+
+// 4. Apply with a global override (e.g. a faster variant)
+.ease-toast--fast {
+  @include use-motion-recipe("toast-enter", (duration: 0.15s));
+}
+
+// 5. Apply with a per-step override (only tweak the 2nd step's delay)
+.ease-toast--delayed-slide {
+  @include use-motion-recipe("toast-enter", (), (2: (delay: 0.2s)));
+}
+```
+
+Compiles to:
+
+```css
+.ease-toast {
+  animation: fade-in 0.25s ease-out 0s both, slide-up 0.3s ease-out 0.05s both;
+}
+
+.ease-toast--fast {
+  animation: fade-in 0.15s ease-out 0s both, slide-up 0.15s ease-out 0s both;
+}
+
+.ease-toast--delayed-slide {
+  animation: fade-in 0.25s ease-out 0s both, slide-up 0.3s ease-out 0.2s both;
+}
+```
+
+### API Reference
+
+| Mixin / Function | Parameters | Description |
+|---|---|---|
+| `define-motion-recipe($name, $steps)` | `$name`: recipe identifier · `$steps`: list of step maps (`name`, `duration`, `delay`, `easing`, `fill-mode` — only `name` is required, the rest default sensibly) | Registers a named recipe made of one or more animation steps |
+| `compose-motion-recipe($new-name, $recipe-names, $overrides: ())` | `$new-name`: identifier for the new recipe · `$recipe-names`: list of existing recipe names to concatenate, in order · `$overrides`: (optional) map applied to every combined step | Builds a new recipe by combining the steps of existing recipes |
+| `use-motion-recipe($name, $overrides: (), $step-overrides: ())` | `$name`: recipe to output · `$overrides`: (optional) map applied to all steps at the call site · `$step-overrides`: (optional) map of 1-based step index => override map | Outputs a resolved `animation` shorthand declaration for the recipe |
+| `motion-recipe-get($name)` | `$name`: recipe identifier | Function that returns the resolved list of step maps for a recipe |
+| `motion-recipe-exists($name)` | `$name`: recipe identifier | Function that returns `true`/`false` |
+
+## Why is this useful?
+
+EaseMotion CSS already provides individual motion utilities, but common UI patterns like toasts, modals, drawers, and notifications are usually built from several coordinated animation steps played together — and developers end up hand-copying the same duration/delay/easing combinations across components. The Motion Recipe Composer:
+
+- Turns a full interaction pattern into a single named, reusable recipe.
+- Lets recipes be composed from smaller recipes instead of duplicated (e.g. `toast-enter` built from `fade-in` + `slide-up`).
+- Supports both global overrides (fast/slow variants) and per-step overrides (tweak just one part of the sequence) without redefining the whole recipe.
+- Is pure SCSS — framework agnostic, no dependency on EaseMotion's core or any other library — and compiles to a plain, reusable `animation` declaration.

--- a/submissions/scss/motion-recipe-composer-mp/_motion-recipe-composer.scss
+++ b/submissions/scss/motion-recipe-composer-mp/_motion-recipe-composer.scss
@@ -1,0 +1,138 @@
+// =============================================================================
+// Motion Recipe Composer
+// -----------------------------------------------------------------------------
+// A framework-agnostic SCSS utility for declaratively defining "recipes" —
+// named combinations of one or more animation steps (name, duration, delay,
+// easing, fill-mode) — then composing recipes together and outputting a
+// single resolved `animation` shorthand declaration at compile time.
+//
+// This utility does not generate @keyframes for you; it composes references
+// to keyframes you already define, so it stays fully framework agnostic.
+// =============================================================================
+
+// Internal registry. Holds every defined recipe as a list of resolved step
+// maps. Not intended to be used directly by consumers.
+$__motion-recipes: () !default;
+
+// -----------------------------------------------------------------------------
+// motion-recipe-exists($name)
+// Returns true if a recipe with the given name has already been defined.
+// -----------------------------------------------------------------------------
+@function motion-recipe-exists($name) {
+  @return map-has-key($__motion-recipes, $name);
+}
+
+// -----------------------------------------------------------------------------
+// motion-recipe-get($name)
+// Returns the resolved list of step maps for a defined recipe.
+// Errors at compile time if the recipe has not been defined yet.
+// -----------------------------------------------------------------------------
+@function motion-recipe-get($name) {
+  @if not motion-recipe-exists($name) {
+    @error "Motion recipe `#{$name}` does not exist. Define it first using define-motion-recipe().";
+  }
+  @return map-get($__motion-recipes, $name);
+}
+
+// -----------------------------------------------------------------------------
+// _motion-step-defaults($step)
+// Internal helper. Fills in sane defaults for any keys missing from a step.
+// -----------------------------------------------------------------------------
+@function _motion-step-defaults($step) {
+  @return map-merge((
+    name: null,
+    duration: 0.3s,
+    delay: 0s,
+    easing: ease,
+    fill-mode: both
+  ), $step);
+}
+
+// -----------------------------------------------------------------------------
+// define-motion-recipe($name, $steps)
+// Registers a new named recipe.
+//
+// $name  : Unique identifier for the recipe (string).
+// $steps : List of step maps. Each step map may define:
+//            name       - keyframes name to reference (required)
+//            duration   - default 0.3s
+//            delay      - default 0s
+//            easing     - default ease
+//            fill-mode  - default both
+// -----------------------------------------------------------------------------
+@mixin define-motion-recipe($name, $steps) {
+  $resolved-steps: ();
+
+  @each $step in $steps {
+    $resolved-steps: append($resolved-steps, _motion-step-defaults($step));
+  }
+
+  $__motion-recipes: map-merge($__motion-recipes, ($name: $resolved-steps)) !global;
+}
+
+// -----------------------------------------------------------------------------
+// compose-motion-recipe($new-name, $recipe-names, $overrides: ())
+// Creates a new recipe by concatenating the steps of one or more existing
+// recipes, in order. Useful for building complex interaction patterns
+// (e.g. a "toast" recipe composed of a "fade-in" recipe and a "slide-up"
+// recipe) without redefining steps.
+//
+// $new-name     : Identifier for the composed recipe.
+// $recipe-names : List of previously-defined recipe names, in play order.
+// $overrides    : (optional) Map applied on top of every combined step,
+//                 e.g. to unify duration/easing across the composed recipe.
+// -----------------------------------------------------------------------------
+@mixin compose-motion-recipe($new-name, $recipe-names, $overrides: ()) {
+  $combined: ();
+
+  @each $recipe-name in $recipe-names {
+    $combined: join($combined, motion-recipe-get($recipe-name));
+  }
+
+  @if length($overrides) > 0 {
+    $overridden: ();
+    @each $step in $combined {
+      $overridden: append($overridden, map-merge($step, $overrides));
+    }
+    $combined: $overridden;
+  }
+
+  $__motion-recipes: map-merge($__motion-recipes, ($new-name: $combined)) !global;
+}
+
+// -----------------------------------------------------------------------------
+// use-motion-recipe($name, $overrides: (), $step-overrides: ())
+// Outputs a single `animation` shorthand declaration combining every step
+// of the recipe as a comma-separated animation list.
+//
+// $name           : Recipe to output.
+// $overrides      : (optional) Map applied to every step at the call site
+//                   (e.g. speed up every step for a "fast" variant) without
+//                   mutating the registry.
+// $step-overrides : (optional) Map of 1-based step index => override map,
+//                   for tweaking a single step (e.g. only the 2nd step's
+//                   delay) without affecting the others.
+// -----------------------------------------------------------------------------
+@mixin use-motion-recipe($name, $overrides: (), $step-overrides: ()) {
+  $steps: motion-recipe-get($name);
+  $animation-list: ();
+  $index: 1;
+
+  @each $step in $steps {
+    $merged: map-merge($step, $overrides);
+
+    @if map-has-key($step-overrides, $index) {
+      $merged: map-merge($merged, map-get($step-overrides, $index));
+    }
+
+    $animation-list: append(
+      $animation-list,
+      map-get($merged, name) map-get($merged, duration) map-get($merged, easing) map-get($merged, delay) map-get($merged, fill-mode),
+      comma
+    );
+
+    $index: $index + 1;
+  }
+
+  animation: #{$animation-list};
+}


### PR DESCRIPTION
## Pull Request Description
Adds a framework-agnostic SCSS utility (`_motion-recipe-composer.scss`) for declaratively defining reusable "motion recipes" — combinations of animation steps with their own duration/delay/easing — and composing them into complete interaction patterns (toasts, modals, drawers, notifications) that compile to a single `animation` shorthand.

Closes #37062

---
## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (describe below)

**Other:** New SCSS utility submission (SCSS Integration track per CONTRIBUTING.md), not an HTML/CSS example.

---
## Submission Checklist
- [x] All changes are inside `submissions/` — specifically `submissions/scss/motion-recipe-composer-mp/`
- [ ] Includes `demo.html` — **N/A**: SCSS-track submissions require `_your-mixin.scss` + `README.md` only
- [ ] Includes `style.css` — **N/A** for the same reason; see `_motion-recipe-composer.scss`
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A compile-time SCSS system for defining named "motion recipes" (sequences of animation steps), composing recipes from other recipes, and outputting a resolved `animation` shorthand with support for global and per-step overrides.

**How does a developer use it?**
```scss
@include define-motion-recipe("fade-in", ((name: fade-in, duration: 0.25s)));
@include define-motion-recipe("slide-up", ((name: slide-up, duration: 0.3s)));
@include compose-motion-recipe("toast-enter", ("fade-in", "slide-up"));

.ease-toast {
  @include use-motion-recipe("toast-enter");
}
```

**Why does it fit EaseMotion CSS?**
Real UI patterns (toasts, modals, drawers) are rarely single animations — they're combinations developers currently hand-assemble and duplicate per component. This utility turns that combination into a declarative, named, reusable recipe, extending EaseMotion's animation-first philosophy while staying framework agnostic and compiling to plain CSS.

---
## Demo
- [ ] Demo added — **N/A**, SCSS-track submissions demonstrate usage via SCSS/CSS code samples in the README instead of `demo.html`.

---
## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

N/A — compile-time SCSS utility producing plain CSS `animation` declarations; no runtime browser-specific behavior of its own.

---
## Notes for Maintainer
Follows the SCSS Integration track (`submissions/scss/`) per CONTRIBUTING.md, so only `_motion-recipe-composer.scss` and `README.md` are included — demo/browser-testing sections above are marked N/A rather than left silently unchecked.

---
> **Reminder:** Only the repository maintainer may merge pull requests.