### PR TITLE
feat: add retro crt terminal interface component

### DIFF
--- a/submissions/examples/retro-crt-terminal-interface/README.md
+++ b/submissions/examples/retro-crt-terminal-interface/README.md
@@ -1,0 +1,10 @@
+# Retro CRT Terminal Interface
+
+## What does this do?
+This adds a highly stylized retro CRT monitor interface. It replicates the physical constraints of 1980s monitors by adding curvature via `border-radius` and `inset box-shadow`, mimicking scanlines with `linear-gradient` backgrounds, creating RGB color-split aberration via `text-shadow`, and generating an unstable phosphor flicker via rapid opacity `@keyframes`.
+
+## How is it used?
+Include the CSS in your stylesheet and use the HTML structure for the monitor container. To output text, simply add paragraph tags inside `.terminal-content`. It's ideal for Easter eggs, 404 pages, or portfolio sites aiming for a hacker/retro aesthetic.
+
+## Why is it useful?
+Creating realistic CRT effects purely in CSS avoids the need for WebGL shaders or heavy HTML5 canvas manipulation, providing an extremely lightweight and thematic component. It demonstrates the creative power of stacking multiple background layers and text shadows.

--- a/submissions/examples/retro-crt-terminal-interface/demo.html
+++ b/submissions/examples/retro-crt-terminal-interface/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Retro CRT Terminal</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="crt-monitor">
+        <div class="crt-screen">
+            <div class="scanlines"></div>
+            <div class="terminal-content">
+                <p>SYS_INIT v1.0.4</p>
+                <p>LOADING KERNEL MODULES... <span class="status">[OK]</span></p>
+                <p>MOUNTING VIRTUAL FILESYSTEM... <span class="status">[OK]</span></p>
+                <p>ESTABLISHING UPLINK... <span class="status blink-warn">[WAIT]</span></p>
+                <br>
+                <p>> AWAITING INPUT<span class="cursor">_</span></p>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/retro-crt-terminal-interface/style.css
+++ b/submissions/examples/retro-crt-terminal-interface/style.css
@@ -1,0 +1,115 @@
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background-color: #111;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    font-family: 'Courier New', Courier, monospace;
+}
+
+.crt-monitor {
+    width: 600px;
+    height: 450px;
+    background: #1a1a1a;
+    border-radius: 40px;
+    padding: 30px;
+    box-shadow: 
+        inset 0 0 20px #000,
+        0 20px 50px rgba(0,0,0,0.8);
+}
+
+/* The screen surface simulating the bulge of an old CRT tube */
+.crt-screen {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    background-color: #0d1110;
+    border-radius: 30px;
+    overflow: hidden;
+    box-shadow: 
+        inset 0 0 40px rgba(25, 255, 100, 0.2),
+        inset 0 0 10px rgba(0,0,0,0.8);
+    /* Subtle RGB split and text glow */
+    text-shadow: 
+        0.1vw 0vw 0.1vw rgba(255, 0, 0, 0.4), 
+        -0.1vw 0vw 0.1vw rgba(0, 0, 255, 0.4),
+        0 0 5px rgba(25, 255, 100, 0.5);
+}
+
+/* Generating scanlines via repeating linear gradients */
+.scanlines {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0),
+        rgba(255, 255, 255, 0) 50%,
+        rgba(0, 0, 0, 0.25) 50%,
+        rgba(0, 0, 0, 0.25)
+    );
+    background-size: 100% 4px;
+    z-index: 10;
+    pointer-events: none;
+    /* Adding a subtle moving line to simulate screen refresh */
+    animation: scroll-scanlines 10s linear infinite;
+}
+
+.scanlines::after {
+    content: '';
+    position: absolute;
+    top: -100%;
+    left: 0;
+    width: 100%;
+    height: 20%;
+    background: linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0) 0%,
+        rgba(25, 255, 100, 0.1) 50%,
+        rgba(255, 255, 255, 0) 100%
+    );
+    animation: crt-refresh 6s linear infinite;
+}
+
+.terminal-content {
+    color: #19ff64;
+    padding: 30px;
+    font-size: 1.1rem;
+    line-height: 1.6;
+    animation: text-flicker 0.15s infinite;
+}
+
+.status { color: #fff; }
+.status.blink-warn { color: #ffaa00; animation: blink 1s step-end infinite; }
+.cursor { animation: blink 1s step-end infinite; background-color: #19ff64; color: #19ff64; }
+
+/* Keyframes */
+@keyframes scroll-scanlines {
+    0% { background-position: 0 0; }
+    100% { background-position: 0 400px; }
+}
+
+@keyframes crt-refresh {
+    0% { top: -20%; }
+    100% { top: 120%; }
+}
+
+@keyframes blink {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0; }
+}
+
+/* Subtle random opacity flicker mimicking unstable CRT phosphors */
+@keyframes text-flicker {
+    0% { opacity: 0.95; }
+    50% { opacity: 0.85; }
+    100% { opacity: 0.98; }
+}


### PR DESCRIPTION
Fixes #43156
This PR implements a pure CSS Retro CRT Terminal monitor simulation.
### Implementation Details
- Uses `border-radius` and `inset box-shadow` to simulate screen bulge.
- Employs repeating `linear-gradient` backgrounds and `text-shadow` for scanlines and RGB aberration.
- Contains all logic strictly within the required 3 files inside `submissions/examples/retro-crt-terminal-interface/`.
