### PR TITLE
feat: add animated chat message bubbles

### DIFF
--- a/submissions/examples/chat-bubbles-as/README.md
+++ b/submissions/examples/chat-bubbles-as/README.md
@@ -1,0 +1,21 @@
+# Animated Chat Message Bubbles
+
+### What does this do?
+
+It shows a chat thread of sent and received message bubbles with rounded tails, where each bubble fades and slides in with a staggered delay.
+
+### How is it used?
+
+```html
+<div class="chat">
+  <div class="bubble received">Hey, are we still on for today?</div>
+  <div class="bubble sent">Yes, see you at 3.</div>
+  <div class="bubble received">Perfect.</div>
+</div>
+```
+
+Use `received` for incoming messages, which align left with a neutral color, and `sent` for outgoing ones, which align right with the accent color. A cut corner on each bubble suggests a tail.
+
+### Why is it useful?
+
+Message bubbles are the core of chat and support interfaces. This reveals the conversation with a staggered fade and slide, and distinguishes sides with alignment and color, using only CSS with no JavaScript. Motion is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/chat-bubbles-as/demo.html
+++ b/submissions/examples/chat-bubbles-as/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Chat Message Bubbles</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="chat">
+    <div class="bubble received">Hey, are we still on for today?</div>
+    <div class="bubble sent">Yes, see you at 3.</div>
+    <div class="bubble received">Perfect. Should I bring the files?</div>
+    <div class="bubble sent">Please do, thanks!</div>
+    <div class="bubble received">On my way now.</div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/chat-bubbles-as/style.css
+++ b/submissions/examples/chat-bubbles-as/style.css
@@ -1,0 +1,67 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.chat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: min(360px, 92vw);
+  padding: 1.25rem;
+  border-radius: 16px;
+  background: #0e1626;
+  border: 1px solid #1e293b;
+}
+
+.bubble {
+  max-width: 75%;
+  padding: 0.6rem 0.9rem;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  border-radius: 16px;
+  opacity: 0;
+  transform: translateY(8px);
+  animation: bubbleIn 0.4s ease forwards;
+}
+
+.bubble.received {
+  align-self: flex-start;
+  background: #1e293b;
+  color: #e2e8f0;
+  border-bottom-left-radius: 4px;
+}
+
+.bubble.sent {
+  align-self: flex-end;
+  background: #6c63ff;
+  color: #fff;
+  border-bottom-right-radius: 4px;
+}
+
+.bubble:nth-child(2) { animation-delay: 0.12s; }
+.bubble:nth-child(3) { animation-delay: 0.24s; }
+.bubble:nth-child(4) { animation-delay: 0.36s; }
+.bubble:nth-child(5) { animation-delay: 0.48s; }
+
+@keyframes bubbleIn {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bubble {
+    opacity: 1;
+    transform: none;
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds animated chat message bubbles built for #40123. Sent and received bubbles with rounded tails fade and slide in with a staggered delay, using only CSS. Closes #40123.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A chat thread of sent and received bubbles with a staggered entrance and side based alignment and color.

**How does a developer use it?**

```html
<div class="chat">
  <div class="bubble received">Hey, are we still on for today?</div>
  <div class="bubble sent">Yes, see you at 3.</div>
</div>
```

**Why does it fit EaseMotion CSS?**
It reveals the conversation with a staggered fade and slide and distinguishes sides with alignment and color, using only CSS. Motion is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: five bubbles settle to full opacity and sent bubbles align to the right.
