### PR TITLE
feat(submission): add CSS-only radial action menu (#40051)

### DIFF
--- a/submissions/examples/radial-action-menu-ksk/README.md
+++ b/submissions/examples/radial-action-menu-ksk/README.md
@@ -1,0 +1,13 @@
+# CSS-only Radial Action Menu (`radial-action-menu-ksk`)
+
+1. What does this do?  
+Displays a floating radial action menu that expands and collapses with smooth rotation and scale animations, completely without JavaScript using the checkbox hack.
+
+2. How is it used?  
+Wrap the checkbox toggler, trigger label, and list of anchor elements inside a `.radial-menu-container` parent element.
+
+3. Why is it useful?  
+It provides a high-performance, responsive radial navigation pattern that is lightweight, layout-stable, and customizable with CSS variables.
+
+---
+*Created for ECSoC-26 / GSSoC-26 — Resolves #40051.*

--- a/submissions/examples/radial-action-menu-ksk/demo.html
+++ b/submissions/examples/radial-action-menu-ksk/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-only Radial Action Menu Showcase</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      background-color: #0b0f19; /* dark theme base */
+      color: #f8fafc;
+      font-family: system-ui, -apple-system, sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+      padding: 20px;
+    }
+    .wrapper {
+      text-align: center;
+      max-width: 400px;
+      background-color: #141e33; /* deep blue card */
+      border: 1px solid #1e293b;
+      border-radius: 16px;
+      padding: 40px;
+      box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.3);
+    }
+    h1 {
+      font-size: 22px;
+      margin-top: 0;
+      margin-bottom: 8px;
+    }
+    p {
+      color: #94a3b8;
+      font-size: 14px;
+      margin-bottom: 40px;
+      line-height: 1.5;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrapper">
+    <h1>Radial Action Menu</h1>
+    <p>A JavaScript-free floating radial navigation component utilizing the HTML checkbox hack.</p>
+    
+    <div class="radial-menu-container">
+      <input type="checkbox" id="menu-toggle">
+
+      <label for="menu-toggle" class="menu-button">
+        +
+      </label>
+
+      <a href="#" class="item item1">🏠</a>
+      <a href="#" class="item item2">❤️</a>
+      <a href="#" class="item item3">🔍</a>
+      <a href="#" class="item item4">⚙️</a>
+      <a href="#" class="item item5">📩</a>
+      <a href="#" class="item item6">⭐</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/radial-action-menu-ksk/style.css
+++ b/submissions/examples/radial-action-menu-ksk/style.css
@@ -1,0 +1,129 @@
+/* ============================================================
+   EaseMotion CSS — CSS-only Radial Action Menu
+   submissions/examples/radial-action-menu-ksk/style.css
+   ============================================================ */
+
+/* ponytail: clean, JS-free, hardware-accelerated transforms */
+
+.radial-menu-container {
+  position: relative;
+  width: 260px;
+  height: 260px;
+  margin: 0 auto;
+}
+
+/* Hide the checkbox hack controller */
+#menu-toggle {
+  display: none;
+}
+
+/* Main Trigger Button */
+.menu-button {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 56px;
+  height: 56px;
+  background-color: #6c63ff;
+  color: #ffffff;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  font-weight: bold;
+  cursor: pointer;
+  z-index: 10;
+  box-shadow: 0 4px 10px rgba(108, 99, 255, 0.4);
+  transform: translate(-50%, -50%) rotate(0deg);
+  transition: transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275), background-color 0.3s ease, box-shadow 0.3s ease;
+  user-select: none;
+}
+
+.menu-button:hover {
+  box-shadow: 0 6px 15px rgba(108, 99, 255, 0.6);
+  background-color: #5b52e0;
+}
+
+/* Rotate cross to Close sign when active */
+#menu-toggle:checked ~ .menu-button {
+  transform: translate(-50%, -50%) rotate(135deg);
+  background-color: #ef4444;
+  box-shadow: 0 4px 10px rgba(239, 68, 68, 0.4);
+}
+
+/* Circular Menu Items Base */
+.item {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 44px;
+  height: 44px;
+  background-color: #1e293b; /* slate-800 */
+  border: 1px solid #334155;
+  color: #f1f5f9;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  font-size: 18px;
+  z-index: 5;
+  transform: translate(-50%, -50%) scale(0) rotate(-360deg);
+  opacity: 0;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  transition: transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275), opacity 0.3s ease, background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.item:hover {
+  background-color: #334155;
+  border-color: #6c63ff;
+  transform: translate(var(--tx), var(--ty)) scale(1.1) !important;
+}
+
+/* Checkbox hack selectors for circular positioning (Radius = 90px) */
+#menu-toggle:checked ~ .item {
+  opacity: 1;
+}
+
+#menu-toggle:checked ~ .item1 {
+  --tx: -50%;
+  --ty: calc(-50% - 90px);
+  transform: translate(var(--tx), var(--ty)) scale(1) rotate(0deg);
+  transition-delay: 0.02s;
+}
+
+#menu-toggle:checked ~ .item2 {
+  --tx: calc(-50% + 78px);
+  --ty: calc(-50% - 45px);
+  transform: translate(var(--tx), var(--ty)) scale(1) rotate(0deg);
+  transition-delay: 0.04s;
+}
+
+#menu-toggle:checked ~ .item3 {
+  --tx: calc(-50% + 78px);
+  --ty: calc(-50% + 45px);
+  transform: translate(var(--tx), var(--ty)) scale(1) rotate(0deg);
+  transition-delay: 0.06s;
+}
+
+#menu-toggle:checked ~ .item4 {
+  --tx: -50%;
+  --ty: calc(-50% + 90px);
+  transform: translate(var(--tx), var(--ty)) scale(1) rotate(0deg);
+  transition-delay: 0.08s;
+}
+
+#menu-toggle:checked ~ .item5 {
+  --tx: calc(-50% - 78px);
+  --ty: calc(-50% + 45px);
+  transform: translate(var(--tx), var(--ty)) scale(1) rotate(0deg);
+  transition-delay: 0.1s;
+}
+
+#menu-toggle:checked ~ .item6 {
+  --tx: calc(-50% - 78px);
+  --ty: calc(-50% - 45px);
+  transform: translate(var(--tx), var(--ty)) scale(1) rotate(0deg);
+  transition-delay: 0.12s;
+}


### PR DESCRIPTION
Closes #40051.

This PR adds a self-contained submission under `submissions/examples/radial-action-menu-ksk/` containing a JavaScript-free CSS Radial Action Menu.

#### **Key Features Showcase**
1. **Checkbox Hack Toggle**: Triggered purely by HTML checkbox state transitions (`:checked ~ .item`).
2. **Radial Positioning**: Trigonometrically offsets 6 items from the center by `90px` radius.
3. **Smooth Transformations**: Expanding scale, translation, and rotational movements, plus button rotation morphing `+` into a close `x` sign.