### PR TITLE
feat: add id badge

### DIFF
--- a/submissions/examples/id-badge-as/README.md
+++ b/submissions/examples/id-badge-as/README.md
@@ -1,0 +1,22 @@
+# ID Badge
+
+### What does this do?
+
+It shows an employee ID badge hanging from a lanyard. A strap and metal clip sit above a card with a punch hole, a company header, a photo tile, the name and role, ID and access level details, and a small barcode along the bottom. It is all drawn with CSS, no images.
+
+### How is it used?
+
+```html
+<div class="lanyard">
+  <span class="strap left"></span>
+  <span class="strap right"></span>
+  <span class="clip"></span>
+  <div class="badge">...</div>
+</div>
+```
+
+The two `strap` elements angle in from the top to the `clip`, and the `badge` card holds a photo tile, a details list, and a `badge-code` barcode whose bars are sized with a `--w` custom property.
+
+### Why is it useful?
+
+Event apps, HR tools, and access systems display staff or attendee badges. This provides a complete badge with lanyard, photo, details, and barcode, built entirely with CSS.

--- a/submissions/examples/id-badge-as/demo.html
+++ b/submissions/examples/id-badge-as/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ID Badge</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="lanyard">
+    <span class="strap left"></span>
+    <span class="strap right"></span>
+    <span class="clip"></span>
+
+    <div class="badge">
+      <span class="badge-hole"></span>
+      <div class="badge-top">
+        <span class="badge-logo">◆</span>
+        <span class="badge-co">NORTHWIND</span>
+      </div>
+
+      <span class="badge-photo">AK</span>
+      <b class="badge-name">Aarav Kapoor</b>
+      <span class="badge-role">Senior Engineer</span>
+
+      <dl class="badge-meta">
+        <div><dt>ID</dt><dd>NW-04821</dd></div>
+        <div><dt>Access</dt><dd class="lvl">Level 3</dd></div>
+      </dl>
+
+      <div class="badge-code" aria-hidden="true">
+        <i style="--w: 3px;"></i><i style="--w: 1px;"></i><i style="--w: 2px;"></i>
+        <i style="--w: 4px;"></i><i style="--w: 1px;"></i><i style="--w: 3px;"></i>
+        <i style="--w: 2px;"></i><i style="--w: 1px;"></i><i style="--w: 4px;"></i>
+        <i style="--w: 2px;"></i><i style="--w: 3px;"></i><i style="--w: 1px;"></i>
+        <i style="--w: 2px;"></i><i style="--w: 4px;"></i><i style="--w: 1px;"></i>
+        <i style="--w: 3px;"></i><i style="--w: 2px;"></i><i style="--w: 1px;"></i>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/id-badge-as/style.css
+++ b/submissions/examples/id-badge-as/style.css
@@ -1,0 +1,165 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: start center;
+  padding: 0 1.25rem 2rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 20%, #1b2130, #0a0d14 65%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #1f2740;
+}
+
+.lanyard {
+  position: relative;
+  padding-top: 96px;
+}
+
+.strap {
+  position: absolute;
+  top: 0;
+  width: 30px;
+  height: 108px;
+  background: linear-gradient(180deg, #4f46e5, #6366f1);
+}
+
+.strap.left {
+  left: 50%;
+  margin-left: -58px;
+  transform: rotate(9deg);
+  transform-origin: top center;
+}
+
+.strap.right {
+  left: 50%;
+  margin-left: 28px;
+  transform: rotate(-9deg);
+  transform-origin: top center;
+}
+
+.clip {
+  position: absolute;
+  top: 84px;
+  left: 50%;
+  width: 40px;
+  height: 22px;
+  margin-left: -20px;
+  border-radius: 5px;
+  background: linear-gradient(180deg, #c9cdd6, #8b909c);
+  z-index: 3;
+}
+
+.badge {
+  position: relative;
+  width: 260px;
+  padding: 1.4rem 1.3rem 1.2rem;
+  box-sizing: border-box;
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.45);
+  display: grid;
+  justify-items: center;
+  text-align: center;
+}
+
+.badge-hole {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  width: 46px;
+  height: 12px;
+  margin-left: -23px;
+  border-radius: 8px;
+  background: #e8eaf0;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
+.badge-top {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 1rem 0 1.1rem;
+}
+
+.badge-logo {
+  color: #6366f1;
+  font-size: 1rem;
+}
+
+.badge-co {
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  color: #4b5568;
+}
+
+.badge-photo {
+  display: grid;
+  place-items: center;
+  width: 92px;
+  height: 92px;
+  border-radius: 14px;
+  font-size: 1.9rem;
+  font-weight: 700;
+  color: #fff;
+  background: linear-gradient(140deg, #818cf8, #6366f1 55%, #4f46e5);
+  box-shadow: 0 8px 18px rgba(79, 70, 229, 0.35);
+}
+
+.badge-name {
+  margin-top: 0.9rem;
+  font-size: 1.15rem;
+}
+
+.badge-role {
+  font-size: 0.85rem;
+  color: #7a84a0;
+}
+
+.badge-meta {
+  display: flex;
+  gap: 1.6rem;
+  margin: 1.1rem 0 1rem;
+  padding: 0.8rem 0 0;
+  width: 100%;
+  justify-content: center;
+  border-top: 1px solid #eef0f5;
+}
+
+.badge-meta div {
+  display: grid;
+  gap: 2px;
+}
+
+.badge-meta dt {
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #9aa2b4;
+}
+
+.badge-meta dd {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 700;
+  font-family: ui-monospace, Consolas, monospace;
+  color: #2b3350;
+}
+
+.badge-meta .lvl {
+  color: #16a34a;
+}
+
+.badge-code {
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  height: 34px;
+}
+
+.badge-code i {
+  width: var(--w, 2px);
+  height: 100%;
+  margin-right: 2px;
+  background: #1f2740;
+}


### PR DESCRIPTION
## Pull Request Description

Adds an ID badge built for #43238. A lanyard with angled straps and a clip above a badge card with a photo tile, name, role, ID and access details, and a CSS barcode. Pure CSS. Closes #43238.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a lanyard with two straps and a clip above a badge showing a photo tile, name, role, ID, access level, and a barcode.
