### PR TITLE
Add ease-mobile-swipe-delete component

### DIFF
--- a/submissions/examples/ease-mobile-swipe-delete-ij/README.md
+++ b/submissions/examples/ease-mobile-swipe-delete-ij/README.md
@@ -1,0 +1,21 @@
+# ease-mobile-swipe-delete
+
+A swipe-to-delete interaction for mobile-style list rows. Swiping a row to the left reveals a red delete action behind it. The row content translates via `--offset` CSS variable, and the transition uses a spring-like cubic-bezier curve when snapping back.
+
+## Usage
+
+Open `demo.html` in a browser. Click and drag any row to the left; release past the threshold to reveal the delete action, or snap back if under threshold.
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `--swipe-threshold` | `80px` | The swipe distance required to reveal delete |
+| `--delete-color` | `#ef4444` | Background color of the delete action |
+| `--transition-speed` | `0.3s` | Speed of the snap-back transition |
+
+## Notes
+
+- JavaScript sets `--offset` based on drag distance
+- CSS handles all visual transitions via the `--offset` property
+- Touch and mouse input are both supported

--- a/submissions/examples/ease-mobile-swipe-delete-ij/demo.html
+++ b/submissions/examples/ease-mobile-swipe-delete-ij/demo.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-mobile-swipe-delete</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <h1>Swipe to Delete</h1>
+    <p class="subtitle">Swipe a row to reveal the delete action</p>
+    <div class="list">
+      <div class="swipe-row" data-state="idle">
+        <div class="row-bg"><span class="delete-label">Delete</span></div>
+        <div class="row-content" style="--offset: 0px">
+          <span class="row-icon">&#x1f4e7;</span>
+          <span class="row-text">Email from Sarah</span>
+          <span class="row-time">2m ago</span>
+        </div>
+      </div>
+      <div class="swipe-row" data-state="idle">
+        <div class="row-bg"><span class="delete-label">Delete</span></div>
+        <div class="row-content" style="--offset: 0px">
+          <span class="row-icon">&#x1f514;</span>
+          <span class="row-text">Meeting reminder</span>
+          <span class="row-time">15m ago</span>
+        </div>
+      </div>
+      <div class="swipe-row" data-state="idle">
+        <div class="row-bg"><span class="delete-label">Delete</span></div>
+        <div class="row-content" style="--offset: 0px">
+          <span class="row-icon">&#x1f4ac;</span>
+          <span class="row-text">New comment on your post</span>
+          <span class="row-time">1h ago</span>
+        </div>
+      </div>
+      <div class="swipe-row" data-state="idle">
+        <div class="row-bg"><span class="delete-label">Delete</span></div>
+        <div class="row-content" style="--offset: 0px">
+          <span class="row-icon">&#x2b50;</span>
+          <span class="row-text">New follower: DevCommunity</span>
+          <span class="row-time">3h ago</span>
+        </div>
+      </div>
+      <div class="swipe-row" data-state="idle">
+        <div class="row-bg"><span class="delete-label">Delete</span></div>
+        <div class="row-content" style="--offset: 0px">
+          <span class="row-icon">&#x1f4c5;</span>
+          <span class="row-text">Task: Review pull request</span>
+          <span class="row-time">5h ago</span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script>
+    document.querySelectorAll('.swipe-row').forEach(row => {
+      const content = row.querySelector('.row-content');
+      let startX = 0, currentX = 0, dragging = false;
+      const maxSwipe = -80;
+      const threshold = -50;
+
+      const updateOffset = (x) => {
+        currentX = x;
+        const offset = Math.max(maxSwipe, Math.min(0, x - startX));
+        content.style.setProperty('--offset', offset + 'px');
+        if (offset < threshold) row.dataset.state = 'revealed';
+        else row.dataset.state = 'idle';
+      };
+
+      row.addEventListener('touchstart', (e) => {
+        startX = e.touches[0].clientX;
+        currentX = startX;
+        dragging = true;
+      }, { passive: true });
+
+      row.addEventListener('touchmove', (e) => {
+        if (!dragging) return;
+        updateOffset(e.touches[0].clientX);
+      }, { passive: true });
+
+      row.addEventListener('touchend', () => {
+        dragging = false;
+        const offset = Math.max(maxSwipe, Math.min(0, currentX - startX));
+        if (offset < threshold) {
+          content.style.setProperty('--offset', maxSwipe + 'px');
+          row.dataset.state = 'revealed';
+        } else {
+          content.style.setProperty('--offset', '0px');
+          row.dataset.state = 'idle';
+        }
+      }, { passive: true });
+
+      row.addEventListener('mousedown', (e) => {
+        startX = e.clientX;
+        currentX = startX;
+        dragging = true;
+      });
+
+      window.addEventListener('mousemove', (e) => {
+        if (!dragging) return;
+        updateOffset(e.clientX);
+      });
+
+      window.addEventListener('mouseup', () => {
+        if (!dragging) return;
+        dragging = false;
+        const offset = Math.max(maxSwipe, Math.min(0, currentX - startX));
+        if (offset < threshold) {
+          content.style.setProperty('--offset', maxSwipe + 'px');
+          row.dataset.state = 'revealed';
+        } else {
+          content.style.setProperty('--offset', '0px');
+          row.dataset.state = 'idle';
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-mobile-swipe-delete-ij/style.css
+++ b/submissions/examples/ease-mobile-swipe-delete-ij/style.css
@@ -1,0 +1,90 @@
+:root {
+  --swipe-threshold: 80px;
+  --delete-color: #ef4444;
+  --delete-text: #ffffff;
+  --row-bg: #ffffff;
+  --row-border: #e2e8f0;
+  --text-primary: #1e293b;
+  --text-secondary: #64748b;
+  --bg-color: #f8fafc;
+  --transition-speed: 0.3s;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: var(--bg-color);
+  color: var(--text-primary);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding: 20px;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.container { max-width: 420px; width: 100%; }
+
+h1 { font-size: 1.5rem; font-weight: 700; margin-bottom: 4px; }
+
+.subtitle { font-size: 0.875rem; color: var(--text-secondary); margin-bottom: 20px; }
+
+.list {
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--row-border);
+  background: var(--row-bg);
+}
+
+.swipe-row {
+  position: relative;
+  overflow: hidden;
+  touch-action: pan-y;
+  border-bottom: 1px solid var(--row-border);
+}
+
+.swipe-row:last-child { border-bottom: none; }
+
+.row-bg {
+  position: absolute;
+  inset: 0;
+  background: var(--delete-color);
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 24px;
+}
+
+.delete-label {
+  color: var(--delete-text);
+  font-weight: 600;
+  font-size: 0.875rem;
+  letter-spacing: 0.5px;
+}
+
+.row-content {
+  position: relative;
+  background: var(--row-bg);
+  transform: translateX(var(--offset, 0px));
+  transition: transform var(--transition-speed) cubic-bezier(0.4, 0, 0.2, 1);
+  display: flex;
+  align-items: center;
+  padding: 16px;
+  gap: 12px;
+  cursor: default;
+}
+
+.swipe-row[data-state="revealed"] .row-content {
+  transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.swipe-row[data-state="idle"] .row-content {
+  transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.row-icon { font-size: 1.25rem; }
+
+.row-text { flex: 1; font-size: 0.95rem; }
+
+.row-time { font-size: 0.8rem; color: var(--text-secondary); }


### PR DESCRIPTION
## Component: ease-mobile-swipe-delete — Swipe to delete action animation

**Closes #37533**

### What this adds
A swipe-to-delete interaction for list rows. Swiping left reveals a delete action behind the row. The content translates via --offset CSS variable with a spring-back animation.

### Acceptance Criteria covered
- Row content slides with the drag gesture
- CSS handles visual offset via --offset
- JS sets offset variable from drag distance
- Snap-back animation when under threshold

### Files
- submissions/examples/ease-mobile-swipe-delete-ij/demo.html
- submissions/examples/ease-mobile-swipe-delete-ij/style.css
- submissions/examples/ease-mobile-swipe-delete-ij/README.md

### How to review
Open demo.html directly in a browser. Click and drag any list row to the left; the delete action appears behind the sliding row. Release past the threshold to keep it revealed.
