### PR TITLE
feat: add striped progress bar

### DIFF
--- a/submissions/examples/striped-progress-as/README.md
+++ b/submissions/examples/striped-progress-as/README.md
@@ -1,0 +1,20 @@
+# Striped Progress Bar
+
+### What does this do?
+
+It shows a determinate progress bar with animated diagonal stripes. The fill width comes from a custom property and the stripes drift to signal ongoing work. A tone class switches the fill color.
+
+### How is it used?
+
+```html
+<div class="progress is-good" style="--val: 90%"
+     role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100">
+  <span class="progress-fill"></span>
+</div>
+```
+
+Set the fill amount with the `--val` custom property. Add `is-warn` or `is-good` to change the color, or leave the default accent. The `role` and `aria-value` attributes expose the progress to assistive tech.
+
+### Why is it useful?
+
+Upload and task progress often use a striped bar to signal that work is moving. This builds a determinate striped bar with a moving pattern from a repeating gradient, driven by a custom property, using only CSS. The stripe animation is removed under reduced motion.

--- a/submissions/examples/striped-progress-as/demo.html
+++ b/submissions/examples/striped-progress-as/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Striped Progress Bar</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="progress-list">
+    <div>
+      <div class="progress-top"><span>Uploading photos</span><span>35%</span></div>
+      <div class="progress" style="--val: 35%" role="progressbar" aria-valuenow="35" aria-valuemin="0" aria-valuemax="100">
+        <span class="progress-fill"></span>
+      </div>
+    </div>
+    <div>
+      <div class="progress-top"><span>Encoding video</span><span>62%</span></div>
+      <div class="progress is-warn" style="--val: 62%" role="progressbar" aria-valuenow="62" aria-valuemin="0" aria-valuemax="100">
+        <span class="progress-fill"></span>
+      </div>
+    </div>
+    <div>
+      <div class="progress-top"><span>Almost done</span><span>90%</span></div>
+      <div class="progress is-good" style="--val: 90%" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100">
+        <span class="progress-fill"></span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/striped-progress-as/style.css
+++ b/submissions/examples/striped-progress-as/style.css
@@ -1,0 +1,74 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.progress-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+  width: min(360px, 92vw);
+}
+
+.progress-top {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  margin-bottom: 0.4rem;
+  color: #cbd5e1;
+}
+
+.progress {
+  height: 14px;
+  border-radius: 8px;
+  background: #1b2942;
+  overflow: hidden;
+}
+
+.progress-fill {
+  display: block;
+  height: 100%;
+  width: var(--val);
+  border-radius: 8px;
+  background-color: #6c63ff;
+  background-image: repeating-linear-gradient(
+    45deg,
+    rgba(255, 255, 255, 0.22) 0,
+    rgba(255, 255, 255, 0.22) 10px,
+    transparent 10px,
+    transparent 20px
+  );
+  background-size: 28px 28px;
+  animation: progress-stripes 0.8s linear infinite;
+}
+
+.progress.is-warn .progress-fill {
+  background-color: #f59e0b;
+}
+
+.progress.is-good .progress-fill {
+  background-color: #10b981;
+}
+
+@keyframes progress-stripes {
+  from {
+    background-position: 0 0;
+  }
+
+  to {
+    background-position: 28px 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .progress-fill {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a striped progress bar built for #40985. A determinate bar with animated diagonal stripes, a fill from a custom property, and a tone class, using only CSS. Closes #40985.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A determinate progress bar with animated diagonal stripes, where the fill comes from a `--val` custom property and a tone class switches the color.

**How does a developer use it?**

```html
<div class="progress is-good" style="--val: 90%"
     role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100">
  <span class="progress-fill"></span>
</div>
```

**Why does it fit EaseMotion CSS?**
It builds a determinate striped bar with a moving pattern from a repeating gradient, driven by a custom property, using only CSS. The `role` and `aria-value` attributes expose progress to assistive tech and the stripe animation is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: three bars fill to 35, 62, and 90 percent of their tracks and run the stripe animation.
