### PR TITLE
 feat : add ease-button-ripple-hover-k553 submission

### DIFF
--- a/submissions/examples/ease-button-ripple-hover-k553/README.md
+++ b/submissions/examples/ease-button-ripple-hover-k553/README.md
@@ -1,0 +1,18 @@
+# ease-button-ripple-hover
+
+A lightweight, reusable CSS-only ripple hover effect that expands outward from the center of a button, inspired by Material-style interactions.
+
+## Use Cases
+- CTA buttons
+- Forms
+- Landing pages
+- Dashboard actions
+
+## Usage
+
+Add the `ease-button-ripple-hover` class to any button:
+
+```html
+<button class="ease-button-ripple-hover">
+  Submit
+</button>

--- a/submissions/examples/ease-button-ripple-hover-k553/demo.html
+++ b/submissions/examples/ease-button-ripple-hover-k553/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-button-ripple-hover Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: sans-serif;
+      background: #111;
+      color: #fff;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+      margin: 0;
+    }
+    button {
+      font-size: 1rem;
+      padding: 0.75rem 2rem;
+      border: none;
+      border-radius: 6px;
+      background: #4f46e5;
+      color: #fff;
+      cursor: pointer;
+    }
+  </style>
+</head>
+<body>
+
+  <button class="ease-button-ripple-hover">
+    Submit
+  </button>
+
+</body>
+</html>

--- a/submissions/examples/ease-button-ripple-hover-k553/style.css
+++ b/submissions/examples/ease-button-ripple-hover-k553/style.css
@@ -1,0 +1,29 @@
+/* ease-button-ripple-hover
+   A reusable ripple hover effect that originates from the center of a button.
+   Pure CSS — no JavaScript required.
+*/
+
+.ease-button-ripple-hover {
+  position: relative;
+  overflow: hidden;
+  z-index: 0;
+}
+
+.ease-button-ripple-hover::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0;
+  height: 0;
+  background: rgba(255, 255, 255, 0.3);
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  transition: width 0.5s ease, height 0.5s ease;
+  z-index: -1;
+}
+
+.ease-button-ripple-hover:hover::before {
+  width: 300%;
+  height: 300%;
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a reusable CSS-only ripple hover effect, `ease-button-ripple-hover`, that expands outward from the center of a button. Closes #37072.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/ease-button-ripple-hover/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A CSS-only ripple hover effect, `ease-button-ripple-hover`, that expands from the center of a button on hover.

**How does a developer use it?**

```html
<button class="ease-button-ripple-hover">
  Submit
</button>

Why does it fit EaseMotion CSS?
Ripple interactions are widely used in modern UI frameworks (Material Design and beyond) and are a highly requested reusable pattern. This implementation uses pure CSS pseudo-elements with no JavaScript, consistent with the project's lightweight philosophy. Checked against existing ease-btn-* submissions (ease-btn-group, ease-btn-loading) to confirm no overlap.
Demo
[x] Demo added (demo.html works by opening directly in a browser)
Browser Testing
[x] Chrome
[x] Firefox
[x] Edge
[ ] Safari (optional but appreciated)
Notes for Maintainer
Ripple color/opacity is set to rgba(255,255,255,0.3) — happy to adjust for better contrast on light-theme buttons if needed.