### PR TITLE
feat: add org chart

### DIFF
--- a/submissions/examples/org-chart-as/README.md
+++ b/submissions/examples/org-chart-as/README.md
@@ -1,0 +1,26 @@
+# Org Chart
+
+### What does this do?
+
+It shows an organization chart as a connected tree. A lead node sits at the top, three department nodes hang below it, and one of those has two sub team nodes, all joined by clean connector lines drawn purely in CSS. Each node shows an avatar, a name, and a role.
+
+### How is it used?
+
+```html
+<div class="orgchart">
+  <ul>
+    <li>
+      <div class="node lead"><b>Ava Stone</b><em>CEO</em></div>
+      <ul>
+        <li><div class="node"><b>Ravi Kumar</b><em>Engineering</em></div></li>
+      </ul>
+    </li>
+  </ul>
+</div>
+```
+
+The hierarchy is a nested list. Connector lines come from `li::before` and `li::after` borders plus a vertical `ul ul::before`, with first and last child rules rounding the corners, so the tree lines are all CSS and no SVG.
+
+### Why is it useful?
+
+Team pages, admin panels, and about pages show reporting structure as an org chart. This builds one from a nested list and CSS connector lines, so the hierarchy stays semantic and needs no diagramming script.

--- a/submissions/examples/org-chart-as/demo.html
+++ b/submissions/examples/org-chart-as/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Org Chart</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="orgchart">
+    <ul>
+      <li>
+        <div class="node lead">
+          <span class="ava">AS</span>
+          <b>Ava Stone</b>
+          <em>CEO</em>
+        </div>
+        <ul>
+          <li>
+            <div class="node">
+              <span class="ava a2">RK</span>
+              <b>Ravi Kumar</b>
+              <em>Engineering</em>
+            </div>
+            <ul>
+              <li>
+                <div class="node sm"><b>Frontend</b><em>4 people</em></div>
+              </li>
+              <li>
+                <div class="node sm"><b>Backend</b><em>5 people</em></div>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <div class="node">
+              <span class="ava a3">MW</span>
+              <b>Mei Wong</b>
+              <em>Design</em>
+            </div>
+          </li>
+          <li>
+            <div class="node">
+              <span class="ava a4">LP</span>
+              <b>Leo Prado</b>
+              <em>Sales</em>
+            </div>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/submissions/examples/org-chart-as/style.css
+++ b/submissions/examples/org-chart-as/style.css
@@ -1,0 +1,139 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2.5rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(160deg, #eef2fb, #dde4f3);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #1e2740;
+}
+
+.orgchart {
+  overflow-x: auto;
+  padding: 1rem;
+}
+
+.orgchart ul {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  padding-top: 22px;
+  margin: 0;
+  list-style: none;
+}
+
+.orgchart > ul {
+  padding-top: 0;
+}
+
+.orgchart li {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 22px 10px 0;
+}
+
+.orgchart li::before,
+.orgchart li::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 50%;
+  width: 50%;
+  height: 22px;
+  border-top: 2px solid #b9c4dd;
+}
+
+.orgchart li::after {
+  right: auto;
+  left: 50%;
+  border-left: 2px solid #b9c4dd;
+}
+
+.orgchart li:only-child::before,
+.orgchart li:only-child::after {
+  display: none;
+}
+
+.orgchart li:first-child::before,
+.orgchart li:last-child::after {
+  border: 0;
+}
+
+.orgchart li:last-child::before {
+  border-right: 2px solid #b9c4dd;
+  border-radius: 0 6px 0 0;
+}
+
+.orgchart li:first-child::after {
+  border-radius: 6px 0 0 0;
+}
+
+.orgchart ul ul::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 0;
+  height: 22px;
+  border-left: 2px solid #b9c4dd;
+}
+
+.node {
+  display: inline-grid;
+  justify-items: center;
+  gap: 2px;
+  width: 120px;
+  padding: 0.75rem 0.6rem;
+  box-sizing: border-box;
+  background: #fff;
+  border: 1px solid #d8e0ef;
+  border-radius: 12px;
+  box-shadow: 0 6px 16px rgba(31, 39, 64, 0.1);
+}
+
+.node b {
+  font-size: 0.85rem;
+}
+
+.node em {
+  font-style: normal;
+  font-size: 0.72rem;
+  color: #7a84a0;
+}
+
+.node.lead {
+  background: linear-gradient(160deg, #3b56d4, #5b73e8);
+  border: 0;
+  color: #fff;
+}
+
+.node.lead em {
+  color: #d5ddfb;
+}
+
+.node.sm {
+  width: 104px;
+  padding: 0.55rem;
+}
+
+.ava {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  margin-bottom: 2px;
+  border-radius: 50%;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #fff;
+  background: #64748b;
+}
+
+.node.lead .ava { background: rgba(255, 255, 255, 0.25); }
+.ava.a2 { background: #0ea5e9; }
+.ava.a3 { background: #ec4899; }
+.ava.a4 { background: #f59e0b; }


### PR DESCRIPTION
## Pull Request Description

Adds an org chart built for #43194. A nested list hierarchy with a lead node, three departments, and a sub team, joined by pure CSS connector lines from li borders. Each node has an avatar, name, and role. Pure CSS. Closes #43194.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: the lead node is centered above three department nodes, one of which has two sub team nodes, with connector lines aligned.
