### PR TITLE
feat: add tier list

### DIFF
--- a/submissions/examples/tier-list-as/README.md
+++ b/submissions/examples/tier-list-as/README.md
@@ -1,0 +1,22 @@
+# Tier List
+
+### What does this do?
+
+It shows a tier list, the S to D ranking board popular for ranking anything. Each row has a colored tier label on the left and a set of item chips on the right. Chips use a per item gradient and lift on hover, ready to be dragged between rows.
+
+### How is it used?
+
+```html
+<div class="tier-row">
+  <span class="tier-label s">S</span>
+  <div class="tier-items">
+    <span class="chip" style="--c1: #6366f1; --c2: #4338ca;">React</span>
+  </div>
+</div>
+```
+
+Each row pairs a `tier-label` (colored by its `s` to `d` class) with a flexible `tier-items` area. Chips take a two stop gradient from `--c1` and `--c2`, so each item keeps its own color, and a hover lift hints at drag and drop.
+
+### Why is it useful?
+
+Tier lists are a familiar way to rank and compare options, from tools to teams. This provides the classic ranked board layout with pure CSS, ready to wire up sorting or drag and drop.

--- a/submissions/examples/tier-list-as/demo.html
+++ b/submissions/examples/tier-list-as/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tier List</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="tier">
+    <h2 class="tier-title">Framework tier list</h2>
+
+    <div class="tier-row">
+      <span class="tier-label s">S</span>
+      <div class="tier-items">
+        <span class="chip" style="--c1: #6366f1; --c2: #4338ca;">React</span>
+        <span class="chip" style="--c1: #10b981; --c2: #059669;">Svelte</span>
+      </div>
+    </div>
+
+    <div class="tier-row">
+      <span class="tier-label a">A</span>
+      <div class="tier-items">
+        <span class="chip" style="--c1: #f43f5e; --c2: #be123c;">Vue</span>
+        <span class="chip" style="--c1: #0ea5e9; --c2: #0369a1;">Solid</span>
+        <span class="chip" style="--c1: #f59e0b; --c2: #b45309;">Angular</span>
+      </div>
+    </div>
+
+    <div class="tier-row">
+      <span class="tier-label b">B</span>
+      <div class="tier-items">
+        <span class="chip" style="--c1: #8b5cf6; --c2: #6d28d9;">Ember</span>
+        <span class="chip" style="--c1: #14b8a6; --c2: #0f766e;">Preact</span>
+      </div>
+    </div>
+
+    <div class="tier-row">
+      <span class="tier-label c">C</span>
+      <div class="tier-items">
+        <span class="chip" style="--c1: #64748b; --c2: #334155;">Backbone</span>
+        <span class="chip" style="--c1: #a16207; --c2: #713f12;">jQuery</span>
+      </div>
+    </div>
+
+    <div class="tier-row">
+      <span class="tier-label d">D</span>
+      <div class="tier-items">
+        <span class="chip" style="--c1: #71717a; --c2: #3f3f46;">AngularJS</span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/tier-list-as/style.css
+++ b/submissions/examples/tier-list-as/style.css
@@ -1,0 +1,87 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #191d28, #0b0d12 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #eef1f7;
+}
+
+.tier {
+  width: min(440px, 95vw);
+  padding: 1.4rem;
+  box-sizing: border-box;
+  background: #12151d;
+  border: 1px solid #262b36;
+  border-radius: 16px;
+}
+
+.tier-title {
+  margin: 0 0 1.1rem;
+  font-size: 1.05rem;
+}
+
+.tier-row {
+  display: flex;
+  align-items: stretch;
+  gap: 8px;
+  margin-bottom: 8px;
+  background: #0d1017;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.tier-label {
+  display: grid;
+  place-items: center;
+  width: 54px;
+  flex-shrink: 0;
+  font-size: 1.4rem;
+  font-weight: 800;
+  color: #1a1a1a;
+}
+
+.tier-label.s { background: #ff7f7f; }
+.tier-label.a { background: #ffbf7f; }
+.tier-label.b { background: #ffdf7f; }
+.tier-label.c { background: #bfff7f; }
+.tier-label.d { background: #7fdfff; }
+
+.tier-items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-content: center;
+  padding: 8px 8px 8px 0;
+  min-height: 44px;
+}
+
+.chip {
+  display: grid;
+  place-items: center;
+  min-width: 62px;
+  height: 40px;
+  padding: 0 0.7rem;
+  border-radius: 7px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #fff;
+  background: linear-gradient(150deg, var(--c1, #6366f1), var(--c2, #4338ca));
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.35);
+  cursor: grab;
+  transition: transform 0.14s ease, box-shadow 0.14s ease;
+}
+
+.chip:hover {
+  transform: translateY(-3px) scale(1.05);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.45);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chip {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a tier list built for #43251. S to D rows with classic colored tier labels and per item gradient chips that lift on hover. Pure CSS. Closes #43251.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: five tier rows S to D with distinct label colors and ten gradient item chips.
