### PR TITLE
feat: add form error wiggle example

### DIFF
--- a/submissions/examples/form-error-wiggle/README.md
+++ b/submissions/examples/form-error-wiggle/README.md
@@ -1,0 +1,14 @@
+# Form Error Wiggle
+
+A focused form validation motion pattern for inline error states.
+
+## What it demonstrates
+
+- short error wiggle feedback for invalid inputs
+- visible focus ring for the error field
+- delayed message reveal and reduced-motion support
+
+## Files
+
+- `demo.html` - invalid email field example
+- `style.css` - error animation and message styling

--- a/submissions/examples/form-error-wiggle/demo.html
+++ b/submissions/examples/form-error-wiggle/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Form Error Wiggle</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="form-card" aria-labelledby="demo-title">
+    <p class="eyebrow">EaseMotion form example</p>
+    <h1 id="demo-title">Form error wiggle</h1>
+
+    <label class="field field-error">
+      <span>Email address</span>
+      <input type="email" value="kunal@example" aria-invalid="true" aria-describedby="email-error">
+      <small id="email-error">Enter a complete email address.</small>
+    </label>
+  </main>
+</body>
+</html>

--- a/submissions/examples/form-error-wiggle/style.css
+++ b/submissions/examples/form-error-wiggle/style.css
@@ -1,0 +1,135 @@
+:root {
+  --page: #fff7ed;
+  --surface: #ffffff;
+  --ink: #1f2937;
+  --muted: #667085;
+  --danger: #dc2626;
+  --danger-soft: rgba(220, 38, 38, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background:
+    linear-gradient(135deg, rgba(220, 38, 38, 0.10), transparent 42%),
+    var(--page);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.form-card {
+  width: min(560px, calc(100vw - 32px));
+  padding: 36px;
+  border: 1px solid rgba(31, 41, 55, 0.12);
+  border-radius: 22px;
+  background: var(--surface);
+  box-shadow: 0 24px 70px rgba(31, 41, 55, 0.14);
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--danger);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 28px;
+  font-size: clamp(2.1rem, 5vw, 3.5rem);
+  line-height: 1;
+}
+
+.field {
+  display: grid;
+  gap: 8px;
+}
+
+.field span {
+  font-weight: 800;
+}
+
+input {
+  width: 100%;
+  min-height: 54px;
+  padding: 0 16px;
+  border: 1px solid rgba(31, 41, 55, 0.18);
+  border-radius: 14px;
+  color: var(--ink);
+  font: inherit;
+  font-weight: 700;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+input:focus {
+  outline: none;
+}
+
+.field-error input {
+  border-color: var(--danger);
+  background: #fffafa;
+  animation: error-wiggle 520ms ease both;
+}
+
+.field-error input:focus {
+  box-shadow: 0 0 0 5px var(--danger-soft);
+}
+
+small {
+  color: var(--danger);
+  font-weight: 800;
+  opacity: 0;
+  transform: translateY(-4px);
+  animation: message-rise 360ms ease 180ms forwards;
+}
+
+@keyframes error-wiggle {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  18% {
+    transform: translateX(-6px);
+  }
+  36% {
+    transform: translateX(6px);
+  }
+  54% {
+    transform: translateX(-4px);
+  }
+  72% {
+    transform: translateX(4px);
+  }
+}
+
+@keyframes message-rise {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 560px) {
+  .form-card {
+    padding: 28px 20px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .field-error input,
+  small {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a form validation error wiggle example
- include aria-invalid markup and visible error messaging
- support reduced-motion users

## Testing
- git diff --cached --check