### PR TITLE
feat: add skeleton list loader

### DIFF
--- a/submissions/examples/skeleton-list-as/README.md
+++ b/submissions/examples/skeleton-list-as/README.md
@@ -1,0 +1,25 @@
+# Skeleton List Loader
+
+### What does this do?
+
+It shows a loading placeholder for a list of rows, each with a round avatar block and two text bars. A shimmer sweeps across the placeholders to signal that content is loading.
+
+### How is it used?
+
+```html
+<ul class="skel-list" aria-hidden="true">
+  <li class="skel-row">
+    <span class="skel-avatar"></span>
+    <span class="skel-lines">
+      <span class="skel-bar"></span>
+      <span class="skel-bar short"></span>
+    </span>
+  </li>
+</ul>
+```
+
+Repeat the row for as many placeholders as you expect. Mark the list `aria-hidden` while it stands in for real content, then swap it for the loaded list. Add `short` to a bar for a partial width line.
+
+### Why is it useful?
+
+Lists of users, comments, or results show a skeleton while data loads. This builds a multi row skeleton with a shimmer sweep from a single moving gradient, using only CSS. The shimmer is disabled under reduced motion so the blocks rest static.

--- a/submissions/examples/skeleton-list-as/demo.html
+++ b/submissions/examples/skeleton-list-as/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Skeleton List Loader</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <ul class="skel-list" aria-hidden="true">
+    <li class="skel-row">
+      <span class="skel-avatar"></span>
+      <span class="skel-lines"><span class="skel-bar"></span><span class="skel-bar short"></span></span>
+    </li>
+    <li class="skel-row">
+      <span class="skel-avatar"></span>
+      <span class="skel-lines"><span class="skel-bar"></span><span class="skel-bar short"></span></span>
+    </li>
+    <li class="skel-row">
+      <span class="skel-avatar"></span>
+      <span class="skel-lines"><span class="skel-bar"></span><span class="skel-bar short"></span></span>
+    </li>
+    <li class="skel-row">
+      <span class="skel-avatar"></span>
+      <span class="skel-lines"><span class="skel-bar"></span><span class="skel-bar short"></span></span>
+    </li>
+  </ul>
+</body>
+</html>

--- a/submissions/examples/skeleton-list-as/style.css
+++ b/submissions/examples/skeleton-list-as/style.css
@@ -1,0 +1,78 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.skel-list {
+  list-style: none;
+  margin: 0;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  width: min(360px, 94vw);
+  box-sizing: border-box;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 14px;
+}
+
+.skel-row {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.skel-avatar {
+  width: 44px;
+  height: 44px;
+  flex: none;
+  border-radius: 50%;
+}
+
+.skel-lines {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.skel-bar {
+  height: 11px;
+  border-radius: 6px;
+}
+
+.skel-bar.short {
+  width: 55%;
+}
+
+.skel-avatar,
+.skel-bar {
+  background: linear-gradient(90deg, #172440 25%, #223357 50%, #172440 75%);
+  background-size: 200% 100%;
+  animation: skel-shimmer 1.3s linear infinite;
+}
+
+@keyframes skel-shimmer {
+  from {
+    background-position: 200% 0;
+  }
+
+  to {
+    background-position: -200% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skel-avatar,
+  .skel-bar {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a skeleton list loader built for #41034. Multi row placeholders with avatar blocks and text bars and a shimmer sweep, using only CSS. Closes #41034.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A loading placeholder for a list of rows, each with a round avatar block and two text bars, with a shimmer sweeping across them.

**How does a developer use it?**

```html
<ul class="skel-list" aria-hidden="true">
  <li class="skel-row">
    <span class="skel-avatar"></span>
    <span class="skel-lines"><span class="skel-bar"></span><span class="skel-bar short"></span></span>
  </li>
</ul>
```

**Why does it fit EaseMotion CSS?**
It builds a multi row skeleton with a shimmer sweep from a single moving gradient, using only CSS. The shimmer is disabled under reduced motion so the blocks rest static.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: four rows render with four avatar blocks and eight text bars, all running the shimmer animation.
