### PR TITLE
feat: add animated segmented toggle control

### DIFF
--- a/submissions/examples/segmented-toggle-as/README.md
+++ b/submissions/examples/segmented-toggle-as/README.md
@@ -1,0 +1,25 @@
+# Animated Segmented Toggle Control
+
+### What does this do?
+
+It is a segmented control whose highlight pill slides to the selected segment, built with native radio inputs so it works with no JavaScript and stays keyboard accessible.
+
+### How is it used?
+
+```html
+<div class="segmented" role="radiogroup" aria-label="Billing period">
+  <input type="radio" name="seg" id="seg-1" checked />
+  <label for="seg-1">Monthly</label>
+  <input type="radio" name="seg" id="seg-2" />
+  <label for="seg-2">Yearly</label>
+  <input type="radio" name="seg" id="seg-3" />
+  <label for="seg-3">Lifetime</label>
+  <span class="segmented-highlight" aria-hidden="true"></span>
+</div>
+```
+
+Each `input` is visually hidden and paired with a `label`. Selecting a segment moves the `.segmented-highlight` pill with a transform, and the checked label brightens.
+
+### Why is it useful?
+
+Segmented toggles are common for billing switches, view switchers, and filters. This turns the native `:checked` state into a smooth sliding animation using only a transform transition, so it needs no JavaScript. It uses a `radiogroup` role, keeps arrow-key navigation from native radios, shows a visible focus ring, and disables motion under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/segmented-toggle-as/demo.html
+++ b/submissions/examples/segmented-toggle-as/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Segmented Toggle Control</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="segmented" role="radiogroup" aria-label="Billing period">
+    <input type="radio" name="seg" id="seg-1" checked />
+    <label for="seg-1">Monthly</label>
+    <input type="radio" name="seg" id="seg-2" />
+    <label for="seg-2">Yearly</label>
+    <input type="radio" name="seg" id="seg-3" />
+    <label for="seg-3">Lifetime</label>
+    <span class="segmented-highlight" aria-hidden="true"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/segmented-toggle-as/style.css
+++ b/submissions/examples/segmented-toggle-as/style.css
@@ -1,0 +1,74 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.segmented {
+  position: relative;
+  display: flex;
+  padding: 5px;
+  border-radius: 999px;
+  background: #111a2e;
+  border: 1px solid #1e293b;
+}
+
+.segmented input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.segmented label {
+  position: relative;
+  z-index: 1;
+  flex: 1 1 0;
+  min-width: 96px;
+  padding: 0.6rem 1.25rem;
+  text-align: center;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #94a3b8;
+  cursor: pointer;
+  border-radius: 999px;
+  transition: color 0.3s ease;
+  user-select: none;
+}
+
+.segmented input:checked + label {
+  color: #fff;
+}
+
+.segmented input:focus-visible + label {
+  outline: 2px solid #fbbf24;
+  outline-offset: 2px;
+}
+
+.segmented-highlight {
+  position: absolute;
+  top: 5px;
+  left: 5px;
+  bottom: 5px;
+  width: calc((100% - 10px) / 3);
+  border-radius: 999px;
+  background: linear-gradient(135deg, #6c63ff, #4338ca);
+  box-shadow: 0 4px 12px rgba(108, 99, 255, 0.4);
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+#seg-1:checked ~ .segmented-highlight { transform: translateX(0); }
+#seg-2:checked ~ .segmented-highlight { transform: translateX(100%); }
+#seg-3:checked ~ .segmented-highlight { transform: translateX(200%); }
+
+@media (prefers-reduced-motion: reduce) {
+  .segmented-highlight,
+  .segmented label {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an animated segmented toggle control built for #39964. A highlight pill slides to the selected segment using native radio inputs and a transform transition, with no JavaScript. Closes #39964.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A segmented control whose highlight pill slides to the selected option, driven by native radio inputs so it needs no JavaScript.

**How does a developer use it?**

```html
<div class="segmented" role="radiogroup" aria-label="Billing period">
  <input type="radio" name="seg" id="seg-1" checked />
  <label for="seg-1">Monthly</label>
  <input type="radio" name="seg" id="seg-2" />
  <label for="seg-2">Yearly</label>
  <input type="radio" name="seg" id="seg-3" />
  <label for="seg-3">Lifetime</label>
  <span class="segmented-highlight" aria-hidden="true"></span>
</div>
```

**Why does it fit EaseMotion CSS?**
It turns the native `:checked` state into a smooth sliding animation using only a transform transition, staying composable and readable. It uses a `radiogroup` role, keeps native arrow-key navigation, shows a visible focus ring, and disables motion under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: selecting a segment moves the highlight pill via transform, and the control stays keyboard operable through the native radios.
