### PR TITLE
feat: add selectable option cards

### DIFF
--- a/submissions/examples/option-cards-as/README.md
+++ b/submissions/examples/option-cards-as/README.md
@@ -1,0 +1,25 @@
+# Selectable Option Cards
+
+### What does this do?
+
+It shows a group of selectable cards for choosing one option, where the chosen card gets an accent border, a tinted background, and a check badge.
+
+### How is it used?
+
+```html
+<label class="option">
+  <input type="radio" name="plan" class="option-input" checked />
+  <span class="option-card">
+    <span class="option-title">Pro</span>
+    <span class="option-desc">For growing teams</span>
+    <span class="option-price">$12 / mo</span>
+    <span class="option-check" aria-hidden="true"></span>
+  </span>
+</label>
+```
+
+Each card is a `label` wrapping a radio and the card content. Because the inputs share one `name`, only one card can be selected at a time.
+
+### Why is it useful?
+
+Card pickers are common for plans, shipping options, and settings. This styles the selected state from the native `:checked` state with a border, background, and check, so it needs no JavaScript. The group uses a `radiogroup` role, keeps native keyboard selection with a focus ring, and reduces motion under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/option-cards-as/demo.html
+++ b/submissions/examples/option-cards-as/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Selectable Option Cards</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="option-group" role="radiogroup" aria-label="Choose a plan">
+    <label class="option">
+      <input type="radio" name="plan" class="option-input" />
+      <span class="option-card">
+        <span class="option-title">Starter</span>
+        <span class="option-desc">For individuals</span>
+        <span class="option-price">$0 / mo</span>
+        <span class="option-check" aria-hidden="true"></span>
+      </span>
+    </label>
+
+    <label class="option">
+      <input type="radio" name="plan" class="option-input" checked />
+      <span class="option-card">
+        <span class="option-title">Pro</span>
+        <span class="option-desc">For growing teams</span>
+        <span class="option-price">$12 / mo</span>
+        <span class="option-check" aria-hidden="true"></span>
+      </span>
+    </label>
+
+    <label class="option">
+      <input type="radio" name="plan" class="option-input" />
+      <span class="option-card">
+        <span class="option-title">Team</span>
+        <span class="option-desc">For companies</span>
+        <span class="option-price">$29 / mo</span>
+        <span class="option-check" aria-hidden="true"></span>
+      </span>
+    </label>
+  </div>
+</body>
+</html>

--- a/submissions/examples/option-cards-as/style.css
+++ b/submissions/examples/option-cards-as/style.css
@@ -1,0 +1,112 @@
+:root {
+  --accent: #6c63ff;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: var(--text);
+}
+
+.option-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.option {
+  cursor: pointer;
+}
+
+.option-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.option-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  width: 150px;
+  padding: 1.25rem;
+  border-radius: 14px;
+  background: #111a2e;
+  border: 2px solid #26324a;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+}
+
+.option:hover .option-card {
+  transform: translateY(-3px);
+}
+
+.option-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.option-desc {
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.option-price {
+  margin-top: 0.6rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.option-check {
+  position: absolute;
+  top: 0.85rem;
+  right: 0.85rem;
+  width: 20px;
+  height: 20px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #fff;
+  font-size: 0.7rem;
+  opacity: 0;
+  transform: scale(0.4);
+  transition: opacity 0.2s ease, transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.option-check::before {
+  content: "\2713";
+}
+
+.option-input:checked + .option-card {
+  border-color: var(--accent);
+  background: rgba(108, 99, 255, 0.1);
+}
+
+.option-input:checked + .option-card .option-check {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.option-input:focus-visible + .option-card {
+  outline: 2px solid #fbbf24;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .option-card,
+  .option-check {
+    transition: opacity 0.2s ease;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds selectable option cards built for #40420. Choosing a card gives it an accent border, a tinted background, and a check badge, using radio inputs and CSS with no JavaScript. Closes #40420.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A group of selectable cards for choosing one option, with an accent selected state and a check.

**How does a developer use it?**

```html
<label class="option">
  <input type="radio" name="plan" class="option-input" checked />
  <span class="option-card">
    <span class="option-title">Pro</span>
    <span class="option-desc">For growing teams</span>
    <span class="option-price">$12 / mo</span>
    <span class="option-check" aria-hidden="true"></span>
  </span>
</label>
```

**Why does it fit EaseMotion CSS?**
It styles the selected state from the native `:checked` state with a border, background, and check, so it needs no JavaScript. The group uses a `radiogroup` role, keeps keyboard selection with a focus ring, and reduces motion under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the selected card renders with the accent border and a visible check badge.
