### PR TITLE
fix(button): invert ghost text color on hover for readibility

### DIFF
--- a/submissions/ghost-button-fix/README.md
+++ b/submissions/ghost-button-fix/README.md
@@ -1,0 +1,16 @@
+# Fix : Ghost Button Text Invisible on Hover
+
+## Problem Description
+On the documentation/demo page, hovering over the **Ghost BUTTON** variant makes the text completely invisible. The background turn white, but due to theme conflicts, the text color fails to invert properly and remains white.
+
+## Bug Location
+* **File:** 'components/button.css'
+* **Lines:** 124-129
+**Current Selector:**
+```css
+@media (hover: hover) and (pointer: fine) {
+  .ease-btn-ghost:hover {
+    background-color: var(--ease-color-neutral-100, #f1f5f9);
+    color: var(--ease-color-neutral-900, #0f172a);
+  }
+}

--- a/submissions/ghost-button-fix/demo.html
+++ b/submissions/ghost-button-fix/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ghost Button Hover Fix Demo</title>
+    <link rel="stylesheet" href="style.css">
+    <style>
+        body {
+            background-color: #0b132b;
+            color: #ffffff;
+            font-family: sans-serif;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+            margin: 0;
+        }
+        .container {
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h2>Ghost Button Hover Fix</h2>
+        <p>Hover over the button below. The text color now safely changes to dark instead of turning invisible.</p>
+        <button class="ease-btn ease-btn-ghost">Ghost</button>   
+    </div>
+</body>
+</html>

--- a/submissions/ghost-button-fix/style.css
+++ b/submissions/ghost-button-fix/style.css
@@ -1,0 +1,10 @@
+/*
+Fix for ghost button hover contrast issue.
+*/
+
+@media (hover: hover) and (pointer: fine) {
+  .ease-btn-ghost:hover {
+    background-color: #ffffff;
+    color: #0f172a;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes the ghost button hover issue where the text color became invisible (white text on a white background). Now, the text color correctly inverts to dark  (`#0f172a`) on hover, ensuring proper readability.

Closes #38751

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [ x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x ] Includes `demo.html` — self-contained, opens in browser with no server
- [ x] Includes `style.css` — raw CSS for the proposed feature
- [ x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [ x] **No changes to `core/`**
- [x ] **No changes to `components/`**
- [x ] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Fixes the bug where `.ease-btn-ghost` text becomes invisible on hover due to background and color synchronization conflicts.

**How does a developer use it?**

Simply use the component as intended in HTML:
```html
<button class="ease-btn  ease-btn-ghost">Ghost</button>


**Why does it fit EaseMotion CSS?**

It restores the intended UI behavior of the library's built-in components without altering the core framework files.

---

## Demo

- [ x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x ] Chrome
- [x ] Firefox
- [ x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The fix is safely contained inside the assignment submission folder (submissions/ghost-button-fix/) and uses media queries to ensure the hover style only triggers on pointer-accurate devices.

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
