### PR TITLE
feat(scss): add dynamic WCAG color contrast mixin by hanan

### DIFF
--- a/submissions/scss/color-contrast-mixin-hanan/README.md
+++ b/submissions/scss/color-contrast-mixin-hanan/README.md
@@ -1,0 +1,22 @@
+# Dynamic WCAG Color Contrast Mixin
+
+1. **What does this do?**  
+   Provides a SCSS function and mixin that calculates the relative luminance of a background color and automatically selects either a light or dark text color to ensure optimal readability.
+
+2. **How is it used?**
+
+   ```scss
+   @use "color-contrast" as ease;
+
+   .alert-banner-success {
+     // Automatically sets green background and calculates whether dark or light text has better contrast
+     @include ease.ease-contrast-text(#22c55e);
+   }
+
+   .alert-banner-dark {
+     @include ease.ease-contrast-text(#1e1b4b);
+   }
+   ```
+
+3. **Why is it useful?**  
+   Accessibility is a core design principle of EaseMotion CSS. This SCSS tool automates contrast compliance, saving developers from manually calculating contrast ratios for text elements on varied background colors.

--- a/submissions/scss/color-contrast-mixin-hanan/_color-contrast.scss
+++ b/submissions/scss/color-contrast-mixin-hanan/_color-contrast.scss
@@ -1,0 +1,70 @@
+// ============================================================
+// EaseMotion CSS — Dynamic WCAG Color Contrast Mixin
+// ============================================================
+@use "sass:math";
+
+/// Calculates the relative luminance of a single color channel (R, G, or B).
+/// Formula based on W3C WCAG 2.0 specifications.
+@function -ease-channel-luminance($value) {
+  $ratio: math.div($value, 255);
+  @if $ratio <= 0.03928 {
+    @return math.div($ratio, 12.92);
+  } @else {
+    @return math.pow(math.div($ratio + 0.055, 1.055), 2.4);
+  }
+}
+
+/// Calculates the relative luminance of a color.
+/// @param {Color} $color
+/// @return {Number} relative luminance value (0 to 1)
+@function ease-luminance($color) {
+  $r: -ease-channel-luminance(red($color));
+  $g: -ease-channel-luminance(green($color));
+  $b: -ease-channel-luminance(blue($color));
+  @return 0.2126 * $r + 0.7152 * $g + 0.0722 * $b;
+}
+
+/// Automatically selects light or dark text color based on background luminance
+/// to achieve the best contrast ratio.
+/// @param {Color} $background - Background color
+/// @param {Color} $light-text [#ffffff] - Light text choice
+/// @param {Color} $dark-text [#1e293b] - Dark text choice
+/// @return {Color} selected text color
+@function ease-contrast-color(
+  $background,
+  $light-text: #ffffff,
+  $dark-text: #1e293b
+) {
+  $bg-luminance: ease-luminance($background);
+  $light-luminance: ease-luminance($light-text);
+  $dark-luminance: ease-luminance($dark-text);
+
+  // Calculate contrast ratios: (L1 + 0.05) / (L2 + 0.05)
+  $ratio-light: math.div(
+    math.max($bg-luminance, $light-luminance) + 0.05,
+    math.min($bg-luminance, $light-luminance) + 0.05
+  );
+  $ratio-dark: math.div(
+    math.max($bg-luminance, $dark-luminance) + 0.05,
+    math.min($bg-luminance, $dark-luminance) + 0.05
+  );
+
+  @if $ratio-light >= $ratio-dark {
+    @return $light-text;
+  } @else {
+    @return $dark-text;
+  }
+}
+
+/// Applies a background color and the highest contrast text color automatically.
+/// @param {Color} $background - Background color to apply
+/// @param {Color} $light-text [#ffffff] - Light text fallback
+/// @param {Color} $dark-text [#1e293b] - Dark text fallback
+@mixin ease-contrast-text(
+  $background,
+  $light-text: #ffffff,
+  $dark-text: #1e293b
+) {
+  background-color: $background;
+  color: ease-contrast-color($background, $light-text, $dark-text);
+}


### PR DESCRIPTION
## Pull Request Description

This Pull Request introduces a dynamic WCAG-compliant color contrast auto-selector mixin and function under the SCSS track folder (`submissions/scss/color-contrast-mixin-hanan/`). It automatically determines whether a light or dark text color provides the best contrast ratio relative to a background color.

Closes #39705 

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (Reusable SCSS Mixin Track)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/scss/color-contrast-mixin-hanan/`)
- [x] Includes `_color-contrast.scss` (SCSS Mixin Track requirement)
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An automatic WCAG AA-compliant text color selector function and mixin that chooses high-contrast text color based on relative luminance.

**How does a developer use it?**

```scss
@use 'color-contrast' as ease;

.alert-success {
  // Automatically calculates text color contrast on a success green background
  @include ease.ease-contrast-text(#22c55e); 
}

.alert-dark {
  // Automatically calculates text color contrast on a dark navy background
  @include ease.ease-contrast-text(#1e1b4b);
}
```

**Why does it fit EaseMotion CSS?**

It integrates dynamic accessibility calculations into the SCSS layer. This directly aligns with the framework's "accessibility by default" core design philosophy.

---

## Demo

- [ ] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari 

---

## Notes for Maintainer

This submission belongs to the SCSS Track and is placed in submissions/scss/color-contrast-mixin-hanan/ to follow the unique suffix naming rules.

---
