### PR TITLE
Mark engine files as ES modules

### DIFF
--- a/easemotion/package.json
+++ b/easemotion/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
## Summary
- Adds a module marker for the engine directory so the exported ESM entry imports without Node module-type warnings.

Fixes #40211

## Tests
- node --input-type=module -e "import('./easemotion/index.js').then(m=>console.log(Object.keys(m).length))"
