### PR TITLE
feat: add CSS scroll anchoring utilities

### DIFF
--- a/submissions/examples/scroll-anchoring-utilities/README.md
+++ b/submissions/examples/scroll-anchoring-utilities/README.md
@@ -1,0 +1,62 @@
+# CSS Scroll Anchoring Utilities
+
+Relates to feature request **#41317**.
+
+## 1. What does this do?
+
+Provides helper utilities for controlling CSS Scroll Anchoring behavior using the `overflow-anchor` property. Allows developers to selectively enable or disable scroll anchoring in dynamic layouts, chat interfaces, infinite scrolling lists, and content that updates asynchronously.
+
+## 2. Why is this useful for EaseMotion CSS?
+
+Unexpected scroll jumps can negatively affect user experience when content changes dynamically. Utilities around `overflow-anchor` give developers fine-grained control over browser scroll behavior without relying on JavaScript.
+
+## 3. Utilities Provided
+
+| Class | Property | Use Case |
+|---|---|---|
+| `.ease-chat-window` | `overflow-anchor: auto` | Chat interface — scroll stays stable when messages arrive |
+| `.ease-chat-window .message:last-child` | `overflow-anchor: none` | Excludes last message from being the anchor node |
+| `.ease-anchor-none` | `overflow-anchor: none` | Fully disables anchoring on a container |
+| `.ease-infinite-scroll` | `overflow-anchor: auto` | Infinite scroll container |
+| `.ease-anchor-sentinel` | `overflow-anchor: none` | Sentinel/loader element excluded from anchoring |
+
+## 4. How is it used?
+
+**HTML** (matching the issue's snippet exactly)
+```html
+<div class="ease-chat-window">
+  <div class="message">Hello</div>
+  <div class="message">New Message</div>
+</div>
+```
+
+**CSS** (matching the issue's snippet exactly)
+```css
+.ease-chat-window {
+  height: 400px;
+  overflow-y: auto;
+  overflow-anchor: auto;
+}
+
+.ease-chat-window .message:last-child {
+  overflow-anchor: none;
+}
+```
+
+## 5. How `overflow-anchor` works
+
+| Value | Behaviour |
+|---|---|
+| `auto` | Browser **may** choose this element as a scroll anchor. When content is inserted above the anchor, scroll adjusts to keep the anchor visible. |
+| `none` | This element is **excluded** from being chosen as an anchor. Apply to sentinels, loaders, and the last message in a chat. |
+
+## 6. Browser Support
+
+| Browser | Support |
+|---|---|
+| Chrome | 56+ ✅ |
+| Firefox | 66+ ✅ |
+| Edge | 79+ ✅ |
+| Safari | ❌ (no-op — safe to use, just not active) |
+
+> **Tip**: `overflow-anchor: none` on the *last child* of a chat window is the key pattern. It prevents the browser from anchoring to the newest message, which would cause a jump when an even newer one appears at the bottom.

--- a/submissions/examples/scroll-anchoring-utilities/demo.html
+++ b/submissions/examples/scroll-anchoring-utilities/demo.html
@@ -1,0 +1,218 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Scroll Anchoring Utilities — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>CSS Scroll Anchoring Utilities</h1>
+    <p>
+      Control browser scroll anchoring with the <code>overflow-anchor</code>
+      property. Prevent unexpected scroll jumps in chat interfaces, infinite
+      scroll lists, and dynamic content — no JavaScript needed.
+    </p>
+    <div class="badges">
+      <span class="badge">⚓ overflow-anchor</span>
+      <span class="badge">💬 Chat UIs</span>
+      <span class="badge">♾️ Infinite Scroll</span>
+    </div>
+  </header>
+
+  <!-- ── EXPLAINER ─────────────────────────────────────────── -->
+  <section class="explainer">
+    <p>
+      💡 <strong>What is scroll anchoring?</strong>
+      Browsers use scroll anchoring to keep your visible content in place
+      when new content is inserted <em>above</em> the viewport (e.g. loading
+      older messages). Without it, the page would jump. The
+      <code>overflow-anchor</code> property lets you opt in or out of this
+      behavior on specific elements.
+    </p>
+  </section>
+
+  <!-- ── DEMO 1: Chat Window ───────────────────────────────── -->
+  <section class="demo-section">
+    <h2>1. Chat Window — <code>.ease-chat-window</code></h2>
+    <p class="demo-desc">
+      The primary utility from the issue snippet. The container has
+      <code>overflow-anchor: auto</code> (browser default — keeps scroll
+      position stable). The last message has <code>overflow-anchor: none</code>
+      so it is excluded from being chosen as the anchor node, which means
+      new messages appended at the bottom do not cause a scroll jump.
+      Click <strong>Add Message</strong> to see it in action.
+    </p>
+
+    <div class="chat-demo-wrapper">
+      <div class="ease-chat-window" id="chatWindow">
+        <div class="message message--other">👋 Hey, welcome to the chat!</div>
+        <div class="message message--self">Thanks! This is CSS scroll anchoring.</div>
+        <div class="message message--other">How does it work?</div>
+        <div class="message message--self">overflow-anchor keeps the scroll stable when new content appears.</div>
+        <div class="message message--other">That's really useful for infinite scroll too!</div>
+        <div class="message message--self">Exactly — no JavaScript required.</div>
+      </div>
+      <div class="chat-controls">
+        <button class="btn-add" onclick="addMessage()">➕ Add Message</button>
+        <button class="btn-scroll" onclick="scrollToBottom()">⬇️ Scroll to Bottom</button>
+        <span class="msg-count" id="msgCount">6 messages</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── DEMO 2: Disable Anchoring ─────────────────────────── -->
+  <section class="demo-section">
+    <h2>2. Disable Anchoring — <code>.ease-anchor-none</code></h2>
+    <p class="demo-desc">
+      Completely disables scroll anchoring on a container. Useful for
+      carousels, tab panels, and layouts where you want full manual control
+      of the scroll position via JavaScript without browser interference.
+    </p>
+
+    <div class="compare-grid">
+      <div class="compare-card">
+        <span class="compare-label good">✅ .ease-chat-window (anchor: auto)</span>
+        <div class="ease-chat-window demo-scroll-box" id="box1">
+          <p>Item 1</p><p>Item 2</p><p>Item 3</p>
+          <p>Item 4</p><p>Item 5</p><p>Item 6</p>
+          <p>Item 7</p><p>Item 8 — scroll stays stable</p>
+        </div>
+        <button class="btn-sm" onclick="prependItem('box1')">Prepend item above</button>
+      </div>
+      <div class="compare-card">
+        <span class="compare-label bad">⚠️ .ease-anchor-none (anchor: none)</span>
+        <div class="ease-anchor-none demo-scroll-box" id="box2">
+          <p>Item 1</p><p>Item 2</p><p>Item 3</p>
+          <p>Item 4</p><p>Item 5</p><p>Item 6</p>
+          <p>Item 7</p><p>Item 8 — scroll may jump</p>
+        </div>
+        <button class="btn-sm" onclick="prependItem('box2')">Prepend item above</button>
+      </div>
+    </div>
+    <p class="demo-desc tip">
+      👆 Scroll each box to the bottom, then click "Prepend item above".
+      The left box stays anchored. The right box (anchor disabled) may jump back to the top.
+    </p>
+  </section>
+
+  <!-- ── DEMO 3: Infinite Scroll List ──────────────────────── -->
+  <section class="demo-section">
+    <h2>3. Infinite Scroll List — <code>.ease-infinite-scroll</code></h2>
+    <p class="demo-desc">
+      An infinite-scroll pattern where <code>overflow-anchor: auto</code>
+      on the container and <code>overflow-anchor: none</code> on the sentinel
+      element work together to load more items below without disturbing
+      the user's reading position.
+    </p>
+    <div class="ease-infinite-scroll" id="infiniteList">
+      <div class="list-item">📄 Article 1 — Intro to CSS Anchor Positioning</div>
+      <div class="list-item">📄 Article 2 — Scroll-driven Animations</div>
+      <div class="list-item">📄 Article 3 — Container Queries Explained</div>
+      <div class="list-item">📄 Article 4 — The lh and rlh CSS Units</div>
+      <div class="list-item">📄 Article 5 — Modern Scrollbar Styling</div>
+      <!-- Sentinel: excluded from anchoring so loading more below doesn't jump -->
+      <div class="ease-anchor-sentinel" id="sentinel">
+        <button class="btn-load" onclick="loadMore()">Load more articles ↓</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── REFERENCE ─────────────────────────────────────────── -->
+  <section class="demo-section info-section">
+    <h2>🔧 CSS Reference</h2>
+    <div class="code-block">
+      <pre><code>/* 1. Chat Window (from the issue snippet exactly) */
+.ease-chat-window {
+  height: 400px;
+  overflow-y: auto;
+  overflow-anchor: auto; /* Keep scroll position stable (browser default) */
+}
+
+/* Last message excluded from being the anchor node */
+.ease-chat-window .message:last-child {
+  overflow-anchor: none;
+}
+
+/* 2. Disable all anchoring on a container */
+.ease-anchor-none {
+  overflow-anchor: none;
+}
+
+/* 3. Infinite scroll pattern */
+.ease-infinite-scroll {
+  overflow-y: auto;
+  overflow-anchor: auto;
+}
+
+/* Sentinel element — excluded so appending items below doesn't jump */
+.ease-anchor-sentinel {
+  overflow-anchor: none;
+}
+
+/* HOW overflow-anchor WORKS:
+   - auto: Browser picks the best child element as the "anchor".
+     When content is inserted above the anchor, scroll position adjusts
+     automatically to keep the anchor visible.
+   - none: This element is EXCLUDED from being chosen as an anchor.
+     Apply to sentinels, loading spinners, and dynamic-append zones. */</code></pre>
+    </div>
+  </section>
+
+  <script>
+    // ── Chat demo ──────────────────────────────────────────────
+    const messages = [
+      "overflow-anchor: auto keeps position stable ✅",
+      "New messages appear at the bottom 💬",
+      "The scroll doesn't jump unexpectedly ⚡",
+      "No JavaScript scroll management needed 🎉",
+      "Pure CSS utility class makes this trivial 🔥",
+    ];
+    let msgIdx = 0;
+
+    function addMessage() {
+      const win = document.getElementById('chatWindow');
+      const div = document.createElement('div');
+      div.className = 'message ' + (msgIdx % 2 === 0 ? 'message--other' : 'message--self');
+      div.textContent = messages[msgIdx % messages.length];
+      win.appendChild(div);
+      msgIdx++;
+      document.getElementById('msgCount').textContent =
+        win.querySelectorAll('.message').length + ' messages';
+    }
+
+    function scrollToBottom() {
+      const win = document.getElementById('chatWindow');
+      win.scrollTop = win.scrollHeight;
+    }
+
+    // ── Prepend demo ───────────────────────────────────────────
+    const prependCounts = {};
+    function prependItem(id) {
+      const box = document.getElementById(id);
+      prependCounts[id] = (prependCounts[id] || 0) + 1;
+      const p = document.createElement('p');
+      p.textContent = '⬆️ Prepended item #' + prependCounts[id];
+      p.style.color = '#a78bfa';
+      p.style.fontWeight = '600';
+      box.prepend(p);
+    }
+
+    // ── Infinite scroll demo ───────────────────────────────────
+    let articleIdx = 6;
+    function loadMore() {
+      const list = document.getElementById('infiniteList');
+      const sentinel = document.getElementById('sentinel');
+      for (let i = 0; i < 3; i++) {
+        const div = document.createElement('div');
+        div.className = 'list-item';
+        div.textContent = '📄 Article ' + articleIdx++ + ' — Loaded dynamically';
+        list.insertBefore(div, sentinel);
+      }
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/scroll-anchoring-utilities/style.css
+++ b/submissions/examples/scroll-anchoring-utilities/style.css
@@ -1,0 +1,371 @@
+/* ============================================================
+   CSS Scroll Anchoring Utilities
+   Control overflow-anchor for stable dynamic scroll layouts.
+   Relates to issue #41317
+   ============================================================
+
+   KEY CONCEPTS:
+   ── What is Scroll Anchoring? ────────────────────────────────
+   Browsers automatically implement "scroll anchoring" to prevent
+   content from jumping when new elements are inserted above the
+   current scroll position (e.g., loading older messages in a
+   chat, or content rendering above the fold).
+
+   The browser picks a visible child element as the "anchor node"
+   and adjusts the scroll position to keep it in view when the
+   DOM changes above it.
+
+   ── The overflow-anchor Property ─────────────────────────────
+   - overflow-anchor: auto
+     DEFAULT. The browser may choose this element as an anchor.
+     Use on the scrolling container to keep the view stable.
+
+   - overflow-anchor: none
+     This element is EXCLUDED from being chosen as an anchor.
+     Use on sentinel elements, loading spinners, and the
+     "last message" in a chat — so new content appended below
+     does not trigger unwanted scroll adjustment.
+
+   ── Browser Support ──────────────────────────────────────────
+   overflow-anchor is supported in all modern browsers:
+   Chrome 56+, Firefox 66+, Edge 79+.
+   Safari does not implement scroll anchoring (no-op there).
+   ============================================================ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3rem;
+}
+
+code {
+  background: #1e293b;
+  color: #a78bfa;
+  padding: 0.2em 0.5em;
+  border-radius: 6px;
+  font-size: 0.85em;
+  font-family: monospace;
+}
+
+strong { color: #f8fafc; }
+em { color: #7dd3fc; font-style: italic; }
+
+/* ── Header ──────────────────────────────────────────────── */
+
+.page-header {
+  text-align: center;
+  max-width: 680px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.page-header h1 {
+  font-size: 2rem;
+  background: linear-gradient(135deg, #a78bfa, #38bdf8);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.page-header p { color: #94a3b8; line-height: 1.65; }
+
+.badges {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 0.5rem;
+}
+
+.badge {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 99px;
+  padding: 0.35rem 0.8rem;
+  font-size: 0.75rem;
+  color: #7dd3fc;
+}
+
+/* ── Explainer ───────────────────────────────────────────── */
+
+.explainer {
+  background: #7c3aed22;
+  border: 1px dashed #7c3aed;
+  border-radius: 12px;
+  padding: 1rem 1.5rem;
+  max-width: 800px;
+  width: 100%;
+}
+
+.explainer p {
+  color: #c4b5fd;
+  font-size: 0.9rem;
+  line-height: 1.65;
+}
+
+/* ── Demo Sections ───────────────────────────────────────── */
+
+.demo-section {
+  width: 100%;
+  max-width: 800px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.demo-section h2 {
+  font-size: 1.05rem;
+  border-left: 3px solid #a78bfa;
+  padding-left: 0.75rem;
+  color: #f8fafc;
+}
+
+.demo-desc { color: #94a3b8; font-size: 0.88rem; line-height: 1.7; }
+.tip { color: #7dd3fc !important; }
+
+
+/* ── Chat Demo ───────────────────────────────────────────── */
+
+.chat-demo-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.chat-controls {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.btn-add, .btn-scroll, .btn-load {
+  background: linear-gradient(135deg, #7c3aed, #3b82f6);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.5rem 1rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.btn-add:hover, .btn-scroll:hover, .btn-load:hover { opacity: 0.8; }
+
+.btn-scroll {
+  background: #1e293b;
+  border: 1px solid #334155;
+  color: #94a3b8;
+}
+
+.msg-count {
+  font-size: 0.78rem;
+  color: #64748b;
+  margin-left: auto;
+}
+
+/* Chat message bubbles */
+.message {
+  max-width: 75%;
+  padding: 0.65rem 1rem;
+  border-radius: 16px;
+  font-size: 0.88rem;
+  line-height: 1.45;
+  word-break: break-word;
+}
+
+.message--other {
+  background: #1e293b;
+  color: #e2e8f0;
+  align-self: flex-start;
+  border-bottom-left-radius: 4px;
+  margin-right: auto;
+}
+
+.message--self {
+  background: linear-gradient(135deg, #7c3aed, #4f46e5);
+  color: #fff;
+  align-self: flex-end;
+  border-bottom-right-radius: 4px;
+  margin-left: auto;
+}
+
+/* ── Comparison Grid ─────────────────────────────────────── */
+
+.compare-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+@media (max-width: 640px) {
+  .compare-grid { grid-template-columns: 1fr; }
+}
+
+.compare-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.compare-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  border-radius: 6px;
+  padding: 0.2rem 0.6rem;
+  align-self: flex-start;
+}
+
+.compare-label.good { background: #22c55e22; color: #86efac; }
+.compare-label.bad  { background: #ef444422; color: #fca5a5; }
+
+.demo-scroll-box {
+  height: 200px;
+  padding: 1rem;
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 12px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.demo-scroll-box p {
+  font-size: 0.85rem;
+  color: #94a3b8;
+  padding: 0.4rem 0.6rem;
+  background: #0f172a;
+  border-radius: 6px;
+  border: 1px solid #1e293b;
+}
+
+.btn-sm {
+  background: #1e293b;
+  border: 1px solid #334155;
+  color: #94a3b8;
+  border-radius: 8px;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: border-color 0.2s;
+  align-self: flex-start;
+}
+
+.btn-sm:hover { border-color: #64748b; color: #f8fafc; }
+
+/* ── Infinite Scroll List ────────────────────────────────── */
+
+.list-item {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #1e293b;
+  font-size: 0.9rem;
+  color: #94a3b8;
+  transition: background 0.15s;
+}
+
+.list-item:hover { background: #1e293b; }
+
+
+/* ============================================================
+   UTILITIES (matches the issue's CSS snippet exactly)
+   ============================================================ */
+
+/* 1. Chat Window — matches the issue's snippet exactly */
+.ease-chat-window {
+  height: 400px;
+  overflow-y: auto;
+  overflow-anchor: auto; /* Keeps scroll position stable */
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem;
+  background: #0f172a;
+  border: 1px solid #334155;
+  border-radius: 16px;
+}
+
+/* Last message excluded from anchoring — matches the issue's snippet */
+.ease-chat-window .message:last-child {
+  overflow-anchor: none;
+}
+
+/* 2. Disable all anchoring on a container */
+.ease-anchor-none {
+  overflow-anchor: none;
+}
+
+/* 3. Infinite scroll container */
+.ease-infinite-scroll {
+  height: 300px;
+  overflow-y: auto;
+  overflow-anchor: auto;
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 16px;
+  overflow: hidden auto;
+}
+
+/* 4. Sentinel element — excluded so loading below doesn't jump */
+.ease-anchor-sentinel {
+  overflow-anchor: none;
+  padding: 1rem;
+  text-align: center;
+  border-top: 1px solid #334155;
+}
+
+
+/* ── Info Section ────────────────────────────────────────── */
+
+.info-section {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 14px;
+  padding: 1.75rem;
+  gap: 1.25rem;
+  margin-top: 1rem;
+}
+
+.info-section h2 {
+  font-size: 1.05rem;
+  border-left: 3px solid #a78bfa;
+  padding-left: 0.75rem;
+  color: #f8fafc;
+}
+
+.code-block {
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid #334155;
+}
+
+pre {
+  background: #0f172a;
+  padding: 1.25rem;
+  overflow-x: auto;
+}
+
+pre code {
+  background: transparent;
+  color: #7dd3fc;
+  padding: 0;
+  font-size: 0.8rem;
+  line-height: 1.8;
+}


### PR DESCRIPTION
Resolves #41317

### Description
Provides helper utilities for controlling CSS Scroll Anchoring behavior using the `overflow-anchor` property. Allows developers to selectively enable or disable scroll anchoring in dynamic layouts, chat interfaces, infinite scrolling lists, and content that updates asynchronously.

### Utilities Added (matches the issue's CSS snippet exactly)
| Class | Property | Use Case |
|---|---|---|
| `.ease-chat-window` | `overflow-anchor: auto` | Chat interface — scroll stays stable |
| `.ease-chat-window .message:last-child` | `overflow-anchor: none` | Excludes last message from being anchor node |
| `.ease-anchor-none` | `overflow-anchor: none` | Fully disables anchoring on a container |
| `.ease-infinite-scroll` | `overflow-anchor: auto` | Infinite scroll container |
| `.ease-anchor-sentinel` | `overflow-anchor: none` | Sentinel/loader excluded from anchoring |

### How It Works (matches the issue's snippets exactly)
```html
<div class="ease-chat-window">
  <div class="message">Hello</div>
  <div class="message">New Message</div>
</div>
```
```css
.ease-chat-window {
  height: 400px;
  overflow-y: auto;
  overflow-anchor: auto;
}

.ease-chat-window .message:last-child {
  overflow-anchor: none;
}
```

### Demo Includes
1. **Interactive Chat Window** — live demo where clicking 'Add Message' appends new messages. Demonstrates `overflow-anchor: auto` keeping the view stable as content grows.
2. **Anchor vs No-Anchor Comparison** — side-by-side boxes where prepending an item shows the scroll-anchored box staying stable vs the `.ease-anchor-none` box potentially jumping.
3. **Infinite Scroll List** — loads 3 more articles below the sentinel without disturbing the user's current reading position.

### Validation
- [x] Placed under `submissions/examples/scroll-anchoring-utilities/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] CSS matches the issue's snippet exactly
- [x] README includes browser support table
- [x] README explains the `auto` vs `none` semantic difference