### PR TITLE
docs: add npm version audit

### DIFF
--- a/submissions/docs/npm-version-audit-t02/README.md
+++ b/submissions/docs/npm-version-audit-t02/README.md
@@ -1,0 +1,26 @@
+# npm Version Audit
+
+## What does this do?
+
+This documentation demo records the verified mismatch between the repository package version and the currently published npm package version for EaseMotion CSS.
+
+## How is it used?
+
+Open `demo.html` directly in a browser to view the package release audit summary.
+
+```html
+<section class="audit-panel">
+  <div class="version-card repository">Repository package.json: 1.2.0</div>
+  <div class="version-card registry">npm latest: 1.0.0</div>
+</section>
+```
+
+To reproduce the registry check, run:
+
+```bash
+npm view easemotion-css name version dist-tags versions --json
+```
+
+## Why is it useful?
+
+EaseMotion CSS promotes zero-config installation through npm and CDN usage. Keeping the documented release state aligned with the published npm package helps users install the version they expect and gives maintainers a clear audit trail for issue #40040.

--- a/submissions/docs/npm-version-audit-t02/demo.html
+++ b/submissions/docs/npm-version-audit-t02/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EaseMotion CSS npm Version Audit</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <main class="audit-shell">
+    <section class="audit-panel">
+      <p class="audit-kicker">Package release check</p>
+      <h1>npm metadata is behind the repository version</h1>
+      <p class="audit-summary">
+        The repository declares EaseMotion CSS version 1.2.0, while the npm
+        registry currently reports 1.0.0 as the latest published package.
+      </p>
+
+      <div class="version-grid" aria-label="Version comparison">
+        <article class="version-card repository">
+          <span class="version-label">Repository package.json</span>
+          <strong>1.2.0</strong>
+        </article>
+        <article class="version-card registry">
+          <span class="version-label">npm latest</span>
+          <strong>1.0.0</strong>
+        </article>
+      </div>
+
+      <div class="command-box">
+        <span>Reproduction command</span>
+        <code>npm view easemotion-css name version dist-tags versions --json</code>
+      </div>
+
+      <p class="audit-note">
+        This audit supports issue #40040 and gives maintainers a compact
+        reference for aligning the published package, README release notes, and
+        repository metadata.
+      </p>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/docs/npm-version-audit-t02/style.css
+++ b/submissions/docs/npm-version-audit-t02/style.css
@@ -1,0 +1,121 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #eef4f8;
+  color: #1f2933;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 32px;
+}
+
+.audit-shell {
+  width: min(960px, 100%);
+}
+
+.audit-panel {
+  border: 1px solid #c9d6df;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: clamp(24px, 5vw, 48px);
+  box-shadow: 0 24px 60px rgb(31 41 51 / 12%);
+}
+
+.audit-kicker {
+  margin: 0 0 12px;
+  color: #0f766e;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 720px;
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 4rem);
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.audit-summary,
+.audit-note {
+  max-width: 720px;
+  color: #52616b;
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.version-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  margin: 28px 0;
+}
+
+.version-card {
+  min-height: 140px;
+  border: 1px solid #d9e2ec;
+  border-radius: 8px;
+  display: grid;
+  align-content: center;
+  gap: 10px;
+  padding: 24px;
+}
+
+.version-card strong {
+  font-size: clamp(2.4rem, 8vw, 4.6rem);
+  line-height: 0.95;
+}
+
+.version-label {
+  color: #627d98;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.repository {
+  border-left: 6px solid #2563eb;
+}
+
+.registry {
+  border-left: 6px solid #dc2626;
+}
+
+.command-box {
+  border-radius: 8px;
+  background: #102a43;
+  color: #d9e2ec;
+  display: grid;
+  gap: 10px;
+  padding: 20px;
+}
+
+.command-box span {
+  color: #9fb3c8;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.command-box code {
+  overflow-wrap: anywhere;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 18px;
+  }
+
+  .version-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained documentation demo under `submissions/docs/` that records the verified npm release metadata mismatch reported in #40040. The demo compares the repository package version with the currently published npm version and includes the exact registry command maintainers can run to verify it.

Refs #40040

---

## Type of Change

- [ ] New animation / hover effect
- [ ] New component
- [x] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A package version audit page documenting that repository metadata currently lists `1.2.0` while npm reports `1.0.0` as the latest published package.

**How does a developer use it?**

```html
<section class="audit-panel">
  <div class="version-card repository">Repository package.json: 1.2.0</div>
  <div class="version-card registry">npm latest: 1.0.0</div>
</section>
```

**Why does it fit EaseMotion CSS?**

EaseMotion CSS emphasizes zero-config installation. Clear package release metadata helps users install the version they expect from npm and gives maintainers a compact audit artifact for release alignment.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This PR stays inside `submissions/docs/` to follow the current contribution freeze. The underlying issue may still need maintainer action to publish the intended npm version or adjust repository release metadata.
