### PR TITLE
feat: add sankey diagram

### DIFF
--- a/submissions/examples/sankey-diagram-as/README.md
+++ b/submissions/examples/sankey-diagram-as/README.md
@@ -1,0 +1,20 @@
+# Sankey Diagram
+
+### What does this do?
+
+It shows a Sankey diagram of traffic flowing from sources to outcomes. Source and outcome nodes stand as bars on each side, and curved ribbons connect them with a thickness that reflects the size of each flow. Ribbons brighten on hover.
+
+### How is it used?
+
+```html
+<svg viewBox="0 0 300 240">
+  <path class="fl a" d="M36 50 C150 50 150 80 264 80 L264 160 C150 160 150 130 36 130 Z" />
+  <rect class="nd a" x="20" y="10" width="16" height="120" />
+</svg>
+```
+
+Each flow is a filled SVG `path` built from two bezier curves (a top and a bottom edge) so it reads as a smooth ribbon between a segment of a source node and a segment of a target node. Node `rect` bars mark the totals, and classes set the colors.
+
+### Why is it useful?
+
+Sankey diagrams show how quantities split and merge across stages, common for traffic, energy, and budget flows. This renders one from inline SVG ribbons and nodes styled with CSS, with no diagram library.

--- a/submissions/examples/sankey-diagram-as/demo.html
+++ b/submissions/examples/sankey-diagram-as/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sankey Diagram</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <figure class="sankey">
+    <figcaption class="sk-title">Traffic flow</figcaption>
+    <svg viewBox="0 0 300 240" role="img" aria-label="Sankey diagram of traffic sources to outcomes">
+      <g class="sk-flows">
+        <path class="fl a" d="M36 10 C150 10 150 10 264 10 L264 50 C150 50 150 50 36 50 Z" />
+        <path class="fl a" d="M36 50 C150 50 150 80 264 80 L264 160 C150 160 150 130 36 130 Z" />
+        <path class="fl b" d="M36 140 C150 140 150 50 264 50 L264 70 C150 70 150 160 36 160 Z" />
+        <path class="fl b" d="M36 160 C150 160 150 200 264 200 L264 230 C150 230 150 190 36 190 Z" />
+        <path class="fl c" d="M36 200 C150 200 150 160 264 160 L264 190 C150 190 150 230 36 230 Z" />
+      </g>
+
+      <g class="sk-nodes">
+        <rect class="nd a" x="20" y="10" width="16" height="120" />
+        <rect class="nd b" x="20" y="140" width="16" height="50" />
+        <rect class="nd c" x="20" y="200" width="16" height="30" />
+        <rect class="nd out" x="264" y="10" width="16" height="60" />
+        <rect class="nd out" x="264" y="80" width="16" height="110" />
+        <rect class="nd out" x="264" y="200" width="16" height="30" />
+      </g>
+
+      <g class="sk-labels">
+        <text x="16" y="74" text-anchor="end">Search</text>
+        <text x="16" y="168" text-anchor="end">Social</text>
+        <text x="16" y="219" text-anchor="end">Direct</text>
+        <text x="284" y="44">Sign up</text>
+        <text x="284" y="139">Browse</text>
+        <text x="284" y="219">Bounce</text>
+      </g>
+    </svg>
+  </figure>
+</body>
+</html>

--- a/submissions/examples/sankey-diagram-as/style.css
+++ b/submissions/examples/sankey-diagram-as/style.css
@@ -1,0 +1,64 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #141d30, #090c14 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e6ebf6;
+}
+
+.sankey {
+  width: min(440px, 95vw);
+  margin: 0;
+  padding: 1.4rem 1.5rem 1.2rem;
+  box-sizing: border-box;
+  background: #111a2c;
+  border: 1px solid #26314a;
+  border-radius: 16px;
+}
+
+.sk-title {
+  margin-bottom: 0.8rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.sankey svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  overflow: visible;
+}
+
+.fl {
+  fill-opacity: 0.32;
+  transition: fill-opacity 0.2s ease;
+}
+
+.fl:hover {
+  fill-opacity: 0.6;
+}
+
+.fl.a { fill: #6366f1; }
+.fl.b { fill: #ec4899; }
+.fl.c { fill: #f59e0b; }
+
+.nd.a { fill: #818cf8; }
+.nd.b { fill: #f472b6; }
+.nd.c { fill: #fbbf24; }
+.nd.out { fill: #5eead4; }
+
+.sk-labels text {
+  fill: #b7c0d4;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fl {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a Sankey diagram built for #43279. Source and target node bars joined by proportional bezier flow ribbons that brighten on hover, all inline SVG. Pure CSS. Closes #43279.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: three source and three target nodes joined by five proportional flow ribbons in three colors.
