### PR TITLE
feat: add animated tooltip

### DIFF
--- a/submissions/examples/animated-tooltip-as/README.md
+++ b/submissions/examples/animated-tooltip-as/README.md
@@ -1,0 +1,20 @@
+# Animated Tooltip
+
+### What does this do?
+
+It shows tooltips that fade and slide into place when a trigger is hovered or focused, with a small arrow pointing at the trigger and support for top and bottom placement.
+
+### How is it used?
+
+```html
+<span class="tooltip">
+  <button class="tooltip-trigger" type="button">Save</button>
+  <span class="tooltip-text" role="tooltip">Save your changes</span>
+</span>
+```
+
+Wrap a trigger and a `.tooltip-text` in a `.tooltip`. Add `is-bottom` to place the tooltip below the trigger instead of above. The tooltip reveals on `:hover` and on `:focus-within`, so it also appears for keyboard users.
+
+### Why is it useful?
+
+Tooltips give quick hints on controls and icons. This reveals the tooltip with a fade and slide using only a transition, so it needs no JavaScript. It appears on keyboard focus as well as hover, uses `role="tooltip"`, and the transition is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/animated-tooltip-as/demo.html
+++ b/submissions/examples/animated-tooltip-as/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Tooltip</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="tooltip-demo">
+    <span class="tooltip">
+      <button class="tooltip-trigger" type="button">Save</button>
+      <span class="tooltip-text" role="tooltip">Save your changes</span>
+    </span>
+
+    <span class="tooltip is-bottom">
+      <button class="tooltip-trigger" type="button">Settings</button>
+      <span class="tooltip-text" role="tooltip">Open settings</span>
+    </span>
+
+    <span class="tooltip">
+      <button class="tooltip-trigger" type="button">Delete</button>
+      <span class="tooltip-text" role="tooltip">Delete permanently</span>
+    </span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/animated-tooltip-as/style.css
+++ b/submissions/examples/animated-tooltip-as/style.css
@@ -1,0 +1,98 @@
+:root {
+  --tip-bg: #1e293b;
+  --tip-text: #f1f5f9;
+  --accent: #6c63ff;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 3rem 1rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.tooltip-demo {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: center;
+}
+
+.tooltip {
+  position: relative;
+  display: inline-flex;
+}
+
+.tooltip-trigger {
+  padding: 0.65rem 1.2rem;
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: #fff;
+  background: var(--accent);
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.tooltip-trigger:focus-visible {
+  outline: 2px solid #fbbf24;
+  outline-offset: 2px;
+}
+
+.tooltip-text {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  z-index: 2;
+  padding: 0.45rem 0.7rem;
+  border-radius: 8px;
+  font-size: 0.8rem;
+  white-space: nowrap;
+  color: var(--tip-text);
+  background: var(--tip-bg);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+  opacity: 0;
+  transform: translate(-50%, 4px);
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.tooltip-text::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-top-color: var(--tip-bg);
+}
+
+.tooltip.is-bottom .tooltip-text {
+  bottom: auto;
+  top: calc(100% + 10px);
+  transform: translate(-50%, -4px);
+}
+
+.tooltip.is-bottom .tooltip-text::after {
+  top: auto;
+  bottom: 100%;
+  border-top-color: transparent;
+  border-bottom-color: var(--tip-bg);
+}
+
+.tooltip:hover .tooltip-text,
+.tooltip:focus-within .tooltip-text {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tooltip-text {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an animated tooltip built for #39982. Tooltips fade and slide in on hover or focus, with an arrow pointing at the trigger and top or bottom placement, using only CSS. Closes #39982.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
Tooltips that reveal on hover and focus with a fade and slide, an arrow, and top or bottom placement.

**How does a developer use it?**

```html
<span class="tooltip">
  <button class="tooltip-trigger" type="button">Save</button>
  <span class="tooltip-text" role="tooltip">Save your changes</span>
</span>
```

**Why does it fit EaseMotion CSS?**
It reveals the tooltip with only a transition on hover and focus, so it needs no JavaScript. It appears for keyboard focus through `:focus-within`, uses `role="tooltip"`, and the transition is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the tooltip goes from opacity 0 to visible on hover, above or below the trigger per the `is-bottom` modifier.
