### PR TITLE
feat: add gantt chart

### DIFF
--- a/submissions/examples/gantt-chart-as/README.md
+++ b/submissions/examples/gantt-chart-as/README.md
@@ -1,0 +1,22 @@
+# Gantt Chart
+
+### What does this do?
+
+It shows a project Gantt chart. Each task is a row with a name and a colored bar placed on a six column week grid. The bar's start column and length come from `--s` (start week) and `--n` (number of weeks) custom properties, so scheduling a task is just two numbers.
+
+### How is it used?
+
+```html
+<div class="gc-row">
+  <span class="gc-name">Build</span>
+  <span class="gc-track">
+    <span class="gc-bar p3" style="--s: 3; --n: 3;">3w</span>
+  </span>
+</div>
+```
+
+The track is a `repeat(6, 1fr)` grid with striped gridlines, and each bar uses `grid-column: var(--s) / span var(--n)` to sit on the right weeks. Phase classes `p1` through `p5` set the bar colors.
+
+### Why is it useful?
+
+Project planners and roadmaps use Gantt charts to show task timing and overlap. This renders one purely with CSS grid placement driven by two custom properties, with no script or table library.

--- a/submissions/examples/gantt-chart-as/demo.html
+++ b/submissions/examples/gantt-chart-as/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Gantt Chart</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <figure class="gantt">
+    <figcaption class="gc-title">Launch plan</figcaption>
+
+    <div class="gc-head">
+      <span class="gc-name"></span>
+      <span class="gc-track">
+        <b>W1</b><b>W2</b><b>W3</b><b>W4</b><b>W5</b><b>W6</b>
+      </span>
+    </div>
+
+    <div class="gc-row">
+      <span class="gc-name">Research</span>
+      <span class="gc-track">
+        <span class="gc-bar p1" style="--s: 1; --n: 2;">2w</span>
+      </span>
+    </div>
+    <div class="gc-row">
+      <span class="gc-name">Design</span>
+      <span class="gc-track">
+        <span class="gc-bar p2" style="--s: 2; --n: 2;">2w</span>
+      </span>
+    </div>
+    <div class="gc-row">
+      <span class="gc-name">Build</span>
+      <span class="gc-track">
+        <span class="gc-bar p3" style="--s: 3; --n: 3;">3w</span>
+      </span>
+    </div>
+    <div class="gc-row">
+      <span class="gc-name">QA</span>
+      <span class="gc-track">
+        <span class="gc-bar p4" style="--s: 5; --n: 1;">1w</span>
+      </span>
+    </div>
+    <div class="gc-row">
+      <span class="gc-name">Launch</span>
+      <span class="gc-track">
+        <span class="gc-bar p5" style="--s: 6; --n: 1;">1w</span>
+      </span>
+    </div>
+  </figure>
+</body>
+</html>

--- a/submissions/examples/gantt-chart-as/style.css
+++ b/submissions/examples/gantt-chart-as/style.css
@@ -1,0 +1,90 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(160deg, #0f1626, #0a0d16);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e5eaf5;
+}
+
+.gantt {
+  width: min(480px, 95vw);
+  margin: 0;
+  padding: 1.5rem 1.6rem 1.7rem;
+  box-sizing: border-box;
+  background: #121a2c;
+  border: 1px solid #263049;
+  border-radius: 16px;
+  display: grid;
+  gap: 8px;
+}
+
+.gc-title {
+  margin-bottom: 0.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.gc-head,
+.gc-row {
+  display: grid;
+  grid-template-columns: 88px 1fr;
+  align-items: center;
+  gap: 12px;
+}
+
+.gc-name {
+  font-size: 0.85rem;
+  color: #b3bcd0;
+  text-align: right;
+}
+
+.gc-track {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  align-items: center;
+  height: 30px;
+  border-radius: 6px;
+  background: repeating-linear-gradient(
+    90deg,
+    #1a2338 0,
+    #1a2338 calc(16.666% - 1px),
+    #263049 calc(16.666% - 1px),
+    #263049 16.666%
+  );
+}
+
+.gc-head .gc-track {
+  background: none;
+  height: auto;
+}
+
+.gc-head b {
+  text-align: center;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #7f8aa3;
+}
+
+.gc-bar {
+  grid-column: var(--s) / span var(--n);
+  margin: 0 3px;
+  height: 20px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  padding-left: 8px;
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: #0b1020;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+}
+
+.gc-bar.p1 { background: linear-gradient(90deg, #60a5fa, #3b82f6); }
+.gc-bar.p2 { background: linear-gradient(90deg, #a78bfa, #8b5cf6); }
+.gc-bar.p3 { background: linear-gradient(90deg, #34d399, #10b981); }
+.gc-bar.p4 { background: linear-gradient(90deg, #fbbf24, #f59e0b); }
+.gc-bar.p5 { background: linear-gradient(90deg, #fb7185, #f43f5e); }


### PR DESCRIPTION
## Pull Request Description

Adds a Gantt chart built for #43174. Task rows with colored bars placed on a six column week grid, positioned by `--s` (start) and `--n` (span) custom properties. Pure CSS grid. Closes #43174.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium: five task bars render with strictly increasing left positions across the week grid, matching their start weeks.
