### PR TITLE
fix: validate bundle on push runs

### DIFF
--- a/scripts/validate-bundle.mjs
+++ b/scripts/validate-bundle.mjs
@@ -10,9 +10,9 @@ const bundlePath = path.join(rootDir, "easemotion.min.css");
 
 // Skip validation in CI if the changed files do not affect the CSS bundle.
 // This prevents unnecessary bundle conflicts for example/sandbox PRs.
-if (process.env.GITHUB_ACTIONS === "true") {
+if (process.env.GITHUB_ACTIONS === "true" && process.env.GITHUB_BASE_REF) {
   try {
-    const baseBranch = process.env.GITHUB_BASE_REF || "main";
+    const baseBranch = process.env.GITHUB_BASE_REF;
     execSync(`git fetch origin ${baseBranch} --depth=1`, { stdio: "ignore" });
     
     const changedFiles = execSync(`git diff --name-only origin/${baseBranch}`, { encoding: "utf8" })


### PR DESCRIPTION
## Summary

Restricts the changed-file skip in bundle validation to pull request runs where `GITHUB_BASE_REF` is available. Push and manual CI runs now perform full bundle validation.

Closes #40056

## Validation

- `GITHUB_ACTIONS=true npm run validate:bundle` with no `GITHUB_BASE_REF`
- `npm run validate:bundle`
