### PR TITLE
feat: add animation-play-state utility demonstration

### DIFF
--- a/submissions/examples/animation-play-state-utility-38714/README.md
+++ b/submissions/examples/animation-play-state-utility-38714/README.md
@@ -1,0 +1,15 @@
+# Animation Play State Utility Example (`animation-play-state`)
+
+This submission resolves issue #38714 by providing a practical demonstration of the `animation-play-state` CSS property, highlighting its importance for accessibility (WCAG 2.2.2 Pause, Stop, Hide).
+
+## Overview
+Continuous CSS animations (like infinite tickers, bouncing icons, or spinning loaders) can be distracting or cause motion sickness for some users. To comply with web accessibility standards, developers must provide a way for users to pause these animations. The `animation-play-state` property is the perfect CSS-only tool for this job.
+
+## Features
+- **WCAG Compliance Demo:** Demonstrates how to easily pause continuous animations on hover or focus using the `:hover` and `:focus-within` pseudo-classes combined with `animation-play-state: paused`.
+- **Marquee Ticker Example:** A horizontal news ticker that automatically pauses when a user hovers over it to read a specific headline.
+- **Interactive Checkbox Toggle:** Shows how to use the CSS Checkbox Hack (`#pause-animations:checked ~ .container .animated-element`) to give users a global "Pause All Animations" toggle switch entirely without JavaScript.
+
+## Files
+- `demo.html`: The HTML structure containing the ticker and the global animation toggle checkbox.
+- `style.css`: The CSS demonstrating the `animation-play-state` utility.

--- a/submissions/examples/animation-play-state-utility-38714/demo.html
+++ b/submissions/examples/animation-play-state-utility-38714/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Animation Play State Demo</title>
+    <link rel="stylesheet" href="../../../easemotion.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <!-- CSS Checkbox Hack for Global Pause -->
+    <input type="checkbox" id="global-pause" class="sr-only">
+    
+    <div class="demo-wrapper">
+        <header class="demo-header">
+            <h1>Animation Play State Control</h1>
+            <p>Demonstrating accessible ways to pause infinite animations using CSS.</p>
+            
+            <label for="global-pause" class="btn pause-toggle-btn">
+                <span class="icon-pause">⏸️</span> Pause All Animations
+            </label>
+        </header>
+
+        <!-- Example 1: Hover to Pause -->
+        <section class="demo-section">
+            <h2>1. Hover to Pause (Ticker)</h2>
+            <p>This infinite marquee automatically pauses on <code>:hover</code> or <code>:focus-within</code>, allowing users to comfortably read the content.</p>
+            
+            <div class="ticker-wrapper">
+                <div class="ticker-content">
+                    <span class="ticker-item"><a href="#">BREAKING: CSS Grid is awesome</a></span>
+                    <span class="ticker-item"><a href="#">TECH: New features in HTML5</a></span>
+                    <span class="ticker-item"><a href="#">WEB: Accessibility standards updated</a></span>
+                    <span class="ticker-item"><a href="#">CSS: Animation properties explained</a></span>
+                </div>
+            </div>
+        </section>
+
+        <!-- Example 2: Continuous Spinner -->
+        <section class="demo-section">
+            <h2>2. Global Pause Switch</h2>
+            <p>Click the "Pause All Animations" button above. It uses the CSS Checkbox Hack to set <code>animation-play-state: paused</code> globally on these elements.</p>
+            
+            <div class="spinner-container">
+                <div class="spinner"></div>
+                <div class="bouncing-ball"></div>
+            </div>
+        </section>
+
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/animation-play-state-utility-38714/style.css
+++ b/submissions/examples/animation-play-state-utility-38714/style.css
@@ -1,0 +1,188 @@
+:root {
+    --bg-color: #f1f5f9;
+    --text-color: #0f172a;
+    --card-bg: #ffffff;
+    --border: #cbd5e1;
+    --accent: #3b82f6;
+}
+
+/* Screen reader only utility */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    font-family: system-ui, -apple-system, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+}
+
+.demo-wrapper {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem;
+}
+
+.demo-header {
+    text-align: center;
+    margin-bottom: 3rem;
+}
+
+.demo-header h1 { margin-bottom: 0.5rem; }
+.demo-header p { color: #475569; margin-bottom: 2rem; }
+
+/* Global Pause Toggle Button Styling */
+.pause-toggle-btn {
+    display: inline-block;
+    background-color: var(--accent);
+    color: white;
+    padding: 0.75rem 1.5rem;
+    border-radius: 999px;
+    cursor: pointer;
+    font-weight: 600;
+    user-select: none;
+    transition: background-color 0.2s;
+}
+
+.pause-toggle-btn:hover {
+    background-color: #2563eb;
+}
+
+/* Change button appearance when checked */
+#global-pause:checked ~ .demo-wrapper .pause-toggle-btn {
+    background-color: #ef4444; /* Red to indicate paused state */
+}
+
+#global-pause:checked ~ .demo-wrapper .pause-toggle-btn .icon-pause {
+    display: inline-block;
+    transform: rotate(90deg); /* Visual cue */
+}
+
+.demo-section {
+    background-color: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 2rem;
+    margin-bottom: 2rem;
+    box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
+}
+
+.demo-section h2 { margin-top: 0; font-size: 1.25rem; }
+.demo-section p { color: #64748b; margin-bottom: 1.5rem; }
+
+/* 
+  ========================================
+  DEMO 1: TICKER ANIMATION (Pause on Hover)
+  ========================================
+*/
+.ticker-wrapper {
+    background-color: #1e293b;
+    color: white;
+    padding: 1rem;
+    border-radius: 4px;
+    overflow: hidden;
+    white-space: nowrap;
+    position: relative;
+}
+
+.ticker-content {
+    display: inline-block;
+    animation: scroll-left 15s linear infinite;
+}
+
+.ticker-item {
+    margin-right: 3rem;
+}
+
+.ticker-item a {
+    color: #38bdf8;
+    text-decoration: none;
+}
+
+.ticker-item a:hover {
+    text-decoration: underline;
+}
+
+/* Pause the animation on hover OR when a link inside is focused (keyboard accessibility) */
+.ticker-wrapper:hover .ticker-content,
+.ticker-wrapper:focus-within .ticker-content {
+    animation-play-state: paused;
+}
+
+@keyframes scroll-left {
+    0% { transform: translateX(100%); }
+    100% { transform: translateX(-100%); }
+}
+
+/* 
+  ========================================
+  DEMO 2: CONTINUOUS SPINNER & BALL
+  ========================================
+*/
+.spinner-container {
+    display: flex;
+    gap: 3rem;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+    background-color: #f8fafc;
+    border-radius: 4px;
+}
+
+.spinner {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    border: 4px solid var(--border);
+    border-top-color: var(--accent);
+    animation: spin 1s linear infinite;
+}
+
+.bouncing-ball {
+    width: 30px;
+    height: 30px;
+    background-color: #8b5cf6;
+    border-radius: 50%;
+    animation: bounce 0.5s cubic-bezier(0.5, 0.05, 1, 0.5) infinite alternate;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+@keyframes bounce {
+    0% { transform: translateY(0); }
+    100% { transform: translateY(-40px); }
+}
+
+/* 
+  ========================================
+  GLOBAL PAUSE HACK
+  If the global checkbox is checked, pause ALL relevant animations
+  ========================================
+*/
+#global-pause:checked ~ .demo-wrapper .ticker-content,
+#global-pause:checked ~ .demo-wrapper .spinner,
+#global-pause:checked ~ .demo-wrapper .bouncing-ball {
+    animation-play-state: paused !important;
+}
+
+/* Prefers Reduced Motion (Media Query) fallback */
+@media (prefers-reduced-motion: reduce) {
+    .ticker-content,
+    .spinner,
+    .bouncing-ball {
+        animation-play-state: paused !important;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #38714

**Feature**: Added a practical demonstration of the `animation-play-state` CSS property, focusing on web accessibility (WCAG 2.2.2 Pause, Stop, Hide).

**Implementation Details**: 
- Created a `ticker-wrapper` that automatically pauses an infinite scrolling marquee when the user hovers over it (`:hover`) or focuses a link inside it (`:focus-within`) by setting `animation-play-state: paused`, drastically improving readability.
- Implemented a "Global Pause Switch" utilizing the CSS Checkbox Hack (`<input type="checkbox" id="global-pause">`). When checked, the `~` sibling selector targets all animated elements within the wrapper and forces their `animation-play-state` to `paused`, providing a Javascript-free global toggle.
- Included a `@media (prefers-reduced-motion: reduce)` block to automatically pause these animations for users with vestibular disorders based on their OS-level settings.

---

## Submission Checklist

- [x] All changes are isolated in `submissions/examples/animation-play-state-utility-38714/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to framework core files**