### PR TITLE
feat: add react wrappers components

### DIFF
--- a/submissions/examples/react-animation-wrappers-28243/README.md
+++ b/submissions/examples/react-animation-wrappers-28243/README.md
@@ -1,0 +1,28 @@
+# React Animation Wrappers for EaseMotion
+
+This example implements a full suite of React wrapper components for EaseMotion CSS animations, resolving issue #28243.
+
+## Included Components
+- **`<Animate>`**: A declarative component that supports properties like `type`, `duration`, `delay`, `iteration`, `onStart`, and `onEnd`.
+- **`<Hover>`**: Dedicated wrapper for hover interactions (`lift`, `scale`, `glow`, `shake`).
+- **`<ScrollReveal>`**: Wraps an element and utilizes the IntersectionObserver API to trigger animations when scrolled into view.
+
+## Usage
+Simply import the components into your React project:
+```jsx
+import { Animate, Hover, ScrollReveal } from './components';
+
+export default function App() {
+  return (
+    <ScrollReveal type="fade-in">
+      <Hover effect="lift">
+        <Animate type="zoom-in" duration={500}>
+          Hello EaseMotion
+        </Animate>
+      </Hover>
+    </ScrollReveal>
+  );
+}
+```
+
+Tests have been provided using `@testing-library/react`.

--- a/submissions/examples/react-animation-wrappers-28243/demo.html
+++ b/submissions/examples/react-animation-wrappers-28243/demo.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>React Animation Wrappers for EaseMotion</title>
+  
+  <!-- EaseMotion core styles placeholder - assuming available or we emulate standard animations -->
+  <link rel="stylesheet" href="../../../style.css" />
+  <link rel="stylesheet" href="style.css" />
+  
+  <!-- React & ReactDOM -->
+  <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
+  
+  <!-- Babel Standalone for JSX compilation -->
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+
+  <script type="text/babel">
+    const { useState, useEffect, useRef } = React;
+
+    // --- Animate.jsx (Mocked here for the Demo) ---
+    function Animate({ type, duration = 'medium', delay = 0, iteration = 1, onStart, onEnd, tag: Tag = 'div', className = '', style = {}, children, ...props }) {
+      const classes = [];
+      if (type) classes.push(`ease-animate-${type}`);
+      if (['fast', 'medium', 'slow'].includes(duration)) classes.push(`ease-duration-${duration}`);
+      if (iteration === 'infinite') classes.push('ease-iterate-infinite');
+      if (className) classes.push(className);
+
+      const inlineStyle = { ...style };
+      if (delay > 0) { inlineStyle.animationDelay = `${delay}ms`; inlineStyle.transitionDelay = `${delay}ms`; }
+      if (typeof duration === 'number') { inlineStyle.animationDuration = `${duration}ms`; inlineStyle.transitionDuration = `${duration}ms`; }
+      if (typeof iteration === 'number' && iteration !== 1) { inlineStyle.animationIterationCount = iteration; }
+
+      return <Tag className={classes.join(' ')} style={inlineStyle} onAnimationStart={onStart} onAnimationEnd={onEnd} {...props}>{children}</Tag>;
+    }
+
+    // --- Hover.jsx (Mocked here for the Demo) ---
+    function Hover({ effect = 'lift', tag: Tag = 'div', className = '', children, ...props }) {
+      const classes = [`ease-hover-${effect}`];
+      if (className) classes.push(className);
+      return <Tag className={classes.join(' ')} {...props}>{children}</Tag>;
+    }
+
+    // --- ScrollReveal.jsx (Mocked here for the Demo) ---
+    function ScrollReveal({ type = 'fade-in', threshold = 0.1, rootMargin = '0px', triggerOnce = true, children, ...animateProps }) {
+      const [isVisible, setIsVisible] = useState(false);
+      const ref = useRef(null);
+
+      useEffect(() => {
+        const observer = new IntersectionObserver(([entry]) => {
+          if (entry.isIntersecting) {
+            setIsVisible(true);
+            if (triggerOnce && ref.current) observer.unobserve(ref.current);
+          } else if (!triggerOnce) {
+            setIsVisible(false);
+          }
+        }, { threshold, rootMargin });
+        if (ref.current) observer.observe(ref.current);
+        return () => { if (ref.current) observer.unobserve(ref.current); };
+      }, [threshold, rootMargin, triggerOnce]);
+
+      return (
+        <div ref={ref} style={{ opacity: isVisible ? 1 : 0, transition: 'opacity 0.5s ease-in-out' }}>
+          {isVisible ? <Animate type={type} {...animateProps}>{children}</Animate> : <div style={{ visibility: 'hidden' }}>{children}</div>}
+        </div>
+      );
+    }
+
+    // --- App Component ---
+    function App() {
+      return (
+        <div className="demo-container">
+          <header className="demo-header">
+            <Animate type="zoom-in" duration={800} tag="h1">React Wrappers for EaseMotion</Animate>
+            <Animate type="fade-in" delay={500} tag="p">A declarative way to use beautiful animations in modern JSX environments.</Animate>
+          </header>
+
+          <section className="demo-section">
+            <h2>&lt;Hover&gt; Component</h2>
+            <div className="card-grid">
+              <Hover effect="lift" className="demo-card">Lift Effect</Hover>
+              <Hover effect="scale" className="demo-card">Scale Effect</Hover>
+              <Hover effect="glow" className="demo-card">Glow Effect</Hover>
+              <Hover effect="shake" className="demo-card">Shake Effect</Hover>
+            </div>
+          </section>
+
+          <section className="demo-section">
+            <h2>&lt;ScrollReveal&gt; Component</h2>
+            <p className="spacer-text">Scroll down to see the reveal effect in action...</p>
+            <div style={{ height: '500px' }}></div>
+            
+            <ScrollReveal type="slide-up" duration={1000} threshold={0.5}>
+              <div className="demo-card reveal-card">
+                <h3>I Reveal on Scroll!</h3>
+                <p>This component leverages IntersectionObserver to trigger EaseMotion entry classes when intersecting the viewport.</p>
+              </div>
+            </ScrollReveal>
+          </section>
+        </div>
+      );
+    }
+
+    const root = ReactDOM.createRoot(document.getElementById('root'));
+    root.render(<App />);
+  </script>
+</body>
+</html>

--- a/submissions/examples/react-animation-wrappers-28243/src/components/Animate.jsx
+++ b/submissions/examples/react-animation-wrappers-28243/src/components/Animate.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function Animate({
+  type,
+  duration = 'medium',
+  delay = 0,
+  iteration = 1,
+  onStart,
+  onEnd,
+  tag: Tag = 'div',
+  className = '',
+  style = {},
+  children,
+  ...props
+}) {
+  const classes = [];
+  if (type) classes.push(`ease-animate-${type}`);
+  if (['fast', 'medium', 'slow'].includes(duration)) classes.push(`ease-duration-${duration}`);
+  if (iteration === 'infinite') classes.push('ease-iterate-infinite');
+  if (className) classes.push(className);
+
+  const inlineStyle = { ...style };
+  if (delay > 0) {
+    inlineStyle.animationDelay = `${delay}ms`;
+    inlineStyle.transitionDelay = `${delay}ms`;
+  }
+  if (typeof duration === 'number') {
+    inlineStyle.animationDuration = `${duration}ms`;
+    inlineStyle.transitionDuration = `${duration}ms`;
+  }
+  if (typeof iteration === 'number' && iteration !== 1) {
+    inlineStyle.animationIterationCount = iteration;
+  }
+
+  return (
+    <Tag 
+      className={classes.join(' ')} 
+      style={inlineStyle} 
+      onAnimationStart={onStart}
+      onAnimationEnd={onEnd}
+      {...props}
+    >
+      {children}
+    </Tag>
+  );
+}
+
+Animate.propTypes = {
+  type: PropTypes.string,
+  duration: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  delay: PropTypes.number,
+  iteration: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  onStart: PropTypes.func,
+  onEnd: PropTypes.func,
+  tag: PropTypes.elementType,
+  className: PropTypes.string,
+  style: PropTypes.object,
+  children: PropTypes.node
+};

--- a/submissions/examples/react-animation-wrappers-28243/src/components/Hover.jsx
+++ b/submissions/examples/react-animation-wrappers-28243/src/components/Hover.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function Hover({
+  effect = 'lift',
+  tag: Tag = 'div',
+  className = '',
+  children,
+  ...props
+}) {
+  const classes = [`ease-hover-${effect}`];
+  if (className) classes.push(className);
+
+  return (
+    <Tag className={classes.join(' ')} {...props}>
+      {children}
+    </Tag>
+  );
+}
+
+Hover.propTypes = {
+  effect: PropTypes.oneOf(['lift', 'scale', 'shake', 'glow']),
+  tag: PropTypes.elementType,
+  className: PropTypes.string,
+  children: PropTypes.node
+};

--- a/submissions/examples/react-animation-wrappers-28243/src/components/ScrollReveal.jsx
+++ b/submissions/examples/react-animation-wrappers-28243/src/components/ScrollReveal.jsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import Animate from './Animate';
+
+export default function ScrollReveal({
+  type = 'fade-in',
+  threshold = 0.1,
+  rootMargin = '0px',
+  triggerOnce = true,
+  children,
+  ...animateProps
+}) {
+  const [isVisible, setIsVisible] = useState(false);
+  const ref = useRef(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          if (triggerOnce && ref.current) {
+            observer.unobserve(ref.current);
+          }
+        } else if (!triggerOnce) {
+          setIsVisible(false);
+        }
+      },
+      { threshold, rootMargin }
+    );
+
+    if (ref.current) {
+      observer.observe(ref.current);
+    }
+
+    return () => {
+      if (ref.current) observer.unobserve(ref.current);
+    };
+  }, [threshold, rootMargin, triggerOnce]);
+
+  return (
+    <div ref={ref} style={{ opacity: isVisible ? 1 : 0, transition: 'opacity 0.1s' }}>
+      {isVisible ? (
+        <Animate type={type} {...animateProps}>
+          {children}
+        </Animate>
+      ) : (
+        <div style={{ visibility: 'hidden' }}>{children}</div>
+      )}
+    </div>
+  );
+}
+
+ScrollReveal.propTypes = {
+  type: PropTypes.string,
+  threshold: PropTypes.number,
+  rootMargin: PropTypes.string,
+  triggerOnce: PropTypes.bool,
+  children: PropTypes.node
+};

--- a/submissions/examples/react-animation-wrappers-28243/style.css
+++ b/submissions/examples/react-animation-wrappers-28243/style.css
@@ -1,0 +1,108 @@
+/* custom styles for the demo to pass validation */
+:root {
+  --primary-color: #3f51b5;
+  --bg-color: #121212;
+  --surface-color: #1e1e1e;
+  --text-color: #ffffff;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+
+.demo-container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.demo-header {
+  text-align: center;
+  padding: 4rem 0;
+}
+
+.demo-header h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+  background: linear-gradient(90deg, #bb86fc, #03dac6);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.demo-section {
+  margin: 4rem 0;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+.demo-card {
+  background-color: var(--surface-color);
+  border-radius: 8px;
+  padding: 2rem;
+  text-align: center;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.reveal-card {
+  background: linear-gradient(135deg, #1f1c2c, #928dab);
+  color: white;
+  padding: 3rem;
+}
+
+.spacer-text {
+  color: #888;
+  font-style: italic;
+}
+
+/* Fallback EaseMotion classes for standalone demo */
+.ease-animate-zoom-in {
+  animation: ease-zoom-in 1s both;
+}
+.ease-animate-fade-in {
+  animation: ease-fade-in 1s both;
+}
+.ease-animate-slide-up {
+  animation: ease-slide-up 1s both;
+}
+.ease-hover-lift:hover {
+  transform: translateY(-8px);
+  box-shadow: 0 10px 20px rgba(0,0,0,0.2);
+}
+.ease-hover-scale:hover {
+  transform: scale(1.05);
+}
+.ease-hover-glow:hover {
+  box-shadow: 0 0 15px rgba(3, 218, 198, 0.5);
+}
+.ease-hover-shake:hover {
+  animation: ease-shake 0.5s;
+}
+
+@keyframes ease-zoom-in {
+  from { opacity: 0; transform: scale(0.8); }
+  to { opacity: 1; transform: scale(1); }
+}
+@keyframes ease-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+@keyframes ease-slide-up {
+  from { opacity: 0; transform: translateY(50px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes ease-shake {
+  0%, 100% { transform: translateX(0); }
+  25% { transform: translateX(-5px); }
+  50% { transform: translateX(5px); }
+  75% { transform: translateX(-5px); }
+}

--- a/submissions/examples/react-animation-wrappers-28243/tests/Animate.test.jsx
+++ b/submissions/examples/react-animation-wrappers-28243/tests/Animate.test.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Animate from '../components/Animate';
+
+describe('Animate Component', () => {
+  it('renders with correct default classes', () => {
+    const { container } = render(<Animate type="fade-in">Content</Animate>);
+    expect(container.firstChild).toHaveClass('ease-animate-fade-in');
+    expect(container.firstChild).toHaveClass('ease-duration-medium');
+  });
+
+  it('applies custom duration and delay', () => {
+    const { container } = render(<Animate type="slide-up" duration={500} delay={100}>Content</Animate>);
+    expect(container.firstChild).toHaveStyle('animation-duration: 500ms');
+    expect(container.firstChild).toHaveStyle('animation-delay: 100ms');
+  });
+});

--- a/submissions/examples/react-animation-wrappers-28243/tests/Hover.test.jsx
+++ b/submissions/examples/react-animation-wrappers-28243/tests/Hover.test.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Hover from '../components/Hover';
+
+describe('Hover Component', () => {
+  it('renders with default lift effect', () => {
+    const { container } = render(<Hover>Hover Me</Hover>);
+    expect(container.firstChild).toHaveClass('ease-hover-lift');
+  });
+
+  it('renders with custom glow effect', () => {
+    const { container } = render(<Hover effect="glow">Glow Me</Hover>);
+    expect(container.firstChild).toHaveClass('ease-hover-glow');
+  });
+});

--- a/submissions/examples/react-animation-wrappers-28243/tests/ScrollReveal.test.jsx
+++ b/submissions/examples/react-animation-wrappers-28243/tests/ScrollReveal.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import ScrollReveal from '../components/ScrollReveal';
+
+// Mock IntersectionObserver for testing
+const mockIntersectionObserver = jest.fn();
+mockIntersectionObserver.mockReturnValue({
+  observe: () => null,
+  unobserve: () => null,
+  disconnect: () => null
+});
+window.IntersectionObserver = mockIntersectionObserver;
+
+describe('ScrollReveal Component', () => {
+  it('renders initially hidden', () => {
+    const { container } = render(<ScrollReveal type="fade-in">Content</ScrollReveal>);
+    // Initial state before intersection should be opacity: 0
+    expect(container.firstChild).toHaveStyle('opacity: 0');
+  });
+});


### PR DESCRIPTION
## Pull Request Description

Resolves #28243

Adds the full suite of React wrapper components (`<Animate>`, `<Hover>`, `<ScrollReveal>`) as requested in Issue #28243.

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/react-animation-wrappers-28243/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to framework core or templates**