### PR TITLE
feat: add animated filter chips

### DIFF
--- a/submissions/examples/filter-chips-as/README.md
+++ b/submissions/examples/filter-chips-as/README.md
@@ -1,0 +1,20 @@
+# Animated Filter Chips
+
+### What does this do?
+
+It shows selectable filter chips where clicking a chip fills it with an accent color, reveals a check mark, and gives it a small pop. Multiple chips can be active at once.
+
+### How is it used?
+
+```html
+<label class="chip">
+  <input type="checkbox" class="chip-input" />
+  <span class="chip-label">Design</span>
+</label>
+```
+
+Each chip is a `label` wrapping a checkbox and a `.chip-label`. Selecting it toggles the filled state. Because the inputs are checkboxes, several chips can be active together.
+
+### Why is it useful?
+
+Filter chips let users narrow lists by tags or categories. This animates the selected state with a transform pop and a revealed check using only the `:checked` state, so it needs no JavaScript. The chips stay keyboard operable with a focus ring, and the pop is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/filter-chips-as/demo.html
+++ b/submissions/examples/filter-chips-as/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Filter Chips</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="chip-set">
+    <label class="chip">
+      <input type="checkbox" class="chip-input" checked />
+      <span class="chip-label">Design</span>
+    </label>
+    <label class="chip">
+      <input type="checkbox" class="chip-input" />
+      <span class="chip-label">Development</span>
+    </label>
+    <label class="chip">
+      <input type="checkbox" class="chip-input" checked />
+      <span class="chip-label">Marketing</span>
+    </label>
+    <label class="chip">
+      <input type="checkbox" class="chip-input" />
+      <span class="chip-label">Research</span>
+    </label>
+    <label class="chip">
+      <input type="checkbox" class="chip-input" />
+      <span class="chip-label">Support</span>
+    </label>
+  </div>
+</body>
+</html>

--- a/submissions/examples/filter-chips-as/style.css
+++ b/submissions/examples/filter-chips-as/style.css
@@ -1,0 +1,88 @@
+:root {
+  --accent: #6c63ff;
+  --text: #e2e8f0;
+  --muted: #cbd5e1;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: var(--text);
+}
+
+.chip-set {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  max-width: 420px;
+  justify-content: center;
+}
+
+.chip {
+  cursor: pointer;
+}
+
+.chip-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.chip-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--muted);
+  background: #111a2e;
+  border: 1px solid #26324a;
+  transition: color 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+}
+
+.chip-label::before {
+  content: "\2713";
+  width: 0;
+  overflow: hidden;
+  font-size: 0.8rem;
+  opacity: 0;
+  transition: width 0.2s ease, opacity 0.2s ease;
+}
+
+.chip-input:checked + .chip-label {
+  color: #fff;
+  background: var(--accent);
+  border-color: var(--accent);
+  animation: chipPop 0.25s ease;
+}
+
+.chip-input:checked + .chip-label::before {
+  width: 0.9em;
+  opacity: 1;
+}
+
+.chip-input:focus-visible + .chip-label {
+  outline: 2px solid #fbbf24;
+  outline-offset: 2px;
+}
+
+@keyframes chipPop {
+  50% {
+    transform: scale(1.08);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chip-input:checked + .chip-label {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds animated filter chips built for #40102. Selecting a chip fills it with an accent color, reveals a check mark, and gives it a small pop. Multiple chips can be active at once, using checkboxes and CSS with no JavaScript. Closes #40102.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
Selectable filter chips with an accent fill, a revealed check, and a pop on select, supporting multiple active chips.

**How does a developer use it?**

```html
<label class="chip">
  <input type="checkbox" class="chip-input" />
  <span class="chip-label">Design</span>
</label>
```

**Why does it fit EaseMotion CSS?**
It animates the selected state with a transform pop and a revealed check using only `:checked`, so it needs no JavaScript. Chips stay keyboard operable with a focus ring, and the pop is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: a checked chip renders with the accent background and a revealed check, unchecked chips stay dark.
