### PR TITLE
feat: add waterfall chart

### DIFF
--- a/submissions/examples/waterfall-chart-as/README.md
+++ b/submissions/examples/waterfall-chart-as/README.md
@@ -1,0 +1,21 @@
+# Waterfall Chart
+
+### What does this do?
+
+It shows a waterfall chart of cash flow. A starting total bar is followed by floating increase and decrease bars that each pick up where the running total left off, ending with a final total bar. Increases are green, decreases red, totals blue, with value labels, connectors, and a legend.
+
+### How is it used?
+
+```html
+<div class="wf-col">
+  <span class="wf-val up">+35</span>
+  <span class="wf-bar up" style="--base: 50%; --h: 35%;"></span>
+  <span class="wf-x">Sales</span>
+</div>
+```
+
+Each bar floats with `bottom: var(--base)` and `height: var(--h)`, so setting the running total base and the step size positions it. Class `up`, `down`, or `tot` sets the color, and a dashed `::after` links each bar to the next.
+
+### Why is it useful?
+
+Finance and analytics use waterfall charts to explain how a value moves from a start to an end through gains and losses. This renders one from floating CSS bars driven by two custom properties, with no charting library.

--- a/submissions/examples/waterfall-chart-as/demo.html
+++ b/submissions/examples/waterfall-chart-as/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Waterfall Chart</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <figure class="waterfall">
+    <figcaption class="wf-title">Cash flow this quarter</figcaption>
+
+    <div class="wf-plot">
+      <div class="wf-col">
+        <span class="wf-val">50</span>
+        <span class="wf-bar tot" style="--base: 0%; --h: 50%;"></span>
+        <span class="wf-x">Start</span>
+      </div>
+      <div class="wf-col">
+        <span class="wf-val up">+35</span>
+        <span class="wf-bar up" style="--base: 50%; --h: 35%;"></span>
+        <span class="wf-x">Sales</span>
+      </div>
+      <div class="wf-col">
+        <span class="wf-val down">-13</span>
+        <span class="wf-bar down" style="--base: 72%; --h: 13%;"></span>
+        <span class="wf-x">Refunds</span>
+      </div>
+      <div class="wf-col">
+        <span class="wf-val up">+23</span>
+        <span class="wf-bar up" style="--base: 72%; --h: 23%;"></span>
+        <span class="wf-x">Upsell</span>
+      </div>
+      <div class="wf-col">
+        <span class="wf-val down">-35</span>
+        <span class="wf-bar down" style="--base: 60%; --h: 35%;"></span>
+        <span class="wf-x">Costs</span>
+      </div>
+      <div class="wf-col">
+        <span class="wf-val">60</span>
+        <span class="wf-bar tot" style="--base: 0%; --h: 60%;"></span>
+        <span class="wf-x">Net</span>
+      </div>
+    </div>
+
+    <figcaption class="wf-legend">
+      <span class="up">Increase</span>
+      <span class="down">Decrease</span>
+      <span class="tot">Total</span>
+    </figcaption>
+  </figure>
+</body>
+</html>

--- a/submissions/examples/waterfall-chart-as/style.css
+++ b/submissions/examples/waterfall-chart-as/style.css
@@ -1,0 +1,117 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #101a2b, #080b12 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e6ecf6;
+}
+
+.waterfall {
+  width: min(440px, 95vw);
+  margin: 0;
+  padding: 1.5rem 1.6rem 1.4rem;
+  box-sizing: border-box;
+  background: #111a2b;
+  border: 1px solid #263149;
+  border-radius: 16px;
+}
+
+.wf-title {
+  margin-bottom: 1.2rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.wf-plot {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 8px;
+  height: 210px;
+  border-bottom: 2px solid #263149;
+}
+
+.wf-col {
+  position: relative;
+  height: 100%;
+}
+
+.wf-bar {
+  position: absolute;
+  left: 12%;
+  right: 12%;
+  bottom: var(--base, 0%);
+  height: var(--h, 10%);
+  border-radius: 4px;
+}
+
+.wf-bar.up { background: linear-gradient(180deg, #34d399, #10b981); }
+.wf-bar.down { background: linear-gradient(180deg, #fb7185, #ef4444); }
+.wf-bar.tot { background: linear-gradient(180deg, #60a5fa, #3b82f6); }
+
+.wf-bar::after {
+  content: "";
+  position: absolute;
+  left: 100%;
+  top: 0;
+  width: calc(8px + 24%);
+  border-top: 1px dashed #46536f;
+}
+
+.wf-col:last-child .wf-bar::after {
+  display: none;
+}
+
+.wf-val {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: calc(var(--base) + var(--h) + 4px);
+  text-align: center;
+  font-size: 0.72rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: #cbd4e6;
+}
+
+.wf-val.up { color: #34d399; }
+.wf-val.down { color: #fb7185; }
+
+.wf-x {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -22px;
+  text-align: center;
+  font-size: 0.72rem;
+  color: #8593ad;
+}
+
+.wf-legend {
+  display: flex;
+  justify-content: center;
+  gap: 1.3rem;
+  margin-top: 2.2rem;
+  font-size: 0.78rem;
+  color: #aab4c8;
+}
+
+.wf-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.wf-legend span::before {
+  content: "";
+  width: 11px;
+  height: 11px;
+  border-radius: 3px;
+}
+
+.wf-legend .up::before { background: #10b981; }
+.wf-legend .down::before { background: #ef4444; }
+.wf-legend .tot::before { background: #3b82f6; }


### PR DESCRIPTION
## Pull Request Description

Adds a waterfall chart built for #43249. Floating increase and decrease bars between start and net totals, positioned by `--base` and `--h`, with connectors, value labels, and a legend. Pure CSS. Closes #43249.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: six columns with floating green increase and red decrease bars between blue start and net totals, with dashed connectors and value labels.
