### PR TITLE
feat: add pure CSS tilt hover button for retro layouts #38568

### DIFF
--- a/submissions/examples/retro-tilt-button/README.md
+++ b/submissions/examples/retro-tilt-button/README.md
@@ -1,0 +1,15 @@
+# Retro Terminal Tilt Hover Button
+
+A zero-dependency, pure-CSS animated button showcasing interactive pseudo-3D tilting, custom-built for Retro CRT Terminal layouts. 
+
+## Features
+* **Pure CSS Execution:** Achieves complete 3D directional tilting, scale mechanics, and matrix shifts without single line of JavaScript overhead.
+* **Highly Customizable:** Exposes standard CSS Custom Properties (`--tilt-scale`, `--tilt-duration`, `--tilt-deg-x`, etc.) directly at the `:root` level for effortless integration tweaking.
+* **A11y Compliant:** Supports robust keyboard navigation (`:focus-visible` state parameters mapped concurrently alongside hover animations) and leverages semantic semantic markup with ARIA accessibility handles.
+
+## Project Structure
+```text
+retro-tilt-button/
+├── demo.html   # Component container deployment environment
+├── style.css   # Main stylesheet holding animation engine & CRT shaders
+└── README.md   # Documentation

--- a/submissions/examples/retro-tilt-button/demo.html
+++ b/submissions/examples/retro-tilt-button/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Retro Terminal Tilt Button Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Wrapper providing the 3D CSS Context -->
+  <div class="terminal-perspective">
+    <button class="retro-tilt-btn" aria-label="Initialize System Boot Protocol">
+      &gt; INITIALIZE_BOOT
+    </button>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/retro-tilt-button/style.css
+++ b/submissions/examples/retro-tilt-button/style.css
@@ -1,0 +1,145 @@
+/* ==========================================================================
+   Retro Terminal Tilt Button - Variables & Theming
+   ========================================================================== */
+:root {
+  /* Terminal Color Palette */
+  --term-bg: #0c0f12;
+  --term-glow: #00ff66;
+  --term-glow-dim: rgba(0, 255, 102, 0.25);
+  --term-text: #33ff77;
+  --term-text-dark: #051a0b;
+  --term-font: 'Courier New', Courier, monospace;
+
+  /* Animation & Tilt Parameters */
+  --tilt-duration: 0.35s;
+  --tilt-easing: cubic-bezier(0.25, 0.8, 0.25, 1);
+  --tilt-scale: 1.05;
+  
+  /* 3D Transform Properties */
+  --tilt-deg-x: 8deg;
+  --tilt-deg-y: -12deg;
+}
+
+/* Base Terminal Context Styling (Optional/Contextual) */
+body {
+  background-color: var(--term-bg);
+  font-family: var(--term-font);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0;
+  overflow: hidden;
+}
+
+/* ==========================================================================
+   Component: Retro Tilt Button
+   ========================================================================== */
+.terminal-perspective {
+  perspective: 800px;
+}
+
+.retro-tilt-btn {
+  position: relative;
+  background: transparent;
+  color: var(--term-text);
+  border: 2px solid var(--term-text);
+  padding: 1rem 2rem;
+  font-family: var(--term-font);
+  font-size: 1.1rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  cursor: pointer;
+  outline: none;
+  
+  /* Core Animation States */
+  transform-style: preserve-3d;
+  transform: rotateX(0deg) rotateY(0deg) scale(1);
+  transition: 
+    transform var(--tilt-duration) var(--tilt-easing),
+    box-shadow var(--tilt-duration) var(--tilt-easing),
+    background var(--tilt-duration) var(--tilt-easing),
+    color var(--tilt-duration) var(--tilt-easing);
+
+  /* Retro CRT Glow Effect */
+  box-shadow: 0 0 8px var(--term-glow-dim), inset 0 0 4px var(--term-glow-dim);
+  text-shadow: 0 0 4px var(--term-glow-dim);
+}
+
+/* Scanning Line Overlay inside the button */
+.retro-tilt-btn::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: linear-gradient(
+    rgba(18, 16, 16, 0) 50%, 
+    rgba(0, 0, 0, 0.25) 50%
+  ), linear-gradient(
+    90deg, 
+    rgba(255, 0, 0, 0.06), 
+    rgba(0, 255, 0, 0.02), 
+    rgba(0, 0, 255, 0.06)
+  );
+  background-size: 100% 3px, 6px 100%;
+  opacity: 0.4;
+  pointer-events: none;
+  transform: translateZ(1px); /* Layered slightly forward in 3D space */
+}
+
+/* Pseudo-shadow layer beneath the button for depth */
+.retro-tilt-btn::after {
+  content: '';
+  position: absolute;
+  inset: -2px;
+  background: transparent;
+  border: 2px solid var(--term-glow);
+  opacity: 0;
+  transform: translateZ(-10px) scale(0.95);
+  transition: transform var(--tilt-duration) var(--tilt-easing), opacity var(--tilt-duration) var(--tilt-easing);
+  pointer-events: none;
+}
+
+/* ==========================================================================
+   Interactive States (Hover & Focus)
+   ========================================================================== */
+
+/* Pure CSS Pseudo-3D Tilt Matrix Engine */
+.retro-tilt-btn:hover,
+.retro-tilt-btn:focus-visible {
+  color: var(--term-text-dark);
+  background-color: var(--term-glow);
+  
+  /* Activates the pseudo-tilt calculation using explicit variables */
+  transform: 
+    rotateX(var(--tilt-deg-x)) 
+    rotateY(var(--tilt-deg-y)) 
+    scale(var(--tilt-scale));
+  
+  box-shadow: 
+    -5px 5px 0px rgba(0, 255, 102, 0.4),
+    0 0 20px var(--term-glow);
+  text-shadow: none;
+}
+
+/* Displace shadow layer conversely to accentuate depth */
+.retro-tilt-btn:hover::after,
+.retro-tilt-btn:focus-visible::after {
+  opacity: 0.3;
+  transform: translateZ(-25px) translate(8px, -8px) scale(1.02);
+}
+
+/* Active / Click state */
+.retro-tilt-btn:active {
+  transform: 
+    rotateX(calc(var(--tilt-deg-x) * 0.5)) 
+    rotateY(calc(var(--tilt-deg-y) * 0.5)) 
+    scale(0.98);
+  box-shadow: 0 0 10px var(--term-glow);
+}
+
+/* Native Keyboard Focus Outline Fallback Alternative */
+.retro-tilt-btn:focus-visible {
+  outline: 2px dashed #ffffff;
+  outline-offset: 6px;
+}


### PR DESCRIPTION
## 📝 Description
This PR resolves issue #38568 by introducing a high-performance, pure CSS animated button tailored for retro-terminal layouts. The implementation relies entirely on CSS 3D transforms (`perspective` and `preserve-3d`) to handle multi-axis directional tilting during hover and focus states, eliminating the need for any JavaScript overhead.

## 🎯 Changes Introduced
* **Pure CSS 3D Matrix Engines:** Leverages native CSS `transform` properties to calculate real-time tilt mechanics cleanly.
* **Highly Configurable:** Exposes variables (`--tilt-duration`, `--tilt-scale`, `--tilt-deg-x`, `--tilt-deg-y`, and color themes) via CSS custom properties at the `:root` level for effortless user customization.
* **A11y Compliant:** Fully supports keyboard navigation (`:focus-visible` state values mirroring the exact hover transition physics) alongside implicit ARIA labels.
* **Retro Shaders:** Embeds custom CRT scanline overlays (`::before` grid lines) and deep ambient neon glow back-shadows.

## 📁 File Structure Added
Following the repository contribution checklist, all implementation files reside neatly within the isolated `submissions/` directory:
```text
submissions/examples/retro-tilt-button/
├── demo.html   # Sandbox layout context for testing
├── style.css   # Animation rules, matrix configurations, and theme design
└── README.md   # Deployment guide and property customization manual