### PR TITLE
Add Analytics Widgets example

### DIFF
--- a/submissions/examples/analytics-widgets-shambhavi/README.md
+++ b/submissions/examples/analytics-widgets-shambhavi/README.md
@@ -1,0 +1,24 @@
+# Analytics Widgets
+
+A responsive Analytics Widgets dashboard built for EaseMotion CSS.
+
+## Features
+
+- Responsive KPI dashboard
+- Gradient cards
+- Business metrics
+- Hover animation
+- Pure HTML & CSS
+- No JavaScript
+
+## Files
+
+```
+demo.html
+style.css
+README.md
+```
+
+## Usage
+
+Open `demo.html` in your browser.

--- a/submissions/examples/analytics-widgets-shambhavi/demo.html
+++ b/submissions/examples/analytics-widgets-shambhavi/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Analytics Widgets</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+<div class="dashboard">
+
+    <div class="card revenue">
+        <h3>Total Revenue</h3>
+        <h2>$24.5K</h2>
+        <p>▲ +18% this month</p>
+    </div>
+
+    <div class="card users">
+        <h3>Users</h3>
+        <h2>12,840</h2>
+        <p>▲ +7%</p>
+    </div>
+
+    <div class="card orders">
+        <h3>Orders</h3>
+        <h2>1,284</h2>
+        <p>▲ +12%</p>
+    </div>
+
+    <div class="card profit">
+        <h3>Net Profit</h3>
+        <h2>$9.8K</h2>
+        <p>▲ +15%</p>
+    </div>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/analytics-widgets-shambhavi/style.css
+++ b/submissions/examples/analytics-widgets-shambhavi/style.css
@@ -1,0 +1,122 @@
+:root{
+
+    --purple:#7C3AED;
+    --blue:#2563EB;
+    --green:#16A34A;
+    --orange:#EA580C;
+
+}
+
+*{
+
+    margin:0;
+    padding:0;
+    box-sizing:border-box;
+
+}
+
+body{
+
+    min-height:100vh;
+
+    display:flex;
+
+    justify-content:center;
+
+    align-items:center;
+
+    background:#f3f5f9;
+
+    font-family:Arial,sans-serif;
+
+}
+
+.dashboard{
+
+    display:grid;
+
+    grid-template-columns:
+    repeat(auto-fit,minmax(240px,1fr));
+
+    gap:25px;
+
+    width:min(1100px,90%);
+
+}
+
+.card{
+
+    color:white;
+
+    padding:28px;
+
+    border-radius:20px;
+
+    transition:
+    transform .35s ease,
+    box-shadow .35s ease;
+
+}
+
+.card:hover{
+
+    transform:translateY(-8px);
+
+    box-shadow:
+    0 20px 35px rgba(0,0,0,.18);
+
+}
+
+.card h3{
+
+    margin-bottom:15px;
+
+    font-weight:500;
+
+}
+
+.card h2{
+
+    font-size:2rem;
+
+    margin-bottom:10px;
+
+}
+
+.revenue{
+
+    background:
+    linear-gradient(135deg,#8B5CF6,#6D28D9);
+
+}
+
+.users{
+
+    background:
+    linear-gradient(135deg,#3B82F6,#1D4ED8);
+
+}
+
+.orders{
+
+    background:
+    linear-gradient(135deg,#10B981,#047857);
+
+}
+
+.profit{
+
+    background:
+    linear-gradient(135deg,#F97316,#C2410C);
+
+}
+
+@media(max-width:768px){
+
+.dashboard{
+
+grid-template-columns:1fr;
+
+}
+
+}


### PR DESCRIPTION
## Description

Added a standalone Analytics Widgets showcase demonstrating colorful KPI dashboard cards with modern gradients, responsive layouts, and business metrics.

## Changes Made

- Added `analytics-widgets-shambhavi` under `submissions/examples/`
- Created a responsive dashboard layout with colorful KPI cards
- Applied modern gradient backgrounds and hover effects
- Implemented a pure HTML & CSS solution without JavaScript
- Added documentation in `README.md`

## Testing

- Verified the layout in modern browsers
- Confirmed responsive behavior across different screen sizes
- Tested hover effects and browser compatibility