### PR TITLE
feat: add cart summary

### DIFF
--- a/submissions/examples/cart-summary-as/README.md
+++ b/submissions/examples/cart-summary-as/README.md
@@ -1,0 +1,26 @@
+# Cart Summary
+
+### What does this do?
+
+It shows a shopping cart summary card with line items, each with a thumbnail, name, quantity stepper, price, and a remove button, plus a promo code row, a totals block, and a checkout button.
+
+### How is it used?
+
+```html
+<div class="cart">
+  <h2>Your cart <span class="count">2 items</span></h2>
+  <div class="cart-item">
+    <span class="ci-thumb"></span>
+    <div><div class="ci-name">Headphones</div><div class="ci-qty"><button>-</button><span>1</span><button>+</button></div></div>
+    <div><div class="ci-price">$59.00</div><button class="ci-remove">Remove</button></div>
+  </div>
+  <div class="cart-sums"><div class="cart-total"><span>Total</span><b>$112.00</b></div></div>
+  <a class="cart-checkout" href="#">Checkout</a>
+</div>
+```
+
+Each item is a three column grid of thumbnail, details, and price. The quantity stepper and remove are styled controls that a host app wires to real cart logic.
+
+### Why is it useful?
+
+Carts and checkout side panels list the items being bought. This lays out a cart with item rows, a quantity control, a promo row, and a totals block, using only CSS and gradient thumbnails so there are no external images.

--- a/submissions/examples/cart-summary-as/demo.html
+++ b/submissions/examples/cart-summary-as/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cart Summary</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="cart">
+    <h2>Your cart <span class="count">2 items</span></h2>
+
+    <div class="cart-item">
+      <span class="ci-thumb" aria-hidden="true"></span>
+      <div>
+        <div class="ci-name">Wireless headphones</div>
+        <div class="ci-qty">
+          <button type="button" aria-label="Decrease quantity">-</button>
+          <span>1</span>
+          <button type="button" aria-label="Increase quantity">+</button>
+        </div>
+      </div>
+      <div>
+        <div class="ci-price">$59.00</div>
+        <button class="ci-remove" type="button">Remove</button>
+      </div>
+    </div>
+
+    <div class="cart-item">
+      <span class="ci-thumb" aria-hidden="true"></span>
+      <div>
+        <div class="ci-name">USB-C cable</div>
+        <div class="ci-qty">
+          <button type="button" aria-label="Decrease quantity">-</button>
+          <span>2</span>
+          <button type="button" aria-label="Increase quantity">+</button>
+        </div>
+      </div>
+      <div>
+        <div class="ci-price">$24.00</div>
+        <button class="ci-remove" type="button">Remove</button>
+      </div>
+    </div>
+
+    <div class="cart-promo">
+      <input type="text" placeholder="Promo code" aria-label="Promo code" />
+      <button type="button">Apply</button>
+    </div>
+
+    <div class="cart-sums">
+      <div><span>Subtotal</span><span>$107.00</span></div>
+      <div><span>Shipping</span><span>$5.00</span></div>
+      <div class="cart-total"><span>Total</span><b>$112.00</b></div>
+    </div>
+
+    <a class="cart-checkout" href="#">Checkout</a>
+  </div>
+</body>
+</html>

--- a/submissions/examples/cart-summary-as/style.css
+++ b/submissions/examples/cart-summary-as/style.css
@@ -1,0 +1,206 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.cart {
+  width: min(370px, 94vw);
+  box-sizing: border-box;
+  padding: 1.5rem 1.6rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+}
+
+.cart h2 {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 1.2rem;
+  font-size: 1.05rem;
+}
+
+.cart h2 .count {
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  background: #1b2942;
+  color: #94a3b8;
+}
+
+.cart-item {
+  display: grid;
+  grid-template-columns: 48px 1fr auto;
+  align-items: center;
+  gap: 0.8rem;
+  padding: 0.8rem 0;
+  border-top: 1px solid #1b2942;
+}
+
+.ci-thumb {
+  width: 48px;
+  height: 48px;
+  border-radius: 10px;
+}
+
+.cart-item:nth-of-type(1) .ci-thumb {
+  background: linear-gradient(135deg, #6c63ff, #a855f7);
+}
+
+.cart-item:nth-of-type(2) .ci-thumb {
+  background: linear-gradient(135deg, #0ea5e9, #22d3ee);
+}
+
+.ci-name {
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.ci-qty {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.35rem;
+}
+
+.ci-qty button {
+  width: 22px;
+  height: 22px;
+  display: grid;
+  place-items: center;
+  border: 1px solid #26324a;
+  background: #131f34;
+  color: #cbd5e1;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.ci-qty button:hover {
+  border-color: #6c63ff;
+}
+
+.ci-qty span {
+  font-size: 0.82rem;
+  min-width: 1ch;
+  text-align: center;
+}
+
+.ci-price {
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-align: right;
+}
+
+.ci-remove {
+  display: block;
+  margin-top: 0.3rem;
+  font-size: 0.72rem;
+  color: #64748b;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  text-align: right;
+  width: 100%;
+}
+
+.ci-remove:hover {
+  color: #f87171;
+}
+
+.cart-promo {
+  display: flex;
+  gap: 0.5rem;
+  margin: 1.1rem 0;
+}
+
+.cart-promo input {
+  flex: 1;
+  min-width: 0;
+  padding: 0.55rem 0.75rem;
+  font: inherit;
+  font-size: 0.82rem;
+  color: #e2e8f0;
+  background: #0b1424;
+  border: 1px solid #26324a;
+  border-radius: 9px;
+  outline: none;
+}
+
+.cart-promo input:focus {
+  border-color: #6c63ff;
+}
+
+.cart-promo button {
+  padding: 0 0.9rem;
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #cbd5e1;
+  background: #1b2942;
+  border: none;
+  border-radius: 9px;
+  cursor: pointer;
+}
+
+.cart-sums {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding-top: 1rem;
+  border-top: 1px solid #1b2942;
+  font-size: 0.84rem;
+  color: #94a3b8;
+}
+
+.cart-sums div {
+  display: flex;
+  justify-content: space-between;
+}
+
+.cart-total {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0.5rem;
+  padding-top: 0.7rem;
+  border-top: 1px solid #26324a;
+  font-size: 1.05rem;
+  font-weight: 800;
+}
+
+.cart-total b {
+  color: #a5b4fc;
+}
+
+.cart-checkout {
+  display: block;
+  margin-top: 1.2rem;
+  padding: 0.8rem;
+  text-align: center;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #fff;
+  background: #6c63ff;
+  border-radius: 11px;
+  text-decoration: none;
+}
+
+.cart-checkout:hover {
+  background: #5b52e6;
+}
+
+.ci-qty button:focus-visible,
+.cart-checkout:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a cart summary built for #41311. Line items with a quantity stepper, a promo row, and a totals block, using only CSS. Closes #41311.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A shopping cart summary with line items (thumbnail, name, quantity stepper, price, remove), a promo code row, a totals block, and a checkout button.

**How does a developer use it?**

```html
<div class="cart">
  <div class="cart-item"><span class="ci-thumb"></span><div><div class="ci-name">Headphones</div><div class="ci-qty"><button>-</button><span>1</span><button>+</button></div></div><div><div class="ci-price">$59.00</div></div></div>
  <div class="cart-sums"><div class="cart-total"><span>Total</span><b>$112.00</b></div></div>
  <a class="cart-checkout" href="#">Checkout</a>
</div>
```

**Why does it fit EaseMotion CSS?**
It lays out a cart with item rows, a quantity control, a promo row, and a totals block, using only CSS and gradient thumbnails so there are no external images.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: two items render on a three column grid with quantity steppers, a total of $112.00, and a checkout button.
