### PR TITLE
feat: add dark color token demo

### DIFF
--- a/submissions/examples/dark-color-token-demo-ajit/README.md
+++ b/submissions/examples/dark-color-token-demo-ajit/README.md
@@ -1,0 +1,34 @@
+# Dark Color Token Demo
+
+A standalone demo illustrating the use of semantic color tokens with proper dark variants for interactive states.
+
+## Features
+
+- Success color token
+- Danger color token
+- Warning color token
+- Distinct hover (dark) colors
+- CSS-only implementation
+- Responsive layout
+
+## Folder Structure
+
+```
+dark-color-token-demo-ajit/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+Hover over each button to see the darker semantic color variants.
+
+## Browser Support
+
+- Chrome
+- Firefox
+- Edge
+- Safari

--- a/submissions/examples/dark-color-token-demo-ajit/demo.html
+++ b/submissions/examples/dark-color-token-demo-ajit/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Dark Color Token Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+<div class="container">
+
+    <h1>Dark Color Token Demo</h1>
+    <p>
+        Demonstration of semantic color tokens using distinct dark variants
+        for hover states.
+    </p>
+
+    <div class="grid">
+
+        <div class="card success">
+            <h2>Success</h2>
+            <button>Hover Me</button>
+        </div>
+
+        <div class="card danger">
+            <h2>Danger</h2>
+            <button>Hover Me</button>
+        </div>
+
+        <div class="card warning">
+            <h2>Warning</h2>
+            <button>Hover Me</button>
+        </div>
+
+    </div>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/dark-color-token-demo-ajit/style.css
+++ b/submissions/examples/dark-color-token-demo-ajit/style.css
@@ -1,0 +1,119 @@
+:root{
+
+    --ease-color-success:#15803d;
+    --ease-color-success-dark:#166534;
+
+    --ease-color-danger:#b91c1c;
+    --ease-color-danger-dark:#991b1b;
+
+    --ease-color-warning:#b45309;
+    --ease-color-warning-dark:#92400e;
+
+}
+
+*{
+    margin:0;
+    padding:0;
+    box-sizing:border-box;
+    font-family:Arial,Helvetica,sans-serif;
+}
+
+body{
+
+    background:#f5f5f5;
+    display:flex;
+    justify-content:center;
+    align-items:center;
+    min-height:100vh;
+
+}
+
+.container{
+
+    width:900px;
+    text-align:center;
+
+}
+
+.container h1{
+
+    margin-bottom:10px;
+
+}
+
+.container p{
+
+    margin-bottom:40px;
+    color:#666;
+
+}
+
+.grid{
+
+    display:grid;
+    grid-template-columns:repeat(auto-fit,minmax(220px,1fr));
+    gap:25px;
+
+}
+
+.card{
+
+    background:white;
+    border-radius:14px;
+    padding:30px;
+    box-shadow:0 8px 18px rgba(0,0,0,.12);
+
+}
+
+.card h2{
+
+    margin-bottom:20px;
+
+}
+
+button{
+
+    border:none;
+    color:white;
+    padding:12px 26px;
+    border-radius:8px;
+    cursor:pointer;
+    transition:.3s;
+
+}
+
+.success button{
+
+    background:var(--ease-color-success);
+
+}
+
+.success button:hover{
+
+    background:var(--ease-color-success-dark);
+
+}
+
+.danger button{
+
+    background:var(--ease-color-danger);
+
+}
+
+.danger button:hover{
+
+    background:var(--ease-color-danger-dark);
+
+}
+
+.warning button{
+
+    background:var(--ease-color-warning);
+
+}
+
+.warning button:hover{
+
+    background:var(--ease-color-warning-dark);
+
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a standalone demo under `submissions/examples/dark-color-token-demo-ajit/` showcasing semantic color tokens with distinct dark variants for success, danger, and warning states. The demo highlights how darker color tokens improve visual feedback for hover interactions while remaining fully self-contained.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A CSS-only demonstration of semantic success, danger, and warning color tokens with visually distinct dark hover states.

**How does a developer use it?**

```html
<div class="card success">
    <button>Hover Me</button>
</div>

<div class="card danger">
    <button>Hover Me</button>
</div>

<div class="card warning">
    <button>Hover Me</button>
</div>
```

**Why does it fit EaseMotion CSS?**

The example follows EaseMotion CSS's lightweight, reusable, and animation-focused approach while demonstrating semantic color usage entirely within the `submissions/` directory.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(basic compatibility)*

---

## Notes for Maintainer

- All files are contained within `submissions/examples/dark-color-token-demo-ajit/`.
- No changes were made to `core/` or `components/`.
- This submission is intended as a standalone demonstration of semantic color token usage.
```