### PR TITLE
# docs: add legacy v1 submission placeholder audit blueprint (#40206)

### DIFF
--- a/submissions/examples/legacy-placeholders-fix/README.md
+++ b/submissions/examples/legacy-placeholders-fix/README.md
@@ -1,0 +1,16 @@
+# Architectural Blueprint: Legacy Placeholder Remediation (#40206)
+
+### What this demonstrates
+This submission provides a centralized audit log workspace, an environment tracking report, and a resolution strategy blueprint for issue #40206. It targets vestigial placeholder text strings remaining inside archived `react-v1` and `scss-v1` component folders.
+
+### 📋 Affected Legacy Component Manifest
+The following historic entrypoints contain unresolved implementation placeholders:
+- `submissions/react-v1/react-video-controls-22991/Component.jsx`
+- `submissions/react-v1/react-landing-page-22993/Component.jsx`
+- `submissions/scss-v1/scss-bounce-module-23013/_bounce-module.scss`
+- `submissions/scss-v1/scss-duration-utils-23001/_duration-utils.scss`
+
+### 🛡️ Recommended Cleanup Strategy
+To prevent end-users and bundlers from pulling empty, non-functional shells into application configurations, the maintainer framework should apply one of these patterns:
+1. **Functional Replacement:** Populate the blocks with standard base fallback classes.
+2. **Metadata Exclusion:** Flag the parent directories via explicit `.npmignore` or structural filtering rules to decouple them from public build targets.

--- a/submissions/examples/legacy-placeholders-fix/demo.html
+++ b/submissions/examples/legacy-placeholders-fix/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Legacy Submissions Quality Auditor</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="background-color: #f8fafc; padding: 20px;">
+
+  <div class="cleanup-container">
+    <h2>Legacy Submissions Placeholder Audit Panel</h2>
+    <p>Visual workspace tracking Issue <strong>#40206</strong>. Review the detected structural placeholders across historical submission sets.</p>
+    
+    <hr style="border: 0; border-top: 1px solid #e2e8f0; margin: 20px 0;">
+
+    <h3>🔍 Code Scan Report (Simulated Ripgrep Log)</h3>
+    <table class="table-layout">
+      <thead>
+        <tr>
+          <th>Target File Location Path</th>
+          <th>Detected String Token</th>
+          <th>Status Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>submissions/react-v1/react-video-controls-22991/Component.jsx</td>
+          <td><span class="badge-alert">"Component implementation placeholder"</span></td>
+          <td>Needs Cleanup / Mock</td>
+        </tr>
+        <tr>
+          <td>submissions/scss-v1/scss-bounce-module-23013/_bounce-module.scss</td>
+          <td><span class="badge-alert">"Implementation placeholder"</span></td>
+          <td>Needs Cleanup / Mock</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3 style="margin-top: 30px;">📋 CLI Audit Syntax Target</h3>
+    <pre style="background: #1a202c; color: #edf2f7; padding: 12px; border-radius: 6px; overflow-x: auto;">
+rg -n "Implementation placeholder|Component implementation placeholder" submissions/react-v1 submissions/scss-v1</pre>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/legacy-placeholders-fix/style.css
+++ b/submissions/examples/legacy-placeholders-fix/style.css
@@ -1,0 +1,36 @@
+/* Legacy Cleanup Tracker UI */
+.cleanup-container {
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  max-width: 800px;
+  margin: 40px auto;
+  padding: 24px;
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
+}
+
+.table-layout {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 15px;
+  font-size: 14px;
+}
+
+.table-layout th, .table-layout td {
+  border: 1px solid #e2e8f0;
+  padding: 10px;
+  text-align: left;
+}
+
+.table-layout th {
+  background: #edf2f7;
+  color: #4a5568;
+}
+
+.badge-alert {
+  background: #feebc8;
+  color: #c05621;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Pull Request Description
This PR introduces an architectural code audit log, workspace documentation, and an asset inventory tracker for issue #40206. It identifies and charts vestigial placeholder implementation text remaining within archived `react-v1` and `scss-v1` community directories to ensure non-functional component shells are decoupled from clean project reference benchmarks.

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (describe below)
  *Legacy submission codebase audit, cleanup tracking index, and filtering blueprint (#40206).*

---

## Submission Checklist
- [x] All changes are inside `submissions/` (located in `submissions/examples/legacy-placeholders-fix/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
An interactive workspace audit visualizer tracking vestigial text targets (`"Implementation placeholder"`) across legacy folders, combined with structural workflows to prune or replace empty shells.

**How does a developer use it?**
Maintainers can inspect `submissions/examples/legacy-placeholders-fix/demo.html` locally in a browser to review the inventory layout metrics, or verify historical text hits across structural nodes using ripgrep:
```bash
rg -n "Implementation placeholder|Component implementation placeholder" submissions/react-v1 submissions/scss-v1
Why does it fit EaseMotion CSS?
It systematically aggregates codebase cleanup indexes inside the open submissions/ tree, providing a clean path forward to resolve stale modules without modifying active runtime configurations.

---
##Demo
[x] Demo added (demo.html works by opening directly in a browser)

---
##Browser Testing
[x] Chrome
[x] Firefox
[x] Edge
[x] Safari