### PR TITLE
fix: document stacking context animation restart with two CSS workarounds

### DIFF
--- a/submissions/docs/stacking-context-animation-reset-fix/README.md
+++ b/submissions/docs/stacking-context-animation-reset-fix/README.md
@@ -1,0 +1,53 @@
+# Fix: Animation State Resets When Ancestor Receives New Stacking Context
+
+Relates to bug report **#40957**.
+
+## 1. What does this do?
+
+This demo documents and fixes the bug where EaseMotion animations unexpectedly
+restart or flicker when an **ancestor element** dynamically receives a new CSS
+stacking context via properties like `transform`, `filter`, `perspective`,
+`contain`, or `will-change`.
+
+## 2. How is it used?
+
+Two proven fixes are demonstrated side-by-side:
+
+### Fix 1 — Pre-promote the animated element (recommended)
+Add `will-change: transform` to the **child animated element itself** before any
+animation starts. This tells the browser to promote it to its own GPU compositor
+layer from the beginning, so parent stacking context changes don't affect it.
+
+```css
+/* On the EaseMotion animated element */
+.my-animated-card {
+  will-change: transform;  /* pre-promote to own layer */
+  animation: ease-float 2s ease-in-out infinite;
+}
+```
+
+### Fix 2 — Pre-establish stacking context on the wrapper
+If you know the parent container will eventually receive a stacking-context
+property (e.g. when opening a modal or enabling a blur), apply it from the
+**very start** using `transform: translateZ(0)` or `isolation: isolate`.
+
+```css
+.wrapper {
+  /* Apply immediately so no mid-animation layer change occurs */
+  transform: translateZ(0);
+  /* or: isolation: isolate; */
+}
+```
+
+## 3. Why is it useful?
+
+This is a subtle but highly impactful browser rendering behavior that affects
+real-world EaseMotion usage, especially in:
+- **Modals** — opening a modal often applies backdrop-filter or transform to a parent
+- **Scroll effects** — `will-change: transform` added to scroll containers
+- **Blur overlays** — adding `filter: blur()` to a parent for a frosted-glass effect
+- **Dynamic scaling** — parent containers that scale on hover or focus
+
+Without understanding this root cause, developers experience mysterious animation
+restarts that are very difficult to debug. Both fixes are zero-dependency pure CSS
+solutions, fully aligned with EaseMotion's design philosophy.

--- a/submissions/docs/stacking-context-animation-reset-fix/demo.html
+++ b/submissions/docs/stacking-context-animation-reset-fix/demo.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: Animation Reset on New Stacking Context — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>Animation Reset on New Stacking Context — Fix Demo</h1>
+    <p>When a parent dynamically receives <code>transform</code>, <code>filter</code>, <code>will-change</code>, or <code>perspective</code>, child animations flicker or restart. This demo shows the bug and two proven fixes.</p>
+  </header>
+
+  <!-- ── SECTION 1: THE BUG ───────────────────────────────── -->
+  <section class="demo-section">
+    <h2>❌ The Bug — Toggle parent transform → child animation restarts</h2>
+    <p class="demo-desc">
+      The inner box animates with a continuous float. When you click the button,
+      the wrapper receives <code>transform: translateZ(0)</code>, which creates a
+      <strong>new stacking context</strong>. The browser re-promotes the child to a
+      new compositor layer, causing the animation to restart from <code>0%</code>.
+    </p>
+
+    <div class="controls">
+      <button id="bug-btn" onclick="toggleBug()">Toggle Parent <code>transform: translateZ(0)</code></button>
+      <span id="bug-status" class="status-badge off">Off</span>
+    </div>
+
+    <div id="bug-wrapper" class="buggy-wrapper">
+      <div class="demo-box floating-box">
+        <span>🐛 Buggy Box</span>
+        <small>Watch me restart when you toggle above!</small>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── SECTION 2: FIX 1 — Pre-promote the child ──────────── -->
+  <section class="demo-section">
+    <h2>✅ Fix 1 — Pre-promote child with <code>will-change: transform</code></h2>
+    <p class="demo-desc">
+      By adding <code>will-change: transform</code> to the <strong>animated element itself</strong>
+      <em>before</em> the parent changes, the browser already has it on its own compositor
+      layer. When the parent creates a new stacking context, the child's layer is
+      unaffected — the animation continues uninterrupted.
+    </p>
+
+    <div class="controls">
+      <button id="fix1-btn" onclick="toggleFix1()">Toggle Parent <code>transform: translateZ(0)</code></button>
+      <span id="fix1-status" class="status-badge off">Off</span>
+    </div>
+
+    <div id="fix1-wrapper" class="fix1-wrapper">
+      <!--
+        will-change: transform is set on this element in CSS from the start.
+        This pre-promotes it to its own GPU layer so the parent's
+        stacking context change doesn't affect it.
+      -->
+      <div class="demo-box fix1-box">
+        <span>✅ Fix 1 Box</span>
+        <small><code>will-change: transform</code> keeps the animation steady!</small>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── SECTION 3: FIX 2 — Pre-establish stacking context ─── -->
+  <section class="demo-section">
+    <h2>✅ Fix 2 — Pre-establish stacking context on the wrapper</h2>
+    <p class="demo-desc">
+      If the parent <em>will always</em> create a stacking context eventually (e.g.
+      a modal overlay), apply <code>transform: translateZ(0)</code> or
+      <code>isolation: isolate</code> to the wrapper <strong>from the start</strong>.
+      The child is already inside that layer — no transition happens, no restart.
+    </p>
+
+    <div class="controls">
+      <button id="fix2-btn" onclick="toggleFix2()">Toggle an <em>additional</em> class (harmless)</button>
+      <span id="fix2-status" class="status-badge off">Off</span>
+    </div>
+
+    <div id="fix2-wrapper" class="fix2-wrapper">
+      <!-- The wrapper already has transform: translateZ(0) from the start in CSS.
+           No new stacking context is ever created, so no restart occurs. -->
+      <div class="demo-box fix2-box">
+        <span>✅ Fix 2 Box</span>
+        <small>Wrapper already has <code>translateZ(0)</code> — animation never restarts!</small>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── SECTION 4: HOW IT WORKS ──────────────────────────── -->
+  <section class="demo-section info-section">
+    <h2>🔧 Root Cause &amp; Fix Summary</h2>
+
+    <div class="explanation">
+      <p>
+        <strong>Root cause:</strong> CSS properties like <code>transform</code>,
+        <code>filter</code>, <code>perspective</code>, <code>contain: layout</code>,
+        and <code>will-change: transform</code> create a new <em>stacking context</em>
+        and force the browser to promote descendants to a new GPU compositor layer.
+        When this happens to a running animation, the browser re-initialises the
+        animation timeline from <code>0%</code>, causing a visible restart or flicker.
+      </p>
+
+      <div class="fix-table">
+        <div class="fix-row header-row">
+          <span>Fix</span>
+          <span>How</span>
+          <span>Best for</span>
+        </div>
+        <div class="fix-row">
+          <span>1. Pre-promote child</span>
+          <span>Add <code>will-change: transform</code> to the animated element</span>
+          <span>When you don't control the parent's styling</span>
+        </div>
+        <div class="fix-row">
+          <span>2. Pre-establish context</span>
+          <span>Apply <code>transform: translateZ(0)</code> or <code>isolation: isolate</code> to the wrapper from the start</span>
+          <span>When you control the parent and know it will receive a stacking context</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <script>
+    function toggleBug() {
+      const wrapper = document.getElementById('bug-wrapper');
+      const status = document.getElementById('bug-status');
+      const isActive = wrapper.classList.toggle('active');
+      status.textContent = isActive ? 'On' : 'Off';
+      status.className = 'status-badge ' + (isActive ? 'on' : 'off');
+    }
+
+    function toggleFix1() {
+      const wrapper = document.getElementById('fix1-wrapper');
+      const status = document.getElementById('fix1-status');
+      const isActive = wrapper.classList.toggle('active');
+      status.textContent = isActive ? 'On' : 'Off';
+      status.className = 'status-badge ' + (isActive ? 'on' : 'off');
+    }
+
+    function toggleFix2() {
+      const wrapper = document.getElementById('fix2-wrapper');
+      const status = document.getElementById('fix2-status');
+      const isActive = wrapper.classList.toggle('extra');
+      status.textContent = isActive ? 'On' : 'Off';
+      status.className = 'status-badge ' + (isActive ? 'on' : 'off');
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/docs/stacking-context-animation-reset-fix/style.css
+++ b/submissions/docs/stacking-context-animation-reset-fix/style.css
@@ -1,0 +1,316 @@
+/* ============================================================
+   Fix: Animation State Resets When Ancestor Receives New
+   Stacking Context
+   Relates to bug #40957
+
+   ROOT CAUSE: CSS properties like `transform`, `filter`,
+   `perspective`, `contain`, and `will-change` create a new
+   stacking context and force the browser to promote child
+   elements to a new GPU compositor layer. When this happens
+   mid-animation, the browser restarts the animation timeline
+   from 0%, causing a visible flicker or restart.
+
+   FIX 1: Pre-promote the animated element with
+     `will-change: transform`
+   — the child already has its own compositor layer, so parent
+     layer changes don't force a restart.
+
+   FIX 2: Pre-establish the stacking context on the parent
+     wrapper from the start using `transform: translateZ(0)`
+     or `isolation: isolate`.
+   — no new context is ever created mid-animation.
+   ============================================================ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3rem;
+}
+
+code {
+  background: #1e293b;
+  color: #a78bfa;
+  padding: 0.1em 0.4em;
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+
+/* ── Header ──────────────────────────────────────────────── */
+
+.page-header {
+  text-align: center;
+  max-width: 700px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.page-header h1 {
+  font-size: 1.7rem;
+  background: linear-gradient(135deg, #f87171, #fb923c);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.page-header p {
+  color: #94a3b8;
+  line-height: 1.65;
+}
+
+/* ── Demo Sections ───────────────────────────────────────── */
+
+.demo-section {
+  width: 100%;
+  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.demo-section h2 {
+  font-size: 1.1rem;
+  border-left: 3px solid #a78bfa;
+  padding-left: 0.75rem;
+}
+
+.demo-desc {
+  color: #94a3b8;
+  font-size: 0.88rem;
+  line-height: 1.7;
+}
+
+/* ── Controls ────────────────────────────────────────────── */
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.controls button {
+  background: #334155;
+  color: #e2e8f0;
+  border: 1px solid #475569;
+  border-radius: 8px;
+  padding: 0.5rem 1rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.controls button:hover {
+  background: #475569;
+}
+
+.status-badge {
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.25rem 0.7rem;
+  border-radius: 99px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.status-badge.off {
+  background: #1e293b;
+  color: #64748b;
+  border: 1px solid #334155;
+}
+
+.status-badge.on {
+  background: #7c3aed22;
+  color: #a78bfa;
+  border: 1px solid #7c3aed;
+}
+
+/* ── Shared Box ──────────────────────────────────────────── */
+
+.demo-box {
+  width: 200px;
+  height: 120px;
+  border-radius: 14px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 1rem;
+  text-align: center;
+}
+
+.demo-box span {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.demo-box small {
+  font-size: 0.72rem;
+  color: #94a3b8;
+  line-height: 1.4;
+}
+
+/* ── Shared float keyframe ───────────────────────────────── */
+
+@keyframes ease-float {
+  0%, 100% { transform: translateY(0); }
+  50%       { transform: translateY(-14px); }
+}
+
+/* ── BUGGY DEMO ──────────────────────────────────────────── */
+
+.buggy-wrapper {
+  padding: 2rem;
+  background: #1e293b;
+  border: 1px solid #ef4444;
+  border-radius: 14px;
+  display: flex;
+  justify-content: center;
+  /* NO transform/will-change here initially — that's the bug trigger */
+  transition: box-shadow 0.3s;
+}
+
+/* Toggling .active adds transform, creating a new stacking context */
+.buggy-wrapper.active {
+  transform: translateZ(0);
+  box-shadow: 0 0 0 2px #ef4444;
+}
+
+.floating-box {
+  background: linear-gradient(135deg, #ef444433, #f9731633);
+  border: 1px solid #ef4444;
+  /* Animation starts normally */
+  animation: ease-float 2s ease-in-out infinite;
+}
+
+/* ── FIX 1: Pre-promote child with will-change ───────────── */
+
+.fix1-wrapper {
+  padding: 2rem;
+  background: #1e293b;
+  border: 1px solid #22c55e;
+  border-radius: 14px;
+  display: flex;
+  justify-content: center;
+  transition: box-shadow 0.3s;
+}
+
+.fix1-wrapper.active {
+  transform: translateZ(0);
+  box-shadow: 0 0 0 2px #22c55e;
+}
+
+.fix1-box {
+  background: linear-gradient(135deg, #22c55e22, #6c63ff22);
+  border: 1px solid #22c55e;
+  animation: ease-float 2s ease-in-out infinite;
+
+  /*
+   * FIX 1: Tell the browser to pre-promote this element to its own
+   * compositor layer BEFORE the parent creates a stacking context.
+   * When the parent's context changes, the child layer is unaffected.
+   */
+  will-change: transform;
+}
+
+/* ── FIX 2: Pre-establish stacking context on wrapper ───── */
+
+.fix2-wrapper {
+  padding: 2rem;
+  background: #1e293b;
+  border: 1px solid #38bdf8;
+  border-radius: 14px;
+  display: flex;
+  justify-content: center;
+
+  /*
+   * FIX 2: Apply the stacking context trigger IMMEDIATELY so it's
+   * already established before the animation starts. No mid-animation
+   * layer promotion ever happens — nothing to cause a restart.
+   */
+  transform: translateZ(0);
+  /* Alternatively: isolation: isolate; */
+}
+
+.fix2-wrapper.extra {
+  box-shadow: 0 0 0 2px #38bdf8;
+}
+
+.fix2-box {
+  background: linear-gradient(135deg, #38bdf822, #a78bfa22);
+  border: 1px solid #38bdf8;
+  animation: ease-float 2s ease-in-out infinite;
+}
+
+/* ── Info Section ────────────────────────────────────────── */
+
+.info-section {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 14px;
+  padding: 1.75rem;
+}
+
+.explanation {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.explanation p {
+  color: #94a3b8;
+  font-size: 0.88rem;
+  line-height: 1.75;
+}
+
+.explanation strong {
+  color: #f8fafc;
+}
+
+.fix-table {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border: 1px solid #334155;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.fix-row {
+  display: grid;
+  grid-template-columns: 1.4fr 2fr 1.6fr;
+  gap: 1px;
+  font-size: 0.82rem;
+  background: #334155;
+}
+
+.fix-row > span {
+  background: #0f172a;
+  padding: 0.65rem 0.9rem;
+  color: #cbd5e1;
+  line-height: 1.5;
+}
+
+.header-row > span {
+  background: #1e293b;
+  color: #a78bfa;
+  font-weight: 700;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}


### PR DESCRIPTION
Resolves #40957

### Root Cause

When an ancestor element dynamically receives a CSS property that creates a **new stacking context** (`transform`, `filter`, `perspective`, `contain`, `will-change`), the browser is forced to promote all children to a new GPU compositor layer. When this happens to an element with a running CSS animation, the browser re-initialises the animation timeline from `0%`, causing a visible restart or flicker.

### Two Proven Fixes

**Fix 1 — Pre-promote the animated element (Recommended)**

Add `will-change: transform` to the animated child *before* any animation starts. The browser pre-allocates a compositor layer for it, so parent layer changes have no effect.

```css
.my-animated-element {
  will-change: transform;  /* pre-promote to own GPU layer */
  animation: ease-float 2s ease-in-out infinite;
}
```

**Fix 2 — Pre-establish the stacking context on the wrapper**

If you know the parent will eventually receive a stacking-context property, apply it from the very start so no mid-animation layer change ever occurs.

```css
.wrapper {
  transform: translateZ(0);  /* or: isolation: isolate */
}
```

### Demo Includes
- **Interactive toggle** for the bug — click to add `transform: translateZ(0)` to the parent mid-animation and watch the child restart
- **Fix 1 demo** — same toggle, but `will-change: transform` on the child prevents the restart
- **Fix 2 demo** — parent already has stacking context, toggling an extra class causes zero animation disruption
- **Reference table** comparing both fixes and their ideal use cases

### Changes Made
- Added `submissions/docs/stacking-context-animation-reset-fix/demo.html`
- Added `submissions/docs/stacking-context-animation-reset-fix/style.css`
- Added `submissions/docs/stacking-context-animation-reset-fix/README.md`

### Validation
- [x] Placed correctly under `submissions/docs/stacking-context-animation-reset-fix/`
- [x] Includes all 3 required files: `demo.html`, `style.css`, `README.md`
- [x] Zero external dependencies — pure CSS + 3 tiny JS toggle functions
- [x] Does not touch `core/` or `components/`
- [x] Tested in Chrome 138 / macOS
