### PR TITLE
feat: add qr code card

### DIFF
--- a/submissions/examples/qr-card-as/README.md
+++ b/submissions/examples/qr-card-as/README.md
@@ -1,0 +1,26 @@
+# QR Code Card
+
+### What does this do?
+
+It shows a scan to pay card that frames a QR style code with corner finder patterns and scattered data modules drawn as inline SVG, along with a title, an amount, and a caption. There is no external image.
+
+### How is it used?
+
+```html
+<div class="qr-card">
+  <h2>Scan to pay</h2>
+  <div class="qr">
+    <svg viewBox="0 0 25 25" role="img" aria-label="QR code">
+      <rect x="0" y="0" width="7" height="7" fill="#0b1121" />
+      <!-- finder patterns and data modules -->
+    </svg>
+  </div>
+  <div class="qr-amount">$42.00</div>
+</div>
+```
+
+The QR sits on a white panel so the dark modules read clearly. The three finder patterns are drawn as nested squares and the data area is a grid of one by one module rects.
+
+### Why is it useful?
+
+Payment and ticket screens show a QR to scan. This frames a QR style graphic in a clean card with a title and amount, using only CSS and an inline SVG so there are no external assets. This is a decorative placeholder; swap in a real generated QR for production.

--- a/submissions/examples/qr-card-as/demo.html
+++ b/submissions/examples/qr-card-as/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>QR Code Card</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="qr-card">
+    <h2>Scan to pay</h2>
+    <p class="qr-sub">Point your camera at the code</p>
+    <div class="qr">
+      <svg viewBox="0 0 25 25" role="img" aria-label="QR code">
+        <!-- finder patterns -->
+        <rect x="0" y="0" width="7" height="7" fill="#0b1121" />
+        <rect x="1" y="1" width="5" height="5" fill="#fff" />
+        <rect x="2" y="2" width="3" height="3" fill="#0b1121" />
+        <rect x="18" y="0" width="7" height="7" fill="#0b1121" />
+        <rect x="19" y="1" width="5" height="5" fill="#fff" />
+        <rect x="20" y="2" width="3" height="3" fill="#0b1121" />
+        <rect x="0" y="18" width="7" height="7" fill="#0b1121" />
+        <rect x="1" y="19" width="5" height="5" fill="#fff" />
+        <rect x="2" y="20" width="3" height="3" fill="#0b1121" />
+        <!-- timing + data modules -->
+        <g fill="#0b1121">
+          <rect x="9" y="0" width="1" height="1" /><rect x="11" y="0" width="1" height="1" /><rect x="14" y="0" width="1" height="1" />
+          <rect x="8" y="2" width="1" height="1" /><rect x="10" y="2" width="1" height="1" /><rect x="13" y="2" width="1" height="1" /><rect x="15" y="2" width="1" height="1" />
+          <rect x="9" y="3" width="1" height="1" /><rect x="12" y="3" width="1" height="1" /><rect x="16" y="3" width="1" height="1" />
+          <rect x="8" y="4" width="1" height="1" /><rect x="11" y="4" width="1" height="1" /><rect x="14" y="4" width="1" height="1" />
+          <rect x="9" y="5" width="1" height="1" /><rect x="13" y="5" width="1" height="1" /><rect x="16" y="5" width="1" height="1" />
+          <rect x="0" y="9" width="1" height="1" /><rect x="2" y="9" width="1" height="1" /><rect x="5" y="9" width="1" height="1" />
+          <rect x="8" y="8" width="1" height="1" /><rect x="10" y="8" width="1" height="1" /><rect x="12" y="8" width="1" height="1" /><rect x="14" y="8" width="1" height="1" /><rect x="16" y="8" width="1" height="1" /><rect x="19" y="8" width="1" height="1" /><rect x="22" y="8" width="1" height="1" /><rect x="24" y="8" width="1" height="1" />
+          <rect x="9" y="10" width="1" height="1" /><rect x="11" y="10" width="1" height="1" /><rect x="15" y="10" width="1" height="1" /><rect x="18" y="10" width="1" height="1" /><rect x="21" y="10" width="1" height="1" /><rect x="23" y="10" width="1" height="1" />
+          <rect x="8" y="11" width="1" height="1" /><rect x="12" y="11" width="1" height="1" /><rect x="14" y="11" width="1" height="1" /><rect x="20" y="11" width="1" height="1" /><rect x="24" y="11" width="1" height="1" />
+          <rect x="10" y="12" width="1" height="1" /><rect x="13" y="12" width="1" height="1" /><rect x="16" y="12" width="1" height="1" /><rect x="19" y="12" width="1" height="1" /><rect x="22" y="12" width="1" height="1" />
+          <rect x="9" y="13" width="1" height="1" /><rect x="11" y="13" width="1" height="1" /><rect x="15" y="13" width="1" height="1" /><rect x="18" y="13" width="1" height="1" /><rect x="23" y="13" width="1" height="1" />
+          <rect x="8" y="14" width="1" height="1" /><rect x="12" y="14" width="1" height="1" /><rect x="16" y="14" width="1" height="1" /><rect x="20" y="14" width="1" height="1" /><rect x="24" y="14" width="1" height="1" />
+          <rect x="9" y="16" width="1" height="1" /><rect x="11" y="16" width="1" height="1" /><rect x="14" y="16" width="1" height="1" /><rect x="17" y="16" width="1" height="1" /><rect x="21" y="16" width="1" height="1" />
+          <rect x="10" y="18" width="1" height="1" /><rect x="12" y="18" width="1" height="1" /><rect x="15" y="18" width="1" height="1" /><rect x="19" y="18" width="1" height="1" /><rect x="22" y="18" width="1" height="1" /><rect x="24" y="18" width="1" height="1" />
+          <rect x="9" y="20" width="1" height="1" /><rect x="13" y="20" width="1" height="1" /><rect x="16" y="20" width="1" height="1" /><rect x="20" y="20" width="1" height="1" /><rect x="23" y="20" width="1" height="1" />
+          <rect x="11" y="22" width="1" height="1" /><rect x="14" y="22" width="1" height="1" /><rect x="18" y="22" width="1" height="1" /><rect x="21" y="22" width="1" height="1" /><rect x="24" y="22" width="1" height="1" />
+          <rect x="10" y="24" width="1" height="1" /><rect x="13" y="24" width="1" height="1" /><rect x="17" y="24" width="1" height="1" /><rect x="22" y="24" width="1" height="1" />
+        </g>
+      </svg>
+    </div>
+    <div class="qr-amount">$42.00</div>
+    <div class="qr-meta">Corner Coffee · Order #10842</div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/qr-card-as/style.css
+++ b/submissions/examples/qr-card-as/style.css
@@ -1,0 +1,58 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.qr-card {
+  width: min(280px, 90vw);
+  padding: 1.6rem;
+  box-sizing: border-box;
+  text-align: center;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 20px;
+  box-shadow: 0 20px 44px rgba(0, 0, 0, 0.45);
+}
+
+.qr-card h2 {
+  margin: 0 0 0.3rem;
+  font-size: 1.1rem;
+}
+
+.qr-card .qr-sub {
+  margin: 0 0 1.2rem;
+  font-size: 0.8rem;
+  color: #94a3b8;
+}
+
+.qr {
+  padding: 0.9rem;
+  background: #fff;
+  border-radius: 14px;
+  line-height: 0;
+}
+
+.qr svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.qr-amount {
+  margin-top: 1.2rem;
+  font-size: 1.6rem;
+  font-weight: 800;
+}
+
+.qr-meta {
+  margin-top: 0.2rem;
+  font-size: 0.76rem;
+  color: #64748b;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a QR code card built for #41115. A scan to pay card framing an inline SVG QR style graphic with an amount, using only CSS and inline SVG. Closes #41115.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A scan to pay card that frames a QR style code (three corner finder patterns and scattered data modules as inline SVG) with a title, an amount, and a caption.

**How does a developer use it?**

```html
<div class="qr-card">
  <h2>Scan to pay</h2>
  <div class="qr"><svg viewBox="0 0 25 25"><rect x="0" y="0" width="7" height="7" fill="#0b1121" /></svg></div>
  <div class="qr-amount">$42.00</div>
</div>
```

**Why does it fit EaseMotion CSS?**
It frames a QR style graphic in a clean card with a title and amount, using only CSS and an inline SVG so there are no external assets. The README notes it is a decorative placeholder to swap for a real generated QR.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium and by screenshot: the QR renders three finder patterns and a module field on a white panel with the $42.00 amount below.
