### PR TITLE
Add CSS elastic slide tooltip for monochrome neo layouts

### DIFF
--- a/submissions/examples/css-elastic-slide-tooltip-monochrome-neo/README.md
+++ b/submissions/examples/css-elastic-slide-tooltip-monochrome-neo/README.md
@@ -1,0 +1,31 @@
+# CSS Elastic Slide Tooltip - Monochrome Neo Layouts
+
+A pure CSS animated tooltip component designed for monochrome neo-style interfaces.
+
+## Features
+
+- Pure CSS animation
+- Elastic slide transition effect
+- Minimal monochrome design
+- Responsive layout
+- Keyboard accessible
+- CSS custom property controls
+
+
+## Usage
+
+Open `demo.html` directly in any browser.
+
+Hover or focus on buttons to display the animated tooltip.
+
+
+## Customization
+
+Animation values can be changed using CSS variables:
+
+```css
+:root {
+    --tooltip-time: 0.45s;
+    --tooltip-scale: 1;
+    --tooltip-easing: cubic-bezier(.68,-0.55,.27,1.55);
+}

--- a/submissions/examples/css-elastic-slide-tooltip-monochrome-neo/demo.html
+++ b/submissions/examples/css-elastic-slide-tooltip-monochrome-neo/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Elastic Slide Tooltip - Monochrome Neo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+<div class="neo-container">
+
+    <h1>Monochrome Neo UI</h1>
+    <p>Minimal futuristic interface components</p>
+
+    <div class="cards">
+
+        <div class="neo-card">
+            <button class="neo-btn" aria-describedby="tooltip-one">
+                Dashboard
+            </button>
+
+            <div class="tooltip" id="tooltip-one" role="tooltip">
+                View analytics dashboard
+            </div>
+        </div>
+
+
+        <div class="neo-card">
+            <button class="neo-btn" aria-describedby="tooltip-two">
+                Profile
+            </button>
+
+            <div class="tooltip" id="tooltip-two" role="tooltip">
+                Manage user profile
+            </div>
+        </div>
+
+
+        <div class="neo-card">
+            <button class="neo-btn" aria-describedby="tooltip-three">
+                Settings
+            </button>
+
+            <div class="tooltip" id="tooltip-three" role="tooltip">
+                Customize preferences
+            </div>
+        </div>
+
+    </div>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/css-elastic-slide-tooltip-monochrome-neo/style.css
+++ b/submissions/examples/css-elastic-slide-tooltip-monochrome-neo/style.css
@@ -1,0 +1,170 @@
+:root {
+
+    --tooltip-time: 0.45s;
+    --tooltip-scale: 1;
+    --tooltip-easing: cubic-bezier(.68,-0.55,.27,1.55);
+
+}
+
+
+* {
+    box-sizing: border-box;
+}
+
+
+body {
+
+    min-height:100vh;
+
+    display:flex;
+    justify-content:center;
+    align-items:center;
+
+    font-family:Arial, sans-serif;
+
+    background:#000;
+
+    color:#fff;
+
+}
+
+
+.neo-container {
+
+    text-align:center;
+
+}
+
+
+.cards {
+
+    display:flex;
+
+    gap:30px;
+
+    margin-top:40px;
+
+    flex-wrap:wrap;
+
+    justify-content:center;
+
+}
+
+
+
+.neo-card {
+
+    position:relative;
+
+}
+
+
+
+.neo-btn {
+
+    padding:15px 28px;
+
+    background:#fff;
+
+    color:#000;
+
+    border:none;
+
+    border-radius:4px;
+
+    font-size:16px;
+
+    cursor:pointer;
+
+    transition:.3s;
+
+}
+
+
+.neo-btn:hover,
+.neo-btn:focus {
+
+    background:#000;
+
+    color:#fff;
+
+    outline:1px solid white;
+
+}
+
+
+
+.tooltip {
+
+    position:absolute;
+
+    bottom:120%;
+
+    left:50%;
+
+
+    transform:
+
+    translateX(-50%)
+    translateY(25px)
+    scale(.8);
+
+
+    opacity:0;
+
+
+    background:#111;
+
+    color:white;
+
+
+    border:1px solid white;
+
+    padding:12px 18px;
+
+    border-radius:8px;
+
+
+    width:max-content;
+
+
+    pointer-events:none;
+
+
+    transition:
+
+    transform var(--tooltip-time)
+    var(--tooltip-easing),
+
+    opacity var(--tooltip-time) ease;
+
+}
+
+
+
+.neo-card:hover .tooltip,
+.neo-btn:focus + .tooltip {
+
+
+    opacity:1;
+
+
+    transform:
+
+    translateX(-50%)
+    translateY(0)
+    scale(var(--tooltip-scale));
+
+}
+
+
+
+@media(max-width:600px){
+
+    .cards {
+
+        flex-direction:column;
+
+    }
+
+}


### PR DESCRIPTION
## Pull Request Description

Added a pure CSS Elastic Slide Tooltip component for Monochrome Neo layouts.  
The component provides a smooth elastic slide interaction, responsive design, keyboard accessibility, and customizable animation parameters using CSS custom properties.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---Fixes #38516

## Submission Checklist

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A pure CSS Elastic Slide Tooltip component designed with a minimal Monochrome Neo interface aesthetic and smooth animated interactions.

**How does a developer use it?**

```html
<div class="neo-card">

  <button class="neo-btn">
    Dashboard
  </button>

  <div class="tooltip">
    View analytics dashboard
  </div>

</div>