### PR TITLE
feat: add payment methods

### DIFF
--- a/submissions/examples/payment-methods-as/README.md
+++ b/submissions/examples/payment-methods-as/README.md
@@ -1,0 +1,26 @@
+# Payment Methods
+
+### What does this do?
+
+It shows a list of saved payment methods where each row is a selectable radio option with a card brand mark, the last four digits, and the expiry. The selected card is highlighted with a radio dot, and the default card shows a badge. It works with no JavaScript.
+
+### How is it used?
+
+```html
+<fieldset class="pay-methods">
+  <legend>Payment method</legend>
+  <label class="pm-row">
+    <input type="radio" name="pm" checked aria-label="Visa ending 5540" />
+    <span class="pm-radio"></span>
+    <span class="pm-brand visa">VISA</span>
+    <span class="pm-body"><span class="pm-num">•••• 5540</span><span class="pm-exp">Expires 08/28</span></span>
+    <span class="pm-default">Default</span>
+  </label>
+</fieldset>
+```
+
+Give the rows the same radio `name` so only one is chosen. Brand classes are `visa`, `mc`, and `amex`. The `:has(:checked)` selector highlights the chosen row and fills its radio dot.
+
+### Why is it useful?
+
+Checkout screens let you pick from your saved cards. This presents a radio list of payment methods with brand marks and a selected state, using only CSS. The rows are keyboard operable with a focus ring and transitions are removed under reduced motion.

--- a/submissions/examples/payment-methods-as/demo.html
+++ b/submissions/examples/payment-methods-as/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Payment Methods</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <fieldset class="pay-methods">
+    <legend>Payment method</legend>
+
+    <label class="pm-row">
+      <input type="radio" name="pm" checked aria-label="Visa ending 5540" />
+      <span class="pm-radio"></span>
+      <span class="pm-brand visa">VISA</span>
+      <span class="pm-body">
+        <span class="pm-num">•••• 5540</span>
+        <span class="pm-exp">Expires 08/28</span>
+      </span>
+      <span class="pm-default">Default</span>
+    </label>
+
+    <label class="pm-row">
+      <input type="radio" name="pm" aria-label="Mastercard ending 2214" />
+      <span class="pm-radio"></span>
+      <span class="pm-brand mc" aria-hidden="true"></span>
+      <span class="pm-body">
+        <span class="pm-num">•••• 2214</span>
+        <span class="pm-exp">Expires 03/27</span>
+      </span>
+    </label>
+
+    <label class="pm-row">
+      <input type="radio" name="pm" aria-label="Amex ending 1009" />
+      <span class="pm-radio"></span>
+      <span class="pm-brand amex">AMEX</span>
+      <span class="pm-body">
+        <span class="pm-num">•••• 1009</span>
+        <span class="pm-exp">Expires 11/26</span>
+      </span>
+    </label>
+  </fieldset>
+</body>
+</html>

--- a/submissions/examples/payment-methods-as/style.css
+++ b/submissions/examples/payment-methods-as/style.css
@@ -1,0 +1,159 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.pay-methods {
+  width: min(380px, 94vw);
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  border: none;
+}
+
+.pay-methods legend {
+  padding: 0;
+  margin-bottom: 1rem;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.pm-row {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.85rem 1rem;
+  margin-bottom: 0.6rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.pm-row:hover {
+  border-color: #33415c;
+}
+
+.pm-row input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  margin: -1px;
+  overflow: hidden;
+}
+
+.pm-radio {
+  flex: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 2px solid #475569;
+  display: grid;
+  place-items: center;
+  transition: border-color 0.15s ease;
+}
+
+.pm-radio::after {
+  content: "";
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #6c63ff;
+  transform: scale(0);
+  transition: transform 0.15s ease;
+}
+
+.pm-brand {
+  flex: none;
+  width: 46px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  border-radius: 6px;
+  font-size: 0.7rem;
+  font-weight: 800;
+  font-style: italic;
+  color: #fff;
+  letter-spacing: 0.02em;
+}
+
+.pm-brand.visa {
+  background: #1a1f71;
+}
+
+.pm-brand.mc {
+  background: #1b2942;
+}
+
+.pm-brand.mc::before {
+  content: "";
+  width: 30px;
+  height: 18px;
+  background:
+    radial-gradient(circle at 10px 9px, #eb001b 9px, transparent 9px),
+    radial-gradient(circle at 20px 9px, rgba(247, 158, 27, 0.9) 9px, transparent 9px);
+}
+
+.pm-brand.amex {
+  background: #2e77bc;
+}
+
+.pm-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.pm-num {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.pm-exp {
+  font-size: 0.74rem;
+  color: #64748b;
+}
+
+.pm-default {
+  flex: none;
+  font-size: 0.62rem;
+  font-weight: 800;
+  padding: 0.1rem 0.4rem;
+  border-radius: 5px;
+  background: rgba(52, 211, 153, 0.16);
+  color: #6ee7b7;
+}
+
+.pm-row:has(:checked) {
+  border-color: #6c63ff;
+  background: rgba(108, 99, 255, 0.1);
+}
+
+.pm-row:has(:checked) .pm-radio {
+  border-color: #6c63ff;
+}
+
+.pm-row:has(:checked) .pm-radio::after {
+  transform: scale(1);
+}
+
+.pm-row:has(:focus-visible) {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pm-row,
+  .pm-radio,
+  .pm-radio::after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a payment methods list built for #41351. A radio list of saved cards with brand marks and a selected state, using only CSS. Closes #41351.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A list of saved payment methods where each row is a selectable radio option with a card brand mark, last four digits, and expiry; the selected card is highlighted and the default card shows a badge.

**How does a developer use it?**

```html
<fieldset class="pay-methods">
  <legend>Payment method</legend>
  <label class="pm-row">
    <input type="radio" name="pm" checked aria-label="Visa ending 5540" />
    <span class="pm-radio"></span>
    <span class="pm-brand visa">VISA</span>
    <span class="pm-body"><span class="pm-num">•••• 5540</span><span class="pm-exp">Expires 08/28</span></span>
    <span class="pm-default">Default</span>
  </label>
</fieldset>
```

**Why does it fit EaseMotion CSS?**
It presents a radio list of payment methods with brand marks and a selected state via `:has(:checked)`, using only CSS. The rows are keyboard operable with a focus ring and transitions are removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: three method rows render with brand marks and one default badge; the checked row highlights with the accent border and selecting another row moves the highlight.
