### PR TITLE
docs: demo + writeup for em keyframe pruning bug (#40060) — see #41341 for engine fix

### DIFF
--- a/submissions/docs/engine-keyframe-pruning-fix/README.md
+++ b/submissions/docs/engine-keyframe-pruning-fix/README.md
@@ -1,0 +1,63 @@
+# Engine Bug Report + Fix Proposal — em Keyframe Pruning
+
+## What this is
+
+A standalone, browser-openable demo documenting a bug in the motion
+engine's `optimizeHtml()` tree-shaker, and the proposed fix.
+
+This folder is submitted under `submissions/docs/` per repo
+convention. It does **not** modify any engine files directly — the
+actual code fix (2-file diff in `easemotion/engine/compiler.js` and
+`easemotion/engine/optimizer.js`, plus 5 new tests in
+`tests/engine.test.js`) is available on branch
+`fix/40060-em-keyframe-pruning` and was submitted as PR #41341.
+
+That PR was auto-closed by the repository's submission guard, which
+currently treats all `easemotion/engine/` changes as disallowed
+core-file edits — even though `CONTRIBUTING.md`'s "Contributing to
+the Motion Engine" section describes `easemotion/engine/` as an
+active, maintainer-approved contribution track. This doc submission
+exists so the bug and fix are documented and reviewable within the
+current guard rules, while that process question gets resolved.
+
+## The bug
+
+`optimizeHtml()` compiles CSS rules for `em="..."` attributes but
+never registers the keyframe those rules depend on in
+`usedKeyframes` before the optimizer's pruning step runs — so a
+generated rule can end up referencing a `@keyframes` block that's
+already been stripped from the output.
+
+**Repro (from the original issue):**
+```js
+const result = await optimizeHtml('<div em="fade-in"></div>', css);
+// result.css contains the animation rule referencing ease-kf-fade-in,
+// but NOT the @keyframes ease-kf-fade-in block itself.
+```
+
+## Why it happens
+
+`usedKeyframes` is built only from `ease-*` utility classes via a
+naive `ease-*` → `ease-kf-*` string replace. `em=""` attributes
+compile to hashed `_em_xxxxx` class names, which never match that
+pattern, so their required keyframe silently falls through.
+
+## The fix (see PR #41341 / branch `fix/40060-em-keyframe-pruning`)
+
+- Export the compiler's existing `KEYFRAME_MAP` lookup table.
+- In the optimizer's `em` processing loop, register
+  `KEYFRAME_MAP[ast.animation]` into `usedKeyframes` before pruning
+  runs.
+
+## How to view this demo
+
+Open `demo.html` directly in any browser — no server, no build step.
+It inlines a minimal, faithful reproduction of the real
+`pruneKeyframes()` logic (not the full engine, to keep the demo
+import-free and file:// safe) and shows the buggy output next to the
+fixed output side by side.
+
+## Related
+
+- Issue: #40060
+- Fix PR (contains the real engine diff): #41341

--- a/submissions/docs/engine-keyframe-pruning-fix/demo.html
+++ b/submissions/docs/engine-keyframe-pruning-fix/demo.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Engine Bug Demo — em Keyframe Pruning (#40060)</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="wrap">
+    <h1>Motion Engine Bug: em-Generated Keyframes Get Pruned</h1>
+    <p class="lede">
+      A minimal, runnable reproduction of issue
+      <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/40060" target="_blank" rel="noopener">#40060</a>,
+      plus the proposed fix — inlined here so this demo runs standalone,
+      without importing the real engine modules.
+    </p>
+
+    <section class="panel">
+      <h2>Live preview</h2>
+      <div class="stage">
+        <div class="box current"></div>
+        <p class="box-label">Box animates using em="fade-in" styling logic</p>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2>What's broken (current optimizer logic)</h2>
+      <pre id="before-output" class="code-output"></pre>
+    </section>
+
+    <section class="panel">
+      <h2>What the fix produces</h2>
+      <pre id="after-output" class="code-output"></pre>
+    </section>
+
+    <section class="panel explain">
+      <h2>Root cause</h2>
+      <p>
+        <code>usedKeyframes</code> is built only from
+        <code>ease-*</code>-prefixed classes via a naive
+        <code>ease-*</code> → <code>ease-kf-*</code> string replace.
+        <code>em="..."</code> attributes compile to hashed
+        <code>_em_xxxxx</code> class names, which never match that
+        pattern — so the keyframe an em-generated rule actually needs
+        is never registered before pruning runs, and gets stripped.
+      </p>
+      <h2>Fix</h2>
+      <p>
+        Export the compiler's existing <code>KEYFRAME_MAP</code> and,
+        while processing each parsed <code>em</code> AST, register its
+        mapped keyframe into <code>usedKeyframes</code> before pruning
+        executes. See linked PR for the full engine-file diff.
+      </p>
+    </section>
+  </main>
+
+  <script>
+    // ── Minimal, faithful inline reproduction of the real bug ──
+    // (Mirrors easemotion/engine/optimizer.js + compiler.js logic
+    // exactly, scoped down for a standalone, no-import demo.)
+
+    const KEYFRAME_MAP = {
+      'fade-in': 'ease-kf-fade-in',
+    };
+
+    const sampleCss = `
+@keyframes ease-kf-fade-in { from { opacity:0 } to { opacity:1 } }
+@keyframes ease-kf-slide-up { from { transform:translateY(24px) } to { transform:none } }
+`.trim();
+
+    function pruneKeyframes(css, usedKeyframes) {
+      const kfRe = /@keyframes\s+([\w-]+)\s*\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}/g;
+      return css.replace(kfRe, (block, name) => (usedKeyframes.has(name) ? block : ''));
+    }
+
+    // BEFORE: bug reproduced — em-generated rule references a keyframe
+    // that usedKeyframes never learns about.
+    function optimizeBuggy() {
+      const usedKeyframes = new Set(); // never populated from em usage
+      const rule = `._em_a1b2c3 { animation: ${KEYFRAME_MAP['fade-in']} 300ms both; }`;
+      const prunedCss = pruneKeyframes(sampleCss, usedKeyframes);
+      return `${prunedCss}\n\n${rule}`.trim();
+    }
+
+    // AFTER: fix applied — keyframe registered before pruning.
+    function optimizeFixed() {
+      const usedKeyframes = new Set();
+      const animation = 'fade-in';
+      const keyframe = KEYFRAME_MAP[animation];
+      if (keyframe) usedKeyframes.add(keyframe); // <- the fix
+      const rule = `._em_a1b2c3 { animation: ${keyframe} 300ms both; }`;
+      const prunedCss = pruneKeyframes(sampleCss, usedKeyframes);
+      return `${prunedCss}\n\n${rule}`.trim();
+    }
+
+    document.getElementById('before-output').textContent = optimizeBuggy();
+    document.getElementById('after-output').textContent = optimizeFixed();
+  </script>
+</body>
+</html>

--- a/submissions/docs/engine-keyframe-pruning-fix/style.css
+++ b/submissions/docs/engine-keyframe-pruning-fix/style.css
@@ -1,0 +1,116 @@
+:root {
+  --ink: #1a1a2e;
+  --muted: #5a5a72;
+  --bg: #f6f6fb;
+  --panel: #ffffff;
+  --border: #e2e2ef;
+  --accent-bad: #d64545;
+  --accent-good: #2f9e5c;
+  --radius: 10px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2.5rem 1.5rem;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, sans-serif;
+  line-height: 1.55;
+}
+
+.wrap {
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+h1 {
+  font-size: 1.6rem;
+  margin-bottom: 0.4rem;
+}
+
+.lede {
+  color: var(--muted);
+  margin-bottom: 2rem;
+}
+
+.lede a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 1.25rem;
+}
+
+.panel h2 {
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  margin: 0 0 0.75rem;
+}
+
+.stage {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1.5rem 0;
+}
+
+.box {
+  width: 64px;
+  height: 64px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  animation: demo-fade-in 900ms cubic-bezier(0.4, 0, 0.2, 1) both;
+}
+
+@keyframes demo-fade-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.box-label {
+  font-size: 0.85rem;
+  color: var(--muted);
+  margin: 0;
+}
+
+.code-output {
+  background: #12121c;
+  color: #d6d6e6;
+  padding: 1rem;
+  border-radius: 8px;
+  overflow-x: auto;
+  font-size: 0.85rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+#before-output {
+  border-left: 4px solid var(--accent-bad);
+}
+
+#after-output {
+  border-left: 4px solid var(--accent-good);
+}
+
+.explain p {
+  margin: 0 0 1rem;
+}
+
+.explain code {
+  background: #eeeef7;
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+  font-size: 0.9em;
+}


### PR DESCRIPTION
## Pull Request Description

Standalone documentation + demo for the motion engine bug described
in #40060 (`optimizeHtml()` can prune a `@keyframes` block that an
`em="..."`-generated rule still references).

**This PR does not contain the actual code fix.** The real fix — a
2-file diff in `easemotion/engine/compiler.js` and
`easemotion/engine/optimizer.js`, plus 5 new tests in
`tests/engine.test.js` — was submitted as #41341 and auto-closed by
the submission guard, since it (correctly, per the guard's current
rules) touches files outside `submissions/`. That PR is still open
for maintainer review; see notes below.

This submission exists so the bug is documented and the demo is
reviewable within the current guard constraints while the process
question in #41341 gets resolved.

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (`submissions/docs/engine-keyframe-pruning-fix/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — original CSS for this demo's UI
- [x] Includes `README.md` — root cause, fix summary, and links to #40060 / #41341
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A browser-openable demo reproducing the em-keyframe-pruning bug side
by side with the fixed behavior, using an inlined, minimal version
of the real `pruneKeyframes()` logic (no imports from
`easemotion/engine/`, so it runs standalone via `file://`).

**How does a developer use it?**
Open `demo.html` directly — no build step, no server. It renders a
live `em="fade-in"`-style animated box, then prints the buggy vs.
fixed optimizer output below it for comparison.

**Why does it fit EaseMotion CSS?**
It documents a real correctness issue in the motion engine's
build-time tree-shaker in a way that's runnable and verifiable by
anyone reviewing the issue, without needing to check out a branch.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

- The actual engine fix lives on branch `fix/40060-em-keyframe-pruning`
  and was opened as #41341. It was auto-closed by the guard for
  touching `easemotion/engine/compiler.js`, `optimizer.js`, and
  `tests/engine.test.js` — files outside `submissions/`.
- `CONTRIBUTING.md` has a dedicated "Contributing to the Motion
  Engine" section describing `easemotion/engine/` as a
  maintainer-approval contribution track, distinct from the
  `core/`/`components/` freeze. The guard doesn't currently
  distinguish between the two, so genuine engine fixes get closed
  the same as core-file violations.
- `git log` shows only two commits have ever touched
  `easemotion/engine/*.js`: your original `feat: add motion engine`
  commit and my fix commit in #41341 — so this may be the first time
  a contributor has attempted an engine PR under the current
  automation, and it's surfacing a real gap between the docs and the
  guard rules.
- This `submissions/docs/` PR is meant to keep the bug documented and
  reviewable in the meantime. If you'd like the actual fix delivered
  differently (e.g. a different branch structure, or you'll apply it
  yourself), just let me know on #41341 and I'll follow whatever
  process works best.

Happy to adjust anything here — mainly wanted to make sure the bug
and its fix don't get lost due to a tooling/docs mismatch.