### PR TITLE
feat: add barcode

### DIFF
--- a/submissions/examples/barcode-as/README.md
+++ b/submissions/examples/barcode-as/README.md
@@ -1,0 +1,22 @@
+# Barcode
+
+### What does this do?
+
+It shows a product barcode with the number printed below it, on a clean label card. The bars are individual elements whose widths come from a `--w` custom property, alternating dark bars and gaps, so the pattern looks like a scanned barcode.
+
+### How is it used?
+
+```html
+<div class="barcode">
+  <i class="bk" style="--w: 3px;"></i>
+  <i class="wt" style="--w: 2px;"></i>
+  <i class="bk" style="--w: 4px;"></i>
+</div>
+<div class="barcode-num"><span>5</span><span>901234</span><span>123457</span></div>
+```
+
+Each bar is an `i` element with `width: var(--w)`. The `bk` class paints a dark bar and `wt` leaves a gap, and the strip is a flexbox so the bars sit side by side at full height.
+
+### Why is it useful?
+
+Receipts, tickets, product labels, and loyalty cards show barcodes. This renders a barcode look purely from CSS sized bars, with no image or barcode font, ready to drive from encoded widths.

--- a/submissions/examples/barcode-as/demo.html
+++ b/submissions/examples/barcode-as/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Barcode</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="barcode-card">
+    <div class="barcode" role="img" aria-label="Barcode for product 5 901234 123457">
+      <i class="bk" style="--w: 3px;"></i>
+      <i class="wt" style="--w: 2px;"></i>
+      <i class="bk" style="--w: 4px;"></i>
+      <i class="wt" style="--w: 4px;"></i>
+      <i class="bk" style="--w: 1px;"></i>
+      <i class="wt" style="--w: 4px;"></i>
+      <i class="bk" style="--w: 4px;"></i>
+      <i class="wt" style="--w: 1px;"></i>
+      <i class="bk" style="--w: 3px;"></i>
+      <i class="wt" style="--w: 2px;"></i>
+      <i class="bk" style="--w: 1px;"></i>
+      <i class="wt" style="--w: 3px;"></i>
+      <i class="bk" style="--w: 3px;"></i>
+      <i class="wt" style="--w: 4px;"></i>
+      <i class="bk" style="--w: 1px;"></i>
+      <i class="wt" style="--w: 2px;"></i>
+      <i class="bk" style="--w: 1px;"></i>
+      <i class="wt" style="--w: 3px;"></i>
+      <i class="bk" style="--w: 1px;"></i>
+      <i class="wt" style="--w: 4px;"></i>
+      <i class="bk" style="--w: 4px;"></i>
+      <i class="wt" style="--w: 2px;"></i>
+      <i class="bk" style="--w: 3px;"></i>
+      <i class="wt" style="--w: 2px;"></i>
+      <i class="bk" style="--w: 3px;"></i>
+      <i class="wt" style="--w: 4px;"></i>
+      <i class="bk" style="--w: 1px;"></i>
+      <i class="wt" style="--w: 2px;"></i>
+      <i class="bk" style="--w: 1px;"></i>
+      <i class="wt" style="--w: 4px;"></i>
+      <i class="bk" style="--w: 1px;"></i>
+      <i class="wt" style="--w: 3px;"></i>
+      <i class="bk" style="--w: 3px;"></i>
+      <i class="wt" style="--w: 2px;"></i>
+      <i class="bk" style="--w: 4px;"></i>
+      <i class="wt" style="--w: 4px;"></i>
+      <i class="bk" style="--w: 4px;"></i>
+      <i class="wt" style="--w: 3px;"></i>
+      <i class="bk" style="--w: 1px;"></i>
+      <i class="wt" style="--w: 3px;"></i>
+      <i class="bk" style="--w: 2px;"></i>
+      <i class="wt" style="--w: 3px;"></i>
+      <i class="bk" style="--w: 3px;"></i>
+      <i class="wt" style="--w: 1px;"></i>
+      <i class="bk" style="--w: 2px;"></i>
+      <i class="wt" style="--w: 2px;"></i>
+      <i class="bk" style="--w: 2px;"></i>
+      <i class="wt" style="--w: 3px;"></i>
+      <i class="bk" style="--w: 4px;"></i>
+      <i class="wt" style="--w: 4px;"></i>
+    </div>
+    <div class="barcode-num">
+      <span>5</span><span>901234</span><span>123457</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/barcode-as/style.css
+++ b/submissions/examples/barcode-as/style.css
@@ -1,0 +1,53 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(160deg, #2a2f3a, #171a22);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.barcode-card {
+  padding: 1.6rem 1.8rem 1.2rem;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 20px 44px rgba(0, 0, 0, 0.4);
+}
+
+.barcode {
+  display: flex;
+  align-items: stretch;
+  height: 96px;
+  padding: 0 10px;
+}
+
+.barcode i {
+  width: var(--w, 2px);
+  height: 100%;
+}
+
+.barcode .bk {
+  background: #12141a;
+}
+
+.barcode .wt {
+  background: transparent;
+}
+
+.barcode-num {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0.5rem;
+  padding: 0 6px;
+  font-family: ui-monospace, "Courier New", monospace;
+  font-size: 1.05rem;
+  letter-spacing: 0.32em;
+  color: #12141a;
+}
+
+.barcode-num span:first-child {
+  letter-spacing: 0;
+  margin-right: 0.3rem;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a barcode built for #43230. A flexbox strip of dark bars and gaps whose widths come from a `--w` custom property, with the product number printed below on a label card. Pure CSS. Closes #43230.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: fifty bars of four distinct widths forming a barcode over the number 5 901234 123457.
