### PR TITLE
feat: add stacked bar chart

### DIFF
--- a/submissions/examples/stacked-bar-chart-as/README.md
+++ b/submissions/examples/stacked-bar-chart-as/README.md
@@ -1,0 +1,21 @@
+# Stacked Bar Chart
+
+### What does this do?
+
+It shows a stacked bar chart. Each category is a vertical bar built from three colored segments that stack to full height, with the segment heights set by a `--h` custom property. An x axis and a legend name the categories and series.
+
+### How is it used?
+
+```html
+<div class="sbc-bar">
+  <span class="seg c" style="--h: 20%;"></span>
+  <span class="seg b" style="--h: 35%;"></span>
+  <span class="seg a" style="--h: 45%;"></span>
+</div>
+```
+
+Each bar is a flex column. Segments are ordered from top to bottom, each taking `height: var(--h)`, and the `a`, `b`, `c` classes set the series colors. The bar clips its top corners so the stack reads as one rounded column.
+
+### Why is it useful?
+
+Stacked bars compare a total across categories while showing each part's contribution, common in revenue and usage dashboards. This renders one purely with flexbox and a height custom property, with no charting script.

--- a/submissions/examples/stacked-bar-chart-as/demo.html
+++ b/submissions/examples/stacked-bar-chart-as/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Stacked Bar Chart</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <figure class="sbc">
+    <figcaption class="sbc-title">Revenue by channel</figcaption>
+
+    <div class="sbc-plot">
+      <div class="sbc-bar">
+        <span class="seg c" style="--h: 20%;"></span>
+        <span class="seg b" style="--h: 35%;"></span>
+        <span class="seg a" style="--h: 45%;"></span>
+      </div>
+      <div class="sbc-bar">
+        <span class="seg c" style="--h: 20%;"></span>
+        <span class="seg b" style="--h: 30%;"></span>
+        <span class="seg a" style="--h: 50%;"></span>
+      </div>
+      <div class="sbc-bar">
+        <span class="seg c" style="--h: 20%;"></span>
+        <span class="seg b" style="--h: 40%;"></span>
+        <span class="seg a" style="--h: 40%;"></span>
+      </div>
+      <div class="sbc-bar">
+        <span class="seg c" style="--h: 20%;"></span>
+        <span class="seg b" style="--h: 25%;"></span>
+        <span class="seg a" style="--h: 55%;"></span>
+      </div>
+      <div class="sbc-bar">
+        <span class="seg c" style="--h: 15%;"></span>
+        <span class="seg b" style="--h: 25%;"></span>
+        <span class="seg a" style="--h: 60%;"></span>
+      </div>
+    </div>
+
+    <div class="sbc-x">
+      <span>Jan</span><span>Feb</span><span>Mar</span><span>Apr</span><span>May</span>
+    </div>
+
+    <figcaption class="sbc-legend">
+      <span class="a">Direct</span>
+      <span class="b">Partner</span>
+      <span class="c">Ads</span>
+    </figcaption>
+  </figure>
+</body>
+</html>

--- a/submissions/examples/stacked-bar-chart-as/style.css
+++ b/submissions/examples/stacked-bar-chart-as/style.css
@@ -1,0 +1,100 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #101a2e, #080c15 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e4eaf5;
+}
+
+.sbc {
+  width: min(400px, 94vw);
+  margin: 0;
+  padding: 1.5rem 1.6rem 1.5rem;
+  box-sizing: border-box;
+  background: #111a2c;
+  border: 1px solid #253049;
+  border-radius: 16px;
+}
+
+.sbc-title {
+  margin-bottom: 1.1rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.sbc-plot {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-around;
+  gap: 14px;
+  height: 190px;
+  padding-top: 6px;
+  border-bottom: 2px solid #253049;
+}
+
+.sbc-bar {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  width: 100%;
+  max-width: 46px;
+  height: 100%;
+  border-radius: 7px 7px 0 0;
+  overflow: hidden;
+}
+
+.seg {
+  display: block;
+  width: 100%;
+  height: var(--h);
+}
+
+.seg.a { background: linear-gradient(180deg, #6366f1, #4f46e5); }
+.seg.b { background: linear-gradient(180deg, #22d3ee, #0ea5e9); }
+.seg.c { background: linear-gradient(180deg, #f472b6, #ec4899); }
+
+.sbc-x {
+  display: flex;
+  justify-content: space-around;
+  gap: 14px;
+  margin-top: 0.5rem;
+  font-size: 0.78rem;
+  color: #8b96ad;
+}
+
+.sbc-x span {
+  width: 100%;
+  max-width: 46px;
+  text-align: center;
+}
+
+.sbc-legend {
+  display: flex;
+  justify-content: center;
+  gap: 1.3rem;
+  margin-top: 1rem;
+  font-size: 0.8rem;
+  color: #aab4c8;
+}
+
+.sbc-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.sbc-legend span::before {
+  content: "";
+  width: 11px;
+  height: 11px;
+  border-radius: 3px;
+}
+
+.sbc-legend .a::before { background: #6366f1; }
+.sbc-legend .b::before { background: #0ea5e9; }
+.sbc-legend .c::before { background: #ec4899; }


### PR DESCRIPTION
## Pull Request Description

Adds a stacked bar chart built for #43186. Five category bars, each a flex column of three colored segments sized by a `--h` custom property, with an x axis and a legend. Pure CSS. Closes #43186.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium: all five bars fill the full plot height with three stacked segments each, fifteen segments total.
