### PR TITLE
 feat : add ease-tooltip-fade-k553 submission

### DIFF
--- a/submissions/examples/ease-tooltip-fade-k553/README.md
+++ b/submissions/examples/ease-tooltip-fade-k553/README.md
@@ -1,0 +1,33 @@
+# Ease Tooltip Fade
+
+## What does this do?
+A **direction-aware** tooltip that fades and slides in from whichever side
+it's positioned on — top, bottom, left, or right — complete with a small
+caret arrow pointing at the trigger element.
+
+## How is it different from a typical tooltip-fade utility?
+- Provides four directional modifiers (`--top`, `--bottom`, `--left`,
+  `--right`) instead of one fixed slide direction.
+- Includes a CSS-only caret/arrow via `::after`, matching the tooltip's
+  direction automatically.
+- Triggers on `:focus-visible` as well as `:hover` for keyboard accessibility.
+- No JavaScript or positioning library required — pure CSS.
+
+## How is it used?
+\`\`\`html
+<div class="ease-tooltip-fade ease-tooltip-fade--top">
+  Hover me
+  <span class="tooltip">Tooltip text</span>
+</div>
+
+<button class="ease-tooltip-fade ease-tooltip-fade--right">
+  Icon
+  <span class="tooltip">Save changes</span>
+</button>
+\`\`\`
+
+## Why is this useful?
+Tooltips are common across buttons, icons, form fields, and nav items, and
+often need to point in different directions depending on layout. This gives
+developers that flexibility in pure CSS while fitting EaseMotion CSS's
+animation-first, JS-free philosophy.

--- a/submissions/examples/ease-tooltip-fade-k553/demo.html
+++ b/submissions/examples/ease-tooltip-fade-k553/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ease Tooltip Fade Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <div class="demo-grid">
+
+    <div class="ease-tooltip-fade ease-tooltip-fade--top">
+      Hover (top)
+      <span class="tooltip">Tooltip on top</span>
+    </div>
+
+    <div class="ease-tooltip-fade ease-tooltip-fade--bottom">
+      Hover (bottom)
+      <span class="tooltip">Tooltip on bottom</span>
+    </div>
+
+    <div class="ease-tooltip-fade ease-tooltip-fade--left">
+      Hover (left)
+      <span class="tooltip">Tooltip on left</span>
+    </div>
+
+    <div class="ease-tooltip-fade ease-tooltip-fade--right">
+      Hover (right)
+      <span class="tooltip">Tooltip on right</span>
+    </div>
+
+    <button class="ease-tooltip-fade ease-tooltip-fade--top">
+      Icon Button
+      <span class="tooltip">Save changes</span>
+    </button>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-tooltip-fade-k553/style.css
+++ b/submissions/examples/ease-tooltip-fade-k553/style.css
@@ -1,0 +1,128 @@
+/* Ease Tooltip Fade
+   A direction-aware tooltip that fades + slides in from whichever side
+   it's positioned on (top/bottom/left/right), with a small caret arrow —
+   instead of a single fixed-direction fade. */
+
+.ease-tooltip-fade {
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+  font-family: system-ui, sans-serif;
+  padding: 0.6rem 1rem;
+  border-radius: 6px;
+  background: #2a2a3a;
+  color: #fff;
+  border: none;
+}
+
+.ease-tooltip-fade .tooltip {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  background: #111;
+  color: #fff;
+  padding: 0.4rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  white-space: nowrap;
+  transition: opacity 0.25s ease, transform 0.25s ease;
+  z-index: 10;
+}
+
+.ease-tooltip-fade .tooltip::after {
+  content: "";
+  position: absolute;
+  border: 5px solid transparent;
+}
+
+.ease-tooltip-fade:hover .tooltip,
+.ease-tooltip-fade:focus-visible .tooltip {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Top */
+.ease-tooltip-fade--top .tooltip {
+  bottom: 100%;
+  left: 50%;
+  transform: translate(-50%, 4px);
+  margin-bottom: 8px;
+}
+.ease-tooltip-fade--top:hover .tooltip,
+.ease-tooltip-fade--top:focus-visible .tooltip {
+  transform: translate(-50%, 0);
+}
+.ease-tooltip-fade--top .tooltip::after {
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-top-color: #111;
+}
+
+/* Bottom */
+.ease-tooltip-fade--bottom .tooltip {
+  top: 100%;
+  left: 50%;
+  transform: translate(-50%, -4px);
+  margin-top: 8px;
+}
+.ease-tooltip-fade--bottom:hover .tooltip,
+.ease-tooltip-fade--bottom:focus-visible .tooltip {
+  transform: translate(-50%, 0);
+}
+.ease-tooltip-fade--bottom .tooltip::after {
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-bottom-color: #111;
+}
+
+/* Left */
+.ease-tooltip-fade--left .tooltip {
+  right: 100%;
+  top: 50%;
+  transform: translate(4px, -50%);
+  margin-right: 8px;
+}
+.ease-tooltip-fade--left:hover .tooltip,
+.ease-tooltip-fade--left:focus-visible .tooltip {
+  transform: translate(0, -50%);
+}
+.ease-tooltip-fade--left .tooltip::after {
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  border-left-color: #111;
+}
+
+/* Right */
+.ease-tooltip-fade--right .tooltip {
+  left: 100%;
+  top: 50%;
+  transform: translate(-4px, -50%);
+  margin-left: 8px;
+}
+.ease-tooltip-fade--right:hover .tooltip,
+.ease-tooltip-fade--right:focus-visible .tooltip {
+  transform: translate(0, -50%);
+}
+.ease-tooltip-fade--right .tooltip::after {
+  right: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  border-right-color: #111;
+}
+
+.demo-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3rem;
+  padding: 4rem;
+}
+
+/* Respect reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .ease-tooltip-fade .tooltip {
+    transition: opacity 0.25s ease;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-tooltip-fade`, a direction-aware tooltip fade utility with top/bottom/left/right variants and a CSS-only caret arrow. Closes #37076.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/ease-tooltip-fade/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A direction-aware tooltip fade-in animation (top/bottom/left/right variants) with a matching CSS-only caret arrow.

**How does a developer use it?**

```html
<div class="ease-tooltip-fade ease-tooltip-fade--top">
  Hover me
  <span class="tooltip">Tooltip text</span>
</div>

Why does it fit EaseMotion CSS?
Pure CSS, no JS dependency, class-based and customizable — matching the library's animation-first philosophy. Differentiates from a single fixed-direction fade by supporting four directional variants with an auto-matching caret, and includes :focus-visible support for accessibility.
Demo
[x] Demo added (demo.html works by opening directly in a browser)
Browser Testing
[x] Chrome
[x] Firefox
[x] Edge
[ ] Safari (optional but appreciated)
Notes for Maintainer
Expanded on the base fade idea by adding directional variants (top/bottom/left/right) and a caret arrow, since tooltips in real UIs usually need to point in different directions. Open to naming/timing adjustments.