### PR TITLE
feat: add image hover zoom card

### DIFF
--- a/submissions/examples/media-zoom-card-as/README.md
+++ b/submissions/examples/media-zoom-card-as/README.md
@@ -1,0 +1,25 @@
+# Image Hover Zoom Card
+
+### What does this do?
+
+It shows media cards where the image gently zooms on hover inside a clipped frame while the caption slides up, all in CSS. The demo uses gradient art in place of photos so it is self contained.
+
+### How is it used?
+
+```html
+<a class="media-card" href="#">
+  <span class="media-img" aria-hidden="true"></span>
+  <span class="media-overlay">
+    <span class="media-caption">
+      <strong>Northern Lights</strong>
+      <span>Travel</span>
+    </span>
+  </span>
+</a>
+```
+
+Swap the `.media-img` background for a real image, for example `background: url(photo.jpg) center / cover`. The frame clips the overflow so the zoom stays inside the card.
+
+### Why is it useful?
+
+Media cards with a hover zoom are common in galleries, blogs, and product grids. This scales the image inside an `overflow: hidden` frame and reveals the caption with transitions, so it needs no JavaScript. The card is a focusable link that also responds to keyboard focus with a ring, and the motion is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/media-zoom-card-as/demo.html
+++ b/submissions/examples/media-zoom-card-as/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Image Hover Zoom Card</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="media-row">
+    <a class="media-card" href="#">
+      <span class="media-img media-1" aria-hidden="true"></span>
+      <span class="media-overlay">
+        <span class="media-caption">
+          <strong>Northern Lights</strong>
+          <span>Travel</span>
+        </span>
+      </span>
+    </a>
+
+    <a class="media-card" href="#">
+      <span class="media-img media-2" aria-hidden="true"></span>
+      <span class="media-overlay">
+        <span class="media-caption">
+          <strong>Desert Dunes</strong>
+          <span>Nature</span>
+        </span>
+      </span>
+    </a>
+
+    <a class="media-card" href="#">
+      <span class="media-img media-3" aria-hidden="true"></span>
+      <span class="media-overlay">
+        <span class="media-caption">
+          <strong>Coastal Reef</strong>
+          <span>Ocean</span>
+        </span>
+      </span>
+    </a>
+  </div>
+</body>
+</html>

--- a/submissions/examples/media-zoom-card-as/style.css
+++ b/submissions/examples/media-zoom-card-as/style.css
@@ -1,0 +1,103 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.media-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  justify-content: center;
+}
+
+.media-card {
+  position: relative;
+  display: block;
+  width: 220px;
+  height: 280px;
+  border-radius: 16px;
+  overflow: hidden;
+  text-decoration: none;
+}
+
+.media-img {
+  position: absolute;
+  inset: 0;
+  transition: transform 0.5s ease;
+}
+
+.media-card:hover .media-img,
+.media-card:focus-visible .media-img {
+  transform: scale(1.12);
+}
+
+.media-1 {
+  background:
+    radial-gradient(circle at 30% 20%, #a78bfa, transparent 45%),
+    radial-gradient(circle at 80% 70%, #6c63ff, transparent 55%),
+    linear-gradient(160deg, #312e81, #0ea5e9);
+}
+
+.media-2 {
+  background:
+    radial-gradient(circle at 25% 30%, #fb7185, transparent 50%),
+    radial-gradient(circle at 75% 80%, #f59e0b, transparent 55%),
+    linear-gradient(160deg, #7c2d12, #be185d);
+}
+
+.media-3 {
+  background:
+    radial-gradient(circle at 30% 25%, #34d399, transparent 50%),
+    radial-gradient(circle at 80% 75%, #0ea5e9, transparent 55%),
+    linear-gradient(160deg, #064e3b, #0f766e);
+}
+
+.media-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 0.15rem;
+  padding: 1rem;
+  color: #fff;
+  background: linear-gradient(transparent 45%, rgba(2, 6, 23, 0.8));
+}
+
+.media-caption {
+  transform: translateY(10px);
+  transition: transform 0.3s ease;
+}
+
+.media-card:hover .media-caption,
+.media-card:focus-visible .media-caption {
+  transform: translateY(0);
+}
+
+.media-caption strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.media-caption span {
+  font-size: 0.8rem;
+  color: #cbd5e1;
+}
+
+.media-card:focus-visible {
+  outline: 2px solid #fbbf24;
+  outline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .media-img,
+  .media-caption {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an image hover zoom card built for #40166. The image zooms on hover inside a clipped frame while the caption slides up, using CSS with no JavaScript. The demo uses gradient art in place of photos so it is self contained. Closes #40166.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
Media cards that zoom the image on hover inside a clipped frame and reveal a caption overlay.

**How does a developer use it?**

```html
<a class="media-card" href="#">
  <span class="media-img" aria-hidden="true"></span>
  <span class="media-overlay">
    <span class="media-caption"><strong>Northern Lights</strong><span>Travel</span></span>
  </span>
</a>
```

Swap the `.media-img` background for a real image with `background: url(photo.jpg) center / cover`.

**Why does it fit EaseMotion CSS?**
It scales the image inside an `overflow: hidden` frame and reveals the caption with transitions, so it needs no JavaScript. The card is a focusable link that responds to keyboard focus with a ring, and the motion is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: hovering a card scales its image to 1.12 inside the clipped frame.
