### PR TITLE
feat: add animated hero section

### DIFF
--- a/submissions/examples/hero-section-as/README.md
+++ b/submissions/examples/hero-section-as/README.md
@@ -1,0 +1,25 @@
+# Animated Hero Section
+
+### What does this do?
+
+It shows a landing hero with a soft glow background, an eyebrow tag, a large heading, a subheading, and two call to action buttons, where the elements fade and rise in with a staggered delay.
+
+### How is it used?
+
+```html
+<section class="hero">
+  <span class="hero-eyebrow">New in v1.2</span>
+  <h1 class="hero-title">Build interfaces that move</h1>
+  <p class="hero-sub">A human readable, animation first CSS framework.</p>
+  <div class="hero-actions">
+    <a href="#" class="hero-btn">Get started</a>
+    <a href="#" class="hero-btn is-ghost">View docs</a>
+  </div>
+</section>
+```
+
+The direct children of `.hero` animate in with increasing delays, and blurred pseudo elements provide the background glow.
+
+### Why is it useful?
+
+The hero is the first thing visitors see on a landing page. This reveals it with a staggered entrance and a soft background glow, using only CSS with no images. The buttons show a focus ring, and the entrance is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/hero-section-as/demo.html
+++ b/submissions/examples/hero-section-as/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Hero Section</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <section class="hero">
+    <span class="hero-eyebrow">New in v1.2</span>
+    <h1 class="hero-title">Build interfaces that move</h1>
+    <p class="hero-sub">A human readable, animation first CSS framework with a zero config motion engine. No build step required.</p>
+    <div class="hero-actions">
+      <a href="#" class="hero-btn">Get started</a>
+      <a href="#" class="hero-btn is-ghost">View docs</a>
+    </div>
+  </section>
+</body>
+</html>

--- a/submissions/examples/hero-section-as/style.css
+++ b/submissions/examples/hero-section-as/style.css
@@ -1,0 +1,121 @@
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+  background: #0b1121;
+}
+
+.hero {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.1rem;
+  padding: 3rem 1.5rem;
+  box-sizing: border-box;
+  text-align: center;
+  overflow: hidden;
+}
+
+.hero::before,
+.hero::after {
+  content: "";
+  position: absolute;
+  width: 380px;
+  height: 380px;
+  border-radius: 50%;
+  filter: blur(90px);
+  opacity: 0.5;
+  z-index: 0;
+}
+
+.hero::before { top: -6%; left: 8%; background: #6c63ff; }
+.hero::after { bottom: -8%; right: 6%; background: #0ea5e9; }
+
+.hero > * {
+  position: relative;
+  z-index: 1;
+  opacity: 0;
+  transform: translateY(18px);
+  animation: heroIn 0.6s ease forwards;
+}
+
+.hero-eyebrow {
+  padding: 0.3rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #c7d2fe;
+  background: rgba(108, 99, 255, 0.16);
+  border: 1px solid rgba(108, 99, 255, 0.35);
+}
+
+.hero-title {
+  margin: 0;
+  max-width: 16ch;
+  font-size: clamp(2.4rem, 7vw, 3.8rem);
+  line-height: 1.1;
+  font-weight: 800;
+  animation-delay: 0.1s;
+}
+
+.hero-sub {
+  margin: 0;
+  max-width: 44ch;
+  font-size: 1.05rem;
+  color: #94a3b8;
+  animation-delay: 0.2s;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  justify-content: center;
+  margin-top: 0.75rem;
+  animation-delay: 0.3s;
+}
+
+.hero-btn {
+  padding: 0.8rem 1.7rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #fff;
+  text-decoration: none;
+  background: #6c63ff;
+  border-radius: 12px;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.hero-btn:hover {
+  transform: translateY(-2px);
+  background: #574fe0;
+}
+
+.hero-btn.is-ghost {
+  color: #e2e8f0;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid #334155;
+}
+
+.hero-btn:focus-visible {
+  outline: 2px solid #fbbf24;
+  outline-offset: 3px;
+}
+
+@keyframes heroIn {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero > * {
+    opacity: 1;
+    transform: none;
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an animated hero section built for #40564. A landing hero with a glow background, eyebrow tag, large heading, subheading, and two call to action buttons that fade and rise in with a staggered delay, using only CSS. Closes #40564.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A landing hero with a staggered entrance and a soft glow background.

**How does a developer use it?**

```html
<section class="hero">
  <span class="hero-eyebrow">New in v1.2</span>
  <h1 class="hero-title">Build interfaces that move</h1>
  <p class="hero-sub">A human readable, animation first CSS framework.</p>
  <div class="hero-actions">
    <a href="#" class="hero-btn">Get started</a>
    <a href="#" class="hero-btn is-ghost">View docs</a>
  </div>
</section>
```

**Why does it fit EaseMotion CSS?**
It reveals the hero with a staggered entrance and a soft background glow, using only CSS with no images. The buttons show a focus ring, and the entrance is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the hero title settles to full opacity and both call to action buttons render.
