### PR TITLE
feat: add copy to clipboard button component

### DIFF
--- a/submissions/examples/copy-clipboard-ds/README.md
+++ b/submissions/examples/copy-clipboard-ds/README.md
@@ -1,0 +1,16 @@
+# Copy to Clipboard Button
+
+**What does this do?**
+A button that copies text to the clipboard and shows animated visual feedback — the icon pops and a "Copied!" tooltip briefly appears above the button.
+
+**How is it used?**
+```html
+<button class="copy-btn" data-copy-text="Hello World">
+  <span class="copy-icon">📋</span>
+  <span>Copy</span>
+  <span class="copy-tooltip">Copied!</span>
+</button>
+```
+
+**Why is it useful?**
+Copy-to-clipboard buttons are extremely common (code snippets, API keys, share links, referral codes) but EaseMotion CSS doesn't yet have one. This is a small, self-contained, reusable pattern with a clean animated confirmation, respecting `prefers-reduced-motion` for accessibility.

--- a/submissions/examples/copy-clipboard-ds/demo.html
+++ b/submissions/examples/copy-clipboard-ds/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Copy to Clipboard Demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body { font-family: sans-serif; padding: 40px; background: #111; color: #eee; }
+</style>
+</head>
+<body>
+  <button class="copy-btn" data-copy-text="Hello World">
+    <span class="copy-icon">📋</span>
+    <span>Copy</span>
+    <span class="copy-tooltip">Copied!</span>
+  </button>
+
+  <script>
+    document.querySelectorAll('.copy-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const text = btn.getAttribute('data-copy-text');
+        navigator.clipboard.writeText(text).then(() => {
+          btn.classList.add('copied');
+          setTimeout(() => btn.classList.remove('copied'), 1500);
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/copy-clipboard-ds/style.css
+++ b/submissions/examples/copy-clipboard-ds/style.css
@@ -1,0 +1,60 @@
+.copy-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  background: #f5f5f5;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.copy-btn:hover {
+  background: #ebebeb;
+}
+
+.copy-icon {
+  display: inline-block;
+  transition: transform 0.2s ease;
+}
+
+.copy-tooltip {
+  position: absolute;
+  top: -32px;
+  left: 50%;
+  transform: translateX(-50%) translateY(4px);
+  background: #222;
+  color: #fff;
+  font-size: 12px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.copy-btn.copied .copy-tooltip {
+  opacity: 1;
+  transform: translateX(-50%) translateY(-8px);
+}
+
+.copy-btn.copied .copy-icon {
+  animation: copy-pop 0.3s ease;
+}
+
+@keyframes copy-pop {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.3); }
+  100% { transform: scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .copy-icon,
+  .copy-tooltip {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a copy-to-clipboard button component with animated feedback — the icon pops and a "Copied!" tooltip briefly appears above the button after copying.

Closes #38154

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A button that copies text to the clipboard with animated visual confirmation (icon pop + tooltip).

**How does a developer use it?**
```html
<button class="copy-btn" data-copy-text="Hello World">
  <span class="copy-icon">📋</span>
  <span>Copy</span>
  <span class="copy-tooltip">Copied!</span>
</button>
```

**Why does it fit EaseMotion CSS?**
Copy-to-clipboard is an extremely common UI pattern (code snippets, share links, API keys) currently missing from the framework. It's self-contained, animation-first, and respects `prefers-reduced-motion` for accessibility — consistent with the project's philosophy.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Used a generic `copy-btn` class name per the contributing guide — happy to have it renamed to the `ease-` convention. The clipboard write uses the standard `navigator.clipboard.writeText` API.