### PR TITLE
feat: add exclusive accordion

### DIFF
--- a/submissions/examples/exclusive-accordion-as/README.md
+++ b/submissions/examples/exclusive-accordion-as/README.md
@@ -1,0 +1,21 @@
+# Exclusive Accordion
+
+### What does this do?
+
+It shows an accordion where opening one panel closes the others, with a smooth height reveal and a rotating icon.
+
+### How is it used?
+
+```html
+<div class="acc-item">
+  <input type="radio" name="acc" id="a1" class="acc-input" checked />
+  <label for="a1" class="acc-head">First item <span class="acc-icon" aria-hidden="true"></span></label>
+  <div class="acc-body"><div class="acc-inner"><p>Content</p></div></div>
+</div>
+```
+
+All items share one radio `name`, so selecting one closes any other. The panel opens by animating `grid-template-rows` from `0fr` to `1fr`.
+
+### Why is it useful?
+
+Single open accordions keep long content tidy in FAQs, settings, and menus. This animates a smooth open with a `grid-template-rows` transition driven by radio inputs, so it needs no JavaScript. The heads are keyboard reachable with a focus ring, and the transition is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/exclusive-accordion-as/demo.html
+++ b/submissions/examples/exclusive-accordion-as/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Exclusive Accordion</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="accordion">
+    <div class="acc-item">
+      <input type="radio" name="acc" id="a1" class="acc-input" checked />
+      <label for="a1" class="acc-head">What is EaseMotion CSS? <span class="acc-icon" aria-hidden="true"></span></label>
+      <div class="acc-body"><div class="acc-inner"><p>A human readable, animation first CSS framework with a zero config motion engine.</p></div></div>
+    </div>
+    <div class="acc-item">
+      <input type="radio" name="acc" id="a2" class="acc-input" />
+      <label for="a2" class="acc-head">Does it need a build step? <span class="acc-icon" aria-hidden="true"></span></label>
+      <div class="acc-body"><div class="acc-inner"><p>No. Link one stylesheet and start applying the readable class names right away.</p></div></div>
+    </div>
+    <div class="acc-item">
+      <input type="radio" name="acc" id="a3" class="acc-input" />
+      <label for="a3" class="acc-head">Is it accessible? <span class="acc-icon" aria-hidden="true"></span></label>
+      <div class="acc-body"><div class="acc-inner"><p>Yes, and it respects reduced motion preferences out of the box.</p></div></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/exclusive-accordion-as/style.css
+++ b/submissions/examples/exclusive-accordion-as/style.css
@@ -1,0 +1,93 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.accordion {
+  width: min(500px, 94vw);
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid #1e293b;
+  background: #111a2e;
+}
+
+.acc-item + .acc-item {
+  border-top: 1px solid #1e293b;
+}
+
+.acc-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.acc-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.05rem 1.25rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.acc-head:hover {
+  color: #fff;
+}
+
+.acc-icon {
+  width: 9px;
+  height: 9px;
+  border-right: 2px solid #94a3b8;
+  border-bottom: 2px solid #94a3b8;
+  transform: rotate(45deg);
+  transition: transform 0.3s ease, border-color 0.2s ease;
+}
+
+.acc-input:checked ~ .acc-head .acc-icon {
+  transform: rotate(-135deg);
+  border-color: #6c63ff;
+}
+
+.acc-body {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.3s ease;
+}
+
+.acc-input:checked ~ .acc-body {
+  grid-template-rows: 1fr;
+}
+
+.acc-inner {
+  overflow: hidden;
+}
+
+.acc-inner p {
+  margin: 0;
+  padding: 0 1.25rem 1.2rem;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: #94a3b8;
+}
+
+.acc-input:focus-visible ~ .acc-head {
+  outline: 2px solid #fbbf24;
+  outline-offset: -2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .acc-body,
+  .acc-icon {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an exclusive accordion where opening one panel closes the others, using radio inputs and a `grid-template-rows` reveal, with no JavaScript. Closes #40502.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A single open accordion with a smooth height reveal and rotating icons.

**How does a developer use it?**

```html
<div class="acc-item">
  <input type="radio" name="acc" id="a1" class="acc-input" checked />
  <label for="a1" class="acc-head">First item <span class="acc-icon" aria-hidden="true"></span></label>
  <div class="acc-body"><div class="acc-inner"><p>Content</p></div></div>
</div>
```

**Why does it fit EaseMotion CSS?**
It animates the open with a `grid-template-rows` transition driven by radio inputs, so it needs no JavaScript. Heads are keyboard reachable with a focus ring, and the transition is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: opening a second panel closes the first, confirming the single open behavior.
