### PR TITLE
feat: add animated count up stats component

### DIFF
--- a/submissions/examples/count-up-ss/README.md
+++ b/submissions/examples/count-up-ss/README.md
@@ -1,0 +1,11 @@
+# Animated Count Up Numbers
+
+1. **What does this do?**
+   It provides an animated counting-up number component utilizing CSS `@property`, ideal for stats sections.
+2. **How is it used?**
+   Apply the `.count-up-ss` class to an empty element and set the inline style `--count-target-ss: 42;`. You can append suffixes by adding modifier classes like `.count-up-plus-ss` or `.count-up-percent-ss`.
+   ```html
+   <div class="count-up-ss count-up-plus-ss" style="--count-target-ss: 42;"></div>
+   ```
+3. **Why is it useful?**
+   It allows developers to create engaging, dynamic numerical statistics without relying on JavaScript, fitting perfectly into EaseMotion's CSS-first, zero-dependency philosophy.

--- a/submissions/examples/count-up-ss/demo.html
+++ b/submissions/examples/count-up-ss/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Count Up Stats Demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      background: #0f172a;
+      color: #f8fafc;
+    }
+    .stats-container {
+      display: flex;
+      gap: 2rem;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+    .stat-card {
+      background: rgba(255, 255, 255, 0.05);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: 1rem;
+      padding: 2rem;
+      text-align: center;
+      min-width: 150px;
+    }
+    .stat-value {
+      font-size: 3rem;
+      font-weight: 700;
+      color: #a09af8;
+      margin-bottom: 0.5rem;
+    }
+    .stat-label {
+      font-size: 0.875rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #94a3b8;
+    }
+  </style>
+</head>
+<body>
+  <div class="stats-container">
+    <div class="stat-card">
+      <div class="stat-value count-up-ss count-up-plus-ss" style="--count-target-ss: 42;"></div>
+      <div class="stat-label">Utilities</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value count-up-ss" style="--count-target-ss: 12;"></div>
+      <div class="stat-label">Animations</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value count-up-ss count-up-percent-ss" style="--count-target-ss: 100;"></div>
+      <div class="stat-label">CSS Only</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/count-up-ss/style.css
+++ b/submissions/examples/count-up-ss/style.css
@@ -1,0 +1,48 @@
+/* Animated counting-up numbers */
+
+@property --count-val-ss {
+  syntax: '<integer>';
+  initial-value: 0;
+  inherits: false;
+}
+
+.count-up-ss {
+  --count-target-ss: 100;
+  --count-duration-ss: 2000ms;
+  
+  animation: countUpAnim-ss var(--count-duration-ss) cubic-bezier(0.4, 0, 0.2, 1) forwards;
+  counter-reset: count-counter-ss var(--count-val-ss);
+  font-variant-numeric: tabular-nums;
+  display: inline-block;
+}
+
+.count-up-ss::after {
+  content: counter(count-counter-ss);
+}
+
+.count-up-plus-ss::after {
+  content: counter(count-counter-ss) "+";
+}
+
+.count-up-percent-ss::after {
+  content: counter(count-counter-ss) "%";
+}
+
+.count-up-k-ss::after {
+  content: counter(count-counter-ss) "K";
+}
+
+@keyframes countUpAnim-ss {
+  from {
+    --count-val-ss: 0;
+  }
+  to {
+    --count-val-ss: var(--count-target-ss);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .count-up-ss {
+    animation-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an animated, CSS-only counting-up numbers component utilizing `@property` that is perfect for statistics sections (like the 42+ Utilities stat shown in the demo).

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An animated counting-up number component utilizing CSS `@property` to smoothly transition integers from zero to a target value.

**How does a developer use it?**

```html
<!-- Base usage -->
<div class="count-up-ss" style="--count-target-ss: 12;"></div>

<!-- With suffixes -->
<div class="count-up-ss count-up-plus-ss" style="--count-target-ss: 42;"></div>
<div class="count-up-ss count-up-percent-ss" style="--count-target-ss: 100;"></div>