### PR TITLE
feat: add radio pill group

### DIFF
--- a/submissions/examples/radio-pills-as/README.md
+++ b/submissions/examples/radio-pills-as/README.md
@@ -1,0 +1,20 @@
+# Radio Pill Group
+
+### What does this do?
+
+It shows a single choice pill group where selecting one option highlights it with an accent fill and a small pop.
+
+### How is it used?
+
+```html
+<div class="pill-group" role="radiogroup" aria-label="Time range">
+  <label class="pill"><input type="radio" name="range" class="pill-input" checked /><span>Day</span></label>
+  <label class="pill"><input type="radio" name="range" class="pill-input" /><span>Week</span></label>
+</div>
+```
+
+The radios share one `name`, so only one pill can be active at a time.
+
+### Why is it useful?
+
+Single choice pills are common for time ranges, sizes, and view options. This styles the selected pill from the native `:checked` state, using only CSS. The group uses a `radiogroup` role, keeps keyboard selection with a focus ring, and the pop is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/radio-pills-as/demo.html
+++ b/submissions/examples/radio-pills-as/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Radio Pill Group</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="pill-group" role="radiogroup" aria-label="Time range">
+    <label class="pill"><input type="radio" name="range" class="pill-input" checked /><span>Day</span></label>
+    <label class="pill"><input type="radio" name="range" class="pill-input" /><span>Week</span></label>
+    <label class="pill"><input type="radio" name="range" class="pill-input" /><span>Month</span></label>
+    <label class="pill"><input type="radio" name="range" class="pill-input" /><span>Year</span></label>
+  </div>
+</body>
+</html>

--- a/submissions/examples/radio-pills-as/style.css
+++ b/submissions/examples/radio-pills-as/style.css
@@ -1,0 +1,68 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.pill-group {
+  display: inline-flex;
+  gap: 0.5rem;
+  padding: 0.4rem;
+  border-radius: 999px;
+  background: #111a2e;
+  border: 1px solid #26324a;
+}
+
+.pill {
+  cursor: pointer;
+}
+
+.pill-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.pill span {
+  display: block;
+  padding: 0.5rem 1.1rem;
+  border-radius: 999px;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: #94a3b8;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.pill:hover span {
+  color: #e2e8f0;
+}
+
+.pill-input:checked + span {
+  color: #fff;
+  background: #6c63ff;
+  animation: pillPop 0.25s ease;
+}
+
+.pill-input:focus-visible + span {
+  outline: 2px solid #fbbf24;
+  outline-offset: 2px;
+}
+
+@keyframes pillPop {
+  50% {
+    transform: scale(1.06);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pill-input:checked + span {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a radio pill group built for #40581. Selecting one pill highlights it with an accent fill and a pop, built on radio inputs so only one is active, using only CSS. Closes #40581.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A single choice pill group with an accent selected state.

**How does a developer use it?**

```html
<div class="pill-group" role="radiogroup" aria-label="Time range">
  <label class="pill"><input type="radio" name="range" class="pill-input" checked /><span>Day</span></label>
</div>
```

**Why does it fit EaseMotion CSS?**
It styles the selected pill from the native `:checked` state, using only CSS. The group uses a `radiogroup` role, keeps keyboard selection with a focus ring, and the pop is disabled under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: four pills render and the selected one has the accent background.
