### PR TITLE
Submissions/contributing issues limits

### DIFF
--- a/submissions/docs/contributing-issues-limit/README.md
+++ b/submissions/docs/contributing-issues-limit/README.md
@@ -1,0 +1,23 @@
+# CONTRIBUTING.md Update: Max 2 Active Issues Rule
+
+This submission fixes Issue #40410 by adding an explanation of the "max 2 active issues" rule to `CONTRIBUTING.md`.
+
+## New Section to Add
+
+### Issue Assignment Limit
+
+To keep contributions fair and manageable:
+
+- **Maximum Active Issues:** Each contributor may be assigned to at most **2 issues at a time**.
+- **Enforcement:** Maintainers will unassign contributors who exceed this limit. PRs linked to unassigned issues may be closed.
+- **How to Unassign:** If you no longer wish to work on an issue, comment `Unassign me` or ask a maintainer to remove your assignment.
+- **Why:** This ensures everyone gets a chance to contribute and prevents contributors from blocking issues by holding too many at once.
+
+---
+
+## Example Contributor Workflow
+
+1. Pick up to 2 open issues and request assignment.
+2. Work on your submissions and open PRs.
+3. If you finish one issue, you may request another.
+4. If you can’t continue, comment `Unassign me` so others can take it.

--- a/submissions/docs/contributing-issues-limit/README.md
+++ b/submissions/docs/contributing-issues-limit/README.md
@@ -2,22 +2,15 @@
 
 This submission fixes Issue #40410 by adding an explanation of the "max 2 active issues" rule to `CONTRIBUTING.md`.
 
+## Demo
+
+The included `demo.html` + `style.css` show a simple card explaining the rule visually.
+
 ## New Section to Add
 
 ### Issue Assignment Limit
 
-To keep contributions fair and manageable:
-
 - **Maximum Active Issues:** Each contributor may be assigned to at most **2 issues at a time**.
-- **Enforcement:** Maintainers will unassign contributors who exceed this limit. PRs linked to unassigned issues may be closed.
-- **How to Unassign:** If you no longer wish to work on an issue, comment `Unassign me` or ask a maintainer to remove your assignment.
-- **Why:** This ensures everyone gets a chance to contribute and prevents contributors from blocking issues by holding too many at once.
-
----
-
-## Example Contributor Workflow
-
-1. Pick up to 2 open issues and request assignment.
-2. Work on your submissions and open PRs.
-3. If you finish one issue, you may request another.
-4. If you can’t continue, comment `Unassign me` so others can take it.
+- **Enforcement:** Maintainers will unassign contributors who exceed this limit.
+- **How to Unassign:** Comment `Unassign me` or ask a maintainer to remove your assignment.
+- **Why:** Ensures fairness and prevents blocking.

--- a/submissions/docs/contributing-issues-limit/demo.html
+++ b/submissions/docs/contributing-issues-limit/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Contributing Issues Limit Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="card">
+    <h2>Max 2 Active Issues Rule</h2>
+    <p>Contributors may be assigned to at most <strong>2 issues</strong> at a time.</p>
+    <p>If you exceed this limit, maintainers will unassign you.</p>
+    <p>To unassign yourself, comment <code>Unassign me</code> on the issue.</p>
+  </div>
+</body>
+</html>

--- a/submissions/docs/contributing-issues-limit/style.css
+++ b/submissions/docs/contributing-issues-limit/style.css
@@ -1,0 +1,26 @@
+body {
+  font-family: Inter, sans-serif;
+  background: #f9f9f9;
+  color: #333;
+  padding: 2rem;
+}
+
+.card {
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 1.5rem;
+  max-width: 500px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+}
+
+h2 {
+  color: #007bff;
+  margin-bottom: 1rem;
+}
+
+code {
+  background: #eee;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes Issue #40410 by clarifying the "max 2 active issues" rule in `CONTRIBUTING.md`.  
It explains how the rule is enforced, what happens if violated, and how contributors can unassign themselves cleanly.

---

## Type of Change

- [x] 📝 Documentation improvement
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/docs/contributing-issues-limit/`
- [x] Includes `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**  
A clear explanation of the "max 2 active issues" rule.

**Why does it fit EaseMotion CSS?**  
It improves contributor onboarding and prevents confusion about issue assignment limits.

---

## Demo

- [x] Documentation section added (`README.md`)

---

## Notes for Maintainer

Docs improvement under GSSoC’26.  
No core files touched — only inside `submissions/docs/contributing-issues-limit/`.
