### PR TITLE
feat: add scatter plot

### DIFF
--- a/submissions/examples/scatter-plot-as/README.md
+++ b/submissions/examples/scatter-plot-as/README.md
@@ -1,0 +1,25 @@
+# Scatter Plot
+
+### What does this do?
+
+It shows a small scatter plot drawn with inline SVG, plotting points from two series in different colors over an axis frame with gridlines and axis labels, plus a legend naming each series.
+
+### How is it used?
+
+```html
+<figure class="scatter">
+  <h2>Hours studied vs score</h2>
+  <svg viewBox="0 0 260 170">
+    <path class="sc-frame" d="M30 20 V140 H250" />
+    <circle class="pt a" cx="48" cy="124" r="4" />
+    <circle class="pt b" cx="58" cy="100" r="4" />
+  </svg>
+  <figcaption class="sc-legend"><span class="a">Class A</span><span class="b">Class B</span></figcaption>
+</figure>
+```
+
+Each point is an SVG `circle` with an `a` or `b` class for its series color. The frame is an L shaped path and the gridlines are horizontal lines. The legend swatches match the point colors.
+
+### Why is it useful?
+
+Dashboards use a scatter plot to show correlation between two values. This renders a scatter plot from inline SVG circles over a gridded frame with a legend, using only CSS and no charting script.

--- a/submissions/examples/scatter-plot-as/demo.html
+++ b/submissions/examples/scatter-plot-as/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scatter Plot</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <figure class="scatter">
+    <h2>Hours studied vs score</h2>
+    <svg viewBox="0 0 260 170" role="img" aria-label="Scatter plot of two series">
+      <g class="sc-grid">
+        <line x1="30" y1="20" x2="250" y2="20" />
+        <line x1="30" y1="60" x2="250" y2="60" />
+        <line x1="30" y1="100" x2="250" y2="100" />
+      </g>
+      <path class="sc-frame" d="M30 20 V140 H250" />
+      <g class="sc-axis">
+        <text x="12" y="24">100</text>
+        <text x="18" y="104">50</text>
+        <text x="24" y="144">0</text>
+        <text x="30" y="156">0h</text>
+        <text x="230" y="156">10h</text>
+      </g>
+      <g class="pts">
+        <circle class="pt a" cx="48" cy="124" r="4" />
+        <circle class="pt a" cx="70" cy="112" r="4" />
+        <circle class="pt a" cx="92" cy="118" r="4" />
+        <circle class="pt a" cx="108" cy="96" r="4" />
+        <circle class="pt a" cx="132" cy="88" r="4" />
+        <circle class="pt a" cx="150" cy="72" r="4" />
+        <circle class="pt a" cx="176" cy="66" r="4" />
+        <circle class="pt a" cx="200" cy="52" r="4" />
+        <circle class="pt b" cx="58" cy="100" r="4" />
+        <circle class="pt b" cx="84" cy="94" r="4" />
+        <circle class="pt b" cx="106" cy="80" r="4" />
+        <circle class="pt b" cx="128" cy="70" r="4" />
+        <circle class="pt b" cx="158" cy="58" r="4" />
+        <circle class="pt b" cx="182" cy="44" r="4" />
+        <circle class="pt b" cx="210" cy="38" r="4" />
+        <circle class="pt b" cx="232" cy="30" r="4" />
+      </g>
+    </svg>
+    <figcaption class="sc-legend">
+      <span class="a">Class A</span>
+      <span class="b">Class B</span>
+    </figcaption>
+  </figure>
+</body>
+</html>

--- a/submissions/examples/scatter-plot-as/style.css
+++ b/submissions/examples/scatter-plot-as/style.css
@@ -1,0 +1,92 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #16233c, #0b1121 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+}
+
+.scatter {
+  width: min(360px, 94vw);
+  margin: 0;
+  padding: 1.4rem 1.5rem 1.1rem;
+  box-sizing: border-box;
+  background: #0e1626;
+  border: 1px solid #26324a;
+  border-radius: 16px;
+}
+
+.scatter h2 {
+  margin: 0 0 1rem;
+  font-size: 0.95rem;
+}
+
+.scatter svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  overflow: visible;
+}
+
+.sc-frame {
+  stroke: #26324a;
+  stroke-width: 1;
+  fill: none;
+}
+
+.sc-grid {
+  stroke: #1b2942;
+  stroke-width: 1;
+}
+
+.sc-axis {
+  fill: #64748b;
+  font-size: 8px;
+}
+
+.pt {
+  fill-opacity: 0.85;
+  stroke: #0e1626;
+  stroke-width: 1;
+}
+
+.pt.a {
+  fill: #6c63ff;
+}
+
+.pt.b {
+  fill: #34d399;
+}
+
+.sc-legend {
+  display: flex;
+  gap: 1.2rem;
+  margin-top: 0.9rem;
+  font-size: 0.76rem;
+  color: #94a3b8;
+}
+
+.sc-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.sc-legend span::before {
+  content: "";
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.sc-legend .a::before {
+  background: #6c63ff;
+}
+
+.sc-legend .b::before {
+  background: #34d399;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a scatter plot built for #41369. Inline SVG points from two series over a gridded frame with a legend, using only CSS. Closes #41369.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium: 16 points across two color series render over a gridded frame with a two item legend.
