### PR TITLE
feat: add rating input

### DIFF
--- a/submissions/examples/rating-input-as/README.md
+++ b/submissions/examples/rating-input-as/README.md
@@ -1,0 +1,21 @@
+# Rating Input
+
+### What does this do?
+
+It shows an interactive star rating you can set with a click. Hovering previews the rating by filling stars up to the pointer, the chosen value stays filled, and a live caption reads out the selected number. It is fully interactive with no JavaScript.
+
+### How is it used?
+
+```html
+<div class="rating">
+  <input id="s5" type="radio" name="rate" />
+  <label for="s5"><svg viewBox="0 0 24 24"><path d="..." /></svg></label>
+  <input id="s4" type="radio" name="rate" /> ...
+</div>
+```
+
+The stars are radios laid out with `flex-direction: row-reverse`, so `input:checked ~ label` and `label:hover ~ label` fill the chosen star and every lower one. A `:has()` rule writes the selected number into the caption.
+
+### Why is it useful?
+
+Reviews, feedback, and survey forms need a star rating input. This gives an accessible one with hover preview and a live value readout, styled entirely with CSS and no script.

--- a/submissions/examples/rating-input-as/demo.html
+++ b/submissions/examples/rating-input-as/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Rating Input</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="rate-card">
+    <span class="rate-title">How was your order?</span>
+
+    <div class="rating">
+      <input id="s5" type="radio" name="rate" />
+      <label for="s5" aria-label="5 stars"><svg viewBox="0 0 24 24"><path d="M12 2l3 6.9 7.5.6-5.7 5 1.8 7.3L12 24l-6.6 3.8 1.8-7.3-5.7-5 7.5-.6z" /></svg></label>
+      <input id="s4" type="radio" name="rate" />
+      <label for="s4" aria-label="4 stars"><svg viewBox="0 0 24 24"><path d="M12 2l3 6.9 7.5.6-5.7 5 1.8 7.3L12 24l-6.6 3.8 1.8-7.3-5.7-5 7.5-.6z" /></svg></label>
+      <input id="s3" type="radio" name="rate" checked />
+      <label for="s3" aria-label="3 stars"><svg viewBox="0 0 24 24"><path d="M12 2l3 6.9 7.5.6-5.7 5 1.8 7.3L12 24l-6.6 3.8 1.8-7.3-5.7-5 7.5-.6z" /></svg></label>
+      <input id="s2" type="radio" name="rate" />
+      <label for="s2" aria-label="2 stars"><svg viewBox="0 0 24 24"><path d="M12 2l3 6.9 7.5.6-5.7 5 1.8 7.3L12 24l-6.6 3.8 1.8-7.3-5.7-5 7.5-.6z" /></svg></label>
+      <input id="s1" type="radio" name="rate" />
+      <label for="s1" aria-label="1 star"><svg viewBox="0 0 24 24"><path d="M12 2l3 6.9 7.5.6-5.7 5 1.8 7.3L12 24l-6.6 3.8 1.8-7.3-5.7-5 7.5-.6z" /></svg></label>
+    </div>
+
+    <span class="rate-out">You rated <b></b> of 5</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/rating-input-as/style.css
+++ b/submissions/examples/rating-input-as/style.css
@@ -1,0 +1,90 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(160deg, #1c1636, #0c0916);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #efeafc;
+}
+
+.rate-card {
+  display: grid;
+  justify-items: center;
+  gap: 1rem;
+  padding: 2rem 2.4rem;
+  background: #171128;
+  border: 1px solid #2f2450;
+  border-radius: 20px;
+  box-shadow: 0 22px 48px rgba(0, 0, 0, 0.45);
+}
+
+.rate-title {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.rating {
+  display: inline-flex;
+  flex-direction: row-reverse;
+  gap: 6px;
+}
+
+.rating input {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+
+.rating label {
+  cursor: pointer;
+  line-height: 0;
+}
+
+.rating svg {
+  width: 38px;
+  height: 38px;
+  fill: #3a3057;
+  transition: fill 0.12s ease, transform 0.12s ease;
+}
+
+.rating label:hover svg,
+.rating label:hover ~ label svg,
+.rating input:checked ~ label svg {
+  fill: #fbbf24;
+}
+
+.rating label:hover svg {
+  transform: scale(1.15);
+}
+
+.rating input:focus-visible + label svg {
+  outline: 2px solid #a78bfa;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.rate-out {
+  font-size: 0.9rem;
+  color: #b3a9d0;
+}
+
+.rate-out b {
+  color: #fbbf24;
+  font-weight: 700;
+}
+
+.rate-card:has(#s1:checked) .rate-out b::after { content: "1"; }
+.rate-card:has(#s2:checked) .rate-out b::after { content: "2"; }
+.rate-card:has(#s3:checked) .rate-out b::after { content: "3"; }
+.rate-card:has(#s4:checked) .rate-out b::after { content: "4"; }
+.rate-card:has(#s5:checked) .rate-out b::after { content: "5"; }
+
+@media (prefers-reduced-motion: reduce) {
+  .rating svg {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a star rating input built for #43224. Radio stars laid out row-reverse so hover and checked fill the star and every lower one, with a `:has()` driven live value caption. Pure CSS, no JavaScript. Closes #43224.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium: default state fills three stars with caption 3, and clicking the fifth star fills five stars with caption 5.
