### PR TITLE
feat(examples): Spring Physics Accordion for Glassmorphism UI

### DIFF
--- a/submissions/examples/33125-spring-physics-accordion-glassmorphism-sj6/README.md
+++ b/submissions/examples/33125-spring-physics-accordion-glassmorphism-sj6/README.md
@@ -1,0 +1,74 @@
+# Spring Physics Accordion — Glassmorphism UI
+
+A pure CSS, zero-dependency **frosted-glass accordion** whose open
+motion is real spring physics. Opening a panel doesn't just slide — it
+**springs**: the body drops in on a damped oscillation (overshoot,
+small rebound, settle), the whole glass card gives a matching
+squash-and-stretch, and the chevron rotates past its mark and springs
+back. Every bounce is one hand-tuned keyframe timeline sharing a single
+`--sp-spring` duration, so the panel reads like a mass on a real
+spring. Built on native `<details>`/`<summary>`; no JavaScript anywhere.
+
+Resolves Issue: #33125
+
+## ✨ Features
+
+- **Damped spring open** — the body plays a multi-stop keyframe
+  (`sp-body-spring`) that falls past its rest position, rebounds up,
+  overshoots less, and lands. The keyframe *is* the spring; the clock
+  runs `linear` so the shape controls the physics, not an easing curve.
+- **Squash-and-stretch card** — the whole panel stretches ~3% as the
+  body launches out, then recoils and settles on the same timeline, so
+  card and content move as one coupled system.
+- **Spring-back chevron** — rotates on a `cubic-bezier(0.34, 1.56,
+  0.64, 1)` overshoot easing, cresting past 225° before settling.
+- **Genuine glassmorphism** — translucent fill, `backdrop-filter`
+  blur, a hairline inner top-edge highlight, and a soft drop shadow,
+  floating over a live multi-radial color field. Hover lifts the
+  frost's opacity.
+- **Accent coil dot** — a small indicator lights mint and glows when
+  its panel is open, giving each row a quiet on/off tell.
+- **Native accordion semantics** — `<details name="sp-settings">`
+  gives exclusive-open behavior straight from the browser; remove the
+  `name` to allow multiple open.
+- **Keyboard accessible** — `<summary>` is natively focusable and
+  toggles with Enter/Space; 2px mint `:focus-visible` ring.
+- **Genuinely responsive** — fluid shell up to 560px; under 440px the
+  body text realigns to the card edge and padding tightens.
+- **Tunable via custom properties** — spring duration, drop distance,
+  chevron easing, blur amount, glass opacities, and accent on `:root`.
+- **Motion-safe** — `prefers-reduced-motion` stills every spring; the
+  glass, blur, and layout remain fully intact.
+
+## 🔧 Custom Properties
+
+| Property              | Default                              | Role                          |
+| --------------------- | ------------------------------------ | ----------------------------- |
+| `--sp-spring`         | `620ms`                              | Full oscillation length       |
+| `--sp-drop`           | `16px`                               | How far the body falls in     |
+| `--sp-settle-ease`    | `cubic-bezier(0.34, 1.56, 0.64, 1)`  | Chevron overshoot             |
+| `--sp-blur`           | `16px`                               | Backdrop blur radius          |
+| `--sp-glass`          | `rgba(255,255,255,0.14)`             | Panel fill                    |
+| `--sp-stroke`         | `rgba(255,255,255,0.4)`              | Frosted rim                   |
+| `--sp-accent`         | `#8affe4`                            | Mint spring accent            |
+
+## 🚀 Usage
+
+```html
+<details class="sp-item" name="my-settings">
+  <summary class="sp-head">
+    <span class="sp-coil" aria-hidden="true"></span>
+    <span class="sp-head-text">Appearance</span>
+    <span class="sp-chevron" aria-hidden="true"></span>
+  </summary>
+  <div class="sp-body">
+    <p>Pick a theme and accent that follow you across every device…</p>
+  </div>
+</details>
+```
+
+## 📂 Files
+
+- `demo.html` — a frosted "Workspace settings" panel over a color field.
+- `style.css` — spring tokens, damped-oscillation keyframes, glass skin, a11y guards.
+- `README.md` — this document.

--- a/submissions/examples/33125-spring-physics-accordion-glassmorphism-sj6/demo.html
+++ b/submissions/examples/33125-spring-physics-accordion-glassmorphism-sj6/demo.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Spring Physics Accordion — Glassmorphism UI</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="sp-shell">
+    <h1 class="sp-shell-title">Workspace settings</h1>
+    <p class="sp-shell-sub">
+      Open a panel — the frosted card gives a spring squash-and-stretch as
+      the content drops in on a damped bounce and the chevron springs past
+      its mark. Tab + Enter works — no JavaScript.
+    </p>
+
+    <!-- name="sp-settings" makes the accordion exclusive: opening one
+         panel closes the others, natively. -->
+    <details class="sp-item" name="sp-settings" open>
+      <summary class="sp-head">
+        <span class="sp-coil" aria-hidden="true"></span>
+        <span class="sp-head-text">Appearance</span>
+        <span class="sp-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="sp-body">
+        <p>
+          Pick a theme and accent that follow you across every device.
+          Changes preview live and sync the moment you make them — no save
+          button, no reload.
+        </p>
+        <div class="sp-tags">
+          <span class="sp-tag">Auto dark mode</span>
+          <span class="sp-tag">Accent color</span>
+          <span class="sp-tag">Density</span>
+        </div>
+      </div>
+    </details>
+
+    <details class="sp-item" name="sp-settings">
+      <summary class="sp-head">
+        <span class="sp-coil" aria-hidden="true"></span>
+        <span class="sp-head-text">Notifications</span>
+        <span class="sp-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="sp-body">
+        <p>
+          Choose exactly what reaches you and where. Quiet hours pause
+          everything but direct mentions, and each channel remembers its
+          own rules.
+        </p>
+        <div class="sp-tags">
+          <span class="sp-tag">Quiet hours</span>
+          <span class="sp-tag">Email digest</span>
+          <span class="sp-tag">Mentions only</span>
+        </div>
+      </div>
+    </details>
+
+    <details class="sp-item" name="sp-settings">
+      <summary class="sp-head">
+        <span class="sp-coil" aria-hidden="true"></span>
+        <span class="sp-head-text">Privacy &amp; security</span>
+        <span class="sp-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="sp-body">
+        <p>
+          Manage sessions, two-factor methods, and who can see your
+          activity. Revoking a device signs it out instantly, everywhere.
+        </p>
+        <div class="sp-tags">
+          <span class="sp-tag">Two-factor</span>
+          <span class="sp-tag">Active sessions</span>
+          <span class="sp-tag">Visibility</span>
+        </div>
+      </div>
+    </details>
+
+    <details class="sp-item" name="sp-settings">
+      <summary class="sp-head">
+        <span class="sp-coil" aria-hidden="true"></span>
+        <span class="sp-head-text">Billing</span>
+        <span class="sp-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="sp-body">
+        <p>
+          See your current plan, upcoming invoice, and payment method in one
+          place. Upgrades apply immediately and are prorated to the day.
+        </p>
+        <div class="sp-tags">
+          <span class="sp-tag">Plan</span>
+          <span class="sp-tag">Invoices</span>
+          <span class="sp-tag">Payment method</span>
+        </div>
+      </div>
+    </details>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/33125-spring-physics-accordion-glassmorphism-sj6/style.css
+++ b/submissions/examples/33125-spring-physics-accordion-glassmorphism-sj6/style.css
@@ -1,0 +1,256 @@
+/* ==========================================================================
+   Spring Physics Accordion — Glassmorphism UI
+   --------------------------------------------------------------------------
+   Pure CSS accordion for frosted-glass interfaces. Opening a panel doesn't
+   just slide — it SPRINGS: the body drops in on a damped oscillation
+   (overshoot, small rebound, settle), the whole card gives a matching
+   squash-and-stretch, and the chevron rotates past its mark and springs
+   back. Every bounce is one hand-tuned keyframe timeline sharing a single
+   --sp-spring duration, so the panel reads like a mass on a real spring.
+
+   Built on frosted glass: translucent fills, backdrop blur, a hairline
+   inner highlight, and a soft drop shadow — floating over a live color
+   field. Native <details>/<summary>. Zero JavaScript.
+
+   Issue: #33125
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Tokens — the spring first, then the glass
+   -------------------------------------------------------------------------- */
+:root {
+  /* Spring physics */
+  --sp-spring: 620ms;                              /* full oscillation length  */
+  --sp-spring-ease: linear;                        /* the keyframes ARE the
+                                                      spring; keep the clock even */
+  --sp-settle-ease: cubic-bezier(0.34, 1.56, 0.64, 1); /* overshoot for chevron */
+  --sp-drop: 16px;                                 /* how far the body falls in */
+  --sp-toggle-duration: 260ms;
+
+  /* Glass skin */
+  --sp-glass: rgba(255, 255, 255, 0.14);           /* panel fill               */
+  --sp-glass-hover: rgba(255, 255, 255, 0.2);
+  --sp-stroke: rgba(255, 255, 255, 0.4);           /* frosted rim              */
+  --sp-blur: 16px;
+  --sp-heading: #ffffff;
+  --sp-body-color: rgba(255, 255, 255, 0.82);
+  --sp-accent: #8affe4;                            /* mint spring accent       */
+}
+
+/* --------------------------------------------------------------------------
+   2. Demo stage — a live color field for the glass to float on
+   -------------------------------------------------------------------------- */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 44px 18px;
+  box-sizing: border-box;
+  background:
+    radial-gradient(760px 520px at 8% 0%, #6a4bff 0%, transparent 55%),
+    radial-gradient(700px 520px at 100% 12%, #ff4bd8 0%, transparent 52%),
+    radial-gradient(760px 620px at 60% 108%, #2ad0ff 0%, transparent 55%),
+    #2a1b5e;
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  color: var(--sp-body-color);
+}
+
+.sp-shell {
+  width: 100%;
+  max-width: 560px;
+}
+
+.sp-shell-title {
+  margin: 0 0 6px;
+  font-size: clamp(1.4rem, 4vw, 1.9rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--sp-heading);
+  text-shadow: 0 2px 20px rgba(0, 0, 0, 0.25);
+}
+
+.sp-shell-sub {
+  margin: 0 0 24px;
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
+/* --------------------------------------------------------------------------
+   3. Glass panels — native disclosure elements
+   -------------------------------------------------------------------------- */
+.sp-item {
+  position: relative;
+  background: var(--sp-glass);
+  border: 1px solid var(--sp-stroke);
+  border-radius: 16px;
+  box-shadow:
+    0 10px 30px rgba(15, 8, 45, 0.28),
+    inset 0 1px 0 rgba(255, 255, 255, 0.35);   /* top-edge glass highlight */
+  -webkit-backdrop-filter: blur(var(--sp-blur));
+  backdrop-filter: blur(var(--sp-blur));
+  transition: background 200ms ease, border-color 200ms ease;
+  transform-origin: top center;
+}
+
+.sp-item + .sp-item {
+  margin-top: 14px;
+}
+
+.sp-item:not([open]):hover {
+  background: var(--sp-glass-hover);
+  border-color: rgba(255, 255, 255, 0.55);
+}
+
+/* The card gives a spring squash-and-stretch the instant it opens */
+.sp-item[open] {
+  animation: sp-card-spring var(--sp-spring) var(--sp-spring-ease) both;
+}
+
+@keyframes sp-card-spring {
+  0%   { transform: scaleY(1);    }
+  22%  { transform: scaleY(1.03); }  /* stretch as the body launches out */
+  46%  { transform: scaleY(0.99); }  /* recoil */
+  70%  { transform: scaleY(1.008);}
+  86%  { transform: scaleY(0.998);}
+  100% { transform: scaleY(1);    }
+}
+
+/* --------------------------------------------------------------------------
+   4. Summary — the panel header
+   -------------------------------------------------------------------------- */
+.sp-head {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 17px 20px;
+  cursor: pointer;
+  list-style: none;                 /* hide default marker (Firefox) */
+  user-select: none;
+  border-radius: 16px;
+  color: var(--sp-heading);
+  font-size: 0.98rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.sp-head::-webkit-details-marker { display: none; }
+
+.sp-head:focus-visible {
+  outline: 2px solid var(--sp-accent);
+  outline-offset: 2px;
+}
+
+/* A little coil dot that pulses the accent when the panel is open */
+.sp-coil {
+  flex: none;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.5);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
+  transition: background var(--sp-toggle-duration) ease,
+              box-shadow var(--sp-toggle-duration) ease;
+}
+
+.sp-item[open] > .sp-head .sp-coil {
+  background: var(--sp-accent);
+  box-shadow:
+    0 0 12px rgba(138, 255, 228, 0.8),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.6);
+}
+
+.sp-head-text {
+  flex: 1 1 auto;
+}
+
+/* Chevron springs past its mark and settles (overshoot easing) */
+.sp-chevron {
+  flex: none;
+  width: 9px;
+  height: 9px;
+  border-right: 2px solid var(--sp-heading);
+  border-bottom: 2px solid var(--sp-heading);
+  transform: rotate(45deg);
+  transition: transform var(--sp-spring) var(--sp-settle-ease);
+}
+
+.sp-item[open] > .sp-head .sp-chevron {
+  transform: rotate(225deg);
+}
+
+/* --------------------------------------------------------------------------
+   5. Body — springs down on a damped oscillation, then settles
+   --------------------------------------------------------------------------
+   The multi-stop keyframe IS the spring: the content falls past its rest
+   position, rebounds a little, overshoots less, and lands. Opacity resolves
+   early so only the motion bounces, not the fade. */
+.sp-body {
+  padding: 2px 20px 20px 44px;
+  animation: sp-body-spring var(--sp-spring) var(--sp-spring-ease) both;
+}
+
+@keyframes sp-body-spring {
+  0%   { opacity: 0; transform: translateY(calc(var(--sp-drop) * -1)); }
+  30%  { opacity: 1; transform: translateY(4px);   }  /* past rest      */
+  52%  { transform: translateY(-2px); }               /* rebound up     */
+  72%  { transform: translateY(1px);  }
+  88%  { transform: translateY(-0.4px); }
+  100% { opacity: 1; transform: translateY(0); }
+}
+
+.sp-body p {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.62;
+}
+
+.sp-body p + p {
+  margin-top: 10px;
+}
+
+.sp-tags {
+  margin-top: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.sp-tag {
+  padding: 5px 11px;
+  border-radius: 999px;
+  font-size: 0.74rem;
+  font-weight: 600;
+  color: var(--sp-heading);
+  background: rgba(255, 255, 255, 0.16);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+}
+
+/* --------------------------------------------------------------------------
+   6. Small screens — tighter padding, body text realigns to the edge
+   -------------------------------------------------------------------------- */
+@media (max-width: 440px) {
+  .sp-head { padding: 15px 15px; gap: 11px; }
+  .sp-body { padding: 2px 15px 16px 15px; }
+}
+
+/* --------------------------------------------------------------------------
+   7. Reduced motion — the glass stays; the spring is stilled
+   -------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .sp-item[open],
+  .sp-body {
+    animation: none;
+  }
+
+  .sp-chevron,
+  .sp-coil,
+  .sp-item {
+    transition: none;
+  }
+
+  .sp-body {
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS **Spring Physics Accordion** styled for **Glassmorphism UI** layouts as a fully self-contained example under `submissions/examples/33125-spring-physics-accordion-glassmorphism-sj6/`.

Fixes #33125

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/33125-spring-physics-accordion-glassmorphism-sj6/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A zero-JavaScript frosted-glass settings accordion whose open motion is real spring physics. Opening a panel plays a multi-stop keyframe (`sp-body-spring`) that drops the body past its rest position, rebounds up, overshoots less, and lands — a damped oscillation. The whole glass card gives a matching squash-and-stretch (~3%) on the same timeline, and the chevron rotates past 225° on an overshoot easing and springs back. The keyframes *are* the spring: the clock runs `linear` so the keyframe shape controls the physics rather than a single easing curve. Genuine glassmorphism throughout — translucent fill, `backdrop-filter` blur, a hairline inner top-edge highlight, and a soft drop shadow, floating over a live multi-radial color field.

**How does a developer use it?**

```html
<details class="sp-item" name="my-settings">
  <summary class="sp-head">
    <span class="sp-coil" aria-hidden="true"></span>
    <span class="sp-head-text">Appearance</span>
    <span class="sp-chevron" aria-hidden="true"></span>
  </summary>
  <div class="sp-body">
    <p>Pick a theme and accent that follow you across every device…</p>
  </div>
</details>
```

**Why does it fit EaseMotion CSS?**

Human-readable classes, animation-first, zero JS. Spring duration, drop distance, chevron easing, blur amount, glass opacities, and accent are `--sp-*` custom properties on `:root`; `<details name>` provides exclusive-open natively with Enter/Space toggling from `<summary>`; `:focus-visible` shows a mint ring; `prefers-reduced-motion` stills every spring while the glass, blur, and layout stay fully intact.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Distinct from the existing spring-physics submissions (`ease-spring-physics-accordion-modern-saas`, `spring-physics-accordion-arpita`): rather than a single bouncy easing on the panel, this models a coupled system — the body's damped oscillation and the card's squash-and-stretch share one keyframe timeline, so the glass visibly reacts to the content springing out. Skinned specifically for glassmorphism (backdrop blur, translucent rims, inner highlight) over a live gradient field.

@SAPTARSHI-coder Please review this pr 