### PR TITLE
feat(submissions): add scss-staggered-child-animations mixin and util…

### DIFF
--- a/submissions/scss/scss-staggered-child-animations/README.md
+++ b/submissions/scss/scss-staggered-child-animations/README.md
@@ -1,0 +1,43 @@
+# Staggered Child Animations (`ease-stagger`)
+
+This submission provides a set of SCSS mixins and utility classes that utilize `:nth-child()` selectors to automatically apply incremental `animation-delay` values to nested child elements. 
+
+This allows for seamless sequential reveals of lists, grids, or cards without needing to manually apply a delay class (like `.delay-1`, `.delay-2`) to every single item.
+
+## Included Utility Classes
+
+- `.ease-stagger-fast`: 0.05s step delay per child
+- `.ease-stagger-normal`: 0.1s step delay per child
+- `.ease-stagger-slow`: 0.2s step delay per child
+
+## Usage Example
+
+Simply apply the stagger class to the **parent container**, and ensure the child elements have an animation applied (e.g., `.ease-fade-in` or `.ease-slide-up`).
+
+### HTML Example
+
+```html
+<ul class="ease-stagger-normal">
+  <li class="ease-slide-up">Item 1</li>
+  <li class="ease-slide-up">Item 2</li>
+  <li class="ease-slide-up">Item 3</li>
+  <li class="ease-slide-up">Item 4</li>
+</ul>
+```
+
+### SCSS Mixin Usage
+
+If you prefer to use the mixin in your own custom classes:
+
+```scss
+@import 'staggered-child-animations';
+
+.my-custom-grid {
+  // Applies a 0.15s stagger to up to 10 children, starting at a 0.5s initial delay
+  @include ease-stagger-children($count: 10, $step: 0.15s, $start: 0.5s);
+}
+```
+
+## Why this is useful
+
+Currently, developers using EaseMotion CSS have to write inline styles or apply 10 different utility classes to 10 different elements to create a waterfall/staggered reveal effect. This submission significantly cleans up HTML and improves developer experience by offloading the stagger math to CSS pseudo-classes.

--- a/submissions/scss/scss-staggered-child-animations/_staggered-child-animations.scss
+++ b/submissions/scss/scss-staggered-child-animations/_staggered-child-animations.scss
@@ -1,0 +1,48 @@
+// ==========================================
+// Staggered Child Animations Utility Classes
+// EaseMotion CSS Submission
+// Resolves Issue #518
+// ==========================================
+
+// ------------------------------------------
+// Configuration
+// ------------------------------------------
+
+$ease-stagger-max-children: 20 !default;
+$ease-stagger-step-fast: 0.05s !default;
+$ease-stagger-step-normal: 0.1s !default;
+$ease-stagger-step-slow: 0.2s !default;
+$ease-stagger-start: 0s !default;
+
+// ------------------------------------------
+// Mixin
+// Generates `:nth-child` rules for staggered animation delay
+// ------------------------------------------
+
+@mixin ease-stagger-children(
+  $count: $ease-stagger-max-children,
+  $step: $ease-stagger-step-normal,
+  $start: $ease-stagger-start
+) {
+  @for $i from 1 through $count {
+    > *:nth-child(#{$i}) {
+      animation-delay: $start + (($i - 1) * $step);
+    }
+  }
+}
+
+// ------------------------------------------
+// Generate utilities
+// ------------------------------------------
+
+.ease-stagger-fast {
+  @include ease-stagger-children($ease-stagger-max-children, $ease-stagger-step-fast);
+}
+
+.ease-stagger-normal {
+  @include ease-stagger-children($ease-stagger-max-children, $ease-stagger-step-normal);
+}
+
+.ease-stagger-slow {
+  @include ease-stagger-children($ease-stagger-max-children, $ease-stagger-step-slow);
+}

--- a/submissions/scss/scss-staggered-child-animations/demo.html
+++ b/submissions/scss/scss-staggered-child-animations/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ease Stagger Demo</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css">
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body { font-family: 'Inter', sans-serif; display: flex; flex-direction: column; align-items: center; padding: 40px; background: #f9fafb; gap: 40px; }
+    .grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; max-width: 600px; width: 100%; }
+    .card { background: white; padding: 20px; border-radius: 8px; box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1); text-align: center; }
+  </style>
+</head>
+<body>
+  <h1>Staggered Child Animations Demo</h1>
+  <p>Refresh the page to see the staggered `ease-slide-up` reveal effect.</p>
+
+  <div class="grid ease-stagger-normal">
+    <div class="card ease-slide-up">Item 1</div>
+    <div class="card ease-slide-up">Item 2</div>
+    <div class="card ease-slide-up">Item 3</div>
+    <div class="card ease-slide-up">Item 4</div>
+    <div class="card ease-slide-up">Item 5</div>
+    <div class="card ease-slide-up">Item 6</div>
+  </div>
+</body>
+</html>

--- a/submissions/scss/scss-staggered-child-animations/style.css
+++ b/submissions/scss/scss-staggered-child-animations/style.css
@@ -1,0 +1,184 @@
+.ease-stagger-fast > *:nth-child(1) {
+  animation-delay: 0s;
+}
+.ease-stagger-fast > *:nth-child(2) {
+  animation-delay: 0.05s;
+}
+.ease-stagger-fast > *:nth-child(3) {
+  animation-delay: 0.1s;
+}
+.ease-stagger-fast > *:nth-child(4) {
+  animation-delay: 0.15s;
+}
+.ease-stagger-fast > *:nth-child(5) {
+  animation-delay: 0.2s;
+}
+.ease-stagger-fast > *:nth-child(6) {
+  animation-delay: 0.25s;
+}
+.ease-stagger-fast > *:nth-child(7) {
+  animation-delay: 0.3s;
+}
+.ease-stagger-fast > *:nth-child(8) {
+  animation-delay: 0.35s;
+}
+.ease-stagger-fast > *:nth-child(9) {
+  animation-delay: 0.4s;
+}
+.ease-stagger-fast > *:nth-child(10) {
+  animation-delay: 0.45s;
+}
+.ease-stagger-fast > *:nth-child(11) {
+  animation-delay: 0.5s;
+}
+.ease-stagger-fast > *:nth-child(12) {
+  animation-delay: 0.55s;
+}
+.ease-stagger-fast > *:nth-child(13) {
+  animation-delay: 0.6s;
+}
+.ease-stagger-fast > *:nth-child(14) {
+  animation-delay: 0.65s;
+}
+.ease-stagger-fast > *:nth-child(15) {
+  animation-delay: 0.7s;
+}
+.ease-stagger-fast > *:nth-child(16) {
+  animation-delay: 0.75s;
+}
+.ease-stagger-fast > *:nth-child(17) {
+  animation-delay: 0.8s;
+}
+.ease-stagger-fast > *:nth-child(18) {
+  animation-delay: 0.85s;
+}
+.ease-stagger-fast > *:nth-child(19) {
+  animation-delay: 0.9s;
+}
+.ease-stagger-fast > *:nth-child(20) {
+  animation-delay: 0.95s;
+}
+
+.ease-stagger-normal > *:nth-child(1) {
+  animation-delay: 0s;
+}
+.ease-stagger-normal > *:nth-child(2) {
+  animation-delay: 0.1s;
+}
+.ease-stagger-normal > *:nth-child(3) {
+  animation-delay: 0.2s;
+}
+.ease-stagger-normal > *:nth-child(4) {
+  animation-delay: 0.3s;
+}
+.ease-stagger-normal > *:nth-child(5) {
+  animation-delay: 0.4s;
+}
+.ease-stagger-normal > *:nth-child(6) {
+  animation-delay: 0.5s;
+}
+.ease-stagger-normal > *:nth-child(7) {
+  animation-delay: 0.6s;
+}
+.ease-stagger-normal > *:nth-child(8) {
+  animation-delay: 0.7s;
+}
+.ease-stagger-normal > *:nth-child(9) {
+  animation-delay: 0.8s;
+}
+.ease-stagger-normal > *:nth-child(10) {
+  animation-delay: 0.9s;
+}
+.ease-stagger-normal > *:nth-child(11) {
+  animation-delay: 1s;
+}
+.ease-stagger-normal > *:nth-child(12) {
+  animation-delay: 1.1s;
+}
+.ease-stagger-normal > *:nth-child(13) {
+  animation-delay: 1.2s;
+}
+.ease-stagger-normal > *:nth-child(14) {
+  animation-delay: 1.3s;
+}
+.ease-stagger-normal > *:nth-child(15) {
+  animation-delay: 1.4s;
+}
+.ease-stagger-normal > *:nth-child(16) {
+  animation-delay: 1.5s;
+}
+.ease-stagger-normal > *:nth-child(17) {
+  animation-delay: 1.6s;
+}
+.ease-stagger-normal > *:nth-child(18) {
+  animation-delay: 1.7s;
+}
+.ease-stagger-normal > *:nth-child(19) {
+  animation-delay: 1.8s;
+}
+.ease-stagger-normal > *:nth-child(20) {
+  animation-delay: 1.9s;
+}
+
+.ease-stagger-slow > *:nth-child(1) {
+  animation-delay: 0s;
+}
+.ease-stagger-slow > *:nth-child(2) {
+  animation-delay: 0.2s;
+}
+.ease-stagger-slow > *:nth-child(3) {
+  animation-delay: 0.4s;
+}
+.ease-stagger-slow > *:nth-child(4) {
+  animation-delay: 0.6s;
+}
+.ease-stagger-slow > *:nth-child(5) {
+  animation-delay: 0.8s;
+}
+.ease-stagger-slow > *:nth-child(6) {
+  animation-delay: 1s;
+}
+.ease-stagger-slow > *:nth-child(7) {
+  animation-delay: 1.2s;
+}
+.ease-stagger-slow > *:nth-child(8) {
+  animation-delay: 1.4s;
+}
+.ease-stagger-slow > *:nth-child(9) {
+  animation-delay: 1.6s;
+}
+.ease-stagger-slow > *:nth-child(10) {
+  animation-delay: 1.8s;
+}
+.ease-stagger-slow > *:nth-child(11) {
+  animation-delay: 2s;
+}
+.ease-stagger-slow > *:nth-child(12) {
+  animation-delay: 2.2s;
+}
+.ease-stagger-slow > *:nth-child(13) {
+  animation-delay: 2.4s;
+}
+.ease-stagger-slow > *:nth-child(14) {
+  animation-delay: 2.6s;
+}
+.ease-stagger-slow > *:nth-child(15) {
+  animation-delay: 2.8s;
+}
+.ease-stagger-slow > *:nth-child(16) {
+  animation-delay: 3s;
+}
+.ease-stagger-slow > *:nth-child(17) {
+  animation-delay: 3.2s;
+}
+.ease-stagger-slow > *:nth-child(18) {
+  animation-delay: 3.4s;
+}
+.ease-stagger-slow > *:nth-child(19) {
+  animation-delay: 3.6s;
+}
+.ease-stagger-slow > *:nth-child(20) {
+  animation-delay: 3.8s;
+}
+
+/*# sourceMappingURL=style.css.map */


### PR DESCRIPTION
## Pull Request Description

This PR introduces a new set of utility classes and an SCSS mixin (`ease-stagger-*`) that automatically applies incremental animation delays to child elements. This solves the tedious problem of manually adding different `.delay-*` classes to individual list or grid items to create sequential reveal animations. 

Resolves #518

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It adds `ease-stagger-fast`, `ease-stagger-normal`, and `ease-stagger-slow` utility classes that use `:nth-child()` to stagger child animation delays automatically.

**How does a developer use it?**

```html
<!-- Apply the stagger class to the parent container -->
<ul class="ease-stagger-normal">
  <!-- All children automatically get staggered animation-delays -->
  <li class="ease-slide-up">Item 1</li>
  <li class="ease-slide-up">Item 2</li>
  <li class="ease-slide-up">Item 3</li>
</ul>
