### PR TITLE
feat: add image lightbox

### DIFF
--- a/submissions/examples/lightbox-as/README.md
+++ b/submissions/examples/lightbox-as/README.md
@@ -1,0 +1,24 @@
+# Image Lightbox
+
+### What does this do?
+
+It shows a thumbnail gallery where clicking a thumbnail opens the full image in a lightbox over a dimmed backdrop. It uses the CSS `:target` state, so it opens and closes with no JavaScript, and clicking the backdrop or the close button dismisses it. The images are gradient placeholders so there are no external files.
+
+### How is it used?
+
+```html
+<div class="gallery">
+  <a class="thumb t1" href="#img1" aria-label="Open image 1"></a>
+</div>
+
+<div class="lightbox" id="img1" role="dialog">
+  <a class="lb-backdrop" href="#" tabindex="-1"></a>
+  <div class="lb-figure t1"><a class="lb-close" href="#" aria-label="Close">✕</a></div>
+</div>
+```
+
+Each thumbnail links to a lightbox `id`. When that id is the URL target, the lightbox becomes visible and its figure scales up. Any link back to `#` closes it.
+
+### Why is it useful?
+
+Galleries open a larger view when a thumbnail is clicked. This builds a lightbox from the `:target` state with a thumbnail grid and a dimmed overlay, using only CSS. Swap the gradient figures for real images in production. The animations are removed under reduced motion.

--- a/submissions/examples/lightbox-as/demo.html
+++ b/submissions/examples/lightbox-as/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Image Lightbox</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="gallery">
+    <a class="thumb t1" href="#img1" aria-label="Open image 1"></a>
+    <a class="thumb t2" href="#img2" aria-label="Open image 2"></a>
+    <a class="thumb t3" href="#img3" aria-label="Open image 3"></a>
+    <a class="thumb t4" href="#img4" aria-label="Open image 4"></a>
+    <a class="thumb t5" href="#img5" aria-label="Open image 5"></a>
+    <a class="thumb t6" href="#img6" aria-label="Open image 6"></a>
+  </div>
+
+  <div class="lightbox" id="img1" role="dialog" aria-label="Image 1">
+    <a class="lb-backdrop" href="#" aria-label="Close" tabindex="-1"></a>
+    <div class="lb-figure t1"><a class="lb-close" href="#" aria-label="Close">✕</a></div>
+  </div>
+  <div class="lightbox" id="img2" role="dialog" aria-label="Image 2">
+    <a class="lb-backdrop" href="#" aria-label="Close" tabindex="-1"></a>
+    <div class="lb-figure t2"><a class="lb-close" href="#" aria-label="Close">✕</a></div>
+  </div>
+  <div class="lightbox" id="img3" role="dialog" aria-label="Image 3">
+    <a class="lb-backdrop" href="#" aria-label="Close" tabindex="-1"></a>
+    <div class="lb-figure t3"><a class="lb-close" href="#" aria-label="Close">✕</a></div>
+  </div>
+  <div class="lightbox" id="img4" role="dialog" aria-label="Image 4">
+    <a class="lb-backdrop" href="#" aria-label="Close" tabindex="-1"></a>
+    <div class="lb-figure t4"><a class="lb-close" href="#" aria-label="Close">✕</a></div>
+  </div>
+  <div class="lightbox" id="img5" role="dialog" aria-label="Image 5">
+    <a class="lb-backdrop" href="#" aria-label="Close" tabindex="-1"></a>
+    <div class="lb-figure t5"><a class="lb-close" href="#" aria-label="Close">✕</a></div>
+  </div>
+  <div class="lightbox" id="img6" role="dialog" aria-label="Image 6">
+    <a class="lb-backdrop" href="#" aria-label="Close" tabindex="-1"></a>
+    <div class="lb-figure t6"><a class="lb-close" href="#" aria-label="Close">✕</a></div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/lightbox-as/style.css
+++ b/submissions/examples/lightbox-as/style.css
@@ -1,0 +1,135 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.7rem;
+  width: min(360px, 92vw);
+}
+
+.thumb {
+  display: block;
+  aspect-ratio: 1;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.thumb:hover,
+.thumb:focus-visible {
+  transform: translateY(-3px);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.4);
+  outline: none;
+}
+
+.t1 {
+  background: linear-gradient(135deg, #6c63ff, #a855f7);
+}
+
+.t2 {
+  background: linear-gradient(135deg, #0ea5e9, #22d3ee);
+}
+
+.t3 {
+  background: linear-gradient(135deg, #10b981, #34d399);
+}
+
+.t4 {
+  background: linear-gradient(135deg, #f59e0b, #ef4444);
+}
+
+.t5 {
+  background: linear-gradient(135deg, #ec4899, #f472b6);
+}
+
+.t6 {
+  background: linear-gradient(135deg, #8b5cf6, #6366f1);
+}
+
+.lightbox {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.22s ease, visibility 0.22s ease;
+  z-index: 5;
+}
+
+.lightbox:target {
+  opacity: 1;
+  visibility: visible;
+}
+
+.lb-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(4, 8, 18, 0.82);
+  backdrop-filter: blur(2px);
+}
+
+.lb-figure {
+  position: relative;
+  width: min(440px, 90vw);
+  aspect-ratio: 4 / 3;
+  border-radius: 16px;
+  box-shadow: 0 30px 70px rgba(0, 0, 0, 0.6);
+  transform: scale(0.9);
+  transition: transform 0.22s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.lightbox:target .lb-figure {
+  transform: scale(1);
+}
+
+.lb-close {
+  position: absolute;
+  top: -14px;
+  right: -14px;
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  color: #cbd5e1;
+  text-decoration: none;
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.lb-close:hover {
+  color: #fff;
+}
+
+.thumb:focus-visible,
+.lb-close:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .thumb,
+  .lightbox,
+  .lb-figure {
+    transition: opacity 0.22s ease, visibility 0.22s ease;
+  }
+
+  .thumb:hover,
+  .lightbox:target .lb-figure {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an image lightbox built for #41275. A thumbnail grid that opens a full view over a dimmed backdrop using the CSS target state only. Closes #41275.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A thumbnail gallery where clicking a thumbnail opens the full image in a lightbox over a dimmed backdrop, closing on backdrop or close button.

**How does a developer use it?**

```html
<div class="gallery"><a class="thumb t1" href="#img1"></a></div>
<div class="lightbox" id="img1" role="dialog">
  <a class="lb-backdrop" href="#" tabindex="-1"></a>
  <div class="lb-figure t1"><a class="lb-close" href="#" aria-label="Close">✕</a></div>
</div>
```

**Why does it fit EaseMotion CSS?**
It builds a lightbox from the `:target` state with a thumbnail grid and a dimmed overlay, using only CSS and gradient placeholders so there are no external files. The animations are removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: six thumbnails and six lightboxes render, and a lightbox is hidden until its id becomes the URL target, then visible.
