### PR TITLE
feat: add animated tabs with sliding indicator

### DIFF
--- a/submissions/examples/animated-tabs-as/README.md
+++ b/submissions/examples/animated-tabs-as/README.md
@@ -1,0 +1,29 @@
+# Animated Tabs with Sliding Indicator
+
+### What does this do?
+
+It is a tabbed panel where selecting a tab slides an underline indicator to it and fades in the matching content, using only CSS.
+
+### How is it used?
+
+```html
+<div class="tabs">
+  <input type="radio" name="tab" id="tab-1" class="tab-input" checked />
+  <input type="radio" name="tab" id="tab-2" class="tab-input" />
+  <div class="tab-list">
+    <label for="tab-1" class="tab-label">Overview</label>
+    <label for="tab-2" class="tab-label">Features</label>
+    <span class="tab-indicator" aria-hidden="true"></span>
+  </div>
+  <div class="tab-panels">
+    <div class="tab-panel"><h3>Overview</h3><p>...</p></div>
+    <div class="tab-panel"><h3>Features</h3><p>...</p></div>
+  </div>
+</div>
+```
+
+The radio inputs, the tab list, and the panels are siblings, so `:checked` can move the indicator and show the matching panel. All radios share one `name`, so only one tab is active at a time.
+
+### Why is it useful?
+
+Tabs organize content into panels without extra pages. This moves a sliding indicator and fades panels with only transforms and transitions driven by `:checked`, so it needs no JavaScript. The radios keep native keyboard navigation, the tab list shows a focus ring, and the panel animation is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/animated-tabs-as/demo.html
+++ b/submissions/examples/animated-tabs-as/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Tabs with Sliding Indicator</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="tabs">
+    <input type="radio" name="tab" id="tab-1" class="tab-input" checked />
+    <input type="radio" name="tab" id="tab-2" class="tab-input" />
+    <input type="radio" name="tab" id="tab-3" class="tab-input" />
+
+    <div class="tab-list">
+      <label for="tab-1" class="tab-label">Overview</label>
+      <label for="tab-2" class="tab-label">Features</label>
+      <label for="tab-3" class="tab-label">Pricing</label>
+      <span class="tab-indicator" aria-hidden="true"></span>
+    </div>
+
+    <div class="tab-panels">
+      <div class="tab-panel">
+        <h3>Overview</h3>
+        <p>EaseMotion CSS gives you readable, animation-first class names so you can build polished interfaces without a build step.</p>
+      </div>
+      <div class="tab-panel">
+        <h3>Features</h3>
+        <p>Entrance animations, hover effects, and components, all composable and driven by pure CSS with no JavaScript required.</p>
+      </div>
+      <div class="tab-panel">
+        <h3>Pricing</h3>
+        <p>The framework is open source and free to use. Link one stylesheet and start applying the classes right away.</p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/animated-tabs-as/style.css
+++ b/submissions/examples/animated-tabs-as/style.css
@@ -1,0 +1,128 @@
+:root {
+  --card-bg: #111a2e;
+  --border: #1e293b;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --accent: #6c63ff;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: var(--text);
+}
+
+.tabs {
+  width: min(480px, 94vw);
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.tab-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.tab-list {
+  position: relative;
+  display: flex;
+  border-bottom: 1px solid var(--border);
+}
+
+.tab-label {
+  flex: 1 1 0;
+  padding: 1rem 0.5rem;
+  text-align: center;
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: var(--muted);
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.tab-label:hover {
+  color: var(--text);
+}
+
+.tab-indicator {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: calc(100% / 3);
+  height: 3px;
+  background: var(--accent);
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+#tab-1:checked ~ .tab-list .tab-label:nth-child(1),
+#tab-2:checked ~ .tab-list .tab-label:nth-child(2),
+#tab-3:checked ~ .tab-list .tab-label:nth-child(3) {
+  color: #fff;
+}
+
+#tab-2:checked ~ .tab-list .tab-indicator {
+  transform: translateX(100%);
+}
+
+#tab-3:checked ~ .tab-list .tab-indicator {
+  transform: translateX(200%);
+}
+
+.tab-input:focus-visible ~ .tab-list {
+  outline: 2px solid #fbbf24;
+  outline-offset: -2px;
+}
+
+.tab-panels {
+  padding: 1.5rem;
+}
+
+.tab-panel {
+  display: none;
+}
+
+.tab-panel h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.05rem;
+}
+
+.tab-panel p {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: var(--muted);
+}
+
+#tab-1:checked ~ .tab-panels .tab-panel:nth-child(1),
+#tab-2:checked ~ .tab-panels .tab-panel:nth-child(2),
+#tab-3:checked ~ .tab-panels .tab-panel:nth-child(3) {
+  display: block;
+  animation: panelIn 0.3s ease;
+}
+
+@keyframes panelIn {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tab-indicator {
+    transition: none;
+  }
+
+  .tab-panel {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds animated tabs with a sliding indicator built for #39980. Selecting a tab slides an underline indicator and fades in the matching content panel, using radio inputs with no JavaScript. Closes #39980.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A tabbed panel with a sliding underline indicator and fade-in content, driven by radio inputs.

**How does a developer use it?**

```html
<div class="tabs">
  <input type="radio" name="tab" id="tab-1" class="tab-input" checked />
  <input type="radio" name="tab" id="tab-2" class="tab-input" />
  <div class="tab-list">
    <label for="tab-1" class="tab-label">Overview</label>
    <label for="tab-2" class="tab-label">Features</label>
    <span class="tab-indicator" aria-hidden="true"></span>
  </div>
  <div class="tab-panels">
    <div class="tab-panel"><h3>Overview</h3><p>...</p></div>
    <div class="tab-panel"><h3>Features</h3><p>...</p></div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It moves the indicator and swaps panels with only transforms and transitions driven by `:checked`, so it needs no JavaScript. The radios keep native keyboard navigation, the tab list shows a focus ring, and the panel animation is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: selecting a tab shows only its panel and slides the indicator to that tab.
