### PR TITLE
feat: add area line chart

### DIFF
--- a/submissions/examples/line-chart-as/README.md
+++ b/submissions/examples/line-chart-as/README.md
@@ -1,0 +1,25 @@
+# Area Line Chart
+
+### What does this do?
+
+It shows a small area line chart drawn with an inline SVG polyline over a gradient fill, with faint gridlines, dot markers on each point, and day labels along the bottom. There is no charting script.
+
+### How is it used?
+
+```html
+<figure class="line-chart">
+  <div class="lc-head"><h2>Weekly signups</h2><span class="val">1,284</span></div>
+  <svg viewBox="0 0 300 135">
+    <defs><linearGradient id="lc-grad" x1="0" y1="0" x2="0" y2="1">...</linearGradient></defs>
+    <polygon class="lc-area" points="10,130 10,97 ... 290,130" />
+    <polyline class="lc-line" points="10,97 58,80 ... 290,31" />
+  </svg>
+  <figcaption class="lc-x"><span>Mon</span>...</figcaption>
+</figure>
+```
+
+Plot the same points on the `polyline` for the line and on the `polygon` (closed to the baseline) for the gradient area. Add a `circle` marker per point.
+
+### Why is it useful?
+
+Dashboards need a trend line beside the bar and donut charts. This renders an area line chart from an inline SVG path with a gradient fill and gridlines, using only CSS. The line and area are static so it holds still under reduced motion.

--- a/submissions/examples/line-chart-as/demo.html
+++ b/submissions/examples/line-chart-as/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Area Line Chart</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <figure class="line-chart">
+    <div class="lc-head">
+      <h2>Weekly signups</h2>
+      <span class="val">1,284<small>▲ 18%</small></span>
+    </div>
+    <svg viewBox="0 0 300 135" role="img" aria-label="Weekly signups trend line">
+      <defs>
+        <linearGradient id="lc-grad" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stop-color="#6c63ff" stop-opacity="0.45" />
+          <stop offset="1" stop-color="#6c63ff" stop-opacity="0" />
+        </linearGradient>
+      </defs>
+      <g class="lc-grid">
+        <line x1="0" y1="30" x2="300" y2="30" />
+        <line x1="0" y1="65" x2="300" y2="65" />
+        <line x1="0" y1="100" x2="300" y2="100" />
+      </g>
+      <polygon class="lc-area" points="10,130 10,97 58,80 106,86 154,62 202,70 250,44 290,31 290,130" />
+      <polyline class="lc-line" points="10,97 58,80 106,86 154,62 202,70 250,44 290,31" />
+      <g class="lc-dots">
+        <circle class="lc-dot" cx="10" cy="97" r="3.5" />
+        <circle class="lc-dot" cx="58" cy="80" r="3.5" />
+        <circle class="lc-dot" cx="106" cy="86" r="3.5" />
+        <circle class="lc-dot" cx="154" cy="62" r="3.5" />
+        <circle class="lc-dot" cx="202" cy="70" r="3.5" />
+        <circle class="lc-dot" cx="250" cy="44" r="3.5" />
+        <circle class="lc-dot" cx="290" cy="31" r="3.5" />
+      </g>
+    </svg>
+    <figcaption class="lc-x">
+      <span>Mon</span><span>Tue</span><span>Wed</span><span>Thu</span><span>Fri</span><span>Sat</span><span>Sun</span>
+    </figcaption>
+  </figure>
+</body>
+</html>

--- a/submissions/examples/line-chart-as/style.css
+++ b/submissions/examples/line-chart-as/style.css
@@ -1,0 +1,90 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.line-chart {
+  width: min(360px, 94vw);
+  margin: 0;
+  padding: 1.4rem 1.4rem 1rem;
+  box-sizing: border-box;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+}
+
+.lc-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.lc-head h2 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.lc-head .val {
+  font-size: 1.3rem;
+  font-weight: 800;
+}
+
+.lc-head .val small {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #34d399;
+  margin-left: 0.3rem;
+}
+
+.line-chart svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  overflow: visible;
+}
+
+.lc-grid line {
+  stroke: #1b2942;
+  stroke-width: 1;
+}
+
+.lc-area {
+  fill: url("#lc-grad");
+}
+
+.lc-line {
+  fill: none;
+  stroke: #6c63ff;
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.lc-dot {
+  fill: #0e1626;
+  stroke: #6c63ff;
+  stroke-width: 2.5;
+}
+
+.lc-x {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0.5rem;
+  font-size: 0.68rem;
+  color: #64748b;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lc-line,
+  .lc-area {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an area line chart built for #41237. An inline SVG polyline over a gradient fill with gridlines, dot markers, and day labels, using only CSS. Closes #41237.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A small area line chart with a gradient fill under the line, faint gridlines, dot markers per point, and day labels along the bottom.

**How does a developer use it?**

```html
<figure class="line-chart">
  <svg viewBox="0 0 300 135">
    <polygon class="lc-area" points="10,130 10,97 ... 290,130" />
    <polyline class="lc-line" points="10,97 58,80 ... 290,31" />
  </svg>
</figure>
```

**Why does it fit EaseMotion CSS?**
It renders an area line chart from an inline SVG path with a gradient fill and gridlines, using only CSS and no charting script. It is static so it holds still under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium and by screenshot: the line renders over the gradient area with seven dot markers, three gridlines, and seven day labels.
