### PR TITLE
feat: add streak counter

### DIFF
--- a/submissions/examples/streak-counter-as/README.md
+++ b/submissions/examples/streak-counter-as/README.md
@@ -1,0 +1,25 @@
+# Streak Counter
+
+### What does this do?
+
+It shows a daily streak counter card with a big flame and day count, a row of the last seven days marked done or missed with today highlighted, and a best streak note.
+
+### How is it used?
+
+```html
+<div class="streak">
+  <div class="st-flame"><svg>...</svg><b>14</b></div>
+  <p class="st-title">day streak</p>
+  <div class="st-days">
+    <div class="st-day done"><span class="st-dot"><svg>...</svg></span>Mon</div>
+    <div class="st-day today"><span class="st-dot"><svg>...</svg></span>Sat</div>
+    <div class="st-day"><span class="st-dot"></span>Sun</div>
+  </div>
+</div>
+```
+
+Add `done` to completed days for a filled flame dot, `today` to mark the current day with a ring, and leave a day plain for a missed or upcoming day.
+
+### Why is it useful?
+
+Habit and learning apps reward daily streaks to build a habit. This renders a streak card with a flame count and a week of done and missed day dots, using only CSS and inline SVG so there are no external assets.

--- a/submissions/examples/streak-counter-as/demo.html
+++ b/submissions/examples/streak-counter-as/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Streak Counter</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="streak">
+    <div class="st-flame">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2c1 3-1 5-2 6-2 2-3 4-3 7a5 5 0 0 0 10 0c0-2-1-3-1-4 2 1 3 3 3 5a7 7 0 1 1-14 0c0-5 4-8 5-11 1 .5 2 1.5 2 3-1 0-1 .5-1 1 1 0 2-1 1-3-1-2-1-3-2-4z" fill="#f97316" /></svg>
+      <b>14</b>
+    </div>
+    <p class="st-title">day streak</p>
+
+    <div class="st-days">
+      <div class="st-day done"><span class="st-dot"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m5 13 4 4 10-11" stroke-linecap="round" stroke-linejoin="round" /></svg></span>Mon</div>
+      <div class="st-day done"><span class="st-dot"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m5 13 4 4 10-11" stroke-linecap="round" stroke-linejoin="round" /></svg></span>Tue</div>
+      <div class="st-day done"><span class="st-dot"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m5 13 4 4 10-11" stroke-linecap="round" stroke-linejoin="round" /></svg></span>Wed</div>
+      <div class="st-day done"><span class="st-dot"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m5 13 4 4 10-11" stroke-linecap="round" stroke-linejoin="round" /></svg></span>Thu</div>
+      <div class="st-day done"><span class="st-dot"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m5 13 4 4 10-11" stroke-linecap="round" stroke-linejoin="round" /></svg></span>Fri</div>
+      <div class="st-day today"><span class="st-dot"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 8v5M12 16h.01" stroke-linecap="round" /></svg></span>Sat</div>
+      <div class="st-day"><span class="st-dot"></span>Sun</div>
+    </div>
+
+    <p class="st-foot">Best streak: <b>28 days</b></p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/streak-counter-as/style.css
+++ b/submissions/examples/streak-counter-as/style.css
@@ -1,0 +1,110 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.streak {
+  width: min(320px, 92vw);
+  padding: 1.7rem 1.6rem;
+  box-sizing: border-box;
+  text-align: center;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 18px;
+}
+
+.st-flame {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 0.3rem;
+}
+
+.st-flame svg {
+  width: 44px;
+  height: 44px;
+}
+
+.st-flame b {
+  font-size: 3rem;
+  font-weight: 800;
+  line-height: 1;
+  background: linear-gradient(135deg, #fbbf24, #f97316);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.st-title {
+  margin: 0 0 1.4rem;
+  font-size: 0.9rem;
+  color: #94a3b8;
+}
+
+.st-days {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.35rem;
+}
+
+.st-day {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.68rem;
+  color: #64748b;
+}
+
+.st-dot {
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: #1b2942;
+  border: 2px solid #26324a;
+  color: #475569;
+}
+
+.st-dot svg {
+  width: 15px;
+  height: 15px;
+  stroke: currentColor;
+  stroke-width: 2.5;
+  fill: none;
+}
+
+.st-day.done .st-dot {
+  background: linear-gradient(135deg, #fbbf24, #f97316);
+  border-color: transparent;
+  color: #fff;
+}
+
+.st-day.done {
+  color: #cbd5e1;
+}
+
+.st-day.today .st-dot {
+  border-color: #f97316;
+  color: #fbbf24;
+  box-shadow: 0 0 0 4px rgba(249, 115, 22, 0.2);
+}
+
+.st-foot {
+  margin-top: 1.4rem;
+  font-size: 0.78rem;
+  color: #94a3b8;
+}
+
+.st-foot b {
+  color: #fbbf24;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a streak counter built for #41337. A flame day count with a week of done and missed day dots, using only CSS and inline SVG. Closes #41337.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A daily streak card with a big flame and day count, a row of the last seven days marked done or missed with today highlighted, and a best streak note.

**How does a developer use it?**

```html
<div class="streak">
  <div class="st-flame"><svg>...</svg><b>14</b></div>
  <div class="st-days">
    <div class="st-day done"><span class="st-dot"><svg>...</svg></span>Mon</div>
    <div class="st-day today"><span class="st-dot"><svg>...</svg></span>Sat</div>
    <div class="st-day"><span class="st-dot"></span>Sun</div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It renders a streak card with a flame count and a week of done and missed day dots driven by `done` and `today` classes, using only CSS and inline SVG so there are no external assets.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the flame count reads 14 and seven day dots render with five marked done (flame gradient) and one marked today.
