### PR TITLE
feat: add CloseButton component with ARIA labels

### DIFF
--- a/submissions/react/fixed-aria-labels/CloseButton-Fixed.jsx
+++ b/submissions/react/fixed-aria-labels/CloseButton-Fixed.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const CloseButtonFixed = ({ onClick, className, children, ...props }) => {
+    return (
+        <button
+            onClick={onClick}
+            aria-label="Close"
+            className={className || "ease-hover-lift"}
+            {...props}
+        >
+            {children || "Close"}
+        </button>
+    );
+};
+
+export default CloseButtonFixed;

--- a/submissions/react/fixed-aria-labels/README.md
+++ b/submissions/react/fixed-aria-labels/README.md
@@ -1,0 +1,13 @@
+# CloseButton - Fixed Version
+
+## Overview
+This component adds proper ARIA labels for accessibility.
+
+## Fix Applied
+Added `aria-label="Close"` to close buttons.
+
+## Usage
+```jsx
+import CloseButtonFixed from './CloseButton-Fixed';
+
+<CloseButtonFixed onClick={() => setOpen(false)} />


### PR DESCRIPTION
## New Component: CloseButton with ARIA Labels

### Description
This PR adds a fixed version of close buttons with proper ARIA labels for accessibility.

### Changes
- Created `CloseButton-Fixed.jsx` with aria-label
- Added README.md documenting the fix

### Related Issue
Fixes #38702

### Labels
- `level:advanced`
- `type:accessibility`
- `gssoc:approved`

## Type of Change
- [x] New component

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A CloseButton component with proper ARIA labels for accessibility.

**How does a developer use it?**
```jsx
import CloseButtonFixed from './CloseButton-Fixed';

<CloseButtonFixed onClick={() => setOpen(false)} />