### PR TITLE
feat: add feature grid with icons

### DIFF
--- a/submissions/examples/feature-grid-as/README.md
+++ b/submissions/examples/feature-grid-as/README.md
@@ -1,0 +1,23 @@
+# Feature Grid With Icons
+
+### What does this do?
+
+It lays out a responsive grid of feature cards, each with an inline SVG icon badge, a title, and a short description. The cards lift slightly on hover, and the columns auto fit to the screen width.
+
+### How is it used?
+
+```html
+<section class="features">
+  <article class="feature">
+    <div class="feature-icon"><svg>...</svg></div>
+    <h3>Fast</h3>
+    <p>Loads in a blink.</p>
+  </article>
+</section>
+```
+
+The grid uses `repeat(auto-fit, minmax(200px, 1fr))`, so cards wrap to fewer columns as space shrinks. Icons are inline SVG, so there are no external assets.
+
+### Why is it useful?
+
+Feature grids are a staple of landing pages. This lays out a clean, responsive feature section with auto fitting columns and a subtle hover lift, using only CSS. The hover lift is removed under reduced motion.

--- a/submissions/examples/feature-grid-as/demo.html
+++ b/submissions/examples/feature-grid-as/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Feature Grid With Icons</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <section class="features">
+    <article class="feature">
+      <div class="feature-icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24"><path d="M13 2 3 14h7l-1 8 10-12h-7z" stroke-linejoin="round" /></svg>
+      </div>
+      <h3>Fast</h3>
+      <p>Pages load in a blink with a tiny footprint.</p>
+    </article>
+    <article class="feature">
+      <div class="feature-icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24"><path d="M12 3 4 6v5c0 5 3.5 8 8 10 4.5-2 8-5 8-10V6z" stroke-linejoin="round" /></svg>
+      </div>
+      <h3>Secure</h3>
+      <p>Sensible defaults keep your data protected.</p>
+    </article>
+    <article class="feature">
+      <div class="feature-icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9" /><path d="M12 7v5l3 3" stroke-linecap="round" /></svg>
+      </div>
+      <h3>Reliable</h3>
+      <p>Built to stay up around the clock.</p>
+    </article>
+  </section>
+</body>
+</html>

--- a/submissions/examples/feature-grid-as/style.css
+++ b/submissions/examples/feature-grid-as/style.css
@@ -1,0 +1,71 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 3rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.features {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.25rem;
+  width: min(760px, 94vw);
+}
+
+.feature {
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+  padding: 1.5rem 1.35rem;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.feature:hover {
+  transform: translateY(-4px);
+  border-color: #6c63ff;
+}
+
+.feature-icon {
+  width: 44px;
+  height: 44px;
+  display: grid;
+  place-items: center;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #6c63ff, #a855f7);
+  margin-bottom: 1rem;
+}
+
+.feature-icon svg {
+  width: 22px;
+  height: 22px;
+  stroke: #fff;
+  stroke-width: 2;
+  fill: none;
+}
+
+.feature h3 {
+  margin: 0 0 0.4rem;
+  font-size: 1.05rem;
+}
+
+.feature p {
+  margin: 0;
+  font-size: 0.88rem;
+  line-height: 1.55;
+  color: #94a3b8;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .feature {
+    transition: border-color 0.2s ease;
+  }
+
+  .feature:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a feature grid with icons built for #40601. A responsive grid of feature cards with inline SVG icons and a subtle hover lift, using only CSS. Closes #40601.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A responsive grid of feature cards, each with an inline SVG icon badge, a title, and a short description. Cards lift on hover and columns auto fit to the screen.

**How does a developer use it?**

```html
<section class="features">
  <article class="feature">
    <div class="feature-icon"><svg>...</svg></div>
    <h3>Fast</h3>
    <p>Loads in a blink.</p>
  </article>
</section>
```

**Why does it fit EaseMotion CSS?**
It lays out a clean, responsive feature section with auto fitting columns and a subtle hover lift, using only CSS and inline SVG so there are no external assets. The hover lift is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: three cards render across three auto fit columns, each with its inline SVG icon.
