### PR TITLE
feat: add price range slider

### DIFF
--- a/submissions/examples/price-range-as/README.md
+++ b/submissions/examples/price-range-as/README.md
@@ -1,0 +1,21 @@
+# Price Range Slider
+
+### What does this do?
+
+It shows a dual thumb price range slider built from two overlaid native range inputs, with a highlighted selected band between the thumbs and min and max value chips above. Both thumbs stay draggable and keyboard operable.
+
+### How is it used?
+
+```html
+<div class="range" style="--min: 30%; --max: 75%">
+  <div class="range-track"><span class="range-band"></span></div>
+  <input class="range-lo" type="range" min="0" max="100" value="30" aria-label="Minimum price" />
+  <input class="range-hi" type="range" min="0" max="100" value="75" aria-label="Maximum price" />
+</div>
+```
+
+Two native range inputs stack over one track. The inputs are transparent with pointer events only on their thumbs, so each thumb can be grabbed. The selected band reads its edges from the `--min` and `--max` custom properties, which a host app updates as the user drags.
+
+### Why is it useful?
+
+Shop filters let users set a min and max price. This stacks two native range inputs into a min max slider with a styled selected band, using only CSS, so it stays draggable and keyboard operable. The thumbs show a focus ring when tabbed to.

--- a/submissions/examples/price-range-as/demo.html
+++ b/submissions/examples/price-range-as/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Price Range Slider</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="range-card">
+    <div class="range-vals">
+      <span class="range-chip"><span>Min</span>$30</span>
+      <span class="range-chip"><span>Max</span>$75</span>
+    </div>
+    <div class="range" style="--min: 30%; --max: 75%">
+      <div class="range-track"><span class="range-band"></span></div>
+      <input class="range-lo" type="range" min="0" max="100" value="30" aria-label="Minimum price" />
+      <input class="range-hi" type="range" min="0" max="100" value="75" aria-label="Maximum price" />
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/price-range-as/style.css
+++ b/submissions/examples/price-range-as/style.css
@@ -1,0 +1,109 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.range-card {
+  width: min(340px, 92vw);
+  padding: 1.6rem 1.7rem 2rem;
+  box-sizing: border-box;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+}
+
+.range-vals {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 1.3rem;
+}
+
+.range-chip {
+  padding: 0.35rem 0.7rem;
+  border-radius: 8px;
+  background: #131f34;
+  border: 1px solid #26324a;
+  font-size: 0.86rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.range-chip span {
+  color: #64748b;
+  font-weight: 500;
+  margin-right: 0.2rem;
+}
+
+.range {
+  position: relative;
+  height: 24px;
+}
+
+.range-track {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 6px;
+  transform: translateY(-50%);
+  border-radius: 3px;
+  background: #1b2942;
+}
+
+.range-band {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: var(--min, 0%);
+  right: calc(100% - var(--max, 100%));
+  border-radius: 3px;
+  background: #6c63ff;
+}
+
+.range input {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 24px;
+  margin: 0;
+  -webkit-appearance: none;
+  appearance: none;
+  background: transparent;
+  pointer-events: none;
+}
+
+.range input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  pointer-events: auto;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #e2e8f0;
+  border: 3px solid #6c63ff;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
+  cursor: grab;
+}
+
+.range input::-moz-range-thumb {
+  pointer-events: auto;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #e2e8f0;
+  border: 3px solid #6c63ff;
+  cursor: grab;
+}
+
+.range input:focus-visible::-webkit-slider-thumb {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a price range slider built for #41239. Two overlaid native range inputs form a min max slider with a selected band, using only CSS. Closes #41239.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A dual thumb price range slider from two overlaid native range inputs, with a highlighted selected band between the thumbs and min and max value chips.

**How does a developer use it?**

```html
<div class="range" style="--min: 30%; --max: 75%">
  <div class="range-track"><span class="range-band"></span></div>
  <input class="range-lo" type="range" min="0" max="100" value="30" aria-label="Minimum price" />
  <input class="range-hi" type="range" min="0" max="100" value="75" aria-label="Maximum price" />
</div>
```

**Why does it fit EaseMotion CSS?**
It stacks two native range inputs into a min max slider with a styled selected band, using only CSS, with pointer events only on the thumbs so each stays draggable and keyboard operable. The band reads its edges from `--min` and `--max`, which the host app updates on drag.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: two range inputs render and the selected band spans about 45 percent of the track, matching the 30 to 75 percent `--min`/`--max`.
