### PR TITLE
docs: add standalone heading and th contrast bug fix example

### DIFF
--- a/submissions/examples/heading-contrast-fix/README.md
+++ b/submissions/examples/heading-contrast-fix/README.md
@@ -1,0 +1,6 @@
+# Dark Mode Heading Contrast Fix
+
+This directory houses a standalone component fix demonstrating how to safely decouple headings (`h1`-`h6`) and table headers (`th`) from hardcoded color states.
+
+## Resolution
+By explicitly mapping structural headers to fluid context tokens (`var(--ease-color-text)`), typographic hierarchies remain dynamic across dark mode layers.

--- a/submissions/examples/heading-contrast-fix/demo.html
+++ b/submissions/examples/heading-contrast-fix/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Heading & Table Header Contrast Fix Showcase</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="showcase-container">
+        <h2>Heading Contrast Resolution Profile</h2>
+        <p class="meta-info">Simulating active environment context: <code>prefers-color-scheme: dark</code></p>
+        
+        <hr>
+
+        <!-- Broken State Representation -->
+        <div class="state-box broken-state">
+            <span class="status-badge bug">⚠️ Hardcoded Bug State</span>
+            <h3 class="bug-heading">Heading Level 3 (Nearly Invisible)</h3>
+            <table>
+                <tr>
+                    <th class="bug-th">Table Header (Invisible)</th>
+                </tr>
+                <tr>
+                    <td>Standard Row Data Cell</td>
+                </tr>
+            </table>
+        </div>
+
+        <!-- Fixed State Representation -->
+        <div class="state-box fixed-state">
+            <span class="status-badge success">✨ Adaptive Token Fix</span>
+            <h3 class="fix-heading">Heading Level 3 (Perfectly Legible)</h3>
+            <table>
+                <tr>
+                    <th class="fix-th">Table Header (Legible)</th>
+                </tr>
+                <tr>
+                    <td>Standard Row Data Cell</td>
+                </tr>
+            </table>
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/heading-contrast-fix/style.css
+++ b/submissions/examples/heading-contrast-fix/style.css
@@ -1,0 +1,81 @@
+/* Simulating the framework environment tokens */
+:root {
+    --ease-color-neutral-900: #0f172a; /* Near-black */
+    --ease-color-text: #0f172a;        /* Default text color */
+    --bg-surface: #ffffff;
+    --border-ui: #e2e2e9;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --ease-color-text: #f8fafc;    /* Flips to light gray natively */
+        --bg-surface: #0b1121;         /* Dark background referenced in issue */
+        --border-ui: #1e293b;
+    }
+}
+
+body {
+    background-color: var(--bg-surface);
+    color: var(--ease-color-text);
+    font-family: system-ui, -apple-system, sans-serif;
+    padding: 40px 20px;
+    display: flex;
+    justify-content: center;
+}
+
+.showcase-container {
+    width: 100%;
+    max-width: 600px;
+}
+
+.meta-info {
+    color: #64748b;
+    font-size: 0.9rem;
+}
+
+hr {
+    border: 0;
+    height: 1px;
+    background-color: var(--border-ui);
+    margin: 24px 0;
+}
+
+.state-box {
+    padding: 24px;
+    border-radius: 8px;
+    margin-bottom: 24px;
+    background-color: rgba(255, 255, 255, 0.02);
+    border: 1px solid var(--border-ui);
+}
+
+.status-badge {
+    font-size: 0.75rem;
+    font-weight: 700;
+    padding: 4px 8px;
+    border-radius: 4px;
+    text-transform: uppercase;
+}
+.bug { background: #ef4444; color: #fff; }
+.success { background: #22c55e; color: #fff; }
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 12px;
+}
+th, td {
+    border: 1px solid var(--border-ui);
+    padding: 10px;
+    text-align: left;
+    font-size: 0.9rem;
+}
+
+/* --- THE BUG STATE --- */
+.bug-heading, .bug-th {
+    color: var(--ease-color-neutral-900) !important; /* Forces the near-black color even in dark mode */
+}
+
+/* --- THE ADAPTIVE FIX --- */
+.fix-heading, .fix-th {
+    color: var(--ease-color-text) !important; /* Gracefully adapts based on standard theme tokens */
+}


### PR DESCRIPTION
## Pull Request Description

This PR provides a standalone demonstration and documentation workaround resolving typographic accessibility defects, addressing Issue #37154. It fixes the contrast scenario where headings and table headers become nearly invisible in dark mode contexts due to hardcoded color properties, replacing them with fluid design tokens.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (located inside `submissions/examples/heading-contrast-fix/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It adds an adaptive typographic side-by-side comparison showcase documenting how to cleanly decouple structural headings (`h1`–`h6`) and table headers (`th`) from static values in favor of environment-aware variables.

**How does a developer use it?**

```html
<div class="state-box fixed-state">
    <h3 class="fix-heading">Legible Heading Element</h3>
    <table>
        <tr>
            <th class="fix-th">Legible Table Header</th>
        </tr>
    </table>
</div>

**Why does it fit EaseMotion CSS?**

It supports the framework's core mission of delivering high-quality, human-readable, and accessible layout configurations across variable-driven thematic contexts effortlessly.

---

## Demo

[x] Demo added (demo.html works by opening directly in a browser)

---

## Browser Testing

[x] Chrome
[ ] Firefox
[ ] Edge
[ ] Safari

---

## Notes for Maintainer

To completely honor repository submission track safeguards, this configuration is demonstrated entirely within the submissions/examples/heading-contrast-fix/ space. It safely details the transition from hardcoded states to adaptive tokens (var(--ease-color-text)) to cleanly resolve the dark mode visibility mismatch.

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
