### PR TITLE
fix: add visible border to ghost button

### DIFF
--- a/components/buttons.css
+++ b/components/buttons.css
@@ -117,8 +117,8 @@
   --ease-btn-loading-color: var(--ease-color-neutral-700, #334155);
 
   background-color: transparent;
-  color: var(--ease-color-neutral-700, #334155);
-  border-color: transparent;
+  color: var(--ease-color-muted);
+  border-color: var(--ease-color-neutral-300);
 }
 
 @media (hover: hover) and (pointer: fine) {


### PR DESCRIPTION
Closes #41391

## What changed
Added a visible \order-color\ to \.ease-btn-ghost\ so the button box is visible. Previously it had \order-color: transparent\ making it indistinguishable from plain text.

## Changes
- \components/buttons.css\: Changed \order-color: transparent\ to \ar(--ease-color-neutral-300)\ and \color\ to \ar(--ease-color-muted)\ for theme support