### PR TITLE
feat: add capacity pulse board demo

### DIFF
--- a/submissions/examples/capacity-pulse-board/README.md
+++ b/submissions/examples/capacity-pulse-board/README.md
@@ -1,0 +1,15 @@
+# Capacity Pulse Board
+
+Capacity Pulse Board is a responsive infrastructure dashboard that summarizes compute, memory, and queue pressure. It uses visual pulse rings and short operational notes to show how close each system is to capacity limits.
+
+## Features
+
+- Peak capacity buffer summary
+- Three capacity metric cards
+- Circular visual indicators
+- Responsive layout for small screens
+
+## Files
+
+- `demo.html` contains the capacity pulse board markup.
+- `style.css` contains the ring indicators and responsive layout.

--- a/submissions/examples/capacity-pulse-board/demo.html
+++ b/submissions/examples/capacity-pulse-board/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Capacity Pulse Board</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="pulse">
+    <section class="intro">
+      <p>Infrastructure Health</p>
+      <h1>Capacity Pulse Board</h1>
+      <span>Peak buffer: 28%</span>
+    </section>
+
+    <section class="rings" aria-label="Capacity pulse metrics">
+      <article>
+        <div class="ring cpu">68%</div>
+        <strong>Compute</strong>
+        <p>Autoscaling active across three zones.</p>
+      </article>
+      <article>
+        <div class="ring memory">74%</div>
+        <strong>Memory</strong>
+        <p>Two services are approaching soft limits.</p>
+      </article>
+      <article>
+        <div class="ring queue">42%</div>
+        <strong>Queue</strong>
+        <p>Backlog remains below warning threshold.</p>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/capacity-pulse-board/style.css
+++ b/submissions/examples/capacity-pulse-board/style.css
@@ -1,0 +1,117 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #f1f5f2;
+  color: #17231c;
+  font-family: Inter, Arial, sans-serif;
+}
+
+.pulse {
+  width: min(1060px, 92vw);
+  display: grid;
+  grid-template-columns: 0.78fr 1.22fr;
+  gap: 22px;
+}
+
+.intro,
+.rings article {
+  background: #ffffff;
+  border: 1px solid #dce7dc;
+  border-radius: 8px;
+  box-shadow: 0 18px 42px rgba(42, 66, 45, 0.12);
+}
+
+.intro {
+  padding: 34px;
+}
+
+.intro p {
+  margin: 0 0 14px;
+  color: #3f8154;
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 28px;
+  font-size: clamp(2.4rem, 6vw, 4.8rem);
+  line-height: 0.95;
+}
+
+.intro span {
+  display: inline-block;
+  padding: 14px 16px;
+  background: #e3f4e7;
+  color: #2e7144;
+  border-radius: 8px;
+  font-weight: 900;
+}
+
+.rings {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+.rings article {
+  min-height: 280px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.ring {
+  width: 118px;
+  height: 118px;
+  margin-bottom: 24px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  color: #17231c;
+  font-size: 1.6rem;
+  font-weight: 900;
+}
+
+.cpu {
+  background: conic-gradient(#4d9b63 68%, #e2eadf 0);
+}
+
+.memory {
+  background: conic-gradient(#d89539 74%, #eee2d2 0);
+}
+
+.queue {
+  background: conic-gradient(#4e83b7 42%, #dfe8f1 0);
+}
+
+.rings strong {
+  margin-bottom: 10px;
+  font-size: 1.2rem;
+}
+
+.rings p {
+  margin: 0;
+  color: #647064;
+  line-height: 1.5;
+}
+
+@media (max-width: 820px) {
+  body {
+    padding: 28px 0;
+  }
+
+  .pulse,
+  .rings {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a responsive Capacity Pulse Board example
- include compute, memory, and queue capacity indicators

## Validation
- git diff --check