### PR TITLE
feat: add time picker

### DIFF
--- a/submissions/examples/time-picker-as/README.md
+++ b/submissions/examples/time-picker-as/README.md
@@ -1,0 +1,20 @@
+# Time Picker
+
+### What does this do?
+
+It shows a time slot picker grouped into Morning and Afternoon sections. Each slot is a radio input styled as a chip; selecting one highlights it, and unavailable slots show a struck through, disabled state. It is fully interactive with no JavaScript.
+
+### How is it used?
+
+```html
+<label class="tp-slot">
+  <input type="radio" name="slot" />
+  <span>10:00</span>
+</label>
+```
+
+Each slot wraps a radio in a label. The visually hidden radio drives the styling: `input:checked + span` fills the chip, `input:hover + span` shows a hover border, and a `tp-off` class plus `disabled` marks a taken slot.
+
+### Why is it useful?
+
+Booking and scheduling flows need a clear time slot selector. This provides one as an accessible radio group styled entirely with CSS, so exactly one time can be chosen without any script.

--- a/submissions/examples/time-picker-as/demo.html
+++ b/submissions/examples/time-picker-as/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Time Picker</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <form class="tp-card">
+    <h2 class="tp-title">Pick a time</h2>
+    <p class="tp-sub">Thursday, 11 July</p>
+
+    <fieldset class="tp-group">
+      <legend>Morning</legend>
+      <label class="tp-slot"><input type="radio" name="slot" /><span>9:00</span></label>
+      <label class="tp-slot"><input type="radio" name="slot" /><span>9:30</span></label>
+      <label class="tp-slot"><input type="radio" name="slot" checked /><span>10:00</span></label>
+      <label class="tp-slot"><input type="radio" name="slot" /><span>10:30</span></label>
+      <label class="tp-slot tp-off"><input type="radio" name="slot" disabled /><span>11:00</span></label>
+      <label class="tp-slot"><input type="radio" name="slot" /><span>11:30</span></label>
+    </fieldset>
+
+    <fieldset class="tp-group">
+      <legend>Afternoon</legend>
+      <label class="tp-slot"><input type="radio" name="slot" /><span>1:00</span></label>
+      <label class="tp-slot"><input type="radio" name="slot" /><span>1:30</span></label>
+      <label class="tp-slot"><input type="radio" name="slot" /><span>2:00</span></label>
+      <label class="tp-slot tp-off"><input type="radio" name="slot" disabled /><span>2:30</span></label>
+      <label class="tp-slot"><input type="radio" name="slot" /><span>3:00</span></label>
+      <label class="tp-slot"><input type="radio" name="slot" /><span>4:00</span></label>
+    </fieldset>
+
+    <button type="button" class="tp-confirm">Confirm time</button>
+  </form>
+</body>
+</html>

--- a/submissions/examples/time-picker-as/style.css
+++ b/submissions/examples/time-picker-as/style.css
@@ -1,0 +1,125 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(160deg, #eef1f9, #dde3f1);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #1f2740;
+}
+
+.tp-card {
+  width: min(360px, 94vw);
+  padding: 1.6rem 1.6rem 1.7rem;
+  box-sizing: border-box;
+  background: #fff;
+  border-radius: 20px;
+  box-shadow: 0 20px 45px rgba(31, 39, 64, 0.16);
+}
+
+.tp-title {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.tp-sub {
+  margin: 0.2rem 0 1.1rem;
+  font-size: 0.85rem;
+  color: #7b849c;
+}
+
+.tp-group {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  border: 0;
+  margin: 0 0 1rem;
+  padding: 0;
+}
+
+.tp-group legend {
+  grid-column: 1 / -1;
+  padding: 0;
+  margin-bottom: 0.55rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #9aa2b8;
+}
+
+.tp-slot {
+  position: relative;
+  cursor: pointer;
+}
+
+.tp-slot input {
+  position: absolute;
+  opacity: 0;
+  inset: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.tp-slot span {
+  display: block;
+  padding: 0.6rem 0;
+  text-align: center;
+  font-size: 0.9rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  border: 1.5px solid #dbe1ee;
+  border-radius: 10px;
+  background: #f7f9fd;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+
+.tp-slot input:hover + span {
+  border-color: #a9b6e6;
+}
+
+.tp-slot input:checked + span {
+  border-color: #3b56d4;
+  background: #3b56d4;
+  color: #fff;
+  box-shadow: 0 6px 14px rgba(59, 86, 212, 0.35);
+}
+
+.tp-slot input:focus-visible + span {
+  outline: 2px solid #3b56d4;
+  outline-offset: 2px;
+}
+
+.tp-slot.tp-off span {
+  color: #c2c8d6;
+  text-decoration: line-through;
+  background: #f2f3f7;
+  cursor: not-allowed;
+}
+
+.tp-confirm {
+  width: 100%;
+  margin-top: 0.4rem;
+  padding: 0.8rem;
+  border: 0;
+  border-radius: 12px;
+  background: #1f2740;
+  color: #fff;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.tp-confirm:hover {
+  background: #2c375c;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tp-slot span,
+  .tp-confirm {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a time picker built for #43182. Radio based time slots grouped by part of day, with a highlighted selection and struck through disabled slots. Pure CSS, no JavaScript. Closes #43182.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: three column slot grid, the checked slot fills blue with white text, and disabled slots are struck through.
