### PR TITLE
feat: add styled range sliders

### DIFF
--- a/submissions/examples/range-sliders-as/README.md
+++ b/submissions/examples/range-sliders-as/README.md
@@ -1,0 +1,20 @@
+# Styled Range Sliders
+
+### What does this do?
+
+It shows range sliders with an accent filled track and a labelled value, built on native range inputs.
+
+### How is it used?
+
+```html
+<label class="range-field">
+  <span class="range-head"><span>Volume</span><span>70</span></span>
+  <input type="range" class="range" min="0" max="100" value="70" />
+</label>
+```
+
+The slider uses `accent-color` to tint the filled track and thumb, so it stays a real, draggable, keyboard operable range input.
+
+### Why is it useful?
+
+Sliders control values such as volume, brightness, and price. This gives a native range input a branded accent look with `accent-color` while keeping it fully functional and accessible, using only CSS with no JavaScript. The slider shows a focus ring for keyboard users.

--- a/submissions/examples/range-sliders-as/demo.html
+++ b/submissions/examples/range-sliders-as/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Styled Range Sliders</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="range-list">
+    <label class="range-field">
+      <span class="range-head"><span>Volume</span><span>70</span></span>
+      <input type="range" class="range" min="0" max="100" value="70" aria-label="Volume" />
+    </label>
+    <label class="range-field">
+      <span class="range-head"><span>Brightness</span><span>45</span></span>
+      <input type="range" class="range" min="0" max="100" value="45" aria-label="Brightness" />
+    </label>
+    <label class="range-field">
+      <span class="range-head"><span>Contrast</span><span>90</span></span>
+      <input type="range" class="range" min="0" max="100" value="90" aria-label="Contrast" />
+    </label>
+  </div>
+</body>
+</html>

--- a/submissions/examples/range-sliders-as/style.css
+++ b/submissions/examples/range-sliders-as/style.css
@@ -1,0 +1,47 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.range-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  width: min(380px, 92vw);
+  padding: 1.75rem;
+  border-radius: 16px;
+  background: #111a2e;
+  border: 1px solid #1e293b;
+}
+
+.range-head {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.55rem;
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.range-head span:last-child {
+  color: #6c63ff;
+}
+
+.range {
+  width: 100%;
+  height: 6px;
+  accent-color: #6c63ff;
+  cursor: pointer;
+}
+
+.range:focus-visible {
+  outline: 2px solid #fbbf24;
+  outline-offset: 4px;
+  border-radius: 6px;
+}


### PR DESCRIPTION
## Pull Request Description

Adds styled range sliders with an accent filled track and a labelled value, built on native range inputs, using only CSS. Closes #40497.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
Accent styled, fully functional range sliders with value labels.

**How does a developer use it?**

```html
<label class="range-field">
  <span class="range-head"><span>Volume</span><span>70</span></span>
  <input type="range" class="range" min="0" max="100" value="70" />
</label>
```

**Why does it fit EaseMotion CSS?**
It tints a native range input with `accent-color` while keeping it draggable and keyboard operable, using only CSS. The slider shows a focus ring for keyboard users.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: three native range inputs render with the accent color filling the track to their value.
