### PR TITLE
feat: add CSS jello-hover accordion for Cyberpunk Neon layouts

### DIFF
--- a/submissions/examples/cyberpunk-jello-accordion-33043/README.md
+++ b/submissions/examples/cyberpunk-jello-accordion-33043/README.md
@@ -1,0 +1,12 @@
+# Cyberpunk Neon Jello-Hover Accordion
+
+This submission resolves issue #33043.
+
+## Features
+- **Cyberpunk Neon Theme**: Highly stylized design featuring a dark background, glowing neon pink and cyan accents, monospace futuristic typography, and angular, clipped borders (using `clip-path`).
+- **Component**: An interactive FAQ Accordion built specifically for sci-fi/cyberpunk interfaces.
+- **Animation**: The accordion items implement the `ease-hover-jello` effect on hover. The jello wobble perfectly complements the unstable, glitchy aesthetic of the cyberpunk theme.
+
+## File Structure
+- `demo.html`: The HTML layout featuring the cyberpunk styling.
+- `style.css`: Completely original CSS to achieve the neon glow, clip-path geometry, and the custom Jello keyframes.

--- a/submissions/examples/cyberpunk-jello-accordion-33043/demo.html
+++ b/submissions/examples/cyberpunk-jello-accordion-33043/demo.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyberpunk Neon Accordion</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <div class="cyber-container">
+        <h1 class="cyber-glitch" data-text="SYSTEM_DATA_LOGS">SYSTEM_DATA_LOGS</h1>
+        
+        <div class="accordion-grid">
+            <!-- Accordion Item 1 -->
+            <div class="cyber-accordion ease-hover-jello">
+                <button class="cyber-header">
+                    <span class="cyber-id">ID_01</span> What is the Cyber-Grid?
+                    <span class="cyber-icon">[+]</span>
+                </button>
+                <div class="cyber-body">
+                    <p>> Initiating response sequence...</p>
+                    <p>The Cyber-Grid is a decentralized neural network connecting all mainframe terminals within the metropolis sector. Access is restricted to level 4 operatives.</p>
+                </div>
+            </div>
+
+            <!-- Accordion Item 2 -->
+            <div class="cyber-accordion ease-hover-jello">
+                <button class="cyber-header">
+                    <span class="cyber-id">ID_02</span> How to bypass firewall?
+                    <span class="cyber-icon">[+]</span>
+                </button>
+                <div class="cyber-body">
+                    <p>> Warning: Unauthorized inquiry detected.</p>
+                    <p>Bypassing the corporate firewall requires a quantum decryption key and a direct neural link. Doing so is a violation of directive 7A.</p>
+                </div>
+            </div>
+
+            <!-- Accordion Item 3 -->
+            <div class="cyber-accordion ease-hover-jello">
+                <button class="cyber-header">
+                    <span class="cyber-id">ID_03</span> Jello-Hover Protocol
+                    <span class="cyber-icon">[+]</span>
+                </button>
+                <div class="cyber-body">
+                    <p>> Analyzing CSS subroutines...</p>
+                    <p>The Jello-Hover protocol is executed when a user terminal hovers over these data nodes, causing a localized spatial distortion (wobble) on the interface layer.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        // Simple JS to toggle the accordion bodies
+        const headers = document.querySelectorAll('.cyber-header');
+        headers.forEach(header => {
+            header.addEventListener('click', () => {
+                const parent = header.parentElement;
+                const icon = header.querySelector('.cyber-icon');
+                
+                // Toggle active class
+                parent.classList.toggle('active');
+                
+                if (parent.classList.contains('active')) {
+                    icon.textContent = '[-]';
+                } else {
+                    icon.textContent = '[+]';
+                }
+            });
+        });
+    </script>
+</body>
+</html>

--- a/submissions/examples/cyberpunk-jello-accordion-33043/style.css
+++ b/submissions/examples/cyberpunk-jello-accordion-33043/style.css
@@ -1,0 +1,193 @@
+/* Cyberpunk Neon Theme Variables */
+:root {
+  --cy-bg: #050510;
+  --cy-pink: #ff007f;
+  --cy-cyan: #00f0ff;
+  --cy-yellow: #fcee0a;
+  --cy-text: #e0e0e0;
+  --cy-border: #111122;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-color: var(--cy-bg);
+  background-image: 
+    linear-gradient(rgba(0, 240, 255, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0, 240, 255, 0.05) 1px, transparent 1px);
+  background-size: 30px 30px;
+  font-family: 'Share Tech Mono', monospace;
+  color: var(--cy-text);
+  display: flex;
+  justify-content: center;
+  padding: 4rem 1rem;
+}
+
+.cyber-container {
+  width: 100%;
+  max-width: 700px;
+}
+
+/* Glitch Title */
+.cyber-glitch {
+  font-size: 2.5rem;
+  color: var(--cy-cyan);
+  text-transform: uppercase;
+  position: relative;
+  margin-bottom: 3rem;
+  text-shadow: 2px 0 var(--cy-pink), -2px 0 var(--cy-yellow);
+  letter-spacing: 2px;
+}
+
+.cyber-glitch::before,
+.cyber-glitch::after {
+  content: attr(data-text);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--cy-bg);
+}
+
+.cyber-glitch::before {
+  left: 2px;
+  text-shadow: -2px 0 var(--cy-pink);
+  clip: rect(24px, 550px, 90px, 0);
+  animation: glitch-anim-2 3s infinite linear alternate-reverse;
+}
+
+.cyber-glitch::after {
+  left: -2px;
+  text-shadow: -2px 0 var(--cy-cyan);
+  clip: rect(85px, 550px, 140px, 0);
+  animation: glitch-anim 2.5s infinite linear alternate-reverse;
+}
+
+@keyframes glitch-anim {
+  0% { clip: rect(10px, 9999px, 30px, 0); }
+  20% { clip: rect(60px, 9999px, 90px, 0); }
+  40% { clip: rect(30px, 9999px, 50px, 0); }
+  60% { clip: rect(80px, 9999px, 120px, 0); }
+  80% { clip: rect(10px, 9999px, 20px, 0); }
+  100% { clip: rect(40px, 9999px, 60px, 0); }
+}
+@keyframes glitch-anim-2 {
+  0% { clip: rect(65px, 9999px, 100px, 0); }
+  20% { clip: rect(10px, 9999px, 40px, 0); }
+  40% { clip: rect(80px, 9999px, 110px, 0); }
+  60% { clip: rect(20px, 9999px, 60px, 0); }
+  80% { clip: rect(50px, 9999px, 80px, 0); }
+  100% { clip: rect(30px, 9999px, 70px, 0); }
+}
+
+/* Accordion Styles */
+.accordion-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.cyber-accordion {
+  position: relative;
+  background: rgba(0, 240, 255, 0.02);
+  border: 1px solid var(--cy-cyan);
+  clip-path: polygon(0 0, calc(100% - 20px) 0, 100% 20px, 100% 100%, 20px 100%, 0 calc(100% - 20px));
+  box-shadow: 0 0 10px rgba(0, 240, 255, 0.2) inset;
+  transition: all 0.3s ease;
+}
+
+.cyber-accordion::before {
+  content: '';
+  position: absolute;
+  top: 0; right: 0;
+  border-top: 20px solid var(--cy-cyan);
+  border-left: 20px solid transparent;
+  width: 0;
+}
+
+.cyber-accordion.active {
+  border-color: var(--cy-pink);
+  box-shadow: 0 0 15px rgba(255, 0, 127, 0.4) inset, 0 0 10px rgba(255, 0, 127, 0.2);
+}
+
+.cyber-accordion.active::before {
+  border-top-color: var(--cy-pink);
+}
+
+.cyber-header {
+  width: 100%;
+  background: transparent;
+  border: none;
+  color: var(--cy-cyan);
+  font-family: inherit;
+  font-size: 1.2rem;
+  padding: 1.5rem;
+  text-align: left;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  outline: none;
+}
+
+.cyber-accordion.active .cyber-header {
+  color: var(--cy-pink);
+}
+
+.cyber-id {
+  color: var(--cy-yellow);
+  margin-right: 1rem;
+  font-size: 0.9rem;
+}
+
+.cyber-icon {
+  font-weight: bold;
+}
+
+.cyber-body {
+  padding: 0 1.5rem;
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  color: #a0a0a0;
+  transition: max-height 0.3s ease, opacity 0.3s ease, padding 0.3s ease;
+}
+
+.cyber-accordion.active .cyber-body {
+  max-height: 500px;
+  padding: 0 1.5rem 1.5rem 1.5rem;
+  opacity: 1;
+}
+
+.cyber-body p {
+  margin: 0.5rem 0;
+}
+
+.cyber-body p:first-child {
+  color: var(--cy-cyan);
+  font-size: 0.9rem;
+}
+
+/* --- EaseMotion Jello Hover Animation --- */
+/* Resolves Issue #33043 */
+.ease-hover-jello {
+  transform-origin: center;
+}
+
+.ease-hover-jello:not(.active):hover {
+  animation: ease-jello-anim 0.9s both;
+  /* Cyberpunk glitch flash on hover */
+  border-color: var(--cy-yellow);
+  box-shadow: 0 0 10px rgba(252, 238, 10, 0.5) inset;
+}
+
+@keyframes ease-jello-anim {
+  0% { transform: scale3d(1, 1, 1); }
+  30% { transform: scale3d(1.05, 0.95, 1); }
+  40% { transform: scale3d(0.95, 1.05, 1); }
+  50% { transform: scale3d(1.02, 0.98, 1); }
+  65% { transform: scale3d(0.98, 1.02, 1); }
+  75% { transform: scale3d(1.01, 0.99, 1); }
+  100% { transform: scale3d(1, 1, 1); }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #33043

Implements a custom Cyberpunk Neon styled accordion using a JS-controlled grid layout, distinct from the Neumorphic details/summary layout. Features neon glowing borders, glitchy titles, and clipped corners via `clip-path`. The `ease-hover-jello` animation is uniquely tailored and triggers on hover to match the unstable sci-fi aesthetic.

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/cyberpunk-jello-accordion-33043/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to framework core or templates**