### PR TITLE
feat: add animated toggle switch set

### DIFF
--- a/submissions/examples/toggle-switch-set-as/README.md
+++ b/submissions/examples/toggle-switch-set-as/README.md
@@ -1,0 +1,24 @@
+# Animated Toggle Switch Set
+
+### What does this do?
+
+It shows a settings panel of on and off toggle switches, each with a label and a knob that slides with a spring when toggled.
+
+### How is it used?
+
+```html
+<label class="setting">
+  <span class="setting-text">
+    <strong>Email notifications</strong>
+    <span>Get an email when something happens.</span>
+  </span>
+  <input type="checkbox" class="switch-input" checked />
+  <span class="switch" aria-hidden="true"></span>
+</label>
+```
+
+Each row is a `label` wrapping a checkbox and a `.switch`. When the checkbox is checked, the track turns accent and the knob slides across.
+
+### Why is it useful?
+
+Toggle switches are the standard control for settings and preferences. This slides the knob and swaps the track color with a transform and color transition driven by `:checked`, so it needs no JavaScript. The switches stay keyboard operable with a focus ring, and motion is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/toggle-switch-set-as/demo.html
+++ b/submissions/examples/toggle-switch-set-as/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Toggle Switch Set</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="settings">
+    <label class="setting">
+      <span class="setting-text">
+        <strong>Email notifications</strong>
+        <span>Get an email when something happens.</span>
+      </span>
+      <input type="checkbox" class="switch-input" checked />
+      <span class="switch" aria-hidden="true"></span>
+    </label>
+
+    <label class="setting">
+      <span class="setting-text">
+        <strong>Push notifications</strong>
+        <span>Send alerts to this device.</span>
+      </span>
+      <input type="checkbox" class="switch-input" />
+      <span class="switch" aria-hidden="true"></span>
+    </label>
+
+    <label class="setting">
+      <span class="setting-text">
+        <strong>Weekly digest</strong>
+        <span>A summary every Monday.</span>
+      </span>
+      <input type="checkbox" class="switch-input" checked />
+      <span class="switch" aria-hidden="true"></span>
+    </label>
+
+    <label class="setting">
+      <span class="setting-text">
+        <strong>Public profile</strong>
+        <span>Let others find your page.</span>
+      </span>
+      <input type="checkbox" class="switch-input" />
+      <span class="switch" aria-hidden="true"></span>
+    </label>
+  </div>
+</body>
+</html>

--- a/submissions/examples/toggle-switch-set-as/style.css
+++ b/submissions/examples/toggle-switch-set-as/style.css
@@ -1,0 +1,102 @@
+:root {
+  --accent: #6c63ff;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: var(--text);
+}
+
+.settings {
+  width: min(400px, 94vw);
+  padding: 0.5rem 1.25rem;
+  border-radius: 16px;
+  background: #111a2e;
+  border: 1px solid #1e293b;
+}
+
+.setting {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 0;
+  cursor: pointer;
+}
+
+.setting + .setting {
+  border-top: 1px solid #1e293b;
+}
+
+.setting-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.setting-text strong {
+  font-size: 0.92rem;
+}
+
+.setting-text span {
+  font-size: 0.78rem;
+  color: var(--muted);
+}
+
+.switch-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.switch {
+  position: relative;
+  flex-shrink: 0;
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #334155;
+  transition: background 0.25s ease;
+}
+
+.switch::before {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.switch-input:checked + .switch {
+  background: var(--accent);
+}
+
+.switch-input:checked + .switch::before {
+  transform: translateX(20px);
+}
+
+.switch-input:focus-visible + .switch {
+  outline: 2px solid #fbbf24;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .switch,
+  .switch::before {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an animated toggle switch set built for #40108. A settings panel of on and off switches, each with a knob that slides with a spring when toggled, using checkboxes and CSS with no JavaScript. Closes #40108.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A settings panel of labelled toggle switches with a sliding knob and an accent track when on.

**How does a developer use it?**

```html
<label class="setting">
  <span class="setting-text">
    <strong>Email notifications</strong>
    <span>Get an email when something happens.</span>
  </span>
  <input type="checkbox" class="switch-input" checked />
  <span class="switch" aria-hidden="true"></span>
</label>
```

**Why does it fit EaseMotion CSS?**
It slides the knob and swaps the track color with a transform and color transition driven by `:checked`, so it needs no JavaScript. The switches stay keyboard operable with a focus ring, and motion is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: a checked switch renders with the accent track and the knob translated across, an unchecked switch stays gray.
