### PR TITLE
feat: add weather forecast

### DIFF
--- a/submissions/examples/weather-forecast-as/README.md
+++ b/submissions/examples/weather-forecast-as/README.md
@@ -1,0 +1,21 @@
+# Weather Forecast
+
+### What does this do?
+
+It shows a weather panel with the current conditions and a five day forecast strip. Each day has its name, an inline SVG weather icon (sun, partly cloudy, cloud, rain, or storm), and a high and low temperature. Days highlight on hover.
+
+### How is it used?
+
+```html
+<div class="fc-day">
+  <span class="fc-dn">Thu</span>
+  <svg class="ic rain" viewBox="0 0 24 24"><path class="cl" d="..." /><g class="drops">...</g></svg>
+  <span class="fc-hi">19&deg;</span><span class="fc-lo">14&deg;</span>
+</div>
+```
+
+The forecast is a five column grid. Each day holds a small SVG icon whose class (`sun`, `partly`, `cloud`, `rain`, `storm`) selects which parts are colored, plus high and low temperature spans.
+
+### Why is it useful?
+
+Weather widgets and travel apps show a multi day outlook, not just the current temperature. This provides that forecast strip with self contained SVG icons and pure CSS styling, no icon font or image.

--- a/submissions/examples/weather-forecast-as/demo.html
+++ b/submissions/examples/weather-forecast-as/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Weather Forecast</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <section class="fc">
+    <header class="fc-now">
+      <div>
+        <span class="fc-city">San Diego</span>
+        <span class="fc-cond">Sunny &middot; feels 27&deg;</span>
+      </div>
+      <div class="fc-temp">
+        <svg class="ic sun" viewBox="0 0 24 24"><circle cx="12" cy="12" r="5" /><g class="rays"><line x1="12" y1="1" x2="12" y2="4" /><line x1="12" y1="20" x2="12" y2="23" /><line x1="1" y1="12" x2="4" y2="12" /><line x1="20" y1="12" x2="23" y2="12" /><line x1="4" y1="4" x2="6" y2="6" /><line x1="18" y1="18" x2="20" y2="20" /><line x1="20" y1="4" x2="18" y2="6" /><line x1="6" y1="18" x2="4" y2="20" /></g></svg>
+        <b>26&deg;</b>
+      </div>
+    </header>
+
+    <div class="fc-days">
+      <div class="fc-day">
+        <span class="fc-dn">Mon</span>
+        <svg class="ic sun" viewBox="0 0 24 24"><circle cx="12" cy="12" r="5" /><g class="rays"><line x1="12" y1="1" x2="12" y2="4" /><line x1="12" y1="20" x2="12" y2="23" /><line x1="1" y1="12" x2="4" y2="12" /><line x1="20" y1="12" x2="23" y2="12" /><line x1="4" y1="4" x2="6" y2="6" /><line x1="18" y1="18" x2="20" y2="20" /><line x1="20" y1="4" x2="18" y2="6" /><line x1="6" y1="18" x2="4" y2="20" /></g></svg>
+        <span class="fc-hi">27&deg;</span><span class="fc-lo">18&deg;</span>
+      </div>
+
+      <div class="fc-day">
+        <span class="fc-dn">Tue</span>
+        <svg class="ic partly" viewBox="0 0 24 24"><circle cx="8" cy="8" r="3.5" /><path class="cl" d="M9 19h9a3.5 3.5 0 0 0 .3-7 5 5 0 0 0-9.6 1.2A3 3 0 0 0 9 19z" /></svg>
+        <span class="fc-hi">25&deg;</span><span class="fc-lo">17&deg;</span>
+      </div>
+
+      <div class="fc-day">
+        <span class="fc-dn">Wed</span>
+        <svg class="ic cloud" viewBox="0 0 24 24"><path class="cl" d="M7 18h10a4 4 0 0 0 .4-8 5.5 5.5 0 0 0-10.6 1.3A3.4 3.4 0 0 0 7 18z" /></svg>
+        <span class="fc-hi">22&deg;</span><span class="fc-lo">16&deg;</span>
+      </div>
+
+      <div class="fc-day">
+        <span class="fc-dn">Thu</span>
+        <svg class="ic rain" viewBox="0 0 24 24"><path class="cl" d="M7 15h10a4 4 0 0 0 .4-8 5.5 5.5 0 0 0-10.6 1.3A3.4 3.4 0 0 0 7 15z" /><g class="drops"><line x1="8" y1="18" x2="7" y2="21" /><line x1="12" y1="18" x2="11" y2="21" /><line x1="16" y1="18" x2="15" y2="21" /></g></svg>
+        <span class="fc-hi">19&deg;</span><span class="fc-lo">14&deg;</span>
+      </div>
+
+      <div class="fc-day">
+        <span class="fc-dn">Fri</span>
+        <svg class="ic storm" viewBox="0 0 24 24"><path class="cl" d="M7 14h10a4 4 0 0 0 .4-8 5.5 5.5 0 0 0-10.6 1.3A3.4 3.4 0 0 0 7 14z" /><path class="bolt" d="M12 14l-3 5h3l-1 4 4-6h-3z" /></svg>
+        <span class="fc-hi">18&deg;</span><span class="fc-lo">13&deg;</span>
+      </div>
+    </div>
+  </section>
+</body>
+</html>

--- a/submissions/examples/weather-forecast-as/style.css
+++ b/submissions/examples/weather-forecast-as/style.css
@@ -1,0 +1,133 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(160deg, #1b2740, #0c1120);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #eaf0fb;
+}
+
+.fc {
+  width: min(420px, 95vw);
+  padding: 1.5rem 1.6rem 1.6rem;
+  box-sizing: border-box;
+  background: linear-gradient(160deg, #223257, #182444);
+  border: 1px solid #2c3c62;
+  border-radius: 20px;
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.45);
+}
+
+.fc-now {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.4rem;
+}
+
+.fc-city {
+  display: block;
+  font-size: 1.2rem;
+  font-weight: 700;
+}
+
+.fc-cond {
+  font-size: 0.82rem;
+  color: #a9b6d6;
+}
+
+.fc-temp {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.fc-temp b {
+  font-size: 2.1rem;
+  font-weight: 300;
+  font-variant-numeric: tabular-nums;
+}
+
+.fc-days {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 6px;
+  padding-top: 1.2rem;
+  border-top: 1px solid #31426b;
+}
+
+.fc-day {
+  display: grid;
+  justify-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+  border-radius: 12px;
+  transition: background 0.15s ease;
+}
+
+.fc-day:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.fc-dn {
+  font-size: 0.78rem;
+  color: #a9b6d6;
+}
+
+.fc-hi {
+  font-size: 0.9rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.fc-lo {
+  font-size: 0.78rem;
+  color: #8290b3;
+  font-variant-numeric: tabular-nums;
+}
+
+.ic {
+  width: 34px;
+  height: 34px;
+}
+
+.fc-temp .ic {
+  width: 40px;
+  height: 40px;
+}
+
+.ic.sun circle {
+  fill: #fbbf24;
+}
+
+.ic.sun .rays line {
+  stroke: #fbbf24;
+  stroke-width: 2;
+  stroke-linecap: round;
+}
+
+.ic.partly circle {
+  fill: #fbbf24;
+}
+
+.ic .cl {
+  fill: #cdd8ef;
+}
+
+.ic.rain .drops line {
+  stroke: #60a5fa;
+  stroke-width: 2;
+  stroke-linecap: round;
+}
+
+.ic.storm .bolt {
+  fill: #fbbf24;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fc-day {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a weather forecast built for #43240. A current conditions header and a five day strip, each day with a self contained SVG icon and high/low temps. Pure CSS. Closes #43240.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: five forecast days with sun, partly cloudy, cloud, rain, and storm icons and high/low temperatures.
