### PR TITLE
feat: add poll results

### DIFF
--- a/submissions/examples/poll-results-as/README.md
+++ b/submissions/examples/poll-results-as/README.md
@@ -1,0 +1,26 @@
+# Poll Results
+
+### What does this do?
+
+It shows poll results where each option is a bar that fills to its vote percent from a custom property, with the label and percent on top. The leading option is highlighted and marked with a check, and a total votes line sits below.
+
+### How is it used?
+
+```html
+<div class="poll">
+  <h2>Which do you prefer?</h2>
+  <div class="poll-opt is-lead" style="--val: 52%">
+    <span class="poll-fill"></span>
+    <span class="poll-check"><svg>...</svg></span>
+    <span class="poll-label">Pure CSS</span>
+    <span class="poll-pct">52%</span>
+  </div>
+  <div class="poll-total">1,284 votes</div>
+</div>
+```
+
+Set each bar with the `--val` custom property and add `is-lead` to the winning option to accent it and show the check. The fill sits behind the label so the text stays readable.
+
+### Why is it useful?
+
+Surveys and social posts show poll results as filled bars. This renders poll option bars driven by a custom property with a highlighted winner, using only CSS. The bars animate in and hold still under reduced motion.

--- a/submissions/examples/poll-results-as/demo.html
+++ b/submissions/examples/poll-results-as/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Poll Results</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="poll">
+    <h2>Which do you prefer?</h2>
+
+    <div class="poll-opt is-lead" style="--val: 52%">
+      <span class="poll-fill"></span>
+      <span class="poll-check"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m5 13 4 4 10-11" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
+      <span class="poll-label">Pure CSS</span>
+      <span class="poll-pct">52%</span>
+    </div>
+
+    <div class="poll-opt" style="--val: 31%">
+      <span class="poll-fill"></span>
+      <span class="poll-check"></span>
+      <span class="poll-label">A tiny script</span>
+      <span class="poll-pct">31%</span>
+    </div>
+
+    <div class="poll-opt" style="--val: 12%">
+      <span class="poll-fill"></span>
+      <span class="poll-check"></span>
+      <span class="poll-label">A framework</span>
+      <span class="poll-pct">12%</span>
+    </div>
+
+    <div class="poll-opt" style="--val: 5%">
+      <span class="poll-fill"></span>
+      <span class="poll-check"></span>
+      <span class="poll-label">Not sure</span>
+      <span class="poll-pct">5%</span>
+    </div>
+
+    <div class="poll-total">1,284 votes · Poll closed</div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/poll-results-as/style.css
+++ b/submissions/examples/poll-results-as/style.css
@@ -1,0 +1,110 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.poll {
+  width: min(360px, 94vw);
+  padding: 1.5rem 1.6rem;
+  box-sizing: border-box;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+}
+
+.poll h2 {
+  margin: 0 0 1.2rem;
+  font-size: 1rem;
+}
+
+.poll-opt {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  height: 40px;
+  padding: 0 0.85rem;
+  margin-bottom: 0.6rem;
+  border-radius: 9px;
+  border: 1px solid #26324a;
+  overflow: hidden;
+}
+
+.poll-fill {
+  position: absolute;
+  inset: 0;
+  width: var(--val, 0%);
+  background: #1b2942;
+  border-radius: 8px;
+  animation: poll-grow 0.85s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.poll-opt.is-lead .poll-fill {
+  background: rgba(108, 99, 255, 0.35);
+}
+
+.poll-check {
+  position: relative;
+  width: 15px;
+  height: 15px;
+  flex: none;
+  color: #a5b4fc;
+  opacity: 0;
+}
+
+.poll-opt.is-lead .poll-check {
+  opacity: 1;
+}
+
+.poll-check svg {
+  width: 15px;
+  height: 15px;
+  stroke: currentColor;
+  stroke-width: 2.5;
+  fill: none;
+}
+
+.poll-label {
+  position: relative;
+  flex: 1;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.poll-pct {
+  position: relative;
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: #cbd5e1;
+  font-variant-numeric: tabular-nums;
+}
+
+.poll-opt.is-lead {
+  border-color: #6c63ff;
+}
+
+.poll-total {
+  margin-top: 0.9rem;
+  font-size: 0.76rem;
+  color: #64748b;
+}
+
+@keyframes poll-grow {
+  from {
+    width: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .poll-fill {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds poll results built for #41122. Option bars that fill to a custom property percent with a highlighted winner, using only CSS. Closes #41122.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A poll results block where each option bar fills to its vote percent, the leading option is accented and marked with a check, and a total votes line sits below.

**How does a developer use it?**

```html
<div class="poll">
  <div class="poll-opt is-lead" style="--val: 52%">
    <span class="poll-fill"></span>
    <span class="poll-check"><svg>...</svg></span>
    <span class="poll-label">Pure CSS</span>
    <span class="poll-pct">52%</span>
  </div>
  <div class="poll-total">1,284 votes</div>
</div>
```

**Why does it fit EaseMotion CSS?**
It renders poll option bars driven by a `--val` custom property with a highlighted winner via `is-lead`, using only CSS. The fill sits behind the label so text stays readable, and the bars hold still under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: four option bars fill toward 52, 31, 12, and 5 percent, and the leading option shows its check and accent fill.
