### PR TITLE
feat : add skeleton level loading screen k553 submission

### DIFF
--- a/submissions/examples/skeleton-level-loading-screen-k553/README.md
+++ b/submissions/examples/skeleton-level-loading-screen-k553/README.md
@@ -1,0 +1,24 @@
+# Animated Skeleton Loading Screens
+
+A collection of reusable shimmer-animated skeleton loaders for common UI layouts, shown before real content loads.
+
+## Features
+- Profile skeleton (avatar + text lines)
+- Card skeleton (thumbnail + text lines)
+- Article skeleton (title + paragraph lines)
+- Product skeleton (thumbnail + name + price)
+- Smooth CSS-only shimmer animation via `background-position` keyframes
+- Fully responsive layout
+- Toggle button to preview skeleton vs. loaded state
+
+## Files
+- `demo.html` — Markup, skeleton/real content pairs, and toggle logic
+- `style.css` — Styling and shimmer animation
+
+## Usage
+1. Open `demo.html` in your browser.
+2. Click **"Toggle Loaded / Loading"** to switch between the skeleton placeholders and the real content, simulating a page load.
+3. Reuse the `.skeleton`, `.skeleton-line`, `.skeleton-avatar`, and `.skeleton-thumb` classes in your own layouts.
+
+## Customization
+Adjust shimmer speed via the `animation` duration on `.skeleton`, or change skeleton colors in the `background` gradient.

--- a/submissions/examples/skeleton-level-loading-screen-k553/demo.html
+++ b/submissions/examples/skeleton-level-loading-screen-k553/demo.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Animated Skeleton Loading Screens</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="page">
+
+  <h1>Skeleton Loading Examples</h1>
+  <button class="toggle-btn" id="toggleBtn">Toggle Loaded / Loading</button>
+
+  <!-- Profile Skeleton -->
+  <section class="demo-block">
+    <h2>Profile</h2>
+    <div class="profile-card">
+      <div class="skeleton skeleton-avatar" data-real="content"></div>
+      <div class="profile-info">
+        <div class="skeleton skeleton-line short" data-real="content"></div>
+        <div class="skeleton skeleton-line" data-real="content"></div>
+      </div>
+      <div class="profile-real hidden" data-real-content>
+        <img class="avatar" src="https://placehold.co/60x60/1f6feb/ffffff?text=U" alt="User">
+        <div class="profile-info">
+          <p class="name">Jordan Lee</p>
+          <p class="role">Frontend Developer</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Card Skeleton -->
+  <section class="demo-block">
+    <h2>Card</h2>
+    <div class="card">
+      <div class="skeleton skeleton-thumb" data-real="content"></div>
+      <div class="skeleton skeleton-line" data-real="content"></div>
+      <div class="skeleton skeleton-line short" data-real="content"></div>
+      <div class="card-real hidden" data-real-content>
+        <img class="thumb" src="https://placehold.co/280x140/238636/ffffff?text=Card" alt="Card thumbnail">
+        <p class="card-title">New Product Launch</p>
+        <p class="card-desc">Check out our latest release.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Article Skeleton -->
+  <section class="demo-block">
+    <h2>Article</h2>
+    <div class="article">
+      <div class="skeleton skeleton-line title" data-real="content"></div>
+      <div class="skeleton skeleton-line" data-real="content"></div>
+      <div class="skeleton skeleton-line" data-real="content"></div>
+      <div class="skeleton skeleton-line short" data-real="content"></div>
+      <div class="article-real hidden" data-real-content>
+        <p class="article-title">Understanding CSS Animations</p>
+        <p>CSS animations let you smoothly transition properties over time without JavaScript, improving perceived performance and UX.</p>
+        <p>They're widely used for loaders, transitions, and micro-interactions.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Product Skeleton -->
+  <section class="demo-block">
+    <h2>Product</h2>
+    <div class="product-card">
+      <div class="skeleton skeleton-thumb" data-real="content"></div>
+      <div class="skeleton skeleton-line short" data-real="content"></div>
+      <div class="skeleton skeleton-line shorter" data-real="content"></div>
+      <div class="product-real hidden" data-real-content>
+        <img class="thumb" src="https://placehold.co/280x140/8957e5/ffffff?text=Product" alt="Product">
+        <p class="product-name">Wireless Earbuds</p>
+        <p class="product-price">$59.99</p>
+      </div>
+    </div>
+  </section>
+
+</div>
+
+<script>
+  const toggleBtn = document.getElementById('toggleBtn');
+  let loaded = false;
+
+  toggleBtn.addEventListener('click', () => {
+    loaded = !loaded;
+
+    document.querySelectorAll('.skeleton').forEach(el => {
+      el.classList.toggle('hidden', loaded);
+    });
+
+    document.querySelectorAll('[data-real-content]').forEach(el => {
+      el.classList.toggle('hidden', !loaded);
+    });
+
+    toggleBtn.textContent = loaded ? 'Show Skeleton' : 'Toggle Loaded / Loading';
+  });
+</script>
+
+</body>
+</html>

--- a/submissions/examples/skeleton-level-loading-screen-k553/style.css
+++ b/submissions/examples/skeleton-level-loading-screen-k553/style.css
@@ -1,0 +1,199 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', Arial, sans-serif;
+  background: #0d1117;
+  color: #e6edf3;
+  padding: 40px 20px;
+}
+
+.page {
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+.page h1 {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.toggle-btn {
+  display: block;
+  margin: 0 auto 40px;
+  background: #1f6feb;
+  color: #fff;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.95rem;
+  transition: background 0.2s ease;
+}
+
+.toggle-btn:hover {
+  background: #388bfd;
+}
+
+.demo-block {
+  margin-bottom: 36px;
+}
+
+.demo-block h2 {
+  font-size: 1.1rem;
+  margin-bottom: 12px;
+  color: #8b949e;
+}
+
+/* Shared shimmer skeleton */
+.skeleton {
+  background: linear-gradient(
+    90deg,
+    #21262d 25%,
+    #30363d 37%,
+    #21262d 63%
+  );
+  background-size: 400% 100%;
+  animation: shimmer 1.4s ease-in-out infinite;
+  border-radius: 8px;
+}
+
+@keyframes shimmer {
+  0% { background-position: 100% 0; }
+  100% { background-position: -100% 0; }
+}
+
+.hidden {
+  display: none !important;
+}
+
+/* Profile skeleton */
+.profile-card {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 10px;
+  padding: 16px;
+}
+
+.skeleton-avatar {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.profile-info {
+  flex: 1;
+}
+
+.skeleton-line {
+  height: 14px;
+  margin-bottom: 10px;
+  width: 100%;
+}
+
+.skeleton-line.short { width: 70%; }
+.skeleton-line.shorter { width: 40%; }
+.skeleton-line.title { height: 20px; width: 80%; }
+
+.profile-real {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.profile-real .avatar {
+  border-radius: 50%;
+}
+
+.profile-real .name {
+  margin: 0 0 4px;
+  font-weight: 600;
+}
+
+.profile-real .role {
+  margin: 0;
+  color: #8b949e;
+  font-size: 0.9rem;
+}
+
+/* Card skeleton */
+.card, .card-real {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 10px;
+  padding: 16px;
+}
+
+.skeleton-thumb {
+  width: 100%;
+  height: 140px;
+  margin-bottom: 14px;
+}
+
+.card-real .thumb {
+  width: 100%;
+  border-radius: 8px;
+  margin-bottom: 12px;
+}
+
+.card-real .card-title {
+  margin: 0 0 6px;
+  font-weight: 600;
+}
+
+.card-real .card-desc {
+  margin: 0;
+  color: #8b949e;
+  font-size: 0.9rem;
+}
+
+/* Article skeleton */
+.article, .article-real {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 10px;
+  padding: 20px;
+}
+
+.article-real .article-title {
+  margin: 0 0 10px;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.article-real p {
+  color: #c9d1d9;
+  line-height: 1.6;
+}
+
+/* Product skeleton */
+.product-card, .product-real {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 10px;
+  padding: 16px;
+  max-width: 280px;
+}
+
+.product-real .product-name {
+  margin: 10px 0 4px;
+  font-weight: 600;
+}
+
+.product-real .product-price {
+  margin: 0;
+  color: #3fb950;
+  font-weight: 600;
+}
+
+@media (max-width: 480px) {
+  .profile-card {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a new "Animated Skeleton Loading Screens" example to `submissions/examples/`, featuring reusable shimmer-animated skeletons for profile, card, article, and product layouts — closes #37902.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/skeleton-loading-screen/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A set of four reusable skeleton loading placeholders (profile, card, article, product) with a CSS-only shimmer animation, shown before real content loads.

**How does a developer use it?**

```html
<div class="skeleton skeleton-avatar"></div>
<div class="skeleton skeleton-line"></div>
<div class="skeleton skeleton-line short"></div>