### PR TITLE
feat: add cyberpunk glitch HUD action badge animation

### DIFF
--- a/submissions/examples/ease-cyber-glitch-badge-bb/README.md
+++ b/submissions/examples/ease-cyber-glitch-badge-bb/README.md
@@ -1,0 +1,19 @@
+# Cyberpunk Glitch HUD Badges
+
+A set of responsive cyberpunk badge components with periodic light clipping animations.
+
+## What does this do?
+It builds dashboard status badges that trigger color-shifted clipping overlays on hover or focus events, simulating classic cyberpunk HUD glitches.
+
+## How is it used?
+Configure standard elements with the glitch badge selectors:
+
+```html
+<div class="glitch-badge badge-online" tabindex="0">
+  <span class="scan-overlay"></span>
+  <span class="badge-text" data-text="SYS_ONLINE">SYS_ONLINE</span>
+</div>
+```
+
+## Why is it useful?
+It provides themed, lightweight highlight components, leveraging pure CSS animations and pseudo-elements.

--- a/submissions/examples/ease-cyber-glitch-badge-bb/demo.html
+++ b/submissions/examples/ease-cyber-glitch-badge-bb/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cyberpunk Glitch HUD Badges - EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <main class="demo-wrapper">
+    <header class="demo-header">
+      <h1>Cyberpunk Glitch HUD Badges</h1>
+      <p>Action badges styled with periodic light clipping animations, custom holographic scan overlays, and responsive hover offsets.</p>
+    </header>
+
+    <section class="badges-container">
+      <!-- Badge 1: System Online -->
+      <div class="glitch-badge badge-online" tabindex="0">
+        <span class="scan-overlay"></span>
+        <span class="badge-text" data-text="SYS_ONLINE">SYS_ONLINE</span>
+      </div>
+
+      <!-- Badge 2: Warn Critical -->
+      <div class="glitch-badge badge-warning" tabindex="0">
+        <span class="scan-overlay"></span>
+        <span class="badge-text" data-text="WARN_CRITICAL">WARN_CRITICAL</span>
+      </div>
+
+      <!-- Badge 3: Node Blocked -->
+      <div class="glitch-badge badge-blocked" tabindex="0">
+        <span class="scan-overlay"></span>
+        <span class="badge-text" data-text="NODE_MUTED">NODE_MUTED</span>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-cyber-glitch-badge-bb/style.css
+++ b/submissions/examples/ease-cyber-glitch-badge-bb/style.css
@@ -1,0 +1,202 @@
+:root {
+  --bg-primary: #05060b;
+  --bg-badge: #0e111d;
+  --text-main: #f9fafb;
+  --text-muted: #6b7280;
+  
+  /* Cyber Colors */
+  --cyber-green: #10b981;
+  --cyber-yellow: #f59e0b;
+  --cyber-pink: #f43f5e;
+  
+  --font-mono: 'Space Mono', monospace;
+  --ease-elastic: cubic-bezier(0.68, -0.6, 0.32, 1.6);
+  --ease-smooth: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-primary);
+  color: var(--text-main);
+  font-family: var(--font-mono);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2.5rem;
+}
+
+.demo-wrapper {
+  max-width: 800px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 3.5rem;
+}
+
+.demo-header {
+  text-align: center;
+}
+
+.demo-header h1 {
+  font-size: 2.25rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+  letter-spacing: -0.02em;
+  background: linear-gradient(135deg, #ffffff 0%, var(--cyber-pink) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.demo-header p {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.badges-container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 2rem;
+}
+
+/* Base Glitch Badge Styles */
+.glitch-badge {
+  position: relative;
+  background-color: var(--bg-badge);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  cursor: pointer;
+  outline: none;
+  font-weight: 700;
+  font-size: 1rem;
+  overflow: hidden;
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
+  transition: transform 0.4s var(--ease-elastic), 
+              border-color 0.3s var(--ease-smooth),
+              box-shadow 0.3s var(--ease-smooth);
+}
+
+.glitch-badge:hover,
+.glitch-badge:focus-visible {
+  transform: translateY(-4px) scale(1.03);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.7);
+}
+
+/* Badge variants */
+.badge-online {
+  border-color: rgba(16, 185, 129, 0.2);
+  color: var(--cyber-green);
+}
+.badge-online:hover,
+.badge-online:focus-visible {
+  border-color: var(--cyber-green);
+  box-shadow: 0 0 15px -3px rgba(16, 185, 129, 0.3);
+}
+
+.badge-warning {
+  border-color: rgba(245, 158, 11, 0.2);
+  color: var(--cyber-yellow);
+}
+.badge-warning:hover,
+.badge-warning:focus-visible {
+  border-color: var(--cyber-yellow);
+  box-shadow: 0 0 15px -3px rgba(245, 158, 11, 0.3);
+}
+
+.badge-blocked {
+  border-color: rgba(244, 63, 94, 0.2);
+  color: var(--cyber-pink);
+}
+.badge-blocked:hover,
+.badge-blocked:focus-visible {
+  border-color: var(--cyber-pink);
+  box-shadow: 0 0 15px -3px rgba(244, 63, 94, 0.3);
+}
+
+/* Holographic scanline overlay */
+.scan-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+  background: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0),
+    rgba(255, 255, 255, 0.05) 50%,
+    rgba(255, 255, 255, 0)
+  );
+  background-size: 100% 4px;
+  z-index: 1;
+}
+
+/* Periodic Glitch Text effect using data attributes */
+.badge-text {
+  position: relative;
+  display: inline-block;
+  z-index: 2;
+}
+
+.glitch-badge:hover .badge-text::before,
+.glitch-badge:focus-visible .badge-text::before,
+.glitch-badge:hover .badge-text::after,
+.glitch-badge:focus-visible .badge-text::after {
+  content: attr(data-text);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--bg-badge);
+}
+
+.glitch-badge:hover .badge-text::before,
+.glitch-badge:focus-visible .badge-text::before {
+  left: 2px;
+  text-shadow: -1px 0 #ef4444;
+  clip: rect(10px, 9999px, 20px, 0);
+  animation: glitch-anim 1s infinite linear alternate-reverse;
+}
+
+.glitch-badge:hover .badge-text::after,
+.glitch-badge:focus-visible .badge-text::after {
+  left: -2px;
+  text-shadow: -1px 0 #06b6d4;
+  clip: rect(25px, 9999px, 35px, 0);
+  animation: glitch-anim2 1.5s infinite linear alternate-reverse;
+}
+
+@keyframes glitch-anim {
+  0% { clip: rect(15px, 9999px, 22px, 0) }
+  50% { clip: rect(5px, 9999px, 12px, 0) }
+  100% { clip: rect(28px, 9999px, 35px, 0) }
+}
+
+@keyframes glitch-anim2 {
+  0% { clip: rect(3px, 9999px, 9px, 0) }
+  50% { clip: rect(18px, 9999px, 25px, 0) }
+  100% { clip: rect(12px, 9999px, 17px, 0) }
+}
+
+/* Reduced motion preference support */
+@media (prefers-reduced-motion: reduce) {
+  .glitch-badge {
+    transition: none !important;
+    transform: none !important;
+  }
+  .badge-text::before,
+  .badge-text::after {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
# Related Issue
Closes #41158

# Summary
Adds themed cyberpunk action badges with scanline highlights and glitch clipping under Standard Track examples.

# Changes Made
- Created new subdirectory `submissions/examples/ease-cyber-glitch-badge-bb/`
- Added terminal simulation layout `demo.html`
- Added custom mono parameters, scanline grids, and glitch keyframes in `style.css`
- Added usage instructions in `README.md`

# Testing
- Tested animation clipping bounds on various viewports
- Confirmed keyboard navigation focus outlines
- Checked accessibility prefers-reduced-motion compatibility configurations

# Impact
Adds modern micro-animation badge examples to the EaseMotion CSS catalog.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered
