### PR TITLE
feat: add snackbar

### DIFF
--- a/submissions/examples/snackbar-as/README.md
+++ b/submissions/examples/snackbar-as/README.md
@@ -1,0 +1,24 @@
+# Snackbar
+
+### What does this do?
+
+It shows a single snackbar toast with an icon, a message, an undo action, and a thin countdown bar that runs down while it is shown. A close button dismisses it with a slide down. It works with no JavaScript.
+
+### How is it used?
+
+```html
+<input type="checkbox" id="sb-close" class="sb-close" />
+<div class="snackbar" role="status">
+  <span class="sb-icon"><svg>...</svg></span>
+  <span class="sb-text">Message moved to archive</span>
+  <a class="sb-action" href="#">Undo</a>
+  <label class="sb-x" for="sb-close" aria-label="Dismiss">✕</label>
+  <span class="sb-timer"></span>
+</div>
+```
+
+Keep the checkbox before the snackbar so the sibling selector can slide it away. The timer bar animates its scale to zero over a set duration, and the close label dismisses the snackbar.
+
+### Why is it useful?
+
+Apps confirm quick actions with a snackbar that offers an undo. This builds a snackbar with an action, an auto dismiss countdown bar, and a close control, using only a checkbox and CSS. The countdown and slide are removed under reduced motion.

--- a/submissions/examples/snackbar-as/demo.html
+++ b/submissions/examples/snackbar-as/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Snackbar</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <input type="checkbox" id="sb-close" class="sb-close" />
+  <main class="page">
+    <h1>Inbox</h1>
+    <p>The snackbar sits pinned at the bottom with a message and an undo action. Its timer bar counts down, and the close button dismisses it with a slide down.</p>
+  </main>
+  <div class="snackbar" role="status">
+    <span class="sb-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m5 13 4 4 10-11" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
+    <span class="sb-text">Message moved to archive</span>
+    <a class="sb-action" href="#">Undo</a>
+    <label class="sb-x" for="sb-close" aria-label="Dismiss" role="button">✕</label>
+    <span class="sb-timer" aria-hidden="true"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/snackbar-as/style.css
+++ b/submissions/examples/snackbar-as/style.css
@@ -1,0 +1,154 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.page {
+  padding: 2.5rem 1.5rem;
+  max-width: 480px;
+}
+
+.page h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.4rem;
+}
+
+.page p {
+  margin: 0;
+  color: #94a3b8;
+  line-height: 1.6;
+  font-size: 0.95rem;
+}
+
+.sb-close {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  margin: -1px;
+  overflow: hidden;
+}
+
+.snackbar {
+  position: fixed;
+  left: 50%;
+  bottom: 1.5rem;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  width: min(400px, calc(100vw - 2rem));
+  box-sizing: border-box;
+  padding: 0.85rem 1rem;
+  background: #1b2942;
+  border: 1px solid #2b3a57;
+  border-radius: 12px;
+  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.sb-close:checked ~ .snackbar {
+  opacity: 0;
+  transform: translate(-50%, 20px);
+  pointer-events: none;
+}
+
+.sb-icon {
+  width: 22px;
+  height: 22px;
+  flex: none;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: #10b981;
+}
+
+.sb-icon svg {
+  width: 13px;
+  height: 13px;
+  stroke: #06231a;
+  stroke-width: 3;
+  fill: none;
+}
+
+.sb-text {
+  flex: 1;
+  min-width: 0;
+  font-size: 0.9rem;
+  color: #e2e8f0;
+}
+
+.sb-action {
+  flex: none;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #a5b4fc;
+  text-decoration: none;
+}
+
+.sb-action:hover {
+  text-decoration: underline;
+}
+
+.sb-x {
+  flex: none;
+  width: 26px;
+  height: 26px;
+  display: grid;
+  place-items: center;
+  border-radius: 7px;
+  color: #94a3b8;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.sb-x:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: #e2e8f0;
+}
+
+.sb-timer {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  height: 3px;
+  width: 100%;
+  transform-origin: left;
+  background: linear-gradient(90deg, #6c63ff, #a855f7);
+  animation: sb-count 5s linear forwards;
+}
+
+.sb-action:focus-visible,
+.sb-close:focus-visible ~ .snackbar .sb-x {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+@keyframes sb-count {
+  from {
+    transform: scaleX(1);
+  }
+
+  to {
+    transform: scaleX(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .snackbar {
+    transition: opacity 0.3s ease;
+  }
+
+  .sb-close:checked ~ .snackbar {
+    transform: translateX(-50%);
+  }
+
+  .sb-timer {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a snackbar built for #41245. A toast with an undo action and a countdown bar, dismissible with a checkbox, using only CSS. Closes #41245.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A single snackbar toast with an icon, a message, an undo action, a thin countdown bar, and a close button that slides it away.

**How does a developer use it?**

```html
<input type="checkbox" id="sb-close" class="sb-close" />
<div class="snackbar" role="status">
  <span class="sb-icon"><svg>...</svg></span>
  <span class="sb-text">Message moved to archive</span>
  <a class="sb-action" href="#">Undo</a>
  <label class="sb-x" for="sb-close" aria-label="Dismiss">✕</label>
  <span class="sb-timer"></span>
</div>
```

**Why does it fit EaseMotion CSS?**
It builds a snackbar with an action, an auto dismiss countdown bar, and a close control, using only a checkbox and CSS. The countdown and slide are removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the snackbar is fixed, runs the `sb-count` timer animation, and fades from opacity 1 to 0 when the close checkbox is checked.
