### PR TITLE
feat: add animated bar chart

### DIFF
--- a/submissions/examples/bar-chart-as/README.md
+++ b/submissions/examples/bar-chart-as/README.md
@@ -1,0 +1,23 @@
+# Animated Bar Chart
+
+### What does this do?
+
+It shows a simple vertical bar chart where each column grows to its value on load with a staggered delay and reveals its value on hover.
+
+### How is it used?
+
+```html
+<div class="bar-chart">
+  <div class="bar" style="--h: 70%">
+    <span class="bar-val">70</span>
+    <span class="bar-fill"></span>
+    <span class="bar-label">Tue</span>
+  </div>
+</div>
+```
+
+Set `--h` on each `.bar` to its height percentage. The fill grows from zero with `scaleY`, and columns stagger their animation.
+
+### Why is it useful?
+
+Small bar charts summarise data on dashboards and reports. This grows columns from a custom property with a staggered scale animation, using only CSS with no JavaScript. The chart exposes an image role with a label, and under `prefers-reduced-motion: reduce` the bars show their height without animating.

--- a/submissions/examples/bar-chart-as/demo.html
+++ b/submissions/examples/bar-chart-as/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Bar Chart</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="bar-chart" role="img" aria-label="Weekly activity bar chart">
+    <div class="bar" style="--h: 45%"><span class="bar-val">45</span><span class="bar-fill"></span><span class="bar-label">Mon</span></div>
+    <div class="bar" style="--h: 70%"><span class="bar-val">70</span><span class="bar-fill"></span><span class="bar-label">Tue</span></div>
+    <div class="bar" style="--h: 55%"><span class="bar-val">55</span><span class="bar-fill"></span><span class="bar-label">Wed</span></div>
+    <div class="bar" style="--h: 90%"><span class="bar-val">90</span><span class="bar-fill"></span><span class="bar-label">Thu</span></div>
+    <div class="bar" style="--h: 65%"><span class="bar-val">65</span><span class="bar-fill"></span><span class="bar-label">Fri</span></div>
+    <div class="bar" style="--h: 80%"><span class="bar-val">80</span><span class="bar-fill"></span><span class="bar-label">Sat</span></div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/bar-chart-as/style.css
+++ b/submissions/examples/bar-chart-as/style.css
@@ -1,0 +1,92 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.bar-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 1rem;
+  height: 220px;
+  padding: 1.5rem;
+  box-sizing: border-box;
+  border-radius: 16px;
+  background: #111a2e;
+  border: 1px solid #1e293b;
+}
+
+.bar {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  width: 40px;
+  height: 100%;
+}
+
+.bar-fill {
+  display: block;
+  width: 100%;
+  height: 0;
+  border-radius: 8px 8px 4px 4px;
+  background: linear-gradient(180deg, #6c63ff, #4338ca);
+  animation: barGrow 0.8s ease forwards;
+  transition: filter 0.2s ease;
+}
+
+.bar:nth-child(2) .bar-fill { animation-delay: 0.08s; }
+.bar:nth-child(3) .bar-fill { animation-delay: 0.16s; }
+.bar:nth-child(4) .bar-fill { animation-delay: 0.24s; }
+.bar:nth-child(5) .bar-fill { animation-delay: 0.32s; }
+.bar:nth-child(6) .bar-fill { animation-delay: 0.4s; }
+
+.bar:hover .bar-fill {
+  filter: brightness(1.2);
+}
+
+.bar-val {
+  position: absolute;
+  top: -1.4rem;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #cbd5e1;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.bar:hover .bar-val {
+  opacity: 1;
+}
+
+.bar-label {
+  position: absolute;
+  bottom: -1.5rem;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+@keyframes barGrow {
+  to {
+    height: var(--h);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bar-fill {
+    animation: none;
+    height: var(--h);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an animated bar chart built for #40532. Columns grow to their value on load with a staggered delay and reveal their value on hover, driven by a custom property, using only CSS. Closes #40532.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A vertical bar chart whose columns grow to their heights on load.

**How does a developer use it?**

```html
<div class="bar" style="--h: 70%">
  <span class="bar-val">70</span>
  <span class="bar-fill"></span>
  <span class="bar-label">Tue</span>
</div>
```

**Why does it fit EaseMotion CSS?**
It grows columns from a custom property with a staggered animation, using only CSS. The chart exposes an image role with a label, and under `prefers-reduced-motion: reduce` the bars show their height without animating.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the six columns render at heights proportional to their values.
