### PR TITLE
feat: add link preview card

### DIFF
--- a/submissions/examples/link-preview-as/README.md
+++ b/submissions/examples/link-preview-as/README.md
@@ -1,0 +1,24 @@
+# Link Preview Card
+
+### What does this do?
+
+It shows a link preview card, the kind that unfurls when you paste a URL, with a gradient thumbnail, a domain with a favicon dot, a title, and a two line description. The whole card is a link that lifts on hover and focus.
+
+### How is it used?
+
+```html
+<a class="link-preview" href="#">
+  <div class="lp-thumb"></div>
+  <div class="lp-body">
+    <span class="lp-domain">example.com</span>
+    <strong class="lp-title">Article title</strong>
+    <p class="lp-desc">A short description.</p>
+  </div>
+</a>
+```
+
+The card is an anchor, so it is one focusable target. The description clamps to two lines, and the domain shows a small gradient favicon block.
+
+### Why is it useful?
+
+Chat and social apps unfurl pasted links into preview cards. This lays out a horizontal link preview with a thumbnail, domain, title, and description, using only CSS with no external image. The hover lift is removed under reduced motion.

--- a/submissions/examples/link-preview-as/demo.html
+++ b/submissions/examples/link-preview-as/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Link Preview Card</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <a class="link-preview" href="#">
+    <div class="lp-thumb" aria-hidden="true"></div>
+    <div class="lp-body">
+      <span class="lp-domain">easemotion.css</span>
+      <strong class="lp-title">Build interactive components with pure CSS</strong>
+      <p class="lp-desc">A growing library of accessible, self contained CSS components you can drop into any project with no build step.</p>
+    </div>
+  </a>
+</body>
+</html>

--- a/submissions/examples/link-preview-as/style.css
+++ b/submissions/examples/link-preview-as/style.css
@@ -1,0 +1,103 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.link-preview {
+  display: flex;
+  width: min(420px, 94vw);
+  text-decoration: none;
+  color: inherit;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 14px;
+  overflow: hidden;
+  transition: transform 0.16s ease, border-color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.link-preview:hover,
+.link-preview:focus-visible {
+  transform: translateY(-2px);
+  border-color: #6c63ff;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.4);
+  outline: none;
+}
+
+.lp-thumb {
+  flex: none;
+  width: 120px;
+  background: linear-gradient(135deg, #6c63ff, #0ea5e9);
+  position: relative;
+}
+
+.lp-thumb::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.3), transparent 50%);
+}
+
+.lp-body {
+  padding: 0.9rem 1rem;
+  min-width: 0;
+}
+
+.lp-domain {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.72rem;
+  color: #94a3b8;
+  margin-bottom: 0.35rem;
+}
+
+.lp-domain::before {
+  content: "";
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  background: linear-gradient(135deg, #6c63ff, #a855f7);
+  flex: none;
+}
+
+.lp-title {
+  display: block;
+  font-size: 0.95rem;
+  line-height: 1.35;
+  margin-bottom: 0.3rem;
+}
+
+.lp-desc {
+  margin: 0;
+  font-size: 0.8rem;
+  line-height: 1.45;
+  color: #94a3b8;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+@media (max-width: 380px) {
+  .lp-thumb {
+    width: 92px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .link-preview {
+    transition: border-color 0.16s ease, box-shadow 0.16s ease;
+  }
+
+  .link-preview:hover,
+  .link-preview:focus-visible {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a link preview card built for #41120. A URL unfurl style card with a gradient thumbnail, domain, title, and clamped description, using only CSS. Closes #41120.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A link preview card with a gradient thumbnail, a domain with a favicon dot, a title, and a two line description, as a single focusable link that lifts on hover.

**How does a developer use it?**

```html
<a class="link-preview" href="#">
  <div class="lp-thumb"></div>
  <div class="lp-body">
    <span class="lp-domain">example.com</span>
    <strong class="lp-title">Article title</strong>
    <p class="lp-desc">A short description.</p>
  </div>
</a>
```

**Why does it fit EaseMotion CSS?**
It lays out a horizontal link preview with a thumbnail, domain, title, and description, using only CSS with no external image. The description clamps to two lines and the hover lift is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the card is an anchor, the thumbnail sits beside the body, and the domain and title render.
