### PR TITLE
feat: add animated circular progress ring

### DIFF
--- a/submissions/examples/circular-progress-ring-as/README.md
+++ b/submissions/examples/circular-progress-ring-as/README.md
@@ -1,0 +1,23 @@
+# Animated Circular Progress Ring
+
+### What does this do?
+
+It shows circular progress rings drawn with SVG that animate their arc fill on load, with a percentage label in the center and a per-ring accent color.
+
+### How is it used?
+
+```html
+<div class="progress-ring" style="--value: 75; --ring-color: #6c63ff;" role="img" aria-label="Progress 75 percent">
+  <svg viewBox="0 0 120 120" aria-hidden="true">
+    <circle class="ring-track" cx="60" cy="60" r="52"></circle>
+    <circle class="ring-fill" cx="60" cy="60" r="52"></circle>
+  </svg>
+  <span class="ring-label">75%</span>
+</div>
+```
+
+Set `--value` to the percentage and `--ring-color` to the accent color. The fill offset is derived from `--value`, so the same CSS works for any value with no extra classes.
+
+### Why is it useful?
+
+Progress rings appear in dashboards, skill meters, fitness stats, and profile completeness widgets. This implementation animates the SVG stroke with a single keyframe and drives the fill from a custom property, so it stays composable and readable. The resting state already equals the final value, so under `prefers-reduced-motion: reduce` the ring simply shows its value without animating, and each ring exposes an accessible label.

--- a/submissions/examples/circular-progress-ring-as/demo.html
+++ b/submissions/examples/circular-progress-ring-as/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Circular Progress Ring</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="rings">
+    <div class="progress-ring" style="--value: 75; --ring-color: #6c63ff;" role="img" aria-label="Progress 75 percent">
+      <svg viewBox="0 0 120 120" aria-hidden="true">
+        <circle class="ring-track" cx="60" cy="60" r="52"></circle>
+        <circle class="ring-fill" cx="60" cy="60" r="52"></circle>
+      </svg>
+      <span class="ring-label">75%</span>
+    </div>
+
+    <div class="progress-ring" style="--value: 90; --ring-color: #10b981;" role="img" aria-label="Progress 90 percent">
+      <svg viewBox="0 0 120 120" aria-hidden="true">
+        <circle class="ring-track" cx="60" cy="60" r="52"></circle>
+        <circle class="ring-fill" cx="60" cy="60" r="52"></circle>
+      </svg>
+      <span class="ring-label">90%</span>
+    </div>
+
+    <div class="progress-ring" style="--value: 60; --ring-color: #ec4899;" role="img" aria-label="Progress 60 percent">
+      <svg viewBox="0 0 120 120" aria-hidden="true">
+        <circle class="ring-track" cx="60" cy="60" r="52"></circle>
+        <circle class="ring-fill" cx="60" cy="60" r="52"></circle>
+      </svg>
+      <span class="ring-label">60%</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/circular-progress-ring-as/style.css
+++ b/submissions/examples/circular-progress-ring-as/style.css
@@ -1,0 +1,67 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.rings {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 2.5rem;
+}
+
+.progress-ring {
+  position: relative;
+  width: 120px;
+  height: 120px;
+}
+
+.progress-ring svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.ring-track {
+  fill: none;
+  stroke: #1e293b;
+  stroke-width: 10;
+}
+
+.ring-fill {
+  fill: none;
+  stroke: var(--ring-color, #6c63ff);
+  stroke-width: 10;
+  stroke-linecap: round;
+  stroke-dasharray: 327;
+  stroke-dashoffset: calc(327 - 327 * (var(--value) / 100));
+  animation: ringFill 1.3s ease forwards;
+}
+
+.ring-label {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+@keyframes ringFill {
+  from {
+    stroke-dashoffset: 327;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ring-fill {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an animated circular progress ring built for #39962. Rings are drawn with SVG and fill their arc on load, driven by a `--value` custom property, with a centered percentage and a per-ring accent color. All CSS, no JavaScript. Closes #39962.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
SVG circular progress rings whose arc fills on load, with the fill amount driven by a `--value` custom property so one rule covers any percentage.

**How does a developer use it?**

```html
<div class="progress-ring" style="--value: 75; --ring-color: #6c63ff;" role="img" aria-label="Progress 75 percent">
  <svg viewBox="0 0 120 120" aria-hidden="true">
    <circle class="ring-track" cx="60" cy="60" r="52"></circle>
    <circle class="ring-fill" cx="60" cy="60" r="52"></circle>
  </svg>
  <span class="ring-label">75%</span>
</div>
```

**Why does it fit EaseMotion CSS?**
It animates an SVG stroke with a single keyframe and drives the value from a custom property, staying composable and readable. The resting state already equals the target, so under `prefers-reduced-motion: reduce` the ring shows its value without animating, and each ring exposes an accessible label.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the three rings settle to stroke-dashoffsets of 82, 33, and 131, matching 75, 90, and 60 percent.
