### PR TITLE
fix: bypass submission validation for repository maintainers

### DIFF
--- a/.github/workflows/submission-validator.yml
+++ b/.github/workflows/submission-validator.yml
@@ -85,7 +85,24 @@ jobs:
             const failures = [];
             const successes = [];
 
-            let hasExistingCodeChanges = false;
+            // Check collaborator permissions of the PR author
+            let isMaintainer = false;
+            try {
+              const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: context.payload.pull_request.user.login
+              });
+              isMaintainer = ['admin', 'write'].includes(permission.permission);
+              console.log(`PR Author: ${context.payload.pull_request.user.login}, Permission: ${permission.permission}, isMaintainer: ${isMaintainer}`);
+            } catch (e) {
+              console.warn('Could not check collaborator permission level:', e.message);
+            }
+
+            let isSpamExploit = false;
+
+            if (!isMaintainer) {
+              let hasExistingCodeChanges = false;
             let hasDeletions = false;
             const modifiedExistingFiles = [];
 
@@ -298,6 +315,7 @@ jobs:
               } else {
                 successes.push({ folder, present });
               }
+            }
             }
 
             // Store results


### PR DESCRIPTION
## Pull Request Description

Fixes a bug in the PR Submission Validator workflow where PRs opened by repository maintainers or collaborators are automatically failed and closed if they modify core files outside the `submissions/` directory.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (describe below)
  * CI Workflow Validation fix (`submission-validator.yml`)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [ ] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`** *(Note: This modifies workflow files to allow core repository changes by maintainers)*
- [ ] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Checks the collaborator permission level of the PR author, and bypasses validation checks if they have `admin` or `write` access.

**How does a developer use it?**
```yaml
# Maintainers can now submit core bug fixes directly to the repository:
git checkout -b fix/your-bug
# (Core changes will bypass GSSoC submissions constraints)
