### PR TITLE
feat: add horizontal bar chart

### DIFF
--- a/submissions/examples/hbar-chart-as/README.md
+++ b/submissions/examples/hbar-chart-as/README.md
@@ -1,0 +1,22 @@
+# Horizontal Bar Chart
+
+### What does this do?
+
+It renders a horizontal bar chart where each row has a category label, a bar that grows to a percent from a custom property, and a value shown at the end of the bar. The bars animate in on load.
+
+### How is it used?
+
+```html
+<ul class="hbar">
+  <li style="--val: 82%">
+    <span class="hbar-label">Chrome</span>
+    <span class="hbar-track"><span class="hbar-fill">82%</span></span>
+  </li>
+</ul>
+```
+
+Set each bar length with the `--val` custom property. The label sits in a fixed left column and the bar fills the rest, so long labels stay readable.
+
+### Why is it useful?
+
+Horizontal bar charts compare a handful of categories with long labels better than vertical bars. This renders a labeled horizontal bar chart driven by a custom property per row, with an entry animation, using only CSS and no charting script. The animation is removed under reduced motion.

--- a/submissions/examples/hbar-chart-as/demo.html
+++ b/submissions/examples/hbar-chart-as/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Horizontal Bar Chart</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <ul class="hbar">
+    <li style="--val: 82%"><span class="hbar-label">Chrome</span><span class="hbar-track"><span class="hbar-fill">82%</span></span></li>
+    <li style="--val: 54%"><span class="hbar-label">Safari</span><span class="hbar-track"><span class="hbar-fill">54%</span></span></li>
+    <li style="--val: 33%"><span class="hbar-label">Firefox</span><span class="hbar-track"><span class="hbar-fill">33%</span></span></li>
+    <li style="--val: 12%"><span class="hbar-label">Edge</span><span class="hbar-track"><span class="hbar-fill">12%</span></span></li>
+  </ul>
+</body>
+</html>

--- a/submissions/examples/hbar-chart-as/style.css
+++ b/submissions/examples/hbar-chart-as/style.css
@@ -1,0 +1,86 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.hbar {
+  list-style: none;
+  margin: 0;
+  padding: 1.5rem 1.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: min(400px, 94vw);
+  box-sizing: border-box;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+}
+
+.hbar li {
+  display: grid;
+  grid-template-columns: 74px 1fr;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.hbar-label {
+  font-size: 0.82rem;
+  color: #cbd5e1;
+  text-align: right;
+}
+
+.hbar-track {
+  height: 22px;
+  border-radius: 6px;
+  background: #1b2942;
+  overflow: hidden;
+}
+
+.hbar-fill {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  height: 100%;
+  width: var(--val);
+  min-width: 2.4rem;
+  padding-right: 0.5rem;
+  box-sizing: border-box;
+  border-radius: 6px;
+  background: linear-gradient(90deg, #6c63ff, #a855f7);
+  color: #fff;
+  font-size: 0.72rem;
+  font-weight: 700;
+  animation: hbar-grow 0.85s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.hbar li:nth-child(2) .hbar-fill {
+  background: linear-gradient(90deg, #0ea5e9, #22d3ee);
+}
+
+.hbar li:nth-child(3) .hbar-fill {
+  background: linear-gradient(90deg, #10b981, #34d399);
+}
+
+.hbar li:nth-child(4) .hbar-fill {
+  background: linear-gradient(90deg, #f59e0b, #ef4444);
+}
+
+@keyframes hbar-grow {
+  from {
+    width: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hbar-fill {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a horizontal bar chart built for #41024. Labeled rows with bars that grow to a custom property percent and show a value, using only CSS. Closes #41024.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A horizontal bar chart where each row has a category label, a bar that grows to a `--val` percent, and a value at the end of the bar.

**How does a developer use it?**

```html
<ul class="hbar">
  <li style="--val: 82%">
    <span class="hbar-label">Chrome</span>
    <span class="hbar-track"><span class="hbar-fill">82%</span></span>
  </li>
</ul>
```

**Why does it fit EaseMotion CSS?**
It renders a labeled horizontal bar chart driven by a custom property per row, with an entry animation, using only CSS and no charting script. Labels sit in a fixed left column so long names stay readable, and the animation is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: four bars fill toward their `--val` values (82, 54, 33 percent, with the shortest bar held to a small minimum width so its percent label stays legible).
