### PR TITLE
[Feat] #39102 — Add SVG path self-drawing animation (unique folder)

### DIFF
--- a/submissions/examples/svg-drawing-39102-ag/README.md
+++ b/submissions/examples/svg-drawing-39102-ag/README.md
@@ -1,0 +1,18 @@
+# SVG Path Self-Drawing Animation
+
+An interactive success icon component demonstrating self-drawing paths using stroke dashoffsets.
+
+---
+
+## What is Included
+
+1. **`demo.html`**: A showcase dashboard hosting SVG circles, success paths, triggers, and labels.
+2. **`style.css`**: Stroke capacities, dash offsets, draw animations, delays, line caps, and accessibility fallbacks.
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a web browser.
+2. Observe the green circle outline and checkmark path drawing themselves sequentially.
+3. Click **Draw Again** to verify the animation resets and executes cleanly a second time.

--- a/submissions/examples/svg-drawing-39102-ag/demo.html
+++ b/submissions/examples/svg-drawing-39102-ag/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SVG Path Self-Drawing Showcase — EaseMotion CSS</title>
+  <meta name="description" content="Visual showcase demonstrating self-drawing SVG path outlines using stroke dash offsets.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Showcase</span>
+      <h1>SVG Path Drawing</h1>
+      <p class="description">
+        Demonstrates dash-offset path animations. Click the trigger button below 
+        to observe the checkmark outline draw itself.
+      </p>
+    </header>
+
+    <main class="showcase">
+      <div class="showcase-card">
+        <!-- SVG Canvas under Test -->
+        <svg class="drawing-svg" viewBox="0 0 100 100">
+          <circle class="svg-circle" cx="50" cy="50" r="40" />
+          <path class="svg-check" d="M30 52 L45 65 L70 35" />
+        </svg>
+
+        <button class="trigger-btn" onclick="restartDrawing()">Draw Again</button>
+      </div>
+    </main>
+  </div>
+
+  <script>
+    function restartDrawing() {
+      const check = document.querySelector('.svg-check');
+      const circle = document.querySelector('.svg-circle');
+      
+      check.style.animation = 'none';
+      circle.style.animation = 'none';
+      
+      void check.offsetHeight; // Reflow to reset animation
+      
+      check.style.animation = null;
+      circle.style.animation = null;
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/svg-drawing-39102-ag/style.css
+++ b/submissions/examples/svg-drawing-39102-ag/style.css
@@ -1,0 +1,158 @@
+/* ============================================================
+   [FEATURE] SVG Path Self-Drawing Animation — style.css
+   Submission for EaseMotion CSS Issue #39102
+   Stroke-dasharray, stroke-dashoffset transitions, vector draws
+   ============================================================ */
+
+:root {
+  --primary: #10b981;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --card-bg: rgba(31, 41, 55, 0.45);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 520px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(16, 185, 129, 0.15);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+  border-radius: 999px;
+  color: #a7f3d0;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #34d399, #059669);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Showcase Area & Card
+   ============================================================ */
+
+.showcase {
+  display: flex;
+  justify-content: center;
+}
+
+.showcase-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  padding: 32px;
+  border-radius: 24px;
+  backdrop-filter: blur(8px);
+  width: 100%;
+  max-width: 320px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+}
+
+.trigger-btn {
+  background: var(--primary);
+  border: none;
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.85rem;
+  padding: 10px 20px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.trigger-btn:hover {
+  transform: scale(1.02);
+}
+
+/* ============================================================
+   SVG Drawing Elements under Test
+   ============================================================ */
+
+.drawing-svg {
+  width: 120px;
+  height: 120px;
+}
+
+.svg-circle {
+  fill: none;
+  stroke: var(--primary);
+  stroke-width: 4;
+  stroke-dasharray: 252; /* ~2 * pi * 40 */
+  stroke-dashoffset: 252;
+  stroke-linecap: round;
+  animation: drawCircle 0.8s ease forwards;
+}
+
+.svg-check {
+  fill: none;
+  stroke: var(--primary);
+  stroke-width: 6;
+  stroke-dasharray: 60;
+  stroke-dashoffset: 60;
+  stroke-linecap: round;
+  animation: drawCheck 0.5s ease 0.6s forwards;
+}
+
+@keyframes drawCircle {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+@keyframes drawCheck {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .svg-circle, .svg-check {
+    animation: none !important;
+    stroke-dashoffset: 0 !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-svg-drawing` showcase. It demonstrates self-drawing vector icon paths using stroke dasharrays, linecaps, and keyframe delays.

## Root Cause
No self-drawing vector paths or stroke-dashoffset transition examples existed in EaseMotion CSS.

## Changes Made
- `submissions/examples/svg-drawing-39102-ag/demo.html`: SVG elements, checking path geometries, reload controls, buttons.
- `submissions/examples/svg-drawing-39102-ag/style.css`: Stroke widths, dash offsets, draw animations, delays, line caps, reduced motion.
- `submissions/examples/svg-drawing-39102-ag/README.md`: Explains dash offsets, SVG viewboxes, and manual testing.

## How to Test
1. Open `demo.html` in a browser.
2. Observe circle and checkmark draw animations, and click reload to verify.

## Related Issue
Closes #39102