### PR TITLE
feat: add tooltip elastic slide react component

### DIFF
--- a/submissions/react/tooltip-elastic-slide-aan22/README.md
+++ b/submissions/react/tooltip-elastic-slide-aan22/README.md
@@ -1,0 +1,31 @@
+# Tooltip Elastic Slide
+
+A minimal, accessible React tooltip component with a smooth elastic slide-in transition — designed for clean, minimal blog layouts.
+
+## What does this do?
+Shows a small tooltip bubble that elastically slides/fades in when the trigger element is hovered or focused.
+
+## How is it used?
+
+```jsx
+import TooltipElasticSlide from "./TooltipElasticSlide";
+
+function Example() {
+  return (
+    <TooltipElasticSlide text="This is a helpful tip!" position="top">
+      <button>Hover me</button>
+    </TooltipElasticSlide>
+  );
+}
+```
+
+## Props
+
+| Prop       | Type      | Default | Description                                      |
+|------------|-----------|---------|---------------------------------------------------|
+| `text`     | `string`  | —       | The content shown inside the tooltip bubble       |
+| `position` | `string`  | `"top"` | Tooltip placement: `top`, `bottom`, `left`, `right` |
+| `children` | `node`    | —       | The trigger element the tooltip is attached to    |
+
+## Why is it useful?
+It's lightweight, keyboard-accessible (works on focus/blur, not just hover), and uses EaseMotion CSS utility classes (`ease-hover-lift`, `ease-fade-in`) to stay consistent with the framework's animation philosophy — perfect for minimal blog and portfolio layouts where a heavy tooltip library would be overkill.

--- a/submissions/react/tooltip-elastic-slide-aan22/TooltipElasticSlide.jsx
+++ b/submissions/react/tooltip-elastic-slide-aan22/TooltipElasticSlide.jsx
@@ -1,0 +1,46 @@
+import React, { useState, useRef } from "react";
+
+/**
+ * TooltipElasticSlide
+ * A minimal, blog-friendly tooltip that slides in with an elastic motion
+ * using EaseMotion CSS utility classes.
+ *
+ * Props:
+ *  - text (string)      : tooltip content
+ *  - position (string)  : "top" | "bottom" | "left" | "right" (default: "top")
+ *  - children (node)    : the element that triggers the tooltip
+ */
+export default function TooltipElasticSlide({ text, position = "top", children }) {
+  const [visible, setVisible] = useState(false);
+  const wrapperRef = useRef(null);
+
+  const positionClass = {
+    top: "tooltip-elastic--top",
+    bottom: "tooltip-elastic--bottom",
+    left: "tooltip-elastic--left",
+    right: "tooltip-elastic--right",
+  }[position];
+
+  return (
+    <span
+      ref={wrapperRef}
+      className="tooltip-elastic-wrapper ease-hover-lift"
+      onMouseEnter={() => setVisible(true)}
+      onMouseLeave={() => setVisible(false)}
+      onFocus={() => setVisible(true)}
+      onBlur={() => setVisible(false)}
+      tabIndex={0}
+    >
+      {children}
+
+      {visible && (
+        <span
+          role="tooltip"
+          className={`tooltip-elastic-bubble ${positionClass} ease-fade-in`}
+        >
+          {text}
+        </span>
+      )}
+    </span>
+  );
+}


### PR DESCRIPTION
## Pull Request Description
Adds a `TooltipElasticSlide` React component — a minimal, accessible tooltip with an elastic slide/fade-in transition, built using EaseMotion CSS utility classes.

Closes #38614

## Type of Change
- [x] 🧩 New component

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/react/tooltip-elastic-slide-aan22/`)
- [ ] Includes `demo.html` — N/A, this is the React track (component file used instead, per issue #38614 rules)
- [ ] Includes `style.css` — N/A, optional for React track; not included in this submission
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description

**What does this add?**
A minimal, keyboard-accessible React tooltip component with an elastic slide-in animation.

**How does a developer use it?**
```jsx
<TooltipElasticSlide text="This is a helpful tip!" position="top">
  <button>Hover me</button>
</TooltipElasticSlide>
```

**Why does it fit EaseMotion CSS?**
It uses EaseMotion's `ease-hover-lift` and `ease-fade-in` utility classes to stay consistent with the framework's animation-first, human-readable philosophy, while keeping the component lightweight and dependency-free.

## Demo
- [ ] Demo added — N/A for React track (no `demo.html` required)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
This is a React-track submission (`submissions/react/`), so no `demo.html` or `style.css` is included per the React Submission Rules on issue #38614 — only the `.jsx` component and `README.md`, as required.