### PR TITLE
feat: add morph tab component

### DIFF
--- a/submissions/examples/morph-tab-sm/README.md
+++ b/submissions/examples/morph-tab-sm/README.md
@@ -1,0 +1,58 @@
+# Morph Tab
+
+A pure CSS cyberpunk tab component for dashboards, command centers, and creative
+portfolio sections. Native radio inputs hold the active state while the active
+indicator morphs between tabs without JavaScript.
+
+Resolves Issue: #42602
+
+## Features
+
+- Pure CSS implementation with no JavaScript.
+- Uses `ease-*` class names plus `ease-morph-*` keyframes, variables, and
+  selectors.
+- Native form controls power the selected state.
+- Keyboard-friendly labels and focus-visible styling.
+- Responsive tab and panel layout for small screens.
+- Reduced-motion support that removes indicator and panel transitions.
+
+## Usage
+
+```html
+<input
+  class="ease-morph-radio"
+  type="radio"
+  name="ease-morph-tabs"
+  id="ease-tab-design"
+  checked
+/>
+<label
+  class="ease-morph-tab ease-morph-tab-design"
+  role="tab"
+  for="ease-tab-design"
+>
+  Design
+</label>
+```
+
+The active panel and indicator are controlled with sibling selectors:
+
+```css
+#ease-tab-design:checked ~ .ease-morph-panels .ease-morph-panel-design {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+```
+
+## Files
+
+- `demo.html` - self-contained live demo with three tab states.
+- `style.css` - cyberpunk theme, morphing indicator, panel transitions, and
+  responsive/reduced-motion rules.
+- `README.md` - usage and accessibility notes.
+
+## Accessibility
+
+The demo uses native radio inputs so keyboard users can move through options
+without JavaScript. Labels expose clear names, visible focus rings are included,
+and decorative motion is disabled when users request reduced motion.

--- a/submissions/examples/morph-tab-sm/demo.html
+++ b/submissions/examples/morph-tab-sm/demo.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Morph Tab - EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="ease-morph-demo" aria-labelledby="ease-morph-title">
+      <section class="ease-morph-shell">
+        <p class="ease-morph-kicker">Cyberpunk navigation</p>
+        <h1 id="ease-morph-title">Morph Tab</h1>
+        <p class="ease-morph-copy">
+          A zero-JavaScript tab pattern that morphs its active indicator between
+          panels for dashboards, command centers, and creative portfolios.
+        </p>
+
+        <div class="ease-morph-tabs" aria-label="Project phases">
+          <input
+            class="ease-morph-radio"
+            type="radio"
+            name="ease-morph-tabs"
+            id="ease-tab-design"
+            checked
+          />
+          <input
+            class="ease-morph-radio"
+            type="radio"
+            name="ease-morph-tabs"
+            id="ease-tab-build"
+          />
+          <input
+            class="ease-morph-radio"
+            type="radio"
+            name="ease-morph-tabs"
+            id="ease-tab-launch"
+          />
+
+          <div
+            class="ease-morph-tablist"
+            role="tablist"
+            aria-label="Portfolio project phases"
+          >
+            <label
+              class="ease-morph-tab ease-morph-tab-design"
+              role="tab"
+              for="ease-tab-design"
+              >Design</label
+            >
+            <label
+              class="ease-morph-tab ease-morph-tab-build"
+              role="tab"
+              for="ease-tab-build"
+              >Build</label
+            >
+            <label
+              class="ease-morph-tab ease-morph-tab-launch"
+              role="tab"
+              for="ease-tab-launch"
+              >Launch</label
+            >
+            <span class="ease-morph-indicator" aria-hidden="true"></span>
+          </div>
+
+          <div class="ease-morph-panels">
+            <article class="ease-morph-panel ease-morph-panel-design">
+              <span class="ease-morph-panel-index">01</span>
+              <h2>Shape the neon concept</h2>
+              <p>
+                Map the visual system, choose interaction states, and define the
+                glow tokens before the first prototype is cut.
+              </p>
+            </article>
+
+            <article class="ease-morph-panel ease-morph-panel-build">
+              <span class="ease-morph-panel-index">02</span>
+              <h2>Build the interface loop</h2>
+              <p>
+                Convert the concept into reusable sections with clean CSS
+                variables, motion-safe transitions, and responsive spacing.
+              </p>
+            </article>
+
+            <article class="ease-morph-panel ease-morph-panel-launch">
+              <span class="ease-morph-panel-index">03</span>
+              <h2>Ship the final signal</h2>
+              <p>
+                Run checks, verify keyboard flow, and publish a polished demo
+                ready for maintainers to review.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/morph-tab-sm/style.css
+++ b/submissions/examples/morph-tab-sm/style.css
@@ -1,0 +1,277 @@
+/* ==========================================================================
+   Morph Tab - EaseMotion CSS
+   --------------------------------------------------------------------------
+   A pure CSS cyberpunk tab component. Native radio inputs hold the active
+   state, while the active indicator morphs across labels without JavaScript.
+
+   Issue: #42602
+   ========================================================================== */
+
+:root {
+  --ease-morph-bg: #050816;
+  --ease-morph-surface: rgba(12, 18, 39, 0.82);
+  --ease-morph-surface-strong: #111a36;
+  --ease-morph-ink: #eef7ff;
+  --ease-morph-muted: #9aabc7;
+  --ease-morph-cyan: #22d3ee;
+  --ease-morph-pink: #f472b6;
+  --ease-morph-lime: #a3ff12;
+  --ease-morph-border: rgba(34, 211, 238, 0.26);
+  --ease-morph-shadow: 0 1.6rem 4rem rgba(0, 0, 0, 0.42);
+  --ease-morph-radius: 1.25rem;
+  --ease-morph-duration: 460ms;
+  --ease-morph-panel-duration: 360ms;
+  --ease-morph-ease: cubic-bezier(0.68, -0.35, 0.24, 1.35);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1rem;
+  color: var(--ease-morph-ink);
+  font-family:
+    "Segoe UI",
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    sans-serif;
+  background:
+    linear-gradient(
+      120deg,
+      rgba(34, 211, 238, 0.13) 0 1px,
+      transparent 1px 4rem
+    ),
+    radial-gradient(
+      circle at 18% 18%,
+      rgba(244, 114, 182, 0.2),
+      transparent 20rem
+    ),
+    radial-gradient(
+      circle at 82% 10%,
+      rgba(34, 211, 238, 0.2),
+      transparent 22rem
+    ),
+    var(--ease-morph-bg);
+}
+
+.ease-morph-demo {
+  width: min(100%, 45rem);
+}
+
+.ease-morph-shell {
+  position: relative;
+  overflow: hidden;
+  padding: clamp(1.4rem, 5vw, 2.5rem);
+  border: 1px solid var(--ease-morph-border);
+  border-radius: var(--ease-morph-radius);
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.12), transparent 35%),
+    var(--ease-morph-surface);
+  box-shadow: var(--ease-morph-shadow);
+}
+
+.ease-morph-shell::before {
+  content: "";
+  position: absolute;
+  inset: auto -5rem -6rem auto;
+  width: 14rem;
+  height: 14rem;
+  border-radius: 50%;
+  background: rgba(163, 255, 18, 0.16);
+  filter: blur(1.6rem);
+  pointer-events: none;
+}
+
+.ease-morph-kicker {
+  margin: 0 0 0.75rem;
+  color: var(--ease-morph-lime);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.2rem, 8vw, 4.5rem);
+  line-height: 0.92;
+  letter-spacing: -0.07em;
+}
+
+.ease-morph-copy {
+  max-width: 36rem;
+  margin: 1rem 0 1.8rem;
+  color: var(--ease-morph-muted);
+  font-size: clamp(0.95rem, 2vw, 1.05rem);
+  line-height: 1.65;
+}
+
+.ease-morph-tabs {
+  position: relative;
+  z-index: 1;
+}
+
+.ease-morph-radio {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.ease-morph-tablist {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.35rem;
+  padding: 0.35rem;
+  border: 1px solid rgba(34, 211, 238, 0.18);
+  border-radius: 999px;
+  background: rgba(4, 9, 24, 0.64);
+}
+
+.ease-morph-tab {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  min-height: 2.9rem;
+  place-items: center;
+  border-radius: 999px;
+  color: var(--ease-morph-muted);
+  cursor: pointer;
+  font-size: 0.88rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  transition:
+    color 180ms ease,
+    text-shadow 180ms ease;
+}
+
+.ease-morph-tab:focus-visible {
+  outline: 2px solid var(--ease-morph-lime);
+  outline-offset: 0.2rem;
+}
+
+.ease-morph-indicator {
+  position: absolute;
+  z-index: 1;
+  top: 0.35rem;
+  left: 0.35rem;
+  width: calc((100% - 0.7rem) / 3);
+  height: calc(100% - 0.7rem);
+  border-radius: 999px;
+  background:
+    radial-gradient(
+      circle at 30% 24%,
+      rgba(255, 255, 255, 0.8),
+      transparent 0.45rem
+    ),
+    linear-gradient(135deg, var(--ease-morph-cyan), var(--ease-morph-pink));
+  box-shadow:
+    0 0 1.4rem rgba(34, 211, 238, 0.42),
+    inset 0 1px 0 rgba(255, 255, 255, 0.45);
+  transition:
+    transform var(--ease-morph-duration) var(--ease-morph-ease),
+    border-radius var(--ease-morph-duration) var(--ease-morph-ease);
+}
+
+#ease-tab-design:checked ~ .ease-morph-tablist .ease-morph-tab-design,
+#ease-tab-build:checked ~ .ease-morph-tablist .ease-morph-tab-build,
+#ease-tab-launch:checked ~ .ease-morph-tablist .ease-morph-tab-launch {
+  color: #06101d;
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.24);
+}
+
+#ease-tab-build:checked ~ .ease-morph-tablist .ease-morph-indicator {
+  border-radius: 45% 55% 48% 52% / 52% 42% 58% 48%;
+  transform: translateX(100%);
+}
+
+#ease-tab-launch:checked ~ .ease-morph-tablist .ease-morph-indicator {
+  border-radius: 55% 45% 58% 42% / 45% 62% 38% 55%;
+  transform: translateX(200%);
+}
+
+.ease-morph-panels {
+  position: relative;
+  min-height: 13rem;
+  margin-top: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1rem;
+  background:
+    linear-gradient(90deg, rgba(255, 255, 255, 0.055) 1px, transparent 1px),
+    linear-gradient(rgba(255, 255, 255, 0.055) 1px, transparent 1px),
+    var(--ease-morph-surface-strong);
+  background-size: 1.5rem 1.5rem;
+}
+
+.ease-morph-panel {
+  position: absolute;
+  inset: 0;
+  padding: clamp(1.1rem, 4vw, 1.5rem);
+  opacity: 0;
+  transform: translateY(0.65rem) scale(0.98);
+  transition:
+    opacity var(--ease-morph-panel-duration) ease,
+    transform var(--ease-morph-panel-duration) ease;
+}
+
+.ease-morph-panel-index {
+  color: var(--ease-morph-lime);
+  font-size: 0.8rem;
+  font-weight: 900;
+  letter-spacing: 0.16em;
+}
+
+.ease-morph-panel h2 {
+  margin: 0.45rem 0 0.65rem;
+  font-size: clamp(1.35rem, 5vw, 2rem);
+}
+
+.ease-morph-panel p {
+  max-width: 32rem;
+  margin: 0;
+  color: var(--ease-morph-muted);
+  line-height: 1.6;
+}
+
+#ease-tab-design:checked ~ .ease-morph-panels .ease-morph-panel-design,
+#ease-tab-build:checked ~ .ease-morph-panels .ease-morph-panel-build,
+#ease-tab-launch:checked ~ .ease-morph-panels .ease-morph-panel-launch {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+@media (max-width: 36rem) {
+  body {
+    padding: 1rem;
+  }
+
+  .ease-morph-tablist {
+    border-radius: 1rem;
+  }
+
+  .ease-morph-tab {
+    min-height: 2.55rem;
+    font-size: 0.75rem;
+  }
+
+  .ease-morph-panels {
+    min-height: 15rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-morph-tab,
+  .ease-morph-indicator,
+  .ease-morph-panel {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS `morph-tab-sm` example component for the requested Morph Tab issue. The demo uses native radio inputs, a cyberpunk morphing active indicator, panel transitions, keyboard-friendly labels, and reduced-motion handling.

Closes #42602

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [x] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/morph-tab-sm/`)
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A responsive, accessible, pure CSS Morph Tab component with native radio state, morphing active indicator, and panel transitions.

**How does a developer use it?**

```html
<input class="ease-morph-radio" type="radio" name="ease-morph-tabs" id="ease-tab-design" checked />
<label class="ease-morph-tab ease-morph-tab-design" role="tab" for="ease-tab-design">
  Design
</label>
```

**Why does it fit EaseMotion CSS?**

It uses readable `ease-*` classes, `ease-morph-*` selectors and CSS variables, works without JavaScript, and keeps the animation configurable and motion-safe.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari (optional but appreciated)

---

## Validation

- `npx.cmd prettier --check submissions/examples/morph-tab-sm/demo.html submissions/examples/morph-tab-sm/style.css submissions/examples/morph-tab-sm/README.md`
- `npx.cmd stylelint --config .github/workflows/stylelint.config.json submissions/examples/morph-tab-sm/style.css`
- `npx.cmd htmlhint --config .github/workflows/htmlhint.config.json submissions/examples/morph-tab-sm/demo.html`

---

## Notes for Maintainer

Kept the component fully inside `submissions/examples/morph-tab-sm/`, with native form controls for state and `prefers-reduced-motion` support.
