### PR TITLE
feat: add callout note boxes

### DIFF
--- a/submissions/examples/callout-boxes-as/README.md
+++ b/submissions/examples/callout-boxes-as/README.md
@@ -1,0 +1,20 @@
+# Callout Note Boxes
+
+### What does this do?
+
+It provides a set of callout boxes for docs and articles in four tones: info, success, warning, and danger. Each has a colored left bar, a tinted background, an inline SVG icon, and a bold title. It is built with only CSS.
+
+### How is it used?
+
+```html
+<div class="callout is-info">
+  <svg class="callout-icon">...</svg>
+  <div><strong>Note</strong><p>Helpful context here.</p></div>
+</div>
+```
+
+Swap the tone class between `is-info`, `is-success`, `is-warning`, and `is-danger`. Each tone sets a `--tone` and a matching `--tint` custom property that colors the bar, icon, title, and background.
+
+### Why is it useful?
+
+Callouts and admonitions are common in documentation and readme content. This offers a consistent set of note boxes driven by a single tone class, using only CSS and inline SVG so there are no external assets.

--- a/submissions/examples/callout-boxes-as/demo.html
+++ b/submissions/examples/callout-boxes-as/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Callout Note Boxes</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="callout-list">
+    <div class="callout is-info">
+      <svg class="callout-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9" /><path d="M12 11v5M12 8h.01" stroke-linecap="round" /></svg>
+      <div><strong>Note</strong><p>You can group related settings under one panel.</p></div>
+    </div>
+    <div class="callout is-success">
+      <svg class="callout-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9" /><path d="m8 12 3 3 5-6" stroke-linecap="round" stroke-linejoin="round" /></svg>
+      <div><strong>Success</strong><p>Your changes were saved and published.</p></div>
+    </div>
+    <div class="callout is-warning">
+      <svg class="callout-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3 2 20h20z" stroke-linejoin="round" /><path d="M12 10v4M12 17h.01" stroke-linecap="round" /></svg>
+      <div><strong>Warning</strong><p>This action may take a few minutes to finish.</p></div>
+    </div>
+    <div class="callout is-danger">
+      <svg class="callout-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9" /><path d="M12 7v6M12 16h.01" stroke-linecap="round" /></svg>
+      <div><strong>Danger</strong><p>Deleting this project cannot be undone.</p></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/callout-boxes-as/style.css
+++ b/submissions/examples/callout-boxes-as/style.css
@@ -1,0 +1,71 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2.5rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.callout-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: min(440px, 94vw);
+}
+
+.callout {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.9rem 1rem;
+  border-radius: 10px;
+  border-left: 4px solid var(--tone);
+  background: var(--tint);
+}
+
+.callout-icon {
+  flex: none;
+  width: 20px;
+  height: 20px;
+  margin-top: 2px;
+  stroke: var(--tone);
+  stroke-width: 2;
+  fill: none;
+}
+
+.callout strong {
+  display: block;
+  color: var(--tone);
+  font-size: 0.9rem;
+  margin-bottom: 0.2rem;
+}
+
+.callout p {
+  margin: 0;
+  font-size: 0.86rem;
+  line-height: 1.5;
+  color: #cbd5e1;
+}
+
+.callout.is-info {
+  --tone: #3b82f6;
+  --tint: rgba(59, 130, 246, 0.12);
+}
+
+.callout.is-success {
+  --tone: #10b981;
+  --tint: rgba(16, 185, 129, 0.12);
+}
+
+.callout.is-warning {
+  --tone: #f59e0b;
+  --tint: rgba(245, 158, 11, 0.12);
+}
+
+.callout.is-danger {
+  --tone: #ef4444;
+  --tint: rgba(239, 68, 68, 0.12);
+}


### PR DESCRIPTION
## Pull Request Description

Adds callout note boxes built for #40617. A set of docs style callouts in four tones driven by a single class, using only CSS and inline SVG. Closes #40617.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
Callout boxes in four tones (info, success, warning, danger), each with a colored left bar, tinted background, inline SVG icon, and title.

**How does a developer use it?**

```html
<div class="callout is-info">
  <svg class="callout-icon">...</svg>
  <div><strong>Note</strong><p>Helpful context here.</p></div>
</div>
```

**Why does it fit EaseMotion CSS?**
It offers a consistent set of note boxes driven by a single tone class, using only CSS and inline SVG. Each tone sets `--tone` and `--tint` custom properties that color the bar, icon, title, and background.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: four callouts render, each with its own left border tone (blue, green, amber, red).
