### PR TITLE
feat: add slide-right accordion for interactive interface layouts

### DIFF
--- a/submissions/examples/accordion-slideright-lg/README.md
+++ b/submissions/examples/accordion-slideright-lg/README.md
@@ -1,0 +1,45 @@
+# Slide-Right Accordion (Interactive Interface)
+
+A pure CSS accordion component with a smooth slide-right transition, designed for interactive interface layouts.
+
+## Class: `ease-accordion-slideright-lg`
+
+### Features
+- Pure CSS animation combining `max-height` (for the container) with `translateX` (for the content slide-in effect)
+- Content slides in from the left with a fade, giving a directional "slide-right" reveal
+- Fully keyboard accessible (Enter / Space to toggle, focus-visible outline)
+- Uses `aria-expanded` and `aria-controls` for screen reader support
+- Respects `prefers-reduced-motion`
+- Customizable via CSS custom properties
+
+### Usage
+
+```html
+<div class="ease-accordion-slideright-lg">
+  <div class="ease-accordion-slideright-lg__item">
+    <button class="ease-accordion-slideright-lg__header" aria-expanded="true" aria-controls="panel-1">
+      Title
+      <svg class="ease-accordion-slideright-lg__icon"></svg>
+    </button>
+    <div class="ease-accordion-slideright-lg__panel" id="panel-1" data-open="true">
+      <div class="ease-accordion-slideright-lg__panel-inner">
+        <div class="ease-accordion-slideright-lg__content">Content here</div>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+### Customization
+
+```css
+.ease-accordion-slideright-lg {
+  --accordion-accent: #f97316;
+  --accordion-duration: 600ms;
+}
+```
+
+### Author
+Lakshay Gujjar ([@lakshaygujjar273-cys](https://github.com/lakshaygujjar273-cys))
+
+Closes #33062

--- a/submissions/examples/accordion-slideright-lg/demo.html
+++ b/submissions/examples/accordion-slideright-lg/demo.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Slide-Right Accordion — Demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body style="background:#f1f5f9; padding: 2rem;">
+
+<div class="ease-accordion-slideright-lg">
+
+  <div class="ease-accordion-slideright-lg__item">
+    <button class="ease-accordion-slideright-lg__header" aria-expanded="true" aria-controls="panel-1">
+      Getting Started
+      <svg class="ease-accordion-slideright-lg__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <path d="M9 6l6 6-6 6" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </button>
+    <div class="ease-accordion-slideright-lg__panel" id="panel-1" data-open="true">
+      <div class="ease-accordion-slideright-lg__panel-inner">
+        <div class="ease-accordion-slideright-lg__content">
+          Install the framework via CDN or npm, then start using ease-* classes directly in your HTML.
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="ease-accordion-slideright-lg__item">
+    <button class="ease-accordion-slideright-lg__header" aria-expanded="false" aria-controls="panel-2">
+      Customization
+      <svg class="ease-accordion-slideright-lg__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <path d="M9 6l6 6-6 6" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </button>
+    <div class="ease-accordion-slideright-lg__panel" id="panel-2" data-open="false">
+      <div class="ease-accordion-slideright-lg__panel-inner">
+        <div class="ease-accordion-slideright-lg__content">
+          Override any CSS custom property to theme colors, timing, and easing across the whole framework.
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="ease-accordion-slideright-lg__item">
+    <button class="ease-accordion-slideright-lg__header" aria-expanded="false" aria-controls="panel-3">
+      Accessibility
+      <svg class="ease-accordion-slideright-lg__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <path d="M9 6l6 6-6 6" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </button>
+    <div class="ease-accordion-slideright-lg__panel" id="panel-3" data-open="false">
+      <div class="ease-accordion-slideright-lg__panel-inner">
+        <div class="ease-accordion-slideright-lg__content">
+          All interactive components respect prefers-reduced-motion and are fully keyboard operable.
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<script>
+  document.querySelectorAll('.ease-accordion-slideright-lg__header').forEach(header => {
+    header.addEventListener('click', () => {
+      const expanded = header.getAttribute('aria-expanded') === 'true';
+      const panel = document.getElementById(header.getAttribute('aria-controls'));
+      header.setAttribute('aria-expanded', String(!expanded));
+      panel.setAttribute('data-open', String(!expanded));
+    });
+
+    header.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        header.click();
+      }
+    });
+  });
+</script>
+
+</body>
+</html>

--- a/submissions/examples/accordion-slideright-lg/style.css
+++ b/submissions/examples/accordion-slideright-lg/style.css
@@ -1,0 +1,102 @@
+/* Slide-Right Accordion — Interactive Interface style */
+/* Author: Lakshay Gujjar (@lakshaygujjar273-cys) */
+
+.ease-accordion-slideright-lg {
+  --accordion-bg: #ffffff;
+  --accordion-border: #e2e8f0;
+  --accordion-header-bg: #f8fafc;
+  --accordion-header-hover: #eef2ff;
+  --accordion-text: #1e293b;
+  --accordion-accent: #6366f1;
+  --accordion-radius: 12px;
+  --accordion-duration: 450ms;
+  --accordion-easing: cubic-bezier(0.4, 0, 0.2, 1);
+
+  max-width: 560px;
+  margin: 1rem auto;
+  font-family: 'Inter', system-ui, sans-serif;
+}
+
+.ease-accordion-slideright-lg__item {
+  position: relative;
+  background: var(--accordion-bg);
+  border: 1px solid var(--accordion-border);
+  border-radius: var(--accordion-radius);
+  margin-bottom: 0.75rem;
+  overflow: hidden;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.ease-accordion-slideright-lg__header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  background: var(--accordion-header-bg);
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--accordion-text);
+  text-align: left;
+  transition: background var(--accordion-duration) ease;
+}
+
+.ease-accordion-slideright-lg__header:hover,
+.ease-accordion-slideright-lg__header:focus-visible {
+  background: var(--accordion-header-hover);
+  outline: 2px solid var(--accordion-accent);
+  outline-offset: -2px;
+}
+
+.ease-accordion-slideright-lg__icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  transition: transform var(--accordion-duration) var(--accordion-easing);
+}
+
+.ease-accordion-slideright-lg__header[aria-expanded="true"] .ease-accordion-slideright-lg__icon {
+  transform: rotate(90deg);
+}
+
+/* Slide-right panel technique: fixed-height wrapper, content slides in from the left */
+.ease-accordion-slideright-lg__panel {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height var(--accordion-duration) var(--accordion-easing);
+}
+
+.ease-accordion-slideright-lg__panel[data-open="true"] {
+  max-height: 300px;
+}
+
+.ease-accordion-slideright-lg__panel-inner {
+  transform: translateX(-100%);
+  opacity: 0;
+  transition: transform var(--accordion-duration) var(--accordion-easing),
+              opacity var(--accordion-duration) var(--accordion-easing);
+}
+
+.ease-accordion-slideright-lg__panel[data-open="true"] .ease-accordion-slideright-lg__panel-inner {
+  transform: translateX(0);
+  opacity: 1;
+}
+
+.ease-accordion-slideright-lg__content {
+  padding: 0 1.25rem 1.25rem;
+  color: #475569;
+  font-size: 0.925rem;
+  line-height: 1.6;
+}
+
+/* Respect reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .ease-accordion-slideright-lg__icon,
+  .ease-accordion-slideright-lg__panel,
+  .ease-accordion-slideright-lg__panel-inner {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS accordion component with a smooth slide-right transition, styled for interactive interface layouts. Closes #33062.

---

## Type of Change
- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/accordion-slideright-lg/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS, fully accessible accordion component (`ease-accordion-slideright-lg`) with a slide-right open/close transition, designed for interactive interface layouts.

**How does a developer use it?**
```html
<div class="ease-accordion-slideright-lg">
  <div class="ease-accordion-slideright-lg__item">
    <button class="ease-accordion-slideright-lg__header" aria-expanded="true" aria-controls="panel-1">
      Title
      <svg class="ease-accordion-slideright-lg__icon"></svg>
    </button>
    <div class="ease-accordion-slideright-lg__panel" id="panel-1" data-open="true">
      <div class="ease-accordion-slideright-lg__panel-inner">
        <div class="ease-accordion-slideright-lg__content">Content here</div>
      </div>
    </div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It follows the framework's human-readable BEM-style naming (`__header`, `__panel`, `__content`), exposes timing/easing/color via CSS custom properties, needs no JavaScript beyond a small toggle script for `aria-expanded`/`data-open`, and respects `prefers-reduced-motion` for accessibility.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---

## Notes for Maintainer
Used `max-height` on the panel wrapper combined with `translateX` + `opacity` on the inner content to create the slide-right reveal effect without JavaScript height calculations. Happy to adjust the max-height cap (currently 300px) if a more dynamic approach is preferred.