### PR TITLE
feat: add wave chat bubble component

### DIFF
--- a/submissions/examples/wave-chat-bubble/README.md
+++ b/submissions/examples/wave-chat-bubble/README.md
@@ -1,0 +1,45 @@
+# Wave Chat Bubble
+
+## Description
+A chat bubble component with a multi-step animation: bubbles pop in on entrance (staggered per message), and a continuous "wave" shimmer sweeps across each bubble's surface. Includes an animated typing indicator with a wave-bounce effect. Pure CSS, zero JavaScript.
+
+## Features
+- Staggered bubble entrance animation (pop/scale/fade in)
+- Continuous shimmer "wave" sweep across each bubble
+- Sent vs. received bubble styling with distinct tail corners
+- Animated typing indicator (three dots with a wave-bounce)
+- Fully responsive (max-width based, wraps naturally)
+- `role="log"` for accessible live chat semantics
+- Fully customizable via CSS custom properties
+- Respects `prefers-reduced-motion`
+
+## Usage
+```html
+<div class="ease-chat" role="log" aria-label="Chat conversation">
+  <div class="chat-bubble is-received">Received message</div>
+  <div class="chat-bubble is-sent">Sent message</div>
+
+  <div class="chat-typing" aria-label="Typing indicator">
+    <span></span><span></span><span></span>
+  </div>
+</div>
+```
+
+## Customization (CSS custom properties)
+| Property | Default | Description |
+|---|---|---|
+| `--wave-duration` | `3s` | Shimmer sweep cycle duration |
+| `--wave-easing` | `ease-in-out` | Shimmer timing function |
+| `--wave-in-duration` | `0.4s` | Bubble entrance animation duration |
+| `--wave-in-easing` | `cubic-bezier(0.34, 1.56, 0.64, 1)` | Entrance timing function |
+| `--wave-bg-sent` | `#38bdf8` | Sent bubble background |
+| `--wave-bg-received` | `#23273a` | Received bubble background |
+| `--wave-radius` | `18px` | Bubble corner rounding |
+
+## Accessibility & Motion
+Chat container uses `role="log"` for assistive technology to announce new messages appropriately. Respects `prefers-reduced-motion` by disabling both the entrance animation and the shimmer sweep, showing bubbles in their final state immediately.
+
+## Files
+- `demo.html` — live working example with a sample conversation
+- `style.css` — component styles and animations
+- `README.md` — this file

--- a/submissions/examples/wave-chat-bubble/demo.html
+++ b/submissions/examples/wave-chat-bubble/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ease Wave Chat Bubble — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #0f172a;
+      padding: 40px;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="ease-chat" role="log" aria-label="Chat conversation">
+    <div class="chat-bubble is-received">Hey! Have you seen the new EaseMotion release?</div>
+    <div class="chat-bubble is-sent">Yeah, the animation utilities are 🔥</div>
+    <div class="chat-bubble is-received">Right? The wave chat bubble is my favorite so far.</div>
+
+    <div class="chat-typing" aria-label="Typing indicator">
+      <span></span><span></span><span></span>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/wave-chat-bubble/style.css
+++ b/submissions/examples/wave-chat-bubble/style.css
@@ -1,0 +1,143 @@
+/* Ease Wave Chat Bubble — pure CSS multi-step animation, zero JS */
+
+.ease-chat {
+  --wave-duration: 3s;
+  --wave-easing: ease-in-out;
+  --wave-bg-sent: #38bdf8;
+  --wave-bg-received: #23273a;
+  --wave-fg-sent: #0b0f19;
+  --wave-fg-received: #f5f7fa;
+  --wave-radius: 18px;
+  --wave-in-duration: 0.4s;
+  --wave-in-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  width: min(340px, 90vw);
+  font-family: system-ui, sans-serif;
+}
+
+.ease-chat .chat-bubble {
+  position: relative;
+  max-width: 78%;
+  padding: 12px 16px;
+  border-radius: var(--wave-radius);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  overflow: hidden;
+
+  opacity: 0;
+  transform: translateY(10px) scale(0.95);
+  animation: bubble-enter var(--wave-in-duration) var(--wave-in-easing) forwards;
+}
+
+.ease-chat .chat-bubble.is-sent {
+  align-self: flex-end;
+  background: var(--wave-bg-sent);
+  color: var(--wave-fg-sent);
+  border-bottom-right-radius: 4px;
+}
+
+.ease-chat .chat-bubble.is-received {
+  align-self: flex-start;
+  background: var(--wave-bg-received);
+  color: var(--wave-fg-received);
+  border-bottom-left-radius: 4px;
+}
+
+@keyframes bubble-enter {
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+/* staggered entrance for sequential bubbles */
+.ease-chat .chat-bubble:nth-child(1) { animation-delay: 0s; }
+.ease-chat .chat-bubble:nth-child(2) { animation-delay: 0.15s; }
+.ease-chat .chat-bubble:nth-child(3) { animation-delay: 0.3s; }
+.ease-chat .chat-bubble:nth-child(4) { animation-delay: 0.45s; }
+
+/* ---- the "wave" — an animated shimmer sweeping across the bubble surface ---- */
+.ease-chat .chat-bubble::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    100deg,
+    transparent 30%,
+    rgba(255, 255, 255, 0.25) 50%,
+    transparent 70%
+  );
+  transform: translateX(-100%);
+  animation: wave-sweep var(--wave-duration) var(--wave-easing) infinite;
+}
+
+.ease-chat .chat-bubble.is-received::after {
+  background: linear-gradient(
+    100deg,
+    transparent 30%,
+    rgba(255, 255, 255, 0.08) 50%,
+    transparent 70%
+  );
+}
+
+@keyframes wave-sweep {
+  0%   { transform: translateX(-100%); }
+  40%  { transform: translateX(100%); }
+  100% { transform: translateX(100%); }
+}
+
+/* ---- typing indicator: three dots doing a wave bounce ---- */
+.ease-chat .chat-typing {
+  align-self: flex-start;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  background: var(--wave-bg-received);
+  padding: 12px 16px;
+  border-radius: var(--wave-radius);
+  border-bottom-left-radius: 4px;
+  width: fit-content;
+}
+
+.ease-chat .chat-typing span {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #94a3b8;
+  animation: typing-wave 1.2s ease-in-out infinite;
+}
+
+.ease-chat .chat-typing span:nth-child(1) { animation-delay: 0s; }
+.ease-chat .chat-typing span:nth-child(2) { animation-delay: 0.15s; }
+.ease-chat .chat-typing span:nth-child(3) { animation-delay: 0.3s; }
+
+@keyframes typing-wave {
+  0%, 60%, 100% { transform: translateY(0); opacity: 0.5; }
+  30%           { transform: translateY(-5px); opacity: 1; }
+}
+
+.ease-chat .chat-timestamp {
+  font-size: 0.7rem;
+  color: #64748b;
+  margin-top: 4px;
+}
+
+.ease-chat .chat-bubble.is-sent + .chat-timestamp {
+  align-self: flex-end;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-chat .chat-bubble {
+    animation: none !important;
+    opacity: 1;
+    transform: none;
+  }
+  .ease-chat .chat-bubble::after {
+    animation: none !important;
+    display: none;
+  }
+  .ease-chat .chat-typing span {
+    animation: none !important;
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
Closes #42532 

## Pull Request Description
Adds a `wave-chat-bubble` component — chat message bubbles with a staggered pop-in entrance animation and a continuous "wave" shimmer sweeping across each bubble's surface, plus an animated typing indicator with a wave-bounce effect. Pure CSS, zero JavaScript.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/wave-chat-bubble-savni/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] Uses `ease-*` prefixed classes (`ease-chat`)
- [x] Works without JavaScript (pure CSS)
- [x] Responsive and accessible
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A chat bubble component (`.ease-chat`) with multi-step animation: staggered bubble pop-in on load, a continuous shimmer wave sweeping across each bubble, sent/received styling with tail corners, and an animated three-dot typing indicator with a wave-bounce motion.

**How does a developer use it?**
```html
<div class="ease-chat" role="log" aria-label="Chat conversation">
  <div class="chat-bubble is-received">Received message</div>
  <div class="chat-bubble is-sent">Sent message</div>

  <div class="chat-typing" aria-label="Typing indicator">
    <span></span><span></span><span></span>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Fully pure-CSS, zero-JavaScript, multi-step animation (entrance + continuous shimmer + typing wave) built with `ease-*` prefixed classes and `@keyframes`, fully customizable via CSS custom properties (`--wave-duration`, `--wave-easing`, `--wave-in-duration`, `--wave-bg-sent`, etc.) without touching core rules — matching the framework's animation-first, zero-dependency philosophy. Uses `role="log"` for accessible chat semantics and respects `prefers-reduced-motion` by disabling both the entrance and shimmer animations.

---

## Demo
- [x] Demo added (`demo.html` — sample conversation with entrance, shimmer, and typing indicator all visible)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
"Wave" is interpreted as a continuous shimmer sweep across each bubble's surface (like a light wave passing over it) combined with a wave-motion typing indicator — happy to adjust the specific animation style if a different visual interpretation of "wave" was intended.