### PR TITLE
feat: add neumorphic fluid toggle switch (#39104)

### DIFF
--- a/submissions/examples/neumorphic-fluid-toggle/README.md
+++ b/submissions/examples/neumorphic-fluid-toggle/README.md
@@ -1,0 +1,39 @@
+﻿# Neumorphic Fluid Toggle Switch
+
+A soft-UI (neumorphism) toggle switch whose thumb simulates physical
+momentum: it squishes horizontally while traveling across the track and
+bounces slightly as it settles into place - all in pure CSS.
+
+## Usage
+
+```html
+<input type="checkbox" id="fluid-toggle" hidden>
+<label for="fluid-toggle" class="track">
+  <span class="thumb"></span>
+</label>
+```
+
+Include `style.css`. No JavaScript required.
+
+## How it works
+
+- **Neumorphic surface**: layered inset + outer box-shadow pairs on the
+  track and thumb create the soft, embossed look.
+- **Squish on travel**: `:active` briefly scales the thumb
+  (`scaleX(1.35) scaleY(0.85)`) while the user is pressing/dragging it.
+- **Momentum easing**: `cubic-bezier(0.68, -0.55, 0.265, 1.55)` gives the
+  thumb an overshoot "elastic" feel as it crosses the track.
+- **Settle bounce**: on `:checked`, a keyframe animation
+  (`ease-thumb-bounce`) squashes and rebounds the thumb shape as it lands.
+
+## Files
+
+- `demo.html` - standalone interactive demo
+- `style.css` - all styles + animation
+- `README.md` - this file
+
+## Accessibility
+
+Uses a real `<input type="checkbox">` under the hood (visually hidden, not
+`display:none`) so it remains keyboard- and screen-reader-accessible, with a
+visible focus ring via `:focus-visible`.

--- a/submissions/examples/neumorphic-fluid-toggle/demo.html
+++ b/submissions/examples/neumorphic-fluid-toggle/demo.html
@@ -1,0 +1,14 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Neumorphic Fluid Toggle Switch - EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <input type="checkbox" id="fluid-toggle" hidden>
+  <label for="fluid-toggle" class="track">
+    <span class="thumb"></span>
+  </label>
+</body>
+</html>

--- a/submissions/examples/neumorphic-fluid-toggle/style.css
+++ b/submissions/examples/neumorphic-fluid-toggle/style.css
@@ -1,0 +1,101 @@
+﻿/* ==========================================================================
+   EaseMotion CSS - Neumorphic Fluid Toggle Switch
+   Soft-UI toggle whose thumb squishes horizontally while traveling
+   and bounces slightly on settling.
+   ========================================================================== */
+
+body {
+  font-family: system-ui, sans-serif;
+  background: #e0e5ec;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  margin: 0;
+}
+
+/* Hide the native checkbox */
+#fluid-toggle {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Track */
+.track {
+  --track-w: 64px;
+  --track-h: 32px;
+  --thumb-size: 24px;
+
+  position: relative;
+  display: inline-block;
+  width: var(--track-w);
+  height: var(--track-h);
+  border-radius: calc(var(--track-h) / 2);
+  background: #e0e5ec;
+  cursor: pointer;
+  box-shadow:
+    inset 4px 4px 8px rgba(163, 177, 198, 0.6),
+    inset -4px -4px 8px rgba(255, 255, 255, 0.8);
+  transition: background 0.3s ease;
+}
+
+/* Thumb */
+.thumb {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  width: var(--thumb-size);
+  height: var(--thumb-size);
+  border-radius: 50%;
+  background: #e0e5ec;
+  box-shadow:
+    3px 3px 6px rgba(163, 177, 198, 0.7),
+    -3px -3px 6px rgba(255, 255, 255, 0.9);
+
+  transition:
+    left 0.35s cubic-bezier(0.68, -0.55, 0.265, 1.55),
+    transform 0.35s cubic-bezier(0.68, -0.55, 0.265, 1.55),
+    background 0.3s ease;
+}
+
+/* Squish while traveling */
+#fluid-toggle:active + .track .thumb {
+  transform: scaleX(1.35) scaleY(0.85);
+}
+
+/* Checked state */
+#fluid-toggle:checked + .track {
+  background: #6c5ce7;
+  box-shadow:
+    inset 4px 4px 8px rgba(84, 62, 199, 0.6),
+    inset -4px -4px 8px rgba(150, 121, 255, 0.5);
+}
+
+#fluid-toggle:checked + .track .thumb {
+  left: calc(var(--track-w) - var(--thumb-size) - 4px);
+  background: #f4f2ff;
+  animation: ease-thumb-bounce 0.35s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+}
+
+/* Bounce/settle keyframes */
+@keyframes ease-thumb-bounce {
+  0% {
+    transform: scaleX(1) scaleY(1);
+  }
+  40% {
+    transform: scaleX(1.3) scaleY(0.8);
+  }
+  70% {
+    transform: scaleX(0.92) scaleY(1.08);
+  }
+  100% {
+    transform: scaleX(1) scaleY(1);
+  }
+}
+
+/* Focus ring for accessibility */
+#fluid-toggle:focus-visible + .track {
+  outline: 2px solid #6c5ce7;
+  outline-offset: 3px;
+}


### PR DESCRIPTION
Closes #39104

## What this adds
A pure-CSS neumorphic (soft-UI) toggle switch whose thumb simulates physical momentum — squishing horizontally while traveling across the track and bouncing slightly as it settles into place. No JavaScript required.

## How it works
- **Neumorphic surface**: layered `inset` + outer `box-shadow` pairs on the track and thumb create the soft, embossed look
- **Squish on travel**: `:active` briefly scales the thumb (`scaleX(1.35) scaleY(0.85)`) while the user is pressing/dragging it
- **Momentum easing**: `cubic-bezier(0.68, -0.55, 0.265, 1.55)` gives the thumb an elastic overshoot feel as it crosses the track
- **Settle bounce**: on `:checked`, a keyframe animation (`ease-thumb-bounce`) squashes and rebounds the thumb shape as it lands

## Files added
`submissions/examples/neumorphic-fluid-toggle/`
- `demo.html` — standalone interactive demo
- `style.css` — all styles and animation
- `README.md` — usage docs and implementation notes

## How to test
1. Open `demo.html` in a browser
2. Click the toggle and observe the squish-and-bounce motion as the thumb travels and settles
3. Tab to the toggle with keyboard and press Space/Enter to confirm it's keyboard-accessible

## Accessibility
Built on a real `<input type="checkbox">` (visually hidden, not `display:none`), so it stays keyboard- and screen-reader-accessible, with a visible focus ring via `:focus-visible`.