### PR TITLE
feat: add rating summary

### DIFF
--- a/submissions/examples/rating-summary-as/README.md
+++ b/submissions/examples/rating-summary-as/README.md
@@ -1,0 +1,26 @@
+# Rating Summary
+
+### What does this do?
+
+It shows a review summary with a large average score, a star row, and a distribution of five to one star bars. Each bar fills to a percent set with a custom property and grows on load.
+
+### How is it used?
+
+```html
+<div class="rating-summary">
+  <div>
+    <div class="rs-score">4.6<span>out of 5</span></div>
+    <div class="rs-stars">★★★★★</div>
+  </div>
+  <ul class="rs-bars">
+    <li style="--val: 72%"><span>5</span><span class="rs-track"></span></li>
+    <li style="--val: 18%"><span>4</span><span class="rs-track"></span></li>
+  </ul>
+</div>
+```
+
+Set each row fill with the `--val` custom property. The score and star row sit on the left and the distribution bars on the right.
+
+### Why is it useful?
+
+Product and app pages show a rating breakdown so shoppers can judge reviews at a glance. This lays out an average score next to labeled distribution bars driven by a single custom property per row, using only CSS. The bars animate in and stay still under reduced motion.

--- a/submissions/examples/rating-summary-as/demo.html
+++ b/submissions/examples/rating-summary-as/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Rating Summary</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="rating-summary">
+    <div>
+      <div class="rs-score">4.6<span>out of 5</span></div>
+      <div class="rs-stars" aria-hidden="true">★★★★★</div>
+    </div>
+    <ul class="rs-bars">
+      <li style="--val: 72%"><span>5</span><span class="rs-track"></span></li>
+      <li style="--val: 18%"><span>4</span><span class="rs-track"></span></li>
+      <li style="--val: 6%"><span>3</span><span class="rs-track"></span></li>
+      <li style="--val: 3%"><span>2</span><span class="rs-track"></span></li>
+      <li style="--val: 1%"><span>1</span><span class="rs-track"></span></li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/submissions/examples/rating-summary-as/style.css
+++ b/submissions/examples/rating-summary-as/style.css
@@ -1,0 +1,94 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.rating-summary {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1.6rem;
+  align-items: center;
+  width: min(420px, 94vw);
+  padding: 1.5rem 1.75rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+  box-sizing: border-box;
+}
+
+.rs-score {
+  text-align: center;
+  font-size: 2.6rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.rs-score span {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: #94a3b8;
+}
+
+.rs-stars {
+  margin-top: 0.5rem;
+  color: #f59e0b;
+  font-size: 0.9rem;
+  letter-spacing: 0.1em;
+}
+
+.rs-bars {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.rs-bars li {
+  display: grid;
+  grid-template-columns: 0.8rem 1fr;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.78rem;
+  color: #94a3b8;
+}
+
+.rs-track {
+  position: relative;
+  height: 8px;
+  border-radius: 4px;
+  background: #1b2942;
+  overflow: hidden;
+}
+
+.rs-track::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: var(--val);
+  background: #f59e0b;
+  border-radius: 4px;
+  animation: rs-grow 0.9s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@keyframes rs-grow {
+  from {
+    width: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rs-track::before {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a rating summary built for #40908. An average score beside a five to one star distribution where each bar fills to a custom property percent, using only CSS. Closes #40908.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A review summary with a large average score, a star row, and a distribution of five to one star bars that fill by a `--val` percent.

**How does a developer use it?**

```html
<div class="rating-summary">
  <div><div class="rs-score">4.6<span>out of 5</span></div><div class="rs-stars">★★★★★</div></div>
  <ul class="rs-bars">
    <li style="--val: 72%"><span>5</span><span class="rs-track"></span></li>
  </ul>
</div>
```

**Why does it fit EaseMotion CSS?**
It lays out an average score next to labeled distribution bars driven by a single custom property per row, using only CSS. The bars animate in and hold still under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: five bars fill to 72, 18, 6, 3, and 1 percent of their tracks, matching their `--val` values.
