### PR TITLE
feat: add radar chart

### DIFF
--- a/submissions/examples/radar-chart-as/README.md
+++ b/submissions/examples/radar-chart-as/README.md
@@ -1,0 +1,20 @@
+# Radar Chart
+
+### What does this do?
+
+It shows a radar (spider) chart comparing two data series across five axes. Concentric grid polygons and radial axis lines form the frame, and two translucent polygons plot each series over the same five stats, with axis labels and a legend.
+
+### How is it used?
+
+```html
+<svg viewBox="0 0 240 200" role="img" aria-label="Radar chart">
+  <polygon class="rd-shape a" points="120,32 168,92 158,161 95,142 55,87" />
+  <polygon class="rd-shape b" points="120,62 188,86 142,139 85,156 72,92" />
+</svg>
+```
+
+The frame is a set of nested `polygon` gridlines plus axis `line` elements. Each series is one `rd-shape` polygon whose vertex list encodes the value on each axis; the `a` and `b` classes set the fill and stroke colors.
+
+### Why is it useful?
+
+Radar charts compare several dimensions of two or more items at a glance, common in sports, product, and skill comparisons. This renders one from inline SVG polygons with only CSS styling and no charting library.

--- a/submissions/examples/radar-chart-as/demo.html
+++ b/submissions/examples/radar-chart-as/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Radar Chart</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <figure class="radar">
+    <figcaption class="rd-title">Player comparison</figcaption>
+    <svg viewBox="0 0 240 200" role="img" aria-label="Radar chart comparing two players across five stats">
+      <g class="rd-grid">
+        <polygon points="120.0,24.0 199.9,82.0 169.4,176.0 70.6,176.0 40.1,82.0" />
+        <polygon points="120.0,45.0 179.9,88.5 157.0,159.0 83.0,159.0 60.1,88.5" />
+        <polygon points="120.0,66.0 159.9,95.0 144.7,142.0 95.3,142.0 80.1,95.0" />
+        <polygon points="120.0,87.0 140.0,101.5 132.3,125.0 107.7,125.0 100.0,101.5" />
+      </g>
+      <g class="rd-axis">
+        <line x1="120" y1="108" x2="120.0" y2="24.0" />
+        <line x1="120" y1="108" x2="199.9" y2="82.0" />
+        <line x1="120" y1="108" x2="169.4" y2="176.0" />
+        <line x1="120" y1="108" x2="70.6" y2="176.0" />
+        <line x1="120" y1="108" x2="40.1" y2="82.0" />
+      </g>
+      <polygon class="rd-shape b" points="120.0,61.8 187.9,85.9 142.2,138.6 85.4,155.6 72.1,92.4" />
+      <polygon class="rd-shape a" points="120.0,32.4 167.9,92.4 158.5,161.0 95.3,142.0 54.5,86.7" />
+      <g class="rd-labels">
+        <text x="120" y="12" text-anchor="middle">Speed</text>
+        <text x="215" y="79" text-anchor="start">Power</text>
+        <text x="179" y="192" text-anchor="middle">Range</text>
+        <text x="61" y="192" text-anchor="middle">Guard</text>
+        <text x="25" y="79" text-anchor="end">Aim</text>
+      </g>
+    </svg>
+    <figcaption class="rd-legend">
+      <span class="a">Nova</span>
+      <span class="b">Rook</span>
+    </figcaption>
+  </figure>
+</body>
+</html>

--- a/submissions/examples/radar-chart-as/style.css
+++ b/submissions/examples/radar-chart-as/style.css
@@ -1,0 +1,91 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #182034, #0a0e18 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e4e9f4;
+}
+
+.radar {
+  width: min(360px, 94vw);
+  margin: 0;
+  padding: 1.4rem 1.4rem 1.1rem;
+  box-sizing: border-box;
+  background: #101728;
+  border: 1px solid #263149;
+  border-radius: 18px;
+}
+
+.rd-title {
+  margin: 0 0 0.4rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.radar svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  overflow: visible;
+}
+
+.rd-grid polygon {
+  fill: none;
+  stroke: #24304a;
+  stroke-width: 1;
+}
+
+.rd-axis line {
+  stroke: #24304a;
+  stroke-width: 1;
+}
+
+.rd-shape {
+  stroke-width: 2;
+  fill-opacity: 0.35;
+}
+
+.rd-shape.a {
+  fill: #6366f1;
+  stroke: #818cf8;
+}
+
+.rd-shape.b {
+  fill: #f59e0b;
+  stroke: #fbbf24;
+}
+
+.rd-labels text {
+  fill: #8b96ac;
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.rd-legend {
+  display: flex;
+  justify-content: center;
+  gap: 1.4rem;
+  margin-top: 0.6rem;
+  font-size: 0.82rem;
+  color: #aab4c8;
+}
+
+.rd-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.rd-legend span::before {
+  content: "";
+  width: 11px;
+  height: 11px;
+  border-radius: 3px;
+}
+
+.rd-legend .a::before { background: #6366f1; }
+.rd-legend .b::before { background: #f59e0b; }


### PR DESCRIPTION
## Pull Request Description

Adds a radar chart built for #43172. A five axis spider chart with nested grid polygons, radial axes, and two translucent data polygons with a legend, all inline SVG styled with CSS. Closes #43172.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium: four grid rings, five axes, two series polygons, and five axis labels render correctly.
