### PR TITLE
fix: make headings and table headers legible in dark mode

### DIFF
--- a/submissions/examples/fix-headings-dark-mode-37154/README.md
+++ b/submissions/examples/fix-headings-dark-mode-37154/README.md
@@ -1,0 +1,13 @@
+# Fix Headings Visibility in Dark Mode
+
+This submission resolves issue #37154.
+
+## The Bug
+In the framework's core `base.css`, heading tags (`h1`-`h6`) and table headers (`th`) were hardcoded to use `color: var(--ease-color-neutral-900)`. Because this neutral token does not switch to a lighter shade in Dark Mode, the headings rendered as near-black text on a near-black background, making them invisible and inaccessible.
+
+## The Fix
+This submission provides a CSS override that resolves the issue without modifying the core files. By explicitly redefining the text color of headings and table headers to use `var(--ease-color-text)` (or `inherit` the body color), the headings automatically adapt to the active theme context, appearing legible in both Light and Dark modes.
+
+## File Structure
+- `demo.html`: Features headings and a table, along with a theme toggle button to demonstrate the visibility of the text in both themes.
+- `style.css`: Contains the CSS override that fixes the heading colors locally.

--- a/submissions/examples/fix-headings-dark-mode-37154/demo.html
+++ b/submissions/examples/fix-headings-dark-mode-37154/demo.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Headings Dark Mode Fix</title>
+    <!-- Import core framework styles -->
+    <link rel="stylesheet" href="../../../easemotion.css">
+    <link rel="stylesheet" href="style.css">
+    
+    <!-- Simulating the core dark mode background behavior for demonstration -->
+    <style>
+        :root {
+            --ease-color-bg: #ffffff;
+            --ease-color-text: #0f172a;
+        }
+        [data-theme="dark"] {
+            --ease-color-bg: #0b1121;
+            --ease-color-text: #f8fafc;
+        }
+        body {
+            background-color: var(--ease-color-bg);
+            color: var(--ease-color-text);
+            font-family: system-ui, -apple-system, sans-serif;
+            padding: 2rem;
+            transition: background-color 0.3s, color 0.3s;
+        }
+        .demo-container {
+            max-width: 800px;
+            margin: 0 auto;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 1rem;
+        }
+        th, td {
+            border: 1px solid #334155;
+            padding: 0.75rem;
+            text-align: left;
+        }
+    </style>
+</head>
+<body>
+
+    <div class="demo-container">
+        <button id="themeToggle" class="ease-btn ease-btn-primary" style="margin-bottom: 2rem;">Toggle Theme</button>
+
+        <h1>Heading 1 (h1)</h1>
+        <h2>Heading 2 (h2)</h2>
+        <h3>Heading 3 (h3)</h3>
+        
+        <p>This paragraph text is standard and already uses the responsive `--ease-color-text`.</p>
+
+        <table>
+            <thead>
+                <tr>
+                    <th>Table Header 1 (th)</th>
+                    <th>Table Header 2 (th)</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Table Data</td>
+                    <td>Table Data</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <script>
+        const toggleBtn = document.getElementById('themeToggle');
+        
+        toggleBtn.addEventListener('click', () => {
+            const html = document.documentElement;
+            const currentTheme = html.getAttribute('data-theme');
+            html.setAttribute('data-theme', currentTheme === 'dark' ? 'light' : 'dark');
+        });
+    </script>
+</body>
+</html>

--- a/submissions/examples/fix-headings-dark-mode-37154/style.css
+++ b/submissions/examples/fix-headings-dark-mode-37154/style.css
@@ -1,0 +1,29 @@
+/* 
+   Fix for Issue #37154: Headings invisible in dark mode 
+   By default, the core base.css hardcodes h1-h6 and th to --ease-color-neutral-900.
+   We override this to use the dynamic theme text color variable, or inherit the body color.
+*/
+
+h1, h2, h3, h4, h5, h6, th {
+    /* 
+      Override the hardcoded neutral-900 color.
+      If the framework defines --ease-color-text, it will use that.
+      Otherwise, 'inherit' forces it to use the body's current text color, 
+      which correctly flips between light and dark modes.
+    */
+    color: var(--ease-color-heading, inherit) !important;
+}
+
+/* Base button styling for the demo toggle */
+.ease-btn {
+    padding: 0.5rem 1rem;
+    border-radius: 0.375rem;
+    border: none;
+    font-size: 0.875rem;
+    cursor: pointer;
+}
+
+.ease-btn-primary {
+    background-color: #3b82f6;
+    color: #ffffff;
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #37154

**Bug**: Headings (`h1`-`h6`) and table headers (`th`) were completely unreadable in Dark Mode because they were hardcoded to use `--ease-color-neutral-900` (a near-black color) in the framework's core base styles. 

**Fix**: This submission demonstrates the standard fix applied within the `submissions/` directory, utilizing `color: inherit` (or dynamic text tokens) to force these elements to adapt their text color cleanly to the active light/dark background.

---

## Submission Checklist

- [x] All changes are isolated in `submissions/examples/fix-headings-dark-mode-37154/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to framework core files**