### PR TITLE
feat: add rtl-friendly animation demo using logical properties

### DIFF
--- a/submissions/examples/rtl-friendly-animation-38720/README.md
+++ b/submissions/examples/rtl-friendly-animation-38720/README.md
@@ -1,0 +1,15 @@
+# RTL-Friendly Animation Example (`rtl-friendly-animation`)
+
+This submission resolves issue #38720 by providing a demonstration of how to write CSS animations that naturally adapt to both LTR (Left-to-Right) and RTL (Right-to-Left) text directions without requiring duplicate CSS rules.
+
+## Overview
+Traditionally, animating an element "in from the left" required hardcoding `transform: translateX(-100%)` for LTR languages, and then writing an override `.rtl { transform: translateX(100%) }` for RTL languages (like Arabic or Hebrew). By utilizing modern **CSS Logical Properties**, we can write a single animation that automatically respects the document's flow direction.
+
+## Features
+- **Logical Properties:** Uses `inset-inline-start`, `margin-inline-start`, and logical values where applicable.
+- **Directional Agnostic Keyframes:** While `transform: translateX` is physical and doesn't adapt to `dir="rtl"`, we can use `offset-distance` on an `offset-path` (motion path) or simply toggle logical inset properties (e.g., `inset-inline-start: -100%`) to create sliding animations that automatically reverse their physical direction when the document direction changes.
+- **Interactive Demo:** The provided `demo.html` includes a toggle button to switch the document between `dir="ltr"` and `dir="rtl"`, demonstrating the seamless adaptation of the sliding cards and loading spinners.
+
+## Files
+- `demo.html`: The HTML structure with an interactive language/direction toggle.
+- `style.css`: The CSS demonstrating the use of logical properties for animations.

--- a/submissions/examples/rtl-friendly-animation-38720/demo.html
+++ b/submissions/examples/rtl-friendly-animation-38720/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>RTL-Friendly Animation Demo</title>
+    <link rel="stylesheet" href="../../../easemotion.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <main class="demo-container">
+        <header class="demo-header">
+            <h1>Logical Properties in Animation</h1>
+            <p>This demo uses CSS Logical Properties (e.g., <code>inset-inline-start</code>, <code>border-inline-start</code>) so that animations automatically adapt to the document's reading direction.</p>
+            
+            <button id="dirToggle" class="btn">Switch to RTL (Arabic/Hebrew)</button>
+        </header>
+
+        <!-- Demo 1: Sliding Notification -->
+        <section class="demo-section">
+            <h2>1. Sliding Notification</h2>
+            <p>Notice how the notification slides in from the "start" edge, regardless of whether that is the left or the right.</p>
+            
+            <div class="notification-container">
+                <div class="notification-card">
+                    <div class="card-icon">✓</div>
+                    <div class="card-content">
+                        <strong>Success!</strong>
+                        <span>Your settings have been saved.</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Demo 2: Loading Spinner with Logical Border -->
+        <section class="demo-section">
+            <h2>2. Directional Loading Spinner</h2>
+            <p>The spinner's "tail" respects the reading direction. In LTR it spins clockwise; in RTL we can reverse the animation direction or rely on logical borders.</p>
+            
+            <div class="spinner-container">
+                <div class="logical-spinner"></div>
+                <span class="loading-text">Loading data...</span>
+            </div>
+        </section>
+
+    </main>
+
+    <!-- Simple JS just for the toggle button demonstration -->
+    <script>
+        const btn = document.getElementById('dirToggle');
+        btn.addEventListener('click', () => {
+            const currentDir = document.documentElement.getAttribute('dir');
+            if (currentDir === 'ltr') {
+                document.documentElement.setAttribute('dir', 'rtl');
+                btn.textContent = 'Switch to LTR (English)';
+            } else {
+                document.documentElement.setAttribute('dir', 'ltr');
+                btn.textContent = 'Switch to RTL (Arabic/Hebrew)';
+            }
+        });
+    </script>
+</body>
+</html>

--- a/submissions/examples/rtl-friendly-animation-38720/style.css
+++ b/submissions/examples/rtl-friendly-animation-38720/style.css
@@ -1,0 +1,197 @@
+:root {
+    --bg-color: #f8fafc;
+    --text-primary: #1e293b;
+    --text-secondary: #64748b;
+    --accent: #3b82f6;
+    --success: #10b981;
+    --card-bg: #ffffff;
+    --border: #e2e8f0;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    font-family: system-ui, -apple-system, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-primary);
+}
+
+.demo-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 3rem 2rem;
+}
+
+.demo-header {
+    text-align: center;
+    margin-bottom: 4rem;
+}
+
+.demo-header h1 {
+    margin-bottom: 0.5rem;
+}
+
+.demo-header p {
+    color: var(--text-secondary);
+    margin-bottom: 2rem;
+}
+
+.btn {
+    background-color: var(--accent);
+    color: white;
+    border: none;
+    padding: 0.75rem 1.5rem;
+    border-radius: 6px;
+    font-size: 1rem;
+    cursor: pointer;
+    font-weight: 500;
+    box-shadow: 0 4px 6px -1px rgba(59, 130, 246, 0.3);
+    transition: transform 0.1s, box-shadow 0.1s;
+}
+
+.btn:active {
+    transform: translateY(2px);
+    box-shadow: 0 1px 2px -1px rgba(59, 130, 246, 0.3);
+}
+
+.demo-section {
+    background-color: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 2rem;
+    margin-bottom: 2rem;
+    box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
+}
+
+.demo-section h2 {
+    margin-top: 0;
+    font-size: 1.25rem;
+}
+
+/* 
+  ========================================
+  DEMO 1: SLIDING NOTIFICATION
+  Using Logical Properties (inset-inline-start)
+  ========================================
+*/
+.notification-container {
+    position: relative;
+    height: 100px;
+    background-color: #f1f5f9;
+    border-radius: 8px;
+    overflow: hidden;
+    margin-top: 1.5rem;
+}
+
+.notification-card {
+    position: absolute;
+    top: 20px;
+    /* Instead of `left: 20px;`, we use logical inset */
+    inset-inline-start: 20px;
+    
+    display: flex;
+    align-items: center;
+    background-color: white;
+    padding: 1rem;
+    border-radius: 8px;
+    box-shadow: 0 4px 15px rgba(0,0,0,0.1);
+    
+    /* Instead of border-left, we use border-inline-start */
+    border-inline-start: 4px solid var(--success);
+    
+    /* Trigger the animation */
+    animation: slide-in-logical 1s ease-out infinite alternate;
+}
+
+.card-icon {
+    background-color: #d1fae5;
+    color: var(--success);
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-weight: bold;
+    /* Logical margin instead of margin-right */
+    margin-inline-end: 1rem;
+}
+
+.card-content {
+    display: flex;
+    flex-direction: column;
+}
+
+.card-content strong {
+    font-size: 0.95rem;
+}
+
+.card-content span {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+/* Logical Animation Keyframes */
+@keyframes slide-in-logical {
+    0% {
+        /* Starts off-screen on the "start" side (Left for LTR, Right for RTL) */
+        inset-inline-start: -300px;
+        opacity: 0;
+    }
+    10% {
+        opacity: 1;
+    }
+    100% {
+        /* Rests at the natural 20px inset */
+        inset-inline-start: 20px;
+        opacity: 1;
+    }
+}
+
+/* 
+  ========================================
+  DEMO 2: DIRECTIONAL LOADING SPINNER
+  ========================================
+*/
+.spinner-container {
+    display: flex;
+    align-items: center;
+    margin-top: 1.5rem;
+    padding: 1rem;
+    background-color: #f1f5f9;
+    border-radius: 8px;
+}
+
+.logical-spinner {
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    border: 3px solid var(--border);
+    /* Instead of border-top-color, we use logical border block/inline */
+    border-block-start-color: var(--accent);
+    
+    /* Logical margin */
+    margin-inline-end: 1rem;
+    
+    /* Default clockwise spin */
+    animation: spin 1s linear infinite;
+}
+
+.loading-text {
+    font-weight: 500;
+    color: var(--text-secondary);
+}
+
+/* 
+  If the document is RTL, we can reverse the spin direction using
+  the :dir() pseudo-class (supported in modern browsers) or 
+  by relying on [dir="rtl"] attributes.
+*/
+[dir="rtl"] .logical-spinner {
+    animation-direction: reverse;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #38720

**Feature**: Added an interactive demonstration showcasing RTL-friendly (Right-to-Left) animations using modern CSS Logical Properties.

**Implementation Details**: 
- Replaced physical CSS properties (`left`, `margin-left`, `border-left`) with their logical counterparts (`inset-inline-start`, `margin-inline-end`, `border-inline-start`).
- Created an `@keyframes slide-in-logical` animation that animates the `inset-inline-start` property. This ensures that a sliding notification intuitively enters from the Left in an English (LTR) context, but automatically enters from the Right in an Arabic/Hebrew (RTL) context without duplicating any CSS rules.
- Implemented the `[dir="rtl"]` attribute selector to natively reverse a loading spinner's rotation direction (`animation-direction: reverse`) when the document flow changes.
- Included an interactive JS toggle button in `demo.html` specifically to test the instantaneous switch between LTR and RTL document states.

---

## Submission Checklist

- [x] All changes are isolated in `submissions/examples/rtl-friendly-animation-38720/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to framework core files**