### PR TITLE
feat: add ease-count-up number animation component

### DIFF
--- a/submissions/examples/count-up/README.md
+++ b/submissions/examples/count-up/README.md
@@ -1,0 +1,9 @@
+# ease-count-up Component
+
+This submission fixes Issue #39536 by adding a reusable `.ease-count-up` component.  
+It animates numbers from 0 up to a target value, commonly used in stats sections.
+
+## Usage
+
+```html
+<span class="ease-count-up" data-target="42">0</span>+ Utilities

--- a/submissions/examples/count-up/demo.html
+++ b/submissions/examples/count-up/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>EaseMotion Count-Up Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h2>Animated Stats</h2>
+
+  <div class="stat">
+    <span class="ease-count-up" data-target="42">0</span>+ Utilities
+  </div>
+
+  <div class="stat">
+    <span class="ease-count-up" data-target="12">0</span> Animations
+  </div>
+
+  <div class="stat">
+    <span class="ease-count-up" data-target="0">0</span> Dependencies
+  </div>
+
+  <script>
+    function animateCountUp(el) {
+      const target = +el.getAttribute("data-target");
+      let current = 0;
+      const increment = Math.ceil(target / 100); // smooth steps
+      const interval = setInterval(() => {
+        current += increment;
+        if (current >= target) {
+          el.textContent = target;
+          clearInterval(interval);
+        } else {
+          el.textContent = current;
+        }
+      }, 20);
+    }
+
+    document.querySelectorAll(".ease-count-up").forEach(el => {
+      animateCountUp(el);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/count-up/style.css
+++ b/submissions/examples/count-up/style.css
@@ -1,0 +1,10 @@
+.stat {
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin: 1rem 0;
+  color: #007bff;
+}
+
+.ease-count-up {
+  margin-right: 0.3rem;
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes Issue #39536 by adding a reusable `.ease-count-up` component.  
It animates numbers from 0 up to a target value, useful for stats sections like "42+ Utilities".

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/count-up/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**  
A count-up number animation component.

**How does a developer use it?**
```html
<span class="ease-count-up" data-target="42">0</span>+ Utilities
