### PR TITLE
feat: add color swatch picker

### DIFF
--- a/submissions/examples/color-swatch-as/README.md
+++ b/submissions/examples/color-swatch-as/README.md
@@ -1,0 +1,23 @@
+# Color Swatch Picker
+
+### What does this do?
+
+It shows a row of color swatches where the user picks one and a ring animates around the chosen swatch. It uses radio inputs and CSS only, so the selection is keyboard operable and needs no JavaScript.
+
+### How is it used?
+
+```html
+<fieldset class="swatches">
+  <legend>Color</legend>
+  <div class="swatch-row">
+    <label style="--c: #ef4444"><input type="radio" name="color" checked /><span></span></label>
+    <label style="--c: #3b82f6"><input type="radio" name="color" /><span></span></label>
+  </div>
+</fieldset>
+```
+
+Set each swatch color with the `--c` custom property on the label. Give every input the same `name` so only one can be chosen, and the checked swatch draws a ring using a layered box shadow.
+
+### Why is it useful?
+
+Color pickers appear in product options and theme settings. This builds a single choice swatch picker with a clear selected ring using only radio inputs and CSS. Each swatch has a hover lift and a keyboard focus outline, both eased and reduced motion aware.

--- a/submissions/examples/color-swatch-as/demo.html
+++ b/submissions/examples/color-swatch-as/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Color Swatch Picker</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <fieldset class="swatches">
+    <legend>Choose a color</legend>
+    <div class="swatch-row">
+      <label style="--c: #ef4444"><input type="radio" name="color" aria-label="Red" /><span></span></label>
+      <label style="--c: #f59e0b"><input type="radio" name="color" aria-label="Amber" /><span></span></label>
+      <label style="--c: #10b981"><input type="radio" name="color" aria-label="Green" checked /><span></span></label>
+      <label style="--c: #3b82f6"><input type="radio" name="color" aria-label="Blue" /><span></span></label>
+      <label style="--c: #a855f7"><input type="radio" name="color" aria-label="Purple" /><span></span></label>
+    </div>
+  </fieldset>
+</body>
+</html>

--- a/submissions/examples/color-swatch-as/style.css
+++ b/submissions/examples/color-swatch-as/style.css
@@ -1,0 +1,76 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.swatches {
+  border: 1px solid #26324a;
+  border-radius: 16px;
+  background: #0e1626;
+  padding: 1.35rem 1.6rem;
+  margin: 0;
+}
+
+.swatches legend {
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 0 0.4rem;
+}
+
+.swatch-row {
+  display: flex;
+  gap: 0.9rem;
+  margin-top: 1rem;
+}
+
+.swatches label {
+  cursor: pointer;
+  line-height: 0;
+}
+
+.swatches input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.swatches span {
+  display: block;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: var(--c);
+  box-shadow: 0 0 0 0 #0b1121, 0 0 0 0 var(--c);
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.swatches label:hover span {
+  transform: scale(1.08);
+}
+
+.swatches :checked + span {
+  box-shadow: 0 0 0 3px #0b1121, 0 0 0 5px var(--c);
+}
+
+.swatches :focus-visible + span {
+  outline: 2px solid #fff;
+  outline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .swatches span {
+    transition: box-shadow 0.2s ease;
+  }
+
+  .swatches label:hover span {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a color swatch picker built for #40652. A row of swatches with a ring that animates around the chosen one, using only radio inputs and CSS. Closes #40652.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A single choice color swatch picker where the selected swatch draws an animated ring, with hover lift and keyboard focus support.

**How does a developer use it?**

```html
<fieldset class="swatches">
  <legend>Color</legend>
  <div class="swatch-row">
    <label style="--c: #ef4444"><input type="radio" name="color" checked /><span></span></label>
    <label style="--c: #3b82f6"><input type="radio" name="color" /><span></span></label>
  </div>
</fieldset>
```

**Why does it fit EaseMotion CSS?**
It builds a single choice swatch picker with a clear selected ring using only radio inputs and CSS. Each swatch color is set through a `--c` custom property and the ring is a layered box shadow.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: five swatches render and the checked swatch carries a distinct ring shadow that the others do not.
