### PR TITLE
feat: add keyboard focus ring motion example

### DIFF
--- a/submissions/examples/keyboard-focus-ring-motion/README.md
+++ b/submissions/examples/keyboard-focus-ring-motion/README.md
@@ -1,0 +1,14 @@
+# Keyboard Focus Ring Motion
+
+An accessibility-focused EaseMotion example that adds an animated focus ring without changing the element size or causing layout shift.
+
+## What it demonstrates
+
+- `:focus-visible` styling for keyboard users
+- a pseudo-element focus ring that animates independently from layout
+- reduced-motion support for users who prefer less animation
+
+## Files
+
+- `demo.html` - interactive focus demo
+- `style.css` - focus ring animation and responsive layout

--- a/submissions/examples/keyboard-focus-ring-motion/demo.html
+++ b/submissions/examples/keyboard-focus-ring-motion/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Keyboard Focus Ring Motion</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="panel" aria-labelledby="demo-title">
+      <p class="eyebrow">EaseMotion accessibility example</p>
+      <h1 id="demo-title">Keyboard focus ring motion</h1>
+      <p class="intro">
+        Tab through the controls to see a visible focus treatment that moves without shifting layout.
+      </p>
+
+      <div class="action-grid" aria-label="Focus ring examples">
+        <button class="focus-motion">Save draft</button>
+        <button class="focus-motion">Preview</button>
+        <a class="focus-motion link-card" href="#notes">Open notes</a>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/keyboard-focus-ring-motion/style.css
+++ b/submissions/examples/keyboard-focus-ring-motion/style.css
@@ -1,0 +1,137 @@
+:root {
+  color-scheme: light;
+  --ink: #1f2937;
+  --muted: #5b6472;
+  --surface: #ffffff;
+  --page: #eef4f8;
+  --accent: #0f9f8f;
+  --accent-strong: #0b7369;
+  --ring: rgba(15, 159, 143, 0.36);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background:
+    linear-gradient(135deg, rgba(15, 159, 143, 0.12), transparent 42%),
+    var(--page);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.demo-shell {
+  width: min(920px, calc(100vw - 32px));
+}
+
+.panel {
+  padding: 34px;
+  border: 1px solid rgba(31, 41, 55, 0.12);
+  border-radius: 18px;
+  background: var(--surface);
+  box-shadow: 0 22px 55px rgba(31, 41, 55, 0.14);
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--accent-strong);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 3.5rem);
+  line-height: 1;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 16px 0 28px;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.65;
+}
+
+.action-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.focus-motion {
+  position: relative;
+  min-height: 64px;
+  display: inline-grid;
+  place-items: center;
+  padding: 0 18px;
+  border: 1px solid rgba(31, 41, 55, 0.16);
+  border-radius: 14px;
+  background: #f9fbfc;
+  color: var(--ink);
+  font: inherit;
+  font-weight: 800;
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    transform 180ms ease,
+    border-color 180ms ease,
+    background-color 180ms ease;
+}
+
+.focus-motion::after {
+  content: "";
+  position: absolute;
+  inset: -6px;
+  border: 3px solid transparent;
+  border-radius: 18px;
+  opacity: 0;
+  transform: scale(0.94);
+  transition:
+    opacity 180ms ease,
+    transform 180ms ease,
+    border-color 180ms ease;
+  pointer-events: none;
+}
+
+.focus-motion:hover {
+  border-color: rgba(15, 159, 143, 0.42);
+  background: #f2fbf9;
+  transform: translateY(-2px);
+}
+
+.focus-motion:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  background: #f0fffb;
+}
+
+.focus-motion:focus-visible::after {
+  opacity: 1;
+  transform: scale(1);
+  border-color: var(--ring);
+}
+
+@media (max-width: 680px) {
+  .panel {
+    padding: 24px;
+  }
+
+  .action-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .focus-motion,
+  .focus-motion::after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add an accessible focus ring animation example
- keep the focus effect layout-stable with a pseudo-element ring
- include reduced-motion handling and responsive layout

## Testing
- git diff --cached --check
- npm test (fails: repository has no matching test files for tests/**/*.test.js)