### PR TITLE
fix: stop fork updates before main push

### DIFF
--- a/.github/workflows/auto-merge-submissions.yml
+++ b/.github/workflows/auto-merge-submissions.yml
@@ -394,7 +394,14 @@ jobs:
               echo "Pushed updates back to PR branch."
               echo "exitEarly=true" >> $GITHUB_OUTPUT
             else
-              echo "Changes detected and PR is from a fork. Pushing directly to upstream main..."
+              echo "Changes detected and PR is from a fork. Stopping for maintainer review."
+
+              echo "Stopping before any direct push to upstream main. Generated fork updates require maintainer review."
+              comment_body="Generated updates are required for this fork PR, but the workflow will not push directly to \`main\`. A maintainer should apply the generated changes through a reviewed branch or ask the contributor to update the PR branch."
+              curl -s -X POST -H "Authorization: token $GH_TOKEN" -H "Accept: application/vnd.github.v3+json" \
+                "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUM/comments" \
+                -d "$(jq -n --arg body "$comment_body" '{body: $body}')"
+              exit 1
               
               success=false
               for attempt in {1..5}; do


### PR DESCRIPTION
## Summary

Stops the auto-merge workflow before it can push generated fork PR updates directly to `main`. Fork PRs that need generated changes now leave a maintainer-facing comment and fail for review instead.

Closes #40057

## Validation

- Inspected the fork-generated update path in `.github/workflows/auto-merge-submissions.yml`
- `npx prettier --check .github/workflows/auto-merge-submissions.yml` parsed the workflow and reported formatting differences
