### PR TITLE
[Feat] #39103 — Add complex 3D paper unfold/origami reveal (unique folder)

### DIFF
--- a/submissions/examples/origami-reveal-39103-ag/README.md
+++ b/submissions/examples/origami-reveal-39103-ag/README.md
@@ -1,0 +1,20 @@
+# Complex 3D Paper Unfold/Origami Reveal
+
+A 3D perspective unfold card component demonstrating paper fold rotations.
+
+---
+
+## What is Included
+
+1. **`demo.html`**: A showcase dashboard hosting 3D card wrappers, top/bottom fold panels, and disclosure details.
+2. **`style.css`**: Perspective matrices, preserve-3d declarations, transform-origins, rotateX margins, and motion overrides.
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a web browser.
+2. Observe the blue closed folding card.
+3. Hover your cursor over the card.
+4. Verify that the top and bottom folds rotate outward in 3D space, revealing the text panel underneath.
+5. Move the cursor away to confirm the folds close back smoothly.

--- a/submissions/examples/origami-reveal-39103-ag/demo.html
+++ b/submissions/examples/origami-reveal-39103-ag/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Origami 3D Unfold Showcase — EaseMotion CSS</title>
+  <meta name="description" content="Visual showcase of 3D origami folding and card unfold reveal transitions.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Showcase</span>
+      <h1>3D Origami Reveal</h1>
+      <p class="description">
+        Demonstrates 3D perspective fold. Hover over the folded panel below 
+        to trigger the paper unfold reveal transition.
+      </p>
+    </header>
+
+    <main class="showcase">
+      <!-- Origami Card Wrapper under Test -->
+      <div class="origami-wrapper">
+        <div class="origami-card">
+          <!-- Top Fold -->
+          <div class="origami-fold fold-top">
+            <span class="fold-text">Hover to Unfold</span>
+          </div>
+
+          <!-- Content Panel behind folds -->
+          <div class="origami-content">
+            <h3>Secret Document</h3>
+            <p>You have unlocked the 3D origami reveal sequence. It utilizes perspective matrices and rotational folds to simulate paper.</p>
+          </div>
+
+          <!-- Bottom Fold -->
+          <div class="origami-fold fold-bottom"></div>
+        </div>
+      </div>
+    </main>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/origami-reveal-39103-ag/style.css
+++ b/submissions/examples/origami-reveal-39103-ag/style.css
@@ -1,0 +1,170 @@
+/* ============================================================
+   [FEATURE] Complex 3D Paper Unfold/Origami Reveal — style.css
+   Submission for EaseMotion CSS Issue #39103
+   Perspective folds, transform-style preserve-3d, rotateX steps
+   ============================================================ */
+
+:root {
+  --primary: #7c3aed;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: #1f2937;
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 520px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Showcase Area
+   ============================================================ */
+
+.showcase {
+  display: flex;
+  justify-content: center;
+  padding: 40px 0;
+}
+
+/* Origami Perspective Elements under Test */
+.origami-wrapper {
+  perspective: 1000px;
+  width: 100%;
+  max-width: 340px;
+  height: 200px;
+}
+
+.origami-card {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background: #111827;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  transform-style: preserve-3d;
+}
+
+.origami-content {
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.origami-content h3 {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.origami-content p {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+/* Origami Paper Folds */
+.origami-fold {
+  position: absolute;
+  left: -1px;
+  width: calc(100% + 2px);
+  height: 50%;
+  background: #2563eb;
+  z-index: 10;
+  transition: transform 0.5s cubic-bezier(0.16, 1, 0.3, 1), background-color 0.5s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+}
+
+.fold-top {
+  top: -1px;
+  border-radius: 16px 16px 0 0;
+  transform-origin: top;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.15);
+}
+
+.fold-bottom {
+  bottom: -1px;
+  border-radius: 0 0 16px 16px;
+  transform-origin: bottom;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-top: 1px solid rgba(0, 0, 0, 0.15);
+}
+
+.fold-text {
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+/* Interactive Hover States */
+.origami-wrapper:hover .fold-top {
+  transform: rotateX(105deg);
+  background-color: #1d4ed8;
+}
+
+.origami-wrapper:hover .fold-bottom {
+  transform: rotateX(-105deg);
+  background-color: #1d4ed8;
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .origami-fold {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-origami-reveal` showcase. It demonstrates 3D origami paper unfold mechanics using perspective blocks and coordinate rotation transforms.

## Root Cause
No 3D folding animations or paper reveal panels existed in EaseMotion CSS.

## Changes Made
- `submissions/examples/origami-reveal-39103-ag/demo.html`: Perspective wrappers, fold layers, inner details, headings.
- `submissions/examples/origami-reveal-39103-ag/style.css`: Perspective declarations, preserve-3d options, top/bottom origins, rotation degrees.
- `submissions/examples/origami-reveal-39103-ag/README.md`: Explains 3D perspective grids, origin folds, and manual verification steps.

## How to Test
1. Open `demo.html` in a browser.
2. Hover over card folds to confirm 3D rotations.

## Related Issue
Closes #39103