### PR TITLE
feat: add kanban board

### DIFF
--- a/submissions/examples/kanban-board-as/README.md
+++ b/submissions/examples/kanban-board-as/README.md
@@ -1,0 +1,22 @@
+# Kanban Board
+
+### What does this do?
+
+It lays out a three column kanban board with labeled columns, a count badge per column, and task cards that show a colored tag and a title. Cards lift on hover and the board scrolls sideways on narrow screens.
+
+### How is it used?
+
+```html
+<div class="board">
+  <section class="column">
+    <header>To do <span class="count">3</span></header>
+    <article class="task"><span class="tag design">Design</span><p>Draft the logo</p></article>
+  </section>
+</div>
+```
+
+Each column is a flex item that holds its own header and cards. Tag tones are `design`, `dev`, and `qa`.
+
+### Why is it useful?
+
+Task boards are the core view of project tools. This lays out kanban columns with headers, counts, and cards using only CSS, giving a clean starting point a developer can wire to real data. The hover lift is removed under reduced motion.

--- a/submissions/examples/kanban-board-as/demo.html
+++ b/submissions/examples/kanban-board-as/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Kanban Board</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="board">
+    <section class="column">
+      <header>To do <span class="count">3</span></header>
+      <article class="task"><span class="tag design">Design</span><p>Draft the new logo</p></article>
+      <article class="task"><span class="tag dev">Dev</span><p>Set up the API routes</p></article>
+      <article class="task"><span class="tag qa">QA</span><p>Write smoke tests</p></article>
+    </section>
+    <section class="column">
+      <header>In progress <span class="count">2</span></header>
+      <article class="task"><span class="tag dev">Dev</span><p>Build the settings page</p></article>
+      <article class="task"><span class="tag design">Design</span><p>Polish the empty states</p></article>
+    </section>
+    <section class="column">
+      <header>Done <span class="count">2</span></header>
+      <article class="task"><span class="tag qa">QA</span><p>Fix the login bug</p></article>
+      <article class="task"><span class="tag dev">Dev</span><p>Ship the release notes</p></article>
+    </section>
+  </div>
+</body>
+</html>

--- a/submissions/examples/kanban-board-as/style.css
+++ b/submissions/examples/kanban-board-as/style.css
@@ -1,0 +1,109 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 0;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.board {
+  display: flex;
+  gap: 0.9rem;
+  width: min(640px, 100vw);
+  padding: 0 1rem;
+  box-sizing: border-box;
+  overflow-x: auto;
+}
+
+.column {
+  flex: 1 0 190px;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 14px;
+  padding: 0.8rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.column > header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: #cbd5e1;
+  padding: 0 0.2rem 0.2rem;
+}
+
+.column .count {
+  display: grid;
+  place-items: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 5px;
+  box-sizing: border-box;
+  border-radius: 10px;
+  background: #1b2942;
+  color: #94a3b8;
+  font-size: 0.72rem;
+}
+
+.task {
+  background: #131f34;
+  border: 1px solid #223049;
+  border-radius: 10px;
+  padding: 0.7rem 0.8rem;
+  cursor: grab;
+  transition: transform 0.15s ease, border-color 0.15s ease;
+}
+
+.task:hover {
+  transform: translateY(-2px);
+  border-color: #6c63ff;
+}
+
+.tag {
+  display: inline-block;
+  margin-bottom: 0.4rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: 6px;
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.tag.design {
+  background: rgba(168, 85, 247, 0.18);
+  color: #d8b4fe;
+}
+
+.tag.dev {
+  background: rgba(59, 130, 246, 0.18);
+  color: #93c5fd;
+}
+
+.tag.qa {
+  background: rgba(16, 185, 129, 0.18);
+  color: #6ee7b7;
+}
+
+.task p {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  color: #e2e8f0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .task {
+    transition: border-color 0.15s ease;
+  }
+
+  .task:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a kanban board built for #40969. Three labeled columns with count badges and task cards showing a tag and title, using only CSS. Closes #40969.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A three column kanban board with column headers, a count badge per column, and task cards that show a colored tag and a title and lift on hover.

**How does a developer use it?**

```html
<div class="board">
  <section class="column">
    <header>To do <span class="count">3</span></header>
    <article class="task"><span class="tag design">Design</span><p>Draft the logo</p></article>
  </section>
</div>
```

**Why does it fit EaseMotion CSS?**
It lays out kanban columns with headers, counts, and cards using only CSS, giving a clean starting point a developer can wire to real data. The hover lift is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: three columns render side by side with seven task cards and column counts of 3, 2, and 2.
