### PR TITLE
feat(scss): add scroll snap mixin by hanan

### DIFF
--- a/submissions/scss/scroll-snap-mixin-hanan/README.md
+++ b/submissions/scss/scroll-snap-mixin-hanan/README.md
@@ -1,0 +1,24 @@
+# Reusable CSS Scroll Snap Mixins
+
+1. **What does this do?**  
+   Provides reusable SCSS mixins to configure CSS Scroll Snap properties on container and child items.
+
+2. **How is it used?**
+
+   ```scss
+   @use "scroll-snap" as ease;
+
+   .carousel-container {
+     @include ease.ease-scroll-snap-container(
+       $direction: x,
+       $strictness: mandatory
+     );
+   }
+
+   .carousel-item {
+     @include ease.ease-scroll-snap-item($align: center);
+   }
+   ```
+
+3. **Why is it useful?**  
+   It translates the framework's existing scroll snap utilities into SCSS, allowing developers using Sass to build responsive carousel components programmatically without cluttering markup.

--- a/submissions/scss/scroll-snap-mixin-hanan/_scroll-snap.scss
+++ b/submissions/scss/scroll-snap-mixin-hanan/_scroll-snap.scss
@@ -1,0 +1,36 @@
+// ============================================================
+// EaseMotion CSS — Scroll Snap SCSS Mixin
+// ============================================================
+
+/// Configures a parent element as a scroll snap container.
+/// @param {String} $direction - Snap direction: 'x', 'y', or 'both'
+/// @param {String} $strictness - Snap strictness: 'mandatory' or 'proximity'
+/// @param {String} $padding - Optional scroll padding value
+@mixin ease-scroll-snap-container(
+  $direction: x,
+  $strictness: mandatory,
+  $padding: null
+) {
+  scroll-snap-type: if($direction == both, both, #{$direction}) #{$strictness};
+  overflow-#{$direction}: auto;
+
+  @if $padding {
+    scroll-padding: $padding;
+  }
+
+  // Optimize mobile momentum scrolling
+  -webkit-overflow-scrolling: touch;
+}
+
+/// Configures a child element as a scroll snap item.
+/// @param {String} $align - Snap alignment: 'start', 'center', or 'end'
+/// @param {String} $stop - Snap stop: 'normal' or 'always'
+/// @param {String} $margin - Optional scroll margin value
+@mixin ease-scroll-snap-item($align: center, $stop: normal, $margin: null) {
+  scroll-snap-align: $align;
+  scroll-snap-stop: $stop;
+
+  @if $margin {
+    scroll-margin: $margin;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This Pull Request introduces a set of reusable SCSS mixins (`ease-scroll-snap-container` and `ease-scroll-snap-item`) under the SCSS track folder (`submissions/scss/scroll-snap-mixin-hanan/`) to configure CSS Scroll Snap properties.

Closes #39686 

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (Reusable SCSS Mixin Track)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/scss/scroll-snap-mixin-hanan/`)
- [x] Includes `_scroll-snap.scss` (SCSS Mixin Track requirement)
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

SCSS mixins to programmatically apply horizontal and vertical CSS Scroll Snap behaviors.

**How does a developer use it?**

```scss
@use 'scroll-snap' as ease;

.carousel-container {
  @include ease.ease-scroll-snap-container($direction: x, $strictness: mandatory);
}

.carousel-item {
  @include ease.ease-scroll-snap-item($align: center);
}

---
Why does it fit EaseMotion CSS?

It integrates the framework's existing scroll-snapping layout capabilities into the SCSS plugin layer, enabling Sass developers to generate snap properties dynamically using modular parameters.

---
## Demo

- [ ] N/A (SCSS Mixin Track: does not require demo.html)

---

## Browser Testing

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari 

---

## Notes for Maintainer

This submission belongs to the SCSS Track and is placed in submissions/scss/scroll-snap-mixin-hanan/ to follow the unique suffix naming rules. Feel free to adjust the naming or defaults as needed.

---

