### PR TITLE
feat: add vertical tabs

### DIFF
--- a/submissions/examples/vertical-tabs-as/README.md
+++ b/submissions/examples/vertical-tabs-as/README.md
@@ -1,0 +1,28 @@
+# Vertical Tabs
+
+### What does this do?
+
+It shows a vertical tabs panel where a column of tabs on the left switches the content on the right. It uses radio inputs, so the active tab is real and keyboard operable, with no JavaScript.
+
+### How is it used?
+
+```html
+<div class="vtabs">
+  <input type="radio" name="vt" id="vt1" checked />
+  <input type="radio" name="vt" id="vt2" />
+  <div class="vt-list">
+    <label for="vt1">Account</label>
+    <label for="vt2">Billing</label>
+  </div>
+  <div class="vt-panels">
+    <section class="vt-panel">Account settings</section>
+    <section class="vt-panel">Billing settings</section>
+  </div>
+</div>
+```
+
+Keep the radios first so the sibling selectors can reach both the labels and the panels. The checked radio drives the active tab style and shows its matching panel by position.
+
+### Why is it useful?
+
+Settings pages and docs often use side tabs to switch panes. This builds a vertical tab layout where the checked radio drives both the active tab and the visible panel, using only CSS. Tabs are keyboard operable with a focus ring and the panel fade is removed under reduced motion.

--- a/submissions/examples/vertical-tabs-as/demo.html
+++ b/submissions/examples/vertical-tabs-as/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vertical Tabs</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="vtabs">
+    <input type="radio" name="vt" id="vt1" checked />
+    <input type="radio" name="vt" id="vt2" />
+    <input type="radio" name="vt" id="vt3" />
+    <div class="vt-list" role="tablist">
+      <label for="vt1">Account</label>
+      <label for="vt2">Billing</label>
+      <label for="vt3">Notifications</label>
+    </div>
+    <div class="vt-panels">
+      <section class="vt-panel">
+        <h3>Account</h3>
+        <p>Update your name, email, and profile photo. These details appear across your workspace.</p>
+      </section>
+      <section class="vt-panel">
+        <h3>Billing</h3>
+        <p>Manage your plan, payment method, and download past invoices from this panel.</p>
+      </section>
+      <section class="vt-panel">
+        <h3>Notifications</h3>
+        <p>Choose which product and activity emails you receive and how often they arrive.</p>
+      </section>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/vertical-tabs-as/style.css
+++ b/submissions/examples/vertical-tabs-as/style.css
@@ -1,0 +1,114 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.vtabs {
+  display: grid;
+  grid-template-columns: 150px 1fr;
+  gap: 1.1rem;
+  width: min(520px, 94vw);
+  padding: 1.1rem;
+  box-sizing: border-box;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+}
+
+.vtabs > input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  margin: -1px;
+  overflow: hidden;
+}
+
+.vt-list {
+  grid-column: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.vt-list label {
+  padding: 0.6rem 0.8rem;
+  border-left: 2px solid transparent;
+  border-radius: 0 8px 8px 0;
+  color: #94a3b8;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+}
+
+.vt-list label:hover {
+  color: #cbd5e1;
+  background: #16233c;
+}
+
+.vt-panels {
+  grid-column: 2;
+}
+
+.vt-panel {
+  display: none;
+  animation: vt-fade 0.2s ease;
+}
+
+.vt-panel h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.05rem;
+}
+
+.vt-panel p {
+  margin: 0;
+  font-size: 0.88rem;
+  line-height: 1.6;
+  color: #94a3b8;
+}
+
+#vt1:checked ~ .vt-list label[for="vt1"],
+#vt2:checked ~ .vt-list label[for="vt2"],
+#vt3:checked ~ .vt-list label[for="vt3"] {
+  color: #fff;
+  background: #1b2942;
+  border-left-color: #6c63ff;
+}
+
+#vt1:focus-visible ~ .vt-list label[for="vt1"],
+#vt2:focus-visible ~ .vt-list label[for="vt2"],
+#vt3:focus-visible ~ .vt-list label[for="vt3"] {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+#vt1:checked ~ .vt-panels .vt-panel:nth-child(1),
+#vt2:checked ~ .vt-panels .vt-panel:nth-child(2),
+#vt3:checked ~ .vt-panels .vt-panel:nth-child(3) {
+  display: block;
+}
+
+@keyframes vt-fade {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vt-list label {
+    transition: none;
+  }
+
+  .vt-panel {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds vertical tabs built for #40961. A left column of tabs switches the content on the right, driven by radio inputs with no JavaScript. Closes #40961.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A vertical tabs panel where a column of tabs on the left switches which content panel shows on the right, with the active tab highlighted.

**How does a developer use it?**

```html
<div class="vtabs">
  <input type="radio" name="vt" id="vt1" checked />
  <input type="radio" name="vt" id="vt2" />
  <div class="vt-list">
    <label for="vt1">Account</label>
    <label for="vt2">Billing</label>
  </div>
  <div class="vt-panels">
    <section class="vt-panel">Account settings</section>
    <section class="vt-panel">Billing settings</section>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It builds a vertical tab layout where the checked radio drives both the active tab and the visible panel, using only CSS. Tabs are keyboard operable with a focus ring and the panel fade is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: only the first panel shows initially, and selecting the second tab hides the first panel and shows the second.
