### PR TITLE
feat: add color palette card

### DIFF
--- a/submissions/examples/color-palette-as/README.md
+++ b/submissions/examples/color-palette-as/README.md
@@ -1,0 +1,22 @@
+# Color Palette Card
+
+### What does this do?
+
+It shows a color palette card with a row of swatches, each with its hex code below. The swatch color comes from a custom property, and a copy hint appears over the swatch on hover and keyboard focus.
+
+### How is it used?
+
+```html
+<div class="palette">
+  <div class="sw" style="--c: #6c63ff">
+    <div class="sw-chip"><span class="sw-copy">Copy</span><button aria-label="Copy #6C63FF"></button></div>
+    <span class="sw-hex">#6C63FF</span>
+  </div>
+</div>
+```
+
+Set each swatch color with the `--c` custom property and put the same hex in the label. A real button covers the chip, so it is focusable and the copy hint shows with `:focus-within`.
+
+### Why is it useful?
+
+Design tools and brand pages present color palettes. This lays out a palette of swatches with hex labels and a hover copy hint, each driven by a custom property, using only CSS. The hint fade is removed under reduced motion.

--- a/submissions/examples/color-palette-as/demo.html
+++ b/submissions/examples/color-palette-as/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Color Palette Card</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="palette-card">
+    <h2>Brand palette</h2>
+    <p class="sub">Hover a swatch to copy its hex.</p>
+    <div class="palette">
+      <div class="sw" style="--c: #6c63ff">
+        <div class="sw-chip"><span class="sw-copy">Copy</span><button type="button" aria-label="Copy #6C63FF"></button></div>
+        <span class="sw-hex">#6C63FF</span>
+      </div>
+      <div class="sw" style="--c: #22d3ee">
+        <div class="sw-chip"><span class="sw-copy">Copy</span><button type="button" aria-label="Copy #22D3EE"></button></div>
+        <span class="sw-hex">#22D3EE</span>
+      </div>
+      <div class="sw" style="--c: #34d399">
+        <div class="sw-chip"><span class="sw-copy">Copy</span><button type="button" aria-label="Copy #34D399"></button></div>
+        <span class="sw-hex">#34D399</span>
+      </div>
+      <div class="sw" style="--c: #fbbf24">
+        <div class="sw-chip"><span class="sw-copy">Copy</span><button type="button" aria-label="Copy #FBBF24"></button></div>
+        <span class="sw-hex">#FBBF24</span>
+      </div>
+      <div class="sw" style="--c: #f472b6">
+        <div class="sw-chip"><span class="sw-copy">Copy</span><button type="button" aria-label="Copy #F472B6"></button></div>
+        <span class="sw-hex">#F472B6</span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/color-palette-as/style.css
+++ b/submissions/examples/color-palette-as/style.css
@@ -1,0 +1,97 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.palette-card {
+  width: min(420px, 94vw);
+  padding: 1.4rem;
+  box-sizing: border-box;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+}
+
+.palette-card h2 {
+  margin: 0 0 0.2rem;
+  font-size: 1rem;
+}
+
+.palette-card .sub {
+  margin: 0 0 1.2rem;
+  font-size: 0.8rem;
+  color: #94a3b8;
+}
+
+.palette {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 0.6rem;
+}
+
+.sw {
+  cursor: pointer;
+}
+
+.sw-chip {
+  position: relative;
+  height: 84px;
+  border-radius: 10px;
+  background: var(--c);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.sw-copy {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(6, 10, 20, 0.45);
+  color: #fff;
+  font-size: 0.72rem;
+  font-weight: 700;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.sw:hover .sw-copy,
+.sw:focus-within .sw-copy {
+  opacity: 1;
+}
+
+.sw-hex {
+  display: block;
+  margin-top: 0.45rem;
+  text-align: center;
+  font-size: 0.72rem;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  color: #cbd5e1;
+  text-transform: uppercase;
+}
+
+.sw button {
+  position: absolute;
+  inset: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+}
+
+.sw button:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: -3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sw-copy {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a color palette card built for #41105. Swatches with hex labels and a hover copy hint, each driven by a custom property, using only CSS. Closes #41105.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A color palette card with a row of swatches, each showing its hex code and a copy hint on hover and focus.

**How does a developer use it?**

```html
<div class="palette">
  <div class="sw" style="--c: #6c63ff">
    <div class="sw-chip"><span class="sw-copy">Copy</span><button aria-label="Copy #6C63FF"></button></div>
    <span class="sw-hex">#6C63FF</span>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It lays out a palette of swatches with hex labels and a hover copy hint, each driven by a `--c` custom property, using only CSS. A real button covers each chip so it is focusable and the hint shows with `:focus-within`.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: five swatches render, the first chip background is #6c63ff from `--c`, and each swatch shows its hex label with a copy button.
