### PR TITLE
feat: add scroll reveal back to top button

### DIFF
--- a/submissions/examples/back-to-top-as/README.md
+++ b/submissions/examples/back-to-top-as/README.md
@@ -1,0 +1,24 @@
+# Scroll Reveal Back to Top Button
+
+### What does this do?
+
+It shows a floating back to top button that fades and scales in as the page is scrolled down, and links back to the top, using only CSS.
+
+### How is it used?
+
+```html
+<body id="top">
+  <!-- page content -->
+  <a href="#top" class="back-to-top" aria-label="Back to top">
+    <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true">
+      <path d="M12 19V5M6 11l6-6 6 6" />
+    </svg>
+  </a>
+</body>
+```
+
+Give the page top an `id` and point the button `href` at it. The button reveals itself based on scroll position, so nothing needs to toggle it.
+
+### Why is it useful?
+
+A back to top button helps on long pages, and revealing it only after scrolling keeps it out of the way at the top. This drives the entrance from scroll position with `animation-timeline: scroll()`, so it needs no JavaScript. Where scroll timelines are not supported the button simply stays visible, and the arrow hover motion is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/back-to-top-as/demo.html
+++ b/submissions/examples/back-to-top-as/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scroll Reveal Back to Top Button</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body id="top">
+  <section class="page-section">
+    <div>
+      <h2>Scroll down</h2>
+      <p>The back to top button appears once you scroll a little way down the page.</p>
+    </div>
+  </section>
+  <section class="page-section">
+    <div>
+      <h2>Keep going</h2>
+      <p>It is revealed purely from scroll position using a CSS scroll timeline.</p>
+    </div>
+  </section>
+  <section class="page-section">
+    <div>
+      <h2>Almost there</h2>
+      <p>Click the button in the corner to jump back to the top.</p>
+    </div>
+  </section>
+  <section class="page-section">
+    <div>
+      <h2>The end</h2>
+      <p>No JavaScript was used to show or hide the button.</p>
+    </div>
+  </section>
+
+  <a href="#top" class="back-to-top" aria-label="Back to top">
+    <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true">
+      <path d="M12 19V5M6 11l6-6 6 6" />
+    </svg>
+  </a>
+</body>
+</html>

--- a/submissions/examples/back-to-top-as/style.css
+++ b/submissions/examples/back-to-top-as/style.css
@@ -1,0 +1,86 @@
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+  background: #0b1121;
+}
+
+.page-section {
+  min-height: 60vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+  text-align: center;
+  border-bottom: 1px solid #1e293b;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 70%);
+}
+
+.page-section h2 {
+  margin: 0 0 0.5rem;
+}
+
+.page-section p {
+  margin: 0;
+  color: #94a3b8;
+  max-width: 36ch;
+}
+
+.back-to-top {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  display: grid;
+  place-items: center;
+  width: 48px;
+  height: 48px;
+  color: #fff;
+  background: #6c63ff;
+  border-radius: 50%;
+  box-shadow: 0 10px 24px rgba(108, 99, 255, 0.4);
+  text-decoration: none;
+  opacity: 0;
+  transform: scale(0.6);
+  animation: bttReveal linear both;
+  animation-timeline: scroll(root block);
+  animation-range: 120px 360px;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.back-to-top:hover {
+  background: #574fe0;
+  box-shadow: 0 12px 28px rgba(108, 99, 255, 0.55);
+}
+
+.back-to-top:focus-visible {
+  outline: 2px solid #fbbf24;
+  outline-offset: 3px;
+}
+
+.back-to-top svg {
+  transition: transform 0.2s ease;
+}
+
+.back-to-top:hover svg {
+  transform: translateY(-2px);
+}
+
+@keyframes bttReveal {
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@supports not (animation-timeline: scroll()) {
+  .back-to-top {
+    opacity: 1;
+    transform: none;
+    animation: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .back-to-top svg {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a scroll reveal back to top button built for #40157. The button fades and scales in based on scroll position using a CSS scroll timeline, and links back to the top, with no JavaScript. Closes #40157.

## Type of Change

- [x] ✨ New animation / hover effect

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A floating back to top button that reveals itself from scroll position and links to the top of the page.

**How does a developer use it?**

```html
<body id="top">
  <a href="#top" class="back-to-top" aria-label="Back to top">
    <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true">
      <path d="M12 19V5M6 11l6-6 6 6" />
    </svg>
  </a>
</body>
```

**Why does it fit EaseMotion CSS?**
It drives the entrance from scroll position with `animation-timeline: scroll()`, so it needs no JavaScript. Where scroll timelines are not supported the button stays visible via an `@supports` fallback, and the arrow hover motion is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the button opacity goes from 0 at the top of the page to 1 after scrolling down. It uses a scroll timeline, which is a recent CSS feature, with an `@supports` fallback to keep it visible elsewhere.
