### PR TITLE
feat: add css donut chart

### DIFF
--- a/submissions/examples/donut-chart-as/README.md
+++ b/submissions/examples/donut-chart-as/README.md
@@ -1,0 +1,25 @@
+# CSS Donut Chart
+
+### What does this do?
+
+It shows a donut chart drawn with a conic gradient, with a hollow center that displays a total and a legend beside it, scaling in on load.
+
+### How is it used?
+
+```html
+<div class="donut-card">
+  <div class="donut-wrap">
+    <div class="donut" role="img" aria-label="Traffic sources"></div>
+    <span class="donut-center">1,240</span>
+  </div>
+  <ul class="donut-legend">
+    <li><span class="dot" style="--c: #6c63ff"></span> Direct 45%</li>
+  </ul>
+</div>
+```
+
+The ring is a `conic-gradient` with segment stops, and a radial mask punches the hollow center. The total sits in an overlay so it is not affected by the mask.
+
+### Why is it useful?
+
+Donut charts show proportions on dashboards and reports. This builds a segmented ring from a `conic-gradient` with a masked center and reveals it with a scale, using only CSS with no images. The chart exposes an image role with a label, and the scale in is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/donut-chart-as/demo.html
+++ b/submissions/examples/donut-chart-as/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Donut Chart</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="donut-card">
+    <div class="donut-wrap">
+      <div class="donut" role="img" aria-label="Traffic sources donut chart"></div>
+      <span class="donut-center">1,240</span>
+    </div>
+    <ul class="donut-legend">
+      <li><span class="dot" style="--c: #6c63ff"></span> Direct 45%</li>
+      <li><span class="dot" style="--c: #0ea5e9"></span> Referral 25%</li>
+      <li><span class="dot" style="--c: #f59e0b"></span> Social 30%</li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/submissions/examples/donut-chart-as/style.css
+++ b/submissions/examples/donut-chart-as/style.css
@@ -1,0 +1,86 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.donut-card {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  padding: 2rem;
+  border-radius: 18px;
+  background: #111a2e;
+  border: 1px solid #1e293b;
+}
+
+.donut-wrap {
+  position: relative;
+  width: 170px;
+  height: 170px;
+}
+
+.donut {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: conic-gradient(#6c63ff 0 45%, #0ea5e9 45% 70%, #f59e0b 70% 100%);
+  -webkit-mask: radial-gradient(circle 46px at center, transparent 98%, #000);
+  mask: radial-gradient(circle 46px at center, transparent 98%, #000);
+  animation: donutIn 0.6s ease both;
+}
+
+.donut-center {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #f8fafc;
+}
+
+.donut-legend {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  font-size: 0.9rem;
+}
+
+.donut-legend li {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: #cbd5e1;
+}
+
+.dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  background: var(--c);
+}
+
+@keyframes donutIn {
+  from {
+    opacity: 0;
+    transform: scale(0.85);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .donut {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a CSS donut chart built for #40535. A conic gradient ring with a masked hollow center shows a total and a legend, scaling in on load, using only CSS. Closes #40535.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A segmented donut chart with a total in the center and a legend.

**How does a developer use it?**

```html
<div class="donut-wrap">
  <div class="donut" role="img" aria-label="Traffic sources"></div>
  <span class="donut-center">1,240</span>
</div>
```

**Why does it fit EaseMotion CSS?**
It builds a segmented ring from a `conic-gradient` with a masked center and reveals it with a scale, using only CSS with no images. The chart exposes an image role, and the scale in is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the donut renders the conic gradient segments with a hollow center showing the total, plus a three item legend.
