### PR TITLE
feat: add sticker peel-off hover effect

### DIFF
--- a/submissions/examples/sticker-peel-off/README.md
+++ b/submissions/examples/sticker-peel-off/README.md
@@ -1,0 +1,12 @@
+# Sticker Peel-Off Effect
+
+1. **What does this do?** Adds a skeuomorphic corner peel animation to a card — the bottom-right corner visually curls up on hover, like peeling a sticker off a surface.
+
+2. **How is it used?** Apply `.sticker-peel-card` to any `<div>` or card element:
+   ```html
+   <div class="sticker-peel-card">
+     <h3>Hover me to peel!</h3>
+   </div>
+   ```
+
+3. **Why is it useful?** It brings a tactile, physical interaction feel to flat UI elements. It fits the animation-first philosophy by adding a delightful micro-interaction entirely in CSS, zero JavaScript needed.

--- a/submissions/examples/sticker-peel-off/demo.html
+++ b/submissions/examples/sticker-peel-off/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sticker Peel-Off Effect Demo</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+
+  <h1>Sticker Peel-Off Hover Effect</h1>
+  <p>Hover over the cards to see the corner peel!</p>
+
+  <div class="demo-grid">
+
+    <div class="sticker-peel-card">
+      <h3>🎨 Design</h3>
+      <p>A clean card with a skeuomorphic peel effect on the bottom-right corner.</p>
+    </div>
+
+    <div class="sticker-peel-card">
+      <h3>🚀 Motion</h3>
+      <p>Pure CSS hover — no JavaScript needed, just a smooth corner curl.</p>
+    </div>
+
+    <div class="sticker-peel-card">
+      <h3>⚡ Fast</h3>
+      <p>Zero dependency, drops right into any project with a single class.</p>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/sticker-peel-off/style.css
+++ b/submissions/examples/sticker-peel-off/style.css
@@ -1,0 +1,132 @@
+/* ============================================================
+   Sticker Peel-Off Hover Effect
+   A skeuomorphic corner-peel effect using only CSS pseudo-elements.
+   No JavaScript needed.
+   ============================================================ */
+
+/* ── Page Reset & Layout ─────────────────────────────────── */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  background-color: #f0f4f8;
+  font-family: system-ui, -apple-system, sans-serif;
+  padding: 2rem;
+}
+
+h1 {
+  font-size: 1.75rem;
+  color: #1e293b;
+}
+
+p {
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.demo-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  justify-content: center;
+}
+
+/* ── Sticker Peel-Off Card ───────────────────────────────── */
+
+.sticker-peel-card {
+  position: relative;
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 2rem 2rem 2.5rem;
+  width: 240px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+  transition: box-shadow 0.3s ease;
+  cursor: pointer;
+}
+
+.sticker-peel-card h3 {
+  font-size: 1.2rem;
+  color: #1e293b;
+  margin-bottom: 0.5rem;
+}
+
+.sticker-peel-card:hover {
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.14);
+}
+
+/* ── The Peel Corner (bottom-right) ─────────────────────── */
+
+/*
+  ::before creates the folded flap (the "peel" triangle).
+  It uses a linear-gradient to simulate:
+    - the card surface (white)
+    - a shadow fold edge (#ddd)
+    - a darker back-side (#bbb)
+    - and the transparent background behind
+*/
+.sticker-peel-card::before {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 0;
+  height: 0;
+  background: linear-gradient(
+    135deg,
+    #ffffff 45%,
+    #dddddd 50%,
+    #bbbbbb 52%,
+    transparent 62%
+  );
+  box-shadow: -2px -2px 8px rgba(0, 0, 0, 0.1);
+
+  /* Grows on hover */
+  transition: width 0.4s ease-out, height 0.4s ease-out;
+}
+
+/* Expand the peel triangle on hover */
+.sticker-peel-card:hover::before {
+  width: 70px;
+  height: 70px;
+}
+
+/* ── Drop Shadow under the Peeled Corner ─────────────────── */
+
+/*
+  ::after casts a soft curved shadow beneath the peeling corner,
+  giving it a realistic lifted look.
+*/
+.sticker-peel-card::after {
+  content: "";
+  position: absolute;
+  bottom: 4px;
+  right: 4px;
+  width: 0;
+  height: 0;
+  background: transparent;
+  border-radius: 50%;
+  box-shadow: none;
+  transition:
+    width 0.4s ease-out,
+    height 0.4s ease-out,
+    box-shadow 0.4s ease-out;
+}
+
+.sticker-peel-card:hover::after {
+  width: 50px;
+  height: 50px;
+  box-shadow: -4px -4px 12px rgba(0, 0, 0, 0.18);
+}


### PR DESCRIPTION
Resolves #40589

### Description
Adds a skeuomorphic corner peel animation to a card. The bottom-right corner visually curls up on hover, simulating peeling a sticker off a surface — entirely in CSS, zero JavaScript.

### Changes Made
- Added `submissions/examples/sticker-peel-off/demo.html`: Self-contained demo with 3 cards showcasing the effect.
- Added `submissions/examples/sticker-peel-off/style.css`: Uses `::before` for the triangular peel flap with a linear-gradient simulating a fold shadow, and `::after` for a curved drop-shadow beneath the curled corner.
- Added `submissions/examples/sticker-peel-off/README.md`: Explains what, how, and why in the required 3-question format.

### Validation
- [x] Placed correctly under `submissions/examples/sticker-peel-off/`
- [x] Includes all 3 required files: `demo.html`, `style.css`, `README.md`
- [x] Zero JavaScript — pure CSS only
- [x] Does not duplicate any existing EaseMotion CSS class
- [x] Does not touch `core/` or `components/`
