### PR TITLE
feat: add css-only origami fold-out map component

### DIFF
--- a/submissions/examples/css-only-origami-fold-out-map/README.md
+++ b/submissions/examples/css-only-origami-fold-out-map/README.md
@@ -1,0 +1,10 @@
+# CSS-Only Origami Fold-Out Map
+
+## What does this do?
+This adds a highly advanced 3D folding UI component. Using a hidden checkbox hack (`<input type="checkbox">` + `<label>`), it simulates an interactive paper map folding and unfolding using sequential CSS `rotateY` transforms and `transform-origin` pivots. 
+
+## How is it used?
+Copy the `.scene` container and its contents. The logic is driven entirely by the `:checked` pseudo-class interacting with the general sibling combinator `~`. No JavaScript is required. You can place any content (like an actual SVG map or images) inside the `.map-content` divs.
+
+## Why is it useful?
+Complex 3D nesting (panels inside panels) demonstrates the limits of CSS `transform-style: preserve-3d`. It provides a stunning, high-performance micro-interaction for landing pages or digital brochures without relying on heavy WebGL or JavaScript animation libraries.

--- a/submissions/examples/css-only-origami-fold-out-map/demo.html
+++ b/submissions/examples/css-only-origami-fold-out-map/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS-Only Origami Fold-Out Map</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="scene">
+        <!-- We use a hidden checkbox to toggle the folding state -->
+        <input type="checkbox" id="unfold-toggle" class="unfold-toggle">
+        
+        <label class="map-wrapper" for="unfold-toggle">
+            <div class="instruction">Click to Unfold</div>
+            <div class="map-container">
+                <!-- Panel 1: Center (Base) -->
+                <div class="panel panel-center">
+                    <div class="map-content center-content">City Center</div>
+                    
+                    <!-- Panel 2: Left Fold (child of center) -->
+                    <div class="panel panel-left">
+                        <div class="map-content left-content">West District</div>
+                    </div>
+                    
+                    <!-- Panel 3: Right Fold (child of center) -->
+                    <div class="panel panel-right">
+                        <div class="map-content right-content">East District</div>
+                        
+                        <!-- Panel 4: Far Right Fold (child of right) -->
+                        <div class="panel panel-far-right">
+                            <div class="map-content far-right-content">Suburbs</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </label>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-only-origami-fold-out-map/style.css
+++ b/submissions/examples/css-only-origami-fold-out-map/style.css
@@ -1,0 +1,150 @@
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    background-color: #2c3e50;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    overflow: hidden;
+}
+
+.scene {
+    perspective: 1200px;
+}
+
+.unfold-toggle {
+    display: none;
+}
+
+.instruction {
+    position: absolute;
+    top: -40px;
+    left: 50%;
+    transform: translateX(-50%);
+    color: white;
+    font-weight: bold;
+    letter-spacing: 2px;
+    opacity: 0.8;
+    pointer-events: none;
+    transition: opacity 0.3s;
+}
+
+.unfold-toggle:checked ~ .map-wrapper .instruction {
+    opacity: 0;
+}
+
+.map-wrapper {
+    position: relative;
+    display: block;
+    cursor: pointer;
+    transform-style: preserve-3d;
+    transform: rotateX(20deg) rotateZ(-10deg);
+    transition: transform 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.unfold-toggle:checked ~ .map-wrapper {
+    transform: rotateX(0deg) rotateZ(0deg) scale(1.1);
+}
+
+.map-container {
+    transform-style: preserve-3d;
+}
+
+.panel {
+    width: 150px;
+    height: 250px;
+    position: absolute;
+    transform-style: preserve-3d;
+    backface-visibility: hidden;
+    transition: transform 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.map-content {
+    width: 100%;
+    height: 100%;
+    background-color: #ecf0f1;
+    border: 1px solid #bdc3c7;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-weight: bold;
+    color: #34495e;
+    box-shadow: inset 0 0 20px rgba(0,0,0,0.1);
+    background-image: linear-gradient(45deg, rgba(0,0,0,0.05) 25%, transparent 25%, transparent 75%, rgba(0,0,0,0.05) 75%, rgba(0,0,0,0.05)), 
+                      linear-gradient(45deg, rgba(0,0,0,0.05) 25%, transparent 25%, transparent 75%, rgba(0,0,0,0.05) 75%, rgba(0,0,0,0.05));
+    background-size: 20px 20px;
+    background-position: 0 0, 10px 10px;
+}
+
+/* Initial Folded State */
+.panel-center {
+    position: relative;
+    z-index: 2;
+}
+
+.panel-left {
+    top: 0;
+    left: 0;
+    transform-origin: left center;
+    transform: rotateY(175deg); /* Folded over center */
+    z-index: 3;
+}
+
+.panel-right {
+    top: 0;
+    right: 0;
+    transform-origin: right center;
+    transform: rotateY(-175deg); /* Folded over center */
+    z-index: 4;
+}
+
+.panel-far-right {
+    top: 0;
+    right: 0;
+    transform-origin: right center;
+    transform: rotateY(175deg); /* Folded over right */
+    z-index: 5;
+}
+
+/* Coloring for map sections */
+.center-content { border-left: 2px dashed #95a5a6; border-right: 2px dashed #95a5a6; }
+.left-content { background-color: #e0e6ed; }
+.right-content { background-color: #e0e6ed; }
+.far-right-content { background-color: #d5dce4; }
+
+/* Adding some shadow for depth when folded */
+.panel::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.4);
+    transition: background 0.8s;
+    pointer-events: none;
+}
+
+/* Unfolded State */
+.unfold-toggle:checked ~ .map-wrapper .panel-left {
+    transform: translateX(-150px) rotateY(0deg);
+}
+
+.unfold-toggle:checked ~ .map-wrapper .panel-right {
+    transform: translateX(150px) rotateY(0deg);
+}
+
+.unfold-toggle:checked ~ .map-wrapper .panel-far-right {
+    transform: translateX(150px) rotateY(0deg);
+}
+
+/* Remove shadow when unfolded */
+.unfold-toggle:checked ~ .map-wrapper .panel::after {
+    background: rgba(0,0,0,0);
+}


### PR DESCRIPTION
Fixes #43152
This PR introduces an interactive 3D origami fold-out map built entirely with CSS. 
### Implementation Details
- Uses a `<input type="checkbox">` and `<label>` combination to manage the open/closed state without JS.
- Utilizes sequential `rotateY` transforms and `transform-origin` pivots for child panels to simulate physical paper folding.
- Maintains strict 3-file structure (`demo.html`, `style.css`, `README.md`) isolated in `submissions/examples/css-only-origami-fold-out-map/`.