### PR TITLE
feat: add bottom navigation bar

### DIFF
--- a/submissions/examples/bottom-nav-as/README.md
+++ b/submissions/examples/bottom-nav-as/README.md
@@ -1,0 +1,22 @@
+# Bottom Navigation Bar
+
+### What does this do?
+
+It shows a mobile style bottom navigation bar with icon and label items. Selecting an item tints it and lifts the active icon. It uses radio inputs, so the active tab is real and keyboard operable, with no JavaScript.
+
+### How is it used?
+
+```html
+<nav class="bottom-nav" aria-label="Primary">
+  <input type="radio" name="bn" id="bn1" checked />
+  <input type="radio" name="bn" id="bn2" />
+  <label for="bn1"><svg>...</svg><span>Home</span></label>
+  <label for="bn2"><svg>...</svg><span>Search</span></label>
+</nav>
+```
+
+Keep the radios first so the sibling selectors can reach each matching label. The checked radio tints its item and raises its icon.
+
+### Why is it useful?
+
+Mobile apps and responsive sites use a fixed bottom bar for primary navigation. This builds a bottom nav where the checked radio drives the active item color and lift, using only CSS and inline SVG. Items are keyboard operable with a focus ring and the lift is removed under reduced motion.

--- a/submissions/examples/bottom-nav-as/demo.html
+++ b/submissions/examples/bottom-nav-as/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bottom Navigation Bar</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <nav class="bottom-nav" aria-label="Primary">
+    <input type="radio" name="bn" id="bn1" checked />
+    <input type="radio" name="bn" id="bn2" />
+    <input type="radio" name="bn" id="bn3" />
+    <input type="radio" name="bn" id="bn4" />
+    <input type="radio" name="bn" id="bn5" />
+    <label for="bn1"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 11l9-8 9 8M5 10v10h14V10" stroke-linecap="round" stroke-linejoin="round" /></svg><span>Home</span></label>
+    <label for="bn2"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="7" /><path d="m21 21-4-4" stroke-linecap="round" /></svg><span>Search</span></label>
+    <label for="bn3"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 4v16m8-8H4" stroke-linecap="round" /></svg><span>Create</span></label>
+    <label for="bn4"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9a6 6 0 0 1 12 0c0 5 2 6 2 6H4s2-1 2-6" stroke-linecap="round" stroke-linejoin="round" /><path d="M10.5 20a1.5 1.5 0 0 0 3 0" stroke-linecap="round" /></svg><span>Alerts</span></label>
+    <label for="bn5"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="8" r="4" /><path d="M4 21a8 8 0 0 1 16 0" stroke-linecap="round" /></svg><span>Profile</span></label>
+  </nav>
+</body>
+</html>

--- a/submissions/examples/bottom-nav-as/style.css
+++ b/submissions/examples/bottom-nav-as/style.css
@@ -1,0 +1,95 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.bottom-nav {
+  display: flex;
+  width: min(400px, 94vw);
+  padding: 0.4rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 18px;
+  box-shadow: 0 14px 34px rgba(0, 0, 0, 0.4);
+}
+
+.bottom-nav input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  margin: -1px;
+  overflow: hidden;
+}
+
+.bottom-nav label {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.6rem 0;
+  border-radius: 12px;
+  color: #94a3b8;
+  font-size: 0.72rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 0.16s ease, background 0.16s ease;
+}
+
+.bottom-nav label svg {
+  width: 22px;
+  height: 22px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+  transition: transform 0.16s ease;
+}
+
+.bottom-nav label:hover {
+  color: #cbd5e1;
+}
+
+#bn1:checked ~ label[for="bn1"],
+#bn2:checked ~ label[for="bn2"],
+#bn3:checked ~ label[for="bn3"],
+#bn4:checked ~ label[for="bn4"],
+#bn5:checked ~ label[for="bn5"] {
+  color: #a5b4fc;
+  background: rgba(108, 99, 255, 0.12);
+}
+
+#bn1:checked ~ label[for="bn1"] svg,
+#bn2:checked ~ label[for="bn2"] svg,
+#bn3:checked ~ label[for="bn3"] svg,
+#bn4:checked ~ label[for="bn4"] svg,
+#bn5:checked ~ label[for="bn5"] svg {
+  transform: translateY(-3px);
+}
+
+#bn1:focus-visible ~ label[for="bn1"],
+#bn2:focus-visible ~ label[for="bn2"],
+#bn3:focus-visible ~ label[for="bn3"],
+#bn4:focus-visible ~ label[for="bn4"],
+#bn5:focus-visible ~ label[for="bn5"] {
+  outline: 2px solid #6c63ff;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bottom-nav label,
+  .bottom-nav label svg {
+    transition: none;
+  }
+
+  .bottom-nav label svg {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a bottom navigation bar built for #40965. Icon and label items where the checked radio tints the active item and lifts its icon, using only CSS. Closes #40965.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A mobile style bottom navigation bar of icon and label items where selecting one tints it and raises the active icon.

**How does a developer use it?**

```html
<nav class="bottom-nav" aria-label="Primary">
  <input type="radio" name="bn" id="bn1" checked />
  <input type="radio" name="bn" id="bn2" />
  <label for="bn1"><svg>...</svg><span>Home</span></label>
  <label for="bn2"><svg>...</svg><span>Search</span></label>
</nav>
```

**Why does it fit EaseMotion CSS?**
It builds a bottom nav where the checked radio drives the active item color and lift, using only CSS and inline SVG. Items are keyboard operable with a focus ring and the lift is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: selecting the third item makes it the accent color with its icon lifted while the previously active item returns to the muted color.
