### PR TITLE
feat: add CSS variable animation customization demo (#38699)

### DIFF
--- a/submissions/examples/css-variable-animation-customization-rak/README.md
+++ b/submissions/examples/css-variable-animation-customization-rak/README.md
@@ -1,0 +1,36 @@
+# CSS Variable Animation Customization
+
+## What it does
+
+Adds CSS custom properties (`--em-duration`, `--em-delay`, `--em-easing`, `--em-iteration`) that control an animation's timing. The animation reads its values from these variables, so you can change how it behaves by overriding a variable instead of editing the keyframes or writing a new rule.
+
+## How to use it
+
+Add the `em-animate` class to any element to run the animation with the default timing:
+
+```html
+<div class="card em-animate">Hello</div>
+```
+
+To change the timing, override a variable on that element (or any parent):
+
+```css
+.card--slow {
+  --em-duration: 1.2s;
+}
+
+.card--bouncy {
+  --em-easing: cubic-bezier(0.68, -0.55, 0.27, 1.55);
+}
+```
+
+```html
+<div class="card em-animate card--slow">Slower</div>
+<div class="card em-animate card--bouncy">Bouncy</div>
+```
+
+`demo.html` shows six cards using the same animation with different variable values.
+
+## Why it is useful
+
+It keeps timing configuration in one place and lets the same animation be reused with different speeds, delays, and easing without duplicating keyframes. This fits EaseMotion's goal of readable, reusable motion utilities that stay easy to customize.

--- a/submissions/examples/css-variable-animation-customization-rak/demo.html
+++ b/submissions/examples/css-variable-animation-customization-rak/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Variable Animation Customization</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="grid">
+    <div class="card em-animate">
+      <h3>Default</h3>
+      <p>base variables</p>
+    </div>
+    <div class="card em-animate card--fast">
+      <h3>Fast</h3>
+      <p>--em-duration: 0.3s</p>
+    </div>
+    <div class="card em-animate card--slow">
+      <h3>Slow</h3>
+      <p>--em-duration: 1.2s</p>
+    </div>
+    <div class="card em-animate card--bouncy">
+      <h3>Bouncy</h3>
+      <p>custom --em-easing</p>
+    </div>
+    <div class="card em-animate card--delayed">
+      <h3>Delayed</h3>
+      <p>--em-delay: 0.4s</p>
+    </div>
+    <div class="card em-animate card--loop">
+      <h3>Looping</h3>
+      <p>--em-iteration: infinite</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/css-variable-animation-customization-rak/style.css
+++ b/submissions/examples/css-variable-animation-customization-rak/style.css
@@ -1,0 +1,86 @@
+:root {
+  --em-duration: 0.6s;
+  --em-delay: 0s;
+  --em-easing: ease-in-out;
+  --em-iteration: 1;
+}
+
+.em-animate {
+  animation-name: em-float;
+  animation-duration: var(--em-duration);
+  animation-delay: var(--em-delay);
+  animation-timing-function: var(--em-easing);
+  animation-iteration-count: var(--em-iteration);
+  animation-fill-mode: both;
+}
+
+@keyframes em-float {
+  from {
+    transform: translateY(24px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+/* override any variable to retune the same animation */
+.card--fast {
+  --em-duration: 0.3s;
+}
+
+.card--slow {
+  --em-duration: 1.2s;
+}
+
+.card--bouncy {
+  --em-easing: cubic-bezier(0.68, -0.55, 0.27, 1.55);
+  --em-duration: 0.9s;
+}
+
+.card--delayed {
+  --em-delay: 0.4s;
+}
+
+.card--loop {
+  --em-iteration: infinite;
+  --em-duration: 1.5s;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: #0f0f17;
+  color: #f4f4f5;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1.25rem;
+  width: min(720px, 90vw);
+  padding: 2rem;
+}
+
+.card {
+  background: #1c1c27;
+  border: 1px solid #2e2e3d;
+  border-radius: 14px;
+  padding: 1.5rem 1rem;
+  text-align: center;
+}
+
+.card h3 {
+  margin: 0 0 0.35rem;
+  font-size: 1rem;
+}
+
+.card p {
+  margin: 0;
+  font-size: 0.78rem;
+  color: #a1a1aa;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a submission demonstrating CSS custom properties for animation timing,
addressing issue #38699. Animation duration, delay, easing, and iteration count
are driven by `--em-*` variables, so the same animation can be retuned by
overriding a variable instead of editing keyframes.

Closes #38699

---

## Type of Change

- [x] ✨ New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits
  EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

CSS variables (`--em-duration`, `--em-delay`, `--em-easing`, `--em-iteration`)
that let a developer customize an animation's timing without editing its
keyframes.

**How does a developer use it?**

```html
<div class="card em-animate card--slow">Slower</div>
<div class="card em-animate card--bouncy">Bouncy</div>
```

**Why does it fit EaseMotion CSS?**

It keeps motion utilities readable and reusable. One animation can serve many
speeds and easings through simple variable overrides, which matches the
framework's goal of easy, human-readable customization.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome

---

## Notes for Maintainer

Class names use plain `card--*` modifiers for the demo. Feel free to standardize
them to the `ease-*` convention during integration.