### PR TITLE
feat: add volume knob

### DIFF
--- a/submissions/examples/volume-knob-as/README.md
+++ b/submissions/examples/volume-knob-as/README.md
@@ -1,0 +1,21 @@
+# Volume Knob
+
+### What does this do?
+
+It shows a panel of rotary control knobs. Each knob has a conic gradient arc showing its level over a 270 degree sweep, and the dial rotates so its indicator mark points at the current value. A single `--p` value (0 to 1) drives both the arc length and the pointer angle.
+
+### How is it used?
+
+```html
+<div class="knob-cell" style="--p: 0.7;">
+  <div class="knob"><span class="knob-dial"><span class="knob-mark"></span></span></div>
+  <span class="knob-label">Volume</span>
+  <span class="knob-val">70</span>
+</div>
+```
+
+Set `--p` on the cell. The knob fills its conic arc up to `calc(var(--p) * 270deg)` and rotates the dial with `rotate(calc(-135deg + var(--p) * 270deg))`, so one property keeps the arc and the pointer in sync.
+
+### Why is it useful?
+
+Audio mixers, synth UIs, and hardware style dashboards use rotary knobs. This builds one from a conic gradient and a rotation, driven by a single custom property, with no images or script.

--- a/submissions/examples/volume-knob-as/demo.html
+++ b/submissions/examples/volume-knob-as/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Volume Knob</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="knob-panel">
+    <div class="knob-cell" style="--p: 0.7;">
+      <div class="knob" role="img" aria-label="Volume 70 percent">
+        <span class="knob-dial"><span class="knob-mark"></span></span>
+      </div>
+      <span class="knob-label">Volume</span>
+      <span class="knob-val">70</span>
+    </div>
+
+    <div class="knob-cell" style="--p: 0.4;">
+      <div class="knob" role="img" aria-label="Bass 40 percent">
+        <span class="knob-dial"><span class="knob-mark"></span></span>
+      </div>
+      <span class="knob-label">Bass</span>
+      <span class="knob-val">40</span>
+    </div>
+
+    <div class="knob-cell" style="--p: 0.9;">
+      <div class="knob" role="img" aria-label="Treble 90 percent">
+        <span class="knob-dial"><span class="knob-mark"></span></span>
+      </div>
+      <span class="knob-label">Treble</span>
+      <span class="knob-val">90</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/volume-knob-as/style.css
+++ b/submissions/examples/volume-knob-as/style.css
@@ -1,0 +1,86 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #20242e, #0c0e13 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e7ebf2;
+}
+
+.knob-panel {
+  display: flex;
+  gap: 2rem;
+  padding: 1.9rem 2.2rem;
+  background: #161a22;
+  border: 1px solid #2a303c;
+  border-radius: 20px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.knob-cell {
+  display: grid;
+  justify-items: center;
+  gap: 0.6rem;
+}
+
+.knob {
+  position: relative;
+  width: 84px;
+  height: 84px;
+  border-radius: 50%;
+  padding: 9px;
+  box-sizing: border-box;
+  background:
+    conic-gradient(
+      from 225deg,
+      #38bdf8 0 calc(var(--p) * 270deg),
+      #2c333f calc(var(--p) * 270deg) 270deg,
+      transparent 270deg 360deg
+    );
+}
+
+.knob-dial {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 32%, #3a424f, #232935 70%);
+  box-shadow:
+    0 4px 10px rgba(0, 0, 0, 0.45),
+    inset 0 1px 1px rgba(255, 255, 255, 0.08);
+  transform: rotate(calc(-135deg + var(--p) * 270deg));
+}
+
+.knob-mark {
+  position: absolute;
+  left: 50%;
+  top: 7px;
+  width: 4px;
+  height: 15px;
+  margin-left: -2px;
+  border-radius: 2px;
+  background: #7dd3fc;
+  box-shadow: 0 0 6px rgba(56, 189, 248, 0.8);
+}
+
+.knob-label {
+  font-size: 0.8rem;
+  color: #9aa3b4;
+}
+
+.knob-val {
+  font-size: 0.95rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: #e7ebf2;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .knob-dial {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a volume knob panel built for #43180. Rotary knobs with a conic gradient level arc and a rotating dial indicator, both driven by one `--p` custom property. Pure CSS. Closes #43180.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium: three knobs render with distinct dial rotations matching their levels and conic gradient fill arcs.
