### PR TITLE
fix: escape regex special characters in SearchAutocomplete to prevent ReDoS and syntax errors

### DIFF
--- a/submissions/react/react-search-autocomplete-dropdown-with-highlight-motion/SearchAutocomplete.jsx
+++ b/submissions/react/react-search-autocomplete-dropdown-with-highlight-motion/SearchAutocomplete.jsx
@@ -72,8 +72,11 @@ const SearchAutocomplete = ({
   const renderHighlightedText = (text, highlight) => {
     if (!highlight.trim()) return text;
     
+    // Escape special regex characters to prevent ReDoS and syntax errors
+    const escapedHighlight = highlight.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    
     // Split on highlight term and include term in splits, ignore case
-    const parts = text.split(new RegExp(`(${highlight})`, 'gi'));
+    const parts = text.split(new RegExp(`(${escapedHighlight})`, 'gi'));
     
     return parts.map((part, index) => 
       part.toLowerCase() === highlight.toLowerCase() 

--- a/submissions/react/react-search-autocomplete-dropdown-with-highlight-motion/demo.html
+++ b/submissions/react/react-search-autocomplete-dropdown-with-highlight-motion/demo.html
@@ -103,7 +103,8 @@
 
       const renderHighlightedText = (text, highlight) => {
         if (!highlight.trim()) return text;
-        const parts = text.split(new RegExp(`(${highlight})`, 'gi'));
+        const escapedHighlight = highlight.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const parts = text.split(new RegExp(`(${escapedHighlight})`, 'gi'));
         return parts.map((part, index) => 
           part.toLowerCase() === highlight.toLowerCase() 
             ? <strong key={index} className="ease-search-highlight">{part}</strong> 


### PR DESCRIPTION
## Pull Request Description

Resolves #38684

This PR fixes a critical ReDoS vulnerability in the `SearchAutocomplete` component by escaping special regex characters in the query string before passing it to the `RegExp` constructor. Additionally, it updates the corresponding `demo.html` file to apply the same security fix.

---

## Submission Checklist

- [x] Fixed ReDoS in `SearchAutocomplete.jsx`
- [x] Fixed ReDoS in `demo.html`
- [x] No breaking changes to framework styling or layout