### PR TITLE
feat: add color picker

### DIFF
--- a/submissions/examples/color-picker-as/README.md
+++ b/submissions/examples/color-picker-as/README.md
@@ -1,0 +1,22 @@
+# Color Picker
+
+### What does this do?
+
+It shows a color picker panel: a saturation and value square with a cursor, a rainbow hue slider you can drag, a preview swatch with hex and rgb codes, and a row of preset swatches. Choosing a preset live updates the preview color, all with no JavaScript.
+
+### How is it used?
+
+```html
+<div class="cp">
+  <div class="cp-sv"><span class="cp-cursor"></span></div>
+  <input class="cp-hue" type="range" min="0" max="360" value="248" />
+  <span class="cp-preview"></span>
+  <label style="--sw: #ef4444;"><input id="sw2" type="radio" name="sw" /><span></span></label>
+</div>
+```
+
+The SV area layers two gradients over a base color, the hue slider is a styled `range` input with a rainbow track, and each preset radio drives `.cp:has(#sw2:checked) .cp-preview { background: ... }` so the preview follows the selection.
+
+### Why is it useful?
+
+Design tools, theme editors, and settings screens include color pickers. This provides the full picker layout with a draggable hue slider and working preset swatches, styled entirely with CSS.

--- a/submissions/examples/color-picker-as/demo.html
+++ b/submissions/examples/color-picker-as/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Color Picker</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="cp">
+    <div class="cp-sv">
+      <span class="cp-cursor"></span>
+    </div>
+
+    <input class="cp-hue" type="range" min="0" max="360" value="248" aria-label="Hue" />
+
+    <div class="cp-foot">
+      <span class="cp-preview"></span>
+      <span class="cp-codes">
+        <b>#6C63FF</b>
+        <em>rgb(108, 99, 255)</em>
+      </span>
+    </div>
+
+    <fieldset class="cp-presets">
+      <legend>Swatches</legend>
+      <label style="--sw: #6c63ff;"><input id="sw1" type="radio" name="sw" checked /><span></span></label>
+      <label style="--sw: #ef4444;"><input id="sw2" type="radio" name="sw" /><span></span></label>
+      <label style="--sw: #f59e0b;"><input id="sw3" type="radio" name="sw" /><span></span></label>
+      <label style="--sw: #10b981;"><input id="sw4" type="radio" name="sw" /><span></span></label>
+      <label style="--sw: #0ea5e9;"><input id="sw5" type="radio" name="sw" /><span></span></label>
+      <label style="--sw: #ec4899;"><input id="sw6" type="radio" name="sw" /><span></span></label>
+    </fieldset>
+  </div>
+</body>
+</html>

--- a/submissions/examples/color-picker-as/style.css
+++ b/submissions/examples/color-picker-as/style.css
@@ -1,0 +1,171 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(160deg, #1a1f2e, #0b0e16);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #eef1f8;
+}
+
+.cp {
+  width: min(280px, 90vw);
+  padding: 1rem;
+  box-sizing: border-box;
+  background: #1a1f2c;
+  border: 1px solid #2b3243;
+  border-radius: 16px;
+  box-shadow: 0 20px 44px rgba(0, 0, 0, 0.45);
+}
+
+.cp-sv {
+  position: relative;
+  height: 150px;
+  border-radius: 10px;
+  background:
+    linear-gradient(0deg, #000, transparent),
+    linear-gradient(90deg, #fff, transparent),
+    #6c63ff;
+}
+
+.cp-cursor {
+  position: absolute;
+  top: 24%;
+  left: 72%;
+  width: 16px;
+  height: 16px;
+  transform: translate(-50%, -50%);
+  border: 2px solid #fff;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.4);
+}
+
+.cp-hue {
+  width: 100%;
+  height: 14px;
+  margin: 0.9rem 0;
+  appearance: none;
+  -webkit-appearance: none;
+  border-radius: 7px;
+  background: linear-gradient(
+    90deg,
+    #f00, #ff0 17%, #0f0 33%, #0ff 50%, #00f 67%, #f0f 83%, #f00
+  );
+  cursor: pointer;
+}
+
+.cp-hue::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  border: 2px solid #cbd5e1;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.5);
+}
+
+.cp-hue::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  border: 2px solid #cbd5e1;
+}
+
+.cp-foot {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+}
+
+.cp-preview {
+  width: 42px;
+  height: 42px;
+  border-radius: 9px;
+  background: #6c63ff;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  transition: background 0.2s ease;
+}
+
+.cp-codes {
+  display: grid;
+  gap: 1px;
+}
+
+.cp-codes b {
+  font-size: 0.92rem;
+  font-family: ui-monospace, Consolas, monospace;
+}
+
+.cp-codes em {
+  font-style: normal;
+  font-size: 0.74rem;
+  color: #8b95ab;
+}
+
+.cp-presets {
+  display: flex;
+  gap: 8px;
+  margin: 1rem 0 0;
+  padding: 0;
+  border: 0;
+}
+
+.cp-presets legend {
+  float: left;
+  width: 100%;
+  padding: 0;
+  margin-bottom: 0.5rem;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #8b95ab;
+}
+
+.cp-presets label {
+  cursor: pointer;
+  line-height: 0;
+}
+
+.cp-presets input {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+
+.cp-presets span {
+  display: block;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  background: var(--sw);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+  transition: transform 0.12s ease;
+}
+
+.cp-presets input:checked + span {
+  transform: scale(1.12);
+  box-shadow: 0 0 0 2px #fff, inset 0 0 0 1px rgba(0, 0, 0, 0.15);
+}
+
+.cp-presets input:focus-visible + span {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+
+.cp:has(#sw1:checked) .cp-preview { background: #6c63ff; }
+.cp:has(#sw2:checked) .cp-preview { background: #ef4444; }
+.cp:has(#sw3:checked) .cp-preview { background: #f59e0b; }
+.cp:has(#sw4:checked) .cp-preview { background: #10b981; }
+.cp:has(#sw5:checked) .cp-preview { background: #0ea5e9; }
+.cp:has(#sw6:checked) .cp-preview { background: #ec4899; }
+
+@media (prefers-reduced-motion: reduce) {
+  .cp-preview,
+  .cp-presets span {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a color picker built for #43220. An SV gradient square with cursor, a draggable rainbow hue range slider, a preview with hex and rgb codes, and preset swatches that live update the preview via `:has()`. Pure CSS. Closes #43220.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium: the preview reads #6C63FF by default and updates to the clicked preset color (confirmed green rgb(16,185,129) after selecting that swatch). Screenshot checked.
