### PR TITLE
feat: add weather card

### DIFF
--- a/submissions/examples/weather-card-as/README.md
+++ b/submissions/examples/weather-card-as/README.md
@@ -1,0 +1,24 @@
+# Weather Card
+
+### What does this do?
+
+It shows a weather card with the current temperature, an inline SVG condition icon, a high and low, and a strip of the next four days with their icons and temps.
+
+### How is it used?
+
+```html
+<article class="weather">
+  <div class="wx-place"><span>San Francisco</span><span class="tag">Now</span></div>
+  <div class="wx-now"><svg>...</svg><span class="wx-temp">24°</span></div>
+  <div class="wx-meta"><span>H: <b>27°</b></span><span>L: <b>18°</b></span></div>
+  <div class="wx-forecast">
+    <div class="wx-day sun"><span>Tue</span><svg>...</svg><b>25°</b></div>
+  </div>
+</article>
+```
+
+Each forecast day gets a condition class (`sun`, `cloud`, `rain`) that tints its icon. The forecast is a four column grid.
+
+### Why is it useful?
+
+Dashboards and home screens show a weather widget. This lays out a weather card with a big temperature, a condition icon, and a compact forecast strip, using only CSS and inline SVG so there are no external assets.

--- a/submissions/examples/weather-card-as/demo.html
+++ b/submissions/examples/weather-card-as/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Weather Card</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <article class="weather">
+    <div class="wx-place"><span>San Francisco</span><span class="tag">Now</span></div>
+    <div class="wx-now">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4" /><path d="M12 2v2M12 20v2M4 12H2M22 12h-2M5 5l1.5 1.5M17.5 17.5 19 19M19 5l-1.5 1.5M6.5 17.5 5 19" stroke-linecap="round" /></svg>
+      <span class="wx-temp">24°</span>
+    </div>
+    <div class="wx-meta"><span>H: <b>27°</b></span><span>L: <b>18°</b></span><span>Sunny</span></div>
+    <div class="wx-forecast">
+      <div class="wx-day sun">
+        <span>Tue</span>
+        <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4" /><path d="M12 3v2M12 19v2M5 12H3M21 12h-2" stroke-linecap="round" /></svg>
+        <b>25°</b>
+      </div>
+      <div class="wx-day cloud">
+        <span>Wed</span>
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 18a4 4 0 0 1 0-8 5 5 0 0 1 9.6-1A3.5 3.5 0 0 1 18 18z" stroke-linejoin="round" /></svg>
+        <b>22°</b>
+      </div>
+      <div class="wx-day rain">
+        <span>Thu</span>
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 15a4 4 0 0 1 0-8 5 5 0 0 1 9.6-1A3.5 3.5 0 0 1 18 15z" stroke-linejoin="round" /><path d="M9 19l-1 2M13 19l-1 2M17 19l-1 2" stroke-linecap="round" /></svg>
+        <b>19°</b>
+      </div>
+      <div class="wx-day sun">
+        <span>Fri</span>
+        <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4" /><path d="M12 3v2M12 19v2M5 12H3M21 12h-2" stroke-linecap="round" /></svg>
+        <b>26°</b>
+      </div>
+    </div>
+  </article>
+</body>
+</html>

--- a/submissions/examples/weather-card-as/style.css
+++ b/submissions/examples/weather-card-as/style.css
@@ -1,0 +1,113 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.weather {
+  width: min(320px, 92vw);
+  padding: 1.5rem 1.6rem;
+  box-sizing: border-box;
+  background: linear-gradient(160deg, #1e3355, #0e1626);
+  border: 1px solid #26324a;
+  border-radius: 20px;
+  box-shadow: 0 20px 44px rgba(0, 0, 0, 0.4);
+}
+
+.wx-place {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: #cbd5e1;
+}
+
+.wx-place .tag {
+  font-size: 0.68rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: #94a3b8;
+}
+
+.wx-now {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  margin: 0.7rem 0 0.3rem;
+}
+
+.wx-now svg {
+  width: 60px;
+  height: 60px;
+  stroke: #fbbf24;
+  stroke-width: 2;
+  fill: none;
+}
+
+.wx-temp {
+  font-size: 3.2rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.wx-meta {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.82rem;
+  color: #94a3b8;
+  margin-bottom: 1.3rem;
+}
+
+.wx-meta b {
+  color: #e2e8f0;
+}
+
+.wx-forecast {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.wx-day {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.wx-day span {
+  font-size: 0.72rem;
+  color: #94a3b8;
+}
+
+.wx-day svg {
+  width: 24px;
+  height: 24px;
+  stroke-width: 2;
+  fill: none;
+}
+
+.wx-day.sun svg {
+  stroke: #fbbf24;
+}
+
+.wx-day.cloud svg {
+  stroke: #cbd5e1;
+}
+
+.wx-day.rain svg {
+  stroke: #60a5fa;
+}
+
+.wx-day b {
+  font-size: 0.82rem;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a weather card built for #41099. Current temperature, a condition icon, high and low, and a four day forecast strip, using only CSS and inline SVG. Closes #41099.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A weather card with the current temperature and condition icon, a high and low, and a strip of the next four days with icons and temps.

**How does a developer use it?**

```html
<article class="weather">
  <div class="wx-now"><svg>...</svg><span class="wx-temp">24°</span></div>
  <div class="wx-meta"><span>H: <b>27°</b></span><span>L: <b>18°</b></span></div>
  <div class="wx-forecast"><div class="wx-day sun"><span>Tue</span><svg>...</svg><b>25°</b></div></div>
</article>
```

**Why does it fit EaseMotion CSS?**
It lays out a weather card with a big temperature, a condition icon, and a compact forecast strip, using only CSS and inline SVG so there are no external assets. Forecast day classes tint each icon.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the current temperature reads 24° and the forecast renders four day columns with four icons.
