### PR TITLE
feat: add animated steps process flow

### DIFF
--- a/submissions/examples/process-flow-steps-as/README.md
+++ b/submissions/examples/process-flow-steps-as/README.md
@@ -1,0 +1,32 @@
+# Animated Steps / Process Flow
+
+### What does this do?
+
+It shows a horizontal multi-step progress indicator where completed steps are highlighted, the current step pulses, future steps are dimmed, and the connecting lines fill in as steps complete.
+
+### How is it used?
+
+```html
+<div class="process-flow" role="list" aria-label="Checkout progress">
+  <div class="step completed" role="listitem">
+    <div class="step-circle" aria-hidden="true">1</div>
+    <span class="step-label">Cart</span>
+  </div>
+  <div class="step-line completed" aria-hidden="true"></div>
+  <div class="step active" role="listitem" aria-current="step">
+    <div class="step-circle" aria-hidden="true">2</div>
+    <span class="step-label">Checkout</span>
+  </div>
+  <div class="step-line" aria-hidden="true"></div>
+  <div class="step" role="listitem">
+    <div class="step-circle" aria-hidden="true">3</div>
+    <span class="step-label">Payment</span>
+  </div>
+</div>
+```
+
+Add `completed` to a step and the line before the next step to mark progress, and `active` with `aria-current="step"` to mark the current step.
+
+### Why is it useful?
+
+Step indicators are essential for checkout flows, onboarding wizards, and multi-step forms. This implementation adds a pulsing current step, a progressive line fill, and a staggered reveal, all in CSS with readable class names. It stays accessible with list semantics and `aria-current`, and all motion is disabled under `prefers-reduced-motion: reduce`, matching the animation-first philosophy of EaseMotion CSS.

--- a/submissions/examples/process-flow-steps-as/demo.html
+++ b/submissions/examples/process-flow-steps-as/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Steps / Process Flow</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="process-flow" role="list" aria-label="Checkout progress">
+    <div class="step completed" role="listitem">
+      <div class="step-circle" aria-hidden="true">1</div>
+      <span class="step-label">Cart</span>
+    </div>
+    <div class="step-line completed" aria-hidden="true"></div>
+    <div class="step active" role="listitem" aria-current="step">
+      <div class="step-circle" aria-hidden="true">2</div>
+      <span class="step-label">Checkout</span>
+    </div>
+    <div class="step-line" aria-hidden="true"></div>
+    <div class="step" role="listitem">
+      <div class="step-circle" aria-hidden="true">3</div>
+      <span class="step-label">Payment</span>
+    </div>
+    <div class="step-line" aria-hidden="true"></div>
+    <div class="step" role="listitem">
+      <div class="step-circle" aria-hidden="true">4</div>
+      <span class="step-label">Done</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/process-flow-steps-as/style.css
+++ b/submissions/examples/process-flow-steps-as/style.css
@@ -1,0 +1,124 @@
+:root {
+  --step-done: #22c55e;
+  --step-active: #6366f1;
+  --step-idle: #334155;
+  --step-track: #1e293b;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #0b1121;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.process-flow {
+  display: flex;
+  align-items: flex-start;
+  width: min(680px, 92vw);
+  padding: 2rem;
+}
+
+.step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.6rem;
+  flex: 0 0 auto;
+  opacity: 0;
+  animation: stepReveal 0.5s ease forwards;
+}
+
+.step:nth-child(1) { animation-delay: 0.05s; }
+.step:nth-child(3) { animation-delay: 0.2s; }
+.step:nth-child(5) { animation-delay: 0.35s; }
+.step:nth-child(7) { animation-delay: 0.5s; }
+
+.step-circle {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  background: var(--step-idle);
+  color: #94a3b8;
+  transition: background 0.4s ease, color 0.4s ease;
+}
+
+.step-label {
+  font-size: 0.8rem;
+  color: #94a3b8;
+  transition: color 0.4s ease;
+}
+
+.step.completed .step-circle {
+  background: var(--step-done);
+  color: #fff;
+}
+
+.step.completed .step-label {
+  color: #e2e8f0;
+}
+
+.step.active .step-circle {
+  background: var(--step-active);
+  color: #fff;
+  animation: stepPulse 1.8s ease-in-out infinite;
+}
+
+.step.active .step-label {
+  color: #fff;
+}
+
+.step-line {
+  flex: 1 1 auto;
+  height: 3px;
+  margin: 21px -2px 0;
+  border-radius: 2px;
+  background: var(--step-track);
+  position: relative;
+  overflow: hidden;
+}
+
+.step-line::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--step-done);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.6s ease 0.3s;
+}
+
+.step-line.completed::after {
+  transform: scaleX(1);
+}
+
+@keyframes stepReveal {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes stepPulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(99, 102, 241, 0.5); }
+  50% { box-shadow: 0 0 0 10px rgba(99, 102, 241, 0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .step {
+    opacity: 1;
+    animation: none;
+  }
+
+  .step.active .step-circle {
+    animation: none;
+  }
+
+  .step-line::after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an animated steps / process flow indicator built to the request in #39380. Completed steps are highlighted, the current step pulses, future steps are dimmed, and the connector line fills as steps complete. All CSS, no JavaScript. Closes #39380.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A horizontal multi-step progress indicator with completed, active, and future states, a pulsing current step, a progressive line fill, and a staggered reveal.

**How does a developer use it?**

```html
<div class="process-flow" role="list" aria-label="Checkout progress">
  <div class="step completed" role="listitem">
    <div class="step-circle" aria-hidden="true">1</div>
    <span class="step-label">Cart</span>
  </div>
  <div class="step-line completed" aria-hidden="true"></div>
  <div class="step active" role="listitem" aria-current="step">
    <div class="step-circle" aria-hidden="true">2</div>
    <span class="step-label">Checkout</span>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It turns a static progress indicator into a dynamic one using only transforms, transitions, and a pulse keyframe, with readable class names. It uses list semantics and `aria-current`, and disables motion under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Built to the spec in #39380. Verified in Chromium: the active step receives `animation-name: stepPulse` and the completed connector fills to `scaleX(1)`.
