### PR TITLE
[Feat] #27763 — Add truncate multi-line clamp utility classes (unique folder)

### DIFF
--- a/submissions/examples/multiline-clamp-27763-ag/README.md
+++ b/submissions/examples/multiline-clamp-27763-ag/README.md
@@ -1,0 +1,18 @@
+# Truncate Multi-Line Clamp Utility Classes
+
+A text layout showcase demonstrating multi-line clamping and truncation with ellipses.
+
+---
+
+## What is Included
+
+1. **`demo.html`**: A showcase dashboard hosting 2-line and 3-line clamped cards, paragraph blocks, and descriptions.
+2. **`style.css`**: Box-orient rules, webkit-line-clamp values, overflow clippings, heights, and card layouts.
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a web browser.
+2. Observe the **2-Line Clamped Card** — confirm the text truncates with a trailing ellipsis at exactly the end of the second line.
+3. Observe the **3-Line Clamped Card** — confirm the text truncates with a trailing ellipsis at exactly the end of the third line.

--- a/submissions/examples/multiline-clamp-27763-ag/demo.html
+++ b/submissions/examples/multiline-clamp-27763-ag/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Multi-Line Clamp Showcase — EaseMotion CSS</title>
+  <meta name="description" content="Visual typography showcase demonstrating line-clamping and multi-line text truncation.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Utilities</span>
+      <h1>Multi-Line Clamp</h1>
+      <p class="description">
+        Demonstrates line-limiting text truncation. Observe the cards below 
+        clamping paragraphs at exactly 2 and 3 lines.
+      </p>
+    </header>
+
+    <main class="showcase">
+      <!-- 2-line Clamp Card -->
+      <div class="clamp-card">
+        <h3>2-Line Clamped Card</h3>
+        <p class="clamp-2">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id ex eros. Pellentesque hendrerit lorem id urna finibus, sit amet finibus lorem interdum. Aenean sollicitudin scelerisque finibus.</p>
+      </div>
+
+      <!-- 3-line Clamp Card -->
+      <div class="clamp-card">
+        <h3>3-Line Clamped Card</h3>
+        <p class="clamp-3">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id ex eros. Pellentesque hendrerit lorem id urna finibus, sit amet finibus lorem interdum. Aenean sollicitudin scelerisque finibus. Morbi molestie congue ante, eu tristique ex tincidunt vitae.</p>
+      </div>
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/multiline-clamp-27763-ag/style.css
+++ b/submissions/examples/multiline-clamp-27763-ag/style.css
@@ -1,0 +1,118 @@
+/* ============================================================
+   Truncate Multi-Line Clamp Utility Classes — style.css
+   Submission for EaseMotion CSS Issue #27763
+   Line clamp rules, box orient properties, overflow ellipsis
+   ============================================================ */
+
+:root {
+  --bg-gradient: linear-gradient(135deg, #0f172a 0%, #1e1b4b 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f8fafc;
+  --text-secondary: #cbd5e1;
+  --primary: #818cf8;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 520px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(129, 140, 248, 0.15);
+  border: 1px solid rgba(129, 140, 248, 0.3);
+  border-radius: 999px;
+  color: #c7d2fe;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a5b4fc, #818cf8);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Showcase Area
+   ============================================================ */
+
+.showcase {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.clamp-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  padding: 24px;
+  border-radius: 16px;
+  backdrop-filter: blur(8px);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+}
+
+.clamp-card h3 {
+  font-size: 1rem;
+  font-weight: 700;
+  margin-bottom: 12px;
+}
+
+/* ============================================================
+   Line Clamp Utilities under Test
+   ============================================================ */
+
+.clamp-2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  font-size: 0.88rem;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+.clamp-3 {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  font-size: 0.88rem;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}


### PR DESCRIPTION
## Summary
Adds the `ease-multiline-clamp` showcase. It demonstrates multi-line text truncation using webkit box-orient clamping and overflow rules.

## Root Cause
No multi-line text truncation helpers existed in EaseMotion CSS.

## Changes Made
- `submissions/examples/multiline-clamp-27763-ag/demo.html`: Clamped card elements, content paragraphs, and header structures.
- `submissions/examples/multiline-clamp-27763-ag/style.css`: Webkit line clamps, box orientations, overflow parameters, and backgrounds.
- `submissions/examples/multiline-clamp-27763-ag/README.md`: Explains box orient rules, line clamps, and manual testing.

## How to Test
1. Open `demo.html` in a browser.
2. Confirm the 2-line and 3-line cards truncate text correctly.

## Related Issue
Closes #27763