### PR TITLE
feat: add billing price toggle

### DIFF
--- a/submissions/examples/billing-toggle-as/README.md
+++ b/submissions/examples/billing-toggle-as/README.md
@@ -1,0 +1,25 @@
+# Billing Price Toggle
+
+### What does this do?
+
+It shows a monthly and yearly billing toggle that slides a switch and swaps the displayed price, with a save badge on the yearly option.
+
+### How is it used?
+
+```html
+<div class="billing">
+  <input type="checkbox" id="billing" class="bt-input" />
+  <div class="billing-toggle">
+    <span>Monthly</span>
+    <label for="billing" class="bt-track"><span class="bt-knob"></span></label>
+    <span>Yearly</span>
+  </div>
+  <div class="price"><span class="pm">$12<small> / mo</small></span><span class="py">$115<small> / yr</small></span></div>
+</div>
+```
+
+The checkbox, the toggle, and the price are siblings, so the checked state can both slide the knob and swap which price is shown.
+
+### Why is it useful?
+
+Pricing pages often let users switch between monthly and yearly billing. This swaps the price and slides the switch from the `:checked` state, so it needs no JavaScript. The switch stays keyboard operable with a focus ring.

--- a/submissions/examples/billing-toggle-as/demo.html
+++ b/submissions/examples/billing-toggle-as/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Billing Price Toggle</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="billing">
+    <input type="checkbox" id="billing" class="bt-input" aria-label="Toggle yearly billing" />
+    <div class="billing-toggle">
+      <span>Monthly</span>
+      <label for="billing" class="bt-track"><span class="bt-knob"></span></label>
+      <span>Yearly <span class="year-tag">Save 20%</span></span>
+    </div>
+    <div class="price">
+      <span class="pm">$12<small> / mo</small></span>
+      <span class="py">$115<small> / yr</small></span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/billing-toggle-as/style.css
+++ b/submissions/examples/billing-toggle-as/style.css
@@ -1,0 +1,103 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.billing {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.75rem;
+  padding: 2rem 2.5rem;
+  border-radius: 18px;
+  background: #111a2e;
+  border: 1px solid #1e293b;
+}
+
+.bt-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.billing-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: #94a3b8;
+}
+
+.bt-track {
+  position: relative;
+  width: 46px;
+  height: 26px;
+  border-radius: 999px;
+  background: #334155;
+  cursor: pointer;
+  transition: background 0.25s ease;
+}
+
+.bt-knob {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.bt-input:checked + .billing-toggle .bt-track {
+  background: #6c63ff;
+}
+
+.bt-input:checked + .billing-toggle .bt-track .bt-knob {
+  transform: translateX(20px);
+}
+
+.bt-input:focus-visible + .billing-toggle .bt-track {
+  outline: 2px solid #fbbf24;
+  outline-offset: 2px;
+}
+
+.year-tag {
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  color: #10b981;
+  background: rgba(16, 185, 129, 0.14);
+}
+
+.price {
+  font-size: 3rem;
+  font-weight: 800;
+}
+
+.price small {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #94a3b8;
+}
+
+.py {
+  display: none;
+}
+
+.bt-input:checked ~ .price .pm {
+  display: none;
+}
+
+.bt-input:checked ~ .price .py {
+  display: inline;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a billing price toggle built for #40512. A monthly and yearly switch slides and swaps the displayed price, with a save badge on yearly, using a checkbox and CSS with no JavaScript. Closes #40512.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A monthly and yearly billing toggle that swaps the shown price.

**How does a developer use it?**

```html
<div class="billing">
  <input type="checkbox" id="billing" class="bt-input" />
  <div class="billing-toggle"><span>Monthly</span><label for="billing" class="bt-track"><span class="bt-knob"></span></label><span>Yearly</span></div>
  <div class="price"><span class="pm">$12<small> / mo</small></span><span class="py">$115<small> / yr</small></span></div>
</div>
```

**Why does it fit EaseMotion CSS?**
It swaps the price and slides the switch from the `:checked` state, so it needs no JavaScript. The switch stays keyboard operable with a focus ring.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the monthly price shows by default and toggling switches to the yearly price.
