### PR TITLE
feat: add animated indeterminate progress bar

### DIFF
--- a/submissions/examples/indeterminate-progress-as/README.md
+++ b/submissions/examples/indeterminate-progress-as/README.md
@@ -1,0 +1,19 @@
+# Animated Indeterminate Progress Bar
+
+### What does this do?
+
+It shows a slim loading bar with a highlight that sweeps across in a loop, indicating ongoing work of unknown duration, with color variants.
+
+### How is it used?
+
+```html
+<div class="progress-bar" role="progressbar" aria-label="Loading">
+  <span class="progress-fill"></span>
+</div>
+```
+
+Add `is-success` or `is-warning` to the `.progress-bar` to change the sweep color. The fill segment moves with a single transform keyframe.
+
+### Why is it useful?
+
+Indeterminate bars are shown while data loads or a request is in flight. This animates a sweeping highlight with only a transform keyframe, so it needs no JavaScript. The bar carries a `progressbar` role, and under `prefers-reduced-motion: reduce` the sweep is replaced by a calm static fill.

--- a/submissions/examples/indeterminate-progress-as/demo.html
+++ b/submissions/examples/indeterminate-progress-as/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Indeterminate Progress Bar</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="progress-demo">
+    <div class="progress-bar" role="progressbar" aria-label="Loading">
+      <span class="progress-fill"></span>
+    </div>
+
+    <div class="progress-bar is-success" role="progressbar" aria-label="Syncing">
+      <span class="progress-fill"></span>
+    </div>
+
+    <div class="progress-bar is-warning" role="progressbar" aria-label="Uploading">
+      <span class="progress-fill"></span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/indeterminate-progress-as/style.css
+++ b/submissions/examples/indeterminate-progress-as/style.css
@@ -1,0 +1,59 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.progress-demo {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  width: min(420px, 92vw);
+}
+
+.progress-bar {
+  position: relative;
+  height: 8px;
+  border-radius: 999px;
+  background: #1e293b;
+  overflow: hidden;
+}
+
+.progress-fill {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 40%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, transparent, var(--fill, #6c63ff), transparent);
+  animation: sweep 1.4s ease-in-out infinite;
+}
+
+.progress-bar.is-success .progress-fill { --fill: #10b981; }
+.progress-bar.is-warning .progress-fill { --fill: #f59e0b; }
+
+@keyframes sweep {
+  0% {
+    transform: translateX(-120%);
+  }
+
+  100% {
+    transform: translateX(320%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .progress-fill {
+    animation: none;
+    width: 100%;
+    left: 0;
+    opacity: 0.5;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an animated indeterminate progress bar built for #39990. A gradient highlight sweeps across a slim track in a loop to show ongoing work, with color variants. All CSS. Closes #39990.

## Type of Change

- [x] ✨ New animation / hover effect

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A slim indeterminate loading bar whose highlight sweeps across in a loop, with success and warning color variants.

**How does a developer use it?**

```html
<div class="progress-bar" role="progressbar" aria-label="Loading">
  <span class="progress-fill"></span>
</div>
```

**Why does it fit EaseMotion CSS?**
It animates the sweep with only a transform keyframe, so it needs no JavaScript. The bar carries a `progressbar` role, and under `prefers-reduced-motion: reduce` the sweep is replaced by a calm static fill.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: three bars with the sweep animation applied and the success and warning color variants rendering.
