### PR TITLE
feat: add prefers-color-scheme auto-detection demo

### DIFF
--- a/submissions/examples/color-scheme-auto/README.md
+++ b/submissions/examples/color-scheme-auto/README.md
@@ -1,0 +1,11 @@
+# Prefers Color Scheme Auto-Detection
+
+This submission fixes Issue #39534 by adding `@media (prefers-color-scheme)` support.  
+The demo now respects the OS-level dark/light preference on first load.
+
+## Usage
+
+```css
+@media (prefers-color-scheme: dark) {
+  body { background: #121212; color: #f1f1f1; }
+}

--- a/submissions/examples/color-scheme-auto/demo.html
+++ b/submissions/examples/color-scheme-auto/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Prefers Color Scheme Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="card">
+    <h2>Hello EaseMotion!</h2>
+    <p>This demo auto-detects your OS theme preference.</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/color-scheme-auto/style.css
+++ b/submissions/examples/color-scheme-auto/style.css
@@ -1,0 +1,27 @@
+/* Default light theme */
+body {
+  background: #ffffff;
+  color: #333333;
+  font-family: Inter, sans-serif;
+}
+
+.card {
+  padding: 2rem;
+  margin: 2rem;
+  border-radius: 8px;
+  background: #f9f9f9;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+}
+
+/* Dark theme auto-detection */
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #121212;
+    color: #f1f1f1;
+  }
+
+  .card {
+    background: #1e1e1e;
+    box-shadow: 0 2px 6px rgba(255,255,255,0.1);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes Issue #39534 by adding `prefers-color-scheme` auto-detection.  
The demo now respects OS-level dark/light preference on first load.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Accessibility / documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/color-scheme-auto/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**  
Auto-detection of dark/light theme using `prefers-color-scheme`.

**How does a developer use it?**
```css
@media (prefers-color-scheme: dark) {
  body { background: #121212; color: #f1f1f1; }
}
