### PR TITLE
feat: add command bar glow example

### DIFF
--- a/submissions/examples/command-bar-glow/README.md
+++ b/submissions/examples/command-bar-glow/README.md
@@ -1,0 +1,14 @@
+# Command Bar Glow
+
+A focus-state motion example for search bars, command palettes, and action launchers.
+
+## What it demonstrates
+
+- `:focus-within` interaction for grouped input controls
+- soft animated glow without layout shift
+- responsive keyboard hint behavior and reduced-motion support
+
+## Files
+
+- `demo.html` - command bar demo
+- `style.css` - focus glow and input layout styles

--- a/submissions/examples/command-bar-glow/demo.html
+++ b/submissions/examples/command-bar-glow/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Command Bar Glow</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="panel" aria-labelledby="demo-title">
+      <p class="eyebrow">EaseMotion input example</p>
+      <h1 id="demo-title">Command bar glow</h1>
+      <p class="intro">A focus-friendly command palette surface with a soft animated glow.</p>
+
+      <label class="command-bar">
+        <span class="icon">/</span>
+        <input type="text" value="Search docs, actions, and templates" aria-label="Command search">
+        <kbd>Ctrl K</kbd>
+      </label>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/command-bar-glow/style.css
+++ b/submissions/examples/command-bar-glow/style.css
@@ -1,0 +1,165 @@
+:root {
+  --page: #101828;
+  --surface: #ffffff;
+  --ink: #101828;
+  --muted: #667085;
+  --accent: #22c55e;
+  --accent-soft: rgba(34, 197, 94, 0.26);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background:
+    linear-gradient(135deg, rgba(34, 197, 94, 0.18), transparent 38%),
+    var(--page);
+  color: var(--surface);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.demo-shell {
+  width: min(900px, calc(100vw - 32px));
+}
+
+.panel {
+  padding: 36px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.28);
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.2rem, 5vw, 4rem);
+  line-height: 1;
+}
+
+.intro {
+  max-width: 52ch;
+  margin: 16px 0 28px;
+  color: rgba(255, 255, 255, 0.72);
+  line-height: 1.65;
+}
+
+.command-bar {
+  position: relative;
+  display: grid;
+  grid-template-columns: 42px 1fr auto;
+  gap: 12px;
+  align-items: center;
+  min-height: 72px;
+  padding: 12px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 18px;
+  background: var(--surface);
+  color: var(--ink);
+  overflow: hidden;
+  transition:
+    border-color 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.command-bar::before {
+  content: "";
+  position: absolute;
+  inset: -80%;
+  background: conic-gradient(from 90deg, transparent, var(--accent-soft), transparent 34%);
+  opacity: 0;
+  transform: rotate(0deg);
+  transition: opacity 180ms ease;
+  pointer-events: none;
+}
+
+.command-bar:focus-within {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+  box-shadow: 0 18px 45px rgba(34, 197, 94, 0.22);
+}
+
+.command-bar:focus-within::before {
+  opacity: 1;
+  animation: command-spin 2400ms linear infinite;
+}
+
+.icon,
+kbd,
+input {
+  position: relative;
+  z-index: 1;
+}
+
+.icon {
+  width: 38px;
+  height: 38px;
+  display: grid;
+  place-items: center;
+  border-radius: 12px;
+  background: #ecfdf3;
+  color: #027a48;
+  font-weight: 900;
+}
+
+input {
+  width: 100%;
+  border: 0;
+  outline: 0;
+  color: var(--ink);
+  font: inherit;
+  font-weight: 700;
+  background: transparent;
+}
+
+kbd {
+  padding: 6px 10px;
+  border: 1px solid rgba(16, 24, 40, 0.14);
+  border-radius: 10px;
+  background: #f8fafc;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+@keyframes command-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 620px) {
+  .panel {
+    padding: 24px;
+  }
+
+  .command-bar {
+    grid-template-columns: 38px 1fr;
+  }
+
+  kbd {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .command-bar,
+  .command-bar::before {
+    transition: none;
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a command bar focus glow example
- use focus-within for accessible grouped input motion
- include responsive keyboard hint and reduced-motion support

## Testing
- git diff --cached --check