### PR TITLE
feat: make stat cards clickable with links

### DIFF
--- a/submissions/examples/stat-cards-links/README.md
+++ b/submissions/examples/stat-cards-links/README.md
@@ -1,0 +1,15 @@
+# Stat Cards with Links
+
+This submission fixes Issue #38156 by making stat cards clickable.  
+Each card now links to the relevant documentation section:
+
+- **42+ Utilities** → Utilities docs  
+- **12 Animations** → Animations docs  
+- **0 Dependencies** → Intro/Index docs  
+
+## Usage
+
+```html
+<a href="docs/utilities.html" class="stat-card">
+  <h2>42+ Utilities</h2>
+</a>

--- a/submissions/examples/stat-cards-links/demo.html
+++ b/submissions/examples/stat-cards-links/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>EaseMotion Stat Cards Links Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="stats-container">
+    <!-- Linked Stat Cards -->
+    <a href="https://saptarshi-coder.github.io/EaseMotion-css/docs/utilities.html" class="stat-card">
+      <h2>42+ Utilities</h2>
+      <p>Explore layout, buttons, and more</p>
+    </a>
+
+    <a href="https://saptarshi-coder.github.io/EaseMotion-css/docs/animations.html" class="stat-card">
+      <h2>12 Animations</h2>
+      <p>See all motion effects</p>
+    </a>
+
+    <a href="https://saptarshi-coder.github.io/EaseMotion-css/docs/index.html" class="stat-card">
+      <h2>0 Dependencies</h2>
+      <p>Lightweight, zero-config framework</p>
+    </a>
+  </div>
+</body>
+</html>

--- a/submissions/examples/stat-cards-links/style.css
+++ b/submissions/examples/stat-cards-links/style.css
@@ -1,0 +1,23 @@
+.stats-container {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  margin-top: 2rem;
+}
+
+.stat-card {
+  display: block;
+  padding: 1.5rem;
+  background: #f9f9f9;
+  border-radius: 8px;
+  text-align: center;
+  text-decoration: none;
+  color: #333;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.stat-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  color: #007bff;
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes Issue #38156 by making stat cards clickable.  
Each card now links to the relevant documentation section, improving navigation.

---

## Type of Change

- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/stat-cards-links/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**  
Clickable stat cards that link to docs.

**How does a developer use it?**
```html
<a href="docs/utilities.html" class="stat-card">
  <h2>42+ Utilities</h2>
</a>


Thanks for reviewing my PR!