### PR TITLE
feat: add product card

### DIFF
--- a/submissions/examples/product-card-as/README.md
+++ b/submissions/examples/product-card-as/README.md
@@ -1,0 +1,24 @@
+# Product Card
+
+### What does this do?
+
+It shows a shop product card with a gradient image area, a sale badge, a save button, a title, a star rating with a review count, a price next to a struck old price, and an add to cart button.
+
+### How is it used?
+
+```html
+<article class="product">
+  <div class="pr-media"><span class="pr-badge">-25%</span><button class="pr-fav"><svg>...</svg></button></div>
+  <div class="pr-body">
+    <h3>Wireless headphones</h3>
+    <div class="pr-rate"><span class="pr-stars" style="--pct: 90%"></span><span class="pr-reviews">4.5 (218)</span></div>
+    <div class="pr-foot"><div class="pr-price"><b>$59</b><s>$79</s></div><button class="pr-cart">Add to cart</button></div>
+  </div>
+</article>
+```
+
+The star rating draws a gray row and clips a gold copy to the `--pct` width, so any fractional rating shows. The media area is a gradient, so there are no external images.
+
+### Why is it useful?
+
+Store grids are made of product cards. This lays out a product card with a media area, a sale badge, a partial star rating, pricing, and an add to cart action, using only CSS with no images. The cart button has hover and focus styles removed of motion under reduced motion.

--- a/submissions/examples/product-card-as/demo.html
+++ b/submissions/examples/product-card-as/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Product Card</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <article class="product">
+    <div class="pr-media" role="img" aria-label="Product image">
+      <span class="pr-badge">-25%</span>
+      <button class="pr-fav" type="button" aria-label="Save">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 20s-7-4.4-9.5-8.3C.8 9 2 5.5 5.2 5.5c1.9 0 3.1 1 3.8 2.1.7-1.1 1.9-2.1 3.8-2.1 3.2 0 4.4 3.5 2.7 6.2C19 15.6 12 20 12 20z" stroke-linejoin="round" /></svg>
+      </button>
+    </div>
+    <div class="pr-body">
+      <h3>Wireless headphones</h3>
+      <div class="pr-rate">
+        <span class="pr-stars" style="--pct: 90%" role="img" aria-label="Rated 4.5 of 5"></span>
+        <span class="pr-reviews">4.5 (218)</span>
+      </div>
+      <div class="pr-foot">
+        <div class="pr-price"><b>$59</b><s>$79</s></div>
+        <button class="pr-cart" type="button">Add to cart</button>
+      </div>
+    </div>
+  </article>
+</body>
+</html>

--- a/submissions/examples/product-card-as/style.css
+++ b/submissions/examples/product-card-as/style.css
@@ -1,0 +1,161 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.product {
+  width: min(280px, 90vw);
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.pr-media {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  background: linear-gradient(135deg, #6c63ff, #0ea5e9);
+}
+
+.pr-media::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 70% 30%, rgba(255, 255, 255, 0.28), transparent 45%);
+}
+
+.pr-badge {
+  position: absolute;
+  top: 0.7rem;
+  left: 0.7rem;
+  z-index: 1;
+  padding: 0.2rem 0.55rem;
+  border-radius: 7px;
+  background: #ef4444;
+  color: #fff;
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.pr-fav {
+  position: absolute;
+  top: 0.6rem;
+  right: 0.6rem;
+  z-index: 1;
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border: none;
+  border-radius: 50%;
+  background: rgba(11, 17, 33, 0.5);
+  color: #fff;
+  cursor: pointer;
+}
+
+.pr-fav svg {
+  width: 17px;
+  height: 17px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+}
+
+.pr-body {
+  padding: 1rem 1.1rem 1.2rem;
+}
+
+.pr-body h3 {
+  margin: 0 0 0.4rem;
+  font-size: 0.98rem;
+}
+
+.pr-rate {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-bottom: 0.9rem;
+}
+
+.pr-stars {
+  position: relative;
+  display: inline-block;
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  line-height: 1;
+}
+
+.pr-stars::before {
+  content: "★★★★★";
+  color: #334155;
+}
+
+.pr-stars::after {
+  content: "★★★★★";
+  color: #fbbf24;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: var(--pct, 100%);
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.pr-reviews {
+  font-size: 0.74rem;
+  color: #64748b;
+}
+
+.pr-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.7rem;
+}
+
+.pr-price b {
+  font-size: 1.3rem;
+  font-weight: 800;
+}
+
+.pr-price s {
+  margin-left: 0.4rem;
+  font-size: 0.82rem;
+  color: #64748b;
+}
+
+.pr-cart {
+  padding: 0.55rem 0.9rem;
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #fff;
+  background: #6c63ff;
+  border: none;
+  border-radius: 9px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.pr-cart:hover {
+  background: #5b52e6;
+}
+
+.pr-cart:focus-visible,
+.pr-fav:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pr-cart {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a product card built for #41101. A media area with a sale badge, a partial star rating, pricing, and an add to cart button, using only CSS. Closes #41101.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A shop product card with a gradient image, a sale badge, a save button, a title, a partial star rating with review count, a price next to a struck old price, and an add to cart button.

**How does a developer use it?**

```html
<article class="product">
  <div class="pr-media"><span class="pr-badge">-25%</span><button class="pr-fav"><svg>...</svg></button></div>
  <div class="pr-body">
    <h3>Wireless headphones</h3>
    <div class="pr-rate"><span class="pr-stars" style="--pct: 90%"></span><span class="pr-reviews">4.5 (218)</span></div>
    <div class="pr-foot"><div class="pr-price"><b>$59</b><s>$79</s></div><button class="pr-cart">Add to cart</button></div>
  </div>
</article>
```

**Why does it fit EaseMotion CSS?**
It lays out a product card with a media area, a sale badge, a partial star rating that clips a gold star row to `--pct`, pricing, and an add to cart action, using only CSS with no images.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the sale badge shows -25%, the gold star overlay clips over the gray stars for the 90 percent rating, and the price and add to cart button render.
