### PR TITLE
Add CSS elastic slide tooltip for art deco layouts

### DIFF
--- a/submissions/examples/css-elastic-slide-tooltip-art-deco/README.md
+++ b/submissions/examples/css-elastic-slide-tooltip-art-deco/README.md
@@ -1,0 +1,31 @@
+# CSS Elastic Slide Tooltip - Art Deco Layouts
+
+A pure CSS animated tooltip component inspired by Art Deco interface aesthetics.
+
+## Features
+
+- Pure CSS animation
+- Elastic slide transition
+- Art Deco geometric styling
+- Responsive design
+- Keyboard accessible
+- Custom CSS animation variables
+
+
+## Usage
+
+Open `demo.html` directly in a browser.
+
+Hover or focus on buttons to display the tooltip animation.
+
+
+## Customization
+
+Modify animation settings:
+
+```css
+:root {
+    --tooltip-time: 0.45s;
+    --tooltip-scale: 1;
+    --tooltip-easing: cubic-bezier(.68,-0.55,.27,1.55);
+}

--- a/submissions/examples/css-elastic-slide-tooltip-art-deco/demo.html
+++ b/submissions/examples/css-elastic-slide-tooltip-art-deco/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Art Deco Elastic Tooltip</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+<section class="art-deco">
+
+    <h1>Art Deco Collection</h1>
+    <p>Elegant geometric interface</p>
+
+    <div class="items">
+
+        <div class="card">
+
+            <button class="deco-btn" aria-describedby="tooltip-1">
+                Gallery
+            </button>
+
+            <div class="tooltip" id="tooltip-1" role="tooltip">
+                Explore art collections
+            </div>
+
+        </div>
+
+
+        <div class="card">
+
+            <button class="deco-btn" aria-describedby="tooltip-2">
+                Design
+            </button>
+
+            <div class="tooltip" id="tooltip-2" role="tooltip">
+                View premium designs
+            </div>
+
+        </div>
+
+
+        <div class="card">
+
+            <button class="deco-btn" aria-describedby="tooltip-3">
+                Archive
+            </button>
+
+            <div class="tooltip" id="tooltip-3" role="tooltip">
+                Browse historical pieces
+            </div>
+
+        </div>
+
+    </div>
+
+</section>
+
+</body>
+</html>

--- a/submissions/examples/css-elastic-slide-tooltip-art-deco/style.css
+++ b/submissions/examples/css-elastic-slide-tooltip-art-deco/style.css
@@ -1,0 +1,172 @@
+:root {
+
+    --tooltip-time: 0.45s;
+    --tooltip-scale: 1;
+    --tooltip-easing: cubic-bezier(.68,-0.55,.27,1.55);
+
+}
+
+
+* {
+    box-sizing:border-box;
+}
+
+
+body {
+
+    min-height:100vh;
+
+    display:flex;
+    justify-content:center;
+    align-items:center;
+
+    font-family:Arial, sans-serif;
+
+    background:#120b16;
+
+    color:#f5d27a;
+
+}
+
+
+
+.art-deco {
+
+    text-align:center;
+
+}
+
+
+
+.items {
+
+    display:flex;
+
+    gap:35px;
+
+    margin-top:40px;
+
+    flex-wrap:wrap;
+
+    justify-content:center;
+
+}
+
+
+
+.card {
+
+    position:relative;
+
+}
+
+
+
+.deco-btn {
+
+    padding:15px 35px;
+
+    background:transparent;
+
+    color:#f5d27a;
+
+    border:2px solid #f5d27a;
+
+    border-radius:0;
+
+    cursor:pointer;
+
+    font-size:16px;
+
+    letter-spacing:2px;
+
+    transition:.3s;
+
+}
+
+
+
+.deco-btn:hover,
+.deco-btn:focus {
+
+    background:#f5d27a;
+
+    color:#120b16;
+
+}
+
+
+
+.tooltip {
+
+    position:absolute;
+
+    bottom:120%;
+
+    left:50%;
+
+
+    transform:
+
+    translateX(-50%)
+    translateY(25px)
+    scale(.8);
+
+
+    opacity:0;
+
+
+    background:#1f1425;
+
+    color:#fff;
+
+
+    border:1px solid #f5d27a;
+
+    padding:12px 18px;
+
+    border-radius:4px;
+
+
+    width:max-content;
+
+
+    pointer-events:none;
+
+
+    transition:
+
+    transform var(--tooltip-time)
+    var(--tooltip-easing),
+
+    opacity var(--tooltip-time) ease;
+
+}
+
+
+
+.card:hover .tooltip,
+.deco-btn:focus + .tooltip {
+
+    opacity:1;
+
+
+    transform:
+
+    translateX(-50%)
+    translateY(0)
+    scale(var(--tooltip-scale));
+
+}
+
+
+
+@media(max-width:600px){
+
+    .items {
+
+        flex-direction:column;
+
+    }
+
+}


### PR DESCRIPTION
## Pull Request Description

Added a pure CSS Elastic Slide Tooltip component designed for Art Deco layouts.  
The component provides a smooth elastic slide interaction, responsive behavior, keyboard accessibility, and customizable animation parameters using CSS custom properties.
Issue #38513
---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A pure CSS Elastic Slide Tooltip component inspired by Art Deco design aesthetics with elegant geometric styling and smooth animated transitions.

**How does a developer use it?**

```html
<div class="card">

  <button class="deco-btn">
    Gallery
  </button>

  <div class="tooltip">
    Explore art collections
  </div>

</div>