### PR TITLE
feat: add live activity feed

### DIFF
--- a/submissions/examples/live-activity-feed-as/README.md
+++ b/submissions/examples/live-activity-feed-as/README.md
@@ -1,0 +1,32 @@
+# Live Activity Feed
+
+### What does this do?
+
+It shows a real-time style activity feed where each entry slides in from the right with a staggered delay, and the newest entry gets a brief highlight pulse.
+
+### How is it used?
+
+```html
+<div class="activity-feed" role="log" aria-label="Recent activity">
+  <div class="activity-item is-new">
+    <div class="activity-avatar avatar-a" aria-hidden="true">JD</div>
+    <div class="activity-content">
+      <strong>John</strong> liked your post
+      <span class="activity-time">just now</span>
+    </div>
+  </div>
+  <div class="activity-item">
+    <div class="activity-avatar avatar-b" aria-hidden="true">SM</div>
+    <div class="activity-content">
+      <strong>Sarah</strong> commented on your photo
+      <span class="activity-time">5m ago</span>
+    </div>
+  </div>
+</div>
+```
+
+Add `is-new` to the top entry to give it the highlight pulse. Each `activity-item` slides in with a per-item delay for a natural, cascading feel.
+
+### Why is it useful?
+
+Activity feeds are a core pattern in social apps, dashboards, and project tools. This implementation combines a staggered slide-in entrance with a highlight pulse for new items, using only CSS and readable class names. Avatars use initials so the demo is fully self contained, the feed uses a `log` role for assistive tech, and motion is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/live-activity-feed-as/demo.html
+++ b/submissions/examples/live-activity-feed-as/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Live Activity Feed</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="activity-feed" role="log" aria-label="Recent activity">
+    <div class="activity-item is-new">
+      <div class="activity-avatar avatar-a" aria-hidden="true">JD</div>
+      <div class="activity-content">
+        <strong>John</strong> liked your post
+        <span class="activity-time">just now</span>
+      </div>
+    </div>
+    <div class="activity-item">
+      <div class="activity-avatar avatar-b" aria-hidden="true">SM</div>
+      <div class="activity-content">
+        <strong>Sarah</strong> commented on your photo
+        <span class="activity-time">5m ago</span>
+      </div>
+    </div>
+    <div class="activity-item">
+      <div class="activity-avatar avatar-c" aria-hidden="true">AR</div>
+      <div class="activity-content">
+        <strong>Arjun</strong> started following you
+        <span class="activity-time">12m ago</span>
+      </div>
+    </div>
+    <div class="activity-item">
+      <div class="activity-avatar avatar-d" aria-hidden="true">ML</div>
+      <div class="activity-content">
+        <strong>Mia</strong> shared your project
+        <span class="activity-time">30m ago</span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/live-activity-feed-as/style.css
+++ b/submissions/examples/live-activity-feed-as/style.css
@@ -1,0 +1,100 @@
+:root {
+  --feed-bg: #111a2e;
+  --feed-border: #1e293b;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --accent: #6c63ff;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: var(--text);
+}
+
+.activity-feed {
+  width: min(420px, 94vw);
+  background: var(--feed-bg);
+  border: 1px solid var(--feed-border);
+  border-radius: 16px;
+  padding: 0.5rem;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.3);
+}
+
+.activity-item {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.9rem 1rem;
+  border-radius: 10px;
+  opacity: 0;
+  transform: translateX(24px);
+  animation: slideInRight 0.45s ease forwards;
+}
+
+.activity-item:nth-child(1) { animation-delay: 0.05s; }
+.activity-item:nth-child(2) { animation-delay: 0.2s; }
+.activity-item:nth-child(3) { animation-delay: 0.35s; }
+.activity-item:nth-child(4) { animation-delay: 0.5s; }
+
+.activity-item.is-new {
+  animation: slideInRight 0.45s ease forwards, newPulse 2s ease 0.5s;
+}
+
+.activity-avatar {
+  width: 40px;
+  height: 40px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.avatar-a { background: linear-gradient(135deg, #6c63ff, #4338ca); }
+.avatar-b { background: linear-gradient(135deg, #ec4899, #be185d); }
+.avatar-c { background: linear-gradient(135deg, #0ea5e9, #0369a1); }
+.avatar-d { background: linear-gradient(135deg, #10b981, #047857); }
+
+.activity-content {
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.activity-content strong {
+  color: #fff;
+}
+
+.activity-time {
+  display: block;
+  margin-top: 0.15rem;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+@keyframes slideInRight {
+  from { opacity: 0; transform: translateX(24px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes newPulse {
+  0% { background: rgba(108, 99, 255, 0.22); }
+  100% { background: transparent; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .activity-item,
+  .activity-item.is-new {
+    opacity: 1;
+    transform: none;
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a live activity feed built to the request in #39376. Each entry slides in from the right with a staggered delay, and the newest entry gets a brief highlight pulse. All CSS, no JavaScript and no external images. Closes #39376.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A vertical activity feed with staggered slide-in entries, colored initials avatars, action text and timestamps, and a highlight pulse on the newest item.

**How does a developer use it?**

```html
<div class="activity-feed" role="log" aria-label="Recent activity">
  <div class="activity-item is-new">
    <div class="activity-avatar avatar-a" aria-hidden="true">JD</div>
    <div class="activity-content">
      <strong>John</strong> liked your post
      <span class="activity-time">just now</span>
    </div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It combines staggered slide-in entrances with a highlight pulse using only transforms, transitions, and keyframes with readable class names. Avatars use initials so it is fully self contained, the feed uses a `log` role, and motion is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Built to the spec in #39376. The spec HTML referenced external avatar images, replaced with self contained initials avatars. Verified in Chromium: four entries, staggered slide-in settles and the newest item shows the highlight pulse.
