### PR TITLE
feat: add isolated code snippet copy utility #36953

### DIFF
--- a/submissions/examples/copy-code-button/README.md
+++ b/submissions/examples/copy-code-button/README.md
@@ -1,0 +1,8 @@
+# Copy Code Button Utility
+
+A lightweight, composable utility enhancement for EaseMotion CSS documentation and code snippets. It allows developers to quickly copy code blocks with a single click.
+
+## Features
+- Minimalist clipboard integration using standard `navigator.clipboard`.
+- Visual feedback state change (📋 -> ✅).
+- Absolute-positioned, sleek overlay design that doesn't disrupt text layouts.

--- a/submissions/examples/copy-code-button/demo.html
+++ b/submissions/examples/copy-code-button/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Copy Code Button Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="code-container">
+        <button class="copy-btn" onclick="copyCode(this)">📋</button>
+        <pre><code>.ease-motion-fade {
+    opacity: 0;
+    transition: opacity 0.3s ease-in-out;
+}
+.ease-motion-fade:hover {
+    opacity: 1;
+}</code></pre>
+    </div>
+
+    <script>
+        function copyCode(button) {
+            const container = button.closest('.code-container');
+            const codeElement = container.querySelector('code');
+            if (!codeElement) return;
+
+            navigator.clipboard.writeText(codeElement.innerText).then(() => {
+                button.textContent = "✅";
+                setTimeout(() => { button.textContent = "📋"; }, 1500);
+            });
+        }
+    </script>
+</body>
+</html>

--- a/submissions/examples/copy-code-button/style.css
+++ b/submissions/examples/copy-code-button/style.css
@@ -1,0 +1,34 @@
+/* Container styling */
+.code-container {
+    position: relative;
+    background: #1e1e1e;
+    color: #fff;
+    border-radius: 8px;
+    padding: 1.5rem 1rem 1rem 1rem; /* Added top padding so button doesn't overlap text */
+    overflow: auto;
+    font-family: 'Courier New', Courier, monospace;
+    max-width: 500px;
+    margin: 20px auto;
+}
+
+/* Button styling */
+.copy-btn {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    border: none;
+    background: #2d2d2d;
+    font-size: 14px;
+    padding: 6px 10px;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.1s ease;
+}
+
+.copy-btn:hover {
+    background: #444;
+}
+
+.copy-btn:active {
+    transform: scale(0.95);
+}


### PR DESCRIPTION
## Description
This PR resolves #36953 by introducing a clean, isolated code snippet copy utility. It allows users to quickly copy code blocks with a single click, boosting developer experience across documentation and example structures.

### Key Enhancements:
- **Resilient DOM Queries:** Replaced the fragile `.nextElementSibling` selector with a robust `.closest('.code-container')` utility lookup pattern to guarantee the clipboard script handles layout variations seamlessly.
- **Immediate UI Feedback:** Implements a user-friendly toggle (`📋` -> `✅`) with a 1.5-second reset transition.
- **Styling Overlay:** Features an absolute-positioned dark theme icon button that overlays cleanly without text shifting.

## File Allocation
All code adjustments are strictly grouped and isolated inside the requested GSSoC 2026 directory:
- `submissions/examples/copy-code-button/demo.html`
- `submissions/examples/copy-code-button/style.css`
- `submissions/examples/copy-code-button/README.md`

## Checklist
- [x] My code follows the contribution guidelines of this project.
- [x] All file modifications are contained entirely inside the `submissions/` folder.
- [x] No base project or framework configuration files were altered.
- [x] Verified code copy mechanics inside a local sandbox browser environment.