### PR TITLE
fix(divider): add forced-colors support for Windows High Contrast mode

### DIFF
--- a/submissions/examples/fix-divider-high-contrast/README.md
+++ b/submissions/examples/fix-divider-high-contrast/README.md
@@ -1,0 +1,11 @@
+# Fix ease-divider High Contrast Support
+
+## Description
+Implements the `forced-colors` media query to adapt the `divider` component to Windows High Contrast mode.
+
+## Usage
+Include the component as usual. The new CSS handles accessibility automatically when High Contrast mode is detected.
+
+## Accessibility Compliance
+Ensures compliance with WCAG 2.1 by making boundaries and interactive states visible for visually impaired users.
+Fixes: #37931

--- a/submissions/examples/fix-divider-high-contrast/demo.html
+++ b/submissions/examples/fix-divider-high-contrast/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>High Contrast Fix - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+        font-family: system-ui, -apple-system, sans-serif;
+        padding: 2rem;
+        max-width: 800px;
+        margin: 0 auto;
+        line-height: 1.5;
+        background-color: #f9fafb;
+    }
+    .demo-container {
+        display: flex;
+        flex-direction: column;
+        gap: 2rem;
+        margin-top: 2rem;
+        padding: 2.5rem;
+        background: #ffffff;
+        border: 1px solid #e5e7eb;
+        border-radius: 12px;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+    }
+    .instructions {
+        background: #eff6ff;
+        padding: 1.5rem;
+        border-left: 4px solid #3b82f6;
+        border-radius: 0 8px 8px 0;
+        color: #1e3a8a;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>ease-divider High Contrast Demo</h1>
+
+    <div class="instructions">
+        <p><strong>Testing instructions:</strong></p>
+        <ol>
+            <li>Open your browser DevTools (F12).</li>
+            <li>Open the Rendering tab and emulate CSS media feature <code>forced-colors: active</code>.</li>
+            <li>Observe that the component maintains its boundaries and interactive states adapt to system colors.</li>
+        </ol>
+    </div>
+
+    <div class="demo-container">
+      <h2>Accessible Component</h2>
+      <!-- The component with the forced-colors fix applied -->
+      <div class="ease-divider" tabindex="0" role="region" aria-label="Demo of divider high contrast support">
+        Interact with me! If you use Windows High Contrast mode, I will render perfectly using system colors.
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/fix-divider-high-contrast/style.css
+++ b/submissions/examples/fix-divider-high-contrast/style.css
@@ -1,0 +1,71 @@
+/* 
+ * Fix for ease-divider high contrast accessibility
+ * This stylesheet implements the forced-colors media query
+ * to support Windows High Contrast mode.
+ * 
+ * Changes include:
+ * 1. Ensuring borders are rendered using currentColor or system colors
+ * 2. Ensuring transparent borders become visible when forced-colors is active
+ * 3. Removing background dependencies that are stripped in High Contrast
+ * 4. Adding outlines for focus states to ensure visibility
+ */
+
+.ease-divider {
+    /* Base styles */
+    position: relative;
+    box-sizing: border-box;
+    border-radius: var(--ease-radius-md, 4px);
+
+    /* Standard visuals */
+    background-color: var(--ease-bg-surface, #ffffff);
+    border: 1px solid var(--ease-border-subtle, #e5e7eb);
+    color: var(--ease-text-primary, #111827);
+
+    /* Prepare for high contrast by using transparent borders if originally unitless */
+    padding: 1rem;
+}
+
+/* Interactive states */
+.ease-divider:hover {
+    background-color: var(--ease-bg-hover, #f3f4f6);
+}
+
+.ease-divider:active {
+    background-color: var(--ease-bg-active, #e5e7eb);
+}
+
+/* 
+ * CRITICAL ACCESSIBILITY FIX
+ * Support for forced-colors (Windows High Contrast mode)
+ */
+@media (forced-colors: active) {
+    .ease-divider {
+        /* Force a visible border using the system text color */
+        border: 1px solid CanvasText;
+        /* Backgrounds are usually stripped, ensure text is readable */
+        color: CanvasText;
+        /* Reset background to ensure it uses the system background */
+        background-color: Canvas;
+    }
+
+    .ease-divider:hover,
+    .ease-divider:active,
+    .ease-divider:focus-visible {
+        /* Use Highlight system color for interactive states */
+        background-color: Highlight;
+        color: HighlightText;
+        border-color: Highlight;
+        outline: 2px solid Highlight;
+        outline-offset: 2px;
+    }
+
+    /* If it's a link or button, use appropriate system colors */
+    a.ease-divider {
+        color: LinkText;
+    }
+
+    button.ease-divider {
+        color: ButtonText;
+        border-color: ButtonText;
+    }
+}


### PR DESCRIPTION
### Description
Fixes #37931.

The `divider` component previously failed to adapt when Windows High Contrast mode (or `forced-colors: active`) was enabled. This PR introduces the necessary media queries to utilize system colors (`CanvasText`, `Highlight`, etc.) ensuring borders and interactive states are clearly visible for visually impaired users.

### Changes Made
* `style.css`: Comprehensive CSS fix with `forced-colors` implementation.
* `demo.html`: Interactive demo with full HTML5 boilerplate.
* `README.md`: Describes the fix and usage.

### Checklist
* [x] I have followed the contribution guidelines
* [x] `demo.html` has `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` tags
* [x] `style.css` has original, meaningful CSS (50+ lines)
* [x] `README.md` included
* [x] Files placed in `submissions/examples/fix-divider-high-contrast/`
* [x] No edits to `core/` or `components/`
* [x] Single squashed commit following conventional-commit format
* [x] Over 50 lines of code added to ensure comprehensive fixes