### PR TITLE
fix: align manifest repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/saptarshi-coder/easemotion-css.git"
+    "url": "git+https://github.com/SAPTARSHI-coder/EaseMotion-css.git"
   },
   "keywords": [
     "css",


### PR DESCRIPTION
## Summary

Updates the package repository URL to match the canonical repository casing expected by the manifest validator.

Closes #40054

## Validation

- `npm run validate:manifest`
