### PR TITLE
feat: add date range picker

### DIFF
--- a/submissions/examples/date-range-picker-as/README.md
+++ b/submissions/examples/date-range-picker-as/README.md
@@ -1,0 +1,21 @@
+# Date Range Picker
+
+### What does this do?
+
+It shows a calendar with a selected date range. The start and end days are filled circles, the days between them sit on a continuous highlight band, and a footer summarizes the range and the number of nights. The header has month navigation controls.
+
+### How is it used?
+
+```html
+<div class="drp-grid">
+  <span class="d rng rng-start">12</span>
+  <span class="d rng">13</span>
+  <span class="d rng rng-end">18</span>
+</div>
+```
+
+The month is a seven column grid with blank leading cells. Range days get the `rng` class for the highlight band, while `rng-start` and `rng-end` add a filled circle and round the outer edge, so the selection reads as one continuous range.
+
+### Why is it useful?
+
+Booking, travel, and analytics tools let users pick a start and end date. This provides the calendar and range highlight styling with pure CSS, ready to drive from a date library.

--- a/submissions/examples/date-range-picker-as/demo.html
+++ b/submissions/examples/date-range-picker-as/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Date Range Picker</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="drp">
+    <div class="drp-head">
+      <button type="button" class="drp-nav" aria-label="Previous month">&lsaquo;</button>
+      <span class="drp-month">July 2026</span>
+      <button type="button" class="drp-nav" aria-label="Next month">&rsaquo;</button>
+    </div>
+
+    <div class="drp-week">
+      <span>Su</span><span>Mo</span><span>Tu</span><span>We</span><span>Th</span><span>Fr</span><span>Sa</span>
+    </div>
+
+    <div class="drp-grid">
+      <span class="d blank"></span>
+      <span class="d blank"></span>
+      <span class="d blank"></span>
+      <span class="d">1</span>
+      <span class="d">2</span>
+      <span class="d">3</span>
+      <span class="d">4</span>
+      <span class="d">5</span>
+      <span class="d">6</span>
+      <span class="d">7</span>
+      <span class="d">8</span>
+      <span class="d">9</span>
+      <span class="d">10</span>
+      <span class="d">11</span>
+      <span class="d rng rng-start">12</span>
+      <span class="d rng">13</span>
+      <span class="d rng">14</span>
+      <span class="d rng">15</span>
+      <span class="d rng">16</span>
+      <span class="d rng">17</span>
+      <span class="d rng rng-end">18</span>
+      <span class="d">19</span>
+      <span class="d">20</span>
+      <span class="d">21</span>
+      <span class="d">22</span>
+      <span class="d">23</span>
+      <span class="d">24</span>
+      <span class="d">25</span>
+      <span class="d">26</span>
+      <span class="d">27</span>
+      <span class="d">28</span>
+      <span class="d">29</span>
+      <span class="d">30</span>
+      <span class="d">31</span>
+    </div>
+
+    <div class="drp-foot">
+      <span class="drp-range">Jul 12 &ndash; Jul 18</span>
+      <span class="drp-nights">7 nights</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/date-range-picker-as/style.css
+++ b/submissions/examples/date-range-picker-as/style.css
@@ -1,0 +1,128 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(160deg, #eef1f9, #dce3f2);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #1f2740;
+}
+
+.drp {
+  width: min(320px, 94vw);
+  padding: 1.3rem 1.3rem 1rem;
+  box-sizing: border-box;
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: 0 20px 44px rgba(31, 39, 64, 0.15);
+}
+
+.drp-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.drp-month {
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.drp-nav {
+  width: 30px;
+  height: 30px;
+  border: 0;
+  border-radius: 8px;
+  background: #eef1f9;
+  color: #3b56d4;
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.drp-nav:hover {
+  background: #dfe5f6;
+}
+
+.drp-week {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  margin-bottom: 4px;
+}
+
+.drp-week span {
+  text-align: center;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #99a1b7;
+}
+
+.drp-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  row-gap: 2px;
+}
+
+.d {
+  position: relative;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  font-size: 0.85rem;
+  color: #2b3350;
+}
+
+.rng {
+  background-color: #e5e9fb;
+}
+
+.rng-start,
+.rng-end {
+  color: #fff;
+  font-weight: 700;
+  background-image: radial-gradient(circle at center, #3b56d4 15px, transparent 15px);
+}
+
+.rng-start {
+  border-radius: 20px 0 0 20px;
+}
+
+.rng-end {
+  border-radius: 0 20px 20px 0;
+}
+
+.d:not(.blank, .rng):hover {
+  background: #eef1f9;
+  border-radius: 50%;
+}
+
+.drp-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 1rem;
+  padding-top: 0.9rem;
+  border-top: 1px solid #eceff6;
+}
+
+.drp-range {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.drp-nights {
+  font-size: 0.78rem;
+  color: #7b849c;
+  background: #eef1f9;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .drp-nav {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a date range picker built for #43222. A month calendar with a highlighted range, filled start and end circles, month nav, and a footer summary. Pure CSS. Closes #43222.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a July calendar with days 12 to 18 highlighted as a range, filled start and end circles, and a footer showing the range and nights.
