### PR TITLE
feat: add cyberpunk neon jello-hover modal #34087

### DIFF
--- a/submissions/examples/cyberpunk-jello-modal/README.md
+++ b/submissions/examples/cyberpunk-jello-modal/README.md
@@ -1,0 +1,13 @@
+# Cyberpunk Neon Jello-Hover Modal (Pure CSS)
+
+A pure CSS modal design complementing high-contrast Cyberpunk Neon aesthetics. Built without external dependencies or JavaScript bindings.
+
+## Features
+- **Pure CSS Execution**: Leverages the native `:target` utility mechanism to control view states cleanly.
+- **Jello Physics Keyframes**: Implements an elastic structural `scale3d` transformation sequence triggered immediately upon entry initialization and active layout hover.
+- **Sci-Fi Visual Motifs**: Employs `clip-path` angular corner crops, linear accent grids, and variable drop glow-shadow arrays.
+
+## Configuration Options
+Alter the behavior states directly using parameters declared inside the `:root` block of `style.css`:
+- `--jello-duration`: Adjusts the runtime speed of the structural elasticity bounce.
+- `--neon-cyan` / `--neon-magenta`: Modifies the dominant theme color profiles.

--- a/submissions/examples/cyberpunk-jello-modal/demo.html
+++ b/submissions/examples/cyberpunk-jello-modal/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cyberpunk Neon Jello-Hover Modal</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="cyber-grid"></div>
+
+  <main class="page-content">
+    <h1 class="neon-text" data-text="SYSTEM_OVERRIDE">SYSTEM_OVERRIDE</h1>
+    <p>Pure CSS interactive terminal modules. Zero JS overhead required.</p>
+    <a href="#cyber-modal" class="btn btn-trigger" role="button">INITIALIZE MODAL</a>
+  </main>
+
+  <div id="cyber-modal" class="modal-overlay" aria-hidden="true" role="dialog" aria-labelledby="modal-title">
+    <a href="#" class="modal-close-backdrop" aria-label="Dismiss modal" tabindex="-1"></a>
+    
+    <div class="modal-container">
+      <div class="modal-header">
+        <h2 id="modal-title">> ACCESS_GRANTED</h2>
+        <a href="#" class="btn-close" aria-label="Close modal">&times;</a>
+      </div>
+      <div class="modal-body">
+        <p>CRITICAL WARNING: This module utilizes an aggressive <span class="highlight">Jello-Hover animation matrix</span> linked directly via CSS keyframes.</p>
+        <p>Hover over this terminal frame once activated to witness structural elasticity variables distort the local render tree.</p>
+      </div>
+      <div class="modal-footer">
+        <a href="#" class="btn btn-secondary">ABORT</a>
+        <a href="#" class="btn btn-primary">EXECUTE</a>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/cyberpunk-jello-modal/style.css
+++ b/submissions/examples/cyberpunk-jello-modal/style.css
@@ -1,0 +1,248 @@
+/* ==========================================================================
+   CSS Custom Properties (Cyberpunk Config Matrix)
+   ========================================================================== */
+:root {
+  /* Animation Parameters */
+  --modal-fade-speed: 0.3s;
+  --jello-duration: 0.8s;
+
+  /* Cyberpunk Palette */
+  --neon-cyan: #00f3ff;
+  --neon-magenta: #ff0055;
+  --neon-yellow: #fcee0a;
+  --bg-dark: #0a0a12;
+  --panel-bg: rgba(10, 10, 18, 0.95);
+  --text-main: #f1f5f9;
+  
+  /* Structural Shadows */
+  --neon-glow: 0 0 15px var(--neon-cyan), inset 0 0 15px rgba(0, 243, 255, 0.2);
+  --border-spec: 2px solid var(--neon-cyan);
+}
+
+/* ==========================================================================
+   Base Layout & Cyberpunk Grid
+   ========================================================================== */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Courier New', Courier, monospace;
+  background-color: var(--bg-dark);
+  color: var(--text-main);
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  position: relative;
+}
+
+/* Cyberpunk synthwave layout grid */
+.cyber-grid {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-image: 
+    linear-gradient(rgba(0, 243, 255, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0, 243, 255, 0.05) 1px, transparent 1px);
+  background-size: 40px 40px;
+  z-index: 1;
+}
+
+.page-content {
+  position: relative;
+  z-index: 2;
+  text-align: center;
+  padding: 20px;
+}
+
+.neon-text {
+  font-size: 3rem;
+  font-weight: 900;
+  color: #fff;
+  text-shadow: 0 0 10px var(--neon-magenta), 0 0 20px var(--neon-magenta);
+  margin-bottom: 1rem;
+  letter-spacing: 4px;
+}
+
+.page-content p {
+  color: #94a3b8;
+  margin-bottom: 2.5rem;
+}
+
+/* ==========================================================================
+   Buttons
+   ========================================================================== */
+.btn {
+  display: inline-block;
+  text-decoration: none;
+  padding: 0.8rem 2rem;
+  font-weight: bold;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  clip-path: polygon(12px 0px, 100% 0px, 100% 70%, calc(100% - 12px) 100%, 0px 100%, 0px 30%);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.btn-trigger {
+  background: var(--neon-yellow);
+  color: #000;
+  border: none;
+}
+
+.btn-trigger:hover {
+  background: var(--neon-cyan);
+  box-shadow: 0 0 15px var(--neon-cyan);
+}
+
+.btn-primary {
+  background: transparent;
+  color: var(--neon-cyan);
+  border: 1px solid var(--neon-cyan);
+}
+
+.btn-primary:hover {
+  background: var(--neon-cyan);
+  color: #000;
+  box-shadow: 0 0 10px var(--neon-cyan);
+}
+
+.btn-secondary {
+  background: transparent;
+  color: var(--neon-magenta);
+  border: 1px solid var(--neon-magenta);
+  margin-right: 1rem;
+}
+
+.btn-secondary:hover {
+  background: var(--neon-magenta);
+  color: #fff;
+  box-shadow: 0 0 10px var(--neon-magenta);
+}
+
+/* ==========================================================================
+   Pure CSS Jello Modal
+   ========================================================================== */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 100;
+  background: rgba(5, 5, 10, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  
+  /* Closed default bindings */
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--modal-fade-speed) ease, visibility var(--modal-fade-speed) ease;
+}
+
+.modal-close-backdrop {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 101;
+}
+
+/* Modal Frame Component */
+.modal-container {
+  position: relative;
+  z-index: 102;
+  width: 100%;
+  max-width: 550px;
+  background: var(--panel-bg);
+  border: var(--border-spec);
+  box-shadow: var(--neon-glow);
+  padding: 2.5rem;
+  /* Tech angled corners layout */
+  clip-path: polygon(0 0, calc(100% - 30px) 0, 100% 30px, 100% 100%, 30px 100%, 0 calc(100% - 30px));
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+  border-bottom: 1px dashed rgba(0, 243, 255, 0.3);
+  padding-bottom: 0.5rem;
+}
+
+.modal-header h2 {
+  color: var(--neon-cyan);
+  font-size: 1.4rem;
+  letter-spacing: 1px;
+}
+
+.btn-close {
+  color: var(--neon-magenta);
+  text-decoration: none;
+  font-size: 2rem;
+  transition: transform 0.2s;
+}
+
+.btn-close:hover {
+  transform: scale(1.2) rotate(90deg);
+}
+
+.modal-body {
+  line-height: 1.6;
+  margin-bottom: 2rem;
+  font-size: 0.95rem;
+}
+
+.highlight {
+  color: var(--neon-yellow);
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+/* ==========================================================================
+   Activation State (:target) & Jello Physics Matrix
+   ========================================================================== */
+.modal-overlay:target {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* Trigger Jello bounce on entry activation AND continuous hover mechanics */
+.modal-overlay:target .modal-container,
+.modal-container:hover {
+  animation: jello-wobble var(--jello-duration) ease both;
+}
+
+/* Jello Animation Keyframe Physics Engine */
+@keyframes jello-wobble {
+  0% { transform: scale3d(1, 1, 1); }
+  30% { transform: scale3d(1.25, 0.75, 1); }
+  40% { transform: scale3d(0.75, 1.25, 1); }
+  50% { transform: scale3d(1.15, 0.85, 1); }
+  65% { transform: scale3d(0.95, 1.05, 1); }
+  75% { transform: scale3d(1.05, 0.95, 1); }
+  100% { transform: scale3d(1, 1, 1); }
+}
+
+/* Responsive constraints */
+@media (max-width: 576px) {
+  .modal-container {
+    padding: 1.5rem;
+  }
+  .neon-text {
+    font-size: 2rem;
+  }
+}


### PR DESCRIPTION
## 📝 Description
This PR addresses issue #34087 by introducing a pure CSS Cyberpunk Neon Modal example module. It features a custom `3D` elastic wobble entry and hover effect powered by CSS `@keyframes` and matrix physics transitions.

## 🎯 Changes Introduced
- **`demo.html`**: Constructed semantic markup layer including neon canvas anchors and full access structures (`role="dialog"`).
- **`style.css`**: Configured custom cyberpunk themes, grid layers, corner geometric clip-paths, and the core `jello-wobble` animation engine.
- **`README.md`**: Provided deployment blueprints and customization variables.

Fixes #34087