### PR TITLE
feat: add checkout summary accordion with animated height

### DIFF
--- a/submissions/react/react-checkout-summary-accordion-with-animated-height-payalrvs3/CheckoutSummaryAccordion.jsx
+++ b/submissions/react/react-checkout-summary-accordion-with-animated-height-payalrvs3/CheckoutSummaryAccordion.jsx
@@ -1,0 +1,96 @@
+import React, { useId, useState } from "react";
+import "./style.css";
+
+const CheckoutSummaryAccordion = ({
+  title = "Order Summary",
+  items = [
+    { label: "Subtotal", value: 120.0 },
+    { label: "Shipping", value: 10.0 },
+    { label: "Tax", value: 8.4 },
+    { label: "Discount", value: -15.0 },
+  ],
+  total,
+  currency = "$",
+  defaultOpen = false,
+  onCheckout,
+}) => {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+  const panelId = useId();
+
+  // Total is derived from items unless the caller passes an explicit
+  // override (e.g. a server-calculated figure with its own rounding).
+  const computedTotal = items.reduce((sum, item) => sum + item.value, 0);
+  const displayTotal = typeof total === "number" ? total : computedTotal;
+
+  const formatAmount = (value) => {
+    const sign = value < 0 ? "-" : "";
+    return `${sign}${currency}${Math.abs(value).toFixed(2)}`;
+  };
+
+  return (
+    <div className="csa ease-fade-in">
+      <button
+        type="button"
+        className="csa-toggle ease-hover-lift"
+        aria-expanded={isOpen}
+        aria-controls={panelId}
+        onClick={() => setIsOpen((open) => !open)}
+      >
+        <span className="csa-title">{title}</span>
+        <span className="csa-header-right">
+          <span className="csa-total-preview">
+            {formatAmount(displayTotal)}
+          </span>
+          <span
+            className={`csa-chevron${isOpen ? " is-open" : ""}`}
+            aria-hidden="true"
+          >
+            ⌄
+          </span>
+        </span>
+      </button>
+
+      {/* grid-template-rows: 0fr -> 1fr animates height without ever
+          measuring scrollHeight, so it stays correct even if `items`
+          changes while the panel is open. */}
+      <div
+        id={panelId}
+        className={`csa-panel${isOpen ? " is-open" : ""}`}
+        aria-hidden={!isOpen}
+      >
+        <div className="csa-panel-inner">
+          <ul className="csa-items">
+            {items.map((item, index) => (
+              <li
+                key={`${item.label}-${index}`}
+                className={`csa-row${item.value < 0 ? " is-discount" : ""}`}
+              >
+                <span>{item.label}</span>
+                <span>{formatAmount(item.value)}</span>
+              </li>
+            ))}
+          </ul>
+
+          <div className="csa-divider" />
+
+          <div className="csa-row csa-row--total">
+            <span>Total</span>
+            <span>{formatAmount(displayTotal)}</span>
+          </div>
+
+          {onCheckout && (
+            <button
+              type="button"
+              className="csa-cta ease-hover-glow"
+              onClick={onCheckout}
+            >
+              Proceed to Checkout
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CheckoutSummaryAccordion;

--- a/submissions/react/react-checkout-summary-accordion-with-animated-height-payalrvs3/README.md
+++ b/submissions/react/react-checkout-summary-accordion-with-animated-height-payalrvs3/README.md
@@ -1,0 +1,69 @@
+# React Checkout Summary Accordion with Animated Height
+
+A collapsible order-summary panel for checkout pages. The header always shows the total, and expands to reveal the itemized breakdown with a smooth, JS-free height animation.
+
+## Features
+
+- **CSS-driven height animation** - uses `grid-template-rows: 0fr → 1fr` instead of measuring `scrollHeight`, so there's no layout-thrashing re-render and the animation stays correct even if `items` changes while the panel is open.
+- **EaseMotion CSS utility classes** - `ease-fade-in` on mount, `ease-hover-lift` on the toggle, `ease-hover-glow` on the checkout button.
+- **Total is always derived from `items`** unless you pass an explicit `total` override, so the header and footer can never disagree with the line items.
+- **Accessible by default** - real `<button>` toggle, `aria-expanded`, `aria-controls` linked via `useId()` (unique per instance, so multiple accordions on one page never collide), `aria-hidden` on the collapsed panel.
+- **Scoped class names** (`csa-*`) so it won't collide with other copy-pasted components in the same app.
+- Zero external dependencies - just React.
+
+## Props
+
+| Prop          | Type                                  | Default                      | Description                                                                                                                             |
+| ------------- | -------------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `title`       | `string`                               | `"Order Summary"`             | Header label.                                                                                                                             |
+| `items`       | `{ label: string, value: number }[]`   | 4 example rows                | Line items. A negative `value` is treated as a discount and styled with the success color.                                                |
+| `total`       | `number`                               | *(derived from `items`)*      | Optional override for the total. Use this if the total is calculated server-side and shouldn't be re-derived from the visible line items. |
+| `currency`    | `string`                               | `"$"`                          | Prefix applied to every formatted amount.                                                                                                |
+| `defaultOpen` | `boolean`                              | `false`                        | Whether the panel starts expanded.                                                                                                       |
+| `onCheckout`  | `() => void`                           | `undefined`                    | If provided, a "Proceed to Checkout" button renders inside the panel and calls this on click. Omit it to use the component as a pure summary display. |
+
+## Usage
+
+\`\`\`jsx
+import CheckoutSummaryAccordion from "./CheckoutSummaryAccordion";
+
+function App() {
+  return (
+    <CheckoutSummaryAccordion
+      items={[
+        { label: "Subtotal", value: 84.5 },
+        { label: "Shipping", value: 6.0 },
+        { label: "Tax", value: 7.24 },
+        { label: "Promo code", value: -10 },
+      ]}
+      currency="$"
+      onCheckout={() => console.log("proceeding to payment...")}
+    />
+  );
+}
+
+export default App;
+\`\`\`
+
+Used with no props at all, `<CheckoutSummaryAccordion />` renders a self-contained demo with example line items, which is convenient for previewing it in isolation.
+
+## Dependencies
+
+`ease-fade-in`, `ease-hover-lift`, and `ease-hover-glow` are provided by EaseMotion CSS's core stylesheet. Everything else in `style.css` is scoped to this component and has no external requirements.
+
+## Component Structure
+
+\`\`\`
+react-checkout-summary-accordion-with-animated-height-payalrvs3/
+├── CheckoutSummaryAccordion.jsx
+├── style.css
+└── README.md
+\`\`\`
+
+## Browser Support
+
+Built on CSS Grid (`grid-template-rows`) and the `useId` hook (React 18+), both fully supported in current Chrome, Firefox, Edge, and Safari.
+
+## License
+
+MIT

--- a/submissions/react/react-checkout-summary-accordion-with-animated-height-payalrvs3/style.css
+++ b/submissions/react/react-checkout-summary-accordion-with-animated-height-payalrvs3/style.css
@@ -1,0 +1,177 @@
+/* ==========================================================================
+   Checkout Summary Accordion — styles
+   Reads EaseMotion CSS design tokens (--ease-*) with safe fallbacks, so the
+   component matches the host app's theme when EaseMotion CSS is present,
+   and still looks right on its own if it isn't.
+   ========================================================================== */
+
+.csa {
+  width: 100%;
+  max-width: 420px;
+  margin: 0 auto;
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  box-shadow: var(--ease-shadow-md, 0 4px 6px -1px rgba(0, 0, 0, 0.1));
+  overflow: hidden;
+}
+
+/* ── Toggle header ────────────────────────────────────────── */
+
+.csa-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ease-space-3, 0.75rem);
+  padding: var(--ease-space-4, 1rem) var(--ease-space-5, 1.25rem);
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  color: var(--ease-color-text, #1e293b);
+}
+
+.csa-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.csa-header-right {
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-3, 0.75rem);
+}
+
+.csa-total-preview {
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.csa-chevron {
+  display: inline-block;
+  font-size: 1.1rem;
+  line-height: 1;
+  color: var(--ease-color-muted, #64748b);
+  transition: transform var(--ease-speed-medium, 300ms) var(--ease-ease, ease);
+}
+
+.csa-chevron.is-open {
+  transform: rotate(180deg);
+  color: var(--ease-color-primary, #6c63ff);
+}
+
+/* ── Animated height panel ───────────────────────────────────
+   grid-template-rows: 0fr -> 1fr animates the row track itself, so there
+   is no scrollHeight measurement and no re-render just to read the DOM.
+   min-height: 0 on the inner element is required - without it, a grid
+   item's automatic minimum size blocks the track from ever reaching 0. */
+
+.csa-panel {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows var(--ease-speed-medium, 300ms)
+    var(--ease-ease, ease-in-out);
+}
+
+.csa-panel.is-open {
+  grid-template-rows: 1fr;
+}
+
+.csa-panel-inner {
+  min-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  transform: translateY(-4px);
+  transition:
+    opacity var(--ease-speed-fast, 150ms) var(--ease-ease, ease),
+    transform var(--ease-speed-fast, 150ms) var(--ease-ease, ease);
+}
+
+.csa-panel.is-open .csa-panel-inner {
+  opacity: 1;
+  transform: translateY(0);
+  transition-delay: 100ms;
+}
+
+/* ── Line items ───────────────────────────────────────────── */
+
+.csa-items {
+  list-style: none;
+  margin: 0;
+  padding: var(--ease-space-4, 1rem) var(--ease-space-5, 1.25rem) 0;
+  border-top: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+}
+
+.csa-row {
+  display: flex;
+  justify-content: space-between;
+  padding: var(--ease-space-2, 0.5rem) 0;
+  font-size: 0.9rem;
+  color: var(--ease-color-muted, #64748b);
+}
+
+.csa-row.is-discount span:last-child {
+  color: var(--ease-color-success, #15803d);
+}
+
+.csa-divider {
+  height: 1px;
+  margin: var(--ease-space-2, 0.5rem) var(--ease-space-5, 1.25rem) 0;
+  background: var(--ease-color-neutral-200, #e2e8f0);
+}
+
+.csa-row--total {
+  padding: var(--ease-space-4, 1rem) var(--ease-space-5, 1.25rem);
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--ease-color-text, #1e293b);
+}
+
+/* ── Checkout CTA ─────────────────────────────────────────── */
+
+.csa-cta {
+  display: block;
+  width: calc(100% - (2 * var(--ease-space-5, 1.25rem)));
+  margin: 0 var(--ease-space-5, 1.25rem) var(--ease-space-5, 1.25rem);
+  padding: var(--ease-space-3, 0.75rem);
+  border: none;
+  border-radius: var(--ease-radius-md, 0.5rem);
+  background: var(--ease-color-primary, #6c63ff);
+  color: #ffffff;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+/* ── Responsive ───────────────────────────────────────────── */
+
+@media (max-width: 480px) {
+  .csa-toggle,
+  .csa-items {
+    padding-left: var(--ease-space-4, 1rem);
+    padding-right: var(--ease-space-4, 1rem);
+  }
+
+  .csa-row--total {
+    padding-left: var(--ease-space-4, 1rem);
+    padding-right: var(--ease-space-4, 1rem);
+  }
+
+  .csa-cta {
+    width: calc(100% - (2 * var(--ease-space-4, 1rem)));
+    margin-left: var(--ease-space-4, 1rem);
+    margin-right: var(--ease-space-4, 1rem);
+  }
+}
+
+/* ── Reduced motion ───────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .csa-chevron,
+  .csa-panel,
+  .csa-panel-inner {
+    transition-duration: 0.01ms;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a copy-paste ready React component for a checkout order-summary accordion with an animated height transition, for issue #27408.

Height animation uses a CSS Grid `grid-template-rows: 0fr -> 1fr` transition (same technique as `examples/smooth-accordion`) instead of a `scrollHeight` measurement, so it stays accurate even if the line items change while the panel is open. The total is derived from `items` by default, with an optional override.

Closes #27408

## Type of Change
- [x] 🧩 New component

## Submission Checklist
> Adapted for the React track (template defaults to the HTML/CSS track).
- [x] All changes are inside `submissions/react/react-checkout-summary-accordion-with-animated-height-payalrvs3/`
- [x] Includes `CheckoutSummaryAccordion.jsx` - real, working component
- [x] Includes `style.css`
- [x] Includes `README.md` - description, props table, usage example
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?** A collapsible checkout order-summary component - header shows the total at a glance, expands to reveal the breakdown.

**How does a developer use it?**
\`\`\`jsx
<CheckoutSummaryAccordion items={[{ label: "Subtotal", value: 84.5 }]} onCheckout={() => placeOrder()} />
\`\`\`

**Why does it fit EaseMotion CSS?** Uses `ease-fade-in`, `ease-hover-lift`, and `ease-hover-glow` from the core utility set, and the height transition mirrors the framework's own `smooth-accordion` example pattern.

## Demo
- [x] No `demo.html` for this track - verified locally with a scratch Vite + React app (screenshots below).
<img width="800" height="330" alt="ezgif-28bb654844db3f6b" src="https://github.com/user-attachments/assets/970fd343-70fc-4cd7-bd08-04afdb3ad7a3" />

## Browser Testing
- [x] Chrome  - [x] Firefox  - [x] Edge 

## Notes for Maintainer
Two other submissions already exist for this issue (`react-checkout-summary-accordion-with-animated-height` and `-v2-ag`). Per the CONTRIBUTING.md guidance on parallel implementations, I appended `-payalrvs3` to avoid overwriting either. 