### PR TITLE
feat: add-ease-order-summary-slide #36860

### DIFF
--- a/submissions/examples/ease-order-summary-slide/README.md
+++ b/submissions/examples/ease-order-summary-slide/README.md
@@ -1,0 +1,17 @@
+# ease-order-summary-slide
+
+## What this is
+A CSS-only order summary slide with expandable details.
+
+## Why
+It gives checkout and receipt-style layouts a cleaner, more dynamic way to reveal pricing details while staying lightweight and reusable.
+
+## How to test
+1. Open `demo.html` in a browser.
+2. Confirm the summary section slides into view.
+3. Open and close the details section.
+4. Check that the layout stays readable on smaller screens.
+5. Update the CSS custom properties and confirm the component still looks correct.
+
+## Note
+This is a visual demo component and uses only HTML and CSS, so no JavaScript is needed.

--- a/submissions/examples/ease-order-summary-slide/demo.html
+++ b/submissions/examples/ease-order-summary-slide/demo.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-order-summary-slide</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page-shell">
+    <section class="hero">
+      <p class="eyebrow">EaseMotion CSS · CSS Animation</p>
+      <h1>ease-order-summary-slide</h1>
+      <p class="hero-copy">A CSS-only order summary slide with expandable details.</p>
+    </section>
+
+    <section class="demo-panel">
+      <div class="demo-header">
+        <h2>Interactive Demo</h2>
+        <span class="status-pill">Slide + expand</span>
+      </div>
+
+      <article class="summary-card" aria-label="Order summary">
+        <div class="summary-top">
+          <div>
+            <p class="card-kicker">Order summary</p>
+            <h3>Checkout complete</h3>
+          </div>
+          <div class="summary-total">
+            <span>Total</span>
+            <strong>$248.90</strong>
+          </div>
+        </div>
+
+        <div class="summary-slide">
+          <div class="summary-row">
+            <span>Items</span>
+            <strong>3 products</strong>
+          </div>
+          <div class="summary-row">
+            <span>Shipping</span>
+            <strong>Express</strong>
+          </div>
+          <div class="summary-row">
+            <span>Discount</span>
+            <strong>-$18.00</strong>
+          </div>
+        </div>
+
+        <details class="summary-details" open>
+          <summary>View order details</summary>
+          <div class="details-panel">
+            <div class="details-item">
+              <span class="label">Product A</span>
+              <strong>$99.00</strong>
+            </div>
+            <div class="details-item">
+              <span class="label">Product B</span>
+              <strong>$79.90</strong>
+            </div>
+            <div class="details-item">
+              <span class="label">Product C</span>
+              <strong>$88.00</strong>
+            </div>
+          </div>
+        </details>
+
+        <div class="card-footer">
+          <span class="footer-note">Delivered to your saved address</span>
+          <a href="#" class="card-action">Track order</a>
+        </div>
+      </article>
+
+      <div class="preview-note">
+        The summary slides in and the detail section can be expanded or collapsed.
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-order-summary-slide/style.css
+++ b/submissions/examples/ease-order-summary-slide/style.css
@@ -1,0 +1,280 @@
+:root {
+  --ease-summary-bg: #0b1020;
+  --ease-summary-surface: rgba(15, 23, 42, 0.9);
+  --ease-summary-surface-2: rgba(255, 255, 255, 0.05);
+  --ease-summary-border: rgba(255, 255, 255, 0.1);
+  --ease-summary-text: #e8ecf4;
+  --ease-summary-muted: rgba(232, 236, 244, 0.72);
+  --ease-summary-accent: #7c6cff;
+  --ease-summary-accent-2: #22c55e;
+  --ease-summary-radius: 24px;
+  --ease-summary-speed: 520ms;
+  --ease-summary-ease: cubic-bezier(.4, 0, .2, 1);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at top, rgba(124, 108, 255, 0.22), transparent 36%),
+    linear-gradient(180deg, #0b1020 0%, #060915 100%);
+  color: var(--ease-summary-text);
+}
+
+.page-shell {
+  width: min(1100px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 40px 0 72px;
+}
+
+.hero {
+  padding: 28px 0 34px;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: #b6abff;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.4rem, 5vw, 4.25rem);
+  line-height: 0.95;
+}
+
+.hero-copy {
+  max-width: 640px;
+  margin: 16px 0 0;
+  color: var(--ease-summary-muted);
+  line-height: 1.65;
+  font-size: 1.02rem;
+}
+
+.demo-panel {
+  padding: 28px;
+  background: linear-gradient(180deg, rgba(255,255,255,0.06), rgba(255,255,255,0.03));
+  border: 1px solid var(--ease-summary-border);
+  border-radius: calc(var(--ease-summary-radius) + 6px);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.36);
+  backdrop-filter: blur(14px);
+}
+
+.demo-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.demo-header h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(124, 108, 255, 0.16);
+  color: #dccfff;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.summary-card {
+  padding: 26px;
+  border-radius: var(--ease-summary-radius);
+  background: var(--ease-summary-surface);
+  border: 1px solid var(--ease-summary-border);
+  overflow: hidden;
+}
+
+.summary-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.card-kicker {
+  margin: 0 0 8px;
+  color: #b6abff;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.summary-top h3 {
+  margin: 0;
+  font-size: clamp(1.4rem, 2.4vw, 2rem);
+}
+
+.summary-total {
+  text-align: right;
+}
+
+.summary-total span {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--ease-summary-muted);
+  font-size: 0.84rem;
+}
+
+.summary-total strong {
+  font-size: 1.8rem;
+}
+
+.summary-slide {
+  margin-top: 18px;
+  padding: 18px;
+  border-radius: 18px;
+  background: var(--ease-summary-surface-2);
+  border: 1px solid var(--ease-summary-border);
+  animation: ease-summary-slidein var(--ease-summary-speed) var(--ease-summary-ease) both;
+}
+
+.summary-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 0;
+  border-bottom: 1px solid rgba(255,255,255,0.08);
+}
+
+.summary-row:last-child {
+  border-bottom: 0;
+  padding-bottom: 0;
+}
+
+.summary-row span {
+  color: var(--ease-summary-muted);
+}
+
+.summary-details {
+  margin-top: 18px;
+  border-radius: 18px;
+  border: 1px solid var(--ease-summary-border);
+  background: rgba(255, 255, 255, 0.03);
+  overflow: hidden;
+}
+
+.summary-details summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 16px 18px;
+  font-weight: 800;
+  color: var(--ease-summary-text);
+  position: relative;
+}
+
+.summary-details summary::-webkit-details-marker {
+  display: none;
+}
+
+.summary-details summary::after {
+  content: "›";
+  position: absolute;
+  right: 18px;
+  top: 50%;
+  transform: translateY(-50%) rotate(90deg);
+  color: var(--ease-summary-accent);
+  transition: transform var(--ease-summary-speed) var(--ease-summary-ease);
+}
+
+.summary-details[open] summary::after {
+  transform: translateY(-50%) rotate(270deg);
+}
+
+.details-panel {
+  padding: 0 18px 18px;
+  animation: ease-summary-expand 360ms var(--ease-summary-ease) both;
+}
+
+.details-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 0;
+  border-top: 1px solid rgba(255,255,255,0.08);
+}
+
+.details-item .label {
+  color: var(--ease-summary-muted);
+}
+
+.card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  margin-top: 20px;
+  flex-wrap: wrap;
+}
+
+.footer-note {
+  color: var(--ease-summary-muted);
+}
+
+.card-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.1rem;
+  border-radius: 14px;
+  background: linear-gradient(135deg, var(--ease-summary-accent), #a78bfa);
+  color: #fff;
+  font-weight: 800;
+  text-decoration: none;
+  box-shadow: 0 14px 28px rgba(124, 108, 255, 0.22);
+}
+
+.preview-note {
+  margin-top: 16px;
+  color: var(--ease-summary-muted);
+  font-size: 0.92rem;
+}
+
+@keyframes ease-summary-slidein {
+  0% {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes ease-summary-expand {
+  0% {
+    opacity: 0;
+    transform: translateY(-6px);
+    max-height: 0;
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+    max-height: 400px;
+  }
+}
+
+@media (max-width: 640px) {
+  .page-shell { width: min(100% - 1rem, 1100px); padding-top: 20px; }
+  .demo-panel { padding: 18px; }
+  .summary-card { padding: 18px; }
+  .summary-top { flex-direction: column; }
+  .summary-total { text-align: left; }
+  .demo-header { align-items: flex-start; flex-direction: column; }
+}


### PR DESCRIPTION
**Pull Request Description**

closes issue #36860 
Added a new CSS-only component: **`ease-order-summary-slide`**.

This component displays an order summary slide with expandable details. It includes a demo page, component styling, and a short README with the required summary fields.

**Type of Change**

- [✓] New feature / new component
- [✓] CSS animation
- [✓] Documentation update
- [ ] Bug fix
- [ ] Breaking change

**Submission Checklist**

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [✓ ] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [✓ ] Includes `demo.html` — self-contained, opens in browser with no server
- [✓ ] Includes `style.css` — raw CSS for the proposed feature
- [ ✓] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [✓ ] **No changes to `core/`**
- [✓ ] **No changes to `components/`**
- [✓ ] One feature per PR (no bundled unrelated changes)

**What changed**

- Added an order summary card with a slide-in summary section.
- Added expandable order details using a native disclosure pattern.
- Added a short README explaining what it is, why it exists, how to test it, and a note.

**Why**

This component makes checkout summaries easier to scan while keeping the implementation lightweight and reusable.

**How to test**

1. Open `demo.html` in a browser.
2. Confirm the summary section slides into view.
3. Open and close the order details section.
4. Check that the layout remains readable on smaller screens.
5. Update CSS custom properties and confirm the component still renders correctly.

**Notes**

The animation is CSS-only and the demo is intended for visual preview.