### PR TITLE
feat: add password strength meter

### DIFF
--- a/submissions/examples/password-strength-as/README.md
+++ b/submissions/examples/password-strength-as/README.md
@@ -1,0 +1,21 @@
+# Password Strength Meter
+
+### What does this do?
+
+It shows a password field with a segmented strength meter and a label that reflect weak, medium, and strong states through a class.
+
+### How is it used?
+
+```html
+<div class="pw is-strong">
+  <input type="password" value="s3cret" aria-label="Password" />
+  <div class="pw-bars" aria-hidden="true"><span></span><span></span><span></span><span></span></div>
+  <span class="pw-label">Strong</span>
+</div>
+```
+
+Set `is-weak`, `is-medium`, or `is-strong` on the wrapper to fill and color the bars. The host app updates the class as the user types.
+
+### Why is it useful?
+
+Strength meters guide users to safer passwords on sign up forms. This styles a segmented meter and colors it by a state class, using only CSS. The bars are hidden from assistive tech while the text label conveys the strength.

--- a/submissions/examples/password-strength-as/demo.html
+++ b/submissions/examples/password-strength-as/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Password Strength Meter</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="pw-list">
+    <div class="pw is-weak">
+      <input type="password" value="abc" aria-label="Password weak example" />
+      <div class="pw-bars" aria-hidden="true"><span></span><span></span><span></span><span></span></div>
+      <span class="pw-label">Weak</span>
+    </div>
+    <div class="pw is-medium">
+      <input type="password" value="abc12345" aria-label="Password medium example" />
+      <div class="pw-bars" aria-hidden="true"><span></span><span></span><span></span><span></span></div>
+      <span class="pw-label">Medium</span>
+    </div>
+    <div class="pw is-strong">
+      <input type="password" value="Abc123!xyz" aria-label="Password strong example" />
+      <div class="pw-bars" aria-hidden="true"><span></span><span></span><span></span><span></span></div>
+      <span class="pw-label">Strong</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/password-strength-as/style.css
+++ b/submissions/examples/password-strength-as/style.css
@@ -1,0 +1,63 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.pw-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  width: min(340px, 92vw);
+}
+
+.pw input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.75rem 0.9rem;
+  font-size: 0.95rem;
+  color: #e2e8f0;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 10px;
+  outline: none;
+  transition: border-color 0.2s ease;
+}
+
+.pw input:focus {
+  border-color: #6c63ff;
+}
+
+.pw-bars {
+  display: flex;
+  gap: 5px;
+  margin: 0.6rem 0 0.35rem;
+}
+
+.pw-bars span {
+  flex: 1;
+  height: 5px;
+  border-radius: 3px;
+  background: #334155;
+  transition: background 0.2s ease;
+}
+
+.pw-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.pw.is-weak .pw-bars span:nth-child(1) { background: #ef4444; }
+.pw.is-weak .pw-label { color: #ef4444; }
+
+.pw.is-medium .pw-bars span:nth-child(-n + 2) { background: #f59e0b; }
+.pw.is-medium .pw-label { color: #f59e0b; }
+
+.pw.is-strong .pw-bars span { background: #10b981; }
+.pw.is-strong .pw-label { color: #10b981; }


### PR DESCRIPTION
## Pull Request Description

Adds a password strength meter built for #40586. A segmented meter and label reflect weak, medium, and strong states through a class, using only CSS. Closes #40586.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A password field with a segmented strength meter in weak, medium, and strong states.

**How does a developer use it?**

```html
<div class="pw is-strong">
  <input type="password" aria-label="Password" />
  <div class="pw-bars" aria-hidden="true"><span></span><span></span><span></span><span></span></div>
  <span class="pw-label">Strong</span>
</div>
```

**Why does it fit EaseMotion CSS?**
It styles a segmented meter and colors it by a state class, using only CSS. The bars are hidden from assistive tech while the text label conveys the strength.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the strong state fills all four bars green and the weak state fills one red.
