### PR TITLE
feat: add scroll progress steps example

### DIFF
--- a/submissions/examples/scroll-progress-steps/README.md
+++ b/submissions/examples/scroll-progress-steps/README.md
@@ -1,0 +1,14 @@
+# Scroll Progress Steps
+
+A CSS-only progress step example for onboarding, checkout, or workflow screens.
+
+## What it demonstrates
+
+- visible complete and active step states
+- motion that reinforces progress without layout shifts
+- responsive timeline spacing and reduced-motion support
+
+## Files
+
+- `demo.html` - timeline markup
+- `style.css` - progress states, line, and motion styles

--- a/submissions/examples/scroll-progress-steps/demo.html
+++ b/submissions/examples/scroll-progress-steps/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scroll Progress Steps</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="timeline-panel" aria-labelledby="demo-title">
+      <p class="eyebrow">EaseMotion timeline example</p>
+      <h1 id="demo-title">Scroll progress steps</h1>
+      <p class="intro">
+        A responsive step tracker that uses motion to show the current stage without relying on color alone.
+      </p>
+
+      <ol class="progress-steps">
+        <li class="step is-complete">
+          <span class="marker">1</span>
+          <div>
+            <h2>Plan</h2>
+            <p>Define the user path and identify the next visible action.</p>
+          </div>
+        </li>
+        <li class="step is-active">
+          <span class="marker">2</span>
+          <div>
+            <h2>Build</h2>
+            <p>Ship the smallest polished interaction that proves the motion.</p>
+          </div>
+        </li>
+        <li class="step">
+          <span class="marker">3</span>
+          <div>
+            <h2>Review</h2>
+            <p>Check spacing, focus states, and reduced-motion behavior.</p>
+          </div>
+        </li>
+      </ol>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/scroll-progress-steps/style.css
+++ b/submissions/examples/scroll-progress-steps/style.css
@@ -1,0 +1,180 @@
+:root {
+  --page: #f4f7fb;
+  --surface: #ffffff;
+  --ink: #1f2937;
+  --muted: #64748b;
+  --line: #cbd5e1;
+  --complete: #0f766e;
+  --active: #2563eb;
+  --active-soft: rgba(37, 99, 235, 0.14);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background:
+    radial-gradient(circle at top left, rgba(15, 118, 110, 0.12), transparent 34%),
+    var(--page);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.demo-shell {
+  width: min(940px, calc(100vw - 32px));
+}
+
+.timeline-panel {
+  padding: 34px;
+  border: 1px solid rgba(100, 116, 139, 0.22);
+  border-radius: 20px;
+  background: var(--surface);
+  box-shadow: 0 24px 64px rgba(15, 23, 42, 0.14);
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--complete);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 14px;
+  font-size: clamp(2rem, 4vw, 3.4rem);
+  line-height: 1;
+}
+
+.intro {
+  max-width: 62ch;
+  margin-bottom: 30px;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.progress-steps {
+  position: relative;
+  display: grid;
+  gap: 16px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.progress-steps::before {
+  content: "";
+  position: absolute;
+  top: 30px;
+  bottom: 30px;
+  left: 29px;
+  width: 2px;
+  background: var(--line);
+}
+
+.step {
+  position: relative;
+  display: grid;
+  grid-template-columns: 60px 1fr;
+  gap: 16px;
+  align-items: start;
+  padding: 18px;
+  border: 1px solid rgba(100, 116, 139, 0.18);
+  border-radius: 16px;
+  background: #fbfdff;
+  transition:
+    transform 180ms ease,
+    border-color 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.marker {
+  position: relative;
+  z-index: 1;
+  width: 42px;
+  height: 42px;
+  display: grid;
+  place-items: center;
+  border: 2px solid var(--line);
+  border-radius: 50%;
+  background: var(--surface);
+  color: var(--muted);
+  font-weight: 900;
+  transition:
+    transform 180ms ease,
+    border-color 180ms ease,
+    background-color 180ms ease,
+    color 180ms ease;
+}
+
+.step h2 {
+  margin-bottom: 6px;
+  font-size: 1rem;
+}
+
+.step p {
+  margin-bottom: 0;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.step:hover,
+.step:focus-within,
+.step.is-active {
+  transform: translateX(6px);
+  border-color: rgba(37, 99, 235, 0.42);
+  box-shadow: 0 12px 30px rgba(37, 99, 235, 0.12);
+}
+
+.step.is-complete .marker {
+  border-color: var(--complete);
+  background: var(--complete);
+  color: #ffffff;
+}
+
+.step.is-active .marker {
+  border-color: var(--active);
+  background: var(--active-soft);
+  color: var(--active);
+  transform: scale(1.1);
+}
+
+@media (max-width: 640px) {
+  .timeline-panel {
+    padding: 24px;
+  }
+
+  .step {
+    grid-template-columns: 48px 1fr;
+    padding: 16px;
+  }
+
+  .progress-steps::before {
+    left: 23px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .step,
+  .marker {
+    transition: none;
+  }
+
+  .step:hover,
+  .step:focus-within,
+  .step.is-active {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only progress step timeline example
- include active and completed step states with layout-stable motion
- support responsive screens and reduced-motion users

## Testing
- git diff --cached --check
- npm test (known repo behavior: no matching test files for tests/**/*.test.js)