### PR TITLE
feat: add error 404 page

### DIFF
--- a/submissions/examples/error-page-as/README.md
+++ b/submissions/examples/error-page-as/README.md
@@ -1,0 +1,25 @@
+# Error 404 Page
+
+### What does this do?
+
+It shows a centered 404 error page with a large gradient number, a heading, a short message, and two actions to go home or go back. The big number gently floats up and down.
+
+### How is it used?
+
+```html
+<main class="notfound">
+  <div class="nf-code" aria-hidden="true">404</div>
+  <h1>Page not found</h1>
+  <p>The page you are looking for was moved or removed.</p>
+  <div class="nf-actions">
+    <a class="nf-primary" href="#">Go home</a>
+    <a class="nf-ghost" href="#">Go back</a>
+  </div>
+</main>
+```
+
+The number uses `background-clip: text` for the gradient fill and a float keyframe. The two actions pair a primary and a ghost button.
+
+### Why is it useful?
+
+Every site needs a friendly not found page. This presents a clean, centered error state with a gradient headline, clear copy, and paired actions, using only CSS. The float and hover transitions are removed under reduced motion.

--- a/submissions/examples/error-page-as/demo.html
+++ b/submissions/examples/error-page-as/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Error 404 Page</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="notfound">
+    <div class="nf-code" aria-hidden="true">404</div>
+    <h1>Page not found</h1>
+    <p>The page you are looking for was moved, removed, or never existed. Check the address or head back.</p>
+    <div class="nf-actions">
+      <a class="nf-primary" href="#">Go home</a>
+      <a class="nf-ghost" href="#">Go back</a>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/error-page-as/style.css
+++ b/submissions/examples/error-page-as/style.css
@@ -1,0 +1,107 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.notfound {
+  text-align: center;
+  max-width: 400px;
+}
+
+.nf-code {
+  font-size: clamp(6rem, 22vw, 9rem);
+  font-weight: 900;
+  line-height: 1;
+  letter-spacing: -0.03em;
+  background: linear-gradient(135deg, #6c63ff, #22d3ee);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: nf-float 4s ease-in-out infinite;
+}
+
+.nf-code::selection {
+  color: #fff;
+}
+
+.notfound h1 {
+  margin: 0.4rem 0 0.6rem;
+  font-size: 1.5rem;
+}
+
+.notfound p {
+  margin: 0 0 1.8rem;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: #94a3b8;
+}
+
+.nf-actions {
+  display: flex;
+  gap: 0.7rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.nf-primary,
+.nf-ghost {
+  padding: 0.7rem 1.4rem;
+  border-radius: 10px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.nf-primary {
+  background: #6c63ff;
+  color: #fff;
+}
+
+.nf-primary:hover {
+  background: #5b52e6;
+}
+
+.nf-ghost {
+  color: #cbd5e1;
+  border: 1px solid #26324a;
+}
+
+.nf-ghost:hover {
+  border-color: #6c63ff;
+}
+
+.nf-primary:focus-visible,
+.nf-ghost:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+@keyframes nf-float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+
+  50% {
+    transform: translateY(-10px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nf-code {
+    animation: none;
+  }
+
+  .nf-primary,
+  .nf-ghost {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an error 404 page built for #41036. A centered not found state with a floating gradient number and paired actions, using only CSS. Closes #41036.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A centered 404 error page with a large gradient number that floats, a heading, a message, and go home and go back actions.

**How does a developer use it?**

```html
<main class="notfound">
  <div class="nf-code" aria-hidden="true">404</div>
  <h1>Page not found</h1>
  <p>The page was moved or removed.</p>
  <div class="nf-actions">
    <a class="nf-primary" href="#">Go home</a>
    <a class="nf-ghost" href="#">Go back</a>
  </div>
</main>
```

**Why does it fit EaseMotion CSS?**
It presents a clean, centered error state with a gradient headline using `background-clip: text`, clear copy, and paired actions, using only CSS. The float and hover transitions are removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the 404 number renders with a transparent text fill for the gradient clip and runs the float animation, with two action buttons.
