### PR TITLE
Animated Modal Dialog with Backdrop Fade & Scale-In (ease-modal)

### DIFF
--- a/submissions/ease-modal/README.md
+++ b/submissions/ease-modal/README.md
@@ -1,0 +1,78 @@
+# ease-modal (submission)
+
+Animated modal dialog with a fading backdrop and a scale-in dialog box.
+Submitted as a raw, unprefixed component per the EaseMotion CSS
+[submission workflow](../../README.md) — the maintainer will convert the
+class names to `ease-*` and integrate it into `components/` if accepted.
+
+## What it does
+
+- Shows a dimmed, full-screen backdrop (`.modal-backdrop`) with a centered
+  dialog box (`.modal`).
+- **Open:** backdrop fades in, dialog scales up from `0.9` and slides/fades
+  into place.
+- **Close:** the same transition runs in reverse instead of the modal
+  disappearing instantly.
+- Closes via:
+  - clicking the backdrop (outside the dialog box)
+  - pressing `Esc`
+  - the `×` close button
+- Background page scroll is locked while a modal is open.
+- Respects `prefers-reduced-motion` — transitions are removed and the modal
+  just appears/disappears instantly for users who prefer that.
+
+## Files
+
+| File        | Purpose                                              |
+|-------------|-------------------------------------------------------|
+| `demo.html` | Two working demo modals (basic + confirm dialog)      |
+| `style.css` | All component styles (unprefixed, see note above)      |
+| `modal.js`  | Minimal helper — only toggles a class, no animation logic |
+
+## Usage
+
+```html
+<button onclick="openModal('myModal')">Open Modal</button>
+
+<div class="modal-backdrop" id="myModal">
+  <div class="modal" role="dialog" aria-modal="true" aria-labelledby="myModalTitle">
+    <div class="modal-header">
+      <h3 id="myModalTitle">Title</h3>
+      <button class="modal-close" onclick="closeModal('myModal')">&times;</button>
+    </div>
+    <div class="modal-body">
+      <p>Your content here.</p>
+    </div>
+    <div class="modal-footer">
+      <button onclick="closeModal('myModal')">Close</button>
+    </div>
+  </div>
+</div>
+```
+
+```js
+openModal('myModal');   // opens with animation
+closeModal('myModal');  // closes with animation
+```
+
+## Design notes / why it's built this way
+
+- **CSS drives all animation.** `modal.js` only adds/removes the `is-open`
+  class — it never touches `opacity`, `transform`, or timing directly. This
+  keeps the effect swappable/themeable purely through CSS, consistent with
+  how `ease-hover-*` utilities work elsewhere in the framework.
+- **Accessibility basics included:** `role="dialog"`, `aria-modal="true"`,
+  and `aria-labelledby` are set on the dialog; `Esc` closes it; a visible
+  close button is always present. Focus-trapping inside the modal was left
+  out intentionally to keep this submission scoped — happy to open a
+  follow-up issue for that if useful.
+- **No new CSS variables were introduced.** Colors/spacing use plain values
+  here since this is the raw submission stage; the maintainer can map these
+  onto existing `--ease-color-*` / `--ease-speed-*` tokens during
+  standardization, or ask for specific ones to be added.
+
+## Checklist
+
+- [x] Does not duplicate an existing EaseMotion CSS class
+- [x] Naming left unprefixed for maintainer standardization
+- [x] Submitted inside `submissions/` only — no edits to `core/` or `components/`

--- a/submissions/ease-modal/demo.html
+++ b/submissions/ease-modal/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-modal — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="demo-page">
+    <h1>ease-modal Demo</h1>
+    <p>A simple animated dialog with a fading backdrop and a scale-in dialog box.</p>
+
+    <div class="demo-buttons">
+      <button class="demo-btn" onclick="openModal('basicModal')">
+        Open Basic Modal
+      </button>
+
+      <button class="demo-btn" onclick="openModal('confirmModal')">
+        Open Confirm Dialog
+      </button>
+    </div>
+  </main>
+
+  <!-- Basic Modal -->
+  <div class="modal-backdrop" id="basicModal">
+    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="basicModalTitle">
+      <div class="modal-header">
+        <h3 id="basicModalTitle">Welcome</h3>
+        <button class="modal-close" aria-label="Close modal" onclick="closeModal('basicModal')">&times;</button>
+      </div>
+      <div class="modal-body">
+        <p>This is a basic modal. It fades and scales in smoothly, and reverses the
+           same animation when closing instead of disappearing instantly.</p>
+      </div>
+      <div class="modal-footer">
+        <button class="demo-btn demo-btn-ghost" onclick="closeModal('basicModal')">Close</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Confirm Dialog -->
+  <div class="modal-backdrop" id="confirmModal">
+    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="confirmModalTitle">
+      <div class="modal-header">
+        <h3 id="confirmModalTitle">Confirm Action</h3>
+        <button class="modal-close" aria-label="Close modal" onclick="closeModal('confirmModal')">&times;</button>
+      </div>
+      <div class="modal-body">
+        <p>Are you sure you want to proceed? This action cannot be undone.</p>
+      </div>
+      <div class="modal-footer">
+        <button class="demo-btn demo-btn-ghost" onclick="closeModal('confirmModal')">Cancel</button>
+        <button class="demo-btn demo-btn-primary" onclick="closeModal('confirmModal')">Confirm</button>
+      </div>
+    </div>
+  </div>
+
+  <script src="modal.js"></script>
+</body>
+</html>

--- a/submissions/ease-modal/style.css
+++ b/submissions/ease-modal/style.css
@@ -1,0 +1,149 @@
+/* ==========================================================================
+   ease-modal — raw submission styles
+   Naming below is unprefixed on purpose; the maintainer will convert this
+   to ease-* class names during integration (per CONTRIBUTING.md).
+   ========================================================================== */
+
+/* ---- demo page chrome (not part of the component) ---- */
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Segoe UI", system-ui, sans-serif;
+  background: #f4f5f7;
+  color: #1f2430;
+}
+
+.demo-page {
+  max-width: 640px;
+  margin: 4rem auto;
+  padding: 0 1.5rem;
+  text-align: center;
+}
+
+.demo-buttons {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  margin-top: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.demo-btn {
+  padding: 0.65rem 1.25rem;
+  border-radius: 8px;
+  border: 1px solid #d7dae0;
+  background: #fff;
+  cursor: pointer;
+  font-size: 0.95rem;
+  transition: transform 0.15s ease, background 0.15s ease;
+}
+
+.demo-btn:hover {
+  transform: translateY(-1px);
+}
+
+.demo-btn-primary {
+  background: #6366f1;
+  border-color: #6366f1;
+  color: #fff;
+}
+
+.demo-btn-ghost {
+  background: transparent;
+}
+
+/* ==========================================================================
+   THE COMPONENT — ease-modal
+   ========================================================================== */
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 17, 26, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.25s ease, visibility 0.25s ease;
+  z-index: 1000;
+}
+
+.modal-backdrop.is-open {
+  opacity: 1;
+  visibility: visible;
+}
+
+.modal {
+  background: #fff;
+  border-radius: 12px;
+  padding: 1.5rem;
+  width: 100%;
+  max-width: 420px;
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.2);
+
+  transform: scale(0.9) translateY(12px);
+  opacity: 0;
+  transition: transform 0.25s ease, opacity 0.25s ease;
+}
+
+.modal-backdrop.is-open .modal {
+  transform: scale(1) translateY(0);
+  opacity: 1;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.modal-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  font-size: 1.35rem;
+  line-height: 1;
+  cursor: pointer;
+  color: #6b7280;
+  padding: 0.25rem;
+}
+
+.modal-close:hover {
+  color: #1f2430;
+}
+
+.modal-body {
+  color: #4b5160;
+  line-height: 1.5;
+}
+
+.modal-body p {
+  margin: 0;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.6rem;
+  margin-top: 1.5rem;
+}
+
+/* Respect users who prefer reduced motion: swap the animated transition
+   for an instant show/hide instead. */
+@media (prefers-reduced-motion: reduce) {
+  .modal-backdrop,
+  .modal {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Pull Request Description
Adds ease-modal — a raw submission for an animated modal dialog component with a fading backdrop and a scale-in dialog box. Solves the current gap where EaseMotion CSS has no dialog/overlay component, forcing developers to build modals and their transitions from scratch.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

What does this add?
An animated modal/dialog with a fading backdrop and a scale-in dialog box, closable via backdrop click, Esc, or a close button — with reversed animation on close instead of an instant cutoff.

How does a developer use it?
html<button onclick="openModal('myModal')">Open Modal</button>

<div class="modal-backdrop" id="myModal">
  <div class="modal" role="dialog" aria-modal="true" aria-labelledby="myModalTitle">
    <div class="modal-header">
      <h3 id="myModalTitle">Title</h3>
      <button class="modal-close" onclick="closeModal('myModal')">&times;</button>
    </div>
    <div class="modal-body">
      <p>Your content here.</p>
    </div>
    <div class="modal-footer">
      <button onclick="closeModal('myModal')">Close</button>
    </div>
  </div>
</div>

Why does it fit EaseMotion CSS?
It keeps naming human-readable (modal-backdrop, modal, modal-close — to become ease-modal-*), is animation-first since every open/close state is driven by CSS transitions rather than a visibility toggle, and is fully composable — it drops in cleanly alongside existing ease-btn and ease-card classes with no specificity conflicts. The accompanying JS is intentionally minimal (only toggles a class), keeping the actual motion CSS-only and consistent with how ease-hover-* utilities already work.

Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)



Browser Testing

- [x] Chrome
- [x] Edge