### PR TITLE
feat: add ease-temperature-converter component (#39898)

### DIFF
--- a/submissions/examples/ease-temperature-converter/README.md
+++ b/submissions/examples/ease-temperature-converter/README.md
@@ -1,0 +1,53 @@
+﻿# ease-temperature-converter
+
+An interactive Celsius / Fahrenheit / Kelvin converter with a live-updating
+animated gauge that fills and shifts color (blue -> yellow -> red) based on
+the current temperature.
+
+## Usage
+
+Copy `style.css` and the markup/script from `demo.html` into your project.
+Editing any one field live-updates the other two and the gauge.
+
+```html
+<div class="ease-temp">
+  <div class="ease-temp__gauge">
+    <div class="ease-temp__gauge-fill" id="gaugeFill"></div>
+  </div>
+
+  <div class="ease-temp__fields">
+    <div class="ease-temp__field" data-unit="celsius">
+      <label for="celsius">Celsius</label>
+      <input type="number" id="celsius" value="25" step="0.1">
+    </div>
+    <!-- fahrenheit, kelvin fields follow the same pattern -->
+  </div>
+</div>
+```
+
+## How it works
+
+- **Conversion formulas**:
+  - `F = C * 9/5 + 32`
+  - `K = C + 273.15`
+- **Gauge**: maps a Celsius range of -30C to 60C onto a 0-100% fill width
+  via the `--temp-fill` CSS custom property, animated with a
+  `cubic-bezier(0.4, 0, 0.2, 1)` transition on `width`.
+- **Color shift**: the gauge's `--temp-color` custom property switches
+  between blue (cold, <=15C), yellow (warm, 15-30C), and red (hot, >30C),
+  transitioning smoothly via `background-color` transition.
+- **Update pulse**: whenever a field is recalculated from another field's
+  input, a brief `scale()` keyframe pulse (`ease-temp-pulse`) plays on that
+  field's input to give clear visual feedback of the update.
+
+## Files
+
+- `demo.html` - interactive demo with live two-way conversion
+- `style.css` - all styles and animation
+- `README.md` - this file
+
+## Accessibility
+
+Each input has an associated `<label>` via `for`/`id`. Inputs are native
+`<input type="number">` elements, so they're keyboard operable and work with
+screen readers and OS-level numeric input controls out of the box.

--- a/submissions/examples/ease-temperature-converter/demo.html
+++ b/submissions/examples/ease-temperature-converter/demo.html
@@ -1,0 +1,116 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-temperature-converter - EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body {
+    font-family: system-ui, sans-serif;
+    background: #f4f4f7;
+    min-height: 100vh;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+  }
+</style>
+</head>
+<body>
+  <div class="ease-temp" id="tempConverter">
+    <h3 class="ease-temp__title">Temperature Converter</h3>
+
+    <div class="ease-temp__gauge">
+      <div class="ease-temp__gauge-fill" id="gaugeFill"></div>
+    </div>
+
+    <div class="ease-temp__fields">
+      <div class="ease-temp__field" data-unit="celsius">
+        <label for="celsius">Celsius</label>
+        <input type="number" id="celsius" value="25" step="0.1">
+      </div>
+      <div class="ease-temp__field" data-unit="fahrenheit">
+        <label for="fahrenheit">Fahrenheit</label>
+        <input type="number" id="fahrenheit" value="77" step="0.1">
+      </div>
+      <div class="ease-temp__field" data-unit="kelvin">
+        <label for="kelvin">Kelvin</label>
+        <input type="number" id="kelvin" value="298.15" step="0.1">
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const celsiusInput = document.getElementById('celsius');
+    const fahrenheitInput = document.getElementById('fahrenheit');
+    const kelvinInput = document.getElementById('kelvin');
+    const gaugeFill = document.getElementById('gaugeFill');
+
+    // Gauge range: -30C to 60C mapped to 0% - 100%
+    const GAUGE_MIN_C = -30;
+    const GAUGE_MAX_C = 60;
+
+    function pulse(fieldEl) {
+      fieldEl.classList.remove('ease-temp__field--updated');
+      // force reflow so the animation can retrigger
+      void fieldEl.offsetWidth;
+      fieldEl.classList.add('ease-temp__field--updated');
+    }
+
+    function updateGauge(celsius) {
+      const clamped = Math.min(Math.max(celsius, GAUGE_MIN_C), GAUGE_MAX_C);
+      const percent = ((clamped - GAUGE_MIN_C) / (GAUGE_MAX_C - GAUGE_MIN_C)) * 100;
+      gaugeFill.parentElement.parentElement.style.setProperty('--temp-fill', percent + '%');
+
+      let color = '#3498db'; // cold - blue
+      if (celsius > 15 && celsius <= 30) color = '#f1c40f'; // warm - yellow
+      if (celsius > 30) color = '#e74c3c'; // hot - red
+      gaugeFill.parentElement.parentElement.style.setProperty('--temp-color', color);
+    }
+
+    function fromCelsius(celsius) {
+      celsiusInput.value = round(celsius);
+      fahrenheitInput.value = round(celsius * 9 / 5 + 32);
+      kelvinInput.value = round(celsius + 273.15);
+      updateGauge(celsius);
+    }
+
+    function round(n) {
+      return Math.round(n * 100) / 100;
+    }
+
+    celsiusInput.addEventListener('input', () => {
+      const c = parseFloat(celsiusInput.value) || 0;
+      fahrenheitInput.value = round(c * 9 / 5 + 32);
+      kelvinInput.value = round(c + 273.15);
+      updateGauge(c);
+      pulse(fahrenheitInput.closest('.ease-temp__field'));
+      pulse(kelvinInput.closest('.ease-temp__field'));
+    });
+
+    fahrenheitInput.addEventListener('input', () => {
+      const f = parseFloat(fahrenheitInput.value) || 0;
+      const c = (f - 32) * 5 / 9;
+      celsiusInput.value = round(c);
+      kelvinInput.value = round(c + 273.15);
+      updateGauge(c);
+      pulse(celsiusInput.closest('.ease-temp__field'));
+      pulse(kelvinInput.closest('.ease-temp__field'));
+    });
+
+    kelvinInput.addEventListener('input', () => {
+      const k = parseFloat(kelvinInput.value) || 0;
+      const c = k - 273.15;
+      celsiusInput.value = round(c);
+      fahrenheitInput.value = round(c * 9 / 5 + 32);
+      updateGauge(c);
+      pulse(celsiusInput.closest('.ease-temp__field'));
+      pulse(fahrenheitInput.closest('.ease-temp__field'));
+    });
+
+    // Initialize gauge on load
+    updateGauge(parseFloat(celsiusInput.value));
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-temperature-converter/style.css
+++ b/submissions/examples/ease-temperature-converter/style.css
@@ -1,0 +1,99 @@
+﻿/* ==========================================================================
+   EaseMotion CSS - ease-temperature-converter
+   Interactive Celsius / Fahrenheit / Kelvin converter with an animated
+   temperature gauge that fills and shifts color based on value.
+   ========================================================================== */
+
+.ease-temp {
+  --temp-fill: 50%;
+  --temp-color: #3498db;
+
+  font-family: system-ui, sans-serif;
+  max-width: 360px;
+  margin: 0 auto;
+  background: #fff;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.1);
+}
+
+.ease-temp__title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #333;
+  margin: 0 0 1rem;
+}
+
+/* Gauge */
+.ease-temp__gauge {
+  position: relative;
+  height: 18px;
+  border-radius: 9px;
+  background: #eef0f4;
+  overflow: hidden;
+  margin-bottom: 1.25rem;
+}
+
+.ease-temp__gauge-fill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: var(--temp-fill);
+  background: var(--temp-color);
+  border-radius: 9px;
+  transition: width 0.4s cubic-bezier(0.4, 0, 0.2, 1),
+    background-color 0.4s ease;
+}
+
+/* Input fields */
+.ease-temp__fields {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.ease-temp__field {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border: 1px solid #e2e4ea;
+  border-radius: 10px;
+  padding: 0.6rem 0.85rem;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.ease-temp__field:focus-within {
+  border-color: var(--temp-color);
+  box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.15);
+}
+
+.ease-temp__field label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #888;
+  min-width: 74px;
+}
+
+.ease-temp__field input {
+  flex: 1;
+  border: none;
+  outline: none;
+  font-size: 1.05rem;
+  text-align: right;
+  color: #222;
+  background: transparent;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Value pulse when updated */
+@keyframes ease-temp-pulse {
+  0% { transform: scale(1); }
+  40% { transform: scale(1.04); }
+  100% { transform: scale(1); }
+}
+
+.ease-temp__field--updated input {
+  animation: ease-temp-pulse 0.3s ease;
+}


### PR DESCRIPTION
Closes #39898

## What this adds
`ease-temperature-converter` — an interactive Celsius/Fahrenheit/Kelvin converter with a live-updating animated gauge that fills and shifts color (blue -> yellow -> red) based on temperature.

## Behavior
- Editing any one of the three fields recalculates the other two instantly
- Gauge fill (-30C to 60C range) animates via CSS custom properties with a cubic-bezier transition
- Gauge color transitions blue (cold) -> yellow (warm) -> red (hot)
- A brief scale "pulse" animation plays on fields that were just recalculated, for clear visual feedback

## Files added
`submissions/examples/ease-temperature-converter/`
- demo.html — interactive live demo
- style.css — all styles and animation
- README.md — usage, formulas, and implementation notes

## How to test
1. Open demo.html in a browser
2. Type into the Celsius field, confirm Fahrenheit/Kelvin update and pulse
3. Repeat starting from Fahrenheit and Kelvin fields
4. Watch the gauge fill/color shift as you cross 15C and 30C thresholds