### PR TITLE
feat: Add cross-icon-fix demonstration example

### DIFF
--- a/submissions/examples/cross-icon-fix-37309/README.md
+++ b/submissions/examples/cross-icon-fix-37309/README.md
@@ -1,0 +1,12 @@
+# Cross Icon Fix (#37309)
+
+This example demonstrates the fix for the broken cross icon (`.ease-icon-cross`).
+
+## Bug Description
+The cross icon did not render as an 'X' because:
+1. The parent container was missing `position: relative`, causing absolute positioned pseudo-elements to align incorrectly.
+2. The pseudo-elements (`::before` and `::after`) lacked rotation transforms.
+
+## Solution
+- Added `position: relative` to the icon container class.
+- Added `transform: rotate(45deg)` and `transform: rotate(-45deg)` to create the cross shape.

--- a/submissions/examples/cross-icon-fix-37309/demo.html
+++ b/submissions/examples/cross-icon-fix-37309/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cross Icon Fix Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="background: #0f172a; color: #fff; font-family: sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0;">
+  <div style="text-align: center; background: rgba(255,255,255,0.05); padding: 2rem; border-radius: 1rem; border: 1px solid rgba(255,255,255,0.1);">
+    <h2 style="margin-top: 0;">Cross Icon Fix (#37309)</h2>
+    <p style="color: #94a3b8;">Both bars now rotate correctly forming a clean 'X' alignment.</p>
+    <div style="display: flex; justify-content: center; gap: 1.5rem; margin-top: 1.5rem;">
+      <span class="ease-icon-cross"></span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/cross-icon-fix-37309/style.css
+++ b/submissions/examples/cross-icon-fix-37309/style.css
@@ -1,0 +1,25 @@
+.ease-icon-check, .ease-icon-cross {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.ease-icon-cross::before, .ease-icon-cross::after {
+  content: '';
+  position: absolute;
+  width: 0.15rem;
+  height: 0.9rem;
+  background: #ef4444;
+  border-radius: 1px;
+}
+
+.ease-icon-cross::before {
+  transform: rotate(45deg);
+}
+
+.ease-icon-cross::after {
+  transform: rotate(-45deg);
+}


### PR DESCRIPTION
Closes #37309. Adds a demonstration example in submissions/examples/cross-icon-fix-37309/ resolving the broken cross icon issue where absolute elements did not position properly and lacked rotation.