### PR TITLE
feat: add underline draw stopwatch submission

### DIFF
--- a/submissions/examples/underline-draw-stopwatch-km/README.md
+++ b/submissions/examples/underline-draw-stopwatch-km/README.md
@@ -1,0 +1,18 @@
+# Underline Draw Stopwatch
+
+1. **What does this do?** A functional stopwatch (Start / Stop / Reset) displaying MM:SS.CS, featuring an animated underline that continuously "draws" itself left-to-right and retracts right-to-left on a loop while the stopwatch is running, combined with a subtle synchronized pulse on the time display.
+2. **How is it used?** Wrap the stopwatch in a `.uds-stopwatch` container. The time text goes in `.uds-display`, sitting inside a `.uds-display-wrap` alongside a `.uds-underline` element (which holds the animated underline). Three buttons (`.uds-btn-start`, `.uds-btn-stop`, `.uds-btn-reset`) trigger the timing logic. A small inline script handles the actual elapsed-time counting (using `requestAnimationFrame` and `Date.now()`, since real elapsed-time measurement isn't achievable in pure CSS); all visual animation — the underline draw/retract loop and the display pulse — is handled entirely by CSS, toggled via a single `.is-running` class the script adds/removes.
+   ```html
+   <div class="uds-stopwatch">
+     <div class="uds-display-wrap">
+       <span class="uds-display">00:00.00</span>
+       <span class="uds-underline"></span>
+     </div>
+     <div class="uds-controls">
+       <button class="uds-btn-start">Start</button>
+       <button class="uds-btn-stop">Stop</button>
+       <button class="uds-btn-reset">Reset</button>
+     </div>
+   </div>
+   ```
+3. **Why is it useful?** Stopwatches are a commonly needed UI element, but usually presented as flat digit displays. This variant adds a signature animated underline that visually communicates "time is actively passing" through a continuous draw/retract loop, synchronized with a subtle pulse on the digits themselves — genuine sequenced, multi-layered animation rather than a single effect. Freezes cleanly on Stop (via `animation-play-state: paused`) and respects `prefers-reduced-motion` by showing a static full underline and disabling the pulse for users who request reduced motion.

--- a/submissions/examples/underline-draw-stopwatch-km/demo.html
+++ b/submissions/examples/underline-draw-stopwatch-km/demo.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Underline Draw Stopwatch Demo</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <div class="uds-stopwatch">
+    <div class="uds-display-wrap">
+      <span class="uds-display">00:00.00</span>
+      <span class="uds-underline"></span>
+    </div>
+    <div class="uds-controls">
+      <button class="uds-btn uds-btn-start">Start</button>
+      <button class="uds-btn uds-btn-stop">Stop</button>
+      <button class="uds-btn uds-btn-reset">Reset</button>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var wrap = document.querySelector('.uds-stopwatch');
+      var display = wrap.querySelector('.uds-display');
+      var startBtn = wrap.querySelector('.uds-btn-start');
+      var stopBtn = wrap.querySelector('.uds-btn-stop');
+      var resetBtn = wrap.querySelector('.uds-btn-reset');
+
+      var startTime = 0;
+      var elapsed = 0;
+      var timerId = null;
+      var running = false;
+
+      function format(ms) {
+        var centis = Math.floor((ms % 1000) / 10);
+        var totalSeconds = Math.floor(ms / 1000);
+        var seconds = totalSeconds % 60;
+        var minutes = Math.floor(totalSeconds / 60);
+
+        function pad(n) { return n < 10 ? '0' + n : '' + n; }
+
+        return pad(minutes) + ':' + pad(seconds) + '.' + pad(centis);
+      }
+
+      function tick() {
+        var now = Date.now();
+        display.textContent = format(elapsed + (now - startTime));
+        timerId = requestAnimationFrame(tick);
+      }
+
+      startBtn.addEventListener('click', function () {
+        if (running) return;
+        running = true;
+        startTime = Date.now();
+        wrap.classList.add('is-running');
+        timerId = requestAnimationFrame(tick);
+      });
+
+      stopBtn.addEventListener('click', function () {
+        if (!running) return;
+        running = false;
+        elapsed += Date.now() - startTime;
+        wrap.classList.remove('is-running');
+        cancelAnimationFrame(timerId);
+      });
+
+      resetBtn.addEventListener('click', function () {
+        running = false;
+        elapsed = 0;
+        cancelAnimationFrame(timerId);
+        wrap.classList.remove('is-running');
+        display.textContent = format(0);
+      });
+    })();
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/underline-draw-stopwatch-km/style.css
+++ b/submissions/examples/underline-draw-stopwatch-km/style.css
@@ -1,0 +1,106 @@
+.uds-stopwatch {
+  max-width: 280px;
+  margin: 3rem auto;
+  text-align: center;
+  font-family: 'Courier New', monospace;
+}
+
+.uds-display-wrap {
+  position: relative;
+  display: inline-block;
+  padding-bottom: 0.6rem;
+}
+
+.uds-display {
+  font-size: 2.5rem;
+  font-weight: bold;
+  color: #222;
+  letter-spacing: 2px;
+  transition: color 200ms ease;
+}
+
+/* The signature underline-draw effect */
+.uds-underline {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  height: 3px;
+  width: 100%;
+  background: #ddd;
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.uds-underline::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: #4c6ef5;
+  transform: scaleX(0);
+  transform-origin: left;
+  animation-play-state: paused;
+  animation: underline-draw 1s linear infinite;
+}
+
+/* While running: underline continuously draws left-to-right on a loop,
+   and the time display gets a subtle color pulse in sync */
+.uds-stopwatch.is-running .uds-underline::after {
+  animation-play-state: running;
+}
+
+.uds-stopwatch.is-running .uds-display {
+  color: #4c6ef5;
+  animation: display-pulse 1s ease-in-out infinite;
+}
+
+@keyframes underline-draw {
+  0%   { transform: scaleX(0);   transform-origin: left; }
+  50%  { transform: scaleX(1);   transform-origin: left; }
+  50.01% { transform-origin: right; }
+  100% { transform: scaleX(0);   transform-origin: right; }
+}
+
+@keyframes display-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.75; }
+}
+
+.uds-controls {
+  margin-top: 1.5rem;
+  display: flex;
+  gap: 0.6rem;
+  justify-content: center;
+}
+
+.uds-btn {
+  padding: 0.5rem 1.1rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background 150ms ease, transform 100ms ease;
+}
+
+.uds-btn:hover {
+  background: #f0f0f0;
+}
+
+.uds-btn:active {
+  transform: scale(0.95);
+}
+
+.uds-btn-start { border-color: #4c6ef5; color: #4c6ef5; }
+.uds-btn-stop  { border-color: #f76707; color: #f76707; }
+.uds-btn-reset { border-color: #868e96; color: #868e96; }
+
+@media (prefers-reduced-motion: reduce) {
+  .uds-underline::after {
+    animation: none;
+    transform: scaleX(1);
+    transform-origin: left;
+  }
+  .uds-stopwatch.is-running .uds-display {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an Underline Draw Stopwatch submission — a functional Start/Stop/Reset stopwatch (MM:SS.CS) featuring an animated underline that continuously draws left-to-right and retracts right-to-left on a loop while running, synchronized with a subtle pulse on the time display.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A functional stopwatch component with Start/Stop/Reset controls, MM:SS.CS display, and a signature animated underline that draws and retracts on a loop while running, synced with a subtle pulse on the digits.

**How does a developer use it?**

<div class="uds-stopwatch">
  <div class="uds-display-wrap">
    <span class="uds-display">00:00.00</span>
    <span class="uds-underline"></span>
  </div>
  <div class="uds-controls">
    <button class="uds-btn-start">Start</button>
    <button class="uds-btn-stop">Stop</button>
    <button class="uds-btn-reset">Reset</button>
  </div>
</div>

**Why does it fit EaseMotion CSS?**

Stopwatches are a commonly needed UI element usually shown as flat digit displays. This adds genuine multi-layered, sequenced animation (underline draw/retract loop + synced display pulse), controlled entirely through CSS via a single is-running class, matching the framework's animation-first philosophy. A small inline script only handles real elapsed-time counting, which isn't achievable in pure CSS. Respects prefers-reduced-motion.

---

## Demo

- [ x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Underline draw timing (1s loop) and pulse opacity are starting values — happy to adjust once standardized into ease- naming and CSS variables. Resolves #41498.

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
