### PR TITLE
feat: add cookie preferences

### DIFF
--- a/submissions/examples/cookie-prefs-as/README.md
+++ b/submissions/examples/cookie-prefs-as/README.md
@@ -1,0 +1,23 @@
+# Cookie Preferences
+
+### What does this do?
+
+It shows a cookie preferences panel with a row for each cookie category, each with a title, a description, and a toggle switch. The necessary category is on and locked, and accept all and save actions sit at the bottom. It works with no JavaScript.
+
+### How is it used?
+
+```html
+<div class="cprefs" role="dialog" aria-label="Cookie preferences">
+  <div class="cp-row">
+    <div class="cp-text"><strong>Necessary</strong><small>Always on.</small></div>
+    <label class="cp-switch"><input type="checkbox" checked disabled /><span></span></label>
+  </div>
+  <div class="cp-actions"><a class="cp-save" href="#">Save choices</a><a class="cp-accept" href="#">Accept all</a></div>
+</div>
+```
+
+Each category is a real checkbox styled as a switch. Mark the necessary row `disabled` so it stays on and dims. The two actions let a user save their choices or accept everything.
+
+### Why is it useful?
+
+Privacy laws require a preferences panel to manage cookie categories, not just a banner. This builds a cookie preferences panel with per category toggles, a locked necessary row, and actions, using only checkboxes and CSS. The switch transition is removed under reduced motion.

--- a/submissions/examples/cookie-prefs-as/demo.html
+++ b/submissions/examples/cookie-prefs-as/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cookie Preferences</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="cprefs" role="dialog" aria-label="Cookie preferences">
+    <h2>Cookie preferences</h2>
+    <p class="intro">Choose which cookies we can use. You can change this any time.</p>
+
+    <div class="cp-row">
+      <div class="cp-text"><strong>Necessary</strong><small>Required for the site to work. Always on.</small></div>
+      <label class="cp-switch"><input type="checkbox" checked disabled aria-label="Necessary cookies" /><span></span></label>
+    </div>
+    <div class="cp-row">
+      <div class="cp-text"><strong>Analytics</strong><small>Help us understand how the site is used.</small></div>
+      <label class="cp-switch"><input type="checkbox" checked aria-label="Analytics cookies" /><span></span></label>
+    </div>
+    <div class="cp-row">
+      <div class="cp-text"><strong>Marketing</strong><small>Personalise ads across sites.</small></div>
+      <label class="cp-switch"><input type="checkbox" aria-label="Marketing cookies" /><span></span></label>
+    </div>
+    <div class="cp-row">
+      <div class="cp-text"><strong>Preferences</strong><small>Remember your settings and choices.</small></div>
+      <label class="cp-switch"><input type="checkbox" checked aria-label="Preference cookies" /><span></span></label>
+    </div>
+
+    <div class="cp-actions">
+      <a class="cp-save" href="#">Save choices</a>
+      <a class="cp-accept" href="#">Accept all</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/cookie-prefs-as/style.css
+++ b/submissions/examples/cookie-prefs-as/style.css
@@ -1,0 +1,158 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.cprefs {
+  width: min(400px, 94vw);
+  box-sizing: border-box;
+  padding: 1.5rem 1.6rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+}
+
+.cprefs h2 {
+  margin: 0 0 0.3rem;
+  font-size: 1.1rem;
+}
+
+.cprefs .intro {
+  margin: 0 0 1.2rem;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: #94a3b8;
+}
+
+.cp-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.85rem 0;
+  border-top: 1px solid #1b2942;
+}
+
+.cp-row .cp-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.cp-row strong {
+  display: block;
+  font-size: 0.88rem;
+}
+
+.cp-row small {
+  font-size: 0.76rem;
+  color: #94a3b8;
+}
+
+.cp-switch {
+  flex: none;
+  cursor: pointer;
+}
+
+.cp-switch input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  margin: -1px;
+  overflow: hidden;
+}
+
+.cp-switch span {
+  display: block;
+  position: relative;
+  width: 42px;
+  height: 24px;
+  border-radius: 999px;
+  background: #33415c;
+  transition: background 0.2s ease;
+}
+
+.cp-switch span::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform 0.2s ease;
+}
+
+.cp-switch :checked + span {
+  background: #6c63ff;
+}
+
+.cp-switch :checked + span::after {
+  transform: translateX(18px);
+}
+
+.cp-switch input:disabled + span {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.cp-switch :focus-visible + span {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+.cp-actions {
+  display: flex;
+  gap: 0.6rem;
+  margin-top: 1.3rem;
+}
+
+.cp-save,
+.cp-accept {
+  flex: 1;
+  padding: 0.7rem;
+  text-align: center;
+  font-size: 0.86rem;
+  font-weight: 600;
+  border-radius: 10px;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.cp-save {
+  color: #cbd5e1;
+  border: 1px solid #26324a;
+}
+
+.cp-accept {
+  color: #fff;
+  background: #6c63ff;
+}
+
+.cp-save:hover {
+  border-color: #33415c;
+}
+
+.cp-accept:hover {
+  background: #5b52e6;
+}
+
+.cp-save:focus-visible,
+.cp-accept:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cp-switch span,
+  .cp-switch span::after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a cookie preferences panel built for #41306. Per category toggles with a locked necessary row and actions, using only checkboxes and CSS. Closes #41306.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A cookie preferences panel with a row per cookie category, each with a title, description, and toggle switch; the necessary category is on and locked, with save and accept all actions.

**How does a developer use it?**

```html
<div class="cprefs" role="dialog">
  <div class="cp-row"><div class="cp-text"><strong>Necessary</strong><small>Always on.</small></div><label class="cp-switch"><input type="checkbox" checked disabled /><span></span></label></div>
  <div class="cp-actions"><a class="cp-save" href="#">Save choices</a><a class="cp-accept" href="#">Accept all</a></div>
</div>
```

**Why does it fit EaseMotion CSS?**
It builds a cookie preferences panel with per category toggles, a locked necessary row (disabled checkbox), and actions, using only checkboxes and CSS. The switch transition is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: four category rows render with toggles reflecting on, on, off, on, the necessary row is a disabled locked switch, and two actions show.
