### PR TITLE
feat: add logo marquee

### DIFF
--- a/submissions/examples/logo-marquee-as/README.md
+++ b/submissions/examples/logo-marquee-as/README.md
@@ -1,0 +1,23 @@
+# Logo Marquee
+
+### What does this do?
+
+It scrolls a horizontal strip of logos in an endless loop with a soft fade on both edges. The list of logos is duplicated so the loop has no visible seam, and the animation pauses on hover. It uses only CSS.
+
+### How is it used?
+
+```html
+<div class="marquee">
+  <div class="marquee-track">
+    <span class="logo">Acme</span>
+    <span class="logo">Globex</span>
+    <!-- repeat the same set once for a seamless loop -->
+  </div>
+</div>
+```
+
+The track animates to `translateX(-50%)`, so it must contain the logo set twice. The second copy is marked `aria-hidden` so screen readers do not hear duplicates.
+
+### Why is it useful?
+
+Trusted by logo strips are common on landing pages. This builds a seamless infinite marquee with edge fades and a hover pause, using only CSS keyframes. Under reduced motion the scroll is disabled.

--- a/submissions/examples/logo-marquee-as/demo.html
+++ b/submissions/examples/logo-marquee-as/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Logo Marquee</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="marquee" aria-label="Trusted by these companies">
+    <div class="marquee-track">
+      <span class="logo">Acme</span>
+      <span class="logo">Globex</span>
+      <span class="logo">Umbrella</span>
+      <span class="logo">Initech</span>
+      <span class="logo">Hooli</span>
+      <span class="logo">Stark</span>
+      <span class="logo" aria-hidden="true">Acme</span>
+      <span class="logo" aria-hidden="true">Globex</span>
+      <span class="logo" aria-hidden="true">Umbrella</span>
+      <span class="logo" aria-hidden="true">Initech</span>
+      <span class="logo" aria-hidden="true">Hooli</span>
+      <span class="logo" aria-hidden="true">Stark</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/logo-marquee-as/style.css
+++ b/submissions/examples/logo-marquee-as/style.css
@@ -1,0 +1,50 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 0;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.marquee {
+  width: min(680px, 100vw);
+  overflow: hidden;
+  -webkit-mask-image: linear-gradient(90deg, transparent, #000 12%, #000 88%, transparent);
+  mask-image: linear-gradient(90deg, transparent, #000 12%, #000 88%, transparent);
+}
+
+.marquee-track {
+  display: flex;
+  width: max-content;
+  animation: marquee-scroll 18s linear infinite;
+}
+
+.marquee:hover .marquee-track {
+  animation-play-state: paused;
+}
+
+.logo {
+  flex: none;
+  margin: 0 1.75rem;
+  font-size: 1.35rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: #cbd5e1;
+  white-space: nowrap;
+}
+
+@keyframes marquee-scroll {
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .marquee-track {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a logo marquee built for #40609. A horizontal strip of logos scrolls in a seamless endless loop with edge fades and a hover pause, using only CSS. Closes #40609.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A continuously scrolling strip of logos with a soft fade on both edges. The track is duplicated so the loop has no visible seam, and it pauses on hover.

**How does a developer use it?**

```html
<div class="marquee">
  <div class="marquee-track">
    <span class="logo">Acme</span>
    <span class="logo">Globex</span>
    <!-- repeat the same set once for a seamless loop -->
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It builds a seamless infinite marquee with edge fades and a hover pause, using only CSS keyframes. The duplicated set is marked `aria-hidden` and the scroll is disabled under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the track runs the `marquee-scroll` animation over 18s with twelve logos and overflows its container for the loop.
