### PR TITLE
fix: update Bengali README live demo link

### DIFF
--- a/README.bn.md
+++ b/README.bn.md
@@ -42,8 +42,7 @@ UI লেখো যেভাবে ইংরেজিতে বলো। কো�
 />
 ```
 
-**[📖 ডকুমেন্টেশন](https://saptarshi-coder.github.io/EaseMotion-css/) · [🎮 লাইভ ডেমো](https://github.com/SAPTARSHI-coder/EaseMotion-css/blob/main/examples/demo.html) · [📦 npm](https://www.npmjs.com/package/easemotion-css) · [🤝 অবদান রাখুন](./CONTRIBUTING.md)**
-
+**[📖 ডকুমেন্টেশন](https://saptarshi-coder.github.io/EaseMotion-css/) · [🎮 লাইভ ডেমো](https://saptarshi-coder.github.io/EaseMotion-css/demo.html) · [📦 npm](https://www.npmjs.com/package/easemotion-css) · [🤝 অবদান রাখুন](./CONTRIBUTING.md)**
 </div>
 
 ---


### PR DESCRIPTION
## Description

Updated the Live Demo link in the Bengali README so that it opens the rendered GitHub Pages demo instead of the HTML source file on GitHub.

## Changes

- Replaced the GitHub source URL with the GitHub Pages demo URL.
- Verified that the updated link opens the rendered animation demo.

## Testing

- Opened the updated Live Demo URL in the browser.
- Confirmed that the webpage renders correctly.

Fixes #39000