### PR TITLE
feat: add testimonial quote card

### DIFF
--- a/submissions/examples/quote-card-as/README.md
+++ b/submissions/examples/quote-card-as/README.md
@@ -1,0 +1,23 @@
+# Testimonial Quote Card
+
+### What does this do?
+
+It shows a single large testimonial card with a decorative quote mark, a quote, and the author with an initials avatar, that fades and rises in on load.
+
+### How is it used?
+
+```html
+<figure class="quote-card">
+  <blockquote>EaseMotion made our animations effortless.</blockquote>
+  <figcaption>
+    <span class="quote-avatar" aria-hidden="true">JD</span>
+    <span class="quote-author"><strong>Jane Doe</strong><span>CTO, TechCorp</span></span>
+  </figcaption>
+</figure>
+```
+
+It uses semantic `figure`, `blockquote`, and `figcaption` elements, with the large quote mark drawn as a pseudo element.
+
+### Why is it useful?
+
+A featured quote adds social proof to landing and about pages. This presents the quote with a decorative mark and a gentle entrance, using only CSS and an initials avatar so it is self contained. The entrance is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/quote-card-as/demo.html
+++ b/submissions/examples/quote-card-as/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Testimonial Quote Card</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <figure class="quote-card">
+    <blockquote>EaseMotion made our animations effortless and consistent across the whole product, and the team shipped a polished UI in days.</blockquote>
+    <figcaption>
+      <span class="quote-avatar" aria-hidden="true">JD</span>
+      <span class="quote-author">
+        <strong>Jane Doe</strong>
+        <span>CTO, TechCorp</span>
+      </span>
+    </figcaption>
+  </figure>
+</body>
+</html>

--- a/submissions/examples/quote-card-as/style.css
+++ b/submissions/examples/quote-card-as/style.css
@@ -1,0 +1,89 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.quote-card {
+  position: relative;
+  width: min(480px, 92vw);
+  margin: 0;
+  padding: 2.5rem 2.25rem 2rem;
+  border-radius: 20px;
+  background: #111a2e;
+  border: 1px solid #1e293b;
+  box-shadow: 0 14px 34px rgba(0, 0, 0, 0.35);
+  animation: quoteIn 0.6s ease both;
+}
+
+.quote-card blockquote {
+  position: relative;
+  margin: 0 0 1.75rem;
+  padding-top: 1.5rem;
+  font-size: 1.15rem;
+  line-height: 1.6;
+  color: #e2e8f0;
+}
+
+.quote-card blockquote::before {
+  content: "\201C";
+  position: absolute;
+  top: -1.4rem;
+  left: -0.4rem;
+  font-family: Georgia, serif;
+  font-size: 4.5rem;
+  line-height: 1;
+  color: #6c63ff;
+  opacity: 0.5;
+}
+
+.quote-card figcaption {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.quote-avatar {
+  width: 48px;
+  height: 48px;
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  color: #fff;
+  background: linear-gradient(135deg, #6c63ff, #0ea5e9);
+  border-radius: 50%;
+}
+
+.quote-author {
+  display: flex;
+  flex-direction: column;
+}
+
+.quote-author strong {
+  font-size: 0.95rem;
+}
+
+.quote-author span {
+  font-size: 0.82rem;
+  color: #94a3b8;
+}
+
+@keyframes quoteIn {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .quote-card {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a testimonial quote card built for #40561. A single large quote with a decorative mark and the author, that fades and rises in on load, using semantic elements and CSS. Closes #40561.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A featured testimonial quote card with a decorative mark and author.

**How does a developer use it?**

```html
<figure class="quote-card">
  <blockquote>EaseMotion made our animations effortless.</blockquote>
  <figcaption>
    <span class="quote-avatar" aria-hidden="true">JD</span>
    <span class="quote-author"><strong>Jane Doe</strong><span>CTO, TechCorp</span></span>
  </figcaption>
</figure>
```

**Why does it fit EaseMotion CSS?**
It uses semantic `figure`, `blockquote`, and `figcaption`, adds a decorative quote mark and a gentle entrance, all in CSS with an initials avatar so it is self contained. The entrance is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the card settles to full opacity and the decorative quote mark renders.
