### PR TITLE
feat: add animated card hover stack

### DIFF
--- a/submissions/examples/card-hover-stack-as/README.md
+++ b/submissions/examples/card-hover-stack-as/README.md
@@ -1,0 +1,30 @@
+# Animated Card Hover Stack
+
+### What does this do?
+
+It presents a set of overlapping cards as a deck that fans out on hover, and brings any card to the front when it is clicked, using only CSS.
+
+### How is it used?
+
+```html
+<div class="card-stack">
+  <a class="stack-card card-1" id="card-1" href="#card-1">
+    <h3>Featured Project</h3>
+    <p>A CSS animation showcase</p>
+  </a>
+  <a class="stack-card card-2" id="card-2" href="#card-2">
+    <h3>Design System</h3>
+    <p>Component library</p>
+  </a>
+  <a class="stack-card card-3" id="card-3" href="#card-3">
+    <h3>Case Study</h3>
+    <p>UX research findings</p>
+  </a>
+</div>
+```
+
+Hovering the `.card-stack` fans the cards out with a spring easing. Each card is an anchor, so clicking it sets `:target` and lifts it above the others. No JavaScript is used.
+
+### Why is it useful?
+
+Card stacks present multiple items in a compact, tactile way that suits portfolio showcases, featured articles, or deal cards. This implementation leans on transforms, layered shadows, and a spring transition for a riffling feel, and it stays accessible: cards are keyboard focusable with a visible focus ring, and the animation is disabled under `prefers-reduced-motion: reduce`. That fits the animation-first philosophy of EaseMotion CSS.

--- a/submissions/examples/card-hover-stack-as/demo.html
+++ b/submissions/examples/card-hover-stack-as/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Card Hover Stack</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main>
+    <p class="hint">Hover the deck to fan the cards out. Click a card to bring it to the front.</p>
+    <div class="card-stack">
+      <a class="stack-card card-1" id="card-1" href="#card-1">
+        <h3>Featured Project</h3>
+        <p>A CSS animation showcase</p>
+      </a>
+      <a class="stack-card card-2" id="card-2" href="#card-2">
+        <h3>Design System</h3>
+        <p>Component library</p>
+      </a>
+      <a class="stack-card card-3" id="card-3" href="#card-3">
+        <h3>Case Study</h3>
+        <p>UX research findings</p>
+      </a>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/card-hover-stack-as/style.css
+++ b/submissions/examples/card-hover-stack-as/style.css
@@ -1,0 +1,110 @@
+:root {
+  --stack-radius: 16px;
+  --stack-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at 50% 0%, #1e293b, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #f8fafc;
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3rem;
+  padding: 4rem 1rem;
+}
+
+.hint {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #94a3b8;
+  text-align: center;
+}
+
+.card-stack {
+  position: relative;
+  width: 260px;
+  height: 320px;
+}
+
+.stack-card {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 0.35rem;
+  padding: 1.5rem;
+  border-radius: var(--stack-radius);
+  color: #fff;
+  text-decoration: none;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+  transition: transform 0.4s var(--stack-spring), box-shadow 0.4s ease;
+  will-change: transform;
+}
+
+.stack-card h3 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.stack-card p {
+  margin: 0;
+  font-size: 0.9rem;
+  opacity: 0.85;
+}
+
+.card-1 {
+  background: linear-gradient(135deg, #6c63ff, #4338ca);
+  transform: rotate(-3deg) translateY(0);
+  z-index: 3;
+}
+
+.card-2 {
+  background: linear-gradient(135deg, #0ea5e9, #0369a1);
+  transform: rotate(3deg) translateY(10px);
+  z-index: 2;
+}
+
+.card-3 {
+  background: linear-gradient(135deg, #10b981, #047857);
+  transform: rotate(-1deg) translateY(20px);
+  z-index: 1;
+}
+
+.card-stack:hover .card-1 {
+  transform: rotate(-6deg) translate(-64px, -24px) scale(1.03);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+}
+
+.card-stack:hover .card-2 {
+  transform: rotate(0deg) translateY(-8px) scale(1.02);
+}
+
+.card-stack:hover .card-3 {
+  transform: rotate(6deg) translate(64px, 8px) scale(1.01);
+}
+
+.stack-card:target {
+  transform: rotate(0deg) translateY(-16px) scale(1.06);
+  box-shadow: 0 22px 50px rgba(0, 0, 0, 0.5);
+  z-index: 4;
+}
+
+.stack-card:focus-visible {
+  outline: 3px solid #fbbf24;
+  outline-offset: 4px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stack-card {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an animated card hover stack example built to the request in #39387. Overlapping cards sit as a deck, fan out on hover with a spring easing, and any card lifts to the front when clicked, using only CSS. Closes #39387.

## Type of Change

- [x] ✨ New animation / hover effect

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A deck of overlapping cards that fans out on hover and brings a clicked card to the front via `:target`, with no JavaScript.

**How does a developer use it?**

```html
<div class="card-stack">
  <a class="stack-card card-1" id="card-1" href="#card-1">
    <h3>Featured Project</h3>
    <p>A CSS animation showcase</p>
  </a>
  <a class="stack-card card-2" id="card-2" href="#card-2">
    <h3>Design System</h3>
    <p>Component library</p>
  </a>
  <a class="stack-card card-3" id="card-3" href="#card-3">
    <h3>Case Study</h3>
    <p>UX research findings</p>
  </a>
</div>
```

**Why does it fit EaseMotion CSS?**
It is an all-CSS, animation-first pattern using transforms, layered shadows, and a spring transition. It stays accessible: cards are keyboard focusable with a visible focus ring, and motion is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Built to the spec in #39387 (deck layout, hover fan-out, `:target` click-to-front). Verified in Chromium: the top card transform changes on hover and the three cards fan out.
