### PR TITLE
feat: add social proof notifications showcase

### DIFF
--- a/submissions/examples/social-proof-notifications-ak/README.md
+++ b/submissions/examples/social-proof-notifications-ak/README.md
@@ -1,0 +1,18 @@
+# Social Proof Notifications
+
+## What does this do?
+Floating notification toasts that appear at the bottom-left of the screen simulating real-time social proof, sliding in, staying visible, then sliding out automatically.
+
+## How is it used?
+```html
+<div class="sp-notification">
+  <div class="sp-avatar">S</div>
+  <div class="sp-text">
+    <strong>Sarah</strong> from New York purchased Premium Plan
+    <span class="sp-time">just now</span>
+  </div>
+</div>
+```
+
+## Why is it useful?
+Social proof popups are widely used in SaaS landing pages and e-commerce stores to build trust. This showcase demonstrates how EaseMotion's slide-in/slide-out animations can create a realistic notification system without JavaScript, using only CSS animations with delays for the auto-dismiss behavior.

--- a/submissions/examples/social-proof-notifications-ak/demo.html
+++ b/submissions/examples/social-proof-notifications-ak/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Social Proof Notifications</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="social-proof-container">
+    <div class="sp-notification">
+      <div class="sp-avatar">S</div>
+      <div class="sp-text">
+        <strong>Sarah</strong> from New York purchased Premium Plan
+        <span class="sp-time">just now</span>
+      </div>
+    </div>
+    <div class="sp-notification sp-notification--delay-1">
+      <div class="sp-avatar">A</div>
+      <div class="sp-text">
+        <strong>Alex</strong> from Berlin signed up
+        <span class="sp-time">2m ago</span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/social-proof-notifications-ak/style.css
+++ b/submissions/examples/social-proof-notifications-ak/style.css
@@ -1,0 +1,60 @@
+.social-proof-container {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  font-family: sans-serif;
+  z-index: 1000;
+}
+
+.sp-notification {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  padding: 0.75rem 1rem;
+  min-width: 260px;
+  animation: slideInUp 0.5s ease forwards, fadeOut 0.5s ease 4s forwards;
+}
+
+.sp-notification--delay-1 {
+  animation-delay: 1.2s, 5.2s;
+}
+
+.sp-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: #667eea;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  flex-shrink: 0;
+}
+
+.sp-text {
+  font-size: 0.9rem;
+  color: #222;
+}
+
+.sp-time {
+  display: block;
+  font-size: 0.75rem;
+  color: #888;
+  margin-top: 0.15rem;
+}
+
+@keyframes slideInUp {
+  from { transform: translateY(100%); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+
+@keyframes fadeOut {
+  to { opacity: 0; transform: translateX(100%); }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a social proof notification toast showcase — floating notifications that slide in from the bottom-left, stay visible briefly, then auto-dismiss, as requested in issue #39377.

Closes #39377

---

## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/social-proof-notifications-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Floating notification toasts that appear at the bottom-left of the screen, simulating real-time social proof (e.g. "Sarah from New York purchased Premium Plan").

**How does a developer use it?**
```html
<div class="sp-notification">
  <div class="sp-avatar">S</div>
  <div class="sp-text">
    <strong>Sarah</strong> from New York purchased Premium Plan
    <span class="sp-time">just now</span>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Social proof popups are widely used in SaaS landing pages and e-commerce stores to build trust. This showcases how EaseMotion's slide-in/slide-out animations can create a realistic notification system without JavaScript, using only CSS animations with delays for the auto-dismiss behavior.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Used CSS letter-avatars instead of `<img>` tags so the demo stays fully self-contained with no external image dependencies. Class names are unstandardized per the contributing guide — happy to adjust naming or timing on review.