### PR TITLE
feat: add animated stat counter row

### DIFF
--- a/submissions/examples/stat-counter-row-as/README.md
+++ b/submissions/examples/stat-counter-row-as/README.md
@@ -1,0 +1,25 @@
+# Animated Stat Counter Row
+
+### What does this do?
+
+It shows a row of metric tiles whose numbers count up from zero on load, using only CSS, with a staggered entrance and an optional suffix per stat.
+
+### How is it used?
+
+```html
+<div class="stats-row">
+  <div class="stat">
+    <div class="stat-figure">
+      <span class="stat-value" style="--target: 1280;"></span>
+      <span class="stat-suffix">+</span>
+    </div>
+    <div class="stat-label">Active Users</div>
+  </div>
+</div>
+```
+
+Set `--target` on each `.stat-value` to the number it should count to. The count-up uses a registered `@property` custom property with `counter`, so it needs no JavaScript.
+
+### Why is it useful?
+
+Stat rows are common on dashboards and landing pages. This animates a registered custom property so the displayed number counts up, which is an advanced but readable CSS pattern. The resting value equals the target, so if a browser does not support `@property` or the user prefers reduced motion, the final number is shown without animating.

--- a/submissions/examples/stat-counter-row-as/demo.html
+++ b/submissions/examples/stat-counter-row-as/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Stat Counter Row</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="stats-row">
+    <div class="stat">
+      <div class="stat-figure">
+        <span class="stat-value" style="--target: 1280;"></span>
+        <span class="stat-suffix">+</span>
+      </div>
+      <div class="stat-label">Active Users</div>
+    </div>
+
+    <div class="stat">
+      <div class="stat-figure">
+        <span class="stat-value" style="--target: 96;"></span>
+        <span class="stat-suffix">%</span>
+      </div>
+      <div class="stat-label">Satisfaction</div>
+    </div>
+
+    <div class="stat">
+      <div class="stat-figure">
+        <span class="stat-value" style="--target: 42;"></span>
+      </div>
+      <div class="stat-label">Projects Shipped</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/stat-counter-row-as/style.css
+++ b/submissions/examples/stat-counter-row-as/style.css
@@ -1,0 +1,96 @@
+@property --num {
+  syntax: "<integer>";
+  inherits: false;
+  initial-value: 0;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 3rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.stats-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.5rem;
+  max-width: 760px;
+  width: 100%;
+}
+
+.stat {
+  padding: 1.75rem 1.5rem;
+  border-radius: 16px;
+  text-align: center;
+  background: #111a2e;
+  border: 1px solid #1e293b;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
+  opacity: 0;
+  transform: translateY(16px);
+  animation: statIn 0.5s ease forwards;
+}
+
+.stat:nth-child(2) { animation-delay: 0.12s; }
+.stat:nth-child(3) { animation-delay: 0.24s; }
+
+.stat-figure {
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: 0.1rem;
+  font-size: 2.6rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.stat-value {
+  --num: var(--target);
+
+  counter-reset: num var(--num);
+  animation: countUp 2s ease forwards;
+}
+
+.stat-value::after {
+  content: counter(num);
+}
+
+.stat-suffix {
+  color: #6c63ff;
+}
+
+.stat-label {
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  color: #94a3b8;
+}
+
+@keyframes statIn {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes countUp {
+  from {
+    --num: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stat {
+    opacity: 1;
+    transform: none;
+    animation: none;
+  }
+
+  .stat-value {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an animated stat counter row built for #39970. Numbers count up from zero on load using the CSS `@property` and `counter` technique, with a staggered tile entrance and an optional suffix. All CSS, no JavaScript. Closes #39970.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A row of metric tiles whose numbers count up to a target set with `--target`, using a registered custom property, with a staggered entrance.

**How does a developer use it?**

```html
<div class="stat">
  <div class="stat-figure">
    <span class="stat-value" style="--target: 1280;"></span>
    <span class="stat-suffix">+</span>
  </div>
  <div class="stat-label">Active Users</div>
</div>
```

**Why does it fit EaseMotion CSS?**
It animates a registered `@property` custom property so the number counts up with no JavaScript, an advanced but readable pattern. The resting value equals the target, so under `prefers-reduced-motion: reduce` or without `@property` support, the final number is shown without animating.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the three tiles count up and settle on 1280, 96, and 42.
