### PR TITLE
feat: add elastic off-canvas side drawer navigation

### DIFF
--- a/submissions/examples/ease-elastic-drawer-nav-bb/README.md
+++ b/submissions/examples/ease-elastic-drawer-nav-bb/README.md
@@ -1,0 +1,24 @@
+# Elastic Off-Canvas Drawer Navigation
+
+A premium mobile-responsive off-canvas drawer navigation.
+
+## What does this do?
+It builds an off-canvas drawer layout which slides and bounces elastically from the side bounds, while staggered links progressively fade-in depending on active open/close trigger events.
+
+## How is it used?
+Configure standard HTML elements with the drawer container selectors:
+
+```html
+<nav class="drawer-panel" id="drawer-panel">
+  <div class="drawer-header">
+    <h2>Menu Directory</h2>
+    <button class="close-btn" id="close-drawer">✕</button>
+  </div>
+  <ul class="nav-links">
+    <li style="--delay: 1;"><a href="#">Link</a></li>
+  </ul>
+</nav>
+```
+
+## Why is it useful?
+It provides fluid off-canvas navigation options for mobile-responsive viewports, utilizing CSS transit parameters and staggered delay selectors.

--- a/submissions/examples/ease-elastic-drawer-nav-bb/demo.html
+++ b/submissions/examples/ease-elastic-drawer-nav-bb/demo.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Elastic Off-Canvas Drawer Navigation - EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <main class="demo-wrapper">
+    <header class="demo-header">
+      <h1>Elastic Off-Canvas Drawer Navigation</h1>
+      <p>Premium mobile navigation drawer using custom spring-physics transitions to slide and bounce in elastically.</p>
+      <button class="trigger-btn" id="open-drawer">Open Navigation Menu</button>
+    </header>
+
+    <!-- Overlay Scrim Backdrop -->
+    <div class="drawer-scrim" id="drawer-scrim"></div>
+
+    <!-- Drawer Navigation Panel -->
+    <nav class="drawer-panel" id="drawer-panel">
+      <div class="drawer-header">
+        <h2>Menu Directory</h2>
+        <button class="close-btn" id="close-drawer" aria-label="Close menu">✕</button>
+      </div>
+
+      <ul class="nav-links">
+        <li style="--delay: 1;"><a href="#"><span>⚡</span> Overview Console</a></li>
+        <li style="--delay: 2;"><a href="#"><span>📊</span> Telemetry Reports</a></li>
+        <li style="--delay: 3;"><a href="#"><span>🔒</span> Authorization Keys</a></li>
+        <li style="--delay: 4;"><a href="#"><span>⚙️</span> Cluster Config</a></li>
+      </ul>
+
+      <div class="drawer-footer">
+        <div class="node-badge">
+          <span class="pulse-dot"></span> Node Alpha-1 Connected
+        </div>
+      </div>
+    </nav>
+  </main>
+
+  <script>
+    const openBtn = document.getElementById('open-drawer');
+    const closeBtn = document.getElementById('close-drawer');
+    const scrim = document.getElementById('drawer-scrim');
+    const panel = document.getElementById('drawer-panel');
+
+    function toggleDrawer(open) {
+      if (open) {
+        scrim.classList.add('is-active');
+        panel.classList.add('is-active');
+      } else {
+        scrim.classList.remove('is-active');
+        panel.classList.remove('is-active');
+      }
+    }
+
+    openBtn.addEventListener('click', () => toggleDrawer(true));
+    closeBtn.addEventListener('click', () => toggleDrawer(false));
+    scrim.addEventListener('click', () => toggleDrawer(false));
+
+    // Handle escape key to close drawer
+    document.addEventListener('keydown', e => {
+      if (e.key === 'Escape') toggleDrawer(false);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-elastic-drawer-nav-bb/style.css
+++ b/submissions/examples/ease-elastic-drawer-nav-bb/style.css
@@ -1,0 +1,234 @@
+:root {
+  --bg-primary: #080a10;
+  --bg-panel: #111422;
+  --text-main: #f9fafb;
+  --text-muted: #9ca3af;
+  --primary-accent: #6366f1;
+  --font-family: 'Plus Jakarta Sans', system-ui, sans-serif;
+  --ease-elastic: cubic-bezier(0.68, -0.6, 0.32, 1.6);
+  --ease-smooth: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-primary);
+  color: var(--text-main);
+  font-family: var(--font-family);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2.5rem;
+  overflow-x: hidden;
+}
+
+.demo-wrapper {
+  max-width: 800px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+.demo-header {
+  text-align: center;
+}
+
+.demo-header h1 {
+  font-size: 2.25rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+  letter-spacing: -0.025em;
+  background: linear-gradient(135deg, #ffffff 0%, #6366f1 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.demo-header p {
+  font-size: 1rem;
+  color: var(--text-muted);
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+/* Open button config */
+.trigger-btn {
+  background-color: var(--primary-accent);
+  border: none;
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 0.85rem 1.75rem;
+  border-radius: 1rem;
+  cursor: pointer;
+  margin-top: 2rem;
+  box-shadow: 0 10px 20px -5px rgba(99, 102, 241, 0.4);
+  transition: transform 0.4s var(--ease-elastic), 
+              box-shadow 0.3s var(--ease-smooth);
+}
+
+.trigger-btn:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 15px 25px -5px rgba(99, 102, 241, 0.6);
+}
+
+.trigger-btn:active {
+  transform: translateY(-1px);
+}
+
+/* Backdrop Scrim overlay */
+.drawer-scrim {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  opacity: 0;
+  pointer-events: none;
+  z-index: 99;
+  transition: opacity 0.4s var(--ease-smooth);
+}
+
+.drawer-scrim.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Drawer off-canvas panel */
+.drawer-panel {
+  position: fixed;
+  top: 0;
+  right: -360px; /* Hidden off-screen right */
+  width: 100%;
+  max-width: 360px;
+  height: 100vh;
+  background-color: var(--bg-panel);
+  border-left: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: -15px 0 35px -10px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 2.5rem;
+  z-index: 100;
+  transition: transform 0.5s var(--ease-elastic);
+}
+
+/* Active panel state translated on x-axis */
+.drawer-panel.is-active {
+  transform: translateX(-360px);
+}
+
+/* Header Close items */
+.drawer-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+}
+
+.drawer-header h2 {
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 1.25rem;
+  cursor: pointer;
+  transition: color 0.3s var(--ease-smooth);
+}
+
+.close-btn:hover {
+  color: var(--text-main);
+}
+
+/* Nav Links lists with slide-in staggered delays */
+.nav-links {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin-bottom: auto;
+  margin-top: 1.5rem;
+}
+
+.nav-links li {
+  transform: translateX(40px);
+  opacity: 0;
+  transition: transform 0.5s var(--ease-elastic), opacity 0.4s var(--ease-smooth);
+  transition-delay: calc(var(--delay) * 0.06s);
+}
+
+.drawer-panel.is-active .nav-links li {
+  transform: translateX(0);
+  opacity: 1;
+}
+
+.nav-links a {
+  text-decoration: none;
+  color: var(--text-muted);
+  font-weight: 600;
+  font-size: 1.1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  transition: color 0.3s var(--ease-smooth), transform 0.3s var(--ease-smooth);
+}
+
+.nav-links a:hover {
+  color: var(--text-main);
+  transform: translateX(6px);
+}
+
+/* Footer Badge status indicators */
+.drawer-footer {
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  padding-top: 1.5rem;
+}
+
+.node-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #10b981;
+}
+
+.pulse-dot {
+  width: 8px;
+  height: 8px;
+  background-color: #10b981;
+  border-radius: 50%;
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0% { transform: scale(1); box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.7); }
+  70% { transform: scale(1.1); box-shadow: 0 0 0 8px rgba(16, 185, 129, 0); }
+  100% { transform: scale(1); box-shadow: 0 0 0 0 rgba(16, 185, 129, 0); }
+}
+
+/* Reduced motion preference support */
+@media (prefers-reduced-motion: reduce) {
+  .trigger-btn,
+  .drawer-scrim,
+  .drawer-panel,
+  .nav-links li,
+  .nav-links a,
+  .pulse-dot {
+    transition: none !important;
+    transform: none !important;
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
# Related Issue
Closes #41154

# Summary
Adds a premium off-canvas mobile drawer navigation component under Standard Track examples.

# Changes Made
- Created new subdirectory `submissions/examples/ease-elastic-drawer-nav-bb/`
- Added interactive off-canvas layout container `demo.html`
- Added scrim overlays, spring-physics panels, and staggered animation links in `style.css`
- Added detailed instructions in `README.md`

# Testing
- Tested drawer state open/close actions across mobile responsive bounds
- Verified backdrop scrim event triggers and focus outlines
- Handled prefers-reduced-motion compatibility configurations

# Impact
Enriches off-canvas animation highlights in the EaseMotion CSS catalog.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered
