### PR TITLE
feat: add animated status badges

### DIFF
--- a/submissions/examples/status-badges-as/README.md
+++ b/submissions/examples/status-badges-as/README.md
@@ -1,0 +1,20 @@
+# Animated Status Badges
+
+### What does this do?
+
+It shows presence status pills such as online, away, busy, and offline, each with a colored dot, where the online dot has a soft pulsing ring.
+
+### How is it used?
+
+```html
+<span class="badge is-online">
+  <span class="badge-dot" aria-hidden="true"></span>
+  Online
+</span>
+```
+
+Use `is-online`, `is-away`, `is-busy`, or `is-offline` on a `.badge` to set its color. The online badge adds a pulsing ring around the dot to signal a live state.
+
+### Why is it useful?
+
+Status badges show presence or state in chat apps, dashboards, and user lists. This adds the pulsing ring with a single keyframe on a pseudo element, so it needs no JavaScript. The dot is decorative and hidden from assistive tech, and the pulse is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/status-badges-as/demo.html
+++ b/submissions/examples/status-badges-as/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Status Badges</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="badge-row">
+    <span class="badge is-online">
+      <span class="badge-dot" aria-hidden="true"></span>
+      Online
+    </span>
+    <span class="badge is-away">
+      <span class="badge-dot" aria-hidden="true"></span>
+      Away
+    </span>
+    <span class="badge is-busy">
+      <span class="badge-dot" aria-hidden="true"></span>
+      Busy
+    </span>
+    <span class="badge is-offline">
+      <span class="badge-dot" aria-hidden="true"></span>
+      Offline
+    </span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/status-badges-as/style.css
+++ b/submissions/examples/status-badges-as/style.css
@@ -1,0 +1,71 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #cbd5e1;
+  background: #111a2e;
+  border: 1px solid #1e293b;
+}
+
+.badge-dot {
+  position: relative;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--status, #6c63ff);
+}
+
+.badge.is-online { --status: #10b981; }
+.badge.is-away { --status: #f59e0b; }
+.badge.is-busy { --status: #ef4444; }
+.badge.is-offline { --status: #64748b; }
+
+.badge.is-online .badge-dot::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: var(--status);
+  animation: badgePing 1.6s ease-out infinite;
+}
+
+@keyframes badgePing {
+  0% {
+    transform: scale(1);
+    opacity: 0.6;
+  }
+
+  100% {
+    transform: scale(2.6);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .badge.is-online .badge-dot::after {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds animated status badges built for #39996. Presence pills for online, away, busy, and offline, where the online dot has a pulsing ring. All CSS. Closes #39996.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
Presence status pills with a colored dot per state, and a pulsing ring on the online badge.

**How does a developer use it?**

```html
<span class="badge is-online">
  <span class="badge-dot" aria-hidden="true"></span>
  Online
</span>
```

**Why does it fit EaseMotion CSS?**
It adds the pulsing ring with a single keyframe on a pseudo element, so it needs no JavaScript. The dot is decorative and hidden from assistive tech, and the pulse is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: four badges render and the online dot has the pulsing ring animation applied.
