### PR TITLE
feat: add app launcher grid

### DIFF
--- a/submissions/examples/app-grid-as/README.md
+++ b/submissions/examples/app-grid-as/README.md
@@ -1,0 +1,22 @@
+# App Launcher Grid
+
+### What does this do?
+
+It lays out an app launcher grid of rounded icon tiles with labels, like a phone home screen or a product switcher. Tiles use gradient backgrounds and lift on hover, and the grid adapts its column count to the width.
+
+### How is it used?
+
+```html
+<div class="apps">
+  <a class="app" href="#">
+    <span class="app-icon"><svg>...</svg></span>
+    <span class="app-name">Mail</span>
+  </a>
+</div>
+```
+
+The grid uses `repeat(auto-fit, minmax(84px, 1fr))`, so tiles wrap to fit. Each tile gets one of six gradient backgrounds by position.
+
+### Why is it useful?
+
+Product suites and dashboards offer an app switcher grid to jump between tools. This lays out a responsive icon tile grid with labels and a hover lift, using only CSS and inline SVG so there are no external assets. The lift is removed under reduced motion.

--- a/submissions/examples/app-grid-as/demo.html
+++ b/submissions/examples/app-grid-as/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>App Launcher Grid</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="apps">
+    <a class="app" href="#"><span class="app-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18v12H3z" /><path d="m3 7 9 6 9-6" stroke-linecap="round" stroke-linejoin="round" /></svg></span><span class="app-name">Mail</span></a>
+    <a class="app" href="#"><span class="app-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="4" width="18" height="16" rx="2" /><path d="M3 9h18M8 4v16" stroke-linecap="round" /></svg></span><span class="app-name">Calendar</span></a>
+    <a class="app" href="#"><span class="app-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 4h7v7H4zM13 4h7v7h-7zM4 13h7v7H4zM13 13h7v7h-7z" stroke-linejoin="round" /></svg></span><span class="app-name">Files</span></a>
+    <a class="app" href="#"><span class="app-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9" /><path d="M8 12h8M12 8v8" stroke-linecap="round" /></svg></span><span class="app-name">Notes</span></a>
+    <a class="app" href="#"><span class="app-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3 3 9v12h18V9z" stroke-linejoin="round" /><path d="M9 21v-6h6v6" /></svg></span><span class="app-name">Home</span></a>
+    <a class="app" href="#"><span class="app-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="7" /><path d="m21 21-4-4" stroke-linecap="round" /></svg></span><span class="app-name">Search</span></a>
+    <a class="app" href="#"><span class="app-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3v18M3 12h18" stroke-linecap="round" /></svg></span><span class="app-name">Add</span></a>
+    <a class="app" href="#"><span class="app-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="3" /><path d="M12 3v3M12 18v3M3 12h3M18 12h3" stroke-linecap="round" /></svg></span><span class="app-name">Settings</span></a>
+  </div>
+</body>
+</html>

--- a/submissions/examples/app-grid-as/style.css
+++ b/submissions/examples/app-grid-as/style.css
@@ -1,0 +1,100 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.apps {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(84px, 1fr));
+  gap: 1rem;
+  width: min(420px, 94vw);
+  padding: 1.4rem;
+  box-sizing: border-box;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 20px;
+}
+
+.app {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  text-decoration: none;
+  padding: 0.4rem;
+  border-radius: 12px;
+}
+
+.app-icon {
+  width: 52px;
+  height: 52px;
+  display: grid;
+  place-items: center;
+  border-radius: 15px;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.app-icon svg {
+  width: 26px;
+  height: 26px;
+  stroke: #fff;
+  stroke-width: 2;
+  fill: none;
+}
+
+.app-name {
+  font-size: 0.76rem;
+  color: #cbd5e1;
+}
+
+.app:hover .app-icon {
+  transform: translateY(-4px);
+  box-shadow: 0 14px 26px rgba(0, 0, 0, 0.5);
+}
+
+.app:focus-visible {
+  outline: 2px solid #6c63ff;
+  outline-offset: 2px;
+}
+
+.app:nth-child(6n + 1) .app-icon {
+  background: linear-gradient(135deg, #6c63ff, #a855f7);
+}
+
+.app:nth-child(6n + 2) .app-icon {
+  background: linear-gradient(135deg, #0ea5e9, #22d3ee);
+}
+
+.app:nth-child(6n + 3) .app-icon {
+  background: linear-gradient(135deg, #f59e0b, #ef4444);
+}
+
+.app:nth-child(6n + 4) .app-icon {
+  background: linear-gradient(135deg, #10b981, #34d399);
+}
+
+.app:nth-child(6n + 5) .app-icon {
+  background: linear-gradient(135deg, #ec4899, #f472b6);
+}
+
+.app:nth-child(6n) .app-icon {
+  background: linear-gradient(135deg, #8b5cf6, #6366f1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .app-icon {
+    transition: box-shadow 0.18s ease;
+  }
+
+  .app:hover .app-icon {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an app launcher grid built for #41022. Rounded gradient icon tiles with labels that lift on hover, using only CSS and inline SVG. Closes #41022.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
An app launcher grid of rounded gradient icon tiles with labels, like a home screen or product switcher, that lift on hover and reflow to fit the width.

**How does a developer use it?**

```html
<div class="apps">
  <a class="app" href="#">
    <span class="app-icon"><svg>...</svg></span>
    <span class="app-name">Mail</span>
  </a>
</div>
```

**Why does it fit EaseMotion CSS?**
It lays out a responsive icon tile grid with labels and a hover lift, using only CSS and inline SVG so there are no external assets. The lift is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: eight app tiles render with eight inline SVG icons on an auto fit grid.
