### PR TITLE
feat: add login form card

### DIFF
--- a/submissions/examples/login-form-as/README.md
+++ b/submissions/examples/login-form-as/README.md
@@ -1,0 +1,26 @@
+# Login Form Card
+
+### What does this do?
+
+It shows a centered sign in card with a title, email and password fields, a remember me checkbox, a forgot link, a primary submit button, and a create account footer. Fields light up with a focus ring.
+
+### How is it used?
+
+```html
+<form class="login-card">
+  <h1>Welcome back</h1>
+  <label>Email<input type="email" autocomplete="username" /></label>
+  <label>Password<input type="password" autocomplete="current-password" /></label>
+  <div class="login-row">
+    <label><input type="checkbox" /> Remember me</label>
+    <a href="#">Forgot password?</a>
+  </div>
+  <button type="submit">Sign in</button>
+</form>
+```
+
+Labels wrap their inputs so the field is announced with its name. The `autocomplete` hints let password managers fill the form.
+
+### Why is it useful?
+
+A sign in card is one of the most reused screens in any product. This presents a clean, accessible login form with labeled fields, focus states, and a primary action, using only CSS. Focus rings and hover states aid usability and transitions are removed under reduced motion.

--- a/submissions/examples/login-form-as/demo.html
+++ b/submissions/examples/login-form-as/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Login Form Card</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <form class="login-card">
+    <h1>Welcome back</h1>
+    <p class="sub">Sign in to your workspace to continue.</p>
+    <label>Email
+      <input type="email" placeholder="you@example.com" autocomplete="username" />
+    </label>
+    <label>Password
+      <input type="password" placeholder="Your password" autocomplete="current-password" />
+    </label>
+    <div class="login-row">
+      <label><input type="checkbox" /> Remember me</label>
+      <a href="#">Forgot password?</a>
+    </div>
+    <button type="submit">Sign in</button>
+    <p class="login-foot">New here? <a href="#">Create an account</a></p>
+  </form>
+</body>
+</html>

--- a/submissions/examples/login-form-as/style.css
+++ b/submissions/examples/login-form-as/style.css
@@ -1,0 +1,133 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.login-card {
+  width: min(360px, 94vw);
+  box-sizing: border-box;
+  padding: 2rem 1.9rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 18px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.4);
+}
+
+.login-card h1 {
+  margin: 0 0 0.35rem;
+  font-size: 1.4rem;
+}
+
+.login-card .sub {
+  margin: 0 0 1.6rem;
+  font-size: 0.86rem;
+  color: #94a3b8;
+}
+
+.login-card label {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #cbd5e1;
+  margin-bottom: 1rem;
+}
+
+.login-card input[type="email"],
+.login-card input[type="password"] {
+  width: 100%;
+  box-sizing: border-box;
+  margin-top: 0.4rem;
+  padding: 0.65rem 0.85rem;
+  font: inherit;
+  font-size: 0.92rem;
+  color: #e2e8f0;
+  background: #0b1424;
+  border: 1px solid #26324a;
+  border-radius: 9px;
+  outline: none;
+  transition: border-color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.login-card input:focus {
+  border-color: #6c63ff;
+  box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.25);
+}
+
+.login-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.4rem;
+  font-size: 0.82rem;
+}
+
+.login-row label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0;
+  font-weight: 500;
+  color: #94a3b8;
+  cursor: pointer;
+}
+
+.login-row input {
+  accent-color: #6c63ff;
+}
+
+.login-row a {
+  color: #a5b4fc;
+  text-decoration: none;
+}
+
+.login-row a:hover {
+  text-decoration: underline;
+}
+
+.login-card button {
+  width: 100%;
+  padding: 0.75rem;
+  font: inherit;
+  font-weight: 600;
+  color: #fff;
+  background: #6c63ff;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.login-card button:hover {
+  background: #5b52e6;
+}
+
+.login-card button:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+.login-foot {
+  margin: 1.2rem 0 0;
+  text-align: center;
+  font-size: 0.82rem;
+  color: #94a3b8;
+}
+
+.login-foot a {
+  color: #a5b4fc;
+  text-decoration: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .login-card input,
+  .login-card button {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a login form card built for #40949. A centered sign in card with labeled fields, focus rings, a remember row, and a primary action, using only CSS. Closes #40949.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A sign in card with a title, email and password fields, a remember me checkbox, a forgot link, a submit button, and a create account footer.

**How does a developer use it?**

```html
<form class="login-card">
  <h1>Welcome back</h1>
  <label>Email<input type="email" autocomplete="username" /></label>
  <label>Password<input type="password" autocomplete="current-password" /></label>
  <button type="submit">Sign in</button>
</form>
```

**Why does it fit EaseMotion CSS?**
It presents a clean, accessible login form with labeled fields, focus states, and a primary action, using only CSS. Labels wrap their inputs and transitions are removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: one email and one password field render, focusing a field shows the focus ring, and the submit button is present.
