### PR TITLE
feat: add voice message

### DIFF
--- a/submissions/examples/voice-message-as/README.md
+++ b/submissions/examples/voice-message-as/README.md
@@ -1,0 +1,24 @@
+# Voice Message
+
+### What does this do?
+
+It shows a chat voice message bubble with a play button, a waveform of bars, and a duration. The played portion of the waveform is tinted brighter to show progress.
+
+### How is it used?
+
+```html
+<div class="voice">
+  <button class="vm-play" aria-label="Play voice message"><svg>...</svg></button>
+  <div class="vm-wave">
+    <span class="played" style="--h: 40%"></span>
+    <span style="--h: 80%"></span>
+  </div>
+  <span class="vm-time">0:14</span>
+</div>
+```
+
+Set each bar height with the `--h` custom property, and add the `played` class to the bars up to the current position. A host app moves the played boundary as the clip plays.
+
+### Why is it useful?
+
+Messaging apps send voice notes shown as a waveform. This lays out a voice message bubble with a play button, a bar waveform driven by heights, and a played state, using only CSS and inline SVG. The play button hover scale is removed under reduced motion.

--- a/submissions/examples/voice-message-as/demo.html
+++ b/submissions/examples/voice-message-as/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Voice Message</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="voice">
+    <button class="vm-play" type="button" aria-label="Play voice message">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 5v14l12-7z" /></svg>
+    </button>
+    <div class="vm-wave" aria-hidden="true">
+      <span class="played" style="--h: 40%"></span>
+      <span class="played" style="--h: 65%"></span>
+      <span class="played" style="--h: 90%"></span>
+      <span class="played" style="--h: 55%"></span>
+      <span class="played" style="--h: 75%"></span>
+      <span class="played" style="--h: 45%"></span>
+      <span style="--h: 85%"></span>
+      <span style="--h: 60%"></span>
+      <span style="--h: 95%"></span>
+      <span style="--h: 50%"></span>
+      <span style="--h: 70%"></span>
+      <span style="--h: 40%"></span>
+      <span style="--h: 80%"></span>
+      <span style="--h: 55%"></span>
+      <span style="--h: 65%"></span>
+      <span style="--h: 45%"></span>
+      <span style="--h: 90%"></span>
+      <span style="--h: 60%"></span>
+    </div>
+    <span class="vm-time">0:14</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/voice-message-as/style.css
+++ b/submissions/examples/voice-message-as/style.css
@@ -1,0 +1,89 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.voice {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  width: min(320px, 92vw);
+  box-sizing: border-box;
+  padding: 0.7rem 0.9rem;
+  background: linear-gradient(135deg, #6c63ff, #7c5cff);
+  border-radius: 4px 16px 16px 16px;
+}
+
+.vm-play {
+  flex: none;
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+  border: none;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.9);
+  color: #4f46e5;
+  cursor: pointer;
+  transition: transform 0.14s ease;
+}
+
+.vm-play:hover {
+  transform: scale(1.06);
+}
+
+.vm-play svg {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
+}
+
+.vm-play:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+
+.vm-wave {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  height: 34px;
+}
+
+.vm-wave span {
+  flex: 1;
+  height: var(--h, 40%);
+  min-width: 2px;
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.4);
+}
+
+.vm-wave span.played {
+  background: #fff;
+}
+
+.vm-time {
+  flex: none;
+  font-size: 0.74rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.9);
+  font-variant-numeric: tabular-nums;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vm-play {
+    transition: none;
+  }
+
+  .vm-play:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a voice message built for #41255. A chat voice note with a play button, a bar waveform, and a played progress state, using only CSS. Closes #41255.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A chat voice message bubble with a play button, a waveform of bars driven by heights, a duration, and a tinted played portion.

**How does a developer use it?**

```html
<div class="voice">
  <button class="vm-play" aria-label="Play voice message"><svg>...</svg></button>
  <div class="vm-wave"><span class="played" style="--h: 40%"></span><span style="--h: 80%"></span></div>
  <span class="vm-time">0:14</span>
</div>
```

**Why does it fit EaseMotion CSS?**
It lays out a voice message bubble with a play button, a bar waveform, and a played state driven by the `played` class, using only CSS and inline SVG. The play button hover scale is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: eighteen waveform bars render with six marked played and brighter, alongside the play button and 0:14 duration.
