### PR TITLE
feat: add react accordion with liquid ripple for monochrome neo layouts

### DIFF
--- a/submissions/react/react-accordion-liquid-ripple-monochrome-neo-ak/Accordion.jsx
+++ b/submissions/react/react-accordion-liquid-ripple-monochrome-neo-ak/Accordion.jsx
@@ -1,0 +1,75 @@
+import React, { useState, useRef } from "react";
+
+/**
+ * Accordion - a React accordion component with a liquid ripple
+ * interaction transition, styled for Monochrome Neo interfaces.
+ *
+ * Props:
+ * - items (array): list of { title: string, content: node }
+ * - allowMultiple (boolean): allow multiple panels open at once, default false
+ */
+export default function Accordion({ items = [], allowMultiple = false }) {
+  const [openIndexes, setOpenIndexes] = useState([]);
+  const rippleRefs = useRef([]);
+
+  const isOpen = (index) => openIndexes.includes(index);
+
+  const toggleIndex = (index) => {
+    setOpenIndexes((prev) => {
+      if (prev.includes(index)) {
+        return prev.filter((i) => i !== index);
+      }
+      return allowMultiple ? [...prev, index] : [index];
+    });
+  };
+
+  const triggerRipple = (e, index) => {
+    const button = e.currentTarget;
+    const ripple = document.createElement("span");
+    const rect = button.getBoundingClientRect();
+    const size = Math.max(rect.width, rect.height);
+
+    ripple.className = "ease-accordion-ripple";
+    ripple.style.width = ripple.style.height = `${size}px`;
+    ripple.style.left = `${e.clientX - rect.left - size / 2}px`;
+    ripple.style.top = `${e.clientY - rect.top - size / 2}px`;
+
+    button.appendChild(ripple);
+    ripple.addEventListener("animationend", () => ripple.remove());
+  };
+
+  const handleClick = (e, index) => {
+    triggerRipple(e, index);
+    toggleIndex(index);
+  };
+
+  return (
+    <div className="ease-accordion-neo">
+      {items.map((item, index) => (
+        <div key={index} className="ease-accordion-neo__item">
+          <button
+            className="ease-accordion-neo__header"
+            onClick={(e) => handleClick(e, index)}
+            aria-expanded={isOpen(index)}
+          >
+            <span>{item.title}</span>
+            <span
+              className={`ease-accordion-neo__icon ${
+                isOpen(index) ? "ease-accordion-neo__icon--open" : ""
+              }`}
+            >
+              +
+            </span>
+          </button>
+          <div
+            className={`ease-accordion-neo__panel ${
+              isOpen(index) ? "ease-accordion-neo__panel--open" : ""
+            }`}
+          >
+            <div className="ease-accordion-neo__content">{item.content}</div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/submissions/react/react-accordion-liquid-ripple-monochrome-neo-ak/README.md
+++ b/submissions/react/react-accordion-liquid-ripple-monochrome-neo-ak/README.md
@@ -1,0 +1,30 @@
+# React Accordion with Liquid Ripple (Monochrome Neo)
+
+A React accordion component with a liquid ripple click transition, styled for Monochrome Neo interfaces.
+
+## Props
+
+| Prop            | Type      | Default | Description                                          |
+|------------------|-----------|---------|-------------------------------------------------------|
+| `items`          | `array`   | `[]`    | List of `{ title: string, content: node }` panel items |
+| `allowMultiple`  | `boolean` | `false` | Allow multiple panels to stay open at once             |
+
+## Usage
+
+```jsx
+import Accordion from "./Accordion";
+import "./style.css";
+
+const faqItems = [
+  { title: "What is EaseMotion CSS?", content: "A curated animation framework." },
+  { title: "Is it free to use?", content: "Yes, fully open source." },
+];
+
+function FAQ() {
+  return <Accordion items={faqItems} allowMultiple={false} />;
+}
+```
+
+## Why is this useful?
+
+Accordions are a staple UI pattern for FAQs, settings panels, and docs. This component pairs a smooth height-based expand/collapse with a liquid ripple effect on click, giving Monochrome Neo interfaces a tactile, premium feel using only React state and CSS animations.

--- a/submissions/react/react-accordion-liquid-ripple-monochrome-neo-ak/style.css
+++ b/submissions/react/react-accordion-liquid-ripple-monochrome-neo-ak/style.css
@@ -1,0 +1,80 @@
+.ease-accordion-neo {
+  max-width: 480px;
+  font-family: sans-serif;
+  border: 1px solid #2a2a2a;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #111;
+}
+
+.ease-accordion-neo__item {
+  border-bottom: 1px solid #2a2a2a;
+}
+
+.ease-accordion-neo__item:last-child {
+  border-bottom: none;
+}
+
+.ease-accordion-neo__header {
+  position: relative;
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.25rem;
+  background: transparent;
+  border: none;
+  color: #eaeaea;
+  font-size: 0.95rem;
+  cursor: pointer;
+  overflow: hidden;
+  text-align: left;
+}
+
+.ease-accordion-neo__header:hover {
+  background: #1a1a1a;
+}
+
+.ease-accordion-neo__icon {
+  font-size: 1.1rem;
+  transition: transform 0.3s ease;
+  color: #ccc;
+}
+
+.ease-accordion-neo__icon--open {
+  transform: rotate(45deg);
+}
+
+.ease-accordion-neo__panel {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.35s ease;
+  background: #161616;
+}
+
+.ease-accordion-neo__panel--open {
+  max-height: 300px;
+}
+
+.ease-accordion-neo__content {
+  padding: 1rem 1.25rem;
+  color: #a8a8a8;
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.ease-accordion-ripple {
+  position: absolute;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.18);
+  pointer-events: none;
+  transform: scale(0);
+  animation: liquidRipple 0.6s ease-out forwards;
+}
+
+@keyframes liquidRipple {
+  to {
+    transform: scale(2.5);
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a React Accordion component with a liquid ripple interaction transition, styled for Monochrome Neo interfaces, as requested in issue #38577.

Closes #38577

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/react/react-accordion-liquid-ripple-monochrome-neo-ak/`)
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A React `Accordion` component with a liquid ripple click transition and smooth expand/collapse panels, styled for Monochrome Neo interfaces.

**How does a developer use it?**
```jsx
import Accordion from "./Accordion";
import "./style.css";

const faqItems = [
  { title: "What is EaseMotion CSS?", content: "A curated animation framework." },
  { title: "Is it free to use?", content: "Yes, fully open source." },
];

<Accordion items={faqItems} allowMultiple={false} />
```

**Why does it fit EaseMotion CSS?**
Accordions are a staple pattern for FAQs, settings panels, and docs. This pairs a smooth height-based expand/collapse with a liquid ripple effect on click, giving Monochrome Neo interfaces a tactile, premium feel using only React state and CSS animations.

---

## Demo
- [ ] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Submitted as a React track component (`.jsx` + `style.css` + `README.md`) per the issue's `submissions/react/` requirement. Ripple effect is implemented via a dynamically appended `span` cleaned up on `animationend`. Class names are unstandardized per the contributing guide — happy to adjust naming or timing on review.