### PR TITLE
feat: add skill proficiency bars

### DIFF
--- a/submissions/examples/skill-bars-as/README.md
+++ b/submissions/examples/skill-bars-as/README.md
@@ -1,0 +1,20 @@
+# Skill Proficiency Bars
+
+### What does this do?
+
+It shows a list of labelled skill bars that fill to their percentage on load with a staggered delay.
+
+### How is it used?
+
+```html
+<div class="skill">
+  <div class="skill-head"><span>CSS</span><span>90%</span></div>
+  <div class="skill-track"><span class="skill-fill" style="--level: 90%"></span></div>
+</div>
+```
+
+Set `--level` on each `.skill-fill` to the percentage. The bar scales from zero to its level on load, and several bars stagger their fills.
+
+### Why is it useful?
+
+Skill and proficiency bars are common on portfolios, resumes, and profile pages. This fills each bar to a level driven by a custom property and staggers them, using only CSS with no JavaScript. Under `prefers-reduced-motion: reduce` the bars show their level without animating.

--- a/submissions/examples/skill-bars-as/demo.html
+++ b/submissions/examples/skill-bars-as/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Skill Proficiency Bars</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="skills">
+    <div class="skill">
+      <div class="skill-head"><span>HTML</span><span>95%</span></div>
+      <div class="skill-track"><span class="skill-fill" style="--level: 95%"></span></div>
+    </div>
+    <div class="skill">
+      <div class="skill-head"><span>CSS</span><span>90%</span></div>
+      <div class="skill-track"><span class="skill-fill" style="--level: 90%"></span></div>
+    </div>
+    <div class="skill">
+      <div class="skill-head"><span>JavaScript</span><span>80%</span></div>
+      <div class="skill-track"><span class="skill-fill" style="--level: 80%"></span></div>
+    </div>
+    <div class="skill">
+      <div class="skill-head"><span>Design</span><span>70%</span></div>
+      <div class="skill-track"><span class="skill-fill" style="--level: 70%"></span></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/skill-bars-as/style.css
+++ b/submissions/examples/skill-bars-as/style.css
@@ -1,0 +1,65 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.skills {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  width: min(420px, 92vw);
+}
+
+.skill-head {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.4rem;
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.skill-head span:last-child {
+  color: #94a3b8;
+}
+
+.skill-track {
+  height: 9px;
+  border-radius: 999px;
+  background: #1e293b;
+  overflow: hidden;
+}
+
+.skill-fill {
+  display: block;
+  height: 100%;
+  width: var(--level);
+  border-radius: 999px;
+  background: linear-gradient(90deg, #6c63ff, #0ea5e9);
+  transform: scaleX(0);
+  transform-origin: left;
+  animation: fillBar 1.2s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+
+.skill:nth-child(2) .skill-fill { animation-delay: 0.12s; }
+.skill:nth-child(3) .skill-fill { animation-delay: 0.24s; }
+.skill:nth-child(4) .skill-fill { animation-delay: 0.36s; }
+
+@keyframes fillBar {
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skill-fill {
+    animation: none;
+    transform: scaleX(1);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds skill proficiency bars built for #40188. Labelled bars fill to their percentage on load with a staggered delay, driven by a custom property, using only CSS. Closes #40188.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A set of labelled skill bars that fill to a level on load.

**How does a developer use it?**

```html
<div class="skill">
  <div class="skill-head"><span>CSS</span><span>90%</span></div>
  <div class="skill-track"><span class="skill-fill" style="--level: 90%"></span></div>
</div>
```

**Why does it fit EaseMotion CSS?**
It fills each bar to a level driven by a custom property and staggers them, so it needs no JavaScript. Under `prefers-reduced-motion: reduce` the bars show their level without animating.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: four bars settle to their filled scale at the levels set by the custom property.
