### PR TITLE
feat: add scroll snap carousel

### DIFF
--- a/submissions/examples/snap-carousel-as/README.md
+++ b/submissions/examples/snap-carousel-as/README.md
@@ -1,0 +1,20 @@
+# Scroll Snap Carousel
+
+### What does this do?
+
+It lays out a horizontal carousel of cards that snaps each card to the center as the user scrolls or swipes. It uses CSS scroll snap only, so it works with touch, trackpad, and keyboard, with no JavaScript.
+
+### How is it used?
+
+```html
+<div class="carousel" tabindex="0">
+  <article class="slide">Slide 1</article>
+  <article class="slide">Slide 2</article>
+</div>
+```
+
+The track sets `scroll-snap-type: x mandatory` and each slide sets `scroll-snap-align: center`. Side padding lets the first and last slide reach the center.
+
+### Why is it useful?
+
+Carousels are everywhere for galleries and feature highlights. This builds a smooth snapping carousel with native scroll behavior instead of a heavy script. The scrollbar is hidden for a clean look and reduced motion disables smooth scrolling.

--- a/submissions/examples/snap-carousel-as/demo.html
+++ b/submissions/examples/snap-carousel-as/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scroll Snap Carousel</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="carousel" tabindex="0" aria-label="Featured slides, scroll sideways">
+    <article class="slide">Slide 1</article>
+    <article class="slide">Slide 2</article>
+    <article class="slide">Slide 3</article>
+    <article class="slide">Slide 4</article>
+  </div>
+</body>
+</html>

--- a/submissions/examples/snap-carousel-as/style.css
+++ b/submissions/examples/snap-carousel-as/style.css
@@ -1,0 +1,62 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 0;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.carousel {
+  display: flex;
+  gap: 1rem;
+  width: min(560px, 100vw);
+  padding: 1rem 10%;
+  box-sizing: border-box;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  scrollbar-width: none;
+}
+
+.carousel::-webkit-scrollbar {
+  display: none;
+}
+
+.slide {
+  flex: 0 0 80%;
+  scroll-snap-align: center;
+  aspect-ratio: 16 / 10;
+  display: grid;
+  place-items: center;
+  border-radius: 16px;
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: #fff;
+  box-shadow: 0 14px 34px rgba(0, 0, 0, 0.4);
+}
+
+.slide:nth-child(1) {
+  background: linear-gradient(135deg, #6c63ff, #a855f7);
+}
+
+.slide:nth-child(2) {
+  background: linear-gradient(135deg, #0ea5e9, #22d3ee);
+}
+
+.slide:nth-child(3) {
+  background: linear-gradient(135deg, #f59e0b, #ef4444);
+}
+
+.slide:nth-child(4) {
+  background: linear-gradient(135deg, #10b981, #34d399);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .carousel {
+    scroll-behavior: auto;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a scroll snap carousel built for #40599. Cards snap to the center as the user scrolls or swipes, using CSS scroll snap only. Closes #40599.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A horizontal carousel of cards that snaps each card to the center as the user scrolls or swipes, with touch, trackpad, and keyboard support.

**How does a developer use it?**

```html
<div class="carousel" tabindex="0">
  <article class="slide">Slide 1</article>
  <article class="slide">Slide 2</article>
</div>
```

**Why does it fit EaseMotion CSS?**
It builds a smooth snapping carousel with native scroll behavior instead of a heavy script. The scrollbar is hidden for a clean look and reduced motion disables smooth scrolling.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the track reports `scroll-snap-type: x mandatory`, is horizontally scrollable, and each slide snaps to center.
