### PR TITLE
feat: add bullet chart

### DIFF
--- a/submissions/examples/bullet-chart-as/README.md
+++ b/submissions/examples/bullet-chart-as/README.md
@@ -1,0 +1,20 @@
+# Bullet Chart
+
+### What does this do?
+
+It shows a set of bullet graphs, the compact KPI charts popularized by Stephen Few. Each row has a label, a track with three shaded qualitative ranges, a measure bar showing the current value, and a target marker to compare against. The measure width and target position come from `--m` and `--t` custom properties.
+
+### How is it used?
+
+```html
+<span class="bl-track" style="--m: 78%; --t: 90%;">
+  <span class="bl-measure"></span>
+  <span class="bl-target"></span>
+</span>
+```
+
+The track background is a three stop gradient for the poor, ok, and good bands. The `bl-measure` bar takes `width: var(--m)`, and the `bl-target` tick sits at `left: var(--t)`, so one line encodes a full KPI.
+
+### Why is it useful?
+
+Bullet charts pack a value, its ranges, and a goal into one compact row, ideal for dashboards with many metrics. This builds them with pure CSS from two custom properties, with no charting script.

--- a/submissions/examples/bullet-chart-as/demo.html
+++ b/submissions/examples/bullet-chart-as/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bullet Chart</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <figure class="bullet">
+    <figcaption class="bl-title">Quarter targets</figcaption>
+
+    <div class="bl-row">
+      <span class="bl-label">Revenue</span>
+      <span class="bl-track" style="--m: 78%; --t: 90%;">
+        <span class="bl-measure"></span>
+        <span class="bl-target"></span>
+      </span>
+      <span class="bl-val">78</span>
+    </div>
+
+    <div class="bl-row">
+      <span class="bl-label">Profit</span>
+      <span class="bl-track" style="--m: 62%; --t: 55%;">
+        <span class="bl-measure"></span>
+        <span class="bl-target"></span>
+      </span>
+      <span class="bl-val">62</span>
+    </div>
+
+    <div class="bl-row">
+      <span class="bl-label">Orders</span>
+      <span class="bl-track" style="--m: 45%; --t: 70%;">
+        <span class="bl-measure"></span>
+        <span class="bl-target"></span>
+      </span>
+      <span class="bl-val">45</span>
+    </div>
+
+    <div class="bl-row">
+      <span class="bl-label">NPS</span>
+      <span class="bl-track" style="--m: 88%; --t: 80%;">
+        <span class="bl-measure"></span>
+        <span class="bl-target"></span>
+      </span>
+      <span class="bl-val">88</span>
+    </div>
+  </figure>
+</body>
+</html>

--- a/submissions/examples/bullet-chart-as/style.css
+++ b/submissions/examples/bullet-chart-as/style.css
@@ -1,0 +1,85 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(160deg, #0f1626, #090c14);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e6ebf5;
+}
+
+.bullet {
+  width: min(430px, 95vw);
+  margin: 0;
+  padding: 1.5rem 1.6rem 1.4rem;
+  box-sizing: border-box;
+  background: #121a2c;
+  border: 1px solid #26314a;
+  border-radius: 16px;
+  display: grid;
+  gap: 1rem;
+}
+
+.bl-title {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.bl-row {
+  display: grid;
+  grid-template-columns: 64px 1fr 32px;
+  align-items: center;
+  gap: 12px;
+}
+
+.bl-label {
+  font-size: 0.82rem;
+  color: #aab4c8;
+  text-align: right;
+}
+
+.bl-track {
+  position: relative;
+  height: 24px;
+  border-radius: 5px;
+  overflow: hidden;
+  background: linear-gradient(
+    90deg,
+    #384056 0 55%,
+    #2b3346 55% 80%,
+    #222a3b 80% 100%
+  );
+}
+
+.bl-measure {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  transform: translateY(-50%);
+  width: var(--m, 50%);
+  height: 9px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #22d3ee, #6366f1);
+}
+
+.bl-target {
+  position: absolute;
+  top: 3px;
+  bottom: 3px;
+  left: var(--t, 80%);
+  width: 3px;
+  margin-left: -1.5px;
+  border-radius: 2px;
+  background: #f8fafc;
+  box-shadow: 0 0 5px rgba(248, 250, 252, 0.6);
+}
+
+.bl-val {
+  font-size: 0.85rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  color: #cfd7e8;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a bullet chart built for #43208. KPI rows with shaded qualitative range bands, a measure bar sized by `--m`, and a target marker at `--t`. Pure CSS. Closes #43208.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: four KPI rows with range bands, measure bars at proportional widths, and target markers.
