### PR TITLE
feat: add quantity stepper

### DIFF
--- a/submissions/examples/stepper-input-as/README.md
+++ b/submissions/examples/stepper-input-as/README.md
@@ -1,0 +1,21 @@
+# Quantity Stepper
+
+### What does this do?
+
+It shows quantity stepper inputs: a minus button, a numeric value, and a plus button grouped as one control. Buttons have hover, pressed, and focus states, the minus button shows a disabled state when the value is at its minimum, and a `pill` variant rounds the group fully.
+
+### How is it used?
+
+```html
+<span class="stepper">
+  <button type="button" class="step-btn" aria-label="Decrease">&minus;</button>
+  <input class="step-val" type="text" value="3" aria-label="Quantity" readonly />
+  <button type="button" class="step-btn" aria-label="Increase">+</button>
+</span>
+```
+
+Wrap two `step-btn` buttons around a `step-val` field. Add `disabled` to a button for the boundary state, and add the `pill` class to the `stepper` for the rounded style.
+
+### Why is it useful?
+
+Carts, booking forms, and settings use quantity steppers everywhere. This gives a clean, accessible stepper with proper button states and a disabled boundary, styled entirely with CSS.

--- a/submissions/examples/stepper-input-as/demo.html
+++ b/submissions/examples/stepper-input-as/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Quantity Stepper</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="step-wrap">
+    <label class="step-row">
+      <span class="step-name">Tickets</span>
+      <span class="stepper">
+        <button type="button" class="step-btn" disabled aria-label="Decrease">&minus;</button>
+        <input class="step-val" type="text" inputmode="numeric" value="1" aria-label="Quantity" readonly />
+        <button type="button" class="step-btn" aria-label="Increase">+</button>
+      </span>
+    </label>
+
+    <label class="step-row">
+      <span class="step-name">Guests</span>
+      <span class="stepper">
+        <button type="button" class="step-btn" aria-label="Decrease">&minus;</button>
+        <input class="step-val" type="text" inputmode="numeric" value="3" aria-label="Quantity" readonly />
+        <button type="button" class="step-btn" aria-label="Increase">+</button>
+      </span>
+    </label>
+
+    <label class="step-row">
+      <span class="step-name">Rooms</span>
+      <span class="stepper pill">
+        <button type="button" class="step-btn" aria-label="Decrease">&minus;</button>
+        <input class="step-val" type="text" inputmode="numeric" value="12" aria-label="Quantity" readonly />
+        <button type="button" class="step-btn" aria-label="Increase">+</button>
+      </span>
+    </label>
+  </div>
+</body>
+</html>

--- a/submissions/examples/stepper-input-as/style.css
+++ b/submissions/examples/stepper-input-as/style.css
@@ -1,0 +1,102 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(160deg, #eef2fb, #dbe3f4);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #1e2a44;
+}
+
+.step-wrap {
+  display: grid;
+  gap: 1rem;
+  width: min(340px, 92vw);
+  padding: 1.5rem;
+  box-sizing: border-box;
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: 0 18px 40px rgba(31, 45, 70, 0.14);
+}
+
+.step-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.step-name {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.stepper {
+  display: inline-flex;
+  align-items: center;
+  border: 1.5px solid #d5ddec;
+  border-radius: 10px;
+  overflow: hidden;
+  background: #f7f9fd;
+}
+
+.stepper.pill {
+  border-radius: 999px;
+}
+
+.step-btn {
+  width: 38px;
+  height: 38px;
+  border: 0;
+  background: transparent;
+  color: #3b56d4;
+  font-size: 1.15rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.08s ease;
+}
+
+.step-btn:hover:not(:disabled) {
+  background: #e7ecfb;
+}
+
+.step-btn:active:not(:disabled) {
+  transform: scale(0.9);
+  background: #d7defa;
+}
+
+.step-btn:focus-visible {
+  outline: 2px solid #3b56d4;
+  outline-offset: -2px;
+}
+
+.step-btn:disabled {
+  color: #b7c0d4;
+  cursor: not-allowed;
+}
+
+.step-val {
+  width: 44px;
+  height: 38px;
+  border: 0;
+  border-left: 1.5px solid #e2e8f4;
+  border-right: 1.5px solid #e2e8f4;
+  background: #fff;
+  text-align: center;
+  font-size: 0.98rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: #1e2a44;
+}
+
+.step-val:focus {
+  outline: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .step-btn {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a quantity stepper input built for #42143. A minus/value/plus group with hover, pressed, focus, and disabled boundary states, plus a pill variant. Pure CSS. Closes #42143.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium: three steppers render with values 1, 3, and 12, the first minus button is disabled, and the pill variant is fully rounded.
