### PR TITLE
feat: add copy field

### DIFF
--- a/submissions/examples/copy-field-as/README.md
+++ b/submissions/examples/copy-field-as/README.md
@@ -1,0 +1,24 @@
+# Copy Field
+
+### What does this do?
+
+It shows a read only field for a value like an API key or an invite link, with a copy button on the right. A copied confirmation tooltip appears when the copy button is hovered or focused.
+
+### How is it used?
+
+```html
+<div class="copy-field">
+  <input class="cf-input" type="text" readonly value="ease_sk_9f2a..." aria-label="API key" />
+  <button class="cf-btn" aria-label="Copy API key">
+    <svg>...</svg>
+    Copy
+    <span class="cf-hint" role="status">Copied</span>
+  </button>
+</div>
+```
+
+The input is `readonly` so the value can be selected but not edited. The copied hint is hidden until the button is hovered or focused. A host app wires the actual clipboard write.
+
+### Why is it useful?
+
+Dashboards show API keys, invite links, and coupon codes with a copy button. This presents a read only value with a copy button and a copied hint, using only CSS and inline SVG. The whole field shows a focus ring via `:focus-within` and the hint fade is reduced under reduced motion.

--- a/submissions/examples/copy-field-as/demo.html
+++ b/submissions/examples/copy-field-as/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Copy Field</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="copy-block">
+    <span class="label">Your API key</span>
+    <div class="copy-field">
+      <input class="cf-input" type="text" readonly value="ease_sk_9f2a4c17b8e0d3512a6f" aria-label="API key" />
+      <button class="cf-btn" type="button" aria-label="Copy API key">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><rect x="9" y="9" width="11" height="11" rx="2" /><path d="M5 15V5a2 2 0 0 1 2-2h10" /></svg>
+        Copy
+        <span class="cf-hint" role="status">Copied</span>
+      </button>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/copy-field-as/style.css
+++ b/submissions/examples/copy-field-as/style.css
@@ -1,0 +1,134 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.copy-block {
+  width: min(360px, 94vw);
+}
+
+.copy-block .label {
+  display: block;
+  margin-bottom: 0.45rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #cbd5e1;
+}
+
+.copy-field {
+  display: flex;
+  align-items: stretch;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 11px;
+  overflow: hidden;
+  transition: border-color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.copy-field:focus-within {
+  border-color: #6c63ff;
+  box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.22);
+}
+
+.cf-input {
+  flex: 1;
+  min-width: 0;
+  padding: 0.7rem 0.9rem;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.86rem;
+  color: #cbd5e1;
+  background: transparent;
+  border: none;
+  outline: none;
+  text-overflow: ellipsis;
+}
+
+.cf-btn {
+  position: relative;
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0 0.9rem;
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #cbd5e1;
+  background: #131f34;
+  border: none;
+  border-left: 1px solid #26324a;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.cf-btn svg {
+  width: 16px;
+  height: 16px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+}
+
+.cf-btn:hover {
+  background: #1b2942;
+  color: #fff;
+}
+
+.cf-btn:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: -2px;
+}
+
+.cf-hint {
+  position: absolute;
+  bottom: calc(100% + 0.5rem);
+  left: 50%;
+  transform: translate(-50%, 4px);
+  padding: 0.25rem 0.55rem;
+  border-radius: 7px;
+  background: #34d399;
+  color: #06231a;
+  font-size: 0.72rem;
+  font-weight: 700;
+  white-space: nowrap;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.15s ease, transform 0.15s ease, visibility 0.15s ease;
+}
+
+.cf-hint::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+  border-top-color: #34d399;
+}
+
+.cf-btn:hover .cf-hint,
+.cf-btn:focus-visible .cf-hint {
+  opacity: 1;
+  visibility: visible;
+  transform: translate(-50%, 0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .copy-field,
+  .cf-btn,
+  .cf-hint {
+    transition: opacity 0.15s ease, visibility 0.15s ease;
+  }
+
+  .cf-btn:hover .cf-hint,
+  .cf-btn:focus-visible .cf-hint {
+    transform: translateX(-50%);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a copy field built for #41342. A read only value with a copy button and a copied hint, using only CSS and inline SVG. Closes #41342.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A read only field showing a value like an API key with a copy button, plus a copied confirmation tooltip that appears on button hover and focus.

**How does a developer use it?**

```html
<div class="copy-field">
  <input class="cf-input" type="text" readonly value="ease_sk_9f2a..." aria-label="API key" />
  <button class="cf-btn" aria-label="Copy API key"><svg>...</svg>Copy<span class="cf-hint" role="status">Copied</span></button>
</div>
```

**Why does it fit EaseMotion CSS?**
It presents a read only value with a copy button and a copied hint, using only CSS and inline SVG. The whole field shows a focus ring via `:focus-within` and the hint fade is reduced under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the input is read only, the copy button renders, and the Copied hint is hidden until the button is focused.
