### PR TITLE
feat: add react modal with shimmer pulse for modern corporate layouts

### DIFF
--- a/submissions/react/react-modal-shimmer-pulse-corporate-ak/Modal.jsx
+++ b/submissions/react/react-modal-shimmer-pulse-corporate-ak/Modal.jsx
@@ -1,0 +1,48 @@
+import React, { useEffect } from "react";
+
+/**
+ * Modal - a React modal component with a shimmer pulse entrance transition,
+ * designed for Modern Corporate interfaces.
+ *
+ * Props:
+ * - isOpen (boolean): controls modal visibility
+ * - onClose (function): called when the modal should close (backdrop click or Esc)
+ * - title (string): modal header title
+ * - children (node): modal body content
+ */
+export default function Modal({ isOpen, onClose, title, children }) {
+  useEffect(() => {
+    const handleEsc = (e) => {
+      if (e.key === "Escape") onClose();
+    };
+    if (isOpen) document.addEventListener("keydown", handleEsc);
+    return () => document.removeEventListener("keydown", handleEsc);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="ease-modal-backdrop" onClick={onClose}>
+      <div
+        className="ease-modal-corporate"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="ease-modal-title"
+      >
+        <div className="ease-modal-corporate__shimmer-bar" />
+        <div className="ease-modal-corporate__header">
+          <h2 id="ease-modal-title">{title}</h2>
+          <button
+            className="ease-modal-corporate__close"
+            onClick={onClose}
+            aria-label="Close modal"
+          >
+            &times;
+          </button>
+        </div>
+        <div className="ease-modal-corporate__body">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/submissions/react/react-modal-shimmer-pulse-corporate-ak/README.md
+++ b/submissions/react/react-modal-shimmer-pulse-corporate-ak/README.md
@@ -1,0 +1,37 @@
+# React Modal with Shimmer Pulse (Modern Corporate)
+
+A React modal component with a shimmer pulse entrance transition, designed for Modern Corporate interfaces.
+
+## Props
+
+| Prop       | Type         | Default | Description                                      |
+|------------|--------------|---------|---------------------------------------------------|
+| `isOpen`   | `boolean`    | —       | Controls modal visibility                          |
+| `onClose`  | `function`   | —       | Called when the modal should close (backdrop/Esc)  |
+| `title`    | `string`     | —       | Modal header title                                  |
+| `children` | `node`       | —       | Modal body content                                  |
+
+## Usage
+
+```jsx
+import { useState } from "react";
+import Modal from "./Modal";
+import "./style.css";
+
+function App() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Open Modal</button>
+      <Modal isOpen={open} onClose={() => setOpen(false)} title="Confirm Action">
+        <p>Are you sure you want to proceed?</p>
+      </Modal>
+    </>
+  );
+}
+```
+
+## Why is this useful?
+
+Modals are a core UI pattern in corporate dashboards and admin tools for confirmations, forms, and alerts. This component pairs a smooth pulse-in entrance with a shimmering top accent bar, giving Modern Corporate interfaces a polished, premium feel using only React state and CSS animations. It also handles Escape-to-close and backdrop-click-to-close for accessibility.

--- a/submissions/react/react-modal-shimmer-pulse-corporate-ak/style.css
+++ b/submissions/react/react-modal-shimmer-pulse-corporate-ak/style.css
@@ -1,0 +1,84 @@
+.ease-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 15, 20, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  animation: modalBackdropFade 0.25s ease forwards;
+}
+
+.ease-modal-corporate {
+  position: relative;
+  width: 100%;
+  max-width: 480px;
+  background: #fff;
+  border-radius: 14px;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.25);
+  overflow: hidden;
+  animation: modalPulseIn 0.35s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+  font-family: sans-serif;
+}
+
+.ease-modal-corporate__shimmer-bar {
+  height: 4px;
+  width: 100%;
+  background: linear-gradient(
+    90deg,
+    #2563eb 0%,
+    #60a5fa 50%,
+    #2563eb 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmerSweep 1.8s linear infinite;
+}
+
+.ease-modal-corporate__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.25rem 1.5rem 0.75rem;
+}
+
+.ease-modal-corporate__header h2 {
+  margin: 0;
+  font-size: 1.15rem;
+  color: #111827;
+}
+
+.ease-modal-corporate__close {
+  background: none;
+  border: none;
+  font-size: 1.4rem;
+  line-height: 1;
+  color: #6b7280;
+  cursor: pointer;
+  padding: 0.25rem;
+}
+
+.ease-modal-corporate__close:hover {
+  color: #111827;
+}
+
+.ease-modal-corporate__body {
+  padding: 0.5rem 1.5rem 1.5rem;
+  color: #374151;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+@keyframes modalBackdropFade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes modalPulseIn {
+  0% { opacity: 0; transform: scale(0.9) translateY(10px); }
+  100% { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+@keyframes shimmerSweep {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}


### PR DESCRIPTION
Closes #38603
## Pull Request Description
Adds a React modal component with a shimmer pulse entrance transition, styled for Modern Corporate interfaces. Provides teams building corporate dashboards/admin tools a ready-made confirmation/alert modal with polished motion instead of building one from scratch.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/react/react-modal-shimmer-pulse-corporate-ak/`)
- [ ] Includes `demo.html` — N/A, this is a React component submission (see Notes for Maintainer)
- [x] Includes `style.css` — raw CSS for the shimmer pulse animation
- [x] Includes `README.md` — usage, props, and rationale
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A `Modal` React component with a pulse-in entrance and a shimmering gradient accent bar, plus Escape/backdrop-click-to-close handling.

**How does a developer use it?**
```jsx
import { useState } from "react";
import Modal from "./Modal";
import "./style.css";

function App() {
  const [open, setOpen] = useState(false);

  return (
    <>
      <button onClick={() => setOpen(true)}>Open Modal</button>
      <Modal isOpen={open} onClose={() => setOpen(false)} title="Confirm Action">
        <p>Are you sure you want to proceed?</p>
      </Modal>
    </>
  );
}
```

**Why does it fit EaseMotion CSS?**
The animation logic lives entirely in plain, readable CSS (`@keyframes`, `cubic-bezier` easing) — the React component only wires up state and class names, keeping the motion itself framework-agnostic and easy to lift into any project.

---

## Demo
- [ ] Demo added (`demo.html` works by opening directly in a browser) — not applicable; this is a React component, demoed via the usage snippet above and `README.md`

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
This follows the `submissions/react/` pattern (Modal.jsx + style.css + README.md) rather than the vanilla `demo.html` pattern used for CSS-only showcases, since it's a React component. Happy to add a `demo.html` wrapper if the repo wants one for react submissions too — let me know.