### PR TITLE
feat: add funnel chart

### DIFF
--- a/submissions/examples/funnel-chart-as/README.md
+++ b/submissions/examples/funnel-chart-as/README.md
@@ -1,0 +1,20 @@
+# Funnel Chart
+
+### What does this do?
+
+It shows a conversion funnel chart. Each stage is a centered, trapezoid clipped bar whose width shrinks down the funnel, with the stage name on the left and the value centered on the bar. Widths are set by a `--w` custom property, so the funnel silhouette comes straight from the data.
+
+### How is it used?
+
+```html
+<div class="fn-stage" style="--w: 48%;">
+  <span class="fn-name">Add to cart</span>
+  <span class="fn-track"><span class="fn-bar"></span><em class="fn-val">4,050</em></span>
+</div>
+```
+
+Set each stage width with the `--w` inline variable. The `fn-bar` uses a `clip-path` polygon to angle its sides so the stacked bars read as a funnel, and the `fn-val` label sits centered over the bar.
+
+### Why is it useful?
+
+Analytics and marketing dashboards use funnels to show drop off between steps. This renders that funnel from stacked, clipped bars driven by one custom property, with no charting script.

--- a/submissions/examples/funnel-chart-as/demo.html
+++ b/submissions/examples/funnel-chart-as/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Funnel Chart</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <figure class="funnel">
+    <figcaption class="fn-title">Checkout funnel</figcaption>
+
+    <div class="fn-stage" style="--w: 100%;">
+      <span class="fn-name">Visits</span>
+      <span class="fn-track"><span class="fn-bar"></span><em class="fn-val">8,400</em></span>
+    </div>
+    <div class="fn-stage" style="--w: 74%;">
+      <span class="fn-name">Product view</span>
+      <span class="fn-track"><span class="fn-bar"></span><em class="fn-val">6,200</em></span>
+    </div>
+    <div class="fn-stage" style="--w: 48%;">
+      <span class="fn-name">Add to cart</span>
+      <span class="fn-track"><span class="fn-bar"></span><em class="fn-val">4,050</em></span>
+    </div>
+    <div class="fn-stage" style="--w: 29%;">
+      <span class="fn-name">Checkout</span>
+      <span class="fn-track"><span class="fn-bar"></span><em class="fn-val">2,430</em></span>
+    </div>
+    <div class="fn-stage" style="--w: 16%;">
+      <span class="fn-name">Purchase</span>
+      <span class="fn-track"><span class="fn-bar"></span><em class="fn-val">1,340</em></span>
+    </div>
+  </figure>
+</body>
+</html>

--- a/submissions/examples/funnel-chart-as/style.css
+++ b/submissions/examples/funnel-chart-as/style.css
@@ -1,0 +1,80 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #1b2440, #0c101d 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e6ebf6;
+}
+
+.funnel {
+  width: min(430px, 94vw);
+  margin: 0;
+  padding: 1.6rem 1.6rem 1.9rem;
+  box-sizing: border-box;
+  background: #121a2e;
+  border: 1px solid #26304a;
+  border-radius: 18px;
+  display: grid;
+  gap: 8px;
+}
+
+.fn-title {
+  margin-bottom: 0.6rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.fn-stage {
+  display: grid;
+  grid-template-columns: 92px 1fr;
+  align-items: center;
+  gap: 12px;
+  height: 44px;
+}
+
+.fn-name {
+  font-size: 0.82rem;
+  color: #aab3c8;
+  text-align: right;
+}
+
+.fn-track {
+  position: relative;
+  height: 100%;
+  display: grid;
+  place-items: center;
+}
+
+.fn-bar {
+  width: var(--w, 100%);
+  height: 100%;
+  border-radius: 8px;
+  background: linear-gradient(90deg, #6366f1, #8b5cf6);
+  clip-path: polygon(5% 0, 95% 0, 84% 100%, 16% 100%);
+  transition: width 0.5s ease;
+}
+
+.fn-stage:nth-child(3) .fn-bar { background: linear-gradient(90deg, #4f46e5, #7c3aed); }
+.fn-stage:nth-child(4) .fn-bar { background: linear-gradient(90deg, #4338ca, #6d28d9); }
+.fn-stage:nth-child(5) .fn-bar { background: linear-gradient(90deg, #0ea5e9, #6366f1); }
+.fn-stage:nth-child(6) .fn-bar { background: linear-gradient(90deg, #06b6d4, #3b82f6); }
+
+.fn-val {
+  position: absolute;
+  font-style: normal;
+  font-size: 0.84rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: #f4f7ff;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fn-bar {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a funnel chart built for #42159. Centered, trapezoid clipped stage bars that narrow down the funnel, each with a name and a value, widths driven by a `--w` custom property. Pure CSS. Closes #42159.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium: five stage bars render with strictly descending widths (273 down to 44 px) and centered value labels.
