### PR TITLE
feat: add alternating vertical timeline

### DIFF
--- a/submissions/examples/alt-timeline-as/README.md
+++ b/submissions/examples/alt-timeline-as/README.md
@@ -1,0 +1,26 @@
+# Alternating Vertical Timeline
+
+### What does this do?
+
+It lays out a vertical timeline where entries alternate to the left and right of a center spine. Each entry has a dot marker on the line and a card with a date, title, and description. On narrow screens it collapses to a single column.
+
+### How is it used?
+
+```html
+<ol class="timeline">
+  <li>
+    <div class="tl-card">
+      <time>Jan 2024</time>
+      <h3>Kickoff</h3>
+      <p>Set the goals.</p>
+    </div>
+  </li>
+  <li><div class="tl-card">...</div></li>
+</ol>
+```
+
+Odd items sit on the left and even items on the right. A dot is placed on the center line for each entry.
+
+### Why is it useful?
+
+Timelines are common for roadmaps, histories, and changelogs. This lays out an alternating timeline with a center spine using only CSS, and it reflows to one column below 560px so it stays readable on phones.

--- a/submissions/examples/alt-timeline-as/demo.html
+++ b/submissions/examples/alt-timeline-as/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Alternating Vertical Timeline</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <ol class="timeline">
+    <li>
+      <div class="tl-card">
+        <time>Jan 2024</time>
+        <h3>Project kickoff</h3>
+        <p>Set the goals and drafted the first roadmap.</p>
+      </div>
+    </li>
+    <li>
+      <div class="tl-card">
+        <time>Apr 2024</time>
+        <h3>Beta launch</h3>
+        <p>Opened access to the first group of testers.</p>
+      </div>
+    </li>
+    <li>
+      <div class="tl-card">
+        <time>Aug 2024</time>
+        <h3>Public release</h3>
+        <p>Shipped version one to everyone.</p>
+      </div>
+    </li>
+    <li>
+      <div class="tl-card">
+        <time>Dec 2024</time>
+        <h3>Ten thousand users</h3>
+        <p>Crossed a major growth milestone.</p>
+      </div>
+    </li>
+  </ol>
+</body>
+</html>

--- a/submissions/examples/alt-timeline-as/style.css
+++ b/submissions/examples/alt-timeline-as/style.css
@@ -1,0 +1,104 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 3rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  width: min(680px, 94vw);
+  position: relative;
+}
+
+.timeline::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 2px;
+  background: #26324a;
+  transform: translateX(-50%);
+}
+
+.timeline li {
+  position: relative;
+  display: flex;
+  padding: 0.75rem 0;
+}
+
+.timeline li:nth-child(odd) {
+  justify-content: flex-start;
+}
+
+.timeline li:nth-child(even) {
+  justify-content: flex-end;
+}
+
+.timeline li::before {
+  content: "";
+  position: absolute;
+  top: 1.4rem;
+  left: 50%;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #6c63ff;
+  border: 3px solid #0b1121;
+  transform: translateX(-50%);
+  z-index: 1;
+}
+
+.tl-card {
+  width: calc(50% - 2rem);
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 12px;
+  padding: 0.9rem 1.1rem;
+}
+
+.tl-card h3 {
+  margin: 0 0 0.3rem;
+  font-size: 1rem;
+}
+
+.tl-card time {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: #a5b4fc;
+}
+
+.tl-card p {
+  margin: 0.35rem 0 0;
+  font-size: 0.86rem;
+  color: #94a3b8;
+  line-height: 1.5;
+}
+
+@media (max-width: 560px) {
+  .timeline::before {
+    left: 7px;
+  }
+
+  .timeline li,
+  .timeline li:nth-child(even) {
+    justify-content: flex-end;
+    padding-left: 2rem;
+  }
+
+  .timeline li::before {
+    left: 7px;
+  }
+
+  .tl-card {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an alternating vertical timeline built for #40595. Entries alternate left and right of a center spine using only CSS, and it reflows to one column on narrow screens. Closes #40595.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A vertical timeline where each entry alternates to the left and right of a center line, each with a dot marker and a card holding a date, title, and description.

**How does a developer use it?**

```html
<ol class="timeline">
  <li><div class="tl-card"><time>Jan</time><h3>Kickoff</h3><p>...</p></div></li>
  <li><div class="tl-card">...</div></li>
</ol>
```

**Why does it fit EaseMotion CSS?**
It lays out an alternating timeline with a center spine using only CSS, and reflows to a single column below 560px so it stays readable on phones.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the first card sits on the left and the second on the right, confirming the alternating layout.
