### PR TITLE
fix: sync easemotion/all.css component imports with easemotion.css

### DIFF
--- a/easemotion/all.css
+++ b/easemotion/all.css
@@ -1,5 +1,4 @@
 /* EaseMotion CSS — full bundle using modular animation categories */
-
 @import "./variables.css";
 @import "../core/base.css";
 @import "../core/animations.css";
@@ -18,6 +17,34 @@
 @import "../components/loaders.css";
 @import "../components/tooltips.css";
 @import "../components/modals.css";
+@import "../components/command-palette.css";
+@import "../components/announce-bar.css";
+@import "../components/avatar.css";
+@import "../components/breadcrumb.css";
+@import "../components/btn-magnetic.css";
+@import "../components/compare-table.css";
+@import "../components/connection-status.css";
+@import "../components/fab.css";
+@import "../components/kbd.css";
+@import "../components/pagination.css";
+@import "../components/password-strength.css";
+@import "../components/progress.css";
+@import "../components/read-more.css";
+@import "../components/scroll-gallery.css";
+@import "../components/skeleton.css";
+@import "../components/tag.css";
+@import "../components/toast.css";
+@import "../components/view-transitions.css";
+@import "../components/forms.css";
 
-
-
+/* Accessibility: Respect user's reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Fixes #38294 — `easemotion/all.css` was missing 18 component imports and the `prefers-reduced-motion` accessibility block present in `easemotion.css`.

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
> ⚠️ This PR does not fit the standard submissions/ template — see note below.
- [ ] All changes are inside `submissions/`
- [ ] Includes `demo.html`
- [ ] Includes `style.css`
- [ ] Includes `README.md`
- [ ] No changes to `core/`
- [ ] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

**Why the checklist doesn't apply:** This is a direct fix for bug issue #38294, which specifically requires editing `easemotion/all.css` (outside `submissions/`) to add missing `@import` references to files in `components/`. No new components were added or modified — only import statements were added to sync the two bundle entry points. I'm flagging this openly rather than force-checking boxes that don't accurately describe the change.

---

## Feature Description
**What does this add?**
Not a new feature — this restores 18 missing component imports and the reduced-motion accessibility block to `easemotion/all.css` so it matches `easemotion.css`.

**How does a developer use it?**
No usage change; existing