### PR TITLE
feat: add motion namespace generator SCSS utility

### DIFF
--- a/submissions/scss/motion-namespace-generator-mp/README.md
+++ b/submissions/scss/motion-namespace-generator-mp/README.md
@@ -1,0 +1,90 @@
+# Motion Namespace Generator
+
+## What does this do?
+
+A framework-agnostic SCSS utility that automatically generates consistent, collision-safe namespaces for motion selectors and `@keyframes` from a single configurable prefix, so growing motion libraries and design systems don't end up with duplicated or clashing names.
+
+## How is it used?
+
+Optionally set a custom prefix, then use the provided mixins to generate namespaced selectors and keyframes instead of writing raw class/keyframe names by hand.
+
+```scss
+@import "motion-namespace-generator";
+
+// Optional: change the prefix (defaults to "ease")
+@include set-motion-namespace("ease");
+
+// 1. Generate a namespaced @keyframes block
+@include motion-keyframes("fade") {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+// 2. Generate a namespaced selector that uses it
+@include motion-selector("fade") {
+  animation-name: use-motion-keyframe-name("fade");
+  animation-duration: 0.3s;
+}
+
+// 3. Generate a namespaced modifier/variant selector
+@include motion-modifier-selector("fade", "slow") {
+  animation-duration: 1s;
+}
+
+// 4. Get a raw namespaced string without creating a rule
+.my-custom-wrapper {
+  --motion-token: #{motion-namespace("fade")};
+}
+```
+
+Compiles to:
+
+```css
+@keyframes ease-fade-kf {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.ease-fade {
+  animation-name: ease-fade-kf;
+  animation-duration: 0.3s;
+}
+
+.ease-fade--slow {
+  animation-duration: 1s;
+}
+
+.my-custom-wrapper {
+  --motion-token: ease-fade;
+}
+```
+
+If you try to generate the same selector or keyframe namespace twice, compilation fails immediately with a clear error, catching collisions before they ship:
+
+```scss
+@include motion-selector("fade") { opacity: 1; }
+@include motion-selector("fade") { opacity: 0; }
+// Error: Motion namespace collision: `ease-fade` has already been generated.
+```
+
+### API Reference
+
+| Mixin / Function | Parameters | Description |
+|---|---|---|
+| `set-motion-namespace($prefix)` | `$prefix`: new global prefix string | Mixin. Changes the prefix used by every namespace generated afterward |
+| `motion-namespace($name, $separator: "-")` | `$name`: base name · `$separator`: joining character | Function. Returns a namespaced string (e.g. `ease-fade`) without registering it |
+| `motion-modifier-namespace($name, $modifier, $separator: "-")` | `$name`, `$modifier`, `$separator` | Function. Returns a namespaced modifier string (e.g. `ease-fade--slow`) |
+| `motion-keyframe-namespace($name, $separator: "-")` | `$name`, `$separator` | Function. Returns a namespaced keyframe-reserved string (e.g. `ease-fade-kf`) |
+| `motion-selector($name, $separator: "-")` | `$name`, `$separator` | Mixin. Generates, registers, and outputs a namespaced class selector with the given content |
+| `motion-modifier-selector($name, $modifier, $separator: "-")` | `$name`, `$modifier`, `$separator` | Mixin. Generates, registers, and outputs a namespaced modifier selector |
+| `motion-keyframes($name, $separator: "-")` | `$name`, `$separator` | Mixin. Generates, registers, and outputs a namespaced `@keyframes` block |
+| `use-motion-keyframe-name($name, $separator: "-")` | `$name`, `$separator` | Function. Returns a previously-registered keyframe's namespaced name, for use in `animation-name`, without re-registering it |
+
+## Why is this useful?
+
+As EaseMotion CSS and consuming design systems grow, developers commonly hand-invent naming conventions to avoid clashing animation and selector names — leading to duplicated prefixes and inconsistent APIs across a codebase. The Motion Namespace Generator:
+
+- Generates every selector and keyframe name from one configurable source of truth, so the prefix only needs to be decided once.
+- Catches naming collisions at **compile time** with a clear error, instead of silently overwriting an existing animation.
+- Keeps selector and keyframe namespaces distinct (`ease-fade` vs. `ease-fade-kf`) so the same base name can be reused safely across both.
+- Is pure SCSS — framework agnostic, no dependency on EaseMotion's core or any other library — and compiles to plain, predictable CSS class names and keyframe names.

--- a/submissions/scss/motion-namespace-generator-mp/_motion-namespace-generator.scss
+++ b/submissions/scss/motion-namespace-generator-mp/_motion-namespace-generator.scss
@@ -1,0 +1,130 @@
+// =============================================================================
+// Motion Namespace Generator
+// -----------------------------------------------------------------------------
+// A framework-agnostic SCSS utility that generates consistent, collision-safe
+// namespaces for animation selectors and @keyframes from a single
+// configurable prefix. Prevents naming collisions as a motion library or
+// design system grows, without hand-maintaining prefix conventions.
+// =============================================================================
+
+// Global prefix used for every generated namespace. Change it with
+// set-motion-namespace() rather than reassigning directly.
+$__motion-namespace-prefix: "ease" !default;
+
+// Internal registry of every namespace generated so far, used to detect
+// accidental collisions at compile time.
+$__motion-namespace-registry: () !default;
+
+// -----------------------------------------------------------------------------
+// set-motion-namespace($prefix)
+// Sets the global prefix used by all namespace generation going forward.
+// Call this once near the top of your stylesheet, before defining selectors
+// or keyframes, if you want something other than the "ease" default.
+// -----------------------------------------------------------------------------
+@mixin set-motion-namespace($prefix) {
+  $__motion-namespace-prefix: $prefix !global;
+}
+
+// -----------------------------------------------------------------------------
+// motion-namespace($name, $separator: "-")
+// Returns a namespaced string for a selector/utility name, without
+// registering it. Useful when you just need the string (e.g. to reference
+// it elsewhere) without creating a rule.
+// -----------------------------------------------------------------------------
+@function motion-namespace($name, $separator: "-") {
+  @return $__motion-namespace-prefix + $separator + $name;
+}
+
+// -----------------------------------------------------------------------------
+// motion-modifier-namespace($name, $modifier, $separator: "-")
+// Returns a namespaced string for a modifier/variant of a base name,
+// following a BEM-style double-dash convention, e.g. "ease-fade--slow".
+// -----------------------------------------------------------------------------
+@function motion-modifier-namespace($name, $modifier, $separator: "-") {
+  @return motion-namespace($name, $separator) + "--" + $modifier;
+}
+
+// -----------------------------------------------------------------------------
+// motion-keyframe-namespace($name, $separator: "-")
+// Returns a namespaced string reserved for @keyframes names, e.g.
+// "ease-fade-kf". Kept distinct from selector namespaces so a keyframe and
+// a selector can share the same base $name without colliding.
+// -----------------------------------------------------------------------------
+@function motion-keyframe-namespace($name, $separator: "-") {
+  @return motion-namespace($name, $separator) + $separator + "kf";
+}
+
+// -----------------------------------------------------------------------------
+// _motion-register($namespace)
+// Internal helper. Registers a generated namespace and errors at compile
+// time if it has already been used, preventing silent collisions.
+// -----------------------------------------------------------------------------
+@function _motion-register($namespace) {
+  @if index($__motion-namespace-registry, $namespace) {
+    @error "Motion namespace collision: `#{$namespace}` has already been generated. Choose a different name, modifier, or prefix.";
+  }
+  $__motion-namespace-registry: append($__motion-namespace-registry, $namespace) !global;
+  @return $namespace;
+}
+
+// -----------------------------------------------------------------------------
+// motion-selector($name, $separator: "-")
+// Generates and registers a namespaced class selector, then yields its
+// content block inside that selector.
+//
+//   @include motion-selector("fade") { opacity: 1; }
+//   -> .ease-fade { opacity: 1; }
+// -----------------------------------------------------------------------------
+@mixin motion-selector($name, $separator: "-") {
+  $namespace: _motion-register(motion-namespace($name, $separator));
+
+  .#{$namespace} {
+    @content;
+  }
+}
+
+// -----------------------------------------------------------------------------
+// motion-modifier-selector($name, $modifier, $separator: "-")
+// Generates and registers a namespaced modifier selector.
+//
+//   @include motion-modifier-selector("fade", "slow") { animation-duration: 1s; }
+//   -> .ease-fade--slow { animation-duration: 1s; }
+// -----------------------------------------------------------------------------
+@mixin motion-modifier-selector($name, $modifier, $separator: "-") {
+  $namespace: _motion-register(motion-modifier-namespace($name, $modifier, $separator));
+
+  .#{$namespace} {
+    @content;
+  }
+}
+
+// -----------------------------------------------------------------------------
+// motion-keyframes($name, $separator: "-")
+// Generates and registers a namespaced @keyframes block, then yields its
+// content block inside that @keyframes rule.
+//
+//   @include motion-keyframes("fade") {
+//     from { opacity: 0; }
+//     to   { opacity: 1; }
+//   }
+//   -> @keyframes ease-fade-kf { from { opacity: 0; } to { opacity: 1; } }
+// -----------------------------------------------------------------------------
+@mixin motion-keyframes($name, $separator: "-") {
+  $namespace: _motion-register(motion-keyframe-namespace($name, $separator));
+
+  @keyframes #{$namespace} {
+    @content;
+  }
+}
+
+// -----------------------------------------------------------------------------
+// use-motion-keyframe-name($name, $separator: "-")
+// Returns the namespaced keyframe name for use in an `animation-name` or
+// `animation` declaration, WITHOUT registering it again. Use this to
+// reference a keyframe previously defined with motion-keyframes().
+//
+//   .ease-toast { animation-name: use-motion-keyframe-name("fade"); }
+// -----------------------------------------------------------------------------
+@function use-motion-keyframe-name($name, $separator: "-") {
+  @return motion-keyframe-namespace($name, $separator);
+}


### PR DESCRIPTION
## Pull Request Description
Adds a framework-agnostic SCSS utility (`_motion-namespace-generator.scss`) that generates consistent, collision-safe namespaces for motion selectors and `@keyframes` from a single configurable prefix, catching naming collisions at compile time.

Closes #37056

---
## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (describe below)

**Other:** New SCSS utility submission (SCSS Integration track per CONTRIBUTING.md), not an HTML/CSS example.

---
## Submission Checklist
- [x] All changes are inside `submissions/` — specifically `submissions/scss/motion-namespace-generator-mp/`
- [ ] Includes `demo.html` — **N/A**: SCSS-track submissions require `_your-mixin.scss` + `README.md` only
- [ ] Includes `style.css` — **N/A** for the same reason; see `_motion-namespace-generator.scss`
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A compile-time SCSS system that generates namespaced class selectors and `@keyframes` names from a single configurable prefix, and errors at compile time if a namespace is generated twice.

**How does a developer use it?**
```scss
@include motion-keyframes("fade") {
  from { opacity: 0; } to { opacity: 1; }
}

.ease-fade {
  @include motion-selector("fade") {
    animation-name: use-motion-keyframe-name("fade");
  }
}
```

**Why does it fit EaseMotion CSS?**
As the framework and consuming design systems grow, hand-maintained naming conventions inevitably drift and collide. This utility generates every selector/keyframe name from one source of truth and fails fast on collisions, keeping EaseMotion's `ease-*` naming consistent and scalable while staying framework agnostic and compiling to plain CSS.

---
## Demo
- [ ] Demo added — **N/A**, SCSS-track submissions demonstrate usage via SCSS/CSS code samples in the README instead of `demo.html`.

---
## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

N/A — compile-time SCSS utility producing plain CSS class/keyframe names; no runtime browser-specific behavior of its own.

---
## Notes for Maintainer
Follows the SCSS Integration track (`submissions/scss/`) per CONTRIBUTING.md, so only `_motion-namespace-generator.scss` and `README.md` are included — demo/browser-testing sections above are marked N/A rather than left silently unchecked.

---
> **Reminder:** Only the repository maintainer may merge pull requests.