### PR TITLE
feat: add waffle chart

### DIFF
--- a/submissions/examples/waffle-chart-as/README.md
+++ b/submissions/examples/waffle-chart-as/README.md
@@ -1,0 +1,23 @@
+# Waffle Chart
+
+### What does this do?
+
+It shows a waffle chart, a ten by ten grid of cells where a number of cells are filled to show a percentage, with a big value and a label beside it.
+
+### How is it used?
+
+```html
+<div class="waffle-card">
+  <div class="waffle" role="img" aria-label="68 percent complete">
+    <span class="wf-cell on"></span>
+    <!-- 100 cells; add the on class to the first N for N percent -->
+  </div>
+  <div class="wf-info"><div class="wf-value">68%</div><div class="wf-label">Goal reached</div></div>
+</div>
+```
+
+The waffle is a `repeat(10, 1fr)` grid of 100 cells. Add the `on` class to the first N cells for N percent. Add `is-good` on the waffle to switch the fill to green.
+
+### Why is it useful?
+
+Waffle charts show a single percentage as a friendly grid of squares. This renders a hundred cell waffle chart with a filled count driven by a class, plus a big value label, using only CSS with no scripts.

--- a/submissions/examples/waffle-chart-as/demo.html
+++ b/submissions/examples/waffle-chart-as/demo.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Waffle Chart</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="waffle-card">
+    <div class="waffle" role="img" aria-label="68 percent complete">
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell on"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+        <span class="wf-cell"></span>
+    </div>
+    <div class="wf-info">
+      <div class="wf-value">68%</div>
+      <div class="wf-label">Goal reached</div>
+      <div class="wf-sub">68 of 100 tasks done</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/waffle-chart-as/style.css
+++ b/submissions/examples/waffle-chart-as/style.css
@@ -1,0 +1,72 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.waffle-card {
+  display: flex;
+  align-items: center;
+  gap: 1.6rem;
+  padding: 1.8rem 2rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 18px;
+}
+
+.waffle {
+  flex: none;
+  display: grid;
+  grid-template-columns: repeat(10, 1fr);
+  gap: 3px;
+  width: 168px;
+}
+
+.wf-cell {
+  aspect-ratio: 1;
+  border-radius: 3px;
+  background: #16233c;
+}
+
+.wf-cell.on {
+  background: #6c63ff;
+}
+
+.waffle.is-good .wf-cell.on {
+  background: #34d399;
+}
+
+.wf-info .wf-value {
+  font-size: 2.4rem;
+  font-weight: 800;
+  line-height: 1;
+  background: linear-gradient(135deg, #a5b4fc, #6c63ff);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.wf-info .wf-label {
+  margin-top: 0.4rem;
+  font-size: 0.86rem;
+  color: #cbd5e1;
+}
+
+.wf-info .wf-sub {
+  margin-top: 0.2rem;
+  font-size: 0.76rem;
+  color: #64748b;
+}
+
+@media (max-width: 420px) {
+  .waffle-card {
+    flex-direction: column;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a waffle chart built for #41299. A ten by ten grid where a count of cells is filled to show a percentage, with a value label, using only CSS. Closes #41299.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A waffle chart, a hundred cell grid where the first N cells are filled to represent N percent, beside a big value and a label.

**How does a developer use it?**

```html
<div class="waffle-card">
  <div class="waffle"><span class="wf-cell on"></span><!-- 100 cells --></div>
  <div class="wf-info"><div class="wf-value">68%</div><div class="wf-label">Goal reached</div></div>
</div>
```

**Why does it fit EaseMotion CSS?**
It renders a hundred cell waffle chart on a `repeat(10, 1fr)` grid with a filled count driven by the `on` class, plus a big value label, using only CSS with no scripts.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the grid has 100 cells with 68 filled across 10 columns, matching the 68 percent value.
