### PR TITLE
feat: add animated dropdown menu

### DIFF
--- a/submissions/examples/dropdown-menu-as/README.md
+++ b/submissions/examples/dropdown-menu-as/README.md
@@ -1,0 +1,23 @@
+# Animated Dropdown Menu
+
+### What does this do?
+
+It turns a button into a dropdown menu of links that reveals with a smooth fade and slide. It uses the native `details` and `summary` elements, so it opens on click and stays keyboard operable with no JavaScript.
+
+### How is it used?
+
+```html
+<details class="dropdown">
+  <summary>Menu</summary>
+  <ul class="dropdown-panel">
+    <li><a href="#">Profile</a></li>
+    <li><a href="#">Settings</a></li>
+  </ul>
+</details>
+```
+
+The `[open]` state animates the panel in and rotates the caret. Remove `open` from the demo to see it start closed.
+
+### Why is it useful?
+
+Dropdown menus appear in nearly every navigation bar. This animates a native disclosure into a polished menu while keeping it accessible. The caret flips on open and every link shows a focus style.

--- a/submissions/examples/dropdown-menu-as/demo.html
+++ b/submissions/examples/dropdown-menu-as/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Dropdown Menu</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <details class="dropdown" open>
+    <summary>Menu</summary>
+    <ul class="dropdown-panel">
+      <li><a href="#">Profile</a></li>
+      <li><a href="#">Settings</a></li>
+      <li><a href="#">Billing</a></li>
+      <li><a href="#">Sign out</a></li>
+    </ul>
+  </details>
+</body>
+</html>

--- a/submissions/examples/dropdown-menu-as/style.css
+++ b/submissions/examples/dropdown-menu-as/style.css
@@ -1,0 +1,105 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: start center;
+  padding: 4rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.dropdown {
+  position: relative;
+  width: 200px;
+}
+
+.dropdown summary {
+  list-style: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.7rem 1rem;
+  background: #6c63ff;
+  color: #fff;
+  font-weight: 600;
+  border-radius: 10px;
+  user-select: none;
+}
+
+.dropdown summary::-webkit-details-marker {
+  display: none;
+}
+
+.dropdown summary::after {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid #fff;
+  border-bottom: 2px solid #fff;
+  transform: rotate(45deg);
+  transition: transform 0.2s ease;
+}
+
+.dropdown[open] summary::after {
+  transform: rotate(-135deg);
+}
+
+.dropdown summary:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+.dropdown-panel {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  left: 0;
+  right: 0;
+  margin: 0;
+  padding: 0.4rem;
+  list-style: none;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 10px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.45);
+}
+
+.dropdown[open] .dropdown-panel {
+  animation: drop-in 0.18s ease;
+}
+
+.dropdown-panel a {
+  display: block;
+  padding: 0.55rem 0.7rem;
+  color: #cbd5e1;
+  text-decoration: none;
+  border-radius: 7px;
+  font-size: 0.92rem;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.dropdown-panel a:hover,
+.dropdown-panel a:focus-visible {
+  background: #1b2942;
+  color: #fff;
+  outline: none;
+}
+
+@keyframes drop-in {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dropdown[open] .dropdown-panel {
+    animation: none;
+  }
+
+  .dropdown summary::after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an animated dropdown menu built for #40593. It animates the native details and summary disclosure into a polished menu, using only CSS. Closes #40593.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A button that opens a dropdown menu of links with a fade and slide, plus a caret that flips when open.

**How does a developer use it?**

```html
<details class="dropdown">
  <summary>Menu</summary>
  <ul class="dropdown-panel">
    <li><a href="#">Profile</a></li>
    <li><a href="#">Settings</a></li>
  </ul>
</details>
```

**Why does it fit EaseMotion CSS?**
It animates a native disclosure into a menu while keeping it accessible and free of JavaScript. It opens on click, stays keyboard operable, and every link shows a focus style.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: with the menu open the panel is visible with four links and the caret is rotated.
