### PR TITLE
feat: add skeleton content card

### DIFF
--- a/submissions/examples/skeleton-card-as/README.md
+++ b/submissions/examples/skeleton-card-as/README.md
@@ -1,0 +1,24 @@
+# Skeleton Content Card
+
+### What does this do?
+
+It shows a loading placeholder card with a circular avatar and text lines that shimmer with a moving gradient while real content loads.
+
+### How is it used?
+
+```html
+<div class="skeleton-card" role="status" aria-label="Loading content">
+  <div class="skeleton skeleton-avatar"></div>
+  <div class="skeleton-lines">
+    <div class="skeleton skeleton-line w-60"></div>
+    <div class="skeleton skeleton-line w-90"></div>
+    <div class="skeleton skeleton-line w-75"></div>
+  </div>
+</div>
+```
+
+Apply the `skeleton` class to any block to give it the shimmer, and use `skeleton-avatar` or `skeleton-line` for the common shapes. Swap the placeholder for the real content once it arrives.
+
+### Why is it useful?
+
+Skeleton loaders reduce perceived wait time by showing the shape of content before it arrives. This animates the shimmer by moving a gradient background position, so it needs no images or JavaScript. The card has a `status` role for assistive tech, and the shimmer is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/skeleton-card-as/demo.html
+++ b/submissions/examples/skeleton-card-as/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Skeleton Content Card</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="skeleton-card" role="status" aria-label="Loading content">
+    <div class="skeleton skeleton-avatar"></div>
+    <div class="skeleton-lines">
+      <div class="skeleton skeleton-line w-60"></div>
+      <div class="skeleton skeleton-line w-90"></div>
+      <div class="skeleton skeleton-line w-75"></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/skeleton-card-as/style.css
+++ b/submissions/examples/skeleton-card-as/style.css
@@ -1,0 +1,63 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.skeleton-card {
+  display: flex;
+  gap: 1rem;
+  width: min(360px, 92vw);
+  padding: 1.5rem;
+  border-radius: 16px;
+  background: #111a2e;
+  border: 1px solid #1e293b;
+}
+
+.skeleton {
+  background: linear-gradient(90deg, #1e293b 25%, #334155 50%, #1e293b 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.4s ease-in-out infinite;
+}
+
+.skeleton-avatar {
+  flex-shrink: 0;
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+}
+
+.skeleton-lines {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  padding-top: 0.35rem;
+}
+
+.skeleton-line {
+  height: 12px;
+  border-radius: 6px;
+}
+
+.skeleton-line.w-60 { width: 60%; }
+.skeleton-line.w-90 { width: 90%; }
+.skeleton-line.w-75 { width: 75%; }
+
+@keyframes shimmer {
+  to {
+    background-position: -200% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    animation: none;
+    background-position: 0 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a skeleton content card built for #40117. A loading placeholder with an avatar and text lines that shimmer with a moving gradient, using only CSS with no images. Closes #40117.

## Type of Change

- [x] ✨ New animation / hover effect

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A skeleton placeholder card with a shimmering avatar and text lines while content loads.

**How does a developer use it?**

```html
<div class="skeleton-card" role="status" aria-label="Loading content">
  <div class="skeleton skeleton-avatar"></div>
  <div class="skeleton-lines">
    <div class="skeleton skeleton-line w-60"></div>
    <div class="skeleton skeleton-line w-90"></div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It animates the shimmer by moving a gradient background position, so it needs no images or JavaScript. The card has a `status` role, and the shimmer is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: four skeleton blocks render with the shimmer animation applied.
