### PR TITLE
docs: add production usage demo for existing minified CSS build (#38163)

### DIFF
--- a/submissions/docs/minified-css-usage-karishmaram-tech/README.md
+++ b/submissions/docs/minified-css-usage-karishmaram-tech/README.md
@@ -1,0 +1,49 @@
+# Minified CSS — Production Usage Demo
+
+## Context
+
+This submission addresses issue **#38163 — "No minified/production CSS build"**.
+
+During review, it was found that the repository **already ships a production
+minified build** (`easemotion.min.css` at the project root), built and
+maintained by the project's own tooling (see recent commits such as
+`chore: auto-build bundle and resolve folder naming conflicts` and
+`fix(docs): copy minified CSS directly to docs folder...`). There is also an
+open PR (#38181) already targeting the build-script side of this issue.
+
+Because the repository is currently under a **temporary contribution
+freeze** on root files, build scripts, and core framework files, this
+submission does **not** modify:
+
+- `easemotion.css`
+- `easemotion.min.css`
+- anything inside `scripts/`
+- anything inside `core/` or `components/`
+
+Instead, this submission closes the *practical* gap behind the original
+issue — many users didn't know the minified build already existed or how
+to correctly wire it into a production page — by providing a self-contained,
+correct usage example.
+
+## What's included
+
+| File | Purpose |
+|---|---|
+| `demo.html` | Minimal page that links the existing `easemotion.min.css` (via jsDelivr CDN) the way a production deployment should, instead of the dev-only `easemotion.css`. |
+| `style.css` | Page-level demo styling only — does not override or extend core framework classes. |
+| `README.md` | This file. |
+
+## How to view
+
+Open `demo.html` directly in a browser, or serve the folder locally:
+
+```bash
+npx serve submissions/docs/minified-css-usage-karishmaram-tech
+```
+
+## Suggested follow-up for maintainer
+
+If the maintainer confirms the minified build is fully solved by the
+existing pipeline / PR #38181, issue #38163 can likely be closed once that
+PR merges, with this submission serving as the documented usage reference
+under `submissions/docs/`.

--- a/submissions/docs/minified-css-usage-karishmaram-tech/demo.html
+++ b/submissions/docs/minified-css-usage-karishmaram-tech/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EaseMotion CSS — Production (Minified) Usage Demo</title>
+
+  <!--
+    This demo intentionally links the EXISTING minified build
+    (easemotion.min.css) exactly the way a production site should,
+    rather than the full unminified easemotion.css used for local dev.
+    No build files were modified to create this demo.
+  -->
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-center ease-fade-in demo-wrapper">
+    <h1 class="ease-slide-up ease-delay-100">Production Build Demo</h1>
+    <p class="ease-slide-up ease-delay-200">
+      This page loads <code>easemotion.min.css</code> — the framework's
+      production-ready, minified bundle — instead of the full
+      <code>easemotion.css</code> source file.
+    </p>
+
+    <button
+      class="ease-btn ease-btn-primary ease-btn-pill ease-hover-grow ease-delay-300"
+    >
+      Get Started →
+    </button>
+
+    <section class="demo-note">
+      <h2>Why this matters</h2>
+      <p>
+        Shipping the minified bundle in production avoids sending
+        unnecessary whitespace and comments to the browser, reducing
+        payload size without changing any visual behavior.
+      </p>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/docs/minified-css-usage-karishmaram-tech/style.css
+++ b/submissions/docs/minified-css-usage-karishmaram-tech/style.css
@@ -1,0 +1,41 @@
+/*
+  Supplementary styles for the minified-CSS-usage demo page.
+  This file only adds page-level presentation on top of EaseMotion CSS
+  utility classes — it does not modify or override core framework files.
+*/
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Inter', system-ui, sans-serif;
+  background: #0f1115;
+  color: #f5f5f5;
+}
+
+.demo-wrapper {
+  flex-direction: column;
+  gap: 1.25rem;
+  min-height: 100vh;
+  padding: 2rem;
+  text-align: center;
+}
+
+.demo-note {
+  max-width: 32rem;
+  margin-top: 2rem;
+  padding: 1.25rem 1.5rem;
+  border-radius: 0.75rem;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.demo-note h2 {
+  margin-top: 0;
+  font-size: 1.1rem;
+}
+
+.demo-note p {
+  margin-bottom: 0;
+  font-size: 0.95rem;
+  opacity: 0.85;
+}


### PR DESCRIPTION
## Summary
Adds a self-contained `submissions/docs/` example demonstrating correct production usage of the existing `easemotion.min.css` build, addressing the practical gap behind #38163 without touching root CSS files, build scripts, or core framework files (respecting the current contribution freeze).

## Changes
- `submissions/docs/minified-css-usage-karishmaram-tech/demo.html`
- `submissions/docs/minified-css-usage-karishmaram-tech/style.css`
- `submissions/docs/minified-css-usage-karishmaram-tech/README.md`

## Notes for reviewer
- No files outside `submissions/` were modified.
- This does not duplicate the build-script work in #38181; it's a documentation/usage submission.
- Related issue: #38163