### PR TITLE
fix: add print media query styles for ease-menu component #39331

### DIFF
--- a/submissions/examples/ease-menu-print/README.md
+++ b/submissions/examples/ease-menu-print/README.md
@@ -1,0 +1,16 @@
+# Print Optimization for Ease Menu (`#39331`)
+
+This submission introduces print stylesheets to optimize the `.ease-menu` UI component for physical media/printing.
+
+## Problem Solved
+The `.ease-menu` component contained heavy linear gradients, nested box shadows, and dark color palettes. When rendered via print utilities, this wasted massive amounts of physical printer ink and drastically lowered text readability contrast on standard paper.
+
+## Changes Introduced
+- Added a target `@media print` query context blocks inside `style.css`.
+- Stripped heavy background properties, gradients, and edge box shadows using transparent defaults.
+- Overrode color spaces to solid `#000000` to maximize text reading accessibility performance on physical print paper.
+
+## Verification Checklist
+1. Open `demo.html` locally in any standard browser.
+2. Direct trigger the print view configuration panel via `Ctrl + P` (or `Cmd + P`).
+3. Verify that the UI switches cleanly to plain black typography on transparent layouts in the rendering preview frame.

--- a/submissions/examples/ease-menu-print/demo.html
+++ b/submissions/examples/ease-menu-print/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ease Menu Print Optimization Demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    /* Quick center wrapper just for screen viewing */
+    body {
+      background-color: #f5f5f7;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+    }
+    .instructions {
+      margin-bottom: 20px;
+      font-family: sans-serif;
+      text-align: center;
+      color: #333;
+    }
+    @media print {
+      .instructions { display: none; } /* Hide instructions on actual print */
+    }
+  </style>
+</head>
+<body>
+
+  <div class="instructions">
+    <h2>Ease Menu Component</h2>
+    <p>Press <strong>Ctrl + P</strong> (or <strong>Cmd + P</strong> on Mac) to verify the print layout strip-out behavior.</p>
+  </div>
+
+  <!-- The Target Component -->
+  <nav class="ease-menu">
+    <a href="#" class="ease-menu-item">Dashboard</a>
+    <a href="#" class="ease-menu-item">Analytics</a>
+    <a href="#" class="ease-menu-item">Settings</a>
+    <a href="#" class="ease-menu-item">System Logs</a>
+  </nav>
+
+</body>
+</html>

--- a/submissions/examples/ease-menu-print/style.css
+++ b/submissions/examples/ease-menu-print/style.css
@@ -1,0 +1,59 @@
+/* ==========================================
+   Screen Styles (The Problem UI)
+   ========================================== */
+.ease-menu {
+  width: 250px;
+  padding: 20px;
+  border-radius: 12px;
+  font-family: sans-serif;
+  
+  /* Heavy ink-wasting styles mentioned in issue */
+  background: linear-gradient(135deg, #2e0854 0%, #1c053a 100%);
+  color: #ffffff;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  transition: all 0.3s ease;
+}
+
+.ease-menu-item {
+  padding: 10px 15px;
+  margin: 5px 0;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.05);
+  color: #e0d5f0;
+  text-decoration: none;
+  display: block;
+}
+
+.ease-menu-item:hover {
+  background: rgba(255, 255, 255, 0.15);
+  color: #ffffff;
+}
+
+/* ==========================================
+   Print Optimization Fix (The Solution)
+   ========================================== */
+@media print {
+  .ease-menu, 
+  .ease-menu * {
+    /* Strip heavy gradients, backgrounds, and shadows */
+    background: transparent !important;
+    background-image: none !important;
+    box-shadow: none !important;
+    text-shadow: none !important;
+
+    /* Ensure sharp, high-contrast text on white paper */
+    color: #000000 !important;
+  }
+
+  .ease-menu {
+    /* Optional clean boundary for physical paper layout */
+    border: 1px solid #dddddd !important;
+    border-radius: 4px !important;
+    width: 100% !important; /* Let it scale nicely on paper page sizes */
+  }
+
+  .ease-menu-item {
+    border-bottom: 1px dashed #eeeeee !important;
+    padding: 8px 0 !important;
+  }
+}


### PR DESCRIPTION
## Description
This PR resolves issue #39331 by introducing dedicated print media queries (`@media print`) for the `ease-menu` component. 

The original UI relies heavily on linear gradients, nested box shadows, and a dark visual palette. When printed, this causes significant ink wastage and results in unreadable, low-contrast text on physical paper. This fix strips out those heavy screen styles, forcing a transparent background and pure black text to optimize layout performance on physical media.

## Checklist
- [x] No existing issue covers this idea.
- [x] Files are located strictly inside the `submissions/` directory (`submissions/examples/ease-menu-print/`).
- [x] Included `demo.html`, `style.css`, and `README.md` in the folder.
- [x] Followed the repository's contributing guidelines.

## Changes Introduced
* Created a target `@media print` query context blocks inside `style.css`.
* Stripped background gradients, properties, and edge box shadows.
* Reset structural color rules to solid `#000000` to maximize typography contrast performance on standard white printing papers.
* Cleaned up layouts for text print sheets (e.g., setting natural border dividers).

## How to Test / Verify
1. Open `submissions/examples/ease-menu-print/demo.html` in your browser.
2. Press `Ctrl + P` (or `Cmd + P` on macOS) to invoke the native Print Preview dialog.
3. Observe that the heavy gradient theme drops cleanly into a highly readable, high-contrast monochrome list configuration fit for paper printing.

Closes #39331