### PR TITLE
feat(react): add tooltip component with dark minimalist elastic slide

### DIFF
--- a/submissions/react/react-tooltip-elastic-dark-minimal-st/ElasticTooltip.jsx
+++ b/submissions/react/react-tooltip-elastic-dark-minimal-st/ElasticTooltip.jsx
@@ -1,0 +1,73 @@
+import React, { useState, useRef, useEffect, useId } from 'react';
+import './style.css';
+
+const ElasticTooltip = ({
+  position = 'top',
+  content,
+  children,
+  delay = 200,
+  disabled = false,
+  className = ''
+}) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const timeoutRef = useRef(null);
+  const tooltipId = useId();
+
+  const allowedPositions = ['top', 'bottom', 'left', 'right'];
+  const finalPosition = allowedPositions.includes(position) ? position : 'top';
+
+  const showTooltip = () => {
+    if (disabled) return;
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => {
+      setIsVisible(true);
+    }, delay);
+  };
+
+  const hideTooltip = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    setIsVisible(false);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const positionClass = `tooltip-${finalPosition}`;
+
+  return (
+    <div 
+      className="tooltip-container"
+      onMouseEnter={showTooltip}
+      onMouseLeave={hideTooltip}
+      onFocus={showTooltip}
+      onBlur={hideTooltip}
+    >
+      <div 
+        className="tooltip-trigger ease-hover-lift" 
+        aria-describedby={!disabled ? tooltipId : undefined}
+      >
+        {children}
+      </div>
+
+      {!disabled && (
+        <div
+          id={tooltipId}
+          role="tooltip"
+          className={`tooltip-content ease-fade-in ease-zoom-in ${positionClass} ${isVisible ? 'tooltip-visible' : ''} ${className}`}
+          aria-hidden={!isVisible}
+        >
+          {content}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ElasticTooltip;

--- a/submissions/react/react-tooltip-elastic-dark-minimal-st/README.md
+++ b/submissions/react/react-tooltip-elastic-dark-minimal-st/README.md
@@ -1,0 +1,65 @@
+# React Tooltip - Dark Minimalist Elastic Slide
+
+A highly refined, reusable React tooltip component tailored with a "Dark Minimalist" aesthetic (subtle dark grays, flat design, clean muted typography). It features a subtle, elegant elastic slide animation upon hover or focus, leveraging EaseMotion CSS utility classes (`ease-fade-in`, `ease-zoom-in`, `ease-hover-lift`) alongside custom cubic-bezier transition tuning.
+
+## Features
+- **Elastic Slide Animation:** Utilizes a custom, refined `cubic-bezier` transform for a subtle bouncy reveal, enhanced by `ease-zoom-in` and `ease-fade-in`.
+- **EaseMotion Integration:** The trigger element utilizes `ease-hover-lift` to provide immediate interaction feedback.
+- **Dark Minimalist Theme:** Deep clean `#1a1a1a` backgrounds, simple `#333` borders, and distraction-free flat styling.
+- **Accessibility Ready:** Implements `role="tooltip"`, dynamically unique `aria-describedby` utilizing `useId()`, and triggers on both hover and focus.
+- **Configurable & Safe:** Validates positions (`top`, `bottom`, `left`, `right`) and handles long text gracefully with word-breaking.
+- **Responsive:** Scales down cleanly on smaller screens (media queries included).
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `content` | `node` | (Required) | The text or element to display inside the tooltip. |
+| `children` | `node` | (Required) | The target element that triggers the tooltip on hover/focus. |
+| `position` | `string` | `'top'` | Tooltip placement. Options: `'top'`, `'bottom'`, `'left'`, `'right'`. Fallbacks to `'top'` if invalid. |
+| `delay` | `number` | `200` | Delay in milliseconds before showing the tooltip. |
+| `disabled` | `boolean` | `false` | If true, the tooltip will not be displayed. |
+| `className` | `string` | `''` | Additional custom CSS classes for the tooltip content. |
+
+## Usage
+
+```jsx
+import React from 'react';
+import ElasticTooltip from './ElasticTooltip';
+
+export default function App() {
+  return (
+    <div style={{ padding: '100px', display: 'flex', gap: '20px', flexWrap: 'wrap', background: '#0a0a0a', height: '100vh' }}>
+      
+      <ElasticTooltip content="Clean preferences saved." position="top" delay={300}>
+        <button style={btnStyle}>Hover me (Top)</button>
+      </ElasticTooltip>
+
+      <ElasticTooltip content="Minimal design system loaded." position="bottom">
+        <button style={btnStyle}>Focus me (Bottom)</button>
+      </ElasticTooltip>
+      
+      <ElasticTooltip content="Invalid contrast ratio." position="left">
+        <button style={btnStyle}>Warning (Left)</button>
+      </ElasticTooltip>
+      
+      <ElasticTooltip content="Sync complete." position="right">
+        <button style={btnStyle}>System Status (Right)</button>
+      </ElasticTooltip>
+
+    </div>
+  );
+}
+
+const btnStyle = {
+  padding: '10px 20px',
+  background: '#1a1a1a',
+  color: '#e5e5e5',
+  border: '1px solid #333',
+  borderRadius: '6px',
+  fontWeight: '400',
+  cursor: 'pointer',
+  transition: 'all 0.2s',
+  fontFamily: 'sans-serif'
+};
+```

--- a/submissions/react/react-tooltip-elastic-dark-minimal-st/style.css
+++ b/submissions/react/react-tooltip-elastic-dark-minimal-st/style.css
@@ -1,0 +1,140 @@
+/* Container holds the position context */
+.tooltip-container {
+  position: relative;
+  display: inline-flex;
+}
+
+.tooltip-trigger {
+  display: inherit;
+  cursor: pointer;
+  /* EaseMotion util hooks - base for hover lift */
+  transition: transform 0.2s ease;
+}
+
+/* Fallback for EaseMotion hover-lift */
+.tooltip-trigger.ease-hover-lift:hover,
+.tooltip-trigger.ease-hover-lift:focus {
+  transform: translateY(-2px);
+}
+
+/* Base tooltip styling: Dark Minimalist Theme */
+.tooltip-content {
+  position: absolute;
+  background: #1a1a1a; /* Clean dark grey */
+  color: #e5e5e5; /* Muted light grey text */
+  padding: 8px 12px;
+  border-radius: 6px; /* Clean standard radius */
+  font-size: 13px;
+  font-weight: 400;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  letter-spacing: 0.2px;
+  white-space: normal;
+  max-width: 250px;
+  word-break: break-word;
+  pointer-events: none;
+  z-index: 1000;
+  opacity: 0;
+  visibility: hidden;
+  
+  /* Minimal border and ultra-soft shadow */
+  border: 1px solid #333333;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  
+  /* Elastic slide transition */
+  transition: opacity 0.25s ease, visibility 0.25s ease, transform 0.45s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+}
+
+/* Visibility state */
+.tooltip-visible {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* Top position */
+.tooltip-top {
+  bottom: 100%;
+  left: 50%;
+  transform: translate(-50%, 10px) scale(0.95);
+  margin-bottom: 8px;
+}
+.tooltip-top.tooltip-visible {
+  transform: translate(-50%, 0) scale(1);
+}
+
+/* Bottom position */
+.tooltip-bottom {
+  top: 100%;
+  left: 50%;
+  transform: translate(-50%, -10px) scale(0.95);
+  margin-top: 8px;
+}
+.tooltip-bottom.tooltip-visible {
+  transform: translate(-50%, 0) scale(1);
+}
+
+/* Left position */
+.tooltip-left {
+  right: 100%;
+  top: 50%;
+  transform: translate(10px, -50%) scale(0.95);
+  margin-right: 8px;
+}
+.tooltip-left.tooltip-visible {
+  transform: translate(0, -50%) scale(1);
+}
+
+/* Right position */
+.tooltip-right {
+  left: 100%;
+  top: 50%;
+  transform: translate(-10px, -50%) scale(0.95);
+  margin-left: 8px;
+}
+.tooltip-right.tooltip-visible {
+  transform: translate(0, -50%) scale(1);
+}
+
+/* Minimalist pseudo-element pointing arrow */
+.tooltip-content::after {
+  content: '';
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  background: #1a1a1a;
+  border-right: 1px solid #333333;
+  border-bottom: 1px solid #333333;
+}
+
+/* Rotate arrow based on position */
+.tooltip-top::after {
+  bottom: -5px;
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.tooltip-bottom::after {
+  top: -5px;
+  left: 50%;
+  transform: translateX(-50%) rotate(225deg);
+}
+
+.tooltip-left::after {
+  right: -5px;
+  top: 50%;
+  transform: translateY(-50%) rotate(-45deg);
+}
+
+.tooltip-right::after {
+  left: -5px;
+  top: 50%;
+  transform: translateY(-50%) rotate(135deg);
+}
+
+/* Mobile Responsiveness */
+@media (max-width: 600px) {
+  .tooltip-content {
+    max-width: 200px;
+    font-size: 12px;
+    padding: 6px 10px;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Submitting a reusable, highly accessible React Tooltip component with a custom, elegant Elastic Slide animation, styled strictly for Dark Minimalist Layouts. This specifically addresses and resolves issue #38631.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (`submissions/react/react-tooltip-elastic-dark-minimal-st/`)
- [ ] Includes `demo.html` — self-contained, opens in browser with no server *(N/A — React Track Submission)*
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A highly customizable, fully accessible React Tooltip component featuring an elegant elastic entrance and a Dark Minimalist aesthetic (subtle dark grays, flat design, clean muted typography, and minimal drop shadows).

**How does a developer use it?**

```jsx
import ElasticTooltip from './ElasticTooltip';

<ElasticTooltip content="Clean preferences saved." position="top" delay={300}>
  <button className="ease-hover-lift">Hover me (Top)</button>
</ElasticTooltip>
