### PR TITLE
feat: add feature comparison table

### DIFF
--- a/submissions/examples/comparison-table-as/README.md
+++ b/submissions/examples/comparison-table-as/README.md
@@ -1,0 +1,28 @@
+# Feature Comparison Table
+
+### What does this do?
+
+It lays out a plan comparison table with features down the rows and plans across the columns, showing green check marks and gray dashes in each cell. The featured plan column is tinted and accented. It is built with only CSS.
+
+### How is it used?
+
+```html
+<table class="compare">
+  <thead>
+    <tr><th></th><th>Free</th><th class="is-featured">Pro</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">Unlimited projects</th>
+      <td class="no">-</td>
+      <td class="is-featured"><svg>...</svg></td>
+    </tr>
+  </tbody>
+</table>
+```
+
+Add `is-featured` to the header and cells of the plan you want to highlight. Use an inline SVG check for a yes and the `no` class for a dash.
+
+### Why is it useful?
+
+Comparison tables help users pick a plan by scanning features side by side. This styles an accessible data table with proper row and column headers, an accented column, and clear yes and no marks, using only CSS and inline SVG.

--- a/submissions/examples/comparison-table-as/demo.html
+++ b/submissions/examples/comparison-table-as/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Feature Comparison Table</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <table class="compare">
+    <caption class="sr-only">Plan feature comparison</caption>
+    <thead>
+      <tr>
+        <th scope="col"></th>
+        <th scope="col">Free</th>
+        <th scope="col" class="is-featured">Pro</th>
+        <th scope="col">Team</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row">Unlimited projects</th>
+        <td class="no">-</td>
+        <td class="is-featured"><svg viewBox="0 0 24 24" aria-label="Yes"><path d="m5 13 4 4 10-11" stroke-linecap="round" stroke-linejoin="round" /></svg></td>
+        <td><svg viewBox="0 0 24 24" aria-label="Yes"><path d="m5 13 4 4 10-11" stroke-linecap="round" stroke-linejoin="round" /></svg></td>
+      </tr>
+      <tr>
+        <th scope="row">Custom domains</th>
+        <td class="no">-</td>
+        <td class="is-featured"><svg viewBox="0 0 24 24" aria-label="Yes"><path d="m5 13 4 4 10-11" stroke-linecap="round" stroke-linejoin="round" /></svg></td>
+        <td><svg viewBox="0 0 24 24" aria-label="Yes"><path d="m5 13 4 4 10-11" stroke-linecap="round" stroke-linejoin="round" /></svg></td>
+      </tr>
+      <tr>
+        <th scope="row">Priority support</th>
+        <td class="no">-</td>
+        <td class="is-featured no">-</td>
+        <td><svg viewBox="0 0 24 24" aria-label="Yes"><path d="m5 13 4 4 10-11" stroke-linecap="round" stroke-linejoin="round" /></svg></td>
+      </tr>
+      <tr>
+        <th scope="row">Seats included</th>
+        <td>1</td>
+        <td class="is-featured">3</td>
+        <td>10</td>
+      </tr>
+    </tbody>
+  </table>
+</body>
+</html>

--- a/submissions/examples/comparison-table-as/style.css
+++ b/submissions/examples/comparison-table-as/style.css
@@ -1,0 +1,79 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2.5rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.compare {
+  border-collapse: collapse;
+  width: min(520px, 96vw);
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.compare th,
+.compare td {
+  padding: 0.8rem 1rem;
+  text-align: center;
+  border-bottom: 1px solid #1b2942;
+  font-size: 0.9rem;
+}
+
+.compare thead th {
+  font-size: 0.95rem;
+  color: #e2e8f0;
+  background: #111c30;
+}
+
+.compare tbody th {
+  text-align: left;
+  font-weight: 500;
+  color: #cbd5e1;
+}
+
+.compare tbody tr:last-child th,
+.compare tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.compare .is-featured {
+  background: rgba(108, 99, 255, 0.12);
+  color: #c7d2fe;
+}
+
+.compare thead .is-featured {
+  color: #a5b4fc;
+}
+
+.compare td svg {
+  width: 18px;
+  height: 18px;
+  stroke: #10b981;
+  stroke-width: 2.5;
+  fill: none;
+  vertical-align: middle;
+}
+
+.compare td.no {
+  color: #475569;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a feature comparison table built for #40627. Features run down the rows and plans across the columns with check and dash marks, and the featured plan column is accented. Closes #40627.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A plan comparison table with features as rows and plans as columns, green check marks and gray dashes in the cells, and a tinted featured column.

**How does a developer use it?**

```html
<table class="compare">
  <thead><tr><th></th><th>Free</th><th class="is-featured">Pro</th></tr></thead>
  <tbody>
    <tr>
      <th scope="row">Unlimited projects</th>
      <td class="no">-</td>
      <td class="is-featured"><svg>...</svg></td>
    </tr>
  </tbody>
</table>
```

**Why does it fit EaseMotion CSS?**
It styles an accessible data table with proper row and column headers, an accented column, and clear yes and no marks, using only CSS and inline SVG.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: four feature rows render with five check icons and the featured column carries its accent tint.
