### PR TITLE
fix: remove stale generated em animation classes on attribute change (#40059)

### DIFF
--- a/easemotion/engine/runtime.js
+++ b/easemotion/engine/runtime.js
@@ -42,13 +42,22 @@ function getStyleElement() {
 /**
  * Process a single element's `em=""` attribute.
  * Compiles the animation, injects the CSS rule (if not already done),
- * and applies the generated class to the element.
+ * removes stale generated classes, and applies the current generated class.
  *
  * @param {Element} el
  */
 function processElement(el) {
   const value = el.getAttribute('em');
-  if (!value) return;
+  
+  // If the attribute is removed or empty, clean up all generated classes and bail
+  if (!value) {
+    for (const clsName of Array.from(el.classList)) {
+      if (clsName.startsWith('_em_')) {
+        el.classList.remove(clsName);
+      }
+    }
+    return;
+  }
 
   const ast = parse(value);
   if (!ast) {
@@ -69,7 +78,14 @@ function processElement(el) {
     }
   }
 
-  // Apply class to element (idempotent)
+  // Remove any existing stale generated animation classes (except the current one)
+  for (const clsName of Array.from(el.classList)) {
+    if (clsName.startsWith('_em_') && clsName !== cls) {
+      el.classList.remove(clsName);
+    }
+  }
+
+  // Apply current class to element (idempotent)
   if (!el.classList.contains(cls)) {
     el.classList.add(cls);
   }


### PR DESCRIPTION
## Pull Request Description
This PR fixes a critical bug in the core runtime engine where updating or removing the `em` attribute on an element leaves behind stale, previously generated `_em_*` CSS classes. This causes class accumulation over time in dynamic UIs, leading to animation style conflicts due to CSS cascade specificity.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission (Core Runtime Engine)
- [ ] Other (describe below)

---

## Submission Checklist
> ⚠️ **Note for Maintainers:** This is a core engine bug fix addressing issue #40059, not a standalone component submission, so changes are located in the `easemotion/engine/` core directory rather than `submissions/`.

- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description
**What does this add?**
It adds a cleanup mechanism to the MutationObserver runtime loop that strips out stale `_em_*` classes before applying a newly compiled animation class.

**How does a developer use it?**
It works automatically behind the scenes when updating or removing attributes dynamically via JavaScript:
```javascript
// The runtime now properly swaps out the stale class instead of accumulating both
document.getElementById('box').setAttribute('em', 'slide-up'); 

// Removing the attribute now completely cleans up all engine-generated classes
document.getElementById('box').removeAttribute('em');