### PR TITLE
feat: add neumorphic buttons

### DIFF
--- a/submissions/examples/neumorphic-buttons-as/README.md
+++ b/submissions/examples/neumorphic-buttons-as/README.md
@@ -1,0 +1,18 @@
+# Neumorphic Buttons
+
+### What does this do?
+
+It shows soft UI buttons that look raised from the surface using paired light and dark shadows, and press inward with inset shadows when clicked.
+
+### How is it used?
+
+```html
+<button class="neu-btn" type="button">Save</button>
+<button class="neu-btn is-accent" type="button">Continue</button>
+```
+
+The buttons and the page share the same background color, which is what gives the extruded look. Add `is-accent` to tint a button, or `neu-icon` for a round icon button.
+
+### Why is it useful?
+
+The soft neumorphic style suits calm dashboards and settings panels. This builds the raised and pressed states from paired box shadows and switches them on `:active`, so it needs no JavaScript. The buttons show a focus ring, and the shadow transition is kept minimal under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/neumorphic-buttons-as/demo.html
+++ b/submissions/examples/neumorphic-buttons-as/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Neumorphic Buttons</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="neu-row">
+    <button class="neu-btn" type="button">Save</button>
+    <button class="neu-btn is-accent" type="button">Continue</button>
+    <button class="neu-btn neu-icon" type="button" aria-label="Like">
+      <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+        <path d="M20.8 4.6a5.5 5.5 0 0 0-7.8 0L12 5.6l-1-1a5.5 5.5 0 1 0-7.8 7.8l1 1L12 21l7.8-7.6 1-1a5.5 5.5 0 0 0 0-7.8z" />
+      </svg>
+    </button>
+  </div>
+</body>
+</html>

--- a/submissions/examples/neumorphic-buttons-as/style.css
+++ b/submissions/examples/neumorphic-buttons-as/style.css
@@ -1,0 +1,69 @@
+:root {
+  --neu-bg: #e0e5ec;
+  --neu-dark: #b8bec9;
+  --neu-light: #ffffff;
+  --accent: #6c63ff;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: var(--neu-bg);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.neu-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: center;
+}
+
+.neu-btn {
+  padding: 0.9rem 1.8rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #4b5563;
+  background: var(--neu-bg);
+  border: none;
+  border-radius: 14px;
+  cursor: pointer;
+  box-shadow: 8px 8px 16px var(--neu-dark), -8px -8px 16px var(--neu-light);
+  transition: color 0.2s ease, box-shadow 0.15s ease;
+}
+
+.neu-btn:hover {
+  color: var(--accent);
+}
+
+.neu-btn:active {
+  box-shadow: inset 6px 6px 12px var(--neu-dark), inset -6px -6px 12px var(--neu-light);
+}
+
+.neu-btn.is-accent {
+  color: var(--accent);
+}
+
+.neu-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.neu-icon {
+  width: 54px;
+  height: 54px;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border-radius: 50%;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .neu-btn {
+    transition: color 0.2s ease;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds neumorphic buttons built for #40181. Soft UI buttons look raised with paired shadows and press inward with inset shadows on click, using only CSS. Closes #40181.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
Soft UI buttons with a raised look and an inset pressed state, plus an accent and a round icon variant.

**How does a developer use it?**

```html
<button class="neu-btn" type="button">Save</button>
<button class="neu-btn is-accent" type="button">Continue</button>
```

**Why does it fit EaseMotion CSS?**
It builds the raised and pressed states from paired box shadows and switches them on `:active`, so it needs no JavaScript. The buttons show a focus ring, and the shadow transition is minimal under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the button uses outset shadows at rest and inset shadows on press.
