### PR TITLE
feat(react): add tooltip component with art deco elastic slide

### DIFF
--- a/submissions/react/react-tooltip-elastic-art-deco-st/ElasticTooltip.jsx
+++ b/submissions/react/react-tooltip-elastic-art-deco-st/ElasticTooltip.jsx
@@ -1,0 +1,73 @@
+import React, { useState, useRef, useEffect, useId } from 'react';
+import './style.css';
+
+const ElasticTooltip = ({
+  position = 'top',
+  content,
+  children,
+  delay = 200,
+  disabled = false,
+  className = ''
+}) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const timeoutRef = useRef(null);
+  const tooltipId = useId();
+
+  const allowedPositions = ['top', 'bottom', 'left', 'right'];
+  const finalPosition = allowedPositions.includes(position) ? position : 'top';
+
+  const showTooltip = () => {
+    if (disabled) return;
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => {
+      setIsVisible(true);
+    }, delay);
+  };
+
+  const hideTooltip = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    setIsVisible(false);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const positionClass = `tooltip-${finalPosition}`;
+
+  return (
+    <div 
+      className="tooltip-container"
+      onMouseEnter={showTooltip}
+      onMouseLeave={hideTooltip}
+      onFocus={showTooltip}
+      onBlur={hideTooltip}
+    >
+      <div 
+        className="tooltip-trigger ease-hover-lift" 
+        aria-describedby={!disabled ? tooltipId : undefined}
+      >
+        {children}
+      </div>
+
+      {!disabled && (
+        <div
+          id={tooltipId}
+          role="tooltip"
+          className={`tooltip-content ease-fade-in ease-zoom-in ${positionClass} ${isVisible ? 'tooltip-visible' : ''} ${className}`}
+          aria-hidden={!isVisible}
+        >
+          {content}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ElasticTooltip;

--- a/submissions/react/react-tooltip-elastic-art-deco-st/README.md
+++ b/submissions/react/react-tooltip-elastic-art-deco-st/README.md
@@ -1,0 +1,66 @@
+# React Tooltip - Art Deco Elastic Slide
+
+A highly refined, reusable React tooltip component tailored with a vintage "Art Deco" aesthetic (deep onyx backgrounds, metallic gold text, geometric borders, and sharp box shadows). It features an exceptionally smooth, sweeping elastic slide animation upon hover or focus, leveraging EaseMotion CSS utility classes (`ease-fade-in`, `ease-zoom-in`, `ease-hover-lift`) alongside custom cubic-bezier transition tuning.
+
+## Features
+- **Elastic Slide Animation:** Utilizes a custom, sophisticated `cubic-bezier(0.68, -0.55, 0.265, 1.55)` transform for a classic bouncy reveal, enhanced by `ease-zoom-in` and `ease-fade-in`.
+- **EaseMotion Integration:** The trigger element utilizes `ease-hover-lift` to provide immediate interaction feedback.
+- **Art Deco Theme:** Vintage geometric design featuring deep `#0f1214` onyx backgrounds, `#d4af37` metallic gold text, double outlined borders, uppercase geometric fonts, and sharp, hard drop shadows.
+- **Accessibility Ready:** Implements `role="tooltip"`, dynamically unique `aria-describedby` utilizing `useId()`, and triggers on both hover and focus.
+- **Configurable & Safe:** Validates positions (`top`, `bottom`, `left`, `right`) and handles long text gracefully with word-breaking.
+- **Responsive:** Scales down cleanly on smaller screens (media queries included).
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `content` | `node` | (Required) | The text or element to display inside the tooltip. |
+| `children` | `node` | (Required) | The target element that triggers the tooltip on hover/focus. |
+| `position` | `string` | `'top'` | Tooltip placement. Options: `'top'`, `'bottom'`, `'left'`, `'right'`. Fallbacks to `'top'` if invalid. |
+| `delay` | `number` | `200` | Delay in milliseconds before showing the tooltip. |
+| `disabled` | `boolean` | `false` | If true, the tooltip will not be displayed. |
+| `className` | `string` | `''` | Additional custom CSS classes for the tooltip content. |
+
+## Usage
+
+```jsx
+import React from 'react';
+import ElasticTooltip from './ElasticTooltip';
+
+export default function App() {
+  return (
+    <div style={{ padding: '100px', display: 'flex', gap: '20px', flexWrap: 'wrap', background: '#080a0c', height: '100vh' }}>
+      
+      <ElasticTooltip content="The Gatsby Collection" position="top" delay={300}>
+        <button style={btnStyle}>Hover me (Top)</button>
+      </ElasticTooltip>
+
+      <ElasticTooltip content="Golden Age Archives" position="bottom">
+        <button style={btnStyle}>Focus me (Bottom)</button>
+      </ElasticTooltip>
+      
+      <ElasticTooltip content="Strict geometric form required." position="left">
+        <button style={btnStyle}>Warning (Left)</button>
+      </ElasticTooltip>
+      
+      <ElasticTooltip content="1920s Standard" position="right">
+        <button style={btnStyle}>System Status (Right)</button>
+      </ElasticTooltip>
+
+    </div>
+  );
+}
+
+const btnStyle = {
+  padding: '12px 24px',
+  background: '#d4af37',
+  color: '#0f1214',
+  border: '2px solid #0f1214',
+  fontWeight: '600',
+  textTransform: 'uppercase',
+  letterSpacing: '2px',
+  cursor: 'pointer',
+  boxShadow: '4px 4px 0 #000',
+  transition: 'all 0.3s'
+};
+```

--- a/submissions/react/react-tooltip-elastic-art-deco-st/style.css
+++ b/submissions/react/react-tooltip-elastic-art-deco-st/style.css
@@ -1,0 +1,152 @@
+/* Container holds the position context */
+.tooltip-container {
+  position: relative;
+  display: inline-flex;
+}
+
+.tooltip-trigger {
+  display: inherit;
+  cursor: pointer;
+  /* EaseMotion util hooks - base for hover lift */
+  transition: transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+/* Fallback for EaseMotion hover-lift */
+.tooltip-trigger.ease-hover-lift:hover,
+.tooltip-trigger.ease-hover-lift:focus {
+  transform: translateY(-3px);
+  filter: drop-shadow(0 6px 4px rgba(0,0,0,0.4));
+}
+
+/* Base tooltip styling: Art Deco Theme */
+.tooltip-content {
+  position: absolute;
+  background: #0f1214; /* Deep onyx */
+  color: #d4af37; /* Metallic gold */
+  padding: 12px 18px;
+  
+  /* Geometric Art Deco Double Border */
+  border: 2px solid #d4af37;
+  outline: 1px solid #d4af37;
+  outline-offset: -4px;
+  
+  border-radius: 0; /* Strict sharp corners */
+  font-size: 11px;
+  font-weight: 600;
+  font-family: 'Futura', 'Trebuchet MS', 'Montserrat', sans-serif; /* Geometric sans */
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  text-align: center;
+  white-space: normal;
+  max-width: 250px;
+  word-break: break-word;
+  pointer-events: none;
+  z-index: 1000;
+  opacity: 0;
+  visibility: hidden;
+  
+  /* Vintage sharp shadow */
+  box-shadow: 4px 4px 0 rgba(0, 0, 0, 0.8);
+  
+  /* Elastic slide transition */
+  transition: opacity 0.3s ease, visibility 0.3s ease, transform 0.5s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+}
+
+/* Visibility state */
+.tooltip-visible {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* Top position */
+.tooltip-top {
+  bottom: 100%;
+  left: 50%;
+  transform: translate(-50%, 15px) scale(0.95);
+  margin-bottom: 12px;
+}
+.tooltip-top.tooltip-visible {
+  transform: translate(-50%, 0) scale(1);
+}
+
+/* Bottom position */
+.tooltip-bottom {
+  top: 100%;
+  left: 50%;
+  transform: translate(-50%, -15px) scale(0.95);
+  margin-top: 12px;
+}
+.tooltip-bottom.tooltip-visible {
+  transform: translate(-50%, 0) scale(1);
+}
+
+/* Left position */
+.tooltip-left {
+  right: 100%;
+  top: 50%;
+  transform: translate(15px, -50%) scale(0.95);
+  margin-right: 12px;
+}
+.tooltip-left.tooltip-visible {
+  transform: translate(0, -50%) scale(1);
+}
+
+/* Right position */
+.tooltip-right {
+  left: 100%;
+  top: 50%;
+  transform: translate(-15px, -50%) scale(0.95);
+  margin-left: 12px;
+}
+.tooltip-right.tooltip-visible {
+  transform: translate(0, -50%) scale(1);
+}
+
+/* Diamond pseudo-element pointing arrow (Art Deco style) */
+.tooltip-content::after {
+  content: '';
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  background: #0f1214;
+  border-right: 2px solid #d4af37;
+  border-bottom: 2px solid #d4af37;
+  box-shadow: 4px 4px 0 rgba(0, 0, 0, 0.8);
+}
+
+/* Rotate arrow based on position */
+.tooltip-top::after {
+  bottom: -6px;
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.tooltip-bottom::after {
+  top: -6px;
+  left: 50%;
+  transform: translateX(-50%) rotate(225deg);
+  box-shadow: -4px -4px 0 rgba(0,0,0,0.8);
+}
+
+.tooltip-left::after {
+  right: -6px;
+  top: 50%;
+  transform: translateY(-50%) rotate(-45deg);
+}
+
+.tooltip-right::after {
+  left: -6px;
+  top: 50%;
+  transform: translateY(-50%) rotate(135deg);
+  box-shadow: -4px 4px 0 rgba(0,0,0,0.8);
+}
+
+/* Mobile Responsiveness */
+@media (max-width: 600px) {
+  .tooltip-content {
+    max-width: 200px;
+    font-size: 10px;
+    padding: 10px 14px;
+    letter-spacing: 1px;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Submitting a reusable, highly accessible React Tooltip component with a custom, snappy Elastic Slide animation, styled elegantly for Art Deco Layouts. This specifically addresses and resolves issue #38634.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (`submissions/react/react-tooltip-elastic-art-deco-st/`)
- [ ] Includes `demo.html` — self-contained, opens in browser with no server *(N/A — React Track Submission)*
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A highly customizable, fully accessible React Tooltip component featuring an elastic bouncy entrance and a classic Art Deco aesthetic (deep onyx backgrounds, metallic gold accents, geometric double-borders, and vintage sharp drop shadows).

**How does a developer use it?**

```jsx
import ElasticTooltip from './ElasticTooltip';

<ElasticTooltip content="The Gatsby Collection" position="top" delay={300}>
  <button className="ease-hover-lift">Hover me (Top)</button>
</ElasticTooltip>
