### PR TITLE
feat: add expandable rows

### DIFF
--- a/submissions/examples/expandable-rows-as/README.md
+++ b/submissions/examples/expandable-rows-as/README.md
@@ -1,0 +1,26 @@
+# Expandable Rows
+
+### What does this do?
+
+It shows a table of rows where each one expands to reveal more detail when clicked. It uses the native `details` and `summary` elements, so it works with no JavaScript, the columns stay aligned with the header, and a caret rotates on open.
+
+### How is it used?
+
+```html
+<div class="exp-table">
+  <div class="exp-headrow"><span>Order</span><span>Customer</span><span>Total</span><span></span></div>
+  <details class="exp-row">
+    <summary>
+      <span>#10842</span><span class="muted">Ada</span><span>$120.00</span>
+      <svg class="exp-caret">...</svg>
+    </summary>
+    <div class="exp-detail"><div class="exp-detail-grid">...</div></div>
+  </details>
+</div>
+```
+
+Each row is a `details` element whose `summary` is a grid that matches the header columns. The detail panel slides open below and the caret flips.
+
+### Why is it useful?
+
+Data tables and order lists often let a row expand to show details. This builds expandable rows with aligned columns and a rotating caret using only the details element and CSS. Rows are keyboard operable and the open animation is removed under reduced motion.

--- a/submissions/examples/expandable-rows-as/demo.html
+++ b/submissions/examples/expandable-rows-as/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Expandable Rows</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="exp-table">
+    <div class="exp-headrow">
+      <span>Order</span><span>Customer</span><span>Total</span><span></span>
+    </div>
+
+    <details class="exp-row" open>
+      <summary>
+        <span>#10842</span><span class="muted">Ada Lovelace</span><span>$120.00</span>
+        <svg class="exp-caret" viewBox="0 0 24 24" aria-hidden="true"><path d="m6 9 6 6 6-6" stroke-linecap="round" stroke-linejoin="round" /></svg>
+      </summary>
+      <div class="exp-detail">
+        <div class="exp-detail-grid">
+          <div><span>Status</span>Shipped</div>
+          <div><span>Carrier</span>Ease Post</div>
+          <div><span>Placed</span>12 Jul 2026</div>
+          <div><span>Items</span>3 products</div>
+        </div>
+      </div>
+    </details>
+
+    <details class="exp-row">
+      <summary>
+        <span>#10843</span><span class="muted">Alan Turing</span><span>$64.50</span>
+        <svg class="exp-caret" viewBox="0 0 24 24" aria-hidden="true"><path d="m6 9 6 6 6-6" stroke-linecap="round" stroke-linejoin="round" /></svg>
+      </summary>
+      <div class="exp-detail">
+        <div class="exp-detail-grid">
+          <div><span>Status</span>Processing</div>
+          <div><span>Carrier</span>Pending</div>
+          <div><span>Placed</span>12 Jul 2026</div>
+          <div><span>Items</span>1 product</div>
+        </div>
+      </div>
+    </details>
+
+    <details class="exp-row">
+      <summary>
+        <span>#10844</span><span class="muted">Grace Hopper</span><span>$233.00</span>
+        <svg class="exp-caret" viewBox="0 0 24 24" aria-hidden="true"><path d="m6 9 6 6 6-6" stroke-linecap="round" stroke-linejoin="round" /></svg>
+      </summary>
+      <div class="exp-detail">
+        <div class="exp-detail-grid">
+          <div><span>Status</span>Delivered</div>
+          <div><span>Carrier</span>Ease Post</div>
+          <div><span>Placed</span>10 Jul 2026</div>
+          <div><span>Items</span>5 products</div>
+        </div>
+      </div>
+    </details>
+  </div>
+</body>
+</html>

--- a/submissions/examples/expandable-rows-as/style.css
+++ b/submissions/examples/expandable-rows-as/style.css
@@ -1,0 +1,132 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.exp-table {
+  width: min(460px, 96vw);
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.exp-headrow {
+  display: grid;
+  grid-template-columns: 1.2fr 1.4fr 0.9fr 28px;
+  gap: 0.6rem;
+  padding: 0.7rem 1rem;
+  background: #111c30;
+  border-bottom: 1px solid #26324a;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #94a3b8;
+}
+
+.exp-row {
+  border-bottom: 1px solid #1b2942;
+}
+
+.exp-row:last-child {
+  border-bottom: none;
+}
+
+.exp-row summary {
+  list-style: none;
+  display: grid;
+  grid-template-columns: 1.2fr 1.4fr 0.9fr 28px;
+  gap: 0.6rem;
+  align-items: center;
+  padding: 0.8rem 1rem;
+  cursor: pointer;
+  font-size: 0.88rem;
+  transition: background 0.14s ease;
+}
+
+.exp-row summary::-webkit-details-marker {
+  display: none;
+}
+
+.exp-row summary:hover {
+  background: #131f34;
+}
+
+.exp-row summary .muted {
+  color: #94a3b8;
+}
+
+.exp-caret {
+  width: 16px;
+  height: 16px;
+  justify-self: end;
+  stroke: #64748b;
+  stroke-width: 2;
+  fill: none;
+  transition: transform 0.2s ease;
+}
+
+.exp-row[open] .exp-caret {
+  transform: rotate(180deg);
+}
+
+.exp-row[open] summary {
+  background: #131f34;
+}
+
+.exp-row summary:focus-visible {
+  outline: 2px solid #6c63ff;
+  outline-offset: -2px;
+}
+
+.exp-detail {
+  padding: 0.2rem 1rem 1rem 1rem;
+  animation: exp-open 0.2s ease;
+}
+
+.exp-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.6rem 1.2rem;
+  padding: 0.9rem 1rem;
+  background: #0b1424;
+  border: 1px solid #1b2942;
+  border-radius: 10px;
+}
+
+.exp-detail-grid div {
+  font-size: 0.84rem;
+}
+
+.exp-detail-grid span {
+  display: block;
+  font-size: 0.68rem;
+  color: #64748b;
+  margin-bottom: 0.15rem;
+}
+
+@keyframes exp-open {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .exp-caret,
+  .exp-row summary {
+    transition: none;
+  }
+
+  .exp-detail {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds expandable rows built for #41241. Table rows that expand to reveal details with a rotating caret, using the native details element and CSS only. Closes #41241.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A table of rows where each expands to reveal a detail panel, with columns aligned to the header and a caret that flips on open.

**How does a developer use it?**

```html
<div class="exp-table">
  <div class="exp-headrow"><span>Order</span><span>Customer</span><span>Total</span><span></span></div>
  <details class="exp-row">
    <summary><span>#10842</span><span class="muted">Ada</span><span>$120.00</span><svg class="exp-caret">...</svg></summary>
    <div class="exp-detail"><div class="exp-detail-grid">...</div></div>
  </details>
</div>
```

**Why does it fit EaseMotion CSS?**
It builds expandable rows with aligned columns and a rotating caret using only the details element and CSS. Rows are keyboard operable and the open animation is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium and by screenshot: the open row shows its detail panel while the two closed rows stay collapsed with a down caret.
