### PR TITLE
feat: add loading button

### DIFF
--- a/submissions/examples/loading-button-as/README.md
+++ b/submissions/examples/loading-button-as/README.md
@@ -1,0 +1,18 @@
+# Loading Button
+
+### What does this do?
+
+It shows a button with a loading state that replaces its label with a spinner and blocks clicks, toggled with a class.
+
+### How is it used?
+
+```html
+<button class="btn">Save changes</button>
+<button class="btn is-loading" aria-busy="true">Save changes</button>
+```
+
+Add `is-loading` when an action starts. The label becomes transparent and a spinner is drawn in the center, and `pointer-events` are disabled so it cannot be clicked again.
+
+### Why is it useful?
+
+Buttons need to show progress while an action is in flight, such as submitting a form. This swaps the button to a spinner with a class and a keyframe, so it needs no JavaScript beyond toggling the class. Pair it with `aria-busy` for assistive tech, and the spinner slows under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/loading-button-as/demo.html
+++ b/submissions/examples/loading-button-as/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Loading Button</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="btn-row">
+    <button class="btn" type="button">Save changes</button>
+    <button class="btn is-loading" type="button" aria-label="Saving" aria-busy="true">Save changes</button>
+    <button class="btn is-ghost is-loading" type="button" aria-label="Loading" aria-busy="true">Load more</button>
+  </div>
+</body>
+</html>

--- a/submissions/examples/loading-button-as/style.css
+++ b/submissions/examples/loading-button-as/style.css
@@ -1,0 +1,74 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.btn-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.btn {
+  position: relative;
+  padding: 0.8rem 1.6rem;
+  min-width: 150px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #fff;
+  background: #6c63ff;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.btn:hover {
+  background: #574fe0;
+}
+
+.btn.is-ghost {
+  background: #1e293b;
+  border: 1px solid #334155;
+}
+
+.btn.is-loading {
+  color: transparent;
+  pointer-events: none;
+}
+
+.btn.is-loading::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 18px;
+  height: 18px;
+  border: 2px solid rgba(255, 255, 255, 0.4);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: btnSpin 0.7s linear infinite;
+}
+
+.btn:focus-visible {
+  outline: 2px solid #fbbf24;
+  outline-offset: 2px;
+}
+
+@keyframes btnSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .btn.is-loading::after {
+    animation-duration: 2s;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a loading button built for #40522. A button shows a spinner in place of its label and blocks clicks when it has the loading class, using only CSS. Closes #40522.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A button with a loading state that shows a spinner, in solid and ghost variants.

**How does a developer use it?**

```html
<button class="btn is-loading" aria-busy="true">Save changes</button>
```

**Why does it fit EaseMotion CSS?**
It swaps the button to a spinner with a class and a keyframe, so it needs no JavaScript beyond toggling the class. Pair with `aria-busy`, and the spinner slows under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the loading button hides its label and shows the spinner with the spin animation applied.
