### PR TITLE
feat: add pure CSS shimmer pulse modal for futuristic HUD layouts

### DIFF
--- a/submissions/examples/css-modal-shimmer-pulse-hud/README.md
+++ b/submissions/examples/css-modal-shimmer-pulse-hud/README.md
@@ -1,0 +1,49 @@
+# Shimmer Pulse Modal — Futuristic HUD
+
+A pure CSS animated modal with a shimmer pulse interaction transition, styled for Futuristic HUD interfaces. Zero JavaScript animation overhead — JS is used only to toggle a class for open/close.
+
+## Usage
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<button class="hud-modal-trigger" id="openModal">Open HUD Panel</button>
+
+<div class="hud-modal-overlay" id="modalOverlay">
+  <div class="hud-modal" role="dialog" aria-modal="true" aria-labelledby="hudModalTitle" tabindex="-1" id="hudModal">
+    <div class="hud-modal__shimmer-edge"></div>
+    <div class="hud-modal__header">
+      <h2 id="hudModalTitle">System Status</h2>
+      <button class="hud-modal__close" id="closeModal" aria-label="Close panel">&times;</button>
+    </div>
+    <div class="hud-modal__body">
+      <p>Your content here.</p>
+    </div>
+  </div>
+</div>
+```
+
+Toggle `.is-open` on `.hud-modal-overlay` via JS (see `demo.html` for a minimal open/close/Esc handler).
+
+## Custom Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `--hud-modal-timing` | `0.4s` | Entrance/exit transition duration |
+| `--hud-modal-easing` | `cubic-bezier(0.34, 1.56, 0.64, 1)` | Entrance/exit easing |
+| `--hud-modal-scale-from` | `0.85` | Starting scale for the pulse-in |
+| `--hud-modal-shimmer-duration` | `1.6s` | Speed of the shimmer sweep |
+| `--hud-accent` / `--hud-accent-soft` | `#00e5ff` / `#7df9ff` | Shimmer/accent colors |
+
+Override any of these on `.hud-modal` or a parent to customize per use case.
+
+## Accessibility
+
+- `role="dialog"`, `aria-modal="true"`, `aria-labelledby` on the panel
+- Closes on Escape key and backdrop click
+- Focus moves to the modal on open and back to the trigger on close
+- Respects `prefers-reduced-motion`
+
+## Why does it fit EaseMotion CSS?
+
+The shimmer sweep and pulse-in entrance are implemented entirely with CSS `@keyframes` and transitions, driven by human-readable custom properties. JavaScript is limited to a single class toggle, keeping the animation logic transparent and framework-agnostic — in line with the human-readable, animation-first philosophy.

--- a/submissions/examples/css-modal-shimmer-pulse-hud/demo.html
+++ b/submissions/examples/css-modal-shimmer-pulse-hud/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Shimmer Pulse Modal — Futuristic HUD</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <button class="hud-modal-trigger" id="openModal">Open HUD Panel</button>
+
+  <div class="hud-modal-overlay" id="modalOverlay">
+    <div
+      class="hud-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="hudModalTitle"
+      tabindex="-1"
+      id="hudModal"
+    >
+      <div class="hud-modal__shimmer-edge"></div>
+      <div class="hud-modal__header">
+        <h2 id="hudModalTitle">System Status</h2>
+        <button class="hud-modal__close" id="closeModal" aria-label="Close panel">&times;</button>
+      </div>
+      <div class="hud-modal__body">
+        <p>All systems nominal. Shimmer pulse animation is pure CSS — no JavaScript drives the motion.</p>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    // JS here only toggles visibility (open/close + focus + Esc).
+    // All animation/timing/easing is done in CSS via custom properties.
+    const trigger = document.getElementById('openModal');
+    const overlay = document.getElementById('modalOverlay');
+    const modal = document.getElementById('hudModal');
+    const closeBtn = document.getElementById('closeModal');
+
+    function openModal() {
+      overlay.classList.add('is-open');
+      modal.focus();
+      document.addEventListener('keydown', onKeydown);
+    }
+    function closeModal() {
+      overlay.classList.remove('is-open');
+      trigger.focus();
+      document.removeEventListener('keydown', onKeydown);
+    }
+    function onKeydown(e) {
+      if (e.key === 'Escape') closeModal();
+    }
+
+    trigger.addEventListener('click', openModal);
+    closeBtn.addEventListener('click', closeModal);
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) closeModal();
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/css-modal-shimmer-pulse-hud/style.css
+++ b/submissions/examples/css-modal-shimmer-pulse-hud/style.css
@@ -1,0 +1,161 @@
+:root {
+  --hud-modal-timing: 0.4s;
+  --hud-modal-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --hud-modal-scale-from: 0.85;
+  --hud-modal-shimmer-duration: 1.6s;
+  --hud-accent: #00e5ff;
+  --hud-accent-soft: #7df9ff;
+  --hud-bg: #0a0e14;
+  --hud-panel-bg: #10161f;
+  --hud-border: rgba(0, 229, 255, 0.35);
+  --hud-text: #e6faff;
+  --hud-text-dim: #8fa5ad;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--hud-bg);
+  font-family: "Segoe UI", system-ui, sans-serif;
+}
+
+.hud-modal-trigger {
+  padding: 0.75rem 1.5rem;
+  background: transparent;
+  border: 1px solid var(--hud-accent);
+  color: var(--hud-accent);
+  border-radius: 6px;
+  font-size: 0.95rem;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.hud-modal-trigger:hover,
+.hud-modal-trigger:focus-visible {
+  background: var(--hud-accent);
+  color: #00131a;
+  outline: none;
+}
+
+.hud-modal-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 8, 12, 0.7);
+  backdrop-filter: blur(3px);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--hud-modal-timing) var(--hud-modal-easing),
+    visibility 0s linear var(--hud-modal-timing);
+  z-index: 1000;
+  padding: 1rem;
+}
+
+.hud-modal-overlay.is-open {
+  opacity: 1;
+  visibility: visible;
+  transition: opacity var(--hud-modal-timing) var(--hud-modal-easing);
+}
+
+.hud-modal {
+  position: relative;
+  width: 100%;
+  max-width: 460px;
+  background: var(--hud-panel-bg);
+  border: 1px solid var(--hud-border);
+  border-radius: 10px;
+  box-shadow: 0 0 40px rgba(0, 229, 255, 0.15);
+  overflow: hidden;
+  transform: scale(var(--hud-modal-scale-from)) translateY(10px);
+  opacity: 0;
+  transition: transform var(--hud-modal-timing) var(--hud-modal-easing),
+    opacity var(--hud-modal-timing) var(--hud-modal-easing);
+}
+
+.hud-modal:focus {
+  outline: none;
+}
+
+.hud-modal-overlay.is-open .hud-modal {
+  transform: scale(1) translateY(0);
+  opacity: 1;
+}
+
+.hud-modal__shimmer-edge {
+  height: 3px;
+  width: 100%;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--hud-accent) 45%,
+    var(--hud-accent-soft) 50%,
+    var(--hud-accent) 55%,
+    transparent 100%
+  );
+  background-size: 250% 100%;
+  animation: hudShimmerSweep var(--hud-modal-shimmer-duration) linear infinite;
+}
+
+.hud-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.1rem 1.4rem 0.6rem;
+}
+
+.hud-modal__header h2 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--hud-text);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.hud-modal__close {
+  background: none;
+  border: none;
+  font-size: 1.4rem;
+  line-height: 1;
+  color: var(--hud-text-dim);
+  cursor: pointer;
+  padding: 0.25rem;
+}
+
+.hud-modal__close:hover,
+.hud-modal__close:focus-visible {
+  color: var(--hud-accent);
+  outline: none;
+}
+
+.hud-modal__body {
+  padding: 0.4rem 1.4rem 1.4rem;
+  color: var(--hud-text-dim);
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+@keyframes hudShimmerSweep {
+  0% { background-position: 200% 0; }
+  100% { background-position: -50% 0; }
+}
+
+@media (max-width: 480px) {
+  .hud-modal {
+    max-width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hud-modal-overlay,
+  .hud-modal,
+  .hud-modal__shimmer-edge {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS animated modal with a shimmer pulse interaction transition, styled for Futuristic HUD interfaces, with zero JS animation overhead.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-modal-shimmer-pulse-hud/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS modal with a pulse-in entrance and a shimmering sweep along the top edge, styled for futuristic HUD interfaces.

**How does a developer use it?**
```html
<button class="hud-modal-trigger" id="openModal">Open HUD Panel</button>

<div class="hud-modal-overlay" id="modalOverlay">
  <div class="hud-modal" role="dialog" aria-modal="true" id="hudModal">
    <div class="hud-modal__shimmer-edge"></div>
    ...
  </div>
</div>
```
Toggle `.is-open` on `.hud-modal-overlay` via JS — see `demo.html`.

**Why does it fit EaseMotion CSS?**
All animation (shimmer sweep, pulse-in entrance) is done via CSS `@keyframes`/transitions and exposed through readable custom properties (`--hud-modal-timing`, `--hud-modal-easing`, `--hud-modal-scale-from`, etc.), keeping motion logic transparent and framework-agnostic. JS is limited to a single class toggle.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---

## Notes for Maintainer
Fully keyboard accessible (Esc to close, focus management), respects `prefers-reduced-motion`, and responsive down to mobile widths.

Closes #38483