### PR TITLE
feat: add multi select dropdown

### DIFF
--- a/submissions/examples/multiselect-as/README.md
+++ b/submissions/examples/multiselect-as/README.md
@@ -1,0 +1,23 @@
+# Multi Select Dropdown
+
+### What does this do?
+
+It shows a multi select dropdown where the trigger opens a panel of checkbox options. Any number of options can be checked at once, and each checked option fills its check box. It works with no JavaScript.
+
+### How is it used?
+
+```html
+<details class="msel">
+  <summary>Filter by tag</summary>
+  <div class="msel-list">
+    <label class="msel-opt"><input type="checkbox" checked /><span class="box"></span>Design</label>
+    <label class="msel-opt"><input type="checkbox" /><span class="box"></span>Engineering</label>
+  </div>
+</details>
+```
+
+Each option is a label with a hidden checkbox and a styled `.box`. Because they are checkboxes, more than one can be on. The caret flips when the panel is open.
+
+### Why is it useful?
+
+Filters and tag pickers need a multi select where several options can be on at once. This builds a checkbox based multi select in a disclosure panel, using only CSS. Options are keyboard operable with a focus ring and the animations are removed under reduced motion.

--- a/submissions/examples/multiselect-as/demo.html
+++ b/submissions/examples/multiselect-as/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Multi Select Dropdown</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <details class="msel" open>
+    <summary>Filter by tag</summary>
+    <div class="msel-list">
+      <label class="msel-opt"><input type="checkbox" checked /><span class="box"></span>Design</label>
+      <label class="msel-opt"><input type="checkbox" /><span class="box"></span>Engineering</label>
+      <label class="msel-opt"><input type="checkbox" checked /><span class="box"></span>Marketing</label>
+      <label class="msel-opt"><input type="checkbox" /><span class="box"></span>Research</label>
+      <label class="msel-opt"><input type="checkbox" checked /><span class="box"></span>Support</label>
+    </div>
+  </details>
+</body>
+</html>

--- a/submissions/examples/multiselect-as/style.css
+++ b/submissions/examples/multiselect-as/style.css
@@ -1,0 +1,153 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: start center;
+  padding: 4rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.msel {
+  position: relative;
+  width: 240px;
+}
+
+.msel summary {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.65rem 0.9rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 10px;
+  font-size: 0.9rem;
+  color: #cbd5e1;
+  cursor: pointer;
+}
+
+.msel summary::-webkit-details-marker {
+  display: none;
+}
+
+.msel summary::after {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid #94a3b8;
+  border-bottom: 2px solid #94a3b8;
+  transform: rotate(45deg);
+  transition: transform 0.2s ease;
+}
+
+.msel[open] summary {
+  border-color: #6c63ff;
+}
+
+.msel[open] summary::after {
+  transform: rotate(-135deg);
+}
+
+.msel summary:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+.msel-list {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  left: 0;
+  right: 0;
+  padding: 0.35rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 10px;
+  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.5);
+  z-index: 2;
+}
+
+.msel[open] .msel-list {
+  animation: msel-drop 0.16s ease;
+}
+
+.msel-opt {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.5rem 0.6rem;
+  border-radius: 7px;
+  font-size: 0.88rem;
+  color: #cbd5e1;
+  cursor: pointer;
+  transition: background 0.14s ease;
+}
+
+.msel-opt:hover {
+  background: #1b2942;
+}
+
+.msel-opt input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  margin: -1px;
+  overflow: hidden;
+}
+
+.msel-opt .box {
+  flex: none;
+  width: 18px;
+  height: 18px;
+  display: grid;
+  place-items: center;
+  border: 2px solid #475569;
+  border-radius: 5px;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.msel-opt .box::after {
+  content: "";
+  width: 5px;
+  height: 9px;
+  border: solid #fff;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg) scale(0);
+  transition: transform 0.15s ease;
+}
+
+.msel-opt :checked + .box {
+  background: #6c63ff;
+  border-color: #6c63ff;
+}
+
+.msel-opt :checked + .box::after {
+  transform: rotate(45deg) scale(1);
+}
+
+.msel-opt :focus-visible + .box {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+@keyframes msel-drop {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .msel summary::after,
+  .msel-opt .box,
+  .msel-opt .box::after {
+    transition: none;
+  }
+
+  .msel[open] .msel-list {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a multi select dropdown built for #41087. A disclosure panel of checkbox options where any number can be selected, using the native details element and CSS only. Closes #41087.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A multi select dropdown where the trigger opens a panel of checkbox options, several of which can be checked at once, each filling its check box.

**How does a developer use it?**

```html
<details class="msel">
  <summary>Filter by tag</summary>
  <div class="msel-list">
    <label class="msel-opt"><input type="checkbox" checked /><span class="box"></span>Design</label>
    <label class="msel-opt"><input type="checkbox" /><span class="box"></span>Engineering</label>
  </div>
</details>
```

**Why does it fit EaseMotion CSS?**
It builds a checkbox based multi select in a disclosure panel, using only CSS. Options are keyboard operable with a focus ring and the animations are removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: five options render and exactly the three checked ones fill their boxes, confirming a real multi select.
