### PR TITLE
feat: add animated link underlines

### DIFF
--- a/submissions/examples/link-underlines-as/README.md
+++ b/submissions/examples/link-underlines-as/README.md
@@ -1,0 +1,19 @@
+# Animated Link Underlines
+
+### What does this do?
+
+It shows a set of link hover styles where an underline animates in differently: sliding in from the left, expanding from the center, and sliding in from the right.
+
+### How is it used?
+
+```html
+<a href="#" class="link link-slide">Slide in</a>
+<a href="#" class="link link-center">Center out</a>
+<a href="#" class="link link-right">From right</a>
+```
+
+Add `link` plus one of `link-slide`, `link-center`, or `link-right` to a link. The underline direction comes from the `transform-origin`.
+
+### Why is it useful?
+
+Animated underlines make navigation and inline links feel responsive. This animates the underline with a `scaleX` transform and a chosen `transform-origin`, so it needs no JavaScript. The effect also triggers on keyboard focus, and the transition is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/link-underlines-as/demo.html
+++ b/submissions/examples/link-underlines-as/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Link Underlines</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <nav class="link-row">
+    <a href="#" class="link link-slide">Slide in</a>
+    <a href="#" class="link link-center">Center out</a>
+    <a href="#" class="link link-right">From right</a>
+  </nav>
+</body>
+</html>

--- a/submissions/examples/link-underlines-as/style.css
+++ b/submissions/examples/link-underlines-as/style.css
@@ -1,0 +1,65 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.link-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2.5rem;
+  justify-content: center;
+}
+
+.link {
+  position: relative;
+  color: #cbd5e1;
+  text-decoration: none;
+  font-size: 1.1rem;
+  font-weight: 600;
+  padding-bottom: 3px;
+  transition: color 0.2s ease;
+}
+
+.link:hover {
+  color: #fff;
+}
+
+.link::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  border-radius: 2px;
+  background: #6c63ff;
+  transform: scaleX(0);
+  transition: transform 0.25s ease;
+}
+
+.link-slide::after { transform-origin: left; }
+.link-center::after { transform-origin: center; }
+.link-right::after { transform-origin: right; }
+
+.link:hover::after,
+.link:focus-visible::after {
+  transform: scaleX(1);
+}
+
+.link:focus-visible {
+  outline: none;
+  color: #fff;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .link::after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds animated link underlines built for #40427. Underlines animate in from the left, from the center, or from the right on hover and focus, using only CSS. Closes #40427.

## Type of Change

- [x] ✨ New animation / hover effect

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
Three animated link underline styles selected by class.

**How does a developer use it?**

```html
<a href="#" class="link link-slide">Slide in</a>
<a href="#" class="link link-center">Center out</a>
<a href="#" class="link link-right">From right</a>
```

**Why does it fit EaseMotion CSS?**
It animates the underline with a `scaleX` transform and a chosen `transform-origin`, so it needs no JavaScript. The effect also triggers on keyboard focus, and the transition is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: hovering a link scales its underline from 0 toward full width from the chosen origin.
