### PR TITLE
feat: add receipt card

### DIFF
--- a/submissions/examples/receipt-card-as/README.md
+++ b/submissions/examples/receipt-card-as/README.md
@@ -1,0 +1,26 @@
+# Receipt Card
+
+### What does this do?
+
+It shows an order receipt with a header, itemized lines with quantities and prices, a subtotal and tax, a bold total, and a zigzag torn bottom edge.
+
+### How is it used?
+
+```html
+<div class="receipt">
+  <div class="rc-head"><h3>Corner Coffee</h3><span>Order #10842</span></div>
+  <ul class="rc-items">
+    <li><span>Flat white<small>x2</small></span><b>$7.00</b></li>
+  </ul>
+  <div class="rc-sums">
+    <div><span>Subtotal</span><span>$22.50</span></div>
+    <div class="rc-total"><span>Total</span><b>$24.50</b></div>
+  </div>
+</div>
+```
+
+Line items use flex with `justify-content: space-between` so labels and prices align. The torn bottom edge is drawn with two diagonal gradients on a pseudo element.
+
+### Why is it useful?
+
+Checkout and order confirmation screens show a receipt summary. This lays out a receipt with aligned line items, a totals block, and a torn paper edge from a CSS gradient, using only CSS with no images.

--- a/submissions/examples/receipt-card-as/demo.html
+++ b/submissions/examples/receipt-card-as/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Receipt Card</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="receipt">
+    <div class="rc-head">
+      <h3>Corner Coffee</h3>
+      <span>Order #10842 · 12 Jul, 09:14</span>
+    </div>
+    <ul class="rc-items">
+      <li><span>Flat white<small>x2</small></span><b>$7.00</b></li>
+      <li><span>Blueberry muffin<small>x1</small></span><b>$3.50</b></li>
+      <li><span>Avocado toast<small>x1</small></span><b>$9.00</b></li>
+      <li><span>Orange juice<small>x1</small></span><b>$3.00</b></li>
+    </ul>
+    <div class="rc-sums">
+      <div><span>Subtotal</span><span>$22.50</span></div>
+      <div><span>Tax</span><span>$2.00</span></div>
+      <div class="rc-total"><span>Total</span><b>$24.50</b></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/receipt-card-as/style.css
+++ b/submissions/examples/receipt-card-as/style.css
@@ -1,0 +1,112 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.receipt {
+  position: relative;
+  width: min(300px, 90vw);
+  padding: 1.5rem 1.5rem 2rem;
+  box-sizing: border-box;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-bottom: none;
+  border-radius: 14px 14px 0 0;
+  filter: drop-shadow(0 18px 34px rgba(0, 0, 0, 0.4));
+}
+
+.receipt::after {
+  content: "";
+  position: absolute;
+  left: -1px;
+  right: -1px;
+  bottom: -14px;
+  height: 14px;
+  background:
+    linear-gradient(-45deg, transparent 9px, #0e1626 0) left / 16px 100% repeat-x,
+    linear-gradient(45deg, transparent 9px, #0e1626 0) left / 16px 100% repeat-x;
+}
+
+.rc-head {
+  text-align: center;
+  padding-bottom: 1rem;
+  border-bottom: 1px dashed #33415c;
+}
+
+.rc-head h3 {
+  margin: 0 0 0.25rem;
+  font-size: 1.05rem;
+}
+
+.rc-head span {
+  font-size: 0.74rem;
+  color: #64748b;
+}
+
+.rc-items {
+  list-style: none;
+  margin: 0;
+  padding: 1rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  border-bottom: 1px dashed #33415c;
+}
+
+.rc-items li {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.6rem;
+  font-size: 0.86rem;
+}
+
+.rc-items li span {
+  color: #cbd5e1;
+}
+
+.rc-items li small {
+  color: #64748b;
+  font-size: 0.72rem;
+  margin-left: 0.3rem;
+}
+
+.rc-items li b {
+  color: #e2e8f0;
+  font-variant-numeric: tabular-nums;
+}
+
+.rc-sums {
+  padding: 1rem 0 0.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.rc-sums div {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.82rem;
+  color: #94a3b8;
+}
+
+.rc-total {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0.6rem;
+  padding-top: 0.7rem;
+  border-top: 1px solid #26324a;
+  font-size: 1.05rem;
+  font-weight: 800;
+}
+
+.rc-total b {
+  color: #a5b4fc;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a receipt card built for #41103. Itemized lines, a totals block, and a torn paper bottom edge, using only CSS. Closes #41103.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
An order receipt with a header, itemized lines with quantities and prices, subtotal and tax, a bold total, and a zigzag torn bottom edge.

**How does a developer use it?**

```html
<div class="receipt">
  <div class="rc-head"><h3>Corner Coffee</h3></div>
  <ul class="rc-items"><li><span>Flat white<small>x2</small></span><b>$7.00</b></li></ul>
  <div class="rc-sums"><div class="rc-total"><span>Total</span><b>$24.50</b></div></div>
</div>
```

**Why does it fit EaseMotion CSS?**
It lays out a receipt with aligned line items, a totals block, and a torn paper edge from a CSS gradient on a pseudo element, using only CSS with no images.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: four line items render with a subtotal, tax, and a bold total of $24.50.
