### PR TITLE
feat: add quiz option

### DIFF
--- a/submissions/examples/quiz-option-as/README.md
+++ b/submissions/examples/quiz-option-as/README.md
@@ -1,0 +1,23 @@
+# Quiz Option
+
+### What does this do?
+
+It shows a multiple choice quiz question where the options are radio buttons styled as answer cards. When the quiz is answered, the correct option shows a green check and the chosen wrong option shows a red cross. It works with no JavaScript.
+
+### How is it used?
+
+```html
+<fieldset class="quiz answered">
+  <legend>Which CSS property distributes space in flexbox?</legend>
+  <div class="q-list">
+    <label class="q-opt is-correct"><input type="radio" name="q" /><span class="q-key">A</span><span class="q-text">justify-content</span><span class="q-mark"><svg>...</svg></span></label>
+    <label class="q-opt is-wrong"><input type="radio" name="q" checked /><span class="q-key">B</span><span class="q-text">text-align</span><span class="q-mark"><svg>...</svg></span></label>
+  </div>
+</fieldset>
+```
+
+Before answering, options highlight on selection. Adding `answered` to the fieldset reveals the marks: `is-correct` turns green with a check, and a chosen `is-wrong` turns red with a cross.
+
+### Why is it useful?
+
+Quizzes and courses show answer options with a correct and wrong reveal. This styles radio options as answer cards with selected, correct, and wrong states, using only CSS. Options are keyboard operable with a focus ring and transitions are removed under reduced motion.

--- a/submissions/examples/quiz-option-as/demo.html
+++ b/submissions/examples/quiz-option-as/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Quiz Option</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <fieldset class="quiz answered">
+    <span class="q-tag">Question 3 of 10</span>
+    <legend>Which CSS property distributes space along the main axis in flexbox?</legend>
+    <div class="q-list">
+      <label class="q-opt is-correct">
+        <input type="radio" name="q" aria-label="justify-content" />
+        <span class="q-key">A</span>
+        <span class="q-text">justify-content</span>
+        <span class="q-mark"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m5 13 4 4 10-11" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
+      </label>
+      <label class="q-opt is-wrong">
+        <input type="radio" name="q" checked aria-label="text-align" />
+        <span class="q-key">B</span>
+        <span class="q-text">text-align</span>
+        <span class="q-mark"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6l12 12M18 6 6 18" stroke-linecap="round" /></svg></span>
+      </label>
+      <label class="q-opt">
+        <input type="radio" name="q" aria-label="align-items" />
+        <span class="q-key">C</span>
+        <span class="q-text">align-items</span>
+        <span class="q-mark"></span>
+      </label>
+      <label class="q-opt">
+        <input type="radio" name="q" aria-label="vertical-align" />
+        <span class="q-key">D</span>
+        <span class="q-text">vertical-align</span>
+        <span class="q-mark"></span>
+      </label>
+    </div>
+  </fieldset>
+</body>
+</html>

--- a/submissions/examples/quiz-option-as/style.css
+++ b/submissions/examples/quiz-option-as/style.css
@@ -1,0 +1,148 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.quiz {
+  width: min(400px, 94vw);
+  box-sizing: border-box;
+  margin: 0;
+  padding: 1.6rem 1.7rem;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+}
+
+.quiz legend {
+  padding: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.q-tag {
+  display: inline-block;
+  margin-bottom: 0.7rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #a5b4fc;
+}
+
+.q-list {
+  margin-top: 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.q-opt {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  padding: 0.85rem 1rem;
+  border: 1.5px solid #26324a;
+  border-radius: 11px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.q-opt:hover {
+  border-color: #33415c;
+}
+
+.q-opt input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  margin: -1px;
+  overflow: hidden;
+}
+
+.q-key {
+  flex: none;
+  width: 26px;
+  height: 26px;
+  display: grid;
+  place-items: center;
+  border-radius: 7px;
+  background: #1b2942;
+  color: #94a3b8;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.q-opt span.q-text {
+  flex: 1;
+  font-size: 0.9rem;
+}
+
+.q-mark {
+  flex: none;
+  width: 22px;
+  height: 22px;
+  display: grid;
+  place-items: center;
+  opacity: 0;
+}
+
+.q-mark svg {
+  width: 20px;
+  height: 20px;
+  stroke-width: 2.5;
+  fill: none;
+}
+
+.q-opt:has(:checked) {
+  border-color: #6c63ff;
+  background: rgba(108, 99, 255, 0.1);
+}
+
+.q-opt:has(:checked) .q-key {
+  background: #6c63ff;
+  color: #fff;
+}
+
+.quiz.answered .q-opt.is-correct {
+  border-color: #34d399;
+  background: rgba(16, 185, 129, 0.12);
+}
+
+.quiz.answered .q-opt.is-correct .q-mark {
+  opacity: 1;
+  color: #34d399;
+}
+
+.quiz.answered .q-opt.is-wrong:has(:checked) {
+  border-color: #f87171;
+  background: rgba(239, 68, 68, 0.12);
+}
+
+.quiz.answered .q-opt.is-wrong:has(:checked) .q-mark {
+  opacity: 1;
+  color: #f87171;
+}
+
+.quiz.answered .q-opt {
+  cursor: default;
+}
+
+.q-opt:has(:focus-visible) {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .q-opt {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a quiz option built for #41354. Radio answer cards with selected, correct, and wrong reveal states, using only CSS. Closes #41354.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A multiple choice quiz question with radio options styled as answer cards; when answered, the correct option shows a green check and the chosen wrong option shows a red cross.

**How does a developer use it?**

```html
<fieldset class="quiz answered">
  <legend>Which CSS property distributes space in flexbox?</legend>
  <div class="q-list">
    <label class="q-opt is-correct"><input type="radio" name="q" /><span class="q-key">A</span><span class="q-text">justify-content</span><span class="q-mark"><svg>...</svg></span></label>
    <label class="q-opt is-wrong"><input type="radio" name="q" checked /><span class="q-key">B</span><span class="q-text">text-align</span><span class="q-mark"><svg>...</svg></span></label>
  </div>
</fieldset>
```

**Why does it fit EaseMotion CSS?**
It styles radio options as answer cards with selected, correct, and wrong states, using only CSS. Adding `answered` to the fieldset reveals the marks. Options are keyboard operable with a focus ring and transitions are removed under reduced motion.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: four answer options render, and in the answered state the correct option shows a green check (green border) while the chosen wrong option shows a red cross.
