### PR TITLE
feat: add CSS line grid typography utilities

### DIFF
--- a/submissions/examples/line-grid-typography/README.md
+++ b/submissions/examples/line-grid-typography/README.md
@@ -1,0 +1,57 @@
+# CSS Line Grid Typography Utilities
+
+Relates to feature request **#41316**.
+
+## 1. What does this do?
+
+Introduces utility classes inspired by the CSS Line Grid specification to align text, headings, lists, and other typographic elements to a consistent baseline rhythm. Uses CSS grid with the `lh` length unit so every child is automatically spaced by exactly one line-height unit — no manual margin math.
+
+## 2. Why is this useful for EaseMotion CSS?
+
+Consistent baseline alignment is essential for editorial layouts, documentation, and design systems, but it usually requires manual calculations. Native-inspired line grid utilities would help developers build visually balanced interfaces while keeping typography predictable and maintainable.
+
+## 3. Utilities Provided
+
+| Class | `line-height` | `row-gap` | Best For |
+|---|---|---|---|
+| `.ease-line-grid` | `1.75` | `calc(1lh)` | Body text, general articles |
+| `.ease-line-grid-sm` | `1.5` | `calc(1lh)` | Sidebars, data tables, API docs |
+| `.ease-line-grid-lg` | `2.0` | `calc(1lh)` | Editorial, long-form reading |
+
+## 4. How is it used?
+
+**HTML** (matching the issue's snippet exactly)
+```html
+<article class="ease-line-grid">
+  <h2>Baseline Grid</h2>
+  <p>
+    Typography automatically aligns to a consistent vertical rhythm.
+  </p>
+</article>
+```
+
+**CSS** (matching the issue's snippet exactly)
+```css
+.ease-line-grid {
+  line-height: 1.75;
+  display: grid;
+  row-gap: calc(1lh);
+}
+
+.ease-line-grid > * {
+  margin: 0;
+}
+```
+
+## 5. What is the `lh` unit?
+
+The `lh` CSS length unit equals the computed `line-height` of the element. `calc(1lh)` therefore always equals exactly **one line of space**, keeping every child spaced by a single baseline unit regardless of font size.
+
+| Browser | `lh` unit support |
+|---|---|
+| Chrome | 109+ |
+| Firefox | 120+ |
+| Safari | 17.2+ |
+| Edge | 109+ |
+
+> **Tip**: The `> * { margin: 0; }` rule is important — it removes browser-default margins so only the grid's `row-gap` controls vertical spacing. Without it, you'd get double gaps between elements.

--- a/submissions/examples/line-grid-typography/demo.html
+++ b/submissions/examples/line-grid-typography/demo.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Line Grid Typography Utilities — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>CSS Line Grid Typography Utilities</h1>
+    <p>
+      Align text, headings, and lists to a consistent baseline rhythm using
+      native CSS — inspired by the CSS Line Grid specification. No JavaScript,
+      no manual margin math.
+    </p>
+    <div class="badges">
+      <span class="badge">📐 Baseline Rhythm</span>
+      <span class="badge">🔲 Line Grid</span>
+      <span class="badge">✍️ Vertical Spacing</span>
+    </div>
+  </header>
+
+  <!-- ── WHAT IS BASELINE GRID ─────────────────────────────── -->
+  <section class="explainer">
+    <p>
+      💡 <strong>What is a baseline grid?</strong>
+      It's an invisible vertical rhythm where every line of text sits on a
+      consistent unit. Like notebook paper for your layout. Without it, mixing
+      headings and paragraphs creates uneven gaps. With it, the eye flows
+      naturally down the page.
+    </p>
+  </section>
+
+  <!-- ── DEMO 1: Basic Line Grid ───────────────────────────── -->
+  <section class="demo-section">
+    <h2>1. Basic Line Grid — <code>.ease-line-grid</code></h2>
+    <p class="demo-desc">
+      The primary utility from the issue snippet. Sets a consistent
+      <code>line-height</code> and uses <code>row-gap: calc(1lh)</code>
+      to space children by exactly one line-height unit. All child margins
+      are reset to zero so spacing is controlled entirely by the grid.
+    </p>
+
+    <div class="compare-grid">
+      <div class="compare-card">
+        <span class="compare-label bad">❌ Without .ease-line-grid</span>
+        <article class="no-grid sample-article">
+          <h2>Baseline Grid</h2>
+          <p>Typography automatically aligns to a consistent vertical rhythm.</p>
+          <h3>Why it matters</h3>
+          <p>Without a line grid, spacing between headings and paragraphs is unpredictable.</p>
+          <ul>
+            <li>Uneven gaps</li>
+            <li>Hard to maintain</li>
+            <li>Manual margin tweaking</li>
+          </ul>
+        </article>
+      </div>
+
+      <div class="compare-card">
+        <span class="compare-label good">✅ With .ease-line-grid</span>
+        <article class="ease-line-grid sample-article">
+          <h2>Baseline Grid</h2>
+          <p>Typography automatically aligns to a consistent vertical rhythm.</p>
+          <h3>Why it matters</h3>
+          <p>With a line grid, every element snaps to a predictable vertical unit.</p>
+          <ul>
+            <li>Consistent spacing</li>
+            <li>Easy to maintain</li>
+            <li>No margin math needed</li>
+          </ul>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── DEMO 2: Compact Grid ───────────────────────────────── -->
+  <section class="demo-section">
+    <h2>2. Compact Variant — <code>.ease-line-grid-sm</code></h2>
+    <p class="demo-desc">
+      A tighter rhythm with <code>line-height: 1.5</code> — great for
+      sidebars, data tables, and code documentation where vertical space
+      is at a premium.
+    </p>
+    <article class="ease-line-grid-sm sample-article sample-article--bordered">
+      <h3>Compact Line Grid</h3>
+      <p>Tighter line-height for dense content like sidebars and data tables.</p>
+      <h4>Subheading</h4>
+      <p>Each element still snaps to the rhythm — just a smaller unit.</p>
+      <ul>
+        <li>API reference docs</li>
+        <li>Log output panels</li>
+        <li>Sidebar navigation</li>
+      </ul>
+    </article>
+  </section>
+
+  <!-- ── DEMO 3: Relaxed Grid ──────────────────────────────── -->
+  <section class="demo-section">
+    <h2>3. Relaxed Variant — <code>.ease-line-grid-lg</code></h2>
+    <p class="demo-desc">
+      A generous rhythm with <code>line-height: 2</code> — ideal for
+      editorial long-form articles and blog posts where readability is
+      the top priority.
+    </p>
+    <article class="ease-line-grid-lg sample-article sample-article--bordered">
+      <h3>Relaxed Line Grid</h3>
+      <p>Open, generous spacing for editorial content and long-form reading.</p>
+      <h4>Subheading</h4>
+      <p>The extra breathing room makes long paragraphs significantly more comfortable to read.</p>
+    </article>
+  </section>
+
+  <!-- ── DEMO 4: Real-world Article ───────────────────────── -->
+  <section class="demo-section">
+    <h2>4. Real-world Article Layout</h2>
+    <p class="demo-desc">
+      A full article layout using <code>.ease-line-grid</code>. Notice how
+      headings, paragraphs, lists, and blockquotes all share the same vertical
+      rhythm automatically.
+    </p>
+    <article class="ease-line-grid article-layout">
+      <h2>The Art of Typographic Rhythm</h2>
+      <p>
+        Good typography is invisible. When readers notice your type, something
+        has gone wrong. A consistent vertical rhythm is the foundation of great
+        editorial design.
+      </p>
+      <h3>What is Vertical Rhythm?</h3>
+      <p>
+        Vertical rhythm refers to the consistent spacing between lines of text
+        and blocks of content on a page. When every element aligns to a
+        baseline grid, the eye can flow naturally from one line to the next.
+      </p>
+      <blockquote>
+        "Typography is the craft of endowing human language with a durable visual
+        form." — Robert Bringhurst
+      </blockquote>
+      <h3>How Line Grid Helps</h3>
+      <ul>
+        <li>Eliminates manual margin calculations</li>
+        <li>Keeps headings and body text in sync</li>
+        <li>Works with any font size or line height</li>
+        <li>Scales naturally across viewport sizes</li>
+      </ul>
+      <p>
+        With <code>.ease-line-grid</code>, all of this is automatic. Set it
+        once on your article container and every child aligns perfectly.
+      </p>
+    </article>
+  </section>
+
+  <!-- ── REFERENCE ─────────────────────────────────────────── -->
+  <section class="demo-section info-section">
+    <h2>🔧 CSS Reference</h2>
+    <div class="code-block">
+      <pre><code>/* 1. Base Line Grid (from the issue snippet exactly) */
+.ease-line-grid {
+  line-height: 1.75;
+  display: grid;
+  row-gap: calc(1lh); /* 1lh = 1 line-height unit */
+}
+
+.ease-line-grid > * {
+  margin: 0; /* Reset all child margins — grid handles spacing */
+}
+
+/* 2. Compact (tighter rhythm for sidebars / data) */
+.ease-line-grid-sm {
+  line-height: 1.5;
+  display: grid;
+  row-gap: calc(1lh);
+}
+
+.ease-line-grid-sm > * {
+  margin: 0;
+}
+
+/* 3. Relaxed (generous rhythm for editorial / articles) */
+.ease-line-grid-lg {
+  line-height: 2;
+  display: grid;
+  row-gap: calc(1lh);
+}
+
+.ease-line-grid-lg > * {
+  margin: 0;
+}
+
+/* WHAT IS 1lh?
+   The 'lh' unit equals the computed line-height of the element.
+   calc(1lh) therefore always equals exactly one "line" of space,
+   keeping every child spaced by a single baseline unit.
+   Browser support: Chrome 109+, Firefox 120+, Safari 17.2+
+   Fallback: Use em-based row-gap for older browsers. */</code></pre>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/line-grid-typography/style.css
+++ b/submissions/examples/line-grid-typography/style.css
@@ -1,0 +1,293 @@
+/* ============================================================
+   CSS Line Grid Typography Utilities
+   Consistent baseline rhythm using CSS grid and the lh unit.
+   Relates to issue #41316
+   ============================================================
+
+   KEY CONCEPTS:
+   ── The Baseline Grid Pattern ────────────────────────────────
+   The CSS Line Grid pattern uses three properties together:
+
+   1. line-height: <number>
+      Sets the baseline unit. All vertical spacing derives from this.
+      1.75 = comfortable for body text.
+      1.5  = compact for sidebars/data.
+      2.0  = relaxed for editorial long-form.
+
+   2. display: grid + row-gap: calc(1lh)
+      The 'lh' unit = the computed line-height of the element.
+      So calc(1lh) always equals exactly ONE baseline unit of space.
+      This replaces the fragile old technique of:
+        margin-bottom: 1.75em (on every element individually).
+
+   3. .ease-line-grid > * { margin: 0; }
+      Resets browser default margins on all children so only the
+      grid's row-gap controls vertical space. Prevents double gaps.
+
+   ── The lh Unit ──────────────────────────────────────────────
+   'lh' is a CSS length unit equal to the line-height of the element.
+   - 1lh = line-height × font-size (in pixels, at runtime)
+   - calc(1lh) = exactly one line of space
+   - calc(2lh) = exactly two lines of space
+   Browser support: Chrome 109+, Firefox 120+, Safari 17.2+
+   ============================================================ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3rem;
+}
+
+code {
+  background: #1e293b;
+  color: #a78bfa;
+  padding: 0.2em 0.5em;
+  border-radius: 6px;
+  font-size: 0.85em;
+  font-family: monospace;
+}
+
+strong { color: #f8fafc; }
+
+/* ── Header ──────────────────────────────────────────────── */
+
+.page-header {
+  text-align: center;
+  max-width: 680px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.page-header h1 {
+  font-size: 2rem;
+  background: linear-gradient(135deg, #a78bfa, #38bdf8);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.page-header p { color: #94a3b8; line-height: 1.65; }
+
+.badges {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 0.5rem;
+}
+
+.badge {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 99px;
+  padding: 0.35rem 0.8rem;
+  font-size: 0.75rem;
+  color: #7dd3fc;
+}
+
+/* ── Explainer ───────────────────────────────────────────── */
+
+.explainer {
+  background: #7c3aed22;
+  border: 1px dashed #7c3aed;
+  border-radius: 12px;
+  padding: 1rem 1.5rem;
+  max-width: 800px;
+  width: 100%;
+}
+
+.explainer p {
+  color: #c4b5fd;
+  font-size: 0.9rem;
+  line-height: 1.65;
+}
+
+/* ── Demo Sections ───────────────────────────────────────── */
+
+.demo-section {
+  width: 100%;
+  max-width: 800px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.demo-section h2 {
+  font-size: 1.05rem;
+  border-left: 3px solid #a78bfa;
+  padding-left: 0.75rem;
+  color: #f8fafc;
+}
+
+.demo-desc {
+  color: #94a3b8;
+  font-size: 0.88rem;
+  line-height: 1.7;
+}
+
+/* ── Comparison Grid ─────────────────────────────────────── */
+
+.compare-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+@media (max-width: 640px) {
+  .compare-grid { grid-template-columns: 1fr; }
+}
+
+.compare-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.compare-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  border-radius: 6px;
+  padding: 0.2rem 0.6rem;
+  align-self: flex-start;
+}
+
+.compare-label.bad  { background: #ef444422; color: #fca5a5; }
+.compare-label.good { background: #22c55e22; color: #86efac; }
+
+/* ── Sample Articles ─────────────────────────────────────── */
+
+.sample-article {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 12px;
+  padding: 1.5rem;
+  color: #94a3b8;
+  font-size: 0.9rem;
+}
+
+.sample-article h2 { font-size: 1.25rem; color: #f8fafc; }
+.sample-article h3 { font-size: 1.05rem; color: #e2e8f0; }
+.sample-article h4 { font-size: 0.95rem; color: #e2e8f0; }
+.sample-article ul { padding-left: 1.25rem; }
+.sample-article li { color: #94a3b8; }
+
+.sample-article--bordered {
+  border: 2px solid #334155;
+}
+
+/* The "without" version — browser defaults create uneven spacing */
+.no-grid h2 { margin-bottom: 0.5rem; }
+.no-grid h3 { margin-top: 1.5rem; margin-bottom: 0.5rem; }
+.no-grid p  { margin-bottom: 0.75rem; }
+.no-grid ul { margin-top: 0.5rem; }
+
+
+/* ── Real-world Article ──────────────────────────────────── */
+
+.article-layout {
+  font-size: 1rem;
+  max-width: 100%;
+}
+
+.article-layout h2 { font-size: 1.5rem; color: #f8fafc; }
+.article-layout h3 { font-size: 1.15rem; color: #e2e8f0; }
+
+.article-layout blockquote {
+  border-left: 3px solid #a78bfa;
+  padding-left: 1rem;
+  color: #c4b5fd;
+  font-style: italic;
+}
+
+
+/* ============================================================
+   UTILITIES (matches the issue's CSS snippet exactly)
+   ============================================================ */
+
+/* 1. Base Line Grid — matches the issue's snippet exactly */
+.ease-line-grid {
+  line-height: 1.75;
+  display: grid;
+  row-gap: calc(1lh);
+}
+
+.ease-line-grid > * {
+  margin: 0;
+}
+
+/* 2. Compact variant — tighter rhythm for sidebars / data */
+.ease-line-grid-sm {
+  line-height: 1.5;
+  display: grid;
+  row-gap: calc(1lh);
+}
+
+.ease-line-grid-sm > * {
+  margin: 0;
+}
+
+/* 3. Relaxed variant — generous rhythm for editorial / articles */
+.ease-line-grid-lg {
+  line-height: 2;
+  display: grid;
+  row-gap: calc(1lh);
+}
+
+.ease-line-grid-lg > * {
+  margin: 0;
+}
+
+
+/* ── Info Section ────────────────────────────────────────── */
+
+.info-section {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 14px;
+  padding: 1.75rem;
+  gap: 1.25rem;
+  margin-top: 1rem;
+}
+
+.info-section h2 {
+  font-size: 1.05rem;
+  border-left: 3px solid #a78bfa;
+  padding-left: 0.75rem;
+  color: #f8fafc;
+}
+
+.code-block {
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid #334155;
+}
+
+pre {
+  background: #0f172a;
+  padding: 1.25rem;
+  overflow-x: auto;
+}
+
+pre code {
+  background: transparent;
+  color: #7dd3fc;
+  padding: 0;
+  font-size: 0.8rem;
+  line-height: 1.8;
+}


### PR DESCRIPTION
Resolves #41316

### Description
Introduces utility classes inspired by the CSS Line Grid specification to align text, headings, lists, and other typographic elements to a consistent baseline rhythm using CSS grid and the native `lh` length unit. No JavaScript, no manual margin math.

### Utilities Added (matches the issue's CSS snippet exactly)
| Class | `line-height` | Best For |
|---|---|---|
| `.ease-line-grid` | `1.75` | Body text, general articles |
| `.ease-line-grid-sm` | `1.5` | Sidebars, data tables, API docs |
| `.ease-line-grid-lg` | `2.0` | Editorial, long-form reading |

### How It Works (matches the issue's snippets exactly)
```html
<article class="ease-line-grid">
  <h2>Baseline Grid</h2>
  <p>
    Typography automatically aligns to a consistent vertical rhythm.
  </p>
</article>
```
```css
.ease-line-grid {
  line-height: 1.75;
  display: grid;
  row-gap: calc(1lh);
}

.ease-line-grid > * {
  margin: 0;
}
```

### Key Concept: the `lh` unit
`lh` is a CSS length unit equal to the computed `line-height` of the element. `calc(1lh)` therefore always equals exactly one baseline unit of space, keeping children in perfect vertical rhythm at any font size. Supported in Chrome 109+, Firefox 120+, Safari 17.2+.

### Demo Includes
1. **Side-by-side comparison** — shows the visible difference with and without `.ease-line-grid` using mixed heading/paragraph/list content.
2. **Compact variant** — `.ease-line-grid-sm` for dense sidebar/data layouts.
3. **Relaxed variant** — `.ease-line-grid-lg` for editorial long-form articles.
4. **Full article layout** — real-world article with headings, paragraphs, lists, and a blockquote all auto-aligned to the grid.

### Validation
- [x] Placed under `submissions/examples/line-grid-typography/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] CSS matches the issue's snippet exactly
- [x] README explains the `lh` unit and browser support
- [x] Includes `> * { margin: 0; }` to prevent double-gap issue