### PR TITLE
feat: add animated back to top button component

### DIFF
--- a/submissions/examples/ease-back-to-top/README.md
+++ b/submissions/examples/ease-back-to-top/README.md
@@ -1,0 +1,68 @@
+# Ease Back to Top
+
+## What does this do?
+
+Displays an animated floating "back to top" button that springs into view after the user scrolls past 200 px, and smoothly disappears when back at the top — available in three visual variants: a classic circle, a scroll-progress ring, and an expanding pill label.
+
+## How is it used?
+
+**1. Add the anchor at the page top:**
+
+```html
+<div id="top"></div>
+```
+
+**2. Pick a variant and add it before `</body>`:**
+
+### Variant A — Classic Circle
+
+```html
+<a href="#top" class="btt-btn is-visible" aria-label="Back to top of page">
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+       stroke-width="2.5" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
+  </svg>
+</a>
+```
+
+### Variant B — Scroll Progress Ring
+
+Wrap the button in `.btt-progress-wrap` with an SVG ring overlay. The JS scroll listener updates `stroke-dashoffset` on `#btt-ring-bar` to reflect page progress.
+
+### Variant C — Expanding Pill
+
+```html
+<a href="#top" class="btt-pill" aria-label="Back to top of page">
+  <!-- arrow svg -->
+  <span class="btt-pill-label" aria-hidden="true">Top</span>
+</a>
+```
+
+Hover expands the pill to reveal the "Top" label.
+
+**3. Add the scroll trigger script (vanilla JS, no dependencies):**
+
+```html
+<script>
+  var THRESHOLD = 200;
+  var btn = document.getElementById('btt-circle');
+
+  window.addEventListener('scroll', function () {
+    btn.classList.toggle('is-visible', window.scrollY > THRESHOLD);
+  }, { passive: true });
+</script>
+```
+
+See `demo.html` for the complete multi-variant implementation including progress ring logic.
+
+## Why is it useful?
+
+EaseMotion CSS is built on the idea that motion should be composable, readable, and expressive. A "back to top" button is one of the most universally needed UI patterns on long-content pages, and this submission extends EaseMotion's motion language to it with:
+
+- **Elastic spring entrance** using `cubic-bezier(0.34, 1.56, 0.64, 1)` — the same easing curve used across EaseMotion's hover and entrance classes.
+- **Three distinct variants** (circle, progress ring, pill) that map cleanly to future `ease-btt`, `ease-btt-ring`, and `ease-btt-pill` utility classes, demonstrating composable modifier thinking.
+- **Scroll-progress ring** gives instant visual feedback on reading depth — a common UX pattern in modern editorial and documentation sites.
+- **Keyboard + screen reader accessible** — `aria-label`, `:focus-visible` ring, and `prefers-reduced-motion` all handled.
+- **Opens directly in the browser** — `demo.html` requires no server, no build step, and no CDN beyond an optional Google Font.
+
+Once curated, the maintainer can standardise class names to `ease-back-to-top`, `ease-btt-ring`, `ease-btt-pill` and integrate the keyframe/transition tokens into `core/animations.css`.

--- a/submissions/examples/ease-back-to-top/demo.html
+++ b/submissions/examples/ease-back-to-top/demo.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Animated back to top button demo — EaseMotion CSS submission. Three variants: circle, progress ring, and expanding pill label." />
+  <title>Ease Back to Top — Animated Button Component | EaseMotion CSS</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <!-- =====================================================
+       PAGE TOP ANCHOR
+       ===================================================== -->
+  <div id="top"></div>
+
+  <!-- =====================================================
+       SCROLLABLE CONTENT
+       ===================================================== -->
+  <main>
+
+    <section class="page-section">
+      <div class="section-inner">
+        <p class="section-label">EaseMotion CSS — Submission</p>
+        <h2>Ease Back to Top</h2>
+        <p>Scroll down to see three animated back-to-top button variants appear: a classic circle, a scroll-progress ring, and an expanding pill. All pure CSS + minimal JS for the scroll trigger.</p>
+      </div>
+    </section>
+
+    <section class="page-section">
+      <div class="section-inner">
+        <p class="section-label">Section 01</p>
+        <h2>Smooth Scroll Behaviour</h2>
+        <p>The button fades and springs into view after the user scrolls past 200 px, keeping the viewport clean at the top of the page.</p>
+      </div>
+    </section>
+
+    <section class="page-section">
+      <div class="section-inner">
+        <p class="section-label">Section 02</p>
+        <h2>Zero Dependencies</h2>
+        <p>No libraries, no frameworks. The scroll listener is fewer than 30 lines of vanilla JavaScript — the visual layer is entirely CSS.</p>
+      </div>
+    </section>
+
+    <section class="page-section">
+      <div class="section-inner">
+        <p class="section-label">Section 03</p>
+        <h2>Three Visual Variants</h2>
+        <p>Choose the <strong>circle</strong> button on the left, the <strong>progress ring</strong> in the centre, or the <strong>expanding pill</strong> on the right. Hover each one to see micro-interactions.</p>
+      </div>
+    </section>
+
+    <section class="page-section">
+      <div class="section-inner">
+        <p class="section-label">Section 04</p>
+        <h2>Accessibility First</h2>
+        <p>Every button carries <code>aria-label</code>, works on keyboard focus, and respects <code>prefers-reduced-motion</code>.</p>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- =====================================================
+       VARIANT 1 — Classic Circle (bottom-left)
+       ===================================================== -->
+  <a
+    id="btt-circle"
+    href="#top"
+    class="btt-btn"
+    aria-label="Back to top of page"
+    style="right: auto; left: 1.75rem;"
+  >
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" aria-hidden="true">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
+    </svg>
+  </a>
+
+  <!-- =====================================================
+       VARIANT 2 — Progress Ring (bottom-centre)
+       ===================================================== -->
+  <div
+    id="btt-progress-wrap"
+    class="btt-progress-wrap"
+    style="right: 50%; transform: translateX(50%) translateY(16px) scale(0.85);"
+  >
+    <!-- SVG ring -->
+    <svg class="btt-progress-svg" viewBox="0 0 52 52" aria-hidden="true">
+      <circle class="btt-progress-track" cx="26" cy="26" r="23" />
+      <circle id="btt-ring-bar" class="btt-progress-bar" cx="26" cy="26" r="23" />
+    </svg>
+    <!-- Inner button -->
+    <a
+      href="#top"
+      class="btt-progress-btn"
+      aria-label="Back to top of page — scroll progress shown"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
+      </svg>
+    </a>
+  </div>
+
+  <!-- =====================================================
+       VARIANT 3 — Expanding Pill (bottom-right)
+       ===================================================== -->
+  <a
+    id="btt-pill"
+    href="#top"
+    class="btt-pill"
+    aria-label="Back to top of page"
+  >
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" aria-hidden="true">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
+    </svg>
+    <span class="btt-pill-label" aria-hidden="true">Top</span>
+  </a>
+
+  <!-- =====================================================
+       SCROLL LOGIC (vanilla JS, no dependencies)
+       ===================================================== -->
+  <script>
+    (function () {
+      var THRESHOLD = 200;
+
+      var circle  = document.getElementById('btt-circle');
+      var wrap    = document.getElementById('btt-progress-wrap');
+      var pill    = document.getElementById('btt-pill');
+      var ringBar = document.getElementById('btt-ring-bar');
+
+      // Progress ring circumference: 2π × r(23) ≈ 144.51
+      var CIRCUMFERENCE = 2 * Math.PI * 23;
+
+      function onScroll() {
+        var scrollTop = window.scrollY || document.documentElement.scrollTop;
+        var docHeight = document.documentElement.scrollHeight - window.innerHeight;
+        var progress  = docHeight > 0 ? scrollTop / docHeight : 0;
+
+        // Show / hide
+        var show = scrollTop > THRESHOLD;
+
+        toggleVisible(circle, show);
+        toggleVisible(pill,   show);
+
+        // Progress wrap has a centred transform — handle separately
+        if (show) {
+          wrap.classList.add('is-visible');
+          wrap.style.transform = 'translateX(50%) translateY(0) scale(1)';
+        } else {
+          wrap.classList.remove('is-visible');
+          wrap.style.transform = 'translateX(50%) translateY(16px) scale(0.85)';
+        }
+
+        // Update ring
+        var offset = CIRCUMFERENCE * (1 - progress);
+        ringBar.style.strokeDashoffset = offset;
+      }
+
+      function toggleVisible(el, show) {
+        if (show) el.classList.add('is-visible');
+        else       el.classList.remove('is-visible');
+      }
+
+      window.addEventListener('scroll', onScroll, { passive: true });
+      onScroll(); // run once on load
+    })();
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-back-to-top/style.css
+++ b/submissions/examples/ease-back-to-top/style.css
@@ -1,0 +1,412 @@
+/* ============================================================
+   ease-back-to-top — Animated Back to Top Button Component
+   Submission for EaseMotion CSS (GSSoC 2026)
+   ============================================================ */
+
+/* ----- Design Tokens ----- */
+:root {
+  --btt-size:        52px;
+  --btt-radius:      50%;
+  --btt-right:       1.75rem;
+  --btt-bottom:      1.75rem;
+  --btt-bg:          #6c63ff;
+  --btt-bg-hover:    #574fe0;
+  --btt-color:       #ffffff;
+  --btt-shadow:      0 8px 28px rgba(108, 99, 255, 0.45);
+  --btt-shadow-hover:0 12px 36px rgba(108, 99, 255, 0.65);
+  --btt-duration:    0.3s;
+  --btt-ease:        cubic-bezier(0.34, 1.56, 0.64, 1);
+  --btt-ring-color:  rgba(255, 255, 255, 0.35);
+  --btt-ring-size:   4px;
+}
+
+/* ----- Base Reset ----- */
+*, *::before, *::after { box-sizing: border-box; }
+
+/* =============================================================
+   PAGE SCAFFOLD (demo layout only)
+   ============================================================= */
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
+  background: #070d1a;
+  color: #e2e8f0;
+  scroll-behavior: smooth;
+}
+
+.page-section {
+  min-height: 80vh;
+  display: grid;
+  place-items: center;
+  padding: 4rem 2rem;
+  text-align: center;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.page-section:nth-child(odd) {
+  background: radial-gradient(ellipse at 50% 0%, #0f1f3d, #070d1a 70%);
+}
+
+.page-section:nth-child(even) {
+  background: radial-gradient(ellipse at 50% 100%, #110f2e, #070d1a 70%);
+}
+
+.section-inner { max-width: 480px; }
+
+.section-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #6c63ff;
+  margin-bottom: 1rem;
+}
+
+.page-section h2 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0 0 1rem;
+  background: linear-gradient(135deg, #e2e8f0 30%, #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.page-section p {
+  margin: 0;
+  color: #94a3b8;
+  line-height: 1.7;
+  font-size: 1rem;
+}
+
+/* =============================================================
+   BACK TO TOP — CORE
+   ============================================================= */
+.btt-btn {
+  position: fixed;
+  right: var(--btt-right);
+  bottom: var(--btt-bottom);
+  z-index: 999;
+
+  /* Size & shape */
+  width: var(--btt-size);
+  height: var(--btt-size);
+  border-radius: var(--btt-radius);
+  border: none;
+  cursor: pointer;
+
+  /* Colour */
+  background: var(--btt-bg);
+  color: var(--btt-color);
+
+  /* Layout */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  /* Shadow */
+  box-shadow: var(--btt-shadow);
+
+  /* Text decoration (when used as <a>) */
+  text-decoration: none;
+
+  /* Hidden by default — shown via .is-visible */
+  opacity: 0;
+  transform: translateY(16px) scale(0.85);
+  pointer-events: none;
+  visibility: hidden;
+
+  transition:
+    opacity       var(--btt-duration) var(--btt-ease),
+    transform     var(--btt-duration) var(--btt-ease),
+    background    0.2s ease,
+    box-shadow    0.2s ease,
+    visibility    0s   var(--btt-duration);
+}
+
+/* ----- Visible state (toggled by JS or scroll-timeline) ----- */
+.btt-btn.is-visible {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+  visibility: visible;
+  transition:
+    opacity   var(--btt-duration) var(--btt-ease),
+    transform var(--btt-duration) var(--btt-ease),
+    background 0.2s ease,
+    box-shadow 0.2s ease,
+    visibility 0s 0s;
+}
+
+/* ----- Hover ----- */
+.btt-btn:hover {
+  background: var(--btt-bg-hover);
+  box-shadow: var(--btt-shadow-hover);
+  transform: translateY(-3px) scale(1.06);
+}
+
+/* ----- Active press ----- */
+.btt-btn:active {
+  transform: translateY(0) scale(0.96);
+}
+
+/* ----- Focus ring ----- */
+.btt-btn:focus-visible {
+  outline: 2px solid #fbbf24;
+  outline-offset: 3px;
+}
+
+/* ----- Arrow icon ----- */
+.btt-btn svg {
+  width: 22px;
+  height: 22px;
+  transition: transform 0.2s ease;
+  flex-shrink: 0;
+}
+
+.btt-btn:hover svg {
+  transform: translateY(-2px);
+}
+
+/* =============================================================
+   VARIANT — SQUARE (rounded corners, not circle)
+   ============================================================= */
+.btt-btn.btt-square {
+  border-radius: 12px;
+  width: 48px;
+  height: 48px;
+}
+
+/* =============================================================
+   VARIANT — WITH SCROLL PROGRESS RING
+   ============================================================= */
+.btt-progress-wrap {
+  position: fixed;
+  right: var(--btt-right);
+  bottom: var(--btt-bottom);
+  z-index: 999;
+  width: var(--btt-size);
+  height: var(--btt-size);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  opacity: 0;
+  transform: translateY(16px) scale(0.85);
+  pointer-events: none;
+  visibility: hidden;
+
+  transition:
+    opacity   var(--btt-duration) var(--btt-ease),
+    transform var(--btt-duration) var(--btt-ease),
+    visibility 0s var(--btt-duration);
+}
+
+.btt-progress-wrap.is-visible {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+  visibility: visible;
+  transition:
+    opacity   var(--btt-duration) var(--btt-ease),
+    transform var(--btt-duration) var(--btt-ease),
+    visibility 0s 0s;
+}
+
+/* SVG ring sits behind the button */
+.btt-progress-svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+  pointer-events: none;
+}
+
+.btt-progress-track {
+  fill: none;
+  stroke: rgba(108, 99, 255, 0.2);
+  stroke-width: var(--btt-ring-size);
+}
+
+.btt-progress-bar {
+  fill: none;
+  stroke: var(--btt-bg);
+  stroke-width: var(--btt-ring-size);
+  stroke-linecap: round;
+  /* Circumference of r=23: 2π×23 ≈ 144.51 */
+  stroke-dasharray: 144.51;
+  stroke-dashoffset: 144.51;         /* updated by JS */
+  transition: stroke-dashoffset 0.1s linear;
+}
+
+/* Core button inside the progress wrap */
+.btt-progress-btn {
+  width: calc(var(--btt-size) - 12px);
+  height: calc(var(--btt-size) - 12px);
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  background: var(--btt-bg);
+  color: var(--btt-color);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: var(--btt-shadow);
+  text-decoration: none;
+  transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  position: relative;
+  z-index: 1;
+}
+
+.btt-progress-btn:hover {
+  background: var(--btt-bg-hover);
+  box-shadow: var(--btt-shadow-hover);
+  transform: scale(1.08);
+}
+
+.btt-progress-btn:active  { transform: scale(0.95); }
+
+.btt-progress-btn:focus-visible {
+  outline: 2px solid #fbbf24;
+  outline-offset: 3px;
+}
+
+.btt-progress-btn svg {
+  width: 20px;
+  height: 20px;
+  transition: transform 0.2s ease;
+}
+
+.btt-progress-btn:hover svg { transform: translateY(-2px); }
+
+/* =============================================================
+   VARIANT — PILL LABEL
+   Expands to show "Top" label on hover
+   ============================================================= */
+.btt-pill {
+  position: fixed;
+  right: var(--btt-right);
+  bottom: var(--btt-bottom);
+  z-index: 999;
+
+  height: var(--btt-size);
+  padding: 0 1rem;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  background: var(--btt-bg);
+  color: var(--btt-color);
+  font-family: inherit;
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  box-shadow: var(--btt-shadow);
+  text-decoration: none;
+
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+
+  /* Collapsed: only icon width */
+  max-width: var(--btt-size);
+  overflow: hidden;
+  white-space: nowrap;
+
+  opacity: 0;
+  transform: translateY(16px) scale(0.85);
+  pointer-events: none;
+  visibility: hidden;
+
+  transition:
+    max-width  0.35s ease,
+    padding    0.35s ease,
+    opacity    var(--btt-duration) var(--btt-ease),
+    transform  var(--btt-duration) var(--btt-ease),
+    background 0.2s ease,
+    box-shadow 0.2s ease,
+    visibility 0s var(--btt-duration);
+}
+
+.btt-pill.is-visible {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+  visibility: visible;
+  transition:
+    max-width  0.35s ease,
+    padding    0.35s ease,
+    opacity    var(--btt-duration) var(--btt-ease),
+    transform  var(--btt-duration) var(--btt-ease),
+    background 0.2s ease,
+    box-shadow 0.2s ease,
+    visibility 0s 0s;
+}
+
+.btt-pill:hover {
+  max-width: 120px;
+  background: var(--btt-bg-hover);
+  box-shadow: var(--btt-shadow-hover);
+}
+
+.btt-pill:active { transform: scale(0.96); }
+
+.btt-pill:focus-visible {
+  outline: 2px solid #fbbf24;
+  outline-offset: 3px;
+}
+
+.btt-pill svg {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  transition: transform 0.2s ease;
+}
+
+.btt-pill:hover svg { transform: translateY(-2px); }
+
+.btt-pill-label {
+  overflow: hidden;
+  max-width: 0;
+  opacity: 0;
+  transition: max-width 0.3s ease, opacity 0.25s ease;
+}
+
+.btt-pill:hover .btt-pill-label {
+  max-width: 60px;
+  opacity: 1;
+}
+
+/* =============================================================
+   DEMO VARIANT LABELS (demo page only)
+   ============================================================= */
+.variant-label {
+  position: fixed;
+  z-index: 998;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #64748b;
+  white-space: nowrap;
+}
+
+/* =============================================================
+   REDUCED MOTION
+   ============================================================= */
+@media (prefers-reduced-motion: reduce) {
+  .btt-btn,
+  .btt-progress-wrap,
+  .btt-pill {
+    transition: opacity 0.1s ease, visibility 0s;
+    transform: none !important;
+  }
+
+  .btt-btn:hover,
+  .btt-progress-btn:hover,
+  .btt-pill:hover { transform: none; }
+
+  .btt-btn svg,
+  .btt-progress-btn svg,
+  .btt-pill svg { transition: none; }
+}


### PR DESCRIPTION
Adds 3 CSS variants of a back-to-top button: classic circle, scroll-progress ring, and expanding pill label. Scroll trigger is ~30 lines of vanilla JS. Elastic spring easing, keyboard accessible, prefers-reduced-motion respected.

Track: Standard (HTML/CSS) — submissions/examples/ease-back-to-top/
Files: demo.html · style.css · README.md