### PR TITLE
Add ease-stopwatch-timer component (Closes #39865)

### DIFF
--- a/submissions/examples/ease-stopwatch-timer/README.md
+++ b/submissions/examples/ease-stopwatch-timer/README.md
@@ -1,0 +1,33 @@
+# ease-stopwatch-timer
+
+Closes #39865
+
+A CSS-first stopwatch/timer component for EaseMotion CSS, with Start / Stop / Reset controls and a pulsing "active" ring animation while the timer is running.
+
+## Preview
+
+Open `demo.html` directly in a browser — no build step required.
+
+## What it demonstrates
+
+- **ease-fade-in** — heading entrance
+- **ease-slide-up** — component entrance animation
+- **ease-hover-grow** — button hover feedback
+- **ease-card / ease-card-shadow** — base container styling
+- A custom @keyframes pulse (ease-stopwatch-pulse) that respects prefers-reduced-motion
+
+## Features
+
+- HH:MM:SS display with tabular numerals (no layout jitter as digits change)
+- Start / Stop / Reset controls with disabled-state handling
+- Pulsing ring animation while the stopwatch is actively running
+- Reduced-motion users get a static (non-pulsing) ring automatically
+- Pure vanilla JS — no dependencies
+
+## Files
+
+| File | Purpose |
+|---|---|
+| demo.html | Markup + stopwatch logic |
+| style.css | Component styling, animation, responsive sizing |
+| README.md | This file |

--- a/submissions/examples/ease-stopwatch-timer/demo.html
+++ b/submissions/examples/ease-stopwatch-timer/demo.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>EaseMotion CSS — ease-stopwatch-timer Component</title>
+<link rel="stylesheet" href="../../../easemotion.min.css" />
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<main class="stopwatch-page">
+  <h1 class="ease-fade-in">ease-stopwatch-timer</h1>
+  <p class="stopwatch-sub ease-fade-in">A CSS-first stopwatch component with a pulsing active state.</p>
+
+  <div class="ease-stopwatch ease-card ease-card-shadow ease-slide-up" id="stopwatch">
+    <div class="ease-stopwatch-ring">
+      <span class="ease-stopwatch-display" id="display">00:00:00</span>
+    </div>
+
+    <div class="ease-stopwatch-controls">
+      <button class="ease-stopwatch-btn ease-stopwatch-btn--start ease-hover-grow" id="startBtn">Start</button>
+      <button class="ease-stopwatch-btn ease-stopwatch-btn--stop ease-hover-grow" id="stopBtn" disabled>Stop</button>
+      <button class="ease-stopwatch-btn ease-stopwatch-btn--reset ease-hover-grow" id="resetBtn">Reset</button>
+    </div>
+  </div>
+</main>
+
+<script>
+  (function () {
+    const display = document.getElementById('display');
+    const stopwatch = document.getElementById('stopwatch');
+    const startBtn = document.getElementById('startBtn');
+    const stopBtn = document.getElementById('stopBtn');
+    const resetBtn = document.getElementById('resetBtn');
+
+    let elapsedMs = 0;
+    let intervalId = null;
+    let lastTick = null;
+
+    function format(ms) {
+      const totalSeconds = Math.floor(ms / 1000);
+      const hours = String(Math.floor(totalSeconds / 3600)).padStart(2, '0');
+      const minutes = String(Math.floor((totalSeconds % 3600) / 60)).padStart(2, '0');
+      const seconds = String(totalSeconds % 60).padStart(2, '0');
+      return `${hours}:${minutes}:${seconds}`;
+    }
+
+    function tick() {
+      const now = Date.now();
+      elapsedMs += now - lastTick;
+      lastTick = now;
+      display.textContent = format(elapsedMs);
+    }
+
+    startBtn.addEventListener('click', () => {
+      if (intervalId) return;
+      lastTick = Date.now();
+      intervalId = setInterval(tick, 250);
+      stopwatch.classList.add('ease-stopwatch--running');
+      startBtn.disabled = true;
+      stopBtn.disabled = false;
+    });
+
+    stopBtn.addEventListener('click', () => {
+      clearInterval(intervalId);
+      intervalId = null;
+      stopwatch.classList.remove('ease-stopwatch--running');
+      startBtn.disabled = false;
+      stopBtn.disabled = true;
+    });
+
+    resetBtn.addEventListener('click', () => {
+      clearInterval(intervalId);
+      intervalId = null;
+      elapsedMs = 0;
+      display.textContent = format(0);
+      stopwatch.classList.remove('ease-stopwatch--running');
+      startBtn.disabled = false;
+      stopBtn.disabled = true;
+    });
+  })();
+</script>
+
+</body>
+</html>

--- a/submissions/examples/ease-stopwatch-timer/style.css
+++ b/submissions/examples/ease-stopwatch-timer/style.css
@@ -1,0 +1,144 @@
+/* ==========================================================
+   ease-stopwatch-timer — component styles
+   Uses: ease-fade-in, ease-slide-up, ease-hover-grow,
+         ease-card, ease-card-shadow
+   ========================================================== */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  background: #0f0f14;
+  color: #f5f5f7;
+  padding: 48px 20px;
+}
+
+.stopwatch-page h1 {
+  margin: 0 0 4px;
+  font-size: 1.6rem;
+  text-align: center;
+}
+
+.stopwatch-sub {
+  margin: 0 0 32px;
+  color: #a1a1aa;
+  text-align: center;
+  font-size: 0.95rem;
+}
+
+/* ----- Component root ----- */
+.ease-stopwatch {
+  width: 300px;
+  max-width: 90vw;
+  padding: 32px 28px;
+  border-radius: 20px;
+  background: #17171d;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+}
+
+/* ----- Ring / display ----- */
+.ease-stopwatch-ring {
+  width: 190px;
+  height: 190px;
+  border-radius: 50%;
+  border: 4px solid rgba(255, 255, 255, 0.12);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.ease-stopwatch-display {
+  font-variant-numeric: tabular-nums;
+  font-size: 1.9rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+/* Pulsing active state while running */
+.ease-stopwatch--running .ease-stopwatch-ring {
+  border-color: #22c55e;
+  box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.5);
+  animation: ease-stopwatch-pulse 1.4s ease-out infinite;
+}
+
+@keyframes ease-stopwatch-pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.45);
+  }
+  70% {
+    box-shadow: 0 0 0 14px rgba(34, 197, 94, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(34, 197, 94, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-stopwatch--running .ease-stopwatch-ring {
+    animation: none;
+  }
+}
+
+/* ----- Controls ----- */
+.ease-stopwatch-controls {
+  display: flex;
+  gap: 12px;
+  width: 100%;
+}
+
+.ease-stopwatch-btn {
+  flex: 1;
+  padding: 10px 0;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: transparent;
+  color: #f5f5f7;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, opacity 0.2s ease;
+}
+
+.ease-stopwatch-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.ease-stopwatch-btn--start {
+  background: #22c55e;
+  border-color: #22c55e;
+  color: #0f0f14;
+}
+
+.ease-stopwatch-btn--start:hover:not(:disabled) {
+  background: #16a34a;
+}
+
+.ease-stopwatch-btn--stop {
+  background: #ef4444;
+  border-color: #ef4444;
+  color: #0f0f14;
+}
+
+.ease-stopwatch-btn--stop:hover:not(:disabled) {
+  background: #dc2626;
+}
+
+.ease-stopwatch-btn--reset:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.3);
+}


### PR DESCRIPTION
Closes #39865

## Description
This PR implements the ease-stopwatch-timer component — a CSS-first stopwatch with Start/Stop/Reset controls and a pulsing "active" ring animation while running.

## Implementation Details
- **ease-fade-in** — heading entrance
- **ease-slide-up** — component entrance animation
- **ease-hover-grow** — button hover feedback
- **ease-card / ease-card-shadow** — base container styling
- Custom @keyframes pulse animation, respects prefers-reduced-motion
- Pure vanilla JS timer logic — no dependencies

## Features
- HH:MM:SS display with tabular numerals
- Start / Stop / Reset controls with proper disabled-state handling
- Pulsing ring while actively running
- Accessible: reduced-motion users get a static ring

## Checklist
- [x] Demo added (demo.html works by opening directly in a browser)
- [x] Files placed only inside submissions/examples/ease-stopwatch-timer/
- [x] Includes demo.html, style.css, README.md
- [x] Tested in Chrome / Edge

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari