### PR TITLE
docs: clarify max 2 active issues rule in CONTRIBUTING.md

### DIFF
--- a/submissions/docs/contributing-issues-limit/README.md
+++ b/submissions/docs/contributing-issues-limit/README.md
@@ -1,0 +1,23 @@
+# CONTRIBUTING.md Update: Max 2 Active Issues Rule
+
+This submission fixes Issue #40410 by adding an explanation of the "max 2 active issues" rule to `CONTRIBUTING.md`.
+
+## New Section to Add
+
+### Issue Assignment Limit
+
+To keep contributions fair and manageable:
+
+- **Maximum Active Issues:** Each contributor may be assigned to at most **2 issues at a time**.
+- **Enforcement:** Maintainers will unassign contributors who exceed this limit. PRs linked to unassigned issues may be closed.
+- **How to Unassign:** If you no longer wish to work on an issue, comment `Unassign me` or ask a maintainer to remove your assignment.
+- **Why:** This ensures everyone gets a chance to contribute and prevents contributors from blocking issues by holding too many at once.
+
+---
+
+## Example Contributor Workflow
+
+1. Pick up to 2 open issues and request assignment.
+2. Work on your submissions and open PRs.
+3. If you finish one issue, you may request another.
+4. If you can’t continue, comment `Unassign me` so others can take it.


### PR DESCRIPTION
## Pull Request Description

This PR fixes Issue #40410 by clarifying the "max 2 active issues" rule in `CONTRIBUTING.md`.  
It explains how the rule is enforced, what happens if violated, and how contributors can unassign themselves cleanly.

---

## Type of Change

- [x] 📝 Documentation improvement
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/docs/contributing-issues-limit/`
- [x] Includes `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**  
A clear explanation of the "max 2 active issues" rule.

**Why does it fit EaseMotion CSS?**  
It improves contributor onboarding and prevents confusion about issue assignment limits.

---

## Demo

- [x] Documentation section added (`README.md`)

---

## Notes for Maintainer

Docs improvement under GSSoC’26.  
No core files touched — only inside `submissions/docs/contributing-issues-limit/`.
