### PR TITLE
feat: add order tracking

### DIFF
--- a/submissions/examples/order-tracking-as/README.md
+++ b/submissions/examples/order-tracking-as/README.md
@@ -1,0 +1,21 @@
+# Order Tracking
+
+### What does this do?
+
+It shows a delivery order tracker with four horizontal stages from ordered to delivered, each with an icon and a label, a connecting progress line that fills to the current stage, and an estimated arrival note.
+
+### How is it used?
+
+```html
+<ol class="track" style="--progress: 66">
+  <li class="track-step is-done"><span class="ts-dot"><svg>...</svg></span>Ordered</li>
+  <li class="track-step is-current"><span class="ts-dot"><svg>...</svg></span>Shipped</li>
+  <li class="track-step"><span class="ts-dot"><svg>...</svg></span>Delivered</li>
+</ol>
+```
+
+Set `--progress` (0 to 100) for how far the connecting line fills. Mark completed stages `is-done` and the active one `is-current`, which give the icons their filled and ringed looks.
+
+### Why is it useful?
+
+Shops show a shipment tracker so customers know where a package is. This renders a horizontal delivery tracker with stage icons, a filled progress line driven by a custom property, and done and current states, using only CSS and inline SVG.

--- a/submissions/examples/order-tracking-as/demo.html
+++ b/submissions/examples/order-tracking-as/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Order Tracking</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="track-card">
+    <div class="track-head">
+      <h2>Order #10842</h2>
+      <span class="eta">Arrives Wed, 15 Jul</span>
+    </div>
+    <ol class="track" style="--progress: 66">
+      <li class="track-step is-done">
+        <span class="ts-dot"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m5 13 4 4 10-11" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
+        Ordered
+      </li>
+      <li class="track-step is-done">
+        <span class="ts-dot"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3 4 6v5c0 5 3.5 8 8 10 4.5-2 8-5 8-10V6z" stroke-linejoin="round" /></svg></span>
+        Packed
+      </li>
+      <li class="track-step is-current">
+        <span class="ts-dot"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 7h11v8H3zM14 10h4l3 3v2h-7z" stroke-linejoin="round" /><circle cx="7" cy="18" r="1.6" /><circle cx="17" cy="18" r="1.6" /></svg></span>
+        Shipped
+      </li>
+      <li class="track-step">
+        <span class="ts-dot"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 10l9-6 9 6v9a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1z" stroke-linejoin="round" /><path d="M9 20v-6h6v6" /></svg></span>
+        Delivered
+      </li>
+    </ol>
+  </div>
+</body>
+</html>

--- a/submissions/examples/order-tracking-as/style.css
+++ b/submissions/examples/order-tracking-as/style.css
@@ -1,0 +1,125 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.track-card {
+  width: min(440px, 96vw);
+  padding: 1.8rem 1.9rem;
+  box-sizing: border-box;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+}
+
+.track-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 1.8rem;
+}
+
+.track-head h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.track-head .eta {
+  font-size: 0.78rem;
+  color: #a5b4fc;
+  font-weight: 600;
+}
+
+.track {
+  position: relative;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+}
+
+.track::before,
+.track::after {
+  content: "";
+  position: absolute;
+  top: 17px;
+  left: 12%;
+  right: 12%;
+  height: 3px;
+  border-radius: 2px;
+}
+
+.track::before {
+  background: #26324a;
+}
+
+.track::after {
+  right: auto;
+  width: calc((100% - 24%) * var(--progress, 0) / 100);
+  background: linear-gradient(90deg, #6c63ff, #a855f7);
+}
+
+.track-step {
+  position: relative;
+  flex: 1;
+  text-align: center;
+  font-size: 0.74rem;
+  color: #64748b;
+}
+
+.ts-dot {
+  position: relative;
+  z-index: 1;
+  width: 36px;
+  height: 36px;
+  margin: 0 auto 0.55rem;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: #16233c;
+  border: 2px solid #26324a;
+  color: #64748b;
+}
+
+.ts-dot svg {
+  width: 18px;
+  height: 18px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+}
+
+.track-step.is-done {
+  color: #cbd5e1;
+}
+
+.track-step.is-done .ts-dot {
+  background: #6c63ff;
+  border-color: #6c63ff;
+  color: #fff;
+}
+
+.track-step.is-current {
+  color: #fff;
+  font-weight: 700;
+}
+
+.track-step.is-current .ts-dot {
+  background: #0e1626;
+  border-color: #6c63ff;
+  color: #a5b4fc;
+  box-shadow: 0 0 0 4px rgba(108, 99, 255, 0.25);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .track::after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an order tracking component built for #41277. A horizontal delivery tracker with stage icons and a filled progress line, using only CSS. Closes #41277.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A delivery order tracker with four horizontal stages from ordered to delivered, each with an icon and a label, a connecting progress line that fills to the current stage, and an arrival note.

**How does a developer use it?**

```html
<ol class="track" style="--progress: 66">
  <li class="track-step is-done"><span class="ts-dot"><svg>...</svg></span>Ordered</li>
  <li class="track-step is-current"><span class="ts-dot"><svg>...</svg></span>Shipped</li>
  <li class="track-step"><span class="ts-dot"><svg>...</svg></span>Delivered</li>
</ol>
```

**Why does it fit EaseMotion CSS?**
It renders a horizontal delivery tracker with stage icons, a filled progress line driven by the `--progress` custom property, and `is-done` and `is-current` states, using only CSS and inline SVG.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium and by screenshot: four stages render with two done and one current, and the progress line fills to the shipped step.
