### PR TITLE
feat: add signal bars

### DIFF
--- a/submissions/examples/signal-bars-as/README.md
+++ b/submissions/examples/signal-bars-as/README.md
@@ -1,0 +1,20 @@
+# Signal Bars
+
+### What does this do?
+
+It shows cellular style signal strength meters. Each meter is five ascending bars; a level class fills the first N bars in a strength color (green, amber, red) while the rest stay dim. A `searching` variant animates all bars with a staggered scan.
+
+### How is it used?
+
+```html
+<div class="sig lvl-3 ok" role="img" aria-label="Signal strength 3 of 5">
+  <i></i><i></i><i></i><i></i><i></i>
+  <span class="sig-label">Fair</span>
+</div>
+```
+
+Add a strength class pair to the wrapper: `lvl-5 strong`, `lvl-3 ok`, or `lvl-1 weak`. The fill uses `:nth-child(-n + N)` to color the first N bars. Use `searching` for the animated scanning state.
+
+### Why is it useful?
+
+Status bars, device UIs, and connection panels show signal strength with ascending bars. This provides that meter, including a searching animation, using only CSS selectors and no images or script.

--- a/submissions/examples/signal-bars-as/demo.html
+++ b/submissions/examples/signal-bars-as/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Signal Bars</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="sig-grid">
+    <div class="sig lvl-5 strong" role="img" aria-label="Signal strength 5 of 5">
+      <i></i><i></i><i></i><i></i><i></i>
+      <span class="sig-label">Excellent</span>
+    </div>
+
+    <div class="sig lvl-3 ok" role="img" aria-label="Signal strength 3 of 5">
+      <i></i><i></i><i></i><i></i><i></i>
+      <span class="sig-label">Fair</span>
+    </div>
+
+    <div class="sig lvl-1 weak" role="img" aria-label="Signal strength 1 of 5">
+      <i></i><i></i><i></i><i></i><i></i>
+      <span class="sig-label">Poor</span>
+    </div>
+
+    <div class="sig searching" role="img" aria-label="Searching for signal">
+      <i></i><i></i><i></i><i></i><i></i>
+      <span class="sig-label">Searching</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/signal-bars-as/style.css
+++ b/submissions/examples/signal-bars-as/style.css
@@ -1,0 +1,74 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #182135, #0a0f1a 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #dbe2ef;
+}
+
+.sig-grid {
+  display: grid;
+  grid-template-columns: repeat(2, auto);
+  gap: 2rem 2.6rem;
+}
+
+.sig {
+  display: grid;
+  grid-auto-flow: column;
+  align-items: flex-end;
+  justify-content: start;
+  gap: 4px;
+  height: 46px;
+}
+
+.sig i {
+  display: block;
+  width: 9px;
+  border-radius: 3px;
+  background: #2b3650;
+}
+
+.sig i:nth-child(1) { height: 30%; }
+.sig i:nth-child(2) { height: 46%; }
+.sig i:nth-child(3) { height: 62%; }
+.sig i:nth-child(4) { height: 80%; }
+.sig i:nth-child(5) { height: 100%; }
+
+.sig.strong.lvl-5 i:nth-child(-n + 5) { background: #22c55e; }
+.sig.ok.lvl-3 i:nth-child(-n + 3) { background: #f59e0b; }
+.sig.weak.lvl-1 i:nth-child(-n + 1) { background: #ef4444; }
+
+.sig-label {
+  grid-row: 1;
+  align-self: center;
+  margin-left: 8px;
+  font-size: 0.82rem;
+  color: #9aa6bf;
+  white-space: nowrap;
+}
+
+.sig.searching i {
+  animation: sig-scan 1.2s ease-in-out infinite;
+  background: #38bdf8;
+}
+
+.sig.searching i:nth-child(2) { animation-delay: 0.12s; }
+.sig.searching i:nth-child(3) { animation-delay: 0.24s; }
+.sig.searching i:nth-child(4) { animation-delay: 0.36s; }
+.sig.searching i:nth-child(5) { animation-delay: 0.48s; }
+
+@keyframes sig-scan {
+  0%, 100% { opacity: 0.25; }
+  50% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sig.searching i {
+    animation: none;
+    opacity: 0.7;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a signal strength meter built for #42126. Five ascending bars with level classes that fill the first N bars in a strength color, plus a staggered searching animation. Pure CSS. Closes #42126.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Re-submitting from the existing verified branch after the earlier PR was auto-closed by the daily rate limit. Nothing changed.
