### PR TITLE
feat: add product tour tooltip

### DIFF
--- a/submissions/examples/tour-tooltip-as/README.md
+++ b/submissions/examples/tour-tooltip-as/README.md
@@ -1,0 +1,28 @@
+# Product Tour Tooltip
+
+### What does this do?
+
+It shows a product tour step that points at a highlighted target with an arrow. The card has a step counter, a title, a description, progress dots, and back and next buttons.
+
+### How is it used?
+
+```html
+<div class="tour">
+  <span class="tour-target">Filters</span>
+  <div class="tour-pop" role="dialog" aria-label="Tour step 2 of 4">
+    <div class="tour-count">Step 2 of 4</div>
+    <h3>Filter your results</h3>
+    <p>Narrow the list by status, owner, or date.</p>
+    <div class="tour-foot">
+      <div class="tour-dots"><span></span><span class="is-active"></span></div>
+      <div class="tour-nav"><button>Back</button><button class="primary">Next</button></div>
+    </div>
+  </div>
+</div>
+```
+
+The highlighted target uses a ring shadow, and the card draws its arrow with a bordered pseudo element. Mark the current dot with `is-active`.
+
+### Why is it useful?
+
+Onboarding tours walk new users through features with step callouts. This presents a tour tooltip anchored to a target with an arrow, a step counter, and navigation, using only CSS. The active dot stretches into a pill and the transitions are removed under reduced motion.

--- a/submissions/examples/tour-tooltip-as/demo.html
+++ b/submissions/examples/tour-tooltip-as/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Product Tour Tooltip</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="tour">
+    <span class="tour-target">Filters</span>
+    <div class="tour-pop" role="dialog" aria-label="Tour step 2 of 4">
+      <div class="tour-count">Step 2 of 4</div>
+      <h3>Filter your results</h3>
+      <p>Narrow the list by status, owner, or date. Your filters are saved for next time.</p>
+      <div class="tour-foot">
+        <div class="tour-dots" aria-hidden="true">
+          <span></span>
+          <span class="is-active"></span>
+          <span></span>
+          <span></span>
+        </div>
+        <div class="tour-nav">
+          <button type="button">Back</button>
+          <button class="primary" type="button">Next</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/tour-tooltip-as/style.css
+++ b/submissions/examples/tour-tooltip-as/style.css
@@ -1,0 +1,142 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 3rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.tour {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.4rem;
+}
+
+.tour-target {
+  padding: 0.6rem 1.1rem;
+  border-radius: 10px;
+  background: #0e1626;
+  border: 2px solid #6c63ff;
+  box-shadow: 0 0 0 6px rgba(108, 99, 255, 0.22);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.tour-pop {
+  position: relative;
+  width: min(300px, 92vw);
+  box-sizing: border-box;
+  padding: 1.2rem 1.3rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 14px;
+  box-shadow: 0 20px 44px rgba(0, 0, 0, 0.5);
+}
+
+.tour-pop::before {
+  content: "";
+  position: absolute;
+  top: -9px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0;
+  height: 0;
+  border-left: 9px solid transparent;
+  border-right: 9px solid transparent;
+  border-bottom: 9px solid #0e1626;
+}
+
+.tour-count {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #a5b4fc;
+  margin-bottom: 0.4rem;
+}
+
+.tour-pop h3 {
+  margin: 0 0 0.4rem;
+  font-size: 1.02rem;
+}
+
+.tour-pop p {
+  margin: 0 0 1.1rem;
+  font-size: 0.85rem;
+  line-height: 1.55;
+  color: #94a3b8;
+}
+
+.tour-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.tour-dots {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.tour-dots span {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: #33415c;
+  transition: width 0.2s ease, background 0.2s ease;
+}
+
+.tour-dots span.is-active {
+  width: 18px;
+  background: #6c63ff;
+}
+
+.tour-nav {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.tour-nav button {
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 600;
+  border-radius: 8px;
+  cursor: pointer;
+  border: 1px solid #26324a;
+  background: transparent;
+  color: #cbd5e1;
+  transition: background 0.14s ease, border-color 0.14s ease;
+}
+
+.tour-nav button:hover {
+  border-color: #33415c;
+  background: #1b2942;
+}
+
+.tour-nav button.primary {
+  background: #6c63ff;
+  border-color: #6c63ff;
+  color: #fff;
+}
+
+.tour-nav button.primary:hover {
+  background: #5b52e6;
+}
+
+.tour-nav button:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tour-dots span,
+  .tour-nav button {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a product tour tooltip built for #41095. A step card anchored to a highlighted target with an arrow, step counter, dots, and navigation, using only CSS. Closes #41095.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A product tour step card that points at a highlighted target with an arrow, showing a step counter, title, description, progress dots, and back and next buttons.

**How does a developer use it?**

```html
<div class="tour">
  <span class="tour-target">Filters</span>
  <div class="tour-pop" role="dialog" aria-label="Tour step 2 of 4">
    <div class="tour-count">Step 2 of 4</div>
    <h3>Filter your results</h3>
    <div class="tour-foot">
      <div class="tour-dots"><span></span><span class="is-active"></span></div>
      <div class="tour-nav"><button>Back</button><button class="primary">Next</button></div>
    </div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It presents a tour tooltip anchored to a target with an arrow, a step counter, and navigation, using only CSS. The active dot stretches into a pill and the transitions are removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: four progress dots render with the active one widened to a pill, two navigation buttons, and the step counter text.
