### PR TITLE
feat: add area chart

### DIFF
--- a/submissions/examples/area-chart-as/README.md
+++ b/submissions/examples/area-chart-as/README.md
@@ -1,0 +1,20 @@
+# Area Chart
+
+### What does this do?
+
+It shows an area chart of a weekly trend. A line traces the values, a gradient fill fades from the line down to the axis, gridlines and day labels frame the plot, and two points are marked. Everything is inline SVG styled with CSS.
+
+### How is it used?
+
+```html
+<svg viewBox="0 0 312 170">
+  <polygon class="ar-area" points="18,150 18,109 57,86 ... 294,37 294,150" />
+  <polyline class="ar-line" points="18,109 57,86 97,98 ... 294,37" />
+</svg>
+```
+
+The filled shape is a `polygon` that follows the data then closes down to the baseline, painted with a `linearGradient`. The `polyline` on top draws the crisp line, and `circle` elements highlight key points.
+
+### Why is it useful?
+
+Dashboards use area charts to show a trend with volume underneath. This renders one from an SVG polygon and polyline with a gradient fill, using only CSS and no charting library.

--- a/submissions/examples/area-chart-as/demo.html
+++ b/submissions/examples/area-chart-as/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Area Chart</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <figure class="area">
+    <figcaption class="ar-head">
+      <span class="ar-title">Weekly visitors</span>
+      <span class="ar-total">4,182 <em>+12%</em></span>
+    </figcaption>
+
+    <svg viewBox="0 0 312 170" role="img" aria-label="Area chart of weekly visitors">
+      <defs>
+        <linearGradient id="ar-fill" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stop-color="#6366f1" stop-opacity="0.55" />
+          <stop offset="100%" stop-color="#6366f1" stop-opacity="0" />
+        </linearGradient>
+      </defs>
+
+      <g class="ar-grid">
+        <line x1="18" y1="20" x2="294" y2="20" />
+        <line x1="18" y1="63.3" x2="294" y2="63.3" />
+        <line x1="18" y1="106.7" x2="294" y2="106.7" />
+        <line x1="18" y1="150" x2="294" y2="150" />
+      </g>
+
+      <polygon class="ar-area" points="18,150 18.0,109.6 57.4,86.4 96.9,98.0 136.3,66.2 175.7,77.8 215.1,46.0 254.6,57.6 294.0,37.3 294,150" />
+      <polyline class="ar-line" points="18.0,109.6 57.4,86.4 96.9,98.0 136.3,66.2 175.7,77.8 215.1,46.0 254.6,57.6 294.0,37.3" />
+
+      <g class="ar-dots">
+        <circle cx="136.3" cy="66.2" r="3.5" />
+        <circle cx="294.0" cy="37.3" r="3.5" />
+      </g>
+
+      <g class="ar-x">
+        <text x="18" y="164">Mon</text>
+        <text x="96.9" y="164">Wed</text>
+        <text x="175.7" y="164">Fri</text>
+        <text x="294" y="164" text-anchor="end">Sun</text>
+      </g>
+    </svg>
+  </figure>
+</body>
+</html>

--- a/submissions/examples/area-chart-as/style.css
+++ b/submissions/examples/area-chart-as/style.css
@@ -1,0 +1,82 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #151d33, #0a0e1a 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e6ebf6;
+}
+
+.area {
+  width: min(400px, 94vw);
+  margin: 0;
+  padding: 1.4rem 1.4rem 1rem;
+  box-sizing: border-box;
+  background: #111a2c;
+  border: 1px solid #26314a;
+  border-radius: 16px;
+}
+
+.ar-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 0.9rem;
+}
+
+.ar-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.ar-total {
+  font-size: 1.05rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.ar-total em {
+  font-style: normal;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #34d399;
+}
+
+.area svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  overflow: visible;
+}
+
+.ar-grid line {
+  stroke: #22304a;
+  stroke-width: 1;
+  stroke-dasharray: 2 4;
+}
+
+.ar-area {
+  fill: url("#ar-fill");
+}
+
+.ar-line {
+  fill: none;
+  stroke: #818cf8;
+  stroke-width: 2.5;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+}
+
+.ar-dots circle {
+  fill: #c7d2fe;
+  stroke: #4f46e5;
+  stroke-width: 2;
+}
+
+.ar-x text {
+  fill: #7a86a2;
+  font-size: 10px;
+}


### PR DESCRIPTION
## Pull Request Description

Adds an area chart built for #43206. An SVG polygon with a gradient fill under a polyline trend line, with gridlines, day labels, and marked points. Pure CSS. Closes #43206.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a rising trend line with a gradient area fill, four gridlines, marked points, and day labels.
