### PR TITLE
[Feat] #39377 — Add social proof notifications (unique folder)

### DIFF
--- a/submissions/examples/social-proof-39377-ag/README.md
+++ b/submissions/examples/social-proof-39377-ag/README.md
@@ -1,0 +1,18 @@
+# Social Proof Notifications
+
+An interactive notification toast component demonstrating bottom-left slide-in pop-up cards.
+
+---
+
+## What is Included
+
+1. **`demo.html`**: A showcase dashboard hosting trigger buttons, user avatars, content bodies, and relative coordinates.
+2. **`style.css`**: Fixed screen coordinate rules, scale transformations, avatar highlights, and responsive limits.
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a web browser.
+2. Click **Show Purchase Notification**.
+3. Verify that the social proof pop-up slides in from the bottom-left corner of the viewport.

--- a/submissions/examples/social-proof-39377-ag/demo.html
+++ b/submissions/examples/social-proof-39377-ag/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Social Proof Notifications Showcase — EaseMotion CSS</title>
+  <meta name="description" content="Visual showcase demonstrating pop-up social proof notification cards and bottom slide-in entrances.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Components</span>
+      <h1>Social Proof Pop-ups</h1>
+      <p class="description">
+        Demonstrates real-time purchase notification modals. Click the button below 
+        to trigger the pop-up notification.
+      </p>
+    </header>
+
+    <main class="showcase">
+      <button class="trigger-btn" onclick="triggerNotification()">Show Purchase Notification</button>
+
+      <!-- Social Proof Notification under Test -->
+      <div class="notification-toast" id="toast-node">
+        <div class="user-avatar">💬</div>
+        <div class="toast-body">
+          <p class="toast-user">Sarah from New York</p>
+          <p class="toast-message">Just purchased the Developer Pro Pack!</p>
+          <p class="toast-time">2 minutes ago</p>
+        </div>
+      </div>
+    </main>
+  </div>
+
+  <script>
+    function triggerNotification() {
+      const toast = document.getElementById('toast-node');
+      toast.classList.remove('active');
+      void toast.offsetWidth; // Reflow to restart animation
+      toast.classList.add('active');
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/social-proof-39377-ag/style.css
+++ b/submissions/examples/social-proof-39377-ag/style.css
@@ -1,0 +1,171 @@
+/* ============================================================
+   [FEATURE] Social Proof Notifications — style.css
+   Submission for EaseMotion CSS Issue #39377
+   Slide-in keyframes, bottom-left fixed positioning, layout cards
+   ============================================================ */
+
+:root {
+  --primary: #818cf8;
+  --bg-gradient: linear-gradient(135deg, #0f172a 0%, #1e1b4b 100%);
+  --card-bg: rgba(31, 41, 55, 0.55);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f8fafc;
+  --text-secondary: #cbd5e1;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 520px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(129, 140, 248, 0.15);
+  border: 1px solid rgba(129, 140, 248, 0.3);
+  border-radius: 999px;
+  color: #c7d2fe;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a5b4fc, #818cf8);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Showcase Area & Trigger
+   ============================================================ */
+
+.showcase {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+}
+
+.trigger-btn {
+  background: var(--primary);
+  border: none;
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.9rem;
+  padding: 14px 28px;
+  border-radius: 12px;
+  cursor: pointer;
+  box-shadow: 0 4px 15px rgba(129, 140, 248, 0.3);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.trigger-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(129, 140, 248, 0.45);
+}
+
+/* ============================================================
+   Notification Pop-up under Test
+   ============================================================ */
+
+.notification-toast {
+  position: fixed;
+  bottom: 24px;
+  left: 24px;
+  background: #1e293b;
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  padding: 16px 24px 16px 16px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+  z-index: 100;
+  
+  /* Initial off-screen state */
+  opacity: 0;
+  transform: translateY(50px) scale(0.9);
+  pointer-events: none;
+  
+  transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.4s ease;
+}
+
+.notification-toast.active {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.user-avatar {
+  width: 44px;
+  height: 44px;
+  background: rgba(129, 140, 248, 0.15);
+  border: 1px solid rgba(129, 140, 248, 0.3);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+}
+
+.toast-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.toast-user {
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+
+.toast-message {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.toast-time {
+  font-size: 0.7rem;
+  color: #64748b;
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .notification-toast {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-social-proof` showcase. It demonstrates purchase notification toasts using bottom fixed alignment layouts and scale slide-in animations.

## Root Cause
No social proof pop-up components or bottom-left slide-in transition states existed in EaseMotion CSS.

## Changes Made
- `submissions/examples/social-proof-39377-ag/demo.html`: Toast components, avatar blocks, trigger buttons, click listeners.
- `submissions/examples/social-proof-39377-ag/style.css`: Bottom fixed offsets, slide transitions, rounded avatars, and custom button shadows.
- `submissions/examples/social-proof-39377-ag/README.md`: Explains positioning, entrance speeds, and manual testing.

## How to Test
1. Open `demo.html` in a browser.
2. Click trigger to reveal bottom slide-in toast.

## Related Issue
Closes #39377