### PR TITLE
feat: add profile header

### DIFF
--- a/submissions/examples/profile-header-as/README.md
+++ b/submissions/examples/profile-header-as/README.md
@@ -1,0 +1,26 @@
+# Profile Header
+
+### What does this do?
+
+It shows a social profile header with a gradient cover banner, an avatar overlapping the banner edge, a name with a verified badge, a handle and bio, a stats row of posts, followers, and following, and a follow button.
+
+### How is it used?
+
+```html
+<div class="profile">
+  <div class="pf-cover"></div>
+  <div class="pf-body">
+    <div class="pf-top"><span class="pf-avatar">AL</span><button class="pf-follow">Follow</button></div>
+    <div class="pf-name">Ada Lovelace <span class="pf-verified"><svg>...</svg></span></div>
+    <div class="pf-handle">@ada</div>
+    <p class="pf-bio">Bio text.</p>
+    <div class="pf-stats"><span class="pf-stat"><b>342</b><span>Posts</span></span></div>
+  </div>
+</div>
+```
+
+The avatar uses a negative top margin to overlap the cover, and its border matches the card background so it reads as a cutout. The stats row is a simple flex list.
+
+### Why is it useful?
+
+Social and community apps open a profile with a cover, avatar, and stats. This lays out a profile header with an overlapping avatar, a stats row, and a follow action, using only CSS and an initials avatar so there are no external images.

--- a/submissions/examples/profile-header-as/demo.html
+++ b/submissions/examples/profile-header-as/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Profile Header</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="profile">
+    <div class="pf-cover" aria-hidden="true"></div>
+    <div class="pf-body">
+      <div class="pf-top">
+        <span class="pf-avatar">AL</span>
+        <button class="pf-follow" type="button">Follow</button>
+      </div>
+      <div class="pf-name">
+        Ada Lovelace
+        <span class="pf-verified" aria-label="Verified"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m5 13 4 4 10-11" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
+      </div>
+      <div class="pf-handle">@ada · she/her</div>
+      <p class="pf-bio">Mathematician and writer. Building things with pure CSS and a lot of curiosity.</p>
+      <div class="pf-stats">
+        <span class="pf-stat"><b>342</b><span>Posts</span></span>
+        <span class="pf-stat"><b>18.4k</b><span>Followers</span></span>
+        <span class="pf-stat"><b>1,205</b><span>Following</span></span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/profile-header-as/style.css
+++ b/submissions/examples/profile-header-as/style.css
@@ -1,0 +1,134 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.profile {
+  width: min(380px, 94vw);
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 18px;
+  overflow: hidden;
+}
+
+.pf-cover {
+  height: 96px;
+  background:
+    radial-gradient(circle at 25% 40%, rgba(255, 255, 255, 0.22), transparent 45%),
+    linear-gradient(135deg, #6c63ff, #ec4899);
+}
+
+.pf-body {
+  padding: 0 1.5rem 1.5rem;
+}
+
+.pf-top {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  margin-bottom: 0.8rem;
+}
+
+.pf-avatar {
+  width: 80px;
+  height: 80px;
+  margin-top: -40px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #6c63ff, #a855f7);
+  border: 4px solid #0e1626;
+  color: #fff;
+  font-size: 1.5rem;
+  font-weight: 800;
+}
+
+.pf-follow {
+  padding: 0.5rem 1.2rem;
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #fff;
+  background: #6c63ff;
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.pf-follow:hover {
+  background: #5b52e6;
+}
+
+.pf-follow:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+.pf-name {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 1.15rem;
+  font-weight: 800;
+}
+
+.pf-verified {
+  width: 18px;
+  height: 18px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: #3b82f6;
+  color: #fff;
+  flex: none;
+}
+
+.pf-verified svg {
+  width: 11px;
+  height: 11px;
+  stroke: currentColor;
+  stroke-width: 3;
+  fill: none;
+}
+
+.pf-handle {
+  font-size: 0.82rem;
+  color: #64748b;
+}
+
+.pf-bio {
+  margin: 0.7rem 0 1.1rem;
+  font-size: 0.86rem;
+  line-height: 1.55;
+  color: #cbd5e1;
+}
+
+.pf-stats {
+  display: flex;
+  gap: 1.6rem;
+}
+
+.pf-stat b {
+  font-size: 1rem;
+  font-weight: 800;
+}
+
+.pf-stat span {
+  font-size: 0.78rem;
+  color: #64748b;
+  margin-left: 0.3rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pf-follow {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a profile header built for #41363. A cover banner with an overlapping avatar, name, bio, stats, and a follow button, using only CSS. Closes #41363.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A social profile header with a gradient cover banner, an avatar overlapping the banner edge, a name with a verified badge, a handle and bio, a stats row, and a follow button.

**How does a developer use it?**

```html
<div class="profile">
  <div class="pf-cover"></div>
  <div class="pf-body">
    <div class="pf-top"><span class="pf-avatar">AL</span><button class="pf-follow">Follow</button></div>
    <div class="pf-name">Ada Lovelace <span class="pf-verified"><svg>...</svg></span></div>
    <p class="pf-bio">Bio text.</p>
    <div class="pf-stats"><span class="pf-stat"><b>342</b><span>Posts</span></span></div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It lays out a profile header with an overlapping avatar (negative margin with a border matching the card), a stats row, and a follow action, using only CSS and an initials avatar so there are no external images.

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer

Verified in Chromium: the gradient cover renders with the avatar overlapping it, three stats, a verified badge, and a follow button.
