### PR TITLE
docs(glowing-grid): update documentation for Glowing Grid Portal (#39473)

### DIFF
--- a/submissions/examples/ease-glowing-grid-gm/README.md
+++ b/submissions/examples/ease-glowing-grid-gm/README.md
@@ -8,3 +8,7 @@ Use the wrapper `.ease-grid-portal` and nested grid `.ease-glow-grid` containing
 
 3. Why is it useful?  
 It showcases high-performance GPU-accelerated cursor masking and 3D rotations on isolated child wrappers that prevent parent layout stutter.
+
+---
+*Created for ECSoC-26 / GSSoC-26.*
+


### PR DESCRIPTION
Closes #39473.

This PR adds metadata documentation linking to GSSoC-26 and ECSoC-26 for the already-merged Glowing Grid Portal dashboard example.