### PR TITLE
feat: add like button

### DIFF
--- a/submissions/examples/like-button-as/README.md
+++ b/submissions/examples/like-button-as/README.md
@@ -1,0 +1,21 @@
+# Like Button
+
+### What does this do?
+
+It shows a heart like button that fills red and pops with a small burst when toggled on, with a like count beside it. It works with no JavaScript by using a checkbox, so the liked state is real and keyboard operable.
+
+### How is it used?
+
+```html
+<label class="like">
+  <input type="checkbox" aria-label="Like this post" />
+  <span class="like-heart"><svg>...</svg></span>
+  <span class="like-count">128</span>
+</label>
+```
+
+The hidden checkbox drives the heart fill and the burst ring through sibling selectors. Give the input an `aria-label` so its purpose is announced.
+
+### Why is it useful?
+
+Posts and cards need a like control with clear on and off states. This animates a heart fill and a burst on toggle and pairs it with a count, using only a checkbox and CSS. The control is keyboard operable with a focus ring and the animations are disabled under reduced motion.

--- a/submissions/examples/like-button-as/demo.html
+++ b/submissions/examples/like-button-as/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Like Button</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <label class="like">
+    <input type="checkbox" aria-label="Like this post" />
+    <span class="like-heart">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 20s-7-4.4-9.5-8.3C.8 9 2 5.5 5.2 5.5c1.9 0 3.1 1 3.8 2.1.7-1.1 1.9-2.1 3.8-2.1 3.2 0 4.4 3.5 2.7 6.2C19 15.6 12 20 12 20z" stroke-linejoin="round" /></svg>
+    </span>
+    <span class="like-count">128</span>
+  </label>
+</body>
+</html>

--- a/submissions/examples/like-button-as/style.css
+++ b/submissions/examples/like-button-as/style.css
@@ -1,0 +1,123 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.like {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.5rem 0.9rem 0.5rem 0.7rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 999px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.like input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  margin: -1px;
+  overflow: hidden;
+}
+
+.like-heart {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+}
+
+.like-heart svg {
+  width: 22px;
+  height: 22px;
+  stroke: #94a3b8;
+  stroke-width: 2;
+  fill: none;
+  transition: fill 0.2s ease, stroke 0.2s ease, transform 0.2s ease;
+}
+
+.like-heart::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  border: 2px solid #ef4444;
+  opacity: 0;
+  transform: scale(0.4);
+}
+
+.like input:checked + .like-heart svg {
+  fill: #ef4444;
+  stroke: #ef4444;
+  animation: like-pop 0.35s ease;
+}
+
+.like input:checked + .like-heart::before {
+  animation: like-burst 0.5s ease;
+}
+
+.like-count {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #cbd5e1;
+  font-variant-numeric: tabular-nums;
+}
+
+.like input:checked ~ .like-count {
+  color: #fca5a5;
+}
+
+.like input:focus-visible + .like-heart {
+  outline: 2px solid #6c63ff;
+  outline-offset: 3px;
+  border-radius: 50%;
+}
+
+@keyframes like-pop {
+  0% {
+    transform: scale(1);
+  }
+
+  40% {
+    transform: scale(1.35);
+  }
+
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes like-burst {
+  0% {
+    opacity: 0.9;
+    transform: scale(0.5);
+  }
+
+  100% {
+    opacity: 0;
+    transform: scale(1.7);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .like-heart svg {
+    transition: fill 0.2s ease, stroke 0.2s ease;
+    animation: none !important;
+  }
+
+  .like input:checked + .like-heart::before {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a like button built for #41049. A heart that fills red and bursts on toggle with a like count, using a checkbox and CSS only. Closes #41049.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A heart like button that fills red and pops with a small burst when toggled on, paired with a like count.

**How does a developer use it?**

```html
<label class="like">
  <input type="checkbox" aria-label="Like this post" />
  <span class="like-heart"><svg>...</svg></span>
  <span class="like-count">128</span>
</label>
```

**Why does it fit EaseMotion CSS?**
It animates a heart fill and a burst on toggle and pairs it with a count, using only a checkbox and CSS. The control is keyboard operable with a focus ring and the animations are disabled under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the heart is unfilled by default and fills with red (#ef4444) when the checkbox is checked.
