### PR TITLE
feat(animation): add svg path self-drawing animation

### DIFF
--- a/submissions/examples/svg-path-drawing/README.md
+++ b/submissions/examples/svg-path-drawing/README.md
@@ -1,0 +1,29 @@
+# SVG Path Self-Drawing Animation
+
+An illustration or logo that animates by drawing its own outline smoothly, before fading in its fill color.
+
+## Features
+- Pure CSS `stroke-dasharray` and `stroke-dashoffset` animation
+- Smooth sequential animation using `animation-delay`
+- Scalable vector graphics for crisp edges on any display
+
+## Usage
+```html
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <path class="draw-path" d="..." />
+</svg>
+```
+
+```css
+.draw-path {
+  stroke-dasharray: 500; /* Must be larger than the path's total length */
+  stroke-dashoffset: 500;
+  animation: draw 2s ease-in-out forwards, fill-in 1s ease-in-out 2s forwards;
+}
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (Modern versions)
+
+## Tech Stack
+- HTML + CSS (Inline SVG required)

--- a/submissions/examples/svg-path-drawing/demo.html
+++ b/submissions/examples/svg-path-drawing/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SVG Path Self-Drawing Animation — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>SVG Path Self-Drawing Animation</h1>
+  <p class="subtitle">An illustration that animates by drawing its own outline smoothly, before fading in its fill color.</p>
+  <section class="demo">
+    <h2>Demo</h2>
+    <p class="sec-desc">Watch the star draw itself and then fill.</p>
+    <div class="demo-container">
+      <div class="svg-container">
+        <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+          <path class="draw-path" d="M50 5 L61 39 L97 39 L68 60 L79 95 L50 74 L21 95 L32 60 L3 39 L39 39 Z" />
+        </svg>
+      </div>
+    </div>
+  </section>
+  <section class="docs">
+    <h2>Usage</h2>
+<pre><code>&lt;svg viewBox=&quot;0 0 100 100&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot;&gt;
+  &lt;path class=&quot;draw-path&quot; d=&quot;M50 5 L61 39 L97 39 L68 60 L79 95 L50 74 L21 95 L32 60 L3 39 L39 39 Z&quot; /&gt;
+&lt;/svg&gt;</code></pre>
+  </section>
+</body>
+</html>

--- a/submissions/examples/svg-path-drawing/style.css
+++ b/submissions/examples/svg-path-drawing/style.css
@@ -1,0 +1,71 @@
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  padding: 2rem;
+  background-color: #f3f4f6;
+  color: #1f2937;
+}
+
+.subtitle {
+  color: #4b5563;
+  margin-bottom: 2rem;
+}
+
+.demo {
+  background: white;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1);
+  margin-bottom: 2rem;
+}
+
+.demo-container {
+  padding: 3rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #fff;
+  border-radius: 4px;
+}
+
+/* SVG Path Animation Styles */
+.svg-container {
+  width: 200px;
+  height: 200px;
+}
+
+.draw-path {
+  fill: transparent;
+  stroke: #eab308;
+  stroke-width: 2;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+  /* Length of the path is roughly ~330, setting dasharray to 500 covers it completely */
+  stroke-dasharray: 500;
+  stroke-dashoffset: 500;
+  animation: 
+    draw 2s ease-in-out forwards, 
+    fill-in 1s ease-in-out 2s forwards;
+}
+
+@keyframes draw {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+@keyframes fill-in {
+  from {
+    fill: transparent;
+  }
+  to {
+    fill: #eab308;
+  }
+}
+
+.docs pre {
+  background: #111827;
+  color: #f3f4f6;
+  padding: 1rem;
+  border-radius: 4px;
+  overflow-x: auto;
+}


### PR DESCRIPTION
Fixes #39102

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

## Feature Description

**What does this add?**

Adds an SVG path self-drawing animation where an illustration or logo animates by drawing its own outline smoothly, before fading in its fill color.

**How does a developer use it?**

```html
<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
  <path class="draw-path" d="M50 5 L61 39 L97 39 L68 60 L79 95 L50 74 L21 95 L32 60 L3 39 L39 39 Z" />
</svg>
```

**Why does it fit EaseMotion CSS?**

It acts as a masterclass in CSS/SVG integration using `stroke-dasharray` and `stroke-dashoffset` for high impact animation without JS.

## Demo

- [x] Demo added

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

## Notes for Maintainer

N/A
