### PR TITLE
feat: add animated success checkmark

### DIFF
--- a/submissions/examples/success-checkmark-as/README.md
+++ b/submissions/examples/success-checkmark-as/README.md
@@ -1,0 +1,23 @@
+# Animated Success Checkmark
+
+### What does this do?
+
+It confirms a completed action by drawing a circle and then a checkmark inside it, animating the SVG stroke.
+
+### How is it used?
+
+```html
+<div class="success" role="status">
+  <svg class="success-mark" viewBox="0 0 52 52" aria-hidden="true">
+    <circle class="success-circle" cx="26" cy="26" r="24" />
+    <path class="success-check" d="M14 27l7 7 16-16" />
+  </svg>
+  <p>Payment successful</p>
+</div>
+```
+
+The circle draws first, then the check draws after a short delay, both by animating `stroke-dashoffset` from the full length down to zero.
+
+### Why is it useful?
+
+A drawn checkmark is a satisfying way to confirm a payment, a save, or a signup. This animates the SVG stroke with `stroke-dasharray` and `stroke-dashoffset`, so it needs no JavaScript. The wrapper has a `status` role for assistive tech, and under `prefers-reduced-motion: reduce` the mark is shown fully without drawing.

--- a/submissions/examples/success-checkmark-as/demo.html
+++ b/submissions/examples/success-checkmark-as/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Success Checkmark</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="success" role="status">
+    <svg class="success-mark" viewBox="0 0 52 52" aria-hidden="true">
+      <circle class="success-circle" cx="26" cy="26" r="24" />
+      <path class="success-check" d="M14 27l7 7 16-16" />
+    </svg>
+    <p>Payment successful</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/success-checkmark-as/style.css
+++ b/submissions/examples/success-checkmark-as/style.css
@@ -1,0 +1,70 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.success {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.success-mark {
+  width: 88px;
+  height: 88px;
+}
+
+.success-circle,
+.success-check {
+  fill: none;
+  stroke: #10b981;
+  stroke-width: 3;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.success-circle {
+  stroke-dasharray: 151;
+  stroke-dashoffset: 151;
+  animation: drawCircle 0.6s ease forwards;
+}
+
+.success-check {
+  stroke-dasharray: 40;
+  stroke-dashoffset: 40;
+  animation: drawCheck 0.3s ease 0.6s forwards;
+}
+
+.success p {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+@keyframes drawCircle {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+@keyframes drawCheck {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .success-circle,
+  .success-check {
+    animation: none;
+    stroke-dashoffset: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an animated success checkmark built for #40178. A circle draws itself and then a checkmark draws inside it by animating the SVG stroke, with no JavaScript. Closes #40178.

## Type of Change

- [x] ✨ New animation / hover effect

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A success confirmation with a drawn circle and checkmark.

**How does a developer use it?**

```html
<div class="success" role="status">
  <svg class="success-mark" viewBox="0 0 52 52" aria-hidden="true">
    <circle class="success-circle" cx="26" cy="26" r="24" />
    <path class="success-check" d="M14 27l7 7 16-16" />
  </svg>
  <p>Payment successful</p>
</div>
```

**Why does it fit EaseMotion CSS?**
It animates the SVG stroke with `stroke-dasharray` and `stroke-dashoffset`, so it needs no JavaScript. The wrapper has a `status` role, and under `prefers-reduced-motion: reduce` the mark shows fully without drawing.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: both the circle and the check stroke dash offsets animate to zero, drawing the mark.
