### PR TITLE
feat(examples): Draw-Border Line Accordion for Cyberpunk Neon

### DIFF
--- a/submissions/examples/33190-draw-border-accordion-cyberpunk-neon-sj6/README.md
+++ b/submissions/examples/33190-draw-border-accordion-cyberpunk-neon-sj6/README.md
@@ -1,0 +1,76 @@
+# Draw-Border Line Accordion — Cyberpunk Neon
+
+A pure CSS, zero-dependency **access-panel accordion** for dark neon
+interfaces. Opening a panel runs a **circuit-close** draw: a cyan beam
+launches from the top-left corner (right along the top, down the left
+edge) while a magenta beam launches from the bottom-right (left along
+the bottom, up the right edge). The two race **simultaneously** and seal
+the frame at opposite corners — a circuit completing, not a pen tracing.
+Closing retracts both beams to their home corners. Built on native
+`<details>`/`<summary>`; no JavaScript anywhere.
+
+Resolves Issue: #33190
+
+## ✨ Features
+
+- **Dual-beam circuit close** — `::before` is the cyan beam (two
+  `linear-gradient` lines anchored top-left), `::after` the magenta beam
+  (anchored bottom-right); both grow via a single `background-size`
+  transition with no phase delays, racing in parallel. Each beam carries
+  its own `drop-shadow` glow, and the two colors meet at the seam
+  corners.
+- **Reversible mid-gesture** — the draw is a transition, not a keyframe
+  animation: closing retracts the beams from wherever they are, smoothly.
+- **Standby cue** — hovering a closed panel warms the resting border to
+  faint cyan before any commitment, so the interaction telegraphs.
+- **Native accordion semantics** — `<details name="cy-grid">` gives
+  exclusive-open behavior straight from the browser; remove the `name`
+  to allow multiple open.
+- **Keyboard accessible** — `<summary>` is natively focusable and
+  toggles with Enter/Space; 2px cyan `:focus-visible` ring.
+- **Terminal-native details** — monospace stack, scanline + vignette
+  canvas, bracketed panel tags (`[A1]`), `>` prompt prefixes on readout
+  keys, glowing status values (ok / warn / hot), square corners as the
+  genre demands.
+- **Genuinely responsive** — fluid deck up to 540px; under 420px the
+  readout values wrap beneath their keys.
+- **Tunable via custom properties** — beam thickness, draw duration,
+  easing, both neon colors, and body fade on `:root`.
+- **Motion-safe** — `prefers-reduced-motion` removes the travel; the
+  circuit appears sealed instantly.
+
+## 🔧 Custom Properties
+
+| Property             | Default                           | Role                     |
+| -------------------- | --------------------------------- | ------------------------ |
+| `--cy-line`          | `2px`                             | Beam thickness           |
+| `--cy-draw-duration` | `420ms`                           | Both beams, in parallel  |
+| `--cy-ease`          | `cubic-bezier(0.3, 0.1, 0.2, 1)`  | Fast launch, soft dock   |
+| `--cy-cyan`          | `#2ee6ff`                         | Top-left beam            |
+| `--cy-magenta`       | `#ff3ea5`                         | Bottom-right beam        |
+| `--cy-body-duration` | `240ms`                           | Readout fade on open     |
+
+## 🚀 Usage
+
+```html
+<details class="cy-item" name="my-grid">
+  <summary class="cy-head">
+    <span class="cy-tag">[A1]</span>
+    Perimeter sensors
+    <span class="cy-head-meta">12 nodes</span>
+    <span class="cy-chevron" aria-hidden="true"></span>
+  </summary>
+  <div class="cy-body">
+    <div class="cy-row">
+      <span class="cy-key">mesh integrity</span>
+      <span class="cy-val is-ok">100%</span>
+    </div>
+  </div>
+</details>
+```
+
+## 📂 Files
+
+- `demo.html` — a "Night Grid" access deck (sensors / power / uplink).
+- `style.css` — motion tokens, dual-beam circuit engine, neon terminal skin, a11y guards.
+- `README.md` — this document.

--- a/submissions/examples/33190-draw-border-accordion-cyberpunk-neon-sj6/demo.html
+++ b/submissions/examples/33190-draw-border-accordion-cyberpunk-neon-sj6/demo.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Draw-Border Line Accordion — Cyberpunk Neon</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="cy-deck">
+    <h1 class="cy-deck-title">Night Grid // Access</h1>
+    <p class="cy-deck-sub">
+      Open a panel — a cyan beam launches from the top-left corner, a
+      magenta beam from the bottom-right; they race the frame and seal
+      the circuit. Tab + Enter works — no JavaScript.
+    </p>
+
+    <!-- name="cy-grid" makes the accordion exclusive: opening one panel
+         closes the others, natively. -->
+    <details class="cy-item" name="cy-grid" open>
+      <summary class="cy-head">
+        <span class="cy-tag">[A1]</span>
+        Perimeter sensors
+        <span class="cy-head-meta">12 nodes</span>
+        <span class="cy-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="cy-body">
+        <div class="cy-row">
+          <span class="cy-key">mesh integrity</span>
+          <span class="cy-val is-ok">100%</span>
+        </div>
+        <div class="cy-row">
+          <span class="cy-key">motion events / hr</span>
+          <span class="cy-val">14</span>
+        </div>
+        <div class="cy-row">
+          <span class="cy-key">node 07 battery</span>
+          <span class="cy-val is-warn">22%</span>
+        </div>
+      </div>
+    </details>
+
+    <details class="cy-item" name="cy-grid">
+      <summary class="cy-head">
+        <span class="cy-tag">[B4]</span>
+        Power grid
+        <span class="cy-head-meta">sector 4</span>
+        <span class="cy-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="cy-body">
+        <div class="cy-row">
+          <span class="cy-key">load</span>
+          <span class="cy-val">61%</span>
+        </div>
+        <div class="cy-row">
+          <span class="cy-key">cell array</span>
+          <span class="cy-val is-ok">nominal</span>
+        </div>
+        <div class="cy-row">
+          <span class="cy-key">substation 9 temp</span>
+          <span class="cy-val is-hot">88°C</span>
+        </div>
+      </div>
+    </details>
+
+    <details class="cy-item" name="cy-grid">
+      <summary class="cy-head">
+        <span class="cy-tag">[C9]</span>
+        Encrypted uplink
+        <span class="cy-head-meta">relay chain</span>
+        <span class="cy-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="cy-body">
+        <div class="cy-row">
+          <span class="cy-key">handshake</span>
+          <span class="cy-val is-ok">verified</span>
+        </div>
+        <div class="cy-row">
+          <span class="cy-key">latency</span>
+          <span class="cy-val">31 ms</span>
+        </div>
+        <div class="cy-row">
+          <span class="cy-key">key rotation</span>
+          <span class="cy-val">in 06:12:44</span>
+        </div>
+      </div>
+    </details>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/33190-draw-border-accordion-cyberpunk-neon-sj6/style.css
+++ b/submissions/examples/33190-draw-border-accordion-cyberpunk-neon-sj6/style.css
@@ -1,0 +1,271 @@
+/* ==========================================================================
+   Draw-Border Line Accordion — Cyberpunk Neon
+   --------------------------------------------------------------------------
+   Pure CSS access-panel accordion for dark neon interfaces. Opening a
+   panel runs a CIRCUIT-CLOSE draw: a cyan beam starts at the top-left
+   corner (running right along the top and down the left edge) while a
+   magenta beam starts at the bottom-right (running left along the bottom
+   and up the right edge). The two race simultaneously and seal the frame
+   at opposite corners — a circuit completing, not a pen tracing.
+
+   The draw is a background-size TRANSITION, so closing retracts both
+   beams to their home corners, and interrupting mid-draw reverses
+   smoothly. Built on native <details>/<summary>. Zero JavaScript.
+
+   Issue: #33190
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Tokens — motion first, then the neon skin
+   -------------------------------------------------------------------------- */
+:root {
+  /* Circuit draw */
+  --cy-line: 2px;                                  /* beam thickness         */
+  --cy-draw-duration: 420ms;                       /* both beams, in parallel*/
+  --cy-ease: cubic-bezier(0.3, 0.1, 0.2, 1);       /* fast launch, soft dock */
+  --cy-cyan: #2ee6ff;
+  --cy-magenta: #ff3ea5;
+  --cy-toggle-duration: 200ms;
+  --cy-body-duration: 240ms;
+
+  /* Night-grid skin */
+  --cy-canvas: #05080f;
+  --cy-panel: #0b111e;
+  --cy-edge: #1c2740;
+  --cy-heading: #e9f6ff;
+  --cy-body-color: #7d90b0;
+  --cy-ok: #3ddc97;
+  --cy-warn: #ffc857;
+}
+
+/* --------------------------------------------------------------------------
+   2. Demo stage — a scanlined night grid
+   -------------------------------------------------------------------------- */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 34px 16px;
+  box-sizing: border-box;
+  background:
+    repeating-linear-gradient(0deg, rgba(46, 230, 255, 0.025) 0 1px, transparent 1px 3px),
+    radial-gradient(900px 500px at 50% -10%, rgba(46, 230, 255, 0.08), transparent 60%),
+    radial-gradient(700px 480px at 85% 110%, rgba(255, 62, 165, 0.07), transparent 60%),
+    var(--cy-canvas);
+  font-family: Consolas, "Cascadia Mono", "Courier New", monospace;
+  color: var(--cy-body-color);
+}
+
+.cy-deck {
+  width: 100%;
+  max-width: 540px;
+}
+
+.cy-deck-title {
+  margin: 0 0 3px;
+  font-size: 1.02rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--cy-heading);
+  text-shadow: 0 0 14px rgba(46, 230, 255, 0.5);
+}
+
+.cy-deck-sub {
+  margin: 0 0 18px;
+  font-size: 0.72rem;
+  letter-spacing: 0.03em;
+}
+
+/* --------------------------------------------------------------------------
+   3. Access panels — native disclosure elements
+   -------------------------------------------------------------------------- */
+.cy-item {
+  position: relative;
+  background: var(--cy-panel);
+  border: 1px solid var(--cy-edge);
+  transition: border-color 180ms ease;
+}
+
+.cy-item + .cy-item {
+  margin-top: 12px;
+}
+
+/* Standby cue on hover: the frame goes faintly live before the draw */
+.cy-item:not([open]):hover {
+  border-color: rgba(46, 230, 255, 0.4);
+}
+
+/* --------------------------------------------------------------------------
+   4. The circuit-close — two beams from opposite corners, in parallel
+   --------------------------------------------------------------------------
+   ::before is the CYAN beam anchored top-left: top edge grows rightward,
+   left edge grows downward. ::after is the MAGENTA beam anchored
+   bottom-right: bottom edge grows leftward, right edge grows upward.
+   No phase delays — the beams race together and dock at opposite
+   corners. Transitions make close a retraction to home corners. */
+.cy-item::before,
+.cy-item::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-repeat: no-repeat;
+  transition: background-size var(--cy-draw-duration) var(--cy-ease);
+}
+
+.cy-item::before {
+  background-image:
+    linear-gradient(var(--cy-cyan), var(--cy-cyan)),
+    linear-gradient(var(--cy-cyan), var(--cy-cyan));
+  background-position: left top, left top;
+  background-size: 0 var(--cy-line), var(--cy-line) 0;
+  filter: drop-shadow(0 0 5px rgba(46, 230, 255, 0.7));
+}
+
+.cy-item::after {
+  background-image:
+    linear-gradient(var(--cy-magenta), var(--cy-magenta)),
+    linear-gradient(var(--cy-magenta), var(--cy-magenta));
+  background-position: right bottom, right bottom;
+  background-size: 0 var(--cy-line), var(--cy-line) 0;
+  filter: drop-shadow(0 0 5px rgba(255, 62, 165, 0.7));
+}
+
+.cy-item[open]::before,
+.cy-item[open]::after {
+  background-size: 100% var(--cy-line), var(--cy-line) 100%;
+}
+
+/* --------------------------------------------------------------------------
+   5. Summary — the panel header
+   -------------------------------------------------------------------------- */
+.cy-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  cursor: pointer;
+  list-style: none;                 /* hide default marker (Firefox) */
+  user-select: none;
+  color: var(--cy-heading);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.cy-head::-webkit-details-marker { display: none; }
+
+.cy-head:focus-visible {
+  outline: 2px solid var(--cy-cyan);
+  outline-offset: -2px;
+}
+
+/* Panel ID tag, bracketed like a terminal prompt */
+.cy-tag {
+  flex: none;
+  font-size: 0.68rem;
+  color: var(--cy-cyan);
+  text-shadow: 0 0 8px rgba(46, 230, 255, 0.6);
+}
+
+.cy-head-meta {
+  margin-left: auto;
+  font-size: 0.66rem;
+  font-weight: 400;
+  letter-spacing: 0.04em;
+  text-transform: none;
+  color: var(--cy-body-color);
+}
+
+/* Chevron rotates as the panel opens */
+.cy-chevron {
+  flex: none;
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid var(--cy-body-color);
+  border-bottom: 2px solid var(--cy-body-color);
+  transform: rotate(45deg);
+  transition: transform var(--cy-toggle-duration) var(--cy-ease);
+}
+
+.cy-item[open] > .cy-head .cy-chevron {
+  transform: rotate(225deg);
+}
+
+/* --------------------------------------------------------------------------
+   6. Body — readout rows, quiet fade so the beams stay the star
+   -------------------------------------------------------------------------- */
+.cy-body {
+  padding: 2px 16px 14px;
+  animation: cy-fade var(--cy-body-duration) var(--cy-ease) both;
+}
+
+@keyframes cy-fade {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.cy-row {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 6px 12px;
+  padding: 8px 0;
+  font-size: 0.74rem;
+}
+
+.cy-row + .cy-row {
+  border-top: 1px dashed var(--cy-edge);
+}
+
+.cy-key {
+  color: var(--cy-heading);
+}
+
+.cy-key::before {
+  content: "> ";
+  color: var(--cy-cyan);
+}
+
+.cy-val {
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+}
+
+.cy-val.is-ok   { color: var(--cy-ok);   text-shadow: 0 0 8px rgba(61, 220, 151, 0.45); }
+.cy-val.is-warn { color: var(--cy-warn); text-shadow: 0 0 8px rgba(255, 200, 87, 0.45); }
+.cy-val.is-hot  { color: var(--cy-magenta); text-shadow: 0 0 8px rgba(255, 62, 165, 0.5); }
+
+/* --------------------------------------------------------------------------
+   7. Small screens — values wrap under their keys
+   -------------------------------------------------------------------------- */
+@media (max-width: 420px) {
+  .cy-head { padding: 13px 13px; }
+  .cy-body { padding: 2px 13px 12px; }
+  .cy-val { flex-basis: 100%; margin-left: 18px; }
+}
+
+/* --------------------------------------------------------------------------
+   8. Reduced motion — the circuit appears sealed, nothing travels
+   -------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .cy-item::before,
+  .cy-item::after {
+    transition: none;
+  }
+
+  .cy-body {
+    animation: none;
+  }
+
+  .cy-chevron {
+    transition: none;
+  }
+
+  .cy-item {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS **Draw-Border Line Accordion** styled for **Cyberpunk Neon** layouts as a fully self-contained example under `submissions/examples/33190-draw-border-accordion-cyberpunk-neon-sj6/`.

Fixes #33190

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/33190-draw-border-accordion-cyberpunk-neon-sj6/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A zero-JavaScript "access panel" accordion for dark neon UIs with a circuit-close draw: opening a panel launches a cyan beam from the top-left corner (top edge rightward + left edge downward) and a magenta beam from the bottom-right (bottom edge leftward + right edge upward) — both race in parallel and seal the frame at opposite corners. Each beam is two `linear-gradient` lines grown by one `background-size` transition per pseudo-element, each with its own `drop-shadow` glow. Being transitions, the beams retract to their home corners on close and reverse smoothly if interrupted mid-draw.

**How does a developer use it?**

```html
<details class="cy-item" name="my-grid">
  <summary class="cy-head">
    <span class="cy-tag">[A1]</span>
    Perimeter sensors
    <span class="cy-head-meta">12 nodes</span>
    <span class="cy-chevron" aria-hidden="true"></span>
  </summary>
  <div class="cy-body">
    <div class="cy-row">
      <span class="cy-key">mesh integrity</span>
      <span class="cy-val is-ok">100%</span>
    </div>
  </div>
</details>
```

**Why does it fit EaseMotion CSS?**

Human-readable classes, animation-first, zero JS. Beam thickness, draw duration, easing, both neon colors, and the readout fade are `--cy-*` custom properties on `:root`; `<details name>` provides exclusive-open natively with Enter/Space toggling and a cyan `:focus-visible` ring; hovering a closed panel warms the resting border to faint cyan as a standby cue; `prefers-reduced-motion` removes the travel so the circuit appears sealed instantly.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Deliberately distinct choreography from my glassmorphism draw-border accordion (#33188): that one traces the perimeter sequentially like a pen (two phases, swapped delays for a reverse trace); this one closes a circuit with two simultaneous opposing beams in different colors — no delays anywhere. Square corners are intentional (the gradient lines are straight, and the genre suits them).

@SAPTARSHI-coder Please review
