### PR TITLE
Add Github repository link to demo navbar

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -116,6 +116,14 @@
         </li>
         <li>
           <a
+            href="https://github.com/saptarshi-coder/easemotion-css"
+            target="_blank"
+            rel="noopener noreferrer"
+            >GitHub</a
+          >
+        </li>
+        <li>
+          <a
             href="demo.html"
             class="ease-btn ease-btn-primary ease-btn-sm ease-btn-pill"
             style="


### PR DESCRIPTION
## Pull Request Description

This pull request adds a **GitHub** link to the demo page navbar, allowing users to quickly access the official EaseMotion CSS repository.

---

## Type of Change

* [x] Other (Navigation/UI enhancement)

---

## Submission Checklist

* [ ] All changes are inside `submissions/`
* [ ] Includes `demo.html`
* [ ] Includes `style.css`
* [ ] Includes `README.md`
* [x] **No changes to `core/`**
* [x] **No changes to `components/`**
* [x] One feature per PR (no bundled unrelated changes)

> **Note:** This issue requires updating the demo page navbar (`docs/index.html`), so the `submissions/` checklist items are not applicable.

---

## Feature Description

**What does this add?**

Adds a **GitHub** navigation link to the demo page navbar.

**How does a developer use it?**

Click the **GitHub** link in the navbar to open the official EaseMotion CSS repository in a new browser tab.

**Why does it fit EaseMotion CSS?**

This improves project discoverability, makes it easier for users and contributors to access the source code, and aligns the demo page with common open-source project websites.

---

## Demo

* [x] Verified locally by running the demo page and confirming the GitHub link appears in the navbar and opens the repository in a new tab.

---

## Browser Testing

* [x] Chrome

---

## Notes for Maintainer

* Implements **Issue #30747**.
* Added the official repository link:
  `https://github.com/saptarshi-coder/easemotion-css`
* Opens in a new tab using `target="_blank"` and includes `rel="noopener noreferrer"` for security.
