### PR TITLE
feat: add bento grid

### DIFF
--- a/submissions/examples/bento-grid-as/README.md
+++ b/submissions/examples/bento-grid-as/README.md
@@ -1,0 +1,25 @@
+# Bento Grid
+
+### What does this do?
+
+It lays out a bento style feature grid where tiles of different sizes span multiple columns and rows to make a lively asymmetric layout. Each tile has an icon and a title, one is an accent tile, and tiles lift on hover.
+
+### How is it used?
+
+```html
+<div class="bento">
+  <article class="bento-tile span-2-2 accent">
+    <span class="bt-ic"><svg>...</svg></span>
+    <h3>Lightning fast</h3>
+    <p>...</p>
+  </article>
+  <article class="bento-tile span-2-1">...</article>
+  <article class="bento-tile">...</article>
+</div>
+```
+
+The grid is four columns with fixed row height. Add `span-2-2` for a large square, `span-2-1` for a wide tile, or `span-1-2` for a tall tile. It collapses to two columns below 480px.
+
+### Why is it useful?
+
+Bento grids are a popular way to show product highlights in an asymmetric layout. This builds a bento grid with span classes for wide, tall, and large tiles, using only CSS grid. The hover lift is removed under reduced motion.

--- a/submissions/examples/bento-grid-as/demo.html
+++ b/submissions/examples/bento-grid-as/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bento Grid</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="bento">
+    <article class="bento-tile span-2-2 accent">
+      <span class="bt-ic"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M13 2 3 14h7l-1 8 10-12h-7z" stroke-linejoin="round" /></svg></span>
+      <h3>Lightning fast</h3>
+      <p>Pages load in a blink with a tiny footprint and zero build step.</p>
+    </article>
+    <article class="bento-tile span-2-1">
+      <span class="bt-ic"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3 4 6v5c0 5 3.5 8 8 10 4.5-2 8-5 8-10V6z" stroke-linejoin="round" /></svg></span>
+      <h3>Secure by default</h3>
+    </article>
+    <article class="bento-tile">
+      <span class="bt-ic"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9" /><path d="M12 7v5l3 3" stroke-linecap="round" /></svg></span>
+      <h3>Reliable</h3>
+    </article>
+    <article class="bento-tile">
+      <span class="bt-ic"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 4h7v7H4zM13 4h7v7h-7zM4 13h7v7H4zM13 13h7v7h-7z" stroke-linejoin="round" /></svg></span>
+      <h3>Modular</h3>
+    </article>
+    <article class="bento-tile span-1-2">
+      <span class="bt-ic"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 20V10M6 20v-6M18 20V6" stroke-linecap="round" /></svg></span>
+      <h3>Analytics</h3>
+      <p>Built in usage insights.</p>
+    </article>
+    <article class="bento-tile span-2-1">
+      <span class="bt-ic"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="3" /><path d="M12 3v3M12 18v3M3 12h3M18 12h3" stroke-linecap="round" /></svg></span>
+      <h3>Fully themeable</h3>
+    </article>
+  </div>
+</body>
+</html>

--- a/submissions/examples/bento-grid-as/style.css
+++ b/submissions/examples/bento-grid-as/style.css
@@ -1,0 +1,113 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.bento {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  grid-auto-rows: 116px;
+  gap: 0.8rem;
+  width: min(560px, 96vw);
+}
+
+.bento-tile {
+  position: relative;
+  overflow: hidden;
+  padding: 1.1rem;
+  border-radius: 16px;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  transition: transform 0.18s ease, border-color 0.18s ease;
+}
+
+.bento-tile:hover {
+  transform: translateY(-3px);
+  border-color: #6c63ff;
+}
+
+.bt-ic {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: 10px;
+  background: rgba(108, 99, 255, 0.16);
+  color: #a5b4fc;
+  margin-bottom: 0.7rem;
+}
+
+.bt-ic svg {
+  width: 18px;
+  height: 18px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+}
+
+.bento-tile h3 {
+  margin: 0 0 0.25rem;
+  font-size: 0.95rem;
+}
+
+.bento-tile p {
+  margin: 0;
+  font-size: 0.8rem;
+  line-height: 1.45;
+  color: #94a3b8;
+}
+
+.span-2-2 {
+  grid-column: span 2;
+  grid-row: span 2;
+}
+
+.span-2-1 {
+  grid-column: span 2;
+}
+
+.span-1-2 {
+  grid-row: span 2;
+}
+
+.bento-tile.accent {
+  background: linear-gradient(135deg, #6c63ff, #a855f7);
+  border-color: transparent;
+}
+
+.bento-tile.accent .bt-ic {
+  background: rgba(255, 255, 255, 0.2);
+  color: #fff;
+}
+
+.bento-tile.accent p {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+@media (max-width: 480px) {
+  .bento {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .span-2-2,
+  .span-2-1 {
+    grid-column: span 2;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bento-tile {
+    transition: border-color 0.18s ease;
+  }
+
+  .bento-tile:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a bento grid built for #41295. Feature tiles of varying sizes in an asymmetric grid with span classes, using only CSS grid. Closes #41295.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A bento style feature grid where tiles span multiple columns and rows for an asymmetric layout, each with an icon and title, one accent tile, and a hover lift.

**How does a developer use it?**

```html
<div class="bento">
  <article class="bento-tile span-2-2 accent"><span class="bt-ic"><svg>...</svg></span><h3>Lightning fast</h3></article>
  <article class="bento-tile span-2-1">...</article>
  <article class="bento-tile">...</article>
</div>
```

**Why does it fit EaseMotion CSS?**
It builds a bento grid with `span-2-2`, `span-2-1`, and `span-1-2` classes on a four column grid, collapsing to two columns below 480px, using only CSS grid. The hover lift is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: six tiles render on a four column grid with the large span tile wider than a small tile and one accent tile.
