### PR TITLE
feat: add CSS initial-letter utilities for drop caps and raised initials

### DIFF
--- a/submissions/examples/initial-letter-utilities/README.md
+++ b/submissions/examples/initial-letter-utilities/README.md
@@ -1,0 +1,61 @@
+# CSS `initial-letter` Utilities
+
+Relates to feature request **#41286**.
+
+## 1. What does this do?
+
+Provides utility classes based on the CSS `initial-letter` property to create elegant drop caps and raised initials for articles, blogs, magazines, and documentation — with responsive sizing and graceful float-based fallbacks for browsers without support.
+
+## 2. Why is this useful for EaseMotion CSS?
+
+Editorial layouts are becoming increasingly popular, yet most CSS utility libraries don't provide abstractions for advanced typography. Achieving a drop cap traditionally requires complex markup (wrapping the first letter in a `<span>`) or fragile JavaScript. Native `initial-letter` utilities help developers create premium reading experiences without additional markup or JavaScript.
+
+## 3. Utilities Provided
+
+| Class | `initial-letter` Value | Effect |
+|---|---|---|
+| `.ease-dropcap` | `initial-letter: 3` | Classic sunken drop cap — first letter spans 3 lines |
+| `.ease-raisedcap` | `initial-letter: 3 1` | Raised initial — 3 lines tall but raises above baseline |
+| `.ease-accentcap` | `initial-letter: 3` | Bold italic accent cap in brand teal color |
+
+## 4. How is it used?
+
+**HTML**
+```html
+<article class="ease-article">
+  <p class="ease-dropcap">
+    EaseMotion CSS helps developers build expressive interfaces using modern CSS.
+  </p>
+</article>
+```
+
+**CSS**
+```css
+/* The ::first-letter pseudo-element is the only target */
+.ease-dropcap::first-letter {
+  initial-letter: 3;
+  margin-right: .35rem;
+  color: #8c63ff;
+  font-weight: bold;
+}
+
+/* Graceful fallback using float for unsupported browsers */
+@supports not (initial-letter: 3) {
+  .ease-dropcap::first-letter {
+    float: left;
+    font-size: 3.5rem;
+    line-height: 0.85;
+    margin-right: .35rem;
+    font-weight: bold;
+    color: #8c63ff;
+  }
+}
+```
+
+## 5. The Two-Value Syntax
+
+`initial-letter: <size> <sink>` is a powerful two-value form:
+- **`size`** — How many lines tall the letter appears visually
+- **`sink`** — How many lines it sinks below the first line's baseline
+
+So `initial-letter: 3 1` creates a **raised initial** — 3 lines tall but only sinking 1 line, so it rises *above* the text block. `initial-letter: 3` (one value) is shorthand for `initial-letter: 3 3` (sinks all the way).

--- a/submissions/examples/initial-letter-utilities/demo.html
+++ b/submissions/examples/initial-letter-utilities/demo.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Initial Letter Utilities — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>CSS Initial Letter Utilities</h1>
+    <p>
+      Elegant drop caps and raised initials for articles, blogs, and
+      magazines — powered by the native CSS <code>initial-letter</code>
+      property with graceful fallbacks for all browsers.
+    </p>
+    <div class="badges">
+      <span class="badge">📖 initial-letter</span>
+      <span class="badge">🎨 Drop Cap</span>
+      <span class="badge">✍️ Editorial Layout</span>
+    </div>
+  </header>
+
+  <!-- ── DEMO 1: Standard Drop Cap ─────────────────────────── -->
+  <section class="demo-section">
+    <h2>1. Standard Drop Cap — <code>.ease-dropcap</code></h2>
+    <p class="demo-desc">
+      A classic 3-line drop cap. The first letter sinks down to align with 3 lines of text,
+      a common editorial style seen in newspapers and novels.
+    </p>
+
+    <article class="ease-article">
+      <p class="ease-dropcap">
+        EaseMotion CSS helps developers build expressive interfaces using modern CSS.
+        This drop cap is powered by <code>initial-letter: 3</code>, which sinks the
+        first letter to exactly 3 lines tall without any JavaScript or extra markup.
+        On browsers without support, a float-based fallback kicks in automatically.
+        The result is a rich, editorial reading experience that elevates your typography.
+      </p>
+    </article>
+  </section>
+
+  <!-- ── DEMO 2: Raised Initial ────────────────────────────── -->
+  <section class="demo-section">
+    <h2>2. Raised Initial — <code>.ease-raisedcap</code></h2>
+    <p class="demo-desc">
+      A raised initial sits above the baseline rather than sinking down.
+      Perfect for magazine-style callouts and modern editorial design.
+    </p>
+
+    <article class="ease-article">
+      <p class="ease-raisedcap">
+        Modern displays and high-resolution screens have renewed interest in typographic
+        craftsmanship. A raised initial creates a sense of elegance and hierarchy,
+        drawing the reader's eye immediately to the start of the paragraph.
+        This utility uses <code>initial-letter: 3 1</code>, which sets the letter to
+        3 lines tall but raised to align only with the first baseline.
+      </p>
+    </article>
+  </section>
+
+  <!-- ── DEMO 3: Colored Accent Cap ───────────────────────── -->
+  <section class="demo-section">
+    <h2>3. Colored Accent Cap — <code>.ease-accentcap</code></h2>
+    <p class="demo-desc">
+      A vibrant, bold initial letter in the brand accent color.
+      Pairs beautifully with any article or documentation page to create
+      a distinctive visual identity.
+    </p>
+
+    <article class="ease-article">
+      <p class="ease-accentcap">
+        Typography is the art and technique of arranging type to make written language
+        legible, readable, and appealing when displayed. The arrangement of type involves
+        selecting typefaces, point sizes, line lengths, line-spacing, and letter spacing.
+        With the CSS <code>initial-letter</code> property, we can now achieve stunning
+        typographic results without any external libraries or JavaScript.
+      </p>
+    </article>
+  </section>
+
+  <!-- ── REFERENCE ─────────────────────────────────────────── -->
+  <section class="demo-section info-section">
+    <h2>🔧 CSS Reference</h2>
+    <div class="code-block">
+      <pre><code>/* 1. Drop Cap: Sinks to align with 3 lines of text */
+.ease-dropcap::first-letter {
+  initial-letter: 3;
+  margin-right: .35rem;
+  color: #8c63ff;
+  font-weight: bold;
+}
+
+/* Fallback for browsers that don't support initial-letter */
+@supports not (initial-letter: 3) {
+  .ease-dropcap::first-letter {
+    float: left;
+    font-size: 3rem;
+    line-height: 1;
+    margin-right: .35rem;
+    font-weight: bold;
+    color: #8c63ff;
+  }
+}
+
+/* 2. Raised Cap: 3 lines tall but raised to first baseline */
+.ease-raisedcap::first-letter {
+  /* syntax: initial-letter: <size> <sink> */
+  /* size=3 sink=1 means 3 lines tall, sinking only 1 line */
+  initial-letter: 3 1; 
+}
+
+/* 3. Accent Cap: Colorful large initial */
+.ease-accentcap::first-letter {
+  initial-letter: 3;
+  color: #06b6d4;
+  font-weight: 900;
+  font-style: italic;
+}</code></pre>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/initial-letter-utilities/style.css
+++ b/submissions/examples/initial-letter-utilities/style.css
@@ -1,0 +1,252 @@
+/* ============================================================
+   CSS Initial Letter Utilities
+   Drop caps and raised initials using native CSS initial-letter.
+   Relates to issue #41286
+   ============================================================
+
+   KEY CONCEPTS:
+   - initial-letter: <size>
+     Sets the first letter to span exactly <size> lines of text.
+     The letter sinks to align its top with the cap-height of
+     the first line and its bottom with the baseline of the
+     Nth line (where N = <size>).
+   
+   - initial-letter: <size> <sink>
+     Two-value syntax. <size> controls the total visual height,
+     <sink> controls how many lines it drops below the first line.
+     Example: initial-letter: 3 1 = "raised initial" (3 lines tall,
+     only sinks 1 line, so it rises above the first line's cap-height)
+   
+   - @supports not (initial-letter: 3): A fallback block using
+     float: left + font-size + line-height to approximate the
+     drop cap behavior on browsers without support.
+   ============================================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,700;1,400&family=Inter:wght@400;600&display=swap');
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  font-family: 'Inter', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3rem;
+}
+
+code {
+  background: #1e293b;
+  color: #a78bfa;
+  padding: 0.2em 0.5em;
+  border-radius: 6px;
+  font-size: 0.85em;
+  font-family: monospace;
+}
+
+/* ── Header ──────────────────────────────────────────────── */
+
+.page-header {
+  text-align: center;
+  max-width: 680px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.page-header h1 {
+  font-size: 2rem;
+  background: linear-gradient(135deg, #a78bfa, #38bdf8);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.page-header p {
+  color: #94a3b8;
+  line-height: 1.65;
+}
+
+.badges {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 0.5rem;
+}
+
+.badge {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 99px;
+  padding: 0.35rem 0.8rem;
+  font-size: 0.75rem;
+  color: #7dd3fc;
+}
+
+/* ── Demo Sections ───────────────────────────────────────── */
+
+.demo-section {
+  width: 100%;
+  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.demo-section h2 {
+  font-size: 1.05rem;
+  border-left: 3px solid #a78bfa;
+  padding-left: 0.75rem;
+  color: #f8fafc;
+}
+
+.demo-desc {
+  color: #94a3b8;
+  font-size: 0.88rem;
+  line-height: 1.7;
+}
+
+/* ── Article Base Style ──────────────────────────────────── */
+
+.ease-article {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 14px;
+  padding: 2rem;
+}
+
+.ease-article p {
+  font-family: 'Lora', Georgia, serif;
+  font-size: 1.1rem;
+  line-height: 1.8;
+  color: #cbd5e1;
+}
+
+/* ============================================================
+   UTILITY 1: .ease-dropcap
+   Classic sunken drop cap — 3 lines tall.
+   ============================================================ */
+
+.ease-dropcap::first-letter {
+  initial-letter: 3;
+  margin-right: 0.35rem;
+  color: #8c63ff;
+  font-weight: bold;
+  font-family: 'Lora', Georgia, serif;
+}
+
+/* Graceful float-based fallback for unsupported browsers */
+@supports not (initial-letter: 3) {
+  .ease-dropcap::first-letter {
+    float: left;
+    font-size: 3.5rem;
+    line-height: 0.85;
+    margin-right: 0.35rem;
+    padding-top: 0.1rem;
+    font-weight: bold;
+    color: #8c63ff;
+  }
+}
+
+/* ============================================================
+   UTILITY 2: .ease-raisedcap
+   Raised initial — stays at the top, doesn't sink.
+   initial-letter: <size> <sink>
+   ============================================================ */
+
+.ease-raisedcap::first-letter {
+  /* 3 = 3 lines tall; 1 = only sink by 1 line (raises above first line) */
+  initial-letter: 3 1;
+  margin-right: 0.35rem;
+  color: #f59e0b;
+  font-weight: 700;
+  font-family: 'Lora', Georgia, serif;
+}
+
+@supports not (initial-letter: 3 1) {
+  .ease-raisedcap::first-letter {
+    float: left;
+    font-size: 3.5rem;
+    line-height: 0.85;
+    margin-right: 0.35rem;
+    padding-top: 0.1rem;
+    font-weight: 700;
+    color: #f59e0b;
+  }
+}
+
+/* ============================================================
+   UTILITY 3: .ease-accentcap
+   Bold, italic, colored accent cap in the brand teal color.
+   ============================================================ */
+
+.ease-accentcap::first-letter {
+  initial-letter: 3;
+  margin-right: 0.35rem;
+  color: #06b6d4;
+  font-weight: 900;
+  font-style: italic;
+  font-family: 'Lora', Georgia, serif;
+}
+
+@supports not (initial-letter: 3) {
+  .ease-accentcap::first-letter {
+    float: left;
+    font-size: 3.5rem;
+    line-height: 0.85;
+    margin-right: 0.35rem;
+    padding-top: 0.1rem;
+    font-weight: 900;
+    font-style: italic;
+    color: #06b6d4;
+  }
+}
+
+/* ── Info Section ────────────────────────────────────────── */
+
+.info-section {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 14px;
+  padding: 1.75rem;
+  gap: 1.25rem;
+  margin-top: 1rem;
+}
+
+.info-section h2 {
+  font-size: 1.05rem;
+  border-left: 3px solid #a78bfa;
+  padding-left: 0.75rem;
+  color: #f8fafc;
+}
+
+.code-block {
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid #334155;
+}
+
+pre {
+  background: #0f172a;
+  padding: 1.25rem;
+  overflow-x: auto;
+}
+
+pre code {
+  background: transparent;
+  color: #7dd3fc;
+  padding: 0;
+  font-size: 0.8rem;
+  line-height: 1.8;
+}


### PR DESCRIPTION
Resolves #41286

### Description
Adds utility classes based on the CSS `initial-letter` property to create elegant drop caps and raised initials for articles, blogs, magazines, and documentation. Each utility includes a graceful `float`-based fallback for browsers that don't yet support the specification.

### Utilities Added
| Class | `initial-letter` Value | Effect |
|---|---|---|
| `.ease-dropcap` | `initial-letter: 3` | Classic sunken drop cap — first letter spans 3 lines |
| `.ease-raisedcap` | `initial-letter: 3 1` | Raised initial — 3 lines tall but raised above first baseline |
| `.ease-accentcap` | `initial-letter: 3` | Bold italic accent initial in brand teal |

### How It Works
```css
/* Matches the HTML/CSS snippet from the issue */
.ease-dropcap::first-letter {
  initial-letter: 3;
  margin-right: .35rem;
  color: #8c63ff;
  font-weight: bold;
}

/* Graceful fallback */
@supports not (initial-letter: 3) {
  .ease-dropcap::first-letter {
    float: left;
    font-size: 3.5rem;
    line-height: 0.85;
    margin-right: .35rem;
    font-weight: bold;
    color: #8c63ff;
  }
}
```

### Demo Includes
Three full editorial article cards demonstrating:
1. **`.ease-dropcap`** — Classic sunken 3-line drop cap (purple)
2. **`.ease-raisedcap`** — Raised 3-line initial that pops above the text (amber)
3. **`.ease-accentcap`** — Bold italic accent cap in brand teal

All using a serif body font (Lora) and the `::first-letter` pseudo-element — no extra HTML markup required.

### Validation
- [x] Placed under `submissions/examples/initial-letter-utilities/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] Zero extra HTML markup (only class on `<p>`)
- [x] Every utility has a `@supports not` float-based fallback
