### PR TITLE
feat: Add CSS Blur-Entrance Modal for Neumorphic Soft Layouts (#33976)

### DIFF
--- a/submissions/examples/css-blur-entrance-modal-for-neumorphic-soft-layouts-realtushartyagi-33976/README.md
+++ b/submissions/examples/css-blur-entrance-modal-for-neumorphic-soft-layouts-realtushartyagi-33976/README.md
@@ -1,0 +1,59 @@
+# CSS Blur-Entrance Modal for Neumorphic Soft Layouts
+
+A pure CSS modal component featuring a tactile "blur-entrance" interaction, designed specifically to match the soft, extruded aesthetics of **Neumorphic** (Soft UI) interfaces.
+
+## Files
+- `style.css` – Contains all the EaseMotion CSS variables, the `:target` hack for pure CSS state management, Neumorphic aesthetics (embossed/debossed dual shadows, low contrast borders, soft pill shapes), and the `filter: blur()` entrance animation logic.
+- `demo.html` – A standalone HTML file demonstrating the modal functionality using an anchor link trigger, styled as a soft settings dialog.
+
+## Installation
+1. Copy the folder into your project's `examples` directory.
+2. Link the stylesheet in your HTML file:
+   ```html
+   <link rel="stylesheet" href="./style.css" />
+   ```
+
+## Usage
+This modal relies on the CSS `:target` pseudo-class. By setting an anchor's `href` to the ID of the modal (`#neu-modal`), the browser updates the URL hash, which CSS intercepts to display the modal overlay.
+
+```html
+<!-- Trigger -->
+<a href="#neu-modal" class="demo-trigger-btn">Open Settings</a>
+
+<!-- Modal Structure -->
+<div id="neu-modal" class="ease-neu-modal-overlay">
+  
+  <!-- Clicking this invisible backdrop closes the modal by navigating to # -->
+  <a href="#" class="ease-neu-modal-backdrop-close" tabindex="-1"></a>
+
+  <div class="ease-neu-modal-window" role="dialog" aria-labelledby="modal-title" aria-modal="true">
+    <a href="#" class="ease-neu-modal-close" aria-label="Close modal dialog">X</a>
+    
+    <h2 id="modal-title" class="ease-neu-modal-title">Security Preferences</h2>
+    <p class="ease-neu-modal-text">Modal content goes here...</p>
+    
+    <div class="ease-neu-modal-actions">
+      <a href="#" class="ease-neu-modal-btn ease-neu-modal-btn-secondary">Cancel</a>
+      <a href="#" class="ease-neu-modal-btn">Apply</a>
+    </div>
+  </div>
+
+</div>
+```
+
+## CSS Custom Properties
+Adjust the animation timing, easing, and aesthetics via CSS variables:
+
+| Property | Default Value | Description |
+|----------|---------------|-------------|
+| `--ease-modal-timing` | `0.5s` | The duration of the blur and scale entrance animation. |
+| `--ease-modal-blur` | `blur(14px)` | The initial amount of blur applied before tapering to 0. |
+| `--ease-neu-shadow-outer` | `9px 9px 16px...` | The dual box-shadow creating the soft extruded (embossed) effect. |
+| `--ease-neu-shadow-inner` | `inset 6px 6px...` | The inset box-shadow used for hover or active (debossed) states. |
+
+## Why it fits EaseMotion CSS
+This component perfectly aligns with EaseMotion's philosophy by bringing premium, complex animations to pure CSS. The core interaction is the **Blur-Entrance**: utilizing the CSS `:target` pseudo-class, it simultaneously interpolates `opacity`, `transform: scale()`, and `filter: blur()` to bring the modal into view natively. For Neumorphic interfaces, this creates a soft, tactile "focus-pulling" effect that elegantly draws the user's eye directly to the extruded modal surface, all without requiring any JavaScript libraries.
+
+---
+
+> **Note:** PR modifies only files inside `submissions/examples/css-blur-entrance-modal-for-neumorphic-soft-layouts-realtushartyagi-33976/`.

--- a/submissions/examples/css-blur-entrance-modal-for-neumorphic-soft-layouts-realtushartyagi-33976/demo.html
+++ b/submissions/examples/css-blur-entrance-modal-for-neumorphic-soft-layouts-realtushartyagi-33976/demo.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>CSS Blur-Entrance Modal (Neumorphic Soft)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="./style.css" />
+  <style>
+    body {
+      background-color: #e0e5ec;
+      margin: 0;
+      padding: 0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      font-family: 'Nunito', sans-serif;
+    }
+
+    .demo-trigger-btn {
+      display: inline-flex;
+      align-items: center;
+      padding: 16px 36px;
+      background: #e0e5ec;
+      color: #7c3aed;
+      text-decoration: none;
+      font-weight: 700;
+      font-size: 1.1rem;
+      border-radius: 9999px;
+      box-shadow: 9px 9px 16px rgba(163, 177, 198, 0.6), 
+                 -9px -9px 16px rgba(255, 255, 255, 0.6);
+      transition: box-shadow 0.2s ease, color 0.2s ease;
+      cursor: pointer;
+    }
+    
+    .demo-trigger-btn:hover {
+      box-shadow: inset 6px 6px 10px rgba(163, 177, 198, 0.5), 
+                  inset -6px -6px 10px rgba(255, 255, 255, 0.5);
+      color: #5b21b6;
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Button to trigger the modal using URL anchor -->
+  <a href="#neu-modal" class="demo-trigger-btn">Open Settings</a>
+
+  <!-- The Modal Structure (Hidden by default, shown when URL target matches ID) -->
+  <div id="neu-modal" class="ease-neu-modal-overlay">
+    
+    <!-- Clicking this invisible backdrop closes the modal by navigating to # -->
+    <a href="#" class="ease-neu-modal-backdrop-close" tabindex="-1"></a>
+
+    <div class="ease-neu-modal-window" role="dialog" aria-labelledby="modal-title" aria-modal="true">
+      <a href="#" class="ease-neu-modal-close" aria-label="Close modal dialog">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+      </a>
+      
+      <div class="ease-neu-modal-icon">
+        <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
+      </div>
+      
+      <h2 id="modal-title" class="ease-neu-modal-title">Security Preferences</h2>
+      <p class="ease-neu-modal-text">
+        Notice the soft <strong>Blur-Entrance</strong> interaction. It fades and scales in while un-blurring, capturing the tactile, embossed aesthetics of Neumorphic interfaces using pure CSS.
+      </p>
+      
+      <div class="ease-neu-modal-actions">
+        <a href="#" class="ease-neu-modal-btn ease-neu-modal-btn-secondary">Cancel</a>
+        <a href="#" class="ease-neu-modal-btn">Apply</a>
+      </div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-blur-entrance-modal-for-neumorphic-soft-layouts-realtushartyagi-33976/style.css
+++ b/submissions/examples/css-blur-entrance-modal-for-neumorphic-soft-layouts-realtushartyagi-33976/style.css
@@ -1,0 +1,190 @@
+/* 
+  style.css
+  EaseMotion CSS – Blur-Entrance Modal (Neumorphic Soft Aesthetics)
+*/
+
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap');
+
+:root {
+  /* Neumorphic UI Variables */
+  --ease-neu-bg: #e0e5ec;
+  --ease-neu-text: #4a5568;
+  --ease-neu-text-muted: #718096;
+  
+  --ease-neu-primary: #7c3aed; /* Soft purple accent */
+  
+  /* Neumorphic Shadows (Embossed & Debossed) */
+  --ease-neu-shadow-outer: 9px 9px 16px rgba(163, 177, 198, 0.6), 
+                          -9px -9px 16px rgba(255, 255, 255, 0.6);
+  --ease-neu-shadow-inner: inset 6px 6px 10px rgba(163, 177, 198, 0.5), 
+                           inset -6px -6px 10px rgba(255, 255, 255, 0.5);
+  
+  --ease-neu-radius: 24px;
+  
+  /* Modal Animation Variables */
+  --ease-modal-timing: 0.5s;
+  --ease-modal-easing: cubic-bezier(0.25, 0.8, 0.25, 1);
+  --ease-modal-blur: blur(14px);
+}
+
+/* Modal Overlay Base */
+.ease-neu-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(224, 229, 236, 0.85); /* Slightly transparent neumorphic base */
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 1000;
+  font-family: 'Nunito', sans-serif;
+  
+  /* Initial Hidden State */
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity var(--ease-modal-timing) var(--ease-modal-easing), 
+              visibility var(--ease-modal-timing) var(--ease-modal-easing);
+}
+
+/* Modal Window */
+.ease-neu-modal-window {
+  background: var(--ease-neu-bg);
+  border-radius: var(--ease-neu-radius);
+  box-shadow: var(--ease-neu-shadow-outer);
+  padding: 40px;
+  width: 100%;
+  max-width: 450px;
+  position: relative;
+  text-align: center;
+  
+  /* Initial Hidden State (Blur-Entrance) */
+  opacity: 0;
+  transform: scale(0.9) translateY(15px);
+  filter: var(--ease-modal-blur);
+  transition: opacity var(--ease-modal-timing) var(--ease-modal-easing),
+              transform var(--ease-modal-timing) var(--ease-modal-easing),
+              filter var(--ease-modal-timing) var(--ease-modal-easing);
+}
+
+/* 
+  Active State Mechanics (using :target hack)
+*/
+.ease-neu-modal-overlay:target {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.ease-neu-modal-overlay:target .ease-neu-modal-window {
+  opacity: 1;
+  transform: scale(1) translateY(0);
+  filter: blur(0);
+}
+
+/* Typography & Layout */
+.ease-neu-modal-icon {
+  width: 64px;
+  height: 64px;
+  margin: 0 auto 24px auto;
+  border-radius: 50%;
+  background: var(--ease-neu-bg);
+  box-shadow: var(--ease-neu-shadow-outer);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ease-neu-primary);
+}
+
+.ease-neu-modal-title {
+  margin: 0 0 12px 0;
+  color: var(--ease-neu-text);
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.ease-neu-modal-text {
+  color: var(--ease-neu-text-muted);
+  font-size: 1rem;
+  line-height: 1.6;
+  margin-bottom: 32px;
+}
+
+/* Close Button (X icon) */
+.ease-neu-modal-close {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--ease-neu-bg);
+  box-shadow: var(--ease-neu-shadow-outer);
+  color: var(--ease-neu-text-muted);
+  text-decoration: none;
+  font-size: 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: box-shadow 0.2s ease, color 0.2s ease;
+}
+
+.ease-neu-modal-close:hover {
+  box-shadow: var(--ease-neu-shadow-inner);
+  color: var(--ease-neu-text);
+}
+
+/* Action Buttons */
+.ease-neu-modal-actions {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+}
+
+.ease-neu-modal-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 32px;
+  background: var(--ease-neu-bg);
+  color: var(--ease-neu-primary);
+  text-decoration: none;
+  font-family: inherit;
+  font-weight: 700;
+  font-size: 1rem;
+  border-radius: 9999px; /* Pill shape */
+  box-shadow: var(--ease-neu-shadow-outer);
+  transition: box-shadow 0.2s ease, color 0.2s ease;
+  cursor: pointer;
+}
+
+.ease-neu-modal-btn:hover {
+  box-shadow: var(--ease-neu-shadow-inner);
+  color: #5b21b6;
+}
+
+/* Secondary Button Variant */
+.ease-neu-modal-btn-secondary {
+  color: var(--ease-neu-text);
+}
+
+.ease-neu-modal-btn-secondary:hover {
+  color: var(--ease-neu-text-muted);
+}
+
+/* Close overlay layer (clicking outside closes modal) */
+.ease-neu-modal-backdrop-close {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: -1;
+  cursor: default;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a new pure CSS component: **CSS Blur-Entrance Modal for Neumorphic Soft Layouts**.  
This component implements a tactile, extruded modal window designed specifically for Neumorphic (Soft UI) interfaces. It utilizes the CSS `:target` pseudo-class to natively manage the open/close state without any JavaScript. The primary interaction is a "Blur-Entrance" effect—when the modal is triggered via a URL anchor link, the modal window scales in softly while a `filter: blur(14px)` tapers down to `blur(0px)`. This creates a sophisticated, focus-pulling effect entirely in CSS, ideal for settings menus or gentle confirmation dialogs on soft layouts. Resolves issue #33976.

Fixes #33976

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/css-blur-entrance-modal-for-neumorphic-soft-layouts-realtushartyagi-33976/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A pure CSS modal overlay utilizing the `:target` pseudo-class for state management, styled with the extruded, tactile aesthetics of Neumorphism (soft `#e0e5ec` backgrounds, dual light/dark drop shadows simulating physical depth, and pill-shaped elements). The standout feature is the **Blur-Entrance** interaction: it simultaneously interpolates `opacity`, `transform: scale()`, and `filter: blur()` upon activation to deliver a premium, native-feeling pop-up effect that elevates Soft UI-themed applications using 100% pure CSS.

**How does a developer use it?**

```html
<!-- Trigger -->
<a href="#neu-modal" class="demo-trigger-btn">Open Settings</a>

<!-- Modal Structure -->
<div id="neu-modal" class="ease-neu-modal-overlay">
  
  <!-- Clicking this invisible backdrop closes the modal by navigating to # -->
  <a href="#" class="ease-neu-modal-backdrop-close" tabindex="-1"></a>

  <div class="ease-neu-modal-window" role="dialog" aria-labelledby="modal-title" aria-modal="true">
    <a href="#" class="ease-neu-modal-close" aria-label="Close modal dialog">X</a>
    
    <h2 id="modal-title" class="ease-neu-modal-title">Security Preferences</h2>
    <p class="ease-neu-modal-text">Modal content goes here...</p>
    
    <div class="ease-neu-modal-actions">
      <a href="#" class="ease-neu-modal-btn ease-neu-modal-btn-secondary">Cancel</a>
      <a href="#" class="ease-neu-modal-btn">Apply</a>
    </div>
  </div>

</div>

