### PR TITLE
feat: add avatar with presence indicator

### DIFF
--- a/submissions/examples/avatar-presence-as/README.md
+++ b/submissions/examples/avatar-presence-as/README.md
@@ -1,0 +1,20 @@
+# Avatar With Presence Indicator
+
+### What does this do?
+
+It shows circular avatars with a presence dot in the corner and a matching status ring, for online, away, busy, and offline, with a soft pulse on the online dot.
+
+### How is it used?
+
+```html
+<span class="avatar is-online" title="Online">
+  <span class="avatar-initials">JD</span>
+  <span class="avatar-dot" aria-hidden="true"></span>
+</span>
+```
+
+Add `is-online`, `is-away`, `is-busy`, or `is-offline` to the avatar to set the ring and dot color. The online state adds a pulsing ring around its dot.
+
+### Why is it useful?
+
+Avatars with presence show who is available in chat apps, member lists, and dashboards. This adds a status dot and ring and pulses the live one, using only CSS with initials avatars so it is self contained. The pulse is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/avatar-presence-as/demo.html
+++ b/submissions/examples/avatar-presence-as/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Avatar With Presence Indicator</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="avatar-row">
+    <span class="avatar is-online" title="Online">
+      <span class="avatar-initials">JD</span>
+      <span class="avatar-dot" aria-hidden="true"></span>
+    </span>
+    <span class="avatar is-away" title="Away">
+      <span class="avatar-initials">AR</span>
+      <span class="avatar-dot" aria-hidden="true"></span>
+    </span>
+    <span class="avatar is-busy" title="Busy">
+      <span class="avatar-initials">ML</span>
+      <span class="avatar-dot" aria-hidden="true"></span>
+    </span>
+    <span class="avatar is-offline" title="Offline">
+      <span class="avatar-initials">SK</span>
+      <span class="avatar-dot" aria-hidden="true"></span>
+    </span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/avatar-presence-as/style.css
+++ b/submissions/examples/avatar-presence-as/style.css
@@ -1,0 +1,88 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.avatar-row {
+  display: flex;
+  gap: 2rem;
+}
+
+.avatar {
+  position: relative;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+}
+
+.avatar-initials {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  font-weight: 700;
+  color: #fff;
+  background: linear-gradient(135deg, #6c63ff, #0ea5e9);
+}
+
+.avatar.is-online {
+  --status: #10b981;
+  box-shadow: 0 0 0 2px #10b981;
+}
+
+.avatar.is-away {
+  --status: #f59e0b;
+  box-shadow: 0 0 0 2px #f59e0b;
+}
+
+.avatar.is-busy {
+  --status: #ef4444;
+  box-shadow: 0 0 0 2px #ef4444;
+}
+
+.avatar.is-offline {
+  --status: #64748b;
+  box-shadow: 0 0 0 2px #64748b;
+}
+
+.avatar-dot {
+  position: absolute;
+  bottom: 1px;
+  right: 1px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--status, #64748b);
+  border: 2px solid #0b1121;
+}
+
+.avatar.is-online .avatar-dot::after {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  border-radius: 50%;
+  background: var(--status);
+  opacity: 0.6;
+  animation: dotPing 1.6s ease-out infinite;
+}
+
+@keyframes dotPing {
+  to {
+    transform: scale(2.2);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .avatar.is-online .avatar-dot::after {
+    animation: none;
+  }
+}

--- a/submissions/examples/avatar-presence-as/style.css
+++ b/submissions/examples/avatar-presence-as/style.css
@@ -35,21 +35,25 @@ body {
 
 .avatar.is-online {
   --status: #10b981;
+
   box-shadow: 0 0 0 2px #10b981;
 }
 
 .avatar.is-away {
   --status: #f59e0b;
+
   box-shadow: 0 0 0 2px #f59e0b;
 }
 
 .avatar.is-busy {
   --status: #ef4444;
+
   box-shadow: 0 0 0 2px #ef4444;
 }
 
 .avatar.is-offline {
   --status: #64748b;
+
   box-shadow: 0 0 0 2px #64748b;
 }
 


### PR DESCRIPTION
## Pull Request Description

Adds avatars with a presence indicator built for #40528. Each avatar shows a status dot and matching ring for online, away, busy, or offline, with a soft pulse on the online dot, using only CSS. Closes #40528.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
Avatars with status dots and rings for four presence states.

**How does a developer use it?**

```html
<span class="avatar is-online" title="Online">
  <span class="avatar-initials">JD</span>
  <span class="avatar-dot" aria-hidden="true"></span>
</span>
```

**Why does it fit EaseMotion CSS?**
It adds a status dot and ring and pulses the live one, using only CSS with initials avatars so it is self contained. The pulse is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: four avatars render, the online dot is green and has the pulse animation applied.
