### PR TITLE
feat: add announcement bar

### DIFF
--- a/submissions/examples/announcement-bar-as/README.md
+++ b/submissions/examples/announcement-bar-as/README.md
@@ -1,0 +1,21 @@
+# Announcement Bar
+
+### What does this do?
+
+It shows a top of page announcement bar with a message, an inline call to action link, and a dismiss button. Pressing the close button collapses the bar smoothly. It uses a hidden checkbox for dismissal, so it needs no JavaScript.
+
+### How is it used?
+
+```html
+<input type="checkbox" id="ann-close" class="ann-close" />
+<div class="announce">
+  <p>New release is live. <a href="#">See what changed</a></p>
+  <label class="ann-x" for="ann-close" aria-label="Dismiss">✕</label>
+</div>
+```
+
+Keep the checkbox before the bar so the sibling selector can collapse it. The close label points at the checkbox, so pressing it hides the bar by animating its height and opacity to zero.
+
+### Why is it useful?
+
+Sites use a slim top bar to promote a sale, a launch, or a notice. This builds a dismissible announcement bar with a call to action and a smooth collapse using only a checkbox and CSS. The collapse transition is removed under reduced motion.

--- a/submissions/examples/announcement-bar-as/demo.html
+++ b/submissions/examples/announcement-bar-as/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Announcement Bar</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <input type="checkbox" id="ann-close" class="ann-close" />
+  <div class="announce">
+    <p>Version 2 is live with a faster editor. <a href="#">See what changed</a></p>
+    <label class="ann-x" for="ann-close" aria-label="Dismiss announcement" role="button">✕</label>
+  </div>
+  <main class="page-body">
+    <h1>Your dashboard</h1>
+    <p>The announcement bar above sits at the top of the page. Press the close button and it collapses out of the way, leaving this content in place.</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/announcement-bar-as/style.css
+++ b/submissions/examples/announcement-bar-as/style.css
@@ -1,0 +1,97 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.ann-close {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  margin: -1px;
+  overflow: hidden;
+}
+
+.announce {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  max-height: 70px;
+  padding: 0.8rem 1.25rem;
+  background: linear-gradient(90deg, #6c63ff, #a855f7);
+  color: #fff;
+  overflow: hidden;
+  transition: max-height 0.3s ease, padding 0.3s ease, opacity 0.3s ease;
+}
+
+.ann-close:checked ~ .announce {
+  max-height: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  opacity: 0;
+}
+
+.announce p {
+  margin: 0;
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.announce a {
+  color: #fff;
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.ann-x {
+  flex: none;
+  width: 26px;
+  height: 26px;
+  display: grid;
+  place-items: center;
+  border-radius: 7px;
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.ann-x:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.ann-close:focus-visible ~ .announce .ann-x {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+
+.page-body {
+  padding: 2.5rem 1.5rem;
+}
+
+.page-body h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.4rem;
+}
+
+.page-body p {
+  margin: 0;
+  color: #94a3b8;
+  font-size: 0.92rem;
+  line-height: 1.6;
+  max-width: 460px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .announce,
+  .ann-x {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an announcement bar built for #40981. A top of page bar with a message, a call to action, and a dismiss button that collapses it, using a checkbox and CSS only. Closes #40981.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A slim announcement bar with a message, an inline call to action link, and a dismiss button that smoothly collapses the bar.

**How does a developer use it?**

```html
<input type="checkbox" id="ann-close" class="ann-close" />
<div class="announce">
  <p>New release is live. <a href="#">See what changed</a></p>
  <label class="ann-x" for="ann-close" aria-label="Dismiss">✕</label>
</div>
```

**Why does it fit EaseMotion CSS?**
It builds a dismissible announcement bar with a call to action and a smooth collapse using only a checkbox and CSS. The collapse transition is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the bar is about 52px tall open and collapses to zero height when the dismiss checkbox is checked.
