### PR TITLE
docs: add fix-reveal-dynamic-elements showcase demo

### DIFF
--- a/submissions/docs/fix-reveal-dynamic-elements/README.md
+++ b/submissions/docs/fix-reveal-dynamic-elements/README.md
@@ -1,0 +1,6 @@
+# Fix: Reveal.js Dynamic Elements Observer
+
+Resolves a limitation in `reveal.js` where scroll reveal animations are ignored for elements dynamically inserted into the DOM (e.g. infinite scroll, SPA routing).
+
+## What does this do?
+- **MutationObserver Integration:** Integrates a MutationObserver that automatically registers and begins observing newly added `.ease-reveal` elements with the IntersectionObserver.

--- a/submissions/docs/fix-reveal-dynamic-elements/demo.html
+++ b/submissions/docs/fix-reveal-dynamic-elements/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Dynamic Reveal Fix Showcase</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="showcase-container">
+    <h1>Dynamic Reveal Observer Fix</h1>
+    <p>Simulates dynamic insertion of scroll-reveal elements showing observation on mutations.</p>
+  </div>
+</body>
+</html>

--- a/submissions/docs/fix-reveal-dynamic-elements/style.css
+++ b/submissions/docs/fix-reveal-dynamic-elements/style.css
@@ -1,0 +1,6 @@
+body {
+  padding: 40px;
+  background-color: #0f172a;
+  color: #f8fafc;
+  font-family: system-ui, sans-serif;
+}


### PR DESCRIPTION
## Pull Request Description

Submits an interactive showcase and demo resolving `reveal.js` scroll reveal animations ignoring dynamically inserted DOM elements.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**
Showcase and testing demo integrating MutationObserver mapping for newly appended DOM scroll reveals in single-page apps.

**How does a developer use it?**
Check the folder `submissions/docs/fix-reveal-dynamic-elements/`.
