### PR TITLE
feat: add candlestick chart

### DIFF
--- a/submissions/examples/candlestick-chart-as/README.md
+++ b/submissions/examples/candlestick-chart-as/README.md
@@ -1,0 +1,18 @@
+# Candlestick Chart
+
+### What does this do?
+
+It shows a stock candlestick chart. Each candle has a thin wick (the high to low range) and a thicker body (the open to close range), placed with four custom properties. Up sessions are green and down sessions are red, over a gridded plot with a ticker header.
+
+### How is it used?
+
+```html
+<span class="cd-candle up"
+  style="--wtop: 5.6%; --wh: 41.6%; --btop: 11.1%; --bh: 30.6%;"></span>
+```
+
+Each candle is one element. Its `::before` draws the wick from `--wtop` for `--wh`, and its `::after` draws the body from `--btop` for `--bh`, all as percentages of the plot height. Add `up` or `down` to color the candle.
+
+### Why is it useful?
+
+Trading and finance dashboards rely on candlestick charts to show price action. This renders one from pure CSS pseudo elements positioned by custom properties, with no canvas or charting script.

--- a/submissions/examples/candlestick-chart-as/demo.html
+++ b/submissions/examples/candlestick-chart-as/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Candlestick Chart</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <figure class="candles">
+    <figcaption class="cd-head">
+      <span class="cd-name">ACME</span>
+      <span class="cd-price">56.0 <em class="up">+3.7%</em></span>
+    </figcaption>
+
+    <div class="cd-plot" role="img" aria-label="Candlestick chart of eight trading sessions">
+      <span class="cd-candle up"   style="--wtop: 55.6%; --wh: 44.4%; --btop: 61.1%; --bh: 27.8%;"></span>
+      <span class="cd-candle down" style="--wtop: 44.4%; --wh: 27.8%; --btop: 61.1%; --bh: 5.6%;"></span>
+      <span class="cd-candle up"   style="--wtop: 33.3%; --wh: 41.7%; --btop: 36.1%; --bh: 30.6%;"></span>
+      <span class="cd-candle down" style="--wtop: 27.8%; --wh: 22.2%; --btop: 36.1%; --bh: 11.1%;"></span>
+      <span class="cd-candle up"   style="--wtop: 38.9%; --wh: 22.2%; --btop: 41.7%; --bh: 5.5%;"></span>
+      <span class="cd-candle up"   style="--wtop: 5.6%;  --wh: 41.6%; --btop: 11.1%; --bh: 30.6%;"></span>
+      <span class="cd-candle down" style="--wtop: 0.0%;  --wh: 27.8%; --btop: 11.1%; --bh: 11.1%;"></span>
+      <span class="cd-candle up"   style="--wtop: 13.9%; --wh: 25.0%; --btop: 16.7%; --bh: 5.5%;"></span>
+    </div>
+  </figure>
+</body>
+</html>

--- a/submissions/examples/candlestick-chart-as/style.css
+++ b/submissions/examples/candlestick-chart-as/style.css
@@ -1,0 +1,92 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #0f1a24, #070c12 60%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #dbe6ef;
+}
+
+.candles {
+  width: min(400px, 94vw);
+  margin: 0;
+  padding: 1.4rem 1.5rem 1.5rem;
+  box-sizing: border-box;
+  background: #0d151d;
+  border: 1px solid #1e2c38;
+  border-radius: 16px;
+}
+
+.cd-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 1.1rem;
+}
+
+.cd-name {
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+}
+
+.cd-price {
+  font-size: 0.95rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.cd-price .up {
+  font-style: normal;
+  color: #22c55e;
+  font-size: 0.82rem;
+}
+
+.cd-plot {
+  display: flex;
+  align-items: stretch;
+  gap: 10px;
+  height: 170px;
+  padding: 4px 2px;
+  border-bottom: 1px solid #1e2c38;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent 0,
+    transparent 41px,
+    #14202b 41px,
+    #14202b 42px
+  );
+}
+
+.cd-candle {
+  position: relative;
+  flex: 1;
+}
+
+.cd-candle::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 2px;
+  top: var(--wtop);
+  height: var(--wh);
+}
+
+.cd-candle::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  border-radius: 2px;
+  top: var(--btop);
+  height: var(--bh);
+  min-height: 2px;
+}
+
+.cd-candle.up::before { background: #16a34a; }
+.cd-candle.up::after { background: #22c55e; }
+.cd-candle.down::before { background: #dc2626; }
+.cd-candle.down::after { background: #ef4444; }


### PR DESCRIPTION
## Pull Request Description

Adds a candlestick chart built for #43176. Eight OHLC candles, each a CSS element whose wick and body are positioned by four custom properties, colored green for up and red for down over a gridded plot. Pure CSS. Closes #43176.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: eight candles render with wicks and bodies, five green up and three red down, forming a rising trend over gridlines.
