### PR TITLE
feat: add ease-bar-chart-race component (#40780)

### DIFF
--- a/submissions/examples/ease-bar-chart-race/README.md
+++ b/submissions/examples/ease-bar-chart-race/README.md
@@ -1,0 +1,62 @@
+# ease-bar-chart-race
+
+A pure CSS animated bar chart race component. Bars grow, shrink, and reorder on a continuous loop to simulate ranking changes over time — no JavaScript required.
+
+Resolves #40780.
+
+## Usage
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<div class="ease-bar-chart-race" role="img" aria-label="Animated bar chart race showing ranking changes over time">
+  <div class="ease-bcr-row" style="--rank-order: 1;">
+    <span class="ease-bcr-label">Chrome</span>
+    <div class="ease-bcr-track">
+      <div class="ease-bcr-bar ease-bcr-bar-1"></div>
+    </div>
+    <span class="ease-bcr-value ease-bcr-value-1"></span>
+  </div>
+  <!-- add ease-bcr-row / ease-bcr-bar-N / ease-bcr-value-N up to 5 items -->
+</div>
+```
+
+## Classes
+
+| Class | Purpose |
+|---|---|
+| `.ease-bar-chart-race` | Container. Holds CSS custom properties for sizing/color. |
+| `.ease-bcr-row` | One ranked item (label + track + value). |
+| `.ease-bcr-label` | Item name. |
+| `.ease-bcr-track` | Background track the bar animates inside. |
+| `.ease-bcr-bar`, `.ease-bcr-bar-1`…`.ease-bcr-bar-5` | The animated bar. Suffix selects color + width keyframes. |
+| `.ease-bcr-value`, `.ease-bcr-value-1`…`.ease-bcr-value-5` | Numeric readout, animated via `content` on `::before`. |
+| `.ease-bcr-compact` | Modifier for a smaller footprint (sidebar/card use). |
+
+## Customization
+
+All sizing and color is exposed via CSS custom properties on `.ease-bar-chart-race`:
+
+```css
+.ease-bar-chart-race {
+  --ease-bcr-duration: 8s;      /* full loop length */
+  --ease-bcr-bar-height: 2rem;
+  --ease-bcr-gap: 0.75rem;
+  --ease-bcr-radius: 0.4rem;
+  --ease-bcr-track-bg: #eef1f5;
+  --ease-bcr-label-width: 5.5rem;
+  --ease-bcr-value-width: 3.5rem;
+  --ease-bcr-color-1: #4f46e5;
+  --ease-bcr-color-2: #06b6d4;
+  --ease-bcr-color-3: #f59e0b;
+  --ease-bcr-color-4: #ef4444;
+  --ease-bcr-color-5: #10b981;
+}
+```
+
+## Notes
+
+- Supports up to 5 ranked rows out of the box (`ease-bcr-bar-1` … `ease-bcr-bar-5`); extend the keyframe set following the same pattern for more.
+- Reordering uses the CSS `order` property driven by `@keyframes`, so rows physically swap position in sync with each bar's width change — the "race" effect.
+- Respects `prefers-reduced-motion: reduce` by disabling all animation.
+- Zero dependencies, zero JavaScript.

--- a/submissions/examples/ease-bar-chart-race/demo.html
+++ b/submissions/examples/ease-bar-chart-race/demo.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-bar-chart-race Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="demo-wrapper">
+    <h1>ease-bar-chart-race</h1>
+    <p>A pure CSS animated bar chart race — bars grow and reorder on a continuous loop, no JS required.</p>
+
+    <div class="ease-bar-chart-race" role="img" aria-label="Animated bar chart race showing ranking changes over time">
+      <div class="ease-bcr-row" style="--rank-order: 1;">
+        <span class="ease-bcr-label">Chrome</span>
+        <div class="ease-bcr-track">
+          <div class="ease-bcr-bar ease-bcr-bar-1"></div>
+        </div>
+        <span class="ease-bcr-value ease-bcr-value-1"></span>
+      </div>
+
+      <div class="ease-bcr-row" style="--rank-order: 2;">
+        <span class="ease-bcr-label">Safari</span>
+        <div class="ease-bcr-track">
+          <div class="ease-bcr-bar ease-bcr-bar-2"></div>
+        </div>
+        <span class="ease-bcr-value ease-bcr-value-2"></span>
+      </div>
+
+      <div class="ease-bcr-row" style="--rank-order: 3;">
+        <span class="ease-bcr-label">Edge</span>
+        <div class="ease-bcr-track">
+          <div class="ease-bcr-bar ease-bcr-bar-3"></div>
+        </div>
+        <span class="ease-bcr-value ease-bcr-value-3"></span>
+      </div>
+
+      <div class="ease-bcr-row" style="--rank-order: 4;">
+        <span class="ease-bcr-label">Firefox</span>
+        <div class="ease-bcr-track">
+          <div class="ease-bcr-bar ease-bcr-bar-4"></div>
+        </div>
+        <span class="ease-bcr-value ease-bcr-value-4"></span>
+      </div>
+
+      <div class="ease-bcr-row" style="--rank-order: 5;">
+        <span class="ease-bcr-label">Opera</span>
+        <div class="ease-bcr-track">
+          <div class="ease-bcr-bar ease-bcr-bar-5"></div>
+        </div>
+        <span class="ease-bcr-value ease-bcr-value-5"></span>
+      </div>
+    </div>
+
+    <section class="ease-bcr-variant-block">
+      <h2>Compact variant</h2>
+      <div class="ease-bar-chart-race ease-bcr-compact">
+        <div class="ease-bcr-row" style="--rank-order: 1;">
+          <span class="ease-bcr-label">A</span>
+          <div class="ease-bcr-track">
+            <div class="ease-bcr-bar ease-bcr-bar-1"></div>
+          </div>
+          <span class="ease-bcr-value ease-bcr-value-1"></span>
+        </div>
+        <div class="ease-bcr-row" style="--rank-order: 2;">
+          <span class="ease-bcr-label">B</span>
+          <div class="ease-bcr-track">
+            <div class="ease-bcr-bar ease-bcr-bar-2"></div>
+          </div>
+          <span class="ease-bcr-value ease-bcr-value-2"></span>
+        </div>
+        <div class="ease-bcr-row" style="--rank-order: 3;">
+          <span class="ease-bcr-label">C</span>
+          <div class="ease-bcr-track">
+            <div class="ease-bcr-bar ease-bcr-bar-3"></div>
+          </div>
+          <span class="ease-bcr-value ease-bcr-value-3"></span>
+        </div>
+      </div>
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/ease-bar-chart-race/style.css
+++ b/submissions/examples/ease-bar-chart-race/style.css
@@ -1,0 +1,196 @@
+/* ==========================================================================
+   ease-bar-chart-race
+   Pure CSS animated bar chart race. Bars grow/shrink and rows reorder
+   on a continuous loop to simulate ranking changes over time.
+   No JavaScript required.
+   ========================================================================== */
+
+.ease-bar-chart-race {
+  --ease-bcr-duration: 8s;
+  --ease-bcr-bar-height: 2rem;
+  --ease-bcr-gap: 0.75rem;
+  --ease-bcr-radius: 0.4rem;
+  --ease-bcr-track-bg: #eef1f5;
+  --ease-bcr-label-width: 5.5rem;
+  --ease-bcr-value-width: 3.5rem;
+  --ease-bcr-color-1: #4f46e5;
+  --ease-bcr-color-2: #06b6d4;
+  --ease-bcr-color-3: #f59e0b;
+  --ease-bcr-color-4: #ef4444;
+  --ease-bcr-color-5: #10b981;
+
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-bcr-gap);
+  max-width: 32rem;
+  padding: 1.25rem;
+  font-family: inherit;
+}
+
+.ease-bcr-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  order: var(--rank-order);
+  animation: ease-bcr-reorder var(--ease-bcr-duration) ease-in-out infinite;
+}
+
+.ease-bcr-label {
+  flex: 0 0 var(--ease-bcr-label-width);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #333;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ease-bcr-track {
+  flex: 1 1 auto;
+  height: var(--ease-bcr-bar-height);
+  background: var(--ease-bcr-track-bg);
+  border-radius: var(--ease-bcr-radius);
+  overflow: hidden;
+  position: relative;
+}
+
+.ease-bcr-bar {
+  height: 100%;
+  border-radius: var(--ease-bcr-radius);
+  transform-origin: left center;
+  transition: background-color 0.3s ease;
+}
+
+.ease-bcr-value {
+  flex: 0 0 var(--ease-bcr-value-width);
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #555;
+  text-align: right;
+}
+
+/* Per-bar color + width + reorder timing.
+   Each bar cycles through 3 "frames" that drive width, rank position,
+   and the on-bar numeric readout together. */
+
+.ease-bcr-bar-1 { background: var(--ease-bcr-color-1); animation: ease-bcr-grow-1 var(--ease-bcr-duration) ease-in-out infinite; }
+.ease-bcr-bar-2 { background: var(--ease-bcr-color-2); animation: ease-bcr-grow-2 var(--ease-bcr-duration) ease-in-out infinite; }
+.ease-bcr-bar-3 { background: var(--ease-bcr-color-3); animation: ease-bcr-grow-3 var(--ease-bcr-duration) ease-in-out infinite; }
+.ease-bcr-bar-4 { background: var(--ease-bcr-color-4); animation: ease-bcr-grow-4 var(--ease-bcr-duration) ease-in-out infinite; }
+.ease-bcr-bar-5 { background: var(--ease-bcr-color-5); animation: ease-bcr-grow-5 var(--ease-bcr-duration) ease-in-out infinite; }
+
+.ease-bcr-value-1::before { content: "72"; animation: ease-bcr-count-1 var(--ease-bcr-duration) ease-in-out infinite; }
+.ease-bcr-value-2::before { content: "58"; animation: ease-bcr-count-2 var(--ease-bcr-duration) ease-in-out infinite; }
+.ease-bcr-value-3::before { content: "44"; animation: ease-bcr-count-3 var(--ease-bcr-duration) ease-in-out infinite; }
+.ease-bcr-value-4::before { content: "31"; animation: ease-bcr-count-4 var(--ease-bcr-duration) ease-in-out infinite; }
+.ease-bcr-value-5::before { content: "20"; animation: ease-bcr-count-5 var(--ease-bcr-duration) ease-in-out infinite; }
+
+/* Width keyframes: each bar races to a different width at each third of the loop */
+@keyframes ease-bcr-grow-1 {
+  0%   { width: 72%; }
+  33%  { width: 40%; }
+  66%  { width: 90%; }
+  100% { width: 72%; }
+}
+@keyframes ease-bcr-grow-2 {
+  0%   { width: 58%; }
+  33%  { width: 85%; }
+  66%  { width: 35%; }
+  100% { width: 58%; }
+}
+@keyframes ease-bcr-grow-3 {
+  0%   { width: 44%; }
+  33%  { width: 60%; }
+  66%  { width: 55%; }
+  100% { width: 44%; }
+}
+@keyframes ease-bcr-grow-4 {
+  0%   { width: 31%; }
+  33%  { width: 20%; }
+  66%  { width: 70%; }
+  100% { width: 31%; }
+}
+@keyframes ease-bcr-grow-5 {
+  0%   { width: 20%; }
+  33%  { width: 45%; }
+  66%  { width: 25%; }
+  100% { width: 20%; }
+}
+
+/* Row reorder keyframes: order snaps to match each bar's rank at that frame */
+.ease-bcr-row:nth-child(1) { animation-name: ease-bcr-rank-1; }
+.ease-bcr-row:nth-child(2) { animation-name: ease-bcr-rank-2; }
+.ease-bcr-row:nth-child(3) { animation-name: ease-bcr-rank-3; }
+.ease-bcr-row:nth-child(4) { animation-name: ease-bcr-rank-4; }
+.ease-bcr-row:nth-child(5) { animation-name: ease-bcr-rank-5; }
+
+@keyframes ease-bcr-rank-1 {
+  0%, 32%  { order: 1; }
+  33%, 65% { order: 3; }
+  66%, 99% { order: 1; }
+  100%     { order: 1; }
+}
+@keyframes ease-bcr-rank-2 {
+  0%, 32%  { order: 2; }
+  33%, 65% { order: 1; }
+  66%, 99% { order: 3; }
+  100%     { order: 2; }
+}
+@keyframes ease-bcr-rank-3 {
+  0%, 32%  { order: 3; }
+  33%, 65% { order: 2; }
+  66%, 99% { order: 4; }
+  100%     { order: 3; }
+}
+@keyframes ease-bcr-rank-4 {
+  0%, 32%  { order: 4; }
+  33%, 65% { order: 5; }
+  66%, 99% { order: 2; }
+  100%     { order: 4; }
+}
+@keyframes ease-bcr-rank-5 {
+  0%, 32%  { order: 5; }
+  33%, 65% { order: 4; }
+  66%, 99% { order: 5; }
+  100%     { order: 5; }
+}
+
+/* On-bar numeric readout counting keyframes */
+@keyframes ease-bcr-count-1 { 0% { content: "72"; } 33% { content: "40"; } 66% { content: "90"; } 100% { content: "72"; } }
+@keyframes ease-bcr-count-2 { 0% { content: "58"; } 33% { content: "85"; } 66% { content: "35"; } 100% { content: "58"; } }
+@keyframes ease-bcr-count-3 { 0% { content: "44"; } 33% { content: "60"; } 66% { content: "55"; } 100% { content: "44"; } }
+@keyframes ease-bcr-count-4 { 0% { content: "31"; } 33% { content: "20"; } 66% { content: "70"; } 100% { content: "31"; } }
+@keyframes ease-bcr-count-5 { 0% { content: "20"; } 33% { content: "45"; } 66% { content: "25"; } 100% { content: "20"; } }
+
+/* Compact variant */
+.ease-bcr-compact {
+  --ease-bcr-bar-height: 1.25rem;
+  --ease-bcr-label-width: 2.5rem;
+  --ease-bcr-value-width: 2.5rem;
+  --ease-bcr-gap: 0.5rem;
+  max-width: 18rem;
+}
+.ease-bcr-compact .ease-bcr-label,
+.ease-bcr-compact .ease-bcr-value {
+  font-size: 0.7rem;
+}
+
+/* Demo page scaffolding (not part of the reusable component) */
+.demo-wrapper {
+  max-width: 40rem;
+  margin: 2rem auto;
+  padding: 0 1rem;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+.demo-wrapper h1 { margin-bottom: 0.25rem; }
+.demo-wrapper p { color: #666; margin-bottom: 1.5rem; }
+.ease-bcr-variant-block { margin-top: 2rem; }
+
+/* Respect reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .ease-bcr-row,
+  .ease-bcr-bar,
+  .ease-bcr-value::before {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Description
Implements the `ease-bar-chart-race` component — a pure CSS animated bar chart race. Bars grow/shrink and rows reorder on a continuous 8s loop to simulate ranking changes over time, with no JavaScript required.

Resolves #40780.

## Changes
- `submissions/examples/ease-bar-chart-race/demo.html` (new)
- `submissions/examples/ease-bar-chart-race/style.css` (new)
- `submissions/examples/ease-bar-chart-race/README.md` (new)

## Implementation Details
- Supports up to 5 ranked rows out of the box (`ease-bcr-bar-1`…`ease-bcr-bar-5`), each with its own width + reorder keyframes.
- Reordering uses the CSS `order` property driven by `@keyframes`, synced with each bar's width animation to create the "race" effect.
- Numeric readouts animate via `content` on `::before`.
- Fully customizable via CSS custom properties (`--ease-bcr-duration`, colors, sizing, etc.) on `.ease-bar-chart-race`.
- Includes a `.ease-bcr-compact` modifier for smaller layouts.
- Respects `prefers-reduced-motion: reduce`.
- Zero dependencies, pure CSS.

## Checklist
- [x] Follows the `submissions/examples/[feature-name]/` 3-file pattern
- [x] No core CSS files modified
- [x] Responsive and accessible (`role="img"`, `aria-label`, reduced-motion support)