### PR TITLE
feat: add gauge meter

### DIFF
--- a/submissions/examples/gauge-meter-as/README.md
+++ b/submissions/examples/gauge-meter-as/README.md
@@ -1,0 +1,23 @@
+# Gauge Meter
+
+### What does this do?
+
+It shows a semicircle gauge meter where a needle points to a value set with a custom property, over a green to red arc. It reads like a speedometer or a score dial, with the value shown in the center.
+
+### How is it used?
+
+```html
+<div class="gauge" style="--val: 72" role="img" aria-label="Score 72 out of 100">
+  <div class="gauge-arc"></div>
+  <div class="gauge-hole"></div>
+  <div class="gauge-needle"></div>
+  <div class="gauge-cap"></div>
+  <div class="gauge-value">72</div>
+</div>
+```
+
+Set `--val` from 0 to 100. The needle rotates by `calc(var(--val) * 1.8deg - 90deg)`, so 0 points left, 50 points up, and 100 points right across the half circle.
+
+### Why is it useful?
+
+Scores, speeds, and health metrics read well on a half circle gauge. This builds a semicircle gauge from a conic gradient arc and a needle rotated by a custom property, using only CSS. The needle eases to its value and the transition is removed under reduced motion.

--- a/submissions/examples/gauge-meter-as/demo.html
+++ b/submissions/examples/gauge-meter-as/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Gauge Meter</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="gauge-card">
+    <div class="gauge" style="--val: 72" role="img" aria-label="Score 72 out of 100">
+      <div class="gauge-arc"></div>
+      <div class="gauge-hole"></div>
+      <div class="gauge-needle"></div>
+      <div class="gauge-cap"></div>
+      <div class="gauge-value">72</div>
+    </div>
+    <span class="gauge-label">Performance score</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/gauge-meter-as/style.css
+++ b/submissions/examples/gauge-meter-as/style.css
@@ -1,0 +1,103 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.gauge-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 1.8rem 2rem 1.4rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 18px;
+}
+
+.gauge {
+  position: relative;
+  width: 220px;
+  height: 118px;
+  overflow: hidden;
+}
+
+.gauge-arc {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 220px;
+  height: 220px;
+  border-radius: 50%;
+  background: conic-gradient(
+    from -90deg,
+    #10b981 0deg,
+    #f59e0b 90deg,
+    #ef4444 180deg,
+    #1b2942 180deg
+  );
+}
+
+.gauge-hole {
+  position: absolute;
+  left: 50%;
+  top: 110px;
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+  background: #0e1626;
+  transform: translate(-50%, -50%);
+}
+
+.gauge-needle {
+  position: absolute;
+  left: 50%;
+  bottom: 6px;
+  width: 4px;
+  height: 92px;
+  margin-left: -2px;
+  border-radius: 2px 2px 0 0;
+  background: linear-gradient(#e2e8f0, #94a3b8);
+  transform-origin: bottom center;
+  transform: rotate(calc(var(--val, 0) * 1.8deg - 90deg));
+  transition: transform 1s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.gauge-cap {
+  position: absolute;
+  left: 50%;
+  bottom: 6px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #e2e8f0;
+  transform: translate(-50%, 50%);
+  box-shadow: 0 0 0 4px #0e1626;
+}
+
+.gauge-value {
+  position: absolute;
+  left: 50%;
+  bottom: 24px;
+  transform: translateX(-50%);
+  font-size: 1.6rem;
+  font-weight: 800;
+  z-index: 1;
+}
+
+.gauge-label {
+  font-size: 0.82rem;
+  color: #94a3b8;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gauge-needle {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a gauge meter built for #41053. A semicircle dial with a green to red arc and a needle rotated to a custom property value, using only CSS. Closes #41053.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A semicircle gauge where a needle points to a value over a green to red arc, with the value shown in the center. It reads like a speedometer or a score dial.

**How does a developer use it?**

```html
<div class="gauge" style="--val: 72" role="img" aria-label="Score 72 out of 100">
  <div class="gauge-arc"></div>
  <div class="gauge-hole"></div>
  <div class="gauge-needle"></div>
  <div class="gauge-cap"></div>
  <div class="gauge-value">72</div>
</div>
```

**Why does it fit EaseMotion CSS?**
It builds a semicircle gauge from a conic gradient arc and a needle rotated by `calc(var(--val) * 1.8deg - 90deg)`, using only CSS. The needle eases to its value and the transition is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: for a value of 72 the needle computes to about 40 degrees, matching `72 * 1.8 - 90`.
