### PR TITLE
fix: guard runtime invalid em warning

### DIFF
--- a/easemotion/engine/runtime.js
+++ b/easemotion/engine/runtime.js
@@ -26,6 +26,10 @@ const injected = new Set();
 /** Single shared <style> element for all engine rules */
 let styleEl = null;
 
+function isProduction() {
+  return typeof process !== 'undefined' && process.env?.NODE_ENV === 'production';
+}
+
 /**
  * Ensure the engine's <style> element exists in <head>.
  * @returns {HTMLStyleElement}
@@ -52,7 +56,7 @@ function processElement(el) {
 
   const ast = parse(value);
   if (!ast) {
-    if (process?.env?.NODE_ENV !== 'production') {
+    if (!isProduction()) {
       console.warn(`[EaseMotion Engine] Could not parse em="${value}". Unknown animation name.`);
     }
     return;


### PR DESCRIPTION
## Summary

Guards the invalid `em` warning path so the runtime does not reference an undeclared `process` global in browsers.

Closes #40058

## Validation

- Reproduced invalid `em` handling in a browser-like jsdom environment with `process` removed
- `npm test`
