### PR TITLE
feat: add dot carousel

### DIFF
--- a/submissions/examples/dot-carousel-as/README.md
+++ b/submissions/examples/dot-carousel-as/README.md
@@ -1,0 +1,30 @@
+# Dot Carousel
+
+### What does this do?
+
+It shows a slide carousel with clickable dot indicators below it. Selecting a dot slides the track to that slide and stretches its dot into a pill. It works with no JavaScript by using radio inputs and the checked state.
+
+### How is it used?
+
+```html
+<div class="dotc">
+  <input type="radio" name="dc" id="d1" checked />
+  <input type="radio" name="dc" id="d2" />
+  <div class="dotc-window">
+    <div class="dotc-track">
+      <div class="dotc-slide">1</div>
+      <div class="dotc-slide">2</div>
+    </div>
+  </div>
+  <div class="dotc-dots">
+    <label for="d1" aria-label="Go to slide 1"></label>
+    <label for="d2" aria-label="Go to slide 2"></label>
+  </div>
+</div>
+```
+
+Keep the radios first so the sibling selectors can move the track and fill the active dot. Each dot label points at the radio for its slide.
+
+### Why is it useful?
+
+Hero sliders and galleries pair slides with dot indicators for direct navigation. This drives a sliding track and an active dot from the same radio, using only CSS. Dots are keyboard operable with a focus ring and the slide transition is removed under reduced motion.

--- a/submissions/examples/dot-carousel-as/demo.html
+++ b/submissions/examples/dot-carousel-as/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dot Carousel</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="dotc">
+    <input type="radio" name="dc" id="d1" checked />
+    <input type="radio" name="dc" id="d2" />
+    <input type="radio" name="dc" id="d3" />
+    <input type="radio" name="dc" id="d4" />
+    <div class="dotc-window">
+      <div class="dotc-track">
+        <div class="dotc-slide">1</div>
+        <div class="dotc-slide">2</div>
+        <div class="dotc-slide">3</div>
+        <div class="dotc-slide">4</div>
+      </div>
+    </div>
+    <div class="dotc-dots">
+      <label for="d1" aria-label="Go to slide 1"></label>
+      <label for="d2" aria-label="Go to slide 2"></label>
+      <label for="d3" aria-label="Go to slide 3"></label>
+      <label for="d4" aria-label="Go to slide 4"></label>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/dot-carousel-as/style.css
+++ b/submissions/examples/dot-carousel-as/style.css
@@ -1,0 +1,121 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.dotc {
+  width: min(440px, 94vw);
+}
+
+.dotc > input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  margin: -1px;
+  overflow: hidden;
+}
+
+.dotc-window {
+  overflow: hidden;
+  border-radius: 16px;
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.4);
+}
+
+.dotc-track {
+  display: flex;
+  width: 400%;
+  transition: transform 0.4s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.dotc-slide {
+  width: 25%;
+  aspect-ratio: 16 / 9;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-size: 2rem;
+  font-weight: 800;
+}
+
+.dotc-slide:nth-child(1) {
+  background: linear-gradient(135deg, #6c63ff, #a855f7);
+}
+
+.dotc-slide:nth-child(2) {
+  background: linear-gradient(135deg, #0ea5e9, #22d3ee);
+}
+
+.dotc-slide:nth-child(3) {
+  background: linear-gradient(135deg, #10b981, #34d399);
+}
+
+.dotc-slide:nth-child(4) {
+  background: linear-gradient(135deg, #f59e0b, #ef4444);
+}
+
+#d1:checked ~ .dotc-window .dotc-track {
+  transform: translateX(0);
+}
+
+#d2:checked ~ .dotc-window .dotc-track {
+  transform: translateX(-25%);
+}
+
+#d3:checked ~ .dotc-window .dotc-track {
+  transform: translateX(-50%);
+}
+
+#d4:checked ~ .dotc-window .dotc-track {
+  transform: translateX(-75%);
+}
+
+.dotc-dots {
+  display: flex;
+  justify-content: center;
+  gap: 0.6rem;
+  margin-top: 1rem;
+}
+
+.dotc-dots label {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #33415c;
+  cursor: pointer;
+  transition: background 0.2s ease, width 0.2s ease;
+}
+
+.dotc-dots label:hover {
+  background: #4b5b7a;
+}
+
+#d1:checked ~ .dotc-dots label[for="d1"],
+#d2:checked ~ .dotc-dots label[for="d2"],
+#d3:checked ~ .dotc-dots label[for="d3"],
+#d4:checked ~ .dotc-dots label[for="d4"] {
+  background: #6c63ff;
+  width: 24px;
+}
+
+#d1:focus-visible ~ .dotc-dots label[for="d1"],
+#d2:focus-visible ~ .dotc-dots label[for="d2"],
+#d3:focus-visible ~ .dotc-dots label[for="d3"],
+#d4:focus-visible ~ .dotc-dots label[for="d4"] {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dotc-track,
+  .dotc-dots label {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a dot carousel built for #41030. Slides with clickable dot indicators that move the track and fill the active dot, driven by radios with no JavaScript. Closes #41030.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A slide carousel with dot indicators below it. Selecting a dot slides the track to that slide and stretches its dot into a pill.

**How does a developer use it?**

```html
<div class="dotc">
  <input type="radio" name="dc" id="d1" checked />
  <input type="radio" name="dc" id="d2" />
  <div class="dotc-window"><div class="dotc-track"><div class="dotc-slide">1</div><div class="dotc-slide">2</div></div></div>
  <div class="dotc-dots"><label for="d1"></label><label for="d2"></label></div>
</div>
```

**Why does it fit EaseMotion CSS?**
It drives a sliding track and an active dot from the same radio, using only CSS. Dots are keyboard operable with a focus ring and the slide transition is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: four slides and four dots render, and selecting the third dot translates the track and fills that dot with the accent color.
