### PR TITLE
feat: add animated theme toggle switch

### DIFF
--- a/submissions/examples/theme-toggle-switch-as/README.md
+++ b/submissions/examples/theme-toggle-switch-as/README.md
@@ -1,0 +1,21 @@
+# Animated Theme Toggle Switch
+
+### What does this do?
+
+It is a toggle switch whose knob slides and morphs from a crescent moon to a sun, and re-themes a preview panel from dark to light, using only CSS.
+
+### How is it used?
+
+```html
+<input type="checkbox" id="theme-input" class="theme-input" aria-label="Toggle light mode" />
+<label for="theme-input" class="theme-track">
+  <span class="theme-knob" aria-hidden="true"></span>
+</label>
+<div class="theme-preview">Preview content</div>
+```
+
+The checkbox, the track label, and the preview are siblings, so `:checked` can both move the knob (adjacent sibling) and re-theme the preview (general sibling). The moon shape is drawn with an inset box-shadow and becomes a glowing sun when checked.
+
+### Why is it useful?
+
+A theme switch is a common control. This animates the knob and swaps the panel colors with only transforms and color transitions driven by `:checked`, so it needs no JavaScript. The checkbox stays keyboard operable with a focus ring, and transitions are disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/theme-toggle-switch-as/demo.html
+++ b/submissions/examples/theme-toggle-switch-as/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Theme Toggle Switch</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="theme-demo">
+    <input type="checkbox" id="theme-input" class="theme-input" aria-label="Toggle light mode" />
+    <label for="theme-input" class="theme-track">
+      <span class="theme-knob" aria-hidden="true"></span>
+    </label>
+    <div class="theme-preview">
+      <h3>Preview panel</h3>
+      <p>Flip the switch to preview the light and dark themes with a smooth transition.</p>
+      <button class="preview-btn" type="button">Get started</button>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/theme-toggle-switch-as/style.css
+++ b/submissions/examples/theme-toggle-switch-as/style.css
@@ -1,0 +1,107 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.theme-demo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.theme-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.theme-track {
+  display: inline-flex;
+  align-items: center;
+  width: 60px;
+  height: 32px;
+  padding: 4px;
+  border-radius: 999px;
+  background: #1e293b;
+  cursor: pointer;
+  transition: background 0.3s ease;
+}
+
+.theme-knob {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: transparent;
+  box-shadow: inset -6px -3px 0 0 #cbd5e1;
+  transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1),
+    background 0.3s ease, box-shadow 0.3s ease;
+}
+
+.theme-input:checked + .theme-track {
+  background: #7dd3fc;
+}
+
+.theme-input:checked + .theme-track .theme-knob {
+  transform: translateX(28px);
+  background: #fbbf24;
+  box-shadow: 0 0 8px 2px rgba(251, 191, 36, 0.6);
+}
+
+.theme-input:focus-visible + .theme-track {
+  outline: 2px solid #fbbf24;
+  outline-offset: 3px;
+}
+
+.theme-preview {
+  width: min(320px, 88vw);
+  padding: 1.75rem;
+  border-radius: 16px;
+  background: #111a2e;
+  color: #e2e8f0;
+  border: 1px solid #1e293b;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.3);
+  transition: background 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+}
+
+.theme-preview h3 {
+  margin: 0 0 0.5rem;
+}
+
+.theme-preview p {
+  margin: 0 0 1.25rem;
+  font-size: 0.9rem;
+  opacity: 0.8;
+}
+
+.preview-btn {
+  padding: 0.6rem 1.1rem;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: #fff;
+  background: #6c63ff;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.theme-input:checked ~ .theme-preview {
+  background: #f8fafc;
+  color: #0b1121;
+  border-color: #e2e8f0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .theme-knob,
+  .theme-track,
+  .theme-preview {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an animated theme toggle switch built for #39976. The knob slides and morphs from a moon to a sun and re-themes a preview panel from dark to light, using only CSS. Closes #39976.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A toggle switch whose knob morphs from a crescent moon to a sun and re-themes a preview panel between dark and light.

**How does a developer use it?**

```html
<input type="checkbox" id="theme-input" class="theme-input" aria-label="Toggle light mode" />
<label for="theme-input" class="theme-track">
  <span class="theme-knob" aria-hidden="true"></span>
</label>
<div class="theme-preview">Preview content</div>
```

**Why does it fit EaseMotion CSS?**
It animates the knob and swaps the panel colors with only transforms and color transitions driven by `:checked`, so it needs no JavaScript. The checkbox stays keyboard operable with a focus ring, and transitions are disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: toggling slides the knob by 28px to the sun and the preview background changes from dark to light.
