### PR TITLE
feat: add comment thread

### DIFF
--- a/submissions/examples/comment-thread-as/README.md
+++ b/submissions/examples/comment-thread-as/README.md
@@ -1,0 +1,26 @@
+# Comment Thread
+
+### What does this do?
+
+It lays out a comment thread with initials avatars, an author and time, comment text in a bubble, and reply and like actions. One reply is nested and indented under its parent with a connector line.
+
+### How is it used?
+
+```html
+<ul class="thread">
+  <li class="comment">
+    <span class="c-avatar">AL</span>
+    <div class="c-body">
+      <div class="c-bubble"><span class="c-meta"><strong>Ada</strong><time>2h</time></span><p>Nice work.</p></div>
+      <div class="c-actions"><a href="#">Like</a><a href="#">Reply</a></div>
+      <ul class="thread is-nested"><li class="comment">...</li></ul>
+    </div>
+  </li>
+</ul>
+```
+
+Nest a `thread is-nested` list inside a comment body to show replies. It indents and draws a left connector line.
+
+### Why is it useful?
+
+Discussion sections and reviews show threaded comments. This lays out a comment thread with nested replies, a connector line, and action links, using only CSS and initials avatars so there are no external images. Action links have hover and focus styles and the transition is removed under reduced motion.

--- a/submissions/examples/comment-thread-as/demo.html
+++ b/submissions/examples/comment-thread-as/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Comment Thread</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <ul class="thread">
+    <li class="comment">
+      <span class="c-avatar">AL</span>
+      <div class="c-body">
+        <div class="c-bubble">
+          <span class="c-meta"><strong>Ada Lovelace</strong><time>2h</time></span>
+          <p>This layout is exactly what we needed. Ships nicely on mobile too.</p>
+        </div>
+        <div class="c-actions"><a href="#">Like</a><a href="#">Reply</a></div>
+        <ul class="thread is-nested">
+          <li class="comment">
+            <span class="c-avatar">GT</span>
+            <div class="c-body">
+              <div class="c-bubble">
+                <span class="c-meta"><strong>Grace T.</strong><time>1h</time></span>
+                <p>Agreed. The nested replies read clearly with the connector line.</p>
+              </div>
+              <div class="c-actions"><a href="#">Like</a><a href="#">Reply</a></div>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </li>
+    <li class="comment">
+      <span class="c-avatar">KJ</span>
+      <div class="c-body">
+        <div class="c-bubble">
+          <span class="c-meta"><strong>Katherine J.</strong><time>40m</time></span>
+          <p>One idea: add a subtle hover on the action links. Otherwise looks great.</p>
+        </div>
+        <div class="c-actions"><a href="#">Like</a><a href="#">Reply</a></div>
+      </div>
+    </li>
+  </ul>
+</body>
+</html>

--- a/submissions/examples/comment-thread-as/style.css
+++ b/submissions/examples/comment-thread-as/style.css
@@ -1,0 +1,113 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.thread {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  width: min(440px, 94vw);
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.comment {
+  display: grid;
+  grid-template-columns: 38px 1fr;
+  gap: 0.75rem;
+}
+
+.c-avatar {
+  width: 38px;
+  height: 38px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  color: #fff;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.comment:nth-child(1) > .c-avatar {
+  background: linear-gradient(135deg, #6c63ff, #a855f7);
+}
+
+.comment:nth-child(2) > .c-avatar {
+  background: linear-gradient(135deg, #0ea5e9, #22d3ee);
+}
+
+.c-body {
+  min-width: 0;
+}
+
+.c-bubble {
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 4px 12px 12px 12px;
+  padding: 0.6rem 0.85rem;
+}
+
+.c-meta {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.c-meta strong {
+  font-size: 0.86rem;
+}
+
+.c-meta time {
+  font-size: 0.72rem;
+  color: #64748b;
+}
+
+.c-bubble p {
+  margin: 0;
+  font-size: 0.86rem;
+  line-height: 1.5;
+  color: #cbd5e1;
+}
+
+.c-actions {
+  display: flex;
+  gap: 1rem;
+  margin: 0.4rem 0 0 0.2rem;
+}
+
+.c-actions a {
+  font-size: 0.74rem;
+  font-weight: 600;
+  color: #64748b;
+  text-decoration: none;
+  transition: color 0.14s ease;
+}
+
+.c-actions a:hover,
+.c-actions a:focus-visible {
+  color: #a5b4fc;
+  outline: none;
+}
+
+.thread.is-nested {
+  margin: 0.9rem 0 0;
+  padding-left: 1rem;
+  border-left: 2px solid #26324a;
+  gap: 0.9rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .c-actions a {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a comment thread built for #41041. Comments with avatars, meta, text, actions, and one nested reply with a connector line, using only CSS. Closes #41041.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A comment thread with initials avatars, author and time, comment bubbles, and reply and like actions, including one nested reply indented with a connector line.

**How does a developer use it?**

```html
<ul class="thread">
  <li class="comment">
    <span class="c-avatar">AL</span>
    <div class="c-body">
      <div class="c-bubble"><span class="c-meta"><strong>Ada</strong><time>2h</time></span><p>Nice work.</p></div>
      <div class="c-actions"><a href="#">Like</a><a href="#">Reply</a></div>
      <ul class="thread is-nested"><li class="comment">...</li></ul>
    </div>
  </li>
</ul>
```

**Why does it fit EaseMotion CSS?**
It lays out a comment thread with nested replies, a connector line, and action links, using only CSS and initials avatars so there are no external images. Action links have hover and focus styles and the transition is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: three comments render with one nested thread that is indented and carries a 2px left connector line.
