### PR TITLE
feat: add boarding pass

### DIFF
--- a/submissions/examples/boarding-pass-as/README.md
+++ b/submissions/examples/boarding-pass-as/README.md
@@ -1,0 +1,26 @@
+# Boarding Pass
+
+### What does this do?
+
+It shows a boarding pass card with a route from origin to destination, flight details, and a tear off stub separated by a perforated notch edge and a CSS barcode. There are no images.
+
+### How is it used?
+
+```html
+<div class="pass">
+  <div class="pass-main">
+    <div class="route"><span class="code">DEL</span><div class="route-line"><svg>...</svg></div><span class="code">SFO</span></div>
+    <div class="pass-info">...</div>
+  </div>
+  <div class="pass-stub">
+    <div class="stub-seat"><b>22A</b><span>SEAT</span></div>
+    <div class="barcode"></div>
+  </div>
+</div>
+```
+
+The stub is divided by a dashed border, and the two round notches are drawn with pseudo elements that match the page background. The barcode is a repeating linear gradient.
+
+### Why is it useful?
+
+Travel and event apps show tickets and passes. This builds a boarding pass with a perforated divider from notch pseudo elements and a striped CSS barcode, using only CSS with no images. It reflows spacing on very narrow screens.

--- a/submissions/examples/boarding-pass-as/demo.html
+++ b/submissions/examples/boarding-pass-as/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Boarding Pass</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="pass">
+    <div class="pass-main">
+      <div class="pass-brand">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M2 16l20-6-8-2-3 4-4-1-2 1 3 2-2 3z" stroke-linejoin="round" /></svg>
+        EASE AIR
+      </div>
+      <div class="route">
+        <div><span class="code">DEL</span><span class="city">New Delhi</span></div>
+        <div class="route-line">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M2 16l20-6-8-2-3 4-4-1-2 1 3 2-2 3z" stroke-linejoin="round" /></svg>
+        </div>
+        <div style="text-align:right"><span class="code">SFO</span><span class="city">San Francisco</span></div>
+      </div>
+      <div class="pass-info">
+        <div><span>Flight</span>EA 214</div>
+        <div><span>Date</span>12 Jul</div>
+        <div><span>Boarding</span>08:40</div>
+        <div><span>Gate</span>B12</div>
+      </div>
+    </div>
+    <div class="pass-stub">
+      <div class="stub-seat"><b>22A</b><span>SEAT</span></div>
+      <div class="barcode" role="img" aria-label="Barcode"></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/boarding-pass-as/style.css
+++ b/submissions/examples/boarding-pass-as/style.css
@@ -1,0 +1,184 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.pass {
+  display: flex;
+  width: min(430px, 96vw);
+  filter: drop-shadow(0 20px 40px rgba(0, 0, 0, 0.45));
+}
+
+.pass-main,
+.pass-stub {
+  background: #0e1626;
+  border: 1px solid #26324a;
+}
+
+.pass-main {
+  flex: 1;
+  padding: 1.3rem 1.4rem;
+  border-radius: 16px 0 0 16px;
+  border-right: none;
+  position: relative;
+}
+
+.pass-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: #a5b4fc;
+  margin-bottom: 1.2rem;
+}
+
+.pass-brand svg {
+  width: 18px;
+  height: 18px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+}
+
+.route {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.route .code {
+  font-size: 1.9rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.route .city {
+  display: block;
+  font-size: 0.7rem;
+  color: #64748b;
+  margin-top: 0.2rem;
+}
+
+.route-line {
+  flex: 1;
+  height: 20px;
+  position: relative;
+  color: #6c63ff;
+}
+
+.route-line::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  border-top: 2px dashed #33415c;
+}
+
+.route-line svg {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 22px;
+  height: 22px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: #0e1626;
+}
+
+.pass-info {
+  display: flex;
+  gap: 1.6rem;
+  margin-top: 1.4rem;
+}
+
+.pass-info div {
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.pass-info span {
+  display: block;
+  font-size: 0.66rem;
+  font-weight: 500;
+  color: #64748b;
+  margin-bottom: 0.15rem;
+}
+
+.pass-stub {
+  width: 116px;
+  flex: none;
+  padding: 1.3rem 1rem;
+  border-radius: 0 16px 16px 0;
+  border-left: 2px dashed #33415c;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  position: relative;
+}
+
+.pass-stub::before,
+.pass-stub::after {
+  content: "";
+  position: absolute;
+  left: -11px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #0b1121;
+  border: 1px solid #26324a;
+}
+
+.pass-stub::before {
+  top: -11px;
+}
+
+.pass-stub::after {
+  bottom: -11px;
+}
+
+.stub-seat {
+  text-align: center;
+}
+
+.stub-seat b {
+  display: block;
+  font-size: 1.5rem;
+  font-weight: 800;
+}
+
+.stub-seat span {
+  font-size: 0.64rem;
+  color: #64748b;
+}
+
+.barcode {
+  width: 100%;
+  height: 46px;
+  border-radius: 4px;
+  background: repeating-linear-gradient(
+    90deg,
+    #e2e8f0 0 2px,
+    transparent 2px 3px,
+    #e2e8f0 3px 6px,
+    transparent 6px 8px
+  );
+}
+
+@media (max-width: 380px) {
+  .pass-info {
+    gap: 1rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a boarding pass built for #41093. A route, flight details, and a tear off stub with notches and a CSS barcode, using only CSS with no images. Closes #41093.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A boarding pass card with an origin to destination route, flight info, and a tear off stub with a seat and a barcode, separated by a perforated notch edge.

**How does a developer use it?**

```html
<div class="pass">
  <div class="pass-main">
    <div class="route"><span class="code">DEL</span><div class="route-line"><svg>...</svg></div><span class="code">SFO</span></div>
    <div class="pass-info">...</div>
  </div>
  <div class="pass-stub"><div class="stub-seat"><b>22A</b></div><div class="barcode"></div></div>
</div>
```

**Why does it fit EaseMotion CSS?**
It builds a boarding pass with a perforated divider from notch pseudo elements and a striped CSS barcode, using only CSS with no images.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the DEL to SFO route renders, the main body and stub sit side by side, the barcode is present, and four flight info fields show.
