### PR TITLE
feat: add agenda list

### DIFF
--- a/submissions/examples/agenda-list-as/README.md
+++ b/submissions/examples/agenda-list-as/README.md
@@ -1,0 +1,22 @@
+# Agenda List
+
+### What does this do?
+
+It shows a day agenda that lists events down a time column, each with a start time, a colored accent bar, a title, and a location. The current event is highlighted with a Now badge.
+
+### How is it used?
+
+```html
+<ol class="agenda">
+  <li class="ag-item is-now">
+    <time>10:00</time>
+    <div class="ag-card blue"><strong>Design sync</strong><small><svg>...</svg>Video call</small></div>
+  </li>
+</ol>
+```
+
+Each item is a two column row of the time and an event card. Give the card a color class (`blue`, `cyan`, `green`, `amber`) for its left bar, and add `is-now` to the item that is happening now.
+
+### Why is it useful?
+
+Calendars and schedules show a day view as a list of timed events. This lays out an agenda with a time column, colored event cards, and a now highlight, using only CSS and inline SVG so there are no external assets.

--- a/submissions/examples/agenda-list-as/demo.html
+++ b/submissions/examples/agenda-list-as/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Agenda List</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="agenda-card">
+    <h2>Today</h2>
+    <p class="sub">Tuesday, 14 July</p>
+    <ol class="agenda">
+      <li class="ag-item">
+        <time>08:30</time>
+        <div class="ag-card cyan">
+          <strong>Morning review</strong>
+          <small><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 21s-7-5.7-7-11a7 7 0 0 1 14 0c0 5.3-7 11-7 11z" stroke-linejoin="round" /><circle cx="12" cy="10" r="2.5" /></svg>Room 2A</small>
+        </div>
+      </li>
+      <li class="ag-item is-now">
+        <time>10:00</time>
+        <div class="ag-card blue">
+          <strong>Design sync</strong>
+          <small><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M15 10l4.5-2.5v9L15 14M3 6h12v12H3z" stroke-linejoin="round" /></svg>Video call</small>
+        </div>
+      </li>
+      <li class="ag-item">
+        <time>13:00</time>
+        <div class="ag-card green">
+          <strong>Lunch with Priya</strong>
+          <small><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 21s-7-5.7-7-11a7 7 0 0 1 14 0c0 5.3-7 11-7 11z" stroke-linejoin="round" /><circle cx="12" cy="10" r="2.5" /></svg>The Loft</small>
+        </div>
+      </li>
+      <li class="ag-item">
+        <time>15:30</time>
+        <div class="ag-card amber">
+          <strong>Release planning</strong>
+          <small><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M15 10l4.5-2.5v9L15 14M3 6h12v12H3z" stroke-linejoin="round" /></svg>Video call</small>
+        </div>
+      </li>
+    </ol>
+  </div>
+</body>
+</html>

--- a/submissions/examples/agenda-list-as/style.css
+++ b/submissions/examples/agenda-list-as/style.css
@@ -1,0 +1,118 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.agenda-card {
+  width: min(380px, 94vw);
+  padding: 1.5rem 1.6rem;
+  box-sizing: border-box;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+}
+
+.agenda-card h2 {
+  margin: 0 0 0.2rem;
+  font-size: 1.05rem;
+}
+
+.agenda-card .sub {
+  margin: 0 0 1.3rem;
+  font-size: 0.8rem;
+  color: #94a3b8;
+}
+
+.agenda {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.ag-item {
+  display: grid;
+  grid-template-columns: 48px 1fr;
+  gap: 0.9rem;
+  padding-bottom: 1.1rem;
+}
+
+.ag-item time {
+  font-size: 0.76rem;
+  font-weight: 700;
+  color: #94a3b8;
+  padding-top: 0.2rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.ag-card {
+  padding: 0.7rem 0.9rem;
+  border-radius: 10px;
+  background: #131f34;
+  border-left: 3px solid #6c63ff;
+}
+
+.ag-card.blue {
+  border-left-color: #6c63ff;
+}
+
+.ag-card.cyan {
+  border-left-color: #22d3ee;
+}
+
+.ag-card.green {
+  border-left-color: #34d399;
+}
+
+.ag-card.amber {
+  border-left-color: #f59e0b;
+}
+
+.ag-card strong {
+  display: block;
+  font-size: 0.9rem;
+}
+
+.ag-card small {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  margin-top: 0.25rem;
+  font-size: 0.74rem;
+  color: #94a3b8;
+}
+
+.ag-card small svg {
+  width: 12px;
+  height: 12px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+}
+
+.ag-item.is-now time {
+  color: #a5b4fc;
+}
+
+.ag-item.is-now .ag-card {
+  background: rgba(108, 99, 255, 0.14);
+  box-shadow: 0 0 0 1px #6c63ff;
+}
+
+.ag-item.is-now .ag-card strong::after {
+  content: "Now";
+  margin-left: 0.5rem;
+  font-size: 0.6rem;
+  font-weight: 800;
+  padding: 0.05rem 0.35rem;
+  border-radius: 5px;
+  background: #6c63ff;
+  color: #fff;
+  vertical-align: middle;
+}


### PR DESCRIPTION
## Pull Request Description

Adds an agenda list built for #41357. A day view of timed event cards with a now highlight, using only CSS. Closes #41357.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A day agenda listing events down a time column, each with a start time, a colored accent bar, a title, and a location, with the current event highlighted with a Now badge.

**How does a developer use it?**

```html
<ol class="agenda">
  <li class="ag-item is-now">
    <time>10:00</time>
    <div class="ag-card blue"><strong>Design sync</strong><small><svg>...</svg>Video call</small></div>
  </li>
</ol>
```

**Why does it fit EaseMotion CSS?**
It lays out an agenda with a time column, colored event cards, and a now highlight, using only CSS and inline SVG so there are no external assets.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: four events render on two column rows with four times, and one event is highlighted as happening now.
