### PR TITLE
feat: add animated keyboard keys

### DIFF
--- a/submissions/examples/keyboard-keys-as/README.md
+++ b/submissions/examples/keyboard-keys-as/README.md
@@ -1,0 +1,21 @@
+# Animated Keyboard Keys
+
+### What does this do?
+
+It shows styled keyboard key caps that depress with a small 3D press animation on hover and active, for displaying shortcuts like Ctrl plus K.
+
+### How is it used?
+
+```html
+<span class="shortcut">
+  <kbd class="kbd">Ctrl</kbd>
+  <span class="shortcut-plus" aria-hidden="true">+</span>
+  <kbd class="kbd">K</kbd>
+</span>
+```
+
+Each key uses the semantic `<kbd>` element with the `kbd` class. The raised look comes from a stacked box shadow, and pressing the key moves it down and reduces the shadow.
+
+### Why is it useful?
+
+Keyboard hints appear in docs, command palettes, and help menus. This gives each key a tactile press with only a transform and shadow transition, so it needs no JavaScript. Keys use the semantic `<kbd>` element, and the press transition is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/keyboard-keys-as/demo.html
+++ b/submissions/examples/keyboard-keys-as/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Keyboard Keys</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="shortcut-list">
+    <span class="shortcut">
+      <span class="shortcut-caption">Command palette</span>
+      <kbd class="kbd">Ctrl</kbd>
+      <span class="shortcut-plus" aria-hidden="true">+</span>
+      <kbd class="kbd">K</kbd>
+    </span>
+
+    <span class="shortcut">
+      <span class="shortcut-caption">Save</span>
+      <kbd class="kbd">Ctrl</kbd>
+      <span class="shortcut-plus" aria-hidden="true">+</span>
+      <kbd class="kbd">S</kbd>
+    </span>
+
+    <span class="shortcut">
+      <span class="shortcut-caption">Close dialog</span>
+      <kbd class="kbd">Esc</kbd>
+    </span>
+
+    <span class="shortcut">
+      <span class="shortcut-caption">Navigate</span>
+      <kbd class="kbd">&uarr;</kbd>
+      <kbd class="kbd">&darr;</kbd>
+    </span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/keyboard-keys-as/style.css
+++ b/submissions/examples/keyboard-keys-as/style.css
@@ -1,0 +1,69 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.shortcut-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
+.shortcut {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.shortcut-caption {
+  min-width: 150px;
+  font-size: 0.9rem;
+  color: #94a3b8;
+}
+
+.shortcut-plus {
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 30px;
+  height: 30px;
+  padding: 0 0.55rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #e2e8f0;
+  background: linear-gradient(180deg, #2a3752, #1c2740);
+  border: 1px solid #3a4a6b;
+  border-radius: 7px;
+  box-shadow: 0 2px 0 #0b1121, 0 3px 5px rgba(0, 0, 0, 0.4);
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+.kbd:hover {
+  transform: translateY(1px);
+  box-shadow: 0 1px 0 #0b1121, 0 2px 3px rgba(0, 0, 0, 0.4);
+}
+
+.kbd:active {
+  transform: translateY(2px);
+  box-shadow: 0 0 0 #0b1121;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .kbd {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds animated keyboard keys built for #39994. Semantic `<kbd>` key caps look raised and depress with a small 3D press animation on hover and active, for showing shortcuts. All CSS. Closes #39994.

## Type of Change

- [x] ✨ New animation / hover effect

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
Styled `<kbd>` key caps that press down on hover and active, for displaying keyboard shortcuts.

**How does a developer use it?**

```html
<span class="shortcut">
  <kbd class="kbd">Ctrl</kbd>
  <span class="shortcut-plus" aria-hidden="true">+</span>
  <kbd class="kbd">K</kbd>
</span>
```

**Why does it fit EaseMotion CSS?**
It gives each key a tactile press with only a transform and shadow transition, so it needs no JavaScript. Keys use the semantic `<kbd>` element, and the press transition is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: seven key caps render raised with a stacked shadow and shift down on press.
