### PR TITLE
feat(react): add tooltip component with sleek editorial elastic slide

### DIFF
--- a/submissions/react/react-tooltip-elastic-editorial-st/ElasticTooltip.jsx
+++ b/submissions/react/react-tooltip-elastic-editorial-st/ElasticTooltip.jsx
@@ -1,0 +1,73 @@
+import React, { useState, useRef, useEffect, useId } from 'react';
+import './style.css';
+
+const ElasticTooltip = ({
+  position = 'top',
+  content,
+  children,
+  delay = 200,
+  disabled = false,
+  className = ''
+}) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const timeoutRef = useRef(null);
+  const tooltipId = useId();
+
+  const allowedPositions = ['top', 'bottom', 'left', 'right'];
+  const finalPosition = allowedPositions.includes(position) ? position : 'top';
+
+  const showTooltip = () => {
+    if (disabled) return;
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => {
+      setIsVisible(true);
+    }, delay);
+  };
+
+  const hideTooltip = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    setIsVisible(false);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const positionClass = `tooltip-${finalPosition}`;
+
+  return (
+    <div 
+      className="tooltip-container"
+      onMouseEnter={showTooltip}
+      onMouseLeave={hideTooltip}
+      onFocus={showTooltip}
+      onBlur={hideTooltip}
+    >
+      <div 
+        className="tooltip-trigger ease-hover-lift" 
+        aria-describedby={!disabled ? tooltipId : undefined}
+      >
+        {children}
+      </div>
+
+      {!disabled && (
+        <div
+          id={tooltipId}
+          role="tooltip"
+          className={`tooltip-content ease-fade-in ease-zoom-in ${positionClass} ${isVisible ? 'tooltip-visible' : ''} ${className}`}
+          aria-hidden={!isVisible}
+        >
+          {content}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ElasticTooltip;

--- a/submissions/react/react-tooltip-elastic-editorial-st/README.md
+++ b/submissions/react/react-tooltip-elastic-editorial-st/README.md
@@ -1,0 +1,64 @@
+# React Tooltip - Sleek Editorial Elastic Slide
+
+A highly refined, reusable React tooltip component tailored with a "Sleek Editorial" aesthetic (elegant serif typography, soft ivory backgrounds, delicate drop shadows). It features an exceptionally smooth, sweeping elastic slide animation upon hover or focus, leveraging EaseMotion CSS utility classes (`ease-fade-in`, `ease-zoom-in`, `ease-hover-lift`) alongside custom cubic-bezier transition tuning designed to feel like turning a magazine page.
+
+## Features
+- **Editorial Slide Animation:** Utilizes a custom, sophisticated `cubic-bezier(0.16, 1, 0.3, 1)` transform for a silky smooth reveal, enhanced by `ease-zoom-in` and `ease-fade-in`.
+- **EaseMotion Integration:** The trigger element utilizes `ease-hover-lift` to provide immediate interaction feedback.
+- **Sleek Editorial Theme:** Crisp `#fdfbf7` ivory backgrounds, deep ink-black text, italicized serif typography, and elegant, understated paper-like shadows.
+- **Accessibility Ready:** Implements `role="tooltip"`, dynamically unique `aria-describedby` utilizing `useId()`, and triggers on both hover and focus.
+- **Configurable & Safe:** Validates positions (`top`, `bottom`, `left`, `right`) and handles long text gracefully with word-breaking.
+- **Responsive:** Scales down cleanly on smaller screens (media queries included).
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `content` | `node` | (Required) | The text or element to display inside the tooltip. |
+| `children` | `node` | (Required) | The target element that triggers the tooltip on hover/focus. |
+| `position` | `string` | `'top'` | Tooltip placement. Options: `'top'`, `'bottom'`, `'left'`, `'right'`. Fallbacks to `'top'` if invalid. |
+| `delay` | `number` | `200` | Delay in milliseconds before showing the tooltip. |
+| `disabled` | `boolean` | `false` | If true, the tooltip will not be displayed. |
+| `className` | `string` | `''` | Additional custom CSS classes for the tooltip content. |
+
+## Usage
+
+```jsx
+import React from 'react';
+import ElasticTooltip from './ElasticTooltip';
+
+export default function App() {
+  return (
+    <div style={{ padding: '100px', display: 'flex', gap: '20px', flexWrap: 'wrap', background: '#ffffff', height: '100vh' }}>
+      
+      <ElasticTooltip content="Read the full editorial piece." position="top" delay={300}>
+        <span style={textStyle}>Hover me (Top)</span>
+      </ElasticTooltip>
+
+      <ElasticTooltip content="See author's notes." position="bottom">
+        <span style={textStyle}>Focus me (Bottom)</span>
+      </ElasticTooltip>
+      
+      <ElasticTooltip content="Citation needed." position="left">
+        <span style={textStyle}>Warning (Left)</span>
+      </ElasticTooltip>
+      
+      <ElasticTooltip content="Volume IV, Issue 2" position="right">
+        <span style={textStyle}>Reference (Right)</span>
+      </ElasticTooltip>
+
+    </div>
+  );
+}
+
+const textStyle = {
+  fontSize: '18px',
+  fontFamily: 'Georgia, serif',
+  color: '#333',
+  textDecoration: 'underline',
+  textUnderlineOffset: '4px',
+  textDecorationColor: '#ccc',
+  cursor: 'pointer',
+  transition: 'color 0.3s'
+};
+```

--- a/submissions/react/react-tooltip-elastic-editorial-st/style.css
+++ b/submissions/react/react-tooltip-elastic-editorial-st/style.css
@@ -1,0 +1,142 @@
+/* Container holds the position context */
+.tooltip-container {
+  position: relative;
+  display: inline-flex;
+}
+
+.tooltip-trigger {
+  display: inherit;
+  cursor: pointer;
+  /* EaseMotion util hooks - base for hover lift */
+  transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* Fallback for EaseMotion hover-lift */
+.tooltip-trigger.ease-hover-lift:hover,
+.tooltip-trigger.ease-hover-lift:focus {
+  transform: translateY(-2px);
+}
+
+/* Base tooltip styling: Sleek Editorial Theme */
+.tooltip-content {
+  position: absolute;
+  background: #fdfbf7; /* Elegant ivory/off-white */
+  color: #1a1a1a; /* Deep charcoal/ink */
+  padding: 10px 16px;
+  border-radius: 2px; /* Very sharp, almost no radius for print feel */
+  font-size: 13px;
+  font-weight: 400;
+  font-family: 'Georgia', 'Times New Roman', serif; /* Classic editorial serif */
+  font-style: italic;
+  letter-spacing: 0.5px;
+  line-height: 1.4;
+  white-space: normal;
+  max-width: 260px;
+  word-break: break-word;
+  pointer-events: none;
+  z-index: 1000;
+  opacity: 0;
+  visibility: hidden;
+  
+  /* Delicate border and paper-like shadow */
+  border: 1px solid #e5e2db;
+  box-shadow: 0 10px 30px -10px rgba(0, 0, 0, 0.08);
+  
+  /* Elastic slide transition */
+  transition: opacity 0.4s ease, visibility 0.4s ease, transform 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* Visibility state */
+.tooltip-visible {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* Top position */
+.tooltip-top {
+  bottom: 100%;
+  left: 50%;
+  transform: translate(-50%, 12px) scale(0.98);
+  margin-bottom: 10px;
+}
+.tooltip-top.tooltip-visible {
+  transform: translate(-50%, 0) scale(1);
+}
+
+/* Bottom position */
+.tooltip-bottom {
+  top: 100%;
+  left: 50%;
+  transform: translate(-50%, -12px) scale(0.98);
+  margin-top: 10px;
+}
+.tooltip-bottom.tooltip-visible {
+  transform: translate(-50%, 0) scale(1);
+}
+
+/* Left position */
+.tooltip-left {
+  right: 100%;
+  top: 50%;
+  transform: translate(12px, -50%) scale(0.98);
+  margin-right: 10px;
+}
+.tooltip-left.tooltip-visible {
+  transform: translate(0, -50%) scale(1);
+}
+
+/* Right position */
+.tooltip-right {
+  left: 100%;
+  top: 50%;
+  transform: translate(-12px, -50%) scale(0.98);
+  margin-left: 10px;
+}
+.tooltip-right.tooltip-visible {
+  transform: translate(0, -50%) scale(1);
+}
+
+/* Elegant pseudo-element pointing arrow */
+.tooltip-content::after {
+  content: '';
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  background: #fdfbf7;
+  border-right: 1px solid #e5e2db;
+  border-bottom: 1px solid #e5e2db;
+}
+
+/* Rotate arrow based on position */
+.tooltip-top::after {
+  bottom: -5px;
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.tooltip-bottom::after {
+  top: -5px;
+  left: 50%;
+  transform: translateX(-50%) rotate(225deg);
+}
+
+.tooltip-left::after {
+  right: -5px;
+  top: 50%;
+  transform: translateY(-50%) rotate(-45deg);
+}
+
+.tooltip-right::after {
+  left: -5px;
+  top: 50%;
+  transform: translateY(-50%) rotate(135deg);
+}
+
+/* Mobile Responsiveness */
+@media (max-width: 600px) {
+  .tooltip-content {
+    max-width: 220px;
+    font-size: 12px;
+    padding: 8px 12px;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Submitting a reusable, highly accessible React Tooltip component with a custom, sweeping Elastic Slide animation, beautifully styled for Sleek Editorial Layouts. This specifically addresses and resolves issue #38632.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (`submissions/react/react-tooltip-elastic-editorial-st/`)
- [ ] Includes `demo.html` — self-contained, opens in browser with no server *(N/A — React Track Submission)*
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A highly customizable, fully accessible React Tooltip component featuring an elegant, page-turning elastic entrance and a Sleek Editorial aesthetic (ivory backgrounds, elegant serif typography, deep ink-black text, and paper-like drop shadows).

**How does a developer use it?**

```jsx
import ElasticTooltip from './ElasticTooltip';

<ElasticTooltip content="Read the full editorial piece." position="top" delay={300}>
  <span className="ease-hover-lift">Hover me (Top)</span>
</ElasticTooltip>
