### PR TITLE
feat: add event card

### DIFF
--- a/submissions/examples/event-card-as/README.md
+++ b/submissions/examples/event-card-as/README.md
@@ -1,0 +1,30 @@
+# Event Card
+
+### What does this do?
+
+It shows an event card with a date badge, a title, time and location rows with icons, a stack of overlapping attendee avatars, and a register button.
+
+### How is it used?
+
+```html
+<article class="event">
+  <div class="ev-top">
+    <div class="ev-date"><b>12</b><span>JUL</span></div>
+    <h3 class="ev-title">Design systems meetup</h3>
+  </div>
+  <div class="ev-rows">
+    <div class="ev-row"><svg>...</svg>6:30 PM to 8:30 PM</div>
+    <div class="ev-row"><svg>...</svg>The Loft, 2nd floor</div>
+  </div>
+  <div class="ev-foot">
+    <div class="ev-attendees"><span>AL</span><span class="more">+9</span></div>
+    <button class="ev-cta">Register</button>
+  </div>
+</article>
+```
+
+The attendee avatars overlap with a negative margin, and the last chip can use `more` to show an overflow count. Icons are inline SVG.
+
+### Why is it useful?
+
+Event listings and calendars show cards for meetups and sessions. This lays out an event card with a date badge, detail rows, overlapping attendee avatars, and a call to action, using only CSS and initials avatars so there are no external images.

--- a/submissions/examples/event-card-as/demo.html
+++ b/submissions/examples/event-card-as/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Event Card</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <article class="event">
+    <div class="ev-top">
+      <div class="ev-date"><b>12</b><span>JUL</span></div>
+      <h3 class="ev-title">Design systems meetup</h3>
+    </div>
+    <div class="ev-rows">
+      <div class="ev-row">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9" /><path d="M12 7v5l3 3" stroke-linecap="round" /></svg>
+        6:30 PM to 8:30 PM
+      </div>
+      <div class="ev-row">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 21s-7-5.7-7-11a7 7 0 0 1 14 0c0 5.3-7 11-7 11z" stroke-linejoin="round" /><circle cx="12" cy="10" r="2.5" /></svg>
+        The Loft, 2nd floor
+      </div>
+    </div>
+    <div class="ev-foot">
+      <div class="ev-attendees" aria-label="12 people attending">
+        <span>AL</span>
+        <span>GT</span>
+        <span>KJ</span>
+        <span class="more">+9</span>
+      </div>
+      <button class="ev-cta" type="button">Register</button>
+    </div>
+  </article>
+</body>
+</html>

--- a/submissions/examples/event-card-as/style.css
+++ b/submissions/examples/event-card-as/style.css
@@ -1,0 +1,145 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.event {
+  width: min(330px, 92vw);
+  padding: 1.4rem;
+  box-sizing: border-box;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+}
+
+.ev-top {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1.1rem;
+}
+
+.ev-date {
+  flex: none;
+  width: 58px;
+  height: 62px;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #6c63ff, #a855f7);
+  color: #fff;
+  text-align: center;
+  line-height: 1;
+}
+
+.ev-date b {
+  font-size: 1.5rem;
+  font-weight: 800;
+}
+
+.ev-date span {
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin-top: 0.25rem;
+}
+
+.ev-title {
+  margin: 0.1rem 0 0;
+  font-size: 1.05rem;
+  line-height: 1.35;
+}
+
+.ev-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.2rem;
+}
+
+.ev-row {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-size: 0.84rem;
+  color: #94a3b8;
+}
+
+.ev-row svg {
+  width: 16px;
+  height: 16px;
+  stroke: #6c63ff;
+  stroke-width: 2;
+  fill: none;
+  flex: none;
+}
+
+.ev-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+}
+
+.ev-attendees {
+  display: flex;
+  align-items: center;
+}
+
+.ev-attendees span {
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: #334155;
+  border: 2px solid #0e1626;
+  color: #e2e8f0;
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.ev-attendees span + span {
+  margin-left: -10px;
+}
+
+.ev-attendees .more {
+  background: #1b2942;
+  color: #94a3b8;
+}
+
+.ev-cta {
+  padding: 0.55rem 1.15rem;
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #fff;
+  background: #6c63ff;
+  border: none;
+  border-radius: 9px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.ev-cta:hover {
+  background: #5b52e6;
+}
+
+.ev-cta:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ev-cta {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an event card built for #41097. A date badge, details, overlapping attendee avatars, and a register button, using only CSS. Closes #41097.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
An event card with a date badge, a title, time and location rows with icons, a stack of overlapping attendee avatars, and a register button.

**How does a developer use it?**

```html
<article class="event">
  <div class="ev-top"><div class="ev-date"><b>12</b><span>JUL</span></div><h3 class="ev-title">Design systems meetup</h3></div>
  <div class="ev-rows"><div class="ev-row"><svg>...</svg>6:30 PM</div></div>
  <div class="ev-foot"><div class="ev-attendees"><span>AL</span><span class="more">+9</span></div><button class="ev-cta">Register</button></div>
</article>
```

**Why does it fit EaseMotion CSS?**
It lays out an event card with a date badge, detail rows, overlapping attendee avatars, and a call to action, using only CSS and initials avatars so there are no external images.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the date badge shows 12, two detail rows render, four attendee avatars overlap, and the register button is present.
