### PR TITLE
feat: add accessible pure css fade-in accordion

### DIFF
--- a/submissions/examples/accessible-fade-in-accordion-32822/README.md
+++ b/submissions/examples/accessible-fade-in-accordion-32822/README.md
@@ -1,0 +1,16 @@
+# Accessible CSS Fade-In Accordion (`css-fade-in-accordion`)
+
+This submission resolves issue #32822 by providing a highly accessible, purely CSS-driven accordion component featuring smooth fade-in animations and focus management.
+
+## Overview
+Accordions traditionally rely on JavaScript to toggle classes and manage ARIA states. However, by using the native HTML `<details>` and `<summary>` elements, we get out-of-the-box accessibility (keyboard navigation, screen reader support) without JS. This component styles these native elements to provide a premium fade-in accordion experience.
+
+## Features
+- **Native Accessibility:** Uses `<details>` and `<summary>`. Browsers automatically handle `aria-expanded` and keyboard focus (`Tab`, `Space`, `Enter`).
+- **Smooth Fade-In Animation:** Unlike the abrupt default behavior of `<details>`, this implementation uses a CSS `@keyframes` animation to smoothly fade in and slightly slide down the content when opened.
+- **Custom Indicators:** Replaces the default browser triangle with a custom SVG icon (via CSS background or inline SVGs) that rotates smoothly when the accordion toggles.
+- **No Checkbox Hack Needed:** By leveraging the modern `details[open]` selector, the CSS remains semantic and clean without relying on hidden inputs.
+
+## Files
+- `demo.html`: A responsive FAQ section demonstrating the accessible accordion.
+- `style.css`: The styling logic, including custom focus rings for accessibility and the fade-in keyframes.

--- a/submissions/examples/accessible-fade-in-accordion-32822/demo.html
+++ b/submissions/examples/accessible-fade-in-accordion-32822/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Accessible CSS Fade-In Accordion</title>
+    <link rel="stylesheet" href="../../../easemotion.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <main class="faq-container">
+        
+        <header class="faq-header">
+            <h1>Frequently Asked Questions</h1>
+            <p>Built with native HTML details & summary for maximum accessibility.</p>
+        </header>
+
+        <div class="accordion-group">
+            
+            <!-- Accordion Item 1 -->
+            <details class="ease-accordion" name="faq">
+                <summary class="accordion-header">
+                    <span>What is a purely CSS accordion?</span>
+                    <span class="accordion-icon"></span>
+                </summary>
+                <div class="accordion-content">
+                    <p>A purely CSS accordion uses native HTML elements or CSS pseudo-classes to manage state without JavaScript. In this implementation, we use the semantic <code>&lt;details&gt;</code> and <code>&lt;summary&gt;</code> tags. The browser handles the open/close state natively.</p>
+                </div>
+            </details>
+
+            <!-- Accordion Item 2 -->
+            <details class="ease-accordion" name="faq">
+                <summary class="accordion-header">
+                    <span>How is this implementation accessible?</span>
+                    <span class="accordion-icon"></span>
+                </summary>
+                <div class="accordion-content">
+                    <p>By using the native <code>&lt;details&gt;</code> element, browsers automatically manage keyboard navigation (you can Tab to focus, and use Space/Enter to toggle) and announce the state to screen readers automatically. We also provide high-contrast focus rings in the CSS.</p>
+                </div>
+            </details>
+
+            <!-- Accordion Item 3 -->
+            <details class="ease-accordion" name="faq">
+                <summary class="accordion-header">
+                    <span>How does the fade-in animation work?</span>
+                    <span class="accordion-icon"></span>
+                </summary>
+                <div class="accordion-content">
+                    <p>When the details element is toggled open, it receives the <code>[open]</code> attribute. We target this state in CSS and apply a <code>@keyframes</code> animation to the inner content wrapper, animating its opacity from 0 to 1 and translating it slightly on the Y-axis.</p>
+                </div>
+            </details>
+
+        </div>
+
+    </main>
+
+</body>
+</html>

--- a/submissions/examples/accessible-fade-in-accordion-32822/style.css
+++ b/submissions/examples/accessible-fade-in-accordion-32822/style.css
@@ -1,0 +1,179 @@
+:root {
+    --bg-color: #f3f4f6;
+    --text-primary: #111827;
+    --text-secondary: #4b5563;
+    --accordion-bg: #ffffff;
+    --accordion-border: #e5e7eb;
+    --focus-ring: #3b82f6;
+    --accent-color: #2563eb;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    font-family: system-ui, -apple-system, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-primary);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+}
+
+/* Container */
+.faq-container {
+    max-width: 600px;
+    width: 100%;
+    padding: 2rem;
+    box-sizing: border-box;
+}
+
+.faq-header {
+    text-align: center;
+    margin-bottom: 3rem;
+}
+
+.faq-header h1 {
+    font-size: 1.875rem;
+    margin: 0 0 0.5rem 0;
+}
+
+.faq-header p {
+    color: var(--text-secondary);
+    margin: 0;
+}
+
+/* 
+  ========================================
+  ACCESSIBLE ACCORDION STYLES
+  ========================================
+*/
+
+.accordion-group {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.ease-accordion {
+    background-color: var(--accordion-bg);
+    border: 1px solid var(--accordion-border);
+    border-radius: 8px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+    overflow: hidden; /* Contains the border radius */
+}
+
+/* 
+  Hide the default triangle marker for <details>.
+  Webkit specific and standard list-style removal.
+*/
+.ease-accordion summary {
+    list-style: none;
+}
+.ease-accordion summary::-webkit-details-marker {
+    display: none;
+}
+
+/* The clickable header area */
+.accordion-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1.25rem 1.5rem;
+    cursor: pointer;
+    font-weight: 600;
+    font-size: 1.05rem;
+    user-select: none;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.accordion-header:hover {
+    background-color: #f8fafc;
+    color: var(--accent-color);
+}
+
+/* Focus state for Keyboard Accessibility */
+.accordion-header:focus-visible {
+    outline: 2px solid var(--focus-ring);
+    outline-offset: -2px;
+    background-color: #eff6ff;
+}
+
+/* Custom SVG Plus/Minus Icon */
+.accordion-icon {
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    position: relative;
+    flex-shrink: 0;
+}
+
+.accordion-icon::before,
+.accordion-icon::after {
+    content: '';
+    position: absolute;
+    background-color: currentColor;
+    border-radius: 2px;
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* The Horizontal Line (Always visible) */
+.accordion-icon::before {
+    top: 9px;
+    left: 2px;
+    right: 2px;
+    height: 2px;
+}
+
+/* The Vertical Line (Forms the Plus) */
+.accordion-icon::after {
+    left: 9px;
+    top: 2px;
+    bottom: 2px;
+    width: 2px;
+}
+
+/* When the details is open, rotate the vertical line to make a minus */
+.ease-accordion[open] .accordion-icon::after {
+    transform: rotate(90deg);
+}
+.ease-accordion[open] .accordion-header {
+    color: var(--accent-color);
+    border-bottom: 1px solid var(--accordion-border);
+}
+
+/* 
+  ========================================
+  FADE-IN ANIMATION
+  ========================================
+*/
+
+/* The content wrapper */
+.accordion-content {
+    padding: 1.5rem;
+    color: var(--text-secondary);
+    line-height: 1.6;
+}
+
+.accordion-content p {
+    margin: 0;
+}
+
+/* 
+  Trigger the animation ONLY when the <details> element has the [open] attribute.
+  Because the DOM reveals it instantly, the animation runs immediately upon open.
+*/
+.ease-accordion[open] .accordion-content {
+    animation: fade-in-slide-down 0.4s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+
+@keyframes fade-in-slide-down {
+    0% {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+    100% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #32822

**Feature**: Added `.ease-accordion` utility for creating highly accessible, smoothly animated accordions without JavaScript.

**Implementation Details**: 
- Instead of utilizing the CSS "checkbox hack" which can pose accessibility concerns if not carefully managed with ARIA attributes, this implementation strictly utilizes the native HTML `<details>` and `<summary>` elements. This provides out-of-the-box keyboard navigation (Tab, Space, Enter) and native screen reader support.
- Handled the typically abrupt default behavior of `<details>` by utilizing the `[open]` state selector to trigger a smooth `@keyframes fade-in-slide-down` animation on the inner content wrapper.
- Engineered a custom CSS-drawn plus/minus icon utilizing pseudo-elements (`::before`, `::after`) that animates into a minus sign when the accordion is opened.
- Implemented high-contrast `:focus-visible` states to ensure WCAG compliant keyboard focus visibility.

---

## Submission Checklist

- [x] All changes are isolated in `submissions/examples/accessible-fade-in-accordion-32822/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to framework core files**