### PR TITLE
feat: add chat composer bar

### DIFF
--- a/submissions/examples/chat-composer-as/README.md
+++ b/submissions/examples/chat-composer-as/README.md
@@ -1,0 +1,22 @@
+# Chat Composer Bar
+
+### What does this do?
+
+It shows a chat message composer with an attach button, a message field, an emoji button, and a round send button. The whole bar is a pill that lights up when the field is focused.
+
+### How is it used?
+
+```html
+<form class="composer">
+  <button class="composer-icon" type="button" aria-label="Attach file"><svg>...</svg></button>
+  <input type="text" placeholder="Write a message" aria-label="Message" />
+  <button class="composer-icon" type="button" aria-label="Add emoji"><svg>...</svg></button>
+  <button class="composer-send" type="submit" aria-label="Send message"><svg>...</svg></button>
+</form>
+```
+
+The field flexes to fill the space between the leading and trailing icon buttons. `:focus-within` lights up the whole pill.
+
+### Why is it useful?
+
+Messaging and support widgets need a polished input bar. This lays out a composer with leading and trailing icon buttons around a flexible field and a clear send action, using only CSS and inline SVG. Every button is labeled and shows a focus ring, and the send scale is removed under reduced motion.

--- a/submissions/examples/chat-composer-as/demo.html
+++ b/submissions/examples/chat-composer-as/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Chat Composer Bar</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <form class="composer">
+    <button class="composer-icon" type="button" aria-label="Attach file">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21 11.5 12.5 20a5 5 0 0 1-7-7l8-8a3.5 3.5 0 0 1 5 5l-8 8a2 2 0 0 1-3-3l7.5-7.5" stroke-linecap="round" stroke-linejoin="round" /></svg>
+    </button>
+    <input type="text" placeholder="Write a message" aria-label="Message" />
+    <button class="composer-icon" type="button" aria-label="Add emoji">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9" /><path d="M8.5 14a4 4 0 0 0 7 0M9 9.5h.01M15 9.5h.01" stroke-linecap="round" /></svg>
+    </button>
+    <button class="composer-send" type="submit" aria-label="Send message">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m4 12 16-8-6 16-3-6-7-2z" stroke-linejoin="round" /></svg>
+    </button>
+  </form>
+</body>
+</html>

--- a/submissions/examples/chat-composer-as/style.css
+++ b/submissions/examples/chat-composer-as/style.css
@@ -1,0 +1,109 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.composer {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  width: min(440px, 94vw);
+  padding: 5px 6px 5px 8px;
+  box-sizing: border-box;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 999px;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease;
+}
+
+.composer:focus-within {
+  border-color: #6c63ff;
+  box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.3);
+}
+
+.composer input {
+  flex: 1;
+  min-width: 0;
+  padding: 0.55rem 0.4rem;
+  font: inherit;
+  font-size: 0.94rem;
+  color: #e2e8f0;
+  background: transparent;
+  border: none;
+  outline: none;
+}
+
+.composer input::placeholder {
+  color: #64748b;
+}
+
+.composer-icon {
+  flex: none;
+  width: 38px;
+  height: 38px;
+  display: grid;
+  place-items: center;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: #94a3b8;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.composer-icon:hover {
+  background: #1b2942;
+  color: #cbd5e1;
+}
+
+.composer-send {
+  flex: none;
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+  border: none;
+  border-radius: 50%;
+  background: #6c63ff;
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+
+.composer-send:hover {
+  background: #5b52e6;
+  transform: scale(1.05);
+}
+
+.composer-icon:focus-visible,
+.composer-send:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+.composer svg {
+  width: 20px;
+  height: 20px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .composer,
+  .composer-icon,
+  .composer-send {
+    transition: none;
+  }
+
+  .composer-send:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a chat composer bar built for #40959. An attach button, message field, emoji button, and round send button arranged as a focus aware pill, using only CSS. Closes #40959.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A chat message composer with leading attach, a flexible message field, a trailing emoji button, and a round send button, wrapped in a pill that lights up on focus.

**How does a developer use it?**

```html
<form class="composer">
  <button class="composer-icon" type="button" aria-label="Attach file"><svg>...</svg></button>
  <input type="text" placeholder="Write a message" aria-label="Message" />
  <button class="composer-send" type="submit" aria-label="Send message"><svg>...</svg></button>
</form>
```

**Why does it fit EaseMotion CSS?**
It lays out a composer with leading and trailing icon buttons around a flexible field and a clear send action, using only CSS and inline SVG. Every button is labeled and shows a focus ring, and the send scale is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: two icon buttons and a circular send button sit on one row with the message field flexing between them.
