### PR TITLE
feat: add horizontal timeline

### DIFF
--- a/submissions/examples/horizontal-timeline-as/README.md
+++ b/submissions/examples/horizontal-timeline-as/README.md
@@ -1,0 +1,20 @@
+# Horizontal Timeline
+
+### What does this do?
+
+It lays out milestones along a horizontal line with dot markers, a date, and a short title for each. Completed milestones use a green dot, and the row scrolls sideways when it runs out of width.
+
+### How is it used?
+
+```html
+<ol class="h-timeline">
+  <li class="is-done"><time>2021</time><h3>Founded</h3><p>...</p></li>
+  <li><time>2024</time><h3>Series A</h3><p>...</p></li>
+</ol>
+```
+
+Each `li` becomes an evenly spaced step with a connector drawn to the next one. Add `is-done` to mark a milestone complete.
+
+### Why is it useful?
+
+Horizontal timelines suit roadmaps and process histories that read left to right. This lays out evenly spaced milestones along a spine with markers and labels, using only CSS, and it scrolls horizontally on small screens instead of squashing the content.

--- a/submissions/examples/horizontal-timeline-as/demo.html
+++ b/submissions/examples/horizontal-timeline-as/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Horizontal Timeline</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <ol class="h-timeline">
+    <li class="is-done">
+      <time>2021</time>
+      <h3>Founded</h3>
+      <p>Started in a garage.</p>
+    </li>
+    <li class="is-done">
+      <time>2022</time>
+      <h3>Seed round</h3>
+      <p>Raised first funding.</p>
+    </li>
+    <li class="is-done">
+      <time>2023</time>
+      <h3>Version 1</h3>
+      <p>Public launch day.</p>
+    </li>
+    <li>
+      <time>2024</time>
+      <h3>Series A</h3>
+      <p>Scaled the team.</p>
+    </li>
+    <li>
+      <time>2025</time>
+      <h3>Global</h3>
+      <p>Opened new regions.</p>
+    </li>
+  </ol>
+</body>
+</html>

--- a/submissions/examples/horizontal-timeline-as/style.css
+++ b/submissions/examples/horizontal-timeline-as/style.css
@@ -1,0 +1,83 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 0;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.h-timeline {
+  list-style: none;
+  margin: 0;
+  padding: 2rem 1.5rem;
+  display: flex;
+  gap: 0;
+  width: min(720px, 100vw);
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.h-timeline li {
+  position: relative;
+  flex: 1 0 130px;
+  text-align: center;
+  padding-top: 2.2rem;
+}
+
+.h-timeline li::after {
+  content: "";
+  position: absolute;
+  top: 6px;
+  left: 50%;
+  width: 100%;
+  height: 2px;
+  background: #26324a;
+  z-index: 0;
+}
+
+.h-timeline li:last-child::after {
+  display: none;
+}
+
+.h-timeline li::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #6c63ff;
+  border: 3px solid #0b1121;
+  box-shadow: 0 0 0 2px #6c63ff;
+  z-index: 1;
+}
+
+.h-timeline li.is-done::before {
+  background: #10b981;
+  box-shadow: 0 0 0 2px #10b981;
+}
+
+.h-timeline time {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #a5b4fc;
+}
+
+.h-timeline h3 {
+  margin: 0.3rem 0 0;
+  font-size: 0.9rem;
+}
+
+.h-timeline p {
+  margin: 0.25rem 0 0;
+  font-size: 0.76rem;
+  color: #94a3b8;
+  line-height: 1.45;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a horizontal timeline built for #40943. Milestones sit along a horizontal line with dot markers, dates, and titles, scrolling sideways on overflow, using only CSS. Closes #40943.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A horizontal timeline of milestones, each with a dot marker, a date, and a title. Completed milestones use a green dot and the row scrolls when it overflows.

**How does a developer use it?**

```html
<ol class="h-timeline">
  <li class="is-done"><time>2021</time><h3>Founded</h3><p>...</p></li>
  <li><time>2024</time><h3>Series A</h3><p>...</p></li>
</ol>
```

**Why does it fit EaseMotion CSS?**
It lays out evenly spaced milestones along a spine with markers and labels, using only CSS, and scrolls horizontally on small screens instead of squashing the content.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: five milestones render in a single horizontal row and done markers are green while upcoming markers are the accent color.
