### PR TITLE
feat: add otp code input

### DIFF
--- a/submissions/examples/otp-input-as/README.md
+++ b/submissions/examples/otp-input-as/README.md
@@ -1,0 +1,20 @@
+# OTP Code Input
+
+### What does this do?
+
+It shows a one time passcode input made of separate single character boxes that highlight with an accent border and glow on focus.
+
+### How is it used?
+
+```html
+<div class="otp">
+  <input class="otp-box" inputmode="numeric" maxlength="1" aria-label="Digit 1" />
+  <input class="otp-box" inputmode="numeric" maxlength="1" aria-label="Digit 2" />
+</div>
+```
+
+Each box is a real input with `maxlength="1"` and `inputmode="numeric"` for a numeric keypad on mobile. The focus state gets an accent border and glow.
+
+### Why is it useful?
+
+Verification code inputs appear in sign in and two factor flows. This styles a row of single character boxes with clear focus states, using only CSS. Each box has an accessible label, and advancing between boxes as the user types can be added by the host app.

--- a/submissions/examples/otp-input-as/demo.html
+++ b/submissions/examples/otp-input-as/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>OTP Code Input</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="otp-card">
+    <h2 class="otp-title">Enter verification code</h2>
+    <p class="otp-sub">We sent a 6 digit code to your email.</p>
+    <div class="otp">
+      <input class="otp-box" inputmode="numeric" maxlength="1" value="4" aria-label="Digit 1" />
+      <input class="otp-box" inputmode="numeric" maxlength="1" value="2" aria-label="Digit 2" />
+      <input class="otp-box" inputmode="numeric" maxlength="1" value="8" aria-label="Digit 3" />
+      <input class="otp-box" inputmode="numeric" maxlength="1" aria-label="Digit 4" />
+      <input class="otp-box" inputmode="numeric" maxlength="1" aria-label="Digit 5" />
+      <input class="otp-box" inputmode="numeric" maxlength="1" aria-label="Digit 6" />
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/otp-input-as/style.css
+++ b/submissions/examples/otp-input-as/style.css
@@ -1,0 +1,62 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.otp-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 2rem;
+  border-radius: 18px;
+  background: #111a2e;
+  border: 1px solid #1e293b;
+}
+
+.otp-title {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.otp-sub {
+  margin: -0.75rem 0 0;
+  font-size: 0.85rem;
+  color: #94a3b8;
+}
+
+.otp {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.otp-box {
+  width: 48px;
+  height: 56px;
+  text-align: center;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #f8fafc;
+  background: #0e1626;
+  border: 2px solid #26324a;
+  border-radius: 10px;
+  outline: none;
+  caret-color: #6c63ff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.otp-box:hover {
+  border-color: #3a4a6b;
+}
+
+.otp-box:focus {
+  border-color: #6c63ff;
+  box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.2);
+}


### PR DESCRIPTION
## Pull Request Description

Adds an OTP code input built for #40539. Separate single character boxes highlight with an accent border and glow on focus, using real inputs and CSS. Closes #40539.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A row of single character code boxes with clear focus states.

**How does a developer use it?**

```html
<div class="otp">
  <input class="otp-box" inputmode="numeric" maxlength="1" aria-label="Digit 1" />
</div>
```

**Why does it fit EaseMotion CSS?**
It styles single character boxes with an accent focus state, using only CSS. Each box is a real input with an accessible label and a numeric input mode.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: six boxes render and the focused box shows the accent border.
