### PR TITLE
feat: add before after slider

### DIFF
--- a/submissions/examples/before-after-as/README.md
+++ b/submissions/examples/before-after-as/README.md
@@ -1,0 +1,23 @@
+# Before After Slider
+
+### What does this do?
+
+It shows a before and after image comparison where the after image sits in a resizable panel over the before image. Dragging the handle at the panel edge reveals more or less of the after version. It is genuinely draggable with no JavaScript.
+
+### How is it used?
+
+```html
+<div class="compare">
+  <div class="cmp-before"><span class="cmp-tag">Before</span></div>
+  <div class="cmp-after-wrap">
+    <div class="cmp-after"><span class="cmp-tag">After</span></div>
+    <span class="cmp-handle"><svg>...</svg></span>
+  </div>
+</div>
+```
+
+The after panel uses `resize: horizontal` with `overflow: hidden`, so dragging its edge changes how much of the after image shows. The after image is fixed to the full frame width so it does not stretch as the panel resizes. Swap the gradient placeholders for real images in production.
+
+### Why is it useful?
+
+Edits, retouches, and renovations are shown with a before and after wipe. This builds a draggable image comparison from the CSS `resize` property, using only CSS and gradient placeholders so there are no external files.

--- a/submissions/examples/before-after-as/demo.html
+++ b/submissions/examples/before-after-as/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Before After Slider</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="compare" role="group" aria-label="Before and after comparison, drag the handle">
+    <div class="cmp-before"><span class="cmp-tag">Before</span></div>
+    <div class="cmp-after-wrap">
+      <div class="cmp-after"><span class="cmp-tag">After</span></div>
+      <span class="cmp-handle" aria-hidden="true">
+        <svg viewBox="0 0 24 24"><path d="M9 6 4 12l5 6M15 6l5 6-5 6" stroke-linecap="round" stroke-linejoin="round" /></svg>
+      </span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/before-after-as/style.css
+++ b/submissions/examples/before-after-as/style.css
@@ -1,0 +1,113 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.compare {
+  position: relative;
+  width: min(440px, 92vw);
+  aspect-ratio: 3 / 2;
+  border-radius: 16px;
+  overflow: hidden;
+  border: 1px solid #26324a;
+  box-shadow: 0 20px 44px rgba(0, 0, 0, 0.45);
+  user-select: none;
+}
+
+.cmp-before,
+.cmp-after {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: min(440px, 92vw);
+  height: 100%;
+}
+
+.cmp-before {
+  background:
+    radial-gradient(circle at 70% 30%, rgba(255, 255, 255, 0.12), transparent 40%),
+    linear-gradient(135deg, #334155, #1e293b);
+}
+
+.cmp-after {
+  background:
+    radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.28), transparent 45%),
+    linear-gradient(135deg, #6c63ff, #ec4899);
+}
+
+.cmp-after-wrap {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 55%;
+  min-width: 40px;
+  max-width: 100%;
+  overflow: hidden;
+  resize: horizontal;
+}
+
+.cmp-after-wrap::-webkit-resizer {
+  display: none;
+}
+
+.cmp-after-wrap::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 3px;
+  background: #fff;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.25);
+}
+
+.cmp-handle {
+  position: absolute;
+  right: -17px;
+  bottom: 8px;
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: #fff;
+  color: #4f46e5;
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.5);
+  pointer-events: none;
+}
+
+.cmp-handle svg {
+  width: 18px;
+  height: 18px;
+  stroke: currentColor;
+  stroke-width: 2.5;
+  fill: none;
+}
+
+.cmp-tag {
+  position: absolute;
+  top: 0.7rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(4, 8, 18, 0.55);
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.cmp-before .cmp-tag {
+  right: 0.7rem;
+}
+
+.cmp-after .cmp-tag {
+  left: 0.7rem;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a before after slider built for #41288. A draggable image comparison from the CSS resize property, using only CSS. Closes #41288.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A before and after image comparison where the after image sits in a resizable panel over the before image; dragging the handle reveals more or less of the after version.

**How does a developer use it?**

```html
<div class="compare">
  <div class="cmp-before"><span class="cmp-tag">Before</span></div>
  <div class="cmp-after-wrap">
    <div class="cmp-after"><span class="cmp-tag">After</span></div>
    <span class="cmp-handle"><svg>...</svg></span>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It builds a genuinely draggable image comparison from the CSS `resize` property with `overflow: hidden`, using only CSS and gradient placeholders so there are no external files. The after image is fixed to the frame width so it does not stretch as the panel resizes.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium and by screenshot: the after panel is `resize: horizontal` with `overflow: hidden`, showing the after image over the before with a draggable divider handle.
