### PR TITLE
feat: add animated floating label input

### DIFF
--- a/submissions/examples/floating-label-input-as/README.md
+++ b/submissions/examples/floating-label-input-as/README.md
@@ -1,0 +1,20 @@
+# Animated Floating Label Input
+
+### What does this do?
+
+It provides form fields whose label sits inside the input and floats up above the field when the input is focused or filled, with an accent border on focus, using only CSS.
+
+### How is it used?
+
+```html
+<div class="field">
+  <input type="text" id="name" class="field-input" placeholder=" " />
+  <label for="name" class="field-label">Full name</label>
+</div>
+```
+
+The input needs `placeholder=" "` (a single space) so the `:placeholder-shown` state can tell whether it is empty. The label follows the input in the markup so it can react to `:focus` and `:not(:placeholder-shown)`.
+
+### Why is it useful?
+
+Forms are on almost every page, and floating labels save space while keeping the label visible after typing. This animates the label with a transform and color transition driven purely by input state, so it needs no JavaScript. The label keeps its association through `for`/`id`, the input shows a clear focus ring, and transitions are disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/floating-label-input-as/demo.html
+++ b/submissions/examples/floating-label-input-as/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Floating Label Input</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <form class="field-form" onsubmit="return false">
+    <div class="field">
+      <input type="text" id="name" class="field-input" placeholder=" " autocomplete="name" />
+      <label for="name" class="field-label">Full name</label>
+    </div>
+
+    <div class="field">
+      <input type="email" id="email" class="field-input" placeholder=" " autocomplete="email" />
+      <label for="email" class="field-label">Email address</label>
+    </div>
+
+    <div class="field">
+      <input type="password" id="password" class="field-input" placeholder=" " autocomplete="new-password" />
+      <label for="password" class="field-label">Password</label>
+    </div>
+
+    <button type="submit" class="field-submit">Create account</button>
+  </form>
+</body>
+</html>

--- a/submissions/examples/floating-label-input-as/style.css
+++ b/submissions/examples/floating-label-input-as/style.css
@@ -1,0 +1,102 @@
+:root {
+  --field-bg: #0e1626;
+  --field-border: #26324a;
+  --accent: #6c63ff;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: var(--text);
+}
+
+.field-form {
+  width: min(360px, 92vw);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 2rem;
+  border-radius: 16px;
+  background: #111a2e;
+  border: 1px solid #1e293b;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.3);
+}
+
+.field {
+  position: relative;
+}
+
+.field-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 1.3rem 0.9rem 0.5rem;
+  font-size: 0.95rem;
+  color: var(--text);
+  background: var(--field-bg);
+  border: 1px solid var(--field-border);
+  border-radius: 10px;
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.2);
+}
+
+.field-label {
+  position: absolute;
+  left: 0.95rem;
+  top: 50%;
+  transform: translateY(-50%);
+  transform-origin: left center;
+  color: var(--muted);
+  font-size: 0.95rem;
+  pointer-events: none;
+  transition: top 0.2s ease, transform 0.2s ease, color 0.2s ease;
+}
+
+.field-input:focus + .field-label,
+.field-input:not(:placeholder-shown) + .field-label {
+  top: 0.5rem;
+  transform: translateY(0) scale(0.78);
+  color: var(--accent);
+}
+
+.field-submit {
+  margin-top: 0.25rem;
+  padding: 0.8rem 1rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #fff;
+  background: var(--accent);
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.field-submit:hover {
+  background: #574fe0;
+}
+
+.field-submit:focus-visible {
+  outline: 2px solid #fbbf24;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .field-input,
+  .field-label,
+  .field-submit {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an animated floating label input built for #39972. Labels sit inside the field and float up when the input is focused or filled, with an accent focus border, using only CSS. Closes #39972.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
Form fields whose label floats above the input on focus or when filled, with an accent focus border, driven purely by input state.

**How does a developer use it?**

```html
<div class="field">
  <input type="text" id="name" class="field-input" placeholder=" " />
  <label for="name" class="field-label">Full name</label>
</div>
```

**Why does it fit EaseMotion CSS?**
It animates the label with a transform and color transition using `:placeholder-shown` and `:focus`, so it needs no JavaScript. The label keeps its `for`/`id` association, the input has a clear focus ring, and transitions are disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the label scales from 1 to 0.78 and lifts when the field is focused or filled.
