### PR TITLE
feat: add animated loading spinners

### DIFF
--- a/submissions/examples/loading-spinners-as/README.md
+++ b/submissions/examples/loading-spinners-as/README.md
@@ -1,0 +1,25 @@
+# Animated Loading Spinners
+
+### What does this do?
+
+It shows a set of loading spinners: a rotating ring, three bouncing dots, and pulsing bars, each looping continuously in pure CSS.
+
+### How is it used?
+
+```html
+<span class="spinner spinner-ring" role="status" aria-label="Loading"></span>
+
+<span class="spinner spinner-dots" role="status" aria-label="Loading">
+  <span></span><span></span><span></span>
+</span>
+
+<span class="spinner spinner-bars" role="status" aria-label="Loading">
+  <span></span><span></span><span></span><span></span>
+</span>
+```
+
+Pick the style that fits by using `spinner-ring`, `spinner-dots`, or `spinner-bars`. The dots and bars use inner spans that animate with staggered delays.
+
+### Why is it useful?
+
+Loaders signal that work is in progress and appear across almost every app. These are drawn with CSS from simple keyframes, so there are no images and no JavaScript. Each spinner has a `status` role with a label, and the animations slow down under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/loading-spinners-as/demo.html
+++ b/submissions/examples/loading-spinners-as/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Loading Spinners</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="spinner-row">
+    <div class="spinner-cell">
+      <span class="spinner spinner-ring" role="status" aria-label="Loading"></span>
+      <span class="label">Ring</span>
+    </div>
+
+    <div class="spinner-cell">
+      <span class="spinner spinner-dots" role="status" aria-label="Loading">
+        <span></span><span></span><span></span>
+      </span>
+      <span class="label">Dots</span>
+    </div>
+
+    <div class="spinner-cell">
+      <span class="spinner spinner-bars" role="status" aria-label="Loading">
+        <span></span><span></span><span></span><span></span>
+      </span>
+      <span class="label">Bars</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/loading-spinners-as/style.css
+++ b/submissions/examples/loading-spinners-as/style.css
@@ -1,0 +1,117 @@
+:root {
+  --accent: #6c63ff;
+  --track: #1e293b;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.spinner-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2.5rem;
+  justify-content: center;
+}
+
+.spinner-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.spinner-cell span.label {
+  font-size: 0.78rem;
+  color: #94a3b8;
+}
+
+.spinner-ring {
+  width: 40px;
+  height: 40px;
+  border: 3px solid var(--track);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+.spinner-dots {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 40px;
+}
+
+.spinner-dots span {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: dotBounce 1.2s ease-in-out infinite;
+}
+
+.spinner-dots span:nth-child(2) { animation-delay: 0.15s; }
+.spinner-dots span:nth-child(3) { animation-delay: 0.3s; }
+
+.spinner-bars {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 40px;
+}
+
+.spinner-bars span {
+  width: 6px;
+  height: 100%;
+  border-radius: 3px;
+  background: var(--accent);
+  animation: barPulse 1s ease-in-out infinite;
+}
+
+.spinner-bars span:nth-child(2) { animation-delay: 0.12s; }
+.spinner-bars span:nth-child(3) { animation-delay: 0.24s; }
+.spinner-bars span:nth-child(4) { animation-delay: 0.36s; }
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes dotBounce {
+  0%, 80%, 100% {
+    transform: translateY(0);
+    opacity: 0.4;
+  }
+
+  40% {
+    transform: translateY(-10px);
+    opacity: 1;
+  }
+}
+
+@keyframes barPulse {
+  0%, 100% {
+    transform: scaleY(0.35);
+  }
+
+  50% {
+    transform: scaleY(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner-ring,
+  .spinner-dots span,
+  .spinner-bars span {
+    animation-duration: 2.4s;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds animated loading spinners built for #40082. A rotating ring, three bouncing dots, and pulsing bars, each looping in pure CSS with no images. Closes #40082.

## Type of Change

- [x] ✨ New animation / hover effect

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
Three loader styles, a ring, bouncing dots, and pulsing bars, selectable by class.

**How does a developer use it?**

```html
<span class="spinner spinner-ring" role="status" aria-label="Loading"></span>
<span class="spinner spinner-dots" role="status" aria-label="Loading">
  <span></span><span></span><span></span>
</span>
```

**Why does it fit EaseMotion CSS?**
Each spinner is drawn from simple keyframes with no images and no JavaScript. Each has a `status` role with a label, and the animations slow under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the ring, dots, and bars each have their looping animation applied.
