### PR TITLE
feat: add context menu

### DIFF
--- a/submissions/examples/context-menu-as/README.md
+++ b/submissions/examples/context-menu-as/README.md
@@ -1,0 +1,21 @@
+# Context Menu
+
+### What does this do?
+
+It shows a right click style context menu with icon rows, keyboard shortcut hints, a divider, and a destructive delete item at the end. It is styled as a floating menu panel.
+
+### How is it used?
+
+```html
+<div class="ctx-menu" role="menu" aria-label="Actions">
+  <button class="ctx-item" role="menuitem"><svg>...</svg><span>Copy</span><kbd>Ctrl C</kbd></button>
+  <div class="ctx-sep" role="separator"></div>
+  <button class="ctx-item is-danger" role="menuitem"><svg>...</svg><span>Delete</span><kbd>Del</kbd></button>
+</div>
+```
+
+Each row is a real button with an icon, a label, and an optional `kbd` shortcut. Use `ctx-sep` for a divider and `is-danger` for a destructive action.
+
+### Why is it useful?
+
+Apps show a context menu on right click with actions and shortcuts. This styles a floating menu with icon rows, shortcut hints, dividers, and a danger item, using only CSS and inline SVG. Rows are keyboard operable with hover and focus states, removed of motion under reduced motion.

--- a/submissions/examples/context-menu-as/demo.html
+++ b/submissions/examples/context-menu-as/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Context Menu</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="ctx-menu" role="menu" aria-label="Actions">
+    <button class="ctx-item" type="button" role="menuitem">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><rect x="9" y="9" width="11" height="11" rx="2" /><path d="M5 15V5a2 2 0 0 1 2-2h10" /></svg>
+      <span>Copy</span><kbd>Ctrl C</kbd>
+    </button>
+    <button class="ctx-item" type="button" role="menuitem">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 20h4L18 10l-4-4L4 16z" stroke-linejoin="round" /><path d="M14 6l4 4" /></svg>
+      <span>Rename</span><kbd>F2</kbd>
+    </button>
+    <button class="ctx-item" type="button" role="menuitem">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 12v7a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-7M16 6l-4-4-4 4M12 2v13" stroke-linecap="round" stroke-linejoin="round" /></svg>
+      <span>Share</span>
+    </button>
+    <button class="ctx-item" type="button" role="menuitem">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 20s-7-4.4-9.5-8.3C.8 9 2 5.5 5.2 5.5c1.9 0 3.1 1 3.8 2.1.7-1.1 1.9-2.1 3.8-2.1 3.2 0 4.4 3.5 2.7 6.2C19 15.6 12 20 12 20z" stroke-linejoin="round" /></svg>
+      <span>Add to favorites</span>
+    </button>
+    <div class="ctx-sep" role="separator"></div>
+    <button class="ctx-item is-danger" type="button" role="menuitem">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 7h16M9 7V5h6v2M6 7l1 13h10l1-13" stroke-linecap="round" stroke-linejoin="round" /></svg>
+      <span>Delete</span><kbd>Del</kbd>
+    </button>
+  </div>
+</body>
+</html>

--- a/submissions/examples/context-menu-as/style.css
+++ b/submissions/examples/context-menu-as/style.css
@@ -1,0 +1,89 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.ctx-menu {
+  width: 224px;
+  padding: 0.35rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 12px;
+  box-shadow: 0 20px 44px rgba(0, 0, 0, 0.55);
+}
+
+.ctx-item {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  width: 100%;
+  padding: 0.55rem 0.65rem;
+  font: inherit;
+  font-size: 0.87rem;
+  color: #cbd5e1;
+  background: transparent;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+.ctx-item svg {
+  width: 17px;
+  height: 17px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+  flex: none;
+}
+
+.ctx-item span {
+  flex: 1;
+}
+
+.ctx-item kbd {
+  font-family: inherit;
+  font-size: 0.72rem;
+  color: #64748b;
+  padding: 0.1rem 0.4rem;
+  background: #131f34;
+  border: 1px solid #26324a;
+  border-radius: 5px;
+}
+
+.ctx-item:hover,
+.ctx-item:focus-visible {
+  background: #1b2942;
+  color: #fff;
+  outline: none;
+}
+
+.ctx-sep {
+  height: 1px;
+  margin: 0.35rem 0.4rem;
+  background: #1b2942;
+}
+
+.ctx-item.is-danger {
+  color: #f87171;
+}
+
+.ctx-item.is-danger:hover,
+.ctx-item.is-danger:focus-visible {
+  background: rgba(239, 68, 68, 0.14);
+  color: #fca5a5;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ctx-item {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a context menu built for #41267. A floating menu of icon rows with shortcut hints, a divider, and a danger item, using only CSS and inline SVG. Closes #41267.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A right click style context menu with icon rows, keyboard shortcut hints, a divider, and a destructive delete item at the end.

**How does a developer use it?**

```html
<div class="ctx-menu" role="menu">
  <button class="ctx-item" role="menuitem"><svg>...</svg><span>Copy</span><kbd>Ctrl C</kbd></button>
  <div class="ctx-sep" role="separator"></div>
  <button class="ctx-item is-danger" role="menuitem"><svg>...</svg><span>Delete</span></button>
</div>
```

**Why does it fit EaseMotion CSS?**
It styles a floating menu with icon rows, shortcut hints, dividers, and a danger item, using only CSS and inline SVG. Rows are keyboard operable with hover and focus states, removed of motion under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: five menu items render with one divider, three shortcut hints, and the delete item in the danger red color.
