### PR TITLE
feat: add countdown timer boxes

### DIFF
--- a/submissions/examples/countdown-boxes-as/README.md
+++ b/submissions/examples/countdown-boxes-as/README.md
@@ -1,0 +1,20 @@
+# Countdown Timer Boxes
+
+### What does this do?
+
+It shows a countdown display with separate flip style tiles for days, hours, minutes, and seconds, where the seconds tile has a subtle pulse.
+
+### How is it used?
+
+```html
+<div class="countdown">
+  <div class="cd-unit"><span class="cd-num">02</span><span class="cd-label">Days</span></div>
+  <div class="cd-unit is-live"><span class="cd-num">09</span><span class="cd-label">Seconds</span></div>
+</div>
+```
+
+Each unit is a tile with a center seam drawn by a pseudo element. Add `is-live` to the unit you want to pulse. The values are set in the markup and updated by the host app.
+
+### Why is it useful?
+
+Countdown timers create urgency on launches, sales, and events. This presents the time units in styled tiles with a gentle pulse, using only CSS with no images. The display uses a `timer` role, and the pulse is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/countdown-boxes-as/demo.html
+++ b/submissions/examples/countdown-boxes-as/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Countdown Timer Boxes</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="countdown" role="timer" aria-label="Time remaining">
+    <div class="cd-unit"><span class="cd-num">02</span><span class="cd-label">Days</span></div>
+    <div class="cd-unit"><span class="cd-num">14</span><span class="cd-label">Hours</span></div>
+    <div class="cd-unit"><span class="cd-num">37</span><span class="cd-label">Minutes</span></div>
+    <div class="cd-unit is-live"><span class="cd-num">09</span><span class="cd-label">Seconds</span></div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/countdown-boxes-as/style.css
+++ b/submissions/examples/countdown-boxes-as/style.css
@@ -1,0 +1,73 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.countdown {
+  display: flex;
+  gap: 1rem;
+}
+
+.cd-unit {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.cd-num {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 72px;
+  height: 78px;
+  font-size: 2.4rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: #f8fafc;
+  background: linear-gradient(180deg, #1b2740, #111a2e);
+  border: 1px solid #26324a;
+  border-radius: 12px;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
+}
+
+.cd-num::after {
+  content: "";
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  top: 50%;
+  height: 1px;
+  background: rgba(0, 0, 0, 0.45);
+}
+
+.cd-label {
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #94a3b8;
+}
+
+.cd-unit.is-live .cd-num {
+  animation: cdPulse 1s ease-in-out infinite;
+}
+
+@keyframes cdPulse {
+  50% {
+    color: #a5b4fc;
+    border-color: #6c63ff;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cd-unit.is-live .cd-num {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds countdown timer boxes built for #40507. Days, hours, minutes, and seconds are shown in flip style tiles with a center seam, and the seconds tile pulses, using only CSS. Closes #40507.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A countdown display of styled time unit tiles with a pulsing seconds tile.

**How does a developer use it?**

```html
<div class="countdown">
  <div class="cd-unit"><span class="cd-num">02</span><span class="cd-label">Days</span></div>
  <div class="cd-unit is-live"><span class="cd-num">09</span><span class="cd-label">Seconds</span></div>
</div>
```

**Why does it fit EaseMotion CSS?**
It presents the time units in styled tiles with a gentle pulse, using only CSS with no images. The display uses a `timer` role, and the pulse is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: four unit tiles render and the seconds tile has the pulse animation applied.
