### PR TITLE
feat: add compass

### DIFF
--- a/submissions/examples/compass-as/README.md
+++ b/submissions/examples/compass-as/README.md
@@ -1,0 +1,22 @@
+# Compass
+
+### What does this do?
+
+It shows a compass with a two tone needle that points to a bearing. The dial has cardinal labels, tick marks around the rim, and a digital heading readout. The needle rotates to the angle set by a `--deg` custom property, with a springy settle animation.
+
+### How is it used?
+
+```html
+<div class="compass" style="--deg: 315;">
+  <span class="cp-tick" style="--a: 45;"></span>
+  <b class="cp-dir n">N</b>
+  <span class="cp-needle"></span>
+  <span class="cp-read"><b>315&deg;</b><em>NW</em></span>
+</div>
+```
+
+Set the bearing with `--deg` on the compass. The needle is one element with two triangle halves (a red north tip and a light south tail) that rotates by `rotate(calc(var(--deg) * 1deg))`. Ticks place themselves with per tick `--a` angles.
+
+### Why is it useful?
+
+Maps, navigation, and weather apps show direction with a compass. This builds one entirely with CSS transforms and gradients, driven by a single bearing custom property, with no images or script.

--- a/submissions/examples/compass-as/demo.html
+++ b/submissions/examples/compass-as/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Compass</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="compass" style="--deg: 315;" role="img" aria-label="Compass pointing north-west, heading 315 degrees">
+    <span class="cp-tick" style="--a: 0;"></span>
+    <span class="cp-tick" style="--a: 45;"></span>
+    <span class="cp-tick" style="--a: 90;"></span>
+    <span class="cp-tick" style="--a: 135;"></span>
+    <span class="cp-tick" style="--a: 180;"></span>
+    <span class="cp-tick" style="--a: 225;"></span>
+    <span class="cp-tick" style="--a: 270;"></span>
+    <span class="cp-tick" style="--a: 315;"></span>
+
+    <b class="cp-dir n">N</b>
+    <b class="cp-dir e">E</b>
+    <b class="cp-dir s">S</b>
+    <b class="cp-dir w">W</b>
+
+    <span class="cp-needle"></span>
+    <span class="cp-hub"></span>
+
+    <span class="cp-read"><b>315&deg;</b><em>NW</em></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/compass-as/style.css
+++ b/submissions/examples/compass-as/style.css
@@ -1,0 +1,126 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 20%, #1b2333, #0a0d14 65%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e7ecf5;
+}
+
+.compass {
+  position: relative;
+  width: 240px;
+  height: 240px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 50% 38%, #232d40, #141b28 72%);
+  border: 8px solid #2b3549;
+  box-shadow:
+    0 24px 50px rgba(0, 0, 0, 0.5),
+    inset 0 2px 8px rgba(255, 255, 255, 0.05);
+}
+
+.cp-tick {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  width: 2px;
+  height: 12px;
+  margin-left: -1px;
+  background: #47566f;
+  transform: rotate(calc(var(--a) * 1deg));
+  transform-origin: 50% 110px;
+}
+
+.cp-tick:nth-child(odd) {
+  height: 16px;
+  width: 3px;
+  margin-left: -1.5px;
+  background: #6b7c99;
+}
+
+.cp-dir {
+  position: absolute;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #cdd6e6;
+}
+
+.cp-dir.n { top: 14px; left: 50%; transform: translateX(-50%); color: #fb7185; }
+.cp-dir.s { bottom: 14px; left: 50%; transform: translateX(-50%); }
+.cp-dir.e { right: 16px; top: 50%; transform: translateY(-50%); }
+.cp-dir.w { left: 16px; top: 50%; transform: translateY(-50%); }
+
+.cp-needle {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 12px;
+  height: 150px;
+  transform: translate(-50%, -50%) rotate(calc(var(--deg) * 1deg));
+  transition: transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.cp-needle::before,
+.cp-needle::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  width: 0;
+  height: 0;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+}
+
+.cp-needle::before {
+  top: 0;
+  border-bottom: 75px solid #fb2c5a;
+}
+
+.cp-needle::after {
+  bottom: 0;
+  border-top: 75px solid #d7deeb;
+}
+
+.cp-hub {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 16px;
+  height: 16px;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  background: #f1f5fb;
+  border: 3px solid #2b3549;
+  z-index: 2;
+}
+
+.cp-read {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: grid;
+  justify-items: center;
+  line-height: 1.1;
+}
+
+.cp-read b {
+  font-size: 1.15rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.cp-read em {
+  font-style: normal;
+  font-size: 0.78rem;
+  color: #93a0ba;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cp-needle {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a compass built for #43227. A dial with cardinal labels, rim ticks, a two tone needle rotated by a `--deg` custom property, and a digital heading readout. Pure CSS. Closes #43227.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a needle pointing north-west for a 315 degree bearing, cardinal labels, eight rim ticks, and a heading readout.
