### PR TITLE
feat: add toggle button group

### DIFF
--- a/submissions/examples/toggle-button-group-as/README.md
+++ b/submissions/examples/toggle-button-group-as/README.md
@@ -1,0 +1,20 @@
+# Toggle Button Group
+
+### What does this do?
+
+It shows a connected group of toggle buttons, like a text formatting toolbar, where each button can be turned on independently with an accent active state.
+
+### How is it used?
+
+```html
+<div class="btn-group" role="group" aria-label="Text formatting">
+  <label class="tbtn"><input type="checkbox" class="tbtn-input" checked aria-label="Bold" /><span class="i-bold">B</span></label>
+  <label class="tbtn"><input type="checkbox" class="tbtn-input" aria-label="Italic" /><span class="i-italic">I</span></label>
+</div>
+```
+
+Each button is a `label` with a checkbox and a face. Because they are checkboxes, several can be active at once, and shared borders join them into one group.
+
+### Why is it useful?
+
+Toggle button groups are used for toolbars, view options, and formatting controls. This styles a connected group with per button active states from the `:checked` state, using only CSS. Buttons carry accessible labels and a focus ring, and the group uses a `group` role.

--- a/submissions/examples/toggle-button-group-as/demo.html
+++ b/submissions/examples/toggle-button-group-as/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Toggle Button Group</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="btn-group" role="group" aria-label="Text formatting">
+    <label class="tbtn"><input type="checkbox" class="tbtn-input" checked aria-label="Bold" /><span class="i-bold">B</span></label>
+    <label class="tbtn"><input type="checkbox" class="tbtn-input" aria-label="Italic" /><span class="i-italic">I</span></label>
+    <label class="tbtn"><input type="checkbox" class="tbtn-input" checked aria-label="Underline" /><span class="i-underline">U</span></label>
+    <label class="tbtn"><input type="checkbox" class="tbtn-input" aria-label="Strikethrough" /><span class="i-strike">S</span></label>
+  </div>
+</body>
+</html>

--- a/submissions/examples/toggle-button-group-as/style.css
+++ b/submissions/examples/toggle-button-group-as/style.css
@@ -1,0 +1,65 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.btn-group {
+  display: inline-flex;
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid #26324a;
+}
+
+.tbtn {
+  cursor: pointer;
+}
+
+.tbtn + .tbtn span {
+  border-left: 1px solid #26324a;
+}
+
+.tbtn-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.tbtn span {
+  display: grid;
+  place-items: center;
+  width: 46px;
+  height: 44px;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #94a3b8;
+  background: #111a2e;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.tbtn:hover span {
+  color: #e2e8f0;
+  background: #1a2338;
+}
+
+.tbtn-input:checked + span {
+  color: #fff;
+  background: #6c63ff;
+}
+
+.tbtn-input:focus-visible + span {
+  outline: 2px solid #fbbf24;
+  outline-offset: -2px;
+}
+
+.tbtn span.i-bold { font-weight: 800; }
+.tbtn span.i-italic { font-style: italic; font-family: Georgia, serif; }
+.tbtn span.i-underline { text-decoration: underline; }
+.tbtn span.i-strike { text-decoration: line-through; }


### PR DESCRIPTION
## Pull Request Description

Adds a toggle button group built for #40556. A connected toolbar of toggle buttons where each can be turned on independently with an accent active state, using checkboxes and CSS. Closes #40556.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A connected toggle button group, like a formatting toolbar.

**How does a developer use it?**

```html
<div class="btn-group" role="group" aria-label="Text formatting">
  <label class="tbtn"><input type="checkbox" class="tbtn-input" checked aria-label="Bold" /><span class="i-bold">B</span></label>
</div>
```

**Why does it fit EaseMotion CSS?**
It styles a connected group with per button active states from the `:checked` state, using only CSS. Buttons carry accessible labels and a focus ring, and the group uses a `group` role.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: two buttons are active and render with the accent background, confirming independent multi toggle.
