### PR TITLE
feat: add currency converter

### DIFF
--- a/submissions/examples/currency-converter-as/README.md
+++ b/submissions/examples/currency-converter-as/README.md
@@ -1,0 +1,20 @@
+# Currency Converter
+
+### What does this do?
+
+It shows a currency converter card: a from amount with its currency chip, a circular swap button, a converted amount with its currency chip, and an exchange rate line. The swap button rotates on hover, and the two fields are visually distinct.
+
+### How is it used?
+
+```html
+<span class="cc-field">
+  <input class="cc-amt" type="text" value="1,000.00" readonly />
+  <span class="cc-cur"><span class="cc-flag">&#127482;&#127480;</span> USD</span>
+</span>
+```
+
+Each row pairs an amount input with a currency chip that holds a flag emoji and code. The swap button sits centered on a thin divider line between the two fields, and the rate line summarizes the conversion.
+
+### Why is it useful?
+
+Banking, travel, and checkout apps offer currency conversion. This provides a clean converter layout with a swap control and rate display, styled entirely with CSS and ready to wire up to real rates.

--- a/submissions/examples/currency-converter-as/demo.html
+++ b/submissions/examples/currency-converter-as/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Currency Converter</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <form class="cc">
+    <h2 class="cc-title">Convert</h2>
+
+    <label class="cc-row">
+      <span class="cc-label">Amount</span>
+      <span class="cc-field">
+        <input class="cc-amt" type="text" inputmode="decimal" value="1,000.00" aria-label="Amount to convert" readonly />
+        <span class="cc-cur"><span class="cc-flag">&#127482;&#127480;</span> USD</span>
+      </span>
+    </label>
+
+    <div class="cc-swap-line">
+      <button type="button" class="cc-swap" aria-label="Swap currencies">
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M7 4v13M7 4 4 7M7 4l3 3M17 20V7M17 20l3-3M17 20l-3-3" />
+        </svg>
+      </button>
+    </div>
+
+    <label class="cc-row">
+      <span class="cc-label">Converted</span>
+      <span class="cc-field to">
+        <input class="cc-amt" type="text" value="918.40" aria-label="Converted amount" readonly />
+        <span class="cc-cur"><span class="cc-flag">&#127466;&#127482;</span> EUR</span>
+      </span>
+    </label>
+
+    <p class="cc-rate">1 USD = 0.9184 EUR <span>&#183; updated just now</span></p>
+    <button type="button" class="cc-go">Convert</button>
+  </form>
+</body>
+</html>

--- a/submissions/examples/currency-converter-as/style.css
+++ b/submissions/examples/currency-converter-as/style.css
@@ -1,0 +1,162 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(160deg, #101a33, #0a0e1c);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #eaf0fb;
+}
+
+.cc {
+  width: min(360px, 94vw);
+  padding: 1.7rem 1.6rem 1.6rem;
+  box-sizing: border-box;
+  background: #151e35;
+  border: 1px solid #27324f;
+  border-radius: 20px;
+  box-shadow: 0 22px 48px rgba(0, 0, 0, 0.42);
+}
+
+.cc-title {
+  margin: 0 0 1.2rem;
+  font-size: 1.15rem;
+}
+
+.cc-row {
+  display: block;
+}
+
+.cc-label {
+  display: block;
+  margin-bottom: 0.4rem;
+  font-size: 0.76rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #8b97b6;
+}
+
+.cc-field {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.65rem 0.75rem;
+  border: 1.5px solid #2c3856;
+  border-radius: 13px;
+  background: #0f1730;
+}
+
+.cc-field.to {
+  background: #101d33;
+  border-color: #22406a;
+}
+
+.cc-amt {
+  flex: 1;
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  color: #f3f7ff;
+  font-size: 1.35rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.cc-amt:focus {
+  outline: none;
+}
+
+.cc-cur {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 9px;
+  background: #202c49;
+  font-size: 0.85rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.cc-flag {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.cc-swap-line {
+  position: relative;
+  height: 14px;
+  margin: 6px 0;
+}
+
+.cc-swap {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  border: 3px solid #151e35;
+  border-radius: 50%;
+  background: #3b82f6;
+  color: #fff;
+  cursor: pointer;
+  transition: transform 0.18s ease, background 0.18s ease;
+}
+
+.cc-swap:hover {
+  background: #2563eb;
+  transform: translate(-50%, -50%) rotate(180deg);
+}
+
+.cc-swap svg {
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.cc-rate {
+  margin: 1rem 0 1.2rem;
+  text-align: center;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #cdd7ee;
+}
+
+.cc-rate span {
+  font-weight: 400;
+  color: #7b88a8;
+}
+
+.cc-go {
+  width: 100%;
+  padding: 0.85rem;
+  border: 0;
+  border-radius: 13px;
+  background: linear-gradient(90deg, #3b82f6, #6366f1);
+  color: #fff;
+  font-size: 0.98rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: filter 0.15s ease;
+}
+
+.cc-go:hover {
+  filter: brightness(1.08);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cc-swap,
+  .cc-go {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a currency converter built for #43198. From and to amount fields with currency chips, a centered rotating swap button on a divider, and a rate line. Pure CSS. Closes #43198.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: two amount fields with currency chips, a swap button centered on the divider line, and a rate summary.
