### PR TITLE
feat: add search suggestions

### DIFF
--- a/submissions/examples/search-suggest-as/README.md
+++ b/submissions/examples/search-suggest-as/README.md
@@ -1,0 +1,28 @@
+# Search Suggestions
+
+### What does this do?
+
+It shows a search box that reveals a suggestions dropdown when the field is focused, with a recent searches group and a matching suggestions group. Each row has an icon, and matched text is highlighted. It works with no JavaScript.
+
+### How is it used?
+
+```html
+<div class="search">
+  <div class="search-box">
+    <svg>...</svg>
+    <input class="search-input" type="text" placeholder="Search" />
+  </div>
+  <div class="search-panel">
+    <div class="search-group">Recent</div>
+    <a class="search-item"><svg>...</svg>css transitions</a>
+    <div class="search-group">Suggestions</div>
+    <a class="search-item"><svg>...</svg>css <mark>grid</mark> layout</a>
+  </div>
+</div>
+```
+
+The panel is hidden until the wrapper contains focus, using `:focus-within`. Group headers label sections and `mark` highlights the matched part of a suggestion.
+
+### Why is it useful?
+
+Search bars show suggestions as you focus and type. This reveals a grouped suggestions panel on focus with icons and hover states, using only CSS. The reveal transition is reduced under reduced motion.

--- a/submissions/examples/search-suggest-as/demo.html
+++ b/submissions/examples/search-suggest-as/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Search Suggestions</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="search">
+    <div class="search-box">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="7" /><path d="m21 21-4-4" stroke-linecap="round" /></svg>
+      <input class="search-input" type="text" placeholder="Search components" value="grid" aria-label="Search" />
+    </div>
+    <div class="search-panel" role="listbox" aria-label="Suggestions">
+      <div class="search-group">Recent</div>
+      <a class="search-item" href="#"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9" /><path d="M12 7v5l3 3" stroke-linecap="round" /></svg>flexbox cheatsheet</a>
+      <a class="search-item" href="#"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9" /><path d="M12 7v5l3 3" stroke-linecap="round" /></svg>css transitions</a>
+      <div class="search-group">Suggestions</div>
+      <a class="search-item" href="#"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="7" /><path d="m21 21-4-4" stroke-linecap="round" /></svg>css <mark>grid</mark> layout</a>
+      <a class="search-item" href="#"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="7" /><path d="m21 21-4-4" stroke-linecap="round" /></svg>masonry <mark>grid</mark></a>
+      <a class="search-item" href="#"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="7" /><path d="m21 21-4-4" stroke-linecap="round" /></svg><mark>grid</mark> template areas</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/search-suggest-as/style.css
+++ b/submissions/examples/search-suggest-as/style.css
@@ -1,0 +1,133 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: start center;
+  padding: 4rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.search {
+  position: relative;
+  width: min(360px, 92vw);
+}
+
+.search-box {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.7rem 0.95rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 12px;
+  transition: border-color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.search:focus-within .search-box {
+  border-color: #6c63ff;
+  box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.25);
+}
+
+.search-box svg {
+  width: 18px;
+  height: 18px;
+  stroke: #64748b;
+  stroke-width: 2;
+  fill: none;
+  flex: none;
+}
+
+.search-input {
+  flex: 1;
+  min-width: 0;
+  font: inherit;
+  font-size: 0.92rem;
+  color: #e2e8f0;
+  background: transparent;
+  border: none;
+  outline: none;
+}
+
+.search-input::placeholder {
+  color: #64748b;
+}
+
+.search-panel {
+  position: absolute;
+  top: calc(100% + 0.45rem);
+  left: 0;
+  right: 0;
+  padding: 0.4rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 12px;
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-6px);
+  transition: opacity 0.16s ease, transform 0.16s ease, visibility 0.16s ease;
+  z-index: 2;
+}
+
+.search:focus-within .search-panel {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.search-group {
+  padding: 0.5rem 0.7rem 0.25rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #64748b;
+}
+
+.search-item {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.55rem 0.7rem;
+  border-radius: 8px;
+  color: #cbd5e1;
+  text-decoration: none;
+  font-size: 0.88rem;
+  transition: background 0.14s ease;
+}
+
+.search-item svg {
+  width: 16px;
+  height: 16px;
+  stroke: #64748b;
+  stroke-width: 2;
+  fill: none;
+  flex: none;
+}
+
+.search-item:hover,
+.search-item:focus-visible {
+  background: #1b2942;
+  color: #fff;
+  outline: none;
+}
+
+.search-item mark {
+  background: transparent;
+  color: #a5b4fc;
+  font-weight: 700;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .search-box,
+  .search-panel {
+    transition: opacity 0.16s ease, visibility 0.16s ease;
+  }
+
+  .search:focus-within .search-panel {
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds search suggestions built for #41243. A search box that reveals a grouped suggestions panel on focus, using only CSS. Closes #41243.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A search box that opens a suggestions dropdown on focus, with a recent group and a matching suggestions group, icons per row, and highlighted matched text.

**How does a developer use it?**

```html
<div class="search">
  <div class="search-box"><svg>...</svg><input class="search-input" placeholder="Search" /></div>
  <div class="search-panel">
    <div class="search-group">Recent</div>
    <a class="search-item"><svg>...</svg>css <mark>grid</mark> layout</a>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It reveals a grouped suggestions panel on focus with icons and hover states using `:focus-within`, with `mark` highlighting the matched text, all in CSS. The reveal transition is reduced under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the panel is hidden until the input is focused, then shows five items across two groups with three highlighted match marks.
