### PR TITLE
fix: correct broken button markup and style attribute in docs/demo.html

### DIFF
--- a/docs/demo.html
+++ b/docs/demo.html
@@ -388,7 +388,7 @@
         <div class="ease-flex ease-flex-wrap ease-gap-3" style="margin-bottom: var(--ease-space-8);">
           <button class="ease-btn ease-btn-primary ease-btn-hover">Hover me ✨</button>
           <button class="ease-btn ease-btn-outline ease-btn-hover"
-            style="border-color:rgba(255,255,255,0.3); color: var(--page-text);Hover me 🚀</button>
+            style="border-color:rgba(255,255,255,0.3); color: var(--page-text);">Hover me 🚀</button>
           <button class="ease-btn ease-btn-success ease-btn-hover">Hover me 🌿</button>
         </div>
 


### PR DESCRIPTION
Closes #37025. Corrects an unterminated style attribute and missing closing angle bracket on the outline button under the With ease-btn-hover section in docs/demo.html, which was causing rendering layout bugs.