### PR TITLE
feat: add skeleton loader component

### DIFF
--- a/submissions/examples/skeleton-loader-ds/README.md
+++ b/submissions/examples/skeleton-loader-ds/README.md
@@ -1,0 +1,14 @@
+# Skeleton Loading Screen
+
+**What does this do?**
+Shows animated gray placeholder blocks (shimmer effect) while content is loading, instead of a blank screen or spinner.
+
+**How is it used?**
+```html
+<div class="skeleton skeleton-text"></div>
+<div class="skeleton skeleton-circle"></div>
+<div class="skeleton skeleton-block"></div>
+```
+
+**Why is it useful?**
+Skeleton screens are a standard UX pattern (used by LinkedIn, YouTube, etc.) that reduce perceived load time and prevent layout shift. EaseMotion CSS currently has hover/reveal effects but nothing for loading states — this fills that gap with a pure-CSS, zero-JS, accessible (respects prefers-reduced-motion) component.

--- a/submissions/examples/skeleton-loader-ds/demo.html
+++ b/submissions/examples/skeleton-loader-ds/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Skeleton Loader Demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body { font-family: sans-serif; padding: 40px; background: #111; }
+  .card { max-width: 300px; }
+</style>
+</head>
+<body>
+  <div class="card">
+    <div class="skeleton skeleton-block"></div>
+    <br>
+    <div class="skeleton skeleton-circle"></div>
+    <br>
+    <div class="skeleton skeleton-text"></div>
+    <div class="skeleton skeleton-text" style="width: 80%;"></div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/skeleton-loader-ds/style.css
+++ b/submissions/examples/skeleton-loader-ds/style.css
@@ -1,0 +1,37 @@
+.skeleton {
+  background-color: #e0e0e0;
+  background-image: linear-gradient(90deg, #e0e0e0 0px, #f0f0f0 40px, #e0e0e0 80px);
+  background-size: 600px 100%;
+  animation: skeleton-shimmer-ds 1.5s infinite linear;
+}
+
+.skeleton-text {
+  height: 12px;
+  width: 100%;
+  border-radius: 4px;
+  margin-bottom: 8px;
+}
+
+.skeleton-circle {
+  height: 48px;
+  width: 48px;
+  border-radius: 50%;
+}
+
+.skeleton-block {
+  height: 150px;
+  width: 100%;
+  border-radius: 8px;
+}
+
+@keyframes skeleton-shimmer-ds {
+  0% { background-position: -600px 0; }
+  100% { background-position: 600px 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    animation: none;
+    background-image: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a CSS-only skeleton loading screen component with three variants (text, circle, block). Skeleton screens are a common UX pattern for indicating content is loading while avoiding blank screens and layout shift.

Closes #38136

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A shimmering gray skeleton placeholder to indicate loading state, with text, circle, and block variants.

**How does a developer use it?**
```html
<div class="skeleton skeleton-text"></div>
<div class="skeleton skeleton-circle"></div>
<div class="skeleton skeleton-block"></div>
```

**Why does it fit EaseMotion CSS?**
The framework has hover and reveal effects but nothing for loading states. This is pure CSS, zero JS, human-readable class names, and respects `prefers-reduced-motion` for accessibility — consistent with the project's existing philosophy.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Used a generic `skeleton` class name in the submission per the contributing guide — happy to have it renamed to the `ease-` convention. Let me know if the shimmer timing or sizing needs adjusting.