### PR TITLE
feat: add animated faq accordion

### DIFF
--- a/submissions/examples/faq-accordion-as/README.md
+++ b/submissions/examples/faq-accordion-as/README.md
@@ -1,0 +1,23 @@
+# Animated FAQ Accordion
+
+### What does this do?
+
+It shows an accessible FAQ list where each question expands to reveal its answer, with a chevron that rotates and an answer that fades in, using only HTML and CSS.
+
+### How is it used?
+
+```html
+<details class="faq-item">
+  <summary class="faq-question">
+    How do I install it?
+    <span class="faq-chevron" aria-hidden="true"></span>
+  </summary>
+  <div class="faq-answer">Link one CSS file and start using the classes.</div>
+</details>
+```
+
+Each item is a native `<details>` element, so opening and closing, keyboard support, and screen reader semantics come for free. Add the `open` attribute to any item you want expanded by default.
+
+### Why is it useful?
+
+FAQ sections are common on landing and support pages. Building on `<details>` keeps the disclosure accessible by default, and this adds a chevron rotation and a reveal animation with only transitions and a keyframe, so it needs no JavaScript. The chevron is drawn with CSS borders, the summary shows a focus ring, and the reveal animation is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/faq-accordion-as/demo.html
+++ b/submissions/examples/faq-accordion-as/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated FAQ Accordion</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="faq">
+    <details class="faq-item" open>
+      <summary class="faq-question">
+        How do I install EaseMotion CSS?
+        <span class="faq-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="faq-answer">Link one CSS file in your page head and start applying the readable class names. There is no build step required.</div>
+    </details>
+
+    <details class="faq-item">
+      <summary class="faq-question">
+        Does it need JavaScript?
+        <span class="faq-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="faq-answer">No. The animations and components work with pure CSS, so they run without any JavaScript.</div>
+    </details>
+
+    <details class="faq-item">
+      <summary class="faq-question">
+        Is it accessible?
+        <span class="faq-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="faq-answer">Yes. This FAQ uses native details and summary elements, so keyboard and screen reader support come for free.</div>
+    </details>
+
+    <details class="faq-item">
+      <summary class="faq-question">
+        Can I use it with any framework?
+        <span class="faq-chevron" aria-hidden="true"></span>
+      </summary>
+      <div class="faq-answer">Yes. Because it is plain CSS and markup, it works with React, Vue, Svelte, or plain HTML.</div>
+    </details>
+  </div>
+</body>
+</html>

--- a/submissions/examples/faq-accordion-as/style.css
+++ b/submissions/examples/faq-accordion-as/style.css
@@ -1,0 +1,106 @@
+:root {
+  --card-bg: #111a2e;
+  --border: #1e293b;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --accent: #6c63ff;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 3rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: var(--text);
+}
+
+.faq {
+  width: min(560px, 94vw);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.faq-item {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--card-bg);
+  overflow: hidden;
+}
+
+.faq-question {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.1rem 1.25rem;
+  font-size: 0.98rem;
+  font-weight: 600;
+  cursor: pointer;
+  list-style: none;
+  transition: color 0.2s ease;
+}
+
+.faq-question::-webkit-details-marker {
+  display: none;
+}
+
+.faq-question:hover {
+  color: #fff;
+}
+
+.faq-item[open] .faq-question {
+  color: #fff;
+}
+
+.faq-chevron {
+  flex-shrink: 0;
+  width: 9px;
+  height: 9px;
+  border-right: 2px solid var(--muted);
+  border-bottom: 2px solid var(--muted);
+  transform: rotate(45deg);
+  transition: transform 0.3s ease, border-color 0.2s ease;
+}
+
+.faq-item[open] .faq-chevron {
+  transform: rotate(-135deg);
+  border-color: var(--accent);
+}
+
+.faq-answer {
+  padding: 0 1.25rem 1.2rem;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: var(--muted);
+}
+
+.faq-item[open] .faq-answer {
+  animation: faqReveal 0.3s ease;
+}
+
+.faq-question:focus-visible {
+  outline: 2px solid #fbbf24;
+  outline-offset: -2px;
+}
+
+@keyframes faqReveal {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .faq-chevron {
+    transition: none;
+  }
+
+  .faq-item[open] .faq-answer {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an accessible animated FAQ accordion built for #39978. Each item is a native `<details>` element, so opening, keyboard, and screen reader support come for free, with a rotating chevron and a fade-in answer. Closes #39978.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
An FAQ list built on `<details>` and `<summary>` with a chevron that rotates on open and an answer that fades in.

**How does a developer use it?**

```html
<details class="faq-item">
  <summary class="faq-question">
    How do I install it?
    <span class="faq-chevron" aria-hidden="true"></span>
  </summary>
  <div class="faq-answer">Link one CSS file and start using the classes.</div>
</details>
```

**Why does it fit EaseMotion CSS?**
It keeps the native disclosure accessible and adds a chevron rotation and reveal animation with only transitions and a keyframe, so it needs no JavaScript. The chevron is CSS drawn, the summary shows a focus ring, and the reveal is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the open item shows its answer with the chevron rotated, and closed items keep the down chevron.
