### PR TITLE
feat: add animated toast notification component with stacking and position variants

### DIFF
--- a/submissions/examples/toast-notification/README.md
+++ b/submissions/examples/toast-notification/README.md
@@ -1,0 +1,32 @@
+# Toast Notification Component
+
+## What does this do?
+A fully animated toast notification system with stacking, 5 position
+variants, 4 type variants (success, error, warning, info), auto-dismiss,
+and manual close — pure CSS + minimal JS.
+
+## Usage
+
+```html
+<link rel="stylesheet" href="style.css">
+
+<script>
+  showToast('File saved!', 'success', 3000, 'top-right');
+</script>
+```
+
+## Position variants
+| Class modifier         | Position       |
+|------------------------|----------------|
+| `--top-right`          | Top right      |
+| `--top-left`           | Top left       |
+| `--top-center`         | Top center     |
+| `--bottom-right`       | Bottom right   |
+| `--bottom-left`        | Bottom left    |
+
+## Type variants
+`success` · `error` · `warning` · `info`
+
+## Why it fits EaseMotion CSS
+Fills a gap in the submissions directory. Uses CSS animations, respects
+`prefers-reduced-motion`, and follows the framework's dark-first design.

--- a/submissions/examples/toast-notification/demo.html
+++ b/submissions/examples/toast-notification/demo.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Toast Notification — EaseMotion CSS Submission</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      background: #0b0f19;
+      color: #e2e8f0;
+      font-family: sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+      gap: 12px;
+    }
+    h2 { margin-bottom: 8px; font-size: 18px; color: #94a3b8; }
+    .btn-row { display: flex; flex-wrap: wrap; gap: 10px; justify-content: center; }
+    button {
+      padding: 10px 18px;
+      border-radius: 8px;
+      border: 1px solid #334155;
+      background: #1e293b;
+      color: #e2e8f0;
+      font-size: 14px;
+      cursor: pointer;
+      transition: background 0.2s;
+    }
+    button:hover { background: #334155; }
+  </style>
+</head>
+<body>
+  <h2>Toast Notification Demo</h2>
+  <div class="btn-row">
+    <button onclick="showToast('File saved successfully!', 'success')">Success</button>
+    <button onclick="showToast('Something went wrong.', 'error')">Error</button>
+    <button onclick="showToast('Storage almost full.', 'warning')">Warning</button>
+    <button onclick="showToast('New update available.', 'info')">Info</button>
+    <button onclick="showToast('Toast 1'); showToast('Toast 2'); showToast('Toast 3')">Stack 3</button>
+  </div>
+
+  <script>
+    function getOrCreateContainer(position = 'top-right') {
+      let container = document.querySelector('.ease-toast-container');
+      if (!container) {
+        container = document.createElement('div');
+        container.className = `ease-toast-container ease-toast-container--${position}`;
+        document.body.appendChild(container);
+      }
+      return container;
+    }
+
+    function showToast(message, type = 'info', duration = 3000, position = 'top-right') {
+      const container = getOrCreateContainer(position);
+
+      const toast = document.createElement('div');
+      toast.className = `ease-toast ease-toast--${type}`;
+      toast.innerHTML = `
+        <span class="ease-toast__icon"></span>
+        <span class="ease-toast__message">${message}</span>
+        <button class="ease-toast__close" aria-label="Close">✕</button>
+      `;
+
+      toast.querySelector('.ease-toast__close').addEventListener('click', () => dismiss(toast));
+      container.appendChild(toast);
+
+      if (duration > 0) setTimeout(() => dismiss(toast), duration);
+    }
+
+    function dismiss(toast) {
+      toast.classList.add('removing');
+      toast.addEventListener('animationend', () => toast.remove(), { once: true });
+      // fallback if reduced-motion skips animation
+      setTimeout(() => toast.remove(), 350);
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/toast-notification/style.css
+++ b/submissions/examples/toast-notification/style.css
@@ -1,0 +1,95 @@
+/* Toast Notification — submissions/examples/toast-notification/style.css */
+
+.ease-toast-container {
+  position: fixed;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 360px;
+  width: calc(100% - 32px);
+  pointer-events: none;
+}
+
+/* position variants */
+.ease-toast-container--top-right    { top: 16px; right: 16px; align-items: flex-end; }
+.ease-toast-container--top-left     { top: 16px; left: 16px;  align-items: flex-start; }
+.ease-toast-container--top-center   { top: 16px; left: 50%; transform: translateX(-50%); align-items: center; }
+.ease-toast-container--bottom-right { bottom: 16px; right: 16px; align-items: flex-end; flex-direction: column-reverse; }
+.ease-toast-container--bottom-left  { bottom: 16px; left: 16px;  align-items: flex-start; flex-direction: column-reverse; }
+
+/* toast base */
+.ease-toast {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  background: #1e293b;
+  color: #e2e8f0;
+  border-left: 4px solid #38bdf8;
+  border-radius: 8px;
+  padding: 12px 14px;
+  font-size: 14px;
+  line-height: 1.5;
+  pointer-events: all;
+  width: 100%;
+  box-sizing: border-box;
+  animation: ease-toast-in 0.3s ease forwards;
+}
+
+.ease-toast.removing {
+  animation: ease-toast-out 0.3s ease forwards;
+}
+
+/* type variants */
+.ease-toast--success { border-left-color: #22c55e; }
+.ease-toast--error   { border-left-color: #ef4444; }
+.ease-toast--warning { border-left-color: #f59e0b; }
+.ease-toast--info    { border-left-color: #38bdf8; }
+
+/* icon dot */
+.ease-toast__icon {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-top: 5px;
+  flex-shrink: 0;
+  background: #38bdf8;
+}
+.ease-toast--success .ease-toast__icon { background: #22c55e; }
+.ease-toast--error   .ease-toast__icon { background: #ef4444; }
+.ease-toast--warning .ease-toast__icon { background: #f59e0b; }
+.ease-toast--info    .ease-toast__icon { background: #38bdf8; }
+
+.ease-toast__message { flex: 1; }
+
+/* close button */
+.ease-toast__close {
+  background: none;
+  border: none;
+  color: #64748b;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 0;
+  margin-top: 1px;
+  flex-shrink: 0;
+}
+.ease-toast__close:hover { color: #e2e8f0; }
+
+/* animations */
+@keyframes ease-toast-in {
+  from { opacity: 0; transform: translateX(20px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+@keyframes ease-toast-out {
+  from { opacity: 1; transform: translateX(0); }
+  to   { opacity: 0; transform: translateX(20px); }
+}
+
+/* reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .ease-toast,
+  .ease-toast.removing {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
Adds a self-contained animated toast notification component to
`submissions/examples/toast-notification/`.

Closes #YOUR_ISSUE_NUMBER

## What does this PR do?
- Stacks multiple toasts vertically with gap (no overlap)
- 5 position variants: top-right, top-left, top-center, bottom-right, bottom-left
- 4 type variants: success, error, warning, info
- Auto-dismiss via configurable duration
- Manual close button
- Slide-in / fade-out CSS animations
- `prefers-reduced-motion` support

## Files changed