### PR TITLE
feat: add CSS scroll snap stop utilities

### DIFF
--- a/submissions/examples/scroll-snap-utilities/README.md
+++ b/submissions/examples/scroll-snap-utilities/README.md
@@ -1,0 +1,54 @@
+# CSS Scroll Snap Stop Utilities
+
+Relates to feature request **#41290**.
+
+## 1. What does this do?
+
+Introduces helper utilities around the CSS `scroll-snap-stop` property, allowing developers to create carousels and paginated scrolling experiences with configurable snap behavior and accessibility-friendly defaults — with zero JavaScript.
+
+## 2. Why is this useful for EaseMotion CSS?
+
+Scroll snapping is increasingly used for galleries, onboarding flows, and presentations. Dedicated utilities simplify implementation while encouraging native browser behavior over JavaScript solutions.
+
+## 3. Utilities Provided
+
+| Class | Description | scroll-snap-stop |
+|---|---|---|
+| `.ease-snap-gallery` | Full-width horizontal carousel | `always` — never skips a slide |
+| `.ease-snap-cards` | Peek-style card carousel | `normal` — allows fast swipe |
+| `.ease-snap-pages` | Vertical paginated scroll | `always` — visits each page |
+
+## 4. How is it used?
+
+**HTML** (matching the issue's snippet exactly)
+```html
+<div class="ease-snap-gallery">
+  <section>Slide 1</section>
+  <section>Slide 2</section>
+  <section>Slide 3</section>
+</div>
+```
+
+**CSS** (matching the issue's snippet exactly)
+```css
+.ease-snap-gallery {
+  display: flex;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+}
+
+.ease-snap-gallery > * {
+  flex: 0 0 100%;
+  scroll-snap-align: start;
+  scroll-snap-stop: always;
+}
+```
+
+## 5. Key Property: `scroll-snap-stop`
+
+| Value | Behaviour |
+|---|---|
+| `normal` | A fast scroll/swipe **can skip** multiple snap points |
+| `always` | A fast scroll/swipe **must stop** at every single snap point |
+
+> **Rule of thumb**: Use `always` for step-by-step onboarding or slideshows (every slide matters). Use `normal` for browsable galleries where fast skipping is fine.

--- a/submissions/examples/scroll-snap-utilities/demo.html
+++ b/submissions/examples/scroll-snap-utilities/demo.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Scroll Snap Stop Utilities — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>CSS Scroll Snap Stop Utilities</h1>
+    <p>
+      Native CSS carousels and paginated scrolling using
+      <code>scroll-snap-type</code> and <code>scroll-snap-stop</code>.
+      No JavaScript required — just composable utility classes.
+    </p>
+    <div class="badges">
+      <span class="badge">📸 scroll-snap-stop</span>
+      <span class="badge">🎠 Carousels</span>
+      <span class="badge">📄 Paginated Scroll</span>
+    </div>
+  </header>
+
+  <!-- ── HOW TO USE ─────────────────────────────────────────── -->
+  <section class="how-to">
+    <p class="how-desc">
+      🎯 <strong>Swipe or drag</strong> the galleries below. The key difference between
+      <code>scroll-snap-stop: normal</code> and <code>always</code> is how fast
+      scrolling is handled — <code>always</code> forces the scroll to stop at every
+      single slide.
+    </p>
+  </section>
+
+  <!-- ── DEMO 1: Fullscreen Carousel ───────────────────────── -->
+  <section class="demo-section">
+    <h2>1. Fullscreen Slide Carousel — <code>.ease-snap-gallery</code></h2>
+    <p class="demo-desc">
+      The primary utility. Each slide takes up 100% of the container width.
+      <code>scroll-snap-stop: always</code> ensures a fast swipe cannot skip past a slide — 
+      every slide must be visited in order.
+    </p>
+
+    <div class="ease-snap-gallery">
+      <section class="slide slide-1">
+        <h3>Slide 1</h3>
+        <p>Welcome to the CSS-only carousel</p>
+      </section>
+      <section class="slide slide-2">
+        <h3>Slide 2</h3>
+        <p>No JavaScript. No libraries. Just CSS.</p>
+      </section>
+      <section class="slide slide-3">
+        <h3>Slide 3</h3>
+        <p>Powered by scroll-snap-stop: always</p>
+      </section>
+    </div>
+  </section>
+
+  <!-- ── DEMO 2: Card Peek Carousel ────────────────────────── -->
+  <section class="demo-section">
+    <h2>2. Peek Card Carousel — <code>.ease-snap-cards</code></h2>
+    <p class="demo-desc">
+      Shows multiple cards with a partial "peek" of the next card.
+      <code>scroll-snap-stop: normal</code> allows quick swipes to travel across
+      multiple cards — appropriate for browsing content.
+    </p>
+
+    <div class="ease-snap-cards">
+      <div class="card">🏔️ Mountains</div>
+      <div class="card">🌊 Ocean</div>
+      <div class="card">🌲 Forest</div>
+      <div class="card">🌸 Spring</div>
+      <div class="card">🌅 Sunset</div>
+    </div>
+  </section>
+
+  <!-- ── DEMO 3: Vertical Pagination ───────────────────────── -->
+  <section class="demo-section">
+    <h2>3. Vertical Page Scroll — <code>.ease-snap-pages</code></h2>
+    <p class="demo-desc">
+      A vertical scroll container where each "page" snaps into place.
+      Great for onboarding flows and single-page presentations.
+    </p>
+
+    <div class="ease-snap-pages">
+      <div class="page page-1">
+        <h3>Page 1</h3>
+        <p>Introduction</p>
+      </div>
+      <div class="page page-2">
+        <h3>Page 2</h3>
+        <p>Features</p>
+      </div>
+      <div class="page page-3">
+        <h3>Page 3</h3>
+        <p>Get Started</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── REFERENCE ─────────────────────────────────────────── -->
+  <section class="demo-section info-section">
+    <h2>🔧 CSS Reference</h2>
+    <div class="code-block">
+      <pre><code>/* 1. Fullscreen Carousel (from the issue snippet) */
+.ease-snap-gallery {
+  display: flex;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  /* Hide scrollbar for clean look */
+  scrollbar-width: none;
+}
+
+.ease-snap-gallery > * {
+  flex: 0 0 100%;
+  scroll-snap-align: start;
+  /* ALWAYS stop at every slide — prevents skipping */
+  scroll-snap-stop: always;
+}
+
+/* 2. Peek Card Carousel */
+.ease-snap-cards {
+  display: flex;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.ease-snap-cards > * {
+  flex: 0 0 80%; /* Shows peek of next card */
+  scroll-snap-align: start;
+  scroll-snap-stop: normal; /* Allows fast swipe across cards */
+}
+
+/* 3. Vertical Page Scroll */
+.ease-snap-pages {
+  overflow-y: auto;
+  scroll-snap-type: y mandatory;
+  height: 300px; /* Fixed container height */
+}
+
+.ease-snap-pages > * {
+  height: 100%;
+  scroll-snap-align: start;
+  scroll-snap-stop: always;
+}</code></pre>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/scroll-snap-utilities/style.css
+++ b/submissions/examples/scroll-snap-utilities/style.css
@@ -1,0 +1,313 @@
+/* ============================================================
+   CSS Scroll Snap Stop Utilities
+   Native carousels and paginated scrolling using CSS snap.
+   Relates to issue #41290
+   ============================================================
+
+   KEY CONCEPTS:
+   - scroll-snap-type: <axis> <strictness>
+     Sets the snapping container. axis = x/y/both.
+     strictness = mandatory (always snaps) or proximity (snaps if close).
+   
+   - scroll-snap-align: start | center | end
+     Defines which edge of the child element is the snap point.
+   
+   - scroll-snap-stop: normal | always
+     The KEY property in this feature.
+     - normal: A fast scroll/swipe CAN skip past snap points.
+     - always: A fast scroll/swipe MUST stop at each snap point.
+     Use 'always' for step-by-step onboarding or slides.
+     Use 'normal' for browsable content galleries.
+   
+   - scrollbar-width: none / ::-webkit-scrollbar { display: none }
+     Hides the scrollbar for a clean carousel appearance while
+     still allowing touch/mouse scroll behavior.
+   ============================================================ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3rem;
+}
+
+code {
+  background: #1e293b;
+  color: #a78bfa;
+  padding: 0.2em 0.5em;
+  border-radius: 6px;
+  font-size: 0.85em;
+  font-family: monospace;
+}
+
+strong {
+  color: #f8fafc;
+}
+
+/* ── Header ──────────────────────────────────────────────── */
+
+.page-header {
+  text-align: center;
+  max-width: 680px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.page-header h1 {
+  font-size: 2rem;
+  background: linear-gradient(135deg, #a78bfa, #38bdf8);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.page-header p {
+  color: #94a3b8;
+  line-height: 1.65;
+}
+
+.badges {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 0.5rem;
+}
+
+.badge {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 99px;
+  padding: 0.35rem 0.8rem;
+  font-size: 0.75rem;
+  color: #7dd3fc;
+}
+
+/* ── How to try ──────────────────────────────────────────── */
+
+.how-to {
+  background: #7c3aed22;
+  border: 1px dashed #7c3aed;
+  border-radius: 12px;
+  padding: 1rem 1.5rem;
+  max-width: 800px;
+  width: 100%;
+  text-align: center;
+}
+
+.how-desc {
+  color: #c4b5fd;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+/* ── Demo Sections ───────────────────────────────────────── */
+
+.demo-section {
+  width: 100%;
+  max-width: 800px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.demo-section h2 {
+  font-size: 1.05rem;
+  border-left: 3px solid #a78bfa;
+  padding-left: 0.75rem;
+  color: #f8fafc;
+}
+
+.demo-desc {
+  color: #94a3b8;
+  font-size: 0.88rem;
+  line-height: 1.7;
+}
+
+
+/* ============================================================
+   UTILITY 1: .ease-snap-gallery
+   Fullscreen horizontal carousel.
+   Matches the issue's HTML/CSS snippet exactly.
+   ============================================================ */
+
+.ease-snap-gallery {
+  display: flex;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  border-radius: 16px;
+  
+  /* Hide scrollbar for a clean carousel look */
+  scrollbar-width: none;
+}
+
+.ease-snap-gallery::-webkit-scrollbar {
+  display: none;
+}
+
+/* Each direct child is a full-width snap slide */
+.ease-snap-gallery > * {
+  flex: 0 0 100%;
+  scroll-snap-align: start;
+  /* ALWAYS stop at every slide — prevents skipping on fast swipe */
+  scroll-snap-stop: always;
+}
+
+/* Slide Styles (demo-specific) */
+.slide {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 240px;
+  gap: 0.75rem;
+  color: #fff;
+  font-size: 1.1rem;
+  text-align: center;
+}
+
+.slide h3 { font-size: 1.75rem; font-weight: 700; }
+.slide p { opacity: 0.85; }
+.slide-1 { background: linear-gradient(135deg, #7c3aed, #4f46e5); }
+.slide-2 { background: linear-gradient(135deg, #0891b2, #0284c7); }
+.slide-3 { background: linear-gradient(135deg, #047857, #059669); }
+
+
+/* ============================================================
+   UTILITY 2: .ease-snap-cards
+   Horizontal card carousel with peek effect.
+   ============================================================ */
+
+.ease-snap-cards {
+  display: flex;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  gap: 1rem;
+  padding: 1rem;
+  border-radius: 16px;
+  background: #1e293b;
+  border: 1px solid #334155;
+
+  scrollbar-width: none;
+}
+
+.ease-snap-cards::-webkit-scrollbar {
+  display: none;
+}
+
+/* Cards show ~80% width to "peek" the next card */
+.ease-snap-cards > * {
+  flex: 0 0 80%;
+  scroll-snap-align: start;
+  /* 'normal' allows fast swipe to skip cards for browsing */
+  scroll-snap-stop: normal;
+}
+
+/* Card Styles (demo-specific) */
+.card {
+  height: 180px;
+  border-radius: 12px;
+  background: #0f172a;
+  border: 1px solid #334155;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  flex-shrink: 0;
+}
+
+
+/* ============================================================
+   UTILITY 3: .ease-snap-pages
+   Vertical paginated scroll container.
+   ============================================================ */
+
+.ease-snap-pages {
+  overflow-y: auto;
+  scroll-snap-type: y mandatory;
+  height: 280px;
+  border-radius: 16px;
+  border: 1px solid #334155;
+  scrollbar-width: none;
+}
+
+.ease-snap-pages::-webkit-scrollbar {
+  display: none;
+}
+
+.ease-snap-pages > * {
+  height: 100%;
+  scroll-snap-align: start;
+  scroll-snap-stop: always;
+}
+
+/* Page Styles (demo-specific) */
+.page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  color: #fff;
+  text-align: center;
+}
+
+.page h3 { font-size: 1.5rem; font-weight: 700; }
+.page p  { color: rgba(255,255,255,0.75); }
+.page-1 { background: linear-gradient(180deg, #1e1b4b, #4338ca); }
+.page-2 { background: linear-gradient(180deg, #0c4a6e, #0369a1); }
+.page-3 { background: linear-gradient(180deg, #14532d, #15803d); }
+
+
+/* ── Info Section ────────────────────────────────────────── */
+
+.info-section {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 14px;
+  padding: 1.75rem;
+  gap: 1.25rem;
+  margin-top: 1rem;
+}
+
+.info-section h2 {
+  font-size: 1.05rem;
+  border-left: 3px solid #a78bfa;
+  padding-left: 0.75rem;
+  color: #f8fafc;
+}
+
+.code-block {
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid #334155;
+}
+
+pre {
+  background: #0f172a;
+  padding: 1.25rem;
+  overflow-x: auto;
+}
+
+pre code {
+  background: transparent;
+  color: #7dd3fc;
+  padding: 0;
+  font-size: 0.8rem;
+  line-height: 1.8;
+}


### PR DESCRIPTION
Resolves #41290

### Description
Introduces helper utilities around the CSS `scroll-snap-stop` property, allowing developers to create carousels and paginated scrolling experiences with configurable snap behavior — no JavaScript required.

### Utilities Added (matches the issue's CSS snippet exactly)
| Class | Description | scroll-snap-stop |
|---|---|---|
| `.ease-snap-gallery` | Full-width horizontal carousel | `always` — never skips a slide |
| `.ease-snap-cards` | Peek-style card carousel | `normal` — allows fast swipe |
| `.ease-snap-pages` | Vertical paginated scroll | `always` — visits each page |

### How It Works (matches the issue's snippets exactly)
```html
<div class="ease-snap-gallery">
  <section>Slide 1</section>
  <section>Slide 2</section>
  <section>Slide 3</section>
</div>
```
```css
.ease-snap-gallery {
  display: flex;
  overflow-x: auto;
  scroll-snap-type: x mandatory;
}

.ease-snap-gallery > * {
  flex: 0 0 100%;
  scroll-snap-align: start;
  scroll-snap-stop: always;
}
```

### Demo Includes
1. **Fullscreen Carousel** — `.ease-snap-gallery` with `scroll-snap-stop: always` preventing slide-skipping on fast swipe.
2. **Peek Card Carousel** — `.ease-snap-cards` with 80% width cards showing the next card, `scroll-snap-stop: normal` for fast browsing.
3. **Vertical Page Scroll** — `.ease-snap-pages` for onboarding/presentation flows with mandatory vertical snap.

### Validation
- [x] Placed under `submissions/examples/scroll-snap-utilities/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] CSS matches the issue's snippet exactly
- [x] Documents the `always` vs `normal` difference