### PR TITLE
feat: add vertical volume slider

### DIFF
--- a/submissions/examples/vertical-slider-as/README.md
+++ b/submissions/examples/vertical-slider-as/README.md
@@ -1,0 +1,21 @@
+# Vertical Volume Slider
+
+### What does this do?
+
+It shows a panel of vertical sliders for a mixer or volume board. Each is a native range input turned upright with a custom track, an accent fill up to the value, and a round thumb, plus a label and value below.
+
+### How is it used?
+
+```html
+<div class="vslider">
+  <input class="vs-input" type="range" min="0" max="100" value="72" style="--val: 72" aria-label="Bass level" />
+  <span class="vs-label">Bass</span>
+  <span class="vs-value">72</span>
+</div>
+```
+
+The input uses `writing-mode: vertical-lr` to stand upright. Set `--val` to the same number as `value` so the fill portion of the track matches the thumb position.
+
+### Why is it useful?
+
+Audio mixers and equalizers use upright sliders. This styles a native range input into a vertical slider with a custom track and thumb, using only CSS, so it stays draggable and keyboard operable. The thumb shows a focus ring when tabbed to.

--- a/submissions/examples/vertical-slider-as/demo.html
+++ b/submissions/examples/vertical-slider-as/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vertical Volume Slider</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="mixer">
+    <div class="vslider">
+      <input class="vs-input" type="range" min="0" max="100" value="72" style="--val: 72" aria-label="Bass level" />
+      <span class="vs-label">Bass</span>
+      <span class="vs-value">72</span>
+    </div>
+    <div class="vslider">
+      <input class="vs-input" type="range" min="0" max="100" value="45" style="--val: 45" aria-label="Mid level" />
+      <span class="vs-label">Mid</span>
+      <span class="vs-value">45</span>
+    </div>
+    <div class="vslider">
+      <input class="vs-input" type="range" min="0" max="100" value="88" style="--val: 88" aria-label="Treble level" />
+      <span class="vs-label">Treble</span>
+      <span class="vs-value">88</span>
+    </div>
+    <div class="vslider">
+      <input class="vs-input" type="range" min="0" max="100" value="60" style="--val: 60" aria-label="Master level" />
+      <span class="vs-label">Master</span>
+      <span class="vs-value">60</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/vertical-slider-as/style.css
+++ b/submissions/examples/vertical-slider-as/style.css
@@ -1,0 +1,81 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.mixer {
+  display: flex;
+  gap: 1.6rem;
+  padding: 1.6rem 1.9rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 18px;
+}
+
+.vslider {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.7rem;
+}
+
+.vs-input {
+  -webkit-appearance: none;
+  appearance: none;
+  writing-mode: vertical-lr;
+  direction: rtl;
+  width: 8px;
+  height: 150px;
+  border-radius: 4px;
+  background: linear-gradient(
+    to top,
+    #6c63ff calc(var(--val, 70) * 1%),
+    #1b2942 calc(var(--val, 70) * 1%)
+  );
+  cursor: pointer;
+  outline: none;
+}
+
+.vs-input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: #e2e8f0;
+  border: 3px solid #6c63ff;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
+}
+
+.vs-input::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #e2e8f0;
+  border: 3px solid #6c63ff;
+}
+
+.vs-input:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 4px;
+  border-radius: 6px;
+}
+
+.vs-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #cbd5e1;
+}
+
+.vs-value {
+  font-size: 0.72rem;
+  color: #94a3b8;
+  font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a vertical volume slider built for #41078. Native range inputs styled upright into a mixer panel with custom track, fill, and thumb, using only CSS. Closes #41078.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A panel of vertical sliders for a mixer, each a native range input turned upright with a custom track, an accent fill to the value, a round thumb, and a label and value below.

**How does a developer use it?**

```html
<div class="vslider">
  <input class="vs-input" type="range" min="0" max="100" value="72" style="--val: 72" aria-label="Bass level" />
  <span class="vs-label">Bass</span>
  <span class="vs-value">72</span>
</div>
```

**Why does it fit EaseMotion CSS?**
It styles a native range input into a vertical slider with a custom track and thumb using `writing-mode: vertical-lr`, so it stays draggable and keyboard operable, using only CSS. The thumb shows a focus ring when tabbed to.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: four range inputs render taller than wide (upright) with values 72, 45, 88, and 60.
