### PR TITLE
feat: add expanding search input

### DIFF
--- a/submissions/examples/expanding-search-as/README.md
+++ b/submissions/examples/expanding-search-as/README.md
@@ -1,0 +1,23 @@
+# Expanding Search Input
+
+### What does this do?
+
+It is a compact search field that widens smoothly when focused, with a magnifier icon and an accent border and glow on focus.
+
+### How is it used?
+
+```html
+<div class="search">
+  <input type="search" class="search-input" placeholder="Search" aria-label="Search" />
+  <svg class="search-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+    <circle cx="11" cy="11" r="7" />
+    <path d="m21 21-4.3-4.3" />
+  </svg>
+</div>
+```
+
+The input sits at a compact width and grows when focused. The magnifier is an inline SVG, so there are no images to load.
+
+### Why is it useful?
+
+A search box that expands on focus saves header space until the user needs it. This animates the width and border on focus with a transition, so it needs no JavaScript. The input keeps its native `type="search"` behavior and an accessible label, and the width transition is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/expanding-search-as/demo.html
+++ b/submissions/examples/expanding-search-as/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Expanding Search Input</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="search">
+    <input type="search" class="search-input" placeholder="Search" aria-label="Search" />
+    <svg class="search-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+      <circle cx="11" cy="11" r="7" />
+      <path d="m21 21-4.3-4.3" />
+    </svg>
+  </div>
+</body>
+</html>

--- a/submissions/examples/expanding-search-as/style.css
+++ b/submissions/examples/expanding-search-as/style.css
@@ -1,0 +1,58 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.search {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.search-icon {
+  position: absolute;
+  left: 0.8rem;
+  color: #94a3b8;
+  pointer-events: none;
+  transition: color 0.2s ease;
+}
+
+.search-input {
+  width: 180px;
+  padding: 0.7rem 0.9rem 0.7rem 2.4rem;
+  font-size: 0.92rem;
+  color: #e2e8f0;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 999px;
+  outline: none;
+  transition: width 0.3s cubic-bezier(0.34, 1.4, 0.64, 1), border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.search-input::placeholder {
+  color: #64748b;
+}
+
+.search-input:focus {
+  width: 280px;
+  border-color: #6c63ff;
+  box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.2);
+}
+
+.search-input:focus ~ .search-icon,
+.search:focus-within .search-icon {
+  color: #6c63ff;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .search-input {
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an expanding search input built for #40155. A compact search field widens on focus with an accent border and glow, using a magnifier inline SVG and CSS with no JavaScript. Closes #40155.

## Type of Change

- [x] ✨ New animation / hover effect

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A compact search field that widens on focus, with a magnifier icon and an accent focus state.

**How does a developer use it?**

```html
<div class="search">
  <input type="search" class="search-input" placeholder="Search" aria-label="Search" />
  <svg class="search-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
    <circle cx="11" cy="11" r="7" />
    <path d="m21 21-4.3-4.3" />
  </svg>
</div>
```

**Why does it fit EaseMotion CSS?**
It animates the width and border on focus with a transition, so it needs no JavaScript. The input keeps its native `type="search"` behavior and an accessible label, the icon is inline SVG, and the width transition is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the input grows from 180px to 280px on focus with the accent border.
