### PR TITLE
feat: add now playing bar

### DIFF
--- a/submissions/examples/now-playing-as/README.md
+++ b/submissions/examples/now-playing-as/README.md
@@ -1,0 +1,22 @@
+# Now Playing Bar
+
+### What does this do?
+
+It shows a now playing card with track art, title and artist, an animated equalizer of bars that bounce to fake the beat, and a play or pause button. Each equalizer bar animates on its own delay.
+
+### How is it used?
+
+```html
+<div class="now-playing">
+  <div class="np-art"><svg>...</svg></div>
+  <div class="np-meta"><strong>Nightfall</strong><small>Aurora Lane</small></div>
+  <div class="np-eq"><span></span><span></span><span></span><span></span></div>
+  <button class="np-play" aria-label="Pause"><svg>...</svg></button>
+</div>
+```
+
+The equalizer is a row of spans that animate their height up and down, each with a different `animation-delay` so they fall out of sync like real audio levels.
+
+### Why is it useful?
+
+Music widgets show an animated equalizer while a track plays. This builds a now playing card with a bouncing bar equalizer from staggered keyframes, using only CSS. Under reduced motion the bars rest at a steady height.

--- a/submissions/examples/now-playing-as/demo.html
+++ b/submissions/examples/now-playing-as/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Now Playing Bar</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="now-playing">
+    <div class="np-art" aria-hidden="true">
+      <svg viewBox="0 0 24 24"><path d="M9 18V5l10-2v13" stroke-linecap="round" stroke-linejoin="round" /><circle cx="6" cy="18" r="3" /><circle cx="16" cy="16" r="3" /></svg>
+    </div>
+    <div class="np-meta">
+      <strong>Nightfall</strong>
+      <small>Aurora Lane</small>
+    </div>
+    <div class="np-eq" aria-label="Now playing" role="img">
+      <span></span><span></span><span></span><span></span>
+    </div>
+    <button class="np-play" type="button" aria-label="Pause">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 5h4v14H7zM13 5h4v14h-4z" /></svg>
+    </button>
+  </div>
+</body>
+</html>

--- a/submissions/examples/now-playing-as/style.css
+++ b/submissions/examples/now-playing-as/style.css
@@ -1,0 +1,142 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.now-playing {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  width: min(320px, 92vw);
+  box-sizing: border-box;
+  padding: 0.8rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+}
+
+.np-art {
+  flex: none;
+  width: 52px;
+  height: 52px;
+  border-radius: 11px;
+  background: linear-gradient(135deg, #6c63ff, #ec4899);
+  display: grid;
+  place-items: center;
+}
+
+.np-art svg {
+  width: 22px;
+  height: 22px;
+  stroke: rgba(255, 255, 255, 0.9);
+  stroke-width: 2;
+  fill: none;
+}
+
+.np-meta {
+  flex: 1;
+  min-width: 0;
+}
+
+.np-meta strong {
+  display: block;
+  font-size: 0.92rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.np-meta small {
+  font-size: 0.78rem;
+  color: #94a3b8;
+}
+
+.np-eq {
+  flex: none;
+  display: flex;
+  align-items: flex-end;
+  gap: 3px;
+  height: 26px;
+  width: 34px;
+}
+
+.np-eq span {
+  flex: 1;
+  height: 30%;
+  border-radius: 2px;
+  background: linear-gradient(180deg, #a5b4fc, #6c63ff);
+  animation: np-eq 0.9s ease-in-out infinite alternate;
+}
+
+.np-eq span:nth-child(1) {
+  animation-delay: -0.2s;
+}
+
+.np-eq span:nth-child(2) {
+  animation-delay: -0.5s;
+}
+
+.np-eq span:nth-child(3) {
+  animation-delay: -0.1s;
+}
+
+.np-eq span:nth-child(4) {
+  animation-delay: -0.7s;
+}
+
+.np-play {
+  flex: none;
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+  border: none;
+  border-radius: 50%;
+  background: #6c63ff;
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.np-play svg {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
+}
+
+.np-play:hover {
+  background: #5b52e6;
+}
+
+.np-play:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+@keyframes np-eq {
+  0% {
+    height: 20%;
+  }
+
+  100% {
+    height: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .np-eq span {
+    animation: none;
+    height: 60%;
+  }
+
+  .np-play {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a now playing bar built for #41257. A track card with an animated bar equalizer from staggered keyframes, using only CSS. Closes #41257.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A now playing card with track art, title and artist, an animated equalizer of bouncing bars, and a play or pause button.

**How does a developer use it?**

```html
<div class="now-playing">
  <div class="np-art"><svg>...</svg></div>
  <div class="np-meta"><strong>Nightfall</strong><small>Aurora Lane</small></div>
  <div class="np-eq"><span></span><span></span><span></span><span></span></div>
  <button class="np-play" aria-label="Pause"><svg>...</svg></button>
</div>
```

**Why does it fit EaseMotion CSS?**
It builds a now playing card with a bouncing bar equalizer from staggered keyframes, using only CSS. Under reduced motion the bars rest at a steady height.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: four equalizer bars run the `np-eq` animation alongside the track title and play button.
