### PR TITLE
feat: add motion pipeline composer utility

### DIFF
--- a/submissions/scss/37066-motion-pipeline-composer-dp/README.md
+++ b/submissions/scss/37066-motion-pipeline-composer-dp/README.md
@@ -1,0 +1,231 @@
+# Motion Pipeline Composer
+
+## Overview
+
+Motion Pipeline Composer is a compile-time SCSS utility for building reusable
+motion compositions out of small, ordered stages. Instead of hand-writing the
+same groups of motion-related declarations across components, developers
+register named "stages" once and then assemble them, in any order, into a
+"pipeline". At compile time the pipeline is resolved into a single merged set
+of declarations for the selector it is included into.
+
+This encourages:
+
+- Reusable motion composition, where a stage (e.g. a positioning layer or a
+  timing layer) is defined once and reused across many components.
+- Compile-time stage orchestration, where the order and contents of a
+  pipeline are fully resolved by Sass before any CSS is emitted — there is no
+  runtime cost.
+- Reduced duplicated motion workflows, since teams stop copy-pasting the same
+  declaration blocks between buttons, cards, modals, and other components.
+
+The utility is purely a composition layer. It does not define keyframes,
+transitions, or any hardcoded motion effect — what each stage contains is
+entirely up to the developer registering it.
+
+## Features
+
+- Configurable, ordered pipelines built from a simple list of stage names.
+- Central stage registry shared across a project.
+- Per-call stage overrides without mutating the shared registry.
+- Sequential composition with `@content` support for additional customization.
+- Compile-time validation with `@warn` and `@error` for common mistakes.
+- Framework agnostic — works with any CSS/Sass project.
+- Zero runtime cost — everything resolves during compilation.
+
+## File Structure
+
+- `_motion-pipeline-composer.scss` — the utility implementation.
+- `README.md` — this documentation.
+
+## API
+
+### `register-stage($name, $declarations)`
+
+Registers a reusable stage in the global `$motion-stages` registry.
+
+- `$name` — string identifier for the stage.
+- `$declarations` — map of CSS property/value pairs the stage contributes.
+- Returns the updated `$motion-stages` map.
+
+```scss
+$motion-stages: register-stage(
+  base,
+  (
+    will-change: transform,
+    transform-origin: center,
+  )
+);
+```
+
+### `pipeline-stage($name, $overrides: ())`
+
+Resolves the effective declarations for a single stage, checking `$overrides`
+first and falling back to the shared `$motion-stages` registry.
+
+- `$name` — the stage name to resolve.
+- `$overrides` — optional map of stage overrides.
+- Returns a map of declarations, or raises an error if the stage is
+  undefined.
+
+```scss
+$emphasis: pipeline-stage(emphasis);
+```
+
+### `compose-pipeline($pipeline, $overrides: ())`
+
+Resolves an entire pipeline into a single merged map of declarations, in the
+order the stages are listed. Later stages take precedence over earlier ones
+when they share a property.
+
+- `$pipeline` — list of stage names.
+- `$overrides` — optional map of stage overrides applied only for this call.
+- Returns a merged map of declarations.
+
+```scss
+$merged: compose-pipeline((base, emphasis));
+```
+
+### `motion-pipeline($pipeline, $overrides: ())`
+
+Mixin that composes a pipeline with `compose-pipeline()` and outputs the
+resulting declarations into the current selector. Supports `@content` for
+appending additional rules after the composed declarations.
+
+- `$pipeline` — list of stage names, executed sequentially.
+- `$overrides` — optional map of per-call stage overrides.
+
+```scss
+.card {
+  @include motion-pipeline((base, emphasis, interaction)) {
+    cursor: pointer;
+  }
+}
+```
+
+## Example
+
+**Stage registry**
+
+```scss
+$motion-stages: register-stage(
+  base,
+  (
+    will-change: transform,
+    transform-origin: center,
+  )
+);
+
+$motion-stages: register-stage(
+  emphasis,
+  (
+    transform: scale(1.02),
+  )
+);
+
+$motion-stages: register-stage(
+  interaction,
+  (
+    cursor: pointer,
+    outline: none,
+  )
+);
+
+$motion-stages: register-stage(
+  completion,
+  (
+    transform: scale(1),
+  )
+);
+```
+
+**Pipeline definition**
+
+```scss
+$pipeline: (base, emphasis, interaction, completion);
+
+.button {
+  @include motion-pipeline($pipeline);
+}
+```
+
+**Stage override**
+
+```scss
+.button--subtle {
+  @include motion-pipeline(
+    $pipeline,
+    (
+      emphasis: (
+        transform: scale(1.01),
+      ),
+    )
+  );
+}
+```
+
+**Generated CSS**
+
+```css
+.button {
+  will-change: transform;
+  transform-origin: center;
+  transform: scale(1);
+  cursor: pointer;
+  outline: none;
+}
+
+.button--subtle {
+  will-change: transform;
+  transform-origin: center;
+  transform: scale(1);
+  cursor: pointer;
+  outline: none;
+}
+```
+
+Note that `transform` reflects whichever stage sets it last in pipeline
+order — in this example `completion` runs after `emphasis`, so its value
+wins.
+
+## Validation
+
+- **Undefined stage detection** — `pipeline-stage()` raises `@error` when a
+  stage name is not present in either the override map or `$motion-stages`.
+- **Duplicate stage detection** — `compose-pipeline()` tracks stage names it
+  has already processed and raises `@warn` when a stage appears more than
+  once in `$pipeline`, since it will be composed again.
+- **Invalid pipeline detection** — `compose-pipeline()` raises `@error` when
+  `$pipeline` is empty or when it is a map instead of a list of stage names.
+- **Compile-time warnings** — `register-stage()` raises `@warn` when a stage
+  name is re-registered, so accidental overwrites of the shared registry are
+  visible during compilation. Invalid override values (non-map entries) and
+  invalid override map types raise `@error` in `pipeline-stage()` and
+  `compose-pipeline()` respectively.
+
+## Example Use Cases
+
+- Component libraries that need a consistent, reusable motion vocabulary
+  across many components.
+- Design systems that want to standardize how motion layers are named and
+  combined.
+- Reusable UI workflows shared across teams or product surfaces.
+- Dashboards with many interactive widgets that share the same interaction
+  and completion stages.
+- Forms where focus, validation, and completion states benefit from shared
+  motion stages.
+- Enterprise applications that need predictable, auditable motion
+  composition across a large codebase.
+
+## Why This Utility?
+
+- Reduces repetitive composition by letting teams define a motion stage once
+  and reuse it anywhere a pipeline references it.
+- Encourages reusable motion workflows through a shared stage registry
+  instead of ad-hoc, component-specific declarations.
+- Framework agnostic — it produces plain CSS declarations and has no
+  dependency on any specific markup, component model, or JavaScript runtime.
+- Reusable by design — pipelines, stages, and overrides can be composed
+  differently per component without duplicating declaration logic.
+- Compile-time only — all composition, validation, and merging happens while
+  Sass compiles, so there is no added runtime cost or JavaScript required.

--- a/submissions/scss/37066-motion-pipeline-composer-dp/_motion-pipeline-composer.scss
+++ b/submissions/scss/37066-motion-pipeline-composer-dp/_motion-pipeline-composer.scss
@@ -1,0 +1,88 @@
+@use "sass:map";
+@use "sass:list";
+@use "sass:meta";
+
+$motion-stages: () !default;
+
+@function register-stage($name, $declarations) {
+  @if meta.type-of($name) != string {
+    @error "register-stage: stage name must be a string, got #{meta.type-of($name)}.";
+  }
+
+  @if meta.type-of($declarations) != map {
+    @error "register-stage: declarations for stage '#{$name}' must be a map.";
+  }
+
+  @if map.has-key($motion-stages, $name) {
+    @warn "register-stage: stage '#{$name}' is already registered and will be overwritten.";
+  }
+
+  $motion-stages: map.merge(
+    $motion-stages,
+    (
+      $name: $declarations,
+    )
+  ) !global;
+
+  @return $motion-stages;
+}
+
+@function pipeline-stage($name, $overrides: ()) {
+  @if meta.type-of($overrides) != map {
+    @error "pipeline-stage: overrides must be a map, got #{meta.type-of($overrides)}.";
+  }
+
+  @if map.has-key($overrides, $name) {
+    $stage: map.get($overrides, $name);
+
+    @if meta.type-of($stage) != map {
+      @error "pipeline-stage: override for stage '#{$name}' must be a map of declarations.";
+    }
+
+    @return $stage;
+  }
+
+  @if map.has-key($motion-stages, $name) {
+    @return map.get($motion-stages, $name);
+  }
+
+  @error "pipeline-stage: stage '#{$name}' is not registered. Use register-stage() before referencing it in a pipeline.";
+}
+
+@function compose-pipeline($pipeline, $overrides: ()) {
+  @if meta.type-of($pipeline) == map {
+    @error "motion-pipeline: pipeline must be a list of stage names, not a map.";
+  }
+
+  @if list.length($pipeline) == 0 {
+    @error "motion-pipeline: pipeline cannot be empty.";
+  }
+
+  @if meta.type-of($overrides) != map {
+    @error "motion-pipeline: overrides must be a map, got #{meta.type-of($overrides)}.";
+  }
+
+  $seen: ();
+  $merged: ();
+
+  @each $stage-name in $pipeline {
+    @if list.index($seen, $stage-name) {
+      @warn "motion-pipeline: duplicate stage '#{$stage-name}' found in pipeline; it will be composed again.";
+    }
+
+    $seen: list.append($seen, $stage-name);
+    $merged: map.merge($merged, pipeline-stage($stage-name, $overrides));
+  }
+
+  @return $merged;
+}
+
+@mixin motion-pipeline($pipeline, $overrides: ()) {
+  $composed: compose-pipeline($pipeline, $overrides);
+
+  @each $property, $value in $composed {
+    #{$property}: #{$value};
+  }
+
+  @content;
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a **Motion Pipeline Composer** utility under the `submissions/scss/` track.

The utility provides a reusable compile-time SCSS solution for composing reusable motion stages into configurable pipelines. It enables developers to assemble ordered motion workflows, override individual stages, and reuse common composition patterns while remaining completely framework agnostic.

Closes #37066

---

## Type of Change

- [x] 🧩 New SCSS utility submission
- [ ] ✨ New animation
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/scss/`
- [x] Includes `_motion-pipeline-composer.scss`
- [x] Includes `README.md`
- [x] Uses SCSS only
- [x] No HTML
- [x] No CSS
- [x] No JavaScript
- [x] No external dependencies
- [x] Framework agnostic
- [x] Compiles to reusable CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

A reusable compile-time SCSS utility that allows developers to compose configurable motion pipelines from reusable stages. It centralizes stage orchestration, supports stage overrides, and encourages scalable motion composition across component libraries and design systems.

### Key Features

- Configurable pipeline stages
- Reusable stage registry
- Ordered pipeline composition
- Optional stage overrides
- Compile-time validation using `@warn` and `@error`
- Framework-agnostic API
- Reusable compile-time architecture

### Why does it fit EaseMotion CSS?

Complex interfaces often reuse the same motion composition patterns across multiple components. This utility introduces a structured compile-time approach for organizing reusable motion workflows while keeping implementation modular and framework agnostic.

---

## Browser Testing

Not applicable (SCSS utility)

---

## Notes for Maintainer

- Fully self-contained under `submissions/scss/37066-motion-pipeline-composer-dp/`
- Contains only:
  - `_motion-pipeline-composer.scss`
  - `README.md`
- Uses SCSS only
- Framework agnostic
- Generates reusable CSS at compile time
- Includes configurable stage composition, override support, reusable stage registration, and compile-time validation