### PR TITLE
feat: add CSS tada-click accordion for Minimalist Tech layouts

### DIFF
--- a/submissions/examples/minimalist-tada-accordion-33011/README.md
+++ b/submissions/examples/minimalist-tada-accordion-33011/README.md
@@ -1,0 +1,12 @@
+# Minimalist Tech Tada-Click Accordion
+
+This submission resolves issue #33011.
+
+## Features
+- **Minimalist Tech Theme**: A completely unique structure focusing on stark minimalism. Features a grid-based layout with thick borders and brutalist minimalist typography.
+- **Component Structure**: Unlike previous radio-button implementations, this uses a robust `CSS Grid` approach (`grid-template-rows: 0fr` to `1fr`) controlled by a lightweight JavaScript class toggle.
+- **Animation**: Implements the `ease-click-tada` animation. When the user clicks an accordion header to open it, the title performs a distinct "tada" attention-grabbing animation.
+
+## File Structure
+- `demo.html`: Grid-based layout with simple JS for state toggling.
+- `style.css`: Original brutalist/minimalist styles and `ease-tada` keyframes.

--- a/submissions/examples/minimalist-tada-accordion-33011/demo.html
+++ b/submissions/examples/minimalist-tada-accordion-33011/demo.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Minimalist Tada-Click Accordion</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <main class="brutal-minimal-container">
+        <h1 class="page-title">FAQ // Documentation</h1>
+        
+        <div class="accordion-group">
+            
+            <article class="accordion-panel">
+                <button class="accordion-trigger ease-click-tada" aria-expanded="false">
+                    <span class="trigger-text">Q: Grid vs Flexbox?</span>
+                    <span class="trigger-icon"></span>
+                </button>
+                <div class="accordion-content-wrapper">
+                    <div class="accordion-content">
+                        This specific minimalist layout utilizes CSS Grid's fractional unit transition (<code>grid-template-rows: 0fr -> 1fr</code>) for smooth, performant height animations without relying on max-height hacks.
+                    </div>
+                </div>
+            </article>
+
+            <article class="accordion-panel">
+                <button class="accordion-trigger ease-click-tada" aria-expanded="false">
+                    <span class="trigger-text">Q: What is Tada-Click?</span>
+                    <span class="trigger-icon"></span>
+                </button>
+                <div class="accordion-content-wrapper">
+                    <div class="accordion-content">
+                        The "Tada-Click" interaction triggers an EaseMotion CSS keyframe when the user clicks the header. It creates a satisfying, bouncy feedback loop upon interaction.
+                    </div>
+                </div>
+            </article>
+
+            <article class="accordion-panel">
+                <button class="accordion-trigger ease-click-tada" aria-expanded="false">
+                    <span class="trigger-text">Q: Is it accessible?</span>
+                    <span class="trigger-icon"></span>
+                </button>
+                <div class="accordion-content-wrapper">
+                    <div class="accordion-content">
+                        Yes. By using native <code>&lt;button&gt;</code> elements and managing the <code>aria-expanded</code> attribute via JavaScript, this custom structure maintains screen reader support.
+                    </div>
+                </div>
+            </article>
+
+        </div>
+    </main>
+
+    <script>
+        const triggers = document.querySelectorAll('.accordion-trigger');
+
+        triggers.forEach(trigger => {
+            trigger.addEventListener('click', () => {
+                const isExpanded = trigger.getAttribute('aria-expanded') === 'true';
+                
+                // Toggle state
+                trigger.setAttribute('aria-expanded', !isExpanded);
+                
+                // Trigger the click animation by removing and re-adding the class
+                trigger.classList.remove('animate-tada');
+                // Force a reflow to restart the animation
+                void trigger.offsetWidth; 
+                trigger.classList.add('animate-tada');
+            });
+        });
+    </script>
+</body>
+</html>

--- a/submissions/examples/minimalist-tada-accordion-33011/style.css
+++ b/submissions/examples/minimalist-tada-accordion-33011/style.css
@@ -1,0 +1,150 @@
+/* Brutalist/Minimalist Tech Theme Variables */
+:root {
+  --bm-bg: #f4f4f0;
+  --bm-text: #050505;
+  --bm-border: #050505;
+  --bm-highlight: #e0e0dc;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-color: var(--bm-bg);
+  color: var(--bm-text);
+  font-family: 'Space Grotesk', sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+}
+
+.brutal-minimal-container {
+  width: 100%;
+  max-width: 720px;
+}
+
+.page-title {
+  font-size: 2.5rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  border-bottom: 4px solid var(--bm-border);
+  padding-bottom: 1rem;
+  margin-bottom: 3rem;
+  letter-spacing: -1px;
+}
+
+/* Accordion Panel Structure */
+.accordion-group {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.accordion-panel {
+  border: 2px solid var(--bm-border);
+  background: var(--bm-bg);
+  box-shadow: 4px 4px 0px var(--bm-border);
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+/* Trigger Button */
+.accordion-trigger {
+  width: 100%;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 1.5rem;
+  font-family: inherit;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--bm-text);
+  text-align: left;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  transition: background-color 0.2s ease;
+}
+
+.accordion-trigger:hover {
+  background-color: var(--bm-highlight);
+}
+
+.accordion-trigger[aria-expanded="true"] {
+  border-bottom-color: var(--bm-border);
+}
+
+/* Custom Icon */
+.trigger-icon {
+  width: 24px;
+  height: 24px;
+  position: relative;
+}
+
+.trigger-icon::before,
+.trigger-icon::after {
+  content: '';
+  position: absolute;
+  background: var(--bm-border);
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.trigger-icon::before {
+  top: 10px;
+  left: 0;
+  width: 24px;
+  height: 4px;
+}
+
+.trigger-icon::after {
+  top: 0;
+  left: 10px;
+  width: 4px;
+  height: 24px;
+}
+
+.accordion-trigger[aria-expanded="true"] .trigger-icon::after {
+  transform: rotate(90deg);
+  opacity: 0;
+}
+
+.accordion-trigger[aria-expanded="true"] .trigger-icon::before {
+  transform: rotate(180deg);
+}
+
+/* Content Wrapper using CSS Grid */
+.accordion-content-wrapper {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.accordion-trigger[aria-expanded="true"] + .accordion-content-wrapper {
+  grid-template-rows: 1fr;
+}
+
+.accordion-content {
+  overflow: hidden;
+  padding: 0 1.5rem;
+  font-size: 1.1rem;
+  line-height: 1.6;
+}
+
+.accordion-trigger[aria-expanded="true"] + .accordion-content-wrapper .accordion-content {
+  padding: 1.5rem;
+}
+
+/* --- EaseMotion Tada Click Animation --- */
+/* Resolves Issue #33011 */
+.ease-click-tada.animate-tada .trigger-text {
+  display: inline-block;
+  animation: ease-tada-anim 0.8s both;
+}
+
+@keyframes ease-tada-anim {
+  0% { transform: scale3d(1, 1, 1); }
+  10%, 20% { transform: scale3d(0.9, 0.9, 0.9) rotate3d(0, 0, 1, -3deg); }
+  30%, 50%, 70%, 90% { transform: scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg); }
+  40%, 60%, 80% { transform: scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, -3deg); }
+  100% { transform: scale3d(1, 1, 1); }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #33011

Implements a brutalist/minimalist accordion using a unique `CSS Grid` structure (`grid-template-rows: 0fr -> 1fr`) for seamless height animation. The state is toggled via JS managing the `aria-expanded` attribute, ensuring accessibility. The requested `ease-click-tada` animation triggers on the text element upon interaction.

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/minimalist-tada-accordion-33011/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to framework core or templates**