### PR TITLE
feat: add jello bounce tab navigation showcase

### DIFF
--- a/submissions/examples/ease-jello-bounce-tab-item-bb/README.md
+++ b/submissions/examples/ease-jello-bounce-tab-item-bb/README.md
@@ -1,0 +1,19 @@
+# Jello Bounce Tab Navigation Item
+
+An interactive tab menu featuring a jello wobble bounce animation effect on navigation tab items as they are hovered or selected.
+
+## What does this do?
+This demo creates a tab navigation bar. When the cursor hovers over individual tab items, they scale up, stretch, and wobble like jello, giving a playful and elastic micro-interaction.
+
+## How is it used?
+1. Link `style.css` inside your HTML file.
+2. Structure the navigation menu:
+   ```html
+   <div class="tabs-wrapper">
+     <button class="tab-item">...</button>
+   </div>
+   ```
+3. Use keyframe triggers inside the `:hover` or `.active` CSS state selectors.
+
+## Why is it useful?
+Playful micro-animations like the jello wobble provide organic tactile feel to dashboard tabs or main navbar menus, leading to improved interface feedback and user delight.

--- a/submissions/examples/ease-jello-bounce-tab-item-bb/demo.html
+++ b/submissions/examples/ease-jello-bounce-tab-item-bb/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Jello Bounce Tab Navigation Item</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+
+  <!-- Navigation Tab Wrapper -->
+  <div class="tabs-wrapper">
+    <button class="tab-item active" onclick="activateTab(this)">Dashboard</button>
+    <button class="tab-item" onclick="activateTab(this)">Analytics</button>
+    <button class="tab-item" onclick="activateTab(this)">Projects</button>
+    <button class="tab-item" onclick="activateTab(this)">Settings</button>
+  </div>
+
+  <script>
+    function activateTab(element) {
+      document.querySelectorAll('.tab-item').forEach(tab => {
+        tab.classList.remove('active');
+      });
+      element.classList.add('active');
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-jello-bounce-tab-item-bb/style.css
+++ b/submissions/examples/ease-jello-bounce-tab-item-bb/style.css
@@ -1,0 +1,93 @@
+/* Jello Bounce Tab Item Stylesheet */
+
+:root {
+  --bg-color: #07060b;
+  --tab-container-bg: #111018;
+  --text-active: #ffffff;
+  --text-inactive: #64748b;
+  --tab-active-bg: rgba(255, 255, 255, 0.05);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-color);
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Outfit', sans-serif;
+  overflow: hidden;
+}
+
+.tabs-wrapper {
+  background-color: var(--tab-container-bg);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 0.5rem;
+  border-radius: 100px;
+  display: flex;
+  gap: 0.25rem;
+  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.3);
+}
+
+.tab-item {
+  background: none;
+  border: none;
+  padding: 0.8rem 1.6rem;
+  border-radius: 100px;
+  color: var(--text-inactive);
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  outline: none;
+  position: relative;
+  transition: color 0.3s;
+}
+
+/* Hover and Active Interaction states triggering Jello Bounce */
+.tab-item:hover {
+  color: var(--text-active);
+  background-color: var(--tab-active-bg);
+  animation: jello-bounce 0.8s ease both;
+}
+
+.tab-item.active {
+  color: var(--text-active);
+  background-color: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 4px 12px rgba(255, 255, 255, 0.05);
+}
+
+/* Jello Wobble Keyframes */
+@keyframes jello-bounce {
+  11.1% {
+    transform: none;
+  }
+  22.2% {
+    transform: skewX(-12.5deg) skewY(-12.5deg);
+  }
+  33.3% {
+    transform: skewX(6.25deg) skewY(6.25deg);
+  }
+  44.4% {
+    transform: skewX(-3.125deg) skewY(-3.125deg);
+  }
+  55.5% {
+    transform: skewX(1.5625deg) skewY(1.5625deg);
+  }
+  66.6% {
+    transform: skewX(-0.78125deg) skewY(-0.78125deg);
+  }
+  77.7% {
+    transform: skewX(0.390625deg) skewY(0.390625deg);
+  }
+  88.8% {
+    transform: skewX(-0.1953125deg) skewY(-0.1953125deg);
+  }
+  100% {
+    transform: none;
+  }
+}


### PR DESCRIPTION
# Related Issue
Closes #40340

# Summary
Adds a tab navigation menu featuring a jello-wobble hover animation.

# Changes Made
- Created `submissions/examples/ease-jello-bounce-tab-item-bb/demo.html`
- Created `submissions/examples/ease-jello-bounce-tab-item-bb/style.css`
- Created `submissions/examples/ease-jello-bounce-tab-item-bb/README.md`

# Testing
- Checked cross-browser keyframe scaling.
- Verified active state click transitions.

# Impact
Introduces organic motion feedback to tab controls.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered
