### PR TITLE
Add blur entrance modal example

### DIFF
--- a/submissions/examples/33973-blur-entrance-modal-lekhanpro/README.md
+++ b/submissions/examples/33973-blur-entrance-modal-lekhanpro/README.md
@@ -1,0 +1,25 @@
+# Blur Entrance Modal
+
+A pure CSS modal for glassmorphism layouts with a soft blur-entrance reveal. The interaction uses `:target`, so the example works without JavaScript while keeping the open and close controls reachable from the keyboard.
+
+## Features
+
+- Smooth opacity, blur, and scale entrance for the dialog surface
+- Glassmorphism panel treatment with layered translucent surfaces
+- CSS custom properties for duration, easing, blur strength, scale, and accent color
+- Responsive layout for narrow and wide viewports
+- Reduced-motion support for users who prefer less animation
+
+## Custom Properties
+
+```css
+.bem-shell {
+  --bem-duration: 520ms;
+  --bem-easing: cubic-bezier(.2, .8, .2, 1);
+  --bem-blur-start: 22px;
+  --bem-scale-start: .92;
+  --bem-accent-color: #36d1dc;
+}
+```
+
+Open `demo.html` to preview the modal.

--- a/submissions/examples/33973-blur-entrance-modal-lekhanpro/demo.html
+++ b/submissions/examples/33973-blur-entrance-modal-lekhanpro/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Blur Entrance Modal - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="bem-shell">
+    <section class="bem-hero" aria-labelledby="bem-title">
+      <p class="bem-kicker">Glassmorphism modal</p>
+      <h1 id="bem-title">Blur Entrance Modal</h1>
+      <p class="bem-copy">
+        A responsive, JavaScript-free modal that eases from a blurred glass surface into a sharp focus state.
+      </p>
+      <a class="bem-open" href="#blur-entrance-modal">Open modal</a>
+    </section>
+
+    <section class="bem-preview" aria-label="Interface preview">
+      <div class="bem-preview-card bem-preview-card-primary">
+        <span></span>
+        <strong>Launch plan</strong>
+        <p>Finalize campaign touchpoints and handoff timing.</p>
+      </div>
+      <div class="bem-preview-card bem-preview-card-secondary">
+        <span></span>
+        <strong>Review queue</strong>
+        <p>Confirm the final approvals before publishing.</p>
+      </div>
+    </section>
+
+    <div class="bem-overlay" id="blur-entrance-modal" role="dialog" aria-modal="true" aria-labelledby="bem-modal-title">
+      <a class="bem-backdrop" href="#" aria-label="Close modal"></a>
+      <article class="bem-dialog">
+        <a class="bem-close" href="#" aria-label="Close modal">×</a>
+        <p class="bem-modal-kicker">Status update</p>
+        <h2 id="bem-modal-title">Campaign preview is ready</h2>
+        <p>
+          The blurred entrance keeps focus on the confirmation state while preserving the soft depth expected in glassmorphism interfaces.
+        </p>
+        <div class="bem-actions">
+          <a class="bem-action bem-action-primary" href="#">Approve</a>
+          <a class="bem-action bem-action-secondary" href="#">Review details</a>
+        </div>
+      </article>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/33973-blur-entrance-modal-lekhanpro/style.css
+++ b/submissions/examples/33973-blur-entrance-modal-lekhanpro/style.css
@@ -1,0 +1,313 @@
+@import url("../../../core/variables.css");
+@import url("../../../core/utilities.css");
+
+.bem-shell {
+  --bem-duration: 520ms;
+  --bem-easing: cubic-bezier(.2, .8, .2, 1);
+  --bem-blur-start: 22px;
+  --bem-scale-start: .92;
+  --bem-accent-color: #36d1dc;
+  --bem-panel: rgba(255, 255, 255, .16);
+  --bem-panel-strong: rgba(255, 255, 255, .26);
+  --bem-border: rgba(255, 255, 255, .34);
+  --bem-text: #f8fbff;
+  --bem-muted: rgba(248, 251, 255, .72);
+  --bem-shadow: 0 28px 70px rgba(12, 22, 38, .34);
+  min-height: 100vh;
+  overflow: hidden;
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 420px);
+  align-items: center;
+  gap: clamp(2rem, 6vw, 5rem);
+  padding: clamp(2rem, 7vw, 5rem);
+  color: var(--bem-text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 18% 18%, rgba(54, 209, 220, .34), transparent 28rem),
+    radial-gradient(circle at 82% 16%, rgba(119, 102, 255, .32), transparent 25rem),
+    linear-gradient(135deg, #0d1b2a 0%, #1b263b 46%, #213547 100%);
+}
+
+.bem-shell::before,
+.bem-shell::after {
+  content: "";
+  position: absolute;
+  border: 1px solid rgba(255, 255, 255, .2);
+  background: rgba(255, 255, 255, .08);
+  backdrop-filter: blur(18px);
+  pointer-events: none;
+}
+
+.bem-shell::before {
+  width: 19rem;
+  height: 19rem;
+  right: 10%;
+  top: 9%;
+  border-radius: 34% 66% 43% 57%;
+}
+
+.bem-shell::after {
+  width: 13rem;
+  height: 13rem;
+  left: 9%;
+  bottom: 12%;
+  border-radius: 60% 40% 68% 32%;
+}
+
+.bem-hero,
+.bem-preview {
+  position: relative;
+  z-index: 1;
+}
+
+.bem-kicker,
+.bem-modal-kicker {
+  margin: 0 0 .75rem;
+  color: var(--bem-accent-color);
+  font-size: .78rem;
+  font-weight: 800;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+
+.bem-hero h1 {
+  max-width: 11ch;
+  margin: 0;
+  font-size: clamp(2.65rem, 8vw, 6.25rem);
+  line-height: .9;
+  letter-spacing: 0;
+}
+
+.bem-copy {
+  max-width: 38rem;
+  margin: 1.4rem 0 2rem;
+  color: var(--bem-muted);
+  font-size: clamp(1rem, 2vw, 1.2rem);
+  line-height: 1.7;
+}
+
+.bem-open,
+.bem-action {
+  display: inline-flex;
+  min-height: 2.9rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 800;
+  transition: transform 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+
+.bem-open {
+  padding: 0 1.35rem;
+  color: #09202b;
+  background: var(--bem-accent-color);
+  box-shadow: 0 16px 42px rgba(54, 209, 220, .32);
+}
+
+.bem-open:hover,
+.bem-open:focus-visible,
+.bem-action:hover,
+.bem-action:focus-visible,
+.bem-close:hover,
+.bem-close:focus-visible {
+  transform: translateY(-2px);
+}
+
+.bem-open:focus-visible,
+.bem-action:focus-visible,
+.bem-close:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, .92);
+  outline-offset: 4px;
+}
+
+.bem-preview {
+  display: grid;
+  gap: 1rem;
+}
+
+.bem-preview-card {
+  min-height: 12rem;
+  padding: 1.35rem;
+  border: 1px solid var(--bem-border);
+  border-radius: 1.35rem;
+  background: linear-gradient(145deg, var(--bem-panel-strong), rgba(255, 255, 255, .1));
+  box-shadow: var(--bem-shadow);
+  backdrop-filter: blur(20px);
+}
+
+.bem-preview-card-primary {
+  transform: translateX(-1rem);
+}
+
+.bem-preview-card-secondary {
+  transform: translateX(1.5rem);
+}
+
+.bem-preview-card span {
+  display: block;
+  width: 3rem;
+  height: .42rem;
+  margin-bottom: 4.7rem;
+  border-radius: 999px;
+  background: var(--bem-accent-color);
+}
+
+.bem-preview-card strong {
+  display: block;
+  margin-bottom: .45rem;
+  font-size: 1.05rem;
+}
+
+.bem-preview-card p {
+  margin: 0;
+  color: var(--bem-muted);
+  line-height: 1.55;
+}
+
+.bem-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10;
+  display: grid;
+  place-items: center;
+  padding: clamp(1rem, 4vw, 2rem);
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity var(--bem-duration) var(--bem-easing), visibility 0s linear var(--bem-duration);
+}
+
+.bem-overlay:target {
+  visibility: visible;
+  opacity: 1;
+  transition-delay: 0s;
+}
+
+.bem-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(7, 14, 27, .68);
+  backdrop-filter: blur(14px);
+}
+
+.bem-dialog {
+  position: relative;
+  width: min(100%, 34rem);
+  padding: clamp(1.5rem, 5vw, 2.5rem);
+  border: 1px solid var(--bem-border);
+  border-radius: 1.5rem;
+  color: var(--bem-text);
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, .28), rgba(255, 255, 255, .12)),
+    rgba(21, 36, 58, .64);
+  box-shadow: var(--bem-shadow);
+  backdrop-filter: blur(24px) saturate(135%);
+  filter: blur(var(--bem-blur-start));
+  opacity: 0;
+  transform: translateY(1.2rem) scale(var(--bem-scale-start));
+  transition:
+    filter var(--bem-duration) var(--bem-easing),
+    opacity var(--bem-duration) var(--bem-easing),
+    transform var(--bem-duration) var(--bem-easing);
+}
+
+.bem-overlay:target .bem-dialog {
+  filter: blur(0);
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.bem-dialog h2 {
+  max-width: 12ch;
+  margin: 0 0 .9rem;
+  font-size: clamp(2rem, 6vw, 3.25rem);
+  line-height: .98;
+  letter-spacing: 0;
+}
+
+.bem-dialog p:not(.bem-modal-kicker) {
+  margin: 0;
+  color: var(--bem-muted);
+  line-height: 1.7;
+}
+
+.bem-close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  display: grid;
+  width: 2.35rem;
+  height: 2.35rem;
+  place-items: center;
+  border: 1px solid var(--bem-border);
+  border-radius: 50%;
+  color: var(--bem-text);
+  background: rgba(255, 255, 255, .12);
+  text-decoration: none;
+  font-size: 1.45rem;
+  line-height: 1;
+  transition: transform 180ms ease, background 180ms ease;
+}
+
+.bem-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .75rem;
+  margin-top: 1.6rem;
+}
+
+.bem-action {
+  padding: 0 1.1rem;
+}
+
+.bem-action-primary {
+  color: #08222b;
+  background: var(--bem-accent-color);
+}
+
+.bem-action-secondary {
+  color: var(--bem-text);
+  border: 1px solid var(--bem-border);
+  background: rgba(255, 255, 255, .1);
+}
+
+@media (max-width: 760px) {
+  .bem-shell {
+    grid-template-columns: 1fr;
+    align-content: center;
+    padding: 1.25rem;
+  }
+
+  .bem-preview {
+    display: none;
+  }
+
+  .bem-hero h1 {
+    font-size: clamp(2.7rem, 18vw, 4.8rem);
+  }
+
+  .bem-dialog {
+    border-radius: 1.15rem;
+  }
+
+  .bem-actions,
+  .bem-action {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bem-open,
+  .bem-action,
+  .bem-close,
+  .bem-overlay,
+  .bem-dialog {
+    transition: none;
+  }
+
+  .bem-dialog {
+    filter: blur(0);
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a self-contained blur-entrance modal example for glassmorphism layouts
- Uses CSS custom properties for duration, easing, blur strength, scale, and accent color
- Uses a JavaScript-free :target interaction with responsive layout and reduced-motion support

Closes #33973

## Tests
- npm run validate:pack
- npm run lint (blocked locally: stylelint is not installed in this clone)