### PR TITLE
feat: add split button

### DIFF
--- a/submissions/examples/split-button-as/README.md
+++ b/submissions/examples/split-button-as/README.md
@@ -1,0 +1,26 @@
+# Split Button
+
+### What does this do?
+
+It shows a split button that pairs a primary action with a caret that opens a menu of related actions. It uses the native `details` and `summary` elements for the menu, so it opens on click and stays keyboard operable with no JavaScript.
+
+### How is it used?
+
+```html
+<div class="split">
+  <button class="split-main" type="button">Save</button>
+  <details class="split-menu">
+    <summary aria-label="More save options"></summary>
+    <div class="split-list">
+      <a href="#">Save as draft</a>
+      <a href="#">Save and close</a>
+    </div>
+  </details>
+</div>
+```
+
+The main button carries the default action and the caret opens the extra actions. The caret flips when the menu is open. Remove `open` from the demo to see it start closed.
+
+### Why is it useful?
+
+Split buttons offer a main action plus a few alternates without cluttering a toolbar. This joins a primary button and a disclosure caret into one control with a popup menu, using only CSS. The menu animates in, every item has a focus style, and the animation is removed under reduced motion.

--- a/submissions/examples/split-button-as/demo.html
+++ b/submissions/examples/split-button-as/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Split Button</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="split">
+    <button class="split-main" type="button">Save</button>
+    <details class="split-menu" open>
+      <summary aria-label="More save options"></summary>
+      <div class="split-list">
+        <a href="#">Save as draft</a>
+        <a href="#">Save and close</a>
+        <a href="#">Save a copy</a>
+      </div>
+    </details>
+  </div>
+</body>
+</html>

--- a/submissions/examples/split-button-as/style.css
+++ b/submissions/examples/split-button-as/style.css
@@ -1,0 +1,124 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 4rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.split {
+  display: inline-flex;
+  position: relative;
+}
+
+.split-main {
+  padding: 0.65rem 1.2rem;
+  font: inherit;
+  font-weight: 600;
+  color: #fff;
+  background: #6c63ff;
+  border: none;
+  border-radius: 10px 0 0 10px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.split-main:hover {
+  background: #5b52e6;
+}
+
+.split-menu {
+  display: flex;
+}
+
+.split-menu summary {
+  list-style: none;
+  display: grid;
+  place-items: center;
+  width: 40px;
+  height: 100%;
+  background: #5b52e6;
+  border-radius: 0 10px 10px 0;
+  border-left: 1px solid rgba(255, 255, 255, 0.18);
+  cursor: pointer;
+}
+
+.split-menu summary::-webkit-details-marker {
+  display: none;
+}
+
+.split-menu summary::after {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-right: 2px solid #fff;
+  border-bottom: 2px solid #fff;
+  transform: translateY(-2px) rotate(45deg);
+  transition: transform 0.2s ease;
+}
+
+.split-menu[open] summary::after {
+  transform: translateY(1px) rotate(-135deg);
+}
+
+.split-main:focus-visible,
+.split-menu summary:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+.split-list {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  right: 0;
+  min-width: 170px;
+  padding: 0.35rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 10px;
+  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.5);
+}
+
+.split-menu[open] .split-list {
+  animation: split-in 0.16s ease;
+}
+
+.split-list a {
+  display: block;
+  padding: 0.55rem 0.7rem;
+  color: #cbd5e1;
+  text-decoration: none;
+  border-radius: 7px;
+  font-size: 0.88rem;
+  transition: background 0.14s ease;
+}
+
+.split-list a:hover,
+.split-list a:focus-visible {
+  background: #1b2942;
+  color: #fff;
+  outline: none;
+}
+
+@keyframes split-in {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .split-menu summary::after,
+  .split-main,
+  .split-list a {
+    transition: none;
+  }
+
+  .split-menu[open] .split-list {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a split button built for #40976. A primary action joined to a caret that opens a menu of related actions, using the native details element and CSS only. Closes #40976.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A split button pairing a primary action with a caret that opens a popup menu of related actions, with the caret flipping when open.

**How does a developer use it?**

```html
<div class="split">
  <button class="split-main" type="button">Save</button>
  <details class="split-menu">
    <summary aria-label="More save options"></summary>
    <div class="split-list">
      <a href="#">Save as draft</a>
      <a href="#">Save and close</a>
    </div>
  </details>
</div>
```

**Why does it fit EaseMotion CSS?**
It joins a primary button and a disclosure caret into one control with a popup menu, using only CSS. The menu animates in, every item has a focus style, and the animation is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the main button and caret sit on one row and the open menu shows three related actions.
