### PR TITLE
feat: add Button component with ARIA labels

### DIFF
--- a/submissions/react/fixed-aria-button/Button-Fixed.jsx
+++ b/submissions/react/fixed-aria-button/Button-Fixed.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const ButtonFixed = ({ onClick, children, ariaLabel, className, ...props }) => {
+    return (
+        <button
+            onClick={onClick}
+            aria-label={ariaLabel || "Button"}
+            className={className || "ease-hover-lift"}
+            {...props}
+        >
+            {children}
+        </button>
+    );
+};
+
+export default ButtonFixed;
+

--- a/submissions/react/fixed-aria-button/README.md
+++ b/submissions/react/fixed-aria-button/README.md
@@ -1,0 +1,16 @@
+# Button - Fixed Version
+
+## Overview
+This component adds proper ARIA labels for accessibility.
+
+## Fix Applied
+Added `aria-label` to buttons.
+
+## Usage
+```jsx
+import ButtonFixed from './Button-Fixed';
+
+<ButtonFixed onClick={() => setOpen(false)} ariaLabel="Close">
+  Close
+</ButtonFixed>
+


### PR DESCRIPTION
## New Component: Button with ARIA Labels

### Description
This PR adds a fixed version of buttons with proper ARIA labels for accessibility.

### Changes
- Created `Button-Fixed.jsx` with aria-label
- Added README.md documenting the fix

### Related Issue
Fixes #38709

### Labels
- `level:advanced`
- `type:accessibility`
- `gssoc:approved`