### PR TITLE
feat(examples): Jello-Hover Accordion for Modern SaaS

### DIFF
--- a/submissions/examples/33035-jello-hover-accordion-modern-saas-sj6/README.md
+++ b/submissions/examples/33035-jello-hover-accordion-modern-saas-sj6/README.md
@@ -1,0 +1,74 @@
+# Jello-Hover Accordion — Modern SaaS
+
+A pure CSS, zero-dependency **integrations accordion** for SaaS settings
+pages where the jello is deliberately *scoped*: hovering a closed section
+wiggles only its **logo chip** — a small squash-and-stretch that reads as
+a friendly product microinteraction, not a page effect. Opening a section
+gives the panel one soft settle; open sections never wiggle. Built on
+native `<details>`/`<summary>`; no JavaScript anywhere.
+
+Resolves Issue: #33035
+
+## ✨ Features
+
+- **Scoped, one-token jello** — the squash-and-stretch lives on the
+  30px logo chip, and every keyframe is computed from a single amplitude
+  token (`--sa-squash`) via `calc()` (±14% → ∓11% → ±6% → ∓3% → ±1% → 0).
+  One number tunes the whole gesture; scoping it to the chip keeps the
+  header text perfectly still.
+- **Closed sections only** — the wiggle applies via
+  `.sa-item:not([open])`, and the open panel's content holds still after
+  a single `sa-settle` (fade + 3% scaleY from the top) that replays on
+  every open, since closed `<details>` content isn't rendered.
+- **Keyboard parity** — the chip jello also fires on
+  `.sa-head:focus-visible`, so Tab users get the same wink; Enter/Space
+  toggles natively; 2px accent focus ring on the header.
+- **Native accordion semantics** — `<details name="sa-integrations">`
+  gives exclusive-open behavior with zero JS.
+- **SaaS-native details** — dotted-grid canvas, brandable logo chips,
+  Connected / Not-connected state chips, monospace scope tags
+  (`chat:write`), dashed row separators, tabular numerals.
+- **Genuinely responsive** — fluid panel up to 540px; under 420px row
+  values wrap onto their own line so rows stay readable on phones.
+- **Tunable via custom properties** — squash amplitude, wiggle duration,
+  settle duration, easing, and chevron rotation on `:root`.
+- **Motion-safe** — `prefers-reduced-motion` removes the wiggle and the
+  settle; the hover cue survives as an accent border change.
+
+## 🔧 Custom Properties
+
+| Property                | Default                          | Role                            |
+| ----------------------- | -------------------------------- | ------------------------------- |
+| `--sa-squash`           | `0.14`                           | Chip jello amplitude (±14%)     |
+| `--sa-duration`         | `540ms`                          | Whole wiggle gesture            |
+| `--sa-settle-duration`  | `240ms`                          | Panel settle on open            |
+| `--sa-ease`             | `cubic-bezier(0.22, 1, 0.36, 1)` | Settle curve                    |
+| `--sa-toggle-duration`  | `220ms`                          | Chevron rotation                |
+
+## 🚀 Usage
+
+```html
+<details class="sa-item" name="my-integrations">
+  <summary class="sa-head">
+    <span class="sa-logo is-relay" aria-hidden="true">R</span>
+    <span class="sa-head-name">
+      Relay
+      <span class="sa-head-kind">Team chat</span>
+    </span>
+    <span class="sa-state is-on">Connected</span>
+    <span class="sa-chevron" aria-hidden="true"></span>
+  </summary>
+  <div class="sa-body">
+    <div class="sa-row">
+      <span class="sa-row-label">Scopes</span>
+      <span class="sa-scope">chat:write</span>
+    </div>
+  </div>
+</details>
+```
+
+## 📂 Files
+
+- `demo.html` — an "Integrations" settings panel (chat / source control / issues).
+- `style.css` — motion tokens, calc()-driven chip jello, SaaS skin, a11y guards.
+- `README.md` — this document.

--- a/submissions/examples/33035-jello-hover-accordion-modern-saas-sj6/demo.html
+++ b/submissions/examples/33035-jello-hover-accordion-modern-saas-sj6/demo.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Jello-Hover Accordion — Modern SaaS</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <section class="sa-panel" aria-label="Integrations">
+    <h1 class="sa-panel-title">Integrations</h1>
+    <p class="sa-panel-sub">
+      Hover (or Tab to) a closed integration — its logo chip jellos.
+      Open panels settle once and hold still. Enter toggles.
+      No JavaScript.
+    </p>
+
+    <!-- name="sa-integrations" makes the accordion exclusive: opening
+         one section closes the others, natively. -->
+    <details class="sa-item" name="sa-integrations" open>
+      <summary class="sa-head">
+        <span class="sa-logo is-relay" aria-hidden="true">R</span>
+        <span class="sa-head-name">
+          Relay
+          <span class="sa-head-kind">Team chat</span>
+        </span>
+        <span class="sa-state is-on">Connected</span>
+        <span class="sa-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="sa-body">
+        <div class="sa-row">
+          <span class="sa-row-label">Workspace</span>
+          <span class="sa-row-value">acme-hq</span>
+        </div>
+        <div class="sa-row">
+          <span class="sa-row-label">Scopes</span>
+          <span class="sa-scope">chat:write</span>
+          <span class="sa-scope">alerts:read</span>
+        </div>
+        <div class="sa-row">
+          <span class="sa-row-label">Last event</span>
+          <span class="sa-row-value">2 min ago</span>
+        </div>
+      </div>
+    </details>
+
+    <details class="sa-item" name="sa-integrations">
+      <summary class="sa-head">
+        <span class="sa-logo is-forge" aria-hidden="true">F</span>
+        <span class="sa-head-name">
+          Forge
+          <span class="sa-head-kind">Source control</span>
+        </span>
+        <span class="sa-state is-on">Connected</span>
+        <span class="sa-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="sa-body">
+        <div class="sa-row">
+          <span class="sa-row-label">Organization</span>
+          <span class="sa-row-value">acme-eng</span>
+        </div>
+        <div class="sa-row">
+          <span class="sa-row-label">Scopes</span>
+          <span class="sa-scope">repo:read</span>
+          <span class="sa-scope">checks:write</span>
+        </div>
+        <div class="sa-row">
+          <span class="sa-row-label">Repos synced</span>
+          <span class="sa-row-value">24</span>
+        </div>
+      </div>
+    </details>
+
+    <details class="sa-item" name="sa-integrations">
+      <summary class="sa-head">
+        <span class="sa-logo is-orbit" aria-hidden="true">O</span>
+        <span class="sa-head-name">
+          Orbit
+          <span class="sa-head-kind">Issue tracking</span>
+        </span>
+        <span class="sa-state is-off">Not connected</span>
+        <span class="sa-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="sa-body">
+        <div class="sa-row">
+          <span class="sa-row-label">Status</span>
+          <span class="sa-row-value">Awaiting authorization</span>
+        </div>
+        <div class="sa-row">
+          <span class="sa-row-label">Requested scopes</span>
+          <span class="sa-scope">issues:read</span>
+          <span class="sa-scope">issues:write</span>
+        </div>
+        <div class="sa-row">
+          <span class="sa-row-label">Docs</span>
+          <span class="sa-row-value">settings → integrations → orbit</span>
+        </div>
+      </div>
+    </details>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/33035-jello-hover-accordion-modern-saas-sj6/style.css
+++ b/submissions/examples/33035-jello-hover-accordion-modern-saas-sj6/style.css
@@ -1,0 +1,285 @@
+/* ==========================================================================
+   Jello-Hover Accordion — Modern SaaS
+   --------------------------------------------------------------------------
+   Pure CSS integrations accordion for SaaS settings pages, built on
+   native <details>/<summary>. The jello is deliberately SCOPED: hovering
+   a closed section wiggles only its logo chip — a small squash-and-
+   stretch that reads as a friendly product microinteraction, not a page
+   effect. Opening a section gives the panel one soft settle; open
+   sections never wiggle.
+
+   The chip's squash amplitude is a single custom property (--sa-squash)
+   fed through calc() in the keyframes: one number tunes the whole
+   gesture. Zero JavaScript.
+
+   Issue: #33035
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Tokens — motion first, then the SaaS skin
+   -------------------------------------------------------------------------- */
+:root {
+  /* Chip jello */
+  --sa-squash: 0.14;                               /* amplitude: 0.14 = ±14% */
+  --sa-duration: 540ms;                            /* whole wiggle           */
+  --sa-settle-duration: 240ms;                     /* panel settle on open   */
+  --sa-ease: cubic-bezier(0.22, 1, 0.36, 1);       /* settle curve           */
+  --sa-toggle-duration: 220ms;                     /* chevron rotation       */
+
+  /* SaaS settings skin */
+  --sa-canvas: #f7f9fc;
+  --sa-card: #ffffff;
+  --sa-border: #e3e9f1;
+  --sa-heading: #14263b;
+  --sa-body: #5d7188;
+  --sa-accent: #0284c7;
+  --sa-accent-soft: #e5f4fd;
+  --sa-ok: #12855f;
+  --sa-ok-soft: #e2f5ec;
+  --sa-muted-soft: #eef1f6;
+
+  --sa-card-shadow: 0 1px 3px rgba(20, 38, 59, 0.06);
+}
+
+/* --------------------------------------------------------------------------
+   2. Demo stage — an integrations settings panel
+   -------------------------------------------------------------------------- */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 34px 16px;
+  box-sizing: border-box;
+  background:
+    radial-gradient(rgba(2, 132, 199, 0.07) 1px, transparent 1.5px) 0 0 / 22px 22px,
+    var(--sa-canvas);
+  font-family: "Segoe UI", system-ui, -apple-system, Arial, sans-serif;
+  color: var(--sa-body);
+}
+
+.sa-panel {
+  width: 100%;
+  max-width: 540px;
+}
+
+.sa-panel-title {
+  margin: 0 0 3px;
+  font-size: 1.05rem;
+  font-weight: 650;
+  color: var(--sa-heading);
+}
+
+.sa-panel-sub {
+  margin: 0 0 18px;
+  font-size: 0.78rem;
+}
+
+/* --------------------------------------------------------------------------
+   3. Sections — native disclosure cards
+   -------------------------------------------------------------------------- */
+.sa-item {
+  background: var(--sa-card);
+  border: 1px solid var(--sa-border);
+  border-radius: 12px;
+  box-shadow: var(--sa-card-shadow);
+  transition: border-color 180ms ease;
+}
+
+.sa-item + .sa-item {
+  margin-top: 10px;
+}
+
+.sa-item[open] {
+  border-color: var(--sa-accent);
+}
+
+.sa-item:not([open]):hover {
+  border-color: var(--sa-accent);
+}
+
+.sa-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 13px 15px;
+  cursor: pointer;
+  list-style: none;                 /* hide default marker (Firefox) */
+  user-select: none;
+  color: var(--sa-heading);
+  font-size: 0.86rem;
+  font-weight: 600;
+}
+
+.sa-head::-webkit-details-marker { display: none; }
+
+.sa-head:focus-visible {
+  outline: 2px solid var(--sa-accent);
+  outline-offset: -2px;
+  border-radius: 10px;
+}
+
+/* --------------------------------------------------------------------------
+   4. The jello chip — squash-and-stretch scoped to the logo
+   --------------------------------------------------------------------------
+   Only while the section is CLOSED, and also when the summary takes
+   keyboard focus, so Tab users get the same wink. One amplitude token
+   (--sa-squash) drives every keyframe via calc(). */
+.sa-logo {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  flex: none;
+  border-radius: 9px;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.sa-logo.is-relay { background: #6a5ae0; }
+.sa-logo.is-forge { background: #24313f; }
+.sa-logo.is-orbit { background: #0e9f6e; }
+
+.sa-item:not([open]) > .sa-head:hover .sa-logo,
+.sa-item:not([open]) > .sa-head:focus-visible .sa-logo {
+  animation: sa-jello var(--sa-duration) ease-in-out;
+}
+
+@keyframes sa-jello {
+  0%   { transform: scale3d(1, 1, 1); }
+  25%  { transform: scale3d(calc(1 + var(--sa-squash)), calc(1 - var(--sa-squash)), 1); }
+  40%  { transform: scale3d(calc(1 - var(--sa-squash) * 0.8), calc(1 + var(--sa-squash) * 0.8), 1); }
+  55%  { transform: scale3d(calc(1 + var(--sa-squash) * 0.45), calc(1 - var(--sa-squash) * 0.45), 1); }
+  70%  { transform: scale3d(calc(1 - var(--sa-squash) * 0.2), calc(1 + var(--sa-squash) * 0.2), 1); }
+  85%  { transform: scale3d(calc(1 + var(--sa-squash) * 0.08), calc(1 - var(--sa-squash) * 0.08), 1); }
+  100% { transform: scale3d(1, 1, 1); }
+}
+
+.sa-head-name {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.sa-head-kind {
+  font-size: 0.68rem;
+  font-weight: 500;
+  color: var(--sa-body);
+}
+
+/* Connection state chip */
+.sa-state {
+  margin-left: auto;
+  flex: none;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 0.64rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.sa-state.is-on  { background: var(--sa-ok-soft); color: var(--sa-ok); }
+.sa-state.is-off { background: var(--sa-muted-soft); color: var(--sa-body); }
+
+/* Chevron rotates as the section opens */
+.sa-chevron {
+  flex: none;
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid var(--sa-body);
+  border-bottom: 2px solid var(--sa-body);
+  transform: rotate(45deg);
+  transition: transform var(--sa-toggle-duration) var(--sa-ease);
+}
+
+.sa-item[open] > .sa-head .sa-chevron {
+  transform: rotate(225deg);
+}
+
+/* --------------------------------------------------------------------------
+   5. Body — one soft settle on open, then holds still
+   --------------------------------------------------------------------------
+   Content inside a closed <details> is not rendered, so the settle
+   replays on every open. */
+.sa-body {
+  padding: 2px 15px 12px;
+  transform-origin: top center;
+  animation: sa-settle var(--sa-settle-duration) var(--sa-ease) both;
+}
+
+@keyframes sa-settle {
+  from {
+    opacity: 0;
+    transform: translateY(4px) scaleY(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scaleY(1);
+  }
+}
+
+.sa-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  padding: 9px 2px;
+  font-size: 0.8rem;
+}
+
+.sa-row + .sa-row {
+  border-top: 1px dashed var(--sa-border);
+}
+
+.sa-row-label {
+  color: var(--sa-heading);
+  font-weight: 600;
+}
+
+.sa-row-value {
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+}
+
+.sa-scope {
+  flex: none;
+  padding: 2px 8px;
+  border-radius: 6px;
+  background: var(--sa-accent-soft);
+  color: var(--sa-accent);
+  font-family: Consolas, "Courier New", monospace;
+  font-size: 0.68rem;
+}
+
+/* --------------------------------------------------------------------------
+   6. Small screens — tighten paddings, keep rows readable
+   -------------------------------------------------------------------------- */
+@media (max-width: 420px) {
+  .sa-head { padding: 12px 12px; }
+  .sa-body { padding: 2px 12px 10px; }
+  .sa-row-value { flex-basis: 100%; margin-left: 0; }
+}
+
+/* --------------------------------------------------------------------------
+   7. Reduced motion — no wiggle, no settle; hover cue survives as border
+   -------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .sa-item:not([open]) > .sa-head:hover .sa-logo,
+  .sa-item:not([open]) > .sa-head:focus-visible .sa-logo {
+    animation: none;
+  }
+
+  .sa-body {
+    animation: none;
+  }
+
+  .sa-chevron {
+    transition: none;
+  }
+
+  .sa-item {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS **Jello-Hover Accordion** styled for **Modern SaaS** layouts as a fully self-contained example under `submissions/examples/33035-jello-hover-accordion-modern-saas-sj6/`.

Fixes #33035

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/33035-jello-hover-accordion-modern-saas-sj6/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A zero-JavaScript integrations accordion for SaaS settings pages with a deliberately scoped jello: hovering a closed section wiggles only its logo chip — a decaying squash-and-stretch where every keyframe is computed from one amplitude token (`--sa-squash`) via `calc()`. The header text never moves. Opening a section plays a single soft settle (fade + 3% scaleY from the top) that replays on every open; open sections never wiggle.

**How does a developer use it?**

```html
<details class="sa-item" name="my-integrations">
  <summary class="sa-head">
    <span class="sa-logo is-relay" aria-hidden="true">R</span>
    <span class="sa-head-name">
      Relay
      <span class="sa-head-kind">Team chat</span>
    </span>
    <span class="sa-state is-on">Connected</span>
    <span class="sa-chevron" aria-hidden="true"></span>
  </summary>
  <div class="sa-body">
    <div class="sa-row">
      <span class="sa-row-label">Scopes</span>
      <span class="sa-scope">chat:write</span>
    </div>
  </div>
</details>
```

**Why does it fit EaseMotion CSS?**

Human-readable classes, animation-first, zero JS. Squash amplitude, wiggle duration, settle duration, easing, and chevron rotation are `--sa-*` custom properties on `:root`; the chip jello also fires on `:focus-visible`, giving keyboard users the same wink; `<details name>` provides exclusive-open natively with Enter/Space toggling from `<summary>`; `prefers-reduced-motion` removes the wiggle and settle while the hover cue survives as an accent border change.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Deliberately distinct from my Responsive Dashboard jello accordion (#33045): that one wiggles the whole closed card; this one scopes the jello to the 30px logo chip so the header text stays perfectly still — at SaaS-settings density, a whole-card wiggle is too loud. Demo integrations use invented product names (Relay / Forge / Orbit) to avoid trademarked logos.

@SAPTARSHI-coder Please review
