### PR TITLE
feat: add confirm popover

### DIFF
--- a/submissions/examples/confirm-popover-as/README.md
+++ b/submissions/examples/confirm-popover-as/README.md
@@ -1,0 +1,27 @@
+# Confirm Popover
+
+### What does this do?
+
+It shows a small confirm popover that appears above a delete button to ask are you sure, with cancel and confirm actions and an arrow pointing at the button. It works with no JavaScript by using a hidden checkbox.
+
+### How is it used?
+
+```html
+<div class="confirm">
+  <input type="checkbox" id="cf" class="cf-toggle" />
+  <label class="cf-trigger" for="cf"><svg>...</svg>Delete</label>
+  <div class="cf-pop" role="dialog" aria-label="Confirm delete">
+    <p>Delete this item?</p>
+    <div class="cf-actions">
+      <label class="cf-cancel" for="cf">Cancel</label>
+      <a class="cf-yes" href="#">Delete</a>
+    </div>
+  </div>
+</div>
+```
+
+The trigger and the cancel button both point at the same checkbox, so the trigger opens the popover and cancel closes it. The confirm action is a real link or button.
+
+### Why is it useful?
+
+Destructive actions often ask for confirmation in a small inline popover rather than a full modal. This anchors a confirm bubble to a button with an arrow and two actions using only a checkbox and CSS. The reveal transition is reduced under reduced motion.

--- a/submissions/examples/confirm-popover-as/demo.html
+++ b/submissions/examples/confirm-popover-as/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Confirm Popover</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="confirm">
+    <input type="checkbox" id="cf" class="cf-toggle" />
+    <label class="cf-trigger" for="cf">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 7h16M9 7V5h6v2M6 7l1 13h10l1-13" stroke-linecap="round" stroke-linejoin="round" /></svg>
+      Delete
+    </label>
+    <div class="cf-pop" role="dialog" aria-label="Confirm delete">
+      <p>Delete this item? This cannot be undone.</p>
+      <div class="cf-actions">
+        <label class="cf-cancel" for="cf">Cancel</label>
+        <a class="cf-yes" href="#">Delete</a>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/confirm-popover-as/style.css
+++ b/submissions/examples/confirm-popover-as/style.css
@@ -1,0 +1,145 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 4rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.confirm {
+  position: relative;
+  display: inline-block;
+}
+
+.cf-toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  margin: -1px;
+  overflow: hidden;
+}
+
+.cf-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.6rem 1.1rem;
+  background: #ef4444;
+  color: #fff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.cf-trigger svg {
+  width: 16px;
+  height: 16px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+}
+
+.cf-toggle:checked ~ .cf-trigger {
+  background: #dc2626;
+}
+
+.cf-toggle:focus-visible ~ .cf-trigger {
+  outline: 2px solid #fca5a5;
+  outline-offset: 2px;
+}
+
+.cf-pop {
+  position: absolute;
+  bottom: calc(100% + 0.8rem);
+  left: 50%;
+  transform: translateX(-50%) translateY(6px);
+  width: 220px;
+  padding: 1rem;
+  box-sizing: border-box;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 12px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.16s ease, transform 0.16s ease, visibility 0.16s ease;
+  z-index: 2;
+}
+
+.cf-toggle:checked ~ .cf-pop {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0);
+}
+
+.cf-pop::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 8px solid transparent;
+  border-top-color: #0e1626;
+}
+
+.cf-pop p {
+  margin: 0 0 0.9rem;
+  font-size: 0.86rem;
+  line-height: 1.45;
+  color: #cbd5e1;
+}
+
+.cf-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.cf-cancel,
+.cf-yes {
+  padding: 0.4rem 0.85rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+  border-radius: 8px;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.cf-cancel {
+  background: #1b2942;
+  color: #cbd5e1;
+}
+
+.cf-yes {
+  background: #ef4444;
+  color: #fff;
+}
+
+.cf-cancel:hover {
+  background: #24344f;
+}
+
+.cf-yes:hover {
+  background: #dc2626;
+}
+
+.cf-yes:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cf-pop {
+    transition: opacity 0.16s ease, visibility 0.16s ease;
+  }
+
+  .cf-toggle:checked ~ .cf-pop {
+    transform: translateX(-50%);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a confirm popover built for #41264. A small confirm bubble above a delete button with cancel and confirm, using a checkbox and CSS only. Closes #41264.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A confirm popover that appears above a delete button asking are you sure, with cancel and confirm actions and an arrow pointing at the button.

**How does a developer use it?**

```html
<div class="confirm">
  <input type="checkbox" id="cf" class="cf-toggle" />
  <label class="cf-trigger" for="cf"><svg>...</svg>Delete</label>
  <div class="cf-pop" role="dialog">
    <p>Delete this item?</p>
    <div class="cf-actions"><label class="cf-cancel" for="cf">Cancel</label><a class="cf-yes" href="#">Delete</a></div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It anchors a confirm bubble to a button with an arrow and two actions using only a checkbox and CSS. The trigger and cancel share the same checkbox, so cancel genuinely closes the popover. The reveal transition is reduced under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the popover is hidden until the checkbox is checked, then shows with its arrow, cancel, and confirm actions.
