### PR TITLE
[Feat] #27766 — Add custom glassmorphism overlay utilities (unique folder)

### DIFF
--- a/submissions/examples/glassmorphism-27766-ag/README.md
+++ b/submissions/examples/glassmorphism-27766-ag/README.md
@@ -1,0 +1,18 @@
+# Custom Glassmorphism Overlay Utilities
+
+A card component demonstrating frosted glass overlay containers using backdrop-filters.
+
+---
+
+## What is Included
+
+1. **`demo.html`**: A showcase dashboard hosting relative glass panels, text descriptions, and header titles.
+2. **`style.css`**: Frosted blurs, translucent outlines, backdrop parameters, and layout margins.
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a web browser.
+2. Verify the **Glassmorphic Panel** displays with a clean translucent border and background blur texture.
+3. Confirm that moving the card (or viewing the background elements underneath it) reflects the frosted blur effect.

--- a/submissions/examples/glassmorphism-27766-ag/demo.html
+++ b/submissions/examples/glassmorphism-27766-ag/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Glassmorphism Overlay Showcase — EaseMotion CSS</title>
+  <meta name="description" content="Visual showcase demonstrating glassmorphic overlay containers, background blurs, and semi-transparent outlines.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Utilities</span>
+      <h1>Glassmorphism Overlays</h1>
+      <p class="description">
+        Demonstrates modern overlay cards. Observe the semi-transparent 
+        glass panels and blurry frost textures below.
+      </p>
+    </header>
+
+    <main class="showcase">
+      <!-- Glassmorphic Card under Test -->
+      <div class="glass-panel">
+        <h2>Glassmorphic Panel</h2>
+        <p>This layout uses backing blur filters, translucent background alphas, and light border frames to achieve an elevated glass texture.</p>
+      </div>
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/glassmorphism-27766-ag/style.css
+++ b/submissions/examples/glassmorphism-27766-ag/style.css
@@ -1,0 +1,110 @@
+/* ============================================================
+   Custom Glassmorphism Overlay Utilities — style.css
+   Submission for EaseMotion CSS Issue #27766
+   Backdrop-filters, translucent borders, frosted backgrounds
+   ============================================================ */
+
+:root {
+  --bg-gradient: linear-gradient(135deg, #0f172a 0%, #1e1b4b 100%);
+  --text-primary: #f8fafc;
+  --text-secondary: #cbd5e1;
+  --primary: #818cf8;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 520px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(129, 140, 248, 0.15);
+  border: 1px solid rgba(129, 140, 248, 0.3);
+  border-radius: 999px;
+  color: #c7d2fe;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a5b4fc, #818cf8);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Showcase Area
+   ============================================================ */
+
+.showcase {
+  display: flex;
+  justify-content: center;
+}
+
+/* Glassmorphism Panel under Test */
+.glass-panel {
+  width: 100%;
+  max-width: 400px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 24px;
+  padding: 32px;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  transition: border-color 0.3s ease, transform 0.3s ease;
+}
+
+.glass-panel:hover {
+  border-color: rgba(255, 255, 255, 0.18);
+  transform: translateY(-2px);
+}
+
+.glass-panel h2 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.glass-panel p {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  line-height: 1.6;
+}


### PR DESCRIPTION
## Summary
Adds the `ease-glassmorphism` showcase. It demonstrates frosted glass overlay templates utilizing backdrop-filters and translucent outline margins.

## Root Cause
No frosted glass overlays or translucent frame helpers existed in EaseMotion CSS.

## Changes Made
- `submissions/examples/glassmorphism-27766-ag/demo.html`: Frosted card panels, content elements, headers, and descriptions.
- `submissions/examples/glassmorphism-27766-ag/style.css`: Backdrop filter blurs, alpha background variables, container alignments, and hover transforms.
- `submissions/examples/glassmorphism-27766-ag/README.md`: Explains backing blurs, outline configurations, and manual testing.

## How to Test
1. Open `demo.html` in a browser.
2. Confirm the frosted panel elevates and highlights on hover.

## Related Issue
Closes #27766