### PR TITLE
feat: add leaderboard

### DIFF
--- a/submissions/examples/leaderboard-as/README.md
+++ b/submissions/examples/leaderboard-as/README.md
@@ -1,0 +1,20 @@
+# Leaderboard
+
+### What does this do?
+
+It shows a leaderboard as a ranked list where each row has a rank badge, an avatar, a name and level, and a score. The top three rows use gold, silver, and bronze rank badges, and the current user row is highlighted with a You tag.
+
+### How is it used?
+
+```html
+<ol class="board">
+  <li class="board-row rank-1"><span class="br-rank">1</span><span class="br-avatar">AL</span><span class="br-name">Ada<small>Level 24</small></span><b class="br-score">2,480</b></li>
+  <li class="board-row is-you"><span class="br-rank">5</span><span class="br-avatar">ME</span><span class="br-name">Margaret<small>Level 18</small></span><b class="br-score">1,640</b></li>
+</ol>
+```
+
+Add `rank-1`, `rank-2`, or `rank-3` for the podium colors and `is-you` to highlight the current user, which also appends a You label.
+
+### Why is it useful?
+
+Games and challenges show a leaderboard of top players. This lays out a ranked list with podium colors for the top three and a highlighted you row, using only CSS and initials avatars so there are no external images.

--- a/submissions/examples/leaderboard-as/demo.html
+++ b/submissions/examples/leaderboard-as/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Leaderboard</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <ol class="board">
+    <li class="board-row rank-1"><span class="br-rank">1</span><span class="br-avatar">AL</span><span class="br-name">Ada Lovelace<small>Level 24</small></span><b class="br-score">2,480</b></li>
+    <li class="board-row rank-2"><span class="br-rank">2</span><span class="br-avatar">AT</span><span class="br-name">Alan Turing<small>Level 22</small></span><b class="br-score">2,315</b></li>
+    <li class="board-row rank-3"><span class="br-rank">3</span><span class="br-avatar">GH</span><span class="br-name">Grace Hopper<small>Level 21</small></span><b class="br-score">2,090</b></li>
+    <li class="board-row"><span class="br-rank">4</span><span class="br-avatar">KJ</span><span class="br-name">Katherine J.<small>Level 19</small></span><b class="br-score">1,870</b></li>
+    <li class="board-row is-you"><span class="br-rank">5</span><span class="br-avatar">ME</span><span class="br-name">Margaret E.<small>Level 18</small></span><b class="br-score">1,640</b></li>
+    <li class="board-row"><span class="br-rank">6</span><span class="br-avatar">LT</span><span class="br-name">Linus T.<small>Level 17</small></span><b class="br-score">1,505</b></li>
+  </ol>
+</body>
+</html>

--- a/submissions/examples/leaderboard-as/style.css
+++ b/submissions/examples/leaderboard-as/style.css
@@ -1,0 +1,111 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.board {
+  list-style: none;
+  margin: 0;
+  padding: 0.7rem;
+  width: min(360px, 94vw);
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+}
+
+.board-row {
+  display: grid;
+  grid-template-columns: 30px 34px 1fr auto;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 0.7rem;
+  border-radius: 11px;
+  border: 1px solid transparent;
+}
+
+.board-row:hover {
+  background: #131f34;
+}
+
+.br-rank {
+  width: 26px;
+  height: 26px;
+  display: grid;
+  place-items: center;
+  border-radius: 8px;
+  background: #1b2942;
+  color: #94a3b8;
+  font-size: 0.8rem;
+  font-weight: 800;
+}
+
+.rank-1 .br-rank {
+  background: linear-gradient(135deg, #fbbf24, #f59e0b);
+  color: #3b2a06;
+}
+
+.rank-2 .br-rank {
+  background: linear-gradient(135deg, #e2e8f0, #94a3b8);
+  color: #1e293b;
+}
+
+.rank-3 .br-rank {
+  background: linear-gradient(135deg, #f0a675, #b45309);
+  color: #3b1e06;
+}
+
+.br-avatar {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #6c63ff, #a855f7);
+  color: #fff;
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.br-name {
+  font-size: 0.88rem;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.br-name small {
+  display: block;
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: #64748b;
+}
+
+.br-score {
+  font-size: 0.92rem;
+  font-weight: 800;
+  color: #a5b4fc;
+  font-variant-numeric: tabular-nums;
+}
+
+.board-row.is-you {
+  background: rgba(108, 99, 255, 0.14);
+  border-color: #6c63ff;
+}
+
+.board-row.is-you .br-name::after {
+  content: " You";
+  color: #a5b4fc;
+  font-weight: 700;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a leaderboard built for #41326. A ranked list with podium colors for the top three and a highlighted you row, using only CSS. Closes #41326.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A leaderboard where each row has a rank badge, avatar, name and level, and score; the top three use gold, silver, and bronze badges and the current user row is highlighted with a You tag.

**How does a developer use it?**

```html
<ol class="board">
  <li class="board-row rank-1"><span class="br-rank">1</span><span class="br-avatar">AL</span><span class="br-name">Ada<small>Level 24</small></span><b class="br-score">2,480</b></li>
  <li class="board-row is-you">...</li>
</ol>
```

**Why does it fit EaseMotion CSS?**
It lays out a ranked list with podium colors for the top three and a highlighted you row, using only CSS and initials avatars so there are no external images.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: six rows render, the top three carry podium rank badges (rank one gold), and one row is highlighted as the current user.
