### PR TITLE
feat: add Input component with ARIA labels

### DIFF
--- a/submissions/react/fixed-aria-input/Input-Fixed.jsx
+++ b/submissions/react/fixed-aria-input/Input-Fixed.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const InputFixed = ({ type, placeholder, value, onChange, ariaLabel, className, ...props }) => {
+    return (
+        <input
+            type={type || "text"}
+            placeholder={placeholder}
+            value={value}
+            onChange={onChange}
+            aria-label={ariaLabel || placeholder || "Input field"}
+            className={className || "w-full p-2 border rounded"}
+            {...props}
+        />
+    );
+};
+
+export default InputFixed;
+
+

--- a/submissions/react/fixed-aria-input/README.md
+++ b/submissions/react/fixed-aria-input/README.md
@@ -1,0 +1,17 @@
+# Input - Fixed Version
+
+## Overview
+This component adds proper ARIA labels for accessibility.
+
+## Fix Applied
+Added `aria-label` to input fields.
+
+## Usage
+```jsx
+import InputFixed from './Input-Fixed';
+
+<InputFixed 
+  type="text" 
+  placeholder="Search" 
+  ariaLabel="Search" 
+/>


### PR DESCRIPTION
## New Component: Input with ARIA Labels

### Description
This PR adds a fixed version of input fields with proper ARIA labels for accessibility.

### Changes
- Created `Input-Fixed.jsx` with aria-label
- Added README.md documenting the fix

### Related Issue
Fixes #38713

### Labels
- `level:advanced`
- `type:accessibility`
- `gssoc:approved`