### PR TITLE
docs: add RTL support for directional animations

### DIFF
--- a/submissions/docs/rtl-support/README.md
+++ b/submissions/docs/rtl-support/README.md
@@ -1,0 +1,11 @@
+# RTL Support for Directional Animations
+
+This submission fixes Issue #42627 by adding RTL overrides for directional animations.  
+Classes like `ease-slide-left` and `ease-slide-right` now flip automatically when the page uses `dir="rtl"`.
+
+## Usage
+
+```html
+<html lang="ar" dir="rtl">
+  <div class="ease-slide-left">...</div>
+</html>

--- a/submissions/docs/rtl-support/demo.html
+++ b/submissions/docs/rtl-support/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <title>RTL Animation Support Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h2>RTL Slide Animation Example</h2>
+
+  <div class="ease-slide-left box">Slide Left (RTL flips)</div>
+  <div class="ease-slide-right box">Slide Right (RTL flips)</div>
+</body>
+</html>

--- a/submissions/docs/rtl-support/style.css
+++ b/submissions/docs/rtl-support/style.css
@@ -1,0 +1,36 @@
+.box {
+  background: #007bff;
+  color: #fff;
+  padding: 1rem;
+  margin: 1rem 0;
+  border-radius: 6px;
+  width: 200px;
+  text-align: center;
+}
+
+/* Default LTR animations */
+.ease-slide-left {
+  animation: slideLeft 1s ease forwards;
+}
+.ease-slide-right {
+  animation: slideRight 1s ease forwards;
+}
+
+@keyframes slideLeft {
+  from { transform: translateX(100px); opacity: 0; }
+  to   { transform: translateX(0); opacity: 1; }
+}
+
+@keyframes slideRight {
+  from { transform: translateX(-100px); opacity: 0; }
+  to   { transform: translateX(0); opacity: 1; }
+}
+
+/* RTL overrides */
+[dir="rtl"] .ease-slide-left {
+  animation: slideRight 1s ease forwards; /* flip direction */
+}
+
+[dir="rtl"] .ease-slide-right {
+  animation: slideLeft 1s ease forwards; /* flip direction */
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes Issue #42627 by adding RTL overrides for directional animations.  
Animations like `ease-slide-left` and `ease-slide-right` now flip automatically when `[dir="rtl"]` is set.

---

## Type of Change

- [x] 📝 Documentation / accessibility improvement
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/docs/rtl-support/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**  
RTL support for directional animations.

**How does a developer use it?**
```html
<html dir="rtl">
  <div class="ease-slide-left">...</div>
</html>
