### PR TITLE
feat: add print utility classes demonstration

### DIFF
--- a/submissions/examples/print-utility-classes-38718/README.md
+++ b/submissions/examples/print-utility-classes-38718/README.md
@@ -1,0 +1,16 @@
+# Print Utility Classes Example (`print-utility-classes`)
+
+This submission resolves issue #38718 by providing a comprehensive demonstration of CSS print utility classes using the `@media print` query.
+
+## Overview
+Web pages often look terrible when printed out of the box (e.g., via `Ctrl+P`). Navigation bars, footers, interactive buttons, and dark mode backgrounds waste printer ink and clutter the printed page. By leveraging `@media print`, we can transform a web document into a clean, print-friendly format.
+
+## Features
+- **Ink Saving:** Automatically strips dark backgrounds and colored text, forcing the layout to a high-contrast black-on-white theme to save printer ink.
+- **Element Hiding:** Uses a `.d-print-none` utility class to hide non-essential print items like navigation bars, sidebars, and interactive buttons.
+- **Link Expansion:** Uses the `::after` pseudo-element and the `attr(href)` CSS function to automatically append the actual URL next to hyperlinks on the printed page, since users cannot click links on paper.
+- **Page Breaks:** Demonstrates the use of `break-inside: avoid` and `page-break-before: always` to prevent awkward page splits (e.g., cutting a chart or a paragraph in half).
+
+## Files
+- `demo.html`: A mock article layout with a navigation bar and interactive elements that look great on screen.
+- `style.css`: Contains standard screen styles alongside a robust `@media print` block implementing the print utilities.

--- a/submissions/examples/print-utility-classes-38718/demo.html
+++ b/submissions/examples/print-utility-classes-38718/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Print Utility Classes Demo</title>
+    <link rel="stylesheet" href="../../../easemotion.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <!-- This navigation should be hidden when printing -->
+    <nav class="navbar d-print-none">
+        <div class="nav-brand">NewsPortal</div>
+        <div class="nav-links">
+            <a href="#">Home</a>
+            <a href="#">Technology</a>
+            <a href="#">Science</a>
+        </div>
+        <button class="btn" onclick="window.print()">🖨️ Print Article</button>
+    </nav>
+
+    <main class="article-container">
+        
+        <header class="article-header">
+            <h1>The Future of CSS: Beyond the Screen</h1>
+            <p class="meta">Published on <time datetime="2024-10-24">October 24, 2024</time> by Jane Doe</p>
+        </header>
+
+        <section class="article-content">
+            <p>Cascading Style Sheets (CSS) have traditionally been associated with screens—monitors, tablets, and smartphones. However, a significant yet often overlooked aspect of CSS is its ability to style documents for print.</p>
+            
+            <h2>Why Print Styles Matter</h2>
+            <p>When a user prints a web page, they usually want the core content—not the navigation bars, interactive buttons, or heavy background images that consume expensive printer ink. Consider visiting the <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/@media">MDN Web Docs on Media Queries</a> to learn more.</p>
+
+            <!-- This block should not be split across pages when printed -->
+            <div class="highlight-box avoid-page-break">
+                <h3>Developer Pro Tip</h3>
+                <p>Always use the <code>@media print</code> query to redefine your styles. Hide elements with <code>display: none;</code> and ensure text is set to black for maximum contrast on paper.</p>
+            </div>
+
+            <h2>Page Break Control</h2>
+            <p>Using CSS properties like <code>page-break-before</code> and <code>break-inside</code>, developers can control exactly how content flows onto physical pages, preventing awkward cuts in the middle of important diagrams or tables.</p>
+
+            <!-- Example of forcing a new page -->
+            <div class="force-new-page">
+                <h2>Appendix: Code Example</h2>
+                <p>This section is forced onto a new physical page when printed, regardless of the space left on the previous page.</p>
+                <pre><code>
+@media print {
+  .d-print-none {
+    display: none !important;
+  }
+}
+                </code></pre>
+            </div>
+
+        </section>
+
+    </main>
+
+    <!-- Footer hidden on print -->
+    <footer class="site-footer d-print-none">
+        <p>&copy; 2024 NewsPortal Inc. All rights reserved.</p>
+    </footer>
+
+</body>
+</html>

--- a/submissions/examples/print-utility-classes-38718/style.css
+++ b/submissions/examples/print-utility-classes-38718/style.css
@@ -1,0 +1,179 @@
+:root {
+    --bg-page: #f1f5f9;
+    --bg-surface: #ffffff;
+    --text-primary: #1e293b;
+    --text-muted: #64748b;
+    --accent: #3b82f6;
+    --accent-light: #eff6ff;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+    background-color: var(--bg-page);
+    color: var(--text-primary);
+    line-height: 1.6;
+}
+
+/* 
+  ========================================
+  SCREEN STYLES (Default)
+  ========================================
+*/
+.navbar {
+    background-color: var(--text-primary);
+    color: white;
+    padding: 1rem 2rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    position: sticky;
+    top: 0;
+    z-index: 100;
+}
+
+.nav-brand {
+    font-size: 1.25rem;
+    font-weight: bold;
+}
+
+.nav-links a {
+    color: white;
+    text-decoration: none;
+    margin: 0 1rem;
+}
+
+.btn {
+    background-color: var(--accent);
+    color: white;
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-weight: bold;
+}
+
+.article-container {
+    max-width: 800px;
+    margin: 2rem auto;
+    background-color: var(--bg-surface);
+    padding: 3rem;
+    border-radius: 8px;
+    box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
+}
+
+.article-header {
+    margin-bottom: 2rem;
+    border-bottom: 2px solid var(--bg-page);
+    padding-bottom: 1rem;
+}
+
+.article-header h1 {
+    font-size: 2.5rem;
+    margin: 0 0 0.5rem 0;
+    line-height: 1.2;
+}
+
+.meta {
+    color: var(--text-muted);
+    font-style: italic;
+}
+
+.article-content a {
+    color: var(--accent);
+    text-decoration: none;
+    border-bottom: 1px dotted var(--accent);
+}
+
+.highlight-box {
+    background-color: var(--accent-light);
+    border-left: 4px solid var(--accent);
+    padding: 1.5rem;
+    margin: 2rem 0;
+    border-radius: 0 8px 8px 0;
+}
+
+.highlight-box h3 {
+    margin-top: 0;
+    color: var(--accent);
+}
+
+pre {
+    background-color: #1e293b;
+    color: #e2e8f0;
+    padding: 1rem;
+    border-radius: 4px;
+    overflow-x: auto;
+}
+
+.site-footer {
+    text-align: center;
+    padding: 2rem;
+    color: var(--text-muted);
+}
+
+/* 
+  ========================================
+  PRINT UTILITIES
+  Triggered only when the user prints (Ctrl+P)
+  ========================================
+*/
+@media print {
+    
+    /* 1. Global Reset for Ink Saving */
+    * {
+        background: transparent !important;
+        color: #000 !important; /* Force black text */
+        box-shadow: none !important;
+        text-shadow: none !important;
+    }
+
+    body {
+        background-color: #fff !important;
+        font-size: 12pt; /* Use points for print typography */
+        margin: 0; 
+    }
+
+    /* 2. Hide Non-Printable Elements */
+    .d-print-none {
+        display: none !important;
+    }
+
+    /* 3. Reformat Container for Paper */
+    .article-container {
+        margin: 0;
+        padding: 0;
+        border: none;
+        max-width: 100%; /* Utilize full page width */
+    }
+
+    /* 4. Link Expansion 
+       Because users can't click on paper, we append the URL after the link text */
+    .article-content a::after {
+        content: " (" attr(href) ")";
+        font-size: 0.9em;
+        word-break: break-all;
+    }
+
+    /* 5. Page Break Controls */
+    .avoid-page-break {
+        /* Prevents the highlight box from being split across two pages */
+        break-inside: avoid;
+        page-break-inside: avoid; 
+        
+        /* Adjust borders for print since backgrounds are removed */
+        border: 1px solid #000;
+    }
+
+    .force-new-page {
+        /* Forces this section to start on a new physical page */
+        break-before: page;
+        page-break-before: always;
+    }
+
+    /* 6. Header/Footer Margins (Handled by @page) */
+    @page {
+        margin: 2cm;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #38718

**Feature**: Added a comprehensive demonstration of CSS Print Utilities utilizing the `@media print` query.

**Implementation Details**: 
- Created a standard article layout with elements that are traditionally problematic when printed (navigation bars, dark backgrounds, interactive buttons, floating blocks).
- Implemented a robust `@media print` block in `style.css` that systematically fixes print issues:
  - **Ink Saving**: Forces a global transparent background and black text to save printer ink.
  - **Element Hiding**: Introduced the `.d-print-none` class to easily strip out non-essential navigation and footers.
  - **Link Expansion**: Utilized the `::after` pseudo-element and `attr(href)` function to automatically print URLs next to hyperlinks, solving the issue of unclickable paper.
  - **Page Breaks**: Demonstrated `break-inside: avoid` to prevent blocks from splitting across pages, and `page-break-before: always` to force appendix sections onto new pages.

---

## Submission Checklist

- [x] All changes are isolated in `submissions/examples/print-utility-classes-38718/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to framework core files**