### PR TITLE
feat: add seat map

### DIFF
--- a/submissions/examples/seat-map-as/README.md
+++ b/submissions/examples/seat-map-as/README.md
@@ -1,0 +1,21 @@
+# Seat Map
+
+### What does this do?
+
+It shows a cinema style seat selection map. Rows of seats sit below a curved screen, with an aisle gap in the middle. Available seats can be toggled on and off, selected seats turn green, and taken seats are dimmed and disabled. It is fully interactive with no JavaScript.
+
+### How is it used?
+
+```html
+<div class="sm-row">
+  <span class="sm-rl">A</span>
+  <label class="seat"><input type="checkbox" /><span></span></label>
+  <label class="seat taken"><input type="checkbox" disabled /><span></span></label>
+</div>
+```
+
+Each seat is a checkbox inside a label. The hidden checkbox drives the styling: `input:checked + span` marks a selected seat, and a `taken` class plus `disabled` renders an unavailable one. An empty `sm-aisle` span creates the walkway.
+
+### Why is it useful?
+
+Ticketing for cinemas, flights, and events needs a seat picker. This provides one as an accessible checkbox grid styled entirely with CSS, so seats can be chosen without any script.

--- a/submissions/examples/seat-map-as/demo.html
+++ b/submissions/examples/seat-map-as/demo.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Seat Map</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <form class="seatmap">
+    <div class="sm-screen">Screen</div>
+
+    <div class="sm-rows">
+      <div class="sm-row">
+        <span class="sm-rl">A</span>
+        <label class="seat"><input type="checkbox" /><span></span></label>
+        <label class="seat"><input type="checkbox" /><span></span></label>
+        <label class="seat taken"><input type="checkbox" disabled /><span></span></label>
+        <label class="seat"><input type="checkbox" /><span></span></label>
+        <span class="sm-aisle"></span>
+        <label class="seat"><input type="checkbox" /><span></span></label>
+        <label class="seat taken"><input type="checkbox" disabled /><span></span></label>
+        <label class="seat"><input type="checkbox" /><span></span></label>
+        <label class="seat"><input type="checkbox" /><span></span></label>
+      </div>
+
+      <div class="sm-row">
+        <span class="sm-rl">B</span>
+        <label class="seat"><input type="checkbox" /><span></span></label>
+        <label class="seat"><input type="checkbox" /><span></span></label>
+        <label class="seat"><input type="checkbox" /><span></span></label>
+        <label class="seat"><input type="checkbox" /><span></span></label>
+        <span class="sm-aisle"></span>
+        <label class="seat"><input type="checkbox" /><span></span></label>
+        <label class="seat"><input type="checkbox" /><span></span></label>
+        <label class="seat taken"><input type="checkbox" disabled /><span></span></label>
+        <label class="seat"><input type="checkbox" /><span></span></label>
+      </div>
+
+      <div class="sm-row">
+        <span class="sm-rl">C</span>
+        <label class="seat"><input type="checkbox" /><span></span></label>
+        <label class="seat taken"><input type="checkbox" disabled /><span></span></label>
+        <label class="seat taken"><input type="checkbox" disabled /><span></span></label>
+        <label class="seat"><input type="checkbox" /><span></span></label>
+        <span class="sm-aisle"></span>
+        <label class="seat"><input type="checkbox" /><span></span></label>
+        <label class="seat"><input type="checkbox" /><span></span></label>
+        <label class="seat"><input type="checkbox" /><span></span></label>
+        <label class="seat"><input type="checkbox" /><span></span></label>
+      </div>
+
+      <div class="sm-row">
+        <span class="sm-rl">D</span>
+        <label class="seat"><input type="checkbox" /><span></span></label>
+        <label class="seat"><input type="checkbox" /><span></span></label>
+        <label class="seat"><input type="checkbox" checked /><span></span></label>
+        <label class="seat"><input type="checkbox" checked /><span></span></label>
+        <span class="sm-aisle"></span>
+        <label class="seat"><input type="checkbox" /><span></span></label>
+        <label class="seat taken"><input type="checkbox" disabled /><span></span></label>
+        <label class="seat"><input type="checkbox" /><span></span></label>
+        <label class="seat"><input type="checkbox" /><span></span></label>
+      </div>
+    </div>
+
+    <div class="sm-legend">
+      <span class="lg-free">Available</span>
+      <span class="lg-sel">Selected</span>
+      <span class="lg-taken">Taken</span>
+    </div>
+  </form>
+</body>
+</html>

--- a/submissions/examples/seat-map-as/style.css
+++ b/submissions/examples/seat-map-as/style.css
@@ -1,0 +1,136 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #161a26, #0a0d14 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e6eaf4;
+}
+
+.seatmap {
+  width: min(420px, 96vw);
+  padding: 1.6rem 1.6rem 1.4rem;
+  box-sizing: border-box;
+  background: #131826;
+  border: 1px solid #262f45;
+  border-radius: 18px;
+}
+
+.sm-screen {
+  margin: 0 auto 1.6rem;
+  width: 80%;
+  padding: 0.5rem;
+  text-align: center;
+  font-size: 0.72rem;
+  letter-spacing: 0.35em;
+  text-transform: uppercase;
+  color: #93a1bd;
+  background: linear-gradient(180deg, #313c56, #1a2133);
+  border-radius: 50% 50% 6px 6px / 70% 70% 6px 6px;
+  box-shadow: 0 -12px 30px rgba(99, 102, 241, 0.25);
+}
+
+.sm-rows {
+  display: grid;
+  gap: 9px;
+  justify-content: center;
+}
+
+.sm-row {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.sm-rl {
+  width: 16px;
+  font-size: 0.72rem;
+  color: #6b7793;
+  text-align: center;
+}
+
+.sm-aisle {
+  width: 16px;
+}
+
+.seat {
+  cursor: pointer;
+  line-height: 0;
+}
+
+.seat input {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+
+.seat span {
+  display: block;
+  width: 24px;
+  height: 22px;
+  border-radius: 6px 6px 3px 3px;
+  background: #2f3a54;
+  border: 1.5px solid #3c4966;
+  transition: background 0.15s ease, transform 0.1s ease;
+}
+
+.seat input:hover + span {
+  background: #3d4c6d;
+}
+
+.seat input:checked + span {
+  background: linear-gradient(180deg, #34d399, #10b981);
+  border-color: #34d399;
+  transform: translateY(-1px);
+}
+
+.seat input:focus-visible + span {
+  outline: 2px solid #60a5fa;
+  outline-offset: 2px;
+}
+
+.seat.taken span {
+  background: #202634;
+  border-color: #202634;
+  cursor: not-allowed;
+}
+
+.seat.taken input {
+  cursor: not-allowed;
+}
+
+.sm-legend {
+  display: flex;
+  justify-content: center;
+  gap: 1.3rem;
+  margin-top: 1.5rem;
+  font-size: 0.76rem;
+  color: #9aa6bf;
+}
+
+.sm-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.sm-legend span::before {
+  content: "";
+  width: 14px;
+  height: 13px;
+  border-radius: 4px 4px 2px 2px;
+}
+
+.lg-free::before { background: #2f3a54; border: 1.5px solid #3c4966; }
+.lg-sel::before { background: #10b981; }
+.lg-taken::before { background: #202634; }
+
+@media (prefers-reduced-motion: reduce) {
+  .seat span {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a seat map built for #43190. A cinema seat picker with a curved screen, rows and an aisle, checkbox seats that turn green when selected, and dimmed disabled taken seats. Pure CSS, no JavaScript. Closes #43190.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: four rows of seats below a curved screen, six taken seats dimmed, two selected seats green, plus a legend.
