### PR TITLE
fix: respect prefers-color-scheme on initial theme load

### DIFF
--- a/docs/animation-combo.html
+++ b/docs/animation-combo.html
@@ -31,9 +31,18 @@
     <link rel="stylesheet" href="docs.css" />
     <script>
       (function () {
-        var t = localStorage.getItem("em-theme") || "dark";
-        document.documentElement.setAttribute("data-theme", t);
-      })();
+          var savedTheme = localStorage.getItem("em-theme");
+
+          if (savedTheme) {
+            document.documentElement.setAttribute("data-theme", savedTheme);
+          } else {
+            var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+            document.documentElement.setAttribute(
+              "data-theme",
+              prefersDark ? "dark" : "light"
+            );
+          }
+        })();
     </script>
     <link rel="stylesheet" href="animation-combo.css" />
   </head>

--- a/docs/animations-preview.html
+++ b/docs/animations-preview.html
@@ -31,8 +31,17 @@
     <link rel="stylesheet" href="docs.css" />
     <script>
       (function () {
-        var t = localStorage.getItem("em-theme") || "dark";
-        document.documentElement.setAttribute("data-theme", t);
+        var savedTheme = localStorage.getItem("em-theme");
+
+        if (savedTheme) {
+          document.documentElement.setAttribute("data-theme", savedTheme);
+        } else {
+          var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+          document.documentElement.setAttribute(
+            "data-theme",
+            prefersDark ? "dark" : "light"
+          );
+        }
       })();
     </script>
     <link rel="stylesheet" href="animations-preview.css?v=2" />

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -14,9 +14,18 @@
     <link rel="stylesheet" href="docs.css" />
   <script>
     (function () {
-      var t = localStorage.getItem("em-theme") || "dark";
-      document.documentElement.setAttribute("data-theme", t);
-    })();
+        var savedTheme = localStorage.getItem("em-theme");
+
+        if (savedTheme) {
+          document.documentElement.setAttribute("data-theme", savedTheme);
+        } else {
+          var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+          document.documentElement.setAttribute(
+            "data-theme",
+            prefersDark ? "dark" : "light"
+          );
+        }
+      })();
   </script>
 <title>EaseMotion CSS — Interactive Demo</title>
   <meta name="description"

--- a/docs/index.html
+++ b/docs/index.html
@@ -51,9 +51,18 @@
     <!-- Apply stored theme before first paint to avoid flash -->
     <script>
       (function () {
-        var t = localStorage.getItem("em-theme") || "dark";
-        document.documentElement.setAttribute("data-theme", t);
-      })();
+          var savedTheme = localStorage.getItem("em-theme");
+
+          if (savedTheme) {
+            document.documentElement.setAttribute("data-theme", savedTheme);
+          } else {
+            var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+            document.documentElement.setAttribute(
+              "data-theme",
+              prefersDark ? "dark" : "light"
+            );
+          }
+        })();
     </script>
 
     <style>


### PR DESCRIPTION
## Pull Request Description

This PR fixes the missing `prefers-color-scheme` auto-detection for the demo theme.

Previously, when no `em-theme` preference was stored in `localStorage`, the demo pages always defaulted to the dark theme. With this update, the demo now:

* Uses the saved `em-theme` value from `localStorage` when available.
* Automatically detects the user's OS-level color scheme using `window.matchMedia("(prefers-color-scheme: dark)")` when no saved preference exists.
* Preserves the existing manual theme toggle and theme persistence behavior.

**Fixes #39534**

---

## Type of Change

* [ ] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [x] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

* [ ] All changes are inside `submissions/`
* [ ] Includes `demo.html` — self-contained, opens in browser with no server
* [ ] Includes `style.css` — raw CSS for the proposed feature
* [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] **No changes to `core/`**
* [x] **No changes to `components/`**
* [x] One feature per PR

---

## Feature Description

**What does this add?**

Adds automatic detection of the user's preferred color scheme on the initial page load when no theme preference has been saved.

**How does a developer use it?**

No additional configuration is required. The demo automatically applies the saved theme when available, otherwise it follows the system's `prefers-color-scheme` setting.

**Why does it fit EaseMotion CSS?**

It provides a smoother and more intuitive demo experience by respecting the user's system theme while maintaining existing manual theme selection behavior.

---

## Demo

* [x] Existing demo pages updated and tested locally.

---

## Browser Testing

* [x] Chrome
* [ ] Firefox
* [ ] Edge
* [ ] Safari

---

## Notes for Maintainer

This change only updates the initial theme initialization logic for the demo pages. Manual theme switching and `localStorage` persistence remain unchanged.
