### PR TITLE
feat: add feature checklist

### DIFF
--- a/submissions/examples/feature-checklist-as/README.md
+++ b/submissions/examples/feature-checklist-as/README.md
@@ -1,0 +1,20 @@
+# Feature Checklist
+
+### What does this do?
+
+It renders a feature checklist that shows what a plan includes with green check icons and what it excludes with muted dash icons and dimmer text. Included and excluded rows are set by a class.
+
+### How is it used?
+
+```html
+<ul class="feature-list">
+  <li class="has"><svg class="fl-icon">...</svg>Unlimited projects</li>
+  <li class="no"><svg class="fl-icon">...</svg>Priority support</li>
+</ul>
+```
+
+Use the `has` class for an included feature with a check icon and the `no` class for an excluded feature with a dash icon. The `no` rows dim automatically.
+
+### Why is it useful?
+
+Pricing and landing pages list plan features as a checklist of yes and no items. This renders an included and excluded feature list with matching icons and muted styling for excluded rows, using only CSS and inline SVG so there are no external assets.

--- a/submissions/examples/feature-checklist-as/demo.html
+++ b/submissions/examples/feature-checklist-as/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Feature Checklist</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="plan-card">
+    <h2>Starter plan</h2>
+    <ul class="feature-list">
+      <li class="has"><svg class="fl-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="m5 13 4 4 10-11" stroke-linecap="round" stroke-linejoin="round" /></svg>Up to 3 projects</li>
+      <li class="has"><svg class="fl-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="m5 13 4 4 10-11" stroke-linecap="round" stroke-linejoin="round" /></svg>Community support</li>
+      <li class="has"><svg class="fl-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="m5 13 4 4 10-11" stroke-linecap="round" stroke-linejoin="round" /></svg>1 GB storage</li>
+      <li class="no"><svg class="fl-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 12h12" stroke-linecap="round" /></svg>Custom domains</li>
+      <li class="no"><svg class="fl-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 12h12" stroke-linecap="round" /></svg>Priority support</li>
+      <li class="no"><svg class="fl-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 12h12" stroke-linecap="round" /></svg>Advanced analytics</li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/submissions/examples/feature-checklist-as/style.css
+++ b/submissions/examples/feature-checklist-as/style.css
@@ -1,0 +1,65 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.plan-card {
+  width: min(320px, 92vw);
+  padding: 1.6rem 1.7rem;
+  box-sizing: border-box;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+}
+
+.plan-card h2 {
+  margin: 0 0 1.2rem;
+  font-size: 1.1rem;
+}
+
+.feature-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.feature-list li {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  font-size: 0.9rem;
+}
+
+.feature-list svg {
+  width: 20px;
+  height: 20px;
+  flex: none;
+  stroke-width: 2.4;
+  fill: none;
+}
+
+.feature-list .has {
+  color: #e2e8f0;
+}
+
+.feature-list .has .fl-icon {
+  stroke: #34d399;
+}
+
+.feature-list .no {
+  color: #64748b;
+}
+
+.feature-list .no .fl-icon {
+  stroke: #475569;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a feature checklist built for #41043. Included rows with green checks and excluded rows with muted dashes, set by a class, using only CSS and inline SVG. Closes #41043.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A marketing feature checklist listing included features with green checks and excluded features with muted dashes and dimmer text.

**How does a developer use it?**

```html
<ul class="feature-list">
  <li class="has"><svg class="fl-icon">...</svg>Unlimited projects</li>
  <li class="no"><svg class="fl-icon">...</svg>Priority support</li>
</ul>
```

**Why does it fit EaseMotion CSS?**
It renders an included and excluded feature list with matching icons and muted styling for excluded rows, using only CSS and inline SVG so there are no external assets.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: three included rows use a green check stroke and three excluded rows use a muted dash stroke.
