### PR TITLE
feat: add weekday picker

### DIFF
--- a/submissions/examples/weekday-picker-as/README.md
+++ b/submissions/examples/weekday-picker-as/README.md
@@ -1,0 +1,23 @@
+# Weekday Picker
+
+### What does this do?
+
+It shows a row of seven day pills where the user can toggle any number of weekdays on. Each pill fills in accent color when its checkbox is checked. It uses checkboxes and CSS only, so it is a real multi select that is keyboard operable with no JavaScript.
+
+### How is it used?
+
+```html
+<fieldset class="weekdays">
+  <legend>Repeat on</legend>
+  <div class="wd-row">
+    <label><input type="checkbox" checked aria-label="Monday" /><span>M</span></label>
+    <label><input type="checkbox" aria-label="Tuesday" /><span>T</span></label>
+  </div>
+</fieldset>
+```
+
+Each day is its own checkbox, so more than one can be on at a time. The `:has(:checked)` selector fills the pill of any checked day. Give each input an `aria-label` with the full day name.
+
+### Why is it useful?
+
+Repeat schedules and reminder settings need a quick weekday chooser. This builds a multi select of day pills where each checked box fills its pill, using only checkboxes and CSS. Pills have hover and focus states and the scale is removed under reduced motion.

--- a/submissions/examples/weekday-picker-as/demo.html
+++ b/submissions/examples/weekday-picker-as/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Weekday Picker</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <fieldset class="weekdays">
+    <legend>Repeat on</legend>
+    <div class="wd-row">
+      <label><input type="checkbox" checked aria-label="Monday" /><span>M</span></label>
+      <label><input type="checkbox" aria-label="Tuesday" /><span>T</span></label>
+      <label><input type="checkbox" checked aria-label="Wednesday" /><span>W</span></label>
+      <label><input type="checkbox" aria-label="Thursday" /><span>T</span></label>
+      <label><input type="checkbox" checked aria-label="Friday" /><span>F</span></label>
+      <label><input type="checkbox" aria-label="Saturday" /><span>S</span></label>
+      <label><input type="checkbox" aria-label="Sunday" /><span>S</span></label>
+    </div>
+  </fieldset>
+</body>
+</html>

--- a/submissions/examples/weekday-picker-as/style.css
+++ b/submissions/examples/weekday-picker-as/style.css
@@ -1,0 +1,83 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.weekdays {
+  border: 1px solid #26324a;
+  border-radius: 16px;
+  background: #0e1626;
+  padding: 1.35rem 1.6rem;
+  margin: 0;
+}
+
+.weekdays legend {
+  font-size: 0.9rem;
+  font-weight: 600;
+  padding: 0 0.4rem;
+}
+
+.wd-row {
+  display: flex;
+  gap: 0.45rem;
+  margin-top: 1rem;
+}
+
+.weekdays label {
+  cursor: pointer;
+}
+
+.weekdays input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  margin: -1px;
+  overflow: hidden;
+}
+
+.weekdays span {
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  background: #1b2942;
+  color: #94a3b8;
+  font-size: 0.82rem;
+  font-weight: 700;
+  transition: background 0.15s ease, color 0.15s ease, transform 0.15s ease;
+}
+
+.weekdays label:hover span {
+  background: #24344f;
+  color: #cbd5e1;
+}
+
+.weekdays label:has(:checked) span {
+  background: #6c63ff;
+  color: #fff;
+  transform: scale(1.05);
+}
+
+.weekdays label:has(:focus-visible) span {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .weekdays span {
+    transition: background 0.15s ease, color 0.15s ease;
+  }
+
+  .weekdays label:has(:checked) span {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a weekday picker built for #40974. A row of seven day pills where each checked box fills its pill, a real multi select using only checkboxes and CSS. Closes #40974.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A weekday multi select of seven round pills where any number of days can be toggled on, each filling in accent color when checked.

**How does a developer use it?**

```html
<fieldset class="weekdays">
  <legend>Repeat on</legend>
  <div class="wd-row">
    <label><input type="checkbox" checked aria-label="Monday" /><span>M</span></label>
    <label><input type="checkbox" aria-label="Tuesday" /><span>T</span></label>
  </div>
</fieldset>
```

**Why does it fit EaseMotion CSS?**
It builds a multi select of day pills where each checked box fills its pill via `:has(:checked)`, using only checkboxes and CSS. Pills have hover and focus states and the scale is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: seven pills render and exactly the three checked days fill with the accent color while the rest stay muted.
