### PR TITLE
feat: add settings list

### DIFF
--- a/submissions/examples/settings-list-as/README.md
+++ b/submissions/examples/settings-list-as/README.md
@@ -1,0 +1,23 @@
+# Settings List
+
+### What does this do?
+
+It shows a settings panel of rows, each with an icon, a title, a helper line, and a toggle switch on the right. The switches are real checkboxes that slide on and off with no JavaScript.
+
+### How is it used?
+
+```html
+<ul class="settings">
+  <li class="set-row">
+    <span class="set-icon"><svg>...</svg></span>
+    <span class="set-text"><strong>Email alerts</strong><small>Get a summary daily</small></span>
+    <label class="switch"><input type="checkbox" checked aria-label="Email alerts" /><span class="track"></span></label>
+  </li>
+</ul>
+```
+
+Each switch is a hidden checkbox with a `.track` that shows the pill and the sliding knob. Give the input an `aria-label` matching the row title.
+
+### Why is it useful?
+
+Preference screens list options as rows with a switch each. This lays out a settings list with labeled rows and a sliding toggle per row, using only checkboxes and CSS. Switches are keyboard operable with a focus ring and the slide is removed under reduced motion.

--- a/submissions/examples/settings-list-as/demo.html
+++ b/submissions/examples/settings-list-as/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Settings List</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <ul class="settings">
+    <li class="set-row">
+      <span class="set-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 6h16v12H4z" /><path d="m4 7 8 6 8-6" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
+      <span class="set-text"><strong>Email alerts</strong><small>Get a daily summary</small></span>
+      <label class="switch"><input type="checkbox" checked aria-label="Email alerts" /><span class="track"></span></label>
+    </li>
+    <li class="set-row">
+      <span class="set-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9a6 6 0 0 1 12 0c0 5 2 6 2 6H4s2-1 2-6" stroke-linecap="round" stroke-linejoin="round" /><path d="M10.5 20a1.5 1.5 0 0 0 3 0" stroke-linecap="round" /></svg></span>
+      <span class="set-text"><strong>Push notifications</strong><small>Alerts on this device</small></span>
+      <label class="switch"><input type="checkbox" aria-label="Push notifications" /><span class="track"></span></label>
+    </li>
+    <li class="set-row">
+      <span class="set-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9" /><path d="M12 3a15 15 0 0 1 0 18M12 3a15 15 0 0 0 0 18M3 12h18" /></svg></span>
+      <span class="set-text"><strong>Public profile</strong><small>Visible to everyone</small></span>
+      <label class="switch"><input type="checkbox" checked aria-label="Public profile" /><span class="track"></span></label>
+    </li>
+    <li class="set-row">
+      <span class="set-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4" /><path d="M12 3v3M12 18v3M3 12h3M18 12h3" stroke-linecap="round" /></svg></span>
+      <span class="set-text"><strong>Dark mode</strong><small>Use a dark theme</small></span>
+      <label class="switch"><input type="checkbox" checked aria-label="Dark mode" /><span class="track"></span></label>
+    </li>
+  </ul>
+</body>
+</html>

--- a/submissions/examples/settings-list-as/style.css
+++ b/submissions/examples/settings-list-as/style.css
@@ -1,0 +1,124 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.settings {
+  list-style: none;
+  margin: 0;
+  padding: 0.5rem;
+  width: min(400px, 94vw);
+  box-sizing: border-box;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+}
+
+.set-row {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.85rem 0.7rem;
+}
+
+.set-row + .set-row {
+  border-top: 1px solid #1b2942;
+}
+
+.set-icon {
+  flex: none;
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  border-radius: 10px;
+  background: #1b2942;
+  color: #a5b4fc;
+}
+
+.set-icon svg {
+  width: 19px;
+  height: 19px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+}
+
+.set-text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.set-text strong {
+  font-size: 0.9rem;
+}
+
+.set-text small {
+  font-size: 0.76rem;
+  color: #94a3b8;
+}
+
+.switch {
+  flex: none;
+  cursor: pointer;
+}
+
+.switch input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  margin: -1px;
+  overflow: hidden;
+}
+
+.switch .track {
+  display: block;
+  position: relative;
+  width: 42px;
+  height: 24px;
+  border-radius: 999px;
+  background: #33415c;
+  transition: background 0.2s ease;
+}
+
+.switch .track::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform 0.2s ease;
+}
+
+.switch :checked + .track {
+  background: #6c63ff;
+}
+
+.switch :checked + .track::after {
+  transform: translateX(18px);
+}
+
+.switch :focus-visible + .track {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .switch .track,
+  .switch .track::after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a settings list built for #41039. Rows with an icon, title, helper line, and a sliding toggle switch, using only checkboxes and CSS. Closes #41039.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A settings panel of rows, each with an icon, a title, a helper line, and a real toggle switch on the right.

**How does a developer use it?**

```html
<ul class="settings">
  <li class="set-row">
    <span class="set-icon"><svg>...</svg></span>
    <span class="set-text"><strong>Email alerts</strong><small>Get a summary daily</small></span>
    <label class="switch"><input type="checkbox" checked aria-label="Email alerts" /><span class="track"></span></label>
  </li>
</ul>
```

**Why does it fit EaseMotion CSS?**
It lays out a settings list with labeled rows and a sliding toggle per row, using only checkboxes and CSS. Switches are keyboard operable with a focus ring and the slide is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: four rows render, the toggles reflect their checked states (on, off, on, on), and a checked switch slides its knob 18px to the accent track.
