### PR TITLE
feat: add versus bar

### DIFF
--- a/submissions/examples/versus-bar-as/README.md
+++ b/submissions/examples/versus-bar-as/README.md
@@ -1,0 +1,24 @@
+# Versus Bar
+
+### What does this do?
+
+It shows a head to head versus bar that splits a single track into two colored segments for option A and option B, sized by a percent from a custom property, with each side labeled and a VS badge over the seam.
+
+### How is it used?
+
+```html
+<div class="versus" style="--a: 63%">
+  <div class="vs-labels"><span class="a-label"><b>63%</b> Cats</span><span class="b-label">Dogs <b>37%</b></span></div>
+  <div class="vs-bar">
+    <span class="a"></span>
+    <span class="b"></span>
+    <span class="vs-badge">VS</span>
+  </div>
+</div>
+```
+
+Set the A share with the `--a` custom property; the A segment takes that width and the B segment fills the rest. The VS badge is positioned at the same `--a` boundary so it sits on the seam.
+
+### Why is it useful?
+
+Polls and match ups show two sides competing on one bar. This splits a single bar into two sized segments with labels and a center badge, driven by a custom property, using only CSS. The A side animates in and holds still under reduced motion.

--- a/submissions/examples/versus-bar-as/demo.html
+++ b/submissions/examples/versus-bar-as/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Versus Bar</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="versus" style="--a: 63%">
+    <div class="vs-labels">
+      <span class="a-label"><b>63%</b> Cats</span>
+      <span class="b-label">Dogs <b>37%</b></span>
+    </div>
+    <div class="vs-bar" role="img" aria-label="Cats 63 percent versus Dogs 37 percent">
+      <span class="a"></span>
+      <span class="b"></span>
+      <span class="vs-badge">VS</span>
+    </div>
+    <div class="vs-foot">
+      <span>8,204 votes</span>
+      <span>Poll closes in 2 days</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/versus-bar-as/style.css
+++ b/submissions/examples/versus-bar-as/style.css
@@ -1,0 +1,98 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.versus {
+  width: min(400px, 94vw);
+  padding: 1.5rem 1.6rem;
+  box-sizing: border-box;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+}
+
+.vs-labels {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.6rem;
+  font-size: 0.86rem;
+}
+
+.vs-labels .a-label b,
+.vs-labels .b-label b {
+  font-weight: 800;
+}
+
+.vs-labels .a-label {
+  color: #a5b4fc;
+}
+
+.vs-labels .b-label {
+  color: #f9a8d4;
+  text-align: right;
+}
+
+.vs-bar {
+  position: relative;
+  display: flex;
+  height: 30px;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.vs-bar .a {
+  width: var(--a, 50%);
+  background: linear-gradient(90deg, #6c63ff, #7c5cff);
+  animation: vs-grow-a 0.9s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.vs-bar .b {
+  flex: 1;
+  background: linear-gradient(90deg, #ec4899, #f472b6);
+}
+
+.vs-badge {
+  position: absolute;
+  top: 50%;
+  left: var(--a, 50%);
+  transform: translate(-50%, -50%);
+  z-index: 1;
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: #0e1626;
+  border: 2px solid #26324a;
+  font-size: 0.68rem;
+  font-weight: 800;
+  color: #e2e8f0;
+}
+
+.vs-foot {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0.7rem;
+  font-size: 0.74rem;
+  color: #64748b;
+}
+
+@keyframes vs-grow-a {
+  from {
+    width: 50%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vs-bar .a {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a versus bar built for #41279. A single track split into two sized segments for a head to head with labels and a VS badge, using only CSS. Closes #41279.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A head to head versus bar that splits one track into two colored segments for A and B, sized by a percent, with side labels and a VS badge on the seam.

**How does a developer use it?**

```html
<div class="versus" style="--a: 63%">
  <div class="vs-labels"><span class="a-label"><b>63%</b> Cats</span><span class="b-label">Dogs <b>37%</b></span></div>
  <div class="vs-bar"><span class="a"></span><span class="b"></span><span class="vs-badge">VS</span></div>
</div>
```

**Why does it fit EaseMotion CSS?**
It splits a single bar into two sized segments with labels and a center badge, driven by the `--a` custom property, using only CSS. The A side animates in and holds still under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the A segment takes 63 percent of the bar with gradient fills on both sides and the VS badge positioned on the seam.
