### PR TITLE
fix: reset copy button state on page refresh

### DIFF
--- a/submissions/examples/fix-copy-btn-state-37361/README.md
+++ b/submissions/examples/fix-copy-btn-state-37361/README.md
@@ -1,0 +1,13 @@
+# Fix Copy Button State
+
+This submission resolves issue #37361.
+
+## The Bug
+In the Animation Builder, the "Copy" button occasionally remains stuck in the "Copied!" state after a page refresh. Certain browsers aggressively cache DOM state (like input values and button texts) between soft reloads, causing the button to display an inaccurate status.
+
+## The Fix
+This submission demonstrates the correct way to handle ephemeral UI states like copy confirmations. By leveraging the `pageshow` event (which fires even when pages are loaded from the browser's bfcache) and explicitly resetting the button text on load, we guarantee the button always starts in the default "Copy" state.
+
+## File Structure
+- `demo.html`: Contains the copy button implementation with robust state resetting logic.
+- `style.css`: Basic styling for the button and layout.

--- a/submissions/examples/fix-copy-btn-state-37361/demo.html
+++ b/submissions/examples/fix-copy-btn-state-37361/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Copy Button State Fix</title>
+    <link rel="stylesheet" href="../../../easemotion.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="container">
+        <h1>Copy Button State Fix</h1>
+        <p>Resolves issue #37361. Test this by clicking Copy, then rapidly refreshing the page before the timeout finishes. The button will correctly reset to "Copy" upon reload.</p>
+
+        <div class="code-block">
+            <code id="generatedCodeEl">.ease-animation-bounce { animation: ease-bounce 1s; }</code>
+            <button id="copyBtn" class="ease-btn ease-btn-primary" autocomplete="off">Copy</button>
+        </div>
+    </div>
+
+    <script>
+        const copyBtn = document.getElementById("copyBtn");
+        const generatedCodeEl = document.getElementById("generatedCodeEl");
+        const defaultText = "Copy";
+        const copiedText = "Copied!";
+
+        // 1. Standard copy logic
+        copyBtn.addEventListener("click", async () => {
+            try {
+                await navigator.clipboard.writeText(generatedCodeEl.textContent);
+                copyBtn.textContent = copiedText;
+
+                setTimeout(() => {
+                    copyBtn.textContent = defaultText;
+                }, 1500);
+            } catch (error) {
+                console.error("Failed to copy:", error);
+                copyBtn.textContent = "Failed";
+            }
+        });
+
+        // 2. THE FIX: Explicitly reset state on page load and pageshow 
+        // (pageshow handles back/forward cache restorations which bypass DOMContentLoaded)
+        function resetCopyState() {
+            if (copyBtn) {
+                copyBtn.textContent = defaultText;
+            }
+        }
+
+        window.addEventListener("DOMContentLoaded", resetCopyState);
+        window.addEventListener("pageshow", resetCopyState);
+    </script>
+</body>
+</html>

--- a/submissions/examples/fix-copy-btn-state-37361/style.css
+++ b/submissions/examples/fix-copy-btn-state-37361/style.css
@@ -1,0 +1,34 @@
+body {
+    background-color: #f8fafc;
+    font-family: system-ui, -apple-system, sans-serif;
+    margin: 0;
+    padding: 2rem;
+    color: #334155;
+    display: flex;
+    justify-content: center;
+}
+
+.container {
+    max-width: 600px;
+    width: 100%;
+}
+
+.code-block {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background-color: #1e293b;
+    padding: 1rem;
+    border-radius: 0.5rem;
+    margin-top: 2rem;
+}
+
+code {
+    color: #a5b4fc;
+    font-family: 'Fira Code', monospace;
+}
+
+.ease-btn {
+    min-width: 80px;
+    transition: all 0.2s ease;
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #37361

**Bug**: The "Copy" button could get stuck displaying "Copied!" if the user refreshed the page before the timeout completed, due to aggressive browser caching of DOM state or the bfcache.

**Fix**: This submission demonstrates best practices for fixing this by explicitly resetting the button text on both `DOMContentLoaded` and `pageshow` events (to handle back/forward cache). The button also specifies `autocomplete="off"` to discourage the browser from preserving its state.

---

## Submission Checklist

- [x] All changes are isolated in `submissions/examples/fix-copy-btn-state-37361/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to framework core files**