### PR TITLE
docs: add live CDN import snippet demo

### DIFF
--- a/submissions/docs/import-cdn-snippet/README.md
+++ b/submissions/docs/import-cdn-snippet/README.md
@@ -1,0 +1,14 @@
+# Import CDN Snippet Demo
+
+This submission adds a live **Import CDN snippet** for EaseMotion CSS.  
+It shows how developers can quickly use the framework without cloning or installing.
+
+## Usage
+
+Copy this snippet into your `<head>`:
+
+```html
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+/>

--- a/submissions/docs/import-cdn-snippet/demo.html
+++ b/submissions/docs/import-cdn-snippet/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>EaseMotion CDN Import Demo</title>
+  <!-- Live CDN Import -->
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+</head>
+<body>
+  <div class="ease-center ease-fade-in">
+    <h1>Hello, EaseMotion via CDN!</h1>
+    <button class="ease-btn ease-btn-primary ease-hover-grow">
+      Try Me →
+    </button>
+  </div>
+</body>
+</html>

--- a/submissions/docs/import-cdn-snippet/style.css
+++ b/submissions/docs/import-cdn-snippet/style.css
@@ -1,0 +1,9 @@
+body {
+  font-family: Inter, sans-serif;
+  background: #f9f9f9;
+  padding: 2rem;
+}
+
+h1 {
+  color: #333;
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes Issue #36514 by adding a live **Import CDN snippet** demo.  
It shows how to use EaseMotion CSS directly from jsDelivr without cloning or installing.

---

## Type of Change

- [x] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/docs/import-cdn-snippet/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/` or `components/`

---

## Feature Description

**What does this add?**  
A demo showing how to import EaseMotion CSS via CDN.

**How does a developer use it?**
```html
<link
  rel="stylesheet"
  href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
/>


Thanks for reviewing my PR!