### PR TITLE
feat: add CSS jello-hover accordion for Minimalist Tech layouts

### DIFF
--- a/submissions/examples/minimalist-jello-accordion-33042/README.md
+++ b/submissions/examples/minimalist-jello-accordion-33042/README.md
@@ -1,0 +1,12 @@
+# Minimalist Tech Jello-Hover Accordion
+
+This submission resolves issue #33042.
+
+## Features
+- **Minimalist Tech Theme**: Clean, high-contrast monochrome design utilizing sharp 1px borders, generous whitespace, and a strong sans-serif typography hierarchy suitable for technical documentation or minimal interfaces.
+- **Component**: An interactive, zero-JS CSS-only Accordion using `input[type="radio"]` logic for a smooth, single-open accordion experience.
+- **Animation**: The accordion items implement the `ease-hover-jello` effect on hover. The playful jello wobble adds a touch of personality to an otherwise strict and stark interface.
+
+## File Structure
+- `demo.html`: The HTML layout using the radio-button hack for CSS-only state management.
+- `style.css`: Completely original minimal styles and custom Jello keyframes.

--- a/submissions/examples/minimalist-jello-accordion-33042/demo.html
+++ b/submissions/examples/minimalist-jello-accordion-33042/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Minimalist Tech Accordion</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <div class="min-container">
+        <header class="min-header">
+            <h1>TECH_DOCS</h1>
+            <p>System Architecture FAQ</p>
+        </header>
+        
+        <div class="min-accordion">
+            
+            <!-- Accordion Item 1 -->
+            <div class="min-item ease-hover-jello">
+                <input type="radio" name="min-acc" id="acc1" class="min-radio" checked>
+                <label for="acc1" class="min-label">
+                    <span class="label-num">01</span>
+                    What is the core stack?
+                    <span class="min-icon"></span>
+                </label>
+                <div class="min-content">
+                    <p>The core stack utilizes a strict separation of concerns, heavily relying on native Web APIs and CSS for presentation logic to minimize JavaScript overhead.</p>
+                </div>
+            </div>
+
+            <!-- Accordion Item 2 -->
+            <div class="min-item ease-hover-jello">
+                <input type="radio" name="min-acc" id="acc2" class="min-radio">
+                <label for="acc2" class="min-label">
+                    <span class="label-num">02</span>
+                    How is state managed?
+                    <span class="min-icon"></span>
+                </label>
+                <div class="min-content">
+                    <p>In this specific component, state is managed entirely through the DOM using the CSS <code>:checked</code> pseudo-class paired with hidden radio inputs. This guarantees zero JS runtime cost.</p>
+                </div>
+            </div>
+
+            <!-- Accordion Item 3 -->
+            <div class="min-item ease-hover-jello">
+                <input type="radio" name="min-acc" id="acc3" class="min-radio">
+                <label for="acc3" class="min-label">
+                    <span class="label-num">03</span>
+                    Jello-Hover interaction
+                    <span class="min-icon"></span>
+                </label>
+                <div class="min-content">
+                    <p>When the user hovers over the accordion item, a playful spatial distortion (Jello effect) executes. This micro-interaction contrasts with the stark, minimalist aesthetic.</p>
+                </div>
+            </div>
+
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/minimalist-jello-accordion-33042/style.css
+++ b/submissions/examples/minimalist-jello-accordion-33042/style.css
@@ -1,0 +1,166 @@
+/* Minimalist Tech Theme Variables */
+:root {
+  --min-bg: #ffffff;
+  --min-text: #1a1a1a;
+  --min-muted: #888888;
+  --min-border: #e0e0e0;
+  --min-hover: #f9f9f9;
+  --min-accent: #000000;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-color: var(--min-bg);
+  color: var(--min-text);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+}
+
+.min-container {
+  width: 100%;
+  max-width: 600px;
+}
+
+.min-header {
+  margin-bottom: 3rem;
+  border-bottom: 2px solid var(--min-accent);
+  padding-bottom: 1rem;
+}
+
+.min-header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: -0.5px;
+}
+
+.min-header p {
+  margin: 0.5rem 0 0 0;
+  color: var(--min-muted);
+  font-size: 0.9rem;
+}
+
+/* Accordion Styles (CSS Only) */
+.min-accordion {
+  display: flex;
+  flex-direction: column;
+}
+
+.min-item {
+  border-bottom: 1px solid var(--min-border);
+  background: var(--min-bg);
+  transition: background-color 0.2s ease;
+}
+
+.min-radio {
+  display: none;
+}
+
+.min-label {
+  display: flex;
+  align-items: center;
+  padding: 1.5rem 0;
+  cursor: pointer;
+  font-weight: 400;
+  font-size: 1.1rem;
+  transition: transform 0.3s ease;
+}
+
+.label-num {
+  font-size: 0.75rem;
+  color: var(--min-muted);
+  margin-right: 1.5rem;
+  font-weight: 600;
+  letter-spacing: 1px;
+}
+
+.min-icon {
+  margin-left: auto;
+  position: relative;
+  width: 16px;
+  height: 16px;
+}
+
+.min-icon::before,
+.min-icon::after {
+  content: '';
+  position: absolute;
+  background-color: var(--min-accent);
+  transition: transform 0.3s ease;
+}
+
+.min-icon::before {
+  top: 7px;
+  left: 0;
+  width: 16px;
+  height: 2px;
+}
+
+.min-icon::after {
+  top: 0;
+  left: 7px;
+  width: 2px;
+  height: 16px;
+}
+
+/* Open State */
+.min-radio:checked + .min-label .min-icon::after {
+  transform: rotate(90deg);
+  opacity: 0;
+}
+
+.min-radio:checked + .min-label .min-icon::before {
+  transform: rotate(180deg);
+}
+
+.min-radio:checked + .min-label {
+  font-weight: 600;
+}
+
+.min-content {
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition: max-height 0.4s cubic-bezier(0, 1, 0, 1), opacity 0.3s ease, padding 0.3s ease;
+}
+
+.min-content p {
+  margin: 0 0 1.5rem 0;
+  padding-left: 2.75rem;
+  color: var(--min-muted);
+  line-height: 1.6;
+  font-size: 0.95rem;
+}
+
+.min-radio:checked ~ .min-content {
+  max-height: 500px;
+  opacity: 1;
+  transition: max-height 0.4s ease-in-out, opacity 0.4s ease 0.1s, padding 0.3s ease;
+}
+
+/* --- EaseMotion Jello Hover Animation --- */
+/* Resolves Issue #33042 */
+.ease-hover-jello {
+  transform-origin: center;
+}
+
+/* Apply Jello only when hovering over an item that is NOT checked */
+.min-item:has(.min-radio:not(:checked)):hover {
+  animation: ease-jello-anim 0.9s both;
+  background-color: var(--min-hover);
+  border-bottom-color: var(--min-accent);
+}
+
+@keyframes ease-jello-anim {
+  0% { transform: scale3d(1, 1, 1); }
+  30% { transform: scale3d(1.02, 0.98, 1); }
+  40% { transform: scale3d(0.98, 1.02, 1); }
+  50% { transform: scale3d(1.01, 0.99, 1); }
+  65% { transform: scale3d(0.99, 1.01, 1); }
+  75% { transform: scale3d(1.005, 0.995, 1); }
+  100% { transform: scale3d(1, 1, 1); }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #33042

Implements a custom Minimalist Tech themed accordion using a CSS-only `input[type="radio"]` structure for state management, eliminating the need for JS. The design features sharp monochrome styling and high contrast. The requested `ease-hover-jello` animation is uniquely tailored for this layout, triggering playfully on hover to offset the stark minimal aesthetic.

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/minimalist-jello-accordion-33042/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to framework core or templates**