### PR TITLE
feat: add masonry gallery

### DIFF
--- a/submissions/examples/masonry-gallery-as/README.md
+++ b/submissions/examples/masonry-gallery-as/README.md
@@ -1,0 +1,20 @@
+# Masonry Gallery
+
+### What does this do?
+
+It lays out tiles of different heights into balanced columns with no row gaps, the classic masonry look. It uses the CSS columns layout, so the number of columns adapts to the width and tiles never break across a column.
+
+### How is it used?
+
+```html
+<div class="masonry">
+  <figure class="tile" style="--h: 160px"></figure>
+  <figure class="tile" style="--h: 220px"></figure>
+</div>
+```
+
+Set each tile height with the `--h` custom property (or let real images set their own height). `break-inside: avoid` keeps a tile whole within its column.
+
+### Why is it useful?
+
+Image and card galleries with varied heights look best in a masonry layout. This builds a responsive masonry grid with the columns layout, dropping from three columns to two below 520px, using only CSS with no scripts.

--- a/submissions/examples/masonry-gallery-as/demo.html
+++ b/submissions/examples/masonry-gallery-as/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Masonry Gallery</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="masonry">
+    <figure class="tile" style="--h: 150px">1</figure>
+    <figure class="tile" style="--h: 220px">2</figure>
+    <figure class="tile" style="--h: 120px">3</figure>
+    <figure class="tile" style="--h: 190px">4</figure>
+    <figure class="tile" style="--h: 130px">5</figure>
+    <figure class="tile" style="--h: 200px">6</figure>
+    <figure class="tile" style="--h: 170px">7</figure>
+    <figure class="tile" style="--h: 140px">8</figure>
+    <figure class="tile" style="--h: 210px">9</figure>
+  </div>
+</body>
+</html>

--- a/submissions/examples/masonry-gallery-as/style.css
+++ b/submissions/examples/masonry-gallery-as/style.css
@@ -1,0 +1,60 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.masonry {
+  width: min(560px, 94vw);
+  column-count: 3;
+  column-gap: 0.85rem;
+}
+
+.tile {
+  margin: 0 0 0.85rem;
+  height: var(--h);
+  border-radius: 12px;
+  break-inside: avoid;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-weight: 700;
+  font-size: 1.1rem;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+}
+
+.tile:nth-child(6n + 1) {
+  background: linear-gradient(135deg, #6c63ff, #a855f7);
+}
+
+.tile:nth-child(6n + 2) {
+  background: linear-gradient(135deg, #0ea5e9, #22d3ee);
+}
+
+.tile:nth-child(6n + 3) {
+  background: linear-gradient(135deg, #f59e0b, #ef4444);
+}
+
+.tile:nth-child(6n + 4) {
+  background: linear-gradient(135deg, #10b981, #34d399);
+}
+
+.tile:nth-child(6n + 5) {
+  background: linear-gradient(135deg, #ec4899, #f472b6);
+}
+
+.tile:nth-child(6n) {
+  background: linear-gradient(135deg, #8b5cf6, #6366f1);
+}
+
+@media (max-width: 520px) {
+  .masonry {
+    column-count: 2;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a masonry gallery built for #40956. Tiles of varied heights pack into balanced columns with the CSS columns layout, using only CSS. Closes #40956.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A masonry gallery where tiles of different heights pack into columns with no row gaps and tiles never break across a column.

**How does a developer use it?**

```html
<div class="masonry">
  <figure class="tile" style="--h: 160px"></figure>
  <figure class="tile" style="--h: 220px"></figure>
</div>
```

**Why does it fit EaseMotion CSS?**
It builds a responsive masonry grid with the columns layout, dropping from three columns to two below 520px, using only CSS with no scripts. `break-inside: avoid` keeps each tile whole.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: nine tiles distribute across three distinct column positions with `column-count: 3`.
