### PR TITLE
feat: add skeleton wave loader example

### DIFF
--- a/submissions/examples/skeleton-wave-loader/README.md
+++ b/submissions/examples/skeleton-wave-loader/README.md
@@ -1,0 +1,14 @@
+# Skeleton Wave Loader
+
+A reusable loading placeholder pattern for cards, lists, and dashboard panels.
+
+## What it demonstrates
+
+- animated shimmer motion with a pseudo-element
+- stable placeholder dimensions that avoid layout shift
+- responsive layout and reduced-motion support
+
+## Files
+
+- `demo.html` - loading card preview
+- `style.css` - skeleton layout and shimmer animation

--- a/submissions/examples/skeleton-wave-loader/demo.html
+++ b/submissions/examples/skeleton-wave-loader/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Skeleton Wave Loader</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell" aria-labelledby="demo-title">
+    <section class="copy">
+      <p class="eyebrow">EaseMotion loading example</p>
+      <h1 id="demo-title">Skeleton wave loader</h1>
+      <p>A lightweight placeholder pattern for cards, lists, and dashboards while content is loading.</p>
+    </section>
+
+    <section class="preview-card" aria-label="Loading card preview">
+      <div class="avatar skeleton"></div>
+      <div class="lines">
+        <span class="line skeleton wide"></span>
+        <span class="line skeleton medium"></span>
+        <span class="line skeleton narrow"></span>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/skeleton-wave-loader/style.css
+++ b/submissions/examples/skeleton-wave-loader/style.css
@@ -1,0 +1,129 @@
+:root {
+  --page: #f3f6fa;
+  --surface: #ffffff;
+  --ink: #1f2937;
+  --muted: #65758b;
+  --base: #e7edf4;
+  --shine: rgba(255, 255, 255, 0.76);
+  --accent: #0f766e;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background:
+    linear-gradient(135deg, rgba(15, 118, 110, 0.12), transparent 38%),
+    var(--page);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.demo-shell {
+  width: min(960px, calc(100vw - 32px));
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(320px, 1fr);
+  gap: 28px;
+  align-items: center;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  max-width: 10ch;
+  font-size: clamp(2.3rem, 5vw, 4.4rem);
+  line-height: 0.94;
+}
+
+.copy p:last-child {
+  max-width: 44ch;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.preview-card {
+  display: grid;
+  grid-template-columns: 72px 1fr;
+  gap: 18px;
+  align-items: center;
+  padding: 24px;
+  border: 1px solid rgba(31, 41, 55, 0.12);
+  border-radius: 20px;
+  background: var(--surface);
+  box-shadow: 0 24px 64px rgba(31, 41, 55, 0.14);
+}
+
+.avatar {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+}
+
+.lines {
+  display: grid;
+  gap: 12px;
+}
+
+.line {
+  height: 14px;
+  border-radius: 999px;
+}
+
+.wide {
+  width: 100%;
+}
+
+.medium {
+  width: 72%;
+}
+
+.narrow {
+  width: 46%;
+}
+
+.skeleton {
+  position: relative;
+  overflow: hidden;
+  background: var(--base);
+}
+
+.skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(100deg, transparent 0%, var(--shine) 50%, transparent 100%);
+  transform: translateX(-120%);
+  animation: skeleton-wave 1400ms ease-in-out infinite;
+}
+
+@keyframes skeleton-wave {
+  to {
+    transform: translateX(120%);
+  }
+}
+
+@media (max-width: 740px) {
+  .demo-shell {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton::after {
+    animation: none;
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- add a skeleton wave loading placeholder example
- include stable card dimensions and shimmer animation
- support responsive layouts and reduced-motion users

## Testing
- git diff --cached --check