### PR TITLE
feat: add formatting toolbar

### DIFF
--- a/submissions/examples/toolbar-as/README.md
+++ b/submissions/examples/toolbar-as/README.md
@@ -1,0 +1,21 @@
+# Formatting Toolbar
+
+### What does this do?
+
+It shows a text formatting toolbar with grouped icon buttons and thin dividers between the groups. Toggle buttons like bold and italic show a pressed state through a checkbox, so the active state is real and keyboard operable, with no JavaScript.
+
+### How is it used?
+
+```html
+<div class="toolbar" role="toolbar" aria-label="Text formatting">
+  <label class="tb-toggle" aria-label="Bold"><input type="checkbox" /><svg>...</svg></label>
+  <span class="tb-divider"></span>
+  <button class="tb-btn" type="button" aria-label="Align left"><svg>...</svg></button>
+</div>
+```
+
+Use `tb-toggle` labels with a hidden checkbox for on and off buttons, `tb-btn` for one shot actions, and `tb-divider` to split groups. The `:has(:checked)` selector paints the pressed state.
+
+### Why is it useful?
+
+Editors and comment boxes need a compact formatting toolbar. This lays out grouped icon buttons with dividers and a pressed toggle state, using only CSS and inline SVG. Buttons are labeled and show a focus ring, and transitions are removed under reduced motion.

--- a/submissions/examples/toolbar-as/demo.html
+++ b/submissions/examples/toolbar-as/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Formatting Toolbar</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="toolbar" role="toolbar" aria-label="Text formatting">
+    <label class="tb-toggle" aria-label="Bold">
+      <input type="checkbox" checked />
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 5h6a4 4 0 0 1 0 8H7zM7 13h7a4 4 0 0 1 0 8H7z" stroke-linejoin="round" /></svg>
+    </label>
+    <label class="tb-toggle" aria-label="Italic">
+      <input type="checkbox" />
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M19 5h-6M11 19H5M15 5 9 19" stroke-linecap="round" /></svg>
+    </label>
+    <label class="tb-toggle" aria-label="Underline">
+      <input type="checkbox" />
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 4v6a6 6 0 0 0 12 0V4M5 20h14" stroke-linecap="round" /></svg>
+    </label>
+
+    <span class="tb-divider" aria-hidden="true"></span>
+
+    <button class="tb-btn" type="button" aria-label="Align left">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 6h16M4 12h10M4 18h13" stroke-linecap="round" /></svg>
+    </button>
+    <button class="tb-btn" type="button" aria-label="Align center">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 6h16M7 12h10M6 18h12" stroke-linecap="round" /></svg>
+    </button>
+    <button class="tb-btn" type="button" aria-label="Align right">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 6h16M10 12h10M7 18h13" stroke-linecap="round" /></svg>
+    </button>
+
+    <span class="tb-divider" aria-hidden="true"></span>
+
+    <button class="tb-btn" type="button" aria-label="Insert link">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 15 15 9M8 12H6a3 3 0 0 1 0-6h3M16 12h2a3 3 0 0 1 0 6h-3" stroke-linecap="round" /></svg>
+    </button>
+    <button class="tb-btn" type="button" aria-label="Insert list">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 6h11M9 12h11M9 18h11M4 6h.01M4 12h.01M4 18h.01" stroke-linecap="round" /></svg>
+    </button>
+  </div>
+</body>
+</html>

--- a/submissions/examples/toolbar-as/style.css
+++ b/submissions/examples/toolbar-as/style.css
@@ -1,0 +1,85 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.toolbar {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.35rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 12px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
+}
+
+.tb-btn,
+.tb-toggle {
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: #cbd5e1;
+  cursor: pointer;
+  transition: background 0.14s ease, color 0.14s ease;
+}
+
+.tb-btn svg,
+.tb-toggle svg {
+  width: 18px;
+  height: 18px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+}
+
+.tb-btn:hover,
+.tb-toggle:hover {
+  background: #1b2942;
+  color: #fff;
+}
+
+.tb-toggle input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  margin: -1px;
+  overflow: hidden;
+}
+
+.tb-toggle:has(:checked) {
+  background: rgba(108, 99, 255, 0.2);
+  color: #a5b4fc;
+}
+
+.tb-btn:focus-visible,
+.tb-toggle:has(:focus-visible) {
+  outline: 2px solid #6c63ff;
+  outline-offset: 2px;
+}
+
+.tb-divider {
+  width: 1px;
+  align-self: stretch;
+  margin: 0.25rem 0.3rem;
+  background: #26324a;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tb-btn,
+  .tb-toggle {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a formatting toolbar built for #41018. Grouped icon buttons with dividers and a pressed toggle state driven by checkboxes, using only CSS. Closes #41018.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A text formatting toolbar with grouped icon buttons, thin dividers, and toggle buttons that show a real pressed state.

**How does a developer use it?**

```html
<div class="toolbar" role="toolbar" aria-label="Text formatting">
  <label class="tb-toggle" aria-label="Bold"><input type="checkbox" /><svg>...</svg></label>
  <span class="tb-divider"></span>
  <button class="tb-btn" type="button" aria-label="Align left"><svg>...</svg></button>
</div>
```

**Why does it fit EaseMotion CSS?**
It lays out grouped icon buttons with dividers and a pressed toggle state via `:has(:checked)`, using only CSS and inline SVG. Buttons are labeled and show a focus ring, and transitions are removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: three toggles, five action buttons, and two dividers render, and the checked bold toggle shows the accent pressed background while an unchecked toggle is transparent.
