### PR TITLE
feat: add off canvas drawer

### DIFF
--- a/submissions/examples/drawer-menu-as/README.md
+++ b/submissions/examples/drawer-menu-as/README.md
@@ -1,0 +1,22 @@
+# Off Canvas Drawer
+
+### What does this do?
+
+It shows a slide in drawer that enters from the left when the menu button is pressed and closes on a backdrop click. It uses a hidden checkbox as the toggle, so it needs no JavaScript and animates with a smooth slide.
+
+### How is it used?
+
+```html
+<input type="checkbox" id="drawer-toggle" class="drawer-toggle" />
+<label class="drawer-btn" for="drawer-toggle">Menu</label>
+<label class="drawer-scrim" for="drawer-toggle"></label>
+<aside class="drawer">
+  <nav><a href="#">Dashboard</a></nav>
+</aside>
+```
+
+The checkbox, the open button, and the scrim all share the same `for` id. When the checkbox is checked the drawer slides in and the scrim appears; clicking the scrim unchecks it.
+
+### Why is it useful?
+
+Off canvas drawers hold navigation and filters on mobile layouts. This builds a toggled drawer with a dimmed backdrop and a slide animation using only a checkbox and CSS. Links have hover and focus styles and the slide is removed under reduced motion.

--- a/submissions/examples/drawer-menu-as/demo.html
+++ b/submissions/examples/drawer-menu-as/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Off Canvas Drawer</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <input type="checkbox" id="drawer-toggle" class="drawer-toggle" />
+  <label class="drawer-btn" for="drawer-toggle">☰ Menu</label>
+  <label class="drawer-scrim" for="drawer-toggle" aria-hidden="true"></label>
+  <aside class="drawer">
+    <h2>Workspace</h2>
+    <nav>
+      <a href="#">Dashboard</a>
+      <a href="#">Projects</a>
+      <a href="#">Team</a>
+      <a href="#">Reports</a>
+      <a href="#">Settings</a>
+    </nav>
+  </aside>
+</body>
+</html>

--- a/submissions/examples/drawer-menu-as/style.css
+++ b/submissions/examples/drawer-menu-as/style.css
@@ -1,0 +1,101 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  padding: 2rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.drawer-toggle {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.drawer-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.7rem 1.2rem;
+  background: #6c63ff;
+  color: #fff;
+  font-weight: 600;
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.drawer-toggle:focus-visible + .drawer-btn {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+.drawer-scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(4, 8, 18, 0.6);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.28s ease, visibility 0.28s ease;
+}
+
+.drawer-toggle:checked ~ .drawer-scrim {
+  opacity: 1;
+  visibility: visible;
+}
+
+.drawer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: min(280px, 82vw);
+  background: #0e1626;
+  border-right: 1px solid #26324a;
+  box-shadow: 0 0 50px rgba(0, 0, 0, 0.5);
+  transform: translateX(-100%);
+  transition: transform 0.28s cubic-bezier(0.22, 1, 0.36, 1);
+  padding: 1.4rem 1rem;
+  box-sizing: border-box;
+}
+
+.drawer-toggle:checked ~ .drawer {
+  transform: translateX(0);
+}
+
+.drawer h2 {
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  padding: 0 0.6rem;
+}
+
+.drawer nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.drawer a {
+  padding: 0.65rem 0.6rem;
+  border-radius: 8px;
+  color: #cbd5e1;
+  text-decoration: none;
+  font-size: 0.92rem;
+  transition: background 0.15s ease;
+}
+
+.drawer a:hover,
+.drawer a:focus-visible {
+  background: #1b2942;
+  color: #fff;
+  outline: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .drawer,
+  .drawer-scrim {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an off canvas drawer built for #40939. A menu button slides a navigation panel in from the left over a dimmed backdrop, using a checkbox toggle and CSS only. Closes #40939.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A slide in drawer that enters from the left on a menu press and closes on a backdrop click, with a dimmed scrim.

**How does a developer use it?**

```html
<input type="checkbox" id="drawer-toggle" class="drawer-toggle" />
<label class="drawer-btn" for="drawer-toggle">Menu</label>
<label class="drawer-scrim" for="drawer-toggle"></label>
<aside class="drawer"><nav><a href="#">Dashboard</a></nav></aside>
```

**Why does it fit EaseMotion CSS?**
It builds a toggled drawer with a dimmed backdrop and a slide animation using only a checkbox and CSS. Links have hover and focus styles and the slide is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the drawer sits translated 280px off screen when closed and moves to translateX(0) when the toggle is checked.
