### PR TITLE
feat: add image hotspots

### DIFF
--- a/submissions/examples/image-hotspots-as/README.md
+++ b/submissions/examples/image-hotspots-as/README.md
@@ -1,0 +1,20 @@
+# Image Hotspots
+
+### What does this do?
+
+It shows a shoppable scene with interactive hotspots. Pulsing dots sit on top of the artwork at set positions; hovering or focusing a dot pops a tooltip card with the item name and price, complete with a little pointer arrow. The scene itself is drawn with CSS so the demo needs no image file.
+
+### How is it used?
+
+```html
+<button class="hotspot" style="--x: 34%; --y: 66%;">
+  <span class="hs-dot"></span>
+  <span class="hs-card"><b>Velvet Sofa</b><em>$899</em></span>
+</button>
+```
+
+Each hotspot is positioned with `--x` and `--y` percentages over the scene. The `hs-dot` pulses with a keyframe, and `.hotspot:hover .hs-card` (plus `:focus-visible` for keyboards) reveals the tooltip.
+
+### Why is it useful?
+
+Shoppable images, product tours, and interactive diagrams pin details to points on a picture. This provides the hotspot and tooltip pattern with pure CSS positioning and reveal, ready to place over any real image.

--- a/submissions/examples/image-hotspots-as/demo.html
+++ b/submissions/examples/image-hotspots-as/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Image Hotspots</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <figure class="scene">
+    <div class="scene-art" aria-hidden="true">
+      <span class="art-floor"></span>
+      <span class="art-sofa"></span>
+      <span class="art-lamp"></span>
+      <span class="art-plant"></span>
+      <span class="art-sun"></span>
+    </div>
+
+    <button class="hotspot" style="--x: 34%; --y: 66%;" aria-label="Velvet sofa, 899 dollars">
+      <span class="hs-dot"></span>
+      <span class="hs-card">
+        <b>Velvet Sofa</b>
+        <em>$899</em>
+      </span>
+    </button>
+
+    <button class="hotspot" style="--x: 71%; --y: 44%;" aria-label="Arc lamp, 149 dollars">
+      <span class="hs-dot"></span>
+      <span class="hs-card">
+        <b>Arc Lamp</b>
+        <em>$149</em>
+      </span>
+    </button>
+
+    <button class="hotspot" style="--x: 84%; --y: 70%;" aria-label="Fiddle leaf plant, 39 dollars">
+      <span class="hs-dot"></span>
+      <span class="hs-card">
+        <b>Fiddle Leaf</b>
+        <em>$39</em>
+      </span>
+    </button>
+
+    <figcaption class="scene-cap">Shop the look &middot; hover a dot</figcaption>
+  </figure>
+</body>
+</html>

--- a/submissions/examples/image-hotspots-as/style.css
+++ b/submissions/examples/image-hotspots-as/style.css
@@ -1,0 +1,179 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: #0c1018;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #eef2fa;
+}
+
+.scene {
+  position: relative;
+  width: min(440px, 96vw);
+  aspect-ratio: 4 / 3;
+  margin: 0;
+  border-radius: 18px;
+  overflow: hidden;
+  background: linear-gradient(180deg, #f3d9b1 0 62%, #d8a87a 62% 100%);
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.5);
+}
+
+.scene-art span {
+  position: absolute;
+}
+
+.art-sun {
+  top: 10%;
+  right: 14%;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #fff3d1, #ffd98a);
+  box-shadow: 0 0 40px rgba(255, 217, 138, 0.8);
+}
+
+.art-sofa {
+  left: 12%;
+  bottom: 12%;
+  width: 46%;
+  height: 26%;
+  border-radius: 14px 14px 6px 6px;
+  background: linear-gradient(180deg, #7c5cff, #5b3fd6);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.25);
+}
+
+.art-lamp {
+  right: 24%;
+  top: 20%;
+  width: 6px;
+  height: 44%;
+  border-radius: 3px;
+  background: #3a3a44;
+}
+
+.art-lamp::after {
+  content: "";
+  position: absolute;
+  top: -6px;
+  left: -18px;
+  width: 44px;
+  height: 16px;
+  border-radius: 20px 20px 4px 4px;
+  background: #f5c518;
+}
+
+.art-plant {
+  right: 10%;
+  bottom: 12%;
+  width: 30px;
+  height: 22%;
+  border-radius: 0 0 6px 6px;
+  background: linear-gradient(180deg, #2f8f5b, #256b46);
+}
+
+.hotspot {
+  position: absolute;
+  left: var(--x);
+  top: var(--y);
+  transform: translate(-50%, -50%);
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  z-index: 2;
+}
+
+.hs-dot {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: #fff;
+  border: 3px solid #6366f1;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
+}
+
+.hs-dot::before {
+  content: "";
+  position: absolute;
+  inset: -6px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.7);
+  animation: hs-pulse 1.8s ease-out infinite;
+}
+
+@keyframes hs-pulse {
+  0% { transform: scale(0.7); opacity: 0.9; }
+  100% { transform: scale(1.7); opacity: 0; }
+}
+
+.hs-card {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 10px);
+  transform: translate(-50%, 6px);
+  display: grid;
+  gap: 1px;
+  padding: 0.5rem 0.8rem;
+  white-space: nowrap;
+  background: #0f1424;
+  border: 1px solid #2a3350;
+  border-radius: 10px;
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.4);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.18s ease, transform 0.18s ease;
+}
+
+.hs-card b {
+  font-size: 0.85rem;
+}
+
+.hs-card em {
+  font-style: normal;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: #a5b4fc;
+}
+
+.hs-card::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-top-color: #0f1424;
+}
+
+.hotspot:hover .hs-card,
+.hotspot:focus-visible .hs-card {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.scene-cap {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 0.5rem;
+  text-align: center;
+  font-size: 0.76rem;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.35);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hs-dot::before {
+    animation: none;
+  }
+
+  .hs-card {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds image hotspots built for #43236. Pulsing markers positioned by `--x`/`--y` over a CSS drawn scene, each revealing a tooltip card on hover or focus. Pure CSS. Closes #43236.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium: three hotspot tooltips are hidden by default (opacity 0) and reveal on hover (opacity 1); screenshot shows the Arc Lamp card open.
