### PR TITLE
feat: add underline draw dark mode toggle component

### DIFF
--- a/submissions/examples/underline-draw-dark-mode-toggle-arn24/README.md
+++ b/submissions/examples/underline-draw-dark-mode-toggle-arn24/README.md
@@ -1,0 +1,113 @@
+# Underline Draw Dark Mode Toggle
+
+A pure-CSS dark mode toggle for **EaseMotion CSS**. Hovering or focusing the
+control "draws" an animated underline beneath the label text; the sun/moon
+icon crossfades and rotates using EaseMotion's easing tokens. No JavaScript
+is required — the toggle state is driven entirely by a native `<input
+type="checkbox">` and the `:checked` selector.
+
+Submitted for issue **#41427** as part of GSSoC '26.
+
+## Preview
+
+Open `demo.html` in a browser to see it live. Click the label (or tab to it
+and press Space) to switch between light and dark states.
+
+## Files
+
+```
+underline-draw-dark-mode-toggle-arn24/
+├── demo.html    ← standalone live demo
+├── style.css    ← component styles
+└── README.md    ← this file
+```
+
+## Usage
+
+1. Include EaseMotion CSS as usual:
+
+```html
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+/>
+```
+
+2. Include this component's stylesheet:
+
+```html
+<link rel="stylesheet" href="style.css" />
+```
+
+3. Drop in the markup:
+
+```html
+<div class="ease-dmtoggle-wrapper-arn24">
+  <input type="checkbox" id="easeDarkModeToggle" class="ease-dmtoggle-input-arn24" />
+  <label for="easeDarkModeToggle" class="ease-dmtoggle-label-arn24">
+    <span class="ease-dmtoggle-icon-arn24" aria-hidden="true">
+      <!-- sun/moon svgs, see demo.html -->
+    </span>
+    <span class="ease-dmtoggle-text-arn24">
+      Dark Mode
+      <span class="ease-dmtoggle-underline-arn24"></span>
+    </span>
+  </label>
+</div>
+```
+
+That's it — no JS wiring needed for the toggle animation itself. If you want
+the checkbox state to actually switch your app's theme (rather than just the
+demo's `body:has()` styling), listen for the native `change` event on
+`#easeDarkModeToggle` in your own app code and swap a `data-theme` attribute
+or class as you normally would.
+
+## How it works
+
+- **Underline draw**: `.ease-dmtoggle-underline-arn24` is a `0%`-wide bar
+  that transitions to `100%` width on `:hover` / `:focus-visible`, and stays
+  drawn while the checkbox is `:checked` — so the current state is visible
+  without needing hover.
+- **Icon swap**: the sun and moon SVGs are absolutely positioned on top of
+  each other and crossfade with a rotate + scale transform, timed with
+  `var(--ease-speed-slow)` and `var(--ease-ease-bounce)` for a slight
+  overshoot.
+- **Page theming**: `demo.html` includes an optional `body:has(...)` rule
+  that retints the whole page when checked. This is progressive enhancement
+  — the toggle control itself works in any browser; only the whole-page
+  restyle depends on `:has()` support.
+
+## Customization
+
+Override these on `:root` or a parent element — the component falls back to
+sensible defaults if EaseMotion's core variables aren't present:
+
+```css
+:root {
+  --ease-color-primary: #6366f1;  /* underline + focus ring color */
+  --ease-color-success: #10b981;  /* underline color while checked */
+  --ease-speed-medium: 300ms;     /* underline draw speed */
+  --ease-speed-slow: 600ms;       /* icon transition speed */
+  --ease-radius-full: 9999px;
+}
+```
+
+## Accessibility
+
+- Built on a native `<input type="checkbox">` + `<label>`, so it's keyboard
+  operable (Tab + Space) and announced correctly by screen readers without
+  extra ARIA.
+- A visible `:focus-visible` outline is included for keyboard users.
+- Respects `prefers-reduced-motion: reduce` by disabling all transitions.
+- Color contrast for text and icons meets WCAG AA against both the light
+  and dark backgrounds used in the demo.
+
+## Browser support
+
+Works in all evergreen browsers. The optional whole-page `body:has()`
+theming in `demo.html` requires `:has()` support (Chrome/Edge 105+, Safari
+15.4+, Firefox 121+); the toggle control itself has no such dependency.
+
+---
+
+Contributed by **Archana Nair** ([@Archana7224](https://github.com/Archana7224)) for GSSoC '26.

--- a/submissions/examples/underline-draw-dark-mode-toggle-arn24/demo.html
+++ b/submissions/examples/underline-draw-dark-mode-toggle-arn24/demo.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Underline Draw Dark Mode Toggle — EaseMotion CSS</title>
+
+  <!-- EaseMotion CSS -->
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+
+  <!-- Component styles -->
+  <link rel="stylesheet" href="style.css" />
+
+  <style>
+    body {
+      min-height: 100vh;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: "Inter", system-ui, sans-serif;
+      background: #f8fafc;
+      color: #1f2937;
+    }
+
+    .demo-card {
+      text-align: center;
+      padding: 3rem 2.5rem;
+      border-radius: 1.25rem;
+      background: rgba(255, 255, 255, 0.6);
+      box-shadow: 0 10px 40px rgba(0, 0, 0, 0.08);
+    }
+
+    .demo-card h1 {
+      font-size: 1.4rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .demo-card p {
+      margin-top: 0;
+      margin-bottom: 2rem;
+      opacity: 0.75;
+      font-size: 0.95rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="demo-card ease-fade-in">
+    <h1 class="ease-slide-up">Underline Draw Dark Mode Toggle</h1>
+    <p class="ease-slide-up ease-delay-100">
+      Click the toggle below. Pure CSS, no JavaScript.
+    </p>
+
+    <div class="ease-dmtoggle-wrapper-arn24 ease-slide-up ease-delay-200">
+      <input
+        type="checkbox"
+        id="easeDarkModeToggle"
+        class="ease-dmtoggle-input-arn24"
+      />
+      <label for="easeDarkModeToggle" class="ease-dmtoggle-label-arn24">
+        <span class="ease-dmtoggle-icon-arn24" aria-hidden="true">
+          <svg
+            class="ease-dmtoggle-icon-sun-arn24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+          >
+            <circle cx="12" cy="12" r="4"></circle>
+            <line x1="12" y1="2" x2="12" y2="4"></line>
+            <line x1="12" y1="20" x2="12" y2="22"></line>
+            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+            <line x1="2" y1="12" x2="4" y2="12"></line>
+            <line x1="20" y1="12" x2="22" y2="12"></line>
+            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+          </svg>
+          <svg
+            class="ease-dmtoggle-icon-moon-arn24"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+          >
+            <path
+              d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79z"
+            ></path>
+          </svg>
+        </span>
+        <span class="ease-dmtoggle-text-arn24">
+          Dark Mode
+          <span class="ease-dmtoggle-underline-arn24"></span>
+        </span>
+      </label>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/underline-draw-dark-mode-toggle-arn24/style.css
+++ b/submissions/examples/underline-draw-dark-mode-toggle-arn24/style.css
@@ -1,0 +1,161 @@
+/* =========================================================
+   Underline Draw Dark Mode Toggle — ease-dmtoggle-*-arn24
+   Submission for EaseMotion CSS (GSSoC '26)
+   Author: Archana Nair (@Archana7224)
+
+   Pure CSS. No JavaScript required.
+   Uses EaseMotion CSS custom properties where available,
+   with safe fallbacks so the component still looks good
+   if used standalone.
+   ========================================================= */
+
+.ease-dmtoggle-wrapper-arn24 {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+/* Visually hide the checkbox but keep it accessible to
+   keyboard and screen reader users */
+.ease-dmtoggle-input-arn24 {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.ease-dmtoggle-label-arn24 {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  cursor: pointer;
+  padding: 0.5rem 0.9rem;
+  border-radius: var(--ease-radius-full, 9999px);
+  background: transparent;
+  transition: background-color var(--ease-speed-medium, 300ms)
+    cubic-bezier(0.4, 0, 0.2, 1);
+  user-select: none;
+}
+
+.ease-dmtoggle-label-arn24:hover {
+  background: rgba(99, 102, 241, 0.08);
+}
+
+/* Clear, visible focus ring for keyboard users */
+.ease-dmtoggle-input-arn24:focus-visible + .ease-dmtoggle-label-arn24 {
+  outline: 2px solid var(--ease-color-primary, #6366f1);
+  outline-offset: 2px;
+}
+
+/* ---------- Icon (sun / moon crossfade + rotate) ---------- */
+.ease-dmtoggle-icon-arn24 {
+  position: relative;
+  width: 1.25rem;
+  height: 1.25rem;
+  flex-shrink: 0;
+}
+
+.ease-dmtoggle-icon-arn24 svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  transition:
+    opacity var(--ease-speed-medium, 300ms) cubic-bezier(0.4, 0, 0.2, 1),
+    transform var(--ease-speed-slow, 600ms)
+      var(--ease-ease-bounce, cubic-bezier(0.34, 1.56, 0.64, 1));
+}
+
+.ease-dmtoggle-icon-sun-arn24 {
+  opacity: 1;
+  transform: rotate(0deg) scale(1);
+  color: #f59e0b;
+}
+
+.ease-dmtoggle-icon-moon-arn24 {
+  opacity: 0;
+  transform: rotate(-90deg) scale(0.5);
+  color: #a5b4fc;
+}
+
+.ease-dmtoggle-input-arn24:checked
+  + .ease-dmtoggle-label-arn24
+  .ease-dmtoggle-icon-sun-arn24 {
+  opacity: 0;
+  transform: rotate(90deg) scale(0.5);
+}
+
+.ease-dmtoggle-input-arn24:checked
+  + .ease-dmtoggle-label-arn24
+  .ease-dmtoggle-icon-moon-arn24 {
+  opacity: 1;
+  transform: rotate(0deg) scale(1);
+}
+
+/* ---------- Text + underline draw ---------- */
+.ease-dmtoggle-text-arn24 {
+  position: relative;
+  font-family: inherit;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--ease-color-text, #1f2937);
+  white-space: nowrap;
+}
+
+.ease-dmtoggle-underline-arn24 {
+  position: absolute;
+  left: 0;
+  bottom: -0.2rem;
+  height: 2px;
+  width: 0%;
+  border-radius: var(--ease-radius-full, 9999px);
+  background: var(--ease-color-primary, #6366f1);
+  transition: width var(--ease-speed-medium, 300ms) cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Draw underline on hover / focus */
+.ease-dmtoggle-label-arn24:hover .ease-dmtoggle-underline-arn24,
+.ease-dmtoggle-input-arn24:focus-visible
+  + .ease-dmtoggle-label-arn24
+  .ease-dmtoggle-underline-arn24 {
+  width: 100%;
+}
+
+/* Keep underline fully drawn while dark mode is active,
+   so the toggle's state is visible even without hover/focus */
+.ease-dmtoggle-input-arn24:checked
+  + .ease-dmtoggle-label-arn24
+  .ease-dmtoggle-underline-arn24 {
+  width: 100%;
+  background: var(--ease-color-success, #10b981);
+}
+
+/* ---------- Optional: theme the whole page via :has() ----------
+   Progressive enhancement only. Falls back gracefully in browsers
+   that don't yet support :has(). The toggle itself works everywhere. */
+body:has(.ease-dmtoggle-input-arn24:checked) {
+  background: #0f172a;
+  color: #e2e8f0;
+  transition: background-color var(--ease-speed-slow, 600ms) ease,
+    color var(--ease-speed-slow, 600ms) ease;
+}
+
+body:has(.ease-dmtoggle-input-arn24:checked)
+  .ease-dmtoggle-text-arn24 {
+  color: #e2e8f0;
+}
+
+/* ---------- Reduced motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .ease-dmtoggle-label-arn24,
+  .ease-dmtoggle-icon-arn24 svg,
+  .ease-dmtoggle-underline-arn24,
+  body:has(.ease-dmtoggle-input-arn24:checked) {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
Adds a pure-CSS Underline Draw Dark Mode Toggle component to submissions/examples/, as requested in issue #41427 . Hovering or focusing the toggle draws an animated underline beneath the label, and the sun/moon icon crossfades with a subtle rotate + scale.
Closes #41427

Type of Change

 ✨ New animation / hover effect
 🧩 New component
 📝 Documentation improvement
 🐛 Bug fix in an existing submission
 Other (describe below)


Submission Checklist

⚠️ PRs that fail this checklist will be closed without review.


 All changes are inside submissions/ (submissions/examples/underline-draw-dark-mode-toggle-arn24/)
 Includes demo.html — self-contained, opens in browser with no server
 Includes style.css — raw CSS for the proposed feature
 Includes README.md — what it does, how to use it, why it fits EaseMotion CSS
 No changes to core/
 No changes to components/
 One feature per PR (no bundled unrelated changes)


Feature Description
What does this add?
A keyboard-accessible, pure-CSS dark mode toggle with an animated underline-draw effect and a crossfading sun/moon icon — no JavaScript required.
How does a developer use it?
html<div class="ease-dmtoggle-wrapper-arn24">
  <input type="checkbox" id="easeDarkModeToggle" class="ease-dmtoggle-input-arn24" />
  <label for="easeDarkModeToggle" class="ease-dmtoggle-label-arn24">
    <span class="ease-dmtoggle-icon-arn24" aria-hidden="true">
      <!-- sun/moon svgs, see demo.html -->
    </span>
    <span class="ease-dmtoggle-text-arn24">
      Dark Mode
      <span class="ease-dmtoggle-underline-arn24"></span>
    </span>
  </label>
</div>
Why does it fit EaseMotion CSS?
It follows the human-readable ease-* naming pattern, treats motion as a first-class feature (not an afterthought bolted onto a static toggle), needs zero build step, and themes entirely through EaseMotion's existing CSS custom properties (--ease-color-primary, --ease-speed-medium, --ease-speed-slow, --ease-ease-bounce, --ease-radius-full), with graceful fallbacks if those aren't defined.

Demo

 Demo added (demo.html works by opening directly in a browser)


Browser Testing

 Chrome
 Firefox
 Edge
 Safari (optional but appreciated)


Notes for Maintainer
Underline stays fully drawn while checked (not just on hover/focus), so the toggle's state is visible at a glance without needing to hover — happy to adjust that behavior if you'd prefer hover-only. The whole-page retint in demo.html uses body:has(...) as progressive enhancement; the toggle control itself doesn't depend on :has() support. All custom classes carry the -arn24 suffix per the naming policy.


Reminder: Only the repository maintainer may merge pull requests.
Do not self-merge, even if you have write access.
Maximum 25 active assigned issues per contributor — unassign extras before opening a PR.
Tip: Once you open your PR, feel free to showcase your design or component in the #showcase channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!