### PR TITLE
feat: add CSS-only accordion component (checkbox hack)

### DIFF
--- a/submissions/examples/accordion-mp/README.md
+++ b/submissions/examples/accordion-mp/README.md
@@ -1,0 +1,55 @@
+# CSS-only Accordion — `ease-accordion-mp`
+
+A fully CSS-only accordion component using the checkbox hack. No
+JavaScript, no fixed pixel heights — panel expand/collapse animates
+smoothly using the `grid-template-rows: 0fr → 1fr` technique.
+
+## What does this do?
+
+Provides an accordion where each item independently expands/collapses on
+click, with a smoothly animated height transition and a rotating chevron
+icon, implemented with zero JavaScript.
+
+## How is it used?
+
+```html
+<div class="ease-accordion-mp">
+  <div class="ease-accordion-mp__item">
+    <input type="checkbox" id="acc-1" class="ease-accordion-mp__toggle" />
+    <label for="acc-1" class="ease-accordion-mp__header">
+      <span>Question or heading text</span>
+      <span class="ease-accordion-mp__icon" aria-hidden="true"></span>
+    </label>
+    <div class="ease-accordion-mp__panel">
+      <div class="ease-accordion-mp__panel-inner">
+        Panel content goes here.
+      </div>
+    </div>
+  </div>
+  <!-- repeat .ease-accordion-mp__item for each panel -->
+</div>
+```
+
+Each item needs a unique `id`/`for` pair linking its checkbox and label.
+Add the `checked` attribute to any checkbox you want open by default.
+
+To make the accordion single-open (only one panel at a time), change every
+`type="checkbox"` to `type="radio"` and give them all the same `name`
+attribute.
+
+## Why is it useful?
+
+This closes a gap on EaseMotion's roadmap — a CSS-only accordion/tabs
+pattern was planned but not yet implemented. It fits the framework's
+animation-first, dependency-free philosophy: the entire open/close motion
+is driven by native CSS transitions on `grid-template-rows`, which avoids
+the common `max-height` hack's arbitrary guessed values and mistimed
+transitions. Because it's checkbox-driven, it also works with zero
+JavaScript and remains keyboard accessible (tab to the label, hit
+Space/Enter to toggle, since labels linked to checkboxes proxy activation).
+
+## Files in this submission
+
+- `demo.html` — self-contained demo, opens directly in a browser
+- `style.css` — `ease-accordion-mp` styles and the grid-based height animation
+- `README.md` — this file

--- a/submissions/examples/accordion-mp/demo.html
+++ b/submissions/examples/accordion-mp/demo.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>CSS-only Accordion — EaseMotion CSS submission</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="accordion-mp-page">
+    <h1 class="accordion-mp-page__title">CSS-only Accordion</h1>
+    <p class="accordion-mp-page__subtitle">
+      No JavaScript — built with the checkbox hack. Each panel animates its
+      open/close height with a pure CSS transition.
+    </p>
+
+    <div class="ease-accordion-mp">
+
+      <div class="ease-accordion-mp__item">
+        <input
+          type="checkbox"
+          id="acc-mp-1"
+          class="ease-accordion-mp__toggle"
+          checked
+        />
+        <label for="acc-mp-1" class="ease-accordion-mp__header">
+          <span>What is EaseMotion CSS?</span>
+          <span class="ease-accordion-mp__icon" aria-hidden="true"></span>
+        </label>
+        <div class="ease-accordion-mp__panel">
+          <div class="ease-accordion-mp__panel-inner">
+            EaseMotion CSS is a curated animation framework. Contributors
+            submit raw HTML/CSS demos, and the maintainer standardizes and
+            integrates the best ones into the core library.
+          </div>
+        </div>
+      </div>
+
+      <div class="ease-accordion-mp__item">
+        <input
+          type="checkbox"
+          id="acc-mp-2"
+          class="ease-accordion-mp__toggle"
+        />
+        <label for="acc-mp-2" class="ease-accordion-mp__header">
+          <span>How does this accordion animate without JS?</span>
+          <span class="ease-accordion-mp__icon" aria-hidden="true"></span>
+        </label>
+        <div class="ease-accordion-mp__panel">
+          <div class="ease-accordion-mp__panel-inner">
+            Each panel pairs a hidden checkbox with a
+            <code>&lt;label&gt;</code> header. The checked state drives
+            <code>grid-template-rows</code> from <code>0fr</code> to
+            <code>1fr</code>, which the browser can transition smoothly —
+            no fixed pixel heights, no JavaScript required.
+          </div>
+        </div>
+      </div>
+
+      <div class="ease-accordion-mp__item">
+        <input
+          type="checkbox"
+          id="acc-mp-3"
+          class="ease-accordion-mp__toggle"
+        />
+        <label for="acc-mp-3" class="ease-accordion-mp__header">
+          <span>Can multiple panels be open at once?</span>
+          <span class="ease-accordion-mp__icon" aria-hidden="true"></span>
+        </label>
+        <div class="ease-accordion-mp__panel">
+          <div class="ease-accordion-mp__panel-inner">
+            Yes. Since each panel is controlled by its own independent
+            checkbox (not a radio group), any number of panels can be open
+            at the same time. Swapping the inputs to
+            <code>type="radio"</code> with a shared <code>name</code> turns
+            this into a single-open accordion instead.
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/accordion-mp/style.css
+++ b/submissions/examples/accordion-mp/style.css
@@ -1,0 +1,140 @@
+/* ==========================================================================
+   ease-accordion-mp
+   CSS-only accordion built with the checkbox hack.
+   Height animation uses the grid-template-rows 0fr -> 1fr trick, which
+   transitions smoothly without needing fixed pixel heights or JS.
+   ========================================================================== */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Segoe UI", ui-sans-serif, system-ui, sans-serif;
+  background: #f4f1ea;
+  color: #1a1a1a;
+}
+
+.accordion-mp-page {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 48px 24px 80px;
+}
+
+.accordion-mp-page__title {
+  font-size: 28px;
+  margin: 0 0 8px;
+}
+
+.accordion-mp-page__subtitle {
+  margin: 0 0 32px;
+  color: #555;
+  line-height: 1.5;
+}
+
+/* --------------------------------------------------------------------------
+   Accordion container
+   -------------------------------------------------------------------------- */
+.ease-accordion-mp {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ease-accordion-mp__item {
+  border: 1px solid #ddd6c8;
+  border-radius: 10px;
+  background: #fffdf8;
+  overflow: hidden;
+}
+
+/* Hide the real checkbox but keep it accessible/focusable */
+.ease-accordion-mp__toggle {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  pointer-events: none;
+}
+
+.ease-accordion-mp__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px 18px;
+  cursor: pointer;
+  font-weight: 600;
+  user-select: none;
+  transition: background-color 0.2s ease;
+}
+
+.ease-accordion-mp__header:hover {
+  background-color: #f0ecdf;
+}
+
+/* Focus ring driven off the hidden checkbox's focus state, since the
+   checkbox itself has no visible box to show focus on. */
+.ease-accordion-mp__toggle:focus-visible + .ease-accordion-mp__header {
+  outline: 2px solid #6c63ff;
+  outline-offset: -2px;
+}
+
+/* Chevron icon that rotates on open */
+.ease-accordion-mp__icon {
+  flex-shrink: 0;
+  width: 10px;
+  height: 10px;
+  border-right: 2px solid #6c63ff;
+  border-bottom: 2px solid #6c63ff;
+  transform: rotate(45deg);
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.ease-accordion-mp__toggle:checked ~ .ease-accordion-mp__header .ease-accordion-mp__icon {
+  transform: rotate(-135deg);
+}
+
+/* --------------------------------------------------------------------------
+   Panel — the actual height animation
+   grid-template-rows animates between 0fr (collapsed) and 1fr (natural
+   content height). This avoids the classic "max-height hack" which
+   requires guessing an arbitrary large value and never times correctly.
+   -------------------------------------------------------------------------- */
+.ease-accordion-mp__panel {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.ease-accordion-mp__toggle:checked ~ .ease-accordion-mp__panel {
+  grid-template-rows: 1fr;
+}
+
+.ease-accordion-mp__panel-inner {
+  min-height: 0;
+  overflow: hidden;
+  padding: 0 18px;
+  color: #444;
+  line-height: 1.6;
+}
+
+.ease-accordion-mp__toggle:checked ~ .ease-accordion-mp__panel .ease-accordion-mp__panel-inner {
+  padding-bottom: 18px;
+}
+
+.ease-accordion-mp__panel-inner code {
+  background: #eee7d6;
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.9em;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-accordion-mp__panel,
+  .ease-accordion-mp__icon {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a CSS-only accordion component (checkbox-hack based) to close the gap listed on the roadmap, per issue #38832.

---

## Type of Change
- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
> ⚠️ PRs that fail this checklist will be **closed without review**.
- [x] All changes are inside `submissions/` (`submissions/examples/accordion-mp/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (accordion only)

---

## Feature Description

**What does this add?**
A CSS-only accordion where each panel independently expands/collapses with a smooth animated height transition, using the checkbox hack (no JavaScript).

**How does a developer use it?**
```html
<div class="ease-accordion-mp">
  <div class="ease-accordion-mp__item">
    <input type="checkbox" id="acc-1" class="ease-accordion-mp__toggle" />
    <label for="acc-1" class="ease-accordion-mp__header">
      <span>Question or heading text</span>
      <span class="ease-accordion-mp__icon" aria-hidden="true"></span>
    </label>
    <div class="ease-accordion-mp__panel">
      <div class="ease-accordion-mp__panel-inner">
        Panel content goes here.
      </div>
    </div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
This was listed on the roadmap as planned but unimplemented. It's animation-first and dependency-free: the open/close motion is driven entirely by animating `grid-template-rows` from `0fr` to `1fr`, avoiding the classic `max-height` hack's guessed values and mistimed transitions. Being checkbox-driven, it also works with zero JavaScript and stays keyboard accessible.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(not tested)*

---

## Notes for Maintainer
Used `grid-template-rows: 0fr → 1fr` instead of the more common `max-height` trick, since it animates to the panel's true natural height rather than an arbitrary guessed max value — this also means it works correctly for panels of any content length without adjustment. Checkboxes are set to independent (not radio-grouped), so multiple panels can be open at once; swapping to `type="radio"` with a shared `name` gives single-open behavior if preferred. `prefers-reduced-motion` is respected. One flag: issue #38832 was showing as assigned to another contributor (Aryanshravan) when I picked it up — happy to have this closed/redirected if their submission is already in progress.

---
> **Reminder:** Only the repository maintainer may merge pull requests.
> Do not self-merge, even if you have write access.