### PR TITLE
fix: resolve broken cross icon rendering and alignment in compare-table

### DIFF
--- a/components/compare-table.css
+++ b/components/compare-table.css
@@ -75,6 +75,7 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    position: relative;
     width: 1.5rem;
     height: 1.5rem;
     animation: ease-icon-pop 0.3s ease both;
@@ -99,6 +100,14 @@
     background: #ef4444;
     border-radius: 1px;
     animation: ease-icon-draw 0.3s ease 0.1s both;
+  }
+
+  .ease-icon-cross::before {
+    transform: rotate(45deg);
+  }
+
+  .ease-icon-cross::after {
+    transform: rotate(-45deg);
   }
   
   @keyframes ease-icon-draw {


### PR DESCRIPTION
Closes #37309. Adds position: relative to the check/cross icon containers to define a correct absolute anchor base, and applies rotate(45deg) and rotate(-45deg) transforms to the cross icon pseudo-elements to properly render an X symbol.