### PR TITLE
feat: add tab underline slide example

### DIFF
--- a/submissions/examples/tab-underline-slide/README.md
+++ b/submissions/examples/tab-underline-slide/README.md
@@ -1,0 +1,14 @@
+# Tab Underline Slide
+
+A CSS navigation pattern for tab groups and compact settings panels.
+
+## What it demonstrates
+
+- a sliding underline powered by `:has()`
+- hover and keyboard focus-visible states
+- responsive fallback for narrow screens
+
+## Files
+
+- `demo.html` - tab navigation markup
+- `style.css` - underline motion and tab states

--- a/submissions/examples/tab-underline-slide/demo.html
+++ b/submissions/examples/tab-underline-slide/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tab Underline Slide</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-card" aria-labelledby="demo-title">
+    <p class="eyebrow">EaseMotion navigation example</p>
+    <h1 id="demo-title">Tab underline slide</h1>
+    <p class="intro">A compact tab group with a sliding underline and clear keyboard focus states.</p>
+
+    <nav class="tabs" aria-label="Demo sections">
+      <a href="#overview" class="tab active">Overview</a>
+      <a href="#activity" class="tab">Activity</a>
+      <a href="#settings" class="tab">Settings</a>
+    </nav>
+  </main>
+</body>
+</html>

--- a/submissions/examples/tab-underline-slide/style.css
+++ b/submissions/examples/tab-underline-slide/style.css
@@ -1,0 +1,141 @@
+:root {
+  --page: #f7f9fc;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #667085;
+  --accent: #2563eb;
+  --line: rgba(23, 32, 51, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 42%),
+    var(--page);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.demo-card {
+  width: min(760px, calc(100vw - 32px));
+  padding: 36px;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--surface);
+  box-shadow: 0 24px 70px rgba(23, 32, 51, 0.14);
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.2rem, 5vw, 3.8rem);
+  line-height: 1;
+}
+
+.intro {
+  max-width: 50ch;
+  margin: 16px 0 28px;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.tabs {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 4px;
+  padding: 4px;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: #f8fafc;
+}
+
+.tabs::after {
+  content: "";
+  position: absolute;
+  left: 4px;
+  bottom: 4px;
+  width: calc((100% - 8px) / 3);
+  height: 4px;
+  border-radius: 999px;
+  background: var(--accent);
+  transition: transform 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.tab {
+  position: relative;
+  z-index: 1;
+  min-height: 52px;
+  display: grid;
+  place-items: center;
+  border-radius: 12px;
+  color: var(--muted);
+  font-weight: 900;
+  text-decoration: none;
+  transition:
+    color 180ms ease,
+    transform 180ms ease,
+    background-color 180ms ease;
+}
+
+.tab:hover,
+.tab:focus-visible,
+.tab.active {
+  color: var(--ink);
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.tab:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.24);
+  outline-offset: 2px;
+}
+
+.tabs:has(.tab:nth-child(2):hover)::after,
+.tabs:has(.tab:nth-child(2):focus-visible)::after {
+  transform: translateX(100%);
+}
+
+.tabs:has(.tab:nth-child(3):hover)::after,
+.tabs:has(.tab:nth-child(3):focus-visible)::after {
+  transform: translateX(200%);
+}
+
+.tab:hover {
+  transform: translateY(-1px);
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 28px 20px;
+  }
+
+  .tabs {
+    grid-template-columns: 1fr;
+  }
+
+  .tabs::after {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tabs::after,
+  .tab {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a tab underline slide navigation example
- include hover and keyboard focus-visible states
- provide a responsive fallback for small screens

## Testing
- git diff --cached --check