### PR TITLE
feat: add AriaInput component with ARIA labels

### DIFF
--- a/submissions/react/fixed-aria-input-v2/AriaInput.jsx
+++ b/submissions/react/fixed-aria-input-v2/AriaInput.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const AriaInput = ({ type, placeholder, value, onChange, ariaLabel, className, ...props }) => {
+    return (
+        <input
+            type={type || "text"}
+            placeholder={placeholder}
+            value={value}
+            onChange={onChange}
+            aria-label={ariaLabel || placeholder || "Input field"}
+            className={className || "w-full p-2 border rounded"}
+            {...props}
+        />
+    );
+};
+
+export default AriaInput;

--- a/submissions/react/fixed-aria-input-v2/README.md
+++ b/submissions/react/fixed-aria-input-v2/README.md
@@ -1,0 +1,18 @@
+# AriaInput - Fixed Version
+
+## Overview
+This component adds proper ARIA labels for accessibility.
+
+## Fix Applied
+Added `aria-label` to input fields.
+
+## Usage
+```jsx
+import AriaInput from './AriaInput';
+
+<AriaInput 
+  type="text" 
+  placeholder="Search" 
+  ariaLabel="Search" 
+/>
+


### PR DESCRIPTION
## New Component: AriaInput with ARIA Labels

### Description
This PR adds a fixed version of input fields with proper ARIA labels for accessibility.

### Changes
- Created `AriaInput.jsx` with aria-label
- Added README.md documenting the fix

### Related Issue
Fixes #39357

### Labels
- `level:advanced`
- `type:accessibility`
- `gssoc:approved`