### PR TITLE
feat: add file tree

### DIFF
--- a/submissions/examples/tree-view-as/README.md
+++ b/submissions/examples/tree-view-as/README.md
@@ -1,0 +1,23 @@
+# File Tree
+
+### What does this do?
+
+It shows a file explorer tree where folders expand and collapse to reveal nested files, each row with a folder or file icon and a caret that rotates when the folder is open. It works with no JavaScript.
+
+### How is it used?
+
+```html
+<div class="tree" role="tree">
+  <details class="tree-folder" open>
+    <summary><svg class="tf-caret">...</svg><svg class="tf-ic">...</svg>src</summary>
+    <details class="tree-folder"><summary>...components</summary><a class="tree-file"><svg>...</svg>Button.css</a></details>
+    <a class="tree-file"><svg>...</svg>index.css</a>
+  </details>
+</div>
+```
+
+Nest `tree-folder` details inside each other for subfolders and use `tree-file` links for files. Nested folders and files indent automatically, and the caret rotates on open.
+
+### Why is it useful?
+
+Editors and docs show a collapsible file tree in the sidebar. This builds a nested expandable tree with folder and file icons using only the native details element and CSS. Rows are keyboard operable and transitions are removed under reduced motion.

--- a/submissions/examples/tree-view-as/demo.html
+++ b/submissions/examples/tree-view-as/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>File Tree</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="tree" role="tree" aria-label="Project files">
+    <details class="tree-folder" open>
+      <summary>
+        <svg class="tf-caret" viewBox="0 0 24 24" aria-hidden="true"><path d="m9 6 6 6-6 6" stroke-linecap="round" stroke-linejoin="round" /></svg>
+        <svg class="tf-ic" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" stroke-linejoin="round" /></svg>
+        src
+      </summary>
+      <details class="tree-folder" open>
+        <summary>
+          <svg class="tf-caret" viewBox="0 0 24 24" aria-hidden="true"><path d="m9 6 6 6-6 6" stroke-linecap="round" stroke-linejoin="round" /></svg>
+          <svg class="tf-ic" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" stroke-linejoin="round" /></svg>
+          components
+        </summary>
+        <a class="tree-file is-active" href="#"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z" stroke-linejoin="round" /><path d="M14 3v6h6" /></svg>Button.css</a>
+        <a class="tree-file" href="#"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z" stroke-linejoin="round" /><path d="M14 3v6h6" /></svg>Card.css</a>
+      </details>
+      <a class="tree-file" href="#"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z" stroke-linejoin="round" /><path d="M14 3v6h6" /></svg>index.css</a>
+    </details>
+    <details class="tree-folder">
+      <summary>
+        <svg class="tf-caret" viewBox="0 0 24 24" aria-hidden="true"><path d="m9 6 6 6-6 6" stroke-linecap="round" stroke-linejoin="round" /></svg>
+        <svg class="tf-ic" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" stroke-linejoin="round" /></svg>
+        public
+      </summary>
+      <a class="tree-file" href="#"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z" stroke-linejoin="round" /><path d="M14 3v6h6" /></svg>index.html</a>
+    </details>
+    <a class="tree-file" href="#"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z" stroke-linejoin="round" /><path d="M14 3v6h6" /></svg>README.md</a>
+  </div>
+</body>
+</html>

--- a/submissions/examples/tree-view-as/style.css
+++ b/submissions/examples/tree-view-as/style.css
@@ -1,0 +1,118 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.tree {
+  width: min(300px, 92vw);
+  padding: 0.7rem;
+  box-sizing: border-box;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 12px;
+  font-size: 0.86rem;
+}
+
+.tree-folder {
+  margin: 0;
+}
+
+.tree-folder summary {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.5rem;
+  border-radius: 7px;
+  cursor: pointer;
+  color: #cbd5e1;
+  transition: background 0.12s ease;
+}
+
+.tree-folder summary::-webkit-details-marker {
+  display: none;
+}
+
+.tree-folder summary:hover {
+  background: #1b2942;
+}
+
+.tf-caret {
+  width: 14px;
+  height: 14px;
+  flex: none;
+  stroke: #64748b;
+  stroke-width: 2.5;
+  fill: none;
+  transition: transform 0.15s ease;
+}
+
+.tree-folder[open] > summary .tf-caret {
+  transform: rotate(90deg);
+}
+
+.tf-ic {
+  width: 17px;
+  height: 17px;
+  flex: none;
+  stroke: #a5b4fc;
+  stroke-width: 2;
+  fill: none;
+}
+
+.tree-file {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.5rem 0.4rem 1.75rem;
+  border-radius: 7px;
+  color: #94a3b8;
+  text-decoration: none;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+.tree-file svg {
+  width: 16px;
+  height: 16px;
+  flex: none;
+  stroke: #64748b;
+  stroke-width: 2;
+  fill: none;
+}
+
+.tree-file:hover,
+.tree-file:focus-visible {
+  background: #1b2942;
+  color: #e2e8f0;
+  outline: none;
+}
+
+.tree-file.is-active {
+  background: rgba(108, 99, 255, 0.16);
+  color: #a5b4fc;
+}
+
+.tree-folder .tree-folder,
+.tree-folder > .tree-file {
+  margin-left: 0.9rem;
+}
+
+.tree-folder summary:focus-visible {
+  outline: 2px solid #6c63ff;
+  outline-offset: -2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tf-caret,
+  .tree-folder summary,
+  .tree-file {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a file tree built for #41302. A nested expandable tree with folder and file icons, using the native details element and CSS only. Closes #41302.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A file explorer tree where folders expand to reveal nested files, each with a folder or file icon and a caret that rotates on open.

**How does a developer use it?**

```html
<div class="tree" role="tree">
  <details class="tree-folder" open>
    <summary><svg class="tf-caret">...</svg><svg class="tf-ic">...</svg>src</summary>
    <details class="tree-folder"><summary>...components</summary><a class="tree-file"><svg>...</svg>Button.css</a></details>
    <a class="tree-file"><svg>...</svg>index.css</a>
  </details>
</div>
```

**Why does it fit EaseMotion CSS?**
It builds a nested expandable tree with folder and file icons using only the native details element and CSS. Rows are keyboard operable and transitions are removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: three folders and five files render, the nested folder is indented, and one file is marked active.
