### PR TITLE
feat: add chat typing indicator

### DIFF
--- a/submissions/examples/typing-indicator-as/README.md
+++ b/submissions/examples/typing-indicator-as/README.md
@@ -1,0 +1,19 @@
+# Chat Typing Indicator
+
+### What does this do?
+
+It shows a chat typing indicator, a small bubble with three dots that bounce in sequence to signal that someone is composing a message.
+
+### How is it used?
+
+```html
+<div class="typing" role="status" aria-label="Typing">
+  <span></span><span></span><span></span>
+</div>
+```
+
+Drop the `.typing` bubble into a chat thread where you would show that the other person is writing. The three dots animate with staggered delays.
+
+### Why is it useful?
+
+A typing indicator is a familiar cue in chat and support widgets. This builds the looping bounce with staggered delays inside a message bubble, so it needs no JavaScript. The bubble has a `status` role with a label for assistive tech, and the animation slows under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/typing-indicator-as/demo.html
+++ b/submissions/examples/typing-indicator-as/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Chat Typing Indicator</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="chat-frame">
+    <div class="msg">Hey! Give me a second to check.</div>
+    <div class="typing" role="status" aria-label="Contact is typing">
+      <span></span><span></span><span></span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/typing-indicator-as/style.css
+++ b/submissions/examples/typing-indicator-as/style.css
@@ -1,0 +1,72 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.chat-frame {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+  width: min(320px, 92vw);
+  padding: 1.25rem;
+  border-radius: 16px;
+  background: #0e1626;
+  border: 1px solid #1e293b;
+}
+
+.chat-frame .msg {
+  max-width: 80%;
+  padding: 0.6rem 0.9rem;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  background: #1e293b;
+  border-radius: 16px;
+  border-bottom-left-radius: 4px;
+}
+
+.typing {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0.85rem 0.95rem;
+  background: #1e293b;
+  border-radius: 16px;
+  border-bottom-left-radius: 4px;
+}
+
+.typing span {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #94a3b8;
+  animation: typingBounce 1.2s ease-in-out infinite;
+}
+
+.typing span:nth-child(2) { animation-delay: 0.15s; }
+.typing span:nth-child(3) { animation-delay: 0.3s; }
+
+@keyframes typingBounce {
+  0%, 60%, 100% {
+    transform: translateY(0);
+    opacity: 0.4;
+  }
+
+  30% {
+    transform: translateY(-6px);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .typing span {
+    animation-duration: 2.4s;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a chat typing indicator built for #40168. A bubble with three dots that bounce in sequence signals that someone is typing, looping in pure CSS. Closes #40168.

## Type of Change

- [x] ✨ New animation / hover effect

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A chat typing indicator bubble with three sequentially bouncing dots.

**How does a developer use it?**

```html
<div class="typing" role="status" aria-label="Typing">
  <span></span><span></span><span></span>
</div>
```

**Why does it fit EaseMotion CSS?**
It builds the looping bounce with staggered delays inside a message bubble, so it needs no JavaScript. The bubble has a `status` role with a label, and the animation slows under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: three dots render with the bounce animation applied.
