### PR TITLE
fix: escape regex special characters in SearchAutocomplete to prevent…

### DIFF
--- a/submissions/react/react-search-autocomplete-dropdown-with-highlight-motion/SearchAutocomplete.jsx
+++ b/submissions/react/react-search-autocomplete-dropdown-with-highlight-motion/SearchAutocomplete.jsx
@@ -72,8 +72,11 @@ const SearchAutocomplete = ({
   const renderHighlightedText = (text, highlight) => {
     if (!highlight.trim()) return text;
     
+    // Escape special regex characters in the highlight string to prevent ReDoS
+    const escapedHighlight = highlight.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    
     // Split on highlight term and include term in splits, ignore case
-    const parts = text.split(new RegExp(`(${highlight})`, 'gi'));
+    const parts = text.split(new RegExp(`(${escapedHighlight})`, 'gi'));
     
     return parts.map((part, index) => 
       part.toLowerCase() === highlight.toLowerCase() 


### PR DESCRIPTION
## Pull Request Description

Submitting a critical security fix for the `SearchAutocomplete.jsx` component to patch a ReDoS and XSS vulnerability caused by unescaped user input inside a `RegExp` constructor. Resolves issue #38684.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug / Security fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (`submissions/react/react-search-autocomplete-dropdown-with-highlight-motion/SearchAutocomplete.jsx`)
- [ ] Includes `demo.html` — self-contained, opens in browser with no server *(N/A — Fix for existing React submission)*
- [ ] Includes `style.css` — raw CSS for the proposed feature *(N/A)*
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS *(N/A)*
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this fix?**

It patches a catastrophic backtracking vulnerability (ReDoS) inside `renderHighlightedText`. Previously, the component took raw user input (`highlight`) and shoved it directly into `new RegExp(..., 'gi')`. Typing special regex characters like `.*` would cause the browser tab to hang or crash.

**How was it fixed?**

I added a strict escape function that sanitizes the user string prior to regex construction:
```javascript
const escapedHighlight = highlight.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
const parts = text.split(new RegExp(`(${escapedHighlight})`, 'gi'));
