### PR TITLE
fix: improve heading visibility in dark mode

### DIFF
--- a/submissions/examples/dark-mode-heading-fix-ajit/README.md
+++ b/submissions/examples/dark-mode-heading-fix-ajit/README.md
@@ -1,0 +1,39 @@
+# Dark Mode Heading Fix
+
+## Problem
+
+Heading elements used a fixed color such as:
+
+```css
+color: var(--ease-color-neutral-900);
+```
+
+This caused poor visibility in dark mode.
+
+## Solution
+
+Use the semantic theme token instead:
+
+```css
+color: var(--ease-color-text);
+```
+
+The heading color automatically updates in both light and dark themes.
+
+## Features
+
+- Theme-aware heading colors
+- Light/Dark mode toggle
+- Fully self-contained demo
+- No changes outside `submissions/`
+
+## Files
+
+```
+dark-mode-heading-fix-ajit/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+Open `demo.html` directly in your browser to view the demo.

--- a/submissions/examples/dark-mode-heading-fix-ajit/demo.html
+++ b/submissions/examples/dark-mode-heading-fix-ajit/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dark Mode Heading Fix</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="container">
+    <button id="toggleTheme">🌙 Toggle Theme</button>
+
+    <h1>Heading Level 1</h1>
+    <h2>Heading Level 2</h2>
+    <h3>Heading Level 3</h3>
+    <h4>Heading Level 4</h4>
+    <h5>Heading Level 5</h5>
+    <h6>Heading Level 6</h6>
+
+    <p>
+        This demo shows a fix for invisible headings in dark mode by using
+        the theme-aware CSS variable
+        <code>var(--ease-color-text)</code>.
+    </p>
+</div>
+
+<script>
+const btn = document.getElementById("toggleTheme");
+
+btn.addEventListener("click", () => {
+    document.body.classList.toggle("dark");
+});
+</script>
+
+</body>
+</html>

--- a/submissions/examples/dark-mode-heading-fix-ajit/style.css
+++ b/submissions/examples/dark-mode-heading-fix-ajit/style.css
@@ -1,0 +1,72 @@
+*{
+    margin:0;
+    padding:0;
+    box-sizing:border-box;
+    font-family:Arial,Helvetica,sans-serif;
+}
+
+:root{
+    --ease-bg:#ffffff;
+    --ease-color-text:#1f2937;
+}
+
+body.dark{
+    --ease-bg:#111827;
+    --ease-color-text:#f9fafb;
+}
+
+body{
+    background:var(--ease-bg);
+    color:var(--ease-color-text);
+    transition:.3s ease;
+    min-height:100vh;
+    display:flex;
+    justify-content:center;
+    align-items:center;
+}
+
+.container{
+    width:700px;
+    max-width:90%;
+}
+
+button{
+    padding:10px 20px;
+    margin-bottom:25px;
+    cursor:pointer;
+    border:none;
+    border-radius:8px;
+    background:#2563eb;
+    color:#fff;
+}
+
+button:hover{
+    opacity:.9;
+}
+
+/* Fixed Heading Color */
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6{
+    color:var(--ease-color-text);
+    margin:10px 0;
+}
+
+p{
+    margin-top:20px;
+    line-height:1.6;
+}
+
+code{
+    background:#e5e7eb;
+    padding:2px 6px;
+    border-radius:4px;
+}
+
+body.dark code{
+    background:#374151;
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a self-contained example demonstrating a fix for invisible headings in dark mode by replacing fixed heading colors with a theme-aware color token. The demo ensures headings remain readable in both light and dark themes.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A standalone demo showing how to fix heading visibility in dark mode using the semantic `--ease-color-text` CSS variable.

**How does a developer use it?**

```html
<h1>Heading Level 1</h1>
<h2>Heading Level 2</h2>
<h3>Heading Level 3</h3>
```

```css
h1,
h2,
h3,
h4,
h5,
h6 {
    color: var(--ease-color-text);
}
```

**Why does it fit EaseMotion CSS?**

The example follows EaseMotion CSS principles by using semantic theme-aware CSS variables, maintaining readability across themes, and providing a clean, self-contained submission inside the `submissions/` directory.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

- All files are located under `submissions/examples/dark-mode-heading-fix-ajit/`.
- No changes were made to `core/` or `components/`.
- Demonstrates the use of `var(--ease-color-text)` for improved heading visibility in both light and dark themes.