### PR TITLE
feat: add sticky cta bar

### DIFF
--- a/submissions/examples/sticky-cta-bar-as/README.md
+++ b/submissions/examples/sticky-cta-bar-as/README.md
@@ -1,0 +1,22 @@
+# Sticky CTA Bar
+
+### What does this do?
+
+It shows a sticky bottom call to action bar pinned to the foot of the page with a message, a price, an action button, and a dismiss button that slides it away. It works with no JavaScript by using a checkbox.
+
+### How is it used?
+
+```html
+<input type="checkbox" id="cta-close" class="cta-close" />
+<div class="cta-bar">
+  <div class="cta-text"><b>Pro plan</b> $19/mo<small>Billed yearly</small></div>
+  <a class="cta-btn" href="#">Start free trial</a>
+  <label class="cta-x" for="cta-close" aria-label="Dismiss">✕</label>
+</div>
+```
+
+Keep the checkbox before the bar so the sibling selector can slide it out. When checked, the bar translates down out of view.
+
+### Why is it useful?
+
+Product and pricing pages keep a persistent bottom bar so the main action is always in reach. This builds a fixed bottom CTA bar with a dismiss control using only a checkbox and CSS. The slide transition is removed under reduced motion.

--- a/submissions/examples/sticky-cta-bar-as/demo.html
+++ b/submissions/examples/sticky-cta-bar-as/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sticky CTA Bar</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <input type="checkbox" id="cta-close" class="cta-close" />
+  <main class="page">
+    <h1>The Pro plan</h1>
+    <p>Everything in Free, plus unlimited projects, custom domains, and priority support. The call to action bar stays pinned to the bottom as you read.</p>
+    <p>Scroll or read on. When you are ready, the action is always one tap away at the bottom of the screen. Press the close button to dismiss the bar.</p>
+  </main>
+  <div class="cta-bar">
+    <div class="cta-text"><b>Pro plan</b> $19/mo<small>Billed yearly, cancel anytime</small></div>
+    <a class="cta-btn" href="#">Start free trial</a>
+    <label class="cta-x" for="cta-close" aria-label="Dismiss" role="button">✕</label>
+  </div>
+</body>
+</html>

--- a/submissions/examples/sticky-cta-bar-as/style.css
+++ b/submissions/examples/sticky-cta-bar-as/style.css
@@ -1,0 +1,116 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.page {
+  padding: 2.5rem 1.5rem 7rem;
+  max-width: 520px;
+}
+
+.page h1 {
+  margin: 0 0 0.6rem;
+  font-size: 1.5rem;
+}
+
+.page p {
+  margin: 0 0 1rem;
+  color: #94a3b8;
+  line-height: 1.6;
+  font-size: 0.95rem;
+}
+
+.cta-close {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  margin: -1px;
+  overflow: hidden;
+}
+
+.cta-bar {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.85rem 1.1rem;
+  background: #0e1626;
+  border-top: 1px solid #26324a;
+  box-shadow: 0 -14px 34px rgba(0, 0, 0, 0.4);
+  transition: transform 0.32s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.cta-close:checked ~ .cta-bar {
+  transform: translateY(120%);
+}
+
+.cta-text {
+  flex: 1;
+  min-width: 0;
+  font-size: 0.9rem;
+  color: #cbd5e1;
+}
+
+.cta-text b {
+  color: #fff;
+}
+
+.cta-text small {
+  display: block;
+  font-size: 0.74rem;
+  color: #64748b;
+}
+
+.cta-btn {
+  flex: none;
+  padding: 0.65rem 1.3rem;
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: #fff;
+  background: #6c63ff;
+  border-radius: 10px;
+  text-decoration: none;
+  transition: background 0.15s ease;
+}
+
+.cta-btn:hover {
+  background: #5b52e6;
+}
+
+.cta-x {
+  flex: none;
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  border-radius: 8px;
+  color: #64748b;
+  font-size: 1.2rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.cta-x:hover {
+  background: #1b2942;
+  color: #cbd5e1;
+}
+
+.cta-btn:focus-visible,
+.cta-close:focus-visible ~ .cta-bar .cta-x {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cta-bar,
+  .cta-btn {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a sticky CTA bar built for #41107. A fixed bottom bar with a message, price, action button, and a dismiss control, using a checkbox and CSS only. Closes #41107.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A sticky bottom call to action bar with a message, a price, an action button, and a dismiss button that slides it out of view.

**How does a developer use it?**

```html
<input type="checkbox" id="cta-close" class="cta-close" />
<div class="cta-bar">
  <div class="cta-text"><b>Pro plan</b> $19/mo</div>
  <a class="cta-btn" href="#">Start free trial</a>
  <label class="cta-x" for="cta-close" aria-label="Dismiss">✕</label>
</div>
```

**Why does it fit EaseMotion CSS?**
It builds a fixed bottom CTA bar with a dismiss control using only a checkbox and CSS. The slide transition is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the bar computes to `position: fixed`, has the action button, and translates downward out of view when the dismiss checkbox is checked.
