### PR TITLE
feat: add incident ownership roster demo

### DIFF
--- a/submissions/examples/incident-ownership-roster/README.md
+++ b/submissions/examples/incident-ownership-roster/README.md
@@ -1,0 +1,15 @@
+# Incident Ownership Roster
+
+Incident Ownership Roster is a responsive response-coverage panel for assigning incident roles. It shows the lead, service owner, and customer communications coverage in a compact roster view.
+
+## Features
+
+- Response coverage summary
+- Assigned and standby ownership states
+- Compact role cards
+- Responsive layout for mobile screens
+
+## Files
+
+- `demo.html` contains the incident ownership roster markup.
+- `style.css` contains the roster layout and status styling.

--- a/submissions/examples/incident-ownership-roster/demo.html
+++ b/submissions/examples/incident-ownership-roster/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Incident Ownership Roster</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="roster">
+    <section class="summary">
+      <p>Response Coverage</p>
+      <h1>Incident Ownership Roster</h1>
+      <span>Coverage locked for 8 hours</span>
+    </section>
+
+    <section class="owners" aria-label="Incident ownership roster">
+      <article>
+        <strong>Incident Lead</strong>
+        <span>Assigned</span>
+        <p>Coordinates timeline, decisions, and escalation notes.</p>
+      </article>
+      <article>
+        <strong>Service Owner</strong>
+        <span>Assigned</span>
+        <p>Owns mitigation work for the affected API group.</p>
+      </article>
+      <article>
+        <strong>Customer Comms</strong>
+        <span>Standby</span>
+        <p>Prepares status updates and support-facing language.</p>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/incident-ownership-roster/style.css
+++ b/submissions/examples/incident-ownership-roster/style.css
@@ -1,0 +1,105 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #f4f7fb;
+  color: #172132;
+  font-family: Inter, Arial, sans-serif;
+}
+
+.roster {
+  width: min(1040px, 92vw);
+  display: grid;
+  grid-template-columns: 0.82fr 1.18fr;
+  gap: 22px;
+}
+
+.summary,
+.owners article {
+  background: #ffffff;
+  border: 1px solid #dce4ef;
+  border-radius: 8px;
+  box-shadow: 0 18px 42px rgba(42, 58, 83, 0.12);
+}
+
+.summary {
+  padding: 34px;
+}
+
+.summary p {
+  margin: 0 0 14px;
+  color: #426eb4;
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 28px;
+  font-size: clamp(2.4rem, 6vw, 4.8rem);
+  line-height: 0.95;
+}
+
+.summary span {
+  display: inline-block;
+  padding: 14px 16px;
+  background: #e8f0ff;
+  color: #335d9f;
+  border-radius: 8px;
+  font-weight: 900;
+}
+
+.owners {
+  display: grid;
+  gap: 16px;
+}
+
+.owners article {
+  padding: 24px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+  align-items: start;
+}
+
+.owners strong {
+  font-size: 1.2rem;
+}
+
+.owners span {
+  padding: 8px 10px;
+  background: #e1f4ea;
+  color: #28714e;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.owners article:last-child span {
+  background: #fff0d7;
+  color: #956113;
+}
+
+.owners p {
+  grid-column: 1 / -1;
+  margin: 0;
+  color: #667184;
+  line-height: 1.55;
+}
+
+@media (max-width: 780px) {
+  body {
+    padding: 28px 0;
+  }
+
+  .roster,
+  .owners article {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a responsive Incident Ownership Roster example
- include incident lead, service owner, and customer communications coverage

## Validation
- git diff --check