### PR TITLE
feat: add notification count badges

### DIFF
--- a/submissions/examples/notification-count-badges-as/README.md
+++ b/submissions/examples/notification-count-badges-as/README.md
@@ -1,0 +1,23 @@
+# Notification Count Badges
+
+### What does this do?
+
+It shows header icon buttons, each with a small count badge in the corner that pops in with a spring.
+
+### How is it used?
+
+```html
+<button class="icon-btn" aria-label="Notifications, 3 unread">
+  <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+    <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+    <path d="M10 21a2 2 0 0 0 4 0" />
+  </svg>
+  <span class="icon-badge" aria-hidden="true">3</span>
+</button>
+```
+
+Place an `.icon-badge` inside a relatively positioned `.icon-btn`. The badge is decorative, so the count is also given to screen readers through the button `aria-label`.
+
+### Why is it useful?
+
+Count badges signal unread messages, cart items, or alerts in app headers. This pops the badge in with a scale keyframe, using inline SVG icons so it is self contained with no images and no JavaScript. Buttons show a focus ring, and the pop is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/notification-count-badges-as/demo.html
+++ b/submissions/examples/notification-count-badges-as/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Notification Count Badges</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="icon-row">
+    <button class="icon-btn" aria-label="Notifications, 3 unread">
+      <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+        <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+        <path d="M10 21a2 2 0 0 0 4 0" />
+      </svg>
+      <span class="icon-badge" aria-hidden="true">3</span>
+    </button>
+
+    <button class="icon-btn" aria-label="Messages, 12 unread">
+      <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+        <rect x="3" y="5" width="18" height="14" rx="2" />
+        <path d="m3 7 9 6 9-6" />
+      </svg>
+      <span class="icon-badge" aria-hidden="true">12</span>
+    </button>
+
+    <button class="icon-btn" aria-label="Cart, 5 items">
+      <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+        <circle cx="9" cy="20" r="1.4" />
+        <circle cx="18" cy="20" r="1.4" />
+        <path d="M2 3h3l2.4 12a2 2 0 0 0 2 1.6h8a2 2 0 0 0 2-1.6L22 7H6" />
+      </svg>
+      <span class="icon-badge" aria-hidden="true">5</span>
+    </button>
+  </div>
+</body>
+</html>

--- a/submissions/examples/notification-count-badges-as/style.css
+++ b/submissions/examples/notification-count-badges-as/style.css
@@ -1,0 +1,76 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.icon-row {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.icon-btn {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 48px;
+  height: 48px;
+  color: #cbd5e1;
+  background: #111a2e;
+  border: 1px solid #26324a;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.icon-btn:hover {
+  color: #fff;
+  border-color: #3a4a6b;
+}
+
+.icon-btn:focus-visible {
+  outline: 2px solid #fbbf24;
+  outline-offset: 2px;
+}
+
+.icon-badge {
+  position: absolute;
+  top: -5px;
+  right: -5px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
+  box-sizing: border-box;
+  display: grid;
+  place-items: center;
+  font-size: 0.7rem;
+  font-weight: 700;
+  line-height: 1;
+  color: #fff;
+  background: #ef4444;
+  border: 2px solid #0b1121;
+  border-radius: 999px;
+  animation: badgeIn 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+.icon-btn:nth-child(2) .icon-badge { animation-delay: 0.12s; }
+.icon-btn:nth-child(3) .icon-badge { animation-delay: 0.24s; }
+
+@keyframes badgeIn {
+  from {
+    transform: scale(0);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .icon-badge {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds notification count badges built for #40121. Header icon buttons each show a count badge that pops in with a spring, using inline SVG icons and CSS with no images and no JavaScript. Closes #40121.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
Icon buttons with a corner count badge that pops in, for headers and toolbars.

**How does a developer use it?**

```html
<button class="icon-btn" aria-label="Notifications, 3 unread">
  <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
    <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
    <path d="M10 21a2 2 0 0 0 4 0" />
  </svg>
  <span class="icon-badge" aria-hidden="true">3</span>
</button>
```

**Why does it fit EaseMotion CSS?**
It pops the badge in with a scale keyframe using inline SVG icons, so it is self contained with no images and no JavaScript. The count is exposed to screen readers through the button label, buttons show a focus ring, and the pop is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: three icon buttons render with count badges and the pop-in animation applied.
