### PR TITLE
feat : add ease otp input submission

### DIFF
--- a/submissions/examples/ease-otp-input/README.md
+++ b/submissions/examples/ease-otp-input/README.md
@@ -1,0 +1,38 @@
+# Ease OTP Input
+
+## What does this do?
+An OTP (One-Time Password) verification input with auto-advancing focus,
+a **staggered "wave" fill animation** when a code is pasted, and a
+**shake-then-clear** error state — instead of a static focus-border-only
+input.
+
+## How is it different from a typical OTP input utility?
+- Pasting a full code fills each box in sequence with a small delay,
+  creating a wave-like cascading fill rather than instantly populating all
+  boxes at once.
+- Incorrect codes trigger a shake animation on every box, then automatically
+  clear and refocus the first box — clear feedback without needing extra UI.
+- Correct codes animate each box into a success state in a quick stagger,
+  rather than all boxes changing color simultaneously.
+- Backspace correctly moves focus to the previous box when the current one
+  is empty.
+
+## How is it used?
+\`\`\`html
+<div class="ease-otp">
+  <div class="ease-otp__boxes" data-length="6">
+    <input type="text" inputmode="numeric" maxlength="1" class="ease-otp__box" />
+    <!-- repeat per digit -->
+  </div>
+  <button class="verify-btn">Verify</button>
+</div>
+\`\`\`
+
+See `demo.html` for the JS handling auto-advance, paste distribution, and
+verify/error logic (all animation styling itself is in `style.css`).
+
+## Why is this useful?
+OTP verification is one of the most common authentication UI patterns, and
+small touches like paste support and clear error feedback significantly
+improve real-world usability — a practical, beginner-friendly showcase for
+EaseMotion CSS.

--- a/submissions/examples/ease-otp-input/demo.html
+++ b/submissions/examples/ease-otp-input/demo.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ease OTP Input Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <div class="ease-otp" id="otp1">
+    <h3>Enter 6-digit code</h3>
+    <div class="ease-otp__boxes" data-length="6">
+      <input type="text" inputmode="numeric" maxlength="1" class="ease-otp__box" />
+      <input type="text" inputmode="numeric" maxlength="1" class="ease-otp__box" />
+      <input type="text" inputmode="numeric" maxlength="1" class="ease-otp__box" />
+      <input type="text" inputmode="numeric" maxlength="1" class="ease-otp__box" />
+      <input type="text" inputmode="numeric" maxlength="1" class="ease-otp__box" />
+      <input type="text" inputmode="numeric" maxlength="1" class="ease-otp__box" />
+    </div>
+    <div class="ease-otp__actions">
+      <button class="verify-btn">Verify (try "123456" = success, anything else = error)</button>
+    </div>
+    <p class="ease-otp__hint">Tip: paste a 6-digit code to auto-fill all boxes</p>
+  </div>
+
+  <script>
+    document.querySelectorAll('.ease-otp').forEach(otpEl => {
+      const boxes = [...otpEl.querySelectorAll('.ease-otp__box')];
+
+      boxes.forEach((box, i) => {
+        box.addEventListener('input', () => {
+          box.value = box.value.replace(/[^0-9]/g, '');
+          if (box.value) {
+            box.classList.add('is-filled');
+            if (boxes[i + 1]) boxes[i + 1].focus();
+          } else {
+            box.classList.remove('is-filled');
+          }
+        });
+
+        box.addEventListener('keydown', (e) => {
+          if (e.key === 'Backspace' && !box.value && boxes[i - 1]) {
+            boxes[i - 1].focus();
+          }
+        });
+
+        box.addEventListener('paste', (e) => {
+          e.preventDefault();
+          const pasted = (e.clipboardData.getData('text') || '').replace(/[^0-9]/g, '').split('');
+          pasted.slice(0, boxes.length).forEach((digit, idx) => {
+            setTimeout(() => {
+              boxes[idx].value = digit;
+              boxes[idx].classList.add('is-filled', 'wave-in');
+              boxes[idx].addEventListener('animationend', () => boxes[idx].classList.remove('wave-in'), { once: true });
+            }, idx * 70);
+          });
+          setTimeout(() => boxes[Math.min(pasted.length, boxes.length) - 1]?.focus(), pasted.length * 70);
+        });
+      });
+
+      otpEl.querySelector('.verify-btn').addEventListener('click', () => {
+        const code = boxes.map(b => b.value).join('');
+        const correct = '123456';
+
+        if (code === correct) {
+          boxes.forEach((b, i) => {
+            setTimeout(() => b.classList.add('is-success'), i * 60);
+          });
+        } else {
+          boxes.forEach(b => {
+            b.classList.add('is-error', 'shake');
+            b.addEventListener('animationend', () => {
+              b.classList.remove('shake');
+            }, { once: true });
+          });
+          setTimeout(() => {
+            boxes.forEach(b => {
+              b.value = '';
+              b.classList.remove('is-error', 'is-filled');
+            });
+            boxes[0].focus();
+          }, 900);
+        }
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-otp-input/style.css
+++ b/submissions/examples/ease-otp-input/style.css
@@ -1,0 +1,110 @@
+/* Ease OTP Input
+   Adds auto-advance with a staggered "wave" fill animation on paste,
+   and a shake-then-clear error state, instead of a static
+   focus-border-only OTP input. */
+
+.ease-otp {
+  max-width: 420px;
+  margin: 3rem auto;
+  font-family: system-ui, sans-serif;
+  color: #fff;
+  text-align: center;
+}
+
+.ease-otp h3 {
+  margin-bottom: 1.5rem;
+  font-size: 1.1rem;
+}
+
+.ease-otp__boxes {
+  display: flex;
+  justify-content: center;
+  gap: 0.6rem;
+  margin-bottom: 1.5rem;
+}
+
+.ease-otp__box {
+  width: 48px;
+  height: 56px;
+  text-align: center;
+  font-size: 1.4rem;
+  font-weight: 700;
+  border-radius: 10px;
+  border: 2px solid #2a2a3a;
+  background: #14141f;
+  color: #fff;
+  transition: border-color 0.25s ease, transform 0.2s ease, background 0.25s ease;
+}
+
+.ease-otp__box:focus {
+  outline: none;
+  border-color: #2575fc;
+  transform: translateY(-2px);
+}
+
+.ease-otp__box.is-filled {
+  border-color: #3b3b52;
+  background: #1a1a2a;
+}
+
+/* Staggered wave-in fill animation, used on paste */
+@keyframes ease-otp-wave-in {
+  0%   { transform: scale(0.85) translateY(6px); opacity: 0.4; }
+  60%  { transform: scale(1.08) translateY(-3px); opacity: 1; }
+  100% { transform: scale(1) translateY(0); opacity: 1; }
+}
+
+.ease-otp__box.wave-in {
+  animation: ease-otp-wave-in 0.35s ease-out;
+}
+
+/* Success state */
+.ease-otp__box.is-success {
+  border-color: #22c55e;
+  background: rgba(34, 197, 94, 0.1);
+  animation: ease-otp-wave-in 0.3s ease-out;
+}
+
+/* Error state: shake then the JS clears the value */
+.ease-otp__box.is-error {
+  border-color: #ef4444;
+  background: rgba(239, 68, 68, 0.08);
+}
+
+.ease-otp__box.shake {
+  animation: ease-otp-shake 0.4s ease;
+}
+
+@keyframes ease-otp-shake {
+  0%, 100% { transform: translateX(0); }
+  25%      { transform: translateX(-6px); }
+  75%      { transform: translateX(6px); }
+}
+
+.ease-otp__actions {
+  margin-bottom: 0.75rem;
+}
+
+.verify-btn {
+  padding: 0.7rem 1.4rem;
+  border: none;
+  border-radius: 8px;
+  background: #2575fc;
+  color: #fff;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.ease-otp__hint {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.4);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-otp__box {
+    transition: border-color 0.25s ease, background 0.25s ease;
+  }
+  .wave-in, .shake {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-otp-input`, a 6-digit OTP verification input with auto-advance, a staggered wave fill animation on paste, and a shake-then-clear error state. Closes #39675.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/ease-otp-input/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A 6-digit OTP input with auto-advancing focus, a staggered wave-fill animation on paste, success state stagger, and shake-then-clear error feedback.

**How does a developer use it?**

```html
<div class="ease-otp">
  <div class="ease-otp__boxes">
    <input class="ease-otp__box" maxlength="1" />
  </div>
</div>