### PR TITLE
feat: add music visualizer

### DIFF
--- a/submissions/examples/music-visualizer-as/README.md
+++ b/submissions/examples/music-visualizer-as/README.md
@@ -1,0 +1,19 @@
+# Music Visualizer
+
+### What does this do?
+
+It shows a now playing card with an animated audio equalizer. Twenty bars bounce up and down on staggered durations and delays, giving the look of a live spectrum. The card also shows a cover tile and track details.
+
+### How is it used?
+
+```html
+<div class="equalizer" role="img" aria-label="Audio playing">
+  <i></i><i></i><i></i><i></i><i></i><i></i>
+</div>
+```
+
+Each `i` is one bar. Its height animates between a low and full value with `viz-bounce`, and `:nth-child` rules vary the duration and negative delay so no two neighbors move together. Add as many bars as you like.
+
+### Why is it useful?
+
+Music players, podcast apps, and voice UIs use an equalizer to signal that audio is playing. This gives that animated spectrum with pure CSS keyframes, and it settles into a static pattern when reduced motion is requested.

--- a/submissions/examples/music-visualizer-as/demo.html
+++ b/submissions/examples/music-visualizer-as/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Music Visualizer</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="viz-card">
+    <div class="viz-info">
+      <span class="viz-cover" aria-hidden="true">&#9834;</span>
+      <span class="viz-meta">
+        <b>Midnight Drive</b>
+        <em>Neon Skyline</em>
+      </span>
+    </div>
+
+    <div class="equalizer" role="img" aria-label="Audio playing">
+      <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+      <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+      <i></i><i></i><i></i><i></i>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/music-visualizer-as/style.css
+++ b/submissions/examples/music-visualizer-as/style.css
@@ -1,0 +1,95 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 30% 20%, #1e123a, #0a0713 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #ece7ff;
+}
+
+.viz-card {
+  width: min(360px, 92vw);
+  padding: 1.5rem 1.6rem 1.7rem;
+  box-sizing: border-box;
+  background: linear-gradient(160deg, #1b1436, #140d29);
+  border: 1px solid #33265c;
+  border-radius: 20px;
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.45);
+}
+
+.viz-info {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  margin-bottom: 1.4rem;
+}
+
+.viz-cover {
+  display: grid;
+  place-items: center;
+  width: 46px;
+  height: 46px;
+  border-radius: 12px;
+  font-size: 1.4rem;
+  color: #fff;
+  background: linear-gradient(135deg, #a855f7, #ec4899);
+}
+
+.viz-meta {
+  display: grid;
+  line-height: 1.35;
+}
+
+.viz-meta b {
+  font-size: 0.98rem;
+}
+
+.viz-meta em {
+  font-style: normal;
+  font-size: 0.8rem;
+  color: #a99fce;
+}
+
+.equalizer {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 3px;
+  height: 90px;
+}
+
+.equalizer i {
+  flex: 1;
+  min-width: 4px;
+  border-radius: 3px 3px 1px 1px;
+  background: linear-gradient(180deg, #f472b6, #a855f7 55%, #6366f1);
+  transform-origin: bottom;
+  animation: viz-bounce 0.9s ease-in-out infinite alternate;
+}
+
+.equalizer i:nth-child(4n + 1) { animation-duration: 0.7s; }
+.equalizer i:nth-child(4n + 2) { animation-duration: 1.05s; }
+.equalizer i:nth-child(4n + 3) { animation-duration: 0.85s; }
+.equalizer i:nth-child(4n) { animation-duration: 1.2s; }
+
+.equalizer i:nth-child(3n + 1) { animation-delay: -0.2s; }
+.equalizer i:nth-child(3n + 2) { animation-delay: -0.5s; }
+.equalizer i:nth-child(3n) { animation-delay: -0.8s; }
+
+@keyframes viz-bounce {
+  0% { height: 12%; opacity: 0.75; }
+  100% { height: 100%; opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .equalizer i {
+    animation: none;
+    height: 50%;
+  }
+  .equalizer i:nth-child(2n) { height: 60%; }
+  .equalizer i:nth-child(3n) { height: 85%; }
+  .equalizer i:nth-child(3n + 1) { height: 40%; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a music visualizer built for #43178. A now playing card with a twenty bar equalizer that bounces on staggered durations and delays. Pure CSS, with a static reduced motion fallback. Closes #43178.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium: twenty bars animate with four distinct durations and varied heights; reduced motion freezes them into a static pattern.
