### PR TITLE
feat: add ripple click effect submission

### DIFF
--- a/submissions/examples/41297-ripple-click-effect/README.md
+++ b/submissions/examples/41297-ripple-click-effect/README.md
@@ -1,0 +1,5 @@
+# Ripple Click Effect
+
+1. **What does this do?** Creates a circular ripple wave that expands outward from the exact point a user clicks or taps a button, then fades out.
+2. **How is it used?** Apply the `.ripple-btn` class to any button or clickable element. A small inline script listens for clicks, calculates the click position relative to the element, and injects a `.ripple-span` element at that point to animate the ripple.
+3. **Why is it useful?** EaseMotion CSS currently has hover-based feedback (grow, shimmer) but nothing for the actual click/tap moment, which matters most on touch devices where hover doesn't apply. This resolves issue #41297 by giving buttons tactile visual feedback on press. The effect respects `prefers-reduced-motion` by disabling the animation for users who request reduced motion.

--- a/submissions/examples/41297-ripple-click-effect/demo.html
+++ b/submissions/examples/41297-ripple-click-effect/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Ripple Click Effect Demo</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <button class="ripple-btn">Click Me</button>
+
+  <a href="#" class="ripple-btn ripple-link">Ripple Link</a>
+
+  <script>
+    document.querySelectorAll('.ripple-btn').forEach(function (el) {
+      el.addEventListener('click', function (e) {
+        var rect = el.getBoundingClientRect();
+        var size = Math.max(rect.width, rect.height);
+        var span = document.createElement('span');
+
+        span.className = 'ripple-span';
+        span.style.width = span.style.height = size + 'px';
+        span.style.left = (e.clientX - rect.left - size / 2) + 'px';
+        span.style.top = (e.clientY - rect.top - size / 2) + 'px';
+
+        el.appendChild(span);
+
+        span.addEventListener('animationend', function () {
+          span.remove();
+        });
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/41297-ripple-click-effect/style.css
+++ b/submissions/examples/41297-ripple-click-effect/style.css
@@ -1,0 +1,36 @@
+.ripple-btn {
+  position: relative;
+  overflow: hidden;
+  display: inline-block;
+  cursor: pointer;
+  padding: 0.8rem 1.6rem;
+  border: 0;
+  border-radius: 8px;
+  background: #6c63ff;
+  color: white;
+  font-size: 1rem;
+  text-decoration: none;
+}
+
+.ripple-span {
+  position: absolute;
+  border-radius: 50%;
+  transform: scale(0);
+  background-color: rgba(255, 255, 255, 0.55);
+  pointer-events: none;
+  animation: ripple-expand 600ms ease-out;
+}
+
+@keyframes ripple-expand {
+  to {
+    transform: scale(2.5);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ripple-span {
+    animation: none;
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a Ripple Click Effect submission — a circular ripple animation that expands outward from the exact point a user clicks or taps a button, then fades out. This solves the gap where EaseMotion CSS has hover-based feedback but nothing for the actual click/tap moment, which matters especially on touch devices where hover doesn't apply.

## Type of Change

- [x] ✨ New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A ripple click effect that gives buttons and links tactile visual feedback on click/tap, not just hover.

**How does a developer use it?**

<button class="ripple-btn">Click Me</button>

<a href="#" class="ripple-btn ripple-link">Ripple Link</a>

**Why does it fit EaseMotion CSS?**

It's a small, single-purpose, composable class — apply .ripple-btn to any clickable element and it just works, matching the framework's human-readable, animation-first philosophy. It also respects prefers-reduced-motion, consistent with the framework's existing accessibility approach.

## Demo

- [x] Demo added (demo.html works by opening directly in a browser)

## Browser Testing

- [x] Chrome

## Notes for Maintainer

Timing (600ms) and ripple color/opacity are just my starting values — happy to adjust if you'd like different defaults once standardized into ease- naming and CSS variables.

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
