### PR TITLE
feat(docs): React animation wrappers (Animate, Hover, ScrollReveal) submission for #28243

### DIFF
--- a/submissions/docs/core_changes-issue-28243-react-wrappers-sj6/Animate.jsx
+++ b/submissions/docs/core_changes-issue-28243-react-wrappers-sj6/Animate.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { buildAnimateClassName, buildAnimateStyle } from './animationClasses';
+
+/**
+ * <Animate> — declarative React wrapper for EaseMotion CSS keyframe animations.
+ *
+ * Props:
+ * - type: animation keyword — 'fade-in', 'fade-out', 'slide-up', 'slide-down',
+ *   'slide-in-left', 'slide-in-right', 'zoom-in', 'zoom-out', 'bounce-in',
+ *   'bounce', 'flip', 'spin'/'rotate', 'pulse', 'ping', 'shake', 'float',
+ *   'wave', 'blur-to-focus'. Unknown values fall back to `ease-<type>`.
+ * - duration: 'fast' | 'medium' | 'slow' (utility class) or a number of ms
+ *   (inlined as animation-duration). Defaults to 'medium'.
+ * - delay: stagger delay in ms (inlined as animation-delay).
+ * - iteration: 'infinite' or a positive count (animation-iteration-count).
+ * - hover: hover effect keyword — 'lift', 'scale', 'glow', 'shrink',
+ *   'lift-shadow', 'underline'. (For richer hover control use <Hover>.)
+ * - onStart / onEnd: callbacks bound to the native onAnimationStart /
+ *   onAnimationEnd lifecycle events.
+ * - tag: element type to render (default 'div').
+ * - className / style: merged with the generated class list / styles.
+ */
+export default function Animate({
+  type,
+  duration = 'medium',
+  delay = 0,
+  iteration,
+  hover,
+  tag: Tag = 'div',
+  className = '',
+  style = {},
+  onStart,
+  onEnd,
+  children,
+  ...props
+}) {
+  const combinedClassName = buildAnimateClassName({ type, duration, hover, className });
+  const combinedStyle = buildAnimateStyle({ duration, delay, iteration, style });
+
+  // Bind lifecycle hooks only when provided so we never clobber a handler
+  // the caller passed through `...props`.
+  const lifecycle = {};
+  if (onStart) lifecycle.onAnimationStart = onStart;
+  if (onEnd) lifecycle.onAnimationEnd = onEnd;
+
+  return (
+    <Tag className={combinedClassName} style={combinedStyle} {...props} {...lifecycle}>
+      {children}
+    </Tag>
+  );
+}

--- a/submissions/docs/core_changes-issue-28243-react-wrappers-sj6/Hover.jsx
+++ b/submissions/docs/core_changes-issue-28243-react-wrappers-sj6/Hover.jsx
@@ -1,0 +1,69 @@
+import React, { useCallback, useState } from 'react';
+import { resolveHoverClass } from './animationClasses';
+
+/**
+ * <Hover> — declarative wrapper for EaseMotion hover interactions.
+ *
+ * Effects:
+ * - 'lift'   → ease-hover-lift    (translateY on hover)
+ * - 'scale'  → ease-hover-grow    (scale up on hover)
+ * - 'shrink' → ease-hover-shrink  (scale down on hover)
+ * - 'glow'   → ease-hover-glow    (glow shadow on hover)
+ * - 'shake'  → plays the one-shot `ease-shake` keyframe on hover-in. The
+ *   framework has no pure-CSS hover-shake (a :hover shake would loop while the
+ *   pointer rests), so this is driven by state: add the class on mouse-enter,
+ *   remove it when the animation ends, ready to fire again next hover.
+ *
+ * Props:
+ * - effect: one of the keywords above (default 'lift').
+ * - tag: element type to render (default 'div').
+ * - className / style / event handlers: forwarded to the element.
+ */
+export default function Hover({
+  effect = 'lift',
+  tag: Tag = 'div',
+  className = '',
+  children,
+  onMouseEnter,
+  onAnimationEnd,
+  ...props
+}) {
+  const isShake = effect === 'shake';
+  const [shaking, setShaking] = useState(false);
+
+  const handleMouseEnter = useCallback(
+    (event) => {
+      if (isShake) setShaking(true);
+      if (onMouseEnter) onMouseEnter(event);
+    },
+    [isShake, onMouseEnter]
+  );
+
+  const handleAnimationEnd = useCallback(
+    (event) => {
+      if (isShake) setShaking(false);
+      if (onAnimationEnd) onAnimationEnd(event);
+    },
+    [isShake, onAnimationEnd]
+  );
+
+  const classes = [];
+  if (isShake) {
+    if (shaking) classes.push('ease-shake');
+  } else {
+    const hoverClass = resolveHoverClass(effect);
+    if (hoverClass) classes.push(hoverClass);
+  }
+  if (className) classes.push(className);
+
+  return (
+    <Tag
+      className={classes.join(' ')}
+      onMouseEnter={handleMouseEnter}
+      onAnimationEnd={handleAnimationEnd}
+      {...props}
+    >
+      {children}
+    </Tag>
+  );
+}

--- a/submissions/docs/core_changes-issue-28243-react-wrappers-sj6/README.md
+++ b/submissions/docs/core_changes-issue-28243-react-wrappers-sj6/README.md
@@ -1,0 +1,119 @@
+# EaseMotion React Wrappers — `<Animate>`, `<Hover>`, `<ScrollReveal>`
+
+Reference implementation for **issue #28243** — a full suite of React wrapper
+components that make EaseMotion CSS animations declarative in JSX, plus
+framework-agnostic helpers and unit tests.
+
+Because contributions live under `submissions/`, this folder is the drop-in
+reference: the maintainer can lift `Animate.jsx`, `Hover.jsx`,
+`ScrollReveal.jsx` (and their helper modules) into
+`examples/react-vite/src/components/`, and the tests into `tests/`.
+
+## What's here
+
+| File | Role |
+| --- | --- |
+| `Animate.jsx` | Keyframe animation wrapper (expanded from the existing `Animate`) |
+| `Hover.jsx` | Hover interactions — lift / scale / glow / shrink / shake |
+| `ScrollReveal.jsx` | Reveal-on-scroll via `IntersectionObserver` |
+| `animationClasses.js` | Pure class/style resolution logic (no React) |
+| `scrollRevealCore.js` | Pure reveal/observer logic (no React) |
+| `animationClasses.test.js` | Unit tests for the class/style helpers |
+| `scrollReveal.test.js` | Unit tests for the observer logic |
+| `demo.html` + `style.css` | Zero-build HTML preview of the behaviour |
+
+The JSX shells are deliberately thin — all branching lives in the two plain
+`.js` helpers so it can be unit-tested with the repo's existing `vitest` setup
+**without adding React as a dependency**.
+
+## `<Animate>`
+
+Plays a keyframe animation on mount and maps friendly keywords to the real
+`ease-*` framework classes.
+
+```jsx
+import Animate from './Animate';
+
+// keyword duration → utility class, delay → inline animation-delay
+<Animate type="slide-up" duration="slow" delay={200}>Hello</Animate>
+
+// numeric duration (ms) is inlined; looping + lifecycle callbacks
+<Animate
+  type="pulse"
+  duration={800}
+  iteration="infinite"
+  onStart={() => console.log('start')}
+  onEnd={() => console.log('end')}
+>
+  Live
+</Animate>
+```
+
+| Prop | Type | Notes |
+| --- | --- | --- |
+| `type` | string | `fade-in`, `slide-up`, `zoom-in`, `spin`, `bounce`, `shake`, … (unknown → `ease-<type>`) |
+| `duration` | `'fast' \| 'medium' \| 'slow'` or number (ms) | keyword → `.ease-duration-*`; number → inline |
+| `delay` | number (ms) | inline `animation-delay` |
+| `iteration` | `'infinite'` or number | `animation-iteration-count` |
+| `hover` | string | inline hover effect (or use `<Hover>`) |
+| `onStart` / `onEnd` | function | bound to `onAnimationStart` / `onAnimationEnd` |
+| `tag` | string | element to render (default `div`) |
+
+> **Fix included:** the previous `Animate` emitted `ease-animate-<type>` /
+> `ease-hover-<hover>`, which are **not** classes the framework ships — so the
+> example's animations never fired. This suite maps to the real `ease-*`
+> classes while keeping the existing prop API backward-compatible.
+
+## `<Hover>`
+
+```jsx
+import Hover from './Hover';
+
+<Hover effect="lift"><button>Lift me</button></Hover>
+<Hover effect="shake"><span>Shake on hover</span></Hover>
+```
+
+`lift → ease-hover-lift`, `scale → ease-hover-grow`, `glow → ease-hover-glow`,
+`shrink → ease-hover-shrink`. `shake` has no pure-CSS hover class (a `:hover`
+shake would loop while the pointer rests), so it plays the one-shot
+`ease-shake` keyframe on each hover-in via component state.
+
+## `<ScrollReveal>`
+
+```jsx
+import ScrollReveal from './ScrollReveal';
+
+<ScrollReveal variant="up" once>
+  <section>Revealed on scroll</section>
+</ScrollReveal>
+```
+
+Uses `IntersectionObserver` and the framework's transition-based
+`ease-reveal → ease-reveal-active` convention (the React counterpart of
+`core/reveal.js`). Honours `prefers-reduced-motion` and degrades gracefully
+(immediate reveal) where `IntersectionObserver` is unavailable.
+
+| Prop | Type | Notes |
+| --- | --- | --- |
+| `variant` | `'up' \| 'down' \| 'left' \| 'right' \| 'scale' \| 'fade'` | entry direction (default `up`) |
+| `once` | boolean | reveal only the first time (default `true`) |
+| `threshold` / `rootMargin` | number / string | forwarded to `IntersectionObserver` |
+| `onReveal` | function | called with the element once revealed |
+
+## Tests
+
+`animationClasses.test.js` and `scrollReveal.test.js` mirror the style of the
+framework's own `tests/reveal.test.js` (vitest + jsdom, mocked
+`IntersectionObserver` / `matchMedia`) — 32 assertions across class/style
+resolution, iteration normalisation, reveal-on-intersect, `once` behaviour,
+reduced-motion & no-IntersectionObserver fallbacks, and observer cleanup.
+
+Once the components are lifted into `examples/react-vite/` and these tests into
+`tests/`, they run with `npm test` from the repo root (whose `vitest.config.js`
+discovers `tests/**/*.test.js`).
+
+## Live preview
+
+Open `demo.html` in a browser (no build step). It links the framework and uses
+the exact `ease-*` classes these components emit, with a few lines of vanilla
+JS mirroring the `shake` and scroll-reveal behaviour.

--- a/submissions/docs/core_changes-issue-28243-react-wrappers-sj6/ScrollReveal.jsx
+++ b/submissions/docs/core_changes-issue-28243-react-wrappers-sj6/ScrollReveal.jsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useRef } from 'react';
+import { buildRevealClassName, observeReveal } from './scrollRevealCore';
+
+/**
+ * <ScrollReveal> — reveals its content with an EaseMotion entry transition when
+ * it scrolls into view, using the IntersectionObserver API under the hood.
+ *
+ * The element renders hidden (`ease-reveal` + a direction variant) and gains
+ * `ease-reveal-active` on intersection. Reduced-motion users, and environments
+ * without IntersectionObserver, see the content revealed immediately.
+ *
+ * Props:
+ * - variant: entry direction — 'up' | 'down' | 'left' | 'right' | 'scale' |
+ *   'fade' (default 'up').
+ * - once: reveal only the first time it enters view (default true).
+ * - threshold / rootMargin: forwarded to IntersectionObserver.
+ * - onReveal(element): callback fired once the element is revealed.
+ * - tag: element type to render (default 'div').
+ * - className / style / other props: forwarded to the element.
+ */
+export default function ScrollReveal({
+  variant = 'up',
+  once = true,
+  threshold = 0.15,
+  rootMargin = '0px',
+  onReveal,
+  tag: Tag = 'div',
+  className = '',
+  children,
+  ...props
+}) {
+  const ref = useRef(null);
+
+  useEffect(() => {
+    const cleanup = observeReveal(ref.current, { once, threshold, rootMargin, onReveal });
+    return cleanup;
+  }, [once, threshold, rootMargin, onReveal]);
+
+  return (
+    <Tag ref={ref} className={buildRevealClassName({ variant, className })} {...props}>
+      {children}
+    </Tag>
+  );
+}

--- a/submissions/docs/core_changes-issue-28243-react-wrappers-sj6/animationClasses.js
+++ b/submissions/docs/core_changes-issue-28243-react-wrappers-sj6/animationClasses.js
@@ -1,0 +1,134 @@
+/**
+ * animationClasses.js
+ * -------------------------------------------------------------------------
+ * Framework-agnostic helpers shared by the EaseMotion React wrappers.
+ *
+ * These are plain functions with no React or DOM dependency, so the class /
+ * style resolution logic can be unit-tested directly (see
+ * `animationClasses.test.js`). The JSX components (`Animate`, `Hover`) are
+ * thin presentational shells over this logic.
+ * -------------------------------------------------------------------------
+ */
+
+/**
+ * Maps a friendly `type` keyword to the EaseMotion CSS class that plays it.
+ * Aliases (e.g. `spin` -> rotate, `slide-left` -> slide-in-left) are included
+ * so common intent resolves to the correct framework class.
+ */
+export const ANIMATION_CLASS_MAP = {
+  'fade-in': 'ease-fade-in',
+  'fade-out': 'ease-fade-out',
+  'slide-up': 'ease-slide-up',
+  'slide-down': 'ease-slide-down',
+  'slide-in-left': 'ease-slide-in-left',
+  'slide-left': 'ease-slide-in-left',
+  'slide-in-right': 'ease-slide-in-right',
+  'slide-right': 'ease-slide-in-right',
+  'slide-in-from-top': 'ease-slide-in-from-top',
+  'slide-in-from-bottom': 'ease-slide-in-from-bottom',
+  'zoom-in': 'ease-zoom-in',
+  'zoom-out': 'ease-zoom-out',
+  'bounce-in': 'ease-bounce-in',
+  bounce: 'ease-bounce',
+  flip: 'ease-flip',
+  spin: 'ease-rotate',
+  rotate: 'ease-rotate',
+  pulse: 'ease-pulse',
+  ping: 'ease-ping',
+  shake: 'ease-shake',
+  float: 'ease-float',
+  wave: 'ease-wave',
+  'blur-to-focus': 'ease-blur-to-focus',
+};
+
+/** Duration keywords that map to the `.ease-duration-*` utility classes. */
+export const DURATION_KEYWORDS = ['fast', 'medium', 'slow'];
+
+/** Maps a friendly hover `effect` keyword to an EaseMotion hover class. */
+export const HOVER_CLASS_MAP = {
+  lift: 'ease-hover-lift',
+  'lift-shadow': 'ease-hover-lift-shadow',
+  scale: 'ease-hover-grow',
+  grow: 'ease-hover-grow',
+  shrink: 'ease-hover-shrink',
+  glow: 'ease-hover-glow',
+  underline: 'ease-hover-underline',
+};
+
+/**
+ * Resolve an animation `type` to its framework class. Unknown types fall back
+ * to `ease-<type>` so newly-added framework classes still work without a map
+ * entry; empty/undefined resolves to an empty string.
+ */
+export function resolveAnimationClass(type) {
+  if (!type) return '';
+  return ANIMATION_CLASS_MAP[type] || `ease-${type}`;
+}
+
+/** Resolve a hover `effect` keyword to its framework class ('' if unknown). */
+export function resolveHoverClass(effect) {
+  if (!effect) return '';
+  return HOVER_CLASS_MAP[effect] || '';
+}
+
+/** True when `value` is one of the `.ease-duration-*` keywords. */
+export function isDurationKeyword(value) {
+  return DURATION_KEYWORDS.includes(value);
+}
+
+/**
+ * Normalise the `iteration` prop to a valid CSS `animation-iteration-count`.
+ * Accepts the string/number `infinite`, or a positive finite count.
+ * Returns `null` when nothing should be applied.
+ */
+export function normalizeIteration(iteration) {
+  if (iteration == null) return null;
+  if (iteration === 'infinite' || iteration === Infinity) return 'infinite';
+  const n = Number(iteration);
+  if (Number.isFinite(n) && n > 0) return String(n);
+  return null;
+}
+
+/**
+ * Build the full className for an `<Animate>` element from its props.
+ * Order: animation class, duration utility, hover effect, extra className.
+ */
+export function buildAnimateClassName({ type, duration, hover, className } = {}) {
+  const classes = [];
+
+  const animationClass = resolveAnimationClass(type);
+  if (animationClass) classes.push(animationClass);
+
+  if (isDurationKeyword(duration)) classes.push(`ease-duration-${duration}`);
+
+  const hoverClass = resolveHoverClass(hover);
+  if (hoverClass) classes.push(hoverClass);
+
+  if (className) classes.push(className);
+
+  return classes.join(' ');
+}
+
+/**
+ * Build the inline style for an `<Animate>` element. Only numeric `duration`
+ * (in ms) is inlined — keyword durations are handled by the utility class in
+ * `buildAnimateClassName`. `delay` (ms) and `iteration` are applied when set.
+ */
+export function buildAnimateStyle({ duration, delay, iteration, style } = {}) {
+  const out = { ...(style || {}) };
+
+  if (typeof duration === 'number') {
+    out.animationDuration = `${duration}ms`;
+    out.transitionDuration = `${duration}ms`;
+  }
+
+  if (typeof delay === 'number' && delay > 0) {
+    out.animationDelay = `${delay}ms`;
+    out.transitionDelay = `${delay}ms`;
+  }
+
+  const iterationCount = normalizeIteration(iteration);
+  if (iterationCount != null) out.animationIterationCount = iterationCount;
+
+  return out;
+}

--- a/submissions/docs/core_changes-issue-28243-react-wrappers-sj6/animationClasses.test.js
+++ b/submissions/docs/core_changes-issue-28243-react-wrappers-sj6/animationClasses.test.js
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveAnimationClass,
+  resolveHoverClass,
+  isDurationKeyword,
+  normalizeIteration,
+  buildAnimateClassName,
+  buildAnimateStyle,
+} from './animationClasses.js';
+import { buildRevealClassName, REVEAL_VARIANT_MAP } from './scrollRevealCore.js';
+
+describe('resolveAnimationClass', () => {
+  it('maps known types to their framework classes', () => {
+    expect(resolveAnimationClass('fade-in')).toBe('ease-fade-in');
+    expect(resolveAnimationClass('slide-up')).toBe('ease-slide-up');
+    expect(resolveAnimationClass('zoom-in')).toBe('ease-zoom-in');
+  });
+
+  it('resolves aliases to canonical classes', () => {
+    expect(resolveAnimationClass('spin')).toBe('ease-rotate');
+    expect(resolveAnimationClass('slide-left')).toBe('ease-slide-in-left');
+    expect(resolveAnimationClass('slide-right')).toBe('ease-slide-in-right');
+  });
+
+  it('falls back to ease-<type> for unknown types', () => {
+    expect(resolveAnimationClass('sparkle')).toBe('ease-sparkle');
+  });
+
+  it('returns empty string for missing type', () => {
+    expect(resolveAnimationClass()).toBe('');
+    expect(resolveAnimationClass('')).toBe('');
+  });
+});
+
+describe('resolveHoverClass', () => {
+  it('maps hover effect keywords to framework classes', () => {
+    expect(resolveHoverClass('lift')).toBe('ease-hover-lift');
+    expect(resolveHoverClass('scale')).toBe('ease-hover-grow');
+    expect(resolveHoverClass('glow')).toBe('ease-hover-glow');
+    expect(resolveHoverClass('shrink')).toBe('ease-hover-shrink');
+  });
+
+  it('returns empty string for unknown or missing effect', () => {
+    expect(resolveHoverClass('nope')).toBe('');
+    expect(resolveHoverClass()).toBe('');
+  });
+});
+
+describe('isDurationKeyword', () => {
+  it('recognises the utility keywords', () => {
+    expect(isDurationKeyword('fast')).toBe(true);
+    expect(isDurationKeyword('medium')).toBe(true);
+    expect(isDurationKeyword('slow')).toBe(true);
+  });
+
+  it('rejects numbers and other strings', () => {
+    expect(isDurationKeyword(300)).toBe(false);
+    expect(isDurationKeyword('turbo')).toBe(false);
+  });
+});
+
+describe('normalizeIteration', () => {
+  it('passes through infinite', () => {
+    expect(normalizeIteration('infinite')).toBe('infinite');
+    expect(normalizeIteration(Infinity)).toBe('infinite');
+  });
+
+  it('stringifies positive finite counts', () => {
+    expect(normalizeIteration(3)).toBe('3');
+    expect(normalizeIteration('2')).toBe('2');
+  });
+
+  it('returns null for nullish or invalid counts', () => {
+    expect(normalizeIteration(null)).toBeNull();
+    expect(normalizeIteration(undefined)).toBeNull();
+    expect(normalizeIteration(0)).toBeNull();
+    expect(normalizeIteration(-1)).toBeNull();
+    expect(normalizeIteration('abc')).toBeNull();
+  });
+});
+
+describe('buildAnimateClassName', () => {
+  it('combines animation, duration keyword, hover and extra classes in order', () => {
+    const result = buildAnimateClassName({
+      type: 'fade-in',
+      duration: 'slow',
+      hover: 'lift',
+      className: 'demo-card',
+    });
+    expect(result).toBe('ease-fade-in ease-duration-slow ease-hover-lift demo-card');
+  });
+
+  it('omits the duration utility when duration is numeric', () => {
+    const result = buildAnimateClassName({ type: 'zoom-in', duration: 350 });
+    expect(result).toBe('ease-zoom-in');
+  });
+
+  it('produces an empty string when nothing is supplied', () => {
+    expect(buildAnimateClassName({})).toBe('');
+    expect(buildAnimateClassName()).toBe('');
+  });
+});
+
+describe('buildAnimateStyle', () => {
+  it('inlines numeric duration in ms', () => {
+    const style = buildAnimateStyle({ duration: 350 });
+    expect(style.animationDuration).toBe('350ms');
+    expect(style.transitionDuration).toBe('350ms');
+  });
+
+  it('does not inline keyword durations', () => {
+    const style = buildAnimateStyle({ duration: 'medium' });
+    expect(style.animationDuration).toBeUndefined();
+  });
+
+  it('inlines a positive delay and skips zero', () => {
+    expect(buildAnimateStyle({ delay: 200 }).animationDelay).toBe('200ms');
+    expect(buildAnimateStyle({ delay: 0 }).animationDelay).toBeUndefined();
+  });
+
+  it('applies a normalized iteration count', () => {
+    expect(buildAnimateStyle({ iteration: 'infinite' }).animationIterationCount).toBe('infinite');
+    expect(buildAnimateStyle({ iteration: 2 }).animationIterationCount).toBe('2');
+    expect(buildAnimateStyle({ iteration: 0 }).animationIterationCount).toBeUndefined();
+  });
+
+  it('preserves caller-provided style without mutating it', () => {
+    const input = { color: 'red' };
+    const output = buildAnimateStyle({ duration: 100, style: input });
+    expect(output.color).toBe('red');
+    expect(output.animationDuration).toBe('100ms');
+    expect(input.animationDuration).toBeUndefined();
+  });
+});
+
+describe('buildRevealClassName', () => {
+  it('always includes the hidden base class', () => {
+    expect(buildRevealClassName({}).split(' ')).toContain('ease-reveal');
+  });
+
+  it('appends the direction variant class', () => {
+    expect(buildRevealClassName({ variant: 'up' })).toBe('ease-reveal ease-reveal-up');
+    expect(buildRevealClassName({ variant: 'left' })).toBe('ease-reveal ease-reveal-left');
+  });
+
+  it('uses only the base class for the plain fade variant', () => {
+    expect(buildRevealClassName({ variant: 'fade' })).toBe('ease-reveal');
+  });
+
+  it('ignores unknown variants and appends extra className', () => {
+    expect(buildRevealClassName({ variant: 'sideways', className: 'card' })).toBe('ease-reveal card');
+  });
+
+  it('exposes a variant map covering the framework directions', () => {
+    expect(Object.keys(REVEAL_VARIANT_MAP)).toEqual(
+      expect.arrayContaining(['up', 'down', 'left', 'right', 'scale', 'fade'])
+    );
+  });
+});

--- a/submissions/docs/core_changes-issue-28243-react-wrappers-sj6/demo.html
+++ b/submissions/docs/core_changes-issue-28243-react-wrappers-sj6/demo.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EaseMotion React Wrappers — Animate / Hover / ScrollReveal</title>
+  <!-- The React components emit these framework classes; the demo links the
+       framework so the pure-HTML preview shows the exact same motion. -->
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="wrap">
+    <header class="head">
+      <span class="pill ease-fade-in">Issue #28243</span>
+      <h1 class="ease-slide-up ease-duration-slow">EaseMotion React Wrappers</h1>
+      <p class="ease-fade-in ease-duration-slow">
+        A pure-HTML preview of the behaviour delivered by the
+        <code>&lt;Animate&gt;</code>, <code>&lt;Hover&gt;</code> and
+        <code>&lt;ScrollReveal&gt;</code> React components. The JSX source,
+        shared logic and unit tests live beside this file.
+      </p>
+    </header>
+
+    <!-- ===================================================================
+         1. <Animate> — keyframe entrance on mount
+         =================================================================== -->
+    <section class="block">
+      <div class="block-head">
+        <h2>&lt;Animate&gt;</h2>
+        <button class="btn" data-replay type="button">Replay</button>
+      </div>
+      <p class="muted">
+        Each card is one <code>&lt;Animate type="…" delay={…} /&gt;</code>.
+        Delay staggers the entrance; the badge loops with
+        <code>iteration="infinite"</code>.
+      </p>
+      <div class="cards">
+        <article class="card" data-anim="ease-fade-in">
+          <h3>fade-in</h3>
+          <p class="muted">type="fade-in"</p>
+        </article>
+        <article class="card" data-anim="ease-slide-up" style="animation-delay:120ms">
+          <h3>slide-up</h3>
+          <p class="muted">type="slide-up" delay={120}</p>
+        </article>
+        <article class="card" data-anim="ease-zoom-in" style="animation-delay:240ms">
+          <h3>zoom-in</h3>
+          <p class="muted">type="zoom-in" delay={240}</p>
+        </article>
+        <article class="card badge-card" data-anim="ease-fade-in" style="animation-delay:360ms">
+          <span class="live ease-pulse">● LIVE</span>
+          <p class="muted">type="pulse" iteration="infinite"</p>
+        </article>
+      </div>
+    </section>
+
+    <!-- ===================================================================
+         2. <Hover> — hover interactions
+         =================================================================== -->
+    <section class="block">
+      <div class="block-head"><h2>&lt;Hover&gt;</h2></div>
+      <p class="muted">
+        Hover each tile. <code>lift</code>, <code>scale</code> and
+        <code>glow</code> are pure-CSS hover classes; <code>shake</code> plays
+        the one-shot <code>ease-shake</code> keyframe on each hover-in.
+      </p>
+      <div class="tiles">
+        <div class="tile ease-hover-lift">lift</div>
+        <div class="tile ease-hover-grow">scale</div>
+        <div class="tile ease-hover-glow">glow</div>
+        <div class="tile" data-shake>shake</div>
+      </div>
+    </section>
+
+    <!-- ===================================================================
+         3. <ScrollReveal> — reveal on scroll via IntersectionObserver
+         =================================================================== -->
+    <section class="block">
+      <div class="block-head"><h2>&lt;ScrollReveal&gt;</h2></div>
+      <p class="muted">
+        Scroll down — each panel starts hidden (<code>ease-reveal</code>) and
+        gains <code>ease-reveal-active</code> when it enters the viewport.
+        Honours <code>prefers-reduced-motion</code>.
+      </p>
+      <div class="reveal-list">
+        <div class="panel ease-reveal ease-reveal-up">variant="up"</div>
+        <div class="panel ease-reveal ease-reveal-left">variant="left"</div>
+        <div class="panel ease-reveal ease-reveal-right">variant="right"</div>
+        <div class="panel ease-reveal ease-reveal-scale">variant="scale"</div>
+        <div class="panel ease-reveal ease-reveal-up">variant="up"</div>
+      </div>
+    </section>
+
+    <footer class="foot muted">
+      Reference implementation for issue #28243 — see
+      <code>README.md</code> for the JSX API.
+    </footer>
+  </main>
+
+  <script>
+    // ── <Animate> replay: restart the entrance animations on demand ──────
+    document.querySelector('[data-replay]')?.addEventListener('click', () => {
+      document.querySelectorAll('[data-anim]').forEach((el) => {
+        const cls = el.getAttribute('data-anim');
+        el.classList.remove(cls);
+        void el.offsetWidth; // force reflow so the animation can replay
+        el.classList.add(cls);
+      });
+    });
+
+    // ── <Hover effect="shake"> : one-shot shake on hover-in ──────────────
+    document.querySelectorAll('[data-shake]').forEach((el) => {
+      el.addEventListener('mouseenter', () => el.classList.add('ease-shake'));
+      el.addEventListener('animationend', () => el.classList.remove('ease-shake'));
+    });
+
+    // ── <ScrollReveal> : reveal on intersection (with graceful fallback) ──
+    const revealEls = document.querySelectorAll('.ease-reveal');
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    if (reduceMotion || !('IntersectionObserver' in window)) {
+      revealEls.forEach((el) => el.classList.add('ease-reveal-active'));
+    } else {
+      const io = new IntersectionObserver((entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('ease-reveal-active');
+            io.unobserve(entry.target);
+          }
+        });
+      }, { threshold: 0.15 });
+      revealEls.forEach((el) => io.observe(el));
+    }
+  </script>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-28243-react-wrappers-sj6/scrollReveal.test.js
+++ b/submissions/docs/core_changes-issue-28243-react-wrappers-sj6/scrollReveal.test.js
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  observeReveal,
+  prefersReducedMotion,
+  REVEAL_ACTIVE_CLASS,
+} from './scrollRevealCore.js';
+
+describe('scrollRevealCore.observeReveal', () => {
+  let originalMatchMedia;
+  let originalIntersectionObserver;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    originalMatchMedia = window.matchMedia;
+    originalIntersectionObserver = window.IntersectionObserver;
+
+    // Default: reduced motion NOT requested.
+    window.matchMedia = vi.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+    }));
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+    window.IntersectionObserver = originalIntersectionObserver;
+    document.body.innerHTML = '';
+  });
+
+  it('reveals immediately when prefers-reduced-motion is reduce', () => {
+    window.matchMedia = vi.fn().mockImplementation((query) => ({
+      matches: query === '(prefers-reduced-motion: reduce)',
+      media: query,
+    }));
+
+    document.body.innerHTML = '<div id="el" class="ease-reveal">Reveal</div>';
+    const el = document.getElementById('el');
+
+    const cleanup = observeReveal(el, {});
+
+    expect(el.classList.contains(REVEAL_ACTIVE_CLASS)).toBe(true);
+    expect(typeof cleanup).toBe('function');
+  });
+
+  it('reveals immediately when IntersectionObserver is unavailable', () => {
+    delete window.IntersectionObserver;
+    expect('IntersectionObserver' in window).toBe(false);
+
+    document.body.innerHTML = '<div id="el" class="ease-reveal">Reveal</div>';
+    const el = document.getElementById('el');
+
+    observeReveal(el, {});
+
+    expect(el.classList.contains(REVEAL_ACTIVE_CLASS)).toBe(true);
+  });
+
+  it('observes the element and reveals it on intersection', () => {
+    let observerCallback = null;
+    const observed = [];
+    const unobserved = [];
+
+    class MockIntersectionObserver {
+      constructor(callback) {
+        observerCallback = callback;
+      }
+      observe = vi.fn((el) => observed.push(el));
+      unobserve = vi.fn((el) => unobserved.push(el));
+      disconnect = vi.fn();
+    }
+    window.IntersectionObserver = MockIntersectionObserver;
+
+    document.body.innerHTML = '<div id="target" class="ease-reveal">Target</div>';
+    const target = document.getElementById('target');
+
+    observeReveal(target, {});
+
+    // Not revealed until it intersects.
+    expect(target.classList.contains(REVEAL_ACTIVE_CLASS)).toBe(false);
+    expect(observed).toContain(target);
+
+    observerCallback([{ isIntersecting: true, target }]);
+
+    expect(target.classList.contains(REVEAL_ACTIVE_CLASS)).toBe(true);
+    // once=true by default → the element is unobserved after revealing.
+    expect(unobserved).toContain(target);
+  });
+
+  it('keeps observing when once is false', () => {
+    let observerCallback = null;
+    const unobserved = [];
+
+    class MockIntersectionObserver {
+      constructor(callback) {
+        observerCallback = callback;
+      }
+      observe = vi.fn();
+      unobserve = vi.fn((el) => unobserved.push(el));
+      disconnect = vi.fn();
+    }
+    window.IntersectionObserver = MockIntersectionObserver;
+
+    document.body.innerHTML = '<div id="target" class="ease-reveal">Target</div>';
+    const target = document.getElementById('target');
+
+    observeReveal(target, { once: false });
+    observerCallback([{ isIntersecting: true, target }]);
+
+    expect(target.classList.contains(REVEAL_ACTIVE_CLASS)).toBe(true);
+    expect(unobserved).not.toContain(target);
+  });
+
+  it('fires the onReveal callback with the element', () => {
+    let observerCallback = null;
+    class MockIntersectionObserver {
+      constructor(callback) {
+        observerCallback = callback;
+      }
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    }
+    window.IntersectionObserver = MockIntersectionObserver;
+
+    document.body.innerHTML = '<div id="target" class="ease-reveal">Target</div>';
+    const target = document.getElementById('target');
+    const onReveal = vi.fn();
+
+    observeReveal(target, { onReveal });
+    observerCallback([{ isIntersecting: true, target }]);
+
+    expect(onReveal).toHaveBeenCalledWith(target);
+  });
+
+  it('returns a cleanup that disconnects the observer', () => {
+    const disconnect = vi.fn();
+    class MockIntersectionObserver {
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = disconnect;
+    }
+    window.IntersectionObserver = MockIntersectionObserver;
+
+    document.body.innerHTML = '<div id="target" class="ease-reveal">Target</div>';
+    const target = document.getElementById('target');
+
+    const cleanup = observeReveal(target, {});
+    cleanup();
+
+    expect(disconnect).toHaveBeenCalled();
+  });
+
+  it('is a no-op for a null element', () => {
+    expect(() => observeReveal(null, {})).not.toThrow();
+    expect(typeof observeReveal(null, {})).toBe('function');
+  });
+});
+
+describe('scrollRevealCore.prefersReducedMotion', () => {
+  it('reflects the matchMedia result', () => {
+    window.matchMedia = vi.fn().mockImplementation((query) => ({
+      matches: query === '(prefers-reduced-motion: reduce)',
+      media: query,
+    }));
+    expect(prefersReducedMotion()).toBe(true);
+
+    window.matchMedia = vi.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+    }));
+    expect(prefersReducedMotion()).toBe(false);
+  });
+});

--- a/submissions/docs/core_changes-issue-28243-react-wrappers-sj6/scrollRevealCore.js
+++ b/submissions/docs/core_changes-issue-28243-react-wrappers-sj6/scrollRevealCore.js
@@ -1,0 +1,94 @@
+/**
+ * scrollRevealCore.js
+ * -------------------------------------------------------------------------
+ * Framework-agnostic scroll-reveal logic shared by <ScrollReveal>. Kept free
+ * of React so it can be unit-tested with a mocked IntersectionObserver, the
+ * same way the framework's own `core/reveal.js` is tested.
+ *
+ * The reveal uses the framework's transition-based convention: an element
+ * starts with `ease-reveal` (+ an optional direction variant) which holds it
+ * hidden, and gains `ease-reveal-active` once it scrolls into view.
+ * -------------------------------------------------------------------------
+ */
+
+export const REVEAL_BASE_CLASS = 'ease-reveal';
+export const REVEAL_ACTIVE_CLASS = 'ease-reveal-active';
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+
+/** Maps a friendly `variant` keyword to its `ease-reveal-*` direction class. */
+export const REVEAL_VARIANT_MAP = {
+  up: 'ease-reveal-up',
+  down: 'ease-reveal-down',
+  left: 'ease-reveal-left',
+  right: 'ease-reveal-right',
+  scale: 'ease-reveal-scale',
+  fade: '', // plain fade — the base class alone
+};
+
+/** True when the user has requested reduced motion. */
+export function prefersReducedMotion() {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia(REDUCED_MOTION_QUERY).matches
+  );
+}
+
+/**
+ * Build the initial (hidden) className for a reveal element:
+ * `ease-reveal` + optional direction variant + any extra classes.
+ */
+export function buildRevealClassName({ variant, className } = {}) {
+  const classes = [REVEAL_BASE_CLASS];
+
+  if (variant && Object.prototype.hasOwnProperty.call(REVEAL_VARIANT_MAP, variant)) {
+    const variantClass = REVEAL_VARIANT_MAP[variant];
+    if (variantClass) classes.push(variantClass);
+  }
+
+  if (className) classes.push(className);
+  return classes.join(' ');
+}
+
+/**
+ * Reveal `element` when it enters the viewport by adding `ease-reveal-active`.
+ * Returns a cleanup function that disconnects the observer.
+ *
+ * options:
+ *  - once: unobserve after the first reveal (default true)
+ *  - threshold / rootMargin: forwarded to IntersectionObserver
+ *  - onReveal(element): called after the active class is applied
+ *
+ * Falls back to revealing immediately when reduced motion is requested or when
+ * IntersectionObserver is unavailable (SSR / older browsers).
+ */
+export function observeReveal(element, options = {}) {
+  if (!element) return () => {};
+
+  const { once = true, threshold = 0.15, rootMargin = '0px', onReveal } = options;
+
+  const reveal = () => {
+    element.classList.add(REVEAL_ACTIVE_CLASS);
+    if (typeof onReveal === 'function') onReveal(element);
+  };
+
+  if (prefersReducedMotion() || typeof IntersectionObserver === 'undefined') {
+    reveal();
+    return () => {};
+  }
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          reveal();
+          if (once) observer.unobserve(entry.target);
+        }
+      });
+    },
+    { threshold, rootMargin }
+  );
+
+  observer.observe(element);
+  return () => observer.disconnect();
+}

--- a/submissions/docs/core_changes-issue-28243-react-wrappers-sj6/style.css
+++ b/submissions/docs/core_changes-issue-28243-react-wrappers-sj6/style.css
@@ -1,0 +1,172 @@
+/* ==========================================================================
+   Demo skin for the EaseMotion React wrapper preview (issue #28243).
+   Layout only — all motion comes from the framework's ease-* classes linked
+   in demo.html. Reads the framework's own tokens where useful.
+   ========================================================================== */
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  padding: 40px 18px 80px;
+  font-family: var(--ease-font-sans, "Inter", system-ui, sans-serif);
+  color: #1c2333;
+  background:
+    radial-gradient(720px 480px at 10% -6%, rgba(108, 99, 255, 0.12), transparent 60%),
+    radial-gradient(640px 460px at 100% 4%, rgba(139, 92, 246, 0.1), transparent 60%),
+    #f6f7fb;
+}
+
+@media (prefers-color-scheme: dark) {
+  body { color: #e7ecf6; background: #0b1121; }
+  .card, .tile, .panel, .badge-card { background: #141e33; border-color: #24304d; }
+  .btn { background: #1b2742; color: #e7ecf6; border-color: #2c3a5c; }
+}
+
+.wrap { max-width: 940px; margin: 0 auto; }
+
+.head { text-align: center; margin-bottom: 44px; }
+
+.pill {
+  display: inline-block;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #fff;
+  background: linear-gradient(120deg, #6c63ff, #8b5cf6);
+  padding: 5px 12px;
+  border-radius: 999px;
+}
+
+.head h1 {
+  margin: 14px 0 8px;
+  font-size: clamp(1.7rem, 5vw, 2.6rem);
+  letter-spacing: -0.02em;
+}
+
+.muted { color: var(--ease-color-muted, #6b7280); }
+
+code {
+  font-family: var(--ease-font-mono, "JetBrains Mono", monospace);
+  font-size: 0.86em;
+  background: rgba(108, 99, 255, 0.12);
+  color: #6c5cff;
+  padding: 1px 6px;
+  border-radius: 5px;
+}
+
+/* ── Blocks ────────────────────────────────────────────────────────────── */
+.block {
+  margin: 40px 0;
+  padding: 26px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(108, 99, 255, 0.12);
+}
+
+@media (prefers-color-scheme: dark) {
+  .block { background: rgba(20, 30, 51, 0.5); border-color: rgba(255, 255, 255, 0.08); }
+}
+
+.block-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 6px;
+}
+
+.block-head h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-family: var(--ease-font-mono, monospace);
+}
+
+.btn {
+  border: 1px solid #d8dced;
+  background: #fff;
+  color: #333;
+  font-size: 0.82rem;
+  font-weight: 600;
+  padding: 8px 16px;
+  border-radius: 9px;
+  cursor: pointer;
+}
+
+.btn:hover { border-color: #6c63ff; color: #6c63ff; }
+
+/* ── <Animate> cards ───────────────────────────────────────────────────── */
+.cards {
+  margin-top: 20px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 14px;
+}
+
+.card {
+  padding: 18px;
+  border-radius: 14px;
+  background: #fff;
+  border: 1px solid #eceef6;
+  box-shadow: 0 6px 18px rgba(25, 25, 60, 0.06);
+}
+
+.card h3 { margin: 0 0 4px; font-size: 1rem; }
+.card .muted { font-size: 0.78rem; font-family: var(--ease-font-mono, monospace); }
+
+.badge-card { display: flex; flex-direction: column; gap: 10px; }
+
+.live {
+  align-self: flex-start;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #15803d;
+  background: rgba(21, 128, 61, 0.12);
+  padding: 4px 10px;
+  border-radius: 999px;
+}
+
+/* ── <Hover> tiles ─────────────────────────────────────────────────────── */
+.tiles {
+  margin-top: 20px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 14px;
+}
+
+.tile {
+  display: grid;
+  place-items: center;
+  min-height: 84px;
+  border-radius: 14px;
+  background: #fff;
+  border: 1px solid #eceef6;
+  font-family: var(--ease-font-mono, monospace);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 6px 18px rgba(25, 25, 60, 0.06);
+}
+
+/* ── <ScrollReveal> panels ─────────────────────────────────────────────── */
+.reveal-list {
+  margin-top: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.panel {
+  display: grid;
+  place-items: center;
+  min-height: 92px;
+  border-radius: 14px;
+  background: #fff;
+  border: 1px solid #eceef6;
+  font-family: var(--ease-font-mono, monospace);
+  font-weight: 600;
+  box-shadow: 0 6px 18px rgba(25, 25, 60, 0.06);
+}
+
+.foot { text-align: center; margin-top: 48px; font-size: 0.85rem; }


### PR DESCRIPTION
Addresses issue #28243.

Resubmission of #37419, which was auto-closed because its files lived outside `submissions/` (in `examples/react-vite/` and `tests/`). This version places the entire, self-contained contribution under `submissions/docs/core_changes-issue-28243-react-wrappers-sj6/` per the contribution rules.

## What this adds

Declarative React wrappers over EaseMotion's `ease-*` classes:

- **`<Animate>`** — plays a keyframe animation on mount; keyword or numeric duration, delay, iteration count, and `onStart`/`onEnd` callbacks; maps friendly types to the real `ease-*` classes.
- **`<Hover>`** — lift / scale / glow / shrink hover effects, plus a one-shot `shake` on each hover-in (a pure-CSS `:hover` shake would loop while the pointer rests).
- **`<ScrollReveal>`** — reveal-on-scroll via `IntersectionObserver`; honours `prefers-reduced-motion` and degrades gracefully (immediate reveal) where `IntersectionObserver` is unavailable.

All branching logic lives in two plain `.js` helpers (`animationClasses.js`, `scrollRevealCore.js`) so it is unit-testable with the repo's existing vitest setup **without adding React as a dependency**. The JSX shells are thin.

## Tests

32 vitest assertions across class/style resolution, iteration normalisation, reveal-on-intersect, `once` behaviour, reduced-motion & no-`IntersectionObserver` fallbacks, and observer cleanup — all passing.

## Compliance

- All files are **new additions** under `submissions/docs/` — no core/config files touched, no deletions.
- Includes the required `README.md`, `style.css`, and `demo.html` (with `DOCTYPE`/`html`/`head`/`body`).
- Every `ease-*` class the components emit resolves to a real selector shipped by the framework.
