### PR TITLE
feat: add CSS corner-shape utilities (squircle, notch, bevel, scoop)

### DIFF
--- a/submissions/examples/corner-shape-utilities/README.md
+++ b/submissions/examples/corner-shape-utilities/README.md
@@ -1,0 +1,46 @@
+# CSS `corner-shape` Utilities
+
+Relates to feature request **#41212**.
+
+## 1. What does this do?
+
+Provides utility classes built around the emerging CSS `corner-shape` property to create bevel, notch, scoop, and squircle corners without relying on SVGs, `clip-path`, or pseudo-elements. Each utility includes a graceful `@supports` fallback for browsers that don't yet support the specification.
+
+## 2. Why is this useful for EaseMotion CSS?
+
+Modern UI design is moving beyond simple rounded corners. Developers currently recreate unique corner styles using complex `clip-path` calculations or SVG masks, which are hard to maintain and don't compose well with borders or box-shadows. Native `corner-shape` utilities would provide expressive styling while keeping EaseMotion CSS lightweight and aligned with evolving CSS standards.
+
+## 3. Utilities Provided
+
+| Class | `corner-shape` | Effect |
+|---|---|---|
+| `.ease-shape-squircle` | `squircle` | Mathematically continuous superellipse (like Apple app icons) |
+| `.ease-shape-notch` | `notch` | Cuts inward at 90° — cyberpunk/gaming aesthetic |
+| `.ease-shape-bevel` | `bevel` | Slices corner with a straight line — brutalist/octagonal |
+| `.ease-shape-scoop` | `scoop` | Inverted curve — great for ticket or coupon effects |
+
+## 4. How is it used?
+
+```css
+/* You MUST specify border-radius for corner-shape to work */
+.ease-corner-card {
+  border-radius: 32px;
+}
+
+/* Apply the shape modifier */
+.ease-shape-squircle { corner-shape: squircle; }
+.ease-shape-notch    { corner-shape: notch; }
+.ease-shape-bevel    { corner-shape: bevel; }
+.ease-shape-scoop    { corner-shape: scoop; }
+
+/* Graceful fallback for unsupported browsers */
+@supports not (corner-shape: squircle) {
+  .ease-shape-squircle {
+    border-radius: 24px; /* A slightly smaller radius mimics squircle volume */
+  }
+}
+```
+
+## 5. Browser Support
+
+`corner-shape` is part of the CSS Borders Level 4 draft spec. As of 2025, support is limited to early preview builds of certain browsers. The `@supports not` fallback in each utility ensures users see well-styled rounded corners on all other browsers until the spec is fully adopted.

--- a/submissions/examples/corner-shape-utilities/demo.html
+++ b/submissions/examples/corner-shape-utilities/demo.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS corner-shape Utilities — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>CSS corner-shape Utilities</h1>
+    <p>
+      Modern UI design requires more than just rounded corners. These utilities
+      use the emerging CSS <code>corner-shape</code> property to create native squircles,
+      notches, and bevels without SVGs or messy clip-paths.
+    </p>
+    <div class="badges">
+      <span class="badge">📐 corner-shape</span>
+      <span class="badge">🍏 squircle</span>
+      <span class="badge">✂️ notch</span>
+    </div>
+  </header>
+
+  <!-- ── HOW TO TEST ───────────────────────────────────────── -->
+  <section class="how-to">
+    <p class="how-desc">
+      🎯 <strong>Note:</strong> <code>corner-shape</code> is an emerging specification.
+      If your browser doesn't support it yet, you will see standard rounded corners
+      as a graceful fallback thanks to <code>@supports</code> checks.
+    </p>
+  </section>
+
+  <!-- ── DEMO: Corner Shapes ───────────────────────────────── -->
+  <section class="demo-section">
+
+    <div class="demo-grid">
+
+      <!-- Squircle (Apple style) -->
+      <div class="ease-corner-card ease-shape-squircle">
+        <div class="icon-placeholder">🍏</div>
+        <h3>Squircle</h3>
+        <p>A mathematically continuous curve used extensively in modern mobile OS interfaces. Much smoother than standard border-radius.</p>
+        <code>corner-shape: squircle;</code>
+      </div>
+
+      <!-- Notch (Sci-fi / Gaming style) -->
+      <div class="ease-corner-card ease-shape-notch">
+        <div class="icon-placeholder">🎮</div>
+        <h3>Notch</h3>
+        <p>Cuts inward at a 90-degree angle. Perfect for cyberpunk, gaming, or futuristic interfaces.</p>
+        <code>corner-shape: notch;</code>
+      </div>
+
+      <!-- Bevel (Octagonal / Retro style) -->
+      <div class="ease-corner-card ease-shape-bevel">
+        <div class="icon-placeholder">🛑</div>
+        <h3>Bevel</h3>
+        <p>Slices off the corner with a straight line. Great for brutalist or retro-futuristic UI design.</p>
+        <code>corner-shape: bevel;</code>
+      </div>
+
+      <!-- Scoop (Inverted curve) -->
+      <div class="ease-corner-card ease-shape-scoop">
+        <div class="icon-placeholder">🎟️</div>
+        <h3>Scoop</h3>
+        <p>Inverts the border-radius curve inward. Excellent for creating ticket or coupon effects.</p>
+        <code>corner-shape: scoop;</code>
+      </div>
+
+    </div>
+
+  </section>
+
+  <!-- ── REFERENCE ─────────────────────────────────────────── -->
+  <section class="demo-section info-section">
+    <h2>🔧 CSS Reference</h2>
+    <div class="code-block">
+      <pre><code>/* 1. Base Setup */
+.ease-shape-squircle {
+  /* You MUST specify a border-radius for corner-shape to work */
+  border-radius: 2rem;
+  
+  /* Then specify how that radius is drawn */
+  corner-shape: squircle;
+}
+
+/* 2. Graceful Fallback Strategy */
+/* If the browser DOES NOT support corner-shape... */
+@supports not (corner-shape: squircle) {
+  .ease-shape-squircle {
+    /* Provide a slightly smaller radius to mimic the squircle volume */
+    border-radius: 1.5rem; 
+  }
+}
+
+/* Other shapes */
+.ease-shape-notch { corner-shape: notch; }
+.ease-shape-bevel { corner-shape: bevel; }
+.ease-shape-scoop { corner-shape: scoop; }</code></pre>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/corner-shape-utilities/style.css
+++ b/submissions/examples/corner-shape-utilities/style.css
@@ -1,0 +1,256 @@
+/* ============================================================
+   CSS corner-shape Utilities
+   Exploring modern UI corner shaping without SVGs.
+   Relates to issue #41212
+   ============================================================
+
+   KEY CONCEPTS:
+   - border-radius: Must be defined for corner-shape to have
+     any effect. It sets the size/bounding area of the cut.
+   - corner-shape: Modifies how the border-radius is drawn.
+     Values include: round (default), squircle, bevel, scoop, notch.
+   - @supports: Used here to provide a fallback border-radius
+     value that closely mimics the visual volume of the shape
+     if the browser doesn't support the emerging spec.
+   ============================================================ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3rem;
+}
+
+code {
+  background: #1e293b;
+  color: #a78bfa;
+  padding: 0.2em 0.5em;
+  border-radius: 6px;
+  font-size: 0.85em;
+  font-family: monospace;
+}
+
+strong {
+  color: #f8fafc;
+}
+
+/* ── Header ──────────────────────────────────────────────── */
+
+.page-header {
+  text-align: center;
+  max-width: 680px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.page-header h1 {
+  font-size: 2rem;
+  background: linear-gradient(135deg, #a78bfa, #38bdf8);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.page-header p {
+  color: #94a3b8;
+  line-height: 1.65;
+}
+
+.badges {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 0.5rem;
+}
+
+.badge {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 99px;
+  padding: 0.35rem 0.8rem;
+  font-size: 0.75rem;
+  color: #7dd3fc;
+}
+
+/* ── How to try ──────────────────────────────────────────── */
+
+.how-to {
+  background: #7c3aed22;
+  border: 1px dashed #7c3aed;
+  border-radius: 12px;
+  padding: 1rem 1.5rem;
+  max-width: 900px;
+  width: 100%;
+  text-align: center;
+}
+
+.how-desc {
+  color: #c4b5fd;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+/* ── Demo Sections ───────────────────────────────────────── */
+
+.demo-section {
+  width: 100%;
+  max-width: 900px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.demo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+}
+
+/* ── Base Card Style ─────────────────────────────────────── */
+
+.ease-corner-card {
+  background: #1e293b;
+  border: 2px solid #334155;
+  padding: 2.5rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.75rem;
+  transition: transform 0.2s, box-shadow 0.2s;
+  
+  /* Must declare border-radius for corner-shape to take effect */
+  border-radius: 32px;
+}
+
+.ease-corner-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 10px 25px rgba(0,0,0,0.4);
+  border-color: #475569;
+}
+
+.icon-placeholder {
+  font-size: 2.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.ease-corner-card h3 {
+  color: #f8fafc;
+  font-size: 1.25rem;
+}
+
+.ease-corner-card p {
+  color: #94a3b8;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  flex-grow: 1;
+}
+
+.ease-corner-card code {
+  background: #0f172a;
+  color: #38bdf8;
+  font-size: 0.75rem;
+  width: 100%;
+}
+
+
+/* ============================================================
+   UTILITIES: The Shapes
+   ============================================================ */
+
+/* 1. Squircle (Superellipse) */
+.ease-shape-squircle {
+  corner-shape: squircle;
+}
+/* Graceful fallback for squircle volume */
+@supports not (corner-shape: squircle) {
+  .ease-shape-squircle {
+    border-radius: 24px;
+  }
+}
+
+/* 2. Notch (Sci-fi / Gaming) */
+.ease-shape-notch {
+  corner-shape: notch;
+  /* Notches usually look better slightly smaller */
+  border-radius: 24px;
+}
+@supports not (corner-shape: notch) {
+  .ease-shape-notch {
+    border-radius: 8px; /* fallback to hard cornerish */
+  }
+}
+
+/* 3. Bevel (Octagonal) */
+.ease-shape-bevel {
+  corner-shape: bevel;
+}
+@supports not (corner-shape: bevel) {
+  .ease-shape-bevel {
+    border-radius: 12px; 
+  }
+}
+
+/* 4. Scoop (Ticket / Inverted) */
+.ease-shape-scoop {
+  corner-shape: scoop;
+}
+@supports not (corner-shape: scoop) {
+  .ease-shape-scoop {
+    border-radius: 0; /* A ticket shape looks better square than rounded if scoop fails */
+  }
+}
+
+
+/* ── Info Section ────────────────────────────────────────── */
+
+.info-section {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 14px;
+  padding: 1.75rem;
+  gap: 1.25rem;
+  margin-top: 1rem;
+}
+
+.info-section h2 {
+  font-size: 1.15rem;
+  border-left: 3px solid #a78bfa;
+  padding-left: 0.75rem;
+}
+
+.code-block {
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid #334155;
+}
+
+pre {
+  background: #0f172a;
+  padding: 1.25rem;
+  overflow-x: auto;
+}
+
+pre code {
+  background: transparent;
+  color: #7dd3fc;
+  padding: 0;
+  font-size: 0.8rem;
+  line-height: 1.8;
+}


### PR DESCRIPTION
Resolves #41212

### Description
Adds utility classes built around the emerging CSS `corner-shape` property to create bevel, notch, scoop, and squircle corners without relying on SVGs, `clip-path`, or pseudo-elements. Each utility includes a graceful `@supports not` fallback for browsers that don't yet support the specification.

### Utilities Added
| Class | `corner-shape` Value | Effect |
|---|---|---|
| `.ease-shape-squircle` | `squircle` | Mathematically continuous superellipse (Apple-style app icons) |
| `.ease-shape-notch` | `notch` | 90° inward cut — cyberpunk/gaming aesthetic |
| `.ease-shape-bevel` | `bevel` | Straight-line corner slice — brutalist/octagonal style |
| `.ease-shape-scoop` | `scoop` | Inverted inward curve — great for ticket/coupon effects |

### How It Works
```css
/* border-radius MUST be set for corner-shape to take effect */
.ease-corner-card { border-radius: 32px; }

.ease-shape-squircle { corner-shape: squircle; }
.ease-shape-notch    { corner-shape: notch; }
.ease-shape-bevel    { corner-shape: bevel; }
.ease-shape-scoop    { corner-shape: scoop; }

/* Graceful fallback */
@supports not (corner-shape: squircle) {
  .ease-shape-squircle { border-radius: 24px; }
}
```

### Demo Includes
4 cards displayed in a responsive grid, each demonstrating a different `corner-shape` value with appropriate fallbacks. Cards include hover animations to showcase that the shapes work seamlessly with CSS transforms.

### Validation
- [x] Placed under `submissions/examples/corner-shape-utilities/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] Zero external dependencies
- [x] Every shape utility includes a `@supports not` fallback
