### PR TITLE
feat: add media player controls

### DIFF
--- a/submissions/examples/media-controls-as/README.md
+++ b/submissions/examples/media-controls-as/README.md
@@ -1,0 +1,29 @@
+# Media Player Controls
+
+### What does this do?
+
+It shows a music player control bar with track art, title and artist, a progress track with an elapsed fill and a knob, timestamps at each end, and transport buttons for previous, play, and next. The play button stands out as a filled circle.
+
+### How is it used?
+
+```html
+<div class="player">
+  <div class="pl-head">
+    <div class="pl-art"><svg>...</svg></div>
+    <div class="pl-meta"><span class="pl-title">Nightfall</span><span class="pl-artist">Aurora Lane</span></div>
+  </div>
+  <div class="pl-track" style="--played: 42%" role="progressbar" aria-valuenow="42"></div>
+  <div class="pl-times"><span>1:47</span><span>4:12</span></div>
+  <div class="pl-controls">
+    <button class="pl-btn"><svg>...</svg></button>
+    <button class="pl-btn pl-play"><svg>...</svg></button>
+    <button class="pl-btn"><svg>...</svg></button>
+  </div>
+</div>
+```
+
+Set the elapsed amount with the `--played` custom property on the track. The knob follows the same value.
+
+### Why is it useful?
+
+Audio and video widgets need a clean control bar. This lays out a media player with a progress bar, times, and transport controls, using only CSS and inline SVG so a developer can wire real playback on top. Buttons are labeled and show a focus ring, and transitions are removed under reduced motion.

--- a/submissions/examples/media-controls-as/demo.html
+++ b/submissions/examples/media-controls-as/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Media Player Controls</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="player">
+    <div class="pl-head">
+      <div class="pl-art" aria-hidden="true">
+        <svg viewBox="0 0 24 24"><path d="M9 18V5l10-2v13" stroke-linecap="round" stroke-linejoin="round" /><circle cx="6" cy="18" r="3" /><circle cx="16" cy="16" r="3" /></svg>
+      </div>
+      <div class="pl-meta">
+        <span class="pl-title">Nightfall</span>
+        <span class="pl-artist">Aurora Lane</span>
+      </div>
+    </div>
+
+    <div class="pl-track" style="--played: 42%" role="progressbar" aria-valuenow="42" aria-valuemin="0" aria-valuemax="100"></div>
+    <div class="pl-times"><span>1:47</span><span>4:12</span></div>
+
+    <div class="pl-controls">
+      <button class="pl-btn" type="button" aria-label="Previous">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18 5v14L8 12zM6 5v14" /></svg>
+      </button>
+      <button class="pl-btn pl-play" type="button" aria-label="Play">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 5v14l12-7z" /></svg>
+      </button>
+      <button class="pl-btn" type="button" aria-label="Next">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 5v14l10-7zM18 5v14" /></svg>
+      </button>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/media-controls-as/style.css
+++ b/submissions/examples/media-controls-as/style.css
@@ -1,0 +1,159 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.player {
+  width: min(340px, 94vw);
+  padding: 1.3rem;
+  box-sizing: border-box;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 18px;
+  box-shadow: 0 20px 44px rgba(0, 0, 0, 0.45);
+}
+
+.pl-head {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  margin-bottom: 1.1rem;
+}
+
+.pl-art {
+  width: 54px;
+  height: 54px;
+  flex: none;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #6c63ff, #ec4899);
+  display: grid;
+  place-items: center;
+}
+
+.pl-art svg {
+  width: 24px;
+  height: 24px;
+  stroke: rgba(255, 255, 255, 0.9);
+  stroke-width: 2;
+  fill: none;
+}
+
+.pl-meta {
+  min-width: 0;
+}
+
+.pl-title {
+  display: block;
+  font-size: 0.95rem;
+  font-weight: 700;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.pl-artist {
+  font-size: 0.8rem;
+  color: #94a3b8;
+}
+
+.pl-track {
+  position: relative;
+  height: 6px;
+  border-radius: 3px;
+  background: #1b2942;
+  margin-bottom: 0.45rem;
+}
+
+.pl-track::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: var(--played, 40%);
+  border-radius: 3px;
+  background: linear-gradient(90deg, #6c63ff, #a855f7);
+}
+
+.pl-track::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: var(--played, 40%);
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #fff;
+  transform: translate(-50%, -50%);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
+}
+
+.pl-times {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.72rem;
+  color: #64748b;
+  margin-bottom: 1rem;
+}
+
+.pl-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+}
+
+.pl-btn {
+  display: grid;
+  place-items: center;
+  border: none;
+  background: transparent;
+  color: #cbd5e1;
+  cursor: pointer;
+  padding: 0;
+  transition: color 0.15s ease;
+}
+
+.pl-btn svg {
+  width: 24px;
+  height: 24px;
+  fill: currentColor;
+}
+
+.pl-btn:hover {
+  color: #fff;
+}
+
+.pl-play {
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  background: #6c63ff;
+  color: #fff;
+}
+
+.pl-play svg {
+  width: 26px;
+  height: 26px;
+}
+
+.pl-play:hover {
+  background: #5b52e6;
+  color: #fff;
+}
+
+.pl-btn:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pl-btn {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds media player controls built for #41045. Track art, meta, a progress bar with a knob, times, and transport buttons, using only CSS. Closes #41045.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A music player control bar with track art, title and artist, a progress track with an elapsed fill and knob, timestamps, and previous, play, and next buttons.

**How does a developer use it?**

```html
<div class="player">
  <div class="pl-track" style="--played: 42%" role="progressbar" aria-valuenow="42"></div>
  <div class="pl-controls">
    <button class="pl-btn"><svg>...</svg></button>
    <button class="pl-btn pl-play"><svg>...</svg></button>
    <button class="pl-btn"><svg>...</svg></button>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It lays out a media player with a progress bar, times, and transport controls, using only CSS and inline SVG so real playback can be wired on top. The elapsed amount is driven by `--played`, buttons are labeled with focus rings, and transitions are removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: three transport buttons including the play button render, and the progress fill sits at 42 percent, matching `--played`.
