### PR TITLE
feat: add file upload dropzone

### DIFF
--- a/submissions/examples/file-dropzone-as/README.md
+++ b/submissions/examples/file-dropzone-as/README.md
@@ -1,0 +1,22 @@
+# File Upload Dropzone
+
+### What does this do?
+
+It shows a styled file upload dropzone with a dashed border, an upload icon, and a two line prompt. The whole area is a label wrapping a native file input, so clicking anywhere opens the file picker and the border highlights on hover and focus.
+
+### How is it used?
+
+```html
+<label class="dropzone">
+  <input type="file" accept=".png,.jpg,.pdf" />
+  <svg class="dz-icon">...</svg>
+  <span class="dz-title">Drop files here or <b>browse</b></span>
+  <span class="dz-hint">PNG, JPG or PDF up to 10MB</span>
+</label>
+```
+
+Because the input is inside the label, the entire panel is the click target, and `:focus-within` shows the highlight when the input is focused by keyboard.
+
+### Why is it useful?
+
+Upload areas appear in forms for avatars, documents, and images. This turns a plain file input into a large, inviting dropzone with clear affordance and a focus state, using only CSS and inline SVG. The highlight transition is removed under reduced motion.

--- a/submissions/examples/file-dropzone-as/demo.html
+++ b/submissions/examples/file-dropzone-as/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>File Upload Dropzone</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <label class="dropzone">
+    <input type="file" accept=".png,.jpg,.jpeg,.pdf" />
+    <svg class="dz-icon" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M12 16V4m0 0-4 4m4-4 4 4" stroke-linecap="round" stroke-linejoin="round" />
+      <path d="M4 15v3a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-3" stroke-linecap="round" />
+    </svg>
+    <span class="dz-title">Drop files here or <b>browse</b></span>
+    <span class="dz-hint">PNG, JPG or PDF up to 10MB</span>
+  </label>
+</body>
+</html>

--- a/submissions/examples/file-dropzone-as/style.css
+++ b/submissions/examples/file-dropzone-as/style.css
@@ -1,0 +1,73 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.dropzone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.6rem;
+  width: min(400px, 94vw);
+  box-sizing: border-box;
+  padding: 2.4rem 1.5rem;
+  text-align: center;
+  background: #0e1626;
+  border: 2px dashed #334155;
+  border-radius: 16px;
+  cursor: pointer;
+  transition: border-color 0.18s ease, background 0.18s ease;
+}
+
+.dropzone:hover,
+.dropzone:focus-within {
+  border-color: #6c63ff;
+  background: rgba(108, 99, 255, 0.06);
+}
+
+.dropzone input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  overflow: hidden;
+}
+
+.dz-icon {
+  width: 42px;
+  height: 42px;
+  stroke: #6c63ff;
+  stroke-width: 1.8;
+  fill: none;
+}
+
+.dz-title {
+  font-size: 0.98rem;
+  font-weight: 600;
+}
+
+.dz-title b {
+  color: #a5b4fc;
+}
+
+.dz-hint {
+  font-size: 0.78rem;
+  color: #64748b;
+}
+
+.dropzone input:focus-visible ~ .dz-title {
+  text-decoration: underline;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dropzone {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a file upload dropzone built for #40952. A label wrapped file input styled as a large dashed dropzone that highlights on hover and focus, using only CSS. Closes #40952.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A styled file upload dropzone with a dashed border, an upload icon, and a prompt. The whole panel is clickable and highlights on hover and focus.

**How does a developer use it?**

```html
<label class="dropzone">
  <input type="file" accept=".png,.jpg,.pdf" />
  <svg class="dz-icon">...</svg>
  <span class="dz-title">Drop files here or <b>browse</b></span>
  <span class="dz-hint">PNG, JPG or PDF up to 10MB</span>
</label>
```

**Why does it fit EaseMotion CSS?**
It turns a plain file input into a large, inviting dropzone with clear affordance and a `:focus-within` state, using only CSS and inline SVG. The highlight transition is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the panel has a dashed border, wraps the native file input so the whole area is the click target, and shows the upload icon.
