### PR TITLE
Fix SCSS build output

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build": "node scripts/build-minified-css.mjs",
     "build:watch": "node scripts/build-minified-css.mjs --watch",
     "resolve-conflict": "node scripts/resolve-conflict.mjs",
-    "build:scss": "sass scss/_index.scss dist/easemotion.scss.css",
+    "build:scss": "sass scss/easemotion.scss dist/easemotion.scss.css",
     "prepublishOnly": "npm run build",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scss/easemotion.scss
+++ b/scss/easemotion.scss
@@ -1,0 +1,46 @@
+// ============================================
+// EaseMotion CSS - SCSS build entry
+// ============================================
+
+@forward "variables";
+@forward "mixins";
+
+@use "sass:meta";
+
+@include meta.load-css("../core/variables.css");
+@include meta.load-css("../core/base.css");
+@include meta.load-css("../core/animations.css");
+@include meta.load-css("../core/utilities.css");
+@include meta.load-css("../components/ease-marquee.css");
+@include meta.load-css("../components/buttons.css");
+@include meta.load-css("../components/cards.css");
+@include meta.load-css("../components/navbar.css");
+@include meta.load-css("../components/masonry.css");
+@include meta.load-css("../components/chip.css");
+@include meta.load-css("../components/footer.css");
+@include meta.load-css("../components/sidebar.css");
+@include meta.load-css("../components/scroll-progress.css");
+@include meta.load-css("../components/tabs.css");
+@include meta.load-css("../components/badges.css");
+@include meta.load-css("../components/loaders.css");
+@include meta.load-css("../components/tooltips.css");
+@include meta.load-css("../components/modals.css");
+@include meta.load-css("../components/command-palette.css");
+@include meta.load-css("../components/announce-bar.css");
+@include meta.load-css("../components/avatar.css");
+@include meta.load-css("../components/breadcrumb.css");
+@include meta.load-css("../components/btn-magnetic.css");
+@include meta.load-css("../components/compare-table.css");
+@include meta.load-css("../components/connection-status.css");
+@include meta.load-css("../components/fab.css");
+@include meta.load-css("../components/kbd.css");
+@include meta.load-css("../components/pagination.css");
+@include meta.load-css("../components/password-strength.css");
+@include meta.load-css("../components/progress.css");
+@include meta.load-css("../components/read-more.css");
+@include meta.load-css("../components/scroll-gallery.css");
+@include meta.load-css("../components/skeleton.css");
+@include meta.load-css("../components/tag.css");
+@include meta.load-css("../components/toast.css");
+@include meta.load-css("../components/view-transitions.css");
+@include meta.load-css("../components/forms.css");


### PR DESCRIPTION
## Summary
- Adds a SCSS build entry that forwards the SCSS API and emits the framework CSS, so build:scss produces a usable stylesheet.

Fixes #40201

## Tests
- npm run build:scss
