### PR TITLE
feat: add navbar

### DIFF
--- a/submissions/examples/navbar-as/README.md
+++ b/submissions/examples/navbar-as/README.md
@@ -1,0 +1,23 @@
+# Navbar
+
+### What does this do?
+
+It shows a desktop top navigation bar with a logo, a row of nav links where the active one is underlined, and a sign in and get started button pair. Below 680px the links and actions collapse behind a checkbox hamburger.
+
+### How is it used?
+
+```html
+<header class="navbar">
+  <a class="nav-logo" href="#"><svg>...</svg>EaseMotion</a>
+  <input type="checkbox" id="nav-toggle" class="nav-toggle" />
+  <label class="nav-burger" for="nav-toggle" aria-label="Toggle menu"><span></span></label>
+  <nav class="nav-links"><a class="is-active" href="#">Home</a></nav>
+  <div class="nav-actions"><a class="nav-ghost" href="#">Sign in</a><a class="nav-cta" href="#">Get started</a></div>
+</header>
+```
+
+Mark the current page link with `is-active` for the underline. The hamburger checkbox reveals the stacked links and actions on small screens.
+
+### Why is it useful?
+
+The top navbar is the first component on most sites. This lays out a logo, nav links with an active underline, and action buttons, with a checkbox driven mobile menu, using only CSS. Links and buttons show focus rings and transitions are removed under reduced motion.

--- a/submissions/examples/navbar-as/demo.html
+++ b/submissions/examples/navbar-as/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Navbar</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="navbar">
+    <a class="nav-logo" href="#">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 14a8 8 0 0 1 16 0M4 14l8-9 8 9" stroke-linecap="round" stroke-linejoin="round" /></svg>
+      EaseMotion
+    </a>
+    <input type="checkbox" id="nav-toggle" class="nav-toggle" />
+    <label class="nav-burger" for="nav-toggle" aria-label="Toggle menu"><span></span></label>
+    <nav class="nav-links">
+      <a class="is-active" href="#">Home</a>
+      <a href="#">Features</a>
+      <a href="#">Pricing</a>
+      <a href="#">Docs</a>
+    </nav>
+    <div class="nav-actions">
+      <a class="nav-ghost" href="#">Sign in</a>
+      <a class="nav-cta" href="#">Get started</a>
+    </div>
+  </header>
+</body>
+</html>

--- a/submissions/examples/navbar-as/style.css
+++ b/submissions/examples/navbar-as/style.css
@@ -1,0 +1,195 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.navbar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 1.2rem;
+  width: min(820px, 96vw);
+  margin: 0 auto;
+  padding: 0.7rem 1.1rem;
+  box-sizing: border-box;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 14px;
+}
+
+.nav-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1.05rem;
+  font-weight: 800;
+  color: #e2e8f0;
+  text-decoration: none;
+}
+
+.nav-logo svg {
+  width: 22px;
+  height: 22px;
+  stroke: #a5b4fc;
+  stroke-width: 2;
+  fill: none;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  margin-left: 0.6rem;
+}
+
+.nav-links a {
+  position: relative;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: #94a3b8;
+  text-decoration: none;
+  border-radius: 8px;
+  transition: color 0.14s ease;
+}
+
+.nav-links a:hover {
+  color: #e2e8f0;
+}
+
+.nav-links a.is-active {
+  color: #fff;
+}
+
+.nav-links a.is-active::after {
+  content: "";
+  position: absolute;
+  left: 0.75rem;
+  right: 0.75rem;
+  bottom: -2px;
+  height: 2px;
+  border-radius: 2px;
+  background: #6c63ff;
+}
+
+.nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-left: auto;
+}
+
+.nav-ghost {
+  font-size: 0.86rem;
+  font-weight: 600;
+  color: #cbd5e1;
+  text-decoration: none;
+}
+
+.nav-cta {
+  padding: 0.5rem 1rem;
+  font-size: 0.86rem;
+  font-weight: 700;
+  color: #fff;
+  background: #6c63ff;
+  border-radius: 9px;
+  text-decoration: none;
+  transition: background 0.15s ease;
+}
+
+.nav-cta:hover {
+  background: #5b52e6;
+}
+
+.nav-links a:focus-visible,
+.nav-ghost:focus-visible,
+.nav-cta:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+.nav-toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  margin: -1px;
+  overflow: hidden;
+}
+
+.nav-burger {
+  display: none;
+  width: 40px;
+  height: 40px;
+  margin-left: auto;
+  border-radius: 9px;
+  cursor: pointer;
+  position: relative;
+  border: 1px solid #26324a;
+}
+
+.nav-burger::before,
+.nav-burger::after,
+.nav-burger span {
+  content: "";
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  height: 2px;
+  background: #cbd5e1;
+  border-radius: 2px;
+}
+
+.nav-burger::before {
+  top: 13px;
+}
+
+.nav-burger span {
+  top: 19px;
+}
+
+.nav-burger::after {
+  top: 25px;
+}
+
+@media (max-width: 680px) {
+  .navbar {
+    flex-wrap: wrap;
+  }
+
+  .nav-burger {
+    display: block;
+  }
+
+  .nav-links,
+  .nav-actions {
+    display: none;
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    margin: 0.4rem 0 0;
+  }
+
+  .nav-toggle:checked ~ .nav-links,
+  .nav-toggle:checked ~ .nav-actions {
+    display: flex;
+  }
+
+  .nav-cta,
+  .nav-ghost {
+    text-align: center;
+    padding: 0.65rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nav-links a,
+  .nav-cta {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a navbar built for #41250. A top nav with logo, active underlined links, actions, and a checkbox mobile menu, using only CSS. Closes #41250.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A desktop top navbar with a logo, nav links where the active one is underlined, and a sign in and get started button pair, collapsing behind a checkbox hamburger on narrow screens.

**How does a developer use it?**

```html
<header class="navbar">
  <a class="nav-logo" href="#"><svg>...</svg>EaseMotion</a>
  <input type="checkbox" id="nav-toggle" class="nav-toggle" />
  <label class="nav-burger" for="nav-toggle"><span></span></label>
  <nav class="nav-links"><a class="is-active" href="#">Home</a></nav>
  <div class="nav-actions"><a class="nav-ghost" href="#">Sign in</a><a class="nav-cta" href="#">Get started</a></div>
</header>
```

**Why does it fit EaseMotion CSS?**
It lays out a logo, nav links with an active underline, and action buttons, with a checkbox driven mobile menu, using only CSS. Links and buttons show focus rings and transitions are removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: four nav links render, the active link carries its underline pseudo element, and the logo and get started button are present.
