### PR TITLE
feat(react): add tooltip component with monochrome neo elastic slide

### DIFF
--- a/submissions/react/react-tooltip-elastic-monochrome-st/ElasticTooltip.jsx
+++ b/submissions/react/react-tooltip-elastic-monochrome-st/ElasticTooltip.jsx
@@ -1,0 +1,73 @@
+import React, { useState, useRef, useEffect, useId } from 'react';
+import './style.css';
+
+const ElasticTooltip = ({
+  position = 'top',
+  content,
+  children,
+  delay = 200,
+  disabled = false,
+  className = ''
+}) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const timeoutRef = useRef(null);
+  const tooltipId = useId();
+
+  const allowedPositions = ['top', 'bottom', 'left', 'right'];
+  const finalPosition = allowedPositions.includes(position) ? position : 'top';
+
+  const showTooltip = () => {
+    if (disabled) return;
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => {
+      setIsVisible(true);
+    }, delay);
+  };
+
+  const hideTooltip = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    setIsVisible(false);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const positionClass = `tooltip-${finalPosition}`;
+
+  return (
+    <div 
+      className="tooltip-container"
+      onMouseEnter={showTooltip}
+      onMouseLeave={hideTooltip}
+      onFocus={showTooltip}
+      onBlur={hideTooltip}
+    >
+      <div 
+        className="tooltip-trigger ease-hover-lift" 
+        aria-describedby={!disabled ? tooltipId : undefined}
+      >
+        {children}
+      </div>
+
+      {!disabled && (
+        <div
+          id={tooltipId}
+          role="tooltip"
+          className={`tooltip-content ease-fade-in ease-zoom-in ${positionClass} ${isVisible ? 'tooltip-visible' : ''} ${className}`}
+          aria-hidden={!isVisible}
+        >
+          {content}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ElasticTooltip;

--- a/submissions/react/react-tooltip-elastic-monochrome-st/README.md
+++ b/submissions/react/react-tooltip-elastic-monochrome-st/README.md
@@ -1,0 +1,64 @@
+# React Tooltip - Monochrome Neo Elastic Slide
+
+A customizable, reusable React tooltip component tailored with a "Monochrome Neo" aesthetic (high contrast, brutalist sharp borders, and solid hard shadows). It features a smooth, elastic slide animation upon hover or focus, leveraging EaseMotion CSS utility classes (`ease-fade-in`, `ease-zoom-in`, `ease-hover-lift`) alongside custom cubic-bezier transition tuning.
+
+## Features
+- **Elastic Slide Animation:** Utilizes a custom `cubic-bezier` transform for a bouncy, elastic reveal, enhanced by `ease-zoom-in` and `ease-fade-in`.
+- **EaseMotion Integration:** The trigger element utilizes `ease-hover-lift` to provide immediate interaction feedback.
+- **Monochrome Neo Theme:** Stark high-contrast colors (with automatic dark-mode support), 2px solid borders, and brutalist hard shadows.
+- **Accessibility Ready:** Implements `role="tooltip"`, dynamically unique `aria-describedby` utilizing `useId()`, and triggers on both hover and focus.
+- **Configurable & Safe:** Validates positions (`top`, `bottom`, `left`, `right`) and handles long text gracefully with word-breaking.
+- **Responsive:** Scales down cleanly on smaller screens (media queries included).
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `content` | `node` | (Required) | The text or element to display inside the tooltip. |
+| `children` | `node` | (Required) | The target element that triggers the tooltip on hover/focus. |
+| `position` | `string` | `'top'` | Tooltip placement. Options: `'top'`, `'bottom'`, `'left'`, `'right'`. Fallbacks to `'top'` if invalid. |
+| `delay` | `number` | `200` | Delay in milliseconds before showing the tooltip. |
+| `disabled` | `boolean` | `false` | If true, the tooltip will not be displayed. |
+| `className` | `string` | `''` | Additional custom CSS classes for the tooltip content. |
+
+## Usage
+
+```jsx
+import React from 'react';
+import ElasticTooltip from './ElasticTooltip';
+
+export default function App() {
+  return (
+    <div style={{ padding: '100px', display: 'flex', gap: '20px', flexWrap: 'wrap' }}>
+      
+      <ElasticTooltip content="Minimalist configuration saved." position="top" delay={300}>
+        <button style={btnStyle}>Hover me (Top)</button>
+      </ElasticTooltip>
+
+      <ElasticTooltip content="Review the stark contrast analytics." position="bottom">
+        <button style={btnStyle}>Focus me (Bottom)</button>
+      </ElasticTooltip>
+      
+      <ElasticTooltip content="Brutalist shadow detected!" position="left">
+        <button style={btnStyle}>Warning (Left)</button>
+      </ElasticTooltip>
+      
+      <ElasticTooltip content="System operates in monochrome." position="right">
+        <button style={btnStyle}>System Status (Right)</button>
+      </ElasticTooltip>
+
+    </div>
+  );
+}
+
+const btnStyle = {
+  padding: '10px 20px',
+  background: '#ffffff',
+  color: '#000000',
+  border: '2px solid #000000',
+  boxShadow: '3px 3px 0px #000000',
+  fontWeight: 'bold',
+  cursor: 'pointer',
+  transition: 'transform 0.2s, box-shadow 0.2s'
+};
+```

--- a/submissions/react/react-tooltip-elastic-monochrome-st/style.css
+++ b/submissions/react/react-tooltip-elastic-monochrome-st/style.css
@@ -1,0 +1,161 @@
+/* Container holds the position context */
+.tooltip-container {
+  position: relative;
+  display: inline-flex;
+}
+
+.tooltip-trigger {
+  display: inherit;
+  cursor: pointer;
+  /* EaseMotion util hooks - base for hover lift */
+  transition: transform 0.2s ease;
+}
+
+/* Fallback for EaseMotion hover-lift */
+.tooltip-trigger.ease-hover-lift:hover,
+.tooltip-trigger.ease-hover-lift:focus {
+  transform: translateY(-2px);
+}
+
+/* Base tooltip styling: Monochrome Neo Theme */
+.tooltip-content {
+  position: absolute;
+  background: #ffffff; /* Stark white */
+  color: #000000; /* Deep black */
+  padding: 8px 14px;
+  border-radius: 4px; /* Slightly sharp corners */
+  font-size: 14px;
+  font-weight: 600;
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  white-space: normal;
+  max-width: 250px;
+  word-break: break-word;
+  pointer-events: none;
+  z-index: 1000;
+  opacity: 0;
+  visibility: hidden;
+  border: 2px solid #000000; /* Sharp, solid border */
+  box-shadow: 4px 4px 0px #000000; /* Hard brutalist shadow */
+  
+  /* Elastic slide transition */
+  transition: opacity 0.3s ease, visibility 0.3s ease, transform 0.5s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+}
+
+/* Dark mode support if applicable */
+@media (prefers-color-scheme: dark) {
+  .tooltip-content {
+    background: #000000;
+    color: #ffffff;
+    border: 2px solid #ffffff;
+    box-shadow: 4px 4px 0px #ffffff;
+  }
+}
+
+/* Visibility state */
+.tooltip-visible {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* Top position */
+.tooltip-top {
+  bottom: 100%;
+  left: 50%;
+  transform: translate(-50%, 15px) scale(0.95);
+  margin-bottom: 12px;
+}
+.tooltip-top.tooltip-visible {
+  transform: translate(-50%, 0) scale(1);
+}
+
+/* Bottom position */
+.tooltip-bottom {
+  top: 100%;
+  left: 50%;
+  transform: translate(-50%, -15px) scale(0.95);
+  margin-top: 12px;
+}
+.tooltip-bottom.tooltip-visible {
+  transform: translate(-50%, 0) scale(1);
+}
+
+/* Left position */
+.tooltip-left {
+  right: 100%;
+  top: 50%;
+  transform: translate(15px, -50%) scale(0.95);
+  margin-right: 12px;
+}
+.tooltip-left.tooltip-visible {
+  transform: translate(0, -50%) scale(1);
+}
+
+/* Right position */
+.tooltip-right {
+  left: 100%;
+  top: 50%;
+  transform: translate(-15px, -50%) scale(0.95);
+  margin-left: 12px;
+}
+.tooltip-right.tooltip-visible {
+  transform: translate(0, -50%) scale(1);
+}
+
+/* Monochrome Neo pseudo-element pointing arrow */
+.tooltip-content::after {
+  content: '';
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  background: #ffffff;
+  border-right: 2px solid #000000;
+  border-bottom: 2px solid #000000;
+}
+
+@media (prefers-color-scheme: dark) {
+  .tooltip-content::after {
+    background: #000000;
+    border-right-color: #ffffff;
+    border-bottom-color: #ffffff;
+  }
+}
+
+/* Rotate arrow based on position */
+.tooltip-top::after {
+  bottom: -7px;
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.tooltip-bottom::after {
+  top: -7px;
+  left: 50%;
+  transform: translateX(-50%) rotate(225deg);
+}
+
+.tooltip-left::after {
+  right: -7px;
+  top: 50%;
+  transform: translateY(-50%) rotate(-45deg);
+}
+
+.tooltip-right::after {
+  left: -7px;
+  top: 50%;
+  transform: translateY(-50%) rotate(135deg);
+}
+
+/* Mobile Responsiveness */
+@media (max-width: 600px) {
+  .tooltip-content {
+    max-width: 200px;
+    font-size: 13px;
+    padding: 6px 10px;
+    box-shadow: 3px 3px 0px #000000;
+  }
+  @media (prefers-color-scheme: dark) {
+    .tooltip-content {
+      box-shadow: 3px 3px 0px #ffffff;
+    }
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Submitting a reusable, highly accessible React Tooltip component with a custom Elastic Slide animation, strictly styled for Monochrome Neo Layouts. This specifically addresses and resolves issue #38637.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (`submissions/react/react-tooltip-elastic-monochrome-st/`)
- [ ] Includes `demo.html` — self-contained, opens in browser with no server *(N/A — React Track Submission)*
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A highly customizable, fully accessible React Tooltip component featuring an elastic bouncy entrance and a stark high-contrast Monochrome Neo (brutalist) aesthetic.

**How does a developer use it?**

```jsx
import ElasticTooltip from './ElasticTooltip';

<ElasticTooltip content="System operates in monochrome." position="bottom" delay={300}>
  <button className="ease-hover-lift">System Status</button>
</ElasticTooltip>
