### PR TITLE
feat(react): add tooltip component with organic craft elastic slide

### DIFF
--- a/submissions/react/react-tooltip-elastic-organic-craft-st/ElasticTooltip.jsx
+++ b/submissions/react/react-tooltip-elastic-organic-craft-st/ElasticTooltip.jsx
@@ -1,0 +1,73 @@
+import React, { useState, useRef, useEffect, useId } from 'react';
+import './style.css';
+
+const ElasticTooltip = ({
+  position = 'top',
+  content,
+  children,
+  delay = 200,
+  disabled = false,
+  className = ''
+}) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const timeoutRef = useRef(null);
+  const tooltipId = useId();
+
+  const allowedPositions = ['top', 'bottom', 'left', 'right'];
+  const finalPosition = allowedPositions.includes(position) ? position : 'top';
+
+  const showTooltip = () => {
+    if (disabled) return;
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => {
+      setIsVisible(true);
+    }, delay);
+  };
+
+  const hideTooltip = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    setIsVisible(false);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const positionClass = `tooltip-${finalPosition}`;
+
+  return (
+    <div 
+      className="tooltip-container"
+      onMouseEnter={showTooltip}
+      onMouseLeave={hideTooltip}
+      onFocus={showTooltip}
+      onBlur={hideTooltip}
+    >
+      <div 
+        className="tooltip-trigger ease-hover-lift" 
+        aria-describedby={!disabled ? tooltipId : undefined}
+      >
+        {children}
+      </div>
+
+      {!disabled && (
+        <div
+          id={tooltipId}
+          role="tooltip"
+          className={`tooltip-content ease-fade-in ease-zoom-in ${positionClass} ${isVisible ? 'tooltip-visible' : ''} ${className}`}
+          aria-hidden={!isVisible}
+        >
+          {content}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ElasticTooltip;

--- a/submissions/react/react-tooltip-elastic-organic-craft-st/README.md
+++ b/submissions/react/react-tooltip-elastic-organic-craft-st/README.md
@@ -1,0 +1,66 @@
+# React Tooltip - Organic Craft Elastic Slide
+
+A beautifully crafted, reusable React tooltip component tailored with an "Organic Craft" aesthetic (warm cream/sand backgrounds, deep sage green text, irregular rounded corners, and soft diffused shadows). It features an exceptionally smooth, sweeping elastic slide animation upon hover or focus, leveraging EaseMotion CSS utility classes (`ease-fade-in`, `ease-zoom-in`, `ease-hover-lift`) alongside custom cubic-bezier transition tuning.
+
+## Features
+- **Elastic Slide Animation:** Utilizes a custom, fluid `cubic-bezier(0.34, 1.56, 0.64, 1)` transform for an organic bouncy reveal, enhanced by `ease-zoom-in` and `ease-fade-in`.
+- **EaseMotion Integration:** The trigger element utilizes `ease-hover-lift` to provide immediate interaction feedback.
+- **Organic Craft Theme:** Features warm `#fdfbf7` backgrounds, `#4a5d4e` sage green text, an irregular organic `border-radius`, and a rounded pointer arrow for a hand-crafted feel.
+- **Accessibility Ready:** Implements `role="tooltip"`, dynamically unique `aria-describedby` utilizing `useId()`, and triggers on both hover and focus.
+- **Configurable & Safe:** Validates positions (`top`, `bottom`, `left`, `right`) and handles long text gracefully with word-breaking.
+- **Responsive:** Scales down cleanly on smaller screens (media queries included).
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `content` | `node` | (Required) | The text or element to display inside the tooltip. |
+| `children` | `node` | (Required) | The target element that triggers the tooltip on hover/focus. |
+| `position` | `string` | `'top'` | Tooltip placement. Options: `'top'`, `'bottom'`, `'left'`, `'right'`. Fallbacks to `'top'` if invalid. |
+| `delay` | `number` | `200` | Delay in milliseconds before showing the tooltip. |
+| `disabled` | `boolean` | `false` | If true, the tooltip will not be displayed. |
+| `className` | `string` | `''` | Additional custom CSS classes for the tooltip content. |
+
+## Usage
+
+```jsx
+import React from 'react';
+import ElasticTooltip from './ElasticTooltip';
+
+export default function App() {
+  return (
+    <div style={{ padding: '100px', display: 'flex', gap: '20px', flexWrap: 'wrap', background: '#f4f1ea', height: '100vh' }}>
+      
+      <ElasticTooltip content="Handcrafted with care." position="top" delay={300}>
+        <button style={btnStyle}>Hover me (Top)</button>
+      </ElasticTooltip>
+
+      <ElasticTooltip content="Naturally sourced materials." position="bottom">
+        <button style={btnStyle}>Focus me (Bottom)</button>
+      </ElasticTooltip>
+      
+      <ElasticTooltip content="Sustainable practices." position="left">
+        <button style={btnStyle}>Warning (Left)</button>
+      </ElasticTooltip>
+      
+      <ElasticTooltip content="Organic Certification" position="right">
+        <button style={btnStyle}>System Status (Right)</button>
+      </ElasticTooltip>
+
+    </div>
+  );
+}
+
+const btnStyle = {
+  padding: '12px 24px',
+  background: '#4a5d4e',
+  color: '#fdfbf7',
+  border: 'none',
+  borderRadius: '20px 14px 18px 16px',
+  fontFamily: 'Lora, serif',
+  fontSize: '16px',
+  cursor: 'pointer',
+  boxShadow: '0 4px 12px rgba(74, 93, 78, 0.2)',
+  transition: 'all 0.3s'
+};
+```

--- a/submissions/react/react-tooltip-elastic-organic-craft-st/style.css
+++ b/submissions/react/react-tooltip-elastic-organic-craft-st/style.css
@@ -1,0 +1,146 @@
+/* Container holds the position context */
+.tooltip-container {
+  position: relative;
+  display: inline-flex;
+}
+
+.tooltip-trigger {
+  display: inherit;
+  cursor: pointer;
+  /* EaseMotion util hooks - base for hover lift */
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Fallback for EaseMotion hover-lift */
+.tooltip-trigger.ease-hover-lift:hover,
+.tooltip-trigger.ease-hover-lift:focus {
+  transform: translateY(-2px);
+}
+
+/* Base tooltip styling: Organic Craft Theme */
+.tooltip-content {
+  position: absolute;
+  background: #fdfbf7; /* Warm sand/cream */
+  color: #4a5d4e; /* Deep sage green */
+  padding: 12px 18px;
+  
+  /* Organic irregular border radius */
+  border-radius: 20px 14px 18px 16px;
+  border: 1px solid #e2ded3;
+  
+  font-size: 14px;
+  font-weight: 500;
+  font-family: 'Lora', 'Merriweather', 'Palatino Linotype', serif; /* Warm organic font */
+  letter-spacing: 0.3px;
+  text-align: center;
+  white-space: normal;
+  max-width: 250px;
+  word-break: break-word;
+  pointer-events: none;
+  z-index: 1000;
+  opacity: 0;
+  visibility: hidden;
+  
+  /* Soft warm shadow */
+  box-shadow: 0 10px 25px rgba(74, 93, 78, 0.12);
+  
+  /* Elastic slide transition */
+  transition: opacity 0.3s ease, visibility 0.3s ease, transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* Visibility state */
+.tooltip-visible {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* Top position */
+.tooltip-top {
+  bottom: 100%;
+  left: 50%;
+  transform: translate(-50%, 15px) scale(0.95);
+  margin-bottom: 14px;
+}
+.tooltip-top.tooltip-visible {
+  transform: translate(-50%, 0) scale(1);
+}
+
+/* Bottom position */
+.tooltip-bottom {
+  top: 100%;
+  left: 50%;
+  transform: translate(-50%, -15px) scale(0.95);
+  margin-top: 14px;
+}
+.tooltip-bottom.tooltip-visible {
+  transform: translate(-50%, 0) scale(1);
+}
+
+/* Left position */
+.tooltip-left {
+  right: 100%;
+  top: 50%;
+  transform: translate(15px, -50%) scale(0.95);
+  margin-right: 14px;
+}
+.tooltip-left.tooltip-visible {
+  transform: translate(0, -50%) scale(1);
+}
+
+/* Right position */
+.tooltip-right {
+  left: 100%;
+  top: 50%;
+  transform: translate(-15px, -50%) scale(0.95);
+  margin-left: 14px;
+}
+.tooltip-right.tooltip-visible {
+  transform: translate(0, -50%) scale(1);
+}
+
+/* Organic pseudo-element pointing arrow */
+.tooltip-content::after {
+  content: '';
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  background: #fdfbf7;
+  border-right: 1px solid #e2ded3;
+  border-bottom: 1px solid #e2ded3;
+  /* Slightly rounded point for the arrow */
+  border-bottom-right-radius: 4px;
+}
+
+/* Rotate arrow based on position */
+.tooltip-top::after {
+  bottom: -7px;
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.tooltip-bottom::after {
+  top: -7px;
+  left: 50%;
+  transform: translateX(-50%) rotate(225deg);
+}
+
+.tooltip-left::after {
+  right: -7px;
+  top: 50%;
+  transform: translateY(-50%) rotate(-45deg);
+}
+
+.tooltip-right::after {
+  left: -7px;
+  top: 50%;
+  transform: translateY(-50%) rotate(135deg);
+}
+
+/* Mobile Responsiveness */
+@media (max-width: 600px) {
+  .tooltip-content {
+    max-width: 200px;
+    font-size: 13px;
+    padding: 10px 14px;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Submitting a reusable, highly accessible React Tooltip component with a custom, fluid Elastic Slide animation, styled beautifully for Organic Craft Layouts. This specifically addresses and resolves issue #38635.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (`submissions/react/react-tooltip-elastic-organic-craft-st/`)
- [ ] Includes `demo.html` — self-contained, opens in browser with no server *(N/A — React Track Submission)*
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A highly customizable, fully accessible React Tooltip component featuring a fluid, organic bouncy entrance and an Organic Craft aesthetic (warm sand backgrounds, sage green typography, hand-crafted irregular borders, and soft diffused drop shadows).

**How does a developer use it?**

```jsx
import ElasticTooltip from './ElasticTooltip';

<ElasticTooltip content="Handcrafted with care." position="top" delay={300}>
  <button className="ease-hover-lift">Hover me (Top)</button>
</ElasticTooltip>
