### PR TITLE
feat: add push notification banner slide animation (ease-push-notification-banner-mp)

### DIFF
--- a/submissions/examples/ease-push-notification-banner-mp/README.md
+++ b/submissions/examples/ease-push-notification-banner-mp/README.md
@@ -1,0 +1,20 @@
+# Push Notification Banner (ease-push-notification-banner-mp)
+
+### What does this do?
+A CSS-only push notification banner that slides down smoothly from the top of the screen to alert the user, then slides back up either automatically or when dismissed.
+
+### How is it used?
+```html
+<div class="push-notification-banner-mp" id="bannerMp">
+  <div class="banner-icon-mp">🔔</div>
+  <div class="banner-content-mp">
+    <p class="banner-title-mp">New Notification</p>
+    <p class="banner-text-mp">You have a new push notification waiting for you.</p>
+  </div>
+  <button class="banner-close-mp" onclick="hideBannerMp()">&times;</button>
+</div>
+```
+Toggle the `show-mp` class (to slide in) and `slide-out-mp` class (to slide out) via JavaScript to trigger the animation, as shown in `demo.html`.
+
+### Why is it useful?
+Push/toast-style notifications are a common UI need across dashboards, web apps, and landing pages. This component gives EaseMotion CSS a lightweight, dependency-free banner with a natural slide-in/slide-out motion that fits the framework's focus on smooth, purposeful micro-animations.

--- a/submissions/examples/ease-push-notification-banner-mp/demo.html
+++ b/submissions/examples/ease-push-notification-banner-mp/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Push Notification Banner Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <button class="trigger-btn-mp" onclick="showBannerMp()">Show Notification</button>
+
+  <div class="push-notification-banner-mp" id="bannerMp">
+    <div class="banner-icon-mp">🔔</div>
+    <div class="banner-content-mp">
+      <p class="banner-title-mp">New Notification</p>
+      <p class="banner-text-mp">You have a new push notification waiting for you.</p>
+    </div>
+    <button class="banner-close-mp" onclick="hideBannerMp()">&times;</button>
+  </div>
+
+  <script>
+    let hideTimer;
+
+    function showBannerMp() {
+      const banner = document.getElementById('bannerMp');
+      clearTimeout(hideTimer);
+      banner.classList.remove('slide-out-mp');
+      banner.classList.add('show-mp');
+
+      hideTimer = setTimeout(hideBannerMp, 4000);
+    }
+
+    function hideBannerMp() {
+      const banner = document.getElementById('bannerMp');
+      if (!banner.classList.contains('show-mp')) return;
+
+      banner.classList.add('slide-out-mp');
+      setTimeout(() => {
+        banner.classList.remove('show-mp', 'slide-out-mp');
+      }, 400);
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-push-notification-banner-mp/style.css
+++ b/submissions/examples/ease-push-notification-banner-mp/style.css
@@ -1,0 +1,110 @@
+body {
+  font-family: Arial, sans-serif;
+  height: 100vh;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f4f4f9;
+}
+
+.trigger-btn-mp {
+  padding: 12px 22px;
+  font-size: 15px;
+  border: none;
+  border-radius: 8px;
+  background: #4361ee;
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.trigger-btn-mp:hover {
+  background: #3a56d4;
+}
+
+.push-notification-banner-mp {
+  position: fixed;
+  top: -120px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 360px;
+  max-width: 90%;
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+  padding: 16px 18px;
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.push-notification-banner-mp.show-mp {
+  animation: slideDownBanner-mp 0.45s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  pointer-events: auto;
+}
+
+.push-notification-banner-mp.slide-out-mp {
+  animation: slideUpBanner-mp 0.4s ease-in forwards;
+}
+
+.banner-icon-mp {
+  font-size: 22px;
+  line-height: 1;
+}
+
+.banner-content-mp {
+  flex: 1;
+}
+
+.banner-title-mp {
+  margin: 0 0 4px 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: #1a1a2e;
+}
+
+.banner-text-mp {
+  margin: 0;
+  font-size: 13px;
+  color: #555;
+  line-height: 1.4;
+}
+
+.banner-close-mp {
+  border: none;
+  background: transparent;
+  font-size: 18px;
+  line-height: 1;
+  color: #999;
+  cursor: pointer;
+  padding: 0;
+}
+
+.banner-close-mp:hover {
+  color: #333;
+}
+
+@keyframes slideDownBanner-mp {
+  0% {
+    top: -120px;
+    opacity: 0;
+  }
+  100% {
+    top: 24px;
+    opacity: 1;
+  }
+}
+
+@keyframes slideUpBanner-mp {
+  0% {
+    top: 24px;
+    opacity: 1;
+  }
+  100% {
+    top: -120px;
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
Closes #37626

## Pull Request Description
Adds a CSS-only push notification banner component (ease-push-notification-banner-mp). It slides down from the top of the screen to alert the user and slides back up automatically or when dismissed, addressing issue #37626.

---

## Type of Change
- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (`submissions/examples/ease-push-notification-banner-mp/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A push notification banner that slides down smoothly from the top of the screen and slides back up on dismiss or after a timeout.

**How does a developer use it?**
```html
<div class="push-notification-banner-mp" id="bannerMp">
  <div class="banner-icon-mp">🔔</div>
  <div class="banner-content-mp">
    <p class="banner-title-mp">New Notification</p>
    <p class="banner-text-mp">You have a new push notification waiting for you.</p>
  </div>
  <button class="banner-close-mp" onclick="hideBannerMp()">&times;</button>
</div>
```
Toggle the `show-mp` class to trigger the slide-in, and `slide-out-mp` to trigger the slide-out, as demonstrated in `demo.html`.

**Why does it fit EaseMotion CSS?**
Push/toast-style banners are a common UI need, and this keeps the same lightweight, dependency-free, animation-first philosophy as the rest of the framework — no JS libraries, just a clean CSS keyframe transition.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Timing is set to a 4-second auto-dismiss with a 0.45s slide-in / 0.4s slide-out. Feel free to adjust the easing or duration to match the framework's existing animation tokens.