### PR TITLE
feat(examples): Zoom-In Accordion for Creative Portfolios

### DIFF
--- a/submissions/examples/32854-zoom-in-accordion-creative-portfolio-sj6/README.md
+++ b/submissions/examples/32854-zoom-in-accordion-creative-portfolio-sj6/README.md
@@ -1,0 +1,78 @@
+# Zoom-In Accordion — Creative Portfolio
+
+A pure CSS, zero-dependency **exhibition-index accordion** for portfolio
+sites with a **layered zoom**: opening a project makes its artwork settle
+*down* from an over-zoom (1.12 → 1, a camera pulling focus) while the
+text block zooms *up* into place (0.94 → 1) a beat later. Two directions,
+one gesture — it reads as depth, the way a gallery wall does when you
+step toward a piece. Built on native `<details>`/`<summary>`; no
+JavaScript anywhere.
+
+Resolves Issue: #32854
+
+## ✨ Features
+
+- **Layered, opposing zoom** — the artwork's over-zoom is clipped by its
+  frame (`overflow: hidden`), so it settles *into* the frame; the text
+  column scales up from `transform-origin: left top` after
+  `--zi-text-delay`. Opposing directions give parallax-like depth from
+  two cheap transforms.
+- **Replays on every open** — content inside a closed `<details>` is not
+  rendered, so both zoom layers restart naturally each time. Zero JS.
+- **CSS-generated artwork** — three distinct covers built from
+  radial/conic/repeating gradients, no image files; each carries
+  `role="img"` with an `aria-label` description.
+- **Native accordion semantics** — `<details name="zi-index">` gives
+  exclusive-open behavior (one piece at a time), matching how galleries
+  show work; remove the `name` to allow multiple open.
+- **Keyboard accessible** — `<summary>` is natively focusable and toggles
+  with Enter/Space; accent `:focus-visible` outline; the plus mark
+  rotates to × on open (drawn with two pseudo-element bars, no assets).
+- **White-cube gallery skin** — hairline rules, tabular index numbers,
+  serif titles, uppercase category tags, one restrained terracotta
+  accent.
+- **Genuinely responsive** — the artwork/text grid collapses to a single
+  column under 480px with the art staying framed edge-to-edge.
+- **Tunable via custom properties** — art over-zoom, text scale, settle
+  duration, text delay, easing, and marker rotation on `:root`.
+- **Motion-safe** — `prefers-reduced-motion` removes both zoom layers;
+  pieces appear hung, not zoomed.
+
+## 🔧 Custom Properties
+
+| Property               | Default                          | Role                        |
+| ---------------------- | -------------------------------- | --------------------------- |
+| `--zi-art-from`        | `1.12`                           | Artwork starting over-zoom  |
+| `--zi-text-from`       | `0.94`                           | Text starting scale         |
+| `--zi-duration`        | `420ms`                          | Zoom settle time            |
+| `--zi-text-delay`      | `60ms`                           | Text starts after the art   |
+| `--zi-ease`            | `cubic-bezier(0.22, 1, 0.36, 1)` | Focus-pull curve            |
+| `--zi-toggle-duration` | `240ms`                          | Plus-mark rotation          |
+
+## 🚀 Usage
+
+```html
+<details class="zi-item" name="my-index">
+  <summary class="zi-head">
+    <span class="zi-num">01</span>
+    <span class="zi-name">Night Signals</span>
+    <span class="zi-kind">Identity</span>
+    <span class="zi-mark" aria-hidden="true"></span>
+  </summary>
+  <div class="zi-body">
+    <div class="zi-frame">
+      <div class="zi-art is-signals" role="img" aria-label="Cover description"></div>
+    </div>
+    <div class="zi-info">
+      <h2 class="zi-info-title">Project headline</h2>
+      <p class="zi-info-text">Short description.</p>
+    </div>
+  </div>
+</details>
+```
+
+## 📂 Files
+
+- `demo.html` — a three-entry portfolio index (identity / editorial / exhibition).
+- `style.css` — motion tokens, layered zoom engine, white-cube skin, a11y guards.
+- `README.md` — this document.

--- a/submissions/examples/32854-zoom-in-accordion-creative-portfolio-sj6/demo.html
+++ b/submissions/examples/32854-zoom-in-accordion-creative-portfolio-sj6/demo.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Zoom-In Accordion — Creative Portfolio</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="zi-index">
+    <h1 class="zi-index-title">Ilya Renn — Index</h1>
+    <p class="zi-index-sub">
+      Open an entry — the artwork settles from an over-zoom while the text
+      zooms up beside it. Tab + Enter works — no JavaScript.
+    </p>
+
+    <!-- name="zi-index" makes the accordion exclusive: opening one
+         entry closes the others, natively. -->
+    <details class="zi-item" name="zi-index" open>
+      <summary class="zi-head">
+        <span class="zi-num">01</span>
+        <span class="zi-name">Night Signals</span>
+        <span class="zi-kind">Identity</span>
+        <span class="zi-mark" aria-hidden="true"></span>
+      </summary>
+      <div class="zi-body">
+        <div class="zi-frame">
+          <div class="zi-art is-signals" role="img"
+               aria-label="Abstract cover: warm signal glow over dark stripes"></div>
+        </div>
+        <div class="zi-info">
+          <h2 class="zi-info-title">Brand identity for a late-night radio collective</h2>
+          <p class="zi-info-text">
+            A wordmark that hums — variable-weight type and a sweeping
+            signal motif carried across posters, sleeves, and live-show
+            visuals.
+          </p>
+          <ul class="zi-meta">
+            <li><strong>Year</strong> 2026</li>
+            <li><strong>Role</strong> Lead design</li>
+            <li><strong>Medium</strong> Print · Motion</li>
+          </ul>
+        </div>
+      </div>
+    </details>
+
+    <details class="zi-item" name="zi-index">
+      <summary class="zi-head">
+        <span class="zi-num">02</span>
+        <span class="zi-name">Tide Atlas</span>
+        <span class="zi-kind">Editorial</span>
+        <span class="zi-mark" aria-hidden="true"></span>
+      </summary>
+      <div class="zi-body">
+        <div class="zi-frame">
+          <div class="zi-art is-tide" role="img"
+               aria-label="Abstract cover: cool coastal gradient with a deep blue pool"></div>
+        </div>
+        <div class="zi-info">
+          <h2 class="zi-info-title">A 180-page field study of disappearing coastlines</h2>
+          <p class="zi-info-text">
+            Duotone photography, tide-table typography, and fold-out maps —
+            designed to be read slowly and kept longer.
+          </p>
+          <ul class="zi-meta">
+            <li><strong>Year</strong> 2025</li>
+            <li><strong>Role</strong> Art direction</li>
+            <li><strong>Medium</strong> Book</li>
+          </ul>
+        </div>
+      </div>
+    </details>
+
+    <details class="zi-item" name="zi-index">
+      <summary class="zi-head">
+        <span class="zi-num">03</span>
+        <span class="zi-name">Meridian</span>
+        <span class="zi-kind">Exhibition</span>
+        <span class="zi-mark" aria-hidden="true"></span>
+      </summary>
+      <div class="zi-body">
+        <div class="zi-frame">
+          <div class="zi-art is-meridian" role="img"
+               aria-label="Abstract cover: conic sweep of terracotta and ink on bone"></div>
+        </div>
+        <div class="zi-info">
+          <h2 class="zi-info-title">Wayfinding and graphics for a solar-time pavilion</h2>
+          <p class="zi-info-text">
+            Signage that rotates meaning with the sun — angles, shadows,
+            and a palette borrowed from sundials.
+          </p>
+          <ul class="zi-meta">
+            <li><strong>Year</strong> 2024</li>
+            <li><strong>Role</strong> Environmental</li>
+            <li><strong>Medium</strong> Spatial</li>
+          </ul>
+        </div>
+      </div>
+    </details>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/32854-zoom-in-accordion-creative-portfolio-sj6/style.css
+++ b/submissions/examples/32854-zoom-in-accordion-creative-portfolio-sj6/style.css
@@ -1,0 +1,278 @@
+/* ==========================================================================
+   Zoom-In Accordion — Creative Portfolio
+   --------------------------------------------------------------------------
+   Pure CSS exhibition-index accordion for portfolio sites, built on
+   native <details>/<summary>. The signature is a LAYERED ZOOM: when a
+   project opens, its artwork settles DOWN from an over-zoom (1.12 → 1,
+   like a camera pulling focus) while the text block zooms UP into place
+   (0.94 → 1). Two directions, one gesture — it reads as depth, the way
+   a gallery wall does when you step toward a piece.
+
+   Content inside a closed <details> is not rendered, so both zoom layers
+   replay naturally on every open. Zero JavaScript.
+
+   Issue: #32854
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Tokens — motion first, then the white-cube skin
+   -------------------------------------------------------------------------- */
+:root {
+  /* Layered zoom */
+  --zi-art-from: 1.12;                             /* artwork over-zoom      */
+  --zi-text-from: 0.94;                            /* text starting scale    */
+  --zi-duration: 420ms;                            /* zoom settle time       */
+  --zi-text-delay: 60ms;                           /* text follows the art   */
+  --zi-ease: cubic-bezier(0.22, 1, 0.36, 1);       /* focus-pull curve       */
+  --zi-toggle-duration: 240ms;                     /* index marker rotation  */
+
+  /* White-cube gallery skin */
+  --zi-canvas: #fafafa;
+  --zi-ink: #171513;
+  --zi-body: #7c766e;
+  --zi-rule: #e5e2dd;
+  --zi-accent: #d64524;
+
+  font-size: 16px;
+}
+
+/* --------------------------------------------------------------------------
+   2. Demo stage — an exhibition index
+   -------------------------------------------------------------------------- */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 34px 16px;
+  box-sizing: border-box;
+  background: var(--zi-canvas);
+  font-family: "Segoe UI", system-ui, -apple-system, Arial, sans-serif;
+  color: var(--zi-body);
+}
+
+.zi-index {
+  width: 100%;
+  max-width: 560px;
+}
+
+.zi-index-title {
+  margin: 0 0 4px;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: var(--zi-ink);
+}
+
+.zi-index-sub {
+  margin: 0 0 22px;
+  font-size: 0.78rem;
+}
+
+/* --------------------------------------------------------------------------
+   3. Entries — hairline-ruled index rows, native disclosure
+   -------------------------------------------------------------------------- */
+.zi-item {
+  border-top: 1px solid var(--zi-rule);
+}
+
+.zi-item:last-of-type {
+  border-bottom: 1px solid var(--zi-rule);
+}
+
+.zi-head {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  padding: 16px 4px;
+  cursor: pointer;
+  list-style: none;                 /* hide default marker (Firefox) */
+  user-select: none;
+  color: var(--zi-ink);
+  transition: color 160ms ease;
+}
+
+.zi-head::-webkit-details-marker { display: none; }
+
+.zi-head:hover { color: var(--zi-accent); }
+
+.zi-head:focus-visible {
+  outline: 2px solid var(--zi-accent);
+  outline-offset: 2px;
+}
+
+/* Index number — the gallery wall label */
+.zi-num {
+  flex: none;
+  font-variant-numeric: tabular-nums;
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  color: var(--zi-body);
+}
+
+.zi-name {
+  font-family: Georgia, serif;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.zi-kind {
+  margin-left: auto;
+  flex: none;
+  font-size: 0.7rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+/* A "+" that becomes "×" when the entry is open */
+.zi-mark {
+  position: relative;
+  flex: none;
+  align-self: center;
+  width: 14px;
+  height: 14px;
+  transition: transform var(--zi-toggle-duration) var(--zi-ease);
+}
+
+.zi-mark::before,
+.zi-mark::after {
+  content: "";
+  position: absolute;
+  inset: 50% auto auto 50%;
+  translate: -50% -50%;
+  background: currentColor;
+}
+
+.zi-mark::before { width: 14px; height: 1.5px; }
+.zi-mark::after  { width: 1.5px; height: 14px; }
+
+.zi-item[open] > .zi-head .zi-mark {
+  transform: rotate(45deg);
+}
+
+/* --------------------------------------------------------------------------
+   4. The layered zoom — artwork settles down, text zooms up
+   -------------------------------------------------------------------------- */
+.zi-body {
+  display: grid;
+  grid-template-columns: minmax(140px, 220px) 1fr;
+  gap: 16px;
+  padding: 2px 4px 20px;
+}
+
+/* Frame clips the artwork's over-zoom */
+.zi-frame {
+  overflow: hidden;
+  background: #eceae6;
+}
+
+/* CSS-generated artwork — no image files. Settles from over-zoom. */
+.zi-art {
+  aspect-ratio: 4 / 3;
+  animation: zi-art-in var(--zi-duration) var(--zi-ease) both;
+}
+
+@keyframes zi-art-in {
+  from {
+    opacity: 0;
+    transform: scale(var(--zi-art-from));
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.zi-art.is-signals {
+  background:
+    radial-gradient(circle at 70% 25%, rgba(214, 69, 36, 0.65), transparent 45%),
+    repeating-linear-gradient(105deg, #2a2320 0 14px, #38302b 14px 28px);
+}
+
+.zi-art.is-tide {
+  background:
+    radial-gradient(circle at 25% 75%, rgba(36, 96, 130, 0.7), transparent 55%),
+    linear-gradient(15deg, #d9d4cc 0%, #a8b6bd 60%, #5c7a8a 100%);
+}
+
+.zi-art.is-meridian {
+  background:
+    conic-gradient(from 210deg at 60% 40%, #e2ddd4 0 25%, #c96a4a 25% 32%, #e2ddd4 32% 60%, #3a3833 60% 63%, #e2ddd4 63%);
+}
+
+/* Text column zooms up a beat after the art */
+.zi-info {
+  transform-origin: left top;
+  animation: zi-text-in var(--zi-duration) var(--zi-ease) var(--zi-text-delay) both;
+}
+
+@keyframes zi-text-in {
+  from {
+    opacity: 0;
+    transform: scale(var(--zi-text-from));
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.zi-info-title {
+  margin: 0 0 6px;
+  font-family: Georgia, serif;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--zi-ink);
+}
+
+.zi-info-text {
+  margin: 0 0 12px;
+  font-size: 0.8rem;
+  line-height: 1.6;
+}
+
+.zi-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 16px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+}
+
+.zi-meta strong {
+  color: var(--zi-ink);
+  font-weight: 600;
+}
+
+/* --------------------------------------------------------------------------
+   5. Small screens — the two columns stack, art stays framed
+   -------------------------------------------------------------------------- */
+@media (max-width: 480px) {
+  .zi-body {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .zi-kind { display: none; }
+}
+
+/* --------------------------------------------------------------------------
+   6. Reduced motion — pieces appear hung, not zoomed
+   -------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .zi-art,
+  .zi-info {
+    animation: none;
+  }
+
+  .zi-mark {
+    transition: none;
+  }
+
+  .zi-head {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS **Zoom-In Accordion** styled for **Creative Portfolio** layouts as a fully self-contained example under `submissions/examples/32854-zoom-in-accordion-creative-portfolio-sj6/`.

Fixes #32854

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/32854-zoom-in-accordion-creative-portfolio-sj6/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A zero-JavaScript exhibition-index accordion with a layered, opposing zoom: opening a project settles its artwork down from an over-zoom (1.12 → 1, clipped by its frame so it zooms *into* place) while the text column zooms up (0.94 → 1) a 60ms beat later from `transform-origin: left top`. Opposing directions read as parallax depth from two cheap transforms. Artwork covers are CSS gradients (radial/conic/repeating) — no image files — each with `role="img"` and a descriptive `aria-label`. Both layers replay on every open.

**How does a developer use it?**

```html
<details class="zi-item" name="my-index">
  <summary class="zi-head">
    <span class="zi-num">01</span>
    <span class="zi-name">Night Signals</span>
    <span class="zi-kind">Identity</span>
    <span class="zi-mark" aria-hidden="true"></span>
  </summary>
  <div class="zi-body">
    <div class="zi-frame">
      <div class="zi-art is-signals" role="img" aria-label="Cover description"></div>
    </div>
    <div class="zi-info">
      <h2 class="zi-info-title">Project headline</h2>
      <p class="zi-info-text">Short description.</p>
    </div>
  </div>
</details>
```

**Why does it fit EaseMotion CSS?**

Human-readable classes, animation-first, zero JS. Art over-zoom, text scale, settle duration, text delay, easing, and marker rotation are `--zi-*` custom properties on `:root`; `<details name>` provides exclusive-open natively (one piece at a time, like a gallery); `<summary>` gives Tab/Enter operation with an accent `:focus-visible` outline; the plus-to-× marker is two pseudo-element bars, no assets; `prefers-reduced-motion` removes both zoom layers so pieces appear hung, not zoomed.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The over-zoom direction on the artwork is the detail worth preserving: zooming *down into* the frame (with the frame clipping the start) is what makes it feel like focus being pulled rather than a card popping. White-cube skin (hairline rules, tabular index numbers, serif titles) keeps it distinct from the six existing zoom-in accordions for other layout themes.

@SAPTARSHI-coder Please review
