### PR TITLE
fix: preserve selected animations while filtering

### DIFF
--- a/docs/animation-combo.html
+++ b/docs/animation-combo.html
@@ -231,6 +231,9 @@
       const generatedCodeEl = document.getElementById("generatedClass");
       const copyBtn = document.getElementById("copyBtn");
 
+      // Persistent state to retain selected animations across search filter re-renders
+      const selectedAnimations = new Set();
+
       function renderList() {
         const filter = searchInput.value.toLowerCase();
         listContainer.innerHTML = "";
@@ -246,24 +249,30 @@
             const label = document.createElement("label");
             label.style.display = "flex";
             label.style.alignItems = "center";
-            const checkbox = document.createElement("input");
+                       const checkbox = document.createElement("input");
             checkbox.type = "checkbox";
             checkbox.value = anim.name;
+            checkbox.checked = selectedAnimations.has(anim.name);
             checkbox.style.marginRight = "var(--ease-space-2)";
-            checkbox.addEventListener("change", updateGenerated);
+            checkbox.addEventListener("change", (e) => {
+              if (e.target.checked) {
+                selectedAnimations.add(anim.name);
+              } else {
+                selectedAnimations.delete(anim.name);
+              }
+              updateGenerated();
+            });
             const nameSpan = document.createElement("span");
             nameSpan.textContent = anim.name;
             label.appendChild(checkbox);
             label.appendChild(nameSpan);
+            
             card.appendChild(label);
             listContainer.appendChild(card);
           });
       }
-
-      function updateGenerated() {
-        const selected = Array.from(
-          listContainer.querySelectorAll("input[type=checkbox]:checked")
-        ).map((cb) => cb.value);
+             function updateGenerated() {
+        const selected = Array.from(selectedAnimations);
         const duration = durationInput.value;
         const delay = delayInput.value;
         // Build class string: combine selected classes and utility classes for duration/delay if needed.


### PR DESCRIPTION
## Pull Request Description

Fixes #37748

This PR fixes an issue in the Animation Combination Builder where previously selected animations were lost after filtering the animation list using the search box.

### What changed

- Added a persistent `selectedAnimations` state using a `Set`.
- Preserved selected animations across search filter re-renders.
- Restored checkbox state when the animation list is re-rendered.
- Updated generated class output to use the persistent selection state instead of only the currently rendered checkboxes.

### Before

1. Select `ease-fade-in`.
2. Search `slide`.
3. Select `ease-slide-up`.

Generated output:

```text
ease-slide-up
```

### After

Generated output:

```text
ease-fade-in ease-slide-up
```

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [ ] All changes are inside `submissions/`
- [ ] Includes `demo.html`
- [ ] Includes `style.css`
- [ ] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

Not applicable. This PR fixes an existing bug in the Animation Combination Builder documentation page.

---

## Demo

- [x] Verified locally by reproducing the reported issue and confirming the fix.

---

## Browser Testing

- [ ] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer

The fix introduces a persistent selection state so that filtering only changes which animations are visible, without clearing previously selected animations. Existing functionality remains unchanged apart from preserving selections across search re-renders.



> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
