### PR TITLE
feat: add tag cloud

### DIFF
--- a/submissions/examples/tag-cloud-as/README.md
+++ b/submissions/examples/tag-cloud-as/README.md
@@ -1,0 +1,20 @@
+# Tag Cloud
+
+### What does this do?
+
+It shows a tag cloud where each tag sizes by a weight set with a custom property, so popular topics appear larger. Tags wrap across lines, cycle through a few accent colors, and lift and fill on hover.
+
+### How is it used?
+
+```html
+<nav class="tag-cloud" aria-label="Popular topics">
+  <a href="#" style="--w: 6">design</a>
+  <a href="#" style="--w: 2">css</a>
+</nav>
+```
+
+Set each tag weight with the `--w` custom property. The font size is computed as `calc(0.78rem + var(--w) * 0.13rem)`, so higher weights render larger.
+
+### Why is it useful?
+
+Blogs and knowledge bases use a tag cloud to surface popular topics. This sizes and colors tags by a weight custom property and wraps them cleanly, using only CSS. Tags have hover and focus states and the lift is removed under reduced motion.

--- a/submissions/examples/tag-cloud-as/demo.html
+++ b/submissions/examples/tag-cloud-as/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tag Cloud</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <nav class="tag-cloud" aria-label="Popular topics">
+    <a href="#" style="--w: 6">design</a>
+    <a href="#" style="--w: 2">css</a>
+    <a href="#" style="--w: 4">javascript</a>
+    <a href="#" style="--w: 1">svg</a>
+    <a href="#" style="--w: 5">accessibility</a>
+    <a href="#" style="--w: 3">animation</a>
+    <a href="#" style="--w: 2">layout</a>
+    <a href="#" style="--w: 7">frontend</a>
+    <a href="#" style="--w: 1">grid</a>
+    <a href="#" style="--w: 4">react</a>
+    <a href="#" style="--w: 2">typography</a>
+    <a href="#" style="--w: 3">performance</a>
+    <a href="#" style="--w: 5">ux</a>
+    <a href="#" style="--w: 1">tools</a>
+  </nav>
+</body>
+</html>

--- a/submissions/examples/tag-cloud-as/style.css
+++ b/submissions/examples/tag-cloud-as/style.css
@@ -1,0 +1,70 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.tag-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+  justify-content: center;
+  width: min(420px, 94vw);
+  padding: 1.6rem;
+  box-sizing: border-box;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+}
+
+.tag-cloud a {
+  padding: 0.28em 0.7em;
+  font-size: calc(0.78rem + var(--w, 1) * 0.13rem);
+  font-weight: 600;
+  line-height: 1.2;
+  color: #cbd5e1;
+  text-decoration: none;
+  background: #1b2942;
+  border: 1px solid #26324a;
+  border-radius: 999px;
+  transition: background 0.15s ease, color 0.15s ease, transform 0.15s ease;
+}
+
+.tag-cloud a:nth-child(3n + 1) {
+  color: #a5b4fc;
+}
+
+.tag-cloud a:nth-child(3n + 2) {
+  color: #6ee7b7;
+}
+
+.tag-cloud a:nth-child(3n) {
+  color: #fbbf24;
+}
+
+.tag-cloud a:hover,
+.tag-cloud a:focus-visible {
+  background: #6c63ff;
+  color: #fff;
+  border-color: #6c63ff;
+  transform: translateY(-2px);
+  outline: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tag-cloud a {
+    transition: background 0.15s ease, color 0.15s ease;
+  }
+
+  .tag-cloud a:hover,
+  .tag-cloud a:focus-visible {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a tag cloud built for #41047. Tags size by a weight custom property so popular topics appear larger, using only CSS. Closes #41047.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A tag cloud where each tag sizes by a `--w` weight so popular topics render larger, wrapping across lines and lifting and filling on hover.

**How does a developer use it?**

```html
<nav class="tag-cloud" aria-label="Popular topics">
  <a href="#" style="--w: 6">design</a>
  <a href="#" style="--w: 2">css</a>
</nav>
```

**Why does it fit EaseMotion CSS?**
It sizes and colors tags by a weight custom property and wraps them cleanly, using only CSS. The font size is `calc(0.78rem + var(--w) * 0.13rem)`, tags have hover and focus states, and the lift is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: fourteen tags render and a high weight tag is larger than a low weight tag, confirming the weight sizing.
