### PR TITLE
feat: add interactive star rating

### DIFF
--- a/submissions/examples/star-rating-as/README.md
+++ b/submissions/examples/star-rating-as/README.md
@@ -1,0 +1,23 @@
+# Interactive Star Rating
+
+### What does this do?
+
+It is a five star rating control where hovering previews the rating by filling stars up to the pointer, and clicking sets it, using only CSS.
+
+### How is it used?
+
+```html
+<div class="rating" role="radiogroup" aria-label="Rate this">
+  <input type="radio" name="rate" id="r5" /><label for="r5" aria-label="5 stars">&#9733;</label>
+  <input type="radio" name="rate" id="r4" /><label for="r4" aria-label="4 stars">&#9733;</label>
+  <input type="radio" name="rate" id="r3" /><label for="r3" aria-label="3 stars">&#9733;</label>
+  <input type="radio" name="rate" id="r2" /><label for="r2" aria-label="2 stars">&#9733;</label>
+  <input type="radio" name="rate" id="r1" /><label for="r1" aria-label="1 star">&#9733;</label>
+</div>
+```
+
+The stars are ordered from five down to one and laid out with `flex-direction: row-reverse`, so the sibling combinator can fill the hovered star and every star before it.
+
+### Why is it useful?
+
+Star ratings collect quick feedback on products and content. This builds the hover preview and the selected state from the sibling combinator and a transform, so it needs no JavaScript. Each star has an accessible label, the radios keep keyboard support with a focus ring, and the scale is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/star-rating-as/demo.html
+++ b/submissions/examples/star-rating-as/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Interactive Star Rating</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="rating" role="radiogroup" aria-label="Rate this">
+    <input type="radio" name="rate" id="r5" /><label for="r5" aria-label="5 stars">&#9733;</label>
+    <input type="radio" name="rate" id="r4" /><label for="r4" aria-label="4 stars">&#9733;</label>
+    <input type="radio" name="rate" id="r3" /><label for="r3" aria-label="3 stars">&#9733;</label>
+    <input type="radio" name="rate" id="r2" /><label for="r2" aria-label="2 stars">&#9733;</label>
+    <input type="radio" name="rate" id="r1" /><label for="r1" aria-label="1 star">&#9733;</label>
+  </div>
+</body>
+</html>

--- a/submissions/examples/star-rating-as/style.css
+++ b/submissions/examples/star-rating-as/style.css
@@ -1,0 +1,60 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.rating {
+  display: inline-flex;
+  flex-direction: row-reverse;
+  gap: 0.25rem;
+}
+
+.rating input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.rating label {
+  font-size: 2.4rem;
+  line-height: 1;
+  color: #334155;
+  cursor: pointer;
+  transition: color 0.15s ease, transform 0.15s ease;
+}
+
+.rating label:hover,
+.rating label:hover ~ label,
+.rating input:checked ~ label {
+  color: #fbbf24;
+}
+
+.rating label:hover,
+.rating label:hover ~ label {
+  transform: scale(1.12);
+}
+
+.rating input:focus-visible + label {
+  outline: 2px solid #6c63ff;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rating label {
+    transition: color 0.15s ease;
+  }
+
+  .rating label:hover,
+  .rating label:hover ~ label {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an interactive star rating built for #40105. Hovering previews the rating by filling stars up to the pointer, and clicking sets it, using radio inputs and CSS with no JavaScript. Closes #40105.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A five star rating with a hover preview and a selected state, keyboard operable through native radios.

**How does a developer use it?**

```html
<div class="rating" role="radiogroup" aria-label="Rate this">
  <input type="radio" name="rate" id="r5" /><label for="r5" aria-label="5 stars">&#9733;</label>
  <input type="radio" name="rate" id="r4" /><label for="r4" aria-label="4 stars">&#9733;</label>
  <input type="radio" name="rate" id="r3" /><label for="r3" aria-label="3 stars">&#9733;</label>
  <input type="radio" name="rate" id="r2" /><label for="r2" aria-label="2 stars">&#9733;</label>
  <input type="radio" name="rate" id="r1" /><label for="r1" aria-label="1 star">&#9733;</label>
</div>
```

**Why does it fit EaseMotion CSS?**
It builds the hover preview and selected state from the sibling combinator and a transform, so it needs no JavaScript. Each star has an accessible label, the radios keep keyboard support with a focus ring, and the scale is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: hovering the fourth star lights stars one through four gold and leaves the fifth empty.
