### PR TITLE
feat: add floating label textarea

### DIFF
--- a/submissions/examples/floating-textarea-as/README.md
+++ b/submissions/examples/floating-textarea-as/README.md
@@ -1,0 +1,20 @@
+# Floating Label Textarea
+
+### What does this do?
+
+It shows a multi line textarea whose label rests inside the field and floats up to the top edge when the field is focused or has text. It works with no JavaScript by using the placeholder shown state.
+
+### How is it used?
+
+```html
+<label class="field">
+  <textarea placeholder=" " rows="4"></textarea>
+  <span>Your message</span>
+</label>
+```
+
+The `placeholder=" "` is required so the `:placeholder-shown` selector can tell whether the field is empty. When it is not empty, or on focus, the label shrinks and floats up.
+
+### Why is it useful?
+
+Floating labels keep forms compact while still labeling every field. Most examples cover single line inputs, so this adds the multi line textarea case using only CSS. The label stays clickable through the label wrapper and the transition is removed under reduced motion.

--- a/submissions/examples/floating-textarea-as/demo.html
+++ b/submissions/examples/floating-textarea-as/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Floating Label Textarea</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <label class="field">
+    <textarea placeholder=" " rows="4"></textarea>
+    <span>Your message</span>
+  </label>
+</body>
+</html>

--- a/submissions/examples/floating-textarea-as/style.css
+++ b/submissions/examples/floating-textarea-as/style.css
@@ -1,0 +1,61 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.field {
+  position: relative;
+  display: block;
+  width: min(360px, 92vw);
+}
+
+.field textarea {
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 120px;
+  resize: vertical;
+  padding: 1.4rem 0.9rem 0.6rem;
+  font: inherit;
+  font-size: 0.95rem;
+  color: #e2e8f0;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 10px;
+  outline: none;
+  transition: border-color 0.2s ease;
+}
+
+.field textarea:focus {
+  border-color: #6c63ff;
+}
+
+.field span {
+  position: absolute;
+  left: 0.95rem;
+  top: 1.1rem;
+  color: #94a3b8;
+  font-size: 0.95rem;
+  pointer-events: none;
+  transform-origin: left center;
+  transition: transform 0.18s ease, color 0.18s ease;
+}
+
+.field textarea:focus + span,
+.field textarea:not(:placeholder-shown) + span {
+  transform: translateY(-0.75rem) scale(0.8);
+  color: #a5b4fc;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .field span,
+  .field textarea {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a floating label textarea built for #40687. The label floats up when the multi line field is focused or has text, using only CSS and the placeholder shown state. Closes #40687.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A multi line textarea whose label rests inside the field and floats to the top edge on focus or when the field has text.

**How does a developer use it?**

```html
<label class="field">
  <textarea placeholder=" " rows="4"></textarea>
  <span>Your message</span>
</label>
```

**Why does it fit EaseMotion CSS?**
Most floating label examples cover single line inputs, so this adds the multi line textarea case using only CSS and the `:placeholder-shown` state. The label stays clickable through the wrapper and the transition is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: with text in the field the label transform resolves to a scaled and upward translated matrix, confirming the float.
