### PR TITLE
feat: add animated gradient text heading

### DIFF
--- a/submissions/examples/gradient-text-as/README.md
+++ b/submissions/examples/gradient-text-as/README.md
@@ -1,0 +1,17 @@
+# Animated Gradient Text Heading
+
+### What does this do?
+
+It fills heading text with a gradient that flows across the letters in a loop.
+
+### How is it used?
+
+```html
+<h1 class="gradient-text">Build with EaseMotion</h1>
+```
+
+Apply `gradient-text` to any heading. The gradient is clipped to the text and its background position animates, so the color appears to move across the letters.
+
+### Why is it useful?
+
+A flowing gradient headline draws the eye on hero sections and landing pages. This animates a gradient across text by moving its background position with `background-clip: text`, so it needs no JavaScript. The heading stays selectable text, and the animation is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/gradient-text-as/demo.html
+++ b/submissions/examples/gradient-text-as/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Gradient Text Heading</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div>
+    <h1 class="gradient-text">Build with EaseMotion</h1>
+    <p class="gradient-sub">A flowing gradient headline, animated with pure CSS.</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/gradient-text-as/style.css
+++ b/submissions/examples/gradient-text-as/style.css
@@ -1,0 +1,44 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  text-align: center;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.gradient-text {
+  margin: 0;
+  font-size: clamp(2.4rem, 8vw, 4rem);
+  font-weight: 800;
+  line-height: 1.1;
+  background: linear-gradient(90deg, #6c63ff, #0ea5e9, #ec4899, #6c63ff);
+  background-size: 300% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  animation: gradientShift 6s linear infinite;
+}
+
+.gradient-sub {
+  margin: 1rem 0 0;
+  font-size: 1rem;
+  color: #94a3b8;
+}
+
+@keyframes gradientShift {
+  to {
+    background-position: 300% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gradient-text {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an animated gradient text heading built for #40161. The text is filled with a gradient that flows across the letters using `background-clip: text` and a moving background position, with no JavaScript. Closes #40161.

## Type of Change

- [x] ✨ New animation / hover effect

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A heading whose gradient fill flows across the text in a loop.

**How does a developer use it?**

```html
<h1 class="gradient-text">Build with EaseMotion</h1>
```

**Why does it fit EaseMotion CSS?**
It animates a gradient across text by moving its background position with `background-clip: text`, so it needs no JavaScript. The heading stays selectable text, and the animation is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the heading has a transparent text fill, a text background clip, and the gradient shift animation applied.
