### PR TITLE
feat: add CSS jello-hover accordion for Neumorphic Soft layouts

### DIFF
--- a/submissions/examples/neumorphic-jello-accordion-33044/README.md
+++ b/submissions/examples/neumorphic-jello-accordion-33044/README.md
@@ -1,0 +1,12 @@
+# Neumorphic Jello-Hover Accordion
+
+This submission resolves issue #33044.
+
+## Features
+- **Neumorphic Soft Theme**: Utilizes soft, extruded shadows, rounded shapes, and low-contrast UI elements to achieve the classic "soft UI" aesthetic perfectly suited for modern minimal layouts.
+- **Component**: An interactive FAQ Accordion using HTML `<details>` and `<summary>` elements customized entirely with CSS.
+- **Animation**: The accordion items implement an `ease-hover-jello` effect on hover. When you hover over the summary/title of the accordion, it playfully jiggles like jello, encouraging the user to click.
+
+## File Structure
+- `demo.html`: Structure of the neumorphic accordion.
+- `style.css`: Completely unique soft UI styles and custom Jello keyframes.

--- a/submissions/examples/neumorphic-jello-accordion-33044/demo.html
+++ b/submissions/examples/neumorphic-jello-accordion-33044/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neumorphic Jello-Hover Accordion</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <div class="neumorphic-container">
+        <h2 class="title">Frequently Asked Questions</h2>
+        
+        <div class="accordion-wrapper">
+            <!-- Accordion Item 1 -->
+            <details class="neumorphic-accordion ease-hover-jello" open>
+                <summary class="accordion-header">
+                    What is Neumorphism?
+                    <span class="icon">+</span>
+                </summary>
+                <div class="accordion-body">
+                    <p>Neumorphism (or soft UI) is a design style characterized by subtle contrast and solid colors, where UI elements appear to extrude from the background using inner and outer shadows.</p>
+                </div>
+            </details>
+
+            <!-- Accordion Item 2 -->
+            <details class="neumorphic-accordion ease-hover-jello">
+                <summary class="accordion-header">
+                    How does the hover animation work?
+                    <span class="icon">+</span>
+                </summary>
+                <div class="accordion-body">
+                    <p>When you hover over any of these accordion cards, a custom EaseMotion CSS keyframe animation is triggered, causing the entire card to wobble in a playful "jello" motion.</p>
+                </div>
+            </details>
+
+            <!-- Accordion Item 3 -->
+            <details class="neumorphic-accordion ease-hover-jello">
+                <summary class="accordion-header">
+                    Is this accessible?
+                    <span class="icon">+</span>
+                </summary>
+                <div class="accordion-body">
+                    <p>Yes, by using native HTML5 <code>&lt;details&gt;</code> and <code>&lt;summary&gt;</code> tags, keyboard navigation and screen reader support are built-in without needing complex JavaScript.</p>
+                </div>
+            </details>
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/neumorphic-jello-accordion-33044/style.css
+++ b/submissions/examples/neumorphic-jello-accordion-33044/style.css
@@ -1,0 +1,127 @@
+/* Neumorphic Theme Variables */
+:root {
+  --neu-bg: #e0e5ec;
+  --neu-text: #4a5568;
+  --neu-title: #2d3748;
+  --neu-shadow-dark: #a3b1c6;
+  --neu-shadow-light: #ffffff;
+  --neu-accent: #6b46c1;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--neu-bg);
+  font-family: 'Nunito', sans-serif;
+  color: var(--neu-text);
+}
+
+.neumorphic-container {
+  width: 100%;
+  max-width: 600px;
+  padding: 2rem;
+}
+
+.title {
+  text-align: center;
+  color: var(--neu-title);
+  margin-bottom: 2.5rem;
+  font-size: 1.8rem;
+  letter-spacing: 0.5px;
+}
+
+.accordion-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+/* Accordion Styles */
+.neumorphic-accordion {
+  background-color: var(--neu-bg);
+  border-radius: 16px;
+  box-shadow: 9px 9px 16px var(--neu-shadow-dark), 
+              -9px -9px 16px var(--neu-shadow-light);
+  overflow: hidden;
+  transition: box-shadow 0.3s ease;
+}
+
+.neumorphic-accordion[open] {
+  box-shadow: inset 5px 5px 10px var(--neu-shadow-dark), 
+              inset -5px -5px 10px var(--neu-shadow-light);
+}
+
+.accordion-header {
+  padding: 1.5rem;
+  font-weight: 600;
+  font-size: 1.1rem;
+  color: var(--neu-title);
+  cursor: pointer;
+  list-style: none; /* Remove default triangle */
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  outline: none;
+}
+
+/* Hide default marker for webkit */
+.accordion-header::-webkit-details-marker {
+  display: none;
+}
+
+.icon {
+  font-size: 1.5rem;
+  color: var(--neu-accent);
+  transition: transform 0.3s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  box-shadow: 4px 4px 8px var(--neu-shadow-dark), 
+              -4px -4px 8px var(--neu-shadow-light);
+}
+
+.neumorphic-accordion[open] .icon {
+  transform: rotate(45deg);
+  box-shadow: inset 2px 2px 5px var(--neu-shadow-dark), 
+              inset -2px -2px 5px var(--neu-shadow-light);
+}
+
+.accordion-body {
+  padding: 0 1.5rem 1.5rem 1.5rem;
+  line-height: 1.6;
+  opacity: 0;
+  animation: fade-in 0.4s ease forwards;
+}
+
+@keyframes fade-in {
+  from { opacity: 0; transform: translateY(-10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* --- EaseMotion Jello Hover Animation --- */
+/* Resolves Issue #33044 */
+.ease-hover-jello {
+  transform-origin: center;
+}
+
+/* We don't want it to jello when it's open, only when closed and hovered */
+.ease-hover-jello:not([open]):hover,
+.ease-hover-jello:not([open]):focus-within {
+  animation: ease-jello-anim 0.9s both;
+}
+
+@keyframes ease-jello-anim {
+  0% { transform: scale3d(1, 1, 1); }
+  30% { transform: scale3d(1.05, 0.95, 1); }
+  40% { transform: scale3d(0.95, 1.05, 1); }
+  50% { transform: scale3d(1.02, 0.98, 1); }
+  65% { transform: scale3d(0.98, 1.02, 1); }
+  75% { transform: scale3d(1.01, 0.99, 1); }
+  100% { transform: scale3d(1, 1, 1); }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #33044

Implements a custom Neumorphic (Soft UI) accordion using native `<details>` tags with intricate inner/outer shadows. The `ease-hover-jello` animation is applied to the accordion headers to satisfy the issue requirements, adding a playful micro-interaction on hover.

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/neumorphic-jello-accordion-33044/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to framework core or templates**