### PR TITLE
feat: add contribution heatmap

### DIFF
--- a/submissions/examples/heatmap-as/README.md
+++ b/submissions/examples/heatmap-as/README.md
@@ -1,0 +1,21 @@
+# Contribution Heatmap
+
+### What does this do?
+
+It shows a contribution heatmap, the kind on developer profiles, laid out as week columns of day cells that shade by activity level. A less to more legend maps the shades, and the card scrolls sideways when it overflows.
+
+### How is it used?
+
+```html
+<div class="heatmap" role="img" aria-label="Contribution heatmap">
+  <span class="hm-cell"></span>
+  <span class="hm-cell l1"></span>
+  <span class="hm-cell l3"></span>
+</div>
+```
+
+The grid uses `grid-auto-flow: column` with seven rows, so cells fill down each week column and then move to the next week. Give each cell a level class from `l1` to `l4`, or none for an empty day.
+
+### Why is it useful?
+
+Activity heatmaps summarize a period of contributions at a glance. This lays out a column flow grid of day cells shaded by a level class, with a less to more legend, using only CSS. There are no scripts or external assets.

--- a/submissions/examples/heatmap-as/demo.html
+++ b/submissions/examples/heatmap-as/demo.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Contribution Heatmap</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="heatmap-card">
+    <h2>Contribution activity</h2>
+    <p class="sub">312 contributions in the last quarter</p>
+    <div class="heatmap" role="img" aria-label="Contribution heatmap">
+      <span class="hm-cell"></span>
+      <span class="hm-cell l4"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell"></span>
+      <span class="hm-cell l4"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell"></span>
+      <span class="hm-cell l4"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell"></span>
+      <span class="hm-cell l4"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell"></span>
+      <span class="hm-cell l4"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell l4"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell"></span>
+      <span class="hm-cell l4"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell"></span>
+      <span class="hm-cell"></span>
+      <span class="hm-cell l4"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell"></span>
+      <span class="hm-cell l4"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell"></span>
+      <span class="hm-cell l4"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell"></span>
+      <span class="hm-cell l4"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell"></span>
+      <span class="hm-cell l4"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell l4"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell l3"></span>
+      <span class="hm-cell"></span>
+      <span class="hm-cell l4"></span>
+      <span class="hm-cell l1"></span>
+      <span class="hm-cell"></span>
+    </div>
+    <div class="hm-foot">
+      <span>Less</span>
+      <div class="hm-scale">
+        <span class="hm-cell"></span>
+        <span class="hm-cell l1"></span>
+        <span class="hm-cell l2"></span>
+        <span class="hm-cell l3"></span>
+        <span class="hm-cell l4"></span>
+      </div>
+      <span>More</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/heatmap-as/style.css
+++ b/submissions/examples/heatmap-as/style.css
@@ -1,0 +1,83 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.heatmap-card {
+  padding: 1.5rem 1.6rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+  overflow-x: auto;
+}
+
+.heatmap-card h2 {
+  margin: 0 0 0.2rem;
+  font-size: 0.95rem;
+}
+
+.heatmap-card .sub {
+  margin: 0 0 1.1rem;
+  font-size: 0.78rem;
+  color: #94a3b8;
+}
+
+.heatmap {
+  display: grid;
+  grid-auto-flow: column;
+  grid-template-rows: repeat(7, 1fr);
+  grid-auto-columns: 1fr;
+  gap: 4px;
+  width: max-content;
+}
+
+.hm-cell {
+  width: 15px;
+  height: 15px;
+  border-radius: 4px;
+  background: #16233c;
+}
+
+.hm-cell.l1 {
+  background: rgba(108, 99, 255, 0.35);
+}
+
+.hm-cell.l2 {
+  background: rgba(108, 99, 255, 0.6);
+}
+
+.hm-cell.l3 {
+  background: #6c63ff;
+}
+
+.hm-cell.l4 {
+  background: #a5b4fc;
+}
+
+.hm-foot {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.4rem;
+  margin-top: 1rem;
+  font-size: 0.72rem;
+  color: #64748b;
+}
+
+.hm-scale {
+  display: flex;
+  gap: 3px;
+}
+
+.hm-scale span {
+  width: 13px;
+  height: 13px;
+  border-radius: 3px;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a contribution heatmap built for #41261. A column flow grid of day cells shaded by level with a less to more legend, using only CSS. Closes #41261.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A contribution heatmap laid out as week columns of day cells that shade by activity level, with a less to more legend.

**How does a developer use it?**

```html
<div class="heatmap" role="img" aria-label="Contribution heatmap">
  <span class="hm-cell"></span>
  <span class="hm-cell l1"></span>
  <span class="hm-cell l3"></span>
</div>
```

**Why does it fit EaseMotion CSS?**
It lays out a `grid-auto-flow: column` grid with seven rows so cells fill each week column, shaded by a level class from `l1` to `l4`, with a legend, using only CSS and no scripts.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium and by screenshot: 98 cells fill a seven row column flow grid with varied shading and a five step less to more legend.
