### PR TITLE
fix: announce bar slide-down entrance keyframe

### DIFF
--- a/submissions/docs/announce-bar-slide-down-fix-as/README.md
+++ b/submissions/docs/announce-bar-slide-down-fix-as/README.md
@@ -1,0 +1,19 @@
+# Announce Bar Slide-Down Entrance Fix
+
+### What does this do?
+
+It restores the intended slide-down entrance animation on the announce bar, which currently never plays.
+
+### How is it used?
+
+```html
+<div class="ease-announce-bar">
+  <span class="ease-announce-bar-content">Your message</span>
+</div>
+```
+
+### Why is it useful?
+
+`components/announce-bar.css` sets `animation: ease-slide-down 0.3s ease`, but the framework defines no `@keyframes ease-slide-down`. The matching keyframe is named `ease-kf-slide-down` (in `core/animations.css`), and `ease-slide-down` is only a utility class, not a keyframe. An `animation-name` that does not resolve to a keyframe is ignored, so the bar just appears with no entrance.
+
+This showcase uses the correct `ease-kf-slide-down` name so the bar slides in as intended. It also adds a `prefers-reduced-motion: reduce` guard so the entrance is disabled for users who prefer reduced motion, matching the animation-first and accessible philosophy of EaseMotion CSS.

--- a/submissions/docs/announce-bar-slide-down-fix-as/demo.html
+++ b/submissions/docs/announce-bar-slide-down-fix-as/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Announce Bar Slide-Down Entrance</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="ease-announce-bar">
+    <span class="ease-announce-bar-content">New release is live. The slide-down entrance now plays on load.</span>
+  </div>
+
+  <div class="ease-announce-bar is-success">
+    <span class="ease-announce-bar-content">Success variant</span>
+  </div>
+
+  <div class="ease-announce-bar is-warning">
+    <span class="ease-announce-bar-content">Warning variant</span>
+  </div>
+
+  <p style="padding: 1.5rem; font-family: system-ui, sans-serif;">
+    Reload the page to replay the slide-down entrance.
+  </p>
+</body>
+</html>

--- a/submissions/docs/announce-bar-slide-down-fix-as/style.css
+++ b/submissions/docs/announce-bar-slide-down-fix-as/style.css
@@ -1,0 +1,48 @@
+.ease-announce-bar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: #6c63ff;
+  color: #fff;
+  text-align: center;
+  font-size: 0.875rem;
+  animation: ease-kf-slide-down 0.3s ease both;
+}
+
+.ease-announce-bar-content {
+  flex: 1;
+  text-align: center;
+}
+
+.ease-announce-bar.is-success {
+  background: #10b981;
+}
+
+.ease-announce-bar.is-warning {
+  background: #f59e0b;
+}
+
+.ease-announce-bar.is-danger {
+  background: #ef4444;
+}
+
+@keyframes ease-kf-slide-down {
+  from {
+    opacity: 0;
+    transform: translate3d(0, -24px, 0);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-announce-bar {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a docs showcase demonstrating the fix for the announce bar entrance animation. `.ease-announce-bar` currently references `ease-slide-down`, which is not a defined keyframe, so the entrance never plays. The correct keyframe is `ease-kf-slide-down`. Closes #39954.

## Type of Change

- [x] Other (describe below)

Docs showcase demonstrating a core bug fix, submitted under `submissions/docs/` per the Core & Docs Showcase track, since core files are under the contribution freeze.

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A self-contained announce bar showcase whose entrance slide-down actually plays, using the correct `ease-kf-slide-down` keyframe, with a `prefers-reduced-motion` guard.

**How does a developer use it?**

```html
<div class="ease-announce-bar">
  <span class="ease-announce-bar-content">Your message</span>
</div>
```

**Why does it fit EaseMotion CSS?**
It restores an animation the framework already intends to ship and keeps it accessible, matching the animation-first philosophy.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

The underlying bug is in `components/announce-bar.css` (`animation: ease-slide-down` should be `ease-kf-slide-down`). Since core is frozen, this is submitted as a `submissions/docs/` showcase that demonstrates the corrected pattern. Verified in Chromium: the element receives `animation-name: ease-kf-slide-down` and the entrance plays.
