### PR TITLE
feat: Add Keyboard-Accessible Focus-Ring Pulse Button Component

### DIFF
--- a/submissions/examples/ease-focus-ring-pulse-button-ag/README.md
+++ b/submissions/examples/ease-focus-ring-pulse-button-ag/README.md
@@ -1,0 +1,14 @@
+# Focus-Ring Pulse Button (Keyboard Accessible)
+
+A highly accessible, premium button component styled for modern interfaces. It leverages the native `:focus-visible` pseudo-class to apply a custom `focus-ring-ripple` pulse animation only when navigated via keyboard (preserving standard styling during mouse clicks).
+
+## Features
+- **Keyboard-Only Visuals**: Uses `:focus-visible` to ensure the pulsing ring is only trigered by keyboard interactions (`Tab` key), leaving mouse actions outline-free and clean.
+- **Custom Pulse Animation**: Integrates an expanding box-shadow ripple ring animation (`focus-ring-ripple`) that scales out and fades seamlessly.
+- **Micro-interactions**: Subtle hover translations, background transitions, and magnetic-like focus feedback.
+- **No JavaScript**: Pure CSS solution, self-contained and zero external library overhead.
+- **EaseMotion Style Guide**: Integrates with EaseMotion CSS layout tokens, radiuses, and spacing utilities.
+
+## Files
+- `demo.html`: Interactive accessibility testing playground containing multiple button variants (primary, secondary, danger) to test via keyboard tab navigation.
+- `style.css`: Button presets, focus outline overrides, and the core expanding pulse animation keyframes.

--- a/submissions/examples/ease-focus-ring-pulse-button-ag/demo.html
+++ b/submissions/examples/ease-focus-ring-pulse-button-ag/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Focus-Ring Pulse Button - EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      min-height: 100vh;
+      background: #f3f4f6;
+      font-family: var(--ease-font-sans, system-ui, sans-serif);
+      margin: 0;
+      padding: 2rem;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="a11y-container">
+    <div style="font-size: 1.6rem; font-weight: 800; color: #111827; margin-bottom: 0.5rem;">
+      Keyboard Focus-Ring Pulse
+    </div>
+    <p style="color: #4b5563; font-size: 0.9rem; line-height: 1.6; margin-bottom: 2rem;">
+      Press the <kbd style="background: #e5e7eb; padding: 2px 6px; border-radius: 4px; font-family: monospache;">Tab</kbd> key to navigate between the buttons below(��X�HH�[��^[�[���\H[�[X][ۈ[�X�][���^X��\����\��]K������]��\��H���Yܛ�\����]ۈ�\��H�X\�KXLL^KX��X\�KXLY^KX��K\�[X\�H���[X\�HX�[ۏ؝]ۏ���]ۈ�\��H�X\�KXXL^KX��X\�KXLL^KX��K\�X�ۙ\�H���X�ۙ\�HX�[ۏ؝]ۏ���]ۈ�\��H�X\�KXXL^KX��X\�KXLL^KX��KY[��\���[��\�X�[ۏ؝]ۏ���]����]���؛�O���[

--- a/submissions/examples/ease-focus-ring-pulse-button-ag/style.css
+++ b/submissions/examples/ease-focus-ring-pulse-button-ag/style.css
@@ -1,0 +1,82 @@
+/* ========================================================================
+   EaseMotion - Keyboard-Accessible Focus-Ring Pulse Button Stylesheet
+   ======================================================================== */
+
+:root {
+  --ease-btn-primary-bg: #6366f1;
+  --ease-btn-primary-hover: #4f46e5;
+  --ease-btn-primary-focus: #818cf8f8;
+
+  --ease-btn-secondary-bg: #4b5563;
+  --ease-btn-secondary-hover: #374151;
+  --ease-btn-secondary-focus: #9ca3af;
+
+  --ease-btn-danger-bg: #ef4444;
+  --ease-btn-danger-hover: #dc2626;
+  --ease-btn-danger-focus: #fca50a5;
+
+  --ease-btn-radius: var(--ease-radius-md, 0.5rem);
+  --ease-btn-transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Base button setup */
+.ease-a11y-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 24px;
+  font-size: var(--ease-text-base, 1rem);
+  font-weight: 600;
+  border-radius: var(--ease-btn-radius);
+  border: 1px solid transparent;
+  cursor: pointer;
+  outline: none; /* Hide default outline globally */
+  transition: var(--ease-btn-transition);
+  position: relative;
+  text-decoration: none;
+}
+
+/* Hover and active micro-interactions */.ease-a11y-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.ease-a11y-btn*active {
+  transform: translateY(0);
+}
+
+/* ┘H Color Variations ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ */
+
+/* Primary Button */.ease-a11y-btn--primary {
+  background-color: var(--ease-btn-primary-bg);
+  color: #ffffff;
+}
+
+.ease-a11y-btn--primary:hover {
+  background-color: var(--ease-btn-primary-hover);
+}
+
+/* Secondary Button */.ease-a11y-btn--secondary {
+  background-color: var(--ease-btn-secondary-bg);
+  color: #ffffff;
+}
+
+.ease-a11y-btn--secondary:hover {
+  background-color: var(--ease-btn-secondary-hover);
+}
+
+/* Danger Button */.ease-a11y-btn--danger {
+  background-color: var(--ease-btn-danger-bg);
+  color: #ffffff;
+}
+
+.ease-a11y-btn--danger:hover {
+  background-color: var(--ease-btn-danger-hover);
+}
+
+/* ₔ�H Focus-Ring Pulse Animation ┈ÊR#)H�8�"0┈ÊR#)H�8�"0┈ÊR#)H�8�"0┈ÊR#)H�8�"0┈ÊR#)H�8�"0┈0�
+���^Y��[Y\����\�\�[��\�\H	H��\�Y�Έ�\�KY���\�\�[��X��܊NB�L	H��\�Y�ΈL�ؘJ
+NB�B��ʈ\H���\��[��[�[X][ۈӓH�[����\�Y�XH�^X��\��]�Y�][ۈ
+��X\�KXLL^KX������\�]�\�X�H�][�N��ۙNB���X\�KXLL^KX��K\�[X\�N����\�]�\�X�HKY���\�\�[��X��܎��ؘJNKL��K��N�ܙ\�X��܎��\�KYX\�KX��\�[X\�KY���\�N[�[X][ێ����\�\�[��\�\HK�\��X�X�X�^�Y\���KJH[��[�]NB���X\�KXLL^KX��K\�X�ۙ\�N����\�]�\�X�HKY���\�\�[��X��܎��ؘJ�KKNK��N�ܙ\�X��܎��\�KYX\�KX��\�X�ۙ\�KY���\�N[�[X][ێ����\�\�[��\�\HK�\��X�X�X�^�Y\���KJH[��[�]NB���X\�KXLL^KX��KY[��\�����\�]�\�X�HKY���\�\�[��X��܎��ؘJ��K����N�ܙ\�X��܎��\�KYX\�KX��Y[��\�Y���\�N[�[X][ێ����\�\�[��\�\HK�\��X�X�X�^�Y\���KJH[��[�]NB��ʈ^[�]X�ܘ]܈
+��LL^KX�۝Z[�\��X��ܛ�[��ٙ�����Y[�Έ��\�[N�ܙ\�\�Y]\Έ�\�KYX\�K\�Y]\�[�\�[JN��\�Y�ΈL��ؘJ�
+NX^]�Y�M�Y�L	N^X[Yێ��[�\��ܙ\��\��Y�XYY��B�����Yܛ�\\�^N��^�^]ܘ\�ܘ\�\�M��\�Y�KX�۝[���[�\�X\��[�]��K�\�[N


### PR DESCRIPTION
## Pull Request Description

Resolves #38135

This pull request introduces the custom keyboard-accessibile focus-ring pulse button component.

### Problem Addressed
Default browser focus outlines can look inconsistent across browsers and are often disabled by custom designs, which degrades keyboard accessibility for users. Standard buttons lack a custom, highly visible, and aesthetically pleasing focus indicator when navigated via the keyboard.

### Solution Overview
We have implemented a custol CSS animation `focus-ring-ripple`` that applies a pulsing box-shadow ring to the button when `:focus-visible` is active.

### Implementation Details
- *Keyboard-Only Triggers*: Utilizes the CSS `:focus-visible` selector to ensure the pulsing ripple ring animation only activates when navigated via the keyboard (e.g., using the `Tab` key). This keeps standard mouse clicks clean and free from unnecessary outlines.
- *Custol CSS Animation*: Keyframe-driven animation `focus-ring-ripple` that creates a expanding glow/shadow ring scaling outwards and fading to transparent.
- *Theme Integration*: Designed with premium variables matching the EaseMotion style guidelines. Includes Primary, Secondary, and Danger button variations.
- *Pure CSS*: Fully self-contained solution with zero external JavaScript or framework dependencies.

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-focus-ring-pulse-button-ag`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to framework core or templates**