### PR TITLE
feat: add removable tag pills

### DIFF
--- a/submissions/examples/removable-tags-as/README.md
+++ b/submissions/examples/removable-tags-as/README.md
@@ -1,0 +1,20 @@
+# Removable Tag Pills
+
+### What does this do?
+
+It shows a row of tag pills, each with a remove control that collapses the tag away when clicked.
+
+### How is it used?
+
+```html
+<span class="tag-wrap">
+  <input type="checkbox" id="t1" class="tag-remove" />
+  <span class="tag">Design <label for="t1" class="tag-x" aria-label="Remove Design">&times;</label></span>
+</span>
+```
+
+The remove control is a `label` for a hidden checkbox that sits just before the tag. Clicking it checks the box, and the adjacent tag collapses with a transition.
+
+### Why is it useful?
+
+Removable tags are common in filters, token inputs, and selected item lists. This collapses a tag on the remove action driven by the `:checked` state, so it needs no JavaScript. The remove control has an accessible label and a focus ring, and the collapse is softened under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/removable-tags-as/demo.html
+++ b/submissions/examples/removable-tags-as/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Removable Tag Pills</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="tags">
+    <span class="tag-wrap">
+      <input type="checkbox" id="t1" class="tag-remove" />
+      <span class="tag">Design <label for="t1" class="tag-x" aria-label="Remove Design">&times;</label></span>
+    </span>
+    <span class="tag-wrap">
+      <input type="checkbox" id="t2" class="tag-remove" />
+      <span class="tag">Development <label for="t2" class="tag-x" aria-label="Remove Development">&times;</label></span>
+    </span>
+    <span class="tag-wrap">
+      <input type="checkbox" id="t3" class="tag-remove" />
+      <span class="tag">Marketing <label for="t3" class="tag-x" aria-label="Remove Marketing">&times;</label></span>
+    </span>
+    <span class="tag-wrap">
+      <input type="checkbox" id="t4" class="tag-remove" />
+      <span class="tag">Research <label for="t4" class="tag-x" aria-label="Remove Research">&times;</label></span>
+    </span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/removable-tags-as/style.css
+++ b/submissions/examples/removable-tags-as/style.css
@@ -1,0 +1,79 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  max-width: 420px;
+  padding: 1rem;
+  border-radius: 12px;
+  background: #111a2e;
+  border: 1px solid #26324a;
+}
+
+.tag-remove {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #c7d2fe;
+  background: rgba(108, 99, 255, 0.16);
+  transition: opacity 0.25s ease, transform 0.25s ease, margin 0.25s ease;
+}
+
+.tag-x {
+  display: grid;
+  place-items: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  font-size: 0.9rem;
+  line-height: 1;
+  color: #a5b4fc;
+  background: rgba(108, 99, 255, 0.25);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.tag-x:hover {
+  background: #6c63ff;
+  color: #fff;
+}
+
+.tag-remove:checked + .tag {
+  opacity: 0;
+  transform: scale(0.6);
+  margin-right: -0.6rem;
+  pointer-events: none;
+}
+
+.tag-remove:focus-visible + .tag .tag-x {
+  outline: 2px solid #fbbf24;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tag {
+    transition: opacity 0.2s ease;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds removable tag pills built for #40518. Each tag has a remove control that collapses it away on click, using checkboxes and CSS with no JavaScript. Closes #40518.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
Tag pills that can be removed with a collapse animation.

**How does a developer use it?**

```html
<span class="tag-wrap">
  <input type="checkbox" id="t1" class="tag-remove" />
  <span class="tag">Design <label for="t1" class="tag-x" aria-label="Remove Design">&times;</label></span>
</span>
```

**Why does it fit EaseMotion CSS?**
It collapses a tag on the remove action driven by the `:checked` state, so it needs no JavaScript. The remove control has an accessible label and a focus ring, and the collapse is softened under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: clicking a tag remove control takes its opacity to 0 and collapses it.
