### PR TITLE
feat: propose CSS cascade layers architecture to solve specificity conflicts

### DIFF
--- a/submissions/examples/arch-layer-proposal-33443/README.md
+++ b/submissions/examples/arch-layer-proposal-33443/README.md
@@ -1,0 +1,13 @@
+# Architecture Proposal: CSS Cascade Layers (`@layer`)
+
+This submission resolves architectural issue #33443.
+
+## The Problem
+EaseMotion CSS currently lacks Cascade Layer (`@layer`) definitions. Consequently, developers importing the framework often face specificity battles when trying to override framework utility classes (like `.ease-btn`) with their own custom CSS, leading to unpredictable results dependent on stylesheet loading order.
+
+## The Proposal & Fix
+This submission demonstrates how to implement `@layer` to completely resolve specificity conflicts. 
+
+Because we cannot modify the framework's core files or `scripts/bundle.js` directly within this PR (per repository rules), this submission provides:
+1. **`proposed-bundle.js`**: A proposed replacement script for the core maintainers showing exactly how to wrap the concatenated CSS output into an `@layer easemotion` block during the build process.
+2. **`demo.html` & `style.css`**: A working demonstration proving that when framework styles are placed in a layer, developer styles (unlayered) *always* win, regardless of CSS specificity rules or load order.

--- a/submissions/examples/arch-layer-proposal-33443/demo.html
+++ b/submissions/examples/arch-layer-proposal-33443/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cascade Layer Proposal Demo</title>
+    <!-- Note: We are mocking the layered framework behavior in style.css to demonstrate the fix -->
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div style="font-family: sans-serif; padding: 2rem; max-width: 800px; margin: 0 auto;">
+        <h1>Specificity Resolution via Cascade Layers</h1>
+        <p>This page demonstrates how wrapping the framework in <code>@layer</code> solves specificity wars.</p>
+        
+        <div style="margin-top: 2rem; padding: 1.5rem; border: 1px solid #ccc; border-radius: 8px;">
+            <h3>The Button Test</h3>
+            <p>The button below has the framework class <code>.ease-btn</code> (which sets it to blue in the framework layer).</p>
+            <p>However, the developer's custom stylesheet targets a simple <code>button</code> tag (which sets it to red).</p>
+            <p>Because the developer's style is <strong>unlayered</strong>, it effortlessly overrides the framework's layered class, even though a class selector (<code>.ease-btn</code>) technically has higher specificity than a tag selector (<code>button</code>).</p>
+            
+            <button class="ease-btn" style="margin-top: 1rem;">I should be Red</button>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/arch-layer-proposal-33443/proposed-bundle.js
+++ b/submissions/examples/arch-layer-proposal-33443/proposed-bundle.js
@@ -1,0 +1,44 @@
+/**
+ * PROPOSED BUILD SCRIPT UPDATE FOR MAINTAINERS
+ * 
+ * To implement the architecture change requested in #33443, 
+ * the core `scripts/bundle.js` file should be updated as follows:
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// E.g., The list of files to concatenate
+const cssFiles = [
+    'core/variables.css',
+    'core/base.css',
+    'core/animations.css',
+    'core/utilities.css',
+    'components/buttons.css',
+    'components/cards.css'
+];
+
+function build() {
+    let concatenatedSource = '';
+    
+    // Read and concatenate all CSS files
+    cssFiles.forEach(file => {
+        const filePath = path.join(__dirname, '..', file);
+        if (fs.existsSync(filePath)) {
+            concatenatedSource += fs.readFileSync(filePath, 'utf8') + '\n';
+        }
+    });
+
+    // THE FIX: Wrap the entire concatenated source inside a CSS Cascade Layer
+    // This allows developers to easily override framework styles without using !important
+    const layeredSource = `/* EaseMotion CSS - Layered Architecture */\n@layer easemotion {\n${concatenatedSource}\n}\n`;
+
+    // Output the layered source to the dist directory
+    const outPath = path.join(__dirname, '..', 'dist', 'easemotion.css');
+    fs.mkdirSync(path.dirname(outPath), { recursive: true });
+    fs.writeFileSync(outPath, layeredSource);
+    
+    console.log('Build complete with @layer support.');
+}
+
+// build();

--- a/submissions/examples/arch-layer-proposal-33443/style.css
+++ b/submissions/examples/arch-layer-proposal-33443/style.css
@@ -1,0 +1,30 @@
+/* 
+  MOCK FRAMEWORK STYLES 
+  This simulates what the built easemotion.css will look like once 
+  the proposed-bundle.js script is implemented by the maintainers.
+*/
+@layer easemotion {
+    .ease-btn {
+        background-color: blue;
+        color: white;
+        padding: 0.5rem 1rem;
+        border-radius: 4px;
+        border: none;
+        cursor: pointer;
+    }
+}
+
+/* 
+  DEVELOPER STYLES 
+  This represents the styles written by a user of the framework.
+  Notice how we use a very low-specificity selector ('button').
+*/
+
+button {
+    /* 
+      Because this style is unlayered, it automatically beats the 
+      framework's layered .ease-btn styles, turning the button red!
+      Without @layer, this would fail, and the button would remain blue.
+    */
+    background-color: red;
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #33443

**Architecture Request**: Developers using EaseMotion CSS faced specificity conflicts when trying to override framework styles with their own CSS, heavily depending on stylesheet load order.

**Implementation**: Because GSSoC rules strictly prohibit modifying the core framework build scripts (`scripts/bundle.js`), this PR submits an architectural proposal inside the `submissions/` directory. It provides `proposed-bundle.js` showing maintainers exactly how to wrap the concatenated output in an `@layer easemotion` block. It also includes an interactive `demo.html` proving that unlayered developer styles effortlessly override layered framework styles, completely resolving the specificity wars.

---

## Submission Checklist

- [x] All changes are isolated in `submissions/examples/arch-layer-proposal-33443/`
- [x] Includes `proposed-bundle.js` (Architectural Fix)
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to framework core files**