### PR TITLE
feat: add stat usage meters

### DIFF
--- a/submissions/examples/stat-meter-as/README.md
+++ b/submissions/examples/stat-meter-as/README.md
@@ -1,0 +1,20 @@
+# Stat Usage Meters
+
+### What does this do?
+
+It shows a stack of labeled horizontal meters for usage figures like storage, bandwidth, or quota. Each row has a label, a percent value, and a bar that fills to a percent set by a custom property and grows on load.
+
+### How is it used?
+
+```html
+<div class="meter is-warn" style="--val: 88%">
+  <div class="meter-top"><span>API quota</span><span>88%</span></div>
+  <div class="meter-track"><span class="meter-fill"></span></div>
+</div>
+```
+
+Set the fill amount with the `--val` custom property. Add `is-good` for a green tone or `is-warn` for an amber to red tone; the default is the accent gradient.
+
+### Why is it useful?
+
+Usage meters appear in dashboards and account pages. This renders a set of labeled progress meters driven by a single custom property per row, with a smooth fill animation and a color tone, using only CSS. The fill animation is removed under reduced motion.

--- a/submissions/examples/stat-meter-as/demo.html
+++ b/submissions/examples/stat-meter-as/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Stat Usage Meters</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="meters">
+    <div class="meter is-good" style="--val: 34%">
+      <div class="meter-top"><span>Storage</span><span>34%</span></div>
+      <div class="meter-track"><span class="meter-fill"></span></div>
+    </div>
+    <div class="meter" style="--val: 62%">
+      <div class="meter-top"><span>Bandwidth</span><span>62%</span></div>
+      <div class="meter-track"><span class="meter-fill"></span></div>
+    </div>
+    <div class="meter is-warn" style="--val: 88%">
+      <div class="meter-top"><span>API quota</span><span>88%</span></div>
+      <div class="meter-track"><span class="meter-fill"></span></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/stat-meter-as/style.css
+++ b/submissions/examples/stat-meter-as/style.css
@@ -1,0 +1,75 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.meters {
+  display: flex;
+  flex-direction: column;
+  gap: 1.3rem;
+  width: min(360px, 92vw);
+  padding: 1.6rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+  box-sizing: border-box;
+}
+
+.meter-top {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  margin-bottom: 0.45rem;
+}
+
+.meter-top span:first-child {
+  color: #cbd5e1;
+}
+
+.meter-top span:last-child {
+  color: #94a3b8;
+  font-variant-numeric: tabular-nums;
+}
+
+.meter-track {
+  height: 9px;
+  border-radius: 5px;
+  background: #1b2942;
+  overflow: hidden;
+}
+
+.meter-fill {
+  display: block;
+  height: 100%;
+  width: var(--val);
+  border-radius: 5px;
+  background: linear-gradient(90deg, #6c63ff, #a855f7);
+  animation: meter-grow 0.9s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.meter.is-warn .meter-fill {
+  background: linear-gradient(90deg, #f59e0b, #ef4444);
+}
+
+.meter.is-good .meter-fill {
+  background: linear-gradient(90deg, #10b981, #34d399);
+}
+
+@keyframes meter-grow {
+  from {
+    width: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .meter-fill {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds stat usage meters built for #40783. A stack of labeled horizontal meters where each bar fills to a percent from a custom property and grows on load, using only CSS. Closes #40783.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A set of labeled usage meters for figures like storage or bandwidth. Each row shows a label, a percent, and a bar that fills to a `--val` amount with an entry animation and an optional color tone.

**How does a developer use it?**

```html
<div class="meter is-warn" style="--val: 88%">
  <div class="meter-top"><span>API quota</span><span>88%</span></div>
  <div class="meter-track"><span class="meter-fill"></span></div>
</div>
```

**Why does it fit EaseMotion CSS?**
It renders labeled progress meters driven by a single custom property per row, with a smooth fill animation and a color tone (`is-good`, `is-warn`, or the default accent), using only CSS. The animation is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: three meters fill to 34%, 62%, and 88% of their tracks, matching their `--val` values.
