### PR TITLE
feat(react): full suite of React wrapper components (Animate, Hover, ScrollReveal)

### DIFF
--- a/examples/react-vite/README.md
+++ b/examples/react-vite/README.md
@@ -14,3 +14,74 @@ The React Compiler is not enabled on this template because of its impact on dev 
 ## Expanding the Oxlint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and Oxlint's TypeScript related rules in your project.
+
+## EaseMotion React wrapper components
+
+`src/components/` provides declarative React wrappers over EaseMotion CSS. The
+class/style resolution and IntersectionObserver logic live in framework-agnostic
+helpers (`animationClasses.js`, `scrollRevealCore.js`) that are unit-tested from
+the repo root with `npm test` (see `tests/react-*.test.js`).
+
+### `<Animate>`
+
+Plays a keyframe animation on mount.
+
+```jsx
+import Animate from './components/Animate';
+
+// Keyword duration → utility class; delay → inline animation-delay
+<Animate type="slide-up" duration="slow" delay={200}>Hello</Animate>
+
+// Numeric duration (ms) is inlined; iteration + lifecycle callbacks
+<Animate
+  type="pulse"
+  duration={800}
+  iteration="infinite"
+  onStart={() => console.log('start')}
+  onEnd={() => console.log('end')}
+>
+  Live
+</Animate>
+```
+
+| Prop | Type | Notes |
+| --- | --- | --- |
+| `type` | string | `fade-in`, `slide-up`, `zoom-in`, `spin`, `bounce`, `shake`, … (unknown → `ease-<type>`) |
+| `duration` | `'fast' \| 'medium' \| 'slow'` or number (ms) | keyword → `.ease-duration-*`; number → inline |
+| `delay` | number (ms) | inline `animation-delay` |
+| `iteration` | `'infinite'` or number | `animation-iteration-count` |
+| `hover` | string | inline hover effect (or use `<Hover>`) |
+| `onStart` / `onEnd` | function | bound to `onAnimationStart` / `onAnimationEnd` |
+| `tag` | string | element to render (default `div`) |
+
+### `<Hover>`
+
+Applies a hover interaction. `lift`, `scale`, `glow`, and `shrink` map to CSS
+hover classes; `shake` plays the one-shot `ease-shake` keyframe on each hover-in.
+
+```jsx
+import Hover from './components/Hover';
+
+<Hover effect="lift"><button>Lift me</button></Hover>
+<Hover effect="shake"><span>Shake on hover</span></Hover>
+```
+
+### `<ScrollReveal>`
+
+Reveals content when it scrolls into view using `IntersectionObserver`, honoring
+`prefers-reduced-motion` and degrading gracefully where the API is unavailable.
+
+```jsx
+import ScrollReveal from './components/ScrollReveal';
+
+<ScrollReveal variant="up" once>
+  <section>Revealed on scroll</section>
+</ScrollReveal>
+```
+
+| Prop | Type | Notes |
+| --- | --- | --- |
+| `variant` | `'up' \| 'down' \| 'left' \| 'right' \| 'scale' \| 'fade'` | entry direction (default `up`) |
+| `once` | boolean | reveal only the first time (default `true`) |
+| `threshold` / `rootMargin` | number / string | forwarded to `IntersectionObserver` |
+| `onReveal` | function | called with the element once revealed |

--- a/examples/react-vite/src/App.jsx
+++ b/examples/react-vite/src/App.jsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import './App.css';
 import Animate from './components/Animate';
+import Hover from './components/Hover';
+import ScrollReveal from './components/ScrollReveal';
 
 function App() {
   const [activeAnimation, setActiveAnimation] = useState('fade-in');
@@ -131,7 +133,7 @@ function App() {
           <Animate type="zoom-in" duration={350} className="demo-card" style={{ maxWidth: '450px', width: '90%' }}>
             <h3>Modal Dialog</h3>
             <p style={{ color: 'var(--text-muted)', marginBottom: '2rem' }}>
-              This modal dialog enters the screen smoothly using the <code>ease-animate-zoom-in</code> animation.
+              This modal dialog enters the screen smoothly using the <code>ease-zoom-in</code> animation.
             </p>
             <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
               <button className="btn-outline" onClick={() => setIsModalOpen(false)} style={{ margin: 0 }}>
@@ -141,6 +143,38 @@ function App() {
           </Animate>
         </div>
       )}
+
+      {/* Hover + ScrollReveal Showcase */}
+      <ScrollReveal variant="up" className="demo-card" style={{ marginTop: '1.5rem' }}>
+        <span className="pill">04 / Hover &amp; Scroll</span>
+        <h3>Hover effects &amp; scroll reveal</h3>
+        <p style={{ color: 'var(--text-muted)' }}>
+          This card enters with <code>&lt;ScrollReveal&gt;</code> via IntersectionObserver.
+          Hover the tiles below — each is a <code>&lt;Hover&gt;</code> effect.
+        </p>
+        <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap', marginTop: '1.25rem' }}>
+          {[
+            { effect: 'lift', label: 'Lift' },
+            { effect: 'scale', label: 'Scale' },
+            { effect: 'glow', label: 'Glow' },
+            { effect: 'shake', label: 'Shake' }
+          ].map(({ effect, label }) => (
+            <Hover
+              key={effect}
+              effect={effect}
+              className="pill"
+              style={{
+                cursor: 'pointer',
+                padding: '0.75rem 1.25rem',
+                background: 'rgba(168, 85, 247, 0.15)',
+                color: 'var(--accent-purple)'
+              }}
+            >
+              {label}
+            </Hover>
+          ))}
+        </div>
+      </ScrollReveal>
 
       {/* Bottom Showcase Info */}
       <Animate type="fade-in" delay={400} className="demo-card" style={{ background: 'rgba(6, 182, 212, 0.05)', borderColor: 'rgba(6, 182, 212, 0.2)' }}>

--- a/examples/react-vite/src/components/Animate.jsx
+++ b/examples/react-vite/src/components/Animate.jsx
@@ -1,63 +1,50 @@
 import React from 'react';
+import { buildAnimateClassName, buildAnimateStyle } from './animationClasses';
 
 /**
- * Animate component is a React wrapper for EaseMotion CSS animations.
- * It dynamically applies keyframe animations and transition behaviors.
- * 
+ * <Animate> — declarative React wrapper for EaseMotion CSS keyframe animations.
+ *
  * Props:
- * - type: The animation type (e.g. 'fade-in', 'slide-up', 'zoom-in', 'spin', 'bounce')
- * - duration: Custom duration in ms or one of 'fast', 'medium', 'slow' (defaults to 'medium')
- * - delay: Delay in ms (e.g. 100, 200, 300 for staggered lists)
- * - hover: Hover effect class (e.g. 'lift', 'glow', 'scale', 'shake')
- * - tag: HTML tag to render (defaults to 'div')
- * - className: Additional custom classes
+ * - type: animation keyword — 'fade-in', 'fade-out', 'slide-up', 'slide-down',
+ *   'slide-in-left', 'slide-in-right', 'zoom-in', 'zoom-out', 'bounce-in',
+ *   'bounce', 'flip', 'spin'/'rotate', 'pulse', 'ping', 'shake', 'float',
+ *   'wave', 'blur-to-focus'. Unknown values fall back to `ease-<type>`.
+ * - duration: 'fast' | 'medium' | 'slow' (utility class) or a number of ms
+ *   (inlined as animation-duration). Defaults to 'medium'.
+ * - delay: stagger delay in ms (inlined as animation-delay).
+ * - iteration: 'infinite' or a positive count (animation-iteration-count).
+ * - hover: hover effect keyword — 'lift', 'scale', 'glow', 'shrink',
+ *   'lift-shadow', 'underline'. (For richer hover control use <Hover>.)
+ * - onStart / onEnd: callbacks bound to the native onAnimationStart /
+ *   onAnimationEnd lifecycle events.
+ * - tag: element type to render (default 'div').
+ * - className / style: merged with the generated class list / styles.
  */
 export default function Animate({
   type,
   duration = 'medium',
   delay = 0,
+  iteration,
   hover,
   tag: Tag = 'div',
   className = '',
   style = {},
+  onStart,
+  onEnd,
   children,
   ...props
 }) {
-  const classes = [];
+  const combinedClassName = buildAnimateClassName({ type, duration, hover, className });
+  const combinedStyle = buildAnimateStyle({ duration, delay, iteration, style });
 
-  // Core animation class
-  if (type) {
-    classes.push(`ease-animate-${type}`);
-  }
-
-  // Duration override class if standard token
-  if (duration === 'fast' || duration === 'medium' || duration === 'slow') {
-    classes.push(`ease-duration-${duration}`);
-  }
-
-  // Hover effect class
-  if (hover) {
-    classes.push(`ease-hover-${hover}`);
-  }
-
-  // Additional classes
-  if (className) {
-    classes.push(className);
-  }
-
-  // Inline style for custom duration (in ms) and delay
-  const inlineStyle = { ...style };
-  if (delay > 0) {
-    inlineStyle.animationDelay = `${delay}ms`;
-    inlineStyle.transitionDelay = `${delay}ms`;
-  }
-  if (typeof duration === 'number') {
-    inlineStyle.animationDuration = `${duration}ms`;
-    inlineStyle.transitionDuration = `${duration}ms`;
-  }
+  // Bind lifecycle hooks only when provided so we never clobber a handler
+  // the caller passed through `...props`.
+  const lifecycle = {};
+  if (onStart) lifecycle.onAnimationStart = onStart;
+  if (onEnd) lifecycle.onAnimationEnd = onEnd;
 
   return (
-    <Tag className={classes.join(' ')} style={inlineStyle} {...props}>
+    <Tag className={combinedClassName} style={combinedStyle} {...props} {...lifecycle}>
       {children}
     </Tag>
   );

--- a/examples/react-vite/src/components/Hover.jsx
+++ b/examples/react-vite/src/components/Hover.jsx
@@ -1,0 +1,69 @@
+import React, { useCallback, useState } from 'react';
+import { resolveHoverClass } from './animationClasses';
+
+/**
+ * <Hover> — declarative wrapper for EaseMotion hover interactions.
+ *
+ * Effects:
+ * - 'lift'   → ease-hover-lift    (translateY on hover)
+ * - 'scale'  → ease-hover-grow    (scale up on hover)
+ * - 'shrink' → ease-hover-shrink  (scale down on hover)
+ * - 'glow'   → ease-hover-glow    (glow shadow on hover)
+ * - 'shake'  → plays the one-shot `ease-shake` keyframe on hover-in. The
+ *   framework has no pure-CSS hover-shake (a :hover shake would loop while the
+ *   pointer rests), so this is driven by state: add the class on mouse-enter,
+ *   remove it when the animation ends, ready to fire again next hover.
+ *
+ * Props:
+ * - effect: one of the keywords above (default 'lift').
+ * - tag: element type to render (default 'div').
+ * - className / style / event handlers: forwarded to the element.
+ */
+export default function Hover({
+  effect = 'lift',
+  tag: Tag = 'div',
+  className = '',
+  children,
+  onMouseEnter,
+  onAnimationEnd,
+  ...props
+}) {
+  const isShake = effect === 'shake';
+  const [shaking, setShaking] = useState(false);
+
+  const handleMouseEnter = useCallback(
+    (event) => {
+      if (isShake) setShaking(true);
+      if (onMouseEnter) onMouseEnter(event);
+    },
+    [isShake, onMouseEnter]
+  );
+
+  const handleAnimationEnd = useCallback(
+    (event) => {
+      if (isShake) setShaking(false);
+      if (onAnimationEnd) onAnimationEnd(event);
+    },
+    [isShake, onAnimationEnd]
+  );
+
+  const classes = [];
+  if (isShake) {
+    if (shaking) classes.push('ease-shake');
+  } else {
+    const hoverClass = resolveHoverClass(effect);
+    if (hoverClass) classes.push(hoverClass);
+  }
+  if (className) classes.push(className);
+
+  return (
+    <Tag
+      className={classes.join(' ')}
+      onMouseEnter={handleMouseEnter}
+      onAnimationEnd={handleAnimationEnd}
+      {...props}
+    >
+      {children}
+    </Tag>
+  );
+}

--- a/examples/react-vite/src/components/ScrollReveal.jsx
+++ b/examples/react-vite/src/components/ScrollReveal.jsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useRef } from 'react';
+import { buildRevealClassName, observeReveal } from './scrollRevealCore';
+
+/**
+ * <ScrollReveal> — reveals its content with an EaseMotion entry transition when
+ * it scrolls into view, using the IntersectionObserver API under the hood.
+ *
+ * The element renders hidden (`ease-reveal` + a direction variant) and gains
+ * `ease-reveal-active` on intersection. Reduced-motion users, and environments
+ * without IntersectionObserver, see the content revealed immediately.
+ *
+ * Props:
+ * - variant: entry direction — 'up' | 'down' | 'left' | 'right' | 'scale' |
+ *   'fade' (default 'up').
+ * - once: reveal only the first time it enters view (default true).
+ * - threshold / rootMargin: forwarded to IntersectionObserver.
+ * - onReveal(element): callback fired once the element is revealed.
+ * - tag: element type to render (default 'div').
+ * - className / style / other props: forwarded to the element.
+ */
+export default function ScrollReveal({
+  variant = 'up',
+  once = true,
+  threshold = 0.15,
+  rootMargin = '0px',
+  onReveal,
+  tag: Tag = 'div',
+  className = '',
+  children,
+  ...props
+}) {
+  const ref = useRef(null);
+
+  useEffect(() => {
+    const cleanup = observeReveal(ref.current, { once, threshold, rootMargin, onReveal });
+    return cleanup;
+  }, [once, threshold, rootMargin, onReveal]);
+
+  return (
+    <Tag ref={ref} className={buildRevealClassName({ variant, className })} {...props}>
+      {children}
+    </Tag>
+  );
+}

--- a/examples/react-vite/src/components/animationClasses.js
+++ b/examples/react-vite/src/components/animationClasses.js
@@ -1,0 +1,134 @@
+/**
+ * animationClasses.js
+ * -------------------------------------------------------------------------
+ * Framework-agnostic helpers shared by the EaseMotion React wrappers.
+ *
+ * These are plain functions with no React or DOM dependency, so the class /
+ * style resolution logic can be unit-tested directly (see
+ * `tests/react-animation-classes.test.js`). The JSX components
+ * (`Animate`, `Hover`) are thin presentational shells over this logic.
+ * -------------------------------------------------------------------------
+ */
+
+/**
+ * Maps a friendly `type` keyword to the EaseMotion CSS class that plays it.
+ * Aliases (e.g. `spin` -> rotate, `slide-left` -> slide-in-left) are included
+ * so common intent resolves to the correct framework class.
+ */
+export const ANIMATION_CLASS_MAP = {
+  'fade-in': 'ease-fade-in',
+  'fade-out': 'ease-fade-out',
+  'slide-up': 'ease-slide-up',
+  'slide-down': 'ease-slide-down',
+  'slide-in-left': 'ease-slide-in-left',
+  'slide-left': 'ease-slide-in-left',
+  'slide-in-right': 'ease-slide-in-right',
+  'slide-right': 'ease-slide-in-right',
+  'slide-in-from-top': 'ease-slide-in-from-top',
+  'slide-in-from-bottom': 'ease-slide-in-from-bottom',
+  'zoom-in': 'ease-zoom-in',
+  'zoom-out': 'ease-zoom-out',
+  'bounce-in': 'ease-bounce-in',
+  bounce: 'ease-bounce',
+  flip: 'ease-flip',
+  spin: 'ease-rotate',
+  rotate: 'ease-rotate',
+  pulse: 'ease-pulse',
+  ping: 'ease-ping',
+  shake: 'ease-shake',
+  float: 'ease-float',
+  wave: 'ease-wave',
+  'blur-to-focus': 'ease-blur-to-focus',
+};
+
+/** Duration keywords that map to the `.ease-duration-*` utility classes. */
+export const DURATION_KEYWORDS = ['fast', 'medium', 'slow'];
+
+/** Maps a friendly hover `effect` keyword to an EaseMotion hover class. */
+export const HOVER_CLASS_MAP = {
+  lift: 'ease-hover-lift',
+  'lift-shadow': 'ease-hover-lift-shadow',
+  scale: 'ease-hover-grow',
+  grow: 'ease-hover-grow',
+  shrink: 'ease-hover-shrink',
+  glow: 'ease-hover-glow',
+  underline: 'ease-hover-underline',
+};
+
+/**
+ * Resolve an animation `type` to its framework class. Unknown types fall back
+ * to `ease-<type>` so newly-added framework classes still work without a map
+ * entry; empty/undefined resolves to an empty string.
+ */
+export function resolveAnimationClass(type) {
+  if (!type) return '';
+  return ANIMATION_CLASS_MAP[type] || `ease-${type}`;
+}
+
+/** Resolve a hover `effect` keyword to its framework class ('' if unknown). */
+export function resolveHoverClass(effect) {
+  if (!effect) return '';
+  return HOVER_CLASS_MAP[effect] || '';
+}
+
+/** True when `value` is one of the `.ease-duration-*` keywords. */
+export function isDurationKeyword(value) {
+  return DURATION_KEYWORDS.includes(value);
+}
+
+/**
+ * Normalise the `iteration` prop to a valid CSS `animation-iteration-count`.
+ * Accepts the string/number `infinite`, or a positive finite count.
+ * Returns `null` when nothing should be applied.
+ */
+export function normalizeIteration(iteration) {
+  if (iteration == null) return null;
+  if (iteration === 'infinite' || iteration === Infinity) return 'infinite';
+  const n = Number(iteration);
+  if (Number.isFinite(n) && n > 0) return String(n);
+  return null;
+}
+
+/**
+ * Build the full className for an `<Animate>` element from its props.
+ * Order: animation class, duration utility, hover effect, extra className.
+ */
+export function buildAnimateClassName({ type, duration, hover, className } = {}) {
+  const classes = [];
+
+  const animationClass = resolveAnimationClass(type);
+  if (animationClass) classes.push(animationClass);
+
+  if (isDurationKeyword(duration)) classes.push(`ease-duration-${duration}`);
+
+  const hoverClass = resolveHoverClass(hover);
+  if (hoverClass) classes.push(hoverClass);
+
+  if (className) classes.push(className);
+
+  return classes.join(' ');
+}
+
+/**
+ * Build the inline style for an `<Animate>` element. Only numeric `duration`
+ * (in ms) is inlined — keyword durations are handled by the utility class in
+ * `buildAnimateClassName`. `delay` (ms) and `iteration` are applied when set.
+ */
+export function buildAnimateStyle({ duration, delay, iteration, style } = {}) {
+  const out = { ...(style || {}) };
+
+  if (typeof duration === 'number') {
+    out.animationDuration = `${duration}ms`;
+    out.transitionDuration = `${duration}ms`;
+  }
+
+  if (typeof delay === 'number' && delay > 0) {
+    out.animationDelay = `${delay}ms`;
+    out.transitionDelay = `${delay}ms`;
+  }
+
+  const iterationCount = normalizeIteration(iteration);
+  if (iterationCount != null) out.animationIterationCount = iterationCount;
+
+  return out;
+}

--- a/examples/react-vite/src/components/scrollRevealCore.js
+++ b/examples/react-vite/src/components/scrollRevealCore.js
@@ -1,0 +1,94 @@
+/**
+ * scrollRevealCore.js
+ * -------------------------------------------------------------------------
+ * Framework-agnostic scroll-reveal logic shared by <ScrollReveal>. Kept free
+ * of React so it can be unit-tested with a mocked IntersectionObserver, the
+ * same way the framework's own `core/reveal.js` is tested.
+ *
+ * The reveal uses the framework's transition-based convention: an element
+ * starts with `ease-reveal` (+ an optional direction variant) which holds it
+ * hidden, and gains `ease-reveal-active` once it scrolls into view.
+ * -------------------------------------------------------------------------
+ */
+
+export const REVEAL_BASE_CLASS = 'ease-reveal';
+export const REVEAL_ACTIVE_CLASS = 'ease-reveal-active';
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+
+/** Maps a friendly `variant` keyword to its `ease-reveal-*` direction class. */
+export const REVEAL_VARIANT_MAP = {
+  up: 'ease-reveal-up',
+  down: 'ease-reveal-down',
+  left: 'ease-reveal-left',
+  right: 'ease-reveal-right',
+  scale: 'ease-reveal-scale',
+  fade: '', // plain fade — the base class alone
+};
+
+/** True when the user has requested reduced motion. */
+export function prefersReducedMotion() {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia(REDUCED_MOTION_QUERY).matches
+  );
+}
+
+/**
+ * Build the initial (hidden) className for a reveal element:
+ * `ease-reveal` + optional direction variant + any extra classes.
+ */
+export function buildRevealClassName({ variant, className } = {}) {
+  const classes = [REVEAL_BASE_CLASS];
+
+  if (variant && Object.prototype.hasOwnProperty.call(REVEAL_VARIANT_MAP, variant)) {
+    const variantClass = REVEAL_VARIANT_MAP[variant];
+    if (variantClass) classes.push(variantClass);
+  }
+
+  if (className) classes.push(className);
+  return classes.join(' ');
+}
+
+/**
+ * Reveal `element` when it enters the viewport by adding `ease-reveal-active`.
+ * Returns a cleanup function that disconnects the observer.
+ *
+ * options:
+ *  - once: unobserve after the first reveal (default true)
+ *  - threshold / rootMargin: forwarded to IntersectionObserver
+ *  - onReveal(element): called after the active class is applied
+ *
+ * Falls back to revealing immediately when reduced motion is requested or when
+ * IntersectionObserver is unavailable (SSR / older browsers).
+ */
+export function observeReveal(element, options = {}) {
+  if (!element) return () => {};
+
+  const { once = true, threshold = 0.15, rootMargin = '0px', onReveal } = options;
+
+  const reveal = () => {
+    element.classList.add(REVEAL_ACTIVE_CLASS);
+    if (typeof onReveal === 'function') onReveal(element);
+  };
+
+  if (prefersReducedMotion() || typeof IntersectionObserver === 'undefined') {
+    reveal();
+    return () => {};
+  }
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          reveal();
+          if (once) observer.unobserve(entry.target);
+        }
+      });
+    },
+    { threshold, rootMargin }
+  );
+
+  observer.observe(element);
+  return () => observer.disconnect();
+}

--- a/tests/react-animation-classes.test.js
+++ b/tests/react-animation-classes.test.js
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveAnimationClass,
+  resolveHoverClass,
+  isDurationKeyword,
+  normalizeIteration,
+  buildAnimateClassName,
+  buildAnimateStyle,
+} from '../examples/react-vite/src/components/animationClasses.js';
+import {
+  buildRevealClassName,
+  REVEAL_VARIANT_MAP,
+} from '../examples/react-vite/src/components/scrollRevealCore.js';
+
+describe('resolveAnimationClass', () => {
+  it('maps known types to their framework classes', () => {
+    expect(resolveAnimationClass('fade-in')).toBe('ease-fade-in');
+    expect(resolveAnimationClass('slide-up')).toBe('ease-slide-up');
+    expect(resolveAnimationClass('zoom-in')).toBe('ease-zoom-in');
+  });
+
+  it('resolves aliases to canonical classes', () => {
+    expect(resolveAnimationClass('spin')).toBe('ease-rotate');
+    expect(resolveAnimationClass('slide-left')).toBe('ease-slide-in-left');
+    expect(resolveAnimationClass('slide-right')).toBe('ease-slide-in-right');
+  });
+
+  it('falls back to ease-<type> for unknown types', () => {
+    expect(resolveAnimationClass('sparkle')).toBe('ease-sparkle');
+  });
+
+  it('returns empty string for missing type', () => {
+    expect(resolveAnimationClass()).toBe('');
+    expect(resolveAnimationClass('')).toBe('');
+  });
+});
+
+describe('resolveHoverClass', () => {
+  it('maps hover effect keywords to framework classes', () => {
+    expect(resolveHoverClass('lift')).toBe('ease-hover-lift');
+    expect(resolveHoverClass('scale')).toBe('ease-hover-grow');
+    expect(resolveHoverClass('glow')).toBe('ease-hover-glow');
+    expect(resolveHoverClass('shrink')).toBe('ease-hover-shrink');
+  });
+
+  it('returns empty string for unknown or missing effect', () => {
+    expect(resolveHoverClass('nope')).toBe('');
+    expect(resolveHoverClass()).toBe('');
+  });
+});
+
+describe('isDurationKeyword', () => {
+  it('recognises the utility keywords', () => {
+    expect(isDurationKeyword('fast')).toBe(true);
+    expect(isDurationKeyword('medium')).toBe(true);
+    expect(isDurationKeyword('slow')).toBe(true);
+  });
+
+  it('rejects numbers and other strings', () => {
+    expect(isDurationKeyword(300)).toBe(false);
+    expect(isDurationKeyword('turbo')).toBe(false);
+  });
+});
+
+describe('normalizeIteration', () => {
+  it('passes through infinite', () => {
+    expect(normalizeIteration('infinite')).toBe('infinite');
+    expect(normalizeIteration(Infinity)).toBe('infinite');
+  });
+
+  it('stringifies positive finite counts', () => {
+    expect(normalizeIteration(3)).toBe('3');
+    expect(normalizeIteration('2')).toBe('2');
+  });
+
+  it('returns null for nullish or invalid counts', () => {
+    expect(normalizeIteration(null)).toBeNull();
+    expect(normalizeIteration(undefined)).toBeNull();
+    expect(normalizeIteration(0)).toBeNull();
+    expect(normalizeIteration(-1)).toBeNull();
+    expect(normalizeIteration('abc')).toBeNull();
+  });
+});
+
+describe('buildAnimateClassName', () => {
+  it('combines animation, duration keyword, hover and extra classes in order', () => {
+    const result = buildAnimateClassName({
+      type: 'fade-in',
+      duration: 'slow',
+      hover: 'lift',
+      className: 'demo-card',
+    });
+    expect(result).toBe('ease-fade-in ease-duration-slow ease-hover-lift demo-card');
+  });
+
+  it('omits the duration utility when duration is numeric', () => {
+    const result = buildAnimateClassName({ type: 'zoom-in', duration: 350 });
+    expect(result).toBe('ease-zoom-in');
+  });
+
+  it('produces an empty string when nothing is supplied', () => {
+    expect(buildAnimateClassName({})).toBe('');
+    expect(buildAnimateClassName()).toBe('');
+  });
+});
+
+describe('buildAnimateStyle', () => {
+  it('inlines numeric duration in ms', () => {
+    const style = buildAnimateStyle({ duration: 350 });
+    expect(style.animationDuration).toBe('350ms');
+    expect(style.transitionDuration).toBe('350ms');
+  });
+
+  it('does not inline keyword durations', () => {
+    const style = buildAnimateStyle({ duration: 'medium' });
+    expect(style.animationDuration).toBeUndefined();
+  });
+
+  it('inlines a positive delay and skips zero', () => {
+    expect(buildAnimateStyle({ delay: 200 }).animationDelay).toBe('200ms');
+    expect(buildAnimateStyle({ delay: 0 }).animationDelay).toBeUndefined();
+  });
+
+  it('applies a normalized iteration count', () => {
+    expect(buildAnimateStyle({ iteration: 'infinite' }).animationIterationCount).toBe('infinite');
+    expect(buildAnimateStyle({ iteration: 2 }).animationIterationCount).toBe('2');
+    expect(buildAnimateStyle({ iteration: 0 }).animationIterationCount).toBeUndefined();
+  });
+
+  it('preserves caller-provided style without mutating it', () => {
+    const input = { color: 'red' };
+    const output = buildAnimateStyle({ duration: 100, style: input });
+    expect(output.color).toBe('red');
+    expect(output.animationDuration).toBe('100ms');
+    expect(input.animationDuration).toBeUndefined();
+  });
+});
+
+describe('buildRevealClassName', () => {
+  it('always includes the hidden base class', () => {
+    expect(buildRevealClassName({}).split(' ')).toContain('ease-reveal');
+  });
+
+  it('appends the direction variant class', () => {
+    expect(buildRevealClassName({ variant: 'up' })).toBe('ease-reveal ease-reveal-up');
+    expect(buildRevealClassName({ variant: 'left' })).toBe('ease-reveal ease-reveal-left');
+  });
+
+  it('uses only the base class for the plain fade variant', () => {
+    expect(buildRevealClassName({ variant: 'fade' })).toBe('ease-reveal');
+  });
+
+  it('ignores unknown variants and appends extra className', () => {
+    expect(buildRevealClassName({ variant: 'sideways', className: 'card' })).toBe('ease-reveal card');
+  });
+
+  it('exposes a variant map covering the framework directions', () => {
+    expect(Object.keys(REVEAL_VARIANT_MAP)).toEqual(
+      expect.arrayContaining(['up', 'down', 'left', 'right', 'scale', 'fade'])
+    );
+  });
+});

--- a/tests/react-scroll-reveal.test.js
+++ b/tests/react-scroll-reveal.test.js
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  observeReveal,
+  prefersReducedMotion,
+  REVEAL_ACTIVE_CLASS,
+} from '../examples/react-vite/src/components/scrollRevealCore.js';
+
+describe('scrollRevealCore.observeReveal', () => {
+  let originalMatchMedia;
+  let originalIntersectionObserver;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    originalMatchMedia = window.matchMedia;
+    originalIntersectionObserver = window.IntersectionObserver;
+
+    // Default: reduced motion NOT requested.
+    window.matchMedia = vi.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+    }));
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+    window.IntersectionObserver = originalIntersectionObserver;
+    document.body.innerHTML = '';
+  });
+
+  it('reveals immediately when prefers-reduced-motion is reduce', () => {
+    window.matchMedia = vi.fn().mockImplementation((query) => ({
+      matches: query === '(prefers-reduced-motion: reduce)',
+      media: query,
+    }));
+
+    document.body.innerHTML = '<div id="el" class="ease-reveal">Reveal</div>';
+    const el = document.getElementById('el');
+
+    const cleanup = observeReveal(el, {});
+
+    expect(el.classList.contains(REVEAL_ACTIVE_CLASS)).toBe(true);
+    expect(typeof cleanup).toBe('function');
+  });
+
+  it('reveals immediately when IntersectionObserver is unavailable', () => {
+    delete window.IntersectionObserver;
+    expect('IntersectionObserver' in window).toBe(false);
+
+    document.body.innerHTML = '<div id="el" class="ease-reveal">Reveal</div>';
+    const el = document.getElementById('el');
+
+    observeReveal(el, {});
+
+    expect(el.classList.contains(REVEAL_ACTIVE_CLASS)).toBe(true);
+  });
+
+  it('observes the element and reveals it on intersection', () => {
+    let observerCallback = null;
+    const observed = [];
+    const unobserved = [];
+
+    class MockIntersectionObserver {
+      constructor(callback) {
+        observerCallback = callback;
+      }
+      observe = vi.fn((el) => observed.push(el));
+      unobserve = vi.fn((el) => unobserved.push(el));
+      disconnect = vi.fn();
+    }
+    window.IntersectionObserver = MockIntersectionObserver;
+
+    document.body.innerHTML = '<div id="target" class="ease-reveal">Target</div>';
+    const target = document.getElementById('target');
+
+    observeReveal(target, {});
+
+    // Not revealed until it intersects.
+    expect(target.classList.contains(REVEAL_ACTIVE_CLASS)).toBe(false);
+    expect(observed).toContain(target);
+
+    observerCallback([{ isIntersecting: true, target }]);
+
+    expect(target.classList.contains(REVEAL_ACTIVE_CLASS)).toBe(true);
+    // once=true by default → the element is unobserved after revealing.
+    expect(unobserved).toContain(target);
+  });
+
+  it('keeps observing when once is false', () => {
+    let observerCallback = null;
+    const unobserved = [];
+
+    class MockIntersectionObserver {
+      constructor(callback) {
+        observerCallback = callback;
+      }
+      observe = vi.fn();
+      unobserve = vi.fn((el) => unobserved.push(el));
+      disconnect = vi.fn();
+    }
+    window.IntersectionObserver = MockIntersectionObserver;
+
+    document.body.innerHTML = '<div id="target" class="ease-reveal">Target</div>';
+    const target = document.getElementById('target');
+
+    observeReveal(target, { once: false });
+    observerCallback([{ isIntersecting: true, target }]);
+
+    expect(target.classList.contains(REVEAL_ACTIVE_CLASS)).toBe(true);
+    expect(unobserved).not.toContain(target);
+  });
+
+  it('fires the onReveal callback with the element', () => {
+    let observerCallback = null;
+    class MockIntersectionObserver {
+      constructor(callback) {
+        observerCallback = callback;
+      }
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    }
+    window.IntersectionObserver = MockIntersectionObserver;
+
+    document.body.innerHTML = '<div id="target" class="ease-reveal">Target</div>';
+    const target = document.getElementById('target');
+    const onReveal = vi.fn();
+
+    observeReveal(target, { onReveal });
+    observerCallback([{ isIntersecting: true, target }]);
+
+    expect(onReveal).toHaveBeenCalledWith(target);
+  });
+
+  it('returns a cleanup that disconnects the observer', () => {
+    const disconnect = vi.fn();
+    class MockIntersectionObserver {
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = disconnect;
+    }
+    window.IntersectionObserver = MockIntersectionObserver;
+
+    document.body.innerHTML = '<div id="target" class="ease-reveal">Target</div>';
+    const target = document.getElementById('target');
+
+    const cleanup = observeReveal(target, {});
+    cleanup();
+
+    expect(disconnect).toHaveBeenCalled();
+  });
+
+  it('is a no-op for a null element', () => {
+    expect(() => observeReveal(null, {})).not.toThrow();
+    expect(typeof observeReveal(null, {})).toBe('function');
+  });
+});
+
+describe('scrollRevealCore.prefersReducedMotion', () => {
+  it('reflects the matchMedia result', () => {
+    window.matchMedia = vi.fn().mockImplementation((query) => ({
+      matches: query === '(prefers-reduced-motion: reduce)',
+      media: query,
+    }));
+    expect(prefersReducedMotion()).toBe(true);
+
+    window.matchMedia = vi.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+    }));
+    expect(prefersReducedMotion()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Pull Request Description

Expands the React integration example (`examples/react-vite`) into a full suite of declarative wrapper components for EaseMotion CSS animations, with unit tests under `tests/`.

Fixes #28243

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## What's included

### `<Animate>` — expanded
Rewritten to support the declarative props the issue asks for, and to emit the **correct** framework classes:
- `type` — keyframe animation keyword (`fade-in`, `slide-up`, `zoom-in`, `spin`, `bounce`, `shake`, …). Aliases (`spin` → `ease-rotate`, `slide-left` → `ease-slide-in-left`) resolve to canonical classes; unknown types fall back to `ease-<type>`.
- `duration` — `'fast' | 'medium' | 'slow'` (mapped to `.ease-duration-*` utilities) **or** a numeric ms value (inlined).
- `delay` — stagger delay in ms.
- `iteration` — `'infinite'` or a positive count → `animation-iteration-count`.
- `onStart` / `onEnd` — bound to the native `onAnimationStart` / `onAnimationEnd` lifecycle events.

> Note: the previous `Animate` emitted `ease-animate-<type>` / `ease-hover-<hover>`, which are **not** classes the framework ships — so the example's animations weren't firing. This PR maps to the real `ease-*` classes, fixing the example while preserving the existing prop API (`App.jsx` continues to work unchanged).

### `<Hover>` — new
Declarative hover interactions: `lift` → `ease-hover-lift`, `scale` → `ease-hover-grow`, `glow` → `ease-hover-glow`, `shrink` → `ease-hover-shrink`. `shake` has no pure-CSS hover class in the framework (a `:hover` shake would loop while the pointer rests), so it plays the one-shot `ease-shake` keyframe on each hover-in via component state.

### `<ScrollReveal>` — new
Reveals content when it enters the viewport using `IntersectionObserver`, following the framework's transition-based `ease-reveal` → `ease-reveal-active` convention (the React counterpart of `core/reveal.js`). Honors `prefers-reduced-motion` and degrades gracefully (immediate reveal) where `IntersectionObserver` is unavailable. Supports `variant` (`up`/`down`/`left`/`right`/`scale`/`fade`), `once`, `threshold`, `rootMargin`, and an `onReveal` callback.

### Testable, dependency-free logic
Class/style resolution and the observer logic live in framework-agnostic helpers (`animationClasses.js`, `scrollRevealCore.js`) with **no React import**, so they're unit-tested from the repo root with the existing `vitest` setup — **no new root dependencies**.

---

## Tests

Two new files under `tests/`, mirroring the existing `reveal.test.js` style (vitest + jsdom, mocked `IntersectionObserver`/`matchMedia`):
- `tests/react-animation-classes.test.js` — class/style/iteration resolution.
- `tests/react-scroll-reveal.test.js` — reveal-on-intersect, `once`, reduced-motion & no-IO fallbacks, cleanup/disconnect.

```
Test Files  6 passed (6)
      Tests  64 passed (64)
```

The `react-vite` example also builds cleanly (`npm run build`) and passes `oxlint`.

---

## Files

- `examples/react-vite/src/components/Animate.jsx` — expanded
- `examples/react-vite/src/components/Hover.jsx` — new
- `examples/react-vite/src/components/ScrollReveal.jsx` — new
- `examples/react-vite/src/components/animationClasses.js` — new (pure helpers)
- `examples/react-vite/src/components/scrollRevealCore.js` — new (pure helpers)
- `examples/react-vite/src/App.jsx` — demonstrates `<Hover>` + `<ScrollReveal>`
- `examples/react-vite/README.md` — component docs
- `tests/react-animation-classes.test.js`, `tests/react-scroll-reveal.test.js` — new

@SAPTARSHI-coder Please review this pr 