### PR TITLE
feat: add Image component with alt text

### DIFF
--- a/submissions/react/fixed-language-alt/Image-Fixed.jsx
+++ b/submissions/react/fixed-language-alt/Image-Fixed.jsx
@@ -1,0 +1,1 @@
+import React from 'react'; const ImageFixed = ({ src, alt, className, ...props }) => { return <img src={src} alt={alt || 'Flag image'} className={className} {...props} />; }; export default ImageFixed;

--- a/submissions/react/fixed-language-alt/Image-Fixed.jsx
+++ b/submissions/react/fixed-language-alt/Image-Fixed.jsx
@@ -1,1 +1,23 @@
-import React from 'react'; const ImageFixed = ({ src, alt, className, ...props }) => { return <img src={src} alt={alt || 'Flag image'} className={className} {...props} />; }; export default ImageFixed;
+import React from 'react';
+
+const ImageFixed = ({ src, alt, className, style, ...props }) => {
+    const defaultAlt = alt || 'Flag image';
+
+    return (
+        <img
+            src={src}
+            alt={defaultAlt}
+            className={`ease-fade-in ${className || ''}`}
+            style={{
+                maxWidth: '100%',
+                height: 'auto',
+                display: 'block',
+                ...style
+            }}
+            {...props}
+        />
+    );
+};
+
+export default ImageFixed;
+

--- a/submissions/react/fixed-language-alt/README.md
+++ b/submissions/react/fixed-language-alt/README.md
@@ -1,0 +1,11 @@
+# Image - Fixed Version
+## Overview
+This component adds proper alt text for flag images.
+
+## Related Issue
+Fixes #40276
+
+## Labels
+- level:intermediate
+- type:accessibility
+- gssoc:approved

--- a/submissions/react/fixed-language-alt/README.md
+++ b/submissions/react/fixed-language-alt/README.md
@@ -1,11 +1,22 @@
-# Image - Fixed Version
+# Image Component - Fixed Version
+
 ## Overview
-This component adds proper alt text for flag images.
+This component adds proper alt text for flag images with fade-in animation.
 
-## Related Issue
-Fixes #40276
+## Props
 
-## Labels
-- level:intermediate
-- type:accessibility
-- gssoc:approved
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| src | string | Required | Image source URL |
+| alt | string | 'Flag image' | Alt text for accessibility |
+| className | string | '' | Additional CSS classes |
+
+## Usage
+
+```jsx
+import ImageFixed from './Image-Fixed';
+
+<ImageFixed 
+  src="/flags/us.png" 
+  alt="United States flag" 
+/>

--- a/submissions/react/fixed-language-alt/style.css
+++ b/submissions/react/fixed-language-alt/style.css
@@ -1,0 +1,15 @@
+.ease-fade-in {
+  animation: easeFadeIn 0.5s ease-in-out;
+}
+
+@keyframes easeFadeIn {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}


### PR DESCRIPTION
## New Component: Image with Alt Text

### Description
This PR adds a fixed version of images with proper alt text for accessibility.

### Changes
- Created `Image-Fixed.jsx` with alt attribute
- Added README.md documenting the fix

### Related Issue
Fixes #40276

### Labels
- `level:intermediate`
- `type:accessibility`
- `gssoc:approved`