### PR TITLE
feat: add editorial liquid ripple accordion

### DIFF
--- a/submissions/examples/liquid-ripple-accordion-editorial-jp/README.md
+++ b/submissions/examples/liquid-ripple-accordion-editorial-jp/README.md
@@ -1,0 +1,58 @@
+# CSS Liquid Ripple Accordion for Sleek Editorial Layouts
+
+## What does this do?
+
+This submission creates a pure-CSS accordion with subtle liquid-ripple transitions, restrained editorial typography, responsive layout behavior, and native keyboard accessibility.
+
+## How is it used?
+
+Use native `details` and `summary` elements:
+
+```html
+<details class="story-item-jp">
+  <summary class="story-trigger-jp">
+    <span class="story-number-jp">01</span>
+
+    <span class="story-heading-jp">
+      <strong>The Shape of Quiet Interfaces</strong>
+      <small>Design / Motion / Interaction</small>
+    </span>
+
+    <span class="story-mark-jp" aria-hidden="true">↘</span>
+  </summary>
+
+  <div class="story-panel-jp">
+    <div class="story-content-jp">
+      <p>Editorial accordion content.</p>
+    </div>
+  </div>
+</details>
+```
+
+The motion system is customizable through CSS custom properties:
+
+```css
+:root {
+  --editorial-duration-jp: 760ms;
+  --editorial-ease-jp: cubic-bezier(0.22, 1, 0.36, 1);
+  --ripple-scale-jp: 1.2;
+  --ink-opacity-jp: 0.13;
+  --rule-color-jp: #cfc8bc;
+}
+```
+
+Open `demo.html` directly in a browser. No JavaScript, server, CDN, or external framework is required.
+
+## Why is it useful?
+
+Editorial layouts need interactions that feel refined without distracting from reading. This component uses motion sparingly, with soft ink-like ripple fields, typographic hierarchy, and measured transitions.
+
+This example fits EaseMotion CSS because it:
+
+- uses animation to communicate open and closed state;
+- exposes timing, easing, ripple scale, and visual intensity through CSS variables;
+- uses native keyboard-accessible `details` and `summary` controls;
+- provides clear focus-visible states;
+- adapts to narrow screens;
+- respects `prefers-reduced-motion`;
+- requires zero JavaScript and zero external dependencies.

--- a/submissions/examples/liquid-ripple-accordion-editorial-jp/demo.html
+++ b/submissions/examples/liquid-ripple-accordion-editorial-jp/demo.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta
+    name="description"
+    content="Pure CSS liquid ripple accordion for sleek editorial layouts."
+  />
+  <title>Editorial Liquid Ripple Accordion</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page-shell-jp">
+    <header class="masthead-jp">
+      <p class="kicker-jp">EaseMotion CSS / Editorial Study</p>
+      <div class="masthead-grid-jp">
+        <h1>Liquid Ripple Accordion</h1>
+        <p class="deck-jp">
+          A restrained editorial accordion that reveals stories with soft
+          ink-like ripples, typographic hierarchy, native keyboard interaction,
+          and customizable motion tokens.
+        </p>
+      </div>
+    </header>
+
+    <section class="editorial-accordion-jp" aria-label="Editorial story accordion">
+      <details class="story-item-jp" open>
+        <summary class="story-trigger-jp">
+          <span class="story-number-jp">01</span>
+          <span class="story-heading-jp">
+            <strong>The Shape of Quiet Interfaces</strong>
+            <small>Design / Motion / Interaction</small>
+          </span>
+          <span class="story-mark-jp" aria-hidden="true">↘</span>
+        </summary>
+
+        <div class="story-panel-jp">
+          <div class="story-content-jp">
+            <p class="dropcap-jp">
+              Subtle motion can guide attention without overpowering the page.
+              This example uses low-contrast ripple fields and measured timing
+              to keep the interaction calm and editorial.
+            </p>
+
+            <blockquote>
+              Motion should support reading rhythm, not interrupt it.
+            </blockquote>
+          </div>
+        </div>
+      </details>
+
+      <details class="story-item-jp">
+        <summary class="story-trigger-jp">
+          <span class="story-number-jp">02</span>
+          <span class="story-heading-jp">
+            <strong>Designing with Typographic Rhythm</strong>
+            <small>Editorial Systems / Layout</small>
+          </span>
+          <span class="story-mark-jp" aria-hidden="true">↘</span>
+        </summary>
+
+        <div class="story-panel-jp">
+          <div class="story-content-jp">
+            <p class="dropcap-jp">
+              Wide margins, strong headline contrast, and clear metadata allow
+              motion to remain secondary while still making state changes feel
+              deliberate and polished.
+            </p>
+
+            <blockquote>
+              Good transitions disappear into the reading experience.
+            </blockquote>
+          </div>
+        </div>
+      </details>
+
+      <details class="story-item-jp">
+        <summary class="story-trigger-jp">
+          <span class="story-number-jp">03</span>
+          <span class="story-heading-jp">
+            <strong>Ink, Paper, and Digital State</strong>
+            <small>Visual Language / CSS</small>
+          </span>
+          <span class="story-mark-jp" aria-hidden="true">↘</span>
+        </summary>
+
+        <div class="story-panel-jp">
+          <div class="story-content-jp">
+            <p class="dropcap-jp">
+              Layered pseudo-elements create soft expanding ink blooms behind
+              each open story, giving the interface a tactile editorial mood
+              without images or JavaScript.
+            </p>
+
+            <blockquote>
+              The best visual systems feel physical even when they are digital.
+            </blockquote>
+          </div>
+        </div>
+      </details>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/liquid-ripple-accordion-editorial-jp/style.css
+++ b/submissions/examples/liquid-ripple-accordion-editorial-jp/style.css
@@ -1,0 +1,297 @@
+:root {
+  color-scheme: light;
+
+  --editorial-duration-jp: 760ms;
+  --editorial-ease-jp: cubic-bezier(0.22, 1, 0.36, 1);
+  --ripple-scale-jp: 1.2;
+  --ink-opacity-jp: 0.13;
+  --rule-color-jp: #cfc8bc;
+
+  font-family: Georgia, "Times New Roman", serif;
+  background: #f3efe7;
+  color: #171512;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(circle at 12% 10%, rgb(90 72 48 / 0.05), transparent 20rem),
+    linear-gradient(#f7f3eb, #f0ebe1);
+}
+
+.page-shell-jp {
+  width: min(100% - 2rem, 74rem);
+  margin-inline: auto;
+  padding: clamp(2.5rem, 7vw, 6rem) 0;
+}
+
+.masthead-jp {
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--rule-color-jp);
+}
+
+.kicker-jp {
+  margin: 0 0 1.25rem;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.masthead-grid-jp {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(18rem, 0.6fr);
+  align-items: end;
+  gap: 2rem;
+}
+
+h1 {
+  max-width: 8ch;
+  margin: 0;
+  font-size: clamp(3.5rem, 9vw, 8rem);
+  font-weight: 500;
+  line-height: 0.88;
+  letter-spacing: -0.065em;
+}
+
+.deck-jp {
+  margin: 0;
+  color: #5f594f;
+  font-family: Arial, Helvetica, sans-serif;
+  line-height: 1.7;
+}
+
+.editorial-accordion-jp {
+  border-bottom: 1px solid var(--rule-color-jp);
+}
+
+.story-item-jp {
+  position: relative;
+  isolation: isolate;
+  overflow: clip;
+  border-top: 1px solid var(--rule-color-jp);
+}
+
+.story-item-jp::before,
+.story-item-jp::after {
+  content: "";
+  position: absolute;
+  z-index: -1;
+  border-radius: 50%;
+  opacity: 0;
+  pointer-events: none;
+  transform: scale(0.3);
+  transition:
+    transform var(--editorial-duration-jp) var(--editorial-ease-jp),
+    opacity var(--editorial-duration-jp) ease;
+}
+
+.story-item-jp::before {
+  width: 26rem;
+  aspect-ratio: 1;
+  left: 10%;
+  top: -12rem;
+  background: radial-gradient(
+    circle,
+    rgb(74 57 37 / var(--ink-opacity-jp)) 0%,
+    rgb(131 112 85 / 0.07) 34%,
+    transparent 72%
+  );
+  filter: blur(24px);
+}
+
+.story-item-jp::after {
+  width: 18rem;
+  aspect-ratio: 1;
+  right: 8%;
+  bottom: -10rem;
+  background: radial-gradient(
+    circle,
+    rgb(73 85 75 / 0.1) 0%,
+    transparent 70%
+  );
+  filter: blur(20px);
+  transition-delay: 80ms;
+}
+
+.story-item-jp[open]::before,
+.story-item-jp[open]::after {
+  opacity: 1;
+  transform: scale(var(--ripple-scale-jp));
+}
+
+.story-trigger-jp {
+  display: grid;
+  grid-template-columns: 4rem 1fr auto;
+  align-items: center;
+  gap: 1.5rem;
+  min-height: 8rem;
+  padding: 1.25rem 0;
+  cursor: pointer;
+  list-style: none;
+}
+
+.story-trigger-jp::-webkit-details-marker {
+  display: none;
+}
+
+.story-number-jp {
+  align-self: start;
+  padding-top: 0.4rem;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+}
+
+.story-heading-jp {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.story-heading-jp strong {
+  max-width: 18ch;
+  font-size: clamp(1.8rem, 5vw, 3.8rem);
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
+
+.story-heading-jp small {
+  color: #70695e;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.story-mark-jp {
+  display: grid;
+  width: 3rem;
+  aspect-ratio: 1;
+  place-items: center;
+  border: 1px solid #9e9689;
+  border-radius: 50%;
+  font-size: 1.2rem;
+  transition:
+    transform var(--editorial-duration-jp) var(--editorial-ease-jp),
+    background var(--editorial-duration-jp) ease,
+    color var(--editorial-duration-jp) ease;
+}
+
+.story-item-jp[open] .story-mark-jp {
+  transform: rotate(90deg);
+  background: #171512;
+  color: #f7f3eb;
+}
+
+.story-panel-jp {
+  display: grid;
+  grid-template-rows: 0fr;
+  opacity: 0;
+  transform: translateY(-0.6rem);
+  transition:
+    grid-template-rows var(--editorial-duration-jp) var(--editorial-ease-jp),
+    opacity calc(var(--editorial-duration-jp) * 0.7) ease,
+    transform var(--editorial-duration-jp) var(--editorial-ease-jp);
+}
+
+.story-item-jp[open] .story-panel-jp {
+  grid-template-rows: 1fr;
+  opacity: 1;
+  transform: none;
+}
+
+.story-content-jp {
+  overflow: hidden;
+  padding-left: 5.5rem;
+}
+
+.story-content-jp > * {
+  max-width: 48rem;
+}
+
+.dropcap-jp {
+  margin: 0;
+  padding: 0 0 1.25rem;
+  color: #474139;
+  font-size: 1.12rem;
+  line-height: 1.8;
+}
+
+.dropcap-jp::first-letter {
+  float: left;
+  margin: 0.12rem 0.55rem 0 0;
+  font-size: 4.5rem;
+  line-height: 0.78;
+}
+
+blockquote {
+  margin: 0 0 2rem;
+  padding: 1.25rem 0 0;
+  border-top: 1px solid #bdb5a8;
+  font-size: clamp(1.35rem, 3vw, 2rem);
+  font-style: italic;
+  line-height: 1.35;
+}
+
+.story-trigger-jp:hover .story-mark-jp {
+  background: #e4ddd1;
+}
+
+.story-item-jp[open] .story-trigger-jp:hover .story-mark-jp {
+  background: #171512;
+}
+
+.story-trigger-jp:focus-visible {
+  outline: 2px solid #171512;
+  outline-offset: -2px;
+}
+
+@media (max-width: 760px) {
+  .masthead-grid-jp {
+    grid-template-columns: 1fr;
+  }
+
+  .story-trigger-jp {
+    grid-template-columns: 2.5rem 1fr auto;
+    gap: 0.75rem;
+  }
+
+  .story-content-jp {
+    padding-left: 3.25rem;
+  }
+
+  .story-mark-jp {
+    width: 2.5rem;
+  }
+}
+
+@media (max-width: 520px) {
+  .story-trigger-jp {
+    grid-template-columns: 1fr auto;
+  }
+
+  .story-number-jp {
+    grid-column: 1 / -1;
+  }
+
+  .story-content-jp {
+    padding-left: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .story-item-jp::before,
+  .story-item-jp::after,
+  .story-mark-jp,
+  .story-panel-jp {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a **CSS Liquid Ripple Accordion for Sleek Editorial Layouts** for Issue #38449.

This submission provides a pure-CSS accordion designed for refined editorial interfaces. It combines smooth liquid-ripple expansion, restrained typography, paper-inspired visual styling, responsive layouts, native keyboard interaction, and customizable motion parameters through CSS custom properties.

**Closes #38449**

---

## Type of Change

* [x] ✨ New animation / hover effect
* [x] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

* [x] All changes are inside `submissions/examples/liquid-ripple-accordion-editorial-jp/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] **No changes to `core/`**
* [x] **No changes to `components/`**
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A pure-CSS liquid ripple accordion for editorial interfaces, combining subtle ink-like expansion effects, strong typographic hierarchy, responsive behavior, and accessible native accordion controls.

**How does a developer use it?**

```html
<details class="story-item-jp">
  <summary class="story-trigger-jp">
    <span class="story-number-jp">01</span>

    <span class="story-heading-jp">
      <strong>The Shape of Quiet Interfaces</strong>
      <small>Design / Motion / Interaction</small>
    </span>

    <span class="story-mark-jp" aria-hidden="true">↘</span>
  </summary>

  <div class="story-panel-jp">
    <div class="story-content-jp">
      <p>
        Editorial accordion content goes here.
      </p>
    </div>
  </div>
</details>
```

The interaction can be customized using CSS variables:

```css
:root {
  --editorial-duration-jp: 760ms;
  --editorial-ease-jp: cubic-bezier(0.22, 1, 0.36, 1);
  --ripple-scale-jp: 1.2;
  --ink-opacity-jp: 0.13;
  --rule-color-jp: #cfc8bc;
}
```

**Why does it fit EaseMotion CSS?**

The component follows EaseMotion CSS's animation-first philosophy while keeping motion restrained enough for content-heavy editorial interfaces.

Opening an item triggers several coordinated state changes:

* subtle ink-like ripple fields expand;
* the circular directional marker rotates;
* article content reveals smoothly;
* typography and spacing maintain clear reading hierarchy.

The implementation remains readable, reusable, responsive, accessible, and dependency-free.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [ ] Firefox
* [x] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The implementation is completely isolated inside:

```text
submissions/examples/liquid-ripple-accordion-editorial-jp/
```

Only these three files are included:

```text
demo.html
style.css
README.md
```

The editorial visual treatment includes:

* paper-inspired neutral surfaces;
* strong serif headline hierarchy;
* category metadata;
* editorial divider rules;
* drop-cap content styling;
* quotation blocks;
* subtle ink-ripple pseudo-elements;
* responsive layouts;
* native keyboard-accessible `details` and `summary`;
* visible `:focus-visible` states;
* reduced-motion support.

No JavaScript, CDN, framework, or external dependency is used.

---

> **Reminder:** Only the repository maintainer may merge pull requests.
> Do not self-merge, even if you have write access.
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
