### PR TITLE
feat: add achievement badges

### DIFF
--- a/submissions/examples/achievement-badge-as/README.md
+++ b/submissions/examples/achievement-badge-as/README.md
@@ -1,0 +1,24 @@
+# Achievement Badges
+
+### What does this do?
+
+It shows a grid of achievement badges where unlocked ones display a colorful medal and title, and locked ones are dimmed with a small lock overlay. Rare unlocked badges use a purple medal.
+
+### How is it used?
+
+```html
+<div class="achievements">
+  <div class="ach is-unlocked">
+    <span class="ach-medal"><svg>...</svg></span>
+    <span class="ach-name">First win</span>
+  </div>
+  <div class="ach is-unlocked rare">...</div>
+  <div class="ach is-locked">...</div>
+</div>
+```
+
+Use `is-unlocked` for earned badges (add `rare` for a special color) and `is-locked` for badges not yet earned, which dim and get a lock overlay.
+
+### Why is it useful?
+
+Learning apps and games award badges for milestones. This lays out a grid of achievement badges with unlocked, rare, and locked states driven by a class, using only CSS and inline SVG so there are no external assets.

--- a/submissions/examples/achievement-badge-as/demo.html
+++ b/submissions/examples/achievement-badge-as/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Achievement Badges</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="ach-card">
+    <div class="ach-head">
+      <h2>Achievements</h2>
+      <span class="count">4 of 8 unlocked</span>
+    </div>
+    <div class="achievements">
+      <div class="ach is-unlocked">
+        <span class="ach-medal"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="9" r="6" /><path d="M8 14l-2 7 6-3 6 3-2-7" stroke-linejoin="round" /></svg></span>
+        <span class="ach-name">First win</span>
+      </div>
+      <div class="ach is-unlocked rare">
+        <span class="ach-medal"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M13 2 3 14h7l-1 8 10-12h-7z" stroke-linejoin="round" /></svg></span>
+        <span class="ach-name">Speed demon</span>
+      </div>
+      <div class="ach is-unlocked">
+        <span class="ach-medal"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3v6M5 8l4 3M19 8l-4 3M12 15a6 6 0 0 0 6-6H6a6 6 0 0 0 6 6zM9 21h6M12 15v6" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
+        <span class="ach-name">Champion</span>
+      </div>
+      <div class="ach is-unlocked">
+        <span class="ach-medal"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2a10 10 0 0 0-3.2 19.5c.5.1.7-.2.7-.5v-1.7c-2.8.6-3.4-1.3-3.4-1.3-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 .1 1.5 1 1.5 1 .9 1.5 2.3 1.1 2.9.8" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
+        <span class="ach-name">Contributor</span>
+      </div>
+      <div class="ach is-locked">
+        <span class="ach-medal"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3v6M5 8l4 3M19 8l-4 3M12 15a6 6 0 0 0 6-6H6a6 6 0 0 0 6 6z" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
+        <span class="ach-name">Marathon</span>
+      </div>
+      <div class="ach is-locked">
+        <span class="ach-medal"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2 4 6v5c0 5 3.5 8 8 10 4.5-2 8-5 8-10V6z" stroke-linejoin="round" /></svg></span>
+        <span class="ach-name">Guardian</span>
+      </div>
+      <div class="ach is-locked">
+        <span class="ach-medal"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9" /><path d="M12 7v5l3 3" stroke-linecap="round" /></svg></span>
+        <span class="ach-name">Veteran</span>
+      </div>
+      <div class="ach is-locked">
+        <span class="ach-medal"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M13 2 3 14h7l-1 8 10-12h-7z" stroke-linejoin="round" /></svg></span>
+        <span class="ach-name">Legend</span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/achievement-badge-as/style.css
+++ b/submissions/examples/achievement-badge-as/style.css
@@ -1,0 +1,115 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.ach-card {
+  width: min(420px, 94vw);
+  padding: 1.6rem 1.7rem;
+  box-sizing: border-box;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 18px;
+}
+
+.ach-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 1.3rem;
+}
+
+.ach-head h2 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.ach-head .count {
+  font-size: 0.78rem;
+  color: #a5b4fc;
+  font-weight: 600;
+}
+
+.achievements {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1.2rem 0.8rem;
+}
+
+.ach {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  text-align: center;
+}
+
+.ach-medal {
+  position: relative;
+  width: 58px;
+  height: 58px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: #1b2942;
+  color: #64748b;
+}
+
+.ach-medal svg {
+  width: 26px;
+  height: 26px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+}
+
+.ach-name {
+  font-size: 0.72rem;
+  color: #94a3b8;
+  line-height: 1.3;
+}
+
+.ach.is-unlocked .ach-medal {
+  background: linear-gradient(135deg, #fbbf24, #f59e0b);
+  color: #fff;
+  box-shadow: 0 6px 16px rgba(245, 158, 11, 0.35);
+}
+
+.ach.is-unlocked .ach-name {
+  color: #e2e8f0;
+  font-weight: 600;
+}
+
+.ach.is-unlocked.rare .ach-medal {
+  background: linear-gradient(135deg, #a855f7, #6c63ff);
+  box-shadow: 0 6px 16px rgba(108, 99, 255, 0.4);
+}
+
+.ach.is-locked {
+  opacity: 0.55;
+}
+
+.ach.is-locked .ach-medal::after {
+  content: "";
+  position: absolute;
+  right: -2px;
+  bottom: -2px;
+  width: 20px;
+  height: 20px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2'%3E%3Crect x='5' y='11' width='14' height='9' rx='2'/%3E%3Cpath d='M8 11V8a4 4 0 0 1 8 0v3'/%3E%3C/svg%3E");
+  background-size: 12px;
+  background-repeat: no-repeat;
+  background-position: center;
+}


### PR DESCRIPTION
## Pull Request Description

Adds achievement badges built for #41324. A grid of badges with unlocked, rare, and locked states, using only CSS and inline SVG. Closes #41324.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A grid of achievement badges where unlocked ones show a colorful medal and title, rare ones use a purple medal, and locked ones dim with a lock overlay.

**How does a developer use it?**

```html
<div class="achievements">
  <div class="ach is-unlocked"><span class="ach-medal"><svg>...</svg></span><span class="ach-name">First win</span></div>
  <div class="ach is-unlocked rare">...</div>
  <div class="ach is-locked">...</div>
</div>
```

**Why does it fit EaseMotion CSS?**
It lays out a grid of achievement badges with unlocked, rare, and locked states driven by a class, using only CSS and inline SVG so there are no external assets.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: eight badges render with four unlocked (gradient medals) and four locked (dimmed with a lock overlay).
