### PR TITLE
fix: override shadow card elevation to make it prominent

### DIFF
--- a/submissions/examples/fix-shadow-card-elevation-37396/README.md
+++ b/submissions/examples/fix-shadow-card-elevation-37396/README.md
@@ -1,0 +1,15 @@
+# Fix Shadow Card Elevation Effect
+
+This submission resolves issue #37396.
+
+## The Bug
+The `.ease-card-shadow` component defaults to using the `--ease-shadow-lg` CSS variable. In the global framework variables, `--ease-shadow-lg` has a very low opacity (`0.10`), which makes the shadow effect nearly invisible against standard backgrounds. Furthermore, `.ease-card-shadow` removes the default card border, meaning it relies *entirely* on the shadow for its visual boundaries. With such a faint shadow, it looks identical to or worse than a base card.
+
+## The Fix
+Since modifying core CSS files directly is not permitted, this submission provides an override snippet that developers can implement to fix the elevation effect locally. 
+
+By overriding the `--ease-card-elevation` fallback or explicitly redefining the shadow for `.ease-card-shadow` using `var(--ease-shadow-xl)` (which provides stronger depth), the card successfully appears lifted off the page as originally intended.
+
+## File Structure
+- `demo.html`: Shows a side-by-side comparison of a standard Base Card vs. the newly fixed Shadow Card.
+- `style.css`: Contains the CSS override that fixes the shadow elevation issue locally.

--- a/submissions/examples/fix-shadow-card-elevation-37396/demo.html
+++ b/submissions/examples/fix-shadow-card-elevation-37396/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Fix Shadow Card Elevation</title>
+    <!-- Importing core framework styles to demonstrate the bug -->
+    <link rel="stylesheet" href="../../../easemotion.css">
+    <!-- Applying our local fix -->
+    <link rel="stylesheet" href="style.css">
+    <style>
+        body {
+            background-color: #f8fafc;
+            font-family: system-ui, -apple-system, sans-serif;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            margin: 0;
+            padding: 2rem;
+            color: #334155;
+        }
+        .container {
+            display: flex;
+            gap: 2rem;
+            max-width: 800px;
+            width: 100%;
+        }
+        .container > div {
+            flex: 1;
+        }
+    </style>
+</head>
+<body>
+
+    <div style="text-align: center; margin-bottom: 3rem;">
+        <h1>Shadow Card Elevation Fix</h1>
+        <p>Resolves issue #37396 where the shadow was too faint to be seen.</p>
+    </div>
+
+    <div class="container">
+        <!-- Standard Base Card -->
+        <div class="ease-card">
+            <div class="ease-card-header">
+                <h3 class="ease-card-title">Base Card</h3>
+            </div>
+            <div class="ease-card-body">
+                <p>This is the standard card. It uses a 1px border and no shadow.</p>
+            </div>
+        </div>
+
+        <!-- Fixed Shadow Card -->
+        <!-- Note: We apply the fix via the local style.css -->
+        <div class="ease-card ease-card-shadow fixed-shadow-card">
+            <div class="ease-card-header">
+                <h3 class="ease-card-title">Shadow Card</h3>
+            </div>
+            <div class="ease-card-body">
+                <p>This card now correctly uses a prominent elevation shadow, resolving the visual bug.</p>
+            </div>
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/fix-shadow-card-elevation-37396/style.css
+++ b/submissions/examples/fix-shadow-card-elevation-37396/style.css
@@ -1,0 +1,25 @@
+/* 
+   Fix for Issue #37396: 
+   The core .ease-card-shadow relies on --ease-shadow-lg which has 0.10 opacity.
+   We override it locally to provide the expected elevation effect. 
+*/
+
+.fixed-shadow-card.ease-card-shadow {
+    /* We use a much stronger shadow (equivalent to xl but with higher opacity) 
+       to ensure the card lifts off the background clearly. */
+    box-shadow: 
+        0 20px 25px -5px rgba(0, 0, 0, 0.15),
+        0 10px 10px -5px rgba(0, 0, 0, 0.10) !important;
+        
+    /* Maintain the transparent border as intended by the framework */
+    border-color: transparent !important;
+}
+
+/* Optional hover state to further emphasize interactivity, as cards with depth imply clickability */
+.fixed-shadow-card.ease-card-shadow:hover {
+    box-shadow: 
+        0 25px 30px -5px rgba(0, 0, 0, 0.20),
+        0 15px 15px -5px rgba(0, 0, 0, 0.15) !important;
+    transform: translateY(-4px);
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #37396

**Bug**: The `.ease-card-shadow` component defaults to using `--ease-shadow-lg`, which has a very faint opacity (`0.10`) and makes the card indistinguishable from a standard base card, especially given that its border is transparent.

**Fix**: Provided a local CSS override inside the `submissions/` directory that redefines the shadow using stronger `rgba` values, making the elevation effect visible and prominent as intended, fully adhering to repository contribution rules.

---

## Submission Checklist

- [x] All changes are isolated in `submissions/examples/fix-shadow-card-elevation-37396/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to framework core files**