### PR TITLE
feat: add social share buttons

### DIFF
--- a/submissions/examples/social-share-as/README.md
+++ b/submissions/examples/social-share-as/README.md
@@ -1,0 +1,20 @@
+# Social Share Buttons
+
+### What does this do?
+
+It shows a row of round social share buttons that expand into a labeled pill on hover and keyboard focus. Each button uses an inline SVG icon and its own brand color. It is built with only CSS.
+
+### How is it used?
+
+```html
+<nav class="share">
+  <a class="share-btn tw" href="#"><svg>...</svg><span>Tweet</span></a>
+  <a class="share-btn fb" href="#"><svg>...</svg><span>Share</span></a>
+</nav>
+```
+
+Each button keeps its label in a `span` that animates from zero width to full width on hover or focus. Brand color classes are `tw`, `fb`, `wa`, and `li`.
+
+### Why is it useful?
+
+Share buttons appear on articles and product pages. This animates a compact icon button into a labeled pill using only CSS and inline SVG, so there are no external assets. The label also reveals on keyboard focus and the transition is removed under reduced motion.

--- a/submissions/examples/social-share-as/demo.html
+++ b/submissions/examples/social-share-as/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Social Share Buttons</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <nav class="share" aria-label="Share this page">
+    <a class="share-btn tw" href="#" aria-label="Share on X">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18.9 2H22l-7.6 8.7L23 22h-6.8l-5-6.6L5.5 22H2.4l8.2-9.3L1.7 2h6.9l4.5 6zm-1.2 18h1.7L7.4 3.8H5.6z" /></svg>
+      <span>Tweet</span>
+    </a>
+    <a class="share-btn fb" href="#" aria-label="Share on Facebook">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M13 22v-8h2.7l.4-3H13V9c0-.9.3-1.5 1.6-1.5H16V4.9c-.3 0-1.2-.1-2.2-.1-2.2 0-3.8 1.4-3.8 3.9V11H7.5v3H10v8z" /></svg>
+      <span>Share</span>
+    </a>
+    <a class="share-btn wa" href="#" aria-label="Share on WhatsApp">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2a10 10 0 0 0-8.5 15.2L2 22l4.9-1.4A10 10 0 1 0 12 2zm0 18a8 8 0 0 1-4.1-1.1l-.3-.2-2.9.8.8-2.8-.2-.3A8 8 0 1 1 12 20zm4.4-5.9c-.2-.1-1.4-.7-1.6-.8-.2-.1-.4-.1-.5.1l-.7.9c-.1.2-.3.2-.5.1a6.5 6.5 0 0 1-3.2-2.8c-.1-.2 0-.4.1-.5l.4-.5c.1-.2.1-.3 0-.5l-.7-1.7c-.2-.4-.4-.4-.5-.4h-.5c-.2 0-.4.1-.6.3a3 3 0 0 0-.9 2.2c0 1.3 1 2.6 1.1 2.8.1.2 1.9 3 4.6 4.1 1.7.7 2.3.7 3.1.6.5-.1 1.4-.6 1.6-1.1.2-.6.2-1 .1-1.1z" /></svg>
+      <span>Send</span>
+    </a>
+    <a class="share-btn li" href="#" aria-label="Share on LinkedIn">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.98 3.5a2 2 0 1 1 0 4 2 2 0 0 1 0-4zM3 9h4v12H3zM10 9h3.8v1.7h.1a4.2 4.2 0 0 1 3.8-2c4 0 4.8 2.6 4.8 6V21h-4v-5.4c0-1.3 0-3-1.8-3s-2.1 1.4-2.1 2.9V21h-4z" /></svg>
+      <span>Post</span>
+    </a>
+  </nav>
+</body>
+</html>

--- a/submissions/examples/social-share-as/style.css
+++ b/submissions/examples/social-share-as/style.css
@@ -1,0 +1,77 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.share {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.share-btn {
+  display: inline-flex;
+  align-items: center;
+  height: 46px;
+  padding: 0 13px;
+  border-radius: 23px;
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 0.9rem;
+  transition: box-shadow 0.2s ease;
+}
+
+.share-btn svg {
+  width: 20px;
+  height: 20px;
+  fill: currentColor;
+  flex: none;
+}
+
+.share-btn span {
+  max-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  transition: max-width 0.28s ease, margin-left 0.28s ease;
+}
+
+.share-btn:hover span,
+.share-btn:focus-visible span {
+  max-width: 6rem;
+  margin-left: 0.5rem;
+}
+
+.share-btn:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+
+.share-btn.tw {
+  background: #1d9bf0;
+}
+
+.share-btn.fb {
+  background: #1877f2;
+}
+
+.share-btn.wa {
+  background: #25d366;
+}
+
+.share-btn.li {
+  background: #0a66c2;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .share-btn span {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds social share buttons built for #40605. Round icon buttons expand into labeled pills on hover and focus, using only CSS and inline SVG. Closes #40605.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A row of round social share buttons that expand to show a text label on hover and keyboard focus, each with an inline SVG icon and its own brand color.

**How does a developer use it?**

```html
<nav class="share">
  <a class="share-btn tw" href="#"><svg>...</svg><span>Tweet</span></a>
  <a class="share-btn fb" href="#"><svg>...</svg><span>Share</span></a>
</nav>
```

**Why does it fit EaseMotion CSS?**
It animates a compact icon button into a labeled pill using only CSS and inline SVG, so there are no external assets. The label reveals on keyboard focus and the transition is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: four buttons render with four inline SVG icons, and each label starts collapsed to zero width so only the icon shows until hover or focus.
