### PR TITLE
feat: add sidebar nav with sliding indicator

### DIFF
--- a/submissions/examples/sidebar-nav-as/README.md
+++ b/submissions/examples/sidebar-nav-as/README.md
@@ -1,0 +1,23 @@
+# Sidebar Nav With Sliding Indicator
+
+### What does this do?
+
+It shows a vertical sidebar navigation where selecting an item slides an accent bar to it and highlights it.
+
+### How is it used?
+
+```html
+<nav class="sidebar" aria-label="Main">
+  <input type="radio" name="nav" id="n1" class="nav-input" checked />
+  <label for="n1" class="nav-item">Dashboard</label>
+  <input type="radio" name="nav" id="n2" class="nav-input" />
+  <label for="n2" class="nav-item">Projects</label>
+  <span class="nav-indicator" aria-hidden="true"></span>
+</nav>
+```
+
+The radios share one `name`, and the checked one moves the `.nav-indicator` with a transform to the matching row.
+
+### Why is it useful?
+
+Sidebars are the main navigation in dashboards and admin panels. This moves an active indicator with a transform driven by radio inputs, so it needs no JavaScript. The items are keyboard reachable with a focus ring, and the indicator movement is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/sidebar-nav-as/demo.html
+++ b/submissions/examples/sidebar-nav-as/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sidebar Nav With Sliding Indicator</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <nav class="sidebar" aria-label="Main">
+    <input type="radio" name="nav" id="n1" class="nav-input" checked />
+    <label for="n1" class="nav-item">Dashboard</label>
+    <input type="radio" name="nav" id="n2" class="nav-input" />
+    <label for="n2" class="nav-item">Projects</label>
+    <input type="radio" name="nav" id="n3" class="nav-input" />
+    <label for="n3" class="nav-item">Members</label>
+    <input type="radio" name="nav" id="n4" class="nav-input" />
+    <label for="n4" class="nav-item">Reports</label>
+    <input type="radio" name="nav" id="n5" class="nav-input" />
+    <label for="n5" class="nav-item">Settings</label>
+    <span class="nav-indicator" aria-hidden="true"></span>
+  </nav>
+</body>
+</html>

--- a/submissions/examples/sidebar-nav-as/style.css
+++ b/submissions/examples/sidebar-nav-as/style.css
@@ -1,0 +1,88 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.sidebar {
+  position: relative;
+  width: 230px;
+  padding: 0.75rem;
+  border-radius: 16px;
+  background: #111a2e;
+  border: 1px solid #1e293b;
+}
+
+.nav-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.nav-item {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  height: 44px;
+  padding: 0 0.9rem;
+  border-radius: 10px;
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: #94a3b8;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.nav-item::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  background: currentColor;
+}
+
+.nav-item:hover {
+  color: #cbd5e1;
+}
+
+.nav-input:checked + .nav-item {
+  color: #fff;
+}
+
+.nav-input:focus-visible + .nav-item {
+  outline: 2px solid #fbbf24;
+  outline-offset: -2px;
+}
+
+.nav-indicator {
+  position: absolute;
+  left: 0.75rem;
+  right: 0.75rem;
+  top: 0.75rem;
+  height: 44px;
+  border-radius: 10px;
+  background: rgba(108, 99, 255, 0.18);
+  border-left: 3px solid #6c63ff;
+  transition: transform 0.3s cubic-bezier(0.34, 1.4, 0.64, 1);
+}
+
+#n1:checked ~ .nav-indicator { transform: translateY(0); }
+#n2:checked ~ .nav-indicator { transform: translateY(44px); }
+#n3:checked ~ .nav-indicator { transform: translateY(88px); }
+#n4:checked ~ .nav-indicator { transform: translateY(132px); }
+#n5:checked ~ .nav-indicator { transform: translateY(176px); }
+
+@media (prefers-reduced-motion: reduce) {
+  .nav-indicator {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a sidebar nav with a sliding indicator built for #40546. Selecting an item slides an accent bar to it and highlights it, using radio inputs and CSS with no JavaScript. Closes #40546.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A vertical sidebar nav with an active indicator that slides to the selected item.

**How does a developer use it?**

```html
<nav class="sidebar">
  <input type="radio" name="nav" id="n1" class="nav-input" checked />
  <label for="n1" class="nav-item">Dashboard</label>
  <span class="nav-indicator" aria-hidden="true"></span>
</nav>
```

**Why does it fit EaseMotion CSS?**
It moves an active indicator with a transform driven by radio inputs, so it needs no JavaScript. Items are keyboard reachable with a focus ring, and the movement is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: selecting the third item slides the indicator by two rows to align with it.
