### PR TITLE
feat: add cookie consent bar

### DIFF
--- a/submissions/examples/cookie-consent-as/README.md
+++ b/submissions/examples/cookie-consent-as/README.md
@@ -1,0 +1,24 @@
+# Cookie Consent Bar
+
+### What does this do?
+
+It shows a cookie consent bar fixed to the bottom with a message and accept and decline buttons, that slides away when either is chosen.
+
+### How is it used?
+
+```html
+<input type="checkbox" id="cookie" class="cookie-dismiss" />
+<div class="cookie-bar" role="dialog" aria-label="Cookie consent">
+  <p>We use cookies to improve your experience.</p>
+  <div class="cookie-actions">
+    <label for="cookie" class="cookie-btn is-ghost">Decline</label>
+    <label for="cookie" class="cookie-btn">Accept</label>
+  </div>
+</div>
+```
+
+Both buttons are labels for the same checkbox, so either one dismisses the bar. The host app can read the result and store the preference.
+
+### Why is it useful?
+
+Consent bars are required on many sites. This slides the banner out on an action driven by the `:checked` state, so the visual dismissal needs no JavaScript. The bar uses a `dialog` role, and the slide is softened under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/cookie-consent-as/demo.html
+++ b/submissions/examples/cookie-consent-as/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cookie Consent Bar</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <p class="page-note">Scroll or interact with the page. The cookie consent bar sits at the bottom until you accept or decline.</p>
+
+  <input type="checkbox" id="cookie" class="cookie-dismiss" aria-hidden="true" />
+  <div class="cookie-bar" role="dialog" aria-label="Cookie consent">
+    <p>We use cookies to improve your experience and analyze traffic. You can accept or decline.</p>
+    <div class="cookie-actions">
+      <label for="cookie" class="cookie-btn is-ghost">Decline</label>
+      <label for="cookie" class="cookie-btn">Accept</label>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/cookie-consent-as/style.css
+++ b/submissions/examples/cookie-consent-as/style.css
@@ -1,0 +1,85 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 70%);
+}
+
+.page-note {
+  padding: 3rem 2rem;
+  color: #94a3b8;
+  max-width: 40ch;
+}
+
+.cookie-dismiss {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.cookie-bar {
+  position: fixed;
+  left: 50%;
+  bottom: 1.25rem;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  width: min(560px, calc(100vw - 2.5rem));
+  padding: 1rem 1.25rem;
+  border-radius: 14px;
+  background: #111a2e;
+  border: 1px solid #26324a;
+  box-shadow: 0 16px 40px rgba(2, 6, 23, 0.55);
+  transition: transform 0.4s ease, opacity 0.4s ease;
+}
+
+.cookie-bar p {
+  flex: 1;
+  min-width: 220px;
+  margin: 0;
+  font-size: 0.88rem;
+  line-height: 1.5;
+  color: #cbd5e1;
+}
+
+.cookie-actions {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.cookie-btn {
+  padding: 0.5rem 1.1rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #fff;
+  background: #6c63ff;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.cookie-btn.is-ghost {
+  color: #cbd5e1;
+  background: transparent;
+  border: 1px solid #334155;
+}
+
+.cookie-btn:hover {
+  filter: brightness(1.1);
+}
+
+.cookie-dismiss:checked + .cookie-bar {
+  transform: translate(-50%, 150%);
+  opacity: 0;
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cookie-bar {
+    transition: opacity 0.3s ease;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a cookie consent bar built for #40552. A fixed bottom bar with a message and accept and decline buttons slides away when either is chosen, using a checkbox and CSS. Closes #40552.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A dismissible cookie consent bar with accept and decline actions.

**How does a developer use it?**

```html
<input type="checkbox" id="cookie" class="cookie-dismiss" />
<div class="cookie-bar" role="dialog" aria-label="Cookie consent">
  <p>We use cookies to improve your experience.</p>
  <div class="cookie-actions">
    <label for="cookie" class="cookie-btn is-ghost">Decline</label>
    <label for="cookie" class="cookie-btn">Accept</label>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It slides the banner out on an action driven by the `:checked` state, so the visual dismissal needs no JavaScript. The bar uses a `dialog` role, and the slide is softened under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: choosing accept slides the bar out and takes its opacity to 0.
