### PR TITLE
[FEATURE] Add responsive horizontal stepper component with mobile vertical fallback

### DIFF
--- a/submissions/examples/responsive-stepper/README.md
+++ b/submissions/examples/responsive-stepper/README.md
@@ -1,0 +1,30 @@
+# Responsive Stepper
+
+## What does this do?
+A multi-step progress stepper that displays horizontally on desktop
+and collapses to a vertical layout on mobile screens (below 480px)
+with no horizontal overflow.
+
+## How is it used?
+```html
+<div class="stepper-container">
+  <div class="stepper-step completed">
+    <div class="stepper-node">✓</div>
+    <span class="stepper-label">Step 1</span>
+  </div>
+  <div class="stepper-step active">
+    <div class="stepper-node">2</div>
+    <span class="stepper-label">Step 2</span>
+  </div>
+  <div class="stepper-step">
+    <div class="stepper-node">3</div>
+    <span class="stepper-label">Step 3</span>
+  </div>
+</div>
+```
+
+## Why is it useful?
+Fixes the known overflow bug (#1547) where fixed `width: 600px` breaks
+mobile viewports. Uses `width: 100%` + flexbox + a media query to switch
+to vertical stacking at 480px — consistent with EaseMotion CSS's
+mobile-first philosophy.

--- a/submissions/examples/responsive-stepper/demo.html
+++ b/submissions/examples/responsive-stepper/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Responsive Stepper — EaseMotion CSS Submission</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      background: #0b0f19;
+      color: #e2e8f0;
+      font-family: sans-serif;
+      padding: 40px 20px;
+      margin: 0;
+    }
+    h2 { margin-bottom: 24px; font-size: 18px; color: #94a3b8; }
+    .demo-box {
+      max-width: 640px;
+      margin: 0 auto;
+      background: #1e293b;
+      padding: 32px;
+      border-radius: 12px;
+    }
+    p { font-size: 13px; color: #475569; margin-top: 24px; }
+  </style>
+</head>
+<body>
+  <div class="demo-box">
+    <h2>Order Progress</h2>
+    <div class="stepper-container">
+      <div class="stepper-step completed">
+        <div class="stepper-node">✓</div>
+        <span class="stepper-label">Cart</span>
+      </div>
+      <div class="stepper-step completed">
+        <div class="stepper-node">✓</div>
+        <span class="stepper-label">Address</span>
+      </div>
+      <div class="stepper-step active">
+        <div class="stepper-node">3</div>
+        <span class="stepper-label">Payment</span>
+      </div>
+      <div class="stepper-step">
+        <div class="stepper-node">4</div>
+        <span class="stepper-label">Review</span>
+      </div>
+      <div class="stepper-step">
+        <div class="stepper-node">5</div>
+        <span class="stepper-label">Done</span>
+      </div>
+    </div>
+    <p>Resize below 480px — stepper stacks vertically with no overflow.</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/responsive-stepper/style.css
+++ b/submissions/examples/responsive-stepper/style.css
@@ -1,0 +1,112 @@
+/* Responsive Stepper — submissions/examples/responsive-stepper/style.css */
+
+.stepper-container {
+    display: flex;
+    width: 100%;
+    /* fix: was 600px fixed */
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 20px 0;
+    box-sizing: border-box;
+}
+
+.stepper-step {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    flex: 1;
+    position: relative;
+    text-align: center;
+}
+
+/* connector line between steps */
+.stepper-step:not(:last-child)::after {
+    content: '';
+    position: absolute;
+    top: 20px;
+    left: 50%;
+    width: 100%;
+    height: 2px;
+    background: #334155;
+    z-index: 0;
+    transition: background 0.4s ease;
+}
+
+.stepper-step.completed:not(:last-child)::after {
+    background: #38bdf8;
+}
+
+.stepper-node {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: #334155;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 14px;
+    font-weight: 600;
+    color: #94a3b8;
+    position: relative;
+    z-index: 1;
+    transition: background 0.3s ease, transform 0.3s ease, color 0.3s ease;
+}
+
+.stepper-step.active .stepper-node {
+    background: #0ea5e9;
+    color: #fff;
+    transform: scale(1.1);
+}
+
+.stepper-step.completed .stepper-node {
+    background: #38bdf8;
+    color: #0f172a;
+}
+
+.stepper-label {
+    margin-top: 8px;
+    font-size: 12px;
+    color: #64748b;
+    transition: color 0.3s ease;
+}
+
+.stepper-step.active .stepper-label {
+    color: #e2e8f0;
+    font-weight: 600;
+}
+
+.stepper-step.completed .stepper-label {
+    color: #38bdf8;
+}
+
+/* mobile: stack vertically below 480px */
+@media (max-width: 480px) {
+    .stepper-container {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0;
+    }
+
+    .stepper-step {
+        flex-direction: row;
+        align-items: center;
+        flex: unset;
+        width: 100%;
+        gap: 12px;
+        padding: 8px 0;
+        text-align: left;
+    }
+
+    /* vertical connector line */
+    .stepper-step:not(:last-child)::after {
+        top: 40px;
+        left: 19px;
+        width: 2px;
+        height: 100%;
+    }
+
+    .stepper-label {
+        margin-top: 0;
+    }
+}


### PR DESCRIPTION
## Description
No responsive stepper component exists in the submissions directory.
The current stepper pattern uses a fixed pixel width that causes
horizontal overflow on mobile viewports below 480px.

This submission adds a self-contained responsive stepper component
that automatically stacks vertically on mobile — pure CSS, no JS.

## Type
- [ ] Bug fix
- [x] Feature request / New component submission

## Current Behaviour
Stepper containers using fixed `width: 600px` overflow horizontally
on screens below 480px, creating an unwanted horizontal scrollbar.

## Expected Behaviour
Stepper displays horizontally on desktop and collapses to a clean
vertical layout on mobile with no overflow.

## Proposed Solution
- Replace fixed `width: 600px` with `width: 100%`
- Add `@media (max-width: 480px)` to switch `flex-direction: column`
- Reposition connector line from horizontal to vertical on mobile

## Submission Structure
submissions/examples/responsive-stepper/
├── demo.html
├── style.css
└── README.md

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] No existing submission covers this
- [x] Files placed inside `submissions/` directory only
- [x] Includes `demo.html`, `style.css`, `README.md`

## GSSoC
- Participant: Yes (GSSoC 2026)
- GitHub: @YOUR_USERNAME