### PR TITLE
feat: add animated scroll-down indicator

### DIFF
--- a/submissions/examples/scroll-indicator-as/README.md
+++ b/submissions/examples/scroll-indicator-as/README.md
@@ -1,0 +1,21 @@
+# Animated Scroll-Down Indicator
+
+### What does this do?
+
+It shows a scroll hint with a mouse shaped outline whose wheel dot animates downward in a loop, plus a bouncing chevron, inviting the user to scroll for more.
+
+### How is it used?
+
+```html
+<div class="scroll-hint" role="img" aria-label="Scroll down for more">
+  <span class="scroll-label">Scroll</span>
+  <span class="scroll-mouse"><span class="scroll-wheel"></span></span>
+  <span class="scroll-chevron" aria-hidden="true"></span>
+</div>
+```
+
+Drop it at the bottom of a hero section. The mouse and chevron are drawn with CSS, so there are no images to load.
+
+### Why is it useful?
+
+Scroll indicators hint that there is more content below a hero. This builds the looping micro animation with keyframes only, so it needs no JavaScript. The whole hint carries an accessible label, and the animations are disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/scroll-indicator-as/demo.html
+++ b/submissions/examples/scroll-indicator-as/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Scroll-Down Indicator</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scroll-hint" role="img" aria-label="Scroll down for more">
+    <span class="scroll-label">Scroll</span>
+    <span class="scroll-mouse"><span class="scroll-wheel"></span></span>
+    <span class="scroll-chevron" aria-hidden="true"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/scroll-indicator-as/style.css
+++ b/submissions/examples/scroll-indicator-as/style.css
@@ -1,0 +1,87 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.scroll-hint {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.scroll-label {
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #94a3b8;
+}
+
+.scroll-mouse {
+  position: relative;
+  width: 26px;
+  height: 42px;
+  border: 2px solid #94a3b8;
+  border-radius: 999px;
+}
+
+.scroll-wheel {
+  position: absolute;
+  top: 8px;
+  left: 50%;
+  width: 4px;
+  height: 8px;
+  margin-left: -2px;
+  border-radius: 2px;
+  background: #6c63ff;
+  animation: scrollWheel 1.6s ease-in-out infinite;
+}
+
+.scroll-chevron {
+  width: 10px;
+  height: 10px;
+  border-right: 2px solid #6c63ff;
+  border-bottom: 2px solid #6c63ff;
+  transform: rotate(45deg);
+  animation: scrollChevron 1.6s ease-in-out infinite;
+}
+
+@keyframes scrollWheel {
+  0% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+
+  70% {
+    transform: translateY(12px);
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes scrollChevron {
+  0%, 100% {
+    transform: rotate(45deg) translate(0, 0);
+    opacity: 0.5;
+  }
+
+  50% {
+    transform: rotate(45deg) translate(3px, 3px);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scroll-wheel,
+  .scroll-chevron {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an animated scroll-down indicator built for #39986. A mouse shaped outline has a wheel dot that loops downward, with a bouncing chevron, drawn entirely in CSS. Closes #39986.

## Type of Change

- [x] ✨ New animation / hover effect

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A looping scroll hint with a CSS drawn mouse, a wheel dot that animates down, and a bouncing chevron.

**How does a developer use it?**

```html
<div class="scroll-hint" role="img" aria-label="Scroll down for more">
  <span class="scroll-label">Scroll</span>
  <span class="scroll-mouse"><span class="scroll-wheel"></span></span>
  <span class="scroll-chevron" aria-hidden="true"></span>
</div>
```

**Why does it fit EaseMotion CSS?**
It builds the looping micro animation with keyframes only, so it needs no JavaScript and no images. It carries an accessible label and the animations are disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the wheel and chevron have their looping animations applied and the mouse renders from CSS with no images.
