### PR TITLE
feat: add multi step form

### DIFF
--- a/submissions/examples/step-form-as/README.md
+++ b/submissions/examples/step-form-as/README.md
@@ -1,0 +1,24 @@
+# Multi Step Form
+
+### What does this do?
+
+It shows a multi step form that reveals one step at a time. Next and back buttons switch steps, and a row of progress dots fills up to the current step. It works with no JavaScript by using radio inputs and the checked state.
+
+### How is it used?
+
+```html
+<form class="stepper">
+  <input type="radio" name="step" id="s1" checked />
+  <input type="radio" name="step" id="s2" />
+  <input type="radio" name="step" id="s3" />
+  <div class="dots"><span></span><span></span><span></span></div>
+  <fieldset class="step">... <label class="next" for="s2">Next</label></fieldset>
+  <fieldset class="step"><label class="back" for="s1">Back</label> ...</fieldset>
+</form>
+```
+
+Keep the radios first so the sibling selectors can reveal the matching step and fill the dots. Next and back labels point at the radio for the step to show.
+
+### Why is it useful?
+
+Onboarding and checkout flows split a long form into steps. This switches between steps using radios and labels styled as buttons, revealing only the active step and filling the progress dots, using only CSS. The dot transition is removed under reduced motion.

--- a/submissions/examples/step-form-as/demo.html
+++ b/submissions/examples/step-form-as/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Multi Step Form</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <form class="stepper">
+    <input type="radio" name="step" id="s1" checked />
+    <input type="radio" name="step" id="s2" />
+    <input type="radio" name="step" id="s3" />
+
+    <div class="dots" aria-hidden="true"><span></span><span></span><span></span></div>
+
+    <fieldset class="step">
+      <h2>Your details</h2>
+      <p>Step 1 of 3. Tell us who you are.</p>
+      <label class="field">Full name<input type="text" placeholder="Ada Lovelace" /></label>
+      <div class="step-actions">
+        <span class="spacer"></span>
+        <label class="next" for="s2">Next</label>
+      </div>
+    </fieldset>
+
+    <fieldset class="step">
+      <h2>Contact</h2>
+      <p>Step 2 of 3. How can we reach you?</p>
+      <label class="field">Email<input type="email" placeholder="you@example.com" /></label>
+      <div class="step-actions">
+        <label class="back" for="s1">Back</label>
+        <span class="spacer"></span>
+        <label class="next" for="s3">Next</label>
+      </div>
+    </fieldset>
+
+    <fieldset class="step">
+      <h2>Review</h2>
+      <p>Step 3 of 3. Everything look right?</p>
+      <label class="field">Workspace name<input type="text" placeholder="Acme Inc" /></label>
+      <div class="step-actions">
+        <label class="back" for="s2">Back</label>
+        <span class="spacer"></span>
+        <button class="done" type="submit">Finish</button>
+      </div>
+    </fieldset>
+  </form>
+</body>
+</html>

--- a/submissions/examples/step-form-as/style.css
+++ b/submissions/examples/step-form-as/style.css
@@ -1,0 +1,155 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.stepper {
+  width: min(360px, 94vw);
+  box-sizing: border-box;
+  padding: 1.6rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 18px;
+}
+
+.stepper > input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  margin: -1px;
+  overflow: hidden;
+}
+
+.dots {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-bottom: 1.4rem;
+}
+
+.dots span {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #26324a;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.step {
+  display: none;
+  border: none;
+  margin: 0;
+  padding: 0;
+  min-inline-size: auto;
+}
+
+.step h2 {
+  margin: 0 0 0.3rem;
+  font-size: 1.1rem;
+}
+
+.step p {
+  margin: 0 0 1.1rem;
+  font-size: 0.86rem;
+  color: #94a3b8;
+  line-height: 1.55;
+}
+
+.step label.field {
+  display: block;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #cbd5e1;
+  margin-bottom: 1rem;
+}
+
+.step input[type="text"],
+.step input[type="email"] {
+  width: 100%;
+  box-sizing: border-box;
+  margin-top: 0.35rem;
+  padding: 0.6rem 0.8rem;
+  font: inherit;
+  font-size: 0.9rem;
+  color: #e2e8f0;
+  background: #0b1424;
+  border: 1px solid #26324a;
+  border-radius: 9px;
+  outline: none;
+}
+
+.step input:focus {
+  border-color: #6c63ff;
+}
+
+.step-actions {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.6rem;
+  margin-top: 0.4rem;
+}
+
+.step-actions .spacer {
+  flex: 1;
+}
+
+.next,
+.back,
+.done {
+  padding: 0.6rem 1.15rem;
+  border-radius: 9px;
+  font-size: 0.88rem;
+  font-weight: 600;
+  cursor: pointer;
+  user-select: none;
+}
+
+.next,
+.done {
+  background: #6c63ff;
+  color: #fff;
+}
+
+.back {
+  background: #1b2942;
+  color: #cbd5e1;
+}
+
+.next:hover,
+.done:hover {
+  background: #5b52e6;
+}
+
+#s1:checked ~ .step:nth-of-type(1),
+#s2:checked ~ .step:nth-of-type(2),
+#s3:checked ~ .step:nth-of-type(3) {
+  display: block;
+}
+
+#s1:checked ~ .dots span:nth-child(-n + 1),
+#s2:checked ~ .dots span:nth-child(-n + 2),
+#s3:checked ~ .dots span:nth-child(-n + 3) {
+  background: #6c63ff;
+}
+
+#s1:focus-visible ~ .dots,
+#s2:focus-visible ~ .dots,
+#s3:focus-visible ~ .dots {
+  outline: 2px solid #6c63ff;
+  outline-offset: 6px;
+  border-radius: 4px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dots span {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a multi step form built for #41026. Steps switch with next and back buttons and progress dots fill up, driven by radios with no JavaScript. Closes #41026.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A multi step form that reveals one step at a time, with next and back buttons and a progress dots row that fills to the current step.

**How does a developer use it?**

```html
<form class="stepper">
  <input type="radio" name="step" id="s1" checked />
  <input type="radio" name="step" id="s2" />
  <div class="dots"><span></span><span></span><span></span></div>
  <fieldset class="step">... <label class="next" for="s2">Next</label></fieldset>
  <fieldset class="step"><label class="back" for="s1">Back</label> ...</fieldset>
</form>
```

**Why does it fit EaseMotion CSS?**
It switches between steps using radios and labels styled as buttons, revealing only the active step and filling the progress dots, using only CSS. The dot transition is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: only step one shows initially; selecting step two reveals it and hides the others, and the progress dots fill to two of three, then all three at step three.
