### PR TITLE
feat: add file upload dropzone

### DIFF
--- a/submissions/examples/upload-dropzone-as/README.md
+++ b/submissions/examples/upload-dropzone-as/README.md
@@ -1,0 +1,22 @@
+# File Upload Dropzone
+
+### What does this do?
+
+It shows a file upload dropzone with a dashed border, an upload icon, and instructions, that highlights on hover and opens the file picker when clicked.
+
+### How is it used?
+
+```html
+<label class="dropzone">
+  <input type="file" class="dropzone-input" aria-label="Upload a file" />
+  <span class="dropzone-icon" aria-hidden="true"><!-- svg --></span>
+  <strong>Drag and drop or browse</strong>
+  <span>PNG, JPG or PDF up to 10MB</span>
+</label>
+```
+
+The dropzone is a `label` wrapping a real `input type="file"`, so clicking anywhere opens the picker and the control stays keyboard accessible.
+
+### Why is it useful?
+
+Upload areas appear in forms, media managers, and import flows. This styles a dropzone around a native file input with a clear hover and focus state, using only CSS with an inline SVG icon. The hover lift is reduced under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/upload-dropzone-as/demo.html
+++ b/submissions/examples/upload-dropzone-as/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>File Upload Dropzone</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <label class="dropzone">
+    <input type="file" class="dropzone-input" aria-label="Upload a file" />
+    <span class="dropzone-icon" aria-hidden="true">
+      <svg viewBox="0 0 24 24" width="36" height="36" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+        <path d="M17 8l-5-5-5 5" />
+        <path d="M12 3v12" />
+      </svg>
+    </span>
+    <strong>Drag and drop or browse</strong>
+    <span>PNG, JPG or PDF up to 10MB</span>
+  </label>
+</body>
+</html>

--- a/submissions/examples/upload-dropzone-as/style.css
+++ b/submissions/examples/upload-dropzone-as/style.css
@@ -1,0 +1,68 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.dropzone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  width: min(360px, 92vw);
+  padding: 2.5rem 1.5rem;
+  text-align: center;
+  border: 2px dashed #334155;
+  border-radius: 16px;
+  background: #0e1626;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+}
+
+.dropzone:hover {
+  border-color: #6c63ff;
+  background: rgba(108, 99, 255, 0.06);
+  transform: translateY(-2px);
+}
+
+.dropzone-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.dropzone-icon {
+  color: #6c63ff;
+  margin-bottom: 0.5rem;
+}
+
+.dropzone strong {
+  font-size: 0.98rem;
+}
+
+.dropzone span {
+  font-size: 0.82rem;
+  color: #94a3b8;
+}
+
+.dropzone-input:focus-visible + .dropzone-icon {
+  outline: none;
+}
+
+.dropzone:focus-within {
+  border-color: #6c63ff;
+  box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.2);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dropzone {
+    transition: border-color 0.2s ease, background 0.2s ease;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a file upload dropzone built for #40583. A dashed dropzone with an upload icon and instructions highlights on hover and wraps a real file input, using only CSS. Closes #40583.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A styled file upload dropzone around a native file input.

**How does a developer use it?**

```html
<label class="dropzone">
  <input type="file" class="dropzone-input" aria-label="Upload a file" />
  <strong>Drag and drop or browse</strong>
</label>
```

**Why does it fit EaseMotion CSS?**
It styles a dropzone around a native file input with clear hover and focus states, using only CSS with an inline SVG icon. The hover lift is reduced under `prefers-reduced-motion: reduce`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the dropzone renders with a dashed border, an inline SVG icon, and a real file input.
