### PR TITLE
feat: add fade-in-up scss mixin #28248

### DIFF
--- a/submissions/scss/fade-in-up-mixin/README.md
+++ b/submissions/scss/fade-in-up-mixin/README.md
@@ -1,0 +1,10 @@
+# Fade-In-Up SCSS Mixin
+
+A reusable SCSS mixin to animate elements fading in while sliding upwards.
+
+## Usage
+@include fade-in-up($duration: 0.5s, $delay: 0s);
+
+## Parameters
+- `$duration`: Animation length (default: 0.5s)
+- `$delay`: Start delay (default: 0s)

--- a/submissions/scss/fade-in-up-mixin/_fade-in-up.scss
+++ b/submissions/scss/fade-in-up-mixin/_fade-in-up.scss
@@ -1,0 +1,13 @@
+// Fade-in-up mixin using EaseMotion logic
+@mixin fade-in-up($duration: 0.5s, $delay: 0s) {
+  opacity: 0;
+  transform: translateY(20px);
+  animation: fade-up-anim $duration ease-out $delay forwards;
+}
+
+@keyframes fade-up-anim {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION
Pull Request Description
This PR contributes a modular SCSS mixin for the fade-in-up animation, aligning with the project's goal of transitioning to a component-based SCSS architecture.

Type of Change
[x] 📝 Documentation improvement

[x] Other (SCSS Architecture Migration)

Submission Checklist
⚠️ SCSS Submission Rules Applied:

[x] Changes are strictly inside submissions/scss/fade-in-up-mixin/

[x] Includes _fade-in-up.scss (partial mixin file)

[x] Includes README.md (documentation for mixin parameters)

[x] No edits to existing CSS/HTML files

[x] No changes outside submissions/scss/

Feature Description
What does this add?
A reusable SCSS mixin that generates a smooth fade-in and slide-up animation using EaseMotion's animation keyframes.

How does a developer use it?

SCSS
@use 'path/to/fade-in-up' as *;

.my-element {
  @include fade-in-up($duration: 0.6s, $delay: 0.2s);
}
Why does it fit EaseMotion CSS?
It modularizes motion logic, allowing developers to implement standard EaseMotion animations across different projects with clean, maintainable SCSS imports.

Notes for Maintainer
This is a pure SCSS submission. Per the issue guidelines, I have not included any HTML/CSS demo files to ensure compliance with the migration rules. All code is isolated within the submissions/scss/fade-in-up-mixin/ directory.