### PR TITLE
feat: add promo code input with validation animation (ease-promo-code-input-mp)

### DIFF
--- a/submissions/examples/ease-promo-code-input-mp/README.md
+++ b/submissions/examples/ease-promo-code-input-mp/README.md
@@ -1,0 +1,20 @@
+# Promo Code Input (ease-promo-code-input-mp)
+
+### What does this do?
+A CSS-driven promo code input field that visually validates a code on submit — turning green with a success message for a valid code, or red with a shake animation for an invalid/empty one.
+
+### How is it used?
+```html
+<div class="promo-code-input-mp" id="promoWrapMp">
+  <label class="promo-label-mp" for="promoFieldMp">Promo Code</label>
+  <div class="promo-field-row-mp">
+    <input type="text" id="promoFieldMp" class="promo-field-mp" placeholder="Enter code">
+    <button class="promo-apply-btn-mp" onclick="checkPromoMp()">Apply</button>
+  </div>
+  <p class="promo-message-mp" id="promoMessageMp"></p>
+</div>
+```
+Toggle `promo-success-mp` or `promo-error-mp` (plus `shake-mp` for the shake) on the `.promo-code-input-mp` wrapper based on validation result, as shown in `demo.html`.
+
+### Why is it useful?
+Promo/coupon inputs are a near-universal e-commerce and checkout UI pattern. Giving instant visual feedback (color + shake) instead of a plain text error message makes validation feel immediate and satisfying, in line with EaseMotion CSS's animation-first, dependency-free philosophy.

--- a/submissions/examples/ease-promo-code-input-mp/demo.html
+++ b/submissions/examples/ease-promo-code-input-mp/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Promo Code Input Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="promo-code-input-mp" id="promoWrapMp">
+    <label class="promo-label-mp" for="promoFieldMp">Promo Code</label>
+    <div class="promo-field-row-mp">
+      <input
+        type="text"
+        id="promoFieldMp"
+        class="promo-field-mp"
+        placeholder="Enter code (try SAVE20)"
+        autocomplete="off">
+      <button class="promo-apply-btn-mp" onclick="checkPromoMp()">Apply</button>
+    </div>
+    <p class="promo-message-mp" id="promoMessageMp"></p>
+  </div>
+
+  <script>
+    const validCodes = ['SAVE20', 'WELCOME10'];
+
+    function checkPromoMp() {
+      const wrap = document.getElementById('promoWrapMp');
+      const field = document.getElementById('promoFieldMp');
+      const message = document.getElementById('promoMessageMp');
+      const code = field.value.trim().toUpperCase();
+
+      wrap.classList.remove('promo-success-mp', 'promo-error-mp', 'shake-mp');
+
+      if (!code) {
+        message.textContent = 'Please enter a promo code.';
+        wrap.classList.add('promo-error-mp', 'shake-mp');
+      } else if (validCodes.includes(code)) {
+        message.textContent = 'Promo code applied successfully! ✅';
+        wrap.classList.add('promo-success-mp');
+      } else {
+        message.textContent = 'Invalid promo code. Please try again.';
+        wrap.classList.add('promo-error-mp', 'shake-mp');
+      }
+
+      window.setTimeout(() => wrap.classList.remove('shake-mp'), 500);
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-promo-code-input-mp/style.css
+++ b/submissions/examples/ease-promo-code-input-mp/style.css
@@ -1,0 +1,102 @@
+body {
+  font-family: Arial, sans-serif;
+  min-height: 100vh;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f4f4f9;
+}
+
+.promo-code-input-mp {
+  width: 340px;
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 20px 22px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.12);
+}
+
+.promo-label-mp {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+  color: #333;
+  margin-bottom: 8px;
+}
+
+.promo-field-row-mp {
+  display: flex;
+  gap: 8px;
+}
+
+.promo-field-mp {
+  flex: 1;
+  padding: 10px 12px;
+  font-size: 14px;
+  border: 2px solid #ddd;
+  border-radius: 8px;
+  outline: none;
+  transition: border-color 0.3s ease;
+}
+
+.promo-field-mp:focus {
+  border-color: #4361ee;
+}
+
+.promo-apply-btn-mp {
+  padding: 10px 16px;
+  font-size: 14px;
+  font-weight: 600;
+  border: none;
+  border-radius: 8px;
+  background: #4361ee;
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.promo-apply-btn-mp:hover {
+  background: #3a56d4;
+}
+
+.promo-message-mp {
+  min-height: 18px;
+  margin: 10px 0 0 0;
+  font-size: 13px;
+  color: #666;
+}
+
+/* Success state */
+.promo-code-input-mp.promo-success-mp .promo-field-mp {
+  border-color: #2ecc71;
+  background: #f2fdf6;
+}
+
+.promo-code-input-mp.promo-success-mp .promo-message-mp {
+  color: #2ecc71;
+  font-weight: 600;
+}
+
+/* Error state */
+.promo-code-input-mp.promo-error-mp .promo-field-mp {
+  border-color: #e74c3c;
+  background: #fdf2f2;
+}
+
+.promo-code-input-mp.promo-error-mp .promo-message-mp {
+  color: #e74c3c;
+  font-weight: 600;
+}
+
+/* Shake animation for invalid submissions */
+.promo-code-input-mp.shake-mp {
+  animation: shakePromo-mp 0.4s ease;
+}
+
+@keyframes shakePromo-mp {
+  0%, 100% { transform: translateX(0); }
+  20% { transform: translateX(-8px); }
+  40% { transform: translateX(8px); }
+  60% { transform: translateX(-6px); }
+  80% { transform: translateX(6px); }
+}


### PR DESCRIPTION
Closes #37622

## Pull Request Description
Adds a CSS-driven promo code input component (ease-promo-code-input-mp) with a success state (green) and an error state (red + shake) for validation feedback, addressing issue #37622.

---

## Type of Change
- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-promo-code-input-mp/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A promo code input field that visually validates on submit — green success state for a valid code, red + shake for an invalid or empty one.

**How does a developer use it?**
```html
<div class="promo-code-input-mp" id="promoWrapMp">
  <label class="promo-label-mp" for="promoFieldMp">Promo Code</label>
  <div class="promo-field-row-mp">
    <input type="text" id="promoFieldMp" class="promo-field-mp" placeholder="Enter code">
    <button class="promo-apply-btn-mp" onclick="checkPromoMp()">Apply</button>
  </div>
  <p class="promo-message-mp" id="promoMessageMp"></p>
</div>
```

**Why does it fit EaseMotion CSS?**
Promo/coupon inputs are a near-universal checkout pattern. Instant visual feedback (color change + shake) instead of a plain error message feels more responsive, matching EaseMotion's animation-first, dependency-free philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
The shake keyframe uses small `translateX` offsets over 0.4s. Demo hardcodes two valid codes (`SAVE20`, `WELCOME10`) client-side purely for demonstration — real validation logic is left to the consuming app.