### PR TITLE
feat: add phone dialpad

### DIFF
--- a/submissions/examples/phone-dialpad-as/README.md
+++ b/submissions/examples/phone-dialpad-as/README.md
@@ -1,0 +1,21 @@
+# Phone Dialpad
+
+### What does this do?
+
+It shows a phone dialpad: a screen with the dialed number, a three by four grid of round keys with digits and their letter groups (2 ABC, 3 DEF, and so on), and a green call button below. Keys have hover and pressed states.
+
+### How is it used?
+
+```html
+<div class="ph-keys">
+  <button type="button" class="key"><b>2</b><i>ABC</i></button>
+  <button type="button" class="key"><b>0</b><i>+</i></button>
+</div>
+<button type="button" class="ph-call"><svg viewBox="0 0 24 24"><path d="..." /></svg></button>
+```
+
+Each key stacks a large digit `b` over a small letters `i`. The keypad is a three column grid of circular buttons, and the call button is a green circle with a phone glyph. The `:active` state scales keys for tactile feedback.
+
+### Why is it useful?
+
+Dialers, contact apps, and verification screens use a phone keypad. This gives a classic dialpad with letter groups and a call action, styled entirely with CSS and ready for input logic.

--- a/submissions/examples/phone-dialpad-as/demo.html
+++ b/submissions/examples/phone-dialpad-as/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phone Dialpad</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="phone">
+    <div class="ph-screen">
+      <span class="ph-num">+1 (555) 0134</span>
+      <span class="ph-sub">Calling&hellip;</span>
+    </div>
+
+    <div class="ph-keys">
+      <button type="button" class="key"><b>1</b><i>&nbsp;</i></button>
+      <button type="button" class="key"><b>2</b><i>ABC</i></button>
+      <button type="button" class="key"><b>3</b><i>DEF</i></button>
+      <button type="button" class="key"><b>4</b><i>GHI</i></button>
+      <button type="button" class="key"><b>5</b><i>JKL</i></button>
+      <button type="button" class="key"><b>6</b><i>MNO</i></button>
+      <button type="button" class="key"><b>7</b><i>PQRS</i></button>
+      <button type="button" class="key"><b>8</b><i>TUV</i></button>
+      <button type="button" class="key"><b>9</b><i>WXYZ</i></button>
+      <button type="button" class="key"><b>&lowast;</b><i>&nbsp;</i></button>
+      <button type="button" class="key"><b>0</b><i>+</i></button>
+      <button type="button" class="key"><b>#</b><i>&nbsp;</i></button>
+    </div>
+
+    <div class="ph-actions">
+      <button type="button" class="ph-call" aria-label="Call">
+        <svg viewBox="0 0 24 24"><path d="M6.6 10.8a15 15 0 0 0 6.6 6.6l2.2-2.2a1 1 0 0 1 1-.25 11 11 0 0 0 3.5.56 1 1 0 0 1 1 1V20a1 1 0 0 1-1 1A17 17 0 0 1 3 4a1 1 0 0 1 1-1h3.5a1 1 0 0 1 1 1 11 11 0 0 0 .56 3.5 1 1 0 0 1-.25 1z" /></svg>
+      </button>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/phone-dialpad-as/style.css
+++ b/submissions/examples/phone-dialpad-as/style.css
@@ -1,0 +1,131 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(160deg, #1a1e28, #0b0d12);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #f1f3f8;
+}
+
+.phone {
+  width: min(300px, 92vw);
+  padding: 1.3rem 1.4rem 1.5rem;
+  box-sizing: border-box;
+  background: #14171f;
+  border: 1px solid #262b38;
+  border-radius: 26px;
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.5);
+}
+
+.ph-screen {
+  display: grid;
+  justify-items: center;
+  gap: 0.2rem;
+  padding: 0.6rem 0 1.4rem;
+}
+
+.ph-num {
+  font-size: 1.7rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+}
+
+.ph-sub {
+  font-size: 0.8rem;
+  color: #7f8a9e;
+}
+
+.ph-keys {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  justify-items: center;
+}
+
+.key {
+  display: grid;
+  place-items: center;
+  gap: 1px;
+  width: 62px;
+  height: 62px;
+  border: 0;
+  border-radius: 50%;
+  background: #222634;
+  color: #f1f3f8;
+  cursor: pointer;
+  transition: background 0.12s ease, transform 0.08s ease;
+}
+
+.key:hover {
+  background: #2c3242;
+}
+
+.key:active {
+  transform: scale(0.92);
+  background: #3a4256;
+}
+
+.key:focus-visible {
+  outline: 2px solid #4f7cff;
+  outline-offset: 2px;
+}
+
+.key b {
+  font-size: 1.5rem;
+  font-weight: 500;
+  line-height: 1;
+}
+
+.key i {
+  font-style: normal;
+  font-size: 0.56rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  color: #8894aa;
+  min-height: 0.7em;
+}
+
+.ph-actions {
+  display: flex;
+  justify-content: center;
+  margin-top: 1.4rem;
+}
+
+.ph-call {
+  display: grid;
+  place-items: center;
+  width: 62px;
+  height: 62px;
+  border: 0;
+  border-radius: 50%;
+  background: linear-gradient(180deg, #22c55e, #16a34a);
+  color: #fff;
+  cursor: pointer;
+  box-shadow: 0 10px 22px rgba(22, 163, 74, 0.45);
+  transition: transform 0.12s ease;
+}
+
+.ph-call:hover {
+  transform: scale(1.06);
+}
+
+.ph-call:active {
+  transform: scale(0.94);
+}
+
+.ph-call svg {
+  width: 26px;
+  height: 26px;
+  fill: #fff;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .key,
+  .ph-call {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a phone dialpad built for #43242. A dialed number screen, a twelve key grid with digits and letter groups, and a green call button, all with press feedback. Pure CSS. Closes #43242.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: twelve keys (1 to 9, star, 0, hash) with letter groups, a dialed number, and a green call button.
