### PR TITLE
feat: add animated dismissible alert banner

### DIFF
--- a/submissions/examples/dismissible-alert-as/README.md
+++ b/submissions/examples/dismissible-alert-as/README.md
@@ -1,0 +1,24 @@
+# Animated Dismissible Alert Banner
+
+### What does this do?
+
+It shows inline alert banners with an icon and a message that collapse away smoothly when their close button is clicked, in info, success, and warning variants.
+
+### How is it used?
+
+```html
+<input type="checkbox" id="alert-1" class="alert-dismiss" />
+<div class="alert-wrap">
+  <div class="alert is-info">
+    <span class="alert-icon" aria-hidden="true"></span>
+    <p class="alert-body"><strong>Heads up.</strong> Your trial ends in 3 days.</p>
+    <label for="alert-1" class="alert-close" aria-label="Dismiss alert">&times;</label>
+  </div>
+</div>
+```
+
+Each alert pairs a hidden checkbox with an `.alert-wrap`. Clicking the close label checks the box, and the wrapper collapses its row height and fades out. Use `is-info`, `is-success`, or `is-warning` to set the color and icon.
+
+### Why is it useful?
+
+Alerts communicate status inline. This collapses and fades the banner on dismiss with only a `grid-template-rows` and opacity transition driven by `:checked`, so it needs no JavaScript. The close control is keyboard operable and the collapse is softened under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/dismissible-alert-as/demo.html
+++ b/submissions/examples/dismissible-alert-as/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Dismissible Alert Banner</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="alert-group">
+    <input type="checkbox" id="alert-1" class="alert-dismiss" />
+    <div class="alert-wrap">
+      <div class="alert is-info">
+        <span class="alert-icon" aria-hidden="true"></span>
+        <p class="alert-body"><strong>Heads up.</strong> Your free trial ends in 3 days.</p>
+        <label for="alert-1" class="alert-close" aria-label="Dismiss alert">&times;</label>
+      </div>
+    </div>
+
+    <input type="checkbox" id="alert-2" class="alert-dismiss" />
+    <div class="alert-wrap">
+      <div class="alert is-success">
+        <span class="alert-icon" aria-hidden="true"></span>
+        <p class="alert-body"><strong>All set.</strong> Your profile was updated successfully.</p>
+        <label for="alert-2" class="alert-close" aria-label="Dismiss alert">&times;</label>
+      </div>
+    </div>
+
+    <input type="checkbox" id="alert-3" class="alert-dismiss" />
+    <div class="alert-wrap">
+      <div class="alert is-warning">
+        <span class="alert-icon" aria-hidden="true"></span>
+        <p class="alert-body"><strong>Careful.</strong> Storage is almost full.</p>
+        <label for="alert-3" class="alert-close" aria-label="Dismiss alert">&times;</label>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/dismissible-alert-as/style.css
+++ b/submissions/examples/dismissible-alert-as/style.css
@@ -1,0 +1,119 @@
+:root {
+  --card-bg: #111a2e;
+  --border: #1e293b;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: var(--text);
+}
+
+.alert-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  width: min(440px, 94vw);
+}
+
+.alert-dismiss {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.alert-wrap {
+  display: grid;
+  grid-template-rows: 1fr;
+  transition: grid-template-rows 0.35s ease, opacity 0.35s ease;
+}
+
+.alert-dismiss:checked + .alert-wrap {
+  grid-template-rows: 0fr;
+  opacity: 0;
+}
+
+.alert {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  min-height: 0;
+  overflow: hidden;
+  padding: 1rem 1.1rem;
+  border-radius: 12px;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-left: 4px solid var(--alert-accent, #6c63ff);
+}
+
+.alert.is-info { --alert-accent: #0ea5e9; }
+.alert.is-success { --alert-accent: #10b981; }
+.alert.is-warning { --alert-accent: #f59e0b; }
+
+.alert-icon {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: #fff;
+  background: var(--alert-accent, #6c63ff);
+}
+
+.alert.is-info .alert-icon::before { content: "i"; font-style: italic; font-family: Georgia, serif; }
+.alert.is-success .alert-icon::before { content: "\2713"; }
+.alert.is-warning .alert-icon::before { content: "!"; }
+
+.alert-body {
+  flex: 1;
+  margin: 0;
+  font-size: 0.88rem;
+  line-height: 1.5;
+  color: var(--muted);
+}
+
+.alert-body strong {
+  color: var(--text);
+}
+
+.alert-close {
+  flex-shrink: 0;
+  width: 26px;
+  height: 26px;
+  display: grid;
+  place-items: center;
+  border-radius: 6px;
+  font-size: 1.25rem;
+  line-height: 1;
+  color: var(--muted);
+  cursor: pointer;
+  transition: color 0.2s ease, background 0.2s ease;
+}
+
+.alert-close:hover {
+  color: #fff;
+  background: #1e293b;
+}
+
+.alert-dismiss:focus-visible + .alert-wrap .alert-close {
+  outline: 2px solid #fbbf24;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .alert-wrap {
+    transition: opacity 0.2s ease;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an animated dismissible alert banner built for #39992. Inline alerts collapse away smoothly when their close button is clicked, in info, success, and warning variants, using a checkbox and CSS with no JavaScript. Closes #39992.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
Inline alert banners with icon and variants that collapse and fade out when dismissed.

**How does a developer use it?**

```html
<input type="checkbox" id="alert-1" class="alert-dismiss" />
<div class="alert-wrap">
  <div class="alert is-info">
    <span class="alert-icon" aria-hidden="true"></span>
    <p class="alert-body"><strong>Heads up.</strong> Your trial ends in 3 days.</p>
    <label for="alert-1" class="alert-close" aria-label="Dismiss alert">&times;</label>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It collapses and fades the banner with only a `grid-template-rows` and opacity transition driven by `:checked`, so it needs no JavaScript. The close control is keyboard operable and the collapse is softened under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: clicking the close control collapses the alert row height toward zero and fades it out.
