### PR TITLE
feat: add volume control slider component

### DIFF
--- a/submissions/examples/ease-volume-control-slider/README.md
+++ b/submissions/examples/ease-volume-control-slider/README.md
@@ -1,0 +1,43 @@
+# Ease Volume Control Slider
+
+## Description
+A styled range-input volume slider with an animated fill, mute/unmute toggle button with icon swap, and a live percentage label.
+
+## Features
+- Custom-styled `<input type="range">` with animated gradient fill tracking the current value
+- Mute button toggles volume to 0 and remembers the previous level to restore on unmute
+- Icon morphs between speaker and muted-speaker states
+- Fully keyboard accessible (native range input + focusable button)
+- Customizable via CSS custom properties (colors, thumb size, track height)
+- Respects `prefers-reduced-motion`
+
+## Usage
+```html
+<div class="ease-volume" style="--volume-percent: 70%;">
+  <button type="button" class="volume-icon-btn" aria-label="Mute/unmute volume">
+    <svg class="icon-on">...</svg>
+    <svg class="icon-muted">...</svg>
+  </button>
+  <div class="volume-track-wrap">
+    <input type="range" class="volume-slider" min="0" max="100" value="70" aria-label="Volume" />
+  </div>
+  <span class="volume-percent-label">70%</span>
+</div>
+<script src="volume-slider.js"></script>
+```
+
+## Customization (CSS custom properties)
+| Property | Default | Description |
+|---|---|---|
+| `--volume-fill-color` | `#38bdf8` | Filled portion of the track / accent color |
+| `--volume-track-bg` | `#2a2a3f` | Unfilled track background |
+| `--volume-thumb-color` | `#f5f7fa` | Slider thumb color |
+| `--volume-height` | `6px` | Track thickness |
+| `--volume-thumb-size` | `16px` | Thumb diameter |
+| `--volume-duration` | `0.2s` | Transition speed |
+
+## Files
+- `demo.html` — live working example
+- `style.css` — component styles
+- `volume-slider.js` — fill/mute logic
+- `README.md` — this file

--- a/submissions/examples/ease-volume-control-slider/demo.html
+++ b/submissions/examples/ease-volume-control-slider/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ease Volume Control Slider — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #0f172a;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="ease-volume" style="--volume-percent: 70%;">
+    <button type="button" class="volume-icon-btn" aria-label="Mute/unmute volume">
+      <svg class="icon-on" viewBox="0 0 24 24">
+        <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
+        <path d="M15.54 8.46a5 5 0 0 1 0 7.07"></path>
+        <path d="M19.07 4.93a10 10 0 0 1 0 14.14"></path>
+      </svg>
+      <svg class="icon-muted" viewBox="0 0 24 24">
+        <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
+        <line x1="23" y1="9" x2="17" y2="15"></line>
+        <line x1="17" y1="9" x2="23" y2="15"></line>
+      </svg>
+    </button>
+
+    <div class="volume-track-wrap">
+      <input
+        type="range"
+        class="volume-slider"
+        min="0"
+        max="100"
+        value="70"
+        aria-label="Volume"
+      />
+    </div>
+
+    <span class="volume-percent-label">70%</span>
+  </div>
+
+  <script src="volume-slider.js"></script>
+</body>
+</html>

--- a/submissions/examples/ease-volume-control-slider/style.css
+++ b/submissions/examples/ease-volume-control-slider/style.css
@@ -1,0 +1,136 @@
+/* Ease Volume Control Slider — pure CSS styled range input + animated mute icon */
+
+.ease-volume {
+  --volume-track-bg: #2a2a3f;
+  --volume-fill-color: #38bdf8;
+  --volume-thumb-color: #f5f7fa;
+  --volume-duration: 0.2s;
+  --volume-height: 6px;
+  --volume-thumb-size: 16px;
+
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  width: 240px;
+  font-family: system-ui, sans-serif;
+}
+
+.ease-volume .volume-icon-btn {
+  background: transparent;
+  border: none;
+  color: var(--volume-fill-color);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  transition: background var(--volume-duration) ease;
+}
+
+.ease-volume .volume-icon-btn:hover {
+  background: rgba(56, 189, 248, 0.1);
+}
+
+.ease-volume .volume-icon-btn:focus-visible {
+  outline: 2px solid var(--volume-fill-color);
+  outline-offset: 2px;
+}
+
+.ease-volume .volume-icon-btn svg {
+  width: 20px;
+  height: 20px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  transition: transform var(--volume-duration) ease;
+}
+
+.ease-volume.is-muted .volume-icon-btn {
+  color: #64748b;
+}
+
+/* icon swap: sound-on vs muted, based on .is-muted */
+.ease-volume .icon-muted { display: none; }
+.ease-volume.is-muted .icon-on { display: none; }
+.ease-volume.is-muted .icon-muted { display: block; }
+
+.ease-volume .volume-track-wrap {
+  position: relative;
+  flex: 1;
+  display: flex;
+  align-items: center;
+}
+
+.ease-volume .volume-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: var(--volume-height);
+  border-radius: 999px;
+  background: linear-gradient(
+    to right,
+    var(--volume-fill-color) 0%,
+    var(--volume-fill-color) var(--volume-percent, 70%),
+    var(--volume-track-bg) var(--volume-percent, 70%),
+    var(--volume-track-bg) 100%
+  );
+  outline: none;
+  cursor: pointer;
+  transition: background var(--volume-duration) linear;
+}
+
+.ease-volume .volume-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: var(--volume-thumb-size);
+  height: var(--volume-thumb-size);
+  border-radius: 50%;
+  background: var(--volume-thumb-color);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.2);
+  cursor: pointer;
+  transition: transform var(--volume-duration) ease, box-shadow var(--volume-duration) ease;
+}
+
+.ease-volume .volume-slider:hover::-webkit-slider-thumb,
+.ease-volume .volume-slider:focus-visible::-webkit-slider-thumb {
+  transform: scale(1.15);
+  box-shadow: 0 0 0 5px rgba(56, 189, 248, 0.3);
+}
+
+.ease-volume .volume-slider::-moz-range-thumb {
+  width: var(--volume-thumb-size);
+  height: var(--volume-thumb-size);
+  border: none;
+  border-radius: 50%;
+  background: var(--volume-thumb-color);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.2);
+  cursor: pointer;
+  transition: transform var(--volume-duration) ease;
+}
+
+.ease-volume .volume-slider::-moz-range-track {
+  height: var(--volume-height);
+  border-radius: 999px;
+  background: transparent;
+}
+
+.ease-volume .volume-percent-label {
+  min-width: 34px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #94a3b8;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-volume .volume-slider,
+  .ease-volume .volume-icon-btn,
+  .ease-volume .volume-icon-btn svg {
+    transition: none;
+  }
+}

--- a/submissions/examples/ease-volume-control-slider/volume-slider.js
+++ b/submissions/examples/ease-volume-control-slider/volume-slider.js
@@ -1,0 +1,38 @@
+/**
+ * Ease Volume Control Slider
+ * Minimal JS: updates the fill gradient position (--volume-percent) as the
+ * slider moves, and toggles mute state. All visual styling is CSS-driven.
+ */
+(function () {
+  const container = document.querySelector(".ease-volume");
+  if (!container) return;
+
+  const slider = container.querySelector(".volume-slider");
+  const muteBtn = container.querySelector(".volume-icon-btn");
+  const label = container.querySelector(".volume-percent-label");
+
+  let lastVolume = slider.value;
+
+  function updateFill() {
+    slider.style.setProperty("--volume-percent", `${slider.value}%`);
+    label.textContent = `${slider.value}%`;
+    container.classList.toggle("is-muted", Number(slider.value) === 0);
+  }
+
+  slider.addEventListener("input", () => {
+    if (Number(slider.value) > 0) lastVolume = slider.value;
+    updateFill();
+  });
+
+  muteBtn.addEventListener("click", () => {
+    if (Number(slider.value) === 0) {
+      slider.value = lastVolume > 0 ? lastVolume : 50;
+    } else {
+      lastVolume = slider.value;
+      slider.value = 0;
+    }
+    updateFill();
+  });
+
+  updateFill();
+})();


### PR DESCRIPTION
Closes #40669

## Pull Request Description
Adds a volume control slider component — a custom-styled range input with an animated gradient fill, a mute/unmute toggle button with icon morphing, and a live percentage label.

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-volume-control-slider/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A styled `<input type="range">` volume slider with an animated fill gradient tracking the current value, a mute/unmute button that morphs between speaker icons and remembers the previous volume level, and a live percentage label.

**How does a developer use it?**
```html
<div class="ease-volume" style="--volume-percent: 70%;">
  <button type="button" class="volume-icon-btn" aria-label="Mute/unmute volume">
    <svg class="icon-on">...</svg>
    <svg class="icon-muted">...</svg>
  </button>
  <div class="volume-track-wrap">
    <input type="range" class="volume-slider" min="0" max="100" value="70" aria-label="Volume" />
  </div>
  <span class="volume-percent-label">70%</span>
</div>
<script src="volume-slider.js"></script>
```

**Why does it fit EaseMotion CSS?**
Built on a native `<input type="range">` for full keyboard/accessibility support out of the box, with all visual styling (fill gradient, thumb hover/focus scale, icon transitions) handled in CSS and controlled via custom properties (`--volume-fill-color`, `--volume-track-bg`, `--volume-thumb-size`, `--volume-duration`, etc.) — no core rule changes needed. JavaScript is limited to updating the fill position and mute state; no animation logic lives in JS. Respects `prefers-reduced-motion`.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
The issue description was minimal ("Create the ease-volume-control-slider component"), so I implemented a standard media-player-style volume slider (drag to adjust, click to mute/unmute, remembers last volume) as a sensible default. Happy to adjust if a more specific spec was intended.