### PR TITLE
feat: add corporate liquid ripple accordion

### DIFF
--- a/submissions/examples/liquid-ripple-accordion-corporate-jp/README.md
+++ b/submissions/examples/liquid-ripple-accordion-corporate-jp/README.md
@@ -1,0 +1,46 @@
+# CSS Liquid Ripple Accordion for Modern Corporate Layouts
+
+## What does this do?
+
+This submission creates a pure-CSS accordion with smooth liquid-ripple transitions, polished corporate styling, responsive behavior, and native keyboard accessibility.
+
+## How is it used?
+
+```html
+<details class="corporate-item-jp">
+  <summary class="corporate-trigger-jp">
+    <span class="icon-box-jp" aria-hidden="true">01</span>
+    <span class="trigger-copy-jp">
+      <strong>Strategy & Transformation</strong>
+      <small>Align teams, systems, and operating models.</small>
+    </span>
+    <span class="toggle-jp" aria-hidden="true">+</span>
+  </summary>
+
+  <div class="corporate-panel-jp">
+    <div class="corporate-content-jp">
+      <p>Corporate accordion content.</p>
+    </div>
+  </div>
+</details>
+```
+
+Customize the motion through CSS custom properties:
+
+```css
+:root {
+  --corporate-duration-jp: 680ms;
+  --corporate-ease-jp: cubic-bezier(0.22, 1, 0.36, 1);
+  --ripple-scale-jp: 1.22;
+  --ripple-opacity-jp: 0.18;
+  --panel-radius-jp: 1.25rem;
+}
+```
+
+Open `demo.html` directly in a browser. No JavaScript, server, CDN, or external framework is required.
+
+## Why is it useful?
+
+Corporate websites, enterprise dashboards, service pages, documentation, and FAQ sections often need dense information presented clearly without overwhelming the page.
+
+This example fits EaseMotion CSS because it uses motion to communicate state, exposes customizable motion variables, uses native keyboard-accessible controls, includes responsive and reduced-motion behavior, and requires zero JavaScript.

--- a/submissions/examples/liquid-ripple-accordion-corporate-jp/demo.html
+++ b/submissions/examples/liquid-ripple-accordion-corporate-jp/demo.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Pure CSS liquid ripple accordion for modern corporate layouts." />
+  <title>Corporate Liquid Ripple Accordion</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page-shell-jp">
+    <header class="hero-jp">
+      <div>
+        <p class="eyebrow-jp">EaseMotion CSS / Corporate UI</p>
+        <h1>Liquid Ripple Accordion</h1>
+        <p class="lead-jp">A polished, zero-JavaScript accordion for business dashboards, service pages, FAQs, and enterprise product interfaces.</p>
+      </div>
+      <div class="trust-card-jp" aria-label="Component qualities">
+        <span>Responsive</span><span>Accessible</span><span>Customizable</span>
+      </div>
+    </header>
+
+    <section class="corporate-accordion-jp" aria-label="Corporate services accordion">
+      <details class="corporate-item-jp" open>
+        <summary class="corporate-trigger-jp">
+          <span class="icon-box-jp" aria-hidden="true">01</span>
+          <span class="trigger-copy-jp"><strong>Strategy & Transformation</strong><small>Align teams, systems, and operating models.</small></span>
+          <span class="toggle-jp" aria-hidden="true">+</span>
+        </summary>
+        <div class="corporate-panel-jp"><div class="corporate-content-jp">
+          <p>Smooth liquid-ripple layers reinforce the open state while content expands through a native, keyboard-accessible control.</p>
+          <ul><li>Operating model design</li><li>Digital transformation planning</li><li>Change enablement</li></ul>
+        </div></div>
+      </details>
+
+      <details class="corporate-item-jp">
+        <summary class="corporate-trigger-jp">
+          <span class="icon-box-jp" aria-hidden="true">02</span>
+          <span class="trigger-copy-jp"><strong>Technology Enablement</strong><small>Modernize platforms and improve delivery velocity.</small></span>
+          <span class="toggle-jp" aria-hidden="true">+</span>
+        </summary>
+        <div class="corporate-panel-jp"><div class="corporate-content-jp">
+          <p>CSS custom properties make timing, easing, ripple scale, glow, and spacing easy to adapt to an existing design system.</p>
+          <ul><li>Cloud platform modernization</li><li>Workflow automation</li><li>Data and analytics enablement</li></ul>
+        </div></div>
+      </details>
+
+      <details class="corporate-item-jp">
+        <summary class="corporate-trigger-jp">
+          <span class="icon-box-jp" aria-hidden="true">03</span>
+          <span class="trigger-copy-jp"><strong>Risk & Performance</strong><small>Improve resilience, compliance, and measurable outcomes.</small></span>
+          <span class="toggle-jp" aria-hidden="true">+</span>
+        </summary>
+        <div class="corporate-panel-jp"><div class="corporate-content-jp">
+          <p>The layout stays clear and professional across desktop and mobile, with visible focus states and reduced-motion support.</p>
+          <ul><li>Risk assessment</li><li>Performance measurement</li><li>Governance frameworks</li></ul>
+        </div></div>
+      </details>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/liquid-ripple-accordion-corporate-jp/style.css
+++ b/submissions/examples/liquid-ripple-accordion-corporate-jp/style.css
@@ -1,0 +1,63 @@
+:root {
+  color-scheme: light;
+  --corporate-duration-jp: 680ms;
+  --corporate-ease-jp: cubic-bezier(0.22, 1, 0.36, 1);
+  --ripple-scale-jp: 1.22;
+  --ripple-opacity-jp: 0.18;
+  --panel-radius-jp: 1.25rem;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #f4f7fb;
+  color: #172033;
+}
+* { box-sizing: border-box; }
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(circle at 12% 12%, rgb(35 99 235 / 8%), transparent 28rem),
+    radial-gradient(circle at 88% 86%, rgb(20 184 166 / 7%), transparent 26rem),
+    #f4f7fb;
+}
+.page-shell-jp { width: min(100% - 2rem, 72rem); margin-inline: auto; padding: clamp(2.5rem, 7vw, 6rem) 0; }
+.hero-jp { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: end; gap: 2rem; margin-bottom: 2rem; }
+.eyebrow-jp { margin: 0 0 .75rem; color: #245ee8; font-size: .76rem; font-weight: 800; letter-spacing: .13em; text-transform: uppercase; }
+h1 { max-width: 10ch; margin: 0; font-size: clamp(2.8rem, 7vw, 6rem); line-height: .94; letter-spacing: -.055em; }
+.lead-jp { max-width: 45rem; margin: 1.25rem 0 0; color: #61708a; font-size: clamp(1rem, 2vw, 1.13rem); line-height: 1.7; }
+.trust-card-jp { display: grid; gap: .55rem; min-width: 12rem; padding: 1rem; border: 1px solid #d8e0ec; border-radius: 1rem; background: rgb(255 255 255 / 82%); box-shadow: 0 1rem 3rem rgb(29 49 82 / 8%); }
+.trust-card-jp span { display: flex; align-items: center; gap: .55rem; color: #42516b; font-size: .82rem; font-weight: 650; }
+.trust-card-jp span::before { content: ""; width: .5rem; aspect-ratio: 1; border-radius: 50%; background: #20b7a5; box-shadow: 0 0 0 .22rem rgb(32 183 165 / 12%); }
+.corporate-accordion-jp { display: grid; gap: 1rem; }
+.corporate-item-jp { position: relative; isolation: isolate; overflow: clip; border: 1px solid #d8e0ec; border-radius: var(--panel-radius-jp); background: rgb(255 255 255 / 90%); box-shadow: 0 1rem 3.5rem rgb(29 49 82 / 8%), inset 0 1px rgb(255 255 255 / 85%); }
+.corporate-item-jp::before, .corporate-item-jp::after { content: ""; position: absolute; z-index: -1; border-radius: 50%; opacity: 0; pointer-events: none; transform: scale(.3); transition: transform var(--corporate-duration-jp) var(--corporate-ease-jp), opacity var(--corporate-duration-jp) ease; }
+.corporate-item-jp::before { width: 22rem; aspect-ratio: 1; left: -8rem; top: -10rem; background: radial-gradient(circle, rgb(36 94 232 / var(--ripple-opacity-jp)) 0%, rgb(82 139 255 / 8%) 38%, transparent 72%); filter: blur(24px); }
+.corporate-item-jp::after { width: 18rem; aspect-ratio: 1; right: -6rem; bottom: -9rem; background: radial-gradient(circle, rgb(32 183 165 / 14%) 0%, transparent 70%); filter: blur(22px); transition-delay: 90ms; }
+.corporate-item-jp[open]::before, .corporate-item-jp[open]::after { opacity: 1; transform: scale(var(--ripple-scale-jp)); }
+.corporate-trigger-jp { display: grid; grid-template-columns: auto 1fr auto; align-items: center; gap: 1rem; min-height: 6rem; padding: 1rem 1.25rem; cursor: pointer; list-style: none; }
+.corporate-trigger-jp::-webkit-details-marker { display: none; }
+.icon-box-jp { display: grid; width: 3rem; aspect-ratio: 1; place-items: center; border-radius: .85rem; background: linear-gradient(135deg, rgb(36 94 232 / 12%), rgb(32 183 165 / 10%)); color: #245ee8; font-size: .78rem; font-weight: 800; }
+.trigger-copy-jp { display: grid; gap: .3rem; }
+.trigger-copy-jp strong { color: #172033; font-size: clamp(1rem, 3vw, 1.25rem); }
+.trigger-copy-jp small { color: #6d7a91; font-size: .82rem; line-height: 1.45; }
+.toggle-jp { display: grid; width: 2.5rem; aspect-ratio: 1; place-items: center; border: 1px solid #cdd7e6; border-radius: 50%; background: #f7f9fc; color: #245ee8; font-size: 1.25rem; transition: transform var(--corporate-duration-jp) var(--corporate-ease-jp), background var(--corporate-duration-jp) ease, color var(--corporate-duration-jp) ease; }
+.corporate-item-jp[open] .toggle-jp { transform: rotate(45deg); background: #245ee8; color: white; }
+.corporate-panel-jp { display: grid; grid-template-rows: 0fr; opacity: 0; transform: translateY(-.45rem); transition: grid-template-rows var(--corporate-duration-jp) var(--corporate-ease-jp), opacity calc(var(--corporate-duration-jp) * .7) ease, transform var(--corporate-duration-jp) var(--corporate-ease-jp); }
+.corporate-item-jp[open] .corporate-panel-jp { grid-template-rows: 1fr; opacity: 1; transform: none; }
+.corporate-content-jp { overflow: hidden; border-top: 1px solid #e3e8f0; }
+.corporate-content-jp p { max-width: 54rem; margin: 0; padding: 1.25rem 1.25rem 0 5.25rem; color: #58677f; line-height: 1.7; }
+.corporate-content-jp ul { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: .75rem; margin: 1rem 0 0; padding: 0 1.25rem 1.25rem 5.25rem; list-style: none; }
+.corporate-content-jp li { padding: .85rem; border: 1px solid #dfe6f0; border-radius: .8rem; background: rgb(248 250 253 / 84%); color: #41506a; font-size: .83rem; font-weight: 650; }
+.corporate-trigger-jp:focus-visible { outline: 3px solid rgb(36 94 232 / 55%); outline-offset: -5px; }
+@media (max-width: 760px) {
+  .hero-jp { grid-template-columns: 1fr; align-items: start; }
+  .trust-card-jp { min-width: 0; grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .corporate-content-jp p, .corporate-content-jp ul { padding-left: 1rem; padding-right: 1rem; }
+  .corporate-content-jp ul { grid-template-columns: 1fr; }
+}
+@media (max-width: 540px) {
+  .trust-card-jp { grid-template-columns: 1fr; }
+  .corporate-trigger-jp { grid-template-columns: auto 1fr; }
+  .toggle-jp { grid-column: 2; justify-self: end; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .corporate-item-jp::before, .corporate-item-jp::after, .toggle-jp, .corporate-panel-jp { transition: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a **CSS Liquid Ripple Accordion for Modern Corporate Layouts** for Issue #38450.

This submission provides a pure-CSS accordion designed for modern corporate websites, enterprise dashboards, service pages, FAQs, and business product interfaces. It combines smooth liquid-ripple expansion, professional blue and teal styling, responsive behavior, native keyboard accessibility, and customizable motion parameters through CSS custom properties.

**Closes #38450**

---

## Type of Change

* [x] ✨ New animation / hover effect
* [x] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

* [x] All changes are inside `submissions/examples/liquid-ripple-accordion-corporate-jp/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] **No changes to `core/`**
* [x] **No changes to `components/`**
* [x] One feature per PR with no unrelated changes

---

## Feature Description

**What does this add?**

A pure-CSS liquid-ripple accordion for modern corporate interfaces, with professional styling, responsive service layouts, native keyboard interaction, and configurable motion variables.

**How does a developer use it?**

```html
<details class="corporate-item-jp">
  <summary class="corporate-trigger-jp">
    <span class="icon-box-jp" aria-hidden="true">01</span>

    <span class="trigger-copy-jp">
      <strong>Strategy & Transformation</strong>
      <small>Align teams, systems, and operating models.</small>
    </span>

    <span class="toggle-jp" aria-hidden="true">+</span>
  </summary>

  <div class="corporate-panel-jp">
    <div class="corporate-content-jp">
      <p>
        Corporate accordion content goes here.
      </p>
    </div>
  </div>
</details>
```

The motion and visual treatment can be customized through CSS variables:

```css
:root {
  --corporate-duration-jp: 680ms;
  --corporate-ease-jp: cubic-bezier(0.22, 1, 0.36, 1);
  --ripple-scale-jp: 1.22;
  --ripple-opacity-jp: 0.18;
  --panel-radius-jp: 1.25rem;
}
```

**Why does it fit EaseMotion CSS?**

The component follows EaseMotion CSS's animation-first philosophy by using motion to clearly communicate open and closed states.

Opening an item triggers several coordinated visual changes:

* liquid-ripple background layers expand;
* the indicator rotates;
* the content panel reveals smoothly;
* supporting service cards become visible;
* the active section receives stronger visual emphasis.

The implementation remains readable, reusable, responsive, accessible, and dependency-free.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [ ] Firefox
* [x] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The implementation is completely isolated inside:

```text
submissions/examples/liquid-ripple-accordion-corporate-jp/
```

Only the following files are included:

```text
demo.html
style.css
README.md
```

The corporate visual treatment includes:

* professional blue and teal styling;
* clean service and consulting layout;
* liquid-ripple pseudo-element animation;
* responsive capability cards;
* native keyboard-accessible `details` and `summary`;
* visible `:focus-visible` states;
* configurable timing, easing, scale, opacity, and radius variables;
* reduced-motion support.

No JavaScript, CDN, framework, or external dependency is used.

---

> **Reminder:** Only the repository maintainer may merge pull requests.
> Do not self-merge, even if you have write access.
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
