### PR TITLE
feat: add checkbox todo list

### DIFF
--- a/submissions/examples/todo-list-as/README.md
+++ b/submissions/examples/todo-list-as/README.md
@@ -1,0 +1,25 @@
+# Checkbox Todo List
+
+### What does this do?
+
+It shows a todo list where checking an item pops a custom check mark, strikes through the text, and fades it. It uses only checkboxes and CSS, with no JavaScript.
+
+### How is it used?
+
+```html
+<ul class="todo">
+  <li>
+    <label>
+      <input type="checkbox" checked />
+      <span class="box"></span>
+      <span class="text">Buy milk</span>
+    </label>
+  </li>
+</ul>
+```
+
+The hidden checkbox drives the visible `.box` and the `.text` through sibling selectors, so the whole row is clickable and keyboard operable.
+
+### Why is it useful?
+
+Checklists appear in onboarding, forms, and task apps. This styles a native checkbox into a smooth custom control and reflects the done state on the label text, using only CSS. A focus ring shows the active item and transitions are removed under reduced motion.

--- a/submissions/examples/todo-list-as/demo.html
+++ b/submissions/examples/todo-list-as/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Checkbox Todo List</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <ul class="todo">
+    <li><label><input type="checkbox" checked /><span class="box"></span><span class="text">Sketch the wireframes</span></label></li>
+    <li><label><input type="checkbox" checked /><span class="box"></span><span class="text">Pick a color palette</span></label></li>
+    <li><label><input type="checkbox" /><span class="box"></span><span class="text">Build the landing page</span></label></li>
+    <li><label><input type="checkbox" /><span class="box"></span><span class="text">Write the launch post</span></label></li>
+  </ul>
+</body>
+</html>

--- a/submissions/examples/todo-list-as/style.css
+++ b/submissions/examples/todo-list-as/style.css
@@ -1,0 +1,94 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.todo {
+  list-style: none;
+  margin: 0;
+  padding: 0.5rem;
+  width: min(320px, 92vw);
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 14px;
+}
+
+.todo li + li {
+  border-top: 1px solid #1b2942;
+}
+
+.todo label {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.7rem 0.6rem;
+  cursor: pointer;
+}
+
+.todo input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.todo .box {
+  flex: none;
+  width: 22px;
+  height: 22px;
+  border: 2px solid #475569;
+  border-radius: 7px;
+  display: grid;
+  place-items: center;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.todo .box::after {
+  content: "";
+  width: 6px;
+  height: 11px;
+  border: solid #fff;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg) scale(0);
+  transition: transform 0.2s ease;
+}
+
+.todo :checked + .box {
+  background: #10b981;
+  border-color: #10b981;
+}
+
+.todo :checked + .box::after {
+  transform: rotate(45deg) scale(1);
+}
+
+.todo .text {
+  font-size: 0.95rem;
+  transition: color 0.2s ease, opacity 0.2s ease;
+}
+
+.todo :checked ~ .text {
+  text-decoration: line-through;
+  color: #64748b;
+  opacity: 0.7;
+}
+
+.todo input:focus-visible + .box {
+  outline: 2px solid #6c63ff;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .todo .box,
+  .todo .box::after,
+  .todo .text {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a checkbox todo list built for #40614. Checking an item pops a custom check mark and strikes through the text, using only checkboxes and CSS. Closes #40614.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A todo list where checking an item animates a custom check mark, strikes through the text, and fades it.

**How does a developer use it?**

```html
<ul class="todo">
  <li>
    <label>
      <input type="checkbox" checked />
      <span class="box"></span>
      <span class="text">Buy milk</span>
    </label>
  </li>
</ul>
```

**Why does it fit EaseMotion CSS?**
It styles a native checkbox into a smooth custom control and reflects the done state on the label text, using only CSS. The whole row is clickable and keyboard operable, with a focus ring and reduced motion support.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: a checked item shows line-through text and a green box, while an unchecked item has no decoration.
