### PR TITLE
feat: add pagination controls

### DIFF
--- a/submissions/examples/pagination-controls-as/README.md
+++ b/submissions/examples/pagination-controls-as/README.md
@@ -1,0 +1,23 @@
+# Pagination Controls
+
+### What does this do?
+
+It shows a pagination bar with previous and next arrows and numbered page buttons. Clicking a number highlights it as the current page. The numbers are radio inputs, so the active page is real and keyboard operable, with no JavaScript.
+
+### How is it used?
+
+```html
+<nav class="pager" aria-label="Pagination">
+  <button class="pager-arrow" type="button">Prev</button>
+  <label><input type="radio" name="page" checked /><span>1</span></label>
+  <label><input type="radio" name="page" /><span>2</span></label>
+  <span class="gap">...</span>
+  <button class="pager-arrow" type="button">Next</button>
+</nav>
+```
+
+Every page input shares the same `name`, so only one is active. Use `span class="gap"` to show a break between page ranges.
+
+### Why is it useful?
+
+Paginated lists and tables need a clear page switcher. This styles an accessible pagination bar where the active page is driven by a checked radio, using only CSS. Each page tile has hover and focus states and the transitions are removed under reduced motion.

--- a/submissions/examples/pagination-controls-as/demo.html
+++ b/submissions/examples/pagination-controls-as/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pagination Controls</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <nav class="pager" aria-label="Pagination">
+    <button class="pager-arrow" type="button">Prev</button>
+    <label><input type="radio" name="page" aria-label="Page 1" /><span>1</span></label>
+    <label><input type="radio" name="page" aria-label="Page 2" checked /><span>2</span></label>
+    <label><input type="radio" name="page" aria-label="Page 3" /><span>3</span></label>
+    <label><input type="radio" name="page" aria-label="Page 4" /><span>4</span></label>
+    <span class="gap" aria-hidden="true">...</span>
+    <label><input type="radio" name="page" aria-label="Page 12" /><span>12</span></label>
+    <button class="pager-arrow" type="button">Next</button>
+  </nav>
+</body>
+</html>

--- a/submissions/examples/pagination-controls-as/style.css
+++ b/submissions/examples/pagination-controls-as/style.css
@@ -1,0 +1,92 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.pager {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 12px;
+}
+
+.pager-arrow {
+  height: 36px;
+  padding: 0 0.8rem;
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #cbd5e1;
+  background: transparent;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.pager-arrow:hover,
+.pager-arrow:focus-visible {
+  background: #1b2942;
+  color: #fff;
+  outline: none;
+}
+
+.pager label {
+  cursor: pointer;
+}
+
+.pager input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.pager span {
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: #cbd5e1;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.pager label:hover span {
+  background: #1b2942;
+}
+
+.pager label:has(:checked) span {
+  background: #6c63ff;
+  color: #fff;
+}
+
+.pager label:has(:focus-visible) span {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+.pager .gap {
+  width: 24px;
+  text-align: center;
+  color: #64748b;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pager-arrow,
+  .pager span {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds pagination controls built for #40765. Previous and next arrows around numbered page buttons, where the active page is a checked radio, using only CSS. Closes #40765.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A pagination bar with previous and next arrows and numbered page buttons. Clicking a number highlights it as the current page, and a gap marker shows a break between ranges.

**How does a developer use it?**

```html
<nav class="pager" aria-label="Pagination">
  <button class="pager-arrow" type="button">Prev</button>
  <label><input type="radio" name="page" checked /><span>1</span></label>
  <label><input type="radio" name="page" /><span>2</span></label>
  <button class="pager-arrow" type="button">Next</button>
</nav>
```

**Why does it fit EaseMotion CSS?**
It styles an accessible pagination bar where the active page is driven by a checked radio, using only CSS. Each tile has hover and focus states and transitions are removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: five page tiles and two arrows render, and the checked page fills with the accent color while the others stay transparent.
