### PR TITLE
feat: add social login buttons

### DIFF
--- a/submissions/examples/social-login-as/README.md
+++ b/submissions/examples/social-login-as/README.md
@@ -1,0 +1,22 @@
+# Social Login Buttons
+
+### What does this do?
+
+It shows a stack of social sign in buttons for Google, Apple, and GitHub, each with its inline SVG logo and a label, plus an or divider above an email option.
+
+### How is it used?
+
+```html
+<div class="social-login">
+  <button class="sl-btn"><svg>...</svg>Continue with Google</button>
+  <button class="sl-btn"><svg>...</svg>Continue with Apple</button>
+  <div class="sl-or"><span>or</span></div>
+  <button class="sl-btn email">Continue with email</button>
+</div>
+```
+
+Each provider button centers its logo and label. The `sl-or` divider draws lines on both sides of the label with pseudo elements, and the `email` variant is the primary action.
+
+### Why is it useful?
+
+Sign in screens offer social login as the fast path. This lays out a set of provider buttons with brand logos, consistent sizing, and an or divider, using only CSS and inline SVG so there are no external assets. Buttons have hover and focus states, removed of motion under reduced motion.

--- a/submissions/examples/social-login-as/demo.html
+++ b/submissions/examples/social-login-as/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Social Login Buttons</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="social-login">
+    <h2>Sign in</h2>
+    <button class="sl-btn" type="button">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="#ea4335" d="M12 10.2v3.9h5.5a4.7 4.7 0 0 1-2 3.1v2.6h3.3c1.9-1.8 3-4.4 3-7.5 0-.7-.1-1.4-.2-2z" /><path fill="#4285f4" d="M12 22c2.7 0 4.9-.9 6.6-2.4l-3.3-2.6c-.9.6-2 1-3.3 1a5.7 5.7 0 0 1-5.4-4H3.2v2.5A10 10 0 0 0 12 22z" /><path fill="#fbbc05" d="M6.6 14a6 6 0 0 1 0-3.9V7.6H3.2a10 10 0 0 0 0 8.9z" /><path fill="#34a853" d="M12 6.5c1.5 0 2.8.5 3.8 1.5l2.9-2.9A10 10 0 0 0 3.2 7.6l3.4 2.5a5.7 5.7 0 0 1 5.4-3.6z" /></svg>
+      Continue with Google
+    </button>
+    <button class="sl-btn" type="button">
+      <svg viewBox="0 0 24 24" aria-hidden="true" fill="#fff"><path d="M16.4 12.7c0-2 1.6-3 1.7-3a3.7 3.7 0 0 0-2.9-1.6c-1.2-.1-2.4.7-3 .7s-1.6-.7-2.6-.7A3.9 3.9 0 0 0 4 10.2c-1.4 2.5-.4 6.2 1 8.2.7 1 1.5 2.1 2.5 2 1-.03 1.4-.6 2.6-.6s1.6.6 2.6.6 1.7-1 2.4-2a8 8 0 0 0 1-2.2 3.5 3.5 0 0 1-2.1-3.2zM14.6 6.3A3.5 3.5 0 0 0 15.4 4a3.6 3.6 0 0 0-2.3 1.2 3.3 3.3 0 0 0-.8 2.3 3 3 0 0 0 2.3-1.1z" /></svg>
+      Continue with Apple
+    </button>
+    <button class="sl-btn" type="button">
+      <svg viewBox="0 0 24 24" aria-hidden="true" fill="#fff"><path d="M12 2a10 10 0 0 0-3.2 19.5c.5.1.7-.2.7-.5v-1.7c-2.8.6-3.4-1.3-3.4-1.3-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 .1 1.5 1 1.5 1 .9 1.5 2.3 1.1 2.9.8.1-.6.3-1.1.6-1.4-2.2-.2-4.6-1.1-4.6-5a4 4 0 0 1 1-2.7c-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.7 1a9.3 9.3 0 0 1 5 0c1.9-1.3 2.7-1 2.7-1 .5 1.4.2 2.4.1 2.7a4 4 0 0 1 1 2.7c0 3.9-2.4 4.8-4.6 5 .3.3.6.9.6 1.9v2.8c0 .3.2.6.7.5A10 10 0 0 0 12 2z" /></svg>
+      Continue with GitHub
+    </button>
+    <div class="sl-or"><span>or</span></div>
+    <button class="sl-btn email" type="button">Continue with email</button>
+  </div>
+</body>
+</html>

--- a/submissions/examples/social-login-as/style.css
+++ b/submissions/examples/social-login-as/style.css
@@ -1,0 +1,90 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.social-login {
+  width: min(320px, 92vw);
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.social-login h2 {
+  margin: 0 0 0.4rem;
+  text-align: center;
+  font-size: 1.15rem;
+}
+
+.sl-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.65rem;
+  padding: 0.75rem 1rem;
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #e2e8f0;
+  background: #131f34;
+  border: 1px solid #26324a;
+  border-radius: 11px;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.sl-btn svg {
+  width: 19px;
+  height: 19px;
+  flex: none;
+}
+
+.sl-btn:hover {
+  background: #1b2942;
+  border-color: #33415c;
+}
+
+.sl-btn:focus-visible {
+  outline: 2px solid #6c63ff;
+  outline-offset: 2px;
+}
+
+.sl-or {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  margin: 0.4rem 0;
+  color: #64748b;
+  font-size: 0.78rem;
+}
+
+.sl-or::before,
+.sl-or::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: #26324a;
+}
+
+.sl-btn.email {
+  background: #6c63ff;
+  border-color: #6c63ff;
+  color: #fff;
+}
+
+.sl-btn.email:hover {
+  background: #5b52e6;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sl-btn {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds social login buttons built for #41113. Google, Apple, and GitHub sign in buttons with logos and an or divider, using only CSS and inline SVG. Closes #41113.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A stack of social sign in buttons for Google, Apple, and GitHub, each with an inline SVG logo, plus an or divider above an email option.

**How does a developer use it?**

```html
<div class="social-login">
  <button class="sl-btn"><svg>...</svg>Continue with Google</button>
  <div class="sl-or"><span>or</span></div>
  <button class="sl-btn email">Continue with email</button>
</div>
```

**Why does it fit EaseMotion CSS?**
It lays out provider buttons with brand logos, consistent sizing, and an or divider drawn with pseudo elements, using only CSS and inline SVG so there are no external assets.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: four buttons render, three carry provider logos, the or divider is present, and the email button uses the primary style.
