### PR TITLE
fix(ui): add mobile safe area insets for dashboard nav

### DIFF
--- a/submissions/examples/fix-mobile-nav/README.md
+++ b/submissions/examples/fix-mobile-nav/README.md
@@ -1,0 +1,7 @@
+# Mobile Navigation Safe Area Fix
+
+### Overview
+This submission updates the mobile dashboard navigation by incorporating `env(safe-area-inset-bottom)`. This prevents the bottom navigation bar from overlapping content or being hidden under the home indicator on modern mobile devices (like iPhones).
+
+### Fits EaseMotion
+Improves responsive UI quality and mobile UX without altering the core design framework.

--- a/submissions/examples/fix-mobile-nav/demo.html
+++ b/submissions/examples/fix-mobile-nav/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <title>Mobile Safe Area Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body style="margin: 0; padding: 0; background: #f4f4f4; height: 100vh;">
+    <div class="alm-dash-main" style="padding: 20px;">
+        <h2>Dashboard Content</h2>
+        <p>Scroll down. The bottom nav won't overlap this text on iPhones anymore!</p>
+    </div>
+    <div class="alm-dash-sidebar"
+        style="position: fixed; bottom: 0; width: 100%; background: #1f2937; color: white; display: flex; align-items: center; justify-content: center;">
+        📱 Mobile Nav Bar
+    </div>
+</body>
+
+</html>

--- a/submissions/examples/fix-mobile-nav/style.css
+++ b/submissions/examples/fix-mobile-nav/style.css
@@ -1,0 +1,10 @@
+@media (max-width: 768px) {
+    .alm-dash-sidebar {
+        height: calc(65px + env(safe-area-inset-bottom, 0px));
+        padding-bottom: env(safe-area-inset-bottom, 0px);
+    }
+
+    .alm-dash-main {
+        padding-bottom: calc(80px + env(safe-area-inset-bottom, 0px));
+    }
+}


### PR DESCRIPTION
## Pull Request Description
Added `env(safe-area-inset-bottom)` to fix mobile navigation overlap on devices with home indicators. Submitted in the `submissions/` directory as an isolated UI enhancement.

Fixes #37849

---
## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other: Responsive UI enhancement example

---
## Submission Checklist
- [x] All changes are inside `submissions/` 
- [x] Includes `demo.html` 
- [x] Includes `style.css` 
- [x] Includes `README.md` 
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---
## Browser Testing
- [x] Chrome
- [x] Edge
- [x] Safari *(optional but appreciated)*