### PR TITLE
feat: add emoji mood rating

### DIFF
--- a/submissions/examples/emoji-mood-as/README.md
+++ b/submissions/examples/emoji-mood-as/README.md
@@ -1,0 +1,23 @@
+# Emoji Mood Rating
+
+### What does this do?
+
+It shows a row of five emoji faces that act as a mood rating. The user picks one, and the chosen face grows and turns full color while the rest stay grayscale. It works without JavaScript.
+
+### How is it used?
+
+```html
+<fieldset class="mood">
+  <legend>How was it?</legend>
+  <div class="mood-row">
+    <label><input type="radio" name="mood" /><span>😞</span></label>
+    <label><input type="radio" name="mood" checked /><span>😄</span></label>
+  </div>
+</fieldset>
+```
+
+Give every `input` the same `name` so only one can be chosen. The `:has(:checked)` selector highlights the selected face.
+
+### Why is it useful?
+
+Mood and satisfaction pickers are common in feedback widgets. This builds a single choice control with only radio inputs and CSS. The radios stay keyboard operable and a focus ring shows the active face.

--- a/submissions/examples/emoji-mood-as/demo.html
+++ b/submissions/examples/emoji-mood-as/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Emoji Mood Rating</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <fieldset class="mood">
+    <legend>How was your experience?</legend>
+    <div class="mood-row">
+      <label><input type="radio" name="mood" /><span>😞</span></label>
+      <label><input type="radio" name="mood" /><span>🙁</span></label>
+      <label><input type="radio" name="mood" /><span>😐</span></label>
+      <label><input type="radio" name="mood" checked /><span>🙂</span></label>
+      <label><input type="radio" name="mood" /><span>😄</span></label>
+    </div>
+  </fieldset>
+</body>
+</html>

--- a/submissions/examples/emoji-mood-as/style.css
+++ b/submissions/examples/emoji-mood-as/style.css
@@ -1,0 +1,74 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.mood {
+  border: 1px solid #26324a;
+  border-radius: 16px;
+  background: #0e1626;
+  padding: 1.5rem 1.75rem;
+  margin: 0;
+  text-align: center;
+}
+
+.mood legend {
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 0 0.5rem;
+}
+
+.mood-row {
+  display: flex;
+  gap: 0.4rem;
+  margin-top: 1rem;
+}
+
+.mood label {
+  cursor: pointer;
+  border-radius: 12px;
+  padding: 0.5rem;
+  line-height: 1;
+}
+
+.mood input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.mood span {
+  display: block;
+  font-size: 2rem;
+  filter: grayscale(1) opacity(0.55);
+  transition: transform 0.2s ease, filter 0.2s ease;
+}
+
+.mood label:hover span {
+  transform: scale(1.15);
+  filter: grayscale(0.4) opacity(0.85);
+}
+
+.mood label:has(:checked) span {
+  transform: scale(1.3);
+  filter: none;
+}
+
+.mood label:has(:focus-visible) {
+  outline: 2px solid #6c63ff;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mood span {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an emoji mood rating built for #40590. A row of five emoji faces acts as a single choice control, using only radio inputs and CSS. Closes #40590.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A mood rating where the user picks one of five emoji faces and the chosen face grows and turns full color while the rest stay grayscale.

**How does a developer use it?**

```html
<fieldset class="mood">
  <legend>How was it?</legend>
  <div class="mood-row">
    <label><input type="radio" name="mood" /><span>😞</span></label>
    <label><input type="radio" name="mood" checked /><span>😄</span></label>
  </div>
</fieldset>
```

**Why does it fit EaseMotion CSS?**
It builds a single choice control with only radio inputs and CSS, using `:has(:checked)` to highlight the selection. The radios stay keyboard operable and a focus ring shows the active face.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the checked face renders with no filter while the others render grayscale.
