### PR TITLE
fix: document CSS variable animation restart workaround

### DIFF
--- a/submissions/docs/css-variable-animation-restart-fix/README.md
+++ b/submissions/docs/css-variable-animation-restart-fix/README.md
@@ -1,0 +1,51 @@
+# Fix: CSS Variable Update Does Not Restart Keyframe Animations
+
+Relates to bug report **#40951**.
+
+## 1. What does this do?
+
+This demo documents and fixes a browser limitation: when a CSS custom property
+used inside an `animation` shorthand is updated at runtime, the browser does
+**not** automatically restart or recompute the animation. The element keeps
+running the old animation with its previously computed values.
+
+## 2. How is it used?
+
+Add this tiny helper function wherever you need to change an animation-related
+CSS variable at runtime:
+
+```js
+function restartAnimation(el) {
+  el.style.animation = 'none'; // pause the animation
+  void el.offsetWidth;         // force a browser reflow (style flush)
+  el.style.animation = '';     // restore — browser re-reads the variable
+}
+```
+
+Then call it immediately after setting the new variable value:
+
+```js
+element.style.setProperty('--ease-speed-medium', '2s');
+restartAnimation(element); // picks up the new value instantly
+```
+
+## 3. Why is it useful?
+
+EaseMotion CSS is built around CSS custom properties (`--ease-speed-*`,
+`--ease-color-*`, etc.) for theming and token-based design. When developers
+toggle themes or change token values dynamically (e.g., switching between a
+fast and slow motion mode), the animation must restart to reflect the new values.
+
+Without this fix, animations are "frozen" with the old computed values, breaking
+dynamic theming entirely. This helper is minimal (3 lines), zero-dependency,
+and works in all modern browsers.
+
+## Root Cause
+
+Browsers compute `animation-duration` once when the animation first starts.
+CSS variables are resolved at **computed value time**, not at **used value time**
+for running animations. The browser only re-evaluates the animation when it
+detects a style change on the element itself — and the internal variable
+re-resolution doesn't count as one. Reading `offsetWidth` forces a synchronous
+reflow, which causes the browser to flush all pending style calculations and
+treat the animation as newly applied.

--- a/submissions/docs/css-variable-animation-restart-fix/demo.html
+++ b/submissions/docs/css-variable-animation-restart-fix/demo.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: CSS Variable Animation Restart Demo</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+
+  <h1>CSS Variable Animation Restart — Fix Demo</h1>
+  <p class="subtitle">
+    Demonstrates the bug and a reliable fix. Toggle the speed below and watch the animation restart correctly.
+  </p>
+
+  <!-- SECTION 1: THE BUG -->
+  <section class="panel bug-panel">
+    <h2>❌ The Bug (No Fix Applied)</h2>
+    <p>
+      The box animates using <code>--custom-duration</code> via a CSS variable.
+      Changing the variable does <strong>not</strong> restart the animation — the old speed stays.
+    </p>
+    <div class="box-wrapper">
+      <div class="animated-box buggy-box">Buggy Box</div>
+    </div>
+    <div class="controls">
+      <button onclick="setBuggySpeed('0.5s')">Fast (0.5s)</button>
+      <button onclick="setBuggySpeed('2s')">Slow (2s)</button>
+    </div>
+    <p class="note">👆 Click Fast/Slow — the box ignores the change until page refresh.</p>
+  </section>
+
+  <!-- SECTION 2: THE FIX -->
+  <section class="panel fix-panel">
+    <h2>✅ The Fix (Animation Restart Helper)</h2>
+    <p>
+      Same box, same CSS variable — but after changing the variable, we call
+      <code>restartAnimation(el)</code> to force the browser to re-evaluate it.
+    </p>
+    <div class="box-wrapper">
+      <div id="fixed-box" class="animated-box fixed-box">Fixed Box</div>
+    </div>
+    <div class="controls">
+      <button onclick="setFixedSpeed('0.5s')">Fast (0.5s)</button>
+      <button onclick="setFixedSpeed('2s')">Slow (2s)</button>
+    </div>
+    <p class="note">👆 Click Fast/Slow — the box immediately updates its animation speed!</p>
+  </section>
+
+  <!-- HOW IT WORKS -->
+  <section class="panel info-panel">
+    <h2>🔧 How the Fix Works</h2>
+    <p>The helper function works in 3 steps:</p>
+    <ol>
+      <li>Temporarily sets <code>animation: none</code> on the element.</li>
+      <li>Reads <code>offsetWidth</code> to force the browser to flush and recalculate styles (reflow).</li>
+      <li>Removes the override — the browser re-reads the CSS variable with the new value and restarts the animation.</li>
+    </ol>
+    <pre><code>function restartAnimation(el) {
+  el.style.animation = 'none';
+  void el.offsetWidth; // force reflow
+  el.style.animation = '';
+}</code></pre>
+  </section>
+
+  <script>
+    // ─── Bug Demo ───────────────────────────────────────────────────────────
+    // Just sets the variable without restarting — the browser ignores the change
+    function setBuggySpeed(speed) {
+      const buggyBox = document.querySelector('.buggy-box');
+      buggyBox.style.setProperty('--custom-duration', speed);
+      // ❌ No restart — animation carries on with the old computed speed
+    }
+
+    // ─── Fix Helper ──────────────────────────────────────────────────────────
+    // Step 1: set animation to none
+    // Step 2: read offsetWidth to flush the browser's style engine (reflow)
+    // Step 3: remove the override — the browser picks up the new variable value
+    function restartAnimation(el) {
+      el.style.animation = 'none';
+      void el.offsetWidth; // ← This forces a synchronous reflow
+      el.style.animation = '';
+    }
+
+    function setFixedSpeed(speed) {
+      const fixedBox = document.getElementById('fixed-box');
+      fixedBox.style.setProperty('--custom-duration', speed);
+      restartAnimation(fixedBox); // ✅ Force restart — new speed applies immediately
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/docs/css-variable-animation-restart-fix/style.css
+++ b/submissions/docs/css-variable-animation-restart-fix/style.css
@@ -1,0 +1,178 @@
+/* ============================================================
+   Fix Demo: CSS Variable Update Does Not Restart Animations
+   Relates to issue #40951
+   ============================================================ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+}
+
+h1 {
+  font-size: 1.6rem;
+  color: #f8fafc;
+  text-align: center;
+}
+
+.subtitle {
+  color: #94a3b8;
+  text-align: center;
+  max-width: 560px;
+}
+
+/* ── Panels ──────────────────────────────────────────────── */
+
+.panel {
+  background: #1e293b;
+  border-radius: 12px;
+  padding: 1.75rem;
+  width: 100%;
+  max-width: 600px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.bug-panel {
+  border: 1px solid #ef4444;
+}
+
+.fix-panel {
+  border: 1px solid #22c55e;
+}
+
+.info-panel {
+  border: 1px solid #6c63ff;
+}
+
+h2 {
+  font-size: 1.1rem;
+}
+
+p {
+  color: #cbd5e1;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+code {
+  background: #0f172a;
+  color: #a78bfa;
+  padding: 0.1em 0.4em;
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+
+ol {
+  padding-left: 1.5rem;
+  color: #cbd5e1;
+  font-size: 0.9rem;
+  line-height: 2;
+}
+
+pre {
+  background: #0f172a;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  padding: 1rem;
+  overflow-x: auto;
+}
+
+pre code {
+  background: transparent;
+  color: #7dd3fc;
+  padding: 0;
+  font-size: 0.85rem;
+  line-height: 1.7;
+}
+
+/* ── Animated Box ────────────────────────────────────────── */
+
+.box-wrapper {
+  display: flex;
+  justify-content: center;
+  padding: 1rem 0;
+}
+
+/* Both boxes use the same keyframe and the same CSS variable.
+   The ONLY difference is whether restartAnimation() is called. */
+.animated-box {
+  --custom-duration: 1s;
+
+  width: 120px;
+  height: 120px;
+  border-radius: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-align: center;
+  animation: slide-bounce var(--custom-duration) ease-in-out infinite alternate;
+}
+
+.buggy-box {
+  background: linear-gradient(135deg, #ef4444, #f97316);
+  color: white;
+}
+
+.fixed-box {
+  background: linear-gradient(135deg, #6c63ff, #22c55e);
+  color: white;
+}
+
+/* ── Keyframe ────────────────────────────────────────────── */
+
+@keyframes slide-bounce {
+  from {
+    transform: translateX(-40px) scale(0.95);
+  }
+  to {
+    transform: translateX(40px) scale(1.05);
+  }
+}
+
+/* ── Controls ────────────────────────────────────────────── */
+
+.controls {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.controls button {
+  background: #334155;
+  color: #e2e8f0;
+  border: 1px solid #475569;
+  border-radius: 8px;
+  padding: 0.5rem 1.2rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.controls button:hover {
+  background: #475569;
+  border-color: #6c63ff;
+}
+
+.note {
+  font-size: 0.8rem;
+  color: #64748b;
+  text-align: center;
+}


### PR DESCRIPTION
Resolves #40951

### What is the bug?
When an EaseMotion animation uses CSS custom properties (`--ease-speed-medium`, etc.) for `animation-duration`, `animation-delay`, or `transform` values, updating those variables at runtime does **not** cause the browser to restart or recompute the animation. The element keeps running with the previously computed values.

### Root Cause
Browsers resolve CSS variables at **computed value time** — when the animation first starts. Changing a CSS variable later does not count as a style change on the element itself, so the browser never re-evaluates the animation. Reading `offsetWidth` forces a synchronous reflow that flushes all pending style calculations, causing the animation to be treated as newly applied.

### Fix
A 3-line JavaScript helper that reliably restarts any animation after a CSS variable change:

```js
function restartAnimation(el) {
  el.style.animation = 'none'; // pause the animation
  void el.offsetWidth;         // force a browser reflow
  el.style.animation = '';     // restore — browser re-reads the variable
}
```

### Changes Made
- Added `submissions/docs/css-variable-animation-restart-fix/demo.html`: Side-by-side interactive demo showing the buggy behaviour vs. the fixed behaviour with toggle buttons.
- Added `submissions/docs/css-variable-animation-restart-fix/style.css`: Fully self-contained styles for the demo with dark theme.
- Added `submissions/docs/css-variable-animation-restart-fix/README.md`: Explains the bug, the fix, how to use the helper, and the root cause in plain English.

### Validation
- [x] Placed correctly under `submissions/docs/css-variable-animation-restart-fix/`
- [x] Includes all 3 required files: `demo.html`, `style.css`, `README.md`
- [x] Demo is fully self-contained — open in browser with no server needed
- [x] Does not touch `core/` or `components/`
- [x] Tested in Chrome 138 / macOS
