### PR TITLE
feat: add custom select

### DIFF
--- a/submissions/examples/custom-select-as/README.md
+++ b/submissions/examples/custom-select-as/README.md
@@ -1,0 +1,26 @@
+# Custom Select
+
+### What does this do?
+
+It shows a custom styled select with a value display, a caret that flips when open, and a list of options where the selected one shows a check. It uses the native `details` and `summary` elements, so it opens on click and stays keyboard operable with no JavaScript.
+
+### How is it used?
+
+```html
+<details class="cselect">
+  <summary>
+    <span>Medium</span>
+    <svg class="cs-caret">...</svg>
+  </summary>
+  <ul class="cs-list">
+    <li class="cs-option is-selected">Medium</li>
+    <li class="cs-option">Large</li>
+  </ul>
+</details>
+```
+
+Put the current value text in the summary and mark the chosen option with `is-selected`. A host app updates both when the user picks a new option.
+
+### Why is it useful?
+
+Native selects are hard to style consistently, so teams build custom ones. This presents a styled select with a caret, an open panel, and a selected option check, using only CSS. The caret flips on open, options have hover styles, and the animation is removed under reduced motion.

--- a/submissions/examples/custom-select-as/demo.html
+++ b/submissions/examples/custom-select-as/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Custom Select</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <details class="cselect">
+    <summary>
+      <span>Medium</span>
+      <svg class="cs-caret" viewBox="0 0 24 24" aria-hidden="true"><path d="m6 9 6 6 6-6" stroke-linecap="round" stroke-linejoin="round" /></svg>
+    </summary>
+    <ul class="cs-list">
+      <li class="cs-option">Small</li>
+      <li class="cs-option is-selected">Medium</li>
+      <li class="cs-option">Large</li>
+      <li class="cs-option">Extra large</li>
+    </ul>
+  </details>
+</body>
+</html>

--- a/submissions/examples/custom-select-as/style.css
+++ b/submissions/examples/custom-select-as/style.css
@@ -1,0 +1,125 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: start center;
+  padding: 4rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.cselect {
+  position: relative;
+  width: 220px;
+}
+
+.cselect summary {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.65rem 0.9rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 10px;
+  font-size: 0.92rem;
+  cursor: pointer;
+}
+
+.cselect summary::-webkit-details-marker {
+  display: none;
+}
+
+.cselect[open] summary {
+  border-color: #6c63ff;
+}
+
+.cs-caret {
+  width: 16px;
+  height: 16px;
+  stroke: #94a3b8;
+  stroke-width: 2;
+  fill: none;
+  flex: none;
+  transition: transform 0.2s ease;
+}
+
+.cselect[open] .cs-caret {
+  transform: rotate(180deg);
+}
+
+.cselect summary:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+.cs-list {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  left: 0;
+  right: 0;
+  margin: 0;
+  padding: 0.35rem;
+  list-style: none;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 10px;
+  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.5);
+  z-index: 2;
+}
+
+.cselect[open] .cs-list {
+  animation: cs-drop 0.16s ease;
+}
+
+.cs-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.55rem 0.7rem;
+  border-radius: 7px;
+  font-size: 0.88rem;
+  color: #cbd5e1;
+  cursor: pointer;
+  transition: background 0.14s ease;
+}
+
+.cs-option:hover {
+  background: #1b2942;
+  color: #fff;
+}
+
+.cs-option.is-selected {
+  color: #a5b4fc;
+  font-weight: 600;
+}
+
+.cs-option.is-selected::after {
+  content: "";
+  width: 14px;
+  height: 8px;
+  border: solid #a5b4fc;
+  border-width: 0 0 2px 2px;
+  transform: rotate(-45deg);
+  margin-bottom: 3px;
+}
+
+@keyframes cs-drop {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cs-caret {
+    transition: none;
+  }
+
+  .cselect[open] .cs-list {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a custom select built for #41085. A styled select with a caret and an option list with a selected check, using the native details element and CSS only. Closes #41085.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A custom styled select with a value display, a caret that flips when open, and an option list where the selected option shows a check.

**How does a developer use it?**

```html
<details class="cselect">
  <summary><span>Medium</span><svg class="cs-caret">...</svg></summary>
  <ul class="cs-list">
    <li class="cs-option is-selected">Medium</li>
    <li class="cs-option">Large</li>
  </ul>
</details>
```

**Why does it fit EaseMotion CSS?**
It presents a styled select with a caret, an open panel, and a selected option check, using only CSS. The caret flips on open, options have hover styles, and the animation is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: four options render with one marked selected, and the option list is visible when the select is open.
