### PR TITLE
feat: add product gallery

### DIFF
--- a/submissions/examples/product-gallery-as/README.md
+++ b/submissions/examples/product-gallery-as/README.md
@@ -1,0 +1,28 @@
+# Product Gallery
+
+### What does this do?
+
+It shows a product gallery with a large main image and a strip of thumbnails below. Clicking a thumbnail swaps the main image with a crossfade and outlines the selected thumbnail. It works with no JavaScript by using radio inputs.
+
+### How is it used?
+
+```html
+<div class="pgallery">
+  <input type="radio" name="pg" id="pg1" checked />
+  <input type="radio" name="pg" id="pg2" />
+  <div class="pg-main">
+    <div class="pg-view v1"></div>
+    <div class="pg-view v2"></div>
+  </div>
+  <div class="pg-thumbs">
+    <label for="pg1" class="v1"></label>
+    <label for="pg2" class="v2"></label>
+  </div>
+</div>
+```
+
+Keep the radios first so the sibling selectors can fade the matching main view and outline the active thumbnail. Swap the gradient views for real images in production.
+
+### Why is it useful?
+
+Product pages let you flip through photos with a thumbnail strip. This swaps a main image and highlights the active thumbnail from a radio, using only CSS. Thumbnails are keyboard operable with a focus ring and the crossfade is removed under reduced motion.

--- a/submissions/examples/product-gallery-as/demo.html
+++ b/submissions/examples/product-gallery-as/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Product Gallery</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="pgallery">
+    <input type="radio" name="pg" id="pg1" checked />
+    <input type="radio" name="pg" id="pg2" />
+    <input type="radio" name="pg" id="pg3" />
+    <input type="radio" name="pg" id="pg4" />
+    <div class="pg-main">
+      <div class="pg-view v1"></div>
+      <div class="pg-view v2"></div>
+      <div class="pg-view v3"></div>
+      <div class="pg-view v4"></div>
+    </div>
+    <div class="pg-thumbs">
+      <label for="pg1" class="v1" aria-label="View 1"></label>
+      <label for="pg2" class="v2" aria-label="View 2"></label>
+      <label for="pg3" class="v3" aria-label="View 3"></label>
+      <label for="pg4" class="v4" aria-label="View 4"></label>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/product-gallery-as/style.css
+++ b/submissions/examples/product-gallery-as/style.css
@@ -1,0 +1,114 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.pgallery {
+  width: min(340px, 92vw);
+}
+
+.pgallery > input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  margin: -1px;
+  overflow: hidden;
+}
+
+.pg-main {
+  position: relative;
+  aspect-ratio: 1;
+  border-radius: 16px;
+  overflow: hidden;
+  border: 1px solid #26324a;
+}
+
+.pg-view {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+
+.pg-view::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.25), transparent 45%);
+}
+
+.v1 {
+  background: linear-gradient(135deg, #6c63ff, #a855f7);
+}
+
+.v2 {
+  background: linear-gradient(135deg, #0ea5e9, #22d3ee);
+}
+
+.v3 {
+  background: linear-gradient(135deg, #10b981, #34d399);
+}
+
+.v4 {
+  background: linear-gradient(135deg, #f59e0b, #ef4444);
+}
+
+#pg1:checked ~ .pg-main .pg-view.v1,
+#pg2:checked ~ .pg-main .pg-view.v2,
+#pg3:checked ~ .pg-main .pg-view.v3,
+#pg4:checked ~ .pg-main .pg-view.v4 {
+  opacity: 1;
+}
+
+.pg-thumbs {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.6rem;
+  margin-top: 0.7rem;
+}
+
+.pg-thumbs label {
+  aspect-ratio: 1;
+  border-radius: 10px;
+  cursor: pointer;
+  border: 2px solid transparent;
+  transition: border-color 0.15s ease, transform 0.15s ease;
+}
+
+.pg-thumbs label:hover {
+  transform: translateY(-2px);
+}
+
+#pg1:checked ~ .pg-thumbs label[for="pg1"],
+#pg2:checked ~ .pg-thumbs label[for="pg2"],
+#pg3:checked ~ .pg-thumbs label[for="pg3"],
+#pg4:checked ~ .pg-thumbs label[for="pg4"] {
+  border-color: #6c63ff;
+}
+
+#pg1:focus-visible ~ .pg-thumbs label[for="pg1"],
+#pg2:focus-visible ~ .pg-thumbs label[for="pg2"],
+#pg3:focus-visible ~ .pg-thumbs label[for="pg3"],
+#pg4:focus-visible ~ .pg-thumbs label[for="pg4"] {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pg-view,
+  .pg-thumbs label {
+    transition: none;
+  }
+
+  .pg-thumbs label:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a product gallery built for #41315. A main image that swaps from a thumbnail strip, driven by radios with no JavaScript. Closes #41315.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A product gallery with a large main image and a thumbnail strip; selecting a thumbnail crossfades the main image and outlines the active thumbnail.

**How does a developer use it?**

```html
<div class="pgallery">
  <input type="radio" name="pg" id="pg1" checked />
  <input type="radio" name="pg" id="pg2" />
  <div class="pg-main"><div class="pg-view v1"></div><div class="pg-view v2"></div></div>
  <div class="pg-thumbs"><label for="pg1" class="v1"></label><label for="pg2" class="v2"></label></div>
</div>
```

**Why does it fit EaseMotion CSS?**
It swaps a main image and highlights the active thumbnail from a radio, using only CSS. Thumbnails are keyboard operable with a focus ring and the crossfade is removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: four thumbnails render, view one shows initially, and selecting the third thumbnail makes view three opaque while the others are hidden.
