### PR TITLE
fix: add visible border to ghost button

### DIFF
--- a/submissions/examples/ghost-button-border-fix/README.md
+++ b/submissions/examples/ghost-button-border-fix/README.md
@@ -1,0 +1,7 @@
+# Ghost Button Border Fix
+
+## Problem
+`.ease-btn-ghost` has `border-color: transparent` making it invisible — no button box, just text.
+
+## Fix
+Set `border-color: var(--ease-color-neutral-300)` and `color: var(--ease-color-muted)` so the button is visible in both light and dark themes.

--- a/submissions/examples/ghost-button-border-fix/demo.html
+++ b/submissions/examples/ghost-button-border-fix/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html data-theme="dark">
+<head>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <style>
+    body { background: var(--ease-color-bg); padding: 2rem; font-family: Inter, sans-serif; }
+    h2 { color: var(--ease-color-text); margin-bottom: 1rem; }
+    p { color: var(--ease-color-muted); margin-bottom: 2rem; }
+    .row { display: flex; gap: 1rem; flex-wrap: wrap; align-items: center; }
+  </style>
+</head>
+<body>
+  <h2>Ghost Button Missing Border</h2>
+  <p>The ghost button (last one) has no visible box — compare with others.</p>
+  <div class="row">
+    <button class="ease-btn ease-btn-primary">Primary</button>
+    <button class="ease-btn ease-btn-outline">Outline</button>
+    <button class="ease-btn ease-btn-ghost">Ghost</button>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ghost-button-border-fix/style.css
+++ b/submissions/examples/ghost-button-border-fix/style.css
@@ -1,0 +1,4 @@
+.ease-btn-ghost {
+  border-color: var(--ease-color-neutral-300);
+  color: var(--ease-color-muted);
+}


### PR DESCRIPTION
Closes #41391

## What changed
Added demo submission showing that \.ease-btn-ghost\ has \order-color: transparent\ making its bounding box invisible — indistinguishable from plain text.

## Changes
- \submissions/examples/ghost-button-border-fix/demo.html\ — interactive demo comparing ghost button vs other variants
- \submissions/examples/ghost-button-border-fix/style.css\ — proposed fix
- \submissions/examples/ghost-button-border-fix/README.md\ — description