### PR TITLE
feat: add animated gradient border card

### DIFF
--- a/submissions/examples/gradient-border-card-as/README.md
+++ b/submissions/examples/gradient-border-card-as/README.md
@@ -1,0 +1,23 @@
+# Animated Gradient Border Card
+
+### What does this do?
+
+It shows a card whose thin border is a conic gradient that rotates around the edge, with a soft matching glow.
+
+### How is it used?
+
+```html
+<div class="gradient-card">
+  <div class="gradient-card-inner">
+    <h3>Featured Plan</h3>
+    <p>A card with a rotating gradient border.</p>
+    <a href="#" class="card-cta">Learn more</a>
+  </div>
+</div>
+```
+
+The outer `.gradient-card` has a small padding and a conic gradient background, and the inner `.gradient-card-inner` has an opaque background that covers the center, so only a thin gradient ring shows. A colored box shadow adds the glow.
+
+### Why is it useful?
+
+A rotating gradient border highlights a featured card or call to action. This animates a registered `@property` angle to spin the conic gradient, so it needs no JavaScript. If a browser does not support `@property` the border shows as a static gradient, and the rotation is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/gradient-border-card-as/demo.html
+++ b/submissions/examples/gradient-border-card-as/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Gradient Border Card</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="gradient-card">
+    <div class="gradient-card-inner">
+      <h3>Featured Plan</h3>
+      <p>A card with a rotating gradient border and a soft glow to draw attention to a call to action.</p>
+      <a href="#" class="card-cta">Learn more</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/gradient-border-card-as/style.css
+++ b/submissions/examples/gradient-border-card-as/style.css
@@ -1,0 +1,67 @@
+@property --angle {
+  syntax: "<angle>";
+  inherits: false;
+  initial-value: 0deg;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.gradient-card {
+  width: min(320px, 88vw);
+  padding: 2px;
+  border-radius: 18px;
+  background: conic-gradient(from var(--angle), #6c63ff, #0ea5e9, #ec4899, #6c63ff);
+  box-shadow: 0 0 34px rgba(108, 99, 255, 0.35);
+  animation: spin 4s linear infinite;
+}
+
+.gradient-card-inner {
+  padding: 1.9rem;
+  border-radius: 16px;
+  background: #111a2e;
+}
+
+.gradient-card h3 {
+  margin: 0 0 0.6rem;
+  font-size: 1.2rem;
+}
+
+.gradient-card p {
+  margin: 0 0 1.25rem;
+  font-size: 0.9rem;
+  line-height: 1.55;
+  color: #94a3b8;
+}
+
+.gradient-card .card-cta {
+  display: inline-block;
+  padding: 0.6rem 1.1rem;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: #fff;
+  text-decoration: none;
+  background: #1e293b;
+  border-radius: 10px;
+}
+
+@keyframes spin {
+  to {
+    --angle: 360deg;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gradient-card {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an animated gradient border card built for #39998. A conic gradient border rotates around the card edge with a soft glow, using a registered `@property` angle and no JavaScript. Closes #39998.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A card with a rotating conic gradient border and a colored glow, driven by a registered custom property angle.

**How does a developer use it?**

```html
<div class="gradient-card">
  <div class="gradient-card-inner">
    <h3>Featured Plan</h3>
    <p>A card with a rotating gradient border.</p>
    <a href="#" class="card-cta">Learn more</a>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It spins the conic gradient by animating a registered `@property` angle, so it needs no JavaScript. The outer element carries the gradient and the inner element covers the center to leave a thin ring. Without `@property` support the border is a static gradient, and the rotation is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the outer element has the spin animation and the inner element background is opaque, so only the border shows the gradient.
