### PR TITLE
feat: add animated avatar stack

### DIFF
--- a/submissions/examples/avatar-stack-as/README.md
+++ b/submissions/examples/avatar-stack-as/README.md
@@ -1,0 +1,22 @@
+# Animated Avatar Stack
+
+### What does this do?
+
+It shows a row of overlapping avatars that spread apart and lift when the group is hovered, with a trailing chip for the remaining count.
+
+### How is it used?
+
+```html
+<div class="avatar-stack" role="group" aria-label="Project collaborators">
+  <span class="avatar avatar-a" title="Jane Doe">JD</span>
+  <span class="avatar avatar-b" title="Arjun Rao">AR</span>
+  <span class="avatar avatar-c" title="Mia Lopez">ML</span>
+  <span class="avatar avatar-more" aria-label="3 more collaborators">+3</span>
+</div>
+```
+
+The avatars overlap by default with a negative margin, and hovering the stack removes the overlap so they fan out. Use `avatar-more` for the overflow count chip.
+
+### Why is it useful?
+
+Avatar stacks show collaborators or participants in a compact space. This spreads them with a margin and transform transition on hover, using only CSS. Avatars use initials so the demo is self contained, the group and the overflow chip carry accessible labels, and motion is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/avatar-stack-as/demo.html
+++ b/submissions/examples/avatar-stack-as/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Avatar Stack</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="avatar-stack" role="group" aria-label="Project collaborators">
+    <span class="avatar avatar-a" title="Jane Doe">JD</span>
+    <span class="avatar avatar-b" title="Arjun Rao">AR</span>
+    <span class="avatar avatar-c" title="Mia Lopez">ML</span>
+    <span class="avatar avatar-d" title="Sam Kwon">SK</span>
+    <span class="avatar avatar-more" aria-label="3 more collaborators">+3</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/avatar-stack-as/style.css
+++ b/submissions/examples/avatar-stack-as/style.css
@@ -1,0 +1,62 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.avatar-stack {
+  display: flex;
+  padding: 1rem;
+}
+
+.avatar {
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #fff;
+  border: 2px solid #0b1121;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+  transition: margin 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
+    transform 0.3s ease;
+}
+
+.avatar:not(:first-child) {
+  margin-left: -14px;
+}
+
+.avatar-stack:hover .avatar:not(:first-child) {
+  margin-left: 4px;
+}
+
+.avatar-stack:hover .avatar {
+  transform: translateY(-4px);
+}
+
+.avatar-a { background: linear-gradient(135deg, #6c63ff, #4338ca); }
+.avatar-b { background: linear-gradient(135deg, #ec4899, #be185d); }
+.avatar-c { background: linear-gradient(135deg, #0ea5e9, #0369a1); }
+.avatar-d { background: linear-gradient(135deg, #10b981, #047857); }
+
+.avatar-more {
+  background: #1e293b;
+  color: #cbd5e1;
+  font-size: 0.8rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .avatar {
+    transition: none;
+  }
+
+  .avatar-stack:hover .avatar {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an animated avatar stack built for #39984. Overlapping avatars spread apart and lift when the group is hovered, with a trailing overflow count chip. Initials avatars, all CSS, no external images. Closes #39984.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A row of overlapping initials avatars that fan out on hover, with a `+N` overflow chip.

**How does a developer use it?**

```html
<div class="avatar-stack" role="group" aria-label="Project collaborators">
  <span class="avatar avatar-a" title="Jane Doe">JD</span>
  <span class="avatar avatar-b" title="Arjun Rao">AR</span>
  <span class="avatar avatar-more" aria-label="3 more collaborators">+3</span>
</div>
```

**Why does it fit EaseMotion CSS?**
It spreads the avatars with a margin and transform transition on hover, using only CSS. Avatars use initials so it is self contained, the group and overflow chip carry accessible labels, and motion is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the overlapped avatars go from a negative margin to a positive one on hover and lift slightly.
