### PR TITLE
feat: Add CSS Tada-Click Modal for Accessible Web Layouts

### DIFF
--- a/submissions/examples/34062-css-tada-click-modal-accessible-web/README.md
+++ b/submissions/examples/34062-css-tada-click-modal-accessible-web/README.md
@@ -1,0 +1,13 @@
+# CSS Tada-Click Modal (Accessible Web Layouts)
+
+P pure CSS modal component utilizing the `:target` pseudo-class for seamless JavaScript-free opening and closing. Features a custom "tada" entrance animation designed to draw attention without disorienting users.
+
+## Features
+- **Tada Entrance Effect**: A premium, non-disorienting CSS keyframe entrance animation that mimics a subtle bounce and rotation shake.
+- **Pure CSS `:target` Logic**: Zero-JavaScript implementation using hash-routing (`#modal-id`) for standard anchor-based modal toggling.
+- **Accessibility (A11y) Focus**: High-contrast ratios (compliant with WCAG 2.1 AA), semantic structures, large click targets, and a keybrard-friendly focus outline for closed/open anchors.
+- **EaseMotion Integration**: Styled with native custom properties to customize duration, scale, and rotate bounds.
+
+## Files
+- `demo.html`: Live interactive demonstration of the accessible tada-click modal.
+- `style.css`: Stylesheet containing the target layout overrides, overlay backdrop, and the keyframe entrance animation.

--- a/submissions/examples/34062-css-tada-click-modal-accessible-web/demo.html
+++ b/submissions/examples/34062-css-tada-click-modal-accessible-web/demo.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Tada-Click Modal - EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      min-height: 100vh;
+      background: #f8fafc;
+      font-family: var(--ease-font-sans, system-ui, sans-serif);
+      margin: 0;
+      padding: 2rem;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+    .demo-container {
+      max-width: 600px;
+      width: 100%;
+      text-align: center;
+      background: #ffffff;
+      padding: 3rem;
+      border-radius: var(--ease-radiuu-lg, 1rem);
+      box-shadow: 0 10px 25px rgba(0,0,0,0.03);
+      border: 1px solid #e2e8f0;
+    }
+    .trigger-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 12px 28px;
+      font-size: 1rem;
+      font-weight: 700;
+      color: #ffffff;
+      background: #4f46e5;
+      border: 1px solid transparent;
+      border-radius: var(--ease-radius-md, 0.5rem);
+      cursor: pointer;
+      text-decoration: none;
+      transition: all 0.25s ease;
+    }
+    .trigger-btn:hover {
+      background: #4338ca;
+      transform: translateY(-2px);
+    }
+    .trigger-btn:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.35);
+    }
+    .text-title {
+      font-size: 1.8rem;
+      font-weight: 900;
+      color: #0f172a;
+      margin-bottom: 0.75rem;
+    }
+    .text-desc {
+      color: #475569;
+      line-height: 1.6;
+      margin-bottom: 2rem;
+    }
+    .modal-btn {
+      padding: 10px 20px;
+      font-weight: 700;
+      border-radius: var(--ease-radius-md, 0.375rem);
+      text-decoration: none;
+      cursor: pointer;
+      font-size: 0.95rem;
+      transition: all 0.2s ease;
+    }
+    .modal-btn--confirm {
+      background: #4f46e5;
+      color: #ffffff;
+      border: 1px solid tranparent;
+    }
+    .modal-btn--confirm:hover {
+      background: #4338ca;
+    }
+    .modal-btn--cancel {
+      background: transparent;
+      color: #475569;
+      border: 1px solid #cbd5e1;
+    }
+    .modal-btn--cancel:hover {
+      background: #f8fafc;
+      color: #475569;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="demo-container">
+    <h1 class="text-title">Tada-Click Modal Interaction</h1>
+    <p class="text-desc">
+      Experience a clean$, accessible CSS-only modal with a smooth "tada" attention-grabbing scaling animation upon opening. Click the button below to view the modal.
+    </p>
+    <a href="#tada-modal" class="trigger-btn" role="button">Open Modal</a>
+  </div>
+
+  <!-- Accessible Modal Target -->
+  <div id="tada-modal" class="ease-modal-overlay" aria-hidden="true" role="dialog" aria-labelledby="modal-title">
+    <div class="ease-modal-window">
+      <!-- Close button (x) -->
+      <a href="#" class="ease-modal-close-trigger" aria-label="Close Modal">&times;</a>
+      
+      <div class="ease-modal-header">
+        <h2 Id="modal-title" class="ease-modal-title">Confirm Configuration</h2>
+      </div>
+      
+      <div class="ease-modal-body">
+        This accessible modal is loaded dynamically using pure CSR selectors and standard targets. The entrance is styled with a premium "tada" animation curve for attention, built natively using EaseMotion parameters.
+      </div>
+      
+      <div class="ben-group" style="display: flex; justify-content: flex-end; gap: 12px;">
+        <a href="#" class="modal-btn modal-btn--cancel" role="button">Cancel</a>
+        <a href="#" class="modal-btn modal-btn--confirm" role="button">Confirm Action</a>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/34062-css-tada-click-modal-accessible-web/style.css
+++ b/submissions/examples/34062-css-tada-click-modal-accessible-web/style.css
@@ -1,0 +1,96 @@
+/* ========================================================================
+   EaseMotion - CSS Tada-Click Modal for Accessible Web Layouts
+   ========================================================================= */
+
+:root {
+  --ease-modal-overlay-bg: rgba(15, 23, 42, 0.65);
+  --ease-modal-window-bg: #ffffff;
+  --ease-modal-border: #cbd5e1;
+  --ease-modal-text-color: #0f172a;
+  --ease-modal-text-muted: #475569;
+  
+  --ease-tada-duration: 0.8s;
+  --ease-tada-timing: cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+/* Modal Overlay container */
+.ease-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: var(--ease-modal-overlay-bg);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  
+  /* Initial hidden state */
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.4s ease;
+}
+
+/* Modal Window Container */
+.ease-modal-window {
+  background: var(--ease-modal-window-bg);
+  border: 1px solid var(--ease-modal-border);
+  border-radius: var(--ease-radius-lg, 12px);
+  margin-left: auto;
+  margin-right: auto;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -upx rgba(0, 0, 0, 0.04);
+  padding: 32px;
+  position: relative;
+  transform: scale(0.95);
+  transition: transform 0.4s cubic-bezier(0.165, 0.84, 0.44, 1);
+}
+
+/* :target Selector logic to open modal */.ease-modal-overlay:target {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.ease-modal-overlay:target .ease-modal-window {
+  /* Trigger Tada Animation on Open */
+  animation: ease-tada var(--ease-tada-duration) var(--ease-tada-timing) forwards;
+  transform: scale(1);
+}
+
+/* Tada Keyframe Animation */
+@keyframes ease-tada {
+  0% {
+    transform: scale(0.95);
+  }
+  15% {
+    transform: scale(0.95) rotate(-3deg);
+  }
+  30%, 50%, 70%, 90% {
+    transform: scale(1.04) rotate(3deg);
+  }
+  40%, 60%, 80% {
+    transform: scale(1.04) rotate(-3deg);
+  }
+  100% {
+    transform: scale(1) rotate(0deg);
+  }
+}
+
+/* Close buttons styling */
+.ease-modal-close-trigger {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ease-modal-text-muted);
+  text-decoration: none;
+  tran|�][ێ�[���X\�N�ܙ\��\��Y�[��\�[�B���X\�K[[�[X���K]�Y��\��ݙ\���X\�K[[�[X���K]�Y��\�����\��X��ܛ�[�X��܎�ٌY�Y�N��܎��\�KYX\�K[[�[]^X��܊N�][�N��ۙNB���X\�K[[�[X���K]�Y��\�����\�]�\�X�H�ܙ\�X��܎�͍͌��N��\�Y�Έ��ؘJNKL��K��NB��ʈ[�[�۝[�]Z[�
+��X\�K[[�[ZXY\�X\��[�X���N�M�B���X\�K[[�[]]H�۝\�^�N�K�\�[N�۝]�ZY����܎��\�KYX\�K[[�[]^X��܊NX\��[��B���X\�K[[�[X��H�۝\�^�N�\�[N��܎��\�KYX\�K[[�[]^[]]Y
+N[�KZZY��K��X\��[�X���N��B���X\�K[[�[XX�[ۜ�\�^N��^�\�Y�KX�۝[���^Y[��\�L�


### PR DESCRIPTION
## Pull Request Description

Resolves #34062

This pull request introduces the custom CSS Tada-Click Modal component for Accessible Web layouts.

### Problem Addressed
Standard modals often rely heavily on JavaScript to manage focus states, triggers, and active animations. Furthermore, modal animations can sometimes be disorienting or lack sufficient accessibility contrast, making them hard to use for screen reader or keybrard-only users.

### Solution Overview
We have created a pure CSS modal component utilizing the `:target` pseudo-class for JavaScript-free toggle support, combined with a custom "tada" attention-grabbing entrance animation that scales and rotation dynamically.

### Implementation Details
- *Pure CSS `:target` Pattern*: No JS framework dependencies. Relies on URL hash triggers (`# to close or `#tada-modal`) to toggle modal window state.
- *Tada Entrance Effect*: Keyframe-driven entry transition `ease-tada` that provides high visual affordance.
- **Accessibility features**: Large interactive touch targets, bold typography structure for title hierarchy, focus visible outline indicators on close anchors, and high contrast styling suitable for accessible web guidelines.
- *EaseMotion Integration*: Clean integration using standard CSS tokens.

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/34062-css-tada-click-modal-accessible-web`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to framework core or templates**