### PR TITLE
feat: add pin pad

### DIFF
--- a/submissions/examples/pin-pad-as/README.md
+++ b/submissions/examples/pin-pad-as/README.md
@@ -1,0 +1,26 @@
+# PIN Pad
+
+### What does this do?
+
+It shows a numeric PIN entry pad with a row of dots for the filled and empty positions, a three by four keypad of number buttons, and a backspace key.
+
+### How is it used?
+
+```html
+<div class="pinpad">
+  <p class="pin-title">Enter your PIN</p>
+  <div class="pin-dots"><span class="is-filled"></span><span></span></div>
+  <div class="pin-keys">
+    <button>1</button>
+    <span class="pin-blank"></span>
+    <button>0</button>
+    <button class="pin-back" aria-label="Backspace"><svg>...</svg></button>
+  </div>
+</div>
+```
+
+Mark entered positions with `is-filled` on the dots. The keypad is a three column grid; use `pin-blank` for the empty cell and `pin-back` for the backspace key. A host app wires the digits.
+
+### Why is it useful?
+
+Lock screens and payment flows use a PIN pad for quick numeric entry. This lays out a keypad with a dots indicator and a backspace key, using only CSS and inline SVG. Keys have hover, active, and focus states, all reduced under reduced motion.

--- a/submissions/examples/pin-pad-as/demo.html
+++ b/submissions/examples/pin-pad-as/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>PIN Pad</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="pinpad">
+    <p class="pin-title">Enter your PIN</p>
+    <div class="pin-dots" aria-hidden="true">
+      <span class="is-filled"></span>
+      <span class="is-filled"></span>
+      <span></span>
+      <span></span>
+    </div>
+    <div class="pin-keys">
+      <button type="button">1</button>
+      <button type="button">2</button>
+      <button type="button">3</button>
+      <button type="button">4</button>
+      <button type="button">5</button>
+      <button type="button">6</button>
+      <button type="button">7</button>
+      <button type="button">8</button>
+      <button type="button">9</button>
+      <span class="pin-blank"></span>
+      <button type="button">0</button>
+      <button class="pin-back" type="button" aria-label="Backspace">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21 5H8L2 12l6 7h13a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1z" stroke-linejoin="round" /><path d="m12 9 4 6M16 9l-4 6" stroke-linecap="round" /></svg>
+      </button>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/pin-pad-as/style.css
+++ b/submissions/examples/pin-pad-as/style.css
@@ -1,0 +1,105 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.pinpad {
+  width: min(280px, 90vw);
+  padding: 1.8rem 1.6rem;
+  box-sizing: border-box;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 20px;
+  text-align: center;
+}
+
+.pin-title {
+  margin: 0 0 1.3rem;
+  font-size: 0.95rem;
+  color: #cbd5e1;
+}
+
+.pin-dots {
+  display: flex;
+  justify-content: center;
+  gap: 0.8rem;
+  margin-bottom: 1.6rem;
+}
+
+.pin-dots span {
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  border: 2px solid #33415c;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.pin-dots span.is-filled {
+  background: #6c63ff;
+  border-color: #6c63ff;
+}
+
+.pin-keys {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.7rem;
+}
+
+.pin-keys button {
+  height: 56px;
+  font: inherit;
+  font-size: 1.3rem;
+  font-weight: 600;
+  color: #e2e8f0;
+  background: #131f34;
+  border: 1px solid #223049;
+  border-radius: 14px;
+  cursor: pointer;
+  transition: background 0.12s ease, transform 0.12s ease;
+}
+
+.pin-keys button:hover {
+  background: #1b2942;
+}
+
+.pin-keys button:active {
+  transform: scale(0.95);
+  background: #24344f;
+}
+
+.pin-keys button:focus-visible {
+  outline: 2px solid #6c63ff;
+  outline-offset: 2px;
+}
+
+.pin-keys .pin-blank {
+  background: transparent;
+  border: none;
+  cursor: default;
+}
+
+.pin-keys .pin-back svg {
+  width: 24px;
+  height: 24px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pin-dots span,
+  .pin-keys button {
+    transition: none;
+  }
+
+  .pin-keys button:active {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a PIN pad built for #41109. A dots indicator, a numeric keypad, and a backspace key, using only CSS and inline SVG. Closes #41109.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A numeric PIN entry pad with a row of filled and empty dots, a three by four number keypad, and a backspace key.

**How does a developer use it?**

```html
<div class="pinpad">
  <div class="pin-dots"><span class="is-filled"></span><span></span></div>
  <div class="pin-keys">
    <button>1</button>
    <span class="pin-blank"></span>
    <button>0</button>
    <button class="pin-back" aria-label="Backspace"><svg>...</svg></button>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It lays out a keypad with a dots indicator and a backspace key, using only CSS and inline SVG. Keys have hover, active, and focus states, all reduced under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: eleven keys render on a three column grid, two of four dots are filled, and the backspace key is present.
