### PR TITLE
feat: add xp level bar

### DIFF
--- a/submissions/examples/xp-bar-as/README.md
+++ b/submissions/examples/xp-bar-as/README.md
@@ -1,0 +1,24 @@
+# XP Level Bar
+
+### What does this do?
+
+It shows a gamified experience bar with a level badge, an xp progress bar that fills to a percent from a custom property, a note of how much xp is left to the next level, and the current and next level xp labels.
+
+### How is it used?
+
+```html
+<div class="xp" style="--xp: 64%">
+  <span class="xp-level">12</span>
+  <div class="xp-body">
+    <div class="xp-top"><span class="to-next">Level 13 in <b>720 XP</b></span><span>64%</span></div>
+    <div class="xp-track" role="progressbar" aria-valuenow="64"><span class="xp-fill"></span></div>
+    <div class="xp-labels"><span>1,280 XP</span><span>2,000 XP</span></div>
+  </div>
+</div>
+```
+
+Set the fill amount with the `--xp` custom property. The level badge shows the current level and the bar reports its value with `role="progressbar"`.
+
+### Why is it useful?
+
+Games and learning apps show progress to the next level with an xp bar. This renders a level badge with an xp progress bar driven by a custom property and xp labels, using only CSS. The fill animates in and holds still under reduced motion.

--- a/submissions/examples/xp-bar-as/demo.html
+++ b/submissions/examples/xp-bar-as/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>XP Level Bar</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="xp" style="--xp: 64%">
+    <span class="xp-level">12</span>
+    <div class="xp-body">
+      <div class="xp-top">
+        <span class="to-next">Level 13 in <b>720 XP</b></span>
+        <span>64%</span>
+      </div>
+      <div class="xp-track" role="progressbar" aria-valuenow="64" aria-valuemin="0" aria-valuemax="100">
+        <span class="xp-fill"></span>
+      </div>
+      <div class="xp-labels">
+        <span>1,280 XP</span>
+        <span>2,000 XP</span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/xp-bar-as/style.css
+++ b/submissions/examples/xp-bar-as/style.css
@@ -1,0 +1,112 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.xp {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  width: min(360px, 94vw);
+  box-sizing: border-box;
+  padding: 1.3rem 1.4rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+}
+
+.xp-level {
+  position: relative;
+  flex: none;
+  width: 52px;
+  height: 52px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #6c63ff, #a855f7);
+  color: #fff;
+  font-size: 1.3rem;
+  font-weight: 800;
+  box-shadow: 0 6px 16px rgba(108, 99, 255, 0.4);
+}
+
+.xp-level::before {
+  content: "LVL";
+  position: absolute;
+  top: -8px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.52rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  color: #a5b4fc;
+}
+
+.xp-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.xp-top {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 0.45rem;
+  font-size: 0.78rem;
+}
+
+.xp-top .to-next {
+  color: #94a3b8;
+}
+
+.xp-top b {
+  color: #a5b4fc;
+}
+
+.xp-track {
+  height: 10px;
+  border-radius: 6px;
+  background: #1b2942;
+  overflow: hidden;
+}
+
+.xp-fill {
+  display: block;
+  height: 100%;
+  width: var(--xp, 0%);
+  border-radius: 6px;
+  background: linear-gradient(90deg, #6c63ff, #22d3ee);
+  animation: xp-grow 0.9s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.xp-labels {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0.4rem;
+  font-size: 0.7rem;
+  color: #64748b;
+  font-variant-numeric: tabular-nums;
+}
+
+@keyframes xp-grow {
+  from {
+    width: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .xp-fill {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an XP level bar built for #41330. A level badge with an xp progress bar driven by a custom property and xp labels, using only CSS. Closes #41330.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A gamified experience bar with a level badge, an xp progress bar that fills to a `--xp` percent, a to next level note, and current and next level xp labels.

**How does a developer use it?**

```html
<div class="xp" style="--xp: 64%">
  <span class="xp-level">12</span>
  <div class="xp-body">
    <div class="xp-top"><span class="to-next">Level 13 in <b>720 XP</b></span><span>64%</span></div>
    <div class="xp-track" role="progressbar" aria-valuenow="64"><span class="xp-fill"></span></div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It renders a level badge with an xp progress bar driven by the `--xp` custom property and xp labels, using only CSS. The fill animates in and holds still under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the level 12 badge renders and the xp bar fills to 64 percent, matching `--xp`.
