### PR TITLE
feat: add kpi stat tiles

### DIFF
--- a/submissions/examples/kpi-tiles-as/README.md
+++ b/submissions/examples/kpi-tiles-as/README.md
@@ -1,0 +1,22 @@
+# KPI Stat Tiles
+
+### What does this do?
+
+It shows dashboard stat tiles with an icon, a value, a label, and an up or down trend badge, entering with a staggered fade and lifting on hover.
+
+### How is it used?
+
+```html
+<div class="kpi">
+  <span class="kpi-icon" aria-hidden="true">...</span>
+  <span class="kpi-value">$48.2k</span>
+  <span class="kpi-label">Revenue</span>
+  <span class="kpi-trend up">+12%</span>
+</div>
+```
+
+Use `kpi-trend up` for a positive change or `kpi-trend down` for a negative one to set the color. Icons are inline SVG, so there are no images to load.
+
+### Why is it useful?
+
+KPI tiles summarise metrics at the top of dashboards. This reveals tiles with a staggered entrance and styles the up and down trend badges, using only CSS. Under `prefers-reduced-motion: reduce` the tiles appear without the entrance animation.

--- a/submissions/examples/kpi-tiles-as/demo.html
+++ b/submissions/examples/kpi-tiles-as/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>KPI Stat Tiles</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="kpi-row">
+    <div class="kpi">
+      <span class="kpi-icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 1v22M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" /></svg>
+      </span>
+      <span class="kpi-value">$48.2k</span>
+      <span class="kpi-label">Revenue</span>
+      <span class="kpi-trend up">+12%</span>
+    </div>
+
+    <div class="kpi">
+      <span class="kpi-icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M22 21v-2a4 4 0 0 0-3-3.87" /></svg>
+      </span>
+      <span class="kpi-value">8,942</span>
+      <span class="kpi-label">Active users</span>
+      <span class="kpi-trend up">+5%</span>
+    </div>
+
+    <div class="kpi">
+      <span class="kpi-icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 3v18h18" /><path d="M7 14l4-4 3 3 5-6" /></svg>
+      </span>
+      <span class="kpi-value">32%</span>
+      <span class="kpi-label">Bounce rate</span>
+      <span class="kpi-trend down">-3%</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/kpi-tiles-as/style.css
+++ b/submissions/examples/kpi-tiles-as/style.css
@@ -1,0 +1,100 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.kpi-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.25rem;
+  max-width: 720px;
+  width: 100%;
+}
+
+.kpi {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 1.4rem;
+  border-radius: 16px;
+  background: #111a2e;
+  border: 1px solid #1e293b;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
+  opacity: 0;
+  transform: translateY(16px);
+  animation: kpiIn 0.5s ease forwards;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.kpi:nth-child(2) { animation-delay: 0.12s; }
+.kpi:nth-child(3) { animation-delay: 0.24s; }
+
+.kpi:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.4);
+}
+
+.kpi-icon {
+  width: 40px;
+  height: 40px;
+  margin-bottom: 0.4rem;
+  display: grid;
+  place-items: center;
+  border-radius: 12px;
+  color: #fff;
+}
+
+.kpi:nth-child(1) .kpi-icon { background: linear-gradient(135deg, #6c63ff, #4338ca); }
+.kpi:nth-child(2) .kpi-icon { background: linear-gradient(135deg, #0ea5e9, #0369a1); }
+.kpi:nth-child(3) .kpi-icon { background: linear-gradient(135deg, #f59e0b, #b45309); }
+
+.kpi-value {
+  font-size: 1.8rem;
+  font-weight: 700;
+}
+
+.kpi-label {
+  font-size: 0.85rem;
+  color: #94a3b8;
+}
+
+.kpi-trend {
+  align-self: flex-start;
+  margin-top: 0.5rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.kpi-trend.up {
+  color: #10b981;
+  background: rgba(16, 185, 129, 0.14);
+}
+
+.kpi-trend.down {
+  color: #ef4444;
+  background: rgba(239, 68, 68, 0.14);
+}
+
+@keyframes kpiIn {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .kpi {
+    opacity: 1;
+    transform: none;
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds KPI stat tiles built for #40474. Dashboard tiles show an icon, a value, a label, and an up or down trend badge, entering with a staggered fade and lifting on hover, using inline SVG icons and CSS. Closes #40474.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A row of dashboard KPI tiles with icons, values, and colored trend badges.

**How does a developer use it?**

```html
<div class="kpi">
  <span class="kpi-icon" aria-hidden="true">...</span>
  <span class="kpi-value">$48.2k</span>
  <span class="kpi-label">Revenue</span>
  <span class="kpi-trend up">+12%</span>
</div>
```

**Why does it fit EaseMotion CSS?**
It reveals tiles with a staggered entrance and styles the up and down trend badges, using only CSS. Icons are inline SVG, and under `prefers-reduced-motion: reduce` the tiles appear without the entrance animation.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: three tiles render, up trend badges are green and down trend badges are red.
