### PR TITLE
feat: add confetti progress bar component

### DIFF
--- a/submissions/examples/confetti-progress-bar-sm/README.md
+++ b/submissions/examples/confetti-progress-bar-sm/README.md
@@ -1,0 +1,60 @@
+# Confetti Progress Bar
+
+A pure CSS progress component for celebratory portfolio and onboarding moments.
+It pairs a smooth animated fill with a small confetti burst at the leading edge
+of the progress bar.
+
+Resolves Issue: #42622
+
+## Features
+
+- Pure CSS implementation with no JavaScript.
+- Uses `ease-*` class names plus `ease-confetti-*` custom properties and
+  keyframes.
+- Configurable progress through `--ease-confetti-value` on each progress track.
+- Accessible `role="progressbar"` markup with `aria-valuemin`, `aria-valuemax`,
+  and `aria-valuenow`.
+- Responsive layout for narrow screens.
+- Reduced-motion support that disables fill, shine, and confetti animations.
+
+## Usage
+
+```html
+<div
+  class="ease-confetti-track"
+  role="progressbar"
+  aria-label="Launch checklist progress"
+  aria-valuemin="0"
+  aria-valuemax="100"
+  aria-valuenow="96"
+  style="--ease-confetti-value: 96%"
+>
+  <span class="ease-confetti-fill">
+    <span class="ease-confetti-burst" aria-hidden="true"></span>
+  </span>
+</div>
+```
+
+Theme the component by overriding the CSS variables:
+
+```css
+:root {
+  --ease-confetti-primary: #ff6b35;
+  --ease-confetti-secondary: #ffd166;
+  --ease-confetti-accent: #06d6a0;
+  --ease-confetti-duration: 1150ms;
+}
+```
+
+## Files
+
+- `demo.html` - self-contained browser demo with three progress examples.
+- `style.css` - animation tokens, progress bar styles, responsive rules, and
+  reduced-motion handling.
+- `README.md` - usage, feature, and accessibility notes.
+
+## Accessibility
+
+Each track uses native progressbar ARIA attributes so assistive technologies can
+read the current percentage. The decorative confetti burst is hidden from the
+accessibility tree with `aria-hidden="true"`.

--- a/submissions/examples/confetti-progress-bar-sm/demo.html
+++ b/submissions/examples/confetti-progress-bar-sm/demo.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Confetti Progress Bar - EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="ease-confetti-demo" aria-labelledby="ease-confetti-title">
+      <section class="ease-confetti-panel">
+        <p class="ease-confetti-kicker">Portfolio progress</p>
+        <h1 id="ease-confetti-title">Confetti Progress Bar</h1>
+        <p class="ease-confetti-copy">
+          A celebratory progress component for portfolio milestones, course
+          completion, onboarding checklists, and launch-readiness dashboards.
+        </p>
+
+        <div class="ease-confetti-stack" aria-label="Project progress examples">
+          <article class="ease-confetti-item">
+            <div class="ease-confetti-header">
+              <span>Case study polish</span>
+              <strong>82%</strong>
+            </div>
+            <div
+              class="ease-confetti-track"
+              role="progressbar"
+              aria-label="Case study polish progress"
+              aria-valuemin="0"
+              aria-valuemax="100"
+              aria-valuenow="82"
+              style="--ease-confetti-value: 82%"
+            >
+              <span class="ease-confetti-fill">
+                <span class="ease-confetti-burst" aria-hidden="true"></span>
+              </span>
+            </div>
+          </article>
+
+          <article class="ease-confetti-item ease-confetti-item-accent">
+            <div class="ease-confetti-header">
+              <span>Prototype handoff</span>
+              <strong>64%</strong>
+            </div>
+            <div
+              class="ease-confetti-track"
+              role="progressbar"
+              aria-label="Prototype handoff progress"
+              aria-valuemin="0"
+              aria-valuemax="100"
+              aria-valuenow="64"
+              style="--ease-confetti-value: 64%"
+            >
+              <span class="ease-confetti-fill">
+                <span class="ease-confetti-burst" aria-hidden="true"></span>
+              </span>
+            </div>
+          </article>
+
+          <article class="ease-confetti-item ease-confetti-item-warm">
+            <div class="ease-confetti-header">
+              <span>Launch checklist</span>
+              <strong>96%</strong>
+            </div>
+            <div
+              class="ease-confetti-track"
+              role="progressbar"
+              aria-label="Launch checklist progress"
+              aria-valuemin="0"
+              aria-valuemax="100"
+              aria-valuenow="96"
+              style="--ease-confetti-value: 96%"
+            >
+              <span class="ease-confetti-fill">
+                <span class="ease-confetti-burst" aria-hidden="true"></span>
+              </span>
+            </div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/confetti-progress-bar-sm/style.css
+++ b/submissions/examples/confetti-progress-bar-sm/style.css
@@ -1,0 +1,296 @@
+/* ==========================================================================
+   Confetti Progress Bar - EaseMotion CSS
+   --------------------------------------------------------------------------
+   A pure CSS progress component with an animated fill and tiny confetti burst.
+   Values are controlled with --ease-confetti-value on each track.
+
+   Issue: #42622
+   ========================================================================== */
+
+:root {
+  --ease-confetti-bg: #fffaf0;
+  --ease-confetti-card: #ffffff;
+  --ease-confetti-ink: #21160d;
+  --ease-confetti-muted: #7a6552;
+  --ease-confetti-track: #f3dfc4;
+  --ease-confetti-primary: #ff6b35;
+  --ease-confetti-secondary: #ffd166;
+  --ease-confetti-accent: #06d6a0;
+  --ease-confetti-shadow: 0 1.4rem 4rem rgba(128, 75, 26, 0.16);
+  --ease-confetti-radius: 1.25rem;
+  --ease-confetti-duration: 1150ms;
+  --ease-confetti-pop-duration: 1400ms;
+  --ease-confetti-ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1rem;
+  color: var(--ease-confetti-ink);
+  font-family:
+    "Segoe UI",
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    sans-serif;
+  background:
+    radial-gradient(
+      circle at 15% 18%,
+      rgba(255, 107, 53, 0.22),
+      transparent 18rem
+    ),
+    radial-gradient(
+      circle at 88% 12%,
+      rgba(6, 214, 160, 0.2),
+      transparent 18rem
+    ),
+    linear-gradient(
+      135deg,
+      #fff7df 0%,
+      var(--ease-confetti-bg) 55%,
+      #f9efe1 100%
+    );
+}
+
+.ease-confetti-demo {
+  width: min(100%, 43rem);
+}
+
+.ease-confetti-panel {
+  position: relative;
+  overflow: hidden;
+  padding: clamp(1.4rem, 5vw, 2.5rem);
+  border: 1px solid rgba(255, 107, 53, 0.18);
+  border-radius: var(--ease-confetti-radius);
+  background: var(--ease-confetti-card);
+  box-shadow: var(--ease-confetti-shadow);
+}
+
+.ease-confetti-panel::before,
+.ease-confetti-panel::after {
+  content: "";
+  position: absolute;
+  border-radius: 999px;
+  pointer-events: none;
+}
+
+.ease-confetti-panel::before {
+  width: 11rem;
+  height: 11rem;
+  right: -4rem;
+  top: -4rem;
+  background: rgba(255, 209, 102, 0.34);
+}
+
+.ease-confetti-panel::after {
+  width: 8rem;
+  height: 8rem;
+  left: -3rem;
+  bottom: -3rem;
+  background: rgba(6, 214, 160, 0.18);
+}
+
+.ease-confetti-kicker {
+  margin: 0 0 0.75rem;
+  color: var(--ease-confetti-primary);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 10ch;
+  margin: 0;
+  font-size: clamp(2rem, 7vw, 4rem);
+  line-height: 0.95;
+  letter-spacing: -0.06em;
+}
+
+.ease-confetti-copy {
+  max-width: 35rem;
+  margin: 1rem 0 1.8rem;
+  color: var(--ease-confetti-muted);
+  font-size: clamp(0.95rem, 2vw, 1.05rem);
+  line-height: 1.65;
+}
+
+.ease-confetti-stack {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 1rem;
+}
+
+.ease-confetti-item {
+  --ease-confetti-fill-start: var(--ease-confetti-primary);
+  --ease-confetti-fill-end: var(--ease-confetti-secondary);
+  --ease-confetti-dot: var(--ease-confetti-accent);
+
+  padding: 1rem;
+  border: 1px solid rgba(122, 101, 82, 0.14);
+  border-radius: 1rem;
+  background: rgba(255, 250, 240, 0.74);
+}
+
+.ease-confetti-item-accent {
+  --ease-confetti-fill-start: #06d6a0;
+  --ease-confetti-fill-end: #4cc9f0;
+  --ease-confetti-dot: #ff6b35;
+}
+
+.ease-confetti-item-warm {
+  --ease-confetti-fill-start: #ef476f;
+  --ease-confetti-fill-end: #ffd166;
+  --ease-confetti-dot: #06d6a0;
+}
+
+.ease-confetti-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.7rem;
+  font-size: 0.95rem;
+  font-weight: 750;
+}
+
+.ease-confetti-header strong {
+  color: var(--ease-confetti-fill-start);
+  font-size: 0.95rem;
+}
+
+.ease-confetti-track {
+  position: relative;
+  height: 1.05rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background:
+    linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.42) 0 0.45rem,
+      transparent 0.45rem 0.9rem
+    ),
+    var(--ease-confetti-track);
+  background-size: 0.9rem 100%;
+}
+
+.ease-confetti-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: var(--ease-confetti-value, 70%);
+  min-width: 2.2rem;
+  border-radius: inherit;
+  background: linear-gradient(
+    90deg,
+    var(--ease-confetti-fill-start),
+    var(--ease-confetti-fill-end)
+  );
+  box-shadow: inset 0 0.18rem 0 rgba(255, 255, 255, 0.42);
+  transform-origin: left center;
+  animation: ease-confetti-fill var(--ease-confetti-duration)
+    var(--ease-confetti-ease) both;
+}
+
+.ease-confetti-fill::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(
+    110deg,
+    transparent 0 32%,
+    rgba(255, 255, 255, 0.55) 46%,
+    transparent 62%
+  );
+  animation: ease-confetti-shine 1800ms ease-in-out infinite;
+}
+
+.ease-confetti-burst {
+  position: absolute;
+  top: 50%;
+  right: 0;
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+  background: var(--ease-confetti-dot);
+  transform: translate(50%, -50%);
+  box-shadow:
+    0 -1.15rem 0 -0.06rem var(--ease-confetti-dot),
+    0.85rem -0.7rem 0 -0.08rem var(--ease-confetti-secondary),
+    1rem 0.18rem 0 -0.07rem var(--ease-confetti-primary),
+    0.58rem 0.95rem 0 -0.08rem var(--ease-confetti-accent),
+    -0.55rem 0.75rem 0 -0.08rem var(--ease-confetti-secondary),
+    -0.9rem -0.28rem 0 -0.08rem var(--ease-confetti-primary);
+  animation: ease-confetti-pop var(--ease-confetti-pop-duration) ease-out
+    infinite;
+}
+
+@keyframes ease-confetti-fill {
+  from {
+    transform: scaleX(0);
+  }
+
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@keyframes ease-confetti-shine {
+  from {
+    transform: translateX(-110%);
+  }
+
+  to {
+    transform: translateX(110%);
+  }
+}
+
+@keyframes ease-confetti-pop {
+  0%,
+  52% {
+    opacity: 0;
+    transform: translate(50%, -50%) scale(0.45) rotate(0deg);
+  }
+
+  64% {
+    opacity: 1;
+    transform: translate(50%, -50%) scale(1) rotate(12deg);
+  }
+
+  100% {
+    opacity: 0;
+    transform: translate(50%, -50%) scale(1.25) rotate(38deg);
+  }
+}
+
+@media (max-width: 34rem) {
+  body {
+    padding: 1rem;
+  }
+
+  .ease-confetti-header {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-confetti-fill,
+  .ease-confetti-fill::after,
+  .ease-confetti-burst {
+    animation: none;
+  }
+
+  .ease-confetti-burst {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS `confetti-progress-bar-sm` example component for the requested Confetti Progress Bar issue. The demo includes three accessible progressbar examples with animated fill, shine, and a decorative confetti burst.

Closes #42622

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [x] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/confetti-progress-bar-sm/`)
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A responsive, accessible, pure CSS Confetti Progress Bar component with animated progress fill and reduced-motion support.

**How does a developer use it?**

```html
<div
  class="ease-confetti-track"
  role="progressbar"
  aria-label="Launch checklist progress"
  aria-valuemin="0"
  aria-valuemax="100"
  aria-valuenow="96"
  style="--ease-confetti-value: 96%"
>
  <span class="ease-confetti-fill">
    <span class="ease-confetti-burst" aria-hidden="true"></span>
  </span>
</div>
```

**Why does it fit EaseMotion CSS?**

It uses readable `ease-*` classes, named `ease-confetti-*` keyframes, CSS custom properties for theme/motion tuning, and works without JavaScript.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari (optional but appreciated)

---

## Validation

- `npx.cmd prettier --check submissions/examples/confetti-progress-bar-sm/demo.html submissions/examples/confetti-progress-bar-sm/style.css submissions/examples/confetti-progress-bar-sm/README.md`
- `npx.cmd stylelint --config .github/workflows/stylelint.config.json submissions/examples/confetti-progress-bar-sm/style.css`
- `npx.cmd htmlhint --config .github/workflows/htmlhint.config.json submissions/examples/confetti-progress-bar-sm/demo.html`

---

## Notes for Maintainer

Kept the implementation fully inside `submissions/examples/confetti-progress-bar-sm/`, with accessible `role="progressbar"` markup and a `prefers-reduced-motion` fallback.
