### PR TITLE
docs: add print stylesheet demo

### DIFF
--- a/submissions/docs/print-stylesheet/README.md
+++ b/submissions/docs/print-stylesheet/README.md
@@ -1,0 +1,18 @@
+# Print Stylesheet
+
+This submission fixes Issue #42624 by adding a basic `@media print` stylesheet.  
+It ensures printed pages don’t freeze animations mid-state and removes unnecessary UI elements.
+
+## Features
+- Hides navigation bars and buttons when printing
+- Disables animations and transitions
+- Forces clean black-on-white output
+
+## Usage
+Include in your CSS:
+
+```css
+@media print {
+  .nav, .ease-btn { display: none; }
+  * { animation: none; transition: none; }
+}

--- a/submissions/docs/print-stylesheet/demo.html
+++ b/submissions/docs/print-stylesheet/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Print Stylesheet Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <nav class="nav">Navigation Bar (hidden in print)</nav>
+  <div class="content">
+    <h2>EaseMotion Print Example</h2>
+    <p>This content will print cleanly without animations or nav clutter.</p>
+    <button class="ease-btn">Unnecessary Button</button>
+  </div>
+</body>
+</html>

--- a/submissions/docs/print-stylesheet/style.css
+++ b/submissions/docs/print-stylesheet/style.css
@@ -1,0 +1,39 @@
+body {
+  font-family: Inter, sans-serif;
+  background: #f9f9f9;
+  padding: 2rem;
+}
+
+.nav {
+  background: #007bff;
+  color: #fff;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.ease-btn {
+  padding: 0.6rem 1.2rem;
+  background: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+/* Print stylesheet */
+@media print {
+  body {
+    background: #fff !important;
+    color: #000 !important;
+  }
+
+  .nav,
+  .ease-btn {
+    display: none !important; /* hide nav/buttons */
+  }
+
+  * {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes Issue #42624 by adding a basic `@media print` stylesheet.  
It hides navigation/buttons and disables animations so printed pages are clean and readable.

---

## Type of Change

- [x] 📝 Documentation / accessibility improvement
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/docs/print-stylesheet/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**  
A print stylesheet for demos/docs.

**Why does it fit EaseMotion CSS?**  
EaseMotion CSS should be usable in all contexts. Printing without clutter or broken animations improves accessibility.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Notes for Maintainer

Docs + accessibility improvement under GSSoC’26.  
No core files touched — only inside `submissions/docs/print-stylesheet/`.
