### PR TITLE
feat: add odometer

### DIFF
--- a/submissions/examples/odometer-as/README.md
+++ b/submissions/examples/odometer-as/README.md
@@ -1,0 +1,18 @@
+# Odometer
+
+### What does this do?
+
+It shows a mechanical odometer display. Each digit is a reel that shows a vertical strip of 0 to 9, shifted so the right number sits in the window, with faint neighbors above and below for a real dial look. The last reel rolls continuously like a ticking counter.
+
+### How is it used?
+
+```html
+<span class="reel" style="--d: 4;"><span class="strip">0123456789</span></span>
+<span class="reel roll"><span class="strip">0123456789</span></span>
+```
+
+Each reel clips a `strip` of the digits 0 to 9. Setting `--d` translates the strip with `translateY(calc(10px - var(--d) * 40px))` to show that digit. A mask fades the top and bottom edges, and the `roll` variant animates the strip instead.
+
+### Why is it useful?
+
+Dashboards, counters, and vehicle UIs show numbers on rolling reels for a tactile, mechanical feel. This builds one with pure CSS from a single digit strip per reel, no script or images.

--- a/submissions/examples/odometer-as/demo.html
+++ b/submissions/examples/odometer-as/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Odometer</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="odo-wrap">
+    <span class="odo-label">Distance</span>
+    <div class="odometer" role="img" aria-label="Odometer reading 042,318 kilometers">
+      <span class="reel" style="--d: 0;"><span class="strip">0123456789</span></span>
+      <span class="reel" style="--d: 4;"><span class="strip">0123456789</span></span>
+      <span class="reel" style="--d: 2;"><span class="strip">0123456789</span></span>
+      <span class="odo-sep">,</span>
+      <span class="reel" style="--d: 3;"><span class="strip">0123456789</span></span>
+      <span class="reel" style="--d: 1;"><span class="strip">0123456789</span></span>
+      <span class="reel roll"><span class="strip">0123456789</span></span>
+      <span class="odo-unit">km</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/odometer-as/style.css
+++ b/submissions/examples/odometer-as/style.css
@@ -1,0 +1,99 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #1c2130, #0a0d14 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e7ecf6;
+}
+
+.odo-wrap {
+  display: grid;
+  justify-items: center;
+  gap: 0.9rem;
+}
+
+.odo-label {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: #8b95ad;
+}
+
+.odometer {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0.7rem 0.9rem;
+  background: linear-gradient(180deg, #12151d, #191d28);
+  border: 1px solid #2a3040;
+  border-radius: 12px;
+  box-shadow: inset 0 2px 8px rgba(0, 0, 0, 0.6);
+}
+
+.reel {
+  position: relative;
+  width: 30px;
+  height: 60px;
+  overflow: hidden;
+  background: linear-gradient(180deg, #23283a, #171b26);
+  border-radius: 5px;
+  box-shadow: inset 0 0 0 1px #313850;
+  -webkit-mask: linear-gradient(180deg, transparent, #000 26%, #000 74%, transparent);
+  mask: linear-gradient(180deg, transparent, #000 26%, #000 74%, transparent);
+}
+
+.strip {
+  display: block;
+  width: 1ch;
+  margin: 0 auto;
+  font-family: ui-monospace, Consolas, monospace;
+  font-size: 30px;
+  line-height: 40px;
+  text-align: center;
+  color: #f2f6ff;
+  word-break: break-all;
+  transform: translateY(calc(10px - var(--d, 0) * 40px));
+}
+
+.reel.roll .strip {
+  animation: odo-roll 1.6s steps(10, end) infinite;
+}
+
+@keyframes odo-roll {
+  from { transform: translateY(10px); }
+  to { transform: translateY(-390px); }
+}
+
+.reel::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 5px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.06), transparent 40%);
+  pointer-events: none;
+}
+
+.odo-sep {
+  align-self: flex-end;
+  padding-bottom: 6px;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #8b95ad;
+}
+
+.odo-unit {
+  margin-left: 6px;
+  font-size: 0.9rem;
+  color: #9aa4bc;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reel.roll .strip {
+    animation: none;
+    transform: translateY(calc(10px - 8 * 40px));
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an odometer built for #43245. Digit reels that clip a 0 to 9 strip and shift by `--d` to show each number, with masked edges and a continuously rolling last reel. Pure CSS. Closes #43245.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: six digit reels reading 042,31 with a rolling last reel and a km unit, digits centered in masked windows.
