### PR TITLE
feat: add copy-to-clipboard button for class names

### DIFF
--- a/submissions/examples/copy-class-button/README.md
+++ b/submissions/examples/copy-class-button/README.md
@@ -1,0 +1,12 @@
+# Copy-to-Clipboard Button for Class Names
+
+This submission fixes Issue #38157 by adding a small "Copy" button next to class name examples.  
+Users can now copy class names like `ease-fade-in` or `ease-hover-grow` with one click.
+
+## Usage
+
+```html
+<div class="class-example">
+  <code>ease-fade-in</code>
+  <button class="copy-btn" data-class="ease-fade-in">Copy</button>
+</div>

--- a/submissions/examples/copy-class-button/demo.html
+++ b/submissions/examples/copy-class-button/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>EaseMotion Copy Class Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h2>Class Name Examples</h2>
+
+  <div class="class-example">
+    <code>ease-fade-in</code>
+    <button class="copy-btn" data-class="ease-fade-in">Copy</button>
+  </div>
+
+  <div class="class-example">
+    <code>ease-hover-grow</code>
+    <button class="copy-btn" data-class="ease-hover-grow">Copy</button>
+  </div>
+
+  <div class="class-example">
+    <code>ease-slide-up</code>
+    <button class="copy-btn" data-class="ease-slide-up">Copy</button>
+  </div>
+
+  <script>
+    document.querySelectorAll(".copy-btn").forEach(btn => {
+      btn.addEventListener("click", () => {
+        const className = btn.getAttribute("data-class");
+        navigator.clipboard.writeText(className).then(() => {
+          btn.textContent = "Copied!";
+          setTimeout(() => btn.textContent = "Copy", 1500);
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/copy-class-button/style.css
+++ b/submissions/examples/copy-class-button/style.css
@@ -1,0 +1,27 @@
+.class-example {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+code {
+  background: #f4f4f4;
+  padding: 0.3rem 0.6rem;
+  border-radius: 4px;
+  font-family: monospace;
+}
+
+.copy-btn {
+  padding: 0.3rem 0.6rem;
+  border: none;
+  background: #007bff;
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.copy-btn:hover {
+  background: #0056b3;
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes Issue #38157 by adding a copy-to-clipboard button next to class name examples.  
Users can now copy class names like `ease-fade-in` or `ease-hover-grow` with one click.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/copy-class-button/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**  
A copy-to-clipboard button for class name examples.

**How does a developer use it?**
```html
<button class="copy-btn" data-class="ease-fade-in">Copy</button>


Thanks for reviewing my PR!