### PR TITLE
feat: add contact form

### DIFF
--- a/submissions/examples/contact-form-as/README.md
+++ b/submissions/examples/contact-form-as/README.md
@@ -1,0 +1,26 @@
+# Contact Form
+
+### What does this do?
+
+It shows a contact form card with a name and email row, a subject field, a message textarea, and a send button. Fields light up with a focus ring, and the two column row collapses to one column on narrow screens.
+
+### How is it used?
+
+```html
+<form class="contact">
+  <h2>Get in touch</h2>
+  <div class="cf-row">
+    <label>Name<input type="text" autocomplete="name" /></label>
+    <label>Email<input type="email" autocomplete="email" /></label>
+  </div>
+  <label>Subject<input type="text" /></label>
+  <label>Message<textarea></textarea></label>
+  <button type="submit">Send message</button>
+</form>
+```
+
+The name and email sit in a two column grid that becomes one column below 420px. Labels wrap their fields so each control is announced with its name.
+
+### Why is it useful?
+
+Contact and support pages need a tidy form. This lays out a two column then single column contact form with labeled fields, focus states, and a primary action, using only CSS. The transitions are removed under reduced motion.

--- a/submissions/examples/contact-form-as/demo.html
+++ b/submissions/examples/contact-form-as/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Contact Form</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <form class="contact">
+    <h2>Get in touch</h2>
+    <p class="lead">We usually reply within one business day.</p>
+    <div class="cf-row">
+      <label>Name<input type="text" placeholder="Ada Lovelace" autocomplete="name" /></label>
+      <label>Email<input type="email" placeholder="you@example.com" autocomplete="email" /></label>
+    </div>
+    <label>Subject<input type="text" placeholder="How can we help?" /></label>
+    <label>Message<textarea placeholder="Write your message"></textarea></label>
+    <button type="submit">Send message</button>
+  </form>
+</body>
+</html>

--- a/submissions/examples/contact-form-as/style.css
+++ b/submissions/examples/contact-form-as/style.css
@@ -1,0 +1,109 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.contact {
+  width: min(440px, 94vw);
+  box-sizing: border-box;
+  padding: 1.9rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 18px;
+}
+
+.contact h2 {
+  margin: 0 0 0.3rem;
+  font-size: 1.3rem;
+}
+
+.contact .lead {
+  margin: 0 0 1.5rem;
+  font-size: 0.88rem;
+  color: #94a3b8;
+}
+
+.cf-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.contact label {
+  display: block;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #cbd5e1;
+  margin-bottom: 1rem;
+}
+
+.contact input,
+.contact textarea {
+  width: 100%;
+  box-sizing: border-box;
+  margin-top: 0.35rem;
+  padding: 0.6rem 0.8rem;
+  font: inherit;
+  font-size: 0.9rem;
+  color: #e2e8f0;
+  background: #0b1424;
+  border: 1px solid #26324a;
+  border-radius: 9px;
+  outline: none;
+  transition: border-color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.contact textarea {
+  min-height: 110px;
+  resize: vertical;
+}
+
+.contact input:focus,
+.contact textarea:focus {
+  border-color: #6c63ff;
+  box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.22);
+}
+
+.contact button {
+  width: 100%;
+  padding: 0.78rem;
+  font: inherit;
+  font-weight: 600;
+  color: #fff;
+  background: #6c63ff;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.contact button:hover {
+  background: #5b52e6;
+}
+
+.contact button:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+@media (max-width: 420px) {
+  .cf-row {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .contact input,
+  .contact textarea,
+  .contact button {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a contact form built for #41118. A name and email row, subject, message textarea, and send button with focus states and a responsive stack, using only CSS. Closes #41118.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A contact form card with a name and email row, a subject field, a message textarea, and a send button, with a two column to one column layout.

**How does a developer use it?**

```html
<form class="contact">
  <div class="cf-row">
    <label>Name<input type="text" autocomplete="name" /></label>
    <label>Email<input type="email" autocomplete="email" /></label>
  </div>
  <label>Message<textarea></textarea></label>
  <button type="submit">Send message</button>
</form>
```

**Why does it fit EaseMotion CSS?**
It lays out a two column then single column contact form with labeled fields, focus states, and a primary action, using only CSS. The transitions are removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: three inputs and a textarea render, the name and email sit in a two column row, and focusing a field shows the focus ring.
