### PR TITLE
test: add visual regression setup demo

### DIFF
--- a/submissions/examples/visual-regression-setup/README.md
+++ b/submissions/examples/visual-regression-setup/README.md
@@ -1,0 +1,10 @@
+# Visual Regression Testing Setup
+
+This submission fixes Issue #39535 by showing how to set up visual regression testing for EaseMotion submissions.  
+It uses Playwright + pixelmatch to capture screenshots of demo components and compare them against a baseline.
+
+## Steps
+
+1. Install dependencies:
+```bash
+npm install --save-dev playwright pixelmatch jest

--- a/submissions/examples/visual-regression-setup/demo.html
+++ b/submissions/examples/visual-regression-setup/demo.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Visual Regression Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <button class="ease-btn ease-btn-primary">Test Button</button>
+</body>
+</html>

--- a/submissions/examples/visual-regression-setup/style.css
+++ b/submissions/examples/visual-regression-setup/style.css
@@ -1,0 +1,12 @@
+.ease-btn {
+  padding: 0.6rem 1.2rem;
+  border: none;
+  border-radius: 4px;
+  background: #007bff;
+  color: #fff;
+  cursor: pointer;
+}
+
+.ease-btn:hover {
+  background: #0056b3;
+}

--- a/submissions/examples/visual-regression-setup/visual.test.js
+++ b/submissions/examples/visual-regression-setup/visual.test.js
@@ -1,0 +1,19 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const pixelmatch = require('pixelmatch');
+const { PNG } = require('pngjs');
+
+test('Demo component visual regression', async ({ page }) => {
+  await page.goto('http://localhost:3000/submissions/examples/scroll-top-button/demo.html');
+  const screenshot = await page.screenshot();
+
+  const baseline = PNG.sync.read(fs.readFileSync('baseline/scroll-top.png'));
+  const current = PNG.sync.read(screenshot);
+
+  const { width, height } = baseline;
+  const diff = new PNG({ width, height });
+
+  const mismatches = pixelmatch(baseline.data, current.data, diff.data, width, height, { threshold: 0.1 });
+
+  expect(mismatches).toBeLessThan(50); // allow small differences
+});


### PR DESCRIPTION
## Pull Request Description

This PR fixes Issue #39535 by adding a visual regression testing setup demo.  
It shows how to use Playwright + pixelmatch to capture screenshots of demo components and compare them against a baseline.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Testing / infrastructure improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/visual-regression-setup/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**  
A demo setup for visual regression testing.

**How does a developer use it?**
```bash
npx playwright test
