### PR TITLE
feat: add activity rings

### DIFF
--- a/submissions/examples/activity-rings-as/README.md
+++ b/submissions/examples/activity-rings-as/README.md
@@ -1,0 +1,21 @@
+# Activity Rings
+
+### What does this do?
+
+It shows three concentric activity rings, like the ones on a fitness watch. Each ring fills clockwise to its own percentage set by a `--p` custom property, in its own color, with a legend showing the underlying numbers. The rings are pure CSS, made from a conic gradient masked into a ring shape.
+
+### How is it used?
+
+```html
+<div class="rings">
+  <span class="ring move" style="--p: 85;"></span>
+  <span class="ring exercise" style="--p: 65;"></span>
+  <span class="ring stand" style="--p: 40;"></span>
+</div>
+```
+
+Each ring is a circle filled with a `conic-gradient` up to `calc(var(--p) * 1%)`, then a radial `mask` cuts out the middle to leave a ring. The three rings are stacked and centered at different sizes.
+
+### Why is it useful?
+
+Fitness and habit apps show progress on several goals at once with concentric rings. This delivers that widget with pure CSS conic gradients and masks, driven by one custom property per ring, with no SVG or script.

--- a/submissions/examples/activity-rings-as/demo.html
+++ b/submissions/examples/activity-rings-as/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Activity Rings</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="activity">
+    <div class="rings" role="img" aria-label="Three activity rings: move 85 percent, exercise 65 percent, stand 40 percent">
+      <span class="ring move" style="--p: 85;"></span>
+      <span class="ring exercise" style="--p: 65;"></span>
+      <span class="ring stand" style="--p: 40;"></span>
+    </div>
+
+    <ul class="ac-legend">
+      <li class="move"><b>Move</b><span>510 / 600 cal</span></li>
+      <li class="exercise"><b>Exercise</b><span>26 / 40 min</span></li>
+      <li class="stand"><b>Stand</b><span>4 / 10 hr</span></li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/submissions/examples/activity-rings-as/style.css
+++ b/submissions/examples/activity-rings-as/style.css
@@ -1,0 +1,91 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: #05070c;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #f2f5fb;
+}
+
+.activity {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  padding: 1.8rem 2rem;
+  background: #0e121c;
+  border: 1px solid #1d2434;
+  border-radius: 22px;
+}
+
+.rings {
+  position: relative;
+  width: 168px;
+  height: 168px;
+  flex-shrink: 0;
+}
+
+.ring {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 15px), #000 calc(100% - 15px));
+  mask: radial-gradient(farthest-side, transparent calc(100% - 15px), #000 calc(100% - 15px));
+}
+
+.ring.move {
+  width: 168px;
+  height: 168px;
+  background: conic-gradient(from 0deg, #fb2c5a calc(var(--p) * 1%), rgba(251, 44, 90, 0.16) 0);
+}
+
+.ring.exercise {
+  width: 124px;
+  height: 124px;
+  background: conic-gradient(from 0deg, #a3f713 calc(var(--p) * 1%), rgba(163, 247, 19, 0.16) 0);
+}
+
+.ring.stand {
+  width: 80px;
+  height: 80px;
+  background: conic-gradient(from 0deg, #22d3ee calc(var(--p) * 1%), rgba(34, 211, 238, 0.16) 0);
+}
+
+.ac-legend {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.ac-legend li {
+  display: grid;
+  gap: 1px;
+  padding-left: 0.9rem;
+  border-left: 3px solid;
+}
+
+.ac-legend li b {
+  font-size: 0.9rem;
+}
+
+.ac-legend li span {
+  font-size: 0.78rem;
+  color: #9aa4ba;
+  font-variant-numeric: tabular-nums;
+}
+
+.ac-legend .move { border-color: #fb2c5a; }
+.ac-legend .exercise { border-color: #a3f713; }
+.ac-legend .stand { border-color: #22d3ee; }
+
+@media (prefers-reduced-motion: reduce) {
+  .ring {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds activity rings built for #43218. Three concentric conic gradient rings masked into ring shapes, each filling to a `--p` percentage in its own color, with a metrics legend. Pure CSS. Closes #43218.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: three concentric rings at 85, 65, and 40 percent in distinct colors with faint tracks, plus a legend.
