### PR TITLE
fix: trim whitespace in animation search input

### DIFF
--- a/submissions/examples/fix-trim-search-whitespace-37384/README.md
+++ b/submissions/examples/fix-trim-search-whitespace-37384/README.md
@@ -1,0 +1,13 @@
+# Fix Search Whitespace Trim
+
+This submission provides a fix for issue #37384.
+
+## The Bug
+In the documentation playground, the animation search input does not ignore leading or trailing whitespace. Searching for ` fadeIn` or `fadeIn ` fails to match existing animations because the spaces are treated as literal parts of the query string.
+
+## The Fix
+This submission demonstrates the correct implementation of the search filter. By applying `.trim()` to the input value before it is processed by `.includes()`, we ensure that accidental spaces do not break the search functionality.
+
+## File Structure
+- `demo.html`: Contains a functional animation search interface demonstrating the fixed logic where leading/trailing spaces are safely ignored.
+- `style.css`: Basic styling for the search interface and animation cards.

--- a/submissions/examples/fix-trim-search-whitespace-37384/demo.html
+++ b/submissions/examples/fix-trim-search-whitespace-37384/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Search Whitespace Trim Fix</title>
+    <link rel="stylesheet" href="../../../easemotion.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="search-container">
+        <h1>Animation Search Filter Fix</h1>
+        <p>This demo resolves issue #37384. Try searching for " fade " with extra spaces. It will correctly trim the spaces and find the matching animations.</p>
+
+        <div class="search-box">
+            <input 
+                type="text" 
+                id="animSearch" 
+                class="ease-input" 
+                placeholder="Search animations (try adding spaces before/after)..."
+            >
+        </div>
+
+        <div id="results" class="results-grid">
+            <!-- Animation cards will be injected here -->
+        </div>
+    </div>
+
+    <script>
+        const animations = [
+            "fadeIn", "fadeOut", "slideUp", "slideDown", "bounceIn", "zoomOut"
+        ];
+
+        const searchInput = document.getElementById("animSearch");
+        const resultsContainer = document.getElementById("results");
+
+        function renderResults(list) {
+            resultsContainer.innerHTML = '';
+            if (list.length === 0) {
+                resultsContainer.innerHTML = '<p style="color: #888;">No matching animations found.</p>';
+                return;
+            }
+
+            list.forEach(anim => {
+                const card = document.createElement('div');
+                card.className = 'ease-card ease-card-shadow';
+                card.innerHTML = `<h3 class="ease-card-title">${anim}</h3>`;
+                resultsContainer.appendChild(card);
+            });
+        }
+
+        // Initial render
+        renderResults(animations);
+
+        searchInput.addEventListener("input", function () {
+            // THE FIX: Use .trim() to remove accidental leading/trailing whitespace
+            const query = this.value.trim().toLowerCase();
+
+            const filtered = animations.filter(animation =>
+                animation.toLowerCase().includes(query)
+            );
+
+            renderResults(filtered);
+        });
+    </script>
+</body>
+</html>

--- a/submissions/examples/fix-trim-search-whitespace-37384/style.css
+++ b/submissions/examples/fix-trim-search-whitespace-37384/style.css
@@ -1,0 +1,41 @@
+body {
+    background-color: #f8fafc;
+    font-family: system-ui, -apple-system, sans-serif;
+    margin: 0;
+    padding: 2rem;
+    color: #334155;
+}
+
+.search-container {
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+h1 {
+    margin-top: 0;
+}
+
+.search-box {
+    margin: 2rem 0;
+}
+
+.ease-input {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    font-size: 1rem;
+    border: 1px solid #cbd5e1;
+    border-radius: 0.5rem;
+    outline: none;
+    box-sizing: border-box;
+}
+
+.ease-input:focus {
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+}
+
+.results-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 1.5rem;
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #37384

**Bug**: The search input in the documentation/playground did not trim leading or trailing whitespaces. Because of this, searching for ` fadeIn` or `fadeIn ` would fail to match the animation `fadeIn`.

**Fix**: This submission provides a demonstrative implementation in the `submissions/` directory showing how to correctly apply `.trim()` to the search query string before using `.includes()`. This ensures accidental whitespaces do not break the search functionality.

---

## Submission Checklist

- [x] All changes are isolated in `submissions/examples/fix-trim-search-whitespace-37384/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to framework core files**