### PR TITLE
feat: add speedometer

### DIFF
--- a/submissions/examples/speedometer-as/README.md
+++ b/submissions/examples/speedometer-as/README.md
@@ -1,0 +1,23 @@
+# Speedometer
+
+### What does this do?
+
+It shows a speedometer gauge with a needle. A 240 degree dial has numbered ticks from 0 to 160, a colored arc that fills to the current value, a rotating needle, a center hub, and a large digital readout. A single `--frac` custom property (0 to 1) drives both the fill and the needle.
+
+### How is it used?
+
+```html
+<div class="speedo" style="--frac: 0.45;">
+  <svg viewBox="0 0 220 210">
+    <path class="sp-fill" d="M27.3 176 A94 94 0 1 1 192.7 176" pathLength="100" />
+  </svg>
+  <span class="sp-needle"></span>
+  <div class="sp-read"><b>72</b><span>mph</span></div>
+</div>
+```
+
+Set `--frac` on the gauge. The arc uses `pathLength="100"` so `stroke-dasharray: calc(var(--frac) * 100) 100` fills it proportionally, and the needle rotates by `-120 + var(--frac) * 240` degrees to match.
+
+### Why is it useful?
+
+Vehicle dashboards, network monitors, and performance meters show a value on a speedometer. This builds one with an SVG arc and a CSS needle from a single custom property, with no gauge library.

--- a/submissions/examples/speedometer-as/demo.html
+++ b/submissions/examples/speedometer-as/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Speedometer</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="speedo" style="--frac: 0.45;">
+    <svg viewBox="0 0 220 210" role="img" aria-label="Speedometer at 72 miles per hour">
+      <path class="sp-track" d="M27.3 176 A94 94 0 1 1 192.7 176" />
+      <path class="sp-fill" d="M27.3 176 A94 94 0 1 1 192.7 176" pathLength="100" />
+
+      <g class="sp-ticks">
+        <line x1="28.6" y1="159.0" x2="37.3" y2="154.0" />
+        <line x1="16.0" y1="112.0" x2="26.0" y2="112.0" />
+        <line x1="28.6" y1="65.0" x2="37.3" y2="70.0" />
+        <line x1="63.0" y1="30.6" x2="68.0" y2="39.3" />
+        <line x1="110.0" y1="18.0" x2="110.0" y2="28.0" />
+        <line x1="157.0" y1="30.6" x2="152.0" y2="39.3" />
+        <line x1="191.4" y1="65.0" x2="182.7" y2="70.0" />
+        <line x1="204.0" y1="112.0" x2="194.0" y2="112.0" />
+        <line x1="191.4" y1="159.0" x2="182.7" y2="154.0" />
+      </g>
+
+      <g class="sp-nums">
+        <text x="45.9" y="155">0</text>
+        <text x="36.0" y="118">20</text>
+        <text x="45.9" y="81">40</text>
+        <text x="73.0" y="53.9">60</text>
+        <text x="110.0" y="44">80</text>
+        <text x="147.0" y="53.9">100</text>
+        <text x="174.1" y="81">120</text>
+        <text x="184.0" y="118">140</text>
+        <text x="174.1" y="155">160</text>
+      </g>
+    </svg>
+
+    <span class="sp-needle"></span>
+    <span class="sp-hub"></span>
+
+    <div class="sp-read">
+      <b>72</b>
+      <span>mph</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/speedometer-as/style.css
+++ b/submissions/examples/speedometer-as/style.css
@@ -1,0 +1,108 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 20%, #1a2130, #0a0d13 65%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e8edf7;
+}
+
+.speedo {
+  position: relative;
+  width: min(300px, 92vw);
+}
+
+.speedo svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  overflow: visible;
+}
+
+.sp-track,
+.sp-fill {
+  fill: none;
+  stroke-width: 12;
+  stroke-linecap: round;
+}
+
+.sp-track {
+  stroke: #232b3d;
+}
+
+.sp-fill {
+  stroke: #34d399;
+  stroke-dasharray: calc(var(--frac, 0) * 100) 100;
+}
+
+.sp-ticks line {
+  stroke: #5b6885;
+  stroke-width: 2;
+  stroke-linecap: round;
+}
+
+.sp-nums text {
+  fill: #98a4be;
+  font-size: 11px;
+  font-weight: 600;
+  text-anchor: middle;
+}
+
+.sp-needle {
+  position: absolute;
+  left: 50%;
+  top: 53.3%;
+  width: 6px;
+  height: 40%;
+  transform: translate(-50%, -100%) rotate(calc((-120 + var(--frac, 0) * 240) * 1deg));
+  transform-origin: bottom center;
+  background: linear-gradient(180deg, #fb2c5a 0 70%, #7a1226);
+  border-radius: 3px 3px 2px 2px;
+  box-shadow: 0 0 8px rgba(251, 44, 90, 0.5);
+  transition: transform 0.7s cubic-bezier(0.34, 1.4, 0.64, 1);
+}
+
+.sp-hub {
+  position: absolute;
+  left: 50%;
+  top: 53.3%;
+  width: 22px;
+  height: 22px;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 35%, #4a5570, #232b3d);
+  border: 2px solid #5b6885;
+  z-index: 2;
+}
+
+.sp-read {
+  position: absolute;
+  left: 50%;
+  top: 76%;
+  transform: translateX(-50%);
+  display: grid;
+  justify-items: center;
+  line-height: 1;
+}
+
+.sp-read b {
+  font-size: 2.4rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.sp-read span {
+  font-size: 0.8rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #8b97b1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sp-needle {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a speedometer built for #43247. A 240 degree dial with numbered ticks, an SVG fill arc, a rotating needle, and a digital readout, all driven by one `--frac` custom property. Pure CSS. Closes #43247.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a needle pointing near 72 on a 0 to 160 dial with nine numbered ticks, a green fill arc, and a 72 MPH readout.
