### PR TITLE
feat: add pricing toggle glide example

### DIFF
--- a/submissions/examples/pricing-toggle-glide/README.md
+++ b/submissions/examples/pricing-toggle-glide/README.md
@@ -1,0 +1,14 @@
+# Pricing Toggle Glide
+
+A CSS-only billing period toggle for pricing, checkout, and subscription settings screens.
+
+## What it demonstrates
+
+- radio-based segmented control without JavaScript
+- smooth selected-state glider animation
+- keyboard focus styling and reduced-motion support
+
+## Files
+
+- `demo.html` - accessible billing toggle markup
+- `style.css` - glider motion and responsive panel styling

--- a/submissions/examples/pricing-toggle-glide/demo.html
+++ b/submissions/examples/pricing-toggle-glide/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pricing Toggle Glide</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="pricing-panel" aria-labelledby="demo-title">
+    <p class="eyebrow">EaseMotion billing example</p>
+    <h1 id="demo-title">Pricing toggle glide</h1>
+    <p class="intro">A CSS-only billing toggle pattern with a smooth selected-state glide.</p>
+
+    <div class="billing-toggle" role="group" aria-label="Billing period">
+      <input type="radio" name="billing" id="monthly" checked>
+      <label for="monthly">Monthly</label>
+      <input type="radio" name="billing" id="yearly">
+      <label for="yearly">Yearly</label>
+      <span class="glider" aria-hidden="true"></span>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/pricing-toggle-glide/style.css
+++ b/submissions/examples/pricing-toggle-glide/style.css
@@ -1,0 +1,132 @@
+:root {
+  --page: #f8fafc;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #64748b;
+  --accent: #0284c7;
+  --accent-dark: #075985;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background:
+    linear-gradient(135deg, rgba(2, 132, 199, 0.13), transparent 42%),
+    var(--page);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.pricing-panel {
+  width: min(720px, calc(100vw - 32px));
+  display: grid;
+  justify-items: center;
+  padding: 38px;
+  border: 1px solid rgba(23, 32, 51, 0.12);
+  border-radius: 22px;
+  background: var(--surface);
+  text-align: center;
+  box-shadow: 0 24px 70px rgba(23, 32, 51, 0.14);
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.15rem, 5vw, 3.8rem);
+  line-height: 1;
+}
+
+.intro {
+  max-width: 46ch;
+  margin: 16px 0 28px;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.billing-toggle {
+  position: relative;
+  width: min(360px, 100%);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+  padding: 6px;
+  border: 1px solid rgba(23, 32, 51, 0.12);
+  border-radius: 999px;
+  background: #eef6fb;
+}
+
+.billing-toggle input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.billing-toggle label {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  place-items: center;
+  min-height: 46px;
+  border-radius: 999px;
+  color: var(--muted);
+  font-weight: 900;
+  cursor: pointer;
+  transition:
+    color 180ms ease,
+    transform 180ms ease;
+}
+
+.billing-toggle label:hover,
+.billing-toggle input:focus-visible + label {
+  color: var(--accent-dark);
+  transform: translateY(-1px);
+}
+
+.glider {
+  position: absolute;
+  z-index: 1;
+  top: 6px;
+  left: 6px;
+  width: calc(50% - 6px);
+  height: calc(100% - 12px);
+  border-radius: 999px;
+  background: var(--surface);
+  box-shadow: 0 12px 28px rgba(2, 132, 199, 0.18);
+  transition: transform 240ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+#monthly:checked ~ label[for="monthly"],
+#yearly:checked ~ label[for="yearly"] {
+  color: var(--accent-dark);
+}
+
+#yearly:checked ~ .glider {
+  transform: translateX(100%);
+}
+
+@media (max-width: 560px) {
+  .pricing-panel {
+    padding: 30px 20px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .billing-toggle label,
+  .glider {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only pricing toggle glide example
- use radio inputs for accessible selected states
- include keyboard focus styling and reduced-motion support

## Testing
- git diff --cached --check