### PR TITLE
[Feat] #39101 — Add multi-layer 3D parallax depth cards (unique folder)

### DIFF
--- a/submissions/examples/3d-parallax-39101-ag/README.md
+++ b/submissions/examples/3d-parallax-39101-ag/README.md
@@ -1,0 +1,19 @@
+# Multi-layer 3D Parallax Depth Cards
+
+A multi-layered 3D card component demonstrating parallax mouse hover offsets.
+
+---
+
+## What is Included
+
+1. **`demo.html`**: A showcase dashboard hosting 3D perspective grids, background layers, and midground/foreground details.
+2. **`style.css`**: Perspective matrices, preserve-3d configurations, translateZ offsets, and layout alignments.
+
+---
+
+## Verification Steps
+
+1. Open `demo.html` in a web browser.
+2. Move your mouse cursor across the card.
+3. Verify that the card rotates in 3D perspective, and the background (star icon) and foreground text elements move at different depths relative to each other.
+4. Move your cursor away to confirm the card returns smoothly to its neutral state.

--- a/submissions/examples/3d-parallax-39101-ag/demo.html
+++ b/submissions/examples/3d-parallax-39101-ag/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>3D Parallax Depth Cards Showcase — EaseMotion CSS</title>
+  <meta name="description" content="Visual card showcase demonstrating multi-layered 3D parallax offsets and perspective hover transforms.">
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <span class="demo-badge">EaseMotion CSS — Showcase</span>
+      <h1>3D Parallax Depth</h1>
+      <p class="description">
+        Demonstrates multi-layer depth. Hover your cursor over the card below 
+        to observe the 3D parallax shifts.
+      </p>
+    </header>
+
+    <main class="showcase">
+      <!-- 3D Card Container under Test -->
+      <div class="parallax-container" id="parallax-parent">
+        <div class="parallax-card">
+          <!-- Background Layer -->
+          <div class="layer layer-bg"></div>
+
+          <!-- Midground Text Layer -->
+          <div class="layer layer-mid">
+            <h3>Explore 3D Space</h3>
+            <p>Moving your mouse causes separate layers to translate at varying offsets, creating a parallax illusion.</p>
+          </div>
+
+          <!-- Foreground Overlay Glow Layer -->
+          <div class="layer layer-fg">★</div>
+        </div>
+      </div>
+    </main>
+  </div>
+
+  <script>
+    const container = document.getElementById('parallax-parent');
+    const card = container.querySelector('.parallax-card');
+
+    container.addEventListener('mousemove', (e) => {
+      const rect = container.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      
+      const px = (x / rect.width) * 2 - 1; // -1 to 1
+      const py = (y / rect.height) * 2 - 1; // -1 to 1
+      
+      card.style.transform = `rotateY(${px * 12}deg) rotateX(${py * -12}deg)`;
+    });
+
+    container.addEventListener('mouseleave', () => {
+      card.style.transform = null;
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/3d-parallax-39101-ag/style.css
+++ b/submissions/examples/3d-parallax-39101-ag/style.css
@@ -1,0 +1,160 @@
+/* ============================================================
+   [FEATURE] Multi-layer 3D Parallax Depth Cards — style.css
+   Submission for EaseMotion CSS Issue #39101
+   Preserve-3d, translateZ layers, perspective rotations
+   ============================================================ */
+
+:root {
+  --primary: #818cf8;
+  --accent: #22d3ee;
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 100%);
+  --text-primary: #f9fafb;
+  --text-secondary: #9ca3af;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  padding: 48px 20px;
+  font-family: 'Outfit', 'Inter', system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 520px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+/* ── Header ── */
+header { text-align: center; }
+
+.demo-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  background: rgba(124, 58, 237, 0.16);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 999px;
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #22d3ee);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ============================================================
+   Showcase Area
+   ============================================================ */
+
+.showcase {
+  display: flex;
+  justify-content: center;
+  padding: 24px 0;
+}
+
+/* 3D Card Elements under Test */
+.parallax-container {
+  perspective: 1000px;
+  width: 100%;
+  max-width: 340px;
+  height: 220px;
+  cursor: pointer;
+}
+
+.parallax-card {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background: #111827;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  transform-style: preserve-3d;
+  transition: transform 0.15s ease-out;
+  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.3);
+}
+
+.layer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+/* Background Layer */
+.layer-bg {
+  border-radius: 20px;
+  background: radial-gradient(circle at 80% 20%, #1e1b4b 0%, #0f172a 100%);
+  transform: translateZ(-20px);
+}
+
+/* Midground content */
+.layer-mid {
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 12px;
+  transform: translateZ(30px);
+}
+
+.layer-mid h3 {
+  font-size: 1.25rem;
+  font-weight: 800;
+  color: #fff;
+}
+
+.layer-mid p {
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+/* Foreground Element */
+.layer-fg {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 4rem;
+  color: rgba(34, 211, 238, 0.15);
+  top: auto;
+  bottom: 12px;
+  right: 16px;
+  left: auto;
+  width: auto;
+  height: auto;
+  transform: translateZ(65px);
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .parallax-card {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the `ease-3d-parallax` showcase. It demonstrates multi-layered depth cards utilizing CSS preserve-3d options and mouse hover coordinate offsets.

## Root Cause
No multi-layer 3D parallax cards or translateZ layer examples existed in EaseMotion CSS.

## Changes Made
- `submissions/examples/3d-parallax-39101-ag/demo.html`: Container nodes, layer groups, background gradients, star elements.
- `submissions/examples/3d-parallax-39101-ag/style.css`: Perspective definitions, transform-styles, translateZ distances, pointer event configurations.
- `submissions/examples/3d-parallax-39101-ag/README.md`: Explains layer heights, translateZ parameters, and manual testing.

## How to Test
1. Open `demo.html` in a browser.
2. Move cursor across card to check 3D depth adjustments.

## Related Issue
Closes #39101