### PR TITLE
feat: add CSS swing-hover accordion for Cyberpunk Neon layouts

### DIFF
--- a/submissions/examples/cyberpunk-swing-accordion-32998/README.md
+++ b/submissions/examples/cyberpunk-swing-accordion-32998/README.md
@@ -1,0 +1,12 @@
+# Cyberpunk Terminal Swing-Hover Accordion
+
+This submission resolves issue #32998.
+
+## Features
+- **Cyberpunk Terminal Theme**: A retro-hacker terminal interface layout. It uses stark `#00ff00` pure green text on a pure `#000000` background with a monospace font, distinct from the previous neon-glow cyberpunk implementations. 
+- **Component Structure**: A pseudo-command-line interface acting as an accordion. The headers look like bash prompts (`> execute query`), and the bodies appear as standard out logs when expanded.
+- **Animation**: Implements the `ease-hover-swing` animation. When hovering over a collapsed command prompt, the cursor `_` swings back and forth, simulating a glitchy terminal interaction typical of the cyberpunk genre.
+
+## File Structure
+- `demo.html`: The terminal-based accordion layout.
+- `style.css`: Terminal styling and the custom Swing keyframes tailored for text characters.

--- a/submissions/examples/cyberpunk-swing-accordion-32998/demo.html
+++ b/submissions/examples/cyberpunk-swing-accordion-32998/demo.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyberpunk Terminal Accordion</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <div class="terminal-window">
+        <div class="terminal-header">
+            <span>root@cyberdeck:~</span>
+        </div>
+        
+        <div class="terminal-body">
+            <p class="boot-text">System initialized. Awaiting commands...</p>
+            
+            <div class="terminal-accordion-list">
+                
+                <!-- Terminal Command 1 -->
+                <div class="term-accordion">
+                    <button class="term-prompt ease-hover-swing">
+                        <span class="prompt-path">~/docs$</span> cat sys_architecture.txt<span class="term-cursor">_</span>
+                    </button>
+                    <div class="term-output">
+                        <p>[OK] Access Granted.</p>
+                        <p>The mainframe relies on a decentralized, distributed node network. Direct CSS overrides prevent unauthorized DOM manipulation by external scripts.</p>
+                    </div>
+                </div>
+
+                <!-- Terminal Command 2 -->
+                <div class="term-accordion">
+                    <button class="term-prompt ease-hover-swing">
+                        <span class="prompt-path">~/docs$</span> ./run_swing_hover.sh<span class="term-cursor">_</span>
+                    </button>
+                    <div class="term-output">
+                        <p>[EXECUTING] Starting animation daemon...</p>
+                        <p>The EaseMotion swing-hover animation leverages hardware-accelerated CSS transforms applied directly to the terminal cursor node, mimicking system instability.</p>
+                    </div>
+                </div>
+
+                <!-- Terminal Command 3 -->
+                <div class="term-accordion">
+                    <button class="term-prompt ease-hover-swing">
+                        <span class="prompt-path">~/docs$</span> ping server_status<span class="term-cursor">_</span>
+                    </button>
+                    <div class="term-output">
+                        <p>PING 192.168.0.1 (192.168.0.1): 56 data bytes</p>
+                        <p>64 bytes from 192.168.0.1: icmp_seq=0 ttl=64 time=0.042 ms</p>
+                        <p>--- server_status ping statistics ---<br>1 packets transmitted, 1 packets received, 0.0% packet loss</p>
+                    </div>
+                </div>
+
+            </div>
+        </div>
+    </div>
+
+    <script>
+        const prompts = document.querySelectorAll('.term-prompt');
+
+        prompts.forEach(prompt => {
+            prompt.addEventListener('click', () => {
+                const accordion = prompt.parentElement;
+                
+                // Toggle active state
+                accordion.classList.toggle('active');
+            });
+        });
+    </script>
+</body>
+</html>

--- a/submissions/examples/cyberpunk-swing-accordion-32998/style.css
+++ b/submissions/examples/cyberpunk-swing-accordion-32998/style.css
@@ -1,0 +1,128 @@
+/* Cyberpunk Terminal Theme Variables */
+:root {
+  --term-bg: #000000;
+  --term-green: #00ff00;
+  --term-dim: #008800;
+  --term-error: #ff003c;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-color: #111;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-family: 'Fira Code', monospace;
+  padding: 2rem;
+}
+
+.terminal-window {
+  width: 100%;
+  max-width: 800px;
+  background-color: var(--term-bg);
+  border: 1px solid var(--term-dim);
+  box-shadow: 0 0 20px rgba(0, 255, 0, 0.1);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.terminal-header {
+  background-color: #222;
+  color: #888;
+  padding: 0.5rem 1rem;
+  font-size: 0.85rem;
+  border-bottom: 1px solid var(--term-dim);
+}
+
+.terminal-body {
+  padding: 1.5rem;
+  color: var(--term-green);
+}
+
+.boot-text {
+  margin-top: 0;
+  margin-bottom: 2rem;
+  opacity: 0.8;
+}
+
+/* Terminal Accordion Styles */
+.terminal-accordion-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.term-accordion {
+  display: flex;
+  flex-direction: column;
+}
+
+.term-prompt {
+  background: transparent;
+  border: none;
+  color: var(--term-green);
+  font-family: inherit;
+  font-size: 1rem;
+  text-align: left;
+  padding: 0.5rem 0;
+  cursor: pointer;
+  outline: none;
+  display: flex;
+  align-items: center;
+}
+
+.term-prompt:hover {
+  text-shadow: 0 0 5px var(--term-green);
+}
+
+.prompt-path {
+  color: var(--term-dim);
+  margin-right: 0.5rem;
+}
+
+.term-cursor {
+  display: inline-block;
+  margin-left: 2px;
+  animation: blink 1s step-end infinite;
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+.term-accordion.active .term-cursor {
+  display: none; /* Hide blinking cursor when executed/open */
+}
+
+.term-output {
+  display: none;
+  padding-left: 1rem;
+  border-left: 2px solid var(--term-dim);
+  margin: 0.5rem 0 1rem 0;
+  color: #aaddaa;
+  font-size: 0.95rem;
+}
+
+.term-accordion.active .term-output {
+  display: block;
+}
+
+.term-output p {
+  margin: 0.25rem 0;
+}
+
+/* --- EaseMotion Swing Hover Animation --- */
+/* Resolves Issue #32998 */
+.ease-hover-swing:hover .term-cursor {
+  animation: ease-swing-anim 1s infinite alternate; /* Replaces blink with swing on hover */
+}
+
+@keyframes ease-swing-anim {
+  0%, 100% { transform: rotate(0deg); }
+  20% { transform: rotate(15deg); }
+  40% { transform: rotate(-10deg); }
+  60% { transform: rotate(5deg); }
+  80% { transform: rotate(-5deg); }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #32998

Implements a Cyberpunk Terminal accordion layout. Unlike the previous neon-grid structure, this utilizes a pure retro-terminal UI (monospaced green text on black). The accordion headers act as command-line prompts, and the body expands as terminal output via CSS display toggling. The `ease-hover-swing` animation is uniquely applied to the terminal cursor (`_`) to create a thematic glitch effect upon hover.

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/cyberpunk-swing-accordion-32998/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to framework core or templates**