### PR TITLE
feat : add ease bento grid dashboard submission

### DIFF
--- a/submissions/examples/ease-bento-grid-dashboard/README.md
+++ b/submissions/examples/ease-bento-grid-dashboard/README.md
@@ -1,0 +1,42 @@
+# ease-bento-grid-dashboard
+
+A responsive Bento Grid dashboard layout with content-aware auto-span sizing, scroll-triggered stagger entrance, live pulse-indicator cards, and drag-to-reorder affordance — going beyond a static bento grid demo toward something dashboard-realistic.
+
+## Why this is different
+
+Most bento grid examples use hardcoded `grid-template-areas` and load-time animations. This one adds:
+
+- **Content-aware auto-span** — cards declare their own size via `data-size="1x1" | "2x1" | "1x2" | "2x2"`, so the grid layout is driven by data attributes rather than fixed template areas — easier to reorder or extend
+- **Scroll-triggered stagger entrance** — cards fade/slide in with staggered delays as they enter the viewport via `IntersectionObserver`, not just on page load
+- **Live pulse indicator cards** — a pure-CSS animated status dot (`@keyframes` ripple) for "live" metrics, no JS polling required
+- **Drag-to-reorder affordance** — visual drag/drop states (ghost outline, grab cursor, opacity feedback) with working reorder logic in the demo
+- **Density variant** — `.ease-bento-grid--compact` modifier for tighter dashboard layouts
+
+## Classes
+
+| Class | Description |
+|---|---|
+| `ease-bento-grid` | Grid container |
+| `ease-bento-grid--compact` | Tighter gap/padding variant |
+| `ease-bento-card` | Individual dashboard card |
+| `ease-bento-card--visible` | Applied on scroll-into-view (via JS) |
+| `ease-bento-card--drag-ghost` | Drag-over placeholder state |
+| `ease-bento-card__title` | Card label |
+| `ease-bento-card__value` | Main metric value |
+| `ease-bento-card__subtext` | Secondary supporting text |
+| `ease-bento-pulse` | Live status indicator wrapper |
+| `ease-bento-pulse-dot` | Animated pulsing dot |
+
+## Usage
+
+1. Link `style.css` and include the script block from `demo.html`.
+2. Add cards with a `data-size` attribute to control their grid span:
+
+```html
+<div class="ease-bento-grid" id="bentoGrid">
+  <div class="ease-bento-card" data-size="2x1" draggable="true">
+    <p class="ease-bento-card__title">Live Visitors</p>
+    <p class="ease-bento-card__value">2,481</p>
+    <span class="ease-bento-pulse"><span class="ease-bento-pulse-dot"></span>Live</span>
+  </div>
+</div>

--- a/submissions/examples/ease-bento-grid-dashboard/demo.html
+++ b/submissions/examples/ease-bento-grid-dashboard/demo.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ease-bento-grid-dashboard Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="ease-bento-grid" id="bentoGrid">
+
+  <div class="ease-bento-card" data-size="2x1" draggable="true">
+    <p class="ease-bento-card__title">Live Visitors</p>
+    <p class="ease-bento-card__value">2,481</p>
+    <span class="ease-bento-pulse"><span class="ease-bento-pulse-dot"></span>Live</span>
+  </div>
+
+  <div class="ease-bento-card" data-size="1x1" draggable="true">
+    <p class="ease-bento-card__title">Revenue</p>
+    <p class="ease-bento-card__value">$18.2k</p>
+    <p class="ease-bento-card__subtext">+12% this week</p>
+  </div>
+
+  <div class="ease-bento-card" data-size="1x2" draggable="true">
+    <p class="ease-bento-card__title">Server Status</p>
+    <p class="ease-bento-card__value">Online</p>
+    <span class="ease-bento-pulse"><span class="ease-bento-pulse-dot"></span>Healthy</span>
+  </div>
+
+  <div class="ease-bento-card" data-size="1x1" draggable="true">
+    <p class="ease-bento-card__title">New Signups</p>
+    <p class="ease-bento-card__value">312</p>
+    <p class="ease-bento-card__subtext">Today</p>
+  </div>
+
+  <div class="ease-bento-card" data-size="2x2" draggable="true">
+    <p class="ease-bento-card__title">Weekly Traffic</p>
+    <p class="ease-bento-card__value">48.9k</p>
+    <p class="ease-bento-card__subtext">Across all channels</p>
+  </div>
+
+  <div class="ease-bento-card" data-size="1x1" draggable="true">
+    <p class="ease-bento-card__title">Bounce Rate</p>
+    <p class="ease-bento-card__value">32%</p>
+    <p class="ease-bento-card__subtext">-4% vs last week</p>
+  </div>
+
+  <div class="ease-bento-card" data-size="1x1" draggable="true">
+    <p class="ease-bento-card__title">Active Sessions</p>
+    <p class="ease-bento-card__value">184</p>
+    <span class="ease-bento-pulse"><span class="ease-bento-pulse-dot"></span>Live</span>
+  </div>
+
+</div>
+
+<script>
+  // Scroll-triggered stagger entrance
+  const cards = document.querySelectorAll('.ease-bento-card');
+
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach((entry, i) => {
+      if (entry.isIntersecting) {
+        const index = Array.from(cards).indexOf(entry.target);
+        setTimeout(() => {
+          entry.target.classList.add('ease-bento-card--visible');
+        }, index * 80);
+        observer.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.15 });
+
+  cards.forEach(card => observer.observe(card));
+
+  // Drag-to-reorder affordance (visual only — no persistence)
+  let draggedCard = null;
+
+  cards.forEach(card => {
+    card.addEventListener('dragstart', () => {
+      draggedCard = card;
+      card.style.opacity = '0.4';
+    });
+
+    card.addEventListener('dragend', () => {
+      card.style.opacity = '';
+      draggedCard = null;
+    });
+
+    card.addEventListener('dragover', (e) => {
+      e.preventDefault();
+      card.classList.add('ease-bento-card--drag-ghost');
+    });
+
+    card.addEventListener('dragleave', () => {
+      card.classList.remove('ease-bento-card--drag-ghost');
+    });
+
+    card.addEventListener('drop', (e) => {
+      e.preventDefault();
+      card.classList.remove('ease-bento-card--drag-ghost');
+      if (draggedCard && draggedCard !== card) {
+        const grid = document.getElementById('bentoGrid');
+        const cardsArr = Array.from(grid.children);
+        const draggedIndex = cardsArr.indexOf(draggedCard);
+        const targetIndex = cardsArr.indexOf(card);
+        if (draggedIndex < targetIndex) {
+          card.after(draggedCard);
+        } else {
+          card.before(draggedCard);
+        }
+      }
+    });
+  });
+</script>
+
+</body>
+</html>

--- a/submissions/examples/ease-bento-grid-dashboard/style.css
+++ b/submissions/examples/ease-bento-grid-dashboard/style.css
@@ -1,0 +1,158 @@
+/* ease-bento-grid-dashboard
+   Responsive Bento Grid dashboard layout with content-aware auto-span,
+   scroll-triggered stagger entrance, and live pulse indicator cards.
+   Pure CSS + minimal JS (IntersectionObserver), zero dependencies.
+*/
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #0f0f1a;
+  min-height: 100vh;
+  margin: 0;
+  padding: 60px 24px;
+  color: #e5e7eb;
+}
+
+.ease-bento-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  grid-auto-rows: 140px;
+  gap: 18px;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+/* Content-aware auto-span via data-size attribute selectors */
+.ease-bento-card[data-size="1x1"] { grid-column: span 1; grid-row: span 1; }
+.ease-bento-card[data-size="2x1"] { grid-column: span 2; grid-row: span 1; }
+.ease-bento-card[data-size="1x2"] { grid-column: span 1; grid-row: span 2; }
+.ease-bento-card[data-size="2x2"] { grid-column: span 2; grid-row: span 2; }
+
+.ease-bento-card {
+  position: relative;
+  border-radius: 16px;
+  background: linear-gradient(145deg, #1c1c2e, #14141f);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  overflow: hidden;
+  cursor: grab;
+  transition: transform 0.3s cubic-bezier(0.25, 0.8, 0.25, 1),
+              box-shadow 0.3s ease,
+              border-color 0.3s ease;
+
+  /* Scroll-triggered stagger entrance state */
+  opacity: 0;
+  transform: translateY(24px);
+}
+
+.ease-bento-card.ease-bento-card--visible {
+  opacity: 1;
+  transform: translateY(0);
+  transition: opacity 0.5s ease, transform 0.5s cubic-bezier(0.25, 0.8, 0.25, 1),
+              box-shadow 0.3s ease, border-color 0.3s ease;
+}
+
+.ease-bento-card:hover {
+  transform: translateY(-6px) scale(1.015);
+  border-color: rgba(124, 58, 237, 0.5);
+  box-shadow: 0 16px 32px rgba(124, 58, 237, 0.2);
+}
+
+.ease-bento-card:active {
+  cursor: grabbing;
+}
+
+/* Drag-over ghost placeholder affordance (visual only) */
+.ease-bento-card--drag-ghost {
+  border: 2px dashed rgba(124, 58, 237, 0.5);
+  background: rgba(124, 58, 237, 0.06);
+}
+
+.ease-bento-card__title {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #9ca3af;
+  margin: 0 0 8px;
+}
+
+.ease-bento-card__value {
+  font-size: 30px;
+  font-weight: 800;
+  color: #fff;
+  margin: 0;
+}
+
+.ease-bento-card__subtext {
+  font-size: 12.5px;
+  color: #6b7280;
+  margin-top: 4px;
+}
+
+/* Live pulse indicator — pure CSS, no JS polling */
+.ease-bento-pulse {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: #4ade80;
+  font-weight: 600;
+}
+
+.ease-bento-pulse-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #4ade80;
+  position: relative;
+}
+
+.ease-bento-pulse-dot::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: #4ade80;
+  animation: ease-bento-pulse-ring 1.8s ease-out infinite;
+}
+
+@keyframes ease-bento-pulse-ring {
+  0%   { transform: scale(1); opacity: 0.7; }
+  100% { transform: scale(2.6); opacity: 0; }
+}
+
+/* Density variant */
+.ease-bento-grid--compact {
+  gap: 10px;
+}
+
+.ease-bento-grid--compact .ease-bento-card {
+  padding: 12px;
+}
+
+@media (max-width: 720px) {
+  .ease-bento-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .ease-bento-card[data-size="2x2"],
+  .ease-bento-card[data-size="2x1"] {
+    grid-column: span 2;
+  }
+}
+
+@media (max-width: 420px) {
+  .ease-bento-grid {
+    grid-template-columns: 1fr;
+  }
+  .ease-bento-card {
+    grid-column: span 1 !important;
+  }
+}


### PR DESCRIPTION
## Description
Adds a responsive Bento Grid dashboard layout with content-aware auto-span sizing (via `data-size` attributes), scroll-triggered stagger entrance using `IntersectionObserver`, live pulse-indicator cards, and drag-to-reorder affordance.

Closes #39668

## Changes
- Added `submissions/examples/ease-bento-grid-dashboard/demo.html`
- Added `submissions/examples/ease-bento-grid-dashboard/style.css`
- Added `submissions/examples/ease-bento-grid-dashboard/README.md`

## Checklist
- [x] Verified no existing folder covers this feature
- [x] Read the Contribution Guide
- [x] Files added only inside `submissions/examples/`
- [x] Included `demo.html`, `style.css`, `README.md`
- [x] Tested demo locally in browser

## Screenshots/Demo
_(Attach a screenshot or GIF showing the stagger entrance, hover lift, and pulse indicators here)_