### PR TITLE
fix: export documented css subpaths

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,12 @@
   "module": "easemotion/index.js",
   "exports": {
     ".": "./easemotion.css",
+    "./easemotion.css": "./easemotion.css",
+    "./easemotion.min.css": "./easemotion.min.css",
     "./min": "./easemotion.min.css",
+    "./core/*": "./core/*",
+    "./components/*": "./components/*",
+    "./easemotion/*": "./easemotion/*",
     "./engine": "./easemotion/index.js",
     "./engine/parser": "./easemotion/engine/parser.js",
     "./engine/compiler": "./easemotion/engine/compiler.js",


### PR DESCRIPTION
## Summary

Exports the documented CSS package subpaths so modern bundlers and Node package resolution can load the same paths shown in the README and docs.

Closes #40053

## Validation

- `npm run validate:pack`
- packed the package into a temporary project and verified these paths resolve:
  - `easemotion-css/easemotion.min.css`
  - `easemotion-css/core/variables.css`
  - `easemotion-css/components/buttons.css`
  - `easemotion-css/easemotion/fade.css`
