### PR TITLE
feat: add empty state card

### DIFF
--- a/submissions/examples/empty-state-as/README.md
+++ b/submissions/examples/empty-state-as/README.md
@@ -1,0 +1,22 @@
+# Empty State Card
+
+### What does this do?
+
+It shows an empty state panel with a CSS drawn illustration that gently floats, a heading, a description, and a call to action, for when a list or search has no results.
+
+### How is it used?
+
+```html
+<div class="empty">
+  <div class="empty-art" aria-hidden="true"><!-- inline svg --></div>
+  <h3>No results found</h3>
+  <p>Try adjusting your filters or search terms.</p>
+  <a href="#" class="empty-btn">Clear filters</a>
+</div>
+```
+
+The illustration is an inline SVG so there are no images to load, and it floats with a small looping transform.
+
+### Why is it useful?
+
+Empty states guide users when there is nothing to show, in inboxes, searches, and dashboards. This adds a soft floating illustration and a clear message and action, using only CSS. The illustration is hidden from assistive tech, the action shows a focus ring, and the float is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/empty-state-as/demo.html
+++ b/submissions/examples/empty-state-as/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Empty State Card</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="empty">
+    <div class="empty-art" aria-hidden="true">
+      <svg viewBox="0 0 64 64" width="72" height="72" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M8 26h12l4 8h16l4-8h12" />
+        <path d="M12 26 18 12h28l6 14v22a4 4 0 0 1-4 4H16a4 4 0 0 1-4-4z" />
+      </svg>
+    </div>
+    <h3>No results found</h3>
+    <p>Try adjusting your filters or search terms to find what you are looking for.</p>
+    <a href="#" class="empty-btn">Clear filters</a>
+  </div>
+</body>
+</html>

--- a/submissions/examples/empty-state-as/style.css
+++ b/submissions/examples/empty-state-as/style.css
@@ -1,0 +1,75 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.5rem;
+  width: min(340px, 92vw);
+  padding: 2.5rem 2rem;
+  border-radius: 18px;
+  background: #111a2e;
+  border: 1px solid #1e293b;
+}
+
+.empty-art {
+  color: #6c63ff;
+  margin-bottom: 0.75rem;
+  animation: float 3s ease-in-out infinite;
+}
+
+.empty h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.empty p {
+  margin: 0 0 1.25rem;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: #94a3b8;
+}
+
+.empty-btn {
+  display: inline-block;
+  padding: 0.6rem 1.4rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #fff;
+  text-decoration: none;
+  background: #6c63ff;
+  border-radius: 10px;
+  transition: background 0.2s ease;
+}
+
+.empty-btn:hover {
+  background: #574fe0;
+}
+
+.empty-btn:focus-visible {
+  outline: 2px solid #fbbf24;
+  outline-offset: 2px;
+}
+
+@keyframes float {
+  50% {
+    transform: translateY(-8px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .empty-art {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an empty state card built for #40558. A floating inline SVG illustration with a heading, description, and call to action for when there are no results, using only CSS. Closes #40558.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
An empty state panel with a floating illustration, message, and action.

**How does a developer use it?**

```html
<div class="empty">
  <div class="empty-art" aria-hidden="true"><!-- inline svg --></div>
  <h3>No results found</h3>
  <p>Try adjusting your filters.</p>
  <a href="#" class="empty-btn">Clear filters</a>
</div>
```

**Why does it fit EaseMotion CSS?**
It adds a soft floating illustration and a clear message and action, using only CSS. The illustration is inline SVG hidden from assistive tech, and the float is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the inline SVG illustration renders with the float animation applied.
