### PR TITLE
feat: add ripple effect button

### DIFF
--- a/submissions/examples/ripple-button-as/README.md
+++ b/submissions/examples/ripple-button-as/README.md
@@ -1,0 +1,18 @@
+# Ripple Effect Button
+
+### What does this do?
+
+It gives a button a ripple, an expanding circle that fades out from the center, each time it is pressed, using only CSS.
+
+### How is it used?
+
+```html
+<button class="ripple-btn" type="button">Click me</button>
+<button class="ripple-btn is-ghost" type="button">Ghost</button>
+```
+
+The ripple is a `::after` pseudo element that animates from a small scale to a large one and fades out on the `:active` state. Add `is-ghost` for the outline variant.
+
+### Why is it useful?
+
+A ripple gives a button a tactile, responsive feel on press. This plays a one shot expand and fade on `:active` with only a pseudo element and a keyframe, so it needs no JavaScript. The button shows a visible focus ring, and the ripple is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/ripple-button-as/demo.html
+++ b/submissions/examples/ripple-button-as/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ripple Effect Button</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="ripple-row">
+    <button class="ripple-btn" type="button">Click me</button>
+    <button class="ripple-btn" type="button">Get started</button>
+    <button class="ripple-btn is-ghost" type="button">Ghost</button>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ripple-button-as/style.css
+++ b/submissions/examples/ripple-button-as/style.css
@@ -1,0 +1,83 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.ripple-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.ripple-btn {
+  position: relative;
+  overflow: hidden;
+  padding: 0.8rem 1.6rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #fff;
+  background: #6c63ff;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  isolation: isolate;
+}
+
+.ripple-btn.is-ghost {
+  background: transparent;
+  color: #c7d2fe;
+  border: 1px solid #3a4a6b;
+}
+
+.ripple-btn::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.45);
+  transform: scale(0);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.ripple-btn.is-ghost::after {
+  background: rgba(108, 99, 255, 0.4);
+}
+
+.ripple-btn:active::after {
+  animation: ripple 0.6s ease-out;
+}
+
+.ripple-btn:focus-visible {
+  outline: 2px solid #fbbf24;
+  outline-offset: 2px;
+}
+
+@keyframes ripple {
+  0% {
+    transform: scale(0);
+    opacity: 0.5;
+  }
+
+  100% {
+    transform: scale(26);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ripple-btn:active::after {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a ripple effect button built for #40087. A soft circle expands from the center and fades out each time the button is pressed, using a pseudo element and a keyframe with no JavaScript. Closes #40087.

## Type of Change

- [x] ✨ New animation / hover effect

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A button that plays a Material style ripple on press, with a solid and a ghost variant.

**How does a developer use it?**

```html
<button class="ripple-btn" type="button">Click me</button>
<button class="ripple-btn is-ghost" type="button">Ghost</button>
```

**Why does it fit EaseMotion CSS?**
It plays a one shot expand and fade on `:active` with only a pseudo element and a keyframe, so it needs no JavaScript. The button shows a visible focus ring, and the ripple is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: pressing the button scales the ripple pseudo element up from the center and fades it out.
