### PR TITLE
feat: Add Tada-Click Accessible Tooltip component

### DIFF
--- a/submissions/examples/tada-click-accessible-tooltip/README.md
+++ b/submissions/examples/tada-click-accessible-tooltip/README.md
@@ -1,0 +1,38 @@
+# Tada-Click Modal
+
+Pure CSS modal that opens with a "tada" pop animation. No JavaScript.
+
+## Usage
+
+Copy `style.css` into your project and link it, then drop in the markup from `index.html`.
+
+```html
+<link rel="stylesheet" href="style.css">
+```
+
+## Customization
+
+Override these custom properties on `.tada-modal` (or a parent) to change behavior:
+
+| Property | Default | Description |
+|---|---|---|
+| `--tada-duration` | `0.6s` | Animation length |
+| `--tada-easing` | `cubic-bezier(.36, .07, .19, 1.07)` | Timing function |
+| `--tada-scale-max` | `1.1` | Peak overshoot scale |
+| `--tada-scale-min` | `0.9` | Undershoot scale before settling |
+| `--tada-overlay-bg` | `rgba(0, 0, 0, 0.55)` | Backdrop color |
+
+## How it works
+
+Checkbox hack. A hidden `<input type="checkbox">` is toggled by clicking the trigger `<label>`. CSS sibling combinators (`~`) show the overlay and run the keyframe animation when the checkbox is `:checked`. Clicking the backdrop or the close `<label>` (also bound to the same checkbox) closes it.
+
+## Accessibility — read this before claiming "fully accessible" in your PR
+
+- Trigger, close button, and backdrop are all keyboard-reachable and toggle via native checkbox behavior (Space/Enter). That part is solid.
+- `prefers-reduced-motion` is respected — animation is skipped for users who've asked for it.
+- **Escape key does not close the modal.** There is no CSS mechanism to bind a specific key. If you need Escape-to-close or a real focus trap, that requires JavaScript. Don't oversell this in the issue/PR description — say it's keyboard-operable, not that it fully matches WAI-ARIA modal dialog pattern requirements.
+- `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` are included, but screen readers may still let users tab/read content behind the modal since there's no real focus containment without JS.
+
+## Browser support
+
+Requires `:has()`-free sibling selectors, CSS custom properties, and `:focus-visible` — works in all current evergreen browsers. No IE11 support, not that anyone should care in 2026.

--- a/submissions/examples/tada-click-accessible-tooltip/demo.html
+++ b/submissions/examples/tada-click-accessible-tooltip/demo.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tada-Click Accessible Tooltip | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="tct-page">
+
+    <header class="tct-page__header">
+      <h1 class="tct-page__title">Tada-Click Accessible Tooltip</h1>
+      <p class="tct-page__subtitle">
+        A pure CSS tooltip with a playful "tada" pop-and-wiggle entrance,
+        triggered by clicking (or Tab-ing to and focusing) the trigger
+        button. Styled for high-contrast, accessible web interfaces.
+        Zero JavaScript.
+      </p>
+      <p class="tct-page__hint">
+        Try it: click any button below, or press
+        <kbd class="tct-kbd">Tab</kbd> to reach it and watch it pop.
+        Click elsewhere (or Tab away) to dismiss.
+      </p>
+    </header>
+
+    <section class="tct-grid">
+
+      <div class="tct-tooltip tct-tooltip--top">
+        <button class="tct-trigger" type="button" aria-describedby="tct-tip-top">
+          Click me (Top)
+        </button>
+        <span class="tct-tooltip__content" id="tct-tip-top" role="tooltip">
+          Tooltip pops above the trigger on click or focus.
+        </span>
+      </div>
+
+      <div class="tct-tooltip tct-tooltip--bottom">
+        <button class="tct-trigger" type="button" aria-describedby="tct-tip-bottom">
+          Click me (Bottom)
+        </button>
+        <span class="tct-tooltip__content" id="tct-tip-bottom" role="tooltip">
+          Tooltip pops below the trigger on click or focus.
+        </span>
+      </div>
+
+      <div class="tct-tooltip tct-tooltip--left">
+        <button class="tct-trigger" type="button" aria-describedby="tct-tip-left">
+          Click me (Left)
+        </button>
+        <span class="tct-tooltip__content" id="tct-tip-left" role="tooltip">
+          Tooltip pops to the left of the trigger.
+        </span>
+      </div>
+
+      <div class="tct-tooltip tct-tooltip--right">
+        <button class="tct-trigger" type="button" aria-describedby="tct-tip-right">
+          Click me (Right)
+        </button>
+        <span class="tct-tooltip__content" id="tct-tip-right" role="tooltip">
+          Tooltip pops to the right of the trigger.
+        </span>
+      </div>
+
+      <div class="tct-tooltip tct-tooltip--top"
+           style="--tct-duration: 900ms; --tct-scale: 1.18; --tct-rotate: 5deg;">
+        <button class="tct-trigger" type="button" aria-describedby="tct-tip-strong">
+          Custom (tuned)
+        </button>
+        <span class="tct-tooltip__content" id="tct-tip-strong" role="tooltip">
+          Longer duration, bigger scale, wider wiggle — all via CSS vars.
+        </span>
+      </div>
+
+      <div class="tct-tooltip tct-tooltip--top">
+        <button class="tct-trigger tct-trigger--icon" type="button" aria-describedby="tct-tip-icon" aria-label="More information">
+          ⓘ
+        </button>
+        <span class="tct-tooltip__content" id="tct-tip-icon" role="tooltip">
+          Icon-only triggers keep a 44×44px touch target for accessibility.
+        </span>
+      </div>
+
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/tada-click-accessible-tooltip/style.css
+++ b/submissions/examples/tada-click-accessible-tooltip/style.css
@@ -1,0 +1,101 @@
+.tada-modal {
+  --tada-duration: 0.6s;
+  --tada-easing: cubic-bezier(.36, .07, .19, 1.07);
+  --tada-scale-max: 1.1;
+  --tada-scale-min: 0.9;
+  --tada-overlay-bg: rgba(0, 0, 0, 0.55);
+}
+
+.tada-modal__toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  overflow: hidden;
+}
+
+.tada-modal__trigger {
+  display: inline-block;
+  padding: 0.6em 1.2em;
+  background: #4f46e5;
+  color: #fff;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.tada-modal__trigger:focus-visible,
+.tada-modal__toggle:focus-visible ~ .tada-modal__trigger {
+  outline: 3px solid #f59e0b;
+  outline-offset: 2px;
+}
+
+.tada-modal__overlay {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: transparent;
+  opacity: 0;
+  pointer-events: none;
+  transition: background var(--tada-duration) ease, opacity var(--tada-duration) ease;
+  z-index: 1000;
+}
+
+.tada-modal__toggle:checked ~ .tada-modal__overlay {
+  background: var(--tada-overlay-bg);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.tada-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  cursor: pointer;
+}
+
+.tada-modal__box {
+  position: relative;
+  background: #fff;
+  border-radius: 10px;
+  padding: 2rem;
+  max-width: min(90vw, 420px);
+  transform: scale(0);
+  opacity: 0;
+}
+
+.tada-modal__toggle:checked ~ .tada-modal__overlay .tada-modal__box {
+  animation: tada-pop var(--tada-duration) var(--tada-easing) forwards;
+}
+
+@keyframes tada-pop {
+  0%   { transform: scale(0);                    opacity: 0; }
+  50%  { transform: scale(var(--tada-scale-max)); opacity: 1; }
+  70%  { transform: scale(var(--tada-scale-min)); }
+  85%  { transform: scale(1.03); }
+  100% { transform: scale(1); }
+}
+
+.tada-modal__close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.75rem;
+  font-size: 1.4rem;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.tada-modal__close:focus-visible {
+  outline: 3px solid #f59e0b;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tada-modal__toggle:checked ~ .tada-modal__overlay .tada-modal__box {
+    animation: none;
+    transform: scale(1);
+    opacity: 1;
+  }
+  .tada-modal__overlay {
+    transition: none;
+  }
+}


### PR DESCRIPTION
### Description
This PR introduces the **Tada-Click Accessible Tooltip** to the submissions directory.

It is a pure CSS tooltip that pops up with a playful "tada" wiggle when clicked or focused (tabbed to). The animation relies on CSS variables for duration, scale, and rotation, making it easy to customize. It also includes comprehensive accessibility features like focus rings and reduced-motion support.

**Files included:**
- `submissions/examples/tada-click-accessible-tooltip/demo.html`
- `submissions/examples/tada-click-accessible-tooltip/style.css`
- `submissions/examples/tada-click-accessible-tooltip/README.md`

### Related Issue
Closes #<INSERT_ISSUE_NUMBER_HERE>

### Checklist
- [x] I have read the `CONTRIBUTING.md` guidelines.
- [x] I have placed my component inside the `submissions/` directory.
- [x] I have included `demo.html`, `style.css`, and `README.md`.
- [x] I have **NOT** edited any files in the `core/` or `components/` directories.
- [x] My commit history is squashed into a single clean commit.
