### PR TITLE
feat(react): add floating action button fab speed dial menu (#40231)

### DIFF
--- a/submissions/react/react-floating-action-button-fab-speed-dial-menu-ksk/FABSpeedDial.jsx
+++ b/submissions/react/react-floating-action-button-fab-speed-dial-menu-ksk/FABSpeedDial.jsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import './style.css';
+
+/**
+ * FABSpeedDial React Component
+ * 
+ * A Floating Action Button (FAB) that expands into a speed dial list of actions.
+ * 
+ * Props:
+ * - actions: Array of objects representing the dial options:
+ *   [{ icon: React.ReactNode, label: string, onClick: () => void }]
+ * - position: 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left' (default: 'bottom-right')
+ * - themeColor: 'primary' | 'success' | 'danger' | 'warning' (default: 'primary')
+ * - mainIcon: Icon/text to display when closed (default: '+')
+ * - openIcon: Icon/text to display when open (default: '+')
+ */
+export default function FABSpeedDial({
+  actions = [],
+  position = 'bottom-right',
+  themeColor = 'primary',
+  mainIcon = '+',
+  openIcon = '+'
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggleMenu = () => setIsOpen(!isOpen);
+
+  return (
+    <div className={`ease-fab-container ease-fab-${position}`}>
+      {/* Speed Dial Actions List */}
+      <div className={`ease-fab-actions ${isOpen ? 'ease-fab-visible' : ''}`}>
+        {actions.map((action, index) => (
+          <div key={index} className="ease-fab-action-wrapper">
+            {action.label && (
+              <span className="ease-fab-tooltip">{action.label}</span>
+            )}
+            <button
+              className="ease-fab-action-item"
+              onClick={() => {
+                if (action.onClick) action.onClick();
+                setIsOpen(false);
+              }}
+              aria-label={action.label || `Action ${index + 1}`}
+            >
+              {action.icon}
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {/* Main Floating Action Button */}
+      <button
+        className={`ease-fab-trigger ease-fab-theme-${themeColor} ${isOpen ? 'ease-fab-open' : ''}`}
+        onClick={toggleMenu}
+        aria-expanded={isOpen}
+        aria-label="Toggle actions menu"
+      >
+        {isOpen ? openIcon : mainIcon}
+      </button>
+    </div>
+  );
+}

--- a/submissions/react/react-floating-action-button-fab-speed-dial-menu-ksk/README.md
+++ b/submissions/react/react-floating-action-button-fab-speed-dial-menu-ksk/README.md
@@ -1,0 +1,45 @@
+# React Floating Action Button (FAB) Speed Dial Menu
+
+A copy-paste ready, modular React component for a Floating Action Button (FAB) that expands into a speed dial list of actions when clicked. Works with zero external dependencies outside React.
+
+---
+*Created for ECSoC-26 / GSSoC-26 — Resolves #40231.*
+
+## Installation
+
+Simply copy `FABSpeedDial.jsx` and `style.css` into your React project components directory.
+
+## Props Reference
+
+| Prop Name | Type | Default Value | Description |
+| :--- | :--- | :---: | :--- |
+| `actions` | `Array` | `[]` | Array of objects representing the dial options: `[{ icon, label, onClick }]` |
+| `position` | `String` | `'bottom-right'` | Placement of the FAB: `'bottom-right'`, `'bottom-left'`, `'top-right'`, `'top-left'` |
+| `themeColor` | `String` | `'primary'` | Accent color theme of the trigger FAB: `'primary'`, `'success'`, `'danger'`, `'warning'` |
+| `mainIcon` | `ReactNode` | `'+'` | Icon or text displayed inside the main FAB when closed |
+| `openIcon` | `ReactNode` | `'+'` | Icon or text displayed inside the main FAB when open (cross rotates automatically) |
+
+## Usage Example
+
+```jsx
+import React from 'react';
+import FABSpeedDial from './FABSpeedDial';
+
+export default function App() {
+  const actions = [
+    { icon: '🏠', label: 'Home', onClick: () => console.log('Home clicked') },
+    { icon: '🔍', label: 'Search', onClick: () => console.log('Search clicked') },
+    { icon: '⚙️', label: 'Settings', onClick: () => console.log('Settings clicked') }
+  ];
+
+  return (
+    <div className="app">
+      <FABSpeedDial 
+        actions={actions} 
+        position="bottom-right" 
+        themeColor="primary" 
+      />
+    </div>
+  );
+}
+```

--- a/submissions/react/react-floating-action-button-fab-speed-dial-menu-ksk/style.css
+++ b/submissions/react/react-floating-action-button-fab-speed-dial-menu-ksk/style.css
@@ -1,0 +1,163 @@
+/* ============================================================
+   EaseMotion CSS — React FAB Speed Dial Menu Styling
+   submissions/react/react-floating-action-button-fab-speed-dial-menu-ksk/style.css
+   ============================================================ */
+
+/* ponytail: clean, modular layout styles and micro-interaction transitions */
+
+.ease-fab-container {
+  position: fixed;
+  z-index: 999;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+/* Position Configurations */
+.ease-fab-bottom-right {
+  bottom: 24px;
+  right: 24px;
+}
+
+.ease-fab-bottom-left {
+  bottom: 24px;
+  left: 24px;
+}
+
+.ease-fab-top-right {
+  top: 24px;
+  right: 24px;
+  flex-direction: column-reverse;
+}
+
+.ease-fab-top-left {
+  top: 24px;
+  left: 24px;
+  flex-direction: column-reverse;
+}
+
+/* Main Trigger Button */
+.ease-fab-trigger {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  border: none;
+  color: #ffffff;
+  font-size: 24px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+  transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275), background-color 0.3s ease;
+  outline: none;
+}
+
+.ease-fab-trigger:hover {
+  transform: scale(1.05);
+}
+
+.ease-fab-trigger:active {
+  transform: scale(0.95);
+}
+
+/* Rotates button when open */
+.ease-fab-trigger.ease-fab-open {
+  transform: rotate(135deg);
+}
+
+/* Color theme mappings */
+.ease-fab-theme-primary { background-color: #6c63ff; }
+.ease-fab-theme-success { background-color: #10b981; }
+.ease-fab-theme-danger { background-color: #ef4444; }
+.ease-fab-theme-warning { background-color: #f59e0b; }
+
+/* Dial actions wrapper transition */
+.ease-fab-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  pointer-events: none;
+  opacity: 0;
+  transform: scale(0.8) translateY(12px);
+  transition: opacity 0.25s cubic-bezier(0.4, 0, 0.2, 1), transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.ease-fab-top-right .ease-fab-actions,
+.ease-fab-top-left .ease-fab-actions {
+  transform: scale(0.8) translateY(-12px);
+}
+
+.ease-fab-actions.ease-fab-visible {
+  pointer-events: auto;
+  opacity: 1;
+  transform: scale(1) translateY(0);
+}
+
+.ease-fab-action-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+/* Action button items */
+.ease-fab-action-item {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background-color: #1e293b;
+  color: #f1f5f9;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  transition: transform 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+  outline: none;
+}
+
+.ease-fab-action-item:hover {
+  transform: scale(1.08);
+  background-color: #334155;
+  border-color: #6c63ff;
+}
+
+/* Tooltip Labels */
+.ease-fab-tooltip {
+  position: absolute;
+  background-color: #0f172a;
+  color: #ffffff;
+  font-family: system-ui, sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 5px 10px;
+  border-radius: 4px;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transform: scale(0.8);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+}
+
+/* Tooltip placements depending on FAB alignment */
+.ease-fab-bottom-right .ease-fab-tooltip,
+.ease-fab-top-right .ease-fab-tooltip {
+  right: 56px;
+  transform-origin: right center;
+}
+
+.ease-fab-bottom-left .ease-fab-tooltip,
+.ease-fab-top-left .ease-fab-tooltip {
+  left: 56px;
+  transform-origin: left center;
+}
+
+.ease-fab-action-wrapper:hover .ease-fab-tooltip {
+  opacity: 1;
+  transform: scale(1);
+}


### PR DESCRIPTION
Closes #40231.

This PR adds a copy-paste ready, modular React component for a Floating Action Button (FAB) Speed Dial Menu under `submissions/react/react-floating-action-button-fab-speed-dial-menu-ksk/`.

#### **Key Features Showcase**
1. **Interactive Toggle State**: Open/closed states managed using clean React `useState` hooks.
2. **Accessible Layout**: Features standard `aria-expanded` and `aria-label` properties.
3. **Responsive Customization**: Configurable FAB placement positioning (`bottom-right`, `bottom-left`, `top-right`, `top-left`) and colors.
4. **Transition Animations**: Scale-up and fade-in transitions on trigger.