### PR TITLE
feat: add sparkline stat card

### DIFF
--- a/submissions/examples/sparkline-card-as/README.md
+++ b/submissions/examples/sparkline-card-as/README.md
@@ -1,0 +1,27 @@
+# Sparkline Stat Card
+
+### What does this do?
+
+It shows a stat card with a metric label, a big value, a trend delta, and a small bar sparkline built from stacked spans. Each bar height comes from a custom property and the bars rise on load, with the last bar accented.
+
+### How is it used?
+
+```html
+<article class="spark-card">
+  <span class="sc-label">Revenue</span>
+  <div class="sc-row">
+    <span class="sc-value">$12.8k</span>
+    <span class="sc-delta up">▲ 8.4%</span>
+  </div>
+  <div class="sc-spark">
+    <span style="--h: 40%"></span>
+    <span style="--h: 70%"></span>
+  </div>
+</article>
+```
+
+Set each bar height with the `--h` custom property. Use the `up` or `down` class on the delta to color it green or red.
+
+### Why is it useful?
+
+Dashboards pair a headline number with a tiny trend chart. This renders a compact bar sparkline from plain spans driven by custom properties, next to a value and a delta, using only CSS with no charting script. The rise animation is removed under reduced motion.

--- a/submissions/examples/sparkline-card-as/demo.html
+++ b/submissions/examples/sparkline-card-as/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sparkline Stat Card</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <article class="spark-card">
+    <span class="sc-label">Revenue this week</span>
+    <div class="sc-row">
+      <span class="sc-value">$12.8k</span>
+      <span class="sc-delta up">▲ 8.4%</span>
+    </div>
+    <div class="sc-spark" aria-hidden="true">
+      <span style="--h: 35%"></span>
+      <span style="--h: 55%"></span>
+      <span style="--h: 42%"></span>
+      <span style="--h: 68%"></span>
+      <span style="--h: 50%"></span>
+      <span style="--h: 78%"></span>
+      <span style="--h: 62%"></span>
+      <span style="--h: 92%"></span>
+    </div>
+  </article>
+</body>
+</html>

--- a/submissions/examples/sparkline-card-as/style.css
+++ b/submissions/examples/sparkline-card-as/style.css
@@ -1,0 +1,83 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.spark-card {
+  width: min(240px, 92vw);
+  padding: 1.3rem 1.4rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+}
+
+.sc-label {
+  display: block;
+  font-size: 0.78rem;
+  color: #94a3b8;
+}
+
+.sc-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  margin: 0.35rem 0 1.1rem;
+}
+
+.sc-value {
+  font-size: 1.7rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.sc-delta {
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.sc-delta.up {
+  color: #34d399;
+}
+
+.sc-delta.down {
+  color: #f87171;
+}
+
+.sc-spark {
+  display: flex;
+  align-items: flex-end;
+  gap: 4px;
+  height: 46px;
+}
+
+.sc-spark span {
+  flex: 1;
+  height: var(--h);
+  border-radius: 3px 3px 0 0;
+  background: linear-gradient(180deg, #6c63ff, #4f46e5);
+  transform-origin: bottom;
+  animation: sc-rise 0.7s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.sc-spark span:last-child {
+  background: linear-gradient(180deg, #34d399, #10b981);
+}
+
+@keyframes sc-rise {
+  from {
+    transform: scaleY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sc-spark span {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a sparkline stat card built for #40963. A metric, value, and trend delta beside a small bar sparkline whose bar heights come from custom properties, using only CSS. Closes #40963.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A compact stat card with a label, a value, a colored trend delta, and a bar sparkline built from spans that rise on load.

**How does a developer use it?**

```html
<article class="spark-card">
  <span class="sc-label">Revenue</span>
  <div class="sc-row"><span class="sc-value">$12.8k</span><span class="sc-delta up">▲ 8.4%</span></div>
  <div class="sc-spark"><span style="--h: 40%"></span><span style="--h: 70%"></span></div>
</article>
```

**Why does it fit EaseMotion CSS?**
It renders a compact bar sparkline from plain spans driven by custom properties, next to a value and a delta, using only CSS with no charting script. The rise animation is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: eight sparkline bars render at their `--h` heights (35 to 92 percent of the track).
