### PR TITLE
feat: add floating action button speed dial

### DIFF
--- a/submissions/examples/fab-speed-dial-as/README.md
+++ b/submissions/examples/fab-speed-dial-as/README.md
@@ -1,0 +1,24 @@
+# Floating Action Button Speed Dial
+
+### What does this do?
+
+It shows a floating action button that fans out a set of smaller action buttons on hover or focus, each with a staggered delay, while the main plus rotates into a close icon.
+
+### How is it used?
+
+```html
+<div class="fab">
+  <div class="fab-actions">
+    <button class="fab-action" type="button" aria-label="New note">N</button>
+    <button class="fab-action" type="button" aria-label="New event">E</button>
+    <button class="fab-action" type="button" aria-label="New task">T</button>
+  </div>
+  <button class="fab-main" type="button" aria-label="Open quick actions">+</button>
+</div>
+```
+
+Hover or focus the `.fab` and the actions rise into view. Each action button has its own `aria-label`.
+
+### Why is it useful?
+
+A speed dial groups related quick actions behind one button, common in mobile and dashboard interfaces. This reveals the actions with staggered transforms driven by hover and `:focus-within`, so it needs no JavaScript. The buttons show focus rings, and the motion is reduced under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/fab-speed-dial-as/demo.html
+++ b/submissions/examples/fab-speed-dial-as/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Floating Action Button Speed Dial</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="fab">
+    <div class="fab-actions">
+      <button class="fab-action" type="button" aria-label="New note">N</button>
+      <button class="fab-action" type="button" aria-label="New event">E</button>
+      <button class="fab-action" type="button" aria-label="New task">T</button>
+    </div>
+    <button class="fab-main" type="button" aria-label="Open quick actions">+</button>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fab-speed-dial-as/style.css
+++ b/submissions/examples/fab-speed-dial-as/style.css
@@ -1,0 +1,94 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 70%);
+}
+
+.fab {
+  position: fixed;
+  right: 2rem;
+  bottom: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.fab-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.85rem;
+}
+
+.fab-action {
+  width: 44px;
+  height: 44px;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  color: #e2e8f0;
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 50%;
+  cursor: pointer;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
+  opacity: 0;
+  transform: translateY(12px) scale(0.8);
+  pointer-events: none;
+  transition: opacity 0.25s ease, transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.fab-action:nth-child(1) { transition-delay: 0.1s; }
+.fab-action:nth-child(2) { transition-delay: 0.05s; }
+.fab-action:nth-child(3) { transition-delay: 0s; }
+
+.fab:hover .fab-action,
+.fab:focus-within .fab-action {
+  opacity: 1;
+  transform: none;
+  pointer-events: auto;
+}
+
+.fab-action:hover {
+  background: #6c63ff;
+  border-color: #6c63ff;
+  color: #fff;
+}
+
+.fab-main {
+  width: 58px;
+  height: 58px;
+  display: grid;
+  place-items: center;
+  font-size: 1.9rem;
+  line-height: 1;
+  color: #fff;
+  background: #6c63ff;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  box-shadow: 0 10px 24px rgba(108, 99, 255, 0.45);
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), background 0.2s ease;
+}
+
+.fab:hover .fab-main,
+.fab:focus-within .fab-main {
+  transform: rotate(135deg);
+  background: #574fe0;
+}
+
+.fab-main:focus-visible,
+.fab-action:focus-visible {
+  outline: 2px solid #fbbf24;
+  outline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fab-action,
+  .fab-main {
+    transition: opacity 0.2s ease;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a floating action button speed dial built for #40184. On hover or focus the button fans out three smaller actions with staggered delays while the main plus rotates into a close, using only CSS. Closes #40184.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A floating action button that reveals a set of quick actions on hover or focus.

**How does a developer use it?**

```html
<div class="fab">
  <div class="fab-actions">
    <button class="fab-action" type="button" aria-label="New note">N</button>
  </div>
  <button class="fab-main" type="button" aria-label="Open quick actions">+</button>
</div>
```

**Why does it fit EaseMotion CSS?**
It reveals the actions with staggered transforms driven by hover and `:focus-within`, so it needs no JavaScript. The buttons show focus rings, and the motion is reduced under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: hovering the group takes the actions from opacity 0 to 1 and rotates the main button.
