### PR TITLE
feat: add glowing cta button

### DIFF
--- a/submissions/examples/glowing-cta-as/README.md
+++ b/submissions/examples/glowing-cta-as/README.md
@@ -1,0 +1,17 @@
+# Glowing CTA Button
+
+### What does this do?
+
+It shows a call to action button with a soft pulsing glow that also sweeps a shine across itself on hover.
+
+### How is it used?
+
+```html
+<button class="cta-btn" type="button">Get started</button>
+```
+
+Apply `cta-btn` to your primary action. The glow pulses on its own, and hovering sends a shine highlight across the button.
+
+### Why is it useful?
+
+A glowing call to action draws attention to the primary action on a page. This combines a pulsing box shadow with a moving shine highlight, so it needs no JavaScript. The button shows a focus ring, and the glow and shine are disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/glowing-cta-as/demo.html
+++ b/submissions/examples/glowing-cta-as/demo.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Glowing CTA Button</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <button class="cta-btn" type="button">Get started</button>
+</body>
+</html>

--- a/submissions/examples/glowing-cta-as/style.css
+++ b/submissions/examples/glowing-cta-as/style.css
@@ -1,0 +1,76 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.cta-btn {
+  position: relative;
+  overflow: hidden;
+  padding: 0.9rem 2rem;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #fff;
+  background: linear-gradient(135deg, #6c63ff, #4338ca);
+  border: none;
+  border-radius: 12px;
+  cursor: pointer;
+  box-shadow: 0 8px 20px rgba(108, 99, 255, 0.35);
+  animation: ctaGlow 2.4s ease-in-out infinite;
+  transition: transform 0.2s ease;
+}
+
+.cta-btn::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -60%;
+  width: 40%;
+  height: 100%;
+  background: linear-gradient(120deg, transparent, rgba(255, 255, 255, 0.45), transparent);
+  transform: skewX(-20deg);
+}
+
+.cta-btn:hover {
+  transform: translateY(-2px);
+}
+
+.cta-btn:hover::before {
+  animation: ctaShine 0.8s ease;
+}
+
+.cta-btn:focus-visible {
+  outline: 2px solid #fbbf24;
+  outline-offset: 3px;
+}
+
+@keyframes ctaGlow {
+  0%, 100% {
+    box-shadow: 0 8px 20px rgba(108, 99, 255, 0.35);
+  }
+
+  50% {
+    box-shadow: 0 8px 32px rgba(108, 99, 255, 0.75);
+  }
+}
+
+@keyframes ctaShine {
+  to {
+    left: 120%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cta-btn {
+    animation: none;
+  }
+
+  .cta-btn:hover::before {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a glowing CTA button built for #40171. A soft pulsing glow with a shine sweep on hover, using only CSS. Closes #40171.

## Type of Change

- [x] ✨ New animation / hover effect

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A primary button with a pulsing glow and a shine highlight that sweeps across on hover.

**How does a developer use it?**

```html
<button class="cta-btn" type="button">Get started</button>
```

**Why does it fit EaseMotion CSS?**
It combines a pulsing box shadow with a moving shine highlight, so it needs no JavaScript. The button shows a focus ring, and the glow and shine are disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the button has the glow pulse animation applied and shows the shine highlight.
