### PR TITLE
feat: add cyberpunk neon tooltip with elastic slide (React track)

### DIFF
--- a/submissions/react/cyberpunk-neon-tooltip-mp/NeonTooltipMp.jsx
+++ b/submissions/react/cyberpunk-neon-tooltip-mp/NeonTooltipMp.jsx
@@ -1,0 +1,79 @@
+import React, { useState, useRef, useId } from "react";
+import "./style.css";
+
+/**
+ * NeonTooltipMp
+ *
+ * A cyberpunk-neon styled tooltip that slides in with an elastic
+ * (overshoot-and-settle) transition. Built on top of EaseMotion CSS
+ * utility classes for entrance/exit motion, with custom "-mp" scoped
+ * classes handling the neon skin (glow, gradient border, glitch flicker).
+ *
+ * Usage:
+ *   <NeonTooltipMp content="SYSTEM // ONLINE" position="top" accent="cyan">
+ *     <button>hover me</button>
+ *   </NeonTooltipMp>
+ */
+export default function NeonTooltipMp({
+  children,
+  content = "",
+  position = "top",
+  trigger = "hover",
+  delay = 80,
+  accent = "cyan",
+  className = "",
+  disabled = false,
+}) {
+  const [visible, setVisible] = useState(false);
+  const timerRef = useRef(null);
+  const tooltipId = useId();
+
+  const show = () => {
+    if (disabled) return;
+    clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setVisible(true), delay);
+  };
+
+  const hide = () => {
+    clearTimeout(timerRef.current);
+    setVisible(false);
+  };
+
+  const hoverHandlers =
+    trigger === "hover"
+      ? {
+          onMouseEnter: show,
+          onMouseLeave: hide,
+          onFocus: show,
+          onBlur: hide,
+        }
+      : {
+          onClick: () => (visible ? hide() : show()),
+        };
+
+  return (
+    <span
+      className={`neon-tooltip-mp-wrapper ${className}`.trim()}
+      {...hoverHandlers}
+    >
+      {children}
+
+      <span
+        role="tooltip"
+        id={tooltipId}
+        className={[
+          "ease-fade-in-mp",
+          "neon-tooltip-mp",
+          `neon-tooltip-mp--${position}`,
+          `neon-tooltip-mp--${accent}`,
+          visible ? "neon-tooltip-mp--visible ease-elastic-slide-mp" : "",
+        ]
+          .filter(Boolean)
+          .join(" ")}
+        aria-hidden={!visible}
+      >
+        <span className="neon-tooltip-mp__content">{content}</span>
+      </span>
+    </span>
+  );
+}

--- a/submissions/react/cyberpunk-neon-tooltip-mp/README.md
+++ b/submissions/react/cyberpunk-neon-tooltip-mp/README.md
@@ -1,0 +1,82 @@
+# Neon Tooltip (Elastic Slide) — `NeonTooltipMp`
+
+A React tooltip component styled for **cyberpunk neon** interfaces — glowing
+gradient border, dark gradient backdrop, subtle sign-flicker on entrance —
+that slides in with an **elastic slide** transition: it overshoots its
+resting position slightly, then settles, simulating spring physics using
+pure CSS keyframes.
+
+## What does this do?
+
+Wraps any trigger element (button, icon, text) and shows a neon-glow
+tooltip on hover/focus/click, animated in with a bouncy elastic slide and a
+brief flicker instead of a flat fade.
+
+## How is it used?
+
+```jsx
+import NeonTooltipMp from "./NeonTooltipMp";
+
+function Example() {
+  return (
+    <NeonTooltipMp
+      content="SYSTEM // ONLINE"
+      position="top"
+      accent="cyan"
+    >
+      <button className="ease-hover-lift">hover me</button>
+    </NeonTooltipMp>
+  );
+}
+```
+
+Rendered markup uses EaseMotion utility classes alongside the component's
+own scoped classes:
+
+```html
+<span class="neon-tooltip-mp-wrapper">
+  <button class="ease-hover-lift">hover me</button>
+  <span
+    class="ease-fade-in-mp neon-tooltip-mp neon-tooltip-mp--top neon-tooltip-mp--cyan neon-tooltip-mp--visible ease-elastic-slide-mp"
+    role="tooltip"
+  >
+    <span class="neon-tooltip-mp__content">SYSTEM // ONLINE</span>
+  </span>
+</span>
+```
+
+## Why is it useful?
+
+EaseMotion's philosophy is expressive, physics-feeling motion without
+reaching for a JS animation library. This component packages that idea into
+a ready-to-drop React block: developers building cyberpunk/neon/HUD-style
+UIs get a themed, accessible tooltip with a distinctive elastic entrance and
+neon-sign flicker, using only EaseMotion-style utility classes and one
+scoped stylesheet — no extra dependencies.
+
+## Props reference
+
+| Prop        | Type                                          | Default    | Description                                                                 |
+|-------------|-----------------------------------------------|------------|------------------------------------------------------------------------------|
+| `children`  | `ReactNode`                                   | —          | The trigger element the tooltip is attached to.                             |
+| `content`   | `string`                                       | `""`       | Text rendered inside the neon tooltip body.                                 |
+| `position`  | `"top" \| "bottom" \| "left" \| "right"`       | `"top"`    | Which side of the trigger the tooltip slides in from / anchors to.          |
+| `trigger`   | `"hover" \| "click"`                           | `"hover"`  | Interaction mode. `hover` also responds to keyboard focus/blur.             |
+| `delay`     | `number` (ms)                                  | `80`       | Delay before showing the tooltip after the trigger event fires.             |
+| `accent`    | `"cyan" \| "magenta" \| "purple"`              | `"cyan"`   | Neon glow / border color variant.                                            |
+| `className` | `string`                                       | `""`       | Extra class(es) applied to the outer wrapper span.                          |
+| `disabled`  | `boolean`                                      | `false`    | When `true`, suppresses showing the tooltip entirely.                       |
+
+## Accessibility notes
+
+- The tooltip element has `role="tooltip"` and toggles `aria-hidden`.
+- Hover trigger mode also wires up `onFocus`/`onBlur` so keyboard users
+  reach the tooltip via Tab.
+- `prefers-reduced-motion: reduce` disables the elastic + flicker keyframes
+  and falls back to a simple opacity transition.
+
+## Files in this submission
+
+- `NeonTooltipMp.jsx` — the component
+- `style.css` — scoped styling + elastic slide keyframes (imported by the component)
+- `README.md` — this file

--- a/submissions/react/cyberpunk-neon-tooltip-mp/style.css
+++ b/submissions/react/cyberpunk-neon-tooltip-mp/style.css
@@ -1,0 +1,171 @@
+/* ==========================================================================
+   neon-tooltip-mp
+   Cyberpunk neon tooltip skin + elastic slide entrance animation.
+   Scoped entirely under the neon-tooltip-mp-* namespace to avoid
+   collisions with other submissions.
+   ========================================================================== */
+
+.neon-tooltip-mp-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.neon-tooltip-mp {
+  position: absolute;
+  z-index: 50;
+  display: inline-flex;
+  align-items: center;
+  padding: 7px 14px;
+  min-width: max-content;
+  max-width: 260px;
+
+  font-family: "Space Grotesk", "Segoe UI", ui-sans-serif, sans-serif;
+  font-size: 12.5px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #eafcff;
+  background: linear-gradient(160deg, #120019 0%, #05030d 100%);
+  border-radius: 6px;
+
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(4px) scale(0.94);
+  transition: opacity 0.1s linear;
+}
+
+.neon-tooltip-mp--visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Accent variants — border + glow color */
+.neon-tooltip-mp--cyan {
+  border: 1px solid #21f3ff;
+  box-shadow:
+    0 0 6px rgba(33, 243, 255, 0.55),
+    0 0 22px rgba(33, 243, 255, 0.35),
+    inset 0 0 10px rgba(33, 243, 255, 0.12);
+  text-shadow: 0 0 6px rgba(33, 243, 255, 0.65);
+}
+
+.neon-tooltip-mp--magenta {
+  border: 1px solid #ff2ecb;
+  box-shadow:
+    0 0 6px rgba(255, 46, 203, 0.55),
+    0 0 22px rgba(255, 46, 203, 0.35),
+    inset 0 0 10px rgba(255, 46, 203, 0.12);
+  text-shadow: 0 0 6px rgba(255, 46, 203, 0.65);
+}
+
+.neon-tooltip-mp--purple {
+  border: 1px solid #b357ff;
+  box-shadow:
+    0 0 6px rgba(179, 87, 255, 0.55),
+    0 0 22px rgba(179, 87, 255, 0.35),
+    inset 0 0 10px rgba(179, 87, 255, 0.12);
+  text-shadow: 0 0 6px rgba(179, 87, 255, 0.65);
+}
+
+/* Positions */
+.neon-tooltip-mp--top {
+  bottom: calc(100% + 10px);
+  left: 50%;
+  transform-origin: bottom center;
+}
+
+.neon-tooltip-mp--bottom {
+  top: calc(100% + 10px);
+  left: 50%;
+  transform-origin: top center;
+}
+
+.neon-tooltip-mp--left {
+  right: calc(100% + 10px);
+  top: 50%;
+  transform-origin: right center;
+}
+
+.neon-tooltip-mp--right {
+  left: calc(100% + 10px);
+  top: 50%;
+  transform-origin: left center;
+}
+
+.neon-tooltip-mp__content {
+  position: relative;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* --------------------------------------------------------------------------
+   Elastic slide entrance
+   Overshoots past its resting position on each axis, then settles —
+   simulating spring physics with pure keyframes (no JS animation lib).
+   A brief flicker is layered in near the start for a neon-sign feel.
+   -------------------------------------------------------------------------- */
+.ease-elastic-slide-mp.neon-tooltip-mp--top {
+  animation: neon-tooltip-mp-elastic-y 0.55s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.ease-elastic-slide-mp.neon-tooltip-mp--bottom {
+  animation: neon-tooltip-mp-elastic-y-rev 0.55s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.ease-elastic-slide-mp.neon-tooltip-mp--left {
+  animation: neon-tooltip-mp-elastic-x 0.55s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.ease-elastic-slide-mp.neon-tooltip-mp--right {
+  animation: neon-tooltip-mp-elastic-x-rev 0.55s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+@keyframes neon-tooltip-mp-elastic-y {
+  0%   { opacity: 0;   transform: translate(-50%, 16px) scale(0.88); }
+  20%  { opacity: 0.4; }
+  22%  { opacity: 0.1; }
+  26%  { opacity: 0.85; }
+  55%  { opacity: 1;   transform: translate(-50%, -7px) scale(1.04); }
+  75%  { transform: translate(-50%, 3px) scale(0.99); }
+  100% { opacity: 1;   transform: translate(-50%, 0) scale(1); }
+}
+
+@keyframes neon-tooltip-mp-elastic-y-rev {
+  0%   { opacity: 0;   transform: translate(-50%, -16px) scale(0.88); }
+  20%  { opacity: 0.4; }
+  22%  { opacity: 0.1; }
+  26%  { opacity: 0.85; }
+  55%  { opacity: 1;   transform: translate(-50%, 7px) scale(1.04); }
+  75%  { transform: translate(-50%, -3px) scale(0.99); }
+  100% { opacity: 1;   transform: translate(-50%, 0) scale(1); }
+}
+
+@keyframes neon-tooltip-mp-elastic-x {
+  0%   { opacity: 0;   transform: translate(16px, -50%) scale(0.88); }
+  20%  { opacity: 0.4; }
+  22%  { opacity: 0.1; }
+  26%  { opacity: 0.85; }
+  55%  { opacity: 1;   transform: translate(-7px, -50%) scale(1.04); }
+  75%  { transform: translate(3px, -50%) scale(0.99); }
+  100% { opacity: 1;   transform: translate(0, -50%) scale(1); }
+}
+
+@keyframes neon-tooltip-mp-elastic-x-rev {
+  0%   { opacity: 0;   transform: translate(-16px, -50%) scale(0.88); }
+  20%  { opacity: 0.4; }
+  22%  { opacity: 0.1; }
+  26%  { opacity: 0.85; }
+  55%  { opacity: 1;   transform: translate(7px, -50%) scale(1.04); }
+  75%  { transform: translate(-3px, -50%) scale(0.99); }
+  100% { opacity: 1;   transform: translate(0, -50%) scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .neon-tooltip-mp,
+  .ease-elastic-slide-mp.neon-tooltip-mp--top,
+  .ease-elastic-slide-mp.neon-tooltip-mp--bottom,
+  .ease-elastic-slide-mp.neon-tooltip-mp--left,
+  .ease-elastic-slide-mp.neon-tooltip-mp--right {
+    animation: none;
+    transition: opacity 0.15s linear;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a React-integrated Tooltip component (`NeonTooltipMp`) with a cyberpunk neon aesthetic and an elastic slide entrance transition, per issue #38627.

---

## Type of Change
- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
> ⚠️ PRs that fail this checklist will be **closed without review**.
- [x] All changes are inside `submissions/` (`submissions/react/cyberpunk-neon-tooltip-mp/`)
- [x] Includes React component file — `NeonTooltipMp.jsx` (React track equivalent of `demo.html`)
- [x] Includes `style.css` — scoped CSS for the neon skin + elastic slide keyframes
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS, plus full props table
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (tooltip component only)

---

## Feature Description

**What does this add?**
A cyberpunk neon styled React tooltip component with an elastic slide-in transition (overshoot-and-settle) and a brief neon-sign flicker.

**How does a developer use it?**
```html
<span class="neon-tooltip-mp-wrapper">
  <button class="ease-hover-lift">hover me</button>
  <span
    class="ease-fade-in-mp neon-tooltip-mp neon-tooltip-mp--top neon-tooltip-mp--cyan neon-tooltip-mp--visible ease-elastic-slide-mp"
    role="tooltip"
  >
    <span class="neon-tooltip-mp__content">SYSTEM // ONLINE</span>
  </span>
</span>
```

**Why does it fit EaseMotion CSS?**
EaseMotion favors expressive, physics-feeling motion without pulling in a JS animation library. This component packages that into a ready-to-use React block: a themed, accessible tooltip with a distinctive spring-like entrance and neon-sign flicker, built entirely with EaseMotion-style utility classes and one scoped stylesheet.

---

## Demo
- [x] Demo added — since this is the React track, the "demo" is the working component itself (`NeonTooltipMp.jsx`), documented with a usage example in the README rather than a standalone `demo.html`.

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(not tested)*

---

## Notes for Maintainer
This PR follows the **React Integration track** (`submissions/react/`), so it includes `NeonTooltipMp.jsx` + `style.css` + `README.md` rather than `demo.html` — the checklist above is filled out with the closest React-track equivalents. Class names like `ease-fade-in-mp` and `ease-elastic-slide-mp` are placeholders per your naming convention; happy to rename if they collide with existing utilities. This is a companion submission to the retro-terminal tooltip (issue #38628) — both share the same component API and elastic-slide approach but are fully namespaced separately (`neon-tooltip-mp-*` vs `term-tooltip-mp-*`) so they can land independently without conflict. Elastic motion is pure CSS keyframes (overshoot + settle, no spring library). `prefers-reduced-motion` is respected.

---
> **Reminder:** Only the repository maintainer may merge pull requests.
> Do not self-merge, even if you have write access.