### PR TITLE
feat: add ease-toast-notification component (#39915)

### DIFF
--- a/submissions/examples/ease-toast-notification/README.md
+++ b/submissions/examples/ease-toast-notification/README.md
@@ -1,0 +1,77 @@
+﻿# ease-toast-notification
+
+Stacked, positionable toast notifications with smooth entrance/exit
+animation, an optional auto-dismiss progress bar, and pause-on-hover.
+
+## Usage
+
+```html
+<div class="ease-toast-container" id="toastContainer" data-position="top-right"></div>
+```
+
+Positions available via `data-position`: `top-right`, `top-left`,
+`bottom-right`, `bottom-left`, `top-center`.
+
+```js
+function showToast(type, message, duration = 3500) {
+  const container = document.getElementById("toastContainer");
+
+  const toast = document.createElement("div");
+  toast.className = `ease-toast ease-toast--${type}`;
+  toast.innerHTML = `
+    <span class="ease-toast__message">${message}</span>
+    <button class="ease-toast__close" aria-label="Dismiss">&times;</button>
+    <span class="ease-toast__progress" style="animation-duration:${duration}ms;"></span>
+  `;
+
+  const dismiss = () => {
+    toast.classList.add("ease-toast--leaving");
+    toast.addEventListener("animationend", () => toast.remove(), { once: true });
+  };
+
+  toast.querySelector(".ease-toast__close").addEventListener("click", dismiss);
+  const timer = setTimeout(dismiss, duration);
+  toast.addEventListener("mouseenter", () => clearTimeout(timer));
+
+  container.appendChild(toast);
+}
+
+showToast("success", "Changes saved successfully.");
+```
+
+## Variants
+
+- `.ease-toast--success`
+- `.ease-toast--error`
+- `.ease-toast--warning`
+- `.ease-toast--info`
+
+Each sets a distinct accent color on the toast's left border.
+
+## How it works
+
+- **Entrance**: `ease-toast-in` keyframe slides the toast down and scales it
+  up with an elastic `cubic-bezier(0.34, 1.56, 0.64, 1)` easing.
+- **Exit**: adding `.ease-toast--leaving` triggers `ease-toast-out`, which
+  fades, slides, and collapses the toast's height/margin so siblings
+  smoothly reflow into the space, then the element is removed on
+  `animationend`.
+- **Stacking**: multiple toasts stack via the container's `flex` layout;
+  bottom-anchored positions use `flex-direction: column-reverse` so new
+  toasts push existing ones upward correctly.
+- **Auto-dismiss**: each toast schedules its own removal via
+  `setTimeout`, visualized by a shrinking `.ease-toast__progress` bar
+  (`animation-duration` matches the timeout). Hovering a toast clears its
+  timer so it won't disappear mid-read.
+
+## Files
+
+- `demo.html` - interactive demo with 4 toast type triggers
+- `style.css` - all styles and animation
+- `README.md` - this file
+
+## Accessibility
+
+Each toast includes a labeled close button (`aria-label="Dismiss"`). For
+production use, consider adding `role="status"` / `aria-live="polite"` on
+the container so screen readers announce new toasts.

--- a/submissions/examples/ease-toast-notification/demo.html
+++ b/submissions/examples/ease-toast-notification/demo.html
@@ -1,0 +1,75 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-toast-notification - EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body {
+    font-family: system-ui, sans-serif;
+    background: #f4f4f7;
+    min-height: 100vh;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    padding: 2rem;
+  }
+  button {
+    padding: 0.6rem 1rem;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    color: #fff;
+  }
+  .btn-success { background: #2ecc71; }
+  .btn-error   { background: #e74c3c; }
+  .btn-warning { background: #f1c40f; color: #1f2430; }
+  .btn-info    { background: #3498db; }
+</style>
+</head>
+<body>
+  <button class="btn-success" onclick="showToast('success', 'Changes saved successfully.')">Show Success</button>
+  <button class="btn-error" onclick="showToast('error', 'Something went wrong.')">Show Error</button>
+  <button class="btn-warning" onclick="showToast('warning', 'Your session is about to expire.')">Show Warning</button>
+  <button class="btn-info" onclick="showToast('info', 'New update is available.')">Show Info</button>
+
+  <div class="ease-toast-container" id="toastContainer" data-position="top-right"></div>
+
+  <script>
+    const ICONS = {
+      success: '\u2713',
+      error: '\u2715',
+      warning: '\u26A0',
+      info: '\u2139'
+    };
+
+    function showToast(type, message, duration = 3500) {
+      const container = document.getElementById('toastContainer');
+
+      const toast = document.createElement('div');
+      toast.className = `ease-toast ease-toast--${type}`;
+      toast.innerHTML = `
+        <span class="ease-toast__icon">${ICONS[type] || ''}</span>
+        <span class="ease-toast__message">${message}</span>
+        <button class="ease-toast__close" aria-label="Dismiss">&times;</button>
+        <span class="ease-toast__progress" style="animation-duration:${duration}ms;"></span>
+      `;
+
+      const dismiss = () => {
+        toast.classList.add('ease-toast--leaving');
+        toast.addEventListener('animationend', () => toast.remove(), { once: true });
+      };
+
+      toast.querySelector('.ease-toast__close').addEventListener('click', dismiss);
+      const timer = setTimeout(dismiss, duration);
+      toast.addEventListener('mouseenter', () => clearTimeout(timer));
+
+      container.appendChild(toast);
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-toast-notification/style.css
+++ b/submissions/examples/ease-toast-notification/style.css
@@ -1,0 +1,156 @@
+﻿/* ==========================================================================
+   EaseMotion CSS - ease-toast-notification
+   Stacked, positionable toast notifications with entrance/exit animation
+   and auto-dismiss. Pure CSS animation, minimal vanilla JS for lifecycle.
+   ========================================================================== */
+
+.ease-toast-container {
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  z-index: 9999;
+  pointer-events: none;
+  font-family: system-ui, sans-serif;
+}
+
+/* Position variants */
+.ease-toast-container[data-position="top-right"] {
+  top: 1.5rem;
+  right: 1.5rem;
+  align-items: flex-end;
+}
+
+.ease-toast-container[data-position="top-left"] {
+  top: 1.5rem;
+  left: 1.5rem;
+  align-items: flex-start;
+}
+
+.ease-toast-container[data-position="bottom-right"] {
+  bottom: 1.5rem;
+  right: 1.5rem;
+  align-items: flex-end;
+  flex-direction: column-reverse;
+}
+
+.ease-toast-container[data-position="bottom-left"] {
+  bottom: 1.5rem;
+  left: 1.5rem;
+  align-items: flex-start;
+  flex-direction: column-reverse;
+}
+
+.ease-toast-container[data-position="top-center"] {
+  top: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  align-items: center;
+}
+
+/* Individual toast */
+.ease-toast {
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  min-width: 260px;
+  max-width: 360px;
+  background: #1f2430;
+  color: #fff;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+  font-size: 0.9rem;
+  line-height: 1.4;
+  border-left: 4px solid #6c5ce7;
+
+  animation: ease-toast-in 0.35s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+/* Variant accent colors */
+.ease-toast--success { border-left-color: #2ecc71; }
+.ease-toast--error   { border-left-color: #e74c3c; }
+.ease-toast--warning { border-left-color: #f1c40f; }
+.ease-toast--info    { border-left-color: #3498db; }
+
+.ease-toast__icon {
+  flex-shrink: 0;
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.ease-toast__message {
+  flex: 1;
+}
+
+.ease-toast__close {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.6);
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0.15rem;
+  transition: color 0.2s ease;
+}
+
+.ease-toast__close:hover {
+  color: #fff;
+}
+
+/* Entrance animation - slides + fades in from the container's edge */
+@keyframes ease-toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(-12px) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* Exit animation - applied via class before removal */
+.ease-toast--leaving {
+  animation: ease-toast-out 0.3s cubic-bezier(0.4, 0, 1, 1) forwards;
+}
+
+@keyframes ease-toast-out {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    max-height: 100px;
+    margin-bottom: 0;
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-8px) scale(0.95);
+    max-height: 0;
+    margin-bottom: -0.6rem;
+  }
+}
+
+/* Auto-dismiss progress bar (optional visual) */
+.ease-toast__progress {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 3px;
+  background: rgba(255, 255, 255, 0.35);
+  border-radius: 0 0 0 10px;
+  animation-name: ease-toast-progress;
+  animation-timing-function: linear;
+  animation-fill-mode: forwards;
+}
+
+.ease-toast {
+  position: relative;
+  overflow: hidden;
+}
+
+@keyframes ease-toast-progress {
+  from { width: 100%; }
+  to { width: 0%; }
+}


### PR DESCRIPTION
Closes #39915

## What this adds
`ease-toast-notification` — stacked, positionable toast notifications with smooth entrance/exit animation, an auto-dismiss progress bar, and pause-on-hover.

## Behavior
- Entrance: elastic cubic-bezier slide + scale-in
- Exit: fade + collapse (height/margin) so remaining toasts reflow smoothly, then removed on animationend
- 5 position variants via data-position: top-right, top-left, bottom-right, bottom-left, top-center
- 4 type variants (success/error/warning/info) with distinct accent colors
- Auto-dismiss with a visual shrinking progress bar; hover pauses the timer

## Files added
`submissions/examples/ease-toast-notification/`
- demo.html — interactive demo with 4 trigger buttons
- style.css — all styles and animation
- README.md — usage and implementation notes

## How to test
1. Open demo.html in a browser
2. Click each button to trigger a toast type, confirm entrance animation and progress bar
3. Hover a toast to confirm the auto-dismiss timer pauses
4. Click the close (×) button to confirm exit animation plays before removal
5. Let one auto-expire to confirm the exit animation fires there too