### PR TITLE
feat: add message reactions

### DIFF
--- a/submissions/examples/message-reactions-as/README.md
+++ b/submissions/examples/message-reactions-as/README.md
@@ -1,0 +1,24 @@
+# Message Reactions
+
+### What does this do?
+
+It shows a chat message bubble with a row of emoji reaction pills below it. Each pill shows an emoji and a count, the ones you reacted to are highlighted, and an add reaction button sits at the end.
+
+### How is it used?
+
+```html
+<div class="msg">
+  <p class="msg-text">Shipping today</p>
+  <div class="reactions">
+    <button class="reaction is-mine" aria-pressed="true">👍 <span>4</span></button>
+    <button class="reaction" aria-pressed="false">🎉 <span>2</span></button>
+    <button class="reaction-add" aria-label="Add reaction">+</button>
+  </div>
+</div>
+```
+
+Each reaction is a real button with `aria-pressed`. Add the `is-mine` class to the reactions the current user has made so they stand out.
+
+### Why is it useful?
+
+Chat and comment apps let people react with emoji. This lays out a message with reaction pills, a highlighted own reaction state, and an add button, using only CSS. Pills are keyboard operable with a focus ring and the hover lift is removed under reduced motion.

--- a/submissions/examples/message-reactions-as/demo.html
+++ b/submissions/examples/message-reactions-as/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Message Reactions</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="msg">
+    <p class="msg-text">The build is green and the release is shipping today. Nice work everyone.</p>
+    <span class="msg-time">Ada, 10:24</span>
+    <div class="reactions">
+      <button class="reaction is-mine" type="button" aria-pressed="true">👍 <span>4</span></button>
+      <button class="reaction" type="button" aria-pressed="false">🎉 <span>2</span></button>
+      <button class="reaction" type="button" aria-pressed="false">🚀 <span>1</span></button>
+      <button class="reaction-add" type="button" aria-label="Add reaction">+</button>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/message-reactions-as/style.css
+++ b/submissions/examples/message-reactions-as/style.css
@@ -1,0 +1,105 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.msg {
+  width: min(320px, 92vw);
+}
+
+.msg-text {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 4px 14px 14px 14px;
+  font-size: 0.92rem;
+  line-height: 1.5;
+  color: #e2e8f0;
+}
+
+.msg-time {
+  display: block;
+  margin-top: 0.3rem;
+  font-size: 0.7rem;
+  color: #64748b;
+  padding-left: 0.3rem;
+}
+
+.reactions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.55rem;
+  padding-left: 0.3rem;
+}
+
+.reaction {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.2rem 0.55rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #cbd5e1;
+  cursor: pointer;
+  transition: border-color 0.14s ease, background 0.14s ease, transform 0.14s ease;
+}
+
+.reaction:hover {
+  border-color: #6c63ff;
+  transform: translateY(-1px);
+}
+
+.reaction.is-mine {
+  background: rgba(108, 99, 255, 0.18);
+  border-color: #6c63ff;
+  color: #c7d2fe;
+}
+
+.reaction-add {
+  display: inline-grid;
+  place-items: center;
+  width: 28px;
+  height: 26px;
+  padding: 0;
+  font: inherit;
+  font-size: 1rem;
+  color: #94a3b8;
+  background: #0e1626;
+  border: 1px dashed #33415c;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: border-color 0.14s ease, color 0.14s ease;
+}
+
+.reaction-add:hover {
+  border-color: #6c63ff;
+  color: #a5b4fc;
+}
+
+.reaction:focus-visible,
+.reaction-add:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reaction {
+    transition: border-color 0.14s ease, background 0.14s ease;
+  }
+
+  .reaction:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds message reactions built for #41089. A chat bubble with emoji reaction pills, a highlighted own reaction, and an add button, using only CSS. Closes #41089.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A chat message bubble with a row of emoji reaction pills showing an emoji and count, a highlighted own reaction, and an add reaction button.

**How does a developer use it?**

```html
<div class="msg">
  <p class="msg-text">Shipping today</p>
  <div class="reactions">
    <button class="reaction is-mine" aria-pressed="true">👍 <span>4</span></button>
    <button class="reaction" aria-pressed="false">🎉 <span>2</span></button>
    <button class="reaction-add" aria-label="Add reaction">+</button>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It lays out a message with reaction pills, a highlighted own reaction state, and an add button, using only CSS. Pills are real buttons with `aria-pressed`, keyboard operable with a focus ring, and the hover lift is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: three reaction pills render, the own reaction has an accent border while others are muted, and the add button is present.
