### PR TITLE
feat: add credit card preview

### DIFF
--- a/submissions/examples/card-preview-as/README.md
+++ b/submissions/examples/card-preview-as/README.md
@@ -1,0 +1,25 @@
+# Credit Card Preview
+
+### What does this do?
+
+It shows a styled credit card preview with a gradient face, a gold chip, a brand mark, a network dots logo, the card number, the holder name, and the expiry. It reads like a real card.
+
+### How is it used?
+
+```html
+<div class="card-preview" role="img" aria-label="Credit card preview">
+  <div class="cc-top"><div class="cc-chip"></div><div class="cc-brand">EASE</div></div>
+  <div class="cc-number">4921 8830 1276 5540</div>
+  <div class="cc-bottom">
+    <div><span class="cc-label">Card holder</span><span class="cc-value">Ada Lovelace</span></div>
+    <div><span class="cc-label">Expires</span><span class="cc-value">08/28</span></div>
+    <span class="cc-dots"><span></span><span></span></span>
+  </div>
+</div>
+```
+
+The card keeps a 1.586 aspect ratio like a real card. The chip, sheen, and network dots are drawn with CSS shapes and gradients, so there are no external images. A host app updates the number, name, and expiry as the user types.
+
+### Why is it useful?
+
+Checkout and wallet screens show a live preview of the card as it is entered. This renders a credit card face with a chip, number, and details from a gradient and CSS shapes, using only CSS with no external assets.

--- a/submissions/examples/card-preview-as/demo.html
+++ b/submissions/examples/card-preview-as/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Credit Card Preview</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="card-preview" role="img" aria-label="Credit card preview">
+    <div class="cc-top">
+      <div class="cc-chip" aria-hidden="true"></div>
+      <div class="cc-brand">EASE</div>
+    </div>
+    <div class="cc-number">4921 8830 1276 5540</div>
+    <div class="cc-bottom">
+      <div>
+        <span class="cc-label">Card holder</span>
+        <span class="cc-value">Ada Lovelace</span>
+      </div>
+      <div>
+        <span class="cc-label">Expires</span>
+        <span class="cc-value">08/28</span>
+      </div>
+      <span class="cc-dots" aria-hidden="true"><span></span><span></span></span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/card-preview-as/style.css
+++ b/submissions/examples/card-preview-as/style.css
@@ -1,0 +1,117 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.card-preview {
+  position: relative;
+  width: min(340px, 92vw);
+  aspect-ratio: 1.586;
+  padding: 1.4rem 1.5rem;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  border-radius: 18px;
+  color: #fff;
+  background: linear-gradient(135deg, #6c63ff 0%, #a855f7 55%, #ec4899 100%);
+  box-shadow: 0 24px 50px rgba(108, 99, 255, 0.35);
+  overflow: hidden;
+}
+
+.card-preview::after {
+  content: "";
+  position: absolute;
+  top: -40%;
+  right: -20%;
+  width: 70%;
+  height: 160%;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.cc-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  position: relative;
+  z-index: 1;
+}
+
+.cc-chip {
+  width: 44px;
+  height: 34px;
+  border-radius: 7px;
+  background: linear-gradient(135deg, #fcd34d, #d97706);
+  position: relative;
+}
+
+.cc-chip::before {
+  content: "";
+  position: absolute;
+  inset: 6px 8px;
+  border: 1px solid rgba(0, 0, 0, 0.25);
+  border-radius: 3px;
+}
+
+.cc-brand {
+  font-size: 1rem;
+  font-weight: 800;
+  font-style: italic;
+  letter-spacing: 0.02em;
+}
+
+.cc-number {
+  position: relative;
+  z-index: 1;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 1.32rem;
+  letter-spacing: 0.12em;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+}
+
+.cc-bottom {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  position: relative;
+  z-index: 1;
+}
+
+.cc-label {
+  display: block;
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.7);
+  margin-bottom: 0.15rem;
+}
+
+.cc-value {
+  font-size: 0.92rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.cc-dots {
+  display: inline-flex;
+}
+
+.cc-dots span {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.75);
+}
+
+.cc-dots span + span {
+  margin-left: -10px;
+  background: rgba(255, 255, 255, 0.45);
+}


### PR DESCRIPTION
## Pull Request Description

Adds a credit card preview built for #41346. A gradient card face with a chip, number, and details from CSS shapes, using only CSS. Closes #41346.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A styled credit card preview with a gradient face, gold chip, brand mark, network dots, card number, holder name, and expiry, at a real card aspect ratio.

**How does a developer use it?**

```html
<div class="card-preview" role="img" aria-label="Credit card preview">
  <div class="cc-top"><div class="cc-chip"></div><div class="cc-brand">EASE</div></div>
  <div class="cc-number">4921 8830 1276 5540</div>
  <div class="cc-bottom">
    <div><span class="cc-label">Card holder</span><span class="cc-value">Ada Lovelace</span></div>
    <div><span class="cc-label">Expires</span><span class="cc-value">08/28</span></div>
    <span class="cc-dots"><span></span><span></span></span>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It renders a credit card face with a chip, number, and details from a gradient and CSS shapes, using only CSS with no external images.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium and by screenshot: the card renders a gradient face with a gold chip, the number, holder name, expiry, and overlapping network dots.
