### PR TITLE
feat: add social post card

### DIFF
--- a/submissions/examples/post-card-as/README.md
+++ b/submissions/examples/post-card-as/README.md
@@ -1,0 +1,28 @@
+# Social Post Card
+
+### What does this do?
+
+It shows a social feed post card with an author row, post text, a gradient media area, and an action bar for like, comment, and share. The like button toggles red with a checkbox, so the liked state is real and keyboard operable.
+
+### How is it used?
+
+```html
+<article class="post">
+  <header class="post-head">
+    <span class="post-avatar">AL</span>
+    <span class="post-who"><span class="post-name">Ada</span><span class="post-handle">@ada · 2h</span></span>
+  </header>
+  <p class="post-text">Shipped a pure CSS component today.</p>
+  <div class="post-media"></div>
+  <div class="post-actions">
+    <label class="post-like"><input type="checkbox" /><svg>...</svg><span class="post-like-count">128</span></label>
+    <button class="post-act"><svg>...</svg>24</button>
+  </div>
+</article>
+```
+
+The like is a label wrapping a checkbox; the checked state fills the heart. The media area is a gradient, so there are no external images.
+
+### Why is it useful?
+
+Feeds are the core surface of social apps. This lays out a post card with header, media, and an action bar including a real toggle like, using only CSS and an initials avatar. The like animation is removed under reduced motion.

--- a/submissions/examples/post-card-as/demo.html
+++ b/submissions/examples/post-card-as/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Social Post Card</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <article class="post">
+    <header class="post-head">
+      <span class="post-avatar">AL</span>
+      <span class="post-who">
+        <span class="post-name">Ada Lovelace</span>
+        <span class="post-handle">@ada · 2h</span>
+      </span>
+      <button class="post-more" type="button" aria-label="More">⋯</button>
+    </header>
+    <p class="post-text">Shipped a pure CSS component today with no JavaScript at all. Small, fast, and accessible.</p>
+    <div class="post-media" role="img" aria-label="Post image"></div>
+    <div class="post-actions">
+      <label class="post-like">
+        <input type="checkbox" aria-label="Like" />
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 20s-7-4.4-9.5-8.3C.8 9 2 5.5 5.2 5.5c1.9 0 3.1 1 3.8 2.1.7-1.1 1.9-2.1 3.8-2.1 3.2 0 4.4 3.5 2.7 6.2C19 15.6 12 20 12 20z" stroke-linejoin="round" /></svg>
+        <span class="post-like-count">128</span>
+      </label>
+      <button class="post-act" type="button">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12a8 8 0 0 1-11.4 7.2L4 20l1-4.5A8 8 0 1 1 21 12z" stroke-linejoin="round" /></svg>
+        24
+      </button>
+      <button class="post-act" type="button">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 12v7a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-7M16 6l-4-4-4 4M12 2v13" stroke-linecap="round" stroke-linejoin="round" /></svg>
+        Share
+      </button>
+    </div>
+  </article>
+</body>
+</html>

--- a/submissions/examples/post-card-as/style.css
+++ b/submissions/examples/post-card-as/style.css
@@ -1,0 +1,166 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.post {
+  width: min(360px, 94vw);
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.post-head {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.9rem 1rem;
+}
+
+.post-avatar {
+  width: 40px;
+  height: 40px;
+  flex: none;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #6c63ff, #a855f7);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.85rem;
+}
+
+.post-who {
+  flex: 1;
+  min-width: 0;
+}
+
+.post-name {
+  display: block;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.post-handle {
+  font-size: 0.76rem;
+  color: #64748b;
+}
+
+.post-more {
+  border: none;
+  background: transparent;
+  color: #64748b;
+  font-size: 1.2rem;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.post-text {
+  margin: 0;
+  padding: 0 1rem 0.9rem;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: #cbd5e1;
+}
+
+.post-media {
+  aspect-ratio: 16 / 10;
+  background: linear-gradient(135deg, #6c63ff, #ec4899);
+  position: relative;
+}
+
+.post-media::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.25), transparent 45%);
+}
+
+.post-actions {
+  display: flex;
+  gap: 0.4rem;
+  padding: 0.6rem 0.7rem;
+}
+
+.post-act,
+.post-like {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0.7rem;
+  border: none;
+  background: transparent;
+  border-radius: 8px;
+  color: #94a3b8;
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.14s ease, color 0.14s ease;
+}
+
+.post-act:hover,
+.post-like:hover {
+  background: #1b2942;
+  color: #cbd5e1;
+}
+
+.post-act svg,
+.post-like svg {
+  width: 19px;
+  height: 19px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+  transition: fill 0.15s ease, stroke 0.15s ease, transform 0.15s ease;
+}
+
+.post-like input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  margin: -1px;
+  overflow: hidden;
+}
+
+.post-like :checked ~ svg {
+  fill: #ef4444;
+  stroke: #ef4444;
+  transform: scale(1.12);
+}
+
+.post-like :checked ~ .post-like-count {
+  color: #fca5a5;
+}
+
+.post-like :focus-visible ~ svg {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 3px;
+  border-radius: 4px;
+}
+
+.post-spacer {
+  flex: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .post-act,
+  .post-like,
+  .post-act svg,
+  .post-like svg {
+    transition: background 0.14s ease, color 0.14s ease;
+  }
+
+  .post-like :checked ~ svg {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a social post card built for #41091. An author row, text, gradient media, and an action bar with a real toggle like, using only CSS. Closes #41091.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A social feed post card with an author row, post text, a gradient media area, and a like, comment, and share action bar where the like toggles red.

**How does a developer use it?**

```html
<article class="post">
  <header class="post-head">...</header>
  <p class="post-text">Shipped a pure CSS component today.</p>
  <div class="post-media"></div>
  <div class="post-actions">
    <label class="post-like"><input type="checkbox" /><svg>...</svg><span class="post-like-count">128</span></label>
    <button class="post-act"><svg>...</svg>24</button>
  </div>
</article>
```

**Why does it fit EaseMotion CSS?**
It lays out a post card with header, media, and an action bar including a real toggle like, using only CSS and an initials avatar so there are no external images. The like animation is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the like heart is unfilled by default and fills red when its checkbox is checked, alongside comment and share actions.
