### PR TITLE
feat: add intrinsic size transition utilities using interpolate-size

### DIFF
--- a/submissions/examples/intrinsic-size-transition/README.md
+++ b/submissions/examples/intrinsic-size-transition/README.md
@@ -1,0 +1,20 @@
+# Intrinsic Size Transition Utilities
+
+1. **What does this do?** Provides CSS utility classes that enable smooth transitions between intrinsic sizes — such as `height: auto`, `width: max-content`, and `fit-content` — using the modern CSS `interpolate-size: allow-keywords` property. Includes graceful `@supports` fallbacks for browsers that don't yet support the feature.
+
+2. **How is it used?** Add `interpolate-size: allow-keywords` to `:root`, then use the provided classes:
+   - **`.ease-expand-content`** — collapses an element to `block-size: 0` and transitions to `block-size: auto` when the parent receives hover or an `.is-open` class toggle.
+   - **`.ease-expand-card`** — parent wrapper that triggers `.ease-expand-content` to expand on `:hover`.
+   - **`.ease-expand-width-tag`** — transitions `inline-size` from a fixed width to `max-content` on hover.
+
+   ```html
+   <!-- Hover expand card -->
+   <div class="ease-expand-card">
+     <button>Show Details</button>
+     <div class="ease-expand-content">
+       <p>Content that expands smoothly using intrinsic size interpolation.</p>
+     </div>
+   </div>
+   ```
+
+3. **Why is it useful?** One of the biggest limitations in CSS animations has always been the inability to smoothly transition to keyword dimensions like `auto` height — previously requiring JavaScript hacks (`scrollHeight`, `max-height` tricks, ResizeObserver). The new `interpolate-size` specification solves this natively. This fits EaseMotion CSS's zero-dependency, animation-first philosophy perfectly, enabling pure-CSS accordions, expandable cards, and dynamic navigation menus with a single class.

--- a/submissions/examples/intrinsic-size-transition/demo.html
+++ b/submissions/examples/intrinsic-size-transition/demo.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Intrinsic Size Transition Utilities — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>Intrinsic Size Transition Utilities</h1>
+    <p>Smooth CSS-only transitions to <code>height: auto</code>, <code>width: max-content</code>, and <code>fit-content</code> — zero JavaScript.</p>
+    <span class="browser-badge">✅ Uses <code>interpolate-size: allow-keywords</code> with graceful fallback</span>
+  </header>
+
+  <!-- DEMO 1: Expandable Accordion -->
+  <section class="demo-section">
+    <h2>Accordion — Click to Expand</h2>
+    <p class="demo-desc">Each panel smoothly expands to its natural <code>height: auto</code> on click.</p>
+
+    <div class="accordion">
+
+      <div class="accordion-item">
+        <button class="accordion-trigger" onclick="toggleAccordion(this)">
+          <span>What is interpolate-size?</span>
+          <span class="accordion-icon">+</span>
+        </button>
+        <div class="ease-expand-content">
+          <div class="accordion-body">
+            <p><code>interpolate-size: allow-keywords</code> is a new CSS property that allows browsers to smoothly animate between a numeric value (like <code>0</code>) and a keyword value (like <code>auto</code> or <code>max-content</code>) — something that was previously impossible without JavaScript.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="accordion-item">
+        <button class="accordion-trigger" onclick="toggleAccordion(this)">
+          <span>Which browsers support this?</span>
+          <span class="accordion-icon">+</span>
+        </button>
+        <div class="ease-expand-content">
+          <div class="accordion-body">
+            <p>Chrome 129+, Edge 129+, and Safari 18+ support <code>interpolate-size</code>. For older browsers, this demo falls back gracefully — content is still accessible, just without the smooth animation.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="accordion-item">
+        <button class="accordion-trigger" onclick="toggleAccordion(this)">
+          <span>How does the fallback work?</span>
+          <span class="accordion-icon">+</span>
+        </button>
+        <div class="ease-expand-content">
+          <div class="accordion-body">
+            <p>We use <code>@supports (interpolate-size: allow-keywords)</code> to only apply the transition in browsers that understand it. On unsupported browsers, the content simply snaps open/closed instantly — still fully accessible.</p>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- DEMO 2: Hover Expand Card -->
+  <section class="demo-section">
+    <h2>Hover-to-Expand Cards</h2>
+    <p class="demo-desc">Cards reveal hidden content on hover — no JavaScript, pure CSS using <code>block-size: auto</code> transition.</p>
+
+    <div class="cards-grid">
+
+      <div class="ease-expand-card">
+        <div class="card-header">
+          <span class="card-icon">🚀</span>
+          <h3>Zero JS</h3>
+        </div>
+        <div class="ease-expand-content">
+          <p>This expansion uses no JavaScript at all. The browser natively interpolates between <code>0</code> and <code>auto</code> block-size.</p>
+        </div>
+      </div>
+
+      <div class="ease-expand-card">
+        <div class="card-header">
+          <span class="card-icon">🎨</span>
+          <h3>CSS-First</h3>
+        </div>
+        <div class="ease-expand-content">
+          <p>Following EaseMotion's philosophy — expressive, composable animation utilities built entirely on modern CSS standards.</p>
+        </div>
+      </div>
+
+      <div class="ease-expand-card">
+        <div class="card-header">
+          <span class="card-icon">⚡</span>
+          <h3>Performant</h3>
+        </div>
+        <div class="ease-expand-content">
+          <p>No layout thrashing from JS-based height calculations. The browser handles interpolation natively, keeping animations on the compositor thread.</p>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- DEMO 3: Width transition to max-content -->
+  <section class="demo-section">
+    <h2>Width → max-content Transition</h2>
+    <p class="demo-desc">Tags and buttons expand to their natural text width on hover.</p>
+
+    <div class="tags-row">
+      <span class="ease-expand-width-tag">Hover me to expand</span>
+      <span class="ease-expand-width-tag">I grow to fit</span>
+      <span class="ease-expand-width-tag">Max-content width</span>
+    </div>
+  </section>
+
+  <script>
+    // Minimal JS only for toggling the .is-open class — the animation is 100% CSS
+    function toggleAccordion(btn) {
+      const item = btn.closest('.accordion-item');
+      const isOpen = item.classList.contains('is-open');
+      // Close all
+      document.querySelectorAll('.accordion-item').forEach(i => i.classList.remove('is-open'));
+      // Open clicked if it was closed
+      if (!isOpen) item.classList.add('is-open');
+      // Update icon
+      document.querySelectorAll('.accordion-icon').forEach(i => i.textContent = '+');
+      if (!isOpen) btn.querySelector('.accordion-icon').textContent = '−';
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/intrinsic-size-transition/style.css
+++ b/submissions/examples/intrinsic-size-transition/style.css
@@ -1,0 +1,275 @@
+/* ============================================================
+   Intrinsic Size Transition Utilities
+   Smooth CSS transitions to height: auto, width: max-content,
+   and fit-content using the interpolate-size property.
+   Relates to issue #40966
+   ============================================================ */
+
+/* ── Step 1: Enable interpolate-size globally ────────────────
+   This is the KEY property that makes auto/max-content/fit-content
+   animatable. Without it, transitions to keyword values are instant.
+   Set on :root so all child elements inherit the behavior.
+   ─────────────────────────────────────────────────────────── */
+:root {
+  interpolate-size: allow-keywords;
+}
+
+/* ── Page Reset & Base Styles ────────────────────────────── */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3rem;
+}
+
+code {
+  background: #1e293b;
+  color: #a78bfa;
+  padding: 0.1em 0.4em;
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+
+/* ── Page Header ─────────────────────────────────────────── */
+
+.page-header {
+  text-align: center;
+  max-width: 660px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.page-header h1 {
+  font-size: 2rem;
+  background: linear-gradient(135deg, #a78bfa, #38bdf8);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.page-header p {
+  color: #94a3b8;
+  line-height: 1.6;
+}
+
+.browser-badge {
+  display: inline-block;
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 99px;
+  padding: 0.35rem 1rem;
+  font-size: 0.8rem;
+  color: #7dd3fc;
+}
+
+/* ── Demo Sections ───────────────────────────────────────── */
+
+.demo-section {
+  width: 100%;
+  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.demo-section h2 {
+  font-size: 1.2rem;
+  color: #f8fafc;
+  border-left: 3px solid #a78bfa;
+  padding-left: 0.75rem;
+}
+
+.demo-desc {
+  color: #94a3b8;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+/* ============================================================
+   UTILITY 1: ease-expand-content
+   Smoothly expands from block-size: 0 to block-size: auto.
+   Pair with a parent toggle (class or :hover) that sets
+   block-size: auto on the content element.
+   ============================================================ */
+
+/* Fallback for unsupported browsers — content is accessible,
+   just no smooth animation */
+.ease-expand-content {
+  block-size: 0;
+  overflow: hidden;
+}
+
+/* Only apply the smooth transition if the browser supports
+   interpolate-size. This is the @supports guard. */
+@supports (interpolate-size: allow-keywords) {
+  .ease-expand-content {
+    transition: block-size 0.45s ease;
+  }
+}
+
+/* ── Accordion ────────────────────────────────────────────── */
+
+.accordion {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.accordion-item {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.accordion-trigger {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.25rem;
+  background: transparent;
+  border: none;
+  color: #e2e8f0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+  text-align: left;
+}
+
+.accordion-trigger:hover {
+  background: #334155;
+}
+
+.accordion-icon {
+  font-size: 1.25rem;
+  font-weight: 300;
+  color: #a78bfa;
+  transition: transform 0.3s ease;
+  flex-shrink: 0;
+}
+
+/* When .is-open is added by JS, the content block-size transitions to auto */
+.accordion-item.is-open .ease-expand-content {
+  block-size: auto;
+}
+
+.accordion-body {
+  padding: 0 1.25rem 1.25rem;
+}
+
+.accordion-body p {
+  color: #94a3b8;
+  font-size: 0.9rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   UTILITY 2: ease-expand-card + ease-expand-content
+   Content hidden by default, revealed on :hover.
+   No JS needed — pure CSS hover trigger.
+   ============================================================ */
+
+.cards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.ease-expand-card {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 12px;
+  padding: 1.25rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ease-expand-card:hover {
+  border-color: #a78bfa;
+  box-shadow: 0 0 20px rgba(167, 139, 250, 0.15);
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 0.5rem;
+}
+
+.card-icon {
+  font-size: 1.4rem;
+}
+
+.card-header h3 {
+  font-size: 1rem;
+  color: #f8fafc;
+}
+
+/* On hover, ease-expand-content expands to auto height */
+.ease-expand-card:hover .ease-expand-content {
+  block-size: auto;
+}
+
+.ease-expand-content p {
+  color: #94a3b8;
+  font-size: 0.85rem;
+  line-height: 1.65;
+  padding-top: 0.5rem;
+}
+
+/* ============================================================
+   UTILITY 3: ease-expand-width-tag
+   Transitions inline-size from a fixed value to max-content.
+   Great for pill tags, buttons, navigation items.
+   ============================================================ */
+
+.tags-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.ease-expand-width-tag {
+  display: inline-block;
+  background: linear-gradient(135deg, #6c63ff22, #38bdf822);
+  border: 1px solid #334155;
+  border-radius: 99px;
+  padding: 0.4rem 1rem;
+  color: #a78bfa;
+  font-size: 0.85rem;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+
+  /* Collapsed: clamp to a small width */
+  inline-size: 80px;
+}
+
+/* Only animate if browser supports interpolate-size */
+@supports (interpolate-size: allow-keywords) {
+  .ease-expand-width-tag {
+    transition: inline-size 0.4s ease, border-color 0.2s ease;
+  }
+}
+
+.ease-expand-width-tag:hover {
+  inline-size: max-content;
+  border-color: #a78bfa;
+}


### PR DESCRIPTION
Resolves #40966

### Description
Adds CSS utility classes that enable smooth transitions between intrinsic keyword sizes (`height: auto`, `width: max-content`, `fit-content`) using the modern `interpolate-size: allow-keywords` CSS property — with graceful `@supports` fallback for older browsers.

### Utilities Added

| Class | What it does |
|---|---|
| `.ease-expand-content` | Collapses to `block-size: 0` and smoothly expands to `block-size: auto` when triggered |
| `.ease-expand-card` | Hover-triggered parent that reveals `.ease-expand-content` children |
| `.ease-expand-width-tag` | Transitions `inline-size` from a fixed value to `max-content` on hover |

### Demo Includes
- **Accordion** — click-to-expand panels using `.ease-expand-content` + minimal JS class toggle (animation is 100% CSS)
- **Hover-expand cards** — 3 cards that reveal content on hover, pure CSS
- **Width-to-max-content tags** — pill tags that expand to their natural text width on hover

### Browser Support & Fallback Strategy
```css
/* Only applies transition if browser supports interpolate-size */
@supports (interpolate-size: allow-keywords) {
  .ease-expand-content {
    transition: block-size 0.45s ease;
  }
}
```
On unsupported browsers (pre-Chrome 129), content still appears/disappears correctly — just without the smooth animation. Fully accessible.

### Changes Made
- Added `submissions/examples/intrinsic-size-transition/demo.html`
- Added `submissions/examples/intrinsic-size-transition/style.css`
- Added `submissions/examples/intrinsic-size-transition/README.md`

### Validation
- [x] Placed under `submissions/examples/intrinsic-size-transition/`
- [x] Includes all 3 required files: `demo.html`, `style.css`, `README.md`
- [x] Zero external dependencies — pure CSS with a tiny JS class-toggle for the accordion
- [x] Does not duplicate any existing EaseMotion CSS class
- [x] Does not touch `core/` or `components/`
