### PR TITLE
fix: add keyboard/tap support to animation boxes

### DIFF
--- a/submissions/examples/animation-box-accessibility/README.md
+++ b/submissions/examples/animation-box-accessibility/README.md
@@ -1,0 +1,11 @@
+# Accessible Animation Boxes
+
+This submission fixes Issue #38159 by making animation showcase boxes keyboard/tap accessible.  
+Boxes now behave like buttons: they can be focused with Tab, activated with Enter/Space, and replay their animation.
+
+## Usage
+
+```html
+<div class="animation-box" tabindex="0" role="button" aria-label="Replay fade-in animation">
+  ease-fade-in
+</div>

--- a/submissions/examples/animation-box-accessibility/demo.html
+++ b/submissions/examples/animation-box-accessibility/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Accessible Animation Boxes Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h2>Accessible Motion Library</h2>
+
+  <!-- Accessible animation box -->
+  <div class="animation-box" tabindex="0" role="button" aria-label="Replay fade-in animation">
+    ease-fade-in
+  </div>
+
+  <div class="animation-box" tabindex="0" role="button" aria-label="Replay hover-grow animation">
+    ease-hover-grow
+  </div>
+
+  <script>
+    function replayAnimation(el) {
+      el.classList.remove("animate");
+      void el.offsetWidth; // trigger reflow
+      el.classList.add("animate");
+    }
+
+    document.querySelectorAll(".animation-box").forEach(box => {
+      // Mouse click
+      box.addEventListener("click", () => replayAnimation(box));
+
+      // Keyboard support
+      box.addEventListener("keydown", e => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          replayAnimation(box);
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/animation-box-accessibility/style.css
+++ b/submissions/examples/animation-box-accessibility/style.css
@@ -1,0 +1,19 @@
+.animation-box {
+  display: inline-block;
+  padding: 1rem 2rem;
+  margin: 1rem;
+  background: #f4f4f4;
+  border: 2px solid #ccc;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: transform 0.3s ease;
+}
+
+.animation-box.animate {
+  transform: scale(1.1);
+  background: #e0f7ff;
+}
+
+.animation-box:focus {
+  outline: 3px solid #007bff;
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes Issue #38159 by adding keyboard/tap support to animation showcase boxes.  
Boxes now act like buttons: focusable with Tab, triggerable with Enter/Space, and replay their animation.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component / accessibility improvement
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/animation-box-accessibility/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**  
Keyboard/tap accessibility for animation showcase boxes.

**How does a developer use it?**
```html
<div class="animation-box" tabindex="0" role="button">ease-fade-in</div>


Thanks for reviewing my PR!