### PR TITLE
feat: add animated notification toast stack

### DIFF
--- a/submissions/examples/notification-toast-stack-as/README.md
+++ b/submissions/examples/notification-toast-stack-as/README.md
@@ -1,0 +1,26 @@
+# Animated Notification Toast Stack
+
+### What does this do?
+
+It shows a stack of toast notifications that slide in from the right with a staggered delay, each with a status icon, a title, a message, and a timer bar that depletes.
+
+### How is it used?
+
+```html
+<div class="toast-stack" role="status" aria-live="polite">
+  <div class="toast is-success">
+    <span class="toast-icon" aria-hidden="true"></span>
+    <div class="toast-body">
+      <strong>Saved</strong>
+      <span>Your changes were saved successfully.</span>
+    </div>
+    <span class="toast-timer" aria-hidden="true"></span>
+  </div>
+</div>
+```
+
+Use `is-success`, `is-error`, or `is-info` on a `.toast` to set its color and icon. Each toast slides in with a per-item delay and its timer bar shrinks to suggest an auto dismiss.
+
+### Why is it useful?
+
+Toasts are a universal feedback pattern. This implementation combines a slide-in entrance with a depleting timer bar using only transforms and a scale animation, with readable class names. Icons are drawn with CSS so the demo is self contained, the stack uses `aria-live="polite"` for assistive tech, and motion is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/notification-toast-stack-as/demo.html
+++ b/submissions/examples/notification-toast-stack-as/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Notification Toast Stack</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="toast-stack" role="status" aria-live="polite">
+    <div class="toast is-success">
+      <span class="toast-icon" aria-hidden="true"></span>
+      <div class="toast-body">
+        <strong>Saved</strong>
+        <span>Your changes were saved successfully.</span>
+      </div>
+      <span class="toast-timer" aria-hidden="true"></span>
+    </div>
+
+    <div class="toast is-error">
+      <span class="toast-icon" aria-hidden="true"></span>
+      <div class="toast-body">
+        <strong>Upload failed</strong>
+        <span>The file exceeds the size limit.</span>
+      </div>
+      <span class="toast-timer" aria-hidden="true"></span>
+    </div>
+
+    <div class="toast is-info">
+      <span class="toast-icon" aria-hidden="true"></span>
+      <div class="toast-body">
+        <strong>New update</strong>
+        <span>A new version is available.</span>
+      </div>
+      <span class="toast-timer" aria-hidden="true"></span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/notification-toast-stack-as/style.css
+++ b/submissions/examples/notification-toast-stack-as/style.css
@@ -1,0 +1,111 @@
+:root {
+  --toast-bg: #111a2e;
+  --toast-border: #1e293b;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: var(--text);
+}
+
+.toast-stack {
+  position: fixed;
+  top: 1.5rem;
+  right: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  width: min(340px, calc(100vw - 3rem));
+}
+
+.toast {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.85rem;
+  padding: 1rem 1rem 1.15rem;
+  border-radius: 12px;
+  background: var(--toast-bg);
+  border: 1px solid var(--toast-border);
+  border-left: 4px solid var(--toast-accent, #6c63ff);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+  transform: translateX(120%);
+  animation: toastIn 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+.toast:nth-child(2) { animation-delay: 0.15s; }
+.toast:nth-child(3) { animation-delay: 0.3s; }
+
+.toast.is-success { --toast-accent: #10b981; }
+.toast.is-error { --toast-accent: #ef4444; }
+.toast.is-info { --toast-accent: #0ea5e9; }
+
+.toast-icon {
+  flex-shrink: 0;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: 700;
+  background: var(--toast-accent, #6c63ff);
+}
+
+.toast.is-success .toast-icon::before { content: "\2713"; }
+.toast.is-error .toast-icon::before { content: "\2715"; }
+.toast.is-info .toast-icon::before { content: "i"; font-style: italic; font-family: Georgia, serif; }
+
+.toast-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  font-size: 0.88rem;
+}
+
+.toast-body strong {
+  color: #fff;
+}
+
+.toast-body span {
+  color: var(--muted);
+}
+
+.toast-timer {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  height: 3px;
+  width: 100%;
+  transform-origin: left;
+  background: var(--toast-accent, #6c63ff);
+  animation: toastTimer 4s linear forwards;
+}
+
+@keyframes toastIn {
+  to { transform: translateX(0); }
+}
+
+@keyframes toastTimer {
+  from { transform: scaleX(1); }
+  to { transform: scaleX(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .toast {
+    transform: translateX(0);
+    animation: none;
+  }
+
+  .toast-timer {
+    animation: none;
+    transform: scaleX(1);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an animated notification toast stack built for #39968. Toasts slide in from the right with a staggered delay, each with a status icon and a depleting timer bar. Success, error, and info variants. All CSS, no JavaScript. Closes #39968.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A corner toast stack with staggered slide-in entries, a status icon, and a timer bar that depletes, in success, error, and info variants.

**How does a developer use it?**

```html
<div class="toast-stack" role="status" aria-live="polite">
  <div class="toast is-success">
    <span class="toast-icon" aria-hidden="true"></span>
    <div class="toast-body">
      <strong>Saved</strong>
      <span>Your changes were saved successfully.</span>
    </div>
    <span class="toast-timer" aria-hidden="true"></span>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It combines a slide-in entrance with a depleting timer bar using only transforms and a scale animation with readable class names. Icons are CSS drawn so it is self contained, the stack uses `aria-live`, and motion is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: three toasts slide in to their resting position and the timer bars animate their scale.
