### PR TITLE
feat: add 3d flip card

### DIFF
--- a/submissions/examples/flip-card-as/README.md
+++ b/submissions/examples/flip-card-as/README.md
@@ -1,0 +1,28 @@
+# 3D Flip Card
+
+### What does this do?
+
+It shows a card that flips over in 3D on hover or focus to reveal a back side with more detail and a call to action.
+
+### How is it used?
+
+```html
+<div class="flip-card">
+  <div class="flip-card-inner">
+    <div class="flip-card-front">
+      <h3>Aurora</h3>
+      <p>Design system</p>
+    </div>
+    <div class="flip-card-back">
+      <p>A component library with tokens and themes.</p>
+      <a href="#">Explore</a>
+    </div>
+  </div>
+</div>
+```
+
+The `.flip-card` sets the perspective, the `.flip-card-inner` rotates on hover, and the front and back faces hide their back sides so only one shows at a time.
+
+### Why is it useful?
+
+Flip cards fit two sides of content into one space, useful for team members, features, or product cards. This builds the flip with `perspective`, `transform-style: preserve-3d`, and `backface-visibility`, so it needs no JavaScript. It also flips on `:focus-within` for keyboard users, the back link shows a focus ring, and the rotation is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/flip-card-as/demo.html
+++ b/submissions/examples/flip-card-as/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3D Flip Card</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="flip-card">
+    <div class="flip-card-inner">
+      <div class="flip-card-front">
+        <span class="badge" aria-hidden="true"></span>
+        <h3>Aurora</h3>
+        <p>Design system</p>
+      </div>
+      <div class="flip-card-back">
+        <p>A component library with design tokens, dark and light themes, and accessible defaults.</p>
+        <a href="#">Explore</a>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/flip-card-as/style.css
+++ b/submissions/examples/flip-card-as/style.css
@@ -1,0 +1,105 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.flip-card {
+  width: 260px;
+  height: 320px;
+  perspective: 1200px;
+}
+
+.flip-card-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+  transition: transform 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.flip-card:hover .flip-card-inner,
+.flip-card:focus-within .flip-card-inner {
+  transform: rotateY(180deg);
+}
+
+.flip-card-front,
+.flip-card-back {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 1.75rem;
+  box-sizing: border-box;
+  border-radius: 18px;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+}
+
+.flip-card-front {
+  align-items: center;
+  text-align: center;
+  background: #111a2e;
+  border: 1px solid #26324a;
+}
+
+.flip-card-front .badge {
+  width: 56px;
+  height: 56px;
+  margin-bottom: 0.5rem;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #6c63ff, #0ea5e9);
+}
+
+.flip-card-front h3 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.flip-card-front p {
+  margin: 0;
+  color: #94a3b8;
+  font-size: 0.9rem;
+}
+
+.flip-card-back {
+  background: linear-gradient(160deg, #4338ca, #6c63ff);
+  color: #fff;
+  transform: rotateY(180deg);
+}
+
+.flip-card-back p {
+  margin: 0 0 1.25rem;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.flip-card-back a {
+  align-self: flex-start;
+  padding: 0.55rem 1.1rem;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: #4338ca;
+  text-decoration: none;
+  background: #fff;
+  border-radius: 10px;
+}
+
+.flip-card-back a:focus-visible {
+  outline: 2px solid #fbbf24;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .flip-card-inner {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a 3D flip card built for #40159. The card rotates in 3D on hover or focus to reveal a back side with more detail and a call to action, using CSS transforms with no JavaScript. Closes #40159.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A card with a front and back that flips in 3D to reveal the back on hover or focus.

**How does a developer use it?**

```html
<div class="flip-card">
  <div class="flip-card-inner">
    <div class="flip-card-front"><h3>Aurora</h3><p>Design system</p></div>
    <div class="flip-card-back"><p>Details...</p><a href="#">Explore</a></div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It builds the flip with `perspective`, `transform-style: preserve-3d`, and `backface-visibility`, so it needs no JavaScript. It flips on `:focus-within` for keyboard users, the back link shows a focus ring, and the rotation is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: hovering the card rotates the inner element to rotateY(180deg) and shows the back face.
