### PR TITLE
feat: add collapsible sidebar

### DIFF
--- a/submissions/examples/collapsible-sidebar-as/README.md
+++ b/submissions/examples/collapsible-sidebar-as/README.md
@@ -1,0 +1,21 @@
+# Collapsible Sidebar
+
+### What does this do?
+
+It shows a sidebar that collapses from a labeled width to a slim icon rail when the menu button is pressed. The labels fade out while the icons stay, and the width animates smoothly. It works with no JavaScript by using a hidden checkbox.
+
+### How is it used?
+
+```html
+<input type="checkbox" id="side-toggle" class="side-toggle" />
+<aside class="sidebar">
+  <label class="side-btn" for="side-toggle" aria-label="Toggle sidebar"><svg>...</svg><span class="side-btn-text">Menu</span></label>
+  <a class="side-link is-active" href="#"><svg>...</svg><span>Dashboard</span></a>
+</aside>
+```
+
+Keep the checkbox before the sidebar so the sibling selector can shrink it. When checked, the sidebar narrows and the link labels fade to zero opacity, leaving the icons.
+
+### Why is it useful?
+
+Dashboards let users collapse the sidebar to reclaim space while keeping quick icon access. This animates a sidebar between an expanded and a mini rail state using only a checkbox and CSS. The width and label transitions are removed under reduced motion.

--- a/submissions/examples/collapsible-sidebar-as/demo.html
+++ b/submissions/examples/collapsible-sidebar-as/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Collapsible Sidebar</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <input type="checkbox" id="side-toggle" class="side-toggle" />
+  <aside class="sidebar">
+    <label class="side-btn" for="side-toggle" aria-label="Toggle sidebar">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 6h16M4 12h16M4 18h16" stroke-linecap="round" /></svg>
+      <span class="side-btn-text">Menu</span>
+    </label>
+    <a class="side-link is-active" href="#"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 4h7v7H4zM13 4h7v7h-7zM4 13h7v7H4zM13 13h7v7h-7z" stroke-linejoin="round" /></svg><span>Dashboard</span></a>
+    <a class="side-link" href="#"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 7h18M3 12h18M3 17h18" stroke-linecap="round" /></svg><span>Projects</span></a>
+    <a class="side-link" href="#"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="8" r="4" /><path d="M4 21a8 8 0 0 1 16 0" stroke-linecap="round" /></svg><span>Team</span></a>
+    <a class="side-link" href="#"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 20V10M6 20v-6M18 20V6" stroke-linecap="round" /></svg><span>Reports</span></a>
+    <a class="side-link" href="#"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="3" /><path d="M12 3v3M12 18v3M3 12h3M18 12h3" stroke-linecap="round" /></svg><span>Settings</span></a>
+  </aside>
+</body>
+</html>

--- a/submissions/examples/collapsible-sidebar-as/style.css
+++ b/submissions/examples/collapsible-sidebar-as/style.css
@@ -1,0 +1,115 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.side-toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  margin: -1px;
+  overflow: hidden;
+}
+
+.sidebar {
+  width: 216px;
+  height: 360px;
+  box-sizing: border-box;
+  padding: 0.8rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  overflow: hidden;
+  transition: width 0.28s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.side-toggle:checked ~ .sidebar {
+  width: 68px;
+}
+
+.side-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.6rem 0.65rem;
+  margin-bottom: 0.6rem;
+  border-radius: 9px;
+  color: #cbd5e1;
+  cursor: pointer;
+}
+
+.side-btn:hover {
+  background: #1b2942;
+}
+
+.side-btn svg {
+  width: 20px;
+  height: 20px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+  flex: none;
+}
+
+.side-link {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.6rem 0.65rem;
+  border-radius: 9px;
+  color: #94a3b8;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.side-link svg {
+  width: 20px;
+  height: 20px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+  flex: none;
+}
+
+.side-link span {
+  transition: opacity 0.18s ease;
+}
+
+.side-link:hover {
+  background: #1b2942;
+  color: #fff;
+}
+
+.side-link.is-active {
+  background: rgba(108, 99, 255, 0.16);
+  color: #a5b4fc;
+}
+
+.side-toggle:checked ~ .sidebar .side-link span,
+.side-toggle:checked ~ .sidebar .side-btn-text {
+  opacity: 0;
+}
+
+.side-toggle:focus-visible ~ .sidebar .side-btn {
+  outline: 2px solid #6c63ff;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidebar,
+  .side-link span {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a collapsible sidebar built for #41028. It shrinks from a labeled width to a mini icon rail on toggle, using a checkbox and CSS only. Closes #41028.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A sidebar that collapses from a labeled width to a slim icon rail when the menu button is pressed, fading the labels and keeping the icons.

**How does a developer use it?**

```html
<input type="checkbox" id="side-toggle" class="side-toggle" />
<aside class="sidebar">
  <label class="side-btn" for="side-toggle"><svg>...</svg><span class="side-btn-text">Menu</span></label>
  <a class="side-link is-active" href="#"><svg>...</svg><span>Dashboard</span></a>
</aside>
```

**Why does it fit EaseMotion CSS?**
It animates a sidebar between an expanded and a mini rail state using only a checkbox and CSS. The width and label transitions are removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the sidebar goes from 216px wide to 68px when the toggle is checked, and the link labels fade from opacity 1 to 0.
