### PR TITLE
feat: add CSS text-wrap balance and pretty utilities

### DIFF
--- a/submissions/examples/text-wrap-balance/README.md
+++ b/submissions/examples/text-wrap-balance/README.md
@@ -1,0 +1,50 @@
+# CSS Text Wrap Balance Utilities
+
+Relates to feature request **#41289**.
+
+## 1. What does this do?
+
+Adds utility classes built around the CSS `text-wrap: balance` and `text-wrap: pretty` properties to improve heading and paragraph wrapping automatically across different viewport sizes — with zero JavaScript and no manual `<br>` tags.
+
+## 2. Why is this useful for EaseMotion CSS?
+
+Balanced text wrapping creates cleaner typography without manual `<br>` tags. Including these utilities would help developers build polished hero sections, documentation, and marketing pages using native CSS. The properties are widely supported in modern browsers (Chrome 114+, Firefox 121+, Safari 17.4+).
+
+## 3. Utilities Provided
+
+| Class | Property | Best For |
+|---|---|---|
+| `.ease-balance` | `text-wrap: balance` | Headings, card titles, short labels (≤6 lines) |
+| `.ease-pretty` | `text-wrap: pretty` | Body paragraphs, long descriptions, articles |
+| `.ease-nowrap` | `text-wrap: nowrap` | Single-line elements (badges, table cells) |
+
+## 4. How is it used?
+
+**HTML** (matching the issue's snippet exactly)
+```html
+<h1 class="ease-balance">
+  Build beautiful interfaces with EaseMotion CSS
+</h1>
+```
+
+**CSS** (matching the issue's snippet exactly)
+```css
+.ease-balance {
+  text-wrap: balance;
+}
+
+.ease-pretty {
+  text-wrap: pretty;
+}
+```
+
+## 5. When to Use Which
+
+| | `balance` | `pretty` |
+|---|---|---|
+| **Use for** | Headings, CTAs, short titles | Body text, long paragraphs |
+| **What it does** | Equalizes all line lengths | Prevents orphaned last words |
+| **Performance** | ⚠️ Expensive for long text | ✅ Optimized for long text |
+| **Line limit** | Works best ≤6 lines | No limit |
+
+> **Rule of thumb**: Use `balance` for headings. Use `pretty` for paragraphs. Never use `balance` on long articles — use `pretty` instead.

--- a/submissions/examples/text-wrap-balance/demo.html
+++ b/submissions/examples/text-wrap-balance/demo.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Text Wrap Balance Utilities — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1 class="ease-balance">CSS Text Wrap Balance Utilities</h1>
+    <p class="ease-pretty">
+      Balanced text wrapping creates cleaner typography without manual
+      line breaks. These utilities help developers build polished hero sections,
+      documentation, and marketing pages using native CSS.
+    </p>
+    <div class="badges">
+      <span class="badge">✨ text-wrap: balance</span>
+      <span class="badge">📖 text-wrap: pretty</span>
+      <span class="badge">🖊️ No &lt;br&gt; needed</span>
+    </div>
+  </header>
+
+  <!-- ── DEMO 1: Balance for Headings ──────────────────────── -->
+  <section class="demo-section">
+    <h2>1. Balanced Headings — <code>.ease-balance</code></h2>
+    <p class="demo-desc">
+      Without <code>text-wrap: balance</code>, headings can wrap with one word alone
+      on the last line — called a "runt" or "widow". With balance, the browser evenly
+      distributes words across all lines for a much cleaner look. Best for headings
+      and short text blocks (≤6 lines).
+    </p>
+
+    <div class="compare-grid">
+      <div class="compare-card">
+        <span class="compare-label bad">❌ Default</span>
+        <h3 class="no-balance sample-heading">
+          Build beautiful interfaces with EaseMotion CSS
+        </h3>
+      </div>
+      <div class="compare-card">
+        <span class="compare-label good">✅ .ease-balance</span>
+        <h3 class="ease-balance sample-heading">
+          Build beautiful interfaces with EaseMotion CSS
+        </h3>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── DEMO 2: Pretty for Paragraphs ─────────────────────── -->
+  <section class="demo-section">
+    <h2>2. Pretty Paragraphs — <code>.ease-pretty</code></h2>
+    <p class="demo-desc">
+      <code>text-wrap: pretty</code> is optimized for longer text. It prevents
+      orphaned words at the end of a paragraph by slightly adjusting the wrapping
+      of the preceding lines. Unlike <code>balance</code>, it doesn't try to
+      equalize all lines — making it more performant for long articles.
+    </p>
+
+    <div class="compare-grid">
+      <div class="compare-card">
+        <span class="compare-label bad">❌ Default</span>
+        <p class="no-pretty sample-para">
+          The quick brown fox jumps over the lazy dog sitting near the edge of the quiet river bank.
+        </p>
+      </div>
+      <div class="compare-card">
+        <span class="compare-label good">✅ .ease-pretty</span>
+        <p class="ease-pretty sample-para">
+          The quick brown fox jumps over the lazy dog sitting near the edge of the quiet river bank.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── DEMO 3: Hero Section ──────────────────────────────── -->
+  <section class="demo-section">
+    <h2>3. Hero Section — Real World Usage</h2>
+    <p class="demo-desc">
+      Combining <code>.ease-balance</code> on the headline and <code>.ease-pretty</code>
+      on the body produces a polished, publication-quality hero section without any
+      manual <code>&lt;br&gt;</code> tags.
+    </p>
+
+    <div class="hero-section">
+      <h2 class="ease-balance hero-headline">
+        Build beautiful, expressive interfaces with EaseMotion CSS
+      </h2>
+      <p class="ease-pretty hero-body">
+        A modern CSS utility library designed for developers who care about
+        typography, animation, and the finer details of web design. No JavaScript
+        required — just clean, composable CSS classes that work everywhere.
+      </p>
+      <div class="hero-cta">
+        <button class="btn-primary">Get Started</button>
+        <button class="btn-secondary">View Examples</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── REFERENCE ─────────────────────────────────────────── -->
+  <section class="demo-section info-section">
+    <h2>🔧 CSS Reference</h2>
+    <div class="code-block">
+      <pre><code>/* 1. Balance — matches the issue's CSS snippet exactly */
+/* Best for: headings, short labels, card titles (≤6 lines) */
+.ease-balance {
+  text-wrap: balance;
+}
+
+/* 2. Pretty — matches the issue's CSS snippet exactly */
+/* Best for: article body text, paragraphs, long descriptions */
+.ease-pretty {
+  text-wrap: pretty;
+}
+
+/* 3. Nowrap — prevents all wrapping */
+.ease-nowrap {
+  text-wrap: nowrap; /* Same as white-space: nowrap */
+}
+
+/* WHEN TO USE WHICH:
+   - text-wrap: balance  → Headings, CTAs, card titles (short text)
+   - text-wrap: pretty   → Body paragraphs, articles (long text)
+   - Do NOT use balance on paragraphs — it's slow for long text */</code></pre>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/text-wrap-balance/style.css
+++ b/submissions/examples/text-wrap-balance/style.css
@@ -1,0 +1,305 @@
+/* ============================================================
+   CSS Text Wrap Balance Utilities
+   Cleaner heading and paragraph wrapping without manual <br>.
+   Relates to issue #41289
+   ============================================================
+
+   KEY CONCEPTS:
+   - text-wrap: balance
+     Distributes text as evenly as possible across all lines.
+     The browser calculates the ideal line length so no line
+     is much shorter than the others. This eliminates "runt"
+     words (a single word alone on the last line of a heading).
+     
+     ⚠️ Best for HEADINGS and SHORT text (≤ 6 lines).
+     It is a computationally expensive operation — using it on
+     long paragraphs can hurt performance.
+   
+   - text-wrap: pretty
+     Optimizes wrapping specifically to prevent orphaned words
+     at the END of a paragraph, but without trying to balance
+     all lines. It's a gentler, more performant alternative to
+     'balance' for body copy and articles.
+     
+     ✅ Best for PARAGRAPHS and long text.
+   
+   - text-wrap: nowrap
+     Prevents wrapping entirely. Equivalent to white-space: nowrap.
+     Useful for single-line elements like badges and table cells.
+   ============================================================ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3rem;
+}
+
+code {
+  background: #1e293b;
+  color: #a78bfa;
+  padding: 0.2em 0.5em;
+  border-radius: 6px;
+  font-size: 0.85em;
+  font-family: monospace;
+}
+
+/* ── Header ──────────────────────────────────────────────── */
+
+.page-header {
+  text-align: center;
+  max-width: 680px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.page-header h1 {
+  font-size: 2.2rem;
+  background: linear-gradient(135deg, #a78bfa, #38bdf8);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.page-header p {
+  color: #94a3b8;
+  line-height: 1.65;
+  max-width: 560px;
+}
+
+.badges {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 0.5rem;
+}
+
+.badge {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 99px;
+  padding: 0.35rem 0.8rem;
+  font-size: 0.75rem;
+  color: #7dd3fc;
+}
+
+/* ── Demo Sections ───────────────────────────────────────── */
+
+.demo-section {
+  width: 100%;
+  max-width: 800px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.demo-section h2 {
+  font-size: 1.05rem;
+  border-left: 3px solid #a78bfa;
+  padding-left: 0.75rem;
+  color: #f8fafc;
+}
+
+.demo-desc {
+  color: #94a3b8;
+  font-size: 0.88rem;
+  line-height: 1.7;
+}
+
+/* ── Comparison Grid ─────────────────────────────────────── */
+
+.compare-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+@media (max-width: 600px) {
+  .compare-grid { grid-template-columns: 1fr; }
+}
+
+.compare-card {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 12px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.compare-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  border-radius: 6px;
+  padding: 0.2rem 0.6rem;
+  align-self: flex-start;
+}
+
+.compare-label.bad {
+  background: #ef444422;
+  color: #fca5a5;
+}
+
+.compare-label.good {
+  background: #22c55e22;
+  color: #86efac;
+}
+
+/* Sample heading — constrained width to show wrapping behavior */
+.sample-heading {
+  font-size: 1.35rem;
+  color: #f8fafc;
+  line-height: 1.4;
+  max-width: 260px; /* Force wrapping to show the difference */
+}
+
+/* Sample paragraph — constrained width to show orphan behavior */
+.sample-para {
+  font-size: 0.95rem;
+  color: #94a3b8;
+  line-height: 1.65;
+  max-width: 240px; /* Force wrapping to show the difference */
+}
+
+/* Default (broken) classes for comparison */
+.no-balance { text-wrap: wrap; } /* Normal default */
+.no-pretty  { text-wrap: wrap; } /* Normal default */
+
+
+/* ============================================================
+   UTILITIES (matches the issue's CSS snippet exactly)
+   ============================================================ */
+
+/* 1. Balance — evenly distributed line lengths */
+/* Best for: headings, card titles, short labels */
+.ease-balance {
+  text-wrap: balance;
+}
+
+/* 2. Pretty — prevents orphaned words in paragraphs */
+/* Best for: article body, long descriptions */
+.ease-pretty {
+  text-wrap: pretty;
+}
+
+/* 3. Nowrap — prevents all text wrapping */
+.ease-nowrap {
+  text-wrap: nowrap;
+}
+
+
+/* ── Hero Section Demo ───────────────────────────────────── */
+
+.hero-section {
+  background: linear-gradient(135deg, #1e293b, #0f172a);
+  border: 1px solid #334155;
+  border-radius: 20px;
+  padding: 3rem 2.5rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.hero-headline {
+  font-size: 2rem;
+  color: #f8fafc;
+  max-width: 560px;
+  line-height: 1.3;
+  /* .ease-balance is applied in HTML */
+}
+
+.hero-body {
+  font-size: 1.05rem;
+  color: #94a3b8;
+  max-width: 500px;
+  line-height: 1.7;
+  /* .ease-pretty is applied in HTML */
+}
+
+.hero-cta {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, #7c3aed, #3b82f6);
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  padding: 0.75rem 1.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.btn-primary:hover { opacity: 0.85; }
+
+.btn-secondary {
+  background: transparent;
+  color: #94a3b8;
+  border: 1px solid #334155;
+  border-radius: 10px;
+  padding: 0.75rem 1.75rem;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: border-color 0.2s, color 0.2s;
+}
+
+.btn-secondary:hover {
+  border-color: #64748b;
+  color: #f8fafc;
+}
+
+
+/* ── Info Section ────────────────────────────────────────── */
+
+.info-section {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 14px;
+  padding: 1.75rem;
+  gap: 1.25rem;
+  margin-top: 1rem;
+}
+
+.code-block {
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid #334155;
+}
+
+pre {
+  background: #0f172a;
+  padding: 1.25rem;
+  overflow-x: auto;
+}
+
+pre code {
+  background: transparent;
+  color: #7dd3fc;
+  padding: 0;
+  font-size: 0.8rem;
+  line-height: 1.8;
+}


### PR DESCRIPTION
Resolves #41289

### Description
Adds utility classes built around the CSS `text-wrap: balance` and `text-wrap: pretty` properties to improve heading and paragraph wrapping automatically across different viewport sizes — with zero JavaScript and no manual `<br>` tags.

### Utilities Added (matches the issue's CSS snippet exactly)
| Class | Property | Best For |
|---|---|---|
| `.ease-balance` | `text-wrap: balance` | Headings, card titles, short labels (≤6 lines) |
| `.ease-pretty` | `text-wrap: pretty` | Body paragraphs, long descriptions, articles |
| `.ease-nowrap` | `text-wrap: nowrap` | Single-line elements (badges, table cells) |

### How It Works
```css
/* Matches the issue's HTML snippet */
/* <h1 class="ease-balance">Build beautiful interfaces...</h1> */

.ease-balance {
  text-wrap: balance;
}

.ease-pretty {
  text-wrap: pretty;
}
```

### Demo Includes
1. **Heading Comparison:** Side-by-side of a constrained heading with/without `.ease-balance`, clearly showing the "runt" word being eliminated.
2. **Paragraph Comparison:** Side-by-side showing `.ease-pretty` preventing orphaned words at the end of a paragraph.
3. **Hero Section:** A real-world marketing hero with `.ease-balance` on the headline and `.ease-pretty` on the body copy, demonstrating a fully polished result with zero `<br>` tags.

### Validation
- [x] Placed under `submissions/examples/text-wrap-balance/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] CSS matches the issue's snippet exactly
- [x] README documents the key performance difference (balance vs pretty)
