### PR TITLE
feat: add creative portfolio glow pulse card

### DIFF
--- a/submissions/examples/creative-portfolio-glow-pulse-card-38532/README.md
+++ b/submissions/examples/creative-portfolio-glow-pulse-card-38532/README.md
@@ -1,0 +1,52 @@
+# Creative Portfolio Glow Pulse Card
+
+## Description
+A pure CSS project card for creative-portfolio layouts with a smooth **glow pulse** interaction: on hover or keyboard focus, the card lifts slightly and breathes a soft, colour-matched glow in an infinite loop for as long as the interaction lasts. Zero JavaScript.
+
+## Features
+- Continuous glow + scale "pulse" on hover/focus, driven entirely by one CSS `@keyframes` animation
+- Fully keyboard accessible — the whole card is a real `<a>` link, so it's reachable with Tab and activatable with Enter with no `tabindex` hacks
+- Every interaction parameter (duration, easing, scale, glow colour) is exposed as a CSS custom property
+- `(hover: hover) and (pointer: fine)` guard so the glow doesn't get stuck "on" after a tap on touchscreens
+- Respects `prefers-reduced-motion` — the loop stops and a static glow is shown instead
+- Fully responsive: fluid width via `min()`, plus a mobile padding/type tweak at 640px
+
+## How is it used?
+```html
+<a class="portfolio-glow-card" href="/projects/solace">
+  <div class="pgc-thumb" aria-hidden="true"><span class="pgc-thumb-icon">🎨</span></div>
+  <div class="pgc-body">
+    <span class="pgc-tag">Brand Identity</span>
+    <h3 class="pgc-title">Solace — Visual Identity</h3>
+    <p class="pgc-desc">Short project description.</p>
+    <span class="pgc-cta">View project →</span>
+  </div>
+</a>
+```
+
+## Customization (CSS custom properties)
+| Property | Default | Description |
+|---|---|---|
+| `--pgc-pulse-duration` | `2.4s` | Full pulse animation cycle length |
+| `--pgc-pulse-easing` | `ease-in-out` | Timing function for the pulse loop and the settle-back transition |
+| `--pgc-pulse-scale` | `1.035` | Peak scale factor at the midpoint of the pulse |
+| `--pgc-glow-color` | `rgba(168, 85, 247, 0.55)` | Glow colour (any valid CSS colour) |
+| `--pgc-radius` | `20px` | Card corner radius |
+| `--pgc-bg` | `#15131f` | Card background |
+| `--pgc-fg` | `#f4f2fa` | Card text colour |
+| `--pgc-accent` | `#c084fc` | Tag / CTA accent colour |
+
+Override any of these inline or from your own stylesheet:
+```html
+<a class="portfolio-glow-card" href="#" style="--pgc-glow-color: rgba(251,146,60,.55); --pgc-accent:#fdba74;">
+  ...
+</a>
+```
+
+## Why is it useful?
+EaseMotion already ships one-shot hover animations, but a **looping, interaction-scoped** pulse — one that only runs while the user is actually engaged with the element and cleanly stops the moment they leave — is a distinct, frequently-requested pattern for portfolio and gallery-style layouts (issue #38532). It's zero-dependency, fully themeable through custom properties, and reuses the same glow + border-color visual language already established by `.ease-card-glow` in `components/cards.css`, so it should standardize in cleanly alongside it.
+
+## Files
+- `demo.html` — two live variants (default violet + an amber override) showing the custom-property theming
+- `style.css` — the component
+- `README.md` — this file

--- a/submissions/examples/creative-portfolio-glow-pulse-card-38532/demo.html
+++ b/submissions/examples/creative-portfolio-glow-pulse-card-38532/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Creative Portfolio Glow Pulse Card — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: center;
+      gap: 32px;
+      padding: 56px 24px;
+      background: #0b0a10;
+      font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    }
+  </style>
+</head>
+<body>
+
+  <a class="portfolio-glow-card" href="#">
+    <div class="pgc-thumb" aria-hidden="true">
+      <span class="pgc-thumb-icon">🎨</span>
+    </div>
+    <div class="pgc-body">
+      <span class="pgc-tag">Brand Identity</span>
+      <h3 class="pgc-title">Solace - Visual Identity</h3>
+      <p class="pgc-desc">A minimal identity system for a wellness studio, built around calm gradients and custom type.</p>
+      <span class="pgc-cta">View project →</span>
+    </div>
+  </a>
+
+  <a class="portfolio-glow-card" href="#" style="--pgc-glow-color: rgba(251, 146, 60, 0.55); --pgc-accent: #fdba74; --pgc-pulse-duration: 1.8s; --pgc-pulse-scale: 1.05;">
+    <div class="pgc-thumb" aria-hidden="true">
+      <span class="pgc-thumb-icon">🎬</span>
+    </div>
+    <div class="pgc-body">
+      <span class="pgc-tag">Motion Design</span>
+      <h3 class="pgc-title">Aurora - Motion Reel</h3>
+      <p class="pgc-desc">A 45-second title sequence exploring light refraction through layered glass.</p>
+      <span class="pgc-cta">View project →</span>
+    </div>
+  </a>
+
+</body>
+</html>

--- a/submissions/examples/creative-portfolio-glow-pulse-card-38532/style.css
+++ b/submissions/examples/creative-portfolio-glow-pulse-card-38532/style.css
@@ -1,0 +1,141 @@
+/* Creative Portfolio Glow Pulse Card — pure CSS, zero JS
+   Issue: #38532 — Add CSS Glow Pulse Card for Creative Portfolio Layouts */
+
+.portfolio-glow-card {
+  --pgc-pulse-duration: 2.4s;
+  --pgc-pulse-easing: ease-in-out;
+  --pgc-pulse-scale: 1.035;
+  --pgc-glow-color: rgba(168, 85, 247, 0.55);
+  --pgc-radius: 20px;
+  --pgc-bg: #15131f;
+  --pgc-fg: #f4f2fa;
+  --pgc-accent: #c084fc;
+
+  display: flex;
+  flex-direction: column;
+  width: min(320px, 100%);
+  background: var(--pgc-bg);
+  color: var(--pgc-fg);
+  border-radius: var(--pgc-radius);
+  padding: 20px;
+  text-decoration: none;
+  box-shadow: 0 10px 24px -18px rgba(0, 0, 0, 0.6);
+  transition:
+    transform var(--pgc-pulse-duration) var(--pgc-pulse-easing),
+    box-shadow var(--pgc-pulse-duration) var(--pgc-pulse-easing);
+}
+
+.pgc-thumb {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  aspect-ratio: 16 / 10;
+  border-radius: calc(var(--pgc-radius) - 8px);
+  margin-bottom: 18px;
+  background:
+    radial-gradient(circle at 30% 25%, var(--pgc-glow-color), transparent 65%),
+    rgba(255, 255, 255, 0.03);
+}
+
+.pgc-thumb-icon {
+  font-size: 2rem;
+}
+
+.pgc-body {
+  display: flex;
+  flex-direction: column;
+}
+
+.pgc-tag {
+  align-self: flex-start;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--pgc-accent);
+  background: rgba(255, 255, 255, 0.06);
+  padding: 4px 10px;
+  border-radius: 999px;
+  margin-bottom: 12px;
+}
+
+.pgc-title {
+  margin: 0 0 8px;
+  font-size: 1.15rem;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.pgc-desc {
+  margin: 0 0 16px;
+  font-size: 0.875rem;
+  line-height: 1.55;
+  color: rgba(244, 242, 250, 0.7);
+}
+
+.pgc-cta {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--pgc-accent);
+}
+
+/* ── Glow Pulse interaction ────────────────────────────────────
+   Loops only while hovered/focused. Hover is gated behind
+   (hover: hover) and (pointer: fine) so the glow doesn't get
+   stuck "on" after a tap on touchscreens; focus is handled
+   separately so keyboard users always get it. */
+@keyframes pgc-pulse-glow {
+  0%,
+  100% {
+    transform: translateY(-6px) scale(1);
+    box-shadow:
+      0 0 10px 0 var(--pgc-glow-color),
+      0 18px 30px -16px rgba(0, 0, 0, 0.55);
+  }
+
+  50% {
+    transform: translateY(-6px) scale(var(--pgc-pulse-scale));
+    box-shadow:
+      0 0 36px 6px var(--pgc-glow-color),
+      0 22px 34px -14px rgba(0, 0, 0, 0.6);
+  }
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .portfolio-glow-card:hover {
+    animation: pgc-pulse-glow var(--pgc-pulse-duration) var(--pgc-pulse-easing) infinite;
+  }
+}
+
+.portfolio-glow-card:focus-visible {
+  animation: pgc-pulse-glow var(--pgc-pulse-duration) var(--pgc-pulse-easing) infinite;
+  outline: 2px solid var(--pgc-accent);
+  outline-offset: 4px;
+}
+
+/* ── Responsive ─────────────────────────────────────────────── */
+@media (max-width: 640px) {
+  .portfolio-glow-card {
+    padding: 16px;
+  }
+
+  .pgc-title {
+    font-size: 1.05rem;
+  }
+}
+
+/* ── Reduced motion ─────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .portfolio-glow-card {
+    transition: none;
+  }
+
+  .portfolio-glow-card:hover,
+  .portfolio-glow-card:focus-visible {
+    animation: none !important;
+    transform: none !important;
+    box-shadow:
+      0 0 22px 3px var(--pgc-glow-color),
+      0 18px 30px -16px rgba(0, 0, 0, 0.55);
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure-CSS "Glow Pulse" project card for creative-portfolio layouts, per #38532. On hover/focus the card lifts and pulses a colour-matched glow in an infinite loop for the duration of the interaction, and stops cleanly on mouse-leave/blur. Zero JavaScript.

Closes #38532

## Type of Change
- [x] 🧩 New component

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/creative-portfolio-glow-pulse-card-38532/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A keyboard-accessible, pure-CSS "Glow Pulse" card for creative-portfolio project showcases.

**How does a developer use it?**
```html
<a class="portfolio-glow-card" href="/projects/solace">
  <div class="pgc-thumb" aria-hidden="true"><span class="pgc-thumb-icon">🎨</span></div>
  <div class="pgc-body">
    <span class="pgc-tag">Brand Identity</span>
    <h3 class="pgc-title">Solace - Visual Identity</h3>
    <p class="pgc-desc">Short project description.</p>
    <span class="pgc-cta">View project →</span>
  </div>
</a>
```

**Why does it fit EaseMotion CSS?**
Zero-JS, fully themeable through CSS custom properties (duration, easing, scale, colour), respects `prefers-reduced-motion`, and reuses the box-shadow + border-color glow language already established by `.ease-card-glow` in `components/cards.css`.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)
<img width="800" height="330" alt="ezgif-77ba22ab95e13d60" src="https://github.com/user-attachments/assets/0f93d14a-1981-458f-ae61-5731360268b7" />

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge