### PR TITLE
fix: make horizontal stepper responsive on mobile viewports

### DIFF
--- a/submissions/examples/fix-stepper-overflow-37021/README.md
+++ b/submissions/examples/fix-stepper-overflow-37021/README.md
@@ -1,0 +1,15 @@
+# Fix Stepper Overflow on Mobile
+
+This submission resolves issue #37021.
+
+## The Bug
+The horizontal stepper/timeline container used a fixed `width: 600px`. On viewports smaller than 480px, this caused horizontal overflow, forcing the browser to render an ugly horizontal scrollbar and breaking the page layout on mobile devices.
+
+## The Fix
+This submission demonstrates a responsive, overflow-safe implementation of the animated stepper.
+1. Replaced the fixed `width: 600px` with a fluid `width: 100%; max-width: 600px;`.
+2. Implemented a media query (`@media (max-width: 480px)`) that transforms the horizontal flex layout into a vertical stack (`flex-direction: column`), ensuring the stepper remains usable and visually appealing on the smallest of screens.
+
+## File Structure
+- `demo.html`: Contains the responsive stepper HTML structure.
+- `style.css`: Contains the updated, fluid layout rules and responsive media queries.

--- a/submissions/examples/fix-stepper-overflow-37021/demo.html
+++ b/submissions/examples/fix-stepper-overflow-37021/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Responsive Stepper Fix</title>
+    <!-- Import core styles -->
+    <link rel="stylesheet" href="../../../easemotion.css">
+    <link rel="stylesheet" href="style.css">
+    <style>
+        body {
+            background-color: #f8fafc;
+            font-family: system-ui, -apple-system, sans-serif;
+            margin: 0;
+            padding: 2rem 1rem; /* Less padding on sides to simulate mobile better */
+            color: #334155;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        .demo-info {
+            text-align: center;
+            margin-bottom: 3rem;
+            max-width: 600px;
+        }
+    </style>
+</head>
+<body>
+
+    <div class="demo-info">
+        <h1>Responsive Stepper Fix</h1>
+        <p>Resolves issue #37021. Shrink your browser window below 480px to see the stepper automatically switch to a vertical layout without causing a horizontal scrollbar.</p>
+    </div>
+
+    <!-- THE FIX: Responsive Stepper Container -->
+    <div class="responsive-stepper">
+        
+        <!-- Step 1 -->
+        <div class="step active">
+            <div class="step-circle ease-pulse">1</div>
+            <div class="step-label">Account Setup</div>
+            <div class="step-connector"></div>
+        </div>
+
+        <!-- Step 2 -->
+        <div class="step">
+            <div class="step-circle">2</div>
+            <div class="step-label">Profile Details</div>
+            <div class="step-connector"></div>
+        </div>
+
+        <!-- Step 3 -->
+        <div class="step">
+            <div class="step-circle">3</div>
+            <div class="step-label">Verification</div>
+        </div>
+
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/fix-stepper-overflow-37021/style.css
+++ b/submissions/examples/fix-stepper-overflow-37021/style.css
@@ -1,0 +1,102 @@
+/* 
+   Fix for Issue #37021: Horizontal Stepper Overflow 
+   Replaces fixed width with fluid max-width and adds vertical stacking for mobile.
+*/
+
+.responsive-stepper {
+    /* FIX: Changed from fixed width: 600px to fluid max-width */
+    width: 100%;
+    max-width: 600px; 
+    
+    display: flex;
+    justify-content: space-between;
+    position: relative;
+    margin: 0 auto;
+}
+
+.step {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    position: relative;
+    flex: 1;
+    z-index: 1;
+}
+
+.step-circle {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background-color: #e2e8f0;
+    color: #64748b;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+    margin-bottom: 0.5rem;
+    border: 2px solid #fff;
+    transition: all 0.3s ease;
+}
+
+.step.active .step-circle {
+    background-color: #3b82f6;
+    color: #ffffff;
+}
+
+.step-label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    text-align: center;
+}
+
+/* Horizontal Connector */
+.step-connector {
+    position: absolute;
+    top: 20px; /* Half of circle height */
+    left: 50%;
+    width: 100%;
+    height: 2px;
+    background-color: #e2e8f0;
+    z-index: -1;
+}
+
+/* Responsive breakpoint for mobile viewports */
+@media (max-width: 480px) {
+    .responsive-stepper {
+        /* FIX: Stack vertically instead of forcing horizontal layout */
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 1.5rem;
+    }
+
+    .step {
+        flex-direction: row;
+        width: 100%;
+        flex: none;
+    }
+
+    .step-circle {
+        margin-bottom: 0;
+        margin-right: 1rem;
+    }
+
+    /* Change horizontal connector to a vertical line connecting the circles */
+    .step-connector {
+        top: 100%;
+        left: 20px; /* Center of the circle */
+        width: 2px;
+        height: 1.5rem; /* Gap between steps */
+        transform: translateX(-50%); /* perfectly center the 2px line */
+    }
+}
+
+/* Base pulse animation simulating the framework utility */
+@keyframes pulse-anim {
+    0% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.4); }
+    70% { box-shadow: 0 0 0 10px rgba(59, 130, 246, 0); }
+    100% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0); }
+}
+
+.ease-pulse {
+    animation: pulse-anim 2s infinite;
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #37021

**Bug**: The horizontal timeline/stepper component previously relied on a hardcoded `width: 600px`. On mobile viewports under 480px, this caused horizontal overflow and broke the page layout by introducing an unwanted horizontal scrollbar.

**Fix**: This submission demonstrates how to resolve the overflow by using `max-width: 600px; width: 100%`. Additionally, it implements a responsive media query (`< 480px`) that elegantly stacks the steps vertically (and re-orients the connecting line), ensuring a flawless mobile experience.

---

## Submission Checklist

- [x] All changes are isolated in `submissions/examples/fix-stepper-overflow-37021/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to framework core files**