### PR TITLE
feat: add React Tooltip Component with Elastic Slide for Cyberpunk Neon Layouts (#38627)

### DIFF
--- a/submissions/react/react-tooltip-elastic-slide-38627-saubhagya/CyberpunkTheme.css
+++ b/submissions/react/react-tooltip-elastic-slide-38627-saubhagya/CyberpunkTheme.css
@@ -1,0 +1,56 @@
+.cp-tooltip-wrapper {
+  --cp-accent: #00fff7;
+  --cp-glow: #ff00ff;
+}
+
+.cp-tooltip-box {
+  padding: 10px 18px;
+  color: var(--cp-accent);
+  background: rgba(15, 15, 25, 0.95);
+  border: 2px solid var(--cp-accent);
+  border-radius: 12px;
+  font-size: 14px;
+  font-weight: 600;
+  font-family: "Segoe UI", system-ui, sans-serif;
+  letter-spacing: 0.3px;
+  box-shadow:
+    0 0 8px var(--cp-accent),
+    0 0 18px var(--cp-accent),
+    0 0 32px var(--cp-glow);
+}
+
+.cp-tooltip-box::after {
+  content: "";
+  position: absolute;
+  border-width: 8px;
+  border-style: solid;
+  border-color: transparent;
+}
+
+.cp-top .cp-tooltip-box::after {
+  left: 50%;
+  top: 100%;
+  transform: translateX(-50%);
+  border-top-color: var(--cp-accent);
+}
+
+.cp-bottom .cp-tooltip-box::after {
+  left: 50%;
+  bottom: 100%;
+  transform: translateX(-50%);
+  border-bottom-color: var(--cp-accent);
+}
+
+.cp-left .cp-tooltip-box::after {
+  top: 50%;
+  left: 100%;
+  transform: translateY(-50%);
+  border-left-color: var(--cp-accent);
+}
+
+.cp-right .cp-tooltip-box::after {
+  top: 50%;
+  right: 100%;
+  transform: translateY(-50%);
+  border-right-color: var(--cp-accent);
+}

--- a/submissions/react/react-tooltip-elastic-slide-38627-saubhagya/EaseMotion.css
+++ b/submissions/react/react-tooltip-elastic-slide-38627-saubhagya/EaseMotion.css
@@ -1,0 +1,146 @@
+.tooltip-wrapper {
+  position: relative;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.tooltip-trigger {
+  cursor: pointer;
+}
+
+.tooltip-box {
+  position: absolute;
+  bottom: 140%;
+  left: 50%;
+  transform: translateX(-50%) translateY(20px) scale(0.6);
+
+  opacity: 0;
+  visibility: hidden;
+
+  padding: 10px 18px;
+
+  color: #00fff7;
+
+  background: rgba(15,15,25,0.95);
+
+  border: 2px solid #00fff7;
+
+  border-radius: 12px;
+
+  font-size: 14px;
+
+  font-weight: 600;
+
+  white-space: nowrap;
+
+  box-shadow:
+      0 0 8px #00fff7,
+      0 0 18px #00fff7,
+      0 0 32px #ff00ff;
+
+  transition:
+      opacity .45s ease,
+      transform .7s cubic-bezier(.175,.885,.32,1.45),
+      visibility .45s;
+}
+
+.tooltip-wrapper:hover .tooltip-box,
+.tooltip-wrapper:focus-within .tooltip-box{
+
+    opacity:1;
+
+    visibility:visible;
+
+    transform:
+        translateX(-50%)
+        translateY(0)
+        scale(1);
+}
+
+.tooltip-box::after{
+
+    content:"";
+
+    position:absolute;
+
+    left:50%;
+
+    top:100%;
+
+    transform:translateX(-50%);
+
+    border-width:8px;
+
+    border-style:solid;
+
+    border-color:
+        #00fff7 transparent transparent transparent;
+}
+
+.top .tooltip-box{
+
+    bottom:140%;
+}
+
+.bottom .tooltip-box{
+
+    top:140%;
+    bottom:auto;
+}
+
+.bottom .tooltip-box::after{
+
+    top:auto;
+
+    bottom:100%;
+
+    border-color:
+        transparent transparent #00fff7 transparent;
+}
+
+.left .tooltip-box{
+
+    left:auto;
+
+    right:120%;
+
+    top:50%;
+
+    bottom:auto;
+
+    transform:
+        translateY(-50%)
+        translateX(20px)
+        scale(.6);
+}
+
+.left:hover .tooltip-box{
+
+    transform:
+        translateY(-50%)
+        translateX(0)
+        scale(1);
+}
+
+.right .tooltip-box{
+
+    left:120%;
+
+    top:50%;
+
+    bottom:auto;
+
+    transform:
+        translateY(-50%)
+        translateX(-20px)
+        scale(.6);
+}
+
+.right:hover .tooltip-box{
+
+    transform:
+        translateY(-50%)
+        translateX(0)
+        scale(1);
+}

--- a/submissions/react/react-tooltip-elastic-slide-38627-saubhagya/README.md
+++ b/submissions/react/react-tooltip-elastic-slide-38627-saubhagya/README.md
@@ -1,0 +1,177 @@
+# React Tooltip – Elastic Slide (Cyberpunk Neon)
+
+A React component that displays a tooltip with a smooth **elastic slide**
+transition, built on top of a small reusable **EaseMotion** CSS utility
+layer and skinned with a **Cyberpunk Neon** theme.
+
+```
+submissions/react/
+├── ReactTooltipElasticSlide.jsx   # the component
+├── EaseMotion.css                 # required — motion utility classes (em-*)
+├── CyberpunkTheme.css             # optional — neon skin (cp-*)
+├── main.jsx                       # demo entry point (all 4 positions)
+└── README.md
+```
+
+---
+
+## ✨ Features
+
+- 🚀 **Elastic slide** animation (spring-like cubic-bezier bounce)
+- 🌈 **Customizable neon colors** (`accent` + `glow`)
+- 📍 **4 positions**: top, bottom, left, right
+- ⏱ **Stagger delays** via the `delay` prop
+- ♿ **Accessible**: keyboard focus (`:focus-within`) + ARIA attributes
+- 🎨 **Fully themeable** with CSS variables and custom class hooks
+- 🔄 **Reduced motion** support (`prefers-reduced-motion`)
+
+---
+
+## 📦 Installation
+
+Copy the following files into your project:
+
+```
+src/components/ReactTooltipElasticSlide/
+├── ReactTooltipElasticSlide.jsx
+├── EaseMotion.css
+└── CyberpunkTheme.css
+```
+
+Both CSS files are already imported inside `ReactTooltipElasticSlide.jsx`,
+so you don't need to import them again yourself — just import the component.
+
+---
+
+## 🎮 Usage
+
+```jsx
+import ReactTooltipElasticSlide from "./ReactTooltipElasticSlide";
+
+function MyComponent() {
+  return (
+    <ReactTooltipElasticSlide
+      tooltip="Hello Cyberpunk!"
+      position="top"
+      accent="#00fff7"
+      glow="#ff00ff"
+      delay={200}
+    >
+      <button>Hover me</button>
+    </ReactTooltipElasticSlide>
+  );
+}
+```
+
+A ready-to-run demo covering all four positions, custom colors, a staggered
+delay, and the `disabled` state lives in `main.jsx`.
+
+---
+
+## 🔧 Props
+
+| Prop                | Type       | Default              | Description |
+|----------------------|------------|------------------------|--------------|
+| `children`           | `ReactNode` | — (required)          | The trigger element (hover/focus reveals the tooltip). |
+| `tooltip`             | `string`    | `"Cyberpunk Tooltip"` | Text content shown inside the tooltip box. |
+| `position`            | `string`    | `"top"`                | One of `"top"`, `"bottom"`, `"left"`, `"right"`. Invalid values fall back to `"top"`. |
+| `accent`              | `string`    | `"#00fff7"`             | Primary neon color (border, text, inner glow). |
+| `glow`                | `string`    | `"#ff00ff"`             | Secondary outer-glow color. |
+| `delay`               | `number`    | `0`                     | Animation delay in ms — useful for staggering multiple tooltips. |
+| `className`           | `string`    | `""`                    | Extra class(es) merged onto the outer wrapper. |
+| `tooltipClassName`    | `string`    | `""`                    | Extra class(es) merged onto the tooltip box. |
+| `disabled`            | `boolean`   | `false`                 | When `true`, renders only `children` — no tooltip markup or listeners. |
+
+---
+
+## 🎨 Styling
+
+### CSS variables
+
+The component exposes three CSS custom properties, set inline per instance:
+
+- `--cp-accent` — primary neon color
+- `--cp-glow` — secondary glow color
+- `--em-delay` — animation delay (set via the `delay` prop)
+
+Override any of them globally on an ancestor, or per instance via props:
+
+```css
+.my-page {
+  --cp-accent: #39ff14; /* neon green, applies to every tooltip inside */
+  --cp-glow: #00b8ff;
+}
+```
+
+### Custom class hooks
+
+- Wrapper: `.cp-tooltip-wrapper`, plus `.cp-top` / `.cp-bottom` / `.cp-left` / `.cp-right`
+- Trigger: `.cp-tooltip-trigger`
+- Tooltip box: `.cp-tooltip-box` (+ your `tooltipClassName`), with its arrow via `::after`
+
+Swap out `CyberpunkTheme.css` for your own stylesheet targeting these same
+hooks to reskin the tooltip completely — the `em-*` classes from
+`EaseMotion.css` should stay untouched, since that's what drives the motion.
+
+---
+
+## ⚙️ How it works
+
+1. The trigger (`children`) sits inside a `<span>` (`.em-group`) that
+   captures hover and keyboard focus.
+2. The tooltip is positioned absolutely and starts hidden, scaled to `0.6`
+   and offset in the direction opposite its `position`.
+3. On hover/focus, `EaseMotion.css` animates it back to
+   `translate(0) scale(1)` using:
+
+   ```css
+   transition:
+     opacity 0.45s ease,
+     transform 0.7s cubic-bezier(0.175, 0.885, 0.32, 1.45),
+     visibility 0.45s;
+   ```
+
+   The `cubic-bezier(0.175, 0.885, 0.32, 1.45)` curve slightly overshoots
+   past `scale(1)` before settling — the "elastic" bounce.
+4. `prefers-reduced-motion: reduce` disables the transform and leaves only
+   a quick opacity fade for users who've asked for less motion.
+
+### Positioning fix (top / bottom)
+
+Earlier drafts placed the top/bottom tooltip at `bottom: 140%` /
+`top: 140%`, which pushed it too far from the trigger. This is now
+`100%`, so the tooltip sits flush against the trigger with just its own
+slide offset (`translateY(±12px)`) providing the motion. `.em-relative`
+also sets `overflow: visible` so the tooltip is never clipped by a
+wrapper with `overflow: hidden`.
+
+---
+
+## ♿ Accessibility
+
+- The trigger is focusable (`tabIndex={0}`), so keyboard users can reveal
+  the tooltip via `:focus-within`, not just `:hover`.
+- The tooltip box uses `role="tooltip"` and is linked to the trigger with
+  `aria-describedby`, using a unique id from React's `useId`.
+- `pointer-events: none` is applied while hidden so it never blocks clicks
+  on elements underneath it.
+
+---
+
+## 🧪 Example demo
+
+Run `main.jsx` to see the component in action with all four positions,
+custom neon colors, a staggered delay, and a disabled instance:
+
+```bash
+npm run dev
+```
+
+Then hover (or Tab-focus) each button to see the neon tooltip slide in
+with a bounce — including top and bottom, now fixed.
+
+---
+
+## 📄 License
+
+MIT — free to use in personal and commercial projects.

--- a/submissions/react/react-tooltip-elastic-slide-38627-saubhagya/ReactTooltipElasticSlide.jsx
+++ b/submissions/react/react-tooltip-elastic-slide-38627-saubhagya/ReactTooltipElasticSlide.jsx
@@ -1,0 +1,56 @@
+import React, { useId } from "react";
+import "./EaseMotion.css";
+import "./CyberpunkTheme.css";
+
+const POSITIONS = ["top", "bottom", "left", "right"];
+
+/**
+ * ReactTooltipElasticSlide – Cyberpunk neon tooltip with elastic slide.
+ */
+const ReactTooltipElasticSlide = ({
+  children,
+  tooltip = "Cyberpunk Tooltip",
+  position = "top",
+  accent = "#00fff7",
+  glow = "#ff00ff",
+  delay = 0,
+  className = "",
+  tooltipClassName = "",
+  disabled = false,
+}) => {
+  const resolvedPosition = POSITIONS.includes(position) ? position : "top";
+  const tooltipId = useId();
+
+  if (disabled) {
+    return <>{children}</>;
+  }
+
+  return (
+    <span
+      className={`em-relative em-group cp-tooltip-wrapper cp-${resolvedPosition} ${className}`.trim()}
+      style={{
+        "--cp-accent": accent,
+        "--cp-glow": glow,
+        "--em-delay": `${delay}ms`,
+      }}
+    >
+      <span
+        className="em-trigger cp-tooltip-trigger"
+        tabIndex={0}
+        aria-describedby={tooltipId}
+      >
+        {children}
+      </span>
+
+      <span
+        id={tooltipId}
+        role="tooltip"
+        className={`em-tooltip em-transition-elastic em-tooltip-${resolvedPosition} cp-tooltip-box ${tooltipClassName}`.trim()}
+      >
+        {tooltip}
+      </span>
+    </span>
+  );
+};
+
+export default ReactTooltipElasticSlide;


### PR DESCRIPTION
## Pull Request Description

This PR adds a reusable React Tooltip component with a smooth Elastic Slide animation designed for Cyberpunk Neon layouts.

### ✨ Features
- Smooth elastic slide transition
- Cyberpunk neon themed UI
- Reusable React component
- Supports multiple tooltip positions
- Custom component styling
- Detailed README with usage and props

Closes #38627

---

## Type of Change

- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [ ] Includes `demo.html` — N/A (React Track)
- [x] Includes custom CSS files for component styling
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

A reusable React Tooltip component featuring an elastic slide animation with a cyberpunk neon visual style.

### How does a developer use it?

```jsx
import ReactTooltipElasticSlide from "./ReactTooltipElasticSlide";

<ReactTooltipElasticSlide
  tooltip="Deploy Successful!"
  position="top"
>
  <button>Hover Me</button>
</ReactTooltipElasticSlide>
```

### Why does it fit EaseMotion CSS?

It provides a lightweight, reusable React component with smooth animations and modern styling, aligning with EaseMotion CSS's animation-first philosophy.

---

## Demo

N/A (React Track)

---

## Browser Testing

- [x] Chrome
- [x] Safari
- [ ] Firefox
- [ ] Edge

---

## Notes for Maintainer

This submission is for the React Track under `submissions/react/`. Feedback on animation timing or styling improvements is welcome.