### PR TITLE
feat : add ease-stat-cards-k553 submission

### DIFF
--- a/submissions/examples/ease-stat-cards-k553/README.md
+++ b/submissions/examples/ease-stat-cards-k553/README.md
@@ -1,0 +1,40 @@
+# Ease Stat Cards
+
+## What does this do?
+Dashboard statistic cards with a **staggered cascading entrance** and a
+**CSS/SVG stroke-draw sparkline** trend chart per card, in addition to an
+animated count-up number — rather than just a number counter with a uniform
+fade-in.
+
+## How is it different from a typical stat-cards utility?
+- Cards animate in sequence via a `--delay` custom property per card,
+  cascading rather than appearing all at once.
+- Each card includes a small SVG sparkline whose line "draws itself" in
+  using `stroke-dasharray`/`stroke-dashoffset`, timed to finish just after
+  the card's entrance.
+- Trend indicators (up/down %) are color-coded and match the sparkline
+  direction.
+- Uses `IntersectionObserver` so animations trigger when scrolled into view,
+  not just on page load.
+
+## How is it used?
+\`\`\`html
+<div class="ease-stat-card" style="--delay: 120ms" data-target="48250" data-prefix="$">
+  <div class="ease-stat-card__header">
+    <span class="label">Revenue</span>
+    <span class="trend trend--up">▲ 8%</span>
+  </div>
+  <div class="value">$0</div>
+  <svg class="sparkline" viewBox="0 0 100 30">
+    <polyline class="sparkline-path sparkline-path--up" points="..." />
+  </svg>
+</div>
+\`\`\`
+
+See `demo.html` for the JS driving the count-up and scroll-triggered reveal
+(all animation styling itself lives in `style.css`).
+
+## Why is this useful?
+Admin dashboards commonly show KPI cards, and a cascading reveal plus a
+lightweight trend visualization makes the data feel more alive and
+scannable at a glance — a strong real-world showcase for EaseMotion CSS.

--- a/submissions/examples/ease-stat-cards-k553/demo.html
+++ b/submissions/examples/ease-stat-cards-k553/demo.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ease Stat Cards Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <div class="ease-stats-grid">
+
+    <div class="ease-stat-card" style="--delay: 0ms" data-target="1284" data-suffix="">
+      <div class="ease-stat-card__header">
+        <span class="label">Users</span>
+        <span class="trend trend--up">▲ 12%</span>
+      </div>
+      <div class="value">0</div>
+      <svg class="sparkline" viewBox="0 0 100 30" preserveAspectRatio="none">
+        <polyline class="sparkline-path sparkline-path--up" points="0,25 15,20 30,22 45,14 60,16 75,8 100,4" />
+      </svg>
+    </div>
+
+    <div class="ease-stat-card" style="--delay: 120ms" data-target="48250" data-prefix="$">
+      <div class="ease-stat-card__header">
+        <span class="label">Revenue</span>
+        <span class="trend trend--up">▲ 8%</span>
+      </div>
+      <div class="value">$0</div>
+      <svg class="sparkline" viewBox="0 0 100 30" preserveAspectRatio="none">
+        <polyline class="sparkline-path sparkline-path--up" points="0,22 15,24 30,18 45,20 60,10 75,12 100,2" />
+      </svg>
+    </div>
+
+    <div class="ease-stat-card" style="--delay: 240ms" data-target="932" data-suffix="">
+      <div class="ease-stat-card__header">
+        <span class="label">Sales</span>
+        <span class="trend trend--down">▼ 3%</span>
+      </div>
+      <div class="value">0</div>
+      <svg class="sparkline" viewBox="0 0 100 30" preserveAspectRatio="none">
+        <polyline class="sparkline-path sparkline-path--down" points="0,5 15,10 30,8 45,16 60,14 75,22 100,26" />
+      </svg>
+    </div>
+
+    <div class="ease-stat-card" style="--delay: 360ms" data-target="15620" data-suffix="">
+      <div class="ease-stat-card__header">
+        <span class="label">Visitors</span>
+        <span class="trend trend--up">▲ 21%</span>
+      </div>
+      <div class="value">0</div>
+      <svg class="sparkline" viewBox="0 0 100 30" preserveAspectRatio="none">
+        <polyline class="sparkline-path sparkline-path--up" points="0,26 15,22 30,24 45,12 60,14 75,6 100,3" />
+      </svg>
+    </div>
+
+  </div>
+
+  <script>
+    function animateCount(el, target, prefix = '', suffix = '') {
+      const duration = 1200;
+      const start = performance.now();
+      function step(now) {
+        const progress = Math.min((now - start) / duration, 1);
+        const eased = 1 - Math.pow(1 - progress, 3);
+        const value = Math.round(target * eased);
+        el.textContent = prefix + value.toLocaleString() + suffix;
+        if (progress < 1) requestAnimationFrame(step);
+      }
+      requestAnimationFrame(step);
+    }
+
+    const cards = document.querySelectorAll('.ease-stat-card');
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          const card = entry.target;
+          card.classList.add('is-visible');
+          const valueEl = card.querySelector('.value');
+          const target = +card.dataset.target;
+          const prefix = card.dataset.prefix || '';
+          const suffix = card.dataset.suffix || '';
+          setTimeout(() => animateCount(valueEl, target, prefix, suffix), parseInt(getComputedStyle(card).getPropertyValue('--delay')) || 0);
+          observer.unobserve(card);
+        }
+      });
+    }, { threshold: 0.3 });
+
+    cards.forEach(card => observer.observe(card));
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-stat-cards-k553/style.css
+++ b/submissions/examples/ease-stat-cards-k553/style.css
@@ -1,0 +1,119 @@
+/* Ease Stat Cards
+   Adds staggered cascading entrance + a CSS/SVG stroke-draw sparkline
+   trend chart per card, instead of just a count-up number with a
+   uniform fade-in. */
+
+.ease-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1.25rem;
+  max-width: 1000px;
+  margin: 3rem auto;
+  font-family: system-ui, sans-serif;
+}
+
+.ease-stat-card {
+  background: #1a1a2a;
+  border-radius: 14px;
+  padding: 1.5rem;
+  color: #fff;
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 0.5s ease, transform 0.5s cubic-bezier(0.16, 1, 0.3, 1);
+  transition-delay: var(--delay, 0ms);
+}
+
+.ease-stat-card.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.ease-stat-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.label {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.6);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.trend {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+}
+
+.trend--up {
+  color: #22c55e;
+  background: rgba(34, 197, 94, 0.12);
+}
+
+.trend--down {
+  color: #ef4444;
+  background: rgba(239, 68, 68, 0.12);
+}
+
+.value {
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
+/* Sparkline stroke-draw animation */
+.sparkline {
+  width: 100%;
+  height: 32px;
+  overflow: visible;
+}
+
+.sparkline-path {
+  fill: none;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-dasharray: 200;
+  stroke-dashoffset: 200;
+  transition: stroke-dashoffset 1s ease-out;
+  transition-delay: calc(var(--delay, 0ms) + 300ms);
+}
+
+.ease-stat-card.is-visible .sparkline-path {
+  stroke-dashoffset: 0;
+}
+
+.sparkline-path--up {
+  stroke: #22c55e;
+}
+
+.sparkline-path--down {
+  stroke: #ef4444;
+}
+
+@media (max-width: 900px) {
+  .ease-stats-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 520px) {
+  .ease-stats-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-stat-card {
+    transition: opacity 0.4s ease;
+    transform: none;
+  }
+  .sparkline-path {
+    transition: none;
+    stroke-dashoffset: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-stat-cards`, animated dashboard statistic cards with a staggered cascading entrance and a self-drawing SVG sparkline trend chart per card. Closes #37896.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/ease-stat-cards/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Dashboard stat cards with animated count-up numbers, a staggered cascading entrance, and a self-drawing SVG sparkline trend chart per card.

**How does a developer use it?**

```html
<div class="ease-stat-card" style="--delay: 120ms" data-target="48250" data-prefix="$">
  <div class="value">$0</div>
  <svg class="sparkline">...</svg>
</div>