### PR TITLE
feat: add sticky header data table

### DIFF
--- a/submissions/examples/data-table-as/README.md
+++ b/submissions/examples/data-table-as/README.md
@@ -1,0 +1,24 @@
+# Sticky Header Data Table
+
+### What does this do?
+
+It shows a scrollable data table whose header row stays pinned while the body scrolls. Rows use zebra striping and a hover highlight, and the last column shows a colored status pill.
+
+### How is it used?
+
+```html
+<div class="table-wrap" tabindex="0">
+  <table class="data-table">
+    <thead><tr><th>Name</th><th>Status</th></tr></thead>
+    <tbody>
+      <tr><td>Ada</td><td><span class="pill is-active">Active</span></td></tr>
+    </tbody>
+  </table>
+</div>
+```
+
+The scroll box has a fixed height, and `position: sticky` on the header cells keeps them in view. Pill tones are `is-active`, `is-pending`, and `is-off`.
+
+### Why is it useful?
+
+Data tables appear in dashboards and admin panels, and a pinned header keeps columns readable while scrolling. This styles a table with a sticky head, zebra rows, hover highlight, and status pills using only CSS. The scroll box is focusable so it can be scrolled with the keyboard.

--- a/submissions/examples/data-table-as/demo.html
+++ b/submissions/examples/data-table-as/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sticky Header Data Table</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="table-wrap" tabindex="0" aria-label="User table, scroll for more">
+    <table class="data-table">
+      <thead>
+        <tr><th>Name</th><th>Role</th><th>Joined</th><th>Status</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Ada Lovelace</td><td>Engineer</td><td>2021</td><td><span class="pill is-active">Active</span></td></tr>
+        <tr><td>Alan Turing</td><td>Researcher</td><td>2020</td><td><span class="pill is-active">Active</span></td></tr>
+        <tr><td>Grace Hopper</td><td>Admiral</td><td>2019</td><td><span class="pill is-pending">Pending</span></td></tr>
+        <tr><td>Katherine Johnson</td><td>Analyst</td><td>2022</td><td><span class="pill is-active">Active</span></td></tr>
+        <tr><td>Linus Torvalds</td><td>Maintainer</td><td>2018</td><td><span class="pill is-off">Inactive</span></td></tr>
+        <tr><td>Margaret Hamilton</td><td>Lead</td><td>2021</td><td><span class="pill is-active">Active</span></td></tr>
+        <tr><td>Dennis Ritchie</td><td>Engineer</td><td>2017</td><td><span class="pill is-pending">Pending</span></td></tr>
+        <tr><td>Barbara Liskov</td><td>Architect</td><td>2020</td><td><span class="pill is-active">Active</span></td></tr>
+      </tbody>
+    </table>
+  </div>
+</body>
+</html>

--- a/submissions/examples/data-table-as/style.css
+++ b/submissions/examples/data-table-as/style.css
@@ -1,0 +1,89 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.table-wrap {
+  width: min(500px, 94vw);
+  max-height: 260px;
+  overflow: auto;
+  border: 1px solid #26324a;
+  border-radius: 12px;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.86rem;
+}
+
+.data-table th,
+.data-table td {
+  padding: 0.7rem 0.95rem;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.data-table thead th {
+  position: sticky;
+  top: 0;
+  background: #111c30;
+  color: #cbd5e1;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-bottom: 1px solid #26324a;
+}
+
+.data-table tbody tr {
+  transition: background 0.12s ease;
+}
+
+.data-table tbody tr:nth-child(even) {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.data-table tbody tr:hover {
+  background: #1b2942;
+}
+
+.data-table tbody td {
+  border-bottom: 1px solid #16233c;
+  color: #cbd5e1;
+}
+
+.pill {
+  display: inline-block;
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+
+.pill.is-active {
+  background: rgba(16, 185, 129, 0.16);
+  color: #34d399;
+}
+
+.pill.is-pending {
+  background: rgba(245, 158, 11, 0.16);
+  color: #fbbf24;
+}
+
+.pill.is-off {
+  background: rgba(148, 163, 184, 0.16);
+  color: #cbd5e1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .data-table tbody tr {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a sticky header data table built for #40945. The header row stays pinned while the striped body scrolls, with hover highlight and status pills, using only CSS. Closes #40945.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A scrollable data table with a pinned header, zebra rows, a hover highlight, and colored status pills in the last column.

**How does a developer use it?**

```html
<div class="table-wrap" tabindex="0">
  <table class="data-table">
    <thead><tr><th>Name</th><th>Status</th></tr></thead>
    <tbody><tr><td>Ada</td><td><span class="pill is-active">Active</span></td></tr></tbody>
  </table>
</div>
```

**Why does it fit EaseMotion CSS?**
It styles a table with a sticky head, zebra rows, hover highlight, and status pills using only CSS. The scroll box is focusable so it can be scrolled with the keyboard.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the header cells compute to `position: sticky`, the wrapper is scrollable, and eight rows render with eight status pills.
