### PR TITLE
feat: add bottom sheet

### DIFF
--- a/submissions/examples/bottom-sheet-as/README.md
+++ b/submissions/examples/bottom-sheet-as/README.md
@@ -1,0 +1,24 @@
+# Bottom Sheet
+
+### What does this do?
+
+It shows a mobile bottom sheet that slides up from the bottom over a dimmed backdrop, with a grab handle, a title, and a list of options. Tapping the backdrop closes it. It works with no JavaScript by using a checkbox.
+
+### How is it used?
+
+```html
+<input type="checkbox" id="sheet" class="sheet-toggle" />
+<label class="sheet-open" for="sheet">Share</label>
+<label class="sheet-scrim" for="sheet"></label>
+<div class="sheet" role="dialog" aria-label="Share options">
+  <div class="sheet-grip"></div>
+  <h2>Share this page</h2>
+  <ul class="sheet-list"><li><a href="#"><svg>...</svg>Copy link</a></li></ul>
+</div>
+```
+
+Keep the checkbox before the scrim and sheet so the sibling selectors can slide the sheet in and show the backdrop. The open button and the scrim both point at the same checkbox.
+
+### Why is it useful?
+
+Mobile apps present options and share actions in a bottom sheet. This slides a sheet up from the bottom with a backdrop and a grab handle using only a checkbox and CSS. The slide is reduced under reduced motion.

--- a/submissions/examples/bottom-sheet-as/demo.html
+++ b/submissions/examples/bottom-sheet-as/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bottom Sheet</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <input type="checkbox" id="sheet" class="sheet-toggle" checked />
+  <label class="sheet-open" for="sheet">Share</label>
+  <label class="sheet-scrim" for="sheet" aria-hidden="true"></label>
+  <div class="sheet" role="dialog" aria-label="Share options">
+    <div class="sheet-grip" aria-hidden="true"></div>
+    <h2>Share this page</h2>
+    <ul class="sheet-list">
+      <li><a href="#"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="9" y="9" width="11" height="11" rx="2" /><path d="M5 15V5a2 2 0 0 1 2-2h10" /></svg>Copy link</a></li>
+      <li><a href="#"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 6h16v12H4z" /><path d="m4 7 8 6 8-6" stroke-linecap="round" stroke-linejoin="round" /></svg>Send by email</a></li>
+      <li><a href="#"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2a10 10 0 0 0-8.5 15.2L2 22l4.9-1.4A10 10 0 1 0 12 2z" stroke-linejoin="round" /></svg>Message</a></li>
+      <li><a href="#"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="18" cy="5" r="3" /><circle cx="6" cy="12" r="3" /><circle cx="18" cy="19" r="3" /><path d="M8.6 13.5l6.8 4M15.4 6.5l-6.8 4" /></svg>More options</a></li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/submissions/examples/bottom-sheet-as/style.css
+++ b/submissions/examples/bottom-sheet-as/style.css
@@ -1,0 +1,130 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.sheet-toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  margin: -1px;
+  overflow: hidden;
+}
+
+.sheet-open {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.4rem;
+  background: #6c63ff;
+  color: #fff;
+  font-weight: 600;
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.sheet-toggle:focus-visible ~ .sheet-open {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+.sheet-scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(4, 8, 18, 0.62);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+
+.sheet-toggle:checked ~ .sheet-scrim {
+  opacity: 1;
+  visibility: visible;
+}
+
+.sheet {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 0.8rem 1.2rem 1.6rem;
+  background: #0e1626;
+  border-top: 1px solid #26324a;
+  border-radius: 20px 20px 0 0;
+  box-shadow: 0 -18px 40px rgba(0, 0, 0, 0.5);
+  transform: translateY(100%);
+  transition: transform 0.32s cubic-bezier(0.22, 1, 0.36, 1);
+  z-index: 3;
+}
+
+.sheet-toggle:checked ~ .sheet {
+  transform: translateY(0);
+}
+
+.sheet-grip {
+  width: 42px;
+  height: 5px;
+  margin: 0 auto 1rem;
+  border-radius: 3px;
+  background: #33415c;
+}
+
+.sheet h2 {
+  margin: 0 0 0.9rem;
+  font-size: 1rem;
+  text-align: center;
+}
+
+.sheet-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  max-width: 420px;
+  margin-inline: auto;
+}
+
+.sheet-list a {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  padding: 0.8rem 0.7rem;
+  border-radius: 10px;
+  color: #cbd5e1;
+  text-decoration: none;
+  font-size: 0.92rem;
+  transition: background 0.14s ease;
+}
+
+.sheet-list a svg {
+  width: 20px;
+  height: 20px;
+  stroke: #a5b4fc;
+  stroke-width: 2;
+  fill: none;
+  flex: none;
+}
+
+.sheet-list a:hover,
+.sheet-list a:focus-visible {
+  background: #1b2942;
+  color: #fff;
+  outline: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sheet,
+  .sheet-scrim {
+    transition: opacity 0.3s ease, visibility 0.3s ease;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a bottom sheet built for #41269. A sheet that slides up from the bottom over a dimmed backdrop with a grab handle and options, using a checkbox and CSS only. Closes #41269.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A mobile bottom sheet that slides up from the bottom over a dimmed backdrop, with a grab handle, a title, and a list of options, closing on backdrop tap.

**How does a developer use it?**

```html
<input type="checkbox" id="sheet" class="sheet-toggle" />
<label class="sheet-open" for="sheet">Share</label>
<label class="sheet-scrim" for="sheet"></label>
<div class="sheet" role="dialog">
  <div class="sheet-grip"></div>
  <h2>Share this page</h2>
  <ul class="sheet-list"><li><a href="#"><svg>...</svg>Copy link</a></li></ul>
</div>
```

**Why does it fit EaseMotion CSS?**
It slides a sheet up from the bottom with a backdrop and a grab handle using only a checkbox and CSS. The slide is reduced under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the sheet is fixed with a grip and four options, and it translates down off screen when the toggle is unchecked.
