### PR TITLE
feat: add wizard step progress

### DIFF
--- a/submissions/examples/wizard-steps-as/README.md
+++ b/submissions/examples/wizard-steps-as/README.md
@@ -1,0 +1,21 @@
+# Wizard Step Progress
+
+### What does this do?
+
+It renders a horizontal step progress indicator for multi step forms and checkouts. Each step is a numbered circle joined by a connector, and steps show a done, active, or upcoming state. Done steps display a check mark and a filled connector.
+
+### How is it used?
+
+```html
+<ol class="steps">
+  <li class="is-done">Cart</li>
+  <li class="is-active" aria-current="step">Payment</li>
+  <li>Review</li>
+</ol>
+```
+
+Add `is-done` to completed steps and `is-active` to the current one. The step numbers come from a CSS counter, so you never hand write them.
+
+### Why is it useful?
+
+Multi step flows like checkout and onboarding need a clear progress header. This renders a step progress bar with three states driven by simple classes, using only CSS and a counter for the numbers. The active step carries `aria-current` for assistive tech.

--- a/submissions/examples/wizard-steps-as/demo.html
+++ b/submissions/examples/wizard-steps-as/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Wizard Step Progress</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <ol class="steps">
+    <li class="is-done">Cart</li>
+    <li class="is-done">Address</li>
+    <li class="is-active" aria-current="step">Payment</li>
+    <li>Review</li>
+  </ol>
+</body>
+</html>

--- a/submissions/examples/wizard-steps-as/style.css
+++ b/submissions/examples/wizard-steps-as/style.css
@@ -1,0 +1,89 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2.5rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.steps {
+  display: flex;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  width: min(520px, 96vw);
+  counter-reset: step;
+}
+
+.steps li {
+  flex: 1;
+  position: relative;
+  text-align: center;
+  font-size: 0.82rem;
+  color: #64748b;
+  padding-top: 3rem;
+}
+
+.steps li::before {
+  counter-increment: step;
+  content: counter(step);
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: #1b2942;
+  color: #94a3b8;
+  font-weight: 700;
+  border: 2px solid #26324a;
+  z-index: 1;
+}
+
+.steps li::after {
+  content: "";
+  position: absolute;
+  top: 17px;
+  left: -50%;
+  width: 100%;
+  height: 2px;
+  background: #26324a;
+}
+
+.steps li:first-child::after {
+  display: none;
+}
+
+.steps .is-done {
+  color: #cbd5e1;
+}
+
+.steps .is-done::before {
+  content: "\2713";
+  background: #10b981;
+  border-color: #10b981;
+  color: #fff;
+}
+
+.steps .is-done::after {
+  background: #10b981;
+}
+
+.steps .is-active {
+  color: #fff;
+  font-weight: 600;
+}
+
+.steps .is-active::before {
+  background: #6c63ff;
+  border-color: #6c63ff;
+  color: #fff;
+  box-shadow: 0 0 0 4px rgba(108, 99, 255, 0.25);
+}


### PR DESCRIPTION
## Pull Request Description

Adds a wizard step progress indicator built for #40725. A horizontal stepper with done, active, and upcoming states driven by classes, using only CSS. Closes #40725.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A horizontal step progress header for multi step forms. Each step is a numbered circle joined by a connector; done steps show a check and a filled connector, and the active step is highlighted.

**How does a developer use it?**

```html
<ol class="steps">
  <li class="is-done">Cart</li>
  <li class="is-active" aria-current="step">Payment</li>
  <li>Review</li>
</ol>
```

**Why does it fit EaseMotion CSS?**
It renders a step progress bar with three states driven by simple classes, using only CSS and a counter for the numbers so they are never hand written. The active step carries `aria-current`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: four steps render, done steps show a green check circle and the active step shows a purple numbered circle.
