### PR TITLE
Submission/fix validate package reez

### DIFF
--- a/scripts/validate-package.mjs
+++ b/scripts/validate-package.mjs
@@ -38,7 +38,7 @@ if (manifest.name !== "easemotion-css") {
   fail('expected package name to be "easemotion-css"');
 }
 
-if (!manifest.repository?.url?.includes("SAPTARSHI-coder/EaseMotion-css")) {
+if (!manifest.repository?.url?.toLowerCase().includes("saptarshi-coder/easemotion-css")) {
   fail("repository.url must point to SAPTARSHI-coder/EaseMotion-css");
 }
 

--- a/submissions/docs/fix-validate-package-reez/README.md
+++ b/submissions/docs/fix-validate-package-reez/README.md
@@ -1,0 +1,17 @@
+# Bug Showcase: Case-Sensitivity Validation Mismatch (reez)
+
+## What does this do?
+Documents and proposes a fix for a case-sensitive repository URL matching bug in the `validate-package.mjs` script.
+
+## How is it used?
+By changing the validation script to convert the repository URL to lowercase before comparing, build tools can handle both uppercase and lowercase repository references seamlessly.
+
+```javascript
+// Target fix inside scripts/validate-package.mjs:
+if (!manifest.repository?.url?.toLowerCase().includes("saptarshi-coder/easemotion-css")) {
+  fail("repository.url must point to SAPTARSHI-coder/EaseMotion-css");
+}
+```
+
+## Why is it useful?
+Normalizing to lowercase prevents repository validation tasks from failing in local build scripts or CI/CD pipelines when developers clone the repository using mixed-case or lowercase remote names.

--- a/submissions/docs/fix-validate-package-reez/demo.html
+++ b/submissions/docs/fix-validate-package-reez/demo.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bug Showcase: Case-Sensitivity Validation Mismatch</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    :root {
+      --bg-color: #0f172a;
+      --card-bg: #1e293b;
+      --text-main: #f8fafc;
+      --text-muted: #94a3b8;
+      --primary: #38bdf8;
+      --danger: #ef4444;
+      --success: #22c55e;
+      --border: #334155;
+    }
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+      background-color: var(--bg-color);
+      color: var(--text-main);
+      margin: 0;
+      padding: 2rem;
+      line-height: 1.6;
+    }
+    .container {
+      max-width: 800px;
+      margin: 0 auto;
+    }
+    header {
+      border-bottom: 1px solid var(--border);
+      padding-bottom: 1.5rem;
+      margin-bottom: 2rem;
+    }
+    h1 {
+      color: var(--primary);
+      margin: 0 0 0.5rem 0;
+    }
+    .badge {
+      display: inline-block;
+      padding: 0.25rem 0.75rem;
+      border-radius: 9999px;
+      font-size: 0.85rem;
+      font-weight: 600;
+    }
+    .badge-danger {
+      background-color: rgba(239, 68, 68, 0.15);
+      color: var(--danger);
+      border: 1px solid rgba(239, 68, 68, 0.3);
+    }
+    .card {
+      background-color: var(--card-bg);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+    h2 {
+      margin-top: 0;
+      color: var(--primary);
+      font-size: 1.25rem;
+    }
+    pre {
+      background-color: #0b0f19;
+      padding: 1rem;
+      border-radius: 6px;
+      overflow-x: auto;
+      border: 1px solid var(--border);
+    }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 0.9rem;
+    }
+    .diff-del {
+      color: var(--danger);
+      background-color: rgba(239, 68, 68, 0.1);
+      display: block;
+    }
+    .diff-add {
+      color: var(--success);
+      background-color: rgba(34, 197, 94, 0.1);
+      display: block;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>Bug Showcase: Case-Sensitivity Validation Mismatch</h1>
+      <span class="badge badge-danger">Core Tooling Bug Fix</span>
+    </header>
+
+    <main>
+      <section class="card">
+        <h2>❌ The Issue</h2>
+        <p>The manifest validation script (<code>validate-package.mjs</code>) fails locally and in CI build pipelines due to a case-sensitive check on the repository URL. It looks for <code>"SAPTARSHI-coder/EaseMotion-css"</code> with exact casing, but standard packages and git checkouts may list it as lowercase: <code>"saptarshi-coder/easemotion-css"</code>.</p>
+      </section>
+
+      <section class="card">
+        <h2>🔗 Affected File</h2>
+        <p>File path: <code>scripts/validate-package.mjs</code></p>
+      </section>
+
+      <section class="card">
+        <h2>🛠️ Proposed Fix</h2>
+        <p>Normalize both strings to lowercase before checking. Here is the suggested diff:</p>
+        <pre><code><span class="diff-del">- if (!manifest.repository?.url?.includes("SAPTARSHI-coder/EaseMotion-css")) {</span>
+<span class="diff-add">+ if (!manifest.repository?.url?.toLowerCase().includes("saptarshi-coder/easemotion-css")) {</span>
+    fail("repository.url must point to SAPTARSHI-coder/EaseMotion-css");
+  }</code></pre>
+      </section>
+    </main>
+  </div>
+</body>
+</html>

--- a/submissions/docs/fix-validate-package-reez/style.css
+++ b/submissions/docs/fix-validate-package-reez/style.css
@@ -1,0 +1,31 @@
+/* Custom CSS stylesheet for Case-Sensitivity Validation Mismatch Showcase */
+:root {
+  --bg-color: #0f172a;
+  --card-bg: #1e293b;
+  --text-main: #f8fafc;
+  --text-muted: #94a3b8;
+  --primary: #38bdf8;
+  --danger: #ef4444;
+  --success: #22c55e;
+  --border: #334155;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+}
+
+.card {
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  border-color: var(--primary);
+}
+
+.badge {
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}


### PR DESCRIPTION

## Pull Request Description

This Pull Request resolves a case-sensitivity issue in the package manifest validation script (`scripts/validate-package.mjs`). The validation script previously failed if the `repository.url` in `package.json` used lowercase characters instead of exact-casing matches, even though GitHub repository URLs are case-insensitive.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (describe below)
  - **Tooling / Release validation script bug fix**

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [ ] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

*Note: This is a fix for the build tooling/validation system rather than a user submission feature, so the submission checklist files (like demo.html) are not applicable.*

---

## Feature Description

**What does this add?**

N/A (This is a bug fix for developer tooling validation).

**How does a developer use it?**

N/A

**Why does it fit EaseMotion CSS?**

N/A

---

## Demo

- [ ] Demo added (`demo.html` works by opening directly in a browser) (N/A)

---

## Browser Testing

- [x] Chrome (N/A — verified via Node.js CLI validation checks on Windows/macOS/Linux)
- [x] Firefox (N/A)
- [x] Edge (N/A)
- [x] Safari (N/A)

---

## Notes for Maintainer

The `validate-package.mjs` script was previously performing a case-sensitive `.includes()` check for `"SAPTARSHI-coder/EaseMotion-css"`. By normalizing the string to lowercase before performing the match, developers can use lowercase URLs in their package configuration without failing CI validation tasks.

---
