### PR TITLE
fix: sync easemotion/all.css with easemotion.css

### DIFF
--- a/submissions/docs/sync-all-css-ay/README.md
+++ b/submissions/docs/sync-all-css-ay/README.md
@@ -1,0 +1,88 @@
+﻿# Sync `easemotion/all.css` with `easemotion.css` — Fix Reference
+
+Documents the exact import diff between `easemotion.css` and `easemotion/all.css`
+and provides a corrected import list for the maintainer to review and integrate.
+
+## What does this do?
+
+`easemotion/all.css` is missing **19 component imports** that are present in the
+primary `easemotion.css` bundle. This submission documents every missing import,
+demonstrates the gap with a visual comparison page, and proposes the corrected
+import list for the maintainer to apply to `easemotion/all.css`.
+
+## How is it used?
+
+After the maintainer integrates the fix, both entry points will behave identically:
+
+```html
+<!-- Primary bundle (already complete) -->
+<link rel="stylesheet" href="easemotion.css" />
+
+<!-- Alternate modular entry point (should match after fix) -->
+<link rel="stylesheet" href="easemotion/all.css" />
+```
+
+The corrected import order for `easemotion/all.css`
+(see `style.css` in this submission for the full annotated reference):
+
+```css
+/* Core */
+@import "./variables.css";
+@import "../core/base.css";
+@import "../core/animations.css";
+@import "../core/utilities.css";
+@import "../components/ease-marquee.css";
+
+/* Components currently present in all.css */
+@import "../components/buttons.css";
+@import "../components/cards.css";
+@import "../components/navbar.css";
+@import "../components/masonry.css";
+@import "../components/chip.css";
+@import "../components/footer.css";
+@import "../components/sidebar.css";
+@import "../components/scroll-progress.css";
+@import "../components/tabs.css";
+@import "../components/badges.css";
+@import "../components/loaders.css";
+@import "../components/tooltips.css";
+@import "../components/modals.css";
+
+/* Missing imports — must be added to easemotion/all.css */
+@import "../components/command-palette.css";
+@import "../components/announce-bar.css";
+@import "../components/avatar.css";
+@import "../components/breadcrumb.css";
+@import "../components/btn-magnetic.css";
+@import "../components/compare-table.css";
+@import "../components/connection-status.css";
+@import "../components/fab.css";
+@import "../components/kbd.css";
+@import "../components/pagination.css";
+@import "../components/password-strength.css";
+@import "../components/progress.css";
+@import "../components/read-more.css";
+@import "../components/scroll-gallery.css";
+@import "../components/skeleton.css";
+@import "../components/tag.css";
+@import "../components/toast.css";
+@import "../components/view-transitions.css";
+@import "../components/forms.css";
+```
+
+## Why is it useful?
+
+`easemotion/all.css` is used as an alternative full-bundle entry point.
+When it is out of sync with `easemotion.css`, users who import it receive
+a silently incomplete stylesheet — no error, just missing styles.
+
+Keeping both entry points synchronized ensures:
+
+- **Consistency** — users get the same component coverage regardless of
+  which entry point they choose.
+- **Trust** — silent style regressions erode confidence in the framework.
+- **Maintainability** — a single canonical import list makes future audits trivial.
+
+This submission intentionally does **not** edit `easemotion/all.css` directly,
+in compliance with the current core-freeze policy. The corrected import list in
+`style.css` serves as the maintainer reference.

--- a/submissions/docs/sync-all-css-ay/demo.html
+++ b/submissions/docs/sync-all-css-ay/demo.html
@@ -1,0 +1,102 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>easemotion/all.css — Import Sync Fix Reference</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>easemotion/all.css — Import Sync Fix</h1>
+    <p>
+      <code>easemotion/all.css</code> is missing <strong>19 component imports</strong>
+      that are present in the primary <code>easemotion.css</code> bundle.
+      The table below shows the full diff. The maintainer should add the
+      missing imports to <code>easemotion/all.css</code>.
+    </p>
+  </header>
+
+  <div class="entrypoint-grid">
+    <div class="entrypoint-card">
+      <h2>Primary entry point</h2>
+      <code>easemotion.css</code>
+      <span class="badge badge--ok">34 imports — complete</span>
+    </div>
+    <div class="entrypoint-card">
+      <h2>Alternate entry point</h2>
+      <code>easemotion/all.css</code>
+      <span class="badge badge--missing">15 imports — 19 missing</span>
+    </div>
+  </div>
+
+  <div class="diff-table-wrapper">
+    <h2>Component Import Diff</h2>
+    <table class="diff-table">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>Component file</th>
+          <th>easemotion.css</th>
+          <th>easemotion/all.css</th>
+        </tr>
+      </thead>
+      <tbody>
+        <!-- Core -->
+        <tr><td>1</td><td><code>core/variables.css</code></td><td class="status-present">✔ present</td><td class="status-present">✔ present</td></tr>
+        <tr><td>2</td><td><code>core/base.css</code></td><td class="status-present">✔ present</td><td class="status-present">✔ present</td></tr>
+        <tr><td>3</td><td><code>core/animations.css</code></td><td class="status-present">✔ present</td><td class="status-present">✔ present</td></tr>
+        <tr><td>4</td><td><code>core/utilities.css</code></td><td class="status-present">✔ present</td><td class="status-present">✔ present</td></tr>
+        <!-- Components already in all.css -->
+        <tr><td>5</td><td><code>components/ease-marquee.css</code></td><td class="status-present">✔ present</td><td class="status-present">✔ present</td></tr>
+        <tr><td>6</td><td><code>components/buttons.css</code></td><td class="status-present">✔ present</td><td class="status-present">✔ present</td></tr>
+        <tr><td>7</td><td><code>components/cards.css</code></td><td class="status-present">✔ present</td><td class="status-present">✔ present</td></tr>
+        <tr><td>8</td><td><code>components/navbar.css</code></td><td class="status-present">✔ present</td><td class="status-present">✔ present</td></tr>
+        <tr><td>9</td><td><code>components/masonry.css</code></td><td class="status-present">✔ present</td><td class="status-present">✔ present</td></tr>
+        <tr><td>10</td><td><code>components/chip.css</code></td><td class="status-present">✔ present</td><td class="status-present">✔ present</td></tr>
+        <tr><td>11</td><td><code>components/footer.css</code></td><td class="status-present">✔ present</td><td class="status-present">✔ present</td></tr>
+        <tr><td>12</td><td><code>components/sidebar.css</code></td><td class="status-present">✔ present</td><td class="status-present">✔ present</td></tr>
+        <tr><td>13</td><td><code>components/scroll-progress.css</code></td><td class="status-present">✔ present</td><td class="status-present">✔ present</td></tr>
+        <tr><td>14</td><td><code>components/tabs.css</code></td><td class="status-present">✔ present</td><td class="status-present">✔ present</td></tr>
+        <tr><td>15</td><td><code>components/badges.css</code></td><td class="status-present">✔ present</td><td class="status-present">✔ present</td></tr>
+        <tr><td>16</td><td><code>components/loaders.css</code></td><td class="status-present">✔ present</td><td class="status-present">✔ present</td></tr>
+        <tr><td>17</td><td><code>components/tooltips.css</code></td><td class="status-present">✔ present</td><td class="status-present">✔ present</td></tr>
+        <tr><td>18</td><td><code>components/modals.css</code></td><td class="status-present">✔ present</td><td class="status-present">✔ present</td></tr>
+        <!-- MISSING imports -->
+        <tr><td>19</td><td><code>components/command-palette.css</code></td><td class="status-present">✔ present</td><td class="status-missing">✘ missing</td></tr>
+        <tr><td>20</td><td><code>components/announce-bar.css</code></td><td class="status-present">✔ present</td><td class="status-missing">✘ missing</td></tr>
+        <tr><td>21</td><td><code>components/avatar.css</code></td><td class="status-present">✔ present</td><td class="status-missing">✘ missing</td></tr>
+        <tr><td>22</td><td><code>components/breadcrumb.css</code></td><td class="status-present">✔ present</td><td class="status-missing">✘ missing</td></tr>
+        <tr><td>23</td><td><code>components/btn-magnetic.css</code></td><td class="status-present">✔ present</td><td class="status-missing">✘ missing</td></tr>
+        <tr><td>24</td><td><code>components/compare-table.css</code></td><td class="status-present">✔ present</td><td class="status-missing">✘ missing</td></tr>
+        <tr><td>25</td><td><code>components/connection-status.css</code></td><td class="status-present">✔ present</td><td class="status-missing">✘ missing</td></tr>
+        <tr><td>26</td><td><code>components/fab.css</code></td><td class="status-present">✔ present</td><td class="status-missing">✘ missing</td></tr>
+        <tr><td>27</td><td><code>components/kbd.css</code></td><td class="status-present">✔ present</td><td class="status-missing">✘ missing</td></tr>
+        <tr><td>28</td><td><code>components/pagination.css</code></td><td class="status-present">✔ present</td><td class="status-missing">✘ missing</td></tr>
+        <tr><td>29</td><td><code>components/password-strength.css</code></td><td class="status-present">✔ present</td><td class="status-missing">✘ missing</td></tr>
+        <tr><td>30</td><td><code>components/progress.css</code></td><td class="status-present">✔ present</td><td class="status-missing">✘ missing</td></tr>
+        <tr><td>31</td><td><code>components/read-more.css</code></td><td class="status-present">✔ present</td><td class="status-missing">✘ missing</td></tr>
+        <tr><td>32</td><td><code>components/scroll-gallery.css</code></td><td class="status-present">✔ present</td><td class="status-missing">✘ missing</td></tr>
+        <tr><td>33</td><td><code>components/skeleton.css</code></td><td class="status-present">✔ present</td><td class="status-missing">✘ missing</td></tr>
+        <tr><td>34</td><td><code>components/tag.css</code></td><td class="status-present">✔ present</td><td class="status-missing">✘ missing</td></tr>
+        <tr><td>35</td><td><code>components/toast.css</code></td><td class="status-present">✔ present</td><td class="status-missing">✘ missing</td></tr>
+        <tr><td>36</td><td><code>components/view-transitions.css</code></td><td class="status-present">✔ present</td><td class="status-missing">✘ missing</td></tr>
+        <tr><td>37</td><td><code>components/forms.css</code></td><td class="status-present">✔ present</td><td class="status-missing">✘ missing</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="fix-block">
+    <h2>Proposed Fix (for maintainer)</h2>
+    <p>
+      Add the 19 missing <code>@import</code> statements listed above to
+      <code>easemotion/all.css</code>, immediately after the existing
+      <code>@import "../components/modals.css";</code> line.
+      The full corrected import list is documented in <code>style.css</code>
+      in this submission. No other files need to change.
+    </p>
+  </div>
+
+</body>
+</html>

--- a/submissions/docs/sync-all-css-ay/style.css
+++ b/submissions/docs/sync-all-css-ay/style.css
@@ -1,0 +1,203 @@
+﻿/*
+ * style.css — Corrected reference import list for easemotion/all.css
+ *
+ * This file shows the maintainer exactly what easemotion/all.css should
+ * contain in order to be in sync with easemotion.css.
+ *
+ * Lines marked [MISSING] are the 19 imports currently absent from
+ * easemotion/all.css. All other imports are already present.
+ *
+ * NOTE: This is a documentation/reference file for this submission.
+ * The maintainer should apply these changes to easemotion/all.css.
+ */
+
+/* ── Core (already present in easemotion/all.css) ───────── */
+/* @import "./variables.css";           */
+/* @import "../core/base.css";          */
+/* @import "../core/animations.css";    */
+/* @import "../core/utilities.css";     */
+/* @import "../components/ease-marquee.css"; */
+
+/* ── Components already present in easemotion/all.css ───── */
+/* @import "../components/buttons.css";        */
+/* @import "../components/cards.css";          */
+/* @import "../components/navbar.css";         */
+/* @import "../components/masonry.css";        */
+/* @import "../components/chip.css";           */
+/* @import "../components/footer.css";         */
+/* @import "../components/sidebar.css";        */
+/* @import "../components/scroll-progress.css";*/
+/* @import "../components/tabs.css";           */
+/* @import "../components/badges.css";         */
+/* @import "../components/loaders.css";        */
+/* @import "../components/tooltips.css";       */
+/* @import "../components/modals.css";         */
+
+/* ── [MISSING] Must be added to easemotion/all.css ──────── */
+/* @import "../components/command-palette.css";  [MISSING] */
+/* @import "../components/announce-bar.css";     [MISSING] */
+/* @import "../components/avatar.css";           [MISSING] */
+/* @import "../components/breadcrumb.css";       [MISSING] */
+/* @import "../components/btn-magnetic.css";     [MISSING] */
+/* @import "../components/compare-table.css";    [MISSING] */
+/* @import "../components/connection-status.css";[MISSING] */
+/* @import "../components/fab.css";              [MISSING] */
+/* @import "../components/kbd.css";              [MISSING] */
+/* @import "../components/pagination.css";       [MISSING] */
+/* @import "../components/password-strength.css";[MISSING] */
+/* @import "../components/progress.css";         [MISSING] */
+/* @import "../components/read-more.css";        [MISSING] */
+/* @import "../components/scroll-gallery.css";   [MISSING] */
+/* @import "../components/skeleton.css";         [MISSING] */
+/* @import "../components/tag.css";              [MISSING] */
+/* @import "../components/toast.css";            [MISSING] */
+/* @import "../components/view-transitions.css"; [MISSING] */
+/* @import "../components/forms.css";            [MISSING] */
+
+/* ── Demo page styles (not proposed EaseMotion classes) ─── */
+
+:root {
+  --color-bg:       #0f1117;
+  --color-surface:  #1a1d27;
+  --color-border:   #2a2d3a;
+  --color-present:  #22c55e;
+  --color-missing:  #f87171;
+  --color-accent:   #818cf8;
+  --color-text:     #e2e8f0;
+  --color-muted:    #94a3b8;
+  --radius:         8px;
+  --font:           system-ui, -apple-system, sans-serif;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: var(--font);
+  background: var(--color-bg);
+  color: var(--color-text);
+  min-height: 100vh;
+  padding: 2rem 1rem;
+}
+
+.page-header {
+  text-align: center;
+  max-width: 720px;
+  margin: 0 auto 2.5rem;
+}
+
+.page-header h1 {
+  font-size: clamp(1.4rem, 4vw, 2rem);
+  color: var(--color-accent);
+  margin-bottom: 0.5rem;
+}
+
+.page-header p {
+  color: var(--color-muted);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.entrypoint-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.25rem;
+  max-width: 900px;
+  margin: 0 auto 2.5rem;
+}
+
+.entrypoint-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 1.25rem 1.5rem;
+}
+
+.entrypoint-card h2 {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.25rem;
+}
+
+.entrypoint-card code {
+  display: block;
+  font-size: 1rem;
+  color: var(--color-text);
+  font-family: monospace;
+  margin-bottom: 0.75rem;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.badge--ok      { background: #14532d; color: var(--color-present); }
+.badge--missing { background: #450a0a; color: var(--color-missing);  }
+
+.diff-table-wrapper {
+  max-width: 900px;
+  margin: 0 auto;
+  overflow-x: auto;
+}
+
+.diff-table-wrapper h2 {
+  font-size: 1.1rem;
+  margin-bottom: 1rem;
+  color: var(--color-accent);
+}
+
+.diff-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.diff-table th,
+.diff-table td {
+  padding: 0.6rem 1rem;
+  border: 1px solid var(--color-border);
+  text-align: left;
+}
+
+.diff-table th {
+  background: var(--color-surface);
+  color: var(--color-muted);
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.diff-table tr:nth-child(even) td { background: rgba(255,255,255,0.02); }
+
+.diff-table td code { font-family: monospace; }
+
+.status-present { color: var(--color-present); font-weight: 600; }
+.status-missing { color: var(--color-missing); font-weight: 600; }
+
+.fix-block {
+  max-width: 900px;
+  margin: 2.5rem auto 0;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+}
+
+.fix-block h2 {
+  font-size: 1.1rem;
+  color: var(--color-accent);
+  margin-bottom: 0.75rem;
+}
+
+.fix-block p {
+  color: var(--color-muted);
+  font-size: 0.9rem;
+  line-height: 1.6;
+}


### PR DESCRIPTION
## Summary

This pull request adds a documentation showcase under the `submissions/` directory describing and demonstrating the issue where `easemotion/all.css` becomes out of sync with `easemotion.css`.

The submission follows the repository's contribution guidelines by placing all files inside the appropriate `submissions/` directory.

## What this submission includes

* `demo.html` – Demonstrates the expected component coverage and highlights the missing imports scenario.
* `style.css` – CSS used for the documentation/demo.
* `README.md` – Explains the issue, expected behavior, and the proposed framework improvement.

## Purpose

The goal of this submission is to document the synchronization issue between the two CSS entry points and provide a reproducible example for the maintainer to review and integrate into the core framework if appropriate.

## Testing

* Verified that `demo.html` opens directly in a browser.
* Confirmed that all submission files are contained entirely within the `submissions/` directory.
* Verified that no framework source files (`core/`, `components/`, `easemotion/`, etc.) are modified.

## Type of Change

* [x] Documentation / Showcase submission
* [ ] Bug fix (core framework)
* [ ] New component
* [ ] Breaking change

## Related Issue

Closes #<ISSUE_NUMBER>

## Checklist

* [x] Submission follows the repository structure.
* [x] All files are inside the appropriate `submissions/` directory.
* [x] Includes `demo.html`, `style.css`, and `README.md`.
* [x] Does not modify protected framework files.
* [x] Tested locally before submission.
