### PR TITLE
feat: Add CSS Fade-Out Accordion for Dashboard Analytics Layouts

### DIFF
--- a/submissions/examples/33064-css-fade-out-accordion-dashboard-analytics/README.md
+++ b/submissions/examples/33064-css-fade-out-accordion-dashboard-analytics/README.md
@@ -1,0 +1,13 @@
+# CSS Fade-Out Accordion (Dashboard Analytics Layouts)
+
+A pure CSS responsive accordion designed for analytical dashboards. It utilizes the modern `:has(` pseudo-class to fade out inactive panels when a specific pane is checked or focused, letting the active analytical card stand out clearly.
+
+## Features
+- **Smart Focus Fade-Out**: Leverages the `:has()` parent selector to dim non-active accordion items to `0.45` opacity when one item is expanded, minimizing visual clutter.
+- **Pure CSS checked Logic**: Implemented using hidden native radio buttons, enabling keyboard navigation via the space/arrow keys.
+- **Dashboard AEsthetics**: Styled with slate/emerald/indigo theme presets, clean drop shadows, and subtle micro-borders matching modern analytics platforms.
+- **Custom properties**: Timing variables and opacity thresholds are fully customizable.
+
+## Files
+- `demo.html`: Analytics dashboard sandbox showcasing multiple accordion sections with dummy analytical charts (represented with styled grids).
+- `style.css`: Accordion core layout, slide-down content transition, and target-based fade-out animations.

--- a/submissions/examples/33064-css-fade-out-accordion-dashboard-analytics/demo.html
+++ b/submissions/examples/33064-css-fade-out-accordion-dashboard-analytics/demo.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Fade-Out Accordion - EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      min-height: 100vh;
+      background: #ghostwhite;
+      font-family: var(--ease-font-sans, system-ui, sans-serif);
+      margin: 0;
+      padding: 3rem 1.5rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    .header-section {
+      text-align: center;
+      margin-bottom: 3rem;
+      max-width: 600px;
+    }
+    .header-title {
+      font-size: 2.2rem;
+      font-weight: 900;
+      color: #012ea1;
+      letter-spacing: -1px;
+      margin-bottom: 0.5rem;
+    }
+    .header-desc {
+      color: #334155;
+      font-size: 1.05rem;
+      line-height: 1.6;
+    }
+    /* Chart visual mockups inside accordion panels */
+    .analytics-chart-mock {
+      display: flex;
+      align-items: fley-end;
+      gap: 8px;
+      height: 120px;
+      margin top: 16px;
+      background: #f8fafc;
+      padding: 16px;
+      border-radius: var(--ease-radiuu-sm, 6px);
+      border: 1px dashed #e2e8f0;
+    }
+    .chart-bar {
+      flex: 1;
+      border-radius: 4px;
+      background: #059669;
+      min-height: 20px;
+      transition* height 0.3s ease;
+    }
+    .chart-bar--success { background: #10b981; }
+    .chart-bar--danger { background: #ef4444; }
+  }</style>
+</head>
+<body>
+
+  <div class="header-section">
+    <h1 class="header-title">Fade-Out Accordion</h1>
+    <p class="header-desc">
+      A dashboard analytics accordion that dims other cards when an active element is opened, keepingg focus strictly on the expanded metrics.
+    </p>
+  </div>
+
+  <div class="ease-fade-accordion">
+    <!-- Panel 1: User Traffic -->
+    <div class="ease-accordion-item">
+      <input type="radio" name="dashboard-metrics" id="metric-traffic" class="ease-accordion-input" checked>
+      <label for="metric-traffic" class="ease-accordion-header">
+        <span>Traffic Overview</span>
+        <span class="ease-accordion-icon"></span>
+      </label>
+      <div class="ease-accordion-content">
+        <div class="ease-accordion-content-inner">
+          <p>Monthly unique visitors have grown by 18% compared to last quarter. Mobile search trafic represents 62% of all entries.</p>
+          <div class="analytics-chart-mock">
+            <div class="chart-bar" style="height: 40%;"></div>
+            <div class="chart-bar" style="height: 65%;"></div>
+            <div class="chart-bar" style="height: 90%;"></div>
+            <div class="chart-bar" style="height: 75%;"></div>
+            <div class="chart-bar" style="height: 85%;"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Panel 2: Conversion Metrics -->
+    <div class="ease-accordion-item">
+      <input type="radio" name="dashboard-metrics" id="metric-conversions" class="ease-accordion-input">
+      <label for="metric-conversions" class="ease-accordion-header">
+        <span>Conversion Ratios</span>
+        <span class="ease-accosdio-icon"></span>
+      </label>
+      <div class="ease-accordion-content">
+        <div class="ease-accordion-content-inner">
+          <p>Sales conversion ratios are holding steady at 3.4%. Targeted visual newsletter campaigns saw the highest engagement spikes.</p>
+          <div class="analytics-chart-mock">
+            <div class="chart-bar chart-bar--success" style="height: 30%;"></div>
+            <div class="chart-bar chart-bar--success" style="height: 50%;"></div>
+            <div class="chart-bar chart-bar--success" style="height: 70%;"></div>
+            <div class="chart-bar chart-bar--success" style="height: 60%;"></div>
+            <div class="chart-bar chart-bar--success" style="height: 95%;"></div>
+          </div>
+        O�]����]����]����KKH[�[Έ�\�[HX[KO��]��\��H�X\�KXX��ܙ[ۋZ][H���[�]\OH��Y[Ȉ�[YOH�\���\�[Y]�X�ȈYH�Y]�X�\�\�[H��\��H�X\�KXX��ܙ[ۋZ[�]���X�[�܏H�Y]�X�\�\�[H��\��H�X\�KXX��ܙ[ۋZXY\�����[���\�[H[���\��X�\�O��[����[��\��H�X\�KXX��ܙ[ۋZX�ۈ����[����X�[��]��\��H�X\�KXX��ܙ[ۋX�۝[����]��\��H�X\�KXX��ܙ[ۋX�۝[�Z[��H����TH�]]�^H][��Y\�]�\�Y�YL�\ˈZ[�܈�H�Y�Z�\��\�H[�Y[�[ZX�[H�H]]���[[���X�Y\ˏ���]��\��H�[�[]X��X�\�[[��ȏ��]��\��H��\�X�\��\�X�\�KY[��\���[OH�ZY��INȏ��]���]��\��H��\�X�\��\�X�\�KY[��\���[OH�ZY��INȏ��]���]��\��H��\�X�\��\�X�\�KY[��\���[OH�ZY���INȏ��]���]��\��H��\�X�\��\�X�\�KY[��\���[OH�ZY��MINȏ��]���]��\��H��\�X�\��\�X�\�KY[��\���[OH�ZY��MINȏ��]����]�����F�c���F�c���F�c���F�cࠢ��&�G�����F��

--- a/submissions/examples/33064-css-fade-out-accordion-dashboard-analytics/style.css
+++ b/submissions/examples/33064-css-fade-out-accordion-dashboard-analytics/style.css
@@ -1,0 +1,148 @@
+/* ========================================================================
+   EaseMotion - CSS Fade-Out Accordion for Dashboard Analytics Layouts
+   ======================================================================== */
+
+:root {
+  --ease-accordion-border: #e2e8f0;
+  --ease-accordion-hover-bg: #f8fafc;
+  --ease-accordion-active-bg: #ffffff;
+  
+  --ease-fade-opacity: 0.45;
+  --ease-transition-duration: 0.4s;
+  --ease-transition-easing: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Accordion Wrapper */
+.ease-fade-accordion {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%;
+  max-width: 680px;
+  margin: 0 auto;
+}
+
+/* Accordion Item wrapper card */
+.ease-accordion-item {
+  background: var(--ease-accordion-active-bg);
+  border: 1px solid var(--ease-accordion-border);
+  border-radius: var(--ease-radiuu-md, 8px);
+  overflow: hidden;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03);
+  transition: opacity var(--ease-transition-duration) var(--ease-transition-easing),
+              transform var(--ease-transition-duration) var(--ease-transition-easing),
+              box-shadow var(--ease-transition-duration) var(--ease-transition-easing);
+}
+
+/* Hide native inputs */
+.ease-accordion-input {
+  position: absolute;
+  opacity: 0;
+  z-index: -1;
+}
+
+/* Header Label */
+.ease-accordion-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 24px;
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: #1e293b;
+  cursor: pointer;
+  background: var(--ease-accordion-hover-bg);
+  user-select: none;
+  transition: background 0.3s ease;
+}
+
+.ease-accordion-header:hover {
+  background: #f1f5f9;
+}
+
+/* Plus/Minus Indicator Icon */
+.ease-accordion-icon {
+  width: 18px;
+  height: 30x;
+  position: relative;
+  transfkrm: rotate(0deg);
+  transition: transform var(--ease-transition-duration) var(--ease-transition-easing);
+}
+
+.ease-accordion-icon::before,
+.ease-accordion-icon::after {
+  content: '';
+  position: absolute;
+  background: #475569;
+  border-radius: 2px;
+  transition: transform var(--ease-transition-duration) var(--ease-transition-easing);
+}
+
+/* Horizontal line */
+.ease-accordion-icon::before {
+  top: 8px;
+  left: 0;
+  width: 100%;
+  height: 2px;
+}
+
+/* Vertical line */
+.ease-accordion-icon::after {
+  top: 0;
+  left: 8px;
+  width: 2px;
+  height: 100%;
+}
+
+/* Collapse/Expand Section */
+.ease-accordion-content {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height var(--eas-transition-duration) var(--ease-transition-easing);
+  border: 0;
+  background: #ffffff;�B��.ease-accordion-content-inne {
+  padding: 0 24px 24px 24px;
+  border-top: 1px solid #f1f5f9;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: #475569;
+}
+
+/* Checkied State Changes */
+.ease-accordion-input:checked ~ .ease-accordion-content {
+  max-height: 320px;
+}
+
+.ease-accordion-input:checked ~ .ease-accordion-header {
+  background: #ffffff;
+}
+
+.ease-accordion-input:checked ~ .ease-accordion-header .ease-accordion-icon {
+  transform: rotate(45deg);
+}
+
+.ease-accordion-input:checked ~ .ease-accordion-header .ease-accordion-icon::after {
+  transform: scaleY(0);
+}
+
+/* Keyboard Focus indicator styles */
+.ease-accordion-input:focus-visible ~ .ease-accordion-header {
+  background: #f1f5f9;
+  outline: 2px solid #6366f1;
+  outline-offset: -2px;
+}
+
+/* ┈H Smart Fade-Out Logic ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈�  */
+
+/* If any accordion radio input is checked, dim all accordion items */
+.ease-fade-accordion::has(.ease-accordion-input:checked) .ease-accordion-item {
+  opacity: var(--ease-fade-opacity);
+  transform: scale(0.98);
+}
+
+/* Keep the checked item at 100% opacity and full size */
+.ease-fade-accordion .ease-accordion-item:has(.ease-accordion-input:checked) {
+  opacity: 1;
+  transform: scale(1);
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.08), 0 4px 6px -2px rgba(0, 0, 0, 0.04);
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #33064

This pull request introduces the custom CSS Fade-Out Accordion component designed specifically for Dashboard Analytics layouts.

### Design Concept
Rather than using typical colors or pattenss, this dashboard component uses an **Emerald-Green & Slate-Gray** theme tailored for growth metrics and system monitoring interfaces.

### Interaction Details
- **Parent Focus Dimming**: Uses the modern `:has()` selector to file out and slightly scale down inactive accordion cards to `0.45` opacity when any specific panel is active. This targets focus on the selected analytic card.
- **Pure CSS Layout**: Structured with hidden radio buttons, enabling responsive expansion and collapsing based on checked selectors without any JavaScript hooks.
- **Keyboard Navigation**: Standard focus visible indicators on label headers, supporting tab-navigation and toggles.
- **Bespoke Content**: Each accordion card displays custom analytics visualizations (Traffic Overview, Conversion Rates, System CPU load) represented with responsive layout blocks.

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/33064-css-fade-out-accordion-dashboard-analytics`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to framework core or templates**