### PR TITLE
fix(scripts): resolve case-sensitive repository url matching in validation

### DIFF
--- a/scripts/validate-package.mjs
+++ b/scripts/validate-package.mjs
@@ -38,7 +38,7 @@ if (manifest.name !== "easemotion-css") {
   fail('expected package name to be "easemotion-css"');
 }
 
-if (!manifest.repository?.url?.includes("SAPTARSHI-coder/EaseMotion-css")) {
+if (!manifest.repository?.url?.toLowerCase().includes("saptarshi-coder/easemotion-css")) {
   fail("repository.url must point to SAPTARSHI-coder/EaseMotion-css");
 }
 


### PR DESCRIPTION
## Pull Request Description

This Pull Request resolves a case-sensitivity issue in the package manifest validation script (`scripts/validate-package.mjs`). The validation script previously failed if the `repository.url` in `package.json` used lowercase characters instead of exact-casing matches, even though GitHub repository URLs are case-insensitive.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (describe below)
  - **Tooling / Release validation script bug fix**

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [ ] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

*Note: This is a fix for the build tooling/validation system rather than a user submission feature, so the submission checklist files (like demo.html) are not applicable.*

---

## Feature Description

**What does this add?**

N/A (This is a bug fix for developer tooling validation).

**How does a developer use it?**

N/A

**Why does it fit EaseMotion CSS?**

N/A

---

## Demo

- [ ] Demo added (`demo.html` works by opening directly in a browser) (N/A)

---

## Browser Testing

- [x] Chrome (N/A — verified via Node.js CLI validation checks on Windows/macOS/Linux)
- [x] Firefox (N/A)
- [x] Edge (N/A)
- [x] Safari (N/A)

---

## Notes for Maintainer

The `validate-package.mjs` script was previously performing a case-sensitive `.includes()` check for `"SAPTARSHI-coder/EaseMotion-css"`. By normalizing the string to lowercase before performing the match, developers can use lowercase URLs in their package configuration without failing CI validation tasks.

---
