### PR TITLE
feat: add profile hover card

### DIFF
--- a/submissions/examples/hover-card-as/README.md
+++ b/submissions/examples/hover-card-as/README.md
@@ -1,0 +1,24 @@
+# Profile Hover Card
+
+### What does this do?
+
+It reveals a profile hover card when you hover or keyboard focus a username link. The card shows an avatar, name, bio, follower stats, and a follow button, and it fades in above the link.
+
+### How is it used?
+
+```html
+<span class="hovercard">
+  <a href="#" class="hc-trigger">@ada</a>
+  <span class="hc-pop" role="dialog" aria-label="Profile preview">
+    <span class="hc-top"><span class="hc-avatar">AL</span><span class="hc-name">Ada Lovelace</span></span>
+    <p class="hc-bio">Mathematician and writer.</p>
+    <button class="hc-follow" type="button">Follow</button>
+  </span>
+</span>
+```
+
+The card is hidden until the wrapper is hovered or contains focus. Because it uses `:focus-within`, tabbing to the link or its follow button also opens it.
+
+### Why is it useful?
+
+Social apps show a rich profile preview when you hover a mention. This reveals a positioned hover card on hover and focus, staying accessible with `:focus-within`, using only CSS. The fade and lift are reduced under reduced motion.

--- a/submissions/examples/hover-card-as/demo.html
+++ b/submissions/examples/hover-card-as/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Profile Hover Card</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <p class="lead">
+    The first program was written by
+    <span class="hovercard">
+      <a href="#" class="hc-trigger">@ada</a>
+      <span class="hc-pop" role="dialog" aria-label="Profile preview">
+        <span class="hc-top">
+          <span class="hc-avatar">AL</span>
+          <span>
+            <span class="hc-name">Ada Lovelace</span>
+            <span class="hc-handle">@ada</span>
+          </span>
+        </span>
+        <p class="hc-bio">Mathematician and writer, known for early work on the analytical engine.</p>
+        <span class="hc-stats"><span><b>1.2k</b> following</span><span><b>18.4k</b> followers</span></span>
+        <button class="hc-follow" type="button">Follow</button>
+      </span>
+    </span>
+    back in 1843.
+  </p>
+</body>
+</html>

--- a/submissions/examples/hover-card-as/style.css
+++ b/submissions/examples/hover-card-as/style.css
@@ -1,0 +1,137 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 4rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.lead {
+  max-width: 320px;
+  text-align: center;
+  font-size: 0.95rem;
+  line-height: 1.7;
+  color: #cbd5e1;
+}
+
+.hovercard {
+  position: relative;
+  display: inline-block;
+}
+
+.hc-trigger {
+  color: #a5b4fc;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.hc-trigger:hover,
+.hc-trigger:focus-visible {
+  text-decoration: underline;
+  outline: none;
+}
+
+.hc-pop {
+  position: absolute;
+  bottom: calc(100% + 0.7rem);
+  left: 50%;
+  width: 250px;
+  transform: translate(-50%, 6px);
+  padding: 1.1rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 14px;
+  box-shadow: 0 20px 44px rgba(0, 0, 0, 0.55);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.18s ease, transform 0.18s ease, visibility 0.18s ease;
+  z-index: 2;
+}
+
+.hovercard:hover .hc-pop,
+.hovercard:focus-within .hc-pop {
+  opacity: 1;
+  visibility: visible;
+  transform: translate(-50%, 0);
+}
+
+.hc-top {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  margin-bottom: 0.7rem;
+}
+
+.hc-avatar {
+  width: 44px;
+  height: 44px;
+  flex: none;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #6c63ff, #a855f7);
+  color: #fff;
+  font-weight: 700;
+}
+
+.hc-name {
+  display: block;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.hc-handle {
+  font-size: 0.78rem;
+  color: #64748b;
+}
+
+.hc-bio {
+  margin: 0 0 0.8rem;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: #94a3b8;
+}
+
+.hc-stats {
+  display: flex;
+  gap: 1.1rem;
+  margin-bottom: 0.9rem;
+  font-size: 0.78rem;
+  color: #94a3b8;
+}
+
+.hc-stats b {
+  color: #e2e8f0;
+}
+
+.hc-follow {
+  width: 100%;
+  padding: 0.5rem;
+  font: inherit;
+  font-weight: 600;
+  color: #fff;
+  background: #6c63ff;
+  border: none;
+  border-radius: 9px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.hc-follow:hover {
+  background: #5b52e6;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hc-pop {
+    transition: opacity 0.18s ease, visibility 0.18s ease;
+  }
+
+  .hovercard:hover .hc-pop,
+  .hovercard:focus-within .hc-pop {
+    transform: translate(-50%, 0);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a profile hover card built for #41032. A username link reveals a profile preview on hover and focus, using only CSS. Closes #41032.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A username link that reveals a profile hover card with an avatar, name, bio, follower stats, and a follow button, fading in above the link.

**How does a developer use it?**

```html
<span class="hovercard">
  <a href="#" class="hc-trigger">@ada</a>
  <span class="hc-pop" role="dialog" aria-label="Profile preview">
    <span class="hc-top"><span class="hc-avatar">AL</span><span class="hc-name">Ada Lovelace</span></span>
    <p class="hc-bio">Mathematician and writer.</p>
    <button class="hc-follow" type="button">Follow</button>
  </span>
</span>
```

**Why does it fit EaseMotion CSS?**
It reveals a positioned hover card on hover and focus, staying accessible with `:focus-within`, using only CSS. The fade and lift are reduced under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the card is hidden by default and becomes visible with opacity 1 when the trigger link receives focus, via `:focus-within`.
