### PR TITLE
fix: showcase tabs active underline hidden init layout bug by hanan 

### DIFF
--- a/submissions/docs/tabs-hidden-init-hanan/README.md
+++ b/submissions/docs/tabs-hidden-init-hanan/README.md
@@ -1,0 +1,10 @@
+# Core Bug Fix Showcase: Tabs Hidden Initialization layout bug
+
+1. **What does this do?**  
+   Demonstrates and showcases a fix for the bug in `core/tabs.js` where the active tab underline remains `0px` wide if the tabs are initialized inside a hidden container (such as a modal or closed accordion pane).
+
+2. **How is it used?**  
+   The fix is implemented by utilizing a `ResizeObserver` in the javascript layer to detect when the container transitions from `display: none` to visible and dynamically update the underline width and offset values.
+
+3. **Why is it useful?**  
+   It ensures that tab underlines are correctly rendered when tab menus reside in hidden dialog components or dynamic views.

--- a/submissions/docs/tabs-hidden-init-hanan/demo.html
+++ b/submissions/docs/tabs-hidden-init-hanan/demo.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tabs Hidden Initialization Bug Showcase</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <div class="container">
+      <h1>Tabs Hidden Init Bug Showcase</h1>
+      <p>
+        This showcase demonstrates the bug where the tab active underline is 0px
+        wide when tabs are initialized in a hidden container (e.g. modals, tabs,
+        accordion panels) and then shown.
+      </p>
+
+      <div class="actions">
+        <button id="toggle-btn" class="btn">
+          Toggle Hidden Tabs Container
+        </button>
+      </div>
+
+      <!-- The container starts hidden (display: none) -->
+      <div id="hidden-container" class="hidden-wrapper">
+        <div class="ease-tabs">
+          <input
+            type="radio"
+            name="tabs"
+            id="tab1"
+            class="ease-tab-input"
+            checked
+          />
+          <input type="radio" name="tabs" id="tab2" class="ease-tab-input" />
+          <input type="radio" name="tabs" id="tab3" class="ease-tab-input" />
+
+          <div class="ease-tabs-nav">
+            <label for="tab1" class="ease-tab-label">Dashboard</label>
+            <label for="tab2" class="ease-tab-label">Settings</label>
+            <label for="tab3" class="ease-tab-label">Profile</label>
+            <div class="ease-tab-underline"></div>
+          </div>
+
+          <div class="ease-tabs-content">
+            <div class="ease-tab-panel">Dashboard Panel Content</div>
+            <div class="ease-tab-panel">Settings Panel Content</div>
+            <div class="ease-tab-panel">Profile Panel Content</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- We load our fixed script directly in the showcase to demonstrate how it is resolved -->
+    <script>
+      // Toggle container visibility
+      const toggleBtn = document.getElementById("toggle-btn");
+      const container = document.getElementById("hidden-container");
+      toggleBtn.addEventListener("click", () => {
+        container.classList.toggle("is-visible");
+      });
+
+      // Custom fixed tab underline logic using ResizeObserver
+      (function () {
+        const tabContainers = document.querySelectorAll(".ease-tabs");
+
+        function updateUnderlineWidth(container) {
+          const underline = container.querySelector(
+            ".ease-tabs-nav .ease-tab-underline"
+          );
+          if (!underline) return;
+          if (container.classList.contains("ease-tabs-auto")) return;
+
+          const checkedInput = container.querySelector(
+            ".ease-tab-input:checked"
+          );
+          if (!checkedInput) return;
+
+          const navContainer = container.querySelector(".ease-tabs-nav");
+          if (!navContainer) return;
+
+          const labels = navContainer.querySelectorAll(".ease-tab-label");
+          let checkedIndex = -1;
+
+          const inputs = container.querySelectorAll(".ease-tab-input");
+          inputs.forEach((input, index) => {
+            if (input === checkedInput) checkedIndex = index;
+          });
+
+          if (checkedIndex < 0 || checkedIndex >= labels.length) return;
+
+          const activeLabel = labels[checkedIndex];
+          const labelWidth = activeLabel.offsetWidth;
+          const labelLeft = activeLabel.offsetLeft;
+
+          // If offsetWidth is still 0 (e.g. container is display: none), don't break, just skip
+          if (labelWidth === 0) return;
+
+          underline.style.width = labelWidth + "px";
+          underline.style.left = labelLeft + "px";
+        }
+
+        // ResizeObserver to detect when container becomes visible
+        if ("ResizeObserver" in window) {
+          const observer = new ResizeObserver((entries) => {
+            entries.forEach((entry) => {
+              updateUnderlineWidth(entry.target);
+            });
+          });
+          tabContainers.forEach((c) => observer.observe(c));
+        }
+
+        // Standard click/change update fallback
+        tabContainers.forEach((container) => {
+          const inputs = container.querySelectorAll(".ease-tab-input");
+          inputs.forEach((input) => {
+            input.addEventListener("change", () =>
+              updateUnderlineWidth(container)
+            );
+          });
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/submissions/docs/tabs-hidden-init-hanan/style.css
+++ b/submissions/docs/tabs-hidden-init-hanan/style.css
@@ -1,0 +1,148 @@
+/* ============================================================
+   Tabs Hidden Init Bug Showcase Style
+   ============================================================ */
+
+body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    Oxygen,
+    Ubuntu,
+    Cantarell,
+    sans-serif;
+  background-color: #0b0f19;
+  color: #f1f5f9;
+  margin: 0;
+  padding: 40px 20px;
+  display: flex;
+  justify-content: center;
+}
+
+.container {
+  max-width: 600px;
+  width: 100%;
+}
+
+h1 {
+  color: #00f0ff;
+  font-size: 28px;
+  margin-bottom: 12px;
+  text-shadow: 0 0 10px rgba(0, 240, 255, 0.3);
+}
+
+p {
+  color: #94a3b8;
+  line-height: 1.6;
+  margin-bottom: 24px;
+}
+
+.actions {
+  margin-bottom: 24px;
+}
+
+.btn {
+  background-color: #00f0ff;
+  color: #0b0f19;
+  border: none;
+  padding: 12px 24px;
+  font-size: 14px;
+  font-weight: bold;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.btn:hover {
+  opacity: 0.9;
+}
+
+/* Hidden container toggled by classes */
+.hidden-wrapper {
+  display: none;
+  background: rgba(255, 255, 255, 0.03);
+  padding: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+}
+
+.hidden-wrapper.is-visible {
+  display: block;
+}
+
+/* Local replica of ease-tabs styling for standalone demonstration */
+.ease-tabs {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.ease-tab-input {
+  display: none;
+}
+
+.ease-tabs-nav {
+  position: relative;
+  display: flex;
+  border-bottom: 2px solid rgba(255, 255, 255, 0.1);
+  margin-bottom: 16px;
+}
+
+.ease-tab-label {
+  flex: 1;
+  text-align: center;
+  padding: 12px 16px;
+  cursor: pointer;
+  font-weight: 500;
+  color: #94a3b8;
+  transition: color 0.2s;
+}
+
+.ease-tab-input:nth-of-type(1):checked
+  ~ .ease-tabs-nav
+  .ease-tab-label:nth-of-type(1),
+.ease-tab-input:nth-of-type(2):checked
+  ~ .ease-tabs-nav
+  .ease-tab-label:nth-of-type(2),
+.ease-tab-input:nth-of-type(3):checked
+  ~ .ease-tabs-nav
+  .ease-tab-label:nth-of-type(3) {
+  color: #00f0ff;
+}
+
+.ease-tab-underline {
+  position: absolute;
+  bottom: -2px;
+  left: 0;
+  height: 2px;
+  background-color: #00f0ff;
+  width: 0; /* starts at 0, updated by JS */
+  transition:
+    left 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+    width 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: 0 0 8px #00f0ff;
+}
+
+.ease-tabs-content {
+  position: relative;
+}
+
+.ease-tab-panel {
+  display: none;
+  padding: 12px 0;
+  line-height: 1.6;
+}
+
+.ease-tab-input:nth-of-type(1):checked
+  ~ .ease-tabs-content
+  .ease-tab-panel:nth-of-type(1),
+.ease-tab-input:nth-of-type(2):checked
+  ~ .ease-tabs-content
+  .ease-tab-panel:nth-of-type(2),
+.ease-tab-input:nth-of-type(3):checked
+  ~ .ease-tabs-content
+  .ease-tab-panel:nth-of-type(3) {
+  display: block;
+}


### PR DESCRIPTION
## Pull Request Description

This Pull Request submits a documentation and bug fix showcase under `submissions/docs/tabs-hidden-init-hanan/` to address the core layout issue where the active tab underline remains `0px` wide if initialized inside a hidden container.

Closes #40568 

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission (Core Tabs Underline layout fix)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/docs/tabs-hidden-init-hanan/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A showcase fix for the active tab underline width issue inside hidden elements using `ResizeObserver` callbacks to detect visibility changes and dynamically update alignment coordinates.

**How does a developer use it?**

The showcase demonstrates how `ResizeObserver` detects container display toggling:
```javascript
if ('ResizeObserver' in window) {
  const observer = new ResizeObserver((entries) => {
    entries.forEach((entry) => updateUnderlineWidth(entry.target));
  });
  tabContainers.forEach((c) => observer.observe(c));
}
```

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---

## Notes for Maintainer

The bug and its fix are demonstrated in the `submissions/docs/tabs-hidden-init-hanan/` folder. The maintainer can apply the same `ResizeObserver` correction to the main `core/tabs.js` file during integration.
```