### PR TITLE
fix: resolve dark mode heading color issue

### DIFF
--- a/submissions/docs/fix-heading-darkmode-cozy/README.md
+++ b/submissions/docs/fix-heading-darkmode-cozy/README.md
@@ -1,0 +1,9 @@
+# Dark Mode Headings & Table Headers Fix
+
+This submission fixes a bug in `core/base.css` where headings (`h1`–`h6`) and table headers (`th`) were hardcoded to `var(--ease-color-neutral-900)`. In dark mode, this caused the text to be nearly invisible against the dark background.
+
+## Usage
+No new classes are introduced. This is a core bug fix that ensures headings and table headers adapt to the active theme using the semantic `var(--ease-color-text)` variable.
+
+## Why is it useful?
+It restores readability in dark mode, which is a core accessibility requirement. By using `var(--ease-color-text)`, the typography automatically adapts to both light and dark themes correctly.

--- a/submissions/docs/fix-heading-darkmode-cozy/demo.html
+++ b/submissions/docs/fix-heading-darkmode-cozy/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Fix Heading Dark Mode - EaseMotion CSS</title>
+    <!-- Core CSS (simulating the framework) -->
+    <link rel="stylesheet" href="../../../easemotion.css">
+    <!-- The Fix -->
+    <link rel="stylesheet" href="style.css">
+    <style>
+        body {
+            padding: 2rem;
+            font-family: system-ui, -apple-system, sans-serif;
+            background-color: var(--ease-color-bg);
+            color: var(--ease-color-text);
+        }
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            border: 1px solid var(--ease-color-border);
+            padding: 2rem;
+            border-radius: var(--ease-radius-lg);
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Heading 1 (Fixed)</h1>
+        <h2>Heading 2 (Fixed)</h2>
+        <h3>Heading 3 (Fixed)</h3>
+        
+        <table style="width: 100%; margin-top: 2rem; text-align: left;">
+            <thead>
+                <tr>
+                    <th>Table Header (Fixed)</th>
+                    <th>Status</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Row 1</td>
+                    <td>Visible in dark mode</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</body>
+</html>

--- a/submissions/docs/fix-heading-darkmode-cozy/style.css
+++ b/submissions/docs/fix-heading-darkmode-cozy/style.css
@@ -1,0 +1,4 @@
+/* Fix for headings and table headers in dark mode */
+h1, h2, h3, h4, h5, h6, th {
+  color: var(--ease-color-text);
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes a bug in `core/base.css` where headings (`h1`–`h6`) and table headers (`th`) were hardcoded to `var(--ease-color-neutral-900)`. In dark mode, this caused the text to be nearly invisible against the dark background. The fix switches the color to the semantic `var(--ease-color-text)` variable.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (describe below)
  - *Core framework bug fix submitted via the `submissions/docs/` track.*

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It fixes a core accessibility bug by ensuring typography correctly adapts to dark mode.

**How does a developer use it?**

```html
<!-- No new classes required. Existing HTML simply becomes readable in dark mode! -->
<html data-theme="dark">
  <h1>Readable Heading</h1>
  <th>Readable Table Header</th>
</html>
