### PR TITLE
feat: add divider with label

### DIFF
--- a/submissions/examples/divider-label-as/README.md
+++ b/submissions/examples/divider-label-as/README.md
@@ -1,0 +1,18 @@
+# Divider With Label
+
+### What does this do?
+
+It shows a horizontal divider with a centered label, with plain and accent variants.
+
+### How is it used?
+
+```html
+<div class="divider"><span>or continue with</span></div>
+<div class="divider is-accent"><span>Featured</span></div>
+```
+
+The line is drawn by `::before` and `::after` pseudo elements that flex to fill the space on each side of the label.
+
+### Why is it useful?
+
+Labelled dividers separate sections and options in forms and layouts, such as an "or" between sign in choices. This centers the label over the line with flex and pseudo elements, using only CSS with no images or JavaScript.

--- a/submissions/examples/divider-label-as/demo.html
+++ b/submissions/examples/divider-label-as/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Divider With Label</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="divider-stack">
+    <div class="divider"><span>or continue with</span></div>
+    <div class="divider is-plain"><span>Section</span></div>
+    <div class="divider is-accent"><span>Featured</span></div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/divider-label-as/style.css
+++ b/submissions/examples/divider-label-as/style.css
@@ -1,0 +1,49 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.divider-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  width: min(360px, 92vw);
+}
+
+.divider {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  font-size: 0.82rem;
+  color: #94a3b8;
+}
+
+.divider::before,
+.divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, #26324a, transparent);
+}
+
+.divider.is-plain::before,
+.divider.is-plain::after {
+  background: #26324a;
+}
+
+.divider.is-accent {
+  color: #6c63ff;
+  font-weight: 600;
+}
+
+.divider.is-accent::before,
+.divider.is-accent::after {
+  background: linear-gradient(90deg, transparent, rgba(108, 99, 255, 0.5), transparent);
+}


### PR DESCRIPTION
## Pull Request Description

Adds a divider with a centered label, with plain and accent variants, using only CSS. Closes #40484.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A labelled horizontal divider with plain and accent variants.

**How does a developer use it?**

```html
<div class="divider"><span>or continue with</span></div>
```

**Why does it fit EaseMotion CSS?**
It centers the label over the line with flex and pseudo elements, using only CSS with no images or JavaScript.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: three divider variants render with the pseudo element lines on each side of the label.
