### PR TITLE
feat: add thumbs feedback

### DIFF
--- a/submissions/examples/thumbs-feedback-as/README.md
+++ b/submissions/examples/thumbs-feedback-as/README.md
@@ -1,0 +1,23 @@
+# Thumbs Feedback
+
+### What does this do?
+
+It shows a was this helpful widget with a thumbs up and a thumbs down button. Choosing one fills its icon with color and dims the other. It uses radio inputs and CSS only, so it is keyboard operable with no JavaScript.
+
+### How is it used?
+
+```html
+<fieldset class="thumbs">
+  <legend>Was this helpful?</legend>
+  <div class="thumbs-row">
+    <label class="up"><input type="radio" name="fb" /><svg>...</svg></label>
+    <label class="down"><input type="radio" name="fb" /><svg>...</svg></label>
+  </div>
+</fieldset>
+```
+
+Both inputs share the same `name`, so only one can be chosen. The `:has(:checked)` selector fills the selected icon and tints its button with `color-mix`.
+
+### Why is it useful?
+
+Thumbs up and down feedback appears at the end of help articles and answers. This builds a compact two option feedback control with a filled selected state using only radio inputs and CSS. The active button shows a focus ring and the scale animation is removed under reduced motion.

--- a/submissions/examples/thumbs-feedback-as/demo.html
+++ b/submissions/examples/thumbs-feedback-as/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Thumbs Feedback</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <fieldset class="thumbs">
+    <legend>Was this helpful?</legend>
+    <div class="thumbs-row">
+      <label class="up">
+        <input type="radio" name="fb" aria-label="Yes, helpful" />
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 10v11H4a1 1 0 0 1-1-1v-9a1 1 0 0 1 1-1zm0 0 4-7a2 2 0 0 1 2 2v3h5a2 2 0 0 1 2 2.4l-1.4 7A2 2 0 0 1 16.6 21H7" stroke-linejoin="round" /></svg>
+      </label>
+      <label class="down">
+        <input type="radio" name="fb" aria-label="No, not helpful" />
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M17 14V3h3a1 1 0 0 1 1 1v9a1 1 0 0 1-1 1zm0 0-4 7a2 2 0 0 1-2-2v-3H6a2 2 0 0 1-2-2.4l1.4-7A2 2 0 0 1 7.4 3H17" stroke-linejoin="round" /></svg>
+      </label>
+    </div>
+  </fieldset>
+</body>
+</html>

--- a/submissions/examples/thumbs-feedback-as/style.css
+++ b/submissions/examples/thumbs-feedback-as/style.css
@@ -1,0 +1,97 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.thumbs {
+  border: 1px solid #26324a;
+  border-radius: 16px;
+  background: #0e1626;
+  padding: 1.35rem 1.6rem;
+  margin: 0;
+  text-align: center;
+}
+
+.thumbs legend {
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 0 0.4rem;
+}
+
+.thumbs-row {
+  display: flex;
+  gap: 0.9rem;
+  margin-top: 1rem;
+}
+
+.thumbs label {
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  width: 46px;
+  height: 46px;
+  border-radius: 12px;
+  border: 1px solid #26324a;
+  transition: background 0.18s ease, border-color 0.18s ease;
+}
+
+.thumbs .up {
+  color: #10b981;
+}
+
+.thumbs .down {
+  color: #ef4444;
+}
+
+.thumbs input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.thumbs svg {
+  width: 22px;
+  height: 22px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+  transition: transform 0.18s ease, fill 0.18s ease;
+}
+
+.thumbs label:hover {
+  border-color: currentColor;
+}
+
+.thumbs label:has(:checked) {
+  border-color: currentColor;
+  background: color-mix(in srgb, currentColor 14%, transparent);
+}
+
+.thumbs label:has(:checked) svg {
+  fill: currentColor;
+  transform: scale(1.12);
+}
+
+.thumbs label:has(:focus-visible) {
+  outline: 2px solid #6c63ff;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .thumbs label,
+  .thumbs svg {
+    transition: none;
+  }
+
+  .thumbs label:has(:checked) svg {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a thumbs feedback widget built for #40707. A thumbs up and thumbs down control where choosing one fills its icon, using only radio inputs and CSS. Closes #40707.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A was this helpful control with a thumbs up and thumbs down button. The selected one fills with color and the other dims.

**How does a developer use it?**

```html
<fieldset class="thumbs">
  <legend>Was this helpful?</legend>
  <div class="thumbs-row">
    <label class="up"><input type="radio" name="fb" /><svg>...</svg></label>
    <label class="down"><input type="radio" name="fb" /><svg>...</svg></label>
  </div>
</fieldset>
```

**Why does it fit EaseMotion CSS?**
It builds a compact two option feedback control with a filled selected state using only radio inputs and CSS. The active button shows a focus ring and the scale animation is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: selecting the up option fills its icon green while the down icon stays unfilled.
