### PR TITLE
feat: add nested theme override generator utility

### DIFF
--- a/submissions/scss/37059-nested-theme-override-generator-dp/README.md
+++ b/submissions/scss/37059-nested-theme-override-generator-dp/README.md
@@ -1,0 +1,161 @@
+# Nested Theme Override Generator
+
+## Overview
+
+Hierarchical design systems commonly define a chain of themes — a base theme, then a dark theme, then a brand theme, then a high-contrast theme — where each level only changes a handful of tokens from the level before it. Writing out every token at every level duplicates values that never actually changed and makes it easy for themes to drift out of sync.
+
+Nested Theme Override Generator is a compile-time SCSS utility that recursively compares two nested theme maps and produces only the tokens that actually differ. It walks arbitrarily deep nested maps, flattens them into dash-joined custom property names, and emits scoped CSS custom properties for just the overridden values — leaving unchanged tokens to fall through the CSS cascade from a parent theme scope. Everything resolves at compile time, so the output is plain, framework-agnostic CSS with no runtime cost.
+
+## Features
+
+- Recursive comparison of unlimited nested theme maps
+- Emits only genuinely changed values as CSS custom property overrides
+- Dash-joined custom property naming (`colors.primary` → `--colors-primary`)
+- Scoped, configurable selector output (`[data-theme="dark"]`, `.brand`, `:root`, etc.)
+- `flatten-theme()` for producing a full flat token map (useful for a base/root theme)
+- Compile-time validation with `@warn`/`@error` for invalid, empty, or mismatched inputs
+- No animations, keyframes, or transitions generated
+- Zero external dependencies, framework agnostic
+
+## File Structure
+
+- `_nested-theme-override-generator.scss` — the utility (recursion, functions, mixin)
+- `README.md` — documentation
+
+## API
+
+### `flatten-theme($map, $prefix: null)`
+
+Recursively flattens a nested theme map into a single-level map whose keys are dash-joined and whose values are the leaf values. Errors on a non-map input, warns on an empty map or an unsupported leaf value type.
+
+```scss
+$flat: flatten-theme($base);
+// (colors-primary: #2563eb, colors-secondary: #64748b, motion-duration: 200ms)
+```
+
+### `nested-theme-delta($base, $override, $prefix: null)`
+
+Recursively compares a base theme map against an override theme map and returns a flat map containing only the keys whose values actually changed (or that exist only in the override). Nested maps are compared key-by-key at every depth. Errors on non-map inputs or on a structural mismatch (a map compared against a non-map at the same key), and warns on an empty override or an unsupported value type.
+
+```scss
+$delta: nested-theme-delta($base, $dark);
+// (colors-primary: #60a5fa)
+```
+
+### `emit-nested-theme($selector, $theme)` (mixin)
+
+Emits a selector block containing one `--custom-property: value;` declaration per entry in a flat theme map. Works with the output of either `flatten-theme()` (a full theme) or `nested-theme-delta()` (an override only). Errors on a non-map input, warns if the map is empty.
+
+```scss
+@include emit-nested-theme(":root", flatten-theme($base));
+
+@include emit-nested-theme(
+  '[data-theme="dark"]',
+  nested-theme-delta($base, $dark)
+);
+```
+
+## Example
+
+**Base theme**
+
+```scss
+$base: (
+  colors: (
+    primary: #2563eb,
+    secondary: #64748b,
+  ),
+  motion: (
+    duration: 200ms,
+  ),
+);
+```
+
+**Dark theme**
+
+```scss
+$dark: (
+  colors: (
+    primary: #60a5fa,
+    secondary: #64748b,
+  ),
+  motion: (
+    duration: 200ms,
+  ),
+);
+```
+
+**Brand theme**
+
+```scss
+$brand: (
+  colors: (
+    primary: #7c3aed,
+    secondary: #64748b,
+  ),
+  motion: (
+    duration: 200ms,
+  ),
+);
+```
+
+**Generated delta**
+
+```scss
+$dark-delta: nested-theme-delta($base, $dark);
+// (colors-primary: #60a5fa)
+
+$brand-delta: nested-theme-delta($dark, $brand);
+// (colors-primary: #7c3aed)
+```
+
+**Generated CSS variables**
+
+```scss
+@include emit-nested-theme(":root", flatten-theme($base));
+@include emit-nested-theme(
+  '[data-theme="dark"]',
+  nested-theme-delta($base, $dark)
+);
+@include emit-nested-theme(
+  '[data-theme="brand"]',
+  nested-theme-delta($dark, $brand)
+);
+```
+
+```css
+:root {
+  --colors-primary: #2563eb;
+  --colors-secondary: #64748b;
+  --motion-duration: 200ms;
+}
+
+[data-theme="dark"] {
+  --colors-primary: #60a5fa;
+}
+
+[data-theme="brand"] {
+  --colors-primary: #7c3aed;
+}
+```
+
+## Validation
+
+- **Invalid map detection** — every function and mixin checks its map arguments with `type-of()` and raises an `@error` immediately if a non-map value is passed where a theme map is expected.
+- **Recursive comparison** — `nested-theme-delta()` walks nested maps depth-first, recursing whenever both sides hold a map at the same key, and raises an `@error` the moment one side holds a map while the other holds a scalar value at the same key, preventing silently malformed output.
+- **Compile-time warnings** — empty theme maps, empty override maps, and unsupported leaf value types (anything that isn't a color, number, string, or list) trigger an `@warn` so problems are visible during compilation without necessarily halting the build.
+
+## Example Use Cases
+
+- Enterprise design systems maintaining a shared base token set across many teams
+- White-label products that need per-client theme overrides without duplicating every token
+- Brand theming layered on top of a neutral base theme
+- Accessibility themes (e.g. high-contrast) that only need to adjust a small subset of tokens
+
+## Why This Utility?
+
+- **Eliminates duplicated tokens** — only values that actually changed between theme levels are emitted, instead of redeclaring an entire token set at every level.
+- **Supports hierarchical themes** — arbitrarily deep nested maps and multi-level theme chains (base → dark → brand → high-contrast) are handled through recursion.
+- **Framework agnostic** — compiles to plain CSS custom properties with no dependency on any JavaScript framework.
+- **Reusable** — the same flatten, delta, and emit functions work for any theme map shape across any project.
+- **Compile-time only** — all comparison and flattening logic runs during Sass compilation; no animation, keyframe, or transition code is generated, and nothing is computed in the browser.

--- a/submissions/scss/37059-nested-theme-override-generator-dp/_nested-theme-override-generator.scss
+++ b/submissions/scss/37059-nested-theme-override-generator-dp/_nested-theme-override-generator.scss
@@ -1,0 +1,107 @@
+@function _is-map($value) {
+  @return type-of($value) == map;
+}
+
+@function _is-valid-value($value) {
+  $type: type-of($value);
+  @return $type == color or $type == number or $type == string or $type == list
+    or $type == null;
+}
+
+@function _join-name($prefix, $key) {
+  @return if($prefix == null, "#{$key}", "#{$prefix}-#{$key}");
+}
+
+@function flatten-theme($map, $prefix: null) {
+  @if not _is-map($map) {
+    @error "flatten-theme() expects a map, got #{type-of($map)}.";
+  }
+
+  @if length($map) == 0 {
+    @warn "Theme map is empty; no custom properties will be generated.";
+  }
+
+  $result: ();
+
+  @each $key, $value in $map {
+    $name: _join-name($prefix, $key);
+
+    @if _is-map($value) {
+      $result: map-merge($result, flatten-theme($value, $name));
+    } @else {
+      @if not _is-valid-value($value) {
+        @warn "Unsupported value type for '#{$name}': #{type-of($value)}.";
+      }
+      $result: map-merge(
+        $result,
+        (
+          $name: $value,
+        )
+      );
+    }
+  }
+
+  @return $result;
+}
+
+@function nested-theme-delta($base, $override, $prefix: null) {
+  @if not _is-map($base) or not _is-map($override) {
+    @error "nested-theme-delta() expects two maps, got #{type-of($base)} and #{type-of($override)}.";
+  }
+
+  @if length($override) == 0 {
+    @warn "Override theme map is empty; no overrides will be generated.";
+  }
+
+  $delta: ();
+
+  @each $key, $override-value in $override {
+    $name: _join-name($prefix, $key);
+    $base-has-key: map-has-key($base, $key);
+    $base-value: if($base-has-key, map-get($base, $key), null);
+
+    @if _is-map($override-value) {
+      @if $base-has-key and not _is-map($base-value) {
+        @error "Invalid nested structure at '#{$name}': base is #{type-of($base-value)}, override is a map.";
+      }
+      $nested-base: if($base-has-key, $base-value, ());
+      $delta: map-merge(
+        $delta,
+        nested-theme-delta($nested-base, $override-value, $name)
+      );
+    } @else {
+      @if $base-has-key and _is-map($base-value) {
+        @error "Invalid nested structure at '#{$name}': base is a map, override is #{type-of($override-value)}.";
+      }
+      @if not _is-valid-value($override-value) {
+        @warn "Unsupported value type for '#{$name}': #{type-of($override-value)}.";
+      }
+      @if not $base-has-key or $base-value != $override-value {
+        $delta: map-merge(
+          $delta,
+          (
+            $name: $override-value,
+          )
+        );
+      }
+    }
+  }
+
+  @return $delta;
+}
+
+@mixin emit-nested-theme($selector, $theme) {
+  @if not _is-map($theme) {
+    @error "emit-nested-theme() expects a flat map, got #{type-of($theme)}.";
+  }
+
+  @if length($theme) == 0 {
+    @warn "No custom properties to emit for selector '#{$selector}'.";
+  } @else {
+    #{$selector} {
+      @each $name, $value in $theme {
+        --#{$name}: #{$value};
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a **Nested Theme Override Generator** utility under the `submissions/scss/` track.

The utility provides a reusable compile-time SCSS solution for recursively comparing hierarchical theme maps and generating only the required CSS custom property overrides. It simplifies multi-level theme management while reducing duplicated token definitions across design systems.

Closes #37059

---

## Type of Change

- [x] 🧩 New SCSS utility submission
- [ ] ✨ New animation
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/scss/`
- [x] Includes `_nested-theme-override-generator.scss`
- [x] Includes `README.md`
- [x] Uses SCSS only
- [x] No HTML
- [x] No CSS
- [x] No JavaScript
- [x] No external dependencies
- [x] Framework agnostic
- [x] Compiles to reusable CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

A reusable compile-time SCSS utility that recursively compares nested theme maps and emits only the required CSS custom property overrides for child themes, making hierarchical theming more scalable and maintainable.

### Key Features

- Recursive nested theme comparison
- Hierarchical override generation
- Scoped CSS custom property output
- Configurable theme selectors
- Compile-time validation using `@warn` and `@error`
- Framework-agnostic API
- Reusable compile-time architecture

### Why does it fit EaseMotion CSS?

Enterprise design systems frequently support multiple nested themes such as base, dark, brand, and accessibility variants. This utility reduces duplicated token definitions while generating optimized theme overrides entirely at compile time.

---

## Browser Testing

Not applicable (SCSS utility)

---

## Notes for Maintainer

- Fully self-contained under `submissions/scss/37059-nested-theme-override-generator-dp/`
- Contains only:
  - `_nested-theme-override-generator.scss`
  - `README.md`
- Uses SCSS only
- Framework agnostic
- Generates reusable CSS at compile time
- Includes recursive theme comparison, nested override generation, scoped CSS custom properties, and compile-time validation