### PR TITLE
Exclude chip demo from package contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "easemotion.min.css",
     "core/",
     "components/",
+    "!components/*.html",
     "easemotion/",
     "scss/",
     "dist/",


### PR DESCRIPTION
## Summary
- Excludes component demo HTML from the npm files list so the package dry-run no longer ships components/chip-demo.html.

Fixes #40202

## Tests
- npm run validate:pack
