### PR TITLE
feat: add attention ribbon sweep example

### DIFF
--- a/submissions/examples/attention-ribbon-sweep/README.md
+++ b/submissions/examples/attention-ribbon-sweep/README.md
@@ -1,0 +1,14 @@
+# Attention Ribbon Sweep
+
+A CSS emphasis pattern for highlighting new features, release cards, or status banners.
+
+## What it demonstrates
+
+- animated ribbon shine with no JavaScript
+- reusable card sweep effect triggered by hover or keyboard focus
+- responsive card spacing and reduced-motion handling
+
+## Files
+
+- `demo.html` - card and ribbon demo
+- `style.css` - ribbon, sweep animation, and interaction states

--- a/submissions/examples/attention-ribbon-sweep/demo.html
+++ b/submissions/examples/attention-ribbon-sweep/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Attention Ribbon Sweep</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="feature-card" aria-labelledby="demo-title">
+      <span class="ribbon">New motion utility</span>
+      <p class="eyebrow">EaseMotion emphasis example</p>
+      <h1 id="demo-title">Attention ribbon sweep</h1>
+      <p class="intro">
+        A compact highlight ribbon for updates, offers, and status cards. Hover or focus the call-to-action to replay the sweep.
+      </p>
+      <a class="cta" href="#details">View details</a>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/attention-ribbon-sweep/style.css
+++ b/submissions/examples/attention-ribbon-sweep/style.css
@@ -1,0 +1,176 @@
+:root {
+  --page: #f6f8fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #667085;
+  --accent: #dc2626;
+  --accent-dark: #991b1b;
+  --gold: #fbbf24;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background:
+    linear-gradient(135deg, rgba(220, 38, 38, 0.10), transparent 36%),
+    var(--page);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.demo-shell {
+  width: min(820px, calc(100vw - 32px));
+}
+
+.feature-card {
+  position: relative;
+  overflow: hidden;
+  padding: 42px;
+  border: 1px solid rgba(23, 32, 51, 0.12);
+  border-radius: 20px;
+  background: var(--surface);
+  box-shadow: 0 24px 64px rgba(23, 32, 51, 0.14);
+}
+
+.feature-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(110deg, transparent 0%, rgba(251, 191, 36, 0.12) 45%, transparent 74%);
+  transform: translateX(-120%);
+  animation: card-sweep 2600ms ease-in-out infinite;
+  pointer-events: none;
+}
+
+.ribbon {
+  position: absolute;
+  top: 24px;
+  right: -42px;
+  width: 190px;
+  padding: 8px 12px;
+  background: var(--accent);
+  color: #ffffff;
+  font-size: 0.76rem;
+  font-weight: 900;
+  letter-spacing: 0.06em;
+  text-align: center;
+  text-transform: uppercase;
+  transform: rotate(35deg);
+  box-shadow: 0 8px 18px rgba(220, 38, 38, 0.28);
+}
+
+.ribbon::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(100deg, transparent 0%, rgba(255, 255, 255, 0.38) 50%, transparent 100%);
+  transform: translateX(-110%);
+  animation: ribbon-sweep 1800ms ease-in-out infinite;
+}
+
+.eyebrow {
+  position: relative;
+  margin: 0 0 10px;
+  color: var(--accent-dark);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  position: relative;
+  max-width: 12ch;
+  margin: 0;
+  font-size: clamp(2.2rem, 5vw, 4rem);
+  line-height: 0.95;
+}
+
+.intro {
+  position: relative;
+  max-width: 58ch;
+  margin: 18px 0 28px;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.65;
+}
+
+.cta {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  padding: 0 20px;
+  border: 0;
+  border-radius: 999px;
+  background: var(--ink);
+  color: #ffffff;
+  font-weight: 800;
+  text-decoration: none;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    background-color 180ms ease;
+}
+
+.cta:hover,
+.cta:focus-visible {
+  outline: none;
+  background: var(--accent-dark);
+  transform: translateY(-2px);
+  box-shadow: 0 14px 28px rgba(153, 27, 27, 0.22);
+}
+
+.feature-card:has(.cta:hover)::before,
+.feature-card:has(.cta:focus-visible)::before {
+  animation-duration: 1100ms;
+}
+
+@keyframes card-sweep {
+  0% {
+    transform: translateX(-120%);
+  }
+  48%,
+  100% {
+    transform: translateX(120%);
+  }
+}
+
+@keyframes ribbon-sweep {
+  0% {
+    transform: translateX(-110%);
+  }
+  55%,
+  100% {
+    transform: translateX(110%);
+  }
+}
+
+@media (max-width: 640px) {
+  .feature-card {
+    padding: 34px 24px;
+  }
+
+  .ribbon {
+    top: 18px;
+    right: -50px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .feature-card::before,
+  .ribbon::after {
+    animation: none;
+  }
+
+  .cta {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only attention ribbon sweep example
- include hover and keyboard-focus replay behavior
- support responsive layout and reduced-motion users

## Testing
- git diff --cached --check
- npm test (known repo behavior: no matching test files for tests/**/*.test.js)