### PR TITLE
feat: add CSS overflow: clip utilities

### DIFF
--- a/submissions/examples/overflow-clip-utilities/README.md
+++ b/submissions/examples/overflow-clip-utilities/README.md
@@ -1,0 +1,42 @@
+# CSS `overflow: clip` Animation Utilities
+
+Relates to feature request **#41202**.
+
+## 1. What does this do?
+
+Provides utility classes (`.ease-clip-card` and `.ease-clip-margin-card`) that leverage the modern CSS `overflow: clip` property. This allows developers to contain expanding animations, pseudo-elements, and transforms without the negative side effects of traditional `overflow: hidden`.
+
+## 2. Why is this useful for EaseMotion CSS?
+
+Traditionally, containing a rotating gradient glow or an expanding background shape required using `overflow: hidden`. However, `overflow: hidden` technically creates a **scroll container** in the browser's layout engine. This can accidentally swallow scroll wheel events, cause layout thrashing, or create accessibility issues on certain mobile devices.
+
+`overflow: clip` is explicitly designed for visual clipping *without* creating a scroll container. It is lighter on browser rendering and safer for animation components.
+
+Furthermore, `overflow: clip` unlocks the use of `overflow-clip-margin`, which allows you to define exactly how far outside the bounding box an animation is allowed to travel before being clipped.
+
+## 3. How is it used?
+
+**Standard Clipping**
+```css
+/* Replaces overflow: hidden for animated cards */
+.ease-clip-card {
+  position: relative;
+  overflow: clip; 
+  border-radius: 1rem;
+}
+```
+
+**Margin Clipping**
+```css
+/* Allows an animation to pop out slightly before being clipped */
+.ease-clip-margin-card {
+  position: relative;
+  overflow: clip;
+  
+  /* The bounding box is visually expanded by 20px */
+  overflow-clip-margin: 20px; 
+}
+```
+
+## 4. Demo Included
+The provided demo shows a side-by-side comparison of `hidden` vs `clip` for a rotating gradient glow, and a demonstration of a bouncing ball animation utilizing `overflow-clip-margin` to pop outside of the card boundaries.

--- a/submissions/examples/overflow-clip-utilities/demo.html
+++ b/submissions/examples/overflow-clip-utilities/demo.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS overflow: clip Animation Utilities — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>CSS overflow: clip Utilities</h1>
+    <p>
+      Modern clipping utilities using <code>overflow: clip</code> to contain
+      animations, gradients, and transforms without creating scroll containers
+      or scrollbar artifacts.
+    </p>
+    <div class="badges">
+      <span class="badge">✂️ overflow: clip</span>
+      <span class="badge">🎨 overflow-clip-margin</span>
+    </div>
+  </header>
+
+  <!-- ── DEMO 1: Glowing Card (Clip vs Hidden) ────────────── -->
+  <section class="demo-section">
+    <h2>1. The Problem with <code>overflow: hidden</code></h2>
+    <p class="demo-desc">
+      Traditionally, <code>overflow: hidden</code> is used to contain expanding
+      background animations. However, <code>overflow: hidden</code> actually creates
+      a <strong>scroll container</strong>. If not careful, this can interfere with
+      scrolling, layout, or accessibility.
+      <br><br>
+      <code>overflow: clip</code> simply cuts off the paint at the border box
+      <strong>without</strong> creating a scroll container.
+    </p>
+
+    <div class="demo-grid">
+      <!-- Old Way -->
+      <div class="ease-card old-way">
+        <div class="ease-glow"></div>
+        <h3>overflow: hidden</h3>
+        <p>Creates a scroll container. Can sometimes capture wheel events or cause layout shift.</p>
+      </div>
+
+      <!-- New Way -->
+      <div class="ease-card ease-clip-card">
+        <div class="ease-glow"></div>
+        <h3>overflow: clip</h3>
+        <p>Pure visual clipping. No scroll container created. Lighter and safer for animations.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── DEMO 2: Overflow Clip Margin ─────────────────────── -->
+  <section class="demo-section">
+    <h2>2. Expanding the Clip Boundary</h2>
+    <p class="demo-desc">
+      Unlike <code>hidden</code>, <code>overflow: clip</code> can be combined with
+      <code>overflow-clip-margin</code> to allow content to overflow exactly by a
+      specific amount before clipping.
+    </p>
+
+    <div class="demo-grid">
+      <div class="ease-card ease-clip-margin-card">
+        <div class="ease-bounce-ball"></div>
+        <h3>overflow-clip-margin: 20px</h3>
+        <p>The bouncing ball is allowed to overflow the top border by exactly 20px before being clipped.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── REFERENCE ─────────────────────────────────────────── -->
+  <section class="demo-section info-section">
+    <h2>🔧 CSS Reference</h2>
+    <div class="code-block">
+      <pre><code>/* 1. Standard Clip Utility */
+.ease-clip-card {
+  position: relative;
+  overflow: clip; /* Replaces overflow: hidden */
+  border-radius: 1rem;
+}
+
+/* 2. Clip with Margin Utility */
+.ease-clip-margin-card {
+  position: relative;
+  overflow: clip;
+  
+  /* Allows content to overflow up to 20px outside the border box before clipping */
+  overflow-clip-margin: 20px; 
+}
+
+/* Example Animated Element inside the clip */
+.ease-glow {
+  position: absolute;
+  inset: -50%;
+  background: radial-gradient(circle, rgba(167, 139, 250, 0.4), transparent);
+  animation: glowSpin 4s linear infinite;
+}</code></pre>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/overflow-clip-utilities/style.css
+++ b/submissions/examples/overflow-clip-utilities/style.css
@@ -1,0 +1,241 @@
+/* ============================================================
+   CSS overflow: clip Animation Utilities
+   Optimized clipping for animations without scroll containers.
+   Relates to issue #41202
+   ============================================================
+
+   KEY CONCEPTS:
+   - overflow: hidden creates a scroll container. This can trap
+     scroll events or cause layout recalculations.
+   - overflow: clip strictly cuts off visual paint at the edge
+     of the element's box. It NEVER creates a scroll container.
+   - overflow-clip-margin: specifies how far outside the box
+     content is allowed to paint before it is clipped.
+   ============================================================ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3rem;
+}
+
+code {
+  background: #1e293b;
+  color: #a78bfa;
+  padding: 0.1em 0.4em;
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+
+/* ── Header ──────────────────────────────────────────────── */
+
+.page-header {
+  text-align: center;
+  max-width: 680px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.page-header h1 {
+  font-size: 2rem;
+  background: linear-gradient(135deg, #a78bfa, #38bdf8);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.page-header p {
+  color: #94a3b8;
+  line-height: 1.65;
+}
+
+.badges {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 0.5rem;
+}
+
+.badge {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 99px;
+  padding: 0.35rem 0.8rem;
+  font-size: 0.75rem;
+  color: #7dd3fc;
+}
+
+/* ── Demo Sections ───────────────────────────────────────── */
+
+.demo-section {
+  width: 100%;
+  max-width: 760px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.demo-section h2 {
+  font-size: 1.15rem;
+  border-left: 3px solid #a78bfa;
+  padding-left: 0.75rem;
+}
+
+.demo-desc {
+  color: #94a3b8;
+  font-size: 0.88rem;
+  line-height: 1.7;
+}
+
+.demo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 2rem;
+  margin-top: 1rem;
+}
+
+/* ── Shared Card Styles ──────────────────────────────────── */
+
+.ease-card {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 1rem;
+  padding: 2.5rem 1.5rem;
+  position: relative;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 1; /* Establishes stacking context */
+}
+
+.ease-card h3 {
+  color: #f8fafc;
+  font-size: 1.25rem;
+  z-index: 2; /* Keep text above animations */
+}
+
+.ease-card p {
+  color: #94a3b8;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  z-index: 2;
+}
+
+/* ============================================================
+   DEMO 1: The Glow Animation
+   ============================================================ */
+
+/* The animated background element */
+.ease-glow {
+  position: absolute;
+  inset: -100px; /* Expand way past the box */
+  background: conic-gradient(from 0deg, transparent 0 340deg, #8b5cf6 360deg);
+  animation: glowSpin 4s linear infinite;
+  z-index: 0;
+  opacity: 0.5;
+}
+
+@keyframes glowSpin {
+  to { transform: rotate(360deg); }
+}
+
+/* The Old Way: Hidden */
+.old-way {
+  overflow: hidden; /* Creates a scroll container implicitly */
+}
+
+/* 
+   UTILITY 1: .ease-clip-card
+   The Modern Way: Clip
+*/
+.ease-clip-card {
+  overflow: clip; /* Pure visual cut-off, NO scroll container */
+}
+
+
+/* ============================================================
+   DEMO 2: Overflow Clip Margin
+   ============================================================ */
+
+/* 
+   UTILITY 2: .ease-clip-margin-card
+*/
+.ease-clip-margin-card {
+  overflow: clip;
+  
+  /* Allow content to overflow exactly 25px beyond the box before clipping */
+  overflow-clip-margin: 25px;
+  
+  /* Need top margin in grid to prevent overlapping sibling content */
+  margin-top: 25px;
+}
+
+.ease-bounce-ball {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 40px;
+  height: 40px;
+  margin-left: -20px;
+  background: #38bdf8;
+  border-radius: 50%;
+  animation: bounceOut 2s ease-in-out infinite alternate;
+  z-index: 0;
+}
+
+@keyframes bounceOut {
+  0% { transform: translateY(40px); }
+  /* Ball bounces OUTSIDE the card by 25px. 
+     If this was overflow: hidden, it would be cut off entirely at 0px. */
+  100% { transform: translateY(-25px); }
+}
+
+
+/* ── Info Section ────────────────────────────────────────── */
+
+.info-section {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 14px;
+  padding: 1.75rem;
+  gap: 1.25rem;
+  margin-top: 2rem;
+}
+
+.code-block {
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid #334155;
+}
+
+pre {
+  background: #0f172a;
+  padding: 1.25rem;
+  overflow-x: auto;
+}
+
+pre code {
+  background: transparent;
+  color: #7dd3fc;
+  padding: 0;
+  font-size: 0.8rem;
+  line-height: 1.8;
+}


### PR DESCRIPTION
Resolves #41202

### Description
Adds utility classes specifically optimized for the CSS `overflow: clip` property, modernizing how EaseMotion handles bounded animations. Unlike `overflow: hidden`, `clip` strictly cuts off visual paint at the element's box without generating an implicit scroll container, making it safer and more performant for containing glowing gradients, shadows, and transform effects.

### Utilities Added
| Class | What it does |
|---|---|
| `.ease-clip-card` | Standard clipping replacement for `.ease-card` (`overflow: clip`) |
| `.ease-clip-margin-card` | Advanced clipping that allows animations to overflow exactly by a specified amount before being cut off (`overflow-clip-margin`) |

### How It Works
```css
/* Old way - Creates a scroll container implicitly */
.old-way { overflow: hidden; }

/* New way - Pure visual clipping, no scroll container */
.ease-clip-card { overflow: clip; }

/* Margin clipping - Allows content to overflow by 25px before cutting */
.ease-clip-margin-card {
  overflow: clip;
  overflow-clip-margin: 25px;
}
```

### Demo Includes
1. **The Problem with Hidden:** Side-by-side comparison of a rotating gradient glow inside a card using `overflow: hidden` vs `overflow: clip`.
2. **Overflow Clip Margin:** A bouncing ball animation inside a card that leverages `overflow-clip-margin: 25px` to allow the ball to pop outside the top edge of the card before being visually clipped.

### Validation
- [x] Placed under `submissions/examples/overflow-clip-utilities/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] Zero external dependencies
- [x] Tested across modern browsers (Chrome, Firefox, Safari)
