### PR TITLE
feat: add site footer

### DIFF
--- a/submissions/examples/footer-as/README.md
+++ b/submissions/examples/footer-as/README.md
@@ -1,0 +1,27 @@
+# Site Footer
+
+### What does this do?
+
+It shows a responsive site footer with a brand block and blurb, three columns of links, a row of social icons, and a bottom bar with copyright and legal links. The columns collapse on narrow screens.
+
+### How is it used?
+
+```html
+<footer class="footer">
+  <div class="ft-cols">
+    <div class="ft-brand">
+      <div class="logo"><svg>...</svg>EaseMotion</div>
+      <p>Short blurb.</p>
+      <div class="ft-social"><a href="#"><svg>...</svg></a></div>
+    </div>
+    <nav class="ft-group"><h4>Product</h4><a href="#">Features</a></nav>
+  </div>
+  <div class="ft-bottom"><span>© 2026 EaseMotion</span><div class="ft-legal"><a href="#">Privacy</a></div></div>
+</footer>
+```
+
+The top area is a four column grid that becomes two columns below 560px, with the brand block spanning the full width. The bottom bar sits under a divider.
+
+### Why is it useful?
+
+Almost every marketing site ends with a footer. This lays out a multi column footer with a brand block, link groups, social icons, and a bottom bar that reflows responsively, using only CSS and inline SVG so there are no external assets.

--- a/submissions/examples/footer-as/demo.html
+++ b/submissions/examples/footer-as/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Site Footer</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <footer class="footer">
+    <div class="ft-cols">
+      <div class="ft-brand">
+        <div class="logo">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 14a8 8 0 0 1 16 0M4 14l8-9 8 9" stroke-linecap="round" stroke-linejoin="round" /></svg>
+          EaseMotion
+        </div>
+        <p>Accessible, self contained CSS components you can drop into any project with no build step.</p>
+        <div class="ft-social">
+          <a href="#" aria-label="X"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18.9 2H22l-7.6 8.7L23 22h-6.8l-5-6.6L5.5 22H2.4l8.2-9.3L1.7 2h6.9l4.5 6zm-1.2 18h1.7L7.4 3.8H5.6z" /></svg></a>
+          <a href="#" aria-label="GitHub"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2a10 10 0 0 0-3.2 19.5c.5.1.7-.2.7-.5v-1.7c-2.8.6-3.4-1.3-3.4-1.3-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 .1 1.5 1 1.5 1 .9 1.5 2.3 1.1 2.9.8.1-.6.3-1.1.6-1.4-2.2-.2-4.6-1.1-4.6-5a4 4 0 0 1 1-2.7c-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.7 1a9.3 9.3 0 0 1 5 0c1.9-1.3 2.7-1 2.7-1 .5 1.4.2 2.4.1 2.7a4 4 0 0 1 1 2.7c0 3.9-2.4 4.8-4.6 5 .3.3.6.9.6 1.9v2.8c0 .3.2.6.7.5A10 10 0 0 0 12 2z" /></svg></a>
+          <a href="#" aria-label="LinkedIn"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.98 3.5a2 2 0 1 1 0 4 2 2 0 0 1 0-4zM3 9h4v12H3zM10 9h3.8v1.7h.1a4.2 4.2 0 0 1 3.8-2c4 0 4.8 2.6 4.8 6V21h-4v-5.4c0-1.3 0-3-1.8-3s-2.1 1.4-2.1 2.9V21h-4z" /></svg></a>
+        </div>
+      </div>
+      <nav class="ft-group">
+        <h4>Product</h4>
+        <a href="#">Features</a><a href="#">Pricing</a><a href="#">Changelog</a><a href="#">Roadmap</a>
+      </nav>
+      <nav class="ft-group">
+        <h4>Company</h4>
+        <a href="#">About</a><a href="#">Blog</a><a href="#">Careers</a><a href="#">Contact</a>
+      </nav>
+      <nav class="ft-group">
+        <h4>Resources</h4>
+        <a href="#">Docs</a><a href="#">Guides</a><a href="#">Support</a><a href="#">Status</a>
+      </nav>
+    </div>
+    <div class="ft-bottom">
+      <span>© 2026 EaseMotion. All rights reserved.</span>
+      <div class="ft-legal"><a href="#">Privacy</a><a href="#">Terms</a><a href="#">Cookies</a></div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/submissions/examples/footer-as/style.css
+++ b/submissions/examples/footer-as/style.css
@@ -1,0 +1,150 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.footer {
+  width: min(720px, 96vw);
+  box-sizing: border-box;
+  padding: 2rem 2rem 1.2rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 18px;
+}
+
+.ft-cols {
+  display: grid;
+  grid-template-columns: 1.7fr 1fr 1fr 1fr;
+  gap: 2rem;
+  padding-bottom: 1.6rem;
+}
+
+.ft-brand .logo {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1.05rem;
+  font-weight: 800;
+  margin-bottom: 0.7rem;
+}
+
+.ft-brand .logo svg {
+  width: 22px;
+  height: 22px;
+  stroke: #a5b4fc;
+  stroke-width: 2;
+  fill: none;
+}
+
+.ft-brand p {
+  margin: 0 0 1rem;
+  font-size: 0.84rem;
+  line-height: 1.55;
+  color: #94a3b8;
+  max-width: 30ch;
+}
+
+.ft-social {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.ft-social a {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: 9px;
+  background: #131f34;
+  border: 1px solid #26324a;
+  color: #94a3b8;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.ft-social a svg {
+  width: 17px;
+  height: 17px;
+  fill: currentColor;
+}
+
+.ft-social a:hover,
+.ft-social a:focus-visible {
+  color: #a5b4fc;
+  border-color: #6c63ff;
+  outline: none;
+}
+
+.ft-group h4 {
+  margin: 0 0 0.8rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #cbd5e1;
+}
+
+.ft-group a {
+  display: block;
+  margin-bottom: 0.55rem;
+  font-size: 0.85rem;
+  color: #94a3b8;
+  text-decoration: none;
+  transition: color 0.14s ease;
+}
+
+.ft-group a:hover,
+.ft-group a:focus-visible {
+  color: #e2e8f0;
+  outline: none;
+}
+
+.ft-bottom {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  padding-top: 1.2rem;
+  border-top: 1px solid #1b2942;
+  font-size: 0.78rem;
+  color: #64748b;
+}
+
+.ft-legal {
+  display: flex;
+  gap: 1.2rem;
+}
+
+.ft-legal a {
+  color: #64748b;
+  text-decoration: none;
+}
+
+.ft-legal a:hover {
+  color: #cbd5e1;
+}
+
+@media (max-width: 560px) {
+  .ft-cols {
+    grid-template-columns: 1fr 1fr;
+    gap: 1.4rem;
+  }
+
+  .ft-brand {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ft-social a,
+  .ft-group a {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a site footer built for #41247. A brand block, link columns, social icons, and a bottom bar that reflows responsively, using only CSS and inline SVG. Closes #41247.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A responsive site footer with a brand block and blurb, three link columns, a row of social icons, and a bottom bar with copyright and legal links.

**How does a developer use it?**

```html
<footer class="footer">
  <div class="ft-cols">
    <div class="ft-brand">...<div class="ft-social"><a href="#"><svg>...</svg></a></div></div>
    <nav class="ft-group"><h4>Product</h4><a href="#">Features</a></nav>
  </div>
  <div class="ft-bottom"><span>© 2026 EaseMotion</span><div class="ft-legal"><a href="#">Privacy</a></div></div>
</footer>
```

**Why does it fit EaseMotion CSS?**
It lays out a multi column footer with a brand block, link groups, social icons, and a bottom bar that reflows to two columns below 560px, using only CSS and inline SVG so there are no external assets.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the footer renders a four column top area with three link groups, three social icons, three legal links, and a bottom bar.
