### PR TITLE
feat: add profile card

### DIFF
--- a/submissions/examples/profile-card-as/README.md
+++ b/submissions/examples/profile-card-as/README.md
@@ -1,0 +1,23 @@
+# Profile Card
+
+### What does this do?
+
+It shows a profile card with a gradient cover, an avatar overlapping the cover, a name, a role, stats, and a follow button, with a hover lift.
+
+### How is it used?
+
+```html
+<div class="profile-card">
+  <div class="profile-cover" aria-hidden="true"></div>
+  <div class="profile-avatar" aria-hidden="true">JD</div>
+  <h3>Jane Doe</h3>
+  <span class="profile-role">Product Designer</span>
+  <a href="#" class="profile-btn">Follow</a>
+</div>
+```
+
+A negative top margin pulls the avatar up so it overlaps the cover, and a border matching the card color separates it cleanly.
+
+### Why is it useful?
+
+Profile cards appear in social apps, team pages, and directories. This layers an overlapping avatar over a cover and adds a hover lift, using only CSS and an initials avatar so it is self contained. The hover lift is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/profile-card-as/demo.html
+++ b/submissions/examples/profile-card-as/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Profile Card</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="profile-card">
+    <div class="profile-cover" aria-hidden="true"></div>
+    <div class="profile-avatar" aria-hidden="true">JD</div>
+    <h3>Jane Doe</h3>
+    <span class="profile-role">Product Designer</span>
+    <div class="profile-stats">
+      <div><strong>128</strong><span>Posts</span></div>
+      <div><strong>4.8k</strong><span>Followers</span></div>
+      <div><strong>312</strong><span>Following</span></div>
+    </div>
+    <a href="#" class="profile-btn">Follow</a>
+  </div>
+</body>
+</html>

--- a/submissions/examples/profile-card-as/style.css
+++ b/submissions/examples/profile-card-as/style.css
@@ -1,0 +1,110 @@
+:root {
+  --card: #111a2e;
+  --accent: #6c63ff;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.profile-card {
+  width: 260px;
+  border-radius: 18px;
+  overflow: hidden;
+  background: var(--card);
+  border: 1px solid #1e293b;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.3);
+  text-align: center;
+  padding-bottom: 1.5rem;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.profile-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 20px 44px rgba(0, 0, 0, 0.45);
+}
+
+.profile-cover {
+  height: 90px;
+  background: linear-gradient(120deg, #6c63ff, #0ea5e9);
+}
+
+.profile-avatar {
+  width: 80px;
+  height: 80px;
+  margin: -40px auto 0;
+  display: grid;
+  place-items: center;
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: #fff;
+  background: linear-gradient(135deg, #ec4899, #be185d);
+  border-radius: 50%;
+  border: 4px solid var(--card);
+}
+
+.profile-card h3 {
+  margin: 0.75rem 0 0.15rem;
+  font-size: 1.2rem;
+}
+
+.profile-role {
+  font-size: 0.85rem;
+  color: #94a3b8;
+}
+
+.profile-stats {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  margin: 1.1rem 0;
+}
+
+.profile-stats div {
+  display: flex;
+  flex-direction: column;
+}
+
+.profile-stats strong {
+  font-size: 1.05rem;
+}
+
+.profile-stats span {
+  font-size: 0.72rem;
+  color: #94a3b8;
+}
+
+.profile-btn {
+  display: inline-block;
+  padding: 0.55rem 1.6rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #fff;
+  text-decoration: none;
+  background: var(--accent);
+  border-radius: 999px;
+  transition: background 0.2s ease;
+}
+
+.profile-btn:hover {
+  background: #574fe0;
+}
+
+.profile-btn:focus-visible {
+  outline: 2px solid #fbbf24;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .profile-card {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a profile card built for #40549. A gradient cover, an overlapping avatar, name, role, stats, and a follow button, with a hover lift, using only CSS. Closes #40549.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A social style profile card with an overlapping avatar and stats.

**How does a developer use it?**

```html
<div class="profile-card">
  <div class="profile-cover" aria-hidden="true"></div>
  <div class="profile-avatar" aria-hidden="true">JD</div>
  <h3>Jane Doe</h3>
  <a href="#" class="profile-btn">Follow</a>
</div>
```

**Why does it fit EaseMotion CSS?**
It layers an overlapping avatar over a cover and adds a hover lift, using only CSS and an initials avatar so it is self contained. The hover lift is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the avatar overlaps the cover and the three stat blocks render.
