### PR TITLE
feat: add animated breadcrumb

### DIFF
--- a/submissions/examples/breadcrumb-as/README.md
+++ b/submissions/examples/breadcrumb-as/README.md
@@ -1,0 +1,23 @@
+# Animated Breadcrumb
+
+### What does this do?
+
+It shows a breadcrumb trail with chevron separators where each link slides in an underline on hover, and the current page is highlighted.
+
+### How is it used?
+
+```html
+<nav class="breadcrumb" aria-label="Breadcrumb">
+  <a href="#" class="crumb">Home</a>
+  <span class="crumb-sep" aria-hidden="true"></span>
+  <a href="#" class="crumb">Docs</a>
+  <span class="crumb-sep" aria-hidden="true"></span>
+  <span class="crumb is-current" aria-current="page">Buttons</span>
+</nav>
+```
+
+Wrap the trail in a `nav` with an `aria-label`, separate the crumbs with `.crumb-sep`, and mark the last one with `is-current` and `aria-current="page"`.
+
+### Why is it useful?
+
+Breadcrumbs show where a user is in a site hierarchy. This grows a sliding underline on hover with a transform transition, so it needs no JavaScript. The separators are decorative and hidden from assistive tech, the current page is marked with `aria-current`, links show a focus ring, and the underline is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/breadcrumb-as/demo.html
+++ b/submissions/examples/breadcrumb-as/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Breadcrumb</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <a href="#" class="crumb">Home</a>
+    <span class="crumb-sep" aria-hidden="true"></span>
+    <a href="#" class="crumb">Docs</a>
+    <span class="crumb-sep" aria-hidden="true"></span>
+    <a href="#" class="crumb">Components</a>
+    <span class="crumb-sep" aria-hidden="true"></span>
+    <span class="crumb is-current" aria-current="page">Buttons</span>
+  </nav>
+</body>
+</html>

--- a/submissions/examples/breadcrumb-as/style.css
+++ b/submissions/examples/breadcrumb-as/style.css
@@ -1,0 +1,78 @@
+:root {
+  --accent: #6c63ff;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: var(--text);
+}
+
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  font-size: 0.92rem;
+}
+
+.crumb {
+  position: relative;
+  color: var(--muted);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.crumb:hover {
+  color: var(--text);
+}
+
+.crumb:not(.is-current)::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -3px;
+  width: 100%;
+  height: 2px;
+  border-radius: 2px;
+  background: var(--accent);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.2s ease;
+}
+
+.crumb:not(.is-current):hover::after {
+  transform: scaleX(1);
+}
+
+.crumb:focus-visible {
+  outline: 2px solid #fbbf24;
+  outline-offset: 3px;
+  border-radius: 3px;
+}
+
+.crumb.is-current {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.crumb-sep {
+  width: 6px;
+  height: 6px;
+  border-top: 2px solid #475569;
+  border-right: 2px solid #475569;
+  transform: rotate(45deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .crumb:not(.is-current)::after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an animated breadcrumb built for #40098. Chevron separated links slide in an underline on hover, and the current page is highlighted, using only CSS. Closes #40098.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A breadcrumb trail with chevron separators, a sliding underline on hover, and a highlighted current page.

**How does a developer use it?**

```html
<nav class="breadcrumb" aria-label="Breadcrumb">
  <a href="#" class="crumb">Home</a>
  <span class="crumb-sep" aria-hidden="true"></span>
  <span class="crumb is-current" aria-current="page">Buttons</span>
</nav>
```

**Why does it fit EaseMotion CSS?**
It grows a sliding underline on hover with a transform transition, so it needs no JavaScript. Separators are decorative and hidden from assistive tech, the current page uses `aria-current`, links show a focus ring, and the underline is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: hovering a link scales its underline from 0 to full width.
