### PR TITLE
feat: add modal dialog

### DIFF
--- a/submissions/examples/modal-dialog-as/README.md
+++ b/submissions/examples/modal-dialog-as/README.md
@@ -1,0 +1,29 @@
+# Modal Dialog
+
+### What does this do?
+
+It shows a modal dialog that opens from a trigger link and closes with a backdrop click or a cancel button. It uses the CSS `:target` state, so it opens and closes with no JavaScript and animates in with a fade and scale.
+
+### How is it used?
+
+```html
+<a class="modal-open" href="#demo-modal">Open dialog</a>
+
+<div class="modal" id="demo-modal" role="dialog" aria-modal="true">
+  <a class="modal-backdrop" href="#" tabindex="-1"></a>
+  <div class="modal-card">
+    <h3>Delete this file?</h3>
+    <p>This cannot be undone.</p>
+    <div class="modal-actions">
+      <a class="modal-close" href="#">Cancel</a>
+      <a class="modal-confirm" href="#">Delete</a>
+    </div>
+  </div>
+</div>
+```
+
+The trigger points to the modal `id`. When that id is the URL target, the modal becomes visible. Any link back to `#` closes it.
+
+### Why is it useful?
+
+Dialogs confirm actions and show quick forms across most apps. This builds a modal with a dimmed backdrop and an entry animation using only the `:target` state and CSS. The card carries dialog roles and the animation is removed under reduced motion.

--- a/submissions/examples/modal-dialog-as/demo.html
+++ b/submissions/examples/modal-dialog-as/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Modal Dialog</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <a class="modal-open" href="#demo-modal">Delete file</a>
+
+  <div class="modal" id="demo-modal" role="dialog" aria-labelledby="demo-modal-title" aria-modal="true">
+    <a class="modal-backdrop" href="#" aria-label="Close dialog" tabindex="-1"></a>
+    <div class="modal-card">
+      <h3 id="demo-modal-title">Delete this file?</h3>
+      <p>This will permanently remove the file from your workspace. You cannot undo this action.</p>
+      <div class="modal-actions">
+        <a class="modal-close" href="#">Cancel</a>
+        <a class="modal-confirm" href="#">Delete</a>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/modal-dialog-as/style.css
+++ b/submissions/examples/modal-dialog-as/style.css
@@ -1,0 +1,115 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.modal-open {
+  display: inline-block;
+  padding: 0.7rem 1.3rem;
+  background: #6c63ff;
+  color: #fff;
+  font-weight: 600;
+  text-decoration: none;
+  border-radius: 10px;
+}
+
+.modal-open:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.22s ease, visibility 0.22s ease;
+}
+
+.modal:target {
+  opacity: 1;
+  visibility: visible;
+}
+
+.modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(4, 8, 18, 0.72);
+  backdrop-filter: blur(2px);
+}
+
+.modal-card {
+  position: relative;
+  width: min(360px, 92vw);
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+  padding: 1.6rem 1.6rem 1.4rem;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
+  transform: scale(0.92) translateY(8px);
+  transition: transform 0.22s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.modal:target .modal-card {
+  transform: scale(1) translateY(0);
+}
+
+.modal-card h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.15rem;
+}
+
+.modal-card p {
+  margin: 0 0 1.3rem;
+  font-size: 0.9rem;
+  line-height: 1.55;
+  color: #94a3b8;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.6rem;
+}
+
+.modal-close,
+.modal-confirm {
+  padding: 0.55rem 1.05rem;
+  border-radius: 9px;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.modal-close {
+  color: #cbd5e1;
+  background: #1b2942;
+}
+
+.modal-confirm {
+  color: #fff;
+  background: #ef4444;
+}
+
+.modal-close:focus-visible,
+.modal-confirm:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .modal,
+  .modal-card {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a modal dialog built for #40927. It opens from a trigger link and closes on backdrop or cancel, using the CSS target state only. Closes #40927.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A modal dialog with a dimmed backdrop that opens from a link and animates in with a fade and scale, closing on backdrop click or cancel.

**How does a developer use it?**

```html
<a class="modal-open" href="#demo-modal">Open dialog</a>
<div class="modal" id="demo-modal" role="dialog" aria-modal="true">
  <a class="modal-backdrop" href="#" tabindex="-1"></a>
  <div class="modal-card">
    <h3>Delete this file?</h3>
    <div class="modal-actions">
      <a class="modal-close" href="#">Cancel</a>
      <a class="modal-confirm" href="#">Delete</a>
    </div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It builds a modal with a dimmed backdrop and an entry animation using only the `:target` state and CSS. The card carries dialog roles and the animation is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the modal is hidden with opacity 0 until its id is the URL target, at which point it becomes visible with opacity 1 and the card scales up.
