### PR TITLE
fix: improve sidebar hover contrast in light mode

### DIFF
--- a/submissions/examples/fix-sidebar-contrast-36387/README.md
+++ b/submissions/examples/fix-sidebar-contrast-36387/README.md
@@ -1,0 +1,13 @@
+# Fix Sidebar Navigation Contrast
+
+This submission resolves issue #36387.
+
+## The Bug
+On the documentation website in Light Mode, hovering over sidebar navigation buttons caused the background to become very light. This reduced the contrast ratio between the background and the text/icon to an inaccessible level, making the text nearly unreadable.
+
+## The Fix
+This submission demonstrates an accessible and visually pleasing sidebar navigation implementation for Light Mode. By using a slightly darker, semi-transparent background on hover (e.g., `rgba(15, 23, 42, 0.05)`) and maintaining a solid text color (`var(--ease-color-neutral-900)`), the contrast ratio remains robust while still providing clear interactive feedback.
+
+## File Structure
+- `demo.html`: Features a sample sidebar navigation menu demonstrating the corrected hover state.
+- `style.css`: Contains the CSS for the sidebar, specifically targeting the improved hover contrast.

--- a/submissions/examples/fix-sidebar-contrast-36387/demo.html
+++ b/submissions/examples/fix-sidebar-contrast-36387/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sidebar Contrast Fix</title>
+    <!-- Import core framework styles -->
+    <link rel="stylesheet" href="../../../easemotion.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <!-- THE FIX: Sidebar with proper hover contrast -->
+        <aside class="sidebar">
+            <h3 class="sidebar-title">Components</h3>
+            <nav class="sidebar-nav">
+                <a href="#" class="nav-item">
+                    <span class="nav-icon">✨</span>
+                    Animations
+                </a>
+                <a href="#" class="nav-item active">
+                    <span class="nav-icon">📦</span>
+                    Buttons
+                </a>
+                <a href="#" class="nav-item">
+                    <span class="nav-icon">🃏</span>
+                    Cards
+                </a>
+                <a href="#" class="nav-item">
+                    <span class="nav-icon">🧭</span>
+                    Navigation
+                </a>
+            </nav>
+        </aside>
+
+        <main class="content-area">
+            <h1>Sidebar Hover Contrast Fix</h1>
+            <p>Resolves issue #36387.</p>
+            <p>Hover over the links in the sidebar to the left. The hover background is now appropriately contrasted with the text, ensuring full readability and accessibility in Light Mode.</p>
+        </main>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/fix-sidebar-contrast-36387/style.css
+++ b/submissions/examples/fix-sidebar-contrast-36387/style.css
@@ -1,0 +1,71 @@
+body {
+    background-color: #ffffff; /* Explicit light mode bg */
+    color: #0f172a;
+    font-family: system-ui, -apple-system, sans-serif;
+    margin: 0;
+}
+
+.layout-container {
+    display: flex;
+    min-height: 100vh;
+}
+
+.sidebar {
+    width: 280px;
+    background-color: #f8fafc;
+    border-right: 1px solid #e2e8f0;
+    padding: 1.5rem 1rem;
+}
+
+.sidebar-title {
+    font-size: 0.875rem;
+    text-transform: uppercase;
+    color: #64748b;
+    margin-bottom: 1rem;
+    padding-left: 0.75rem;
+    font-weight: 600;
+}
+
+.sidebar-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.nav-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.375rem;
+    color: #334155;
+    text-decoration: none;
+    font-size: 1rem;
+    font-weight: 500;
+    transition: all 0.2s ease;
+}
+
+/* 
+   THE FIX: Issue #36387 
+   Previously, the hover state made the background too light or matched the text color too closely.
+   We now use a semi-transparent dark overlay that maintains high contrast for the text. 
+*/
+.nav-item:hover {
+    background-color: rgba(15, 23, 42, 0.05); /* Slight darkening for contrast */
+    color: #0f172a; /* Ensure text stays dark and readable */
+}
+
+/* Active state contrast */
+.nav-item.active {
+    background-color: #e0e7ff;
+    color: #4338ca;
+}
+
+.nav-icon {
+    font-size: 1.25rem;
+}
+
+.content-area {
+    flex: 1;
+    padding: 2rem 3rem;
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #36387

**Bug**: On the documentation website in Light Mode, the sidebar navigation buttons exhibited a hover state that severely reduced contrast against the background, making the navigation text nearly unreadable and violating accessibility best practices.

**Fix**: This submission provides an updated, accessible hover implementation in the `submissions/` directory. By utilizing a subtle, semi-transparent dark overlay (`rgba(15, 23, 42, 0.05)`) while preserving a solid text color on hover, the navigation links remain distinctly legible and interactive in Light Mode without compromising aesthetics.

---

## Submission Checklist

- [x] All changes are isolated in `submissions/examples/fix-sidebar-contrast-36387/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to framework core files**