### PR TITLE
feat: add prefers-color-scheme theme toggle demo

### DIFF
--- a/submissions/examples/prefers-color-scheme-theme-toggle-harshgupta492/README.md
+++ b/submissions/examples/prefers-color-scheme-theme-toggle-harshgupta492/README.md
@@ -1,0 +1,51 @@
+# Prefers Color Scheme Theme Toggle
+
+## Overview
+
+This example demonstrates how to respect the user's preferred operating system color scheme during the initial page load.
+
+If a theme preference has already been saved in `localStorage`, the saved value is used instead.
+
+---
+
+## Features
+
+- Automatically detects `prefers-color-scheme`
+- Falls back to system preference on first visit
+- Saves theme choice using `localStorage`
+- Manual light/dark theme toggle
+- Smooth CSS transitions
+- Pure HTML, CSS and JavaScript
+
+---
+
+## Folder Structure
+
+```
+prefers-color-scheme-theme-toggle-harshgupta492/
+│
+├── demo.html
+├── style.css
+└── README.md
+```
+
+---
+
+## How it Works
+
+1. Checks whether `em-theme` exists in `localStorage`.
+2. If found, applies the saved theme.
+3. Otherwise, detects the user's system preference using:
+
+```js
+window.matchMedia("(prefers-color-scheme: dark)")
+```
+
+4. Users can manually toggle themes.
+5. Their choice is saved for future visits.
+
+---
+
+## Why it Fits EaseMotion CSS
+
+This submission demonstrates a modern, animated theme-switching experience while respecting the user's system preferences. It showcases smooth transitions, CSS variables, and lightweight JavaScript in a reusable example.

--- a/submissions/examples/prefers-color-scheme-theme-toggle-harshgupta492/demo.html
+++ b/submissions/examples/prefers-color-scheme-theme-toggle-harshgupta492/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Prefers Color Scheme Theme Toggle</title>
+
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+    <div class="container">
+
+        <div class="card">
+
+            <h1>🌗 Smart Theme Demo</h1>
+
+            <p>
+                Automatically follows your operating system theme on first visit.
+                Once you choose a theme, your preference is remembered.
+            </p>
+
+            <button id="themeToggle">
+                Toggle Theme
+            </button>
+
+        </div>
+
+    </div>
+
+    <script>
+        const root = document.documentElement;
+        const toggleBtn = document.getElementById("themeToggle");
+
+        const savedTheme = localStorage.getItem("em-theme");
+
+        const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+
+        let currentTheme = savedTheme
+            ? savedTheme
+            : (prefersDark ? "dark" : "light");
+
+        applyTheme(currentTheme);
+
+        toggleBtn.addEventListener("click", () => {
+
+            currentTheme = currentTheme === "dark"
+                ? "light"
+                : "dark";
+
+            applyTheme(currentTheme);
+
+            localStorage.setItem("em-theme", currentTheme);
+
+        });
+
+        function applyTheme(theme) {
+
+            root.setAttribute("data-theme", theme);
+
+        }
+
+        window.matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", e => {
+
+                if (localStorage.getItem("em-theme")) return;
+
+                applyTheme(e.matches ? "dark" : "light");
+
+            });
+    </script>
+
+</body>
+
+</html>

--- a/submissions/examples/prefers-color-scheme-theme-toggle-harshgupta492/style.css
+++ b/submissions/examples/prefers-color-scheme-theme-toggle-harshgupta492/style.css
@@ -1,0 +1,137 @@
+:root {
+
+    --bg: #f5f5f5;
+    --card: #ffffff;
+    --text: #1f2937;
+    --button: #2563eb;
+    --buttonText: #fff;
+
+}
+
+[data-theme="dark"] {
+
+    --bg: #111827;
+    --card: #1f2937;
+    --text: #f9fafb;
+    --button: #38bdf8;
+    --buttonText: #111827;
+
+}
+
+* {
+
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+
+}
+
+body {
+
+    font-family: Arial, Helvetica, sans-serif;
+
+    background: var(--bg);
+
+    color: var(--text);
+
+    transition:
+        background .4s ease,
+        color .4s ease;
+
+    min-height: 100vh;
+
+    display: flex;
+
+    justify-content: center;
+
+    align-items: center;
+
+}
+
+.container {
+
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    padding: 30px;
+
+}
+
+.card {
+
+    width: 420px;
+
+    background: var(--card);
+
+    padding: 40px;
+
+    border-radius: 20px;
+
+    box-shadow:
+        0 15px 40px rgba(0, 0, 0, .15);
+
+    text-align: center;
+
+    transition:
+        background .4s ease,
+        transform .3s ease;
+
+}
+
+.card:hover {
+
+    transform: translateY(-8px);
+
+}
+
+h1 {
+
+    margin-bottom: 20px;
+
+}
+
+p {
+
+    line-height: 1.7;
+
+    margin-bottom: 30px;
+
+}
+
+button {
+
+    padding: 14px 28px;
+
+    border: none;
+
+    border-radius: 12px;
+
+    cursor: pointer;
+
+    background: var(--button);
+
+    color: var(--buttonText);
+
+    font-size: 16px;
+
+    transition:
+        transform .25s ease,
+        opacity .25s ease;
+
+}
+
+button:hover {
+
+    transform: scale(1.05);
+
+    opacity: .9;
+
+}
+
+button:active {
+
+    transform: scale(.96);
+
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a standalone example demonstrating automatic theme initialization using the browser's `prefers-color-scheme` media query, inspired by the discussion in **#39534**.

The example demonstrates:

* Automatic detection of the user's preferred color scheme on the first visit.
* Using a saved `localStorage` theme when available.
* Manual light/dark theme switching.
* Persistent theme preference.
* Smooth animated transitions.

**Related to #39534**

---

## Type of Change

* [ ] ✨ New animation / hover effect
* [x] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [x] Other (New example submission)

---

## Submission Checklist

* [x] All changes are inside `submissions/`
* [x] Includes `demo.html`
* [x] Includes `style.css`
* [x] Includes `README.md`
* [x] No changes to `core/`
* [x] No changes to `components/`
* [x] One feature per PR

---

## Feature Description

### What does this add?

A reusable theme-switching demo that respects the user's system color preference using `prefers-color-scheme` while allowing manual theme selection with persistent storage.

### How does a developer use it?

Open `demo.html` in any modern browser. The example automatically applies the preferred theme on first load and remembers future selections using `localStorage`.

### Why does it fit EaseMotion CSS?

It demonstrates a modern, reusable UI pattern combining CSS variables, smooth transitions, and browser-native theme detection for a polished user experience.

---

## Demo

* ✅ Tested locally
* ✅ No external dependencies

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [x] Safari

---

## Notes for Maintainer

This submission is completely self-contained under `submissions/examples/` and does not modify any existing project files.
