### PR TITLE
feat: add newsletter signup

### DIFF
--- a/submissions/examples/newsletter-signup-as/README.md
+++ b/submissions/examples/newsletter-signup-as/README.md
@@ -1,0 +1,20 @@
+# Newsletter Signup
+
+### What does this do?
+
+It shows an inline newsletter signup with an email field and a subscribe button joined as one pill. The button sits flush with the input, the control shows a focus ring when the field is focused, and it stacks vertically on narrow screens.
+
+### How is it used?
+
+```html
+<form class="subscribe">
+  <input type="email" placeholder="you@example.com" aria-label="Email address" />
+  <button type="submit">Subscribe</button>
+</form>
+```
+
+The `:focus-within` selector lights up the whole pill when the input is focused. Below 420px the input and button stack.
+
+### Why is it useful?
+
+Newsletter capture forms sit in footers and hero sections everywhere. This joins an input and a button into a single clean control with a focus state and a responsive stack, using only CSS. The transitions are removed under reduced motion.

--- a/submissions/examples/newsletter-signup-as/demo.html
+++ b/submissions/examples/newsletter-signup-as/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Newsletter Signup</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="subscribe-block">
+    <h2>Stay in the loop</h2>
+    <p>Get product news and tips once a month. No spam.</p>
+    <form class="subscribe">
+      <input type="email" placeholder="you@example.com" aria-label="Email address" />
+      <button type="submit">Subscribe</button>
+    </form>
+  </div>
+</body>
+</html>

--- a/submissions/examples/newsletter-signup-as/style.css
+++ b/submissions/examples/newsletter-signup-as/style.css
@@ -1,0 +1,98 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.subscribe-block {
+  width: min(420px, 94vw);
+  text-align: center;
+}
+
+.subscribe-block h2 {
+  margin: 0 0 0.4rem;
+  font-size: 1.3rem;
+}
+
+.subscribe-block p {
+  margin: 0 0 1.3rem;
+  font-size: 0.9rem;
+  color: #94a3b8;
+}
+
+.subscribe {
+  display: flex;
+  padding: 5px;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 999px;
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.subscribe:focus-within {
+  border-color: #6c63ff;
+  box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.32);
+}
+
+.subscribe input {
+  flex: 1;
+  min-width: 0;
+  padding: 0.6rem 1rem;
+  font: inherit;
+  font-size: 0.92rem;
+  color: #e2e8f0;
+  background: transparent;
+  border: none;
+  outline: none;
+}
+
+.subscribe input::placeholder {
+  color: #64748b;
+}
+
+.subscribe button {
+  flex: none;
+  padding: 0.6rem 1.4rem;
+  font: inherit;
+  font-weight: 600;
+  color: #fff;
+  background: #6c63ff;
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.subscribe button:hover {
+  background: #5b52e6;
+}
+
+.subscribe button:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+@media (max-width: 420px) {
+  .subscribe {
+    flex-direction: column;
+    border-radius: 18px;
+    gap: 5px;
+  }
+
+  .subscribe button {
+    border-radius: 14px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .subscribe,
+  .subscribe button {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a newsletter signup built for #40947. An email field and subscribe button joined as one pill with a focus ring and a responsive stack, using only CSS. Closes #40947.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
An inline newsletter signup where the email input and subscribe button form one rounded pill that lights up on focus and stacks on narrow screens.

**How does a developer use it?**

```html
<form class="subscribe">
  <input type="email" placeholder="you@example.com" aria-label="Email address" />
  <button type="submit">Subscribe</button>
</form>
```

**Why does it fit EaseMotion CSS?**
It joins an input and a button into a single clean control with a `:focus-within` state and a responsive stack, using only CSS. The transitions are removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the email input and button sit on the same row as one pill, with no JavaScript in the demo.
