### PR TITLE
feat: add pure css popover confirmation dialog

### DIFF
--- a/submissions/examples/popover-confirm-19895/README.md
+++ b/submissions/examples/popover-confirm-19895/README.md
@@ -1,0 +1,16 @@
+# Pure CSS Popover Confirmation Dialog (`ease-popover-confirm`)
+
+This submission resolves issue #19895 by implementing a native CSS popup dialog for destructive actions.
+
+## Overview
+Confirming destructive actions (like "Delete Item") is a critical UI pattern. Typically, this requires JavaScript to toggle a tooltip or modal. This component utilizes the CSS `:focus-within` pseudo-class to reveal a contextual confirmation popover purely via CSS.
+
+## Features
+- **Zero JavaScript:** State is managed entirely by the browser's focus engine using the `:focus-within` selector on a parent wrapper.
+- **Contextual Positioning:** Uses `position: absolute` and standard CSS transforms to position the popover directly above the trigger button, complete with a CSS triangle caret.
+- **Accessible State:** Buttons remain inaccessible to mouse and keyboard (`pointer-events: none`, `opacity: 0`) until the parent is focused, preventing accidental clicks.
+- **Smooth Animation:** The popover fades in and scales slightly upwards when revealed, providing excellent visual feedback.
+
+## Files
+- `demo.html`: A mock settings page demonstrating a "Delete Account" destructive action that triggers the popover.
+- `style.css`: The styling for the popover and the state management logic.

--- a/submissions/examples/popover-confirm-19895/demo.html
+++ b/submissions/examples/popover-confirm-19895/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Popover Confirm - Pure CSS</title>
+    <link rel="stylesheet" href="../../../easemotion.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <main class="settings-page">
+        <header>
+            <h1>Account Settings</h1>
+            <p>Manage your data and security preferences.</p>
+        </header>
+
+        <section class="danger-zone">
+            <h2>Danger Zone</h2>
+            <div class="setting-row">
+                <div class="setting-info">
+                    <h3>Delete Account</h3>
+                    <p>Once you delete your account, there is no going back. Please be certain.</p>
+                </div>
+                
+                <!-- 
+                  THE POPOVER COMPONENT 
+                  The wrapper must be focusable or contain a focusable element to trigger :focus-within.
+                -->
+                <div class="ease-popover-wrapper">
+                    <!-- The Trigger Button -->
+                    <button class="btn btn-danger" type="button">Delete Account</button>
+                    
+                    <!-- The Hidden Popover -->
+                    <div class="ease-popover">
+                        <p class="popover-msg">Are you absolutely sure?</p>
+                        <div class="popover-actions">
+                            <!-- In a real app, 'Cancel' would just remove focus -->
+                            <button class="btn btn-secondary btn-sm" type="button">Cancel</button>
+                            <button class="btn btn-danger btn-sm" type="button">Yes, Delete</button>
+                        </div>
+                    </div>
+                </div>
+
+            </div>
+        </section>
+    </main>
+
+</body>
+</html>

--- a/submissions/examples/popover-confirm-19895/style.css
+++ b/submissions/examples/popover-confirm-19895/style.css
@@ -1,0 +1,179 @@
+:root {
+    --bg-page: #f8fafc;
+    --text-main: #0f172a;
+    --text-muted: #64748b;
+    --danger-color: #ef4444;
+    --danger-hover: #dc2626;
+    --border-color: #e2e8f0;
+    --popover-bg: #ffffff;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    font-family: system-ui, -apple-system, sans-serif;
+    background-color: var(--bg-page);
+    color: var(--text-main);
+}
+
+/* 
+  ========================================
+  PAGE LAYOUT
+  ========================================
+*/
+.settings-page {
+    max-width: 600px;
+    margin: 4rem auto;
+    padding: 2rem;
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
+}
+
+.settings-page header {
+    margin-bottom: 2rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.danger-zone h2 {
+    color: var(--danger-color);
+    font-size: 1.25rem;
+    margin-bottom: 1rem;
+}
+
+.setting-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1.5rem;
+    border: 1px solid var(--danger-color);
+    border-radius: 6px;
+    background-color: #fef2f2; /* Light red tint */
+}
+
+.setting-info h3 {
+    margin: 0 0 0.25rem 0;
+    font-size: 1rem;
+}
+
+.setting-info p {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--text-muted);
+}
+
+/* Base Buttons */
+.btn {
+    padding: 0.5rem 1rem;
+    border: none;
+    border-radius: 4px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.btn-danger {
+    background-color: var(--danger-color);
+    color: white;
+}
+
+.btn-danger:hover {
+    background-color: var(--danger-hover);
+}
+
+.btn-secondary {
+    background-color: #f1f5f9;
+    color: var(--text-main);
+    border: 1px solid #cbd5e1;
+}
+
+.btn-secondary:hover {
+    background-color: #e2e8f0;
+}
+
+.btn-sm {
+    padding: 0.25rem 0.75rem;
+    font-size: 0.875rem;
+}
+
+/* 
+  ========================================
+  POPOVER CONFIRM COMPONENT (Pure CSS)
+  ========================================
+*/
+
+/* 
+  1. The Wrapper MUST be relative to anchor the absolute popover.
+*/
+.ease-popover-wrapper {
+    position: relative;
+    display: inline-block;
+}
+
+/* 
+  2. The Popover itself.
+  Hidden by default using opacity and pointer-events (better than display:none for animation).
+*/
+.ease-popover {
+    position: absolute;
+    bottom: calc(100% + 12px); /* Position above the button with a gap */
+    right: 0;
+    width: 250px;
+    background-color: var(--popover-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -2px rgba(0,0,0,0.05);
+    padding: 1rem;
+    z-index: 50;
+    
+    /* Hidden State */
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(10px) scale(0.95);
+    
+    /* Smooth Transition */
+    transition: 
+        opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+        transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* 
+  3. The CSS Caret (Triangle pointer)
+*/
+.ease-popover::after {
+    content: '';
+    position: absolute;
+    bottom: -6px;
+    right: 20px; /* Aligned roughly above the right-side button */
+    width: 10px;
+    height: 10px;
+    background-color: var(--popover-bg);
+    border-bottom: 1px solid var(--border-color);
+    border-right: 1px solid var(--border-color);
+    transform: rotate(45deg);
+}
+
+/* 
+  4. STATE MANAGEMENT: The Magic Trigger
+  When ANY element inside the wrapper receives focus (i.e. the user clicks the trigger button),
+  we reveal the popover.
+*/
+.ease-popover-wrapper:focus-within .ease-popover {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0) scale(1);
+}
+
+/* Popover Internals */
+.popover-msg {
+    margin: 0 0 1rem 0;
+    font-size: 0.95rem;
+    font-weight: 500;
+}
+
+.popover-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #19895

**Feature**: Added `.ease-popover` utility for creating contextual confirmation dialogs without JavaScript.

**Implementation Details**: 
- The popover's visibility state is managed entirely by the browser's focus engine. By wrapping the trigger button and the popover in a `.ease-popover-wrapper` and using the `:focus-within` pseudo-class, the popover reveals itself when the user clicks the trigger.
- To ensure the hidden popover doesn't block clicks on underlying elements, it defaults to `opacity: 0` and `pointer-events: none` rather than `display: none`, allowing for a smooth `transition` when revealed.
- Included a CSS-drawn caret (triangle pointer) using the `::after` pseudo-element to firmly associate the popover with its trigger.
- Provided a realistic "Danger Zone / Delete Account" demo scenario.

---

## Submission Checklist

- [x] All changes are isolated in `submissions/examples/popover-confirm-19895/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to framework core files**