### PR TITLE
feat: add Image component with alt text for video playlist

### DIFF
--- a/submissions/react/fixed-video-playlist-v2/Image-Fixed.jsx
+++ b/submissions/react/fixed-video-playlist-v2/Image-Fixed.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+const ImageFixed = ({ src, alt, className, style, ...props }) => {
+  const defaultAlt = alt || 'Video thumbnail';
+  return <img src={src} alt={defaultAlt} className={`ease-fade-in ${className || ''}`} style={{ maxWidth: '100%', height: 'auto', display: 'block', ...style }} {...props} />;
+};
+export default ImageFixed;

--- a/submissions/react/fixed-video-playlist-v2/README.md
+++ b/submissions/react/fixed-video-playlist-v2/README.md
@@ -1,0 +1,7 @@
+# Image Component - Fixed Version
+## Related Issue
+Fixes #40372
+## Labels
+- `level:intermediate`
+- `type:accessibility`
+- `gssoc:approved`

--- a/submissions/react/fixed-video-playlist-v2/style.css
+++ b/submissions/react/fixed-video-playlist-v2/style.css
@@ -1,0 +1,2 @@
+.ease-fade-in { animation: easeFadeIn 0.5s ease-in-out; }
+@keyframes easeFadeIn { from { opacity: 0; transform: scale(0.95); } to { opacity: 1; transform: scale(1); } }


### PR DESCRIPTION
## New Component: Image with Alt Text

### Description
This PR adds a fixed version of images with proper alt text for accessibility.

### Changes
- Created `Image-Fixed.jsx` with alt attribute
- Added `style.css` with fade-in animation
- Added README.md documenting the fix

### Related Issue
Fixes #40372

### Labels
- `level:intermediate`
- `type:accessibility`
- `gssoc:approved`