### PR TITLE
Add neon glow modal example

### DIFF
--- a/submissions/examples/33983-neon-glow-modal-lekhanpro/README.md
+++ b/submissions/examples/33983-neon-glow-modal-lekhanpro/README.md
@@ -1,0 +1,23 @@
+# Neon Glow Modal
+
+A pure CSS modal for marketing landing pages. The component opens with a neon glow entrance using the `:target` pattern, so it works without JavaScript.
+
+## Files
+
+- `demo.html` - Standalone landing-page style modal demo.
+- `style.css` - Scoped component styles and animation tokens.
+- `README.md` - Usage and customization notes.
+
+## Custom Properties
+
+```css
+.ngm-shell {
+  --ngm-duration: 300ms;
+  --ngm-easing: cubic-bezier(0.22, 1, 0.36, 1);
+  --ngm-scale-start: 0.94;
+  --ngm-glow-color: #22d3ee;
+  --ngm-accent-color: #a855f7;
+}
+```
+
+The modal is responsive, keyboard reachable through standard links, and respects `prefers-reduced-motion`.

--- a/submissions/examples/33983-neon-glow-modal-lekhanpro/demo.html
+++ b/submissions/examples/33983-neon-glow-modal-lekhanpro/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS - Neon Glow Modal</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="ngm-shell">
+    <section class="ngm-hero" aria-labelledby="ngm-title">
+      <p class="ngm-kicker">Marketing launch kit</p>
+      <h1 id="ngm-title">Turn visitors into early users.</h1>
+      <p class="ngm-copy">A neon modal pattern for product launches, waitlists, and feature reveals. It is fully CSS-driven and exposes motion tokens for quick tuning.</p>
+      <div class="ngm-actions">
+        <a class="ngm-open" href="#neon-glow-modal">View offer</a>
+        <a class="ngm-link" href="#features">See features</a>
+      </div>
+    </section>
+
+    <div class="ngm-feature-row" id="features" aria-label="Feature highlights">
+      <span>Zero JavaScript</span>
+      <span>Responsive layout</span>
+      <span>Tokenized glow</span>
+    </div>
+
+    <div class="ngm-overlay" id="neon-glow-modal" role="presentation">
+      <a class="ngm-backdrop" href="#" aria-label="Close modal"></a>
+      <section class="ngm-dialog" role="dialog" aria-modal="true" aria-labelledby="ngm-dialog-title" aria-describedby="ngm-dialog-copy">
+        <div class="ngm-dialog-topline">
+          <span>Limited launch</span>
+          <a class="ngm-close" href="#" aria-label="Close modal">x</a>
+        </div>
+        <h2 id="ngm-dialog-title">Claim the neon launch pack</h2>
+        <p id="ngm-dialog-copy">Use this modal to announce a pricing offer, beta invite, or product milestone. The entrance blends a soft scale-up with a glow pulse for a high-energy landing page feel.</p>
+        <ul class="ngm-benefits">
+          <li>Custom duration and easing</li>
+          <li>Configurable glow and accent colors</li>
+          <li>Reduced-motion fallback</li>
+        </ul>
+        <div class="ngm-dialog-actions">
+          <a class="ngm-secondary" href="#">Not now</a>
+          <a class="ngm-primary" href="#">Join waitlist</a>
+        </div>
+      </section>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/33983-neon-glow-modal-lekhanpro/style.css
+++ b/submissions/examples/33983-neon-glow-modal-lekhanpro/style.css
@@ -1,0 +1,274 @@
+@import "../../../core/variables.css";
+@import "../../../core/utilities.css";
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--ease-font-sans, Inter, system-ui, sans-serif);
+  color: #f8fafc;
+  background:
+    radial-gradient(circle at 20% 15%, rgba(34, 211, 238, 0.22), transparent 28rem),
+    radial-gradient(circle at 80% 8%, rgba(168, 85, 247, 0.24), transparent 28rem),
+    linear-gradient(135deg, #050816 0%, #0f172a 48%, #18122b 100%);
+}
+
+.ngm-shell {
+  --ngm-duration: 300ms;
+  --ngm-easing: cubic-bezier(0.22, 1, 0.36, 1);
+  --ngm-scale-start: 0.94;
+  --ngm-glow-color: #22d3ee;
+  --ngm-accent-color: #a855f7;
+  --ngm-panel-bg: rgba(10, 15, 30, 0.86);
+  --ngm-panel-border: rgba(125, 211, 252, 0.42);
+  --ngm-shadow: 0 0 48px rgba(34, 211, 238, 0.28), 0 30px 90px rgba(0, 0, 0, 0.52);
+  min-height: 100vh;
+  display: grid;
+  align-content: center;
+  gap: 2rem;
+  padding: clamp(1rem, 5vw, 4rem);
+}
+
+.ngm-hero {
+  width: min(100%, 48rem);
+}
+
+.ngm-kicker {
+  margin: 0 0 0.75rem;
+  color: var(--ngm-glow-color);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.ngm-hero h1 {
+  margin: 0;
+  max-width: 12ch;
+  font-size: clamp(3rem, 10vw, 7.5rem);
+  line-height: 0.9;
+  letter-spacing: 0;
+}
+
+.ngm-copy {
+  max-width: 38rem;
+  margin: 1.25rem 0 1.5rem;
+  color: #cbd5e1;
+  font-size: clamp(1rem, 2vw, 1.12rem);
+  line-height: 1.75;
+}
+
+.ngm-actions,
+.ngm-dialog-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+}
+
+.ngm-open,
+.ngm-primary,
+.ngm-secondary,
+.ngm-link,
+.ngm-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.ngm-open,
+.ngm-primary {
+  min-height: 2.85rem;
+  padding: 0 1.2rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--ngm-glow-color), var(--ngm-accent-color));
+  color: #020617;
+  font-weight: 900;
+  box-shadow: 0 0 28px rgba(34, 211, 238, 0.38);
+}
+
+.ngm-link,
+.ngm-secondary {
+  min-height: 2.85rem;
+  padding: 0 1.1rem;
+  border-radius: 999px;
+  color: #e0f2fe;
+  border: 1px solid rgba(125, 211, 252, 0.3);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.ngm-feature-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.8rem;
+  width: min(100%, 48rem);
+}
+
+.ngm-feature-row span {
+  padding: 1rem;
+  border: 1px solid rgba(125, 211, 252, 0.2);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.06);
+  color: #bae6fd;
+  font-weight: 800;
+}
+
+.ngm-overlay {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: clamp(1rem, 4vw, 2rem);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity var(--ngm-duration) var(--ngm-easing),
+    visibility var(--ngm-duration) var(--ngm-easing);
+}
+
+.ngm-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(2, 6, 23, 0.72);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+}
+
+.ngm-dialog {
+  position: relative;
+  width: min(100%, 35rem);
+  max-height: min(84vh, 44rem);
+  overflow: auto;
+  padding: clamp(1.2rem, 4vw, 1.8rem);
+  border: 1px solid var(--ngm-panel-border);
+  border-radius: 1.35rem;
+  background: var(--ngm-panel-bg);
+  box-shadow: var(--ngm-shadow);
+  transform: translateY(1.1rem) scale(var(--ngm-scale-start));
+  opacity: 0;
+  transition:
+    transform var(--ngm-duration) var(--ngm-easing),
+    opacity var(--ngm-duration) var(--ngm-easing),
+    box-shadow var(--ngm-duration) var(--ngm-easing);
+}
+
+.ngm-overlay:target {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.ngm-overlay:target .ngm-dialog {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  animation: ngm-glow-pulse 900ms var(--ngm-easing) both;
+}
+
+.ngm-dialog-topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.1rem;
+  color: var(--ngm-glow-color);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.ngm-close {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  font-size: 1.1rem;
+  letter-spacing: 0;
+}
+
+.ngm-dialog h2 {
+  margin: 0;
+  font-size: clamp(1.8rem, 5vw, 2.6rem);
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.ngm-dialog p {
+  margin: 0.9rem 0 1rem;
+  color: #dbeafe;
+  line-height: 1.7;
+}
+
+.ngm-benefits {
+  display: grid;
+  gap: 0.6rem;
+  margin: 0 0 1.4rem;
+  padding: 0;
+  list-style: none;
+}
+
+.ngm-benefits li {
+  padding: 0.75rem 0.9rem;
+  border-radius: 0.9rem;
+  background: rgba(34, 211, 238, 0.08);
+  border: 1px solid rgba(34, 211, 238, 0.18);
+  color: #e0f2fe;
+  font-weight: 700;
+}
+
+.ngm-open:focus-visible,
+.ngm-primary:focus-visible,
+.ngm-secondary:focus-visible,
+.ngm-link:focus-visible,
+.ngm-close:focus-visible {
+  outline: 3px solid var(--ngm-glow-color);
+  outline-offset: 4px;
+}
+
+@keyframes ngm-glow-pulse {
+  0% {
+    box-shadow: 0 0 0 rgba(34, 211, 238, 0), 0 30px 90px rgba(0, 0, 0, 0.52);
+  }
+  55% {
+    box-shadow: 0 0 64px rgba(34, 211, 238, 0.46), 0 30px 90px rgba(0, 0, 0, 0.52);
+  }
+  100% {
+    box-shadow: var(--ngm-shadow);
+  }
+}
+
+@media (max-width: 620px) {
+  .ngm-feature-row {
+    grid-template-columns: 1fr;
+  }
+
+  .ngm-dialog-actions,
+  .ngm-actions {
+    flex-direction: column;
+  }
+
+  .ngm-open,
+  .ngm-primary,
+  .ngm-secondary,
+  .ngm-link {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ngm-overlay,
+  .ngm-dialog {
+    transition: none;
+  }
+
+  .ngm-overlay:target .ngm-dialog {
+    animation: none;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a self-contained neon glow modal example under submissions/examples
- Uses CSS custom properties for duration, easing, scale, glow color, and accent color
- Uses a JavaScript-free :target interaction with responsive layout and reduced-motion support

Closes #33983

## Tests
- npm run validate:pack