### PR TITLE
feat: add code block

### DIFF
--- a/submissions/examples/code-block-as/README.md
+++ b/submissions/examples/code-block-as/README.md
@@ -1,0 +1,24 @@
+# Code Block
+
+### What does this do?
+
+It shows a styled code block with a window style title bar that has traffic light dots, a filename, and a copy button, plus a body with line numbers. It works for any preformatted snippet.
+
+### How is it used?
+
+```html
+<figure class="code-block">
+  <figcaption class="cb-bar">
+    <span class="cb-dots"><span></span><span></span><span></span></span>
+    <span class="cb-file">button.css</span>
+    <button class="cb-copy" type="button"><svg>...</svg>Copy</button>
+  </figcaption>
+  <pre class="cb-body"><code><span class="cb-line">.btn {</span><span class="cb-line">}</span></code></pre>
+</figure>
+```
+
+Wrap each line in a `cb-line` span so the CSS counter can number it. Optional token classes (`k`, `s`, `f`, `c`) tint keywords, strings, selectors, and comments.
+
+### Why is it useful?
+
+Docs and blogs show code snippets in a framed block. This presents a code block with a window style header, a copy affordance, and line numbers, using only CSS. The copy button is a real button with a focus ring and its transition is removed under reduced motion.

--- a/submissions/examples/code-block-as/demo.html
+++ b/submissions/examples/code-block-as/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Code Block</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <figure class="code-block">
+    <figcaption class="cb-bar">
+      <span class="cb-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+      <span class="cb-file">button.css</span>
+      <button class="cb-copy" type="button">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><rect x="9" y="9" width="11" height="11" rx="2" /><path d="M5 15V5a2 2 0 0 1 2-2h10" /></svg>
+        Copy
+      </button>
+    </figcaption>
+    <pre class="cb-body"><code><span class="cb-line"><span class="c">/* accent button */</span></span><span class="cb-line"><span class="f">.btn</span> {</span><span class="cb-line">  <span class="k">background</span>: <span class="s">#6c63ff</span>;</span><span class="cb-line">  <span class="k">color</span>: <span class="s">#fff</span>;</span><span class="cb-line">  <span class="k">border-radius</span>: <span class="s">10px</span>;</span><span class="cb-line">  <span class="k">padding</span>: <span class="s">0.7rem 1.3rem</span>;</span><span class="cb-line">}</span></code></pre>
+  </figure>
+</body>
+</html>

--- a/submissions/examples/code-block-as/style.css
+++ b/submissions/examples/code-block-as/style.css
@@ -1,0 +1,145 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.code-block {
+  width: min(460px, 94vw);
+  margin: 0;
+  background: #0b1220;
+  border: 1px solid #26324a;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+}
+
+.cb-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.6rem 0.85rem;
+  background: #111c30;
+  border-bottom: 1px solid #26324a;
+}
+
+.cb-dots {
+  display: flex;
+  gap: 6px;
+  flex: none;
+}
+
+.cb-dots span {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+}
+
+.cb-dots span:nth-child(1) {
+  background: #ef4444;
+}
+
+.cb-dots span:nth-child(2) {
+  background: #f59e0b;
+}
+
+.cb-dots span:nth-child(3) {
+  background: #10b981;
+}
+
+.cb-file {
+  flex: 1;
+  font-size: 0.78rem;
+  color: #94a3b8;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+}
+
+.cb-copy {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.6rem;
+  font: inherit;
+  font-size: 0.74rem;
+  font-weight: 600;
+  color: #cbd5e1;
+  background: #1b2942;
+  border: 1px solid #26324a;
+  border-radius: 7px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.cb-copy svg {
+  width: 13px;
+  height: 13px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+}
+
+.cb-copy:hover {
+  background: #24344f;
+  color: #fff;
+}
+
+.cb-copy:focus-visible {
+  outline: 2px solid #6c63ff;
+  outline-offset: 2px;
+}
+
+.cb-body {
+  margin: 0;
+  padding: 0.9rem 0;
+  overflow-x: auto;
+  counter-reset: line;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.82rem;
+  line-height: 1.7;
+}
+
+.cb-line {
+  display: block;
+  padding: 0 1rem 0 3.2rem;
+  position: relative;
+  white-space: pre;
+  color: #cbd5e1;
+}
+
+.cb-line::before {
+  counter-increment: line;
+  content: counter(line);
+  position: absolute;
+  left: 0;
+  width: 2.2rem;
+  text-align: right;
+  color: #475569;
+}
+
+.cb-line .k {
+  color: #c792ea;
+}
+
+.cb-line .s {
+  color: #6ee7b7;
+}
+
+.cb-line .f {
+  color: #82aaff;
+}
+
+.cb-line .c {
+  color: #64748b;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cb-copy {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a code block built for #41051. A window style header with dots, filename, and copy button plus a body with line numbers, using only CSS. Closes #41051.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A styled code block with a title bar (traffic light dots, filename, copy button) and a numbered code body.

**How does a developer use it?**

```html
<figure class="code-block">
  <figcaption class="cb-bar">
    <span class="cb-dots"><span></span><span></span><span></span></span>
    <span class="cb-file">button.css</span>
    <button class="cb-copy" type="button"><svg>...</svg>Copy</button>
  </figcaption>
  <pre class="cb-body"><code><span class="cb-line">.btn {</span></code></pre>
</figure>
```

**Why does it fit EaseMotion CSS?**
It presents a code block with a window style header, a copy affordance, and line numbers from a CSS counter, using only CSS. The copy button is a real button with a focus ring and its transition is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: seven numbered code lines render with three window dots, a copy button, and the filename in the header.
