### PR TITLE
feat(examples): add animation play state utility classes

### DIFF
--- a/submissions/examples/animation-play-state-utility-st/README.md
+++ b/submissions/examples/animation-play-state-utility-st/README.md
@@ -1,0 +1,23 @@
+# Animation Play State Utilities
+
+Provides utility classes to easily pause and resume CSS animations without writing custom CSS or JavaScript.
+
+## What does this do?
+It introduces `animation-play-state` utility classes (`.animate-pause`, `.animate-running`, `.hover-pause`, `.hover-running`) to give developers declarative control over when animations play or freeze.
+
+## How is it used?
+
+```html
+<!-- Permanently pause an animation -->
+<div class="ease-spin animate-pause">I am paused</div>
+
+<!-- Pause an infinite animation while the user hovers over it -->
+<div class="ease-spin hover-pause">Hover to pause</div>
+
+<!-- Only animate when the user hovers -->
+<!-- (Requires the base animation to be paused initially) -->
+<div class="ease-spin paused-by-default hover-running">Hover to spin</div>
+```
+
+## Why is it useful?
+It fits EaseMotion's zero-config, declarative philosophy by letting developers control complex interactive animation states purely through HTML utility classes, significantly improving developer experience and accessibility (e.g. pausing distracting animations).

--- a/submissions/examples/animation-play-state-utility-st/demo.html
+++ b/submissions/examples/animation-play-state-utility-st/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Animation Play State Utilities Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-container">
+    <h2>Animation Play State Utilities</h2>
+    <p>These utility classes allow you to control CSS animations without writing custom CSS.</p>
+
+    <div class="demo-card">
+      <h3>1. Pause on Hover (.hover-pause)</h3>
+      <p>The element spins infinitely. Hovering over it pauses the animation.</p>
+      <div class="demo-box hover-pause" tabindex="0">Hover</div>
+    </div>
+
+    <div class="demo-card">
+      <h3>2. Static Paused (.animate-pause)</h3>
+      <p>The element has an animation applied, but is permanently paused by the utility class.</p>
+      <div class="demo-box animate-pause">Paused</div>
+    </div>
+
+    <div class="demo-card">
+      <h3>3. Run on Hover (.hover-running)</h3>
+      <p>The element is paused by default. Hovering over it resumes the animation.</p>
+      <div class="demo-box paused-by-default hover-running" tabindex="0">Hover</div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/animation-play-state-utility-st/style.css
+++ b/submissions/examples/animation-play-state-utility-st/style.css
@@ -1,0 +1,73 @@
+/* 
+  Animation Play State Utilities
+  These classes allow for immediate control over animation states without writing custom CSS.
+*/
+
+/* Forces the animation to pause immediately */
+.animate-pause {
+  animation-play-state: paused !important;
+}
+
+/* Forces the animation to run */
+.animate-running {
+  animation-play-state: running !important;
+}
+
+/* Pauses the animation only while the element is hovered or focused */
+.hover-pause:hover,
+.hover-pause:focus-within,
+.hover-pause:focus {
+  animation-play-state: paused !important;
+}
+
+/* Resumes the animation only while the element is hovered or focused */
+.hover-running:hover,
+.hover-running:focus-within,
+.hover-running:focus {
+  animation-play-state: running !important;
+}
+
+/* 
+  Demo specific styles (will not be merged into core, just for demo.html)
+*/
+.demo-container {
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+  padding: 40px;
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #f4f4f5;
+  min-height: 100vh;
+}
+
+.demo-card {
+  background: white;
+  padding: 24px;
+  border-radius: 12px;
+  box-shadow: 0 4px 6px rgba(0,0,0,0.05);
+}
+
+.demo-box {
+  width: 80px;
+  height: 80px;
+  background: #3b82f6;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-weight: bold;
+  margin-top: 16px;
+  /* Basic infinite spin animation to demonstrate the utility classes */
+  animation: demo-spin 3s linear infinite;
+  cursor: pointer;
+}
+
+.demo-box.paused-by-default {
+  animation-play-state: paused;
+}
+
+@keyframes demo-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}


### PR DESCRIPTION
## Pull Request Description

Submitting a standard HTML/CSS demo that introduces highly requested utility classes for controlling CSS `animation-play-state`. This provides declarative pausing and resuming of animations without needing JavaScript or custom CSS. Resolves issue #38714.

---

## Type of Change

- [x] ✨ New animation / hover effect / utility class
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (`submissions/examples/animation-play-state-utility-st/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It introduces `animation-play-state` utility classes (`.animate-pause`, `.animate-running`, `.hover-pause`, `.hover-running`) to give developers immediate, declarative control over when animations play or freeze.

**How does a developer use it?**

```html
<!-- Pause an infinite animation while the user hovers over it -->
<div class="ease-spin hover-pause">Hover to pause</div>

<!-- Only animate when the user hovers (requires base animation to be paused initially) -->
<div class="ease-spin animate-pause hover-running">Hover to spin</div>
