### PR TITLE
feat: add animated custom checkbox

### DIFF
--- a/submissions/examples/custom-checkbox-as/README.md
+++ b/submissions/examples/custom-checkbox-as/README.md
@@ -1,0 +1,21 @@
+# Animated Custom Checkbox
+
+### What does this do?
+
+It shows custom styled checkboxes where the box fills with the accent color and a checkmark pops in when checked.
+
+### How is it used?
+
+```html
+<label class="check">
+  <input type="checkbox" class="check-input" checked />
+  <span class="check-box" aria-hidden="true"></span>
+  <span class="check-text">Subscribe to updates</span>
+</label>
+```
+
+Each checkbox is a real `input` visually hidden next to a styled `.check-box`. The checkmark is drawn with a rotated border and scales in on the checked state.
+
+### Why is it useful?
+
+Custom checkboxes match a brand while staying accessible because they are built on a real checkbox input. This animates the check with a transform on the checked state, so it needs no JavaScript. The input keeps keyboard support with a focus ring, and the tick animation is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/custom-checkbox-as/demo.html
+++ b/submissions/examples/custom-checkbox-as/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Custom Checkbox</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="check-list">
+    <label class="check">
+      <input type="checkbox" class="check-input" checked />
+      <span class="check-box" aria-hidden="true"></span>
+      <span class="check-text">Subscribe to product updates</span>
+    </label>
+    <label class="check">
+      <input type="checkbox" class="check-input" />
+      <span class="check-box" aria-hidden="true"></span>
+      <span class="check-text">Email me about new features</span>
+    </label>
+    <label class="check">
+      <input type="checkbox" class="check-input" checked />
+      <span class="check-box" aria-hidden="true"></span>
+      <span class="check-text">Accept the terms of service</span>
+    </label>
+  </div>
+</body>
+</html>

--- a/submissions/examples/custom-checkbox-as/style.css
+++ b/submissions/examples/custom-checkbox-as/style.css
@@ -1,0 +1,77 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.check-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.check {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+
+.check-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.check-box {
+  position: relative;
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+  border-radius: 6px;
+  background: #111a2e;
+  border: 2px solid #3a4a6b;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.check-box::after {
+  content: "";
+  position: absolute;
+  left: 6px;
+  top: 2px;
+  width: 6px;
+  height: 11px;
+  border: solid #fff;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg) scale(0);
+  transform-origin: center;
+  transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.check-input:checked + .check-box {
+  background: #6c63ff;
+  border-color: #6c63ff;
+}
+
+.check-input:checked + .check-box::after {
+  transform: rotate(45deg) scale(1);
+}
+
+.check-input:focus-visible + .check-box {
+  outline: 2px solid #fbbf24;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .check-box::after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an animated custom checkbox built on a real checkbox input, where the box fills and a checkmark pops in when checked, using only CSS. Closes #40492.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
Custom styled checkboxes with an animated tick on the checked state.

**How does a developer use it?**

```html
<label class="check">
  <input type="checkbox" class="check-input" checked />
  <span class="check-box" aria-hidden="true"></span>
  <span class="check-text">Subscribe to updates</span>
</label>
```

**Why does it fit EaseMotion CSS?**
It animates the check with a transform on the checked state, so it needs no JavaScript. The input keeps keyboard support with a focus ring, and the tick animation is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: a checked box fills with the accent color and the tick scales to full size.
