### PR TITLE
feat: add mega menu

### DIFF
--- a/submissions/examples/mega-menu-as/README.md
+++ b/submissions/examples/mega-menu-as/README.md
@@ -1,0 +1,25 @@
+# Mega Menu
+
+### What does this do?
+
+It shows a mega menu where a nav item opens a wide panel of links across two columns, each with an icon, a title, and a short description. It uses the native `details` and `summary` elements, so it opens on click and stays keyboard operable with no JavaScript.
+
+### How is it used?
+
+```html
+<details class="mega">
+  <summary>Products</summary>
+  <div class="mega-panel">
+    <a class="mega-item" href="#">
+      <span class="mega-ic"><svg>...</svg></span>
+      <div><strong>Analytics</strong><small>Track usage</small></div>
+    </a>
+  </div>
+</details>
+```
+
+The panel is a two column grid of items. The caret in the summary flips when the menu is open. Remove `open` from the demo to see it start closed.
+
+### Why is it useful?
+
+Product sites use a mega menu to show many destinations in one panel. This opens a wide multi column menu from a nav item with icons and descriptions, using only the details element and CSS. Items have hover and focus styles and the open animation is removed under reduced motion.

--- a/submissions/examples/mega-menu-as/demo.html
+++ b/submissions/examples/mega-menu-as/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mega Menu</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <details class="mega" open>
+    <summary>Products</summary>
+    <div class="mega-panel">
+      <a class="mega-item" href="#">
+        <span class="mega-ic"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 20V10M10 20V4M16 20v-7M22 20H2" stroke-linecap="round" /></svg></span>
+        <div><strong>Analytics</strong><small>Track usage and trends</small></div>
+      </a>
+      <a class="mega-item" href="#">
+        <span class="mega-ic"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3 3 7l9 4 9-4z" stroke-linejoin="round" /><path d="M3 12l9 4 9-4M3 17l9 4 9-4" stroke-linejoin="round" /></svg></span>
+        <div><strong>Warehouse</strong><small>Store all your data</small></div>
+      </a>
+      <a class="mega-item" href="#">
+        <span class="mega-ic"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="4" width="18" height="16" rx="2" /><path d="M3 9h18" /></svg></span>
+        <div><strong>Dashboards</strong><small>Share live reports</small></div>
+      </a>
+      <a class="mega-item" href="#">
+        <span class="mega-ic"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="3" /><path d="M12 3v3M12 18v3M3 12h3M18 12h3" stroke-linecap="round" /></svg></span>
+        <div><strong>Automations</strong><small>Run tasks on a schedule</small></div>
+      </a>
+      <a class="mega-item" href="#">
+        <span class="mega-ic"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 15 15 9M8 12H6a3 3 0 0 1 0-6h3M16 12h2a3 3 0 0 1 0 6h-3" stroke-linecap="round" /></svg></span>
+        <div><strong>Integrations</strong><small>Connect your stack</small></div>
+      </a>
+      <a class="mega-item" href="#">
+        <span class="mega-ic"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3 4 6v5c0 5 3.5 8 8 10 4.5-2 8-5 8-10V6z" stroke-linejoin="round" /></svg></span>
+        <div><strong>Security</strong><small>Keep data protected</small></div>
+      </a>
+    </div>
+  </details>
+</body>
+</html>

--- a/submissions/examples/mega-menu-as/style.css
+++ b/submissions/examples/mega-menu-as/style.css
@@ -1,0 +1,142 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: start center;
+  padding: 3rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.mega {
+  position: relative;
+  width: min(200px, 90vw);
+}
+
+.mega summary {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.65rem 1rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 10px;
+  font-size: 0.92rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.mega summary::-webkit-details-marker {
+  display: none;
+}
+
+.mega summary::after {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid #94a3b8;
+  border-bottom: 2px solid #94a3b8;
+  transform: rotate(45deg);
+  transition: transform 0.2s ease;
+}
+
+.mega[open] summary {
+  border-color: #6c63ff;
+}
+
+.mega[open] summary::after {
+  transform: rotate(-135deg);
+}
+
+.mega summary:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+.mega-panel {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 0;
+  width: min(460px, 92vw);
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.3rem;
+  padding: 0.6rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 14px;
+  box-shadow: 0 20px 44px rgba(0, 0, 0, 0.5);
+  z-index: 2;
+}
+
+.mega[open] .mega-panel {
+  animation: mega-in 0.18s ease;
+}
+
+.mega-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.7rem;
+  padding: 0.7rem;
+  border-radius: 10px;
+  text-decoration: none;
+  transition: background 0.14s ease;
+}
+
+.mega-item:hover,
+.mega-item:focus-visible {
+  background: #1b2942;
+  outline: none;
+}
+
+.mega-ic {
+  flex: none;
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: 9px;
+  background: rgba(108, 99, 255, 0.16);
+  color: #a5b4fc;
+}
+
+.mega-ic svg {
+  width: 18px;
+  height: 18px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+}
+
+.mega-item strong {
+  display: block;
+  font-size: 0.88rem;
+  color: #e2e8f0;
+}
+
+.mega-item small {
+  font-size: 0.76rem;
+  color: #94a3b8;
+}
+
+@keyframes mega-in {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mega summary::after,
+  .mega-item {
+    transition: none;
+  }
+
+  .mega[open] .mega-panel {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a mega menu built for #41253. A nav item that opens a wide two column panel of links with icons and descriptions, using the native details element and CSS only. Closes #41253.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A mega menu where a nav item opens a wide panel of grouped links across two columns, each with an icon, a title, and a short description, plus a caret that flips when open.

**How does a developer use it?**

```html
<details class="mega">
  <summary>Products</summary>
  <div class="mega-panel">
    <a class="mega-item"><span class="mega-ic"><svg>...</svg></span><div><strong>Analytics</strong><small>Track usage</small></div></a>
  </div>
</details>
```

**Why does it fit EaseMotion CSS?**
It opens a wide multi column menu from a nav item with icons and descriptions, using only the details element and CSS. Items have hover and focus styles and the open animation is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: with the menu open six items render across two columns, each with its icon, and the panel is visible.
