### PR TITLE
feat: Add 3D Tilt Social Share Bar Component (Resolves #41830)

### DIFF
--- a/submissions/examples/3d-tilt-social-share-bar-nicks19/README.md
+++ b/submissions/examples/3d-tilt-social-share-bar-nicks19/README.md
@@ -1,0 +1,21 @@
+# 3D Tilt Social Share Bar (Startup Theme)
+
+A modern, glassmorphic social share bar that interacts with the user's cursor. Built with a "Startup" aesthetic, it features a pill-shaped translucent background and individual icons that push out in 3D space.
+
+## Features
+
+- **Perspective Tracking**: Uses a tiny JavaScript snippet to track mouse coordinates and map them to CSS custom properties (`--tilt-x` and `--tilt-y`). The CSS then applies these to a 3D `transform: rotateX() rotateY()`.
+- **Z-Axis Popping**: Individual social buttons use `translateZ(10px)` by default, and push out further (`translateZ(30px)`) when hovered, making them literally pop out of the glass bar.
+- **Glassmorphism Base**: The container uses `backdrop-filter: blur(16px)` combined with a semi-transparent white background to create a frosted glass effect that blends beautifully over any background.
+- **Brand Colors**: On hover, the generic gray icons bloom into their respective brand colors (Twitter Blue, LinkedIn Blue, etc.) accompanied by a soft, color-matched glow.
+
+## Installation
+
+1. Copy the CSS from `style.css` into your stylesheet.
+2. Copy the HTML structure from `demo.html`, ensuring the `.ease-3d-tilt-wrapper` has a unique ID (e.g., `id="tilt-bar"`).
+3. Include the tiny JS script provided in `demo.html` to handle the coordinate tracking.
+
+## Why it fits EaseMotion CSS
+
+- **CSS-Driven Physics**: While JS is used to capture mouse coordinates, the actual animation, interpolation, and 3D rendering are entirely handled natively by the CSS engine via `transition` and `transform`, ensuring high performance.
+- **Micro-interactions**: The addition of spring physics (`cubic-bezier(0.34, 1.56, 0.64, 1)`) on the individual button hovers adds that signature tactile "EaseMotion" feel to the 3D effect.

--- a/submissions/examples/3d-tilt-social-share-bar-nicks19/demo.html
+++ b/submissions/examples/3d-tilt-social-share-bar-nicks19/demo.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>3D Tilt Social Share Bar - Startup Theme</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      margin: 0;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      background: linear-gradient(135deg, #f0f9ff 0%, #e0e7ff 100%);
+      font-family: -apple-system, BlinkMacSystemFont, 'Inter', Roboto, sans-serif;
+    }
+
+    .demo-article-footer {
+      text-align: center;
+      margin-bottom: 40px;
+    }
+
+    .demo-article-footer h2 {
+      margin: 0 0 8px 0;
+      color: #1e293b;
+      font-size: 1.5rem;
+    }
+
+    .demo-article-footer p {
+      margin: 0;
+      color: #64748b;
+    }
+
+  </style>
+</head>
+<body>
+
+  <div class="demo-article-footer">
+    <h2>Enjoyed this post?</h2>
+    <p>Share it with your network</p>
+  </div>
+
+  <!-- The 3D Tilt Container -->
+  <div class="ease-3d-tilt-wrapper" id="tilt-bar">
+    <div class="ease-social-share-bar">
+      
+      <a href="#" class="ease-social-btn" aria-label="Twitter">
+        <!-- SVG Twitter/X Icon -->
+        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723c-.951.555-2.005.959-3.127 1.184a4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z"/></svg>
+      </a>
+
+      <a href="#" class="ease-social-btn" aria-label="LinkedIn">
+        <!-- SVG LinkedIn Icon -->
+        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.225 0z"/></svg>
+      </a>
+
+      <a href="#" class="ease-social-btn" aria-label="Facebook">
+        <!-- SVG Facebook Icon -->
+        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.469h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.469h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
+      </a>
+
+      <a href="#" class="ease-social-btn" aria-label="Copy Link">
+        <!-- SVG Link Icon -->
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
+      </a>
+
+    </div>
+  </div>
+
+  <script>
+    const tiltBar = document.getElementById('tilt-bar');
+    
+    // Tiny logic to calculate 3D tilt coordinates based on mouse position
+    tiltBar.addEventListener('mousemove', (e) => {
+      const rect = tiltBar.getBoundingClientRect();
+      const x = e.clientX - rect.left; // x position within the element
+      const y = e.clientY - rect.top;  // y position within the element
+      
+      // Calculate rotation between -10deg and 10deg
+      const xPct = x / rect.width;
+      const yPct = y / rect.height;
+      const tiltX = (yPct - 0.5) * -20; // max 10deg up/down
+      const tiltY = (xPct - 0.5) * 20;  // max 10deg left/right
+      
+      tiltBar.style.setProperty('--tilt-x', `${tiltX}deg`);
+      tiltBar.style.setProperty('--tilt-y', `${tiltY}deg`);
+    });
+
+    // Reset tilt when mouse leaves
+    tiltBar.addEventListener('mouseleave', () => {
+      tiltBar.style.setProperty('--tilt-x', '0deg');
+      tiltBar.style.setProperty('--tilt-y', '0deg');
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/3d-tilt-social-share-bar-nicks19/style.css
+++ b/submissions/examples/3d-tilt-social-share-bar-nicks19/style.css
@@ -1,0 +1,102 @@
+:root {
+  --ease-share-bg: rgba(255, 255, 255, 0.7);
+  --ease-share-border: rgba(255, 255, 255, 0.5);
+  --ease-share-shadow: 0 10px 40px -10px rgba(0, 0, 0, 0.1);
+  --ease-share-backdrop: blur(16px);
+  --ease-icon-color: #475569;
+  --ease-icon-hover: #0ea5e9;
+  --ease-icon-bg-hover: #f0f9ff;
+}
+
+/* Wrapper handles the perspective tracking */
+.ease-3d-tilt-wrapper {
+  /* Default to 0deg, updated by tiny JS snippet */
+  --tilt-x: 0deg;
+  --tilt-y: 0deg;
+  
+  perspective: 1000px;
+  transform-style: preserve-3d;
+  display: inline-block;
+  
+  /* Smooth transition back to 0 when mouse leaves */
+  transition: transform 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+/* The actual bar gets the rotation */
+.ease-social-share-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 24px;
+  border-radius: 99px; /* Pill shape */
+  
+  background: var(--ease-share-bg);
+  border: 1px solid var(--ease-share-border);
+  box-shadow: var(--ease-share-shadow);
+  backdrop-filter: var(--ease-share-backdrop);
+  -webkit-backdrop-filter: var(--ease-share-backdrop);
+  
+  /* Apply the dynamic rotation variables */
+  transform: rotateX(var(--tilt-x)) rotateY(var(--tilt-y));
+  /* Smoothly animate when variables change slightly */
+  transition: transform 0.1s linear, box-shadow 0.3s ease;
+  
+  /* Keep buttons popping out in 3D */
+  transform-style: preserve-3d;
+}
+
+.ease-social-share-bar:hover {
+  box-shadow: 0 20px 50px -15px rgba(0, 0, 0, 0.15);
+}
+
+/* Individual Social Buttons */
+.ease-social-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  color: var(--ease-icon-color);
+  background: transparent;
+  text-decoration: none;
+  transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  
+  /* Default Z-push */
+  transform: translateZ(10px);
+}
+
+.ease-social-btn svg {
+  width: 20px;
+  height: 20px;
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* Hover States for individual buttons */
+.ease-social-btn:hover {
+  background: var(--ease-icon-bg-hover);
+  color: var(--ease-icon-hover);
+  /* Push the button further out on the Z-axis when hovered to amplify the 3D effect */
+  transform: translateZ(30px) scale(1.1);
+  box-shadow: 0 8px 20px -5px rgba(14, 165, 233, 0.3);
+}
+
+.ease-social-btn:hover svg {
+  transform: scale(1.1);
+}
+
+/* Specific brand colors on hover (Optional Startup touch) */
+.ease-social-btn[aria-label="Twitter"]:hover {
+  color: #1DA1F2;
+  box-shadow: 0 8px 20px -5px rgba(29, 161, 242, 0.3);
+}
+
+.ease-social-btn[aria-label="LinkedIn"]:hover {
+  color: #0A66C2;
+  box-shadow: 0 8px 20px -5px rgba(10, 102, 194, 0.3);
+}
+
+.ease-social-btn[aria-label="Facebook"]:hover {
+  color: #1877F2;
+  box-shadow: 0 8px 20px -5px rgba(24, 119, 242, 0.3);
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #41830 - Feature Request: 3D Tilt Social Share Bar.

This PR introduces an interactive, highly tactile social share bar styled with a modern "Startup" aesthetic. Utilizing a glassmorphism base, the bar dynamically tilts in 3D space as the user hovers over it, and individual social buttons push out dynamically on the Z-axis for a deeply satisfying micro-interaction.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component (pure CSS physics + tiny JS tracker)
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A modern share bar driven by CSS 3D Transforms.
- **Perspective Tracking**: Uses a lightweight JS snippet (provided in `demo.html`) to track the cursor's local coordinates. It maps these coordinates to `--tilt-x` and `--tilt-y` CSS variables natively without any bloated animation libraries.
- **Z-Axis Popping**: Individual social buttons utilize `transform: translateZ(10px)` by default. On hover, they scale and push out further to `translateZ(30px)`, making them literally "pop" out of the glass bar.
- **Glassmorphism Base**: Built using `backdrop-filter: blur(16px)` and semi-transparent layers, providing a clean "Startup" aesthetic that looks fantastic when placed over imagery or gradients.
- **Brand Colors**: The default, neutral slate icons bloom into their respective brand colors (Twitter Blue, LinkedIn Blue, etc.) on hover, accompanied by a soft, color-matched box-shadow glow.

**How does a developer use it?**

```html
<!-- The wrapper tracks mouse coordinates via JS -->
<div class="ease-3d-tilt-wrapper" id="tilt-bar">
  
  <!-- The bar receives the 3D CSS transforms -->
  <div class="ease-social-share-bar">
    
    <a href="#" class="ease-social-btn" aria-label="Twitter">
      <svg>...</svg>
    </a>
    
    <a href="#" class="ease-social-btn" aria-label="LinkedIn">
      <svg>...</svg>
    </a>
    
  </div>
</div>
