### PR TITLE
feat(examples): Magnetic Pull Accordion for Marketing Landing Page

### DIFF
--- a/submissions/examples/33135-magnetic-pull-accordion-marketing-landing-sj6/README.md
+++ b/submissions/examples/33135-magnetic-pull-accordion-marketing-landing-sj6/README.md
@@ -1,0 +1,78 @@
+# Magnetic Pull Accordion — Marketing Landing Page
+
+A pure CSS, zero-dependency **FAQ accordion** for bright marketing
+landing pages. Each question carries a two-pole magnet chip — an indigo
+north half and a pink south half resting a visible gap apart. Hovering
+a closed question **engages the field**: the poles creep toward each
+other and the card lifts to meet the cursor. Opening **snaps** the
+poles into one gradient pill with an accelerating pull, a click-ring
+radiates from the dock, and the answer is pulled up into place with a
+tiny overshoot settle. Built on native `<details>`/`<summary>`; no
+JavaScript anywhere.
+
+Resolves Issue: #33135
+
+## ✨ Features
+
+- **Two-pole magnet chip** — the indicator is two half-pills (indigo /
+  pink) whose separation is a single token (`--mg-gap`). Hover narrows
+  it to `--mg-creep` (attraction at range); open pulls both halves to
+  zero, docking them into one gradient pill.
+- **Magnetic snap easing** — `cubic-bezier(0.7, 0, 0.3, 1.35)` starts
+  slow, accelerates as the gap closes (force grows with proximity) and
+  overshoots a hair on dock, like real magnets clicking shut.
+- **Click-ring on contact** — a radiating box-shadow ring fires once
+  per open, selling the moment the poles touch.
+- **Reversible mid-gesture** — pole travel is a transform transition,
+  not a keyframe: closing releases the poles back to rest from wherever
+  they are, smoothly.
+- **Pulled-in answer** — the body rises 14px into place, overshoots
+  2px, and settles, echoing the same pull physics.
+- **Native accordion semantics** — `<details name="mg-faq">` gives
+  exclusive-open behavior straight from the browser; remove the `name`
+  to allow multiple open.
+- **Keyboard accessible** — `<summary>` is natively focusable and
+  toggles with Enter/Space; `:focus-visible` shows a 2px indigo ring
+  and triggers the same pole creep as hover.
+- **Genuinely responsive** — fluid section up to 620px; under 440px the
+  answer text realigns to the card edge and rows tighten.
+- **Tunable via custom properties** — pole gap, creep distance, snap
+  duration/easing, pull duration, and both brand colors on `:root`.
+- **Motion-safe** — `prefers-reduced-motion` removes all travel; poles
+  rest apart or docked with no animation.
+
+## 🔧 Custom Properties
+
+| Property             | Default                            | Role                          |
+| -------------------- | ---------------------------------- | ----------------------------- |
+| `--mg-gap`           | `6px`                              | Pole separation at rest       |
+| `--mg-creep`         | `2px`                              | Separation while hovered      |
+| `--mg-snap-duration` | `300ms`                            | Pole snap / release           |
+| `--mg-snap-ease`     | `cubic-bezier(0.7, 0, 0.3, 1.35)`  | Accelerating pull, soft dock  |
+| `--mg-pull-duration` | `340ms`                            | Answer pulled into place      |
+| `--mg-accent`        | `#6d5cff`                          | North pole (indigo)           |
+| `--mg-accent-2`      | `#ff5ca8`                          | South pole (pink)             |
+
+## 🚀 Usage
+
+```html
+<details class="mg-item" name="my-faq">
+  <summary class="mg-head">
+    <span class="mg-poles" aria-hidden="true">
+      <span class="mg-pole mg-pole-n"></span>
+      <span class="mg-pole mg-pole-s"></span>
+    </span>
+    How does the 14-day free trial work?
+    <span class="mg-chevron" aria-hidden="true"></span>
+  </summary>
+  <div class="mg-body">
+    <p>Every plan starts with all features unlocked for 14 days…</p>
+  </div>
+</details>
+```
+
+## 📂 Files
+
+- `demo.html` — a pricing FAQ section (trial / plans / cancel / seats).
+- `style.css` — motion tokens, two-pole magnet engine, landing-page skin, a11y guards.
+- `README.md` — this document.

--- a/submissions/examples/33135-magnetic-pull-accordion-marketing-landing-sj6/demo.html
+++ b/submissions/examples/33135-magnetic-pull-accordion-marketing-landing-sj6/demo.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Magnetic Pull Accordion — Marketing Landing Page</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="mg-section">
+    <p class="mg-eyebrow">Pricing FAQ</p>
+    <h1 class="mg-title">Answers that pull you in</h1>
+    <p class="mg-sub">
+      Hover a question — the two magnet poles creep together as the field
+      engages. Open it and they snap into one pill while the answer is
+      pulled up into place. Tab + Enter works — no JavaScript.
+    </p>
+
+    <!-- name="mg-faq" makes the accordion exclusive: opening one
+         question closes the others, natively. -->
+    <details class="mg-item" name="mg-faq" open>
+      <summary class="mg-head">
+        <span class="mg-poles" aria-hidden="true">
+          <span class="mg-pole mg-pole-n"></span>
+          <span class="mg-pole mg-pole-s"></span>
+        </span>
+        How does the 14-day free trial work?
+        <span class="mg-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="mg-body">
+        <p>
+          Every plan starts with all features unlocked for 14 days — no
+          credit card required. When the trial ends, your workspace simply
+          drops to the free tier; nothing is deleted and nothing is charged.
+        </p>
+      </div>
+    </details>
+
+    <details class="mg-item" name="mg-faq">
+      <summary class="mg-head">
+        <span class="mg-poles" aria-hidden="true">
+          <span class="mg-pole mg-pole-n"></span>
+          <span class="mg-pole mg-pole-s"></span>
+        </span>
+        Can I change plans later?
+        <span class="mg-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="mg-body">
+        <p>
+          Anytime. Upgrades apply immediately and we prorate the difference;
+          downgrades take effect at the start of your next billing cycle so
+          you never lose time you already paid for.
+        </p>
+      </div>
+    </details>
+
+    <details class="mg-item" name="mg-faq">
+      <summary class="mg-head">
+        <span class="mg-poles" aria-hidden="true">
+          <span class="mg-pole mg-pole-n"></span>
+          <span class="mg-pole mg-pole-s"></span>
+        </span>
+        What happens if I cancel?
+        <span class="mg-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="mg-body">
+        <p>
+          Your plan stays active until the end of the period you paid for,
+          then the workspace moves to the free tier. You can export
+          everything at any time — your data is yours.
+        </p>
+      </div>
+    </details>
+
+    <details class="mg-item" name="mg-faq">
+      <summary class="mg-head">
+        <span class="mg-poles" aria-hidden="true">
+          <span class="mg-pole mg-pole-n"></span>
+          <span class="mg-pole mg-pole-s"></span>
+        </span>
+        How are team seats billed?
+        <span class="mg-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="mg-body">
+        <p>
+          Per active member, per month. Invite as many viewers as you like
+          for free — only editors count as seats, and removing a seat
+          credits the unused time back to your account.
+        </p>
+      </div>
+    </details>
+
+    <p class="mg-footnote">
+      Still deciding? <a class="mg-link" href="#">Talk to a human →</a>
+    </p>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/33135-magnetic-pull-accordion-marketing-landing-sj6/style.css
+++ b/submissions/examples/33135-magnetic-pull-accordion-marketing-landing-sj6/style.css
@@ -1,0 +1,292 @@
+/* ==========================================================================
+   Magnetic Pull Accordion — Marketing Landing Page
+   --------------------------------------------------------------------------
+   Pure CSS FAQ accordion for bright marketing landing pages. Each question
+   carries a two-pole magnet chip: an indigo north half and a pink south
+   half resting a visible gap apart. Hovering a closed question ENGAGES THE
+   FIELD — the poles creep toward each other and the card lifts to meet the
+   cursor. Opening SNAPS the poles shut into one gradient pill with an
+   accelerating pull (force grows as the gap closes), a click-ring radiates
+   from the dock, and the answer is pulled up into place with a tiny
+   overshoot settle.
+
+   The pole travel is a transform TRANSITION, so closing releases them back
+   to rest and interrupting mid-snap reverses smoothly. Built on native
+   <details>/<summary>. Zero JavaScript.
+
+   Issue: #33135
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Tokens — the magnetic mechanic first, then the landing-page skin
+   -------------------------------------------------------------------------- */
+:root {
+  /* Magnetic pull */
+  --mg-gap: 6px;                                   /* pole separation at rest */
+  --mg-creep: 2px;                                 /* separation while hovered */
+  --mg-snap-duration: 300ms;                       /* pole snap / release      */
+  --mg-snap-ease: cubic-bezier(0.7, 0, 0.3, 1.35); /* slow start, hard pull,
+                                                      tiny overshoot dock     */
+  --mg-pull-duration: 340ms;                       /* answer pulled into place */
+  --mg-pull-ease: cubic-bezier(0.6, 0, 0.2, 1);
+  --mg-accent: #6d5cff;                            /* north pole (indigo)      */
+  --mg-accent-2: #ff5ca8;                          /* south pole (pink)        */
+  --mg-toggle-duration: 220ms;
+
+  /* Landing-page skin */
+  --mg-canvas: #f7f7fd;
+  --mg-card: #ffffff;
+  --mg-edge: #e7e7f3;
+  --mg-heading: #191932;
+  --mg-body-color: #5c5c78;
+}
+
+/* --------------------------------------------------------------------------
+   2. Demo stage — an airy hero section with soft brand glows
+   -------------------------------------------------------------------------- */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 40px 16px;
+  box-sizing: border-box;
+  background:
+    radial-gradient(640px 420px at 12% -8%, rgba(109, 92, 255, 0.12), transparent 60%),
+    radial-gradient(560px 400px at 95% 4%, rgba(255, 92, 168, 0.1), transparent 60%),
+    var(--mg-canvas);
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  color: var(--mg-body-color);
+}
+
+.mg-section {
+  width: 100%;
+  max-width: 620px;
+}
+
+.mg-eyebrow {
+  margin: 0 0 8px;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  background: linear-gradient(90deg, var(--mg-accent), var(--mg-accent-2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.mg-title {
+  margin: 0 0 8px;
+  font-size: clamp(1.5rem, 4.5vw, 2.1rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--mg-heading);
+}
+
+.mg-sub {
+  margin: 0 0 26px;
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+/* --------------------------------------------------------------------------
+   3. Question cards — native disclosure elements
+   -------------------------------------------------------------------------- */
+.mg-item {
+  background: var(--mg-card);
+  border: 1px solid var(--mg-edge);
+  border-radius: 14px;
+  box-shadow: 0 1px 2px rgba(25, 25, 50, 0.05);
+  transition:
+    transform var(--mg-snap-duration) var(--mg-snap-ease),
+    border-color 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.mg-item + .mg-item {
+  margin-top: 12px;
+}
+
+/* Field cue on hover: the closed card rises to meet the cursor */
+.mg-item:not([open]):hover {
+  transform: translateY(-2px);
+  border-color: rgba(109, 92, 255, 0.35);
+  box-shadow: 0 8px 22px rgba(109, 92, 255, 0.12);
+}
+
+/* --------------------------------------------------------------------------
+   4. The magnet — two poles that creep, then snap into one pill
+   --------------------------------------------------------------------------
+   .mg-pole-n is the indigo north half (left), .mg-pole-s the pink south
+   half (right). At rest they sit --mg-gap apart. Hover narrows the gap to
+   --mg-creep (attraction at range). Open pulls both to zero — the halves
+   dock into a single gradient pill — and a click-ring radiates from the
+   chip. Transitions make close a clean release back to rest. */
+.mg-poles {
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: rgba(109, 92, 255, 0.07);
+}
+
+.mg-pole {
+  width: 9px;
+  height: 10px;
+  transition: transform var(--mg-snap-duration) var(--mg-snap-ease);
+}
+
+.mg-pole-n {
+  border-radius: 999px 0 0 999px;
+  background: var(--mg-accent);
+  transform: translateX(calc(var(--mg-gap) / -2));
+}
+
+.mg-pole-s {
+  border-radius: 0 999px 999px 0;
+  background: var(--mg-accent-2);
+  transform: translateX(calc(var(--mg-gap) / 2));
+}
+
+/* Attraction at range — hover or keyboard focus narrows the gap */
+.mg-item:not([open]) .mg-head:hover .mg-pole-n,
+.mg-item:not([open]) .mg-head:focus-visible .mg-pole-n {
+  transform: translateX(calc(var(--mg-creep) / -2));
+}
+
+.mg-item:not([open]) .mg-head:hover .mg-pole-s,
+.mg-item:not([open]) .mg-head:focus-visible .mg-pole-s {
+  transform: translateX(calc(var(--mg-creep) / 2));
+}
+
+/* Contact — the poles dock into one pill */
+.mg-item[open] .mg-pole-n,
+.mg-item[open] .mg-pole-s {
+  transform: translateX(0);
+}
+
+/* The click of contact — a ring radiates once per open */
+.mg-item[open] .mg-poles {
+  animation: mg-click 460ms ease-out;
+}
+
+@keyframes mg-click {
+  from { box-shadow: 0 0 0 0 rgba(109, 92, 255, 0.35); }
+  to   { box-shadow: 0 0 0 14px rgba(109, 92, 255, 0); }
+}
+
+/* --------------------------------------------------------------------------
+   5. Summary — the question row
+   -------------------------------------------------------------------------- */
+.mg-head {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 16px 18px;
+  cursor: pointer;
+  list-style: none;                 /* hide default marker (Firefox) */
+  user-select: none;
+  border-radius: 14px;
+  color: var(--mg-heading);
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.mg-head::-webkit-details-marker { display: none; }
+
+.mg-head:focus-visible {
+  outline: 2px solid var(--mg-accent);
+  outline-offset: 2px;
+}
+
+/* Chevron rotates as the answer opens */
+.mg-chevron {
+  flex: none;
+  margin-left: auto;
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid var(--mg-body-color);
+  border-bottom: 2px solid var(--mg-body-color);
+  transform: rotate(45deg);
+  transition: transform var(--mg-toggle-duration) var(--mg-pull-ease);
+}
+
+.mg-item[open] > .mg-head .mg-chevron {
+  transform: rotate(225deg);
+}
+
+/* --------------------------------------------------------------------------
+   6. Answer — pulled up into place, overshoots a hair, settles
+   -------------------------------------------------------------------------- */
+.mg-body {
+  padding: 0 18px 18px 62px;
+  animation: mg-pull-in var(--mg-pull-duration) var(--mg-pull-ease) both;
+}
+
+@keyframes mg-pull-in {
+  0%   { opacity: 0; transform: translateY(14px); }
+  72%  { opacity: 1; transform: translateY(-2px); }
+  100% { opacity: 1; transform: translateY(0); }
+}
+
+.mg-body p {
+  margin: 0;
+  font-size: 0.88rem;
+  line-height: 1.6;
+}
+
+.mg-body p + p {
+  margin-top: 10px;
+}
+
+/* Footer link under the deck */
+.mg-footnote {
+  margin: 22px 0 0;
+  font-size: 0.86rem;
+  text-align: center;
+}
+
+.mg-link {
+  font-weight: 600;
+  color: var(--mg-accent);
+  text-decoration-color: rgba(109, 92, 255, 0.35);
+  text-underline-offset: 3px;
+}
+
+.mg-link:hover {
+  color: var(--mg-accent-2);
+  text-decoration-color: rgba(255, 92, 168, 0.45);
+}
+
+/* --------------------------------------------------------------------------
+   7. Small screens — tighter rows, answer text realigns to the card edge
+   -------------------------------------------------------------------------- */
+@media (max-width: 440px) {
+  .mg-head { padding: 14px 14px; gap: 11px; }
+  .mg-body { padding: 0 14px 15px 14px; }
+}
+
+/* --------------------------------------------------------------------------
+   8. Reduced motion — poles rest docked-or-apart, nothing travels
+   -------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .mg-item,
+  .mg-pole,
+  .mg-chevron {
+    transition: none;
+  }
+
+  .mg-item[open] .mg-poles,
+  .mg-body {
+    animation: none;
+  }
+
+  .mg-item:not([open]):hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS **Magnetic Pull Accordion** styled for **Marketing Landing Page** layouts as a fully self-contained example under `submissions/examples/33135-magnetic-pull-accordion-marketing-landing-sj6/`.

Fixes #33135

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/33135-magnetic-pull-accordion-marketing-landing-sj6/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A zero-JavaScript pricing-FAQ accordion where the magnetism is literal: each question carries a two-pole magnet chip — an indigo north half and a pink south half resting a `--mg-gap` apart. Hovering a closed question engages the field (the poles creep to `--mg-creep` and the card lifts to meet the cursor); opening snaps both halves into one gradient pill with an accelerating-pull easing (`cubic-bezier(0.7, 0, 0.3, 1.35)` — force grows as the gap closes, tiny overshoot on dock), fires a radiating click-ring at the moment of contact, and pulls the answer up into place with a 2px overshoot settle. Pole travel is a transform transition, so closing releases them smoothly from wherever they are.

**How does a developer use it?**

```html
<details class="mg-item" name="my-faq">
  <summary class="mg-head">
    <span class="mg-poles" aria-hidden="true">
      <span class="mg-pole mg-pole-n"></span>
      <span class="mg-pole mg-pole-s"></span>
    </span>
    How does the 14-day free trial work?
    <span class="mg-chevron" aria-hidden="true"></span>
  </summary>
  <div class="mg-body">
    <p>Every plan starts with all features unlocked for 14 days…</p>
  </div>
</details>
```

**Why does it fit EaseMotion CSS?**

Human-readable classes, animation-first, zero JS. Pole gap, creep distance, snap duration/easing, pull duration, and both brand colors are `--mg-*` custom properties on `:root`; `:focus-visible` triggers the same pole creep as hover so keyboard users get the attraction cue; `<details name>` provides exclusive-open natively with Enter/Space toggling from `<summary>`; `prefers-reduced-motion` removes all travel while the hover cue survives as a border/shadow change.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Deliberately distinct from the existing magnetic-pull submissions (`ease-magnetic-pull-accordion-modern-saas`, `magnetic-pull-accordion-arpita`, and the just-merged #33144 dashboard variant): those animate the whole panel on hover, while this one makes the magnet itself the protagonist — two physical poles whose separation is a single token, with attraction-at-range, snap-on-contact, and a click-ring. Skinned specifically for bright marketing landing pages (light canvas, gradient brand accents, pricing-FAQ copy).

@SAPTARSHI-coder Please review the pr
