### PR TITLE
Add ease-notification-sidebar-slide component

### DIFF
--- a/submissions/examples/ease-notification-sidebar-slide-ij/README.md
+++ b/submissions/examples/ease-notification-sidebar-slide-ij/README.md
@@ -1,0 +1,15 @@
+# ease-notification-sidebar-slide
+
+A slide-in sidebar notification panel with CSS transition on transform.
+
+## Usage
+Open demo.html. Click "Open Notifications" to slide the panel in from the right. Click the close button to dismiss.
+
+## Custom Properties
+| Property | Default | Description |
+|----------|---------|-------------|
+| --primary | #4f46e5 | Primary accent color |
+| --sidebar-width | 320px | Panel width |
+
+## Notes
+Uses CSS transform with cubic-bezier easing for smooth slide animation.

--- a/submissions/examples/ease-notification-sidebar-slide-ij/demo.html
+++ b/submissions/examples/ease-notification-sidebar-slide-ij/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-notification-sidebar-slide</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Notification Sidebar</h1>
+    <p class="subtitle">Slide panel for notifications</p>
+    <div class="layout">
+      <div class="sidebar" id="sidebar">
+        <div class="sidebar-header">
+          <h2>Notifications</h2>
+          <button class="close-btn" id="closeBtn">&times;</button>
+        </div>
+        <div class="notif-list">
+          <div class="notif-item unread"><div class="dot"></div><div class="content"><strong>New message</strong><p>You have 3 unread messages</p></div></div>
+          <div class="notif-item"><div class="dot read"></div><div class="content"><strong>System update</strong><p>Your profile was updated</p></div></div>
+          <div class="notif-item"><div class="dot read"></div><div class="content"><strong>Reminder</strong><p>Meeting at 3pm tomorrow</p></div></div>
+        </div>
+      </div>
+      <div class="main-content">
+        <button class="trigger" id="trigger">Open Notifications</button>
+        <div class="badge" id="badge">1</div>
+      </div>
+    </div>
+  </div>
+  <script>
+    const sidebar = document.getElementById('sidebar');
+    const trigger = document.getElementById('trigger');
+    const closeBtn = document.getElementById('closeBtn');
+    let open = false;
+    trigger.addEventListener('click', () => { open = true; sidebar.classList.add('open'); trigger.style.display = 'none'; });
+    closeBtn.addEventListener('click', () => { open = false; sidebar.classList.remove('open'); trigger.style.display = ''; });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-notification-sidebar-slide-ij/style.css
+++ b/submissions/examples/ease-notification-sidebar-slide-ij/style.css
@@ -1,0 +1,23 @@
+:root{--primary:#4f46e5;--bg:#f8fafc;--text:#1e293b;--sidebar-width:320px}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;display:flex;justify-content:center;padding:20px}
+.container{max-width:700px;width:100%}
+h1{font-size:1.5rem;font-weight:700;margin-bottom:4px}
+.subtitle{font-size:.875rem;color:#64748b;margin-bottom:20px}
+.layout{display:flex;position:relative;border:1px solid #e2e8f0;border-radius:12px;overflow:hidden;min-height:350px;background:#fff}
+.sidebar{position:absolute;right:0;top:0;height:100%;width:var(--sidebar-width);background:#fff;border-left:1px solid #e2e8f0;transform:translateX(100%);transition:transform 0.35s cubic-bezier(0.4,0,0.2,1);z-index:10}
+.sidebar.open{transform:translateX(0)}
+.sidebar-header{display:flex;justify-content:space-between;align-items:center;padding:16px;border-bottom:1px solid #e2e8f0}
+.sidebar-header h2{font-size:1rem;font-weight:600}
+.close-btn{background:none;border:none;font-size:1.5rem;cursor:pointer;color:#94a3b8;padding:4px}
+.notif-list{padding:8px 0}
+.notif-item{display:flex;align-items:flex-start;gap:12px;padding:12px 16px;border-bottom:1px solid #f1f5f9;cursor:pointer}
+.notif-item:hover{background:#f8fafc}
+.dot{width:8px;height:8px;border-radius:50%;background:#3b82f6;flex-shrink:0;margin-top:6px}
+.dot.read{background:#cbd5e1}
+.content strong{font-size:.85rem}
+.content p{font-size:.78rem;color:#64748b;margin-top:2px}
+.main-content{flex:1;display:flex;align-items:center;justify-content:center;padding:20px;position:relative}
+.trigger{background:var(--primary);color:#fff;border:none;padding:12px 24px;border-radius:8px;font-size:1rem;font-weight:600;cursor:pointer;transition:background 0.2s}
+.trigger:hover{background:#4338ca}
+.badge{position:absolute;top:12px;right:12px;background:#ef4444;color:#fff;width:22px;height:22px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:.75rem;font-weight:700}


### PR DESCRIPTION
## Component: ease-notification-sidebar-slide — slide-in sidebar notification panel with CSS transition

**Closes #38876**

### What this adds
A slide-in sidebar panel for notifications. The sidebar slides from the right via a CSS transform transition. A badge counter shows unread count.

### Acceptance Criteria covered
- Slide-in animation from the right edge
- CSS transition on transform property
- Close button to dismiss panel
- Unread notification indicator dots

### Files
- submissions/examples/ease-notification-sidebar-slide-ij/demo.html
- submissions/examples/ease-notification-sidebar-slide-ij/style.css
- submissions/examples/ease-notification-sidebar-slide-ij/README.md

### How to review
Open demo.html directly in a browser. Click "Open Notifications" to see the sidebar slide in from the right. Click the close button to slide it back out.
