### PR TITLE
feat: add date range picker component

### DIFF
--- a/submissions/examples/ease-date-range-picker/README.md
+++ b/submissions/examples/ease-date-range-picker/README.md
@@ -1,0 +1,39 @@
+# Ease Date Range Picker
+
+## Description
+A date range picker with an animated popover showing two connected month calendars. Click a start date, then an end date — the range between them highlights automatically. Popover animates in with a scale/fade/slide transition.
+
+## Features
+- Two-month connected calendar view
+- Click-to-select range (start → end)
+- Animated popover open/close and selected-day "pop" animation
+- Closes when clicking outside
+- Navigate months independently via the left calendar's prev/next controls (right calendar follows)
+- Respects `prefers-reduced-motion`
+
+## Usage
+Include `style.css` and `date-range-picker.js`, and use the markup structure from `demo.html`:
+```html
+<div class="ease-date-range">
+  <input type="text" class="range-input" placeholder="Select date range" readonly />
+  <div class="range-popover">
+    <!-- two .range-month blocks, see demo.html -->
+  </div>
+</div>
+<script src="date-range-picker.js"></script>
+```
+
+## Customization (CSS custom properties)
+| Property | Default | Description |
+|---|---|---|
+| `--range-duration` | `0.25s` | Popover animation duration |
+| `--range-easing` | `cubic-bezier(0.16, 1, 0.3, 1)` | Timing function |
+| `--range-accent` | `#38bdf8` | Selected day / accent color |
+| `--range-in-range` | `rgba(56, 189, 248, 0.15)` | Background for days within the selected range |
+| `--range-bg` | `#14141c` | Popover/input background |
+
+## Files
+- `demo.html` — live working example
+- `style.css` — component styles and animations
+- `date-range-picker.js` — calendar rendering and range selection logic
+- `README.md` — this file

--- a/submissions/examples/ease-date-range-picker/date-range-picker.js
+++ b/submissions/examples/ease-date-range-picker/date-range-picker.js
@@ -1,0 +1,130 @@
+/**
+ * Ease Date Range Picker
+ * Minimal vanilla JS handling calendar rendering and range selection state.
+ * All visual transitions (popover open/close, selected-day pop) are CSS-driven
+ * via the `.is-open`, `.is-start`, `.is-end`, `.is-in-range` classes.
+ */
+(function () {
+  const container = document.querySelector(".ease-date-range");
+  if (!container) return;
+
+  const input = container.querySelector(".range-input");
+  const popover = container.querySelector(".range-popover");
+  const monthEls = container.querySelectorAll(".range-month");
+
+  let viewDate = new Date();
+  let rangeStart = null;
+  let rangeEnd = null;
+
+  const MONTH_NAMES = ["January","February","March","April","May","June","July","August","September","October","November","December"];
+  const WEEKDAYS = ["Su","Mo","Tu","We","Th","Fr","Sa"];
+
+  function sameDay(a, b) {
+    return a && b && a.toDateString() === b.toDateString();
+  }
+
+  function renderMonth(monthEl, monthOffset) {
+    const date = new Date(viewDate.getFullYear(), viewDate.getMonth() + monthOffset, 1);
+    const year = date.getFullYear();
+    const month = date.getMonth();
+
+    monthEl.querySelector(".range-month-header .month-label").textContent =
+      `${MONTH_NAMES[month]} ${year}`;
+
+    const daysGrid = monthEl.querySelector(".range-days");
+    daysGrid.innerHTML = "";
+
+    const firstDay = new Date(year, month, 1).getDay();
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+    const daysInPrevMonth = new Date(year, month, 0).getDate();
+
+    // leading muted days
+    for (let i = firstDay - 1; i >= 0; i--) {
+      daysGrid.appendChild(makeDayBtn(daysInPrevMonth - i, true, null));
+    }
+
+    for (let d = 1; d <= daysInMonth; d++) {
+      const cellDate = new Date(year, month, d);
+      daysGrid.appendChild(makeDayBtn(d, false, cellDate));
+    }
+
+    // trailing muted days to fill grid
+    const totalCells = daysGrid.children.length;
+    const remainder = totalCells % 7;
+    if (remainder !== 0) {
+      for (let d = 1; d <= 7 - remainder; d++) {
+        daysGrid.appendChild(makeDayBtn(d, true, null));
+      }
+    }
+  }
+
+  function makeDayBtn(dayNum, muted, cellDate) {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "range-day";
+    btn.textContent = dayNum;
+
+    if (muted || !cellDate) {
+      btn.classList.add("is-muted");
+      return btn;
+    }
+
+    if (sameDay(cellDate, rangeStart)) btn.classList.add("is-start");
+    if (sameDay(cellDate, rangeEnd)) btn.classList.add("is-end");
+    if (rangeStart && rangeEnd && cellDate > rangeStart && cellDate < rangeEnd) {
+      btn.classList.add("is-in-range");
+    }
+
+    btn.addEventListener("click", () => handleDayClick(cellDate));
+    return btn;
+  }
+
+  function handleDayClick(date) {
+    if (!rangeStart || (rangeStart && rangeEnd)) {
+      rangeStart = date;
+      rangeEnd = null;
+    } else if (date < rangeStart) {
+      rangeEnd = rangeStart;
+      rangeStart = date;
+    } else {
+      rangeEnd = date;
+    }
+    updateInputLabel();
+    renderAll();
+  }
+
+  function updateInputLabel() {
+    if (rangeStart && rangeEnd) {
+      input.value = `${rangeStart.toLocaleDateString()} — ${rangeEnd.toLocaleDateString()}`;
+    } else if (rangeStart) {
+      input.value = `${rangeStart.toLocaleDateString()} — ...`;
+    } else {
+      input.value = "";
+    }
+  }
+
+  function renderAll() {
+    monthEls.forEach((el, i) => renderMonth(el, i));
+  }
+
+  container.querySelectorAll(".range-nav-btn").forEach((btn) => {
+    btn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      const dir = btn.dataset.dir === "next" ? 1 : -1;
+      viewDate.setMonth(viewDate.getMonth() + dir);
+      renderAll();
+    });
+  });
+
+  input.addEventListener("click", () => {
+    container.classList.toggle("is-open");
+  });
+
+  document.addEventListener("click", (e) => {
+    if (!container.contains(e.target)) {
+      container.classList.remove("is-open");
+    }
+  });
+
+  renderAll();
+})();

--- a/submissions/examples/ease-date-range-picker/demo.html
+++ b/submissions/examples/ease-date-range-picker/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ease Date Range Picker — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: flex-start;
+      justify-content: center;
+      padding-top: 100px;
+      background: #0f172a;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="ease-date-range">
+    <input type="text" class="range-input" placeholder="Select date range" readonly />
+
+    <div class="range-popover">
+      <div class="range-month">
+        <div class="range-month-header">
+          <button type="button" class="range-nav-btn" data-dir="prev">‹</button>
+          <span class="month-label"></span>
+          <button type="button" class="range-nav-btn" data-dir="next">›</button>
+        </div>
+        <div class="range-weekdays">
+          <span>Su</span><span>Mo</span><span>Tu</span><span>We</span><span>Th</span><span>Fr</span><span>Sa</span>
+        </div>
+        <div class="range-days"></div>
+      </div>
+
+      <div class="range-month">
+        <div class="range-month-header">
+          <span></span>
+          <span class="month-label"></span>
+          <span></span>
+        </div>
+        <div class="range-weekdays">
+          <span>Su</span><span>Mo</span><span>Tu</span><span>We</span><span>Th</span><span>Fr</span><span>Sa</span>
+        </div>
+        <div class="range-days"></div>
+      </div>
+    </div>
+  </div>
+
+  <script src="date-range-picker.js"></script>
+</body>
+</html>

--- a/submissions/examples/ease-date-range-picker/style.css
+++ b/submissions/examples/ease-date-range-picker/style.css
@@ -1,0 +1,172 @@
+/* Ease Date Range Picker — pure CSS animated popover, JS handles date logic */
+
+.ease-date-range {
+  --range-bg: #14141c;
+  --range-fg: #f5f7fa;
+  --range-border: #2a2a3f;
+  --range-accent: #38bdf8;
+  --range-in-range: rgba(56, 189, 248, 0.15);
+  --range-duration: 0.25s;
+  --range-easing: cubic-bezier(0.16, 1, 0.3, 1);
+
+  position: relative;
+  display: inline-block;
+  font-family: system-ui, sans-serif;
+  width: 280px;
+}
+
+.ease-date-range .range-input {
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--range-bg);
+  border: 1px solid var(--range-border);
+  color: var(--range-fg);
+  padding: 12px 16px;
+  border-radius: 10px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  outline: none;
+  transition: border-color 0.2s ease;
+}
+
+.ease-date-range .range-input:focus {
+  border-color: var(--range-accent);
+}
+
+.ease-date-range .range-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  background: var(--range-bg);
+  border: 1px solid var(--range-border);
+  border-radius: 14px;
+  padding: 18px;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.4);
+  display: flex;
+  gap: 20px;
+  z-index: 100;
+
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-8px) scale(0.97);
+  transform-origin: top left;
+  pointer-events: none;
+  transition:
+    opacity var(--range-duration) var(--range-easing),
+    transform var(--range-duration) var(--range-easing),
+    visibility var(--range-duration);
+}
+
+.ease-date-range.is-open .range-popover {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.range-month {
+  width: 220px;
+}
+
+.range-month-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+  color: var(--range-fg);
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+
+.range-nav-btn {
+  background: transparent;
+  border: none;
+  color: #94a3b8;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.range-nav-btn:hover {
+  background: rgba(56, 189, 248, 0.1);
+  color: var(--range-accent);
+}
+
+.range-weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
+  margin-bottom: 6px;
+}
+.range-weekdays span {
+  font-size: 0.7rem;
+  color: #64748b;
+  text-align: center;
+}
+
+.range-days {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
+}
+
+.range-day {
+  position: relative;
+  background: transparent;
+  border: none;
+  color: #cbd5e1;
+  font-size: 0.8rem;
+  padding: 7px 0;
+  cursor: pointer;
+  border-radius: 6px;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.range-day:hover {
+  background: rgba(56, 189, 248, 0.12);
+}
+
+.range-day:focus-visible {
+  outline: 2px solid var(--range-accent);
+  outline-offset: 1px;
+}
+
+.range-day.is-muted {
+  color: #3f4759;
+  pointer-events: none;
+}
+
+.range-day.is-in-range {
+  background: var(--range-in-range);
+  border-radius: 0;
+}
+
+.range-day.is-start,
+.range-day.is-end {
+  background: var(--range-accent);
+  color: #0b0f19;
+  font-weight: 700;
+  border-radius: 6px;
+  animation: range-pop 0.25s var(--range-easing);
+}
+
+.range-day.is-start { border-radius: 6px 0 0 6px; }
+.range-day.is-end   { border-radius: 0 6px 6px 0; }
+.range-day.is-start.is-end { border-radius: 6px; }
+
+@keyframes range-pop {
+  from { transform: scale(0.7); }
+  to   { transform: scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-date-range .range-popover {
+    transition: opacity 0.15s ease;
+    transform: none;
+  }
+  .range-day.is-start,
+  .range-day.is-end {
+    animation: none;
+  }
+}


### PR DESCRIPTION
Closes #40880

## Pull Request Description
Adds a date range picker component with an animated popover showing two connected month calendars. Users click a start date and an end date; the days between highlight automatically. The popover opens/closes with a smooth scale/fade/slide transition, and selected endpoints animate with a subtle pop.

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-date-range-picker/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A two-month date range picker with a click-to-select range, animated popover, in-range day highlighting, and a pop animation on the selected start/end dates.

**How does a developer use it?**
```html
<div class="ease-date-range">
  <input type="text" class="range-input" placeholder="Select date range" readonly />
  <div class="range-popover">
    <!-- two .range-month blocks — see demo.html for full structure -->
  </div>
</div>
<script src="date-range-picker.js"></script>
```

**Why does it fit EaseMotion CSS?**
All visual transitions — popover open/close (scale + fade + slide) and the selected-day pop-in — are handled purely in CSS via class toggles (`.is-open`, `.is-start`, `.is-end`, `.is-in-range`), fully customizable through CSS custom properties (`--range-duration`, `--range-easing`, `--range-accent`, `--range-in-range`) without touching core rules. JavaScript is scoped strictly to calendar date logic (rendering days, tracking range state, closing on outside click) — no animation logic lives in JS. Respects `prefers-reduced-motion`.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
The issue description was minimal ("Create the ease-date-range-picker component"), so I implemented a standard two-month connected calendar range picker (click start → click end, range highlights between them) as a sensible default. Happy to adjust behavior/scope if a more specific spec was intended.