### PR TITLE
feat: add CSS shape-outside layout utilities

### DIFF
--- a/submissions/examples/shape-outside-utilities/README.md
+++ b/submissions/examples/shape-outside-utilities/README.md
@@ -1,0 +1,49 @@
+# CSS Shape-Outside Component Utilities
+
+Relates to feature request **#41196**.
+
+## 1. What does this do?
+
+Provides utility classes (`.ease-shape-circle` and `.ease-shape-polygon`) that leverage the CSS `shape-outside` property. This allows text and inline content to naturally flow around complex geometric shapes instead of standard rectangular bounding boxes, creating magazine-style editorial layouts purely with CSS.
+
+## 2. How is it used?
+
+The element must be floated (`float: left` or `float: right`) for `shape-outside` to work.
+
+**HTML Setup**
+```html
+<div class="ease-shape-circle float-left"></div>
+<p>
+  This text will automatically wrap around the circular curve of the element,
+  creating a visually engaging layout without any SVG wrappers or JavaScript.
+</p>
+```
+
+**CSS Mechanism**
+```css
+.ease-shape-circle {
+  float: left;
+  width: 200px;
+  height: 200px;
+  border-radius: 50%;
+  
+  /* Tells inline content to wrap around a circular boundary */
+  shape-outside: circle(50%);
+}
+
+.ease-shape-polygon {
+  float: right;
+  width: 250px;
+  height: 250px;
+  
+  /* Wraps text around a custom angled polygon */
+  shape-outside: polygon(30% 0%, 100% 0%, 100% 100%, 0% 100%);
+  
+  /* Often paired with clip-path so the visible background matches the text boundary */
+  clip-path: polygon(30% 0%, 100% 0%, 100% 100%, 0% 100%);
+}
+```
+
+## 3. Why is this useful for EaseMotion CSS?
+
+Most CSS frameworks focus heavily on rigid grid and flexbox layouts. While effective, they rarely provide utilities for more organic, editorial-inspired layouts. Supporting `shape-outside` empowers developers to create visually engaging landing pages, blogs, and portfolios with modern CSS, perfectly aligning with EaseMotion's goal of lightweight, expressive, dependency-free styling.

--- a/submissions/examples/shape-outside-utilities/demo.html
+++ b/submissions/examples/shape-outside-utilities/demo.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Shape-Outside Utilities — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>CSS Shape-Outside Layout Utilities</h1>
+    <p>
+      Reusable utilities built around the <code>shape-outside</code> property to create
+      magazine-style layouts where text naturally wraps around circles, polygons,
+      and custom floating shapes.
+    </p>
+    <div class="badges">
+      <span class="badge">🎨 shape-outside</span>
+      <span class="badge">⭕ circle()</span>
+      <span class="badge">📐 polygon()</span>
+    </div>
+  </header>
+
+  <!-- ── DEMO 1: Circular Shape ────────────────────────────── -->
+  <section class="demo-section">
+    <h2>1. Circular Shape Flow</h2>
+    <p class="demo-desc">
+      Using <code>.ease-shape-circle</code>, text smoothly wraps around a circular
+      gradient element floated to the left.
+    </p>
+
+    <div class="layout-box">
+      <div class="ease-shape-circle float-left"></div>
+      <p>
+        EaseMotion CSS provides expressive utilities for creating visually rich layouts.
+        This text automatically flows around the circular shape without requiring any
+        SVGs or JavaScript. The <code>shape-outside: circle()</code> property tells
+        the browser to wrap inline content around a geometric circle rather than the
+        element's rectangular bounding box. This creates an elegant, magazine-like
+        editorial feel that breaks the typical blocky grid layouts common in modern
+        web design. As you resize the container, the text continues to flow naturally
+        around the curve of the circle.
+      </p>
+    </div>
+  </section>
+
+  <!-- ── DEMO 2: Polygon Shape ─────────────────────────────── -->
+  <section class="demo-section">
+    <h2>2. Custom Polygon Flow</h2>
+    <p class="demo-desc">
+      Using <code>.ease-shape-polygon</code>, text flows around a custom angled
+      shape floated to the right.
+    </p>
+
+    <div class="layout-box">
+      <div class="ease-shape-polygon float-right"></div>
+      <p>
+        By utilizing <code>shape-outside: polygon(...)</code>, we can create complex
+        angled layouts. Notice how the text on the left perfectly matches the diagonal
+        slant of the shape on the right. This technique is incredibly powerful for
+        landing pages, portfolios, and marketing sites where you want to draw the user's
+        eye along a specific path. The <code>clip-path</code> property is used in tandem
+        with <code>shape-outside</code> to ensure the visible background matches the
+        invisible text-wrapping boundary. This demonstrates how modern CSS can achieve
+        layouts that previously required complex images or messy DOM structures.
+      </p>
+    </div>
+  </section>
+
+  <!-- ── REFERENCE ─────────────────────────────────────────── -->
+  <section class="demo-section info-section">
+    <h2>🔧 CSS Reference</h2>
+    <div class="code-block">
+      <pre><code>/* 1. Circle Shape */
+.ease-shape-circle {
+  float: left;
+  width: 200px;
+  height: 200px;
+  border-radius: 50%;
+  margin: 1rem 1.5rem 1rem 0;
+  shape-outside: circle(50%);
+  background: linear-gradient(135deg, #a78bfa, #38bdf8);
+}
+
+/* 2. Polygon Shape (Slanted) */
+.ease-shape-polygon {
+  float: right;
+  width: 250px;
+  height: 250px;
+  margin: 1rem 0 1rem 1.5rem;
+  
+  /* Create the physical diagonal boundary for text */
+  shape-outside: polygon(30% 0%, 100% 0%, 100% 100%, 0% 100%);
+  
+  /* Match the visible background to the same shape */
+  clip-path: polygon(30% 0%, 100% 0%, 100% 100%, 0% 100%);
+  
+  background: linear-gradient(135deg, #f472b6, #fb7185);
+}</code></pre>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/shape-outside-utilities/style.css
+++ b/submissions/examples/shape-outside-utilities/style.css
@@ -1,0 +1,195 @@
+/* ============================================================
+   CSS Shape-Outside Component Utilities
+   Magazine-style editorial layouts using `shape-outside`.
+   Relates to issue #41196
+   ============================================================
+
+   KEY CONCEPTS:
+   - float: shape-outside ONLY works on floated elements.
+   - shape-outside: defines the invisible geometric boundary
+     that inline content (text) wraps around.
+   - clip-path: often used together with shape-outside to make
+     the visible background/image match the invisible boundary.
+   ============================================================ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3rem;
+}
+
+code {
+  background: #1e293b;
+  color: #a78bfa;
+  padding: 0.1em 0.4em;
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+
+/* ── Header ──────────────────────────────────────────────── */
+
+.page-header {
+  text-align: center;
+  max-width: 680px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.page-header h1 {
+  font-size: 2rem;
+  background: linear-gradient(135deg, #a78bfa, #38bdf8);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.page-header p {
+  color: #94a3b8;
+  line-height: 1.65;
+}
+
+.badges {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 0.5rem;
+}
+
+.badge {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 99px;
+  padding: 0.35rem 0.8rem;
+  font-size: 0.75rem;
+  color: #7dd3fc;
+}
+
+/* ── Demo Sections ───────────────────────────────────────── */
+
+.demo-section {
+  width: 100%;
+  max-width: 760px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.demo-section h2 {
+  font-size: 1.15rem;
+  border-left: 3px solid #a78bfa;
+  padding-left: 0.75rem;
+}
+
+.demo-desc {
+  color: #94a3b8;
+  font-size: 0.88rem;
+  line-height: 1.7;
+}
+
+.layout-box {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 14px;
+  padding: 2rem;
+  /* clearfix */
+  overflow: hidden;
+}
+
+.layout-box p {
+  line-height: 1.7;
+  color: #cbd5e1;
+  text-align: justify;
+}
+
+/* ============================================================
+   UTILITY: .ease-shape-circle
+   Text wraps smoothly around a circular element.
+   ============================================================ */
+.ease-shape-circle {
+  width: 200px;
+  height: 200px;
+  border-radius: 50%;
+  
+  /* The core feature: text wraps around a circular boundary */
+  shape-outside: circle(50%);
+  
+  /* Visual styling */
+  background: linear-gradient(135deg, #6366f1, #0ea5e9);
+  box-shadow: inset 0 0 20px rgba(0,0,0,0.2);
+}
+
+.ease-shape-circle.float-left {
+  float: left;
+  margin: 0.5rem 1.5rem 1rem 0;
+}
+
+/* ============================================================
+   UTILITY: .ease-shape-polygon
+   Text flows along a diagonal slanted boundary.
+   ============================================================ */
+.ease-shape-polygon {
+  width: 240px;
+  height: 240px;
+  
+  /* The core feature: text wraps around a diagonal slant */
+  shape-outside: polygon(30% 0%, 100% 0%, 100% 100%, 0% 100%);
+  
+  /* Match the visible shape to the invisible text wrap boundary */
+  clip-path: polygon(30% 0%, 100% 0%, 100% 100%, 0% 100%);
+  
+  /* Visual styling */
+  background: linear-gradient(135deg, #f43f5e, #f97316);
+}
+
+.ease-shape-polygon.float-right {
+  float: right;
+  margin: 0.5rem 0 1rem 1.5rem;
+}
+
+
+/* ── Info Section ────────────────────────────────────────── */
+
+.info-section {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 14px;
+  padding: 1.75rem;
+  gap: 1.25rem;
+}
+
+.code-block {
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid #334155;
+}
+
+pre {
+  background: #0f172a;
+  padding: 1.25rem;
+  overflow-x: auto;
+}
+
+pre code {
+  background: transparent;
+  color: #7dd3fc;
+  padding: 0;
+  font-size: 0.8rem;
+  line-height: 1.8;
+}


### PR DESCRIPTION
Resolves #41196

### Description
Adds reusable utility classes leveraging the CSS `shape-outside` property to enable magazine-style editorial layouts. These utilities allow text and inline content to naturally flow around geometric shapes rather than standard rectangular bounding boxes.

### Utilities Added
| Class | What it does |
|---|---|
| `.ease-shape-circle` | Creates a circular shape boundary that text flows around smoothly (`shape-outside: circle(50%)`) |
| `.ease-shape-polygon` | Creates a custom slanted/diagonal boundary for text wrapping, paired with `clip-path` for visual matching |

### How It Works
```css
/* Must be floated to work */
.ease-shape-polygon {
  float: right;
  
  /* Text wraps around this invisible boundary */
  shape-outside: polygon(30% 0%, 100% 0%, 100% 100%, 0% 100%);
  
  /* Background visual is clipped to match the boundary */
  clip-path: polygon(30% 0%, 100% 0%, 100% 100%, 0% 100%);
}
```

### Demo Includes
1. **Circular Shape Flow:** A left-floated circular gradient where text wraps around the smooth curve.
2. **Polygon Shape Flow:** A right-floated slanted element demonstrating complex diagonal text wrapping using `polygon()`.

### Validation
- [x] Placed under `submissions/examples/shape-outside-utilities/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] Zero external dependencies
- [x] Tested across responsive viewport sizes (text naturally reflows around the shapes)
