### PR TITLE
feat: add notification panel

### DIFF
--- a/submissions/examples/notification-panel-as/README.md
+++ b/submissions/examples/notification-panel-as/README.md
@@ -1,0 +1,27 @@
+# Notification Panel
+
+### What does this do?
+
+It shows a bell button with an unread count badge that opens a panel listing recent notifications. Unread items are marked with a dot. It uses the native `details` and `summary` elements, so it opens on click and stays keyboard operable with no JavaScript.
+
+### How is it used?
+
+```html
+<details class="notif">
+  <summary>
+    <svg>...</svg>
+    <span class="badge">3</span>
+  </summary>
+  <div class="notif-panel">
+    <div class="notif-head">Notifications</div>
+    <a class="notif-item is-unread" href="#">New comment<small>2m ago</small></a>
+    <a class="notif-item" href="#">Weekly summary<small>Yesterday</small></a>
+  </div>
+</details>
+```
+
+Add `is-unread` to rows that need the dot marker. Remove `open` from the demo to see the panel start closed.
+
+### Why is it useful?
+
+A notification panel sits in the header of most apps. This combines a badge, a disclosure, and a list into a compact panel using only CSS and inline SVG. The panel animates in on open and the animation is removed under reduced motion.

--- a/submissions/examples/notification-panel-as/demo.html
+++ b/submissions/examples/notification-panel-as/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Notification Panel</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <details class="notif" open>
+    <summary aria-label="Notifications, 3 unread">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9a6 6 0 0 1 12 0c0 5 2 6 2 6H4s2-1 2-6" stroke-linecap="round" stroke-linejoin="round" /><path d="M10.5 20a1.5 1.5 0 0 0 3 0" stroke-linecap="round" /></svg>
+      <span class="badge">3</span>
+    </summary>
+    <div class="notif-panel">
+      <div class="notif-head">Notifications</div>
+      <a class="notif-item is-unread" href="#">Priya commented on your post<small>2 minutes ago</small></a>
+      <a class="notif-item is-unread" href="#">Your export is ready to download<small>18 minutes ago</small></a>
+      <a class="notif-item is-unread" href="#">New sign in from a new device<small>1 hour ago</small></a>
+      <a class="notif-item" href="#">Weekly summary is available<small>Yesterday</small></a>
+    </div>
+  </details>
+</body>
+</html>

--- a/submissions/examples/notification-panel-as/style.css
+++ b/submissions/examples/notification-panel-as/style.css
@@ -1,0 +1,139 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: start center;
+  padding: 3rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.notif {
+  position: relative;
+}
+
+.notif summary {
+  list-style: none;
+  cursor: pointer;
+  position: relative;
+  width: 46px;
+  height: 46px;
+  display: grid;
+  place-items: center;
+  border-radius: 12px;
+  background: #0e1626;
+  border: 1px solid #26324a;
+}
+
+.notif summary::-webkit-details-marker {
+  display: none;
+}
+
+.notif summary svg {
+  width: 22px;
+  height: 22px;
+  stroke: #cbd5e1;
+  stroke-width: 2;
+  fill: none;
+}
+
+.notif summary:focus-visible {
+  outline: 2px solid #6c63ff;
+  outline-offset: 2px;
+}
+
+.badge {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
+  box-sizing: border-box;
+  border-radius: 9px;
+  background: #ef4444;
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 700;
+  display: grid;
+  place-items: center;
+  border: 2px solid #0b1121;
+}
+
+.notif-panel {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  width: 260px;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 12px;
+  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+}
+
+.notif[open] .notif-panel {
+  animation: notif-pop 0.16s ease;
+}
+
+.notif-head {
+  padding: 0.7rem 0.9rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: #94a3b8;
+  border-bottom: 1px solid #1b2942;
+}
+
+.notif-item {
+  display: block;
+  position: relative;
+  padding: 0.7rem 0.9rem 0.7rem 1.7rem;
+  font-size: 0.85rem;
+  color: #cbd5e1;
+  text-decoration: none;
+  border-bottom: 1px solid #1b2942;
+  transition: background 0.15s ease;
+}
+
+.notif-item:last-child {
+  border-bottom: none;
+}
+
+.notif-item:hover,
+.notif-item:focus-visible {
+  background: #1b2942;
+  outline: none;
+}
+
+.notif-item small {
+  display: block;
+  color: #64748b;
+  font-size: 0.72rem;
+  margin-top: 0.15rem;
+}
+
+.notif-item.is-unread::before {
+  content: "";
+  position: absolute;
+  left: 0.8rem;
+  top: 1rem;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #6c63ff;
+}
+
+@keyframes notif-pop {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .notif[open] .notif-panel {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a notification panel built for #40745. A bell button with an unread badge opens a panel of recent notifications, using the native details element and CSS only. Closes #40745.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A bell button with an unread count badge that opens a panel listing recent notifications, with unread rows marked by a dot.

**How does a developer use it?**

```html
<details class="notif">
  <summary><svg>...</svg><span class="badge">3</span></summary>
  <div class="notif-panel">
    <a class="notif-item is-unread" href="#">New comment<small>2m ago</small></a>
  </div>
</details>
```

**Why does it fit EaseMotion CSS?**
It combines a badge, a disclosure, and a list into a compact panel using only CSS and inline SVG. It opens on click, stays keyboard operable, and the open animation is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: with the panel open four items render, three marked unread with a purple dot, and the badge reads 3.
