### PR TITLE
feat: add nps rating scale

### DIFF
--- a/submissions/examples/nps-scale-as/README.md
+++ b/submissions/examples/nps-scale-as/README.md
@@ -1,0 +1,24 @@
+# NPS Rating Scale
+
+### What does this do?
+
+It shows a net promoter score scale from 0 to 10 where the user picks one number. The chosen number highlights, and the buttons are color banded into detractor (0 to 6), passive (7 to 8), and promoter (9 to 10) ranges. It works with no JavaScript by using radio inputs.
+
+### How is it used?
+
+```html
+<fieldset class="nps">
+  <legend>How likely are you to recommend us?</legend>
+  <div class="nps-row">
+    <label class="det"><input type="radio" name="nps" aria-label="0" /><span>0</span></label>
+    <label class="pro"><input type="radio" name="nps" aria-label="10" checked /><span>10</span></label>
+  </div>
+  <div class="nps-ends"><span>Not likely</span><span>Very likely</span></div>
+</fieldset>
+```
+
+Give each number the band class `det`, `pas`, or `pro` for its range color, and the same `name` so only one can be chosen. Each input carries an `aria-label` with its number.
+
+### Why is it useful?
+
+Surveys ask how likely you are to recommend a product on a zero to ten scale. This builds an NPS scale with color banded ranges and a selected state from radios, using only CSS. Buttons are keyboard operable with a focus ring and the lift is removed under reduced motion.

--- a/submissions/examples/nps-scale-as/demo.html
+++ b/submissions/examples/nps-scale-as/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>NPS Rating Scale</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <fieldset class="nps">
+    <legend>How likely are you to recommend us?</legend>
+    <div class="nps-row">
+      <label class="det"><input type="radio" name="nps" aria-label="0" /><span>0</span></label>
+      <label class="det"><input type="radio" name="nps" aria-label="1" /><span>1</span></label>
+      <label class="det"><input type="radio" name="nps" aria-label="2" /><span>2</span></label>
+      <label class="det"><input type="radio" name="nps" aria-label="3" /><span>3</span></label>
+      <label class="det"><input type="radio" name="nps" aria-label="4" /><span>4</span></label>
+      <label class="det"><input type="radio" name="nps" aria-label="5" /><span>5</span></label>
+      <label class="det"><input type="radio" name="nps" aria-label="6" /><span>6</span></label>
+      <label class="pas"><input type="radio" name="nps" aria-label="7" /><span>7</span></label>
+      <label class="pas"><input type="radio" name="nps" aria-label="8" /><span>8</span></label>
+      <label class="pro"><input type="radio" name="nps" aria-label="9" checked /><span>9</span></label>
+      <label class="pro"><input type="radio" name="nps" aria-label="10" /><span>10</span></label>
+    </div>
+    <div class="nps-ends">
+      <span>Not likely</span>
+      <span>Very likely</span>
+    </div>
+  </fieldset>
+</body>
+</html>

--- a/submissions/examples/nps-scale-as/style.css
+++ b/submissions/examples/nps-scale-as/style.css
@@ -1,0 +1,111 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.nps {
+  border: 1px solid #26324a;
+  border-radius: 16px;
+  background: #0e1626;
+  padding: 1.5rem 1.6rem;
+  margin: 0;
+  width: min(440px, 94vw);
+  box-sizing: border-box;
+}
+
+.nps legend {
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 0 0.4rem;
+  text-align: center;
+}
+
+.nps-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  justify-content: center;
+  margin: 1.1rem 0 0.7rem;
+}
+
+.nps label {
+  cursor: pointer;
+}
+
+.nps input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  margin: -1px;
+  overflow: hidden;
+}
+
+.nps span {
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 34px;
+  border-radius: 8px;
+  border: 1.5px solid #26324a;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #cbd5e1;
+  transition: transform 0.14s ease, background 0.14s ease, color 0.14s ease;
+}
+
+.nps label.det span {
+  border-color: rgba(239, 68, 68, 0.5);
+  color: #fca5a5;
+}
+
+.nps label.pas span {
+  border-color: rgba(245, 158, 11, 0.5);
+  color: #fbbf24;
+}
+
+.nps label.pro span {
+  border-color: rgba(16, 185, 129, 0.5);
+  color: #6ee7b7;
+}
+
+.nps label:hover span {
+  transform: translateY(-2px);
+}
+
+.nps label:has(:checked) span {
+  background: #6c63ff;
+  border-color: #6c63ff;
+  color: #fff;
+  transform: translateY(-2px) scale(1.05);
+}
+
+.nps label:has(:focus-visible) span {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+.nps-ends {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.72rem;
+  color: #64748b;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nps span {
+    transition: background 0.14s ease, color 0.14s ease;
+  }
+
+  .nps label:hover span,
+  .nps label:has(:checked) span {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an NPS rating scale built for #41058. A zero to ten scale with color banded ranges and a selected state from radios, using only CSS. Closes #41058.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A net promoter score scale from 0 to 10 where picking a number highlights it, with buttons banded into detractor, passive, and promoter ranges.

**How does a developer use it?**

```html
<fieldset class="nps">
  <legend>How likely are you to recommend us?</legend>
  <div class="nps-row">
    <label class="det"><input type="radio" name="nps" aria-label="0" /><span>0</span></label>
    <label class="pro"><input type="radio" name="nps" aria-label="10" checked /><span>10</span></label>
  </div>
</fieldset>
```

**Why does it fit EaseMotion CSS?**
It builds an NPS scale with color banded ranges and a selected state from radios via `:has(:checked)`, using only CSS. Buttons are keyboard operable with a focus ring and the lift is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: eleven number buttons render, banded seven detractor, two passive, and two promoter, and the checked number fills with the accent color.
