### PR TITLE
feat: add shimmer image placeholder showcase

### DIFF
--- a/submissions/examples/ease-shimmer-image-placeholder-bb/README.md
+++ b/submissions/examples/ease-shimmer-image-placeholder-bb/README.md
@@ -1,0 +1,20 @@
+# Shimmer Image Placeholder
+
+A high-performance image loading skeletal placeholder featuring a diagonal shimmer sweep and smooth scale-up image transition.
+
+## What does this do?
+This component renders a skeleton loader with a glowing linear-gradient shimmer sweep before transitioning into the fully loaded image with a smooth zoom-in fade.
+
+## How is it used?
+1. Reference `style.css` in your HTML file.
+2. Structure your markup:
+   ```html
+   <div class="skeleton-image-wrapper">
+     <div class="shimmer-sweep"></div>
+     <img class="loaded-image" src="..." alt="..." />
+   </div>
+   ```
+3. Use keyframe animation classes to control shimmer angles and transition speeds.
+
+## Why is it useful?
+Using clean CSS skeleton animations instead of default loading indicators drastically improves perceived performance and keeps users engaged during asynchronous image loading.

--- a/submissions/examples/ease-shimmer-image-placeholder-bb/demo.html
+++ b/submissions/examples/ease-shimmer-image-placeholder-bb/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Shimmer Image Placeholder</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+
+  <div class="skeleton-card" id="card">
+    <div class="image-wrapper">
+      <div class="shimmer-sweep"></div>
+      <img class="image-placeholder-demo" src="https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?q=80&w=600&auto=format&fit=crop" alt="Fluid Glass Art" id="demo-img" />
+    </div>
+    
+    <div class="card-details">
+      <div class="skeleton-text title" id="t1"></div>
+      <div class="skeleton-text subtitle" id="t2"></div>
+    </div>
+  </div>
+
+  <script>
+    // Simulate image loading transition after 2 seconds
+    setTimeout(() => {
+      document.getElementById('card').classList.add('loaded');
+      // Replace skeletons with actual text
+      const t1 = document.getElementById('t1');
+      t1.style.background = 'none';
+      t1.style.height = 'auto';
+      t1.style.color = '#fff';
+      t1.style.fontWeight = '600';
+      t1.style.fontSize = '1.1rem';
+      t1.innerText = 'Abstract Fluid Symphony';
+
+      const t2 = document.getElementById('t2');
+      t2.style.background = 'none';
+      t2.style.height = 'auto';
+      t2.style.color = '#64748b';
+      t2.style.fontSize = '0.9rem';
+      t2.innerText = 'By Digital Artisans';
+    }, 2000);
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-shimmer-image-placeholder-bb/style.css
+++ b/submissions/examples/ease-shimmer-image-placeholder-bb/style.css
@@ -1,0 +1,122 @@
+/* Shimmer Image Placeholder Stylesheet */
+
+:root {
+  --bg-color: #090a0f;
+  --placeholder-bg: #161824;
+  --shimmer-grad: linear-gradient(
+    90deg,
+    rgba(22, 24, 36, 0) 0%,
+    rgba(255, 255, 255, 0.05) 50%,
+    rgba(22, 24, 36, 0) 100%
+  );
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-color);
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Outfit', sans-serif;
+  overflow: hidden;
+}
+
+/* Image Container */
+.skeleton-card {
+  width: 340px;
+  background: #11121a;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 20px;
+  overflow: hidden;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+}
+
+.image-wrapper {
+  position: relative;
+  width: 100%;
+  height: 220px;
+  background-color: var(--placeholder-bg);
+  overflow: hidden;
+}
+
+/* Shimmer Sweep Animation Overlay */
+.shimmer-sweep {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--shimmer-grad);
+  animation: shimmer 1.6s infinite linear;
+  transform: skewX(-20deg) translateX(-100%);
+}
+
+.image-placeholder-demo {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0;
+  transform: scale(0.95);
+  transition: opacity 0.8s cubic-bezier(0.25, 1, 0.5, 1), transform 0.8s cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+/* Card Info Skeleton details */
+.card-details {
+  padding: 1.5rem;
+}
+
+.skeleton-text {
+  height: 12px;
+  background: var(--placeholder-bg);
+  border-radius: 6px;
+  margin-bottom: 0.75rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.skeleton-text::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--shimmer-grad);
+  animation: shimmer 1.6s infinite linear;
+  transform: skewX(-20deg) translateX(-100%);
+}
+
+.skeleton-text.title {
+  width: 70%;
+  height: 18px;
+}
+
+.skeleton-text.subtitle {
+  width: 40%;
+}
+
+/* Simulation triggers - load image after 2s */
+.loaded .image-placeholder-demo {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.loaded .shimmer-sweep,
+.loaded .skeleton-text::after {
+  display: none;
+}
+
+@keyframes shimmer {
+  0% {
+    transform: skewX(-20deg) translateX(-120%);
+  }
+  100% {
+    transform: skewX(-20deg) translateX(120%);
+  }
+}


### PR DESCRIPTION
# Related Issue
Closes #40338 

# Summary
Adds a diagonal skeleton shimmer image loader placeholder with zoom-fade entry.

# Changes Made
- Created `submissions/examples/ease-shimmer-image-placeholder-bb/demo.html`
- Created `submissions/examples/ease-shimmer-image-placeholder-bb/style.css`
- Created `submissions/examples/ease-shimmer-image-placeholder-bb/README.md`

# Testing
- Tested simulated state changes.
- Checked animation loops.

# Impact
Ensures high-fidelity loading states for async image-heavy cards.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered