### PR TITLE
feat: add typewriter loop with variable font weight shift

### DIFF
--- a/submissions/examples/ease-typewriter-weight-bb/README.md
+++ b/submissions/examples/ease-typewriter-weight-bb/README.md
@@ -1,0 +1,20 @@
+# Typewriter Loop with Variable Weight Shift
+
+A responsive typographic loop shifting weights dynamically during execution.
+
+## What does this do?
+It types characters sequentially inside a terminal-like HUD display module, while dynamically interpolating the variable font-weight metrics (`200` to `800`) relative to typing progression limits.
+
+## How is it used?
+Configure standard containers with the typewriter classes and apply the active character output triggers:
+
+```html
+<div class="typewriter-box">
+  <span class="mono-prefix">> dev.status: </span>
+  <span class="dynamic-text" id="typewriter-text"></span>
+  <span class="cursor-blink">|</span>
+</div>
+```
+
+## Why is it useful?
+It creates modern developer status monitors and interactive hero headers, leveraging variable weight fonts to convey tactile terminal feedback.

--- a/submissions/examples/ease-typewriter-weight-bb/demo.html
+++ b/submissions/examples/ease-typewriter-weight-bb/demo.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Typewriter Loop with Variable Weight Shift - EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@200;400;600;800&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <main class="demo-wrapper">
+    <header class="demo-header">
+      <h1>Typewriter Loop with Variable Weight Shift</h1>
+      <p>A typographic display component featuring recursive characters typed in sequence, coupled with dynamic font-weight shifting on active loops.</p>
+    </header>
+
+    <section class="typewriter-container">
+      <div class="typewriter-box">
+        <span class="mono-prefix">> dev.status: </span>
+        <span class="dynamic-text" id="typewriter-text"></span>
+        <span class="cursor-blink">|</span>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    const words = ["analyzing_telemetry...", "system_load_optimal", "compiling_stylesheets...", "deployment_successful"];
+    let wordIndex = 0;
+    let charIndex = 0;
+    let isDeleting = false;
+    const targetElement = document.getElementById("typewriter-text");
+
+    function typeEffect() {
+      const currentWord = words[wordIndex];
+      
+      if (isDeleting) {
+        targetElement.textContent = currentWord.substring(0, charIndex - 1);
+        charIndex--;
+      } else {
+        targetElement.textContent = currentWord.substring(0, charIndex + 1);
+        charIndex++;
+      }
+
+      // Smooth weight morphing based on typing percentage
+      const progress = charIndex / currentWord.length;
+      let weight = 200 + Math.round(progress * 600); // Scale from 200 to 800
+      targetElement.style.fontWeight = weight;
+
+      let typingSpeed = isDeleting ? 40 : 80;
+
+      if (!isDeleting && charIndex === currentWord.length) {
+        // Pause at full word
+        typingSpeed = 2000;
+        isDeleting = true;
+      } else if (isDeleting && charIndex === 0) {
+        isDeleting = false;
+        wordIndex = (wordIndex + 1) % words.length;
+        typingSpeed = 400; // Pause before typing next word
+      }
+
+      setTimeout(typeEffect, typingSpeed);
+    }
+
+    // Initialize typewriter
+    setTimeout(typeEffect, 500);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-typewriter-weight-bb/style.css
+++ b/submissions/examples/ease-typewriter-weight-bb/style.css
@@ -1,0 +1,114 @@
+:root {
+  --bg-primary: #080a10;
+  --bg-box: #111420;
+  --text-main: #f9fafb;
+  --text-muted: #9ca3af;
+  --color-cursor: #f43f5e;
+  --font-family: 'Plus Jakarta Sans', system-ui, sans-serif;
+  --font-mono: 'Space Mono', monospace;
+  --ease-smooth: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-primary);
+  color: var(--text-main);
+  font-family: var(--font-family);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2.5rem;
+}
+
+.demo-wrapper {
+  max-width: 900px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 3.5rem;
+}
+
+.demo-header {
+  text-align: center;
+}
+
+.demo-header h1 {
+  font-size: 2.25rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+  letter-spacing: -0.025em;
+  background: linear-gradient(135deg, #ffffff 0%, #f43f5e 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.demo-header p {
+  font-size: 1rem;
+  color: var(--text-muted);
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+/* Typewriter container styling */
+.typewriter-container {
+  display: flex;
+  justify-content: center;
+}
+
+.typewriter-box {
+  background-color: var(--bg-box);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 1.25rem;
+  padding: 1.75rem 2.5rem;
+  font-size: 1.5rem;
+  font-family: var(--font-mono);
+  box-shadow: 0 10px 30px -10px rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  max-width: 650px;
+  width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.mono-prefix {
+  color: var(--text-muted);
+  font-weight: 400;
+}
+
+.dynamic-text {
+  color: var(--text-main);
+  /* font-weight will be animated via script */
+  transition: font-weight 0.15s var(--ease-smooth);
+  margin-left: 0.25rem;
+}
+
+/* Active cursor blinking animation */
+.cursor-blink {
+  color: var(--color-cursor);
+  font-weight: 700;
+  margin-left: 0.15rem;
+  animation: blink 1s step-end infinite;
+}
+
+@keyframes blink {
+  from, to { color: transparent }
+  50% { color: var(--color-cursor) }
+}
+
+/* Reduced motion preference support */
+@media (prefers-reduced-motion: reduce) {
+  .dynamic-text {
+    transition: none !important;
+  }
+  .cursor-blink {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
# Related Issue
Closes #41150

# Summary
Adds a variable weight shifting typewriter loop under Standard Track examples.

# Changes Made
- Created new subdirectory `submissions/examples/ease-typewriter-weight-bb/`
- Added terminal console simulation mockup `demo.html`
- Added custom mono styling, cursor blink animations, and font-weight selectors in `style.css`
- Added usage instructions in `README.md`

# Testing
- Tested recursive timer intervals across browsers
- Verified accessible cursor blinking settings
- Handled prefers-reduced-motion media settings

# Impact
Enriches typography motion effects within the EaseMotion CSS catalog.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered
