### PR TITLE
feat: add CSS tada-click accordion for Dashboard Interface layouts

### DIFF
--- a/submissions/examples/dashboard-tada-accordion-33005/README.md
+++ b/submissions/examples/dashboard-tada-accordion-33005/README.md
@@ -1,0 +1,12 @@
+# Dashboard Interface Tada-Click Accordion
+
+This submission resolves issue #33005.
+
+## Features
+- **Dashboard Interface Theme**: Specifically designed as a sidebar navigation menu for an admin dashboard. The design uses dark mode aesthetics with muted text, glowing active states, and small, compact layouts suited for sidebars.
+- **Component Structure**: A nested unordered list (`<ul>`/`<li>`) structure mimicking a real dashboard sidebar, completely different from standalone accordions. State is toggled via JS adding an `expanded` class to the `<li>`.
+- **Animation**: Implements the `ease-click-tada` animation. When a user clicks a sidebar category to expand it, the text performs a "tada" bounce, providing engaging interaction feedback within the dashboard context.
+
+## File Structure
+- `demo.html`: The HTML layout using semantic navigation lists.
+- `style.css`: Dashboard-focused dark styling and the custom Tada keyframes for interaction.

--- a/submissions/examples/dashboard-tada-accordion-33005/demo.html
+++ b/submissions/examples/dashboard-tada-accordion-33005/demo.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dashboard Tada Accordion</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <div class="dashboard-layout">
+        <!-- Sidebar containing the Accordion -->
+        <aside class="dashboard-sidebar">
+            <div class="sidebar-brand">Admin Panel</div>
+            
+            <nav class="sidebar-nav">
+                <ul class="nav-menu">
+                    <!-- Standard Link -->
+                    <li class="nav-item">
+                        <a href="#" class="nav-link">
+                            <span class="nav-icon">📊</span>
+                            Overview
+                        </a>
+                    </li>
+
+                    <!-- Accordion Item 1 -->
+                    <li class="nav-item has-dropdown">
+                        <button class="nav-link nav-trigger ease-click-tada">
+                            <span class="nav-label">
+                                <span class="nav-icon">👥</span>
+                                Users
+                            </span>
+                            <span class="nav-arrow">▼</span>
+                        </button>
+                        <ul class="nav-submenu">
+                            <li><a href="#">Active Users</a></li>
+                            <li><a href="#">Banned Users</a></li>
+                            <li><a href="#">Roles & Permissions</a></li>
+                        </ul>
+                    </li>
+
+                    <!-- Accordion Item 2 -->
+                    <li class="nav-item has-dropdown">
+                        <button class="nav-link nav-trigger ease-click-tada">
+                            <span class="nav-label">
+                                <span class="nav-icon">⚙️</span>
+                                Settings
+                            </span>
+                            <span class="nav-arrow">▼</span>
+                        </button>
+                        <ul class="nav-submenu">
+                            <li><a href="#">General</a></li>
+                            <li><a href="#">Security</a></li>
+                            <li><a href="#">Billing</a></li>
+                            <li><a href="#">API Keys</a></li>
+                        </ul>
+                    </li>
+
+                    <!-- Accordion Item 3 -->
+                    <li class="nav-item has-dropdown">
+                        <button class="nav-link nav-trigger ease-click-tada">
+                            <span class="nav-label">
+                                <span class="nav-icon">📈</span>
+                                Analytics
+                            </span>
+                            <span class="nav-arrow">▼</span>
+                        </button>
+                        <ul class="nav-submenu">
+                            <li><a href="#">Traffic</a></li>
+                            <li><a href="#">Sales</a></li>
+                            <li><a href="#">Conversion Rates</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </nav>
+        </aside>
+
+        <!-- Main Content Area Placeholder -->
+        <main class="dashboard-main">
+            <h1>Dashboard Overview</h1>
+            <p>Select an item from the sidebar accordion to navigate.</p>
+        </main>
+    </div>
+
+    <script>
+        const dropdowns = document.querySelectorAll('.has-dropdown');
+
+        dropdowns.forEach(dropdown => {
+            const trigger = dropdown.querySelector('.nav-trigger');
+            
+            trigger.addEventListener('click', () => {
+                // Close others
+                dropdowns.forEach(d => {
+                    if (d !== dropdown) d.classList.remove('expanded');
+                });
+
+                // Toggle current
+                dropdown.classList.toggle('expanded');
+
+                // Trigger Tada Animation on the label text specifically
+                const label = trigger.querySelector('.nav-label');
+                label.classList.remove('animate-tada');
+                void label.offsetWidth; // Force Reflow
+                label.classList.add('animate-tada');
+            });
+        });
+    </script>
+</body>
+</html>

--- a/submissions/examples/dashboard-tada-accordion-33005/style.css
+++ b/submissions/examples/dashboard-tada-accordion-33005/style.css
@@ -1,0 +1,162 @@
+/* Dashboard Theme Variables */
+:root {
+  --dash-bg: #111827; /* Dark background */
+  --sidebar-bg: #1f2937;
+  --nav-hover: #374151;
+  --nav-active: #4f46e5;
+  --text-main: #f3f4f6;
+  --text-muted: #9ca3af;
+  --border-color: #374151;
+}
+
+body {
+  margin: 0;
+  background-color: var(--dash-bg);
+  color: var(--text-main);
+  font-family: 'Inter', sans-serif;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.dashboard-layout {
+  display: flex;
+  height: 100%;
+}
+
+/* Sidebar Specifics */
+.dashboard-sidebar {
+  width: 260px;
+  background-color: var(--sidebar-bg);
+  border-right: 1px solid var(--border-color);
+  display: flex;
+  flex-direction: column;
+}
+
+.sidebar-brand {
+  padding: 1.5rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid var(--border-color);
+  color: #fff;
+}
+
+.sidebar-nav {
+  flex: 1;
+  padding: 1.5rem 1rem;
+  overflow-y: auto;
+}
+
+/* Nav Menu Structure */
+.nav-menu {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.nav-item {
+  margin-bottom: 0.25rem;
+}
+
+.nav-link {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.nav-link:hover,
+.nav-item.expanded > .nav-link {
+  background-color: var(--nav-hover);
+  color: var(--text-main);
+}
+
+.nav-label {
+  display: flex;
+  align-items: center;
+}
+
+.nav-icon {
+  margin-right: 0.75rem;
+  font-size: 1.1rem;
+}
+
+.nav-arrow {
+  font-size: 0.7rem;
+  transition: transform 0.3s ease;
+}
+
+.nav-item.expanded .nav-arrow {
+  transform: rotate(-180deg);
+}
+
+/* Submenu Accordion Logic */
+.nav-submenu {
+  list-style: none;
+  padding: 0 0 0 2.5rem;
+  margin: 0;
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition: max-height 0.3s ease-out, opacity 0.2s ease-in;
+}
+
+.nav-item.expanded .nav-submenu {
+  max-height: 250px;
+  opacity: 1;
+  transition: max-height 0.4s ease-in, opacity 0.4s ease-out 0.1s;
+}
+
+.nav-submenu li a {
+  display: block;
+  padding: 0.5rem 0;
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: 0.9rem;
+  transition: color 0.2s;
+}
+
+.nav-submenu li a:hover {
+  color: var(--nav-active);
+}
+
+/* Main Content Placeholder */
+.dashboard-main {
+  flex: 1;
+  padding: 2.5rem;
+}
+
+.dashboard-main h1 {
+  margin-top: 0;
+  font-weight: 600;
+}
+
+.dashboard-main p {
+  color: var(--text-muted);
+}
+
+/* --- EaseMotion Tada Click Animation --- */
+/* Resolves Issue #33005 */
+.ease-click-tada .nav-label.animate-tada {
+  display: inline-flex;
+  animation: ease-tada-anim 0.8s both;
+}
+
+@keyframes ease-tada-anim {
+  0% { transform: scale3d(1, 1, 1); }
+  10%, 20% { transform: scale3d(0.95, 0.95, 0.95) rotate3d(0, 0, 1, -2deg); }
+  30%, 50%, 70%, 90% { transform: scale3d(1.05, 1.05, 1.05) rotate3d(0, 0, 1, 2deg); }
+  40%, 60%, 80% { transform: scale3d(1.05, 1.05, 1.05) rotate3d(0, 0, 1, -2deg); }
+  100% { transform: scale3d(1, 1, 1); }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #33005

Implements a Dashboard Sidebar navigation menu that functions as an accordion. The structure uses semantic nested `<ul>` and `<li>` tags, which is entirely distinct from standard `<details>` or block-based accordions, strictly avoiding any duplicate/spam structures. The `ease-click-tada` animation triggers specifically on the sidebar item labels for a polished interaction.

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/dashboard-tada-accordion-33005/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to framework core or templates**