### PR TITLE
feat: add calculator keypad

### DIFF
--- a/submissions/examples/calculator-keypad-as/README.md
+++ b/submissions/examples/calculator-keypad-as/README.md
@@ -1,0 +1,22 @@
+# Calculator Keypad
+
+### What does this do?
+
+It shows a calculator interface: a screen with the current expression and result, and a four column keypad of digit, function, and operator keys. Operators are highlighted, the zero key spans two columns, and every key has hover, pressed, and focus states.
+
+### How is it used?
+
+```html
+<div class="calc-keys">
+  <button type="button" class="key op">&divide;</button>
+  <button type="button" class="key">7</button>
+  <button type="button" class="key zero">0</button>
+  <button type="button" class="key eq">=</button>
+</div>
+```
+
+The keypad is a `repeat(4, 1fr)` grid. Key roles come from classes: `fn` for functions, `op` for operators, `eq` for equals, and `zero` which spans two columns with `grid-column: span 2`. The `:active` state scales the key for tactile feedback.
+
+### Why is it useful?
+
+Calculators appear in finance tools, forms, and utility apps. This gives a polished keypad layout with clear key roles and press feedback, styled entirely with CSS and ready for logic to be added.

--- a/submissions/examples/calculator-keypad-as/demo.html
+++ b/submissions/examples/calculator-keypad-as/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Calculator Keypad</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="calc">
+    <div class="calc-screen">
+      <span class="calc-expr">165 &times; 4</span>
+      <span class="calc-out">660</span>
+    </div>
+
+    <div class="calc-keys">
+      <button type="button" class="key fn">AC</button>
+      <button type="button" class="key fn">&plusmn;</button>
+      <button type="button" class="key fn">%</button>
+      <button type="button" class="key op">&divide;</button>
+
+      <button type="button" class="key">7</button>
+      <button type="button" class="key">8</button>
+      <button type="button" class="key">9</button>
+      <button type="button" class="key op">&times;</button>
+
+      <button type="button" class="key">4</button>
+      <button type="button" class="key">5</button>
+      <button type="button" class="key">6</button>
+      <button type="button" class="key op">&minus;</button>
+
+      <button type="button" class="key">1</button>
+      <button type="button" class="key">2</button>
+      <button type="button" class="key">3</button>
+      <button type="button" class="key op">+</button>
+
+      <button type="button" class="key zero">0</button>
+      <button type="button" class="key">.</button>
+      <button type="button" class="key eq">=</button>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/calculator-keypad-as/style.css
+++ b/submissions/examples/calculator-keypad-as/style.css
@@ -1,0 +1,104 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(160deg, #1b1f2a, #0c0e14);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #f2f4f8;
+}
+
+.calc {
+  width: min(300px, 92vw);
+  padding: 1.1rem;
+  box-sizing: border-box;
+  background: #171b26;
+  border: 1px solid #2a303f;
+  border-radius: 22px;
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.5);
+}
+
+.calc-screen {
+  display: grid;
+  justify-items: end;
+  gap: 0.2rem;
+  padding: 1rem 0.8rem 1.1rem;
+  margin-bottom: 0.9rem;
+  min-height: 74px;
+  border-radius: 14px;
+  background: #0e1119;
+}
+
+.calc-expr {
+  font-size: 0.9rem;
+  color: #7d879c;
+  font-variant-numeric: tabular-nums;
+}
+
+.calc-out {
+  font-size: 2.3rem;
+  font-weight: 300;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.calc-keys {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+}
+
+.key {
+  height: 58px;
+  border: 0;
+  border-radius: 14px;
+  background: #2a3040;
+  color: #f2f4f8;
+  font-size: 1.25rem;
+  cursor: pointer;
+  transition: transform 0.08s ease, filter 0.15s ease;
+}
+
+.key:hover {
+  filter: brightness(1.14);
+}
+
+.key:active {
+  transform: scale(0.94);
+}
+
+.key:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
+}
+
+.key.fn {
+  background: #3a4152;
+  color: #cdd4e4;
+  font-size: 1.1rem;
+}
+
+.key.op {
+  background: linear-gradient(180deg, #fb923c, #f97316);
+  color: #fff;
+  font-size: 1.4rem;
+}
+
+.key.eq {
+  background: linear-gradient(180deg, #818cf8, #6366f1);
+  color: #fff;
+}
+
+.key.zero {
+  grid-column: span 2;
+  text-align: left;
+  padding-left: 1.5rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .key {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a calculator keypad built for #43200. A screen with expression and result plus a four column grid of digit, function, and operator keys, with a two column zero and press feedback. Pure CSS. Closes #43200.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: nineteen keys with four operators, a zero key spanning two columns, and a screen showing an expression and result.
