### PR TITLE
feat(examples): Draw-Border Line Accordion for Glassmorphism UI

### DIFF
--- a/submissions/examples/33188-draw-border-accordion-glassmorphism-sj6/README.md
+++ b/submissions/examples/33188-draw-border-accordion-glassmorphism-sj6/README.md
@@ -1,0 +1,86 @@
+# Draw-Border Line Accordion — Glassmorphism UI
+
+A pure CSS, zero-dependency **accordion of frosted-glass cards** where
+opening a section makes a luminous line **draw itself clockwise around
+the card** — top and right edges first, then bottom and left — and
+**retrace the way it came** on close. Because the draw is a
+`background-size` *transition* (not a keyframe animation), it is fully
+reversible mid-gesture: close a half-drawn card and the line walks back
+from wherever it was. Built on native `<details>`/`<summary>`; no
+JavaScript anywhere.
+
+Resolves Issue: #33188
+
+## ✨ Features
+
+- **Two-phase perimeter draw** — `::before` holds the top and right
+  lines, `::after` the bottom and left; each line is a `linear-gradient`
+  that grows via `background-size` (`0 → 100%` along its axis). Phase
+  delays sequence them clockwise on open, and the delays swap in the
+  closed state so the retraction plays in reverse order.
+- **Reversible mid-gesture** — transitions, not animations: interrupting
+  the draw reverses it smoothly from its current length instead of
+  snapping.
+- **Luminous stroke** — the mint line carries a `drop-shadow` glow so it
+  reads as light traveling along the glass edge, not a hairline border.
+- **Real glass recipe** — `backdrop-filter: blur(14px) saturate(1.35)`
+  (with `-webkit-` twin), translucent tint and border, deeper tint when
+  open, and an `@supports` fallback that darkens the card where
+  backdrop-filter is unsupported.
+- **Native accordion semantics** — `<details name="dl-trip">` gives
+  exclusive-open behavior straight from the browser; remove the `name`
+  to allow multiple open.
+- **Keyboard accessible** — `<summary>` is natively focusable and toggles
+  with Enter/Space; a 2px mint `:focus-visible` ring matches the stroke.
+- **Itinerary-style content** — day chips, tabular time column, activity
+  + note rows with hairline separators; body content fades quietly so
+  the drawn line stays the star.
+- **Genuinely responsive** — fluid stack up to 520px; under 420px the
+  notes wrap beneath their activity.
+- **Tunable via custom properties** — stroke thickness, full-perimeter
+  duration, easing, line color, and body fade on `:root`.
+- **Motion-safe** — `prefers-reduced-motion` removes the travel; the
+  line appears fully drawn on open, instantly.
+
+## 🔧 Custom Properties
+
+| Property               | Default       | Role                          |
+| ---------------------- | ------------- | ----------------------------- |
+| `--dl-line`            | `2px`         | Stroke thickness              |
+| `--dl-draw-duration`   | `520ms`       | Full perimeter draw time      |
+| `--dl-ease`            | `ease-in-out` | Pen-like draw curve           |
+| `--dl-line-color`      | `#7ff5e3`     | Luminous stroke color         |
+| `--dl-body-duration`   | `260ms`       | Content fade on open          |
+| `--dl-blur`            | `14px`        | Backdrop frost radius         |
+
+## 🚀 Usage
+
+```html
+<details class="dl-item" name="my-trip">
+  <summary class="dl-head">
+    <span class="dl-day">Day 1</span>
+    Arrival &amp; Higashiyama
+    <span class="dl-head-meta">3 stops</span>
+    <span class="dl-chevron" aria-hidden="true"></span>
+  </summary>
+  <div class="dl-body">
+    <div class="dl-row">
+      <span class="dl-time">09:40</span>
+      <span class="dl-what">Land at KIX, express to Kyoto</span>
+      <span class="dl-note">IC card ready</span>
+    </div>
+  </div>
+</details>
+```
+
+## 📂 Files
+
+- `demo.html` — a three-day Kyoto itinerary in glass cards.
+- `style.css` — motion tokens, two-phase draw engine, glass recipe + fallback, a11y guards.
+- `README.md` — this document.
+
+## 📝 Note
+
+The gradient lines are straight, so they are clipped by the card's
+10px `border-radius` at the corners — kept small deliberately so the
+stroke hugs the glass edge cleanly.

--- a/submissions/examples/33188-draw-border-accordion-glassmorphism-sj6/demo.html
+++ b/submissions/examples/33188-draw-border-accordion-glassmorphism-sj6/demo.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Draw-Border Line Accordion — Glassmorphism UI</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <section class="dl-stack" aria-label="Trip itinerary">
+    <h1 class="dl-stack-title">Kyoto — Itinerary</h1>
+    <p class="dl-stack-sub">
+      Open a day — a luminous line draws itself clockwise around the glass
+      card, and retraces on close. Tab + Enter works — no JavaScript.
+    </p>
+
+    <!-- name="dl-trip" makes the accordion exclusive: opening one day
+         closes the others, natively. -->
+    <details class="dl-item" name="dl-trip" open>
+      <summary class="dl-head">
+        <span class="dl-day">Day 1</span>
+        Arrival &amp; Higashiyama
+        <span class="dl-head-meta">3 stops</span>
+        <span class="dl-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="dl-body">
+        <div class="dl-row">
+          <span class="dl-time">09:40</span>
+          <span class="dl-what">Land at KIX, express to Kyoto</span>
+          <span class="dl-note">IC card ready</span>
+        </div>
+        <div class="dl-row">
+          <span class="dl-time">14:00</span>
+          <span class="dl-what">Kiyomizu-dera &amp; Sannenzaka</span>
+          <span class="dl-note">golden hour up top</span>
+        </div>
+        <div class="dl-row">
+          <span class="dl-time">19:00</span>
+          <span class="dl-what">Pontocho alley dinner</span>
+          <span class="dl-note">no reservation needed</span>
+        </div>
+      </div>
+    </details>
+
+    <details class="dl-item" name="dl-trip">
+      <summary class="dl-head">
+        <span class="dl-day">Day 2</span>
+        Arashiyama west side
+        <span class="dl-head-meta">4 stops</span>
+        <span class="dl-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="dl-body">
+        <div class="dl-row">
+          <span class="dl-time">07:30</span>
+          <span class="dl-what">Bamboo grove before the crowds</span>
+          <span class="dl-note">arrive early</span>
+        </div>
+        <div class="dl-row">
+          <span class="dl-time">10:00</span>
+          <span class="dl-what">Tenryū-ji gardens</span>
+          <span class="dl-note">temple + garden ticket</span>
+        </div>
+        <div class="dl-row">
+          <span class="dl-time">13:30</span>
+          <span class="dl-what">Katsura river walk</span>
+          <span class="dl-note">tea house break</span>
+        </div>
+        <div class="dl-row">
+          <span class="dl-time">17:00</span>
+          <span class="dl-what">Kimono Forest at dusk</span>
+          <span class="dl-note">lit after sunset</span>
+        </div>
+      </div>
+    </details>
+
+    <details class="dl-item" name="dl-trip">
+      <summary class="dl-head">
+        <span class="dl-day">Day 3</span>
+        Fushimi Inari &amp; departure
+        <span class="dl-head-meta">2 stops</span>
+        <span class="dl-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="dl-body">
+        <div class="dl-row">
+          <span class="dl-time">06:00</span>
+          <span class="dl-what">Fushimi Inari summit loop</span>
+          <span class="dl-note">2h round trip</span>
+        </div>
+        <div class="dl-row">
+          <span class="dl-time">12:30</span>
+          <span class="dl-what">Nishiki market, then airport</span>
+          <span class="dl-note">buy omiyage here</span>
+        </div>
+      </div>
+    </details>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/33188-draw-border-accordion-glassmorphism-sj6/style.css
+++ b/submissions/examples/33188-draw-border-accordion-glassmorphism-sj6/style.css
@@ -1,0 +1,289 @@
+/* ==========================================================================
+   Draw-Border Line Accordion — Glassmorphism UI
+   --------------------------------------------------------------------------
+   Pure CSS accordion of frosted-glass cards where opening a section makes
+   a luminous line DRAW ITSELF around the card — clockwise, in two phases:
+   top + right first, then bottom + left. Closing retracts the line in
+   reverse. Because the draw is a background-size TRANSITION (not an
+   animation), it is fully reversible mid-gesture: close a half-drawn
+   card and the line walks back the way it came.
+
+   Built on native <details>/<summary>. Zero JavaScript.
+
+   Issue: #33188
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Tokens — motion first, then the glass recipe
+   -------------------------------------------------------------------------- */
+:root {
+  /* Line draw */
+  --dl-line: 2px;                                  /* stroke thickness       */
+  --dl-draw-duration: 520ms;                       /* full perimeter time    */
+  --dl-ease: ease-in-out;                          /* steady, pen-like       */
+  --dl-line-color: #7ff5e3;                        /* luminous mint          */
+  --dl-toggle-duration: 240ms;                     /* chevron rotation       */
+  --dl-body-duration: 260ms;                       /* content fade           */
+
+  /* Glass recipe */
+  --dl-blur: 14px;
+  --dl-tint: rgba(255, 255, 255, 0.12);
+  --dl-tint-open: rgba(255, 255, 255, 0.18);
+  --dl-edge: rgba(255, 255, 255, 0.28);
+  --dl-heading: #ffffff;
+  --dl-body-color: rgba(255, 255, 255, 0.75);
+
+  --dl-card-shadow: 0 8px 32px rgba(6, 20, 34, 0.3);
+}
+
+/* --------------------------------------------------------------------------
+   2. Demo stage — a deep teal scene for the glass to frost
+   -------------------------------------------------------------------------- */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 34px 16px;
+  box-sizing: border-box;
+  background:
+    radial-gradient(560px 420px at 12% 15%, rgba(127, 245, 227, 0.35), transparent 60%),
+    radial-gradient(520px 460px at 90% 25%, rgba(94, 140, 235, 0.45), transparent 62%),
+    radial-gradient(600px 520px at 50% 100%, rgba(38, 90, 115, 0.6), transparent 65%),
+    linear-gradient(155deg, #123146 0%, #1a2f56 55%, #0c2233 100%);
+  background-attachment: fixed;
+  font-family: "Segoe UI", system-ui, -apple-system, Arial, sans-serif;
+  color: var(--dl-body-color);
+}
+
+.dl-stack {
+  width: 100%;
+  max-width: 520px;
+}
+
+.dl-stack-title {
+  margin: 0 0 3px;
+  font-size: 1.1rem;
+  font-weight: 650;
+  color: var(--dl-heading);
+  text-shadow: 0 1px 8px rgba(6, 20, 34, 0.4);
+}
+
+.dl-stack-sub {
+  margin: 0 0 18px;
+  font-size: 0.78rem;
+}
+
+/* --------------------------------------------------------------------------
+   3. Glass cards with a drawable perimeter
+   -------------------------------------------------------------------------- */
+.dl-item {
+  position: relative;
+  background: var(--dl-tint);
+  -webkit-backdrop-filter: blur(var(--dl-blur)) saturate(1.35);
+  backdrop-filter: blur(var(--dl-blur)) saturate(1.35);
+  border: 1px solid var(--dl-edge);
+  border-radius: 10px;
+  box-shadow: var(--dl-card-shadow);
+  transition: background-color 220ms ease;
+}
+
+.dl-item + .dl-item {
+  margin-top: 12px;
+}
+
+.dl-item[open] {
+  background: var(--dl-tint-open);
+}
+
+/* Fallback: where backdrop-filter is unsupported, deepen the tint */
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .dl-item { background: rgba(16, 42, 60, 0.85); }
+  .dl-item[open] { background: rgba(16, 42, 60, 0.94); }
+}
+
+/* --------------------------------------------------------------------------
+   4. The draw — two pseudo-elements, four growing lines
+   --------------------------------------------------------------------------
+   ::before holds the TOP line (grows left→right) and the RIGHT line
+   (grows top→bottom); ::after holds the BOTTOM (right→left) and LEFT
+   (bottom→top). Phase delays sequence them clockwise on open; the
+   delays swap on close so the line retracts the way it came. */
+.dl-item::before,
+.dl-item::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background-repeat: no-repeat;
+  filter: drop-shadow(0 0 6px rgba(127, 245, 227, 0.55));
+}
+
+.dl-item::before {
+  background-image:
+    linear-gradient(var(--dl-line-color), var(--dl-line-color)),
+    linear-gradient(var(--dl-line-color), var(--dl-line-color));
+  background-position: left top, right top;
+  background-size: 0 var(--dl-line), var(--dl-line) 0;
+  /* closed state: retract second (this pair un-draws after ::after) */
+  transition: background-size calc(var(--dl-draw-duration) / 2) var(--dl-ease)
+    calc(var(--dl-draw-duration) / 2);
+}
+
+.dl-item::after {
+  background-image:
+    linear-gradient(var(--dl-line-color), var(--dl-line-color)),
+    linear-gradient(var(--dl-line-color), var(--dl-line-color));
+  background-position: right bottom, left bottom;
+  background-size: 0 var(--dl-line), var(--dl-line) 0;
+  /* closed state: retract first */
+  transition: background-size calc(var(--dl-draw-duration) / 2) var(--dl-ease);
+}
+
+.dl-item[open]::before {
+  background-size: 100% var(--dl-line), var(--dl-line) 100%;
+  /* open state: draw first */
+  transition-delay: 0s;
+}
+
+.dl-item[open]::after {
+  background-size: 100% var(--dl-line), var(--dl-line) 100%;
+  /* open state: draw second */
+  transition-delay: calc(var(--dl-draw-duration) / 2);
+}
+
+/* --------------------------------------------------------------------------
+   5. Summary — the clickable header row
+   -------------------------------------------------------------------------- */
+.dl-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  cursor: pointer;
+  list-style: none;                 /* hide default marker (Firefox) */
+  user-select: none;
+  color: var(--dl-heading);
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.dl-head::-webkit-details-marker { display: none; }
+
+.dl-head:focus-visible {
+  outline: 2px solid var(--dl-line-color);
+  outline-offset: -2px;
+  border-radius: 8px;
+}
+
+.dl-day {
+  display: grid;
+  place-items: center;
+  min-width: 44px;
+  flex: none;
+  padding: 4px 8px;
+  border-radius: 8px;
+  background: rgba(127, 245, 227, 0.14);
+  border: 1px solid rgba(127, 245, 227, 0.35);
+  color: var(--dl-line-color);
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.dl-head-meta {
+  margin-left: auto;
+  font-size: 0.72rem;
+  color: var(--dl-body-color);
+}
+
+.dl-chevron {
+  flex: none;
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid var(--dl-body-color);
+  border-bottom: 2px solid var(--dl-body-color);
+  transform: rotate(45deg);
+  transition: transform var(--dl-toggle-duration) var(--dl-ease);
+}
+
+.dl-item[open] > .dl-head .dl-chevron {
+  transform: rotate(225deg);
+}
+
+/* --------------------------------------------------------------------------
+   6. Body — quiet fade so the drawn line stays the star
+   -------------------------------------------------------------------------- */
+.dl-body {
+  padding: 2px 16px 14px;
+  animation: dl-fade var(--dl-body-duration) var(--dl-ease) both;
+}
+
+@keyframes dl-fade {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.dl-row {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 6px 12px;
+  padding: 9px 0;
+  font-size: 0.8rem;
+}
+
+.dl-row + .dl-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.dl-time {
+  flex: none;
+  min-width: 52px;
+  font-variant-numeric: tabular-nums;
+  font-size: 0.72rem;
+  color: var(--dl-line-color);
+}
+
+.dl-what {
+  color: var(--dl-heading);
+  font-weight: 600;
+}
+
+.dl-note {
+  margin-left: auto;
+  font-size: 0.72rem;
+}
+
+/* --------------------------------------------------------------------------
+   7. Small screens — tighten paddings, notes wrap under the activity
+   -------------------------------------------------------------------------- */
+@media (max-width: 420px) {
+  .dl-head { padding: 13px 13px; }
+  .dl-body { padding: 2px 13px 12px; }
+  .dl-note { flex-basis: 100%; margin-left: 64px; }
+}
+
+/* --------------------------------------------------------------------------
+   8. Reduced motion — the line appears fully drawn, nothing travels
+   -------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .dl-item::before,
+  .dl-item::after {
+    transition: none;
+  }
+
+  .dl-body {
+    animation: none;
+  }
+
+  .dl-chevron {
+    transition: none;
+  }
+
+  .dl-item {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS **Draw-Border Line Accordion** styled for **Glassmorphism UI** layouts as a fully self-contained example under `submissions/examples/33188-draw-border-accordion-glassmorphism-sj6/`.

Fixes #33188

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/33188-draw-border-accordion-glassmorphism-sj6/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A zero-JavaScript accordion of frosted-glass cards where opening a section makes a luminous mint line draw itself clockwise around the card — top + right first, then bottom + left — and retrace the way it came on close. Each edge is a `linear-gradient` grown via `background-size` on two pseudo-elements, with phase delays that swap between open and closed states so the retraction plays in reverse. Because it's a transition rather than a keyframe animation, interrupting mid-draw reverses smoothly from the line's current length. The stroke carries a `drop-shadow` glow so it reads as light traveling along the glass edge.

**How does a developer use it?**

```html
<details class="dl-item" name="my-trip">
  <summary class="dl-head">
    <span class="dl-day">Day 1</span>
    Arrival &amp; Higashiyama
    <span class="dl-head-meta">3 stops</span>
    <span class="dl-chevron" aria-hidden="true"></span>
  </summary>
  <div class="dl-body">
    <div class="dl-row">
      <span class="dl-time">09:40</span>
      <span class="dl-what">Land at KIX, express to Kyoto</span>
      <span class="dl-note">IC card ready</span>
    </div>
  </div>
</details>
```

**Why does it fit EaseMotion CSS?**

Human-readable classes, animation-first, zero JS. Stroke thickness, perimeter duration, easing, line color, and body fade are `--dl-*` custom properties on `:root`; `<details name>` provides exclusive-open natively with Enter/Space toggling and a mint `:focus-visible` ring matching the stroke; the glass recipe includes the `-webkit-backdrop-filter` twin and an `@supports` fallback that deepens the tint where frost is unsupported; `prefers-reduced-motion` removes the travel so the line appears fully drawn instantly.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The detail worth preserving in integration: the draw is transitions + swapped phase delays (open: before-pair first; closed: after-pair first), which is what makes the close a true reverse trace and keeps mid-gesture interruptions smooth. The card radius is kept at 10px because the straight gradient lines are clipped by the rounded corners (noted in the README).

@SAPTARSHI-coder Please review
