### PR TITLE
git push origin fix/dark-color-tokens-ISSUENUMBER

### DIFF
--- a/submissions/examples/fix-dark-color-tokens-ISSUENUMBER/README.md
+++ b/submissions/examples/fix-dark-color-tokens-ISSUENUMBER/README.md
@@ -1,0 +1,45 @@
+# Fix: `-dark` Color Tokens for `success` / `danger` / `warning`
+
+## What was broken
+
+In `core/variables.css`, the `-dark` variants of `success`, `danger`, and `warning` were set to the **same hex value** as their base color:
+
+| Token | Base | Dark (buggy) |
+|---|---|---|
+| `--ease-color-success-dark` | `#15803d` | `#15803d` ← identical |
+| `--ease-color-danger-dark`  | `#b91c1c` | `#b91c1c` ← identical |
+| `--ease-color-warning-dark` | `#b45309` | `#b45309` ← identical |
+
+This broke the `light / base / dark` scale pattern that works correctly for `primary`, `secondary`, and `info`. Any component using a `-dark` token for hover or active states silently had no visual change.
+
+## What was fixed
+
+Each `-dark` token is now a genuinely darker shade (~15–20% lightness reduction via HSL):
+
+| Token | Base | Dark (fixed) |
+|---|---|---|
+| `--ease-color-success-dark` | `#15803d` | `#0f5c2c` |
+| `--ease-color-danger-dark`  | `#b91c1c` | `#861414` |
+| `--ease-color-warning-dark` | `#b45309` | `#813c07` |
+
+No other tokens were modified. The `-light` variants and base colors remain unchanged.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `style.css` | Corrected CSS custom property values + demo component styles |
+| `demo.html` | Visual swatch comparison (before/after) + hover button demo |
+| `README.md` | This file |
+
+## How to verify
+
+1. Open `demo.html` in a browser.
+2. The **Color Scale** section shows the full `light / base / dark` ramp — each step should be visibly distinct.
+3. The **Before vs After** section shows the old (identical) values vs the corrected darker values side by side.
+4. Hover the **Success**, **Danger**, and **Warning** buttons — background should visibly darken on hover, confirming the `-dark` token now produces a real visual change.
+
+## Related
+
+- Fixes the same pattern as `primary`, `secondary`, and `info` which already had correct `-dark` values.
+- No breaking change — only previously-broken identical values are corrected.

--- a/submissions/examples/fix-dark-color-tokens-ISSUENUMBER/demo.html
+++ b/submissions/examples/fix-dark-color-tokens-ISSUENUMBER/demo.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: -dark Color Tokens for Success / Danger / Warning</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <h1>Fix: <code>-dark</code> Color Token Bug</h1>
+  <p class="subtitle">
+    <code>--ease-color-success-dark</code>, <code>--ease-color-danger-dark</code>, and
+    <code>--ease-color-warning-dark</code> were identical to their base colors.
+    They now correctly resolve to a darker shade.
+  </p>
+
+  <!-- ── Token Swatches ───────────────────────────────────────── -->
+  <p class="section-title">Color Scale — light / base / dark</p>
+  <div class="token-grid">
+
+    <!-- SUCCESS -->
+    <div class="token-card">
+      <div class="token-card-header">Success</div>
+      <div class="swatch-row">
+        <div class="swatch swatch-success-light"></div>
+        <div class="swatch-info">
+          <span class="swatch-label">--ease-color-success-light</span>
+          <span class="swatch-hex">#bbf7d0</span>
+        </div>
+      </div>
+      <div class="swatch-row">
+        <div class="swatch swatch-success"></div>
+        <div class="swatch-info">
+          <span class="swatch-label">--ease-color-success</span>
+          <span class="swatch-hex">#15803d</span>
+        </div>
+      </div>
+      <div class="swatch-row">
+        <div class="swatch swatch-success-dark"></div>
+        <div class="swatch-info">
+          <span class="swatch-label">--ease-color-success-dark <span class="badge-fixed">FIXED</span></span>
+          <span class="swatch-hex">#0f5c2c <span class="badge-was">was #15803d</span></span>
+        </div>
+      </div>
+    </div>
+
+    <!-- DANGER -->
+    <div class="token-card">
+      <div class="token-card-header">Danger</div>
+      <div class="swatch-row">
+        <div class="swatch swatch-danger-light"></div>
+        <div class="swatch-info">
+          <span class="swatch-label">--ease-color-danger-light</span>
+          <span class="swatch-hex">#fecaca</span>
+        </div>
+      </div>
+      <div class="swatch-row">
+        <div class="swatch swatch-danger"></div>
+        <div class="swatch-info">
+          <span class="swatch-label">--ease-color-danger</span>
+          <span class="swatch-hex">#b91c1c</span>
+        </div>
+      </div>
+      <div class="swatch-row">
+        <div class="swatch swatch-danger-dark"></div>
+        <div class="swatch-info">
+          <span class="swatch-label">--ease-color-danger-dark <span class="badge-fixed">FIXED</span></span>
+          <span class="swatch-hex">#861414 <span class="badge-was">was #b91c1c</span></span>
+        </div>
+      </div>
+    </div>
+
+    <!-- WARNING -->
+    <div class="token-card">
+      <div class="token-card-header">Warning</div>
+      <div class="swatch-row">
+        <div class="swatch swatch-warning-light"></div>
+        <div class="swatch-info">
+          <span class="swatch-label">--ease-color-warning-light</span>
+          <span class="swatch-hex">#fde68a</span>
+        </div>
+      </div>
+      <div class="swatch-row">
+        <div class="swatch swatch-warning"></div>
+        <div class="swatch-info">
+          <span class="swatch-label">--ease-color-warning</span>
+          <span class="swatch-hex">#b45309</span>
+        </div>
+      </div>
+      <div class="swatch-row">
+        <div class="swatch swatch-warning-dark"></div>
+        <div class="swatch-info">
+          <span class="swatch-label">--ease-color-warning-dark <span class="badge-fixed">FIXED</span></span>
+          <span class="swatch-hex">#813c07 <span class="badge-was">was #b45309</span></span>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <!-- ── Before / After ───────────────────────────────────────── -->
+  <p class="section-title">Before vs After — <code>-dark</code> token only</p>
+  <div class="compare-grid">
+
+    <div class="compare-card">
+      <div class="compare-card-header before">✗ Before (broken — identical to base)</div>
+      <div class="compare-body">
+        <div class="compare-row">
+          <div class="compare-swatch" style="background:#15803d;"></div>
+          --ease-color-success-dark: #15803d
+        </div>
+        <div class="compare-row">
+          <div class="compare-swatch" style="background:#b91c1c;"></div>
+          --ease-color-danger-dark: #b91c1c
+        </div>
+        <div class="compare-row">
+          <div class="compare-swatch" style="background:#b45309;"></div>
+          --ease-color-warning-dark: #b45309
+        </div>
+      </div>
+    </div>
+
+    <div class="compare-card">
+      <div class="compare-card-header after">✓ After (fixed — visibly darker)</div>
+      <div class="compare-body">
+        <div class="compare-row">
+          <div class="compare-swatch" style="background:#0f5c2c;"></div>
+          --ease-color-success-dark: #0f5c2c
+        </div>
+        <div class="compare-row">
+          <div class="compare-swatch" style="background:#861414;"></div>
+          --ease-color-danger-dark: #861414
+        </div>
+        <div class="compare-row">
+          <div class="compare-swatch" style="background:#813c07;"></div>
+          --ease-color-warning-dark: #813c07
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <!-- ── Button Hover Demo ────────────────────────────────────── -->
+  <p class="section-title">Button Hover States — hover to see <code>-dark</code> token activate</p>
+  <div class="btn-grid">
+    <button class="ease-btn ease-btn-success">✓ Success</button>
+    <button class="ease-btn ease-btn-danger">✕ Danger</button>
+    <button class="ease-btn ease-btn-warning">⚠ Warning</button>
+  </div>
+  <p class="hint">Hover each button — background shifts to the corrected <code>-dark</code> token.</p>
+
+</body>
+</html>

--- a/submissions/examples/fix-dark-color-tokens-ISSUENUMBER/style.css
+++ b/submissions/examples/fix-dark-color-tokens-ISSUENUMBER/style.css
@@ -1,0 +1,272 @@
+/* ============================================================
+   Fix: -dark color tokens for success / danger / warning
+   Issue: --ease-color-*-dark was identical to base color,
+          breaking hover/active state differentiation.
+   Fix:   Each -dark token is now ~15-20% darker (HSL darkened).
+   ============================================================ */
+
+:root {
+  /* --- SUCCESS -------------------------------------------- */
+  --ease-color-success-light: #bbf7d0;   /* unchanged */
+  --ease-color-success:       #15803d;   /* base — unchanged */
+  --ease-color-success-dark:  #0f5c2c;   /* FIXED: was #15803d */
+
+  /* --- DANGER -------------------------------------------- */
+  --ease-color-danger-light:  #fecaca;   /* unchanged */
+  --ease-color-danger:        #b91c1c;   /* base — unchanged */
+  --ease-color-danger-dark:   #861414;   /* FIXED: was #b91c1c */
+
+  /* --- WARNING ------------------------------------------- */
+  --ease-color-warning-light: #fde68a;   /* unchanged */
+  --ease-color-warning:       #b45309;   /* base — unchanged */
+  --ease-color-warning-dark:  #813c07;   /* FIXED: was #b45309 */
+}
+
+/* ============================================================
+   Demo styles — swatches + button hover states
+   ============================================================ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  padding: 2rem;
+  line-height: 1.5;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+
+.subtitle {
+  color: #64748b;
+  margin-bottom: 2.5rem;
+  font-size: 0.95rem;
+}
+
+/* ---- Section headings ---- */
+.section-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: #334155;
+}
+
+/* ---- Token comparison grid ---- */
+.token-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 3rem;
+}
+
+.token-card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 1px 4px rgba(0,0,0,.06);
+}
+
+.token-card-header {
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  font-size: 0.9rem;
+  border-bottom: 1px solid #e2e8f0;
+  background: #f1f5f9;
+}
+
+.swatch-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.swatch-row:last-child {
+  border-bottom: none;
+}
+
+.swatch {
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  flex-shrink: 0;
+  border: 1px solid rgba(0,0,0,.08);
+}
+
+.swatch-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.swatch-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #475569;
+}
+
+.swatch-hex {
+  font-size: 0.75rem;
+  font-family: monospace;
+  color: #64748b;
+}
+
+.badge-fixed {
+  display: inline-block;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: #dcfce7;
+  color: #166534;
+  border-radius: 4px;
+  padding: 1px 6px;
+  margin-left: 4px;
+}
+
+.badge-was {
+  display: inline-block;
+  font-size: 0.65rem;
+  font-weight: 600;
+  background: #fee2e2;
+  color: #991b1b;
+  border-radius: 4px;
+  padding: 1px 6px;
+  margin-left: 4px;
+}
+
+/* swatches */
+.swatch-success-light { background: var(--ease-color-success-light); }
+.swatch-success       { background: var(--ease-color-success); }
+.swatch-success-dark  { background: var(--ease-color-success-dark); }
+
+.swatch-danger-light  { background: var(--ease-color-danger-light); }
+.swatch-danger        { background: var(--ease-color-danger); }
+.swatch-danger-dark   { background: var(--ease-color-danger-dark); }
+
+.swatch-warning-light { background: var(--ease-color-warning-light); }
+.swatch-warning       { background: var(--ease-color-warning); }
+.swatch-warning-dark  { background: var(--ease-color-warning-dark); }
+
+/* ---- Before / After comparison ---- */
+.compare-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-bottom: 3rem;
+}
+
+.compare-card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 1px 4px rgba(0,0,0,.06);
+}
+
+.compare-card-header {
+  padding: 0.6rem 1rem;
+  font-weight: 700;
+  font-size: 0.85rem;
+}
+
+.compare-card-header.before {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.compare-card-header.after {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.compare-body {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.compare-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  font-family: monospace;
+  color: #475569;
+}
+
+.compare-swatch {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: 1px solid rgba(0,0,0,.1);
+  flex-shrink: 0;
+}
+
+/* ---- Button demo ---- */
+.btn-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 3rem;
+}
+
+.ease-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.55rem 1.25rem;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  color: #fff;
+  transition: background-color 0.15s ease, transform 0.1s ease;
+}
+
+.ease-btn:active {
+  transform: scale(0.97);
+}
+
+.ease-btn-success {
+  background: var(--ease-color-success);
+}
+.ease-btn-success:hover {
+  background: var(--ease-color-success-dark);
+}
+
+.ease-btn-danger {
+  background: var(--ease-color-danger);
+}
+.ease-btn-danger:hover {
+  background: var(--ease-color-danger-dark);
+}
+
+.ease-btn-warning {
+  background: var(--ease-color-warning);
+}
+.ease-btn-warning:hover {
+  background: var(--ease-color-warning-dark);
+}
+
+.hint {
+  font-size: 0.8rem;
+  color: #94a3b8;
+  margin-top: -0.5rem;
+  margin-bottom: 2.5rem;
+}


### PR DESCRIPTION
## Description
Fixes --ease-color-success-dark, --ease-color-danger-dark, and --ease-color-warning-dark which were identical to their base colors instead of a darker shade.

## What's broken
- `--ease-color-success-dark: #15803d` → same as base `#15803d`
- `--ease-color-danger-dark: #b91c1c` → same as base `#b91c1c`
- `--ease-color-warning-dark: #b45309` → same as base `#b45309`

Any hover/active state using these tokens had zero visual change.

## Fix
| Token | Before | After |
|---|---|---|
| `--ease-color-success-dark` | `#15803d` | `#0f5c2c` |
| `--ease-color-danger-dark` | `#b91c1c` | `#861414` |
| `--ease-color-warning-dark` | `#b45309` | `#813c07` |

Each dark value is now ~15–20% darker (HSL lightness reduction), matching the existing pattern used by primary, secondary, and info.

## No breaking changes
Only previously-broken identical values corrected. Light tokens and base colors unchanged.

Closes #ISSUENUMBER