### PR TITLE
feat: add account menu

### DIFF
--- a/submissions/examples/account-menu-as/README.md
+++ b/submissions/examples/account-menu-as/README.md
@@ -1,0 +1,25 @@
+# Account Menu
+
+### What does this do?
+
+It shows an avatar in the corner that opens an account menu with a profile header (name, plan badge, and email), a list of icon links, and a red sign out row set apart by a divider. It opens on click with no JavaScript.
+
+### How is it used?
+
+```html
+<details class="account">
+  <summary class="acc-avatar" aria-label="Account menu">AL</summary>
+  <div class="acc-menu" role="menu">
+    <div class="acc-head"><span class="a">AL</span><span class="who"><span class="name">Ada <span class="plan">PRO</span></span><span class="email">ada@example.com</span></span></div>
+    <a class="acc-item"><svg>...</svg>Your profile</a>
+    <div class="acc-sep"></div>
+    <a class="acc-item is-signout"><svg>...</svg>Sign out</a>
+  </div>
+</details>
+```
+
+The avatar is the summary of a `details`, so clicking it toggles the menu. Use `acc-sep` for the divider and `is-signout` for the destructive sign out link.
+
+### Why is it useful?
+
+Apps put an account menu behind the header avatar. This opens an account dropdown from an avatar with a profile header, icon links, and a sign out action, using only the details element and CSS. Items have hover and focus styles and the open animation is removed under reduced motion.

--- a/submissions/examples/account-menu-as/demo.html
+++ b/submissions/examples/account-menu-as/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Account Menu</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <details class="account" open>
+    <summary class="acc-avatar" aria-label="Account menu">AL</summary>
+    <div class="acc-menu" role="menu">
+      <div class="acc-head">
+        <span class="a">AL</span>
+        <span class="who">
+          <span class="name">Ada Lovelace <span class="plan">PRO</span></span>
+          <span class="email">ada@example.com</span>
+        </span>
+      </div>
+      <a class="acc-item" href="#" role="menuitem"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="8" r="4" /><path d="M4 21a8 8 0 0 1 16 0" stroke-linecap="round" /></svg>Your profile</a>
+      <a class="acc-item" href="#" role="menuitem"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="3" /><path d="M12 3v3M12 18v3M3 12h3M18 12h3" stroke-linecap="round" /></svg>Settings</a>
+      <a class="acc-item" href="#" role="menuitem"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="5" width="18" height="14" rx="2" /><path d="M3 10h18" /></svg>Billing</a>
+      <a class="acc-item" href="#" role="menuitem"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9" /><path d="M9.5 9a2.5 2.5 0 0 1 4.5 1.5c0 1.5-2 2-2 3M12 17h.01" stroke-linecap="round" /></svg>Help</a>
+      <div class="acc-sep" role="separator"></div>
+      <a class="acc-item is-signout" href="#" role="menuitem"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M15 12H3m0 0 4-4M3 12l4 4M14 4h5a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1h-5" stroke-linecap="round" stroke-linejoin="round" /></svg>Sign out</a>
+    </div>
+  </details>
+</body>
+</html>

--- a/submissions/examples/account-menu-as/style.css
+++ b/submissions/examples/account-menu-as/style.css
@@ -1,0 +1,172 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-start;
+  padding: 2rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.account {
+  position: relative;
+}
+
+.acc-avatar {
+  list-style: none;
+  width: 42px;
+  height: 42px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #6c63ff, #a855f7);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.85rem;
+  cursor: pointer;
+  border: 2px solid transparent;
+}
+
+.acc-avatar::-webkit-details-marker {
+  display: none;
+}
+
+.account[open] .acc-avatar {
+  border-color: #a5b4fc;
+}
+
+.acc-avatar:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+.acc-menu {
+  position: absolute;
+  top: calc(100% + 0.6rem);
+  right: 0;
+  width: 244px;
+  padding: 0.4rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 14px;
+  box-shadow: 0 20px 44px rgba(0, 0, 0, 0.55);
+  z-index: 2;
+}
+
+.account[open] .acc-menu {
+  animation: acc-in 0.16s ease;
+}
+
+.acc-head {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.7rem 0.6rem;
+  margin-bottom: 0.3rem;
+  border-bottom: 1px solid #1b2942;
+}
+
+.acc-head .a {
+  width: 38px;
+  height: 38px;
+  flex: none;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #6c63ff, #a855f7);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.78rem;
+}
+
+.acc-head .who {
+  min-width: 0;
+}
+
+.acc-head .name {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+
+.acc-head .plan {
+  font-size: 0.62rem;
+  font-weight: 800;
+  padding: 0.05rem 0.35rem;
+  border-radius: 5px;
+  background: rgba(108, 99, 255, 0.2);
+  color: #a5b4fc;
+}
+
+.acc-head .email {
+  font-size: 0.74rem;
+  color: #64748b;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.acc-item {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.55rem 0.6rem;
+  border-radius: 8px;
+  font-size: 0.87rem;
+  color: #cbd5e1;
+  text-decoration: none;
+  transition: background 0.12s ease;
+}
+
+.acc-item svg {
+  width: 17px;
+  height: 17px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+  flex: none;
+}
+
+.acc-item:hover,
+.acc-item:focus-visible {
+  background: #1b2942;
+  color: #fff;
+  outline: none;
+}
+
+.acc-sep {
+  height: 1px;
+  margin: 0.35rem 0.4rem;
+  background: #1b2942;
+}
+
+.acc-item.is-signout {
+  color: #f87171;
+}
+
+.acc-item.is-signout:hover {
+  background: rgba(239, 68, 68, 0.14);
+  color: #fca5a5;
+}
+
+@keyframes acc-in {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .acc-item {
+    transition: none;
+  }
+
+  .account[open] .acc-menu {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an account menu built for #41309. An avatar that opens a dropdown with a profile header, icon links, and a sign out, using the native details element and CSS only. Closes #41309.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
An avatar that opens an account menu with a profile header (name, plan badge, email), a list of icon links, and a red sign out row set apart by a divider.

**How does a developer use it?**

```html
<details class="account">
  <summary class="acc-avatar">AL</summary>
  <div class="acc-menu" role="menu">
    <div class="acc-head">...</div>
    <a class="acc-item"><svg>...</svg>Your profile</a>
    <div class="acc-sep"></div>
    <a class="acc-item is-signout"><svg>...</svg>Sign out</a>
  </div>
</details>
```

**Why does it fit EaseMotion CSS?**
It opens an account dropdown from an avatar with a profile header, icon links, and a sign out action, using only the details element and CSS. Items have hover and focus styles and the open animation is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: with the menu open five items render below a profile header with a plan badge, and the sign out item is in the danger red color.
