### PR TITLE
feat: add property listing card with image zoom (ease-property-card-listing-mp)

### DIFF
--- a/submissions/examples/ease-property-card-listing-mp/README.md
+++ b/submissions/examples/ease-property-card-listing-mp/README.md
@@ -1,0 +1,28 @@
+# Property Card Listing (ease-property-card-listing-mp)
+
+### What does this do?
+A CSS-only property listing card that lifts on hover and zooms its image smoothly, giving real-estate style listings a polished, interactive feel.
+
+### How is it used?
+```html
+<div class="property-card-listing-mp">
+  <div class="property-image-wrap-mp">
+    <img src="house.jpg" alt="House" class="property-image-mp">
+    <span class="property-badge-mp">For Sale</span>
+  </div>
+  <div class="property-info-mp">
+    <div class="property-price-mp">$450,000</div>
+    <h3 class="property-title-mp">Modern Family Home</h3>
+    <p class="property-location-mp">📍 Maple Street, Springfield</p>
+    <div class="property-meta-mp">
+      <span>🛏 4 Beds</span>
+      <span>🛁 3 Baths</span>
+      <span>📐 2,200 sqft</span>
+    </div>
+  </div>
+</div>
+```
+Hovering over `.property-card-listing-mp` lifts the whole card and zooms the image inside `.property-image-wrap-mp` via a scaled `.property-image-mp`.
+
+### Why is it useful?
+Property/listing cards are a very common real-world UI pattern (real estate, rentals, marketplaces). The image-zoom-on-hover effect is a subtle, purposeful micro-interaction that fits EaseMotion CSS's animation-first philosophy without requiring any JavaScript.

--- a/submissions/examples/ease-property-card-listing-mp/demo.html
+++ b/submissions/examples/ease-property-card-listing-mp/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Property Card Listing Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="property-card-listing-mp">
+    <div class="property-image-wrap-mp">
+      <img
+        src="https://images.unsplash.com/photo-1568605114967-8130f3a36994?w=500&auto=format&fit=crop&q=60"
+        alt="Modern house exterior"
+        class="property-image-mp">
+      <span class="property-badge-mp">For Sale</span>
+    </div>
+    <div class="property-info-mp">
+      <div class="property-price-mp">$450,000</div>
+      <h3 class="property-title-mp">Modern Family Home</h3>
+      <p class="property-location-mp">📍 Maple Street, Springfield</p>
+      <div class="property-meta-mp">
+        <span>🛏 4 Beds</span>
+        <span>🛁 3 Baths</span>
+        <span>📐 2,200 sqft</span>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-property-card-listing-mp/style.css
+++ b/submissions/examples/ease-property-card-listing-mp/style.css
@@ -1,0 +1,87 @@
+body {
+  font-family: Arial, sans-serif;
+  min-height: 100vh;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f4f4f9;
+}
+
+.property-card-listing-mp {
+  width: 320px;
+  background: #ffffff;
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.12);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.property-card-listing-mp:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.18);
+}
+
+.property-image-wrap-mp {
+  position: relative;
+  width: 100%;
+  height: 200px;
+  overflow: hidden;
+}
+
+.property-image-mp {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.5s ease;
+}
+
+.property-card-listing-mp:hover .property-image-mp {
+  transform: scale(1.15);
+}
+
+.property-badge-mp {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  background: #4361ee;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 5px 10px;
+  border-radius: 20px;
+}
+
+.property-info-mp {
+  padding: 16px 18px;
+}
+
+.property-price-mp {
+  font-size: 20px;
+  font-weight: 700;
+  color: #1a1a2e;
+  margin-bottom: 6px;
+}
+
+.property-title-mp {
+  margin: 0 0 6px 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: #222;
+}
+
+.property-location-mp {
+  margin: 0 0 12px 0;
+  font-size: 13px;
+  color: #777;
+}
+
+.property-meta-mp {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  color: #555;
+  border-top: 1px solid #eee;
+  padding-top: 10px;
+}


### PR DESCRIPTION
Closes #37623

## Pull Request Description
Adds a CSS-only property listing card component (ease-property-card-listing-mp). The card lifts on hover and zooms its image smoothly, addressing issue #37623.

---

## Type of Change
- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-property-card-listing-mp/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A property/real-estate listing card that lifts on hover and zooms its cover image with a smooth CSS transition.

**How does a developer use it?**
```html
<div class="property-card-listing-mp">
  <div class="property-image-wrap-mp">
    <img src="house.jpg" alt="House" class="property-image-mp">
    <span class="property-badge-mp">For Sale</span>
  </div>
  <div class="property-info-mp">
    <div class="property-price-mp">$450,000</div>
    <h3 class="property-title-mp">Modern Family Home</h3>
    <p class="property-location-mp">📍 Maple Street, Springfield</p>
    <div class="property-meta-mp">
      <span>🛏 4 Beds</span>
      <span>🛁 3 Baths</span>
      <span>📐 2,200 sqft</span>
    </div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Listing/card layouts are a common real-world UI pattern, and the hover lift + image zoom is a subtle, purposeful micro-interaction consistent with EaseMotion's animation-first, dependency-free philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Zoom uses `transform: scale(1.15)` on the image inside an `overflow: hidden` wrapper, and the card lift uses `translateY(-6px)`. Happy to adjust scale/lift values to match existing tokens.