### PR TITLE
feat: add file upload list

### DIFF
--- a/submissions/examples/file-list-as/README.md
+++ b/submissions/examples/file-list-as/README.md
@@ -1,0 +1,26 @@
+# File Upload List
+
+### What does this do?
+
+It shows a list of uploaded files where each row has a type icon, a name and size, and a status. One row is mid upload with a progress bar, one is done with a green check, and one failed with a red error icon.
+
+### How is it used?
+
+```html
+<ul class="file-list">
+  <li class="file-row is-uploading" style="--p: 62%">
+    <span class="fr-ic"><svg>...</svg></span>
+    <div class="fr-body">
+      <div class="fr-top"><span class="fr-name">hero.jpg</span><span class="fr-size">5.1 MB</span></div>
+      <div class="fr-bar"></div>
+    </div>
+    <button class="fr-x" aria-label="Cancel upload"><svg>...</svg></button>
+  </li>
+</ul>
+```
+
+Set the progress with the `--p` custom property on an `is-uploading` row. Use `is-done` for a completed upload and `is-error` for a failure, which color the end icon and name.
+
+### Why is it useful?
+
+Upload forms show the files being sent with their progress. This lays out a file list with type icons, per file progress bars driven by a custom property, and done and error states, using only CSS and inline SVG.

--- a/submissions/examples/file-list-as/demo.html
+++ b/submissions/examples/file-list-as/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>File Upload List</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <ul class="file-list">
+    <li class="file-row is-done">
+      <span class="fr-ic"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z" stroke-linejoin="round" /><path d="M14 3v6h6" /></svg></span>
+      <div class="fr-body">
+        <div class="fr-top"><span class="fr-name">brand-guidelines.pdf</span><span class="fr-size">2.4 MB</span></div>
+        <div class="fr-status">Uploaded</div>
+      </div>
+      <span class="fr-end"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m5 13 4 4 10-11" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
+    </li>
+
+    <li class="file-row is-uploading" style="--p: 62%">
+      <span class="fr-ic"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="4" width="18" height="16" rx="2" /><path d="m3 15 5-4 4 3 4-5 5 4" stroke-linejoin="round" /></svg></span>
+      <div class="fr-body">
+        <div class="fr-top"><span class="fr-name">hero-photo.jpg</span><span class="fr-size">5.1 MB</span></div>
+        <div class="fr-bar"></div>
+      </div>
+      <button class="fr-x" type="button" aria-label="Cancel upload"><svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path d="M6 6l12 12M18 6 6 18" stroke-linecap="round" fill="none" stroke-width="2" /></svg></button>
+    </li>
+
+    <li class="file-row is-error">
+      <span class="fr-ic"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z" stroke-linejoin="round" /><path d="M14 3v6h6" /></svg></span>
+      <div class="fr-body">
+        <div class="fr-top"><span class="fr-name">database-dump.sql</span><span class="fr-size">48 MB</span></div>
+        <div class="fr-status">Upload failed, file too large</div>
+      </div>
+      <span class="fr-end"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9" /><path d="M12 7v6M12 16h.01" stroke-linecap="round" /></svg></span>
+    </li>
+  </ul>
+</body>
+</html>

--- a/submissions/examples/file-list-as/style.css
+++ b/submissions/examples/file-list-as/style.css
@@ -1,0 +1,155 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.file-list {
+  list-style: none;
+  margin: 0;
+  padding: 0.6rem;
+  width: min(380px, 94vw);
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 14px;
+}
+
+.file-row {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  padding: 0.7rem;
+  border-radius: 10px;
+}
+
+.file-row:hover {
+  background: #131f34;
+}
+
+.fr-ic {
+  flex: none;
+  width: 38px;
+  height: 38px;
+  display: grid;
+  place-items: center;
+  border-radius: 9px;
+  background: #1b2942;
+}
+
+.fr-ic svg {
+  width: 19px;
+  height: 19px;
+  stroke: #a5b4fc;
+  stroke-width: 2;
+  fill: none;
+}
+
+.fr-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.fr-top {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.fr-name {
+  font-size: 0.86rem;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.fr-size {
+  flex: none;
+  font-size: 0.72rem;
+  color: #64748b;
+}
+
+.fr-bar {
+  position: relative;
+  height: 5px;
+  margin-top: 0.5rem;
+  border-radius: 3px;
+  background: #1b2942;
+  overflow: hidden;
+}
+
+.fr-bar::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: var(--p, 0%);
+  border-radius: 3px;
+  background: linear-gradient(90deg, #6c63ff, #a855f7);
+}
+
+.fr-status {
+  margin-top: 0.4rem;
+  font-size: 0.72rem;
+  color: #64748b;
+}
+
+.fr-end {
+  flex: none;
+  width: 22px;
+  height: 22px;
+  display: grid;
+  place-items: center;
+}
+
+.fr-end svg {
+  width: 20px;
+  height: 20px;
+  stroke-width: 2;
+  fill: none;
+}
+
+.file-row.is-done .fr-end svg {
+  stroke: #34d399;
+}
+
+.file-row.is-error .fr-end svg {
+  stroke: #f87171;
+}
+
+.file-row.is-error .fr-name {
+  color: #fca5a5;
+}
+
+.fr-x {
+  border: none;
+  background: transparent;
+  color: #64748b;
+  cursor: pointer;
+  padding: 0;
+}
+
+.fr-x:hover {
+  color: #cbd5e1;
+}
+
+.fr-x svg {
+  stroke: currentColor;
+}
+
+.fr-end button:focus-visible,
+.fr-x:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+  border-radius: 6px;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a file upload list built for #41271. File rows with type icons, per file progress, and done and error states, using only CSS and inline SVG. Closes #41271.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A list of uploaded files, each with a type icon, a name and size, and a status: one uploading with a progress bar, one done with a green check, and one failed with a red error icon.

**How does a developer use it?**

```html
<ul class="file-list">
  <li class="file-row is-uploading" style="--p: 62%">
    <span class="fr-ic"><svg>...</svg></span>
    <div class="fr-body"><div class="fr-top"><span class="fr-name">hero.jpg</span><span class="fr-size">5.1 MB</span></div><div class="fr-bar"></div></div>
    <button class="fr-x" aria-label="Cancel upload"><svg>...</svg></button>
  </li>
</ul>
```

**Why does it fit EaseMotion CSS?**
It lays out a file list with type icons, per file progress bars driven by the `--p` custom property, and `is-done` and `is-error` states, using only CSS and inline SVG.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: three rows render, the uploading bar fills to 62 percent, the done icon is green, and the error icon is red.
