### PR TITLE
feat: add treemap

### DIFF
--- a/submissions/examples/treemap-as/README.md
+++ b/submissions/examples/treemap-as/README.md
@@ -1,0 +1,20 @@
+# Treemap
+
+### What does this do?
+
+It shows a treemap: a rectangle split into tiles whose sizes reflect their share of the whole. A large tile dominates, with medium and small tiles filling the rest, each labeled with a category and value. The layout is a CSS grid using named template areas.
+
+### How is it used?
+
+```html
+<div class="tm-grid">
+  <div class="tm-tile a"><span class="tm-name">Videos</span><span class="tm-val">128 GB</span></div>
+  <div class="tm-tile b"><span class="tm-name">Photos</span><span class="tm-val">76 GB</span></div>
+</div>
+```
+
+The `tm-grid` defines a six by four grid and assigns each tile a rectangular region with `grid-template-areas`. Changing a tile's area span resizes it, so the map reflows to match the data proportions.
+
+### Why is it useful?
+
+Treemaps show how parts make up a whole when there are many categories, common for storage, budgets, and portfolios. This builds one with pure CSS grid areas, with no layout script or charting library.

--- a/submissions/examples/treemap-as/demo.html
+++ b/submissions/examples/treemap-as/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Treemap</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <figure class="treemap">
+    <figcaption class="tm-title">Storage by type</figcaption>
+    <div class="tm-grid">
+      <div class="tm-tile a">
+        <span class="tm-name">Videos</span>
+        <span class="tm-val">128 GB</span>
+      </div>
+      <div class="tm-tile b">
+        <span class="tm-name">Photos</span>
+        <span class="tm-val">76 GB</span>
+      </div>
+      <div class="tm-tile c">
+        <span class="tm-name">Apps</span>
+        <span class="tm-val">54 GB</span>
+      </div>
+      <div class="tm-tile d">
+        <span class="tm-name">Docs</span>
+        <span class="tm-val">22 GB</span>
+      </div>
+      <div class="tm-tile e">
+        <span class="tm-name">Music</span>
+        <span class="tm-val">31 GB</span>
+      </div>
+    </div>
+  </figure>
+</body>
+</html>

--- a/submissions/examples/treemap-as/style.css
+++ b/submissions/examples/treemap-as/style.css
@@ -1,0 +1,86 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #141b2c, #090c14 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e6ebf5;
+}
+
+.treemap {
+  width: min(420px, 94vw);
+  margin: 0;
+}
+
+.tm-title {
+  margin-bottom: 0.8rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.tm-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  grid-template-rows: repeat(4, 1fr);
+  grid-template-areas:
+    "a a a b b b"
+    "a a a b b b"
+    "a a a c c d"
+    "e e e c c d";
+  gap: 6px;
+  aspect-ratio: 6 / 4;
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.tm-tile {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 0.7rem 0.8rem;
+  border-radius: 10px;
+  color: #fff;
+  overflow: hidden;
+}
+
+.tm-name {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.tm-val {
+  font-size: 0.76rem;
+  opacity: 0.82;
+  font-variant-numeric: tabular-nums;
+}
+
+.tm-tile.a {
+  grid-area: a;
+  background: linear-gradient(150deg, #6366f1, #4f46e5);
+}
+
+.tm-tile.b {
+  grid-area: b;
+  background: linear-gradient(150deg, #0ea5e9, #0284c7);
+}
+
+.tm-tile.c {
+  grid-area: c;
+  background: linear-gradient(150deg, #14b8a6, #0d9488);
+}
+
+.tm-tile.d {
+  grid-area: d;
+  background: linear-gradient(150deg, #f59e0b, #d97706);
+}
+
+.tm-tile.e {
+  grid-area: e;
+  background: linear-gradient(150deg, #ec4899, #db2777);
+}
+
+.tm-tile.a .tm-name { font-size: 1.15rem; }
+.tm-tile.a .tm-val { font-size: 0.85rem; }


### PR DESCRIPTION
## Pull Request Description

Adds a treemap built for #43211. Proportionally sized tiles laid out with CSS grid template areas, each labeled with a category and value. Pure CSS. Closes #43211.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: five tiles with proportional areas (largest for the biggest value) laid out as a treemap with labels.
