### PR TITLE
feat: add calendar month grid

### DIFF
--- a/submissions/examples/calendar-grid-as/README.md
+++ b/submissions/examples/calendar-grid-as/README.md
@@ -1,0 +1,25 @@
+# Calendar Month Grid
+
+### What does this do?
+
+It lays out a month calendar with weekday headers and day cells on a seven column grid. Today is highlighted, days with events show a dot, and leading blank cells pad the first week so dates line up under the right weekday.
+
+### How is it used?
+
+```html
+<div class="calendar">
+  <div class="cal-head"><span>July 2026</span></div>
+  <div class="cal-grid">
+    <span class="dow">Mo</span>
+    <span class="pad"></span>
+    <button class="day is-today" aria-current="date">10</button>
+    <button class="day has-event">16</button>
+  </div>
+</div>
+```
+
+Add `pad` spans before day one to shift the first day to its weekday. Use `is-today` for the current day and `has-event` to show a dot.
+
+### Why is it useful?
+
+Date pickers and schedule views start from a month grid. This lays out a calendar month on a seven column grid with a highlighted today and event markers, using only CSS. Day cells are real buttons with hover and focus styles.

--- a/submissions/examples/calendar-grid-as/demo.html
+++ b/submissions/examples/calendar-grid-as/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Calendar Month Grid</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="calendar">
+    <div class="cal-head">
+      <span>July 2026</span>
+      <span class="cal-nav">
+        <button type="button" aria-label="Previous month">‹</button>
+        <button type="button" aria-label="Next month">›</button>
+      </span>
+    </div>
+    <div class="cal-grid">
+      <span class="dow">Mo</span>
+      <span class="dow">Tu</span>
+      <span class="dow">We</span>
+      <span class="dow">Th</span>
+      <span class="dow">Fr</span>
+      <span class="dow">Sa</span>
+      <span class="dow">Su</span>
+
+      <span class="pad"></span>
+      <span class="pad"></span>
+      <button class="day" type="button">1</button>
+      <button class="day" type="button">2</button>
+      <button class="day has-event" type="button">3</button>
+      <button class="day" type="button">4</button>
+      <button class="day" type="button">5</button>
+      <button class="day" type="button">6</button>
+      <button class="day" type="button">7</button>
+      <button class="day" type="button">8</button>
+      <button class="day has-event" type="button">9</button>
+      <button class="day is-today" type="button" aria-current="date">10</button>
+      <button class="day" type="button">11</button>
+      <button class="day" type="button">12</button>
+      <button class="day" type="button">13</button>
+      <button class="day" type="button">14</button>
+      <button class="day" type="button">15</button>
+      <button class="day has-event" type="button">16</button>
+      <button class="day" type="button">17</button>
+      <button class="day" type="button">18</button>
+      <button class="day" type="button">19</button>
+      <button class="day" type="button">20</button>
+      <button class="day" type="button">21</button>
+      <button class="day" type="button">22</button>
+      <button class="day" type="button">23</button>
+      <button class="day has-event" type="button">24</button>
+      <button class="day" type="button">25</button>
+      <button class="day" type="button">26</button>
+      <button class="day" type="button">27</button>
+      <button class="day" type="button">28</button>
+      <button class="day" type="button">29</button>
+      <button class="day" type="button">30</button>
+      <button class="day" type="button">31</button>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/calendar-grid-as/style.css
+++ b/submissions/examples/calendar-grid-as/style.css
@@ -1,0 +1,121 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.calendar {
+  width: min(320px, 94vw);
+  padding: 1.2rem;
+  box-sizing: border-box;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+}
+
+.cal-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 1rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
+.cal-nav {
+  display: flex;
+  gap: 0.3rem;
+}
+
+.cal-nav button {
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  border: none;
+  border-radius: 8px;
+  background: #1b2942;
+  color: #cbd5e1;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.cal-nav button:hover {
+  background: #24344f;
+}
+
+.cal-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 3px;
+}
+
+.dow {
+  text-align: center;
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: #64748b;
+  padding-bottom: 0.3rem;
+}
+
+.day {
+  position: relative;
+  aspect-ratio: 1;
+  display: grid;
+  place-items: center;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: #cbd5e1;
+  font: inherit;
+  font-size: 0.82rem;
+  cursor: pointer;
+  transition: background 0.14s ease;
+}
+
+.day:hover {
+  background: #1b2942;
+}
+
+.day.is-muted {
+  color: #475569;
+}
+
+.day.is-today {
+  background: #6c63ff;
+  color: #fff;
+  font-weight: 700;
+}
+
+.day.has-event::after {
+  content: "";
+  position: absolute;
+  bottom: 5px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: #34d399;
+}
+
+.day.is-today.has-event::after {
+  background: #fff;
+}
+
+.day:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 1px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .day {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a calendar month grid built for #40971. Weekday headers and day cells on a seven column grid with a highlighted today and event dots, using only CSS. Closes #40971.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A month calendar with weekday headers and day buttons on a seven column grid, a highlighted today, event dots, and leading pad cells for the first week.

**How does a developer use it?**

```html
<div class="calendar">
  <div class="cal-head"><span>July 2026</span></div>
  <div class="cal-grid">
    <span class="dow">Mo</span>
    <span class="pad"></span>
    <button class="day is-today" aria-current="date">10</button>
    <button class="day has-event">16</button>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It lays out a calendar month on a seven column grid with a highlighted today and event markers, using only CSS. Day cells are real buttons with hover and focus styles.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the grid has seven columns, 31 day cells, four event dots, and today (the 10th) carries the accent background.
