### PR TITLE
feat: add wide-gamut color utilities

### DIFF
--- a/submissions/examples/wide-gamut-colors/README.md
+++ b/submissions/examples/wide-gamut-colors/README.md
@@ -1,0 +1,48 @@
+# Wide-Gamut Color Utilities
+
+Relates to feature request **#41204**.
+
+## 1. What does this do?
+
+Provides examples and utility structures for utilizing modern CSS Color Level 4 and Level 5 specifications. Specifically, it demonstrates how to use the `display-p3` color space for richer, more vibrant colors, and the `oklch()` color space for perceptually uniform gradients.
+
+## 2. Why is this useful for EaseMotion CSS?
+
+For decades, the web has been restricted to the sRGB color space (`hex`, `rgb()`, `hsl()`). However, modern displays (like Apple's XDR displays, modern MacBook screens, and high-end smartphones) are capable of displaying a much wider gamut of colors—specifically the Display P3 color space.
+
+By incorporating wide-gamut color utilities, EaseMotion CSS allows developers to build future-ready, incredibly vibrant UIs that take full advantage of modern hardware, while still maintaining graceful fallback compatibility for older monitors and browsers.
+
+Additionally, standard RGB gradients often suffer from a "dead zone" where the middle of the gradient becomes muddy or grayish. Using `oklch()` interpolation solves this mathematically by keeping the gradient perceptually uniform.
+
+## 3. How is it used?
+
+**Display P3 with sRGB Fallbacks**
+```css
+/* 1. Provide the standard sRGB fallback first */
+.ease-p3-card {
+  background: #00ff00; 
+}
+
+/* 2. Override with the wider color gamut if supported */
+@supports (color: color(display-p3 1 1 1)) {
+  .ease-p3-card {
+    /* A green that is physically impossible to display in sRGB */
+    background: color(display-p3 0 1 0); 
+  }
+}
+```
+
+**Perceptually Uniform Gradients**
+```css
+.ease-oklch-gradient {
+  /* Using 'in oklch' ensures the transition between red and blue doesn't get muddy */
+  background: linear-gradient(
+    to right in oklch,
+    oklch(60% 0.3 20),
+    oklch(60% 0.3 260)
+  );
+}
+```
+
+## 4. Hardware Requirements for Testing
+To actually *see* the difference in the `display-p3` demo, you must view the `demo.html` file on a wide-gamut monitor (like a modern MacBook display) using a compatible browser (Safari, or Chrome 111+ / Firefox 113+). If viewed on a standard sRGB monitor, the browser will gracefully clamp the color, and the two boxes will look identical.

--- a/submissions/examples/wide-gamut-colors/demo.html
+++ b/submissions/examples/wide-gamut-colors/demo.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Wide-Gamut Color Utilities — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>Wide-Gamut Color Utilities</h1>
+    <p>
+      Modern CSS Color Level 4 and 5 utilities providing access to richer,
+      more vibrant colors outside the traditional sRGB color space, complete
+      with automatic fallbacks for older browsers and standard displays.
+    </p>
+    <div class="badges">
+      <span class="badge">🎨 color(display-p3 ...)</span>
+      <span class="badge">🌈 oklch()</span>
+      <span class="badge">🧪 @supports</span>
+    </div>
+  </header>
+
+  <!-- ── HOW TO TEST ───────────────────────────────────────── -->
+  <section class="how-to">
+    <p class="how-desc">
+      🎯 <strong>Note:</strong> To see the difference, you must be viewing this on a modern
+      display that supports a wide color gamut (like an Apple XDR display, modern MacBook,
+      or high-end smartphone) and a modern browser (Safari, Chrome 111+, Firefox 113+).
+    </p>
+  </section>
+
+  <!-- ── DEMO 1: Display-P3 vs sRGB ────────────────────────── -->
+  <section class="demo-section">
+    <h2>1. Display P3 vs sRGB</h2>
+    <p class="demo-desc">
+      <code>display-p3</code> offers significantly brighter and deeper colors, especially
+      in the red and green spectrums. If your monitor supports it, the top box should
+      look noticeably more vibrant and saturated.
+    </p>
+
+    <div class="demo-grid">
+      <div class="color-card ease-p3-card">
+        <h3>Display P3 Green</h3>
+        <code>color(display-p3 0 1 0)</code>
+      </div>
+
+      <div class="color-card srgb-card">
+        <h3>Standard sRGB Green</h3>
+        <code>#00FF00 / rgb(0, 255, 0)</code>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── DEMO 2: Oklch Gradients ───────────────────────────── -->
+  <section class="demo-section">
+    <h2>2. Oklch Perceptually Uniform Gradients</h2>
+    <p class="demo-desc">
+      Standard RGB gradients often pass through a "dead zone" (muddy gray/brown) in the middle.
+      Using <code>oklch()</code> and <code>in oklch</code> interpolation creates perceptually
+      smooth, vibrant gradients without dead zones.
+    </p>
+
+    <div class="gradient-grid">
+      <div class="grad-box ease-oklch-gradient">
+        <h3>Oklch Interpolation (Vibrant & Smooth)</h3>
+        <code>in oklch</code>
+      </div>
+
+      <div class="grad-box srgb-gradient">
+        <h3>Standard sRGB Interpolation (Muddy Center)</h3>
+        <code>in srgb</code>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── REFERENCE ─────────────────────────────────────────── -->
+  <section class="demo-section info-section">
+    <h2>🔧 CSS Reference</h2>
+    <div class="code-block">
+      <pre><code>/* 1. Graceful Degradation using @supports */
+
+/* Base sRGB Fallback */
+.ease-p3-card {
+  background: #00ff00; /* Standard sRGB green */
+}
+
+/* Wide-gamut override */
+@supports (color: color(display-p3 1 1 1)) {
+  .ease-p3-card {
+    /* Much more vibrant green only available in P3 space */
+    background: color(display-p3 0 1 0); 
+  }
+}
+
+/* 2. Oklch Gradients */
+.ease-oklch-gradient {
+  /* Using Oklch interpolation space prevents muddy middle colors */
+  background: linear-gradient(
+    to right in oklch,
+    oklch(60% 0.3 20),  /* Deep Red */
+    oklch(60% 0.3 260)  /* Deep Blue */
+  );
+}</code></pre>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/wide-gamut-colors/style.css
+++ b/submissions/examples/wide-gamut-colors/style.css
@@ -1,0 +1,274 @@
+/* ============================================================
+   Wide-Gamut Color Utilities
+   Exploring CSS Color Level 4 & 5 (Display P3, Oklch).
+   Relates to issue #41204
+   ============================================================
+
+   KEY CONCEPTS:
+   - sRGB: The traditional web color space (hex, rgb, hsl).
+     It covers a relatively small portion of visible colors.
+   - Display P3: A wider color gamut supported by modern screens
+     (Apple devices, modern Androids, high-end monitors).
+     Offers roughly 25% more colors than sRGB, particularly
+     richer reds and greens.
+   - Oklch: A perceptually uniform color space. It makes creating
+     consistent color palettes and smooth gradients much easier
+     than HSL.
+   - @supports (color: ...): Used to provide graceful fallbacks
+     for older browsers that don't understand modern color functions.
+   ============================================================ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3rem;
+}
+
+code {
+  background: #1e293b;
+  color: #a78bfa;
+  padding: 0.2em 0.5em;
+  border-radius: 6px;
+  font-size: 0.85em;
+  font-family: monospace;
+}
+
+strong {
+  color: #f8fafc;
+}
+
+/* ── Header ──────────────────────────────────────────────── */
+
+.page-header {
+  text-align: center;
+  max-width: 680px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.page-header h1 {
+  font-size: 2rem;
+  background: linear-gradient(135deg, #a78bfa, #38bdf8);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.page-header p {
+  color: #94a3b8;
+  line-height: 1.65;
+}
+
+.badges {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 0.5rem;
+}
+
+.badge {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 99px;
+  padding: 0.35rem 0.8rem;
+  font-size: 0.75rem;
+  color: #7dd3fc;
+}
+
+/* ── How to try ──────────────────────────────────────────── */
+
+.how-to {
+  background: #7c3aed22;
+  border: 1px dashed #7c3aed;
+  border-radius: 12px;
+  padding: 1rem 1.5rem;
+  max-width: 760px;
+  width: 100%;
+  text-align: center;
+}
+
+.how-desc {
+  color: #c4b5fd;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+/* ── Demo Sections ───────────────────────────────────────── */
+
+.demo-section {
+  width: 100%;
+  max-width: 760px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.demo-section h2 {
+  font-size: 1.15rem;
+  border-left: 3px solid #a78bfa;
+  padding-left: 0.75rem;
+}
+
+.demo-desc {
+  color: #94a3b8;
+  font-size: 0.88rem;
+  line-height: 1.7;
+}
+
+.demo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1.5rem;
+  margin-top: 1rem;
+}
+
+/* ============================================================
+   UTILITY: Display-P3 vs sRGB
+   ============================================================ */
+
+.color-card {
+  padding: 3rem 1.5rem;
+  border-radius: 14px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 10px 25px rgba(0,0,0,0.3);
+}
+
+.color-card h3 {
+  color: #000;
+  font-size: 1.25rem;
+}
+
+.color-card code {
+  background: rgba(0,0,0,0.2);
+  color: #000;
+  font-weight: bold;
+}
+
+/* The standard sRGB fallback card */
+.srgb-card {
+  background: #00ff00; /* The greenest green in standard CSS */
+}
+
+/* The Wide-Gamut card with graceful degradation */
+.ease-p3-card {
+  background: #00ff00; /* Fallback for old browsers */
+}
+
+@supports (color: color(display-p3 1 1 1)) {
+  .ease-p3-card {
+    /* 
+      A green that is physically outside the capabilities of sRGB.
+      If viewed on a P3 display, this will look significantly
+      more vibrant and "neon" than the #00ff00 fallback.
+    */
+    background: color(display-p3 0 1 0);
+  }
+}
+
+/* ============================================================
+   UTILITY: Oklch Gradients
+   ============================================================ */
+
+.gradient-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin-top: 1rem;
+}
+
+.grad-box {
+  padding: 3rem 1.5rem;
+  border-radius: 14px;
+  text-align: center;
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.grad-box h3 {
+  font-size: 1.15rem;
+  text-shadow: 0 2px 4px rgba(0,0,0,0.5);
+}
+
+.grad-box code {
+  background: rgba(0,0,0,0.4);
+  color: #fff;
+  align-self: center;
+}
+
+/* Standard sRGB Gradient - Often creates a "muddy" or grayish middle section */
+.srgb-gradient {
+  background: linear-gradient(
+    to right in srgb,
+    rgb(255, 0, 0), /* Red */
+    rgb(0, 0, 255)  /* Blue */
+  );
+}
+
+/* Oklch Gradient - Interpolates through perceptually uniform colors, staying vibrant */
+.ease-oklch-gradient {
+  background: linear-gradient(
+    to right in oklch,
+    oklch(60% 0.3 20),  /* Approx Red */
+    oklch(60% 0.3 260)  /* Approx Blue */
+  );
+}
+
+
+/* ── Info Section ────────────────────────────────────────── */
+
+.info-section {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 14px;
+  padding: 1.75rem;
+  gap: 1.25rem;
+  margin-top: 1rem;
+}
+
+.info-section h2 {
+  font-size: 1.15rem;
+  border-left: 3px solid #a78bfa;
+  padding-left: 0.75rem;
+}
+
+.code-block {
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid #334155;
+}
+
+pre {
+  background: #0f172a;
+  padding: 1.25rem;
+  overflow-x: auto;
+}
+
+pre code {
+  background: transparent;
+  color: #7dd3fc;
+  padding: 0;
+  font-size: 0.8rem;
+  line-height: 1.8;
+}


### PR DESCRIPTION
Resolves #41204

### Description
Introduces experimental color utilities using modern CSS Color Level 4 and Level 5 functions. This allows EaseMotion developers to build richer, more vibrant interfaces using the Display P3 wide color gamut and perceptually uniform `oklch()` gradients, while maintaining graceful fallbacks for older browsers and standard sRGB monitors.

### Utilities Added
| Class | What it does |
|---|---|
| `.ease-p3-card` | Example utility demonstrating how to use `@supports (color: color(display-p3 1 1 1))` to provide a vibrant Display P3 color while gracefully degrading to an sRGB hex equivalent on unsupported displays. |
| `.ease-oklch-gradient` | Demonstrates the `in oklch` interpolation method to create smooth, perceptually uniform gradients without the muddy "dead zones" typical of standard sRGB interpolation. |

### How It Works
```css
/* sRGB Fallback */
.ease-p3-card { background: #00ff00; }

/* Wide-gamut override */
@supports (color: color(display-p3 1 1 1)) {
  .ease-p3-card { background: color(display-p3 0 1 0); }
}

/* Oklch Gradient Interpolation */
.ease-oklch-gradient {
  background: linear-gradient(
    to right in oklch,
    oklch(60% 0.3 20),
    oklch(60% 0.3 260)
  );
}
```

### Demo Includes
1. **Display P3 vs sRGB Comparison:** Two side-by-side green cards. On a standard monitor, they look identical. On a wide-gamut monitor (like a modern MacBook), the P3 card looks significantly more vibrant and "neon".
2. **Oklch vs sRGB Interpolation:** Two side-by-side red-to-blue gradients. The standard sRGB gradient gets muddy and dark purple in the middle, whereas the `in oklch` gradient stays vibrant and smooth throughout the transition.

### Validation
- [x] Placed under `submissions/examples/wide-gamut-colors/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] Zero external dependencies
- [x] Includes `@supports` fallback logic
- [x] Tested on macOS with an XDR display in Chrome and Safari
