### PR TITLE
feat: add password toggle

### DIFF
--- a/submissions/examples/password-toggle-as/README.md
+++ b/submissions/examples/password-toggle-as/README.md
@@ -1,0 +1,21 @@
+# Password Toggle
+
+### What does this do?
+
+It shows a password field with a show and hide eye button. The value is masked by default and revealed when you click the eye, and the eye icon switches between open and struck through to match. All of it works with no JavaScript.
+
+### How is it used?
+
+```html
+<div class="pw-field">
+  <input id="pw" class="pw-input" type="text" value="tr0ub4dour" />
+  <input id="pw-reveal" class="pw-check" type="checkbox" />
+  <label class="pw-eye" for="pw-reveal">...</label>
+</div>
+```
+
+The input is masked with `-webkit-text-security: disc`. A hidden checkbox, toggled by the eye label, drives `.pw-field:has(.pw-check:checked) .pw-input { -webkit-text-security: none; }` to reveal the text, and the same `:has` rule swaps the eye icon.
+
+### Why is it useful?
+
+Reveal toggles help users check what they typed on sign in and sign up forms. This builds one entirely in CSS with `-webkit-text-security` and the `:has()` selector, so no script is needed to show or hide the value.

--- a/submissions/examples/password-toggle-as/demo.html
+++ b/submissions/examples/password-toggle-as/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Password Toggle</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <form class="pw-card">
+    <h2 class="pw-title">Sign in</h2>
+
+    <label class="pw-label" for="pw">Password</label>
+    <div class="pw-field">
+      <input id="pw" class="pw-input" type="text" value="tr0ub4dour" autocomplete="off" spellcheck="false" />
+      <input id="pw-reveal" class="pw-check" type="checkbox" />
+      <label class="pw-eye" for="pw-reveal" aria-label="Show or hide password">
+        <svg class="ic-off" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7S2 12 2 12z" />
+          <circle cx="12" cy="12" r="3" />
+        </svg>
+        <svg class="ic-on" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7S2 12 2 12z" />
+          <circle cx="12" cy="12" r="3" />
+          <line x1="4" y1="4" x2="20" y2="20" />
+        </svg>
+      </label>
+    </div>
+    <p class="pw-hint">Click the eye to reveal the password.</p>
+  </form>
+</body>
+</html>

--- a/submissions/examples/password-toggle-as/style.css
+++ b/submissions/examples/password-toggle-as/style.css
@@ -1,0 +1,128 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(160deg, #0f1830, #0a0f1f);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e7ecf7;
+}
+
+.pw-card {
+  width: min(360px, 94vw);
+  padding: 1.7rem 1.7rem 1.5rem;
+  box-sizing: border-box;
+  background: #141d33;
+  border: 1px solid #26314e;
+  border-radius: 18px;
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.4);
+}
+
+.pw-title {
+  margin: 0 0 1.3rem;
+  font-size: 1.2rem;
+}
+
+.pw-label {
+  display: block;
+  margin-bottom: 0.45rem;
+  font-size: 0.82rem;
+  color: #9aa6c2;
+}
+
+.pw-field {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.pw-input {
+  flex: 1;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.75rem 3rem 0.75rem 0.9rem;
+  border: 1.5px solid #2c3856;
+  border-radius: 11px;
+  background: #0e1526;
+  color: #f1f4fb;
+  font-size: 1rem;
+  letter-spacing: 0.12em;
+  -webkit-text-security: disc;
+}
+
+.pw-input:focus {
+  outline: none;
+  border-color: #5b7cff;
+  box-shadow: 0 0 0 3px rgba(91, 124, 255, 0.25);
+}
+
+.pw-field:has(.pw-check:checked) .pw-input {
+  -webkit-text-security: none;
+  letter-spacing: normal;
+}
+
+.pw-check {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  pointer-events: none;
+}
+
+.pw-eye {
+  position: absolute;
+  right: 0.5rem;
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  cursor: pointer;
+  color: #8b97b6;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.pw-eye:hover {
+  color: #cdd6ec;
+  background: rgba(91, 124, 255, 0.12);
+}
+
+.pw-check:focus-visible + .pw-eye {
+  outline: 2px solid #5b7cff;
+  outline-offset: 1px;
+}
+
+.pw-eye svg {
+  width: 20px;
+  height: 20px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+}
+
+.pw-eye .ic-on {
+  display: none;
+}
+
+.pw-field:has(.pw-check:checked) .pw-eye .ic-off {
+  display: none;
+}
+
+.pw-field:has(.pw-check:checked) .pw-eye .ic-on {
+  display: block;
+}
+
+.pw-hint {
+  margin: 0.7rem 0 0;
+  font-size: 0.78rem;
+  color: #6f7c9c;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pw-eye {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a password reveal toggle built for #43184. The field is masked with `-webkit-text-security` and a hidden checkbox driven by the eye label uses `:has()` to reveal the value and swap the icon. Pure CSS, no JavaScript. Closes #43184.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium: the input reports text-security disc by default and none after clicking the eye, and the eye icon swaps from open to struck through.
