### PR TITLE
feat: add retro terminal tooltip with elastic slide (React track)

### DIFF
--- a/submissions/react/retro-terminal-tooltip-mp/README.md
+++ b/submissions/react/retro-terminal-tooltip-mp/README.md
@@ -1,0 +1,78 @@
+# Terminal Tooltip (Elastic Slide) — `TerminalTooltipMp`
+
+A React tooltip component styled like a retro CRT terminal (green phosphor
+text, scanlines, blinking caret) that enters with an **elastic slide**
+transition — it slides in, slightly overshoots its resting position, then
+settles, simulating spring physics using pure CSS keyframes.
+
+## What does this do?
+
+Wraps any trigger element (button, icon, text) and shows a terminal-styled
+tooltip on hover/focus/click, animated in with a bouncy elastic slide instead
+of a flat fade.
+
+## How is it used?
+
+```jsx
+import TerminalTooltipMp from "./TerminalTooltipMp";
+
+function Example() {
+  return (
+    <TerminalTooltipMp content="root@ease:~$ status: ok" position="top">
+      <button className="ease-hover-lift">hover me</button>
+    </TerminalTooltipMp>
+  );
+}
+```
+
+Rendered markup uses EaseMotion utility classes alongside the component's
+own scoped classes:
+
+```html
+<span class="term-tooltip-mp-wrapper">
+  <button class="ease-hover-lift">hover me</button>
+  <span
+    class="ease-fade-in-mp term-tooltip-mp term-tooltip-mp--top term-tooltip-mp--visible ease-elastic-slide-mp"
+    role="tooltip"
+  >
+    <span class="term-tooltip-mp__prompt">$</span>
+    <span class="term-tooltip-mp__content">root@ease:~$ status: ok</span>
+    <span class="term-tooltip-mp__caret"></span>
+  </span>
+</span>
+```
+
+## Why is it useful?
+
+EaseMotion's philosophy is expressive, physics-feeling motion without
+reaching for a JS animation library. This component packages that idea into
+a ready-to-drop React block: developers building retro/hacker/dev-tool style
+UIs get a themed, accessible tooltip with a distinctive elastic entrance,
+using only EaseMotion-style utility classes and one scoped stylesheet — no
+extra dependencies.
+
+## Props reference
+
+| Prop        | Type                                          | Default    | Description                                                                 |
+|-------------|-----------------------------------------------|------------|------------------------------------------------------------------------------|
+| `children`  | `ReactNode`                                   | —          | The trigger element the tooltip is attached to.                             |
+| `content`   | `string`                                       | `""`       | Text rendered inside the terminal tooltip body.                             |
+| `position`  | `"top" \| "bottom" \| "left" \| "right"`       | `"top"`    | Which side of the trigger the tooltip slides in from / anchors to.          |
+| `trigger`   | `"hover" \| "click"`                           | `"hover"`  | Interaction mode. `hover` also responds to keyboard focus/blur.             |
+| `delay`     | `number` (ms)                                  | `80`       | Delay before showing the tooltip after the trigger event fires.             |
+| `className` | `string`                                       | `""`       | Extra class(es) applied to the outer wrapper span.                          |
+| `disabled`  | `boolean`                                      | `false`    | When `true`, suppresses showing the tooltip entirely.                       |
+
+## Accessibility notes
+
+- The tooltip element has `role="tooltip"` and toggles `aria-hidden`.
+- Hover trigger mode also wires up `onFocus`/`onBlur` so keyboard users
+  reach the tooltip via Tab.
+- `prefers-reduced-motion: reduce` disables the elastic keyframes and falls
+  back to a simple opacity transition.
+
+## Files in this submission
+
+- `TerminalTooltipMp.jsx` — the component
+- `style.css` — scoped styling + elastic slide keyframes (imported by the component)
+- `README.md` — this file

--- a/submissions/react/retro-terminal-tooltip-mp/TerminalTooltipMp.jsx
+++ b/submissions/react/retro-terminal-tooltip-mp/TerminalTooltipMp.jsx
@@ -1,0 +1,79 @@
+import React, { useState, useRef, useId } from "react";
+import "./style.css";
+
+/**
+ * TerminalTooltipMp
+ *
+ * A retro-terminal styled tooltip that slides in with an elastic
+ * (overshoot-and-settle) transition. Built on top of EaseMotion CSS
+ * utility classes for entrance/exit motion, with custom "-mp" scoped
+ * classes handling the terminal skin (scanlines, monospace glow, etc).
+ *
+ * Usage:
+ *   <TerminalTooltipMp content="root@ease:~$ status ok" position="top">
+ *     <button>hover me</button>
+ *   </TerminalTooltipMp>
+ */
+export default function TerminalTooltipMp({
+  children,
+  content = "",
+  position = "top",
+  trigger = "hover",
+  delay = 80,
+  className = "",
+  disabled = false,
+}) {
+  const [visible, setVisible] = useState(false);
+  const timerRef = useRef(null);
+  const tooltipId = useId();
+
+  const show = () => {
+    if (disabled) return;
+    clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setVisible(true), delay);
+  };
+
+  const hide = () => {
+    clearTimeout(timerRef.current);
+    setVisible(false);
+  };
+
+  const hoverHandlers =
+    trigger === "hover"
+      ? {
+          onMouseEnter: show,
+          onMouseLeave: hide,
+          onFocus: show,
+          onBlur: hide,
+        }
+      : {
+          onClick: () => (visible ? hide() : show()),
+        };
+
+  return (
+    <span
+      className={`term-tooltip-mp-wrapper ${className}`.trim()}
+      {...hoverHandlers}
+    >
+      {children}
+
+      <span
+        role="tooltip"
+        id={tooltipId}
+        className={[
+          "ease-fade-in-mp",
+          "term-tooltip-mp",
+          `term-tooltip-mp--${position}`,
+          visible ? "term-tooltip-mp--visible ease-elastic-slide-mp" : "",
+        ]
+          .filter(Boolean)
+          .join(" ")}
+        aria-hidden={!visible}
+      >
+        <span className="term-tooltip-mp__prompt">$</span>
+        <span className="term-tooltip-mp__content">{content}</span>
+        <span className="term-tooltip-mp__caret" aria-hidden="true" />
+      </span>
+    </span>
+  );
+}

--- a/submissions/react/retro-terminal-tooltip-mp/style.css
+++ b/submissions/react/retro-terminal-tooltip-mp/style.css
@@ -1,0 +1,160 @@
+/* ==========================================================================
+   term-tooltip-mp
+   Retro terminal tooltip skin + elastic slide entrance animation.
+   Scoped entirely under the term-tooltip-mp-* namespace to avoid
+   collisions with other submissions.
+   ========================================================================== */
+
+.term-tooltip-mp-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.term-tooltip-mp {
+  position: absolute;
+  z-index: 50;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  min-width: max-content;
+  max-width: 260px;
+
+  font-family: "JetBrains Mono", "Fira Code", ui-monospace, monospace;
+  font-size: 12px;
+  line-height: 1.4;
+  color: #59ff9a;
+  background: #0b0f0c;
+  border: 1px solid #2fbf6a;
+  border-radius: 2px;
+  box-shadow:
+    0 0 0 1px rgba(47, 191, 106, 0.15),
+    0 0 12px rgba(47, 191, 106, 0.35);
+
+  /* CRT scanline texture */
+  background-image: repeating-linear-gradient(
+    to bottom,
+    rgba(89, 255, 154, 0.05) 0px,
+    rgba(89, 255, 154, 0.05) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(4px) scale(0.96);
+  transition: opacity 0.1s linear;
+}
+
+.term-tooltip-mp--visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Positions */
+.term-tooltip-mp--top {
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform-origin: bottom center;
+}
+
+.term-tooltip-mp--bottom {
+  top: calc(100% + 8px);
+  left: 50%;
+  transform-origin: top center;
+}
+
+.term-tooltip-mp--left {
+  right: calc(100% + 8px);
+  top: 50%;
+  transform-origin: right center;
+}
+
+.term-tooltip-mp--right {
+  left: calc(100% + 8px);
+  top: 50%;
+  transform-origin: left center;
+}
+
+.term-tooltip-mp__prompt {
+  color: #2fbf6a;
+  font-weight: 700;
+}
+
+.term-tooltip-mp__content {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.term-tooltip-mp__caret {
+  display: inline-block;
+  width: 6px;
+  height: 12px;
+  background: #59ff9a;
+  animation: term-tooltip-mp-blink 1s steps(1) infinite;
+}
+
+@keyframes term-tooltip-mp-blink {
+  0%, 49% { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+
+/* --------------------------------------------------------------------------
+   Elastic slide entrance
+   Overshoots past its resting position on each axis, then settles —
+   simulating spring physics with pure keyframes (no JS animation lib).
+   -------------------------------------------------------------------------- */
+.ease-elastic-slide-mp.term-tooltip-mp--top {
+  animation: term-tooltip-mp-elastic-y 0.5s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.ease-elastic-slide-mp.term-tooltip-mp--bottom {
+  animation: term-tooltip-mp-elastic-y-rev 0.5s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.ease-elastic-slide-mp.term-tooltip-mp--left {
+  animation: term-tooltip-mp-elastic-x 0.5s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.ease-elastic-slide-mp.term-tooltip-mp--right {
+  animation: term-tooltip-mp-elastic-x-rev 0.5s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+@keyframes term-tooltip-mp-elastic-y {
+  0%   { opacity: 0; transform: translate(-50%, 14px) scale(0.9); }
+  55%  { opacity: 1; transform: translate(-50%, -6px) scale(1.03); }
+  75%  { transform: translate(-50%, 2px) scale(0.99); }
+  100% { opacity: 1; transform: translate(-50%, 0) scale(1); }
+}
+
+@keyframes term-tooltip-mp-elastic-y-rev {
+  0%   { opacity: 0; transform: translate(-50%, -14px) scale(0.9); }
+  55%  { opacity: 1; transform: translate(-50%, 6px) scale(1.03); }
+  75%  { transform: translate(-50%, -2px) scale(0.99); }
+  100% { opacity: 1; transform: translate(-50%, 0) scale(1); }
+}
+
+@keyframes term-tooltip-mp-elastic-x {
+  0%   { opacity: 0; transform: translate(14px, -50%) scale(0.9); }
+  55%  { opacity: 1; transform: translate(-6px, -50%) scale(1.03); }
+  75%  { transform: translate(2px, -50%) scale(0.99); }
+  100% { opacity: 1; transform: translate(0, -50%) scale(1); }
+}
+
+@keyframes term-tooltip-mp-elastic-x-rev {
+  0%   { opacity: 0; transform: translate(-14px, -50%) scale(0.9); }
+  55%  { opacity: 1; transform: translate(6px, -50%) scale(1.03); }
+  75%  { transform: translate(-2px, -50%) scale(0.99); }
+  100% { opacity: 1; transform: translate(0, -50%) scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .term-tooltip-mp,
+  .ease-elastic-slide-mp.term-tooltip-mp--top,
+  .ease-elastic-slide-mp.term-tooltip-mp--bottom,
+  .ease-elastic-slide-mp.term-tooltip-mp--left,
+  .ease-elastic-slide-mp.term-tooltip-mp--right {
+    animation: none;
+    transition: opacity 0.15s linear;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a React-integrated Tooltip component (`TerminalTooltipMp`) with a retro terminal aesthetic and an elastic slide entrance transition, per issue #38628.

---

## Type of Change
- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
> ⚠️ PRs that fail this checklist will be **closed without review**.
- [x] All changes are inside `submissions/` (`submissions/react/retro-terminal-tooltip-mp/`)
- [x] Includes React component file — `TerminalTooltipMp.jsx` (React track equivalent of `demo.html`)
- [x] Includes `style.css` — scoped CSS for the terminal skin + elastic slide keyframes
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS, plus full props table
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (tooltip component only)

---

## Feature Description

**What does this add?**
A retro-terminal styled React tooltip component with an elastic slide-in transition (overshoot-and-settle) instead of a flat fade.

**How does a developer use it?**
```html
<span class="term-tooltip-mp-wrapper">
  <button class="ease-hover-lift">hover me</button>
  <span
    class="ease-fade-in-mp term-tooltip-mp term-tooltip-mp--top term-tooltip-mp--visible ease-elastic-slide-mp"
    role="tooltip"
  >
    <span class="term-tooltip-mp__prompt">$</span>
    <span class="term-tooltip-mp__content">root@ease:~$ status: ok</span>
    <span class="term-tooltip-mp__caret"></span>
  </span>
</span>
```

**Why does it fit EaseMotion CSS?**
EaseMotion favors expressive, physics-feeling motion without pulling in a JS animation library. This component packages that into a ready-to-use React block: a themed, accessible tooltip with a distinctive spring-like entrance, built entirely with EaseMotion-style utility classes and one scoped stylesheet.

---

## Demo
- [x] Demo added — since this is the React track, the "demo" is the working component itself (`TerminalTooltipMp.jsx`), documented with a usage example in the README rather than a standalone `demo.html`.

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(not tested)*

---

## Notes for Maintainer
This PR follows the **React Integration track** (`submissions/react/`), so it includes `TerminalTooltipMp.jsx` + `style.css` + `README.md` rather than `demo.html` — the checklist above is filled out with the closest React-track equivalents. Class names like `ease-fade-in-mp` and `ease-elastic-slide-mp` are placeholders per your naming convention; happy to rename if they collide with existing utilities. Elastic motion is achieved with pure CSS keyframes (overshoot + settle) rather than a spring library, to stay dependency-free. `prefers-reduced-motion` is respected.

---
> **Reminder:** Only the repository maintainer may merge pull requests.
> Do not self-merge, even if you have write access.