### PR TITLE
feat: add CSS hyphenation utilities

### DIFF
--- a/submissions/examples/hyphenation-utilities/README.md
+++ b/submissions/examples/hyphenation-utilities/README.md
@@ -1,0 +1,52 @@
+# CSS Hyphenation Utilities
+
+Relates to feature request **#41287**.
+
+## 1. What does this do?
+
+Provides utility classes that intelligently manage automatic word breaking and hyphenation using modern CSS typography properties. Includes language-aware presets and responsive typography helpers.
+
+## 2. Why is this useful for EaseMotion CSS?
+
+Responsive layouts often suffer from overflowing words or inconsistent text wrapping. This is especially common in narrow containers (like sidebars or mobile viewports) when long technical words, URLs, or foreign language words don't have natural break points. Native `hyphens` and `text-wrap` utilities improve readability while reducing the need for manual `<br>` tags or JavaScript-based text manipulation.
+
+## 3. Utilities Provided
+
+| Class | Properties | Use Case |
+|---|---|---|
+| `.ease-hyphenate` | `hyphens: auto`, `overflow-wrap: break-word`, `text-wrap: pretty` | General-purpose auto hyphenation (from the issue snippet) |
+| `.ease-wrap-pretty` | `text-wrap: pretty`, `overflow-wrap: break-word` | Prevents orphaned words without hyphenating |
+| `.ease-hyphenate-article` | Full preset with word-spacing | Best for article/blog body paragraphs |
+| `.ease-no-hyphens` | `hyphens: none`, `overflow-wrap: normal` | Explicitly disables hyphenation for overrides |
+
+## 4. How is it used?
+
+**HTML** (matching the issue's snippet)
+```html
+<p class="ease-hyphenate" lang="en">
+  Supercalifragilisticexpialidocious demonstrates automatic word breaking.
+</p>
+```
+
+**CSS** (matching the issue's CSS snippet exactly)
+```css
+.ease-hyphenate {
+  hyphens: auto;
+  overflow-wrap: break-word;
+  text-wrap: pretty;
+}
+```
+
+## 5. Critical Requirement: `lang` Attribute
+
+> ⚠️ `hyphens: auto` **requires** a `lang` attribute on the element or an ancestor (e.g., `<html lang="en">`). Without it, the browser does not know which hyphenation dictionary to use, and the property silently does nothing.
+
+The `lang` attribute can be set on the `<html>` tag globally, or directly on individual elements for multilingual content:
+
+```html
+<!-- Global (recommended) -->
+<html lang="en">
+
+<!-- Per-element (for mixed-language content) -->
+<p class="ease-hyphenate" lang="de">Donaudampfschifffahrtsgesellschaft</p>
+```

--- a/submissions/examples/hyphenation-utilities/demo.html
+++ b/submissions/examples/hyphenation-utilities/demo.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Hyphenation Utilities — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>CSS Hyphenation Utilities</h1>
+    <p>
+      Intelligent automatic word breaking and hyphenation using modern CSS
+      typography properties. Prevents overflow, improves readability, and
+      requires zero JavaScript.
+    </p>
+    <div class="badges">
+      <span class="badge">🔤 hyphens: auto</span>
+      <span class="badge">📐 overflow-wrap</span>
+      <span class="badge">✨ text-wrap: pretty</span>
+    </div>
+  </header>
+
+  <!-- ── DEMO 1: No utility (the problem) ──────────────────── -->
+  <section class="demo-section">
+    <h2>1. The Problem — No Hyphenation</h2>
+    <p class="demo-desc">
+      Without hyphenation, long words overflow their containers or create awkward
+      gaps in justified text. This is especially bad on narrow mobile screens.
+    </p>
+    <div class="demo-grid">
+      <div class="demo-card">
+        <h3>❌ Default</h3>
+        <p class="no-hyphens narrow-text">
+          Supercalifragilisticexpialidocious demonstrates automatic word breaking.
+          Pneumonoultramicroscopicsilicovolcanoconiosis is an even longer word.
+        </p>
+      </div>
+      <div class="demo-card">
+        <h3>✅ <code>.ease-hyphenate</code></h3>
+        <p class="ease-hyphenate narrow-text" lang="en">
+          Supercalifragilisticexpialidocious demonstrates automatic word breaking.
+          Pneumonoultramicroscopicsilicovolcanoconiosis is an even longer word.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── DEMO 2: text-wrap: pretty ─────────────────────────── -->
+  <section class="demo-section">
+    <h2>2. Pretty Text Wrapping — <code>.ease-wrap-pretty</code></h2>
+    <p class="demo-desc">
+      The newer <code>text-wrap: pretty</code> value prevents orphaned last words
+      (a single word alone on the last line of a paragraph). Browsers using this
+      will slightly reflow preceding lines to avoid orphans.
+    </p>
+    <div class="demo-grid">
+      <div class="demo-card">
+        <h3>❌ Default Wrapping</h3>
+        <p class="no-wrap-pretty">
+          The quick brown fox jumps over the lazy dog near the edge of the river.
+        </p>
+      </div>
+      <div class="demo-card">
+        <h3>✅ <code>text-wrap: pretty</code></h3>
+        <p class="ease-wrap-pretty">
+          The quick brown fox jumps over the lazy dog near the edge of the river.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── DEMO 3: All Together ───────────────────────────────── -->
+  <section class="demo-section">
+    <h2>3. Full Article Typography — <code>.ease-hyphenate-article</code></h2>
+    <p class="demo-desc">
+      Combines <code>hyphens: auto</code>, <code>overflow-wrap: break-word</code>,
+      and <code>text-wrap: pretty</code> for the best reading experience in article bodies.
+    </p>
+    <article class="ease-article">
+      <p class="ease-hyphenate-article" lang="en">
+        Responsive layouts often suffer from overflowing words or inconsistent text wrapping.
+        Native hyphenation utilities improve readability while reducing the need for manual
+        line breaks. Supercalifragilisticexpialidocious demonstrates automatic word breaking.
+        This paragraph also uses <code>text-wrap: pretty</code> to prevent any orphaned words
+        from appearing alone on the final line of the paragraph.
+      </p>
+    </article>
+  </section>
+
+  <!-- ── REFERENCE ─────────────────────────────────────────── -->
+  <section class="demo-section info-section">
+    <h2>🔧 CSS Reference</h2>
+    <div class="code-block">
+      <pre><code>/* 1. Auto Hyphenation (from the issue snippet) */
+/* IMPORTANT: The element or a parent must have a lang attribute */
+.ease-hyphenate {
+  hyphens: auto;
+  overflow-wrap: break-word;
+  text-wrap: pretty;
+}
+
+/* 2. Pretty Text Wrap only (no hyphenation) */
+.ease-wrap-pretty {
+  text-wrap: pretty;
+  overflow-wrap: break-word;
+}
+
+/* 3. Full Article Typography Preset */
+.ease-hyphenate-article {
+  hyphens: auto;
+  overflow-wrap: break-word;
+  text-wrap: pretty;
+  /* Improve readability of long text blocks */
+  word-spacing: 0.05em;
+}
+
+/* 4. Disable Hyphenation (override) */
+.ease-no-hyphens {
+  hyphens: none;
+  overflow-wrap: normal;
+}</code></pre>
+    </div>
+    <div class="warning-box">
+      <strong>⚠️ Important:</strong> For <code>hyphens: auto</code> to work, you must set a
+      <code>lang</code> attribute on the element or its ancestor (e.g., <code>&lt;html lang="en"&gt;</code>).
+      This allows the browser to use the correct language-specific hyphenation dictionary.
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/hyphenation-utilities/style.css
+++ b/submissions/examples/hyphenation-utilities/style.css
@@ -1,0 +1,288 @@
+/* ============================================================
+   CSS Hyphenation Utilities
+   Intelligent word breaking and hyphenation for modern layouts.
+   Relates to issue #41287
+   ============================================================
+
+   KEY CONCEPTS:
+   - hyphens: auto
+     Enables automatic hyphenation based on the browser's built-in
+     language dictionary. Requires a 'lang' attribute on the element
+     or a parent (e.g., <html lang="en">). Without 'lang', hyphens
+     will not activate even if the property is set.
+   
+   - hyphens: manual
+     Only hyphenates at manually-placed soft hyphens (­ / U+00AD)
+     in the HTML. Useful when you want precise control without
+     fully automatic breaking.
+   
+   - overflow-wrap: break-word
+     As a last resort, forces a line break within an unbreakable word
+     (like a URL or hash) if it would overflow the container. More
+     graceful than word-break: break-all.
+   
+   - text-wrap: pretty
+     Prevents "orphaned" words — a single short word alone on the
+     last line of a paragraph. The browser may reflow one or two
+     preceding lines to balance the text block.
+   
+   - text-wrap: balance
+     Distributes text evenly across all lines. Best for headings,
+     short labels, and captions, not long paragraphs.
+   ============================================================ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3rem;
+}
+
+code {
+  background: #1e293b;
+  color: #a78bfa;
+  padding: 0.2em 0.5em;
+  border-radius: 6px;
+  font-size: 0.85em;
+  font-family: monospace;
+}
+
+strong {
+  color: #f8fafc;
+}
+
+/* ── Header ──────────────────────────────────────────────── */
+
+.page-header {
+  text-align: center;
+  max-width: 680px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.page-header h1 {
+  font-size: 2rem;
+  background: linear-gradient(135deg, #a78bfa, #38bdf8);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.page-header p {
+  color: #94a3b8;
+  line-height: 1.65;
+}
+
+.badges {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 0.5rem;
+}
+
+.badge {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 99px;
+  padding: 0.35rem 0.8rem;
+  font-size: 0.75rem;
+  color: #7dd3fc;
+}
+
+/* ── Demo Sections ───────────────────────────────────────── */
+
+.demo-section {
+  width: 100%;
+  max-width: 800px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.demo-section h2 {
+  font-size: 1.05rem;
+  border-left: 3px solid #a78bfa;
+  padding-left: 0.75rem;
+  color: #f8fafc;
+}
+
+.demo-desc {
+  color: #94a3b8;
+  font-size: 0.88rem;
+  line-height: 1.7;
+}
+
+.demo-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-top: 0.5rem;
+}
+
+@media (max-width: 600px) {
+  .demo-grid { grid-template-columns: 1fr; }
+}
+
+.demo-card {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 12px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.demo-card h3 {
+  font-size: 0.9rem;
+  color: #f8fafc;
+}
+
+.demo-card p {
+  font-size: 0.95rem;
+  line-height: 1.65;
+  color: #94a3b8;
+}
+
+/* Simulates a narrow container to show overflow issues */
+.narrow-text {
+  max-width: 220px;
+}
+
+/* Simulates default (broken) behavior */
+.no-hyphens {
+  hyphens: none;
+  overflow-wrap: normal;
+  overflow: hidden; /* Show the overflow effect */
+}
+
+.no-wrap-pretty {
+  max-width: 250px;
+  /* Default — no pretty wrapping */
+}
+
+
+/* ============================================================
+   UTILITY 1: .ease-hyphenate
+   Automatic hyphenation. Matches the issue's CSS snippet.
+   REQUIRES: lang attribute on element or ancestor.
+   ============================================================ */
+
+.ease-hyphenate {
+  hyphens: auto;
+  overflow-wrap: break-word;
+  text-wrap: pretty;
+}
+
+
+/* ============================================================
+   UTILITY 2: .ease-wrap-pretty
+   Pretty text wrapping without automatic hyphenation.
+   Great for body copy and article paragraphs.
+   ============================================================ */
+
+.ease-wrap-pretty {
+  text-wrap: pretty;
+  overflow-wrap: break-word;
+  max-width: 250px; /* for demo only */
+}
+
+
+/* ============================================================
+   UTILITY 3: .ease-hyphenate-article
+   Full article typography preset:
+   hyphens + overflow-wrap + pretty wrapping.
+   ============================================================ */
+
+.ease-hyphenate-article {
+  hyphens: auto;
+  overflow-wrap: break-word;
+  text-wrap: pretty;
+  word-spacing: 0.05em; /* Slightly wider word spacing for readability */
+}
+
+
+/* ============================================================
+   UTILITY 4: .ease-no-hyphens
+   Explicitly disables hyphenation (e.g., override in a child).
+   ============================================================ */
+
+.ease-no-hyphens {
+  hyphens: none;
+  overflow-wrap: normal;
+}
+
+
+/* ── Article Base Style ──────────────────────────────────── */
+
+.ease-article {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 14px;
+  padding: 1.75rem;
+}
+
+.ease-article p {
+  font-size: 1.05rem;
+  line-height: 1.8;
+  color: #cbd5e1;
+}
+
+/* ── Warning Box ─────────────────────────────────────────── */
+
+.warning-box {
+  background: #7c3aed22;
+  border: 1px dashed #7c3aed;
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
+  font-size: 0.88rem;
+  color: #c4b5fd;
+  line-height: 1.6;
+}
+
+/* ── Info Section ────────────────────────────────────────── */
+
+.info-section {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 14px;
+  padding: 1.75rem;
+  gap: 1.25rem;
+  margin-top: 1rem;
+}
+
+.code-block {
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid #334155;
+}
+
+pre {
+  background: #0f172a;
+  padding: 1.25rem;
+  overflow-x: auto;
+}
+
+pre code {
+  background: transparent;
+  color: #7dd3fc;
+  padding: 0;
+  font-size: 0.8rem;
+  line-height: 1.8;
+}


### PR DESCRIPTION
Resolves #41287

### Description
Adds utility classes that intelligently manage automatic word breaking and hyphenation using modern CSS typography properties. Includes language-aware presets and responsive typography helpers.

### Utilities Added
| Class | Properties | Use Case |
|---|---|---|
| `.ease-hyphenate` | `hyphens: auto` + `overflow-wrap: break-word` + `text-wrap: pretty` | General-purpose auto hyphenation (matches the issue snippet) |
| `.ease-wrap-pretty` | `text-wrap: pretty` + `overflow-wrap: break-word` | Prevents orphaned words without hyphenating |
| `.ease-hyphenate-article` | Full preset with `word-spacing` | Best reading experience for article/blog paragraphs |
| `.ease-no-hyphens` | `hyphens: none` + `overflow-wrap: normal` | Explicitly disable hyphenation for overrides |

### How It Works (matches the issue's snippet exactly)
```css
.ease-hyphenate {
  hyphens: auto;
  overflow-wrap: break-word;
  text-wrap: pretty;
}
```

### Key Gotcha Documented
`hyphens: auto` requires a `lang` attribute on the element or ancestor. The demo and README clearly document this critical requirement to prevent silent failures.

### Demo Includes
1. **Overflow Comparison:** Side-by-side of a narrow container with/without `.ease-hyphenate`. Long words like "Supercalifragilisticexpialidocious" overflow on the left, hyphenate cleanly on the right.
2. **Pretty Wrap:** Comparison of default vs `text-wrap: pretty` to show orphan word prevention.
3. **Full Article Preset:** A realistic article paragraph using `.ease-hyphenate-article` combining all three properties.

### Validation
- [x] Placed under `submissions/examples/hyphenation-utilities/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] Zero extra HTML markup (class on `<p>`, `lang` on `<html>`)
- [x] Includes `lang="en"` on demo elements for correct browser behavior
