### PR TITLE
docs(submissions): add shadow card elevation fix demo

### DIFF
--- a/submissions/examples/show-card-fix-rk/README.md
+++ b/submissions/examples/show-card-fix-rk/README.md
@@ -1,0 +1,25 @@
+# Shadow Card Fix
+
+## What does this do?
+Fixes the Shadow Card so it shows a clear, layered elevation effect instead of looking almost identical to the Base Card, with light/medium/strong intensity variants and a hover state that deepens the shadow.
+
+## How is it used?
+```html
+<!-- Base card: no elevation -->
+<div class="card card-base">...</div>
+
+<!-- Shadow card: default (medium) elevation -->
+<div class="card card-shadow">...</div>
+
+<!-- Intensity variants -->
+<div class="card card-shadow card-shadow--light">...</div>
+<div class="card card-shadow card-shadow--medium">...</div>
+<div class="card card-shadow card-shadow--strong">...</div>
+
+<!-- With hover elevation increase -->
+<div class="card card-shadow card-shadow--hover" tabindex="0">...</div>
+```
+Open `demo.html` directly in a browser — no server or build step required.
+
+## Why is it useful?
+The current Shadow Card doesn't visually communicate elevation, which undermines EaseMotion CSS's principle that a class name should describe its behavior — `card-shadow` should look shadowed. This submission demonstrates a soft, layered `box-shadow` scale (light/medium/strong) plus a hover state, giving the maintainer a working reference to standardize into `ease-card-shadow` (and related intensity/hover modifiers) in `components/cards.css`. It only touches this submission folder — no framework source files are modified.

--- a/submissions/examples/show-card-fix-rk/demo.html
+++ b/submissions/examples/show-card-fix-rk/demo.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Shadow Card Fix — EaseMotion CSS Submission</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>Shadow Card — Elevation Fix</h1>
+    <p>
+      A side-by-side comparison showing the Shadow Card with a clear,
+      realistic elevation effect distinct from the Base Card.
+    </p>
+  </header>
+
+  <main>
+
+    <!-- Section 1: Base vs Shadow comparison -->
+    <section class="demo-section" aria-labelledby="comparison-heading">
+      <h2 id="comparison-heading">Base Card vs. Shadow Card</h2>
+      <div class="card-grid">
+
+        <article class="card card-base">
+          <h3 class="card-title">Base Card</h3>
+          <p class="card-text">
+            No elevation. Sits flat against the page background.
+          </p>
+        </article>
+
+        <article class="card card-shadow">
+          <h3 class="card-title">Shadow Card</h3>
+          <p class="card-text">
+            Clearly lifted off the page with a soft, realistic shadow.
+          </p>
+        </article>
+
+      </div>
+    </section>
+
+    <!-- Section 2: Shadow intensity scale -->
+    <section class="demo-section" aria-labelledby="intensity-heading">
+      <h2 id="intensity-heading">Shadow Intensity Scale</h2>
+      <div class="card-grid card-grid--three">
+
+        <article class="card card-shadow card-shadow--light">
+          <h3 class="card-title">Light</h3>
+          <p class="card-text">Subtle lift, good for dense layouts.</p>
+        </article>
+
+        <article class="card card-shadow card-shadow--medium">
+          <h3 class="card-title">Medium</h3>
+          <p class="card-text">Default elevation for standalone cards.</p>
+        </article>
+
+        <article class="card card-shadow card-shadow--strong">
+          <h3 class="card-title">Strong</h3>
+          <p class="card-text">Maximum emphasis for featured content.</p>
+        </article>
+
+      </div>
+    </section>
+
+    <!-- Section 3: Hover elevation -->
+    <section class="demo-section" aria-labelledby="hover-heading">
+      <h2 id="hover-heading">Hover Elevation</h2>
+      <p class="section-note">Hover or focus the card below to see the elevation increase.</p>
+      <div class="card-grid card-grid--single">
+
+        <article class="card card-shadow card-shadow--hover" tabindex="0">
+          <h3 class="card-title">Interactive Shadow Card</h3>
+          <p class="card-text">
+            Hover or tab-focus this card. The shadow softly deepens
+            to suggest it has lifted further off the page.
+          </p>
+        </article>
+
+      </div>
+    </section>
+
+  </main>
+
+  <footer class="page-footer">
+    <p>EaseMotion CSS — submission demo. Pure HTML &amp; CSS, no JavaScript.</p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/show-card-fix-rk/style.css
+++ b/submissions/examples/show-card-fix-rk/style.css
@@ -1,0 +1,172 @@
+/* ==========================================================================
+   Shadow Card Fix — submission demo styles
+   Pure CSS, no build step, no external dependencies.
+   ========================================================================== */
+
+:root {
+  --surface: #ffffff;
+  --page-bg: #f4f5f7;
+  --text-main: #1f2430;
+  --text-muted: #5b6472;
+  --radius-card: 14px;
+  --space-4: 1rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+
+  /* Shadow scale: soft, realistic, low-blur-heavy layered shadows */
+  --shadow-none: none;
+  --shadow-light:
+    0 1px 2px rgba(16, 24, 40, 0.06),
+    0 2px 6px rgba(16, 24, 40, 0.08);
+  --shadow-medium:
+    0 2px 4px rgba(16, 24, 40, 0.08),
+    0 8px 16px rgba(16, 24, 40, 0.12);
+  --shadow-strong:
+    0 4px 6px rgba(16, 24, 40, 0.10),
+    0 16px 28px rgba(16, 24, 40, 0.18);
+  --shadow-hover:
+    0 6px 10px rgba(16, 24, 40, 0.12),
+    0 22px 36px rgba(16, 24, 40, 0.22);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: var(--space-8) var(--space-4);
+  background: var(--page-bg);
+  color: var(--text-main);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+}
+
+.page-header {
+  max-width: 720px;
+  margin: 0 auto var(--space-8);
+  text-align: center;
+}
+
+.page-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.5rem, 4vw, 2rem);
+}
+
+.page-header p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+main {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.demo-section {
+  margin-bottom: var(--space-8);
+}
+
+.demo-section h2 {
+  font-size: 1.25rem;
+  margin-bottom: var(--space-6);
+}
+
+.section-note {
+  margin: -0.75rem 0 var(--space-6);
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+/* ---------- Card grid layouts ---------- */
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--space-6);
+}
+
+.card-grid--three {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.card-grid--single {
+  grid-template-columns: 1fr;
+  max-width: 480px;
+}
+
+@media (max-width: 640px) {
+  .card-grid,
+  .card-grid--three {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ---------- Base card ---------- */
+
+.card {
+  background: var(--surface);
+  border-radius: var(--radius-card);
+  padding: var(--space-6);
+  border: 1px solid rgba(16, 24, 40, 0.06);
+}
+
+.card-title {
+  margin: 0 0 0.5rem;
+  font-size: 1.05rem;
+}
+
+.card-text {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+/* Base Card: intentionally flat, no elevation */
+.card-base {
+  box-shadow: var(--shadow-none);
+}
+
+/* ---------- Shadow Card variants ---------- */
+
+.card-shadow {
+  box-shadow: var(--shadow-medium);
+  border-color: transparent;
+  transition: box-shadow 0.25s ease, transform 0.25s ease;
+}
+
+.card-shadow--light {
+  box-shadow: var(--shadow-light);
+}
+
+.card-shadow--medium {
+  box-shadow: var(--shadow-medium);
+}
+
+.card-shadow--strong {
+  box-shadow: var(--shadow-strong);
+}
+
+/* ---------- Hover elevation ---------- */
+
+.card-shadow--hover:hover,
+.card-shadow--hover:focus-visible {
+  box-shadow: var(--shadow-hover);
+  transform: translateY(-2px);
+  outline: none;
+}
+
+.card-shadow--hover:focus-visible {
+  outline: 2px solid rgba(59, 91, 219, 0.5);
+  outline-offset: 3px;
+}
+
+/* ---------- Footer ---------- */
+
+.page-footer {
+  max-width: 960px;
+  margin: var(--space-8) auto 0;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}


### PR DESCRIPTION
## Pull Request Description
Fixes the reported bug where the Shadow Card appears nearly identical to the Base Card, with no visible elevation. This adds a documentation demo showing the intended layered box-shadow behavior, including a light/medium/strong intensity scale and a hover-elevation state.

---
## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---
## Submission Checklist
> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description

**What does this add?**
A working demo of a properly elevated Shadow Card, with light/medium/strong shadow intensity variants and a hover state that deepens the shadow further.

**How does a developer use it?**
```html
<!-- Base card: no elevation -->
<div class="card card-base">...</div>

<!-- Shadow card: default (medium) elevation -->
<div class="card card-shadow">...</div>

<!-- Intensity variants -->
<div class="card card-shadow card-shadow--light">...</div>
<div class="card card-shadow card-shadow--medium">...</div>
<div class="card card-shadow card-shadow--strong">...</div>

<!-- With hover elevation increase -->
<div class="card card-shadow card-shadow--hover" tabindex="0">...</div>
```

**Why does it fit EaseMotion CSS?**
The current Shadow Card doesn't visually communicate elevation, which undermines the framework's principle that a class name should describe its behavior — `card-shadow` should look shadowed. This demo gives the maintainer a working, layered `box-shadow` reference that can be standardized into `components/cards.css` (e.g. as `ease-card-shadow`), matching the same human-readable, no-guesswork approach used across the rest of EaseMotion CSS.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---
## Browser Testing
- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---
## Notes for Maintainer
This only adds files under `submissions/examples/shadow-card-fix-rk/` — no framework source files were touched. Shadow values (`--shadow-light`, `--shadow-medium`, `--shadow-strong`, `--shadow-hover`) are defined as CSS custom properties in `style.css` so they're easy to tune or rename before merging into `components/cards.css`. Happy to adjust the blur/spread values or naming convention if you'd like them to match an existing scale more closely.