### PR TITLE
feat: add command palette

### DIFF
--- a/submissions/examples/command-palette-as/README.md
+++ b/submissions/examples/command-palette-as/README.md
@@ -1,0 +1,26 @@
+# Command Palette
+
+### What does this do?
+
+It shows a command palette with a search field and a list of grouped commands, each with an icon and a keyboard shortcut hint. One command is highlighted as the active row, and hovering a row highlights it too.
+
+### How is it used?
+
+```html
+<div class="cmdk" role="dialog" aria-label="Command palette">
+  <div class="cmdk-search">
+    <svg>...</svg>
+    <input class="cmdk-input" type="text" placeholder="Type a command" />
+  </div>
+  <ul class="cmdk-list">
+    <li class="cmdk-group">Actions</li>
+    <li class="cmdk-item is-active"><svg>...</svg><span>New file</span><kbd>N</kbd></li>
+  </ul>
+</div>
+```
+
+Use `cmdk-group` rows to label sections and `is-active` on the currently selected command. Each item holds an icon, a label, and a `kbd` shortcut.
+
+### Why is it useful?
+
+Command palettes are the fast way to navigate modern apps. This presents a search led command list with grouped sections, icons, and shortcut keys, using only CSS. The active and hover rows share one highlight style and the transition is removed under reduced motion.

--- a/submissions/examples/command-palette-as/demo.html
+++ b/submissions/examples/command-palette-as/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Command Palette</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="cmdk" role="dialog" aria-label="Command palette">
+    <div class="cmdk-search">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="7" /><path d="m21 21-4-4" stroke-linecap="round" /></svg>
+      <input class="cmdk-input" type="text" placeholder="Type a command or search" aria-label="Command" />
+    </div>
+    <ul class="cmdk-list">
+      <li class="cmdk-group">Actions</li>
+      <li class="cmdk-item is-active">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 5v14M5 12h14" stroke-linecap="round" /></svg>
+        <span>New file</span><kbd>N</kbd>
+      </li>
+      <li class="cmdk-item">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 4h16v16H4z" /><path d="M8 4v16" /></svg>
+        <span>Open folder</span><kbd>O</kbd>
+      </li>
+      <li class="cmdk-item">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M12 5l7 7-7 7" stroke-linecap="round" stroke-linejoin="round" /></svg>
+        <span>Go to line</span><kbd>G</kbd>
+      </li>
+      <li class="cmdk-group">Settings</li>
+      <li class="cmdk-item">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="3" /><path d="M12 3v3M12 18v3M3 12h3M18 12h3" stroke-linecap="round" /></svg>
+        <span>Toggle theme</span><kbd>T</kbd>
+      </li>
+      <li class="cmdk-item">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="8" r="4" /><path d="M4 21a8 8 0 0 1 16 0" stroke-linecap="round" /></svg>
+        <span>Account settings</span><kbd>,</kbd>
+      </li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/submissions/examples/command-palette-as/style.css
+++ b/submissions/examples/command-palette-as/style.css
@@ -1,0 +1,125 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.cmdk {
+  width: min(420px, 94vw);
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 14px;
+  box-shadow: 0 30px 70px rgba(0, 0, 0, 0.55);
+  overflow: hidden;
+}
+
+.cmdk-search {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid #1b2942;
+}
+
+.cmdk-search svg {
+  width: 18px;
+  height: 18px;
+  stroke: #64748b;
+  stroke-width: 2;
+  fill: none;
+  flex: none;
+}
+
+.cmdk-input {
+  flex: 1;
+  min-width: 0;
+  font: inherit;
+  font-size: 0.95rem;
+  color: #e2e8f0;
+  background: transparent;
+  border: none;
+  outline: none;
+}
+
+.cmdk-input::placeholder {
+  color: #64748b;
+}
+
+.cmdk-list {
+  list-style: none;
+  margin: 0;
+  padding: 0.4rem;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.cmdk-group {
+  padding: 0.5rem 0.7rem 0.25rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #64748b;
+}
+
+.cmdk-item {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.55rem 0.7rem;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.12s ease;
+}
+
+.cmdk-item svg {
+  width: 17px;
+  height: 17px;
+  stroke: #94a3b8;
+  stroke-width: 2;
+  fill: none;
+  flex: none;
+}
+
+.cmdk-item span {
+  flex: 1;
+  font-size: 0.9rem;
+  color: #cbd5e1;
+}
+
+.cmdk-item kbd {
+  font-family: inherit;
+  font-size: 0.72rem;
+  color: #94a3b8;
+  padding: 0.1rem 0.4rem;
+  background: #131f34;
+  border: 1px solid #26324a;
+  border-radius: 5px;
+}
+
+.cmdk-item:hover,
+.cmdk-item.is-active {
+  background: rgba(108, 99, 255, 0.16);
+}
+
+.cmdk-item:hover span,
+.cmdk-item.is-active span {
+  color: #fff;
+}
+
+.cmdk-item:hover svg,
+.cmdk-item.is-active svg {
+  stroke: #a5b4fc;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cmdk-item {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a command palette built for #41016. A search led list of grouped commands with icons and shortcut keys, using only CSS. Closes #41016.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A command palette overlay with a search field and grouped commands, each with an icon and a keyboard shortcut hint, with an active highlighted row.

**How does a developer use it?**

```html
<div class="cmdk" role="dialog" aria-label="Command palette">
  <div class="cmdk-search"><svg>...</svg><input class="cmdk-input" placeholder="Type a command" /></div>
  <ul class="cmdk-list">
    <li class="cmdk-group">Actions</li>
    <li class="cmdk-item is-active"><svg>...</svg><span>New file</span><kbd>N</kbd></li>
  </ul>
</div>
```

**Why does it fit EaseMotion CSS?**
It presents a search led command list with grouped sections, icons, and shortcut keys, using only CSS. The active and hover rows share one highlight and the transition is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: five commands render across two groups with five shortcut keys, and the active row carries the accent highlight while others are transparent.
