### PR TITLE
feat : add ease-notification-slide-k553 submission

### DIFF
--- a/submissions/examples/ease-notification-slide-k553/README.md
+++ b/submissions/examples/ease-notification-slide-k553/README.md
@@ -1,0 +1,34 @@
+# Ease Notification Slide
+
+## What does this do?
+Slides notification/toast components into view with **staggered stacking**
+— each notification in a stack animates in slightly after the previous one,
+simulating a "push down" queue effect — instead of a single isolated slide.
+Includes swipe-to-dismiss cursor affordances and top or bottom stack
+positioning.
+
+## How is it different from a typical notification-slide utility?
+- Provides a `.ease-notification-slide-stack` wrapper with staggered
+  `nth-child` animation delays, so multiple notifications feel queued
+  rather than appearing all at once.
+- Includes semantic variants (`--success`, `--error`, `--info`) with
+  colored left borders.
+- Direction adapts automatically based on stack position (top slides down,
+  bottom slides up) via `--top-right` / `--bottom` stack modifiers.
+- Adds `cursor: grab` / `touch-action: pan-y` styling as a swipe-to-dismiss
+  visual affordance.
+
+## How is it used?
+\`\`\`html
+<div class="ease-notification-slide-stack ease-notification-slide-stack--top-right">
+  <div class="ease-notification-slide ease-notification-slide--success">
+    <strong>Success</strong>
+    <p>Profile updated successfully.</p>
+  </div>
+</div>
+\`\`\`
+
+## Why is this useful?
+Real apps rarely show one toast at a time — this utility handles the
+common multi-notification case with a natural staggered entrance, while
+staying pure CSS and fitting EaseMotion CSS's animation-first philosophy.

--- a/submissions/examples/ease-notification-slide-k553/demo.html
+++ b/submissions/examples/ease-notification-slide-k553/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ease Notification Slide Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <div class="ease-notification-slide-stack ease-notification-slide-stack--top-right">
+    <div class="ease-notification-slide ease-notification-slide--success">
+      <strong>Success</strong>
+      <p>Profile updated successfully.</p>
+    </div>
+    <div class="ease-notification-slide ease-notification-slide--error">
+      <strong>Error</strong>
+      <p>Could not save changes.</p>
+    </div>
+    <div class="ease-notification-slide ease-notification-slide--info">
+      <strong>Info</strong>
+      <p>New update available.</p>
+    </div>
+  </div>
+
+  <div class="ease-notification-slide-stack ease-notification-slide-stack--bottom">
+    <div class="ease-notification-slide ease-notification-slide--info">
+      System message from the bottom
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-notification-slide-k553/style.css
+++ b/submissions/examples/ease-notification-slide-k553/style.css
@@ -1,0 +1,104 @@
+/* Ease Notification Slide
+   Notifications slide in and stack — later items push existing ones
+   aside via sibling-aware spacing, rather than a single fixed slide.
+   Includes a swipe-to-dismiss visual affordance. */
+
+.ease-notification-slide-stack {
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  z-index: 1000;
+  pointer-events: none;
+}
+
+.ease-notification-slide-stack--top-right {
+  top: 1.5rem;
+  right: 1.5rem;
+  align-items: flex-end;
+}
+
+.ease-notification-slide-stack--bottom {
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  align-items: center;
+}
+
+.ease-notification-slide {
+  pointer-events: auto;
+  min-width: 240px;
+  max-width: 320px;
+  padding: 0.9rem 1.1rem;
+  border-radius: 10px;
+  background: #1e1e2e;
+  color: #fff;
+  font-family: system-ui, sans-serif;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+  border-left: 4px solid #2575fc;
+  animation: ens-slide-in 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
+
+  /* swipe-to-dismiss affordance */
+  cursor: grab;
+  touch-action: pan-y;
+}
+
+.ease-notification-slide:active {
+  cursor: grabbing;
+  opacity: 0.85;
+}
+
+.ease-notification-slide strong {
+  display: block;
+  margin-bottom: 0.2rem;
+  font-size: 0.95rem;
+}
+
+.ease-notification-slide p {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+
+/* Stack ordering: each later sibling nudges the previous ones,
+   simulated here via nth-child stagger delay so items feel "pushed" */
+.ease-notification-slide-stack .ease-notification-slide:nth-child(1) { animation-delay: 0s; }
+.ease-notification-slide-stack .ease-notification-slide:nth-child(2) { animation-delay: 0.08s; }
+.ease-notification-slide-stack .ease-notification-slide:nth-child(3) { animation-delay: 0.16s; }
+.ease-notification-slide-stack .ease-notification-slide:nth-child(4) { animation-delay: 0.24s; }
+
+.ease-notification-slide--success { border-left-color: #2ecc71; }
+.ease-notification-slide--error   { border-left-color: #e74c3c; }
+.ease-notification-slide--info    { border-left-color: #2575fc; }
+
+@keyframes ens-slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(-16px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.ease-notification-slide-stack--bottom .ease-notification-slide {
+  animation-name: ens-slide-in-bottom;
+}
+
+@keyframes ens-slide-in-bottom {
+  from {
+    opacity: 0;
+    transform: translateY(16px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-notification-slide {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-notification-slide`, a stacking-aware notification/toast slide-in animation with staggered entrance timing and semantic success/error/info variants. Closes #37077.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/ease-notification-slide/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A notification/toast slide-in animation with staggered stacking for multiple notifications, semantic color variants, and top/bottom stack positioning.

**How does a developer use it?**

```html
<div class="ease-notification-slide-stack ease-notification-slide-stack--top-right">
  <div class="ease-notification-slide ease-notification-slide--success">
    <strong>Success</strong>
    <p>Profile updated successfully.</p>
  </div>
</div>

Why does it fit EaseMotion CSS?
Pure CSS, class-based, no JS required — matching the library's animation-first philosophy. Differentiates from a single fixed slide by handling the common multi-notification stacking case with staggered entrance timing and direction-aware animation based on stack position.
Demo
[x] Demo added (demo.html works by opening directly in a browser)
Browser Testing
[x] Chrome
[x] Firefox
[x] Edge
[ ] Safari (optional but appreciated)
Notes for Maintainer
Extended the base slide idea to handle stacked/multiple notifications with staggered timing, since that's the more common real-world case. Open to naming/timing adjustments.