### PR TITLE
feat: add sortable list

### DIFF
--- a/submissions/examples/sortable-list-as/README.md
+++ b/submissions/examples/sortable-list-as/README.md
@@ -1,0 +1,23 @@
+# Sortable List
+
+### What does this do?
+
+It styles a reorderable list where each row has a grab handle, an icon, a title, and a subtitle. Rows lift and cast a stronger shadow while grabbed, showing the visual state of a sortable list using only CSS.
+
+### How is it used?
+
+```html
+<ul class="sortable">
+  <li class="sort-row">
+    <span class="sort-handle" aria-label="Drag to reorder"><svg>...</svg></span>
+    <span class="sort-icon">A</span>
+    <div class="sort-body"><strong>Welcome email</strong><small>Sends on sign up</small></div>
+  </li>
+</ul>
+```
+
+The grip uses a grab cursor and the row shows a lift on `:active`. A developer can attach real drag and drop or a library on top of this styling.
+
+### Why is it useful?
+
+Settings and playlists let users reorder items by dragging a handle. This styles a sortable list with grab handles, a grabbed lift state, and clear row structure, using only CSS, so real drag behavior can be layered on top. The lift is removed under reduced motion.

--- a/submissions/examples/sortable-list-as/demo.html
+++ b/submissions/examples/sortable-list-as/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sortable List</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <ul class="sortable">
+    <li class="sort-row">
+      <span class="sort-handle" aria-label="Drag to reorder"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="9" cy="6" r="1.5" /><circle cx="15" cy="6" r="1.5" /><circle cx="9" cy="12" r="1.5" /><circle cx="15" cy="12" r="1.5" /><circle cx="9" cy="18" r="1.5" /><circle cx="15" cy="18" r="1.5" /></svg></span>
+      <span class="sort-icon">A</span>
+      <div class="sort-body"><strong>Welcome email</strong><small>Sends on sign up</small></div>
+    </li>
+    <li class="sort-row">
+      <span class="sort-handle" aria-label="Drag to reorder"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="9" cy="6" r="1.5" /><circle cx="15" cy="6" r="1.5" /><circle cx="9" cy="12" r="1.5" /><circle cx="15" cy="12" r="1.5" /><circle cx="9" cy="18" r="1.5" /><circle cx="15" cy="18" r="1.5" /></svg></span>
+      <span class="sort-icon">B</span>
+      <div class="sort-body"><strong>Trial reminder</strong><small>Day three of trial</small></div>
+    </li>
+    <li class="sort-row">
+      <span class="sort-handle" aria-label="Drag to reorder"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="9" cy="6" r="1.5" /><circle cx="15" cy="6" r="1.5" /><circle cx="9" cy="12" r="1.5" /><circle cx="15" cy="12" r="1.5" /><circle cx="9" cy="18" r="1.5" /><circle cx="15" cy="18" r="1.5" /></svg></span>
+      <span class="sort-icon">C</span>
+      <div class="sort-body"><strong>Upgrade offer</strong><small>When trial ends</small></div>
+    </li>
+    <li class="sort-row">
+      <span class="sort-handle" aria-label="Drag to reorder"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="9" cy="6" r="1.5" /><circle cx="15" cy="6" r="1.5" /><circle cx="9" cy="12" r="1.5" /><circle cx="15" cy="12" r="1.5" /><circle cx="9" cy="18" r="1.5" /><circle cx="15" cy="18" r="1.5" /></svg></span>
+      <span class="sort-icon">D</span>
+      <div class="sort-body"><strong>Win back</strong><small>After cancel</small></div>
+    </li>
+  </ul>
+</body>
+</html>

--- a/submissions/examples/sortable-list-as/style.css
+++ b/submissions/examples/sortable-list-as/style.css
@@ -1,0 +1,98 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.sortable {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  width: min(360px, 94vw);
+}
+
+.sort-row {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.75rem 0.9rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 12px;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+.sort-row:hover {
+  border-color: #33415c;
+}
+
+.sort-row:active {
+  transform: translateY(-2px) scale(1.01);
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.45);
+  border-color: #6c63ff;
+}
+
+.sort-handle {
+  display: grid;
+  place-items: center;
+  color: #64748b;
+  cursor: grab;
+  flex: none;
+}
+
+.sort-handle:active {
+  cursor: grabbing;
+}
+
+.sort-handle svg {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
+}
+
+.sort-icon {
+  flex: none;
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: 9px;
+  background: linear-gradient(135deg, #6c63ff, #a855f7);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+
+.sort-body {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.sort-body strong {
+  font-size: 0.92rem;
+}
+
+.sort-body small {
+  font-size: 0.76rem;
+  color: #94a3b8;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sort-row {
+    transition: border-color 0.15s ease;
+  }
+
+  .sort-row:active {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a sortable list built for #41020. Rows with grab handles, an icon, and a title that lift while grabbed, using only CSS. Closes #41020.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A reorderable list where each row has a grab handle, an icon, a title, and a subtitle, lifting with a shadow while grabbed.

**How does a developer use it?**

```html
<ul class="sortable">
  <li class="sort-row">
    <span class="sort-handle" aria-label="Drag to reorder"><svg>...</svg></span>
    <span class="sort-icon">A</span>
    <div class="sort-body"><strong>Welcome email</strong><small>Sends on sign up</small></div>
  </li>
</ul>
```

**Why does it fit EaseMotion CSS?**
It styles a sortable list with grab handles, a grabbed lift state, and clear row structure, using only CSS, so real drag behavior can be layered on top. The lift is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: four rows render, each with a grab handle whose cursor computes to `grab`.
