### PR TITLE
docs: add navbar anchor offset showcase

### DIFF
--- a/submissions/docs/navbar-anchor-offset-ss/README.md
+++ b/submissions/docs/navbar-anchor-offset-ss/README.md
@@ -1,0 +1,20 @@
+# Navbar Anchor Offset Fix
+
+## What does this do?
+This demonstrates how to prevent section headings from being hidden beneath a sticky or fixed navigation bar during anchor navigation by using the CSS `scroll-margin-top` property.
+
+## How is it used?
+```html
+<section id="animations" class="doc-section">
+  ...
+</section>
+```
+
+```css
+.doc-section {
+  scroll-margin-top: 90px;
+}
+```
+
+## Why is it useful?
+When users navigate using anchor links (such as `#animations` or `#buttons`), sticky navigation bars can cover the target section heading. Applying `scroll-margin-top` ensures the heading remains fully visible, improving navigation, readability, and accessibility with a simple CSS solution.

--- a/submissions/docs/navbar-anchor-offset-ss/demo.html
+++ b/submissions/docs/navbar-anchor-offset-ss/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Navbar Anchor Offset Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<header class="navbar">
+    <a href="#buttons">Buttons</a>
+    <a href="#cards">Cards</a>
+    <a href="#animations">Animations</a>
+    <a href="#layout">Layout</a>
+    <a href="#docs">Docs</a>
+</header>
+
+<main>
+
+<section id="buttons" class="doc-section">
+    <h2>Buttons</h2>
+    <p>
+        Clicking the navigation link scrolls here while keeping the heading fully
+        visible below the sticky navigation bar.
+    </p>
+</section>
+
+<section id="cards" class="doc-section">
+    <h2>Cards</h2>
+    <p>
+        The <code>scroll-margin-top</code> property creates an offset for anchor
+        navigation without JavaScript.
+    </p>
+</section>
+
+<section id="animations" class="doc-section">
+    <h2>Animations</h2>
+    <p>
+        This demonstrates how section headings remain visible after smooth
+        scrolling.
+    </p>
+</section>
+
+<section id="layout" class="doc-section">
+    <h2>Layout</h2>
+    <p>
+        The same solution works for every section using the shared class.
+    </p>
+</section>
+
+<section id="docs" class="doc-section">
+    <h2>Documentation</h2>
+    <p>
+        A simple CSS rule improves usability and accessibility across the page.
+    </p>
+</section>
+
+</main>
+
+</body>
+</html>

--- a/submissions/docs/navbar-anchor-offset-ss/style.css
+++ b/submissions/docs/navbar-anchor-offset-ss/style.css
@@ -1,0 +1,65 @@
+*{
+    margin:0;
+    padding:0;
+    box-sizing:border-box;
+}
+
+html{
+    scroll-behavior:smooth;
+}
+
+body{
+    font-family:Arial, Helvetica, sans-serif;
+    background:#0f172a;
+    color:white;
+}
+
+.navbar{
+    position:sticky;
+    top:0;
+    z-index:1000;
+
+    display:flex;
+    justify-content:center;
+    gap:2rem;
+
+    padding:1.2rem;
+    background:#111827;
+}
+
+.navbar a{
+    color:white;
+    text-decoration:none;
+    font-weight:600;
+}
+
+.navbar a:hover{
+    color:#8b5cf6;
+}
+
+.doc-section{
+
+    /* Fix */
+
+    scroll-margin-top:90px;
+
+    min-height:100vh;
+
+    padding:5rem 2rem;
+
+    border-bottom:1px solid rgba(255,255,255,.08);
+}
+
+.doc-section h2{
+
+    font-size:2.4rem;
+
+    margin-bottom:1rem;
+}
+
+.doc-section p{
+
+    max-width:700px;
+
+    line-height:1.8;
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a documentation showcase demonstrating how to prevent section headings from being hidden behind a sticky navigation bar during anchor navigation using the CSS `scroll-margin-top` property.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A documentation example showing how to use `scroll-margin-top` to prevent anchor-linked sections from being hidden beneath sticky navigation bars.

**How does a developer use it?**

```html
<section id="animations" class="doc-section">
  ...
</section>
```

```css
.doc-section {
  scroll-margin-top: 90px;
}
```

**Why does it fit EaseMotion CSS?**

This provides a lightweight, CSS-only solution that improves documentation navigation and user experience without requiring JavaScript. It aligns with EaseMotion CSS's focus on simple, reusable, and developer-friendly solutions.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional)*

---

## Notes for Maintainer

- Added as a standalone documentation showcase under `submissions/docs/navbar-anchor-offset-ss`.
- No existing framework files or core library files were modified.