### PR TITLE
feat: Add Kanban Board Task Card with Drag Motion (Resolves #27385)

### DIFF
--- a/submissions/react/react-kanban-board-task-card-with-drag-motion-nicks19/KanbanTaskCard.jsx
+++ b/submissions/react/react-kanban-board-task-card-with-drag-motion-nicks19/KanbanTaskCard.jsx
@@ -1,0 +1,92 @@
+import React, { useState } from 'react';
+import './style.css';
+
+export default function KanbanTaskCard({
+  task,
+  onDragStart,
+  onDragEnd,
+  className = ''
+}) {
+  const [isDragging, setIsDragging] = useState(false);
+
+  const handleDragStart = (e) => {
+    setIsDragging(true);
+    
+    // Setting drag data is required for Firefox to actually drag
+    e.dataTransfer.setData('text/plain', task.id);
+    e.dataTransfer.effectAllowed = 'move';
+    
+    // Create a drag image if desired, or let the browser handle it.
+    // In this case, the browser handles it, and we apply our CSS class to the original element
+    // to give it a "ghost" appearance while dragging.
+
+    // A small delay ensures the class is added *after* the browser captures the drag image,
+    // so the dragged image looks normal, but the element left behind looks ghosted.
+    setTimeout(() => {
+      if (onDragStart) onDragStart(e, task);
+    }, 0);
+  };
+
+  const handleDragEnd = (e) => {
+    setIsDragging(false);
+    if (onDragEnd) onDragEnd(e, task);
+  };
+
+  // Determine priority color
+  const getPriorityColor = (priority) => {
+    switch (priority?.toLowerCase()) {
+      case 'high': return '#ef4444';
+      case 'medium': return '#f59e0b';
+      case 'low': return '#10b981';
+      default: return '#6b7280';
+    }
+  };
+
+  return (
+    <div
+      className={`ease-kanban-card ${isDragging ? 'ease-card-dragging' : ''} ${className}`}
+      draggable="true"
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      aria-grabbed={isDragging}
+    >
+      <div className="ease-card-header">
+        <span className="ease-task-id">{task.id}</span>
+        {task.priority && (
+          <span 
+            className="ease-task-priority"
+            style={{ backgroundColor: getPriorityColor(task.priority) }}
+          >
+            {task.priority}
+          </span>
+        )}
+      </div>
+      
+      <h3 className="ease-task-title">{task.title}</h3>
+      
+      {task.description && (
+        <p className="ease-task-desc">{task.description}</p>
+      )}
+
+      <div className="ease-card-footer">
+        <div className="ease-task-tags">
+          {task.tags && task.tags.map((tag, index) => (
+            <span key={index} className="ease-tag">{tag}</span>
+          ))}
+        </div>
+        
+        {task.assignee && (
+          <div className="ease-task-assignee" title={task.assignee.name}>
+            {task.assignee.avatar ? (
+              <img src={task.assignee.avatar} alt={task.assignee.name} />
+            ) : (
+              <div className="ease-avatar-fallback">
+                {task.assignee.name.charAt(0).toUpperCase()}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/submissions/react/react-kanban-board-task-card-with-drag-motion-nicks19/README.md
+++ b/submissions/react/react-kanban-board-task-card-with-drag-motion-nicks19/README.md
@@ -1,0 +1,75 @@
+# Kanban Board Task Card with Drag Motion
+
+A highly responsive React component designed for Kanban or sprint boards. It utilizes native HTML5 drag-and-drop combined with EaseMotion CSS principles to provide satisfying visual feedback (scaling, rotation, shadow elevation) when a user picks up and drags a task.
+
+## Props
+
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `task` | `Object` | **Required** | The task data object (see structure below) |
+| `onDragStart` | `(event, task) => void` | `undefined` | Callback fired when the drag operation begins |
+| `onDragEnd` | `(event, task) => void` | `undefined` | Callback fired when the drag operation ends (or is cancelled) |
+| `className` | `string` | `''` | Additional custom CSS classes for the card wrapper |
+
+### Task Object Structure
+```typescript
+{
+  id: string,             // e.g., "TSK-102"
+  title: string,
+  description?: string,
+  priority?: string,      // "high", "medium", "low" (automatically color-coded)
+  tags?: string[],
+  assignee?: {
+    name: string,
+    avatar?: string       // URL to image. Falls back to name initial if not provided.
+  }
+}
+```
+
+## Installation
+
+1. Copy `KanbanTaskCard.jsx` and `style.css` into your project components directory.
+2. Ensure you have React installed. No other dependencies are required.
+
+## Usage Example
+
+```jsx
+import React from 'react';
+import KanbanTaskCard from './KanbanTaskCard';
+
+function App() {
+  const sampleTask = {
+    id: "FE-409",
+    title: "Implement drag-and-drop feature",
+    description: "Use HTML5 APIs to allow users to reorder items in the list.",
+    priority: "high",
+    tags: ["feature", "frontend"],
+    assignee: { name: "Alex" }
+  };
+
+  const handleDragStart = (e, task) => {
+    console.log('Started dragging:', task.id);
+  };
+
+  const handleDragEnd = (e, task) => {
+    console.log('Finished dragging:', task.id);
+  };
+
+  return (
+    <div style={{ padding: '40px', width: '320px', background: '#f4f5f7' }}>
+      <KanbanTaskCard 
+        task={sampleTask} 
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+      />
+    </div>
+  );
+}
+
+export default App;
+```
+
+## Why it fits EaseMotion CSS
+
+- **Physical Metaphor**: When picked up (dragged), the `.ease-card-dragging` class triggers an immediate transformation: the card scales up slightly (`1.02`), rotates slightly (`2deg`), drops its opacity, and deepens its shadow. This mimics lifting a physical card off a board.
+- **Hover Responsiveness**: Standard hover states utilize a subtle Y-translation (`-2px`) accompanied by a shadow increase, connected by a `cubic-bezier(0.34, 1.56, 0.64, 1)` transition that makes the card feel springy and reactive to the mouse pointer before it is even clicked.

--- a/submissions/react/react-kanban-board-task-card-with-drag-motion-nicks19/demo.html
+++ b/submissions/react/react-kanban-board-task-card-with-drag-motion-nicks19/demo.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Kanban Task Card Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background: #f1f5f9;
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 40px 20px;
+    }
+    .demo-header {
+      text-align: center;
+      margin-bottom: 40px;
+    }
+    .demo-header h1 {
+      color: #0f172a;
+      margin: 0 0 8px 0;
+    }
+    .demo-header p {
+      color: #64748b;
+      margin: 0;
+    }
+    .kanban-board-mock {
+      display: flex;
+      gap: 24px;
+      padding: 24px;
+      background: #e2e8f0;
+      border-radius: 12px;
+      width: 100%;
+      max-width: 800px;
+      overflow-x: auto;
+    }
+    .kanban-column {
+      background: #f8fafc;
+      border-radius: 8px;
+      width: 320px;
+      flex-shrink: 0;
+      padding: 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+    .kanban-col-header {
+      font-size: 14px;
+      font-weight: 700;
+      color: #475569;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 8px;
+    }
+    .kanban-col-count {
+      background: #e2e8f0;
+      padding: 2px 8px;
+      border-radius: 12px;
+      font-size: 12px;
+    }
+    .drop-zone {
+      min-height: 150px;
+      border: 2px dashed transparent;
+      border-radius: 8px;
+      transition: border-color 0.2s, background-color 0.2s;
+    }
+    .drop-zone.drag-over {
+      border-color: #3b82f6;
+      background-color: #eff6ff;
+    }
+  </style>
+</head>
+<body>
+  <div class="demo-header">
+    <h1>Kanban Task Card</h1>
+    <p>Try dragging the cards between columns to see the motion effects.</p>
+  </div>
+  
+  <div id="root"></div>
+
+  <!-- React dependencies -->
+  <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+
+  <!-- React component code -->
+  <script type="text/babel">
+    const { useState } = React;
+
+    function KanbanTaskCard({ task, onDragStart, onDragEnd, className = '' }) {
+      const [isDragging, setIsDragging] = useState(false);
+
+      const handleDragStart = (e) => {
+        setIsDragging(true);
+        e.dataTransfer.setData('text/plain', task.id);
+        e.dataTransfer.effectAllowed = 'move';
+        
+        setTimeout(() => {
+          if (onDragStart) onDragStart(e, task);
+        }, 0);
+      };
+
+      const handleDragEnd = (e) => {
+        setIsDragging(false);
+        if (onDragEnd) onDragEnd(e, task);
+      };
+
+      const getPriorityColor = (priority) => {
+        switch (priority?.toLowerCase()) {
+          case 'high': return '#ef4444';
+          case 'medium': return '#f59e0b';
+          case 'low': return '#10b981';
+          default: return '#6b7280';
+        }
+      };
+
+      return (
+        <div
+          className={`ease-kanban-card ${isDragging ? 'ease-card-dragging' : ''} ${className}`}
+          draggable="true"
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
+          aria-grabbed={isDragging}
+        >
+          <div className="ease-card-header">
+            <span className="ease-task-id">{task.id}</span>
+            {task.priority && (
+              <span className="ease-task-priority" style={{ backgroundColor: getPriorityColor(task.priority) }}>
+                {task.priority}
+              </span>
+            )}
+          </div>
+          
+          <h3 className="ease-task-title">{task.title}</h3>
+          
+          {task.description && (
+            <p className="ease-task-desc">{task.description}</p>
+          )}
+
+          <div className="ease-card-footer">
+            <div className="ease-task-tags">
+              {task.tags && task.tags.map((tag, index) => (
+                <span key={index} className="ease-tag">{tag}</span>
+              ))}
+            </div>
+            
+            {task.assignee && (
+              <div className="ease-task-assignee" title={task.assignee.name}>
+                {task.assignee.avatar ? (
+                  <img src={task.assignee.avatar} alt={task.assignee.name} />
+                ) : (
+                  <div className="ease-avatar-fallback">
+                    {task.assignee.name.charAt(0).toUpperCase()}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      );
+    }
+
+    function Demo() {
+      const [tasks, setTasks] = useState({
+        todo: [
+          {
+            id: "EASE-101",
+            title: "Design new navigation menu",
+            description: "Create wireframes and interactive prototypes for the new top navigation.",
+            priority: "high",
+            tags: ["design", "ui"],
+            assignee: { name: "Alice", avatar: "https://i.pravatar.cc/150?u=a042581f4e29026024d" }
+          },
+          {
+            id: "EASE-102",
+            title: "Update dependency packages",
+            priority: "low",
+            tags: ["maintenance"],
+            assignee: { name: "Bob" }
+          }
+        ],
+        inProgress: [
+          {
+            id: "EASE-103",
+            title: "Implement drag-and-drop task cards",
+            description: "Use native HTML5 drag and drop APIs with EaseMotion styling.",
+            priority: "medium",
+            tags: ["frontend", "feature"],
+            assignee: { name: "Charlie", avatar: "https://i.pravatar.cc/150?u=a042581f4e29026704d" }
+          }
+        ]
+      });
+
+      const [draggedItem, setDraggedItem] = useState(null);
+
+      const handleDragStart = (e, task, columnId) => {
+        setDraggedItem({ task, sourceColumn: columnId });
+      };
+
+      const handleDragOver = (e) => {
+        e.preventDefault(); // Necessary to allow dropping
+      };
+
+      const handleDragEnter = (e) => {
+        e.preventDefault();
+        e.currentTarget.classList.add('drag-over');
+      };
+
+      const handleDragLeave = (e) => {
+        e.currentTarget.classList.remove('drag-over');
+      };
+
+      const handleDrop = (e, targetColumn) => {
+        e.preventDefault();
+        e.currentTarget.classList.remove('drag-over');
+        
+        if (!draggedItem) return;
+
+        const { task, sourceColumn } = draggedItem;
+        
+        if (sourceColumn === targetColumn) {
+          setDraggedItem(null);
+          return;
+        }
+
+        setTasks(prev => {
+          const newTasks = { ...prev };
+          // Remove from source
+          newTasks[sourceColumn] = newTasks[sourceColumn].filter(t => t.id !== task.id);
+          // Add to target
+          newTasks[targetColumn] = [...newTasks[targetColumn], task];
+          return newTasks;
+        });
+        
+        setDraggedItem(null);
+      };
+
+      return (
+        <div className="kanban-board-mock">
+          {Object.entries(tasks).map(([columnId, columnTasks]) => (
+            <div key={columnId} className="kanban-column">
+              <div className="kanban-col-header">
+                {columnId === 'inProgress' ? 'In Progress' : columnId}
+                <span className="kanban-col-count">{columnTasks.length}</span>
+              </div>
+              
+              <div 
+                className="drop-zone"
+                onDragOver={handleDragOver}
+                onDragEnter={handleDragEnter}
+                onDragLeave={handleDragLeave}
+                onDrop={(e) => handleDrop(e, columnId)}
+              >
+                {columnTasks.map(task => (
+                  <div key={task.id} style={{ marginBottom: '16px' }}>
+                    <KanbanTaskCard 
+                      task={task} 
+                      onDragStart={(e, t) => handleDragStart(e, t, columnId)}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<Demo />);
+  </script>
+</body>
+</html>

--- a/submissions/react/react-kanban-board-task-card-with-drag-motion-nicks19/style.css
+++ b/submissions/react/react-kanban-board-task-card-with-drag-motion-nicks19/style.css
@@ -1,0 +1,126 @@
+.ease-kanban-card {
+  background: #ffffff;
+  border-radius: 8px;
+  padding: 16px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.06);
+  border: 1px solid #e5e7eb;
+  cursor: grab;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  transition: box-shadow 0.2s ease, transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+  position: relative;
+  user-select: none;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.ease-kanban-card:hover {
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  transform: translateY(-2px);
+}
+
+.ease-kanban-card:active {
+  cursor: grabbing;
+}
+
+/* Dragging State Styles */
+.ease-card-dragging {
+  opacity: 0.4;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  transform: scale(1.02) rotate(2deg);
+  z-index: 100;
+  border-color: #cbd5e1;
+  background-color: #f8fafc;
+}
+
+/* Internal Layout */
+.ease-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.ease-task-id {
+  font-size: 12px;
+  color: #9ca3af;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+.ease-task-priority {
+  font-size: 10px;
+  color: white;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.ease-task-title {
+  margin: 0 0 8px 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: #1f2937;
+  line-height: 1.4;
+}
+
+.ease-task-desc {
+  margin: 0 0 16px 0;
+  font-size: 13px;
+  color: #6b7280;
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.ease-card-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-top: 12px;
+}
+
+.ease-task-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.ease-tag {
+  background: #f3f4f6;
+  color: #4b5563;
+  font-size: 11px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-weight: 500;
+}
+
+.ease-task-assignee {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  overflow: hidden;
+  border: 2px solid #ffffff;
+  box-shadow: 0 0 0 1px #e5e7eb;
+  flex-shrink: 0;
+}
+
+.ease-task-assignee img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.ease-avatar-fallback {
+  width: 100%;
+  height: 100%;
+  background: #3b82f6;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 600;
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #27385 - React Component Task: Kanban Board Task Card with Drag Motion.

This PR introduces a highly responsive React component designed for Kanban or sprint boards. It utilizes native HTML5 drag-and-drop APIs combined with EaseMotion CSS principles to provide satisfying visual feedback (scaling, rotation, shadow elevation) when a user picks up and drags a task.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An interactive `KanbanTaskCard.jsx` component representing an individual piece of work on a board.
- Supports structured task data including ID, title, description, priority (auto color-coded), tags, and an assignee avatar.
- Implements `draggable="true"` and wires up `onDragStart` and `onDragEnd` for seamless integration into larger board states.
- Instantly shifts into an elevated "dragging" ghost state while grabbed.

**How does a developer use it?**

```jsx
import KanbanTaskCard from './KanbanTaskCard';

const task = {
  id: "EASE-101",
  title: "Design Navigation",
  priority: "high"
};

<KanbanTaskCard 
  task={task} 
  onDragStart={(e, t) => console.log('Dragging:', t.id)} 
/>
