### PR TITLE
feat: add specifications list

### DIFF
--- a/submissions/examples/spec-list-as/README.md
+++ b/submissions/examples/spec-list-as/README.md
@@ -1,0 +1,21 @@
+# Specifications List
+
+### What does this do?
+
+It shows a product specifications list where each row has a label on the left and a value on the right, joined by a dotted leader line and grouped under section headings.
+
+### How is it used?
+
+```html
+<dl class="specs">
+  <div class="spec-group">Display</div>
+  <div class="spec-row"><dt>Size</dt><span class="lead"></span><dd>6.1 inch</dd></div>
+  <div class="spec-row"><dt>Resolution</dt><span class="lead"></span><dd>2532 x 1170</dd></div>
+</dl>
+```
+
+Each row is a flex line with the label, a stretchy `lead` span that draws the dotted line, and the value aligned right. Use `spec-group` rows to label sections.
+
+### Why is it useful?
+
+Product and spec pages list technical details as label and value pairs. This lays out a grouped specifications list with aligned values and a dotted leader, using only CSS, on semantic `dl`, `dt`, and `dd` elements.

--- a/submissions/examples/spec-list-as/demo.html
+++ b/submissions/examples/spec-list-as/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Specifications List</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <dl class="specs">
+    <h2>Technical specs</h2>
+
+    <div class="spec-group">Display</div>
+    <div class="spec-row"><dt>Size</dt><span class="lead"></span><dd>6.1 inch</dd></div>
+    <div class="spec-row"><dt>Resolution</dt><span class="lead"></span><dd>2532 x 1170</dd></div>
+    <div class="spec-row"><dt>Refresh rate</dt><span class="lead"></span><dd>120 Hz</dd></div>
+
+    <div class="spec-group">Performance</div>
+    <div class="spec-row"><dt>Chip</dt><span class="lead"></span><dd>A18 Bionic</dd></div>
+    <div class="spec-row"><dt>Storage</dt><span class="lead"></span><dd>256 GB</dd></div>
+
+    <div class="spec-group">Battery</div>
+    <div class="spec-row"><dt>Capacity</dt><span class="lead"></span><dd>3900 mAh</dd></div>
+    <div class="spec-row"><dt>Charging</dt><span class="lead"></span><dd>30 W wired</dd></div>
+  </dl>
+</body>
+</html>

--- a/submissions/examples/spec-list-as/style.css
+++ b/submissions/examples/spec-list-as/style.css
@@ -1,0 +1,66 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.specs {
+  width: min(380px, 94vw);
+  margin: 0;
+  padding: 1.5rem 1.7rem;
+  box-sizing: border-box;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+}
+
+.specs > h2 {
+  margin: 0 0 1.2rem;
+  font-size: 1.05rem;
+}
+
+.spec-group {
+  margin: 1.3rem 0 0.6rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #a5b4fc;
+}
+
+.spec-group:first-of-type {
+  margin-top: 0;
+}
+
+.spec-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+  font-size: 0.86rem;
+}
+
+.spec-row dt {
+  color: #94a3b8;
+  flex: none;
+}
+
+.spec-row .lead {
+  flex: 1;
+  border-bottom: 1px dotted #33415c;
+  transform: translateY(-3px);
+}
+
+.spec-row dd {
+  margin: 0;
+  color: #e2e8f0;
+  font-weight: 600;
+  flex: none;
+  text-align: right;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a specifications list built for #41283. Grouped label and value rows joined by a dotted leader, using only CSS. Closes #41283.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A product specifications list with label and value rows joined by a dotted leader and grouped under section headings.

**How does a developer use it?**

```html
<dl class="specs">
  <div class="spec-group">Display</div>
  <div class="spec-row"><dt>Size</dt><span class="lead"></span><dd>6.1 inch</dd></div>
</dl>
```

**Why does it fit EaseMotion CSS?**
It lays out a grouped specifications list with aligned values and a dotted leader, using only CSS, on semantic `dl`, `dt`, and `dd` elements.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: three spec groups render with seven label and value rows, labels on the left and values on the right, each with a dotted leader.
