### PR TITLE
feat: add pie chart

### DIFF
--- a/submissions/examples/pie-chart-as/README.md
+++ b/submissions/examples/pie-chart-as/README.md
@@ -1,0 +1,23 @@
+# Pie Chart
+
+### What does this do?
+
+It shows a pie chart drawn from a single conic gradient, paired with a legend that lists each category, its color swatch, and its percent. There is no charting script.
+
+### How is it used?
+
+```html
+<div class="pie-card">
+  <div class="pie" role="img" aria-label="Traffic sources pie chart"></div>
+  <ul class="pie-legend">
+    <li style="--c: #6c63ff"><span>Direct</span><b>42%</b></li>
+    <li style="--c: #22d3ee"><span>Search</span><b>26%</b></li>
+  </ul>
+</div>
+```
+
+The pie is a `conic-gradient` with a color and a start and end stop per slice. Each legend row sets its swatch color with the `--c` custom property to match its slice.
+
+### Why is it useful?
+
+Dashboards use a pie chart to show a share breakdown. This renders a pie from a conic gradient with a matching legend, using only CSS. The card stacks vertically on very narrow screens.

--- a/submissions/examples/pie-chart-as/demo.html
+++ b/submissions/examples/pie-chart-as/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pie Chart</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="pie-card">
+    <div class="pie" role="img" aria-label="Traffic sources pie chart"></div>
+    <ul class="pie-legend">
+      <li style="--c: #6c63ff"><span>Direct</span><b>42%</b></li>
+      <li style="--c: #22d3ee"><span>Search</span><b>26%</b></li>
+      <li style="--c: #34d399"><span>Social</span><b>17%</b></li>
+      <li style="--c: #f59e0b"><span>Referral</span><b>10%</b></li>
+      <li style="--c: #f472b6"><span>Email</span><b>5%</b></li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/submissions/examples/pie-chart-as/style.css
+++ b/submissions/examples/pie-chart-as/style.css
@@ -1,0 +1,77 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.pie-card {
+  display: flex;
+  align-items: center;
+  gap: 1.8rem;
+  padding: 1.8rem 2rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 18px;
+}
+
+.pie {
+  flex: none;
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+  background: conic-gradient(
+    #6c63ff 0 42%,
+    #22d3ee 42% 68%,
+    #34d399 68% 85%,
+    #f59e0b 85% 95%,
+    #f472b6 95% 100%
+  );
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+}
+
+.pie-legend {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.pie-legend li {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.86rem;
+}
+
+.pie-legend li::before {
+  content: "";
+  width: 12px;
+  height: 12px;
+  border-radius: 4px;
+  background: var(--c);
+  flex: none;
+}
+
+.pie-legend li span {
+  flex: 1;
+  color: #cbd5e1;
+}
+
+.pie-legend li b {
+  color: #e2e8f0;
+  font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 420px) {
+  .pie-card {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pie chart built for #41259. A conic gradient pie with a matching legend of categories and percents, using only CSS. Closes #41259.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A pie chart from a single conic gradient, next to a legend listing each category with a color swatch and a percent.

**How does a developer use it?**

```html
<div class="pie-card">
  <div class="pie" role="img" aria-label="Traffic sources pie chart"></div>
  <ul class="pie-legend"><li style="--c: #6c63ff"><span>Direct</span><b>42%</b></li></ul>
</div>
```

**Why does it fit EaseMotion CSS?**
It renders a pie from a `conic-gradient` with a matching legend, using only CSS. Each legend swatch takes its color from a `--c` custom property, and the card stacks on very narrow screens.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the pie uses a conic gradient and the five legend items render, the first swatch matching its slice color #6c63ff.
