### PR TITLE
feat: add sunburst chart

### DIFF
--- a/submissions/examples/sunburst-chart-as/README.md
+++ b/submissions/examples/sunburst-chart-as/README.md
@@ -1,0 +1,20 @@
+# Sunburst Chart
+
+### What does this do?
+
+It shows a sunburst chart: a two ring radial hierarchy. The inner ring holds top level categories and the outer ring splits each one into subcategories, with a total in the center. Segments share colors by family and highlight on hover.
+
+### How is it used?
+
+```html
+<svg viewBox="0 0 220 220">
+  <path class="seg a1" d="M110 18 A92 92 0 0 1 201.82 104.22 L171.88 106.11 A62 62 0 0 0 110 48 Z" />
+  <path class="seg a" d="M110 50 A60 60 0 0 1 145.27 158.54 L127.63 134.27 A30 30 0 0 0 110 80 Z" />
+</svg>
+```
+
+Each segment is an SVG annular sector: two arcs joined by radial lines. Inner segments use a base color and their outer children use lighter shades of the same hue, so the hierarchy is easy to read.
+
+### Why is it useful?
+
+Sunburst charts show hierarchical part to whole data, like budgets, files, or categories with subcategories. This renders one from inline SVG sectors styled with CSS, with no charting library.

--- a/submissions/examples/sunburst-chart-as/demo.html
+++ b/submissions/examples/sunburst-chart-as/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sunburst Chart</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <figure class="sunburst">
+    <figcaption class="sb-title">Budget breakdown</figcaption>
+    <svg viewBox="0 0 220 220" role="img" aria-label="Sunburst chart of budget categories and subcategories">
+      <g class="sb-outer">
+        <path class="seg a1" d="M110.0 18.0 A92 92 0 0 1 201.82 104.22 L171.88 106.11 A62 62 0 0 0 110.0 48.0 Z" />
+        <path class="seg a2" d="M201.82 104.22 A92 92 0 0 1 164.08 184.43 L146.44 160.16 A62 62 0 0 0 171.88 106.11 Z" />
+        <path class="seg b1" d="M164.08 184.43 A92 92 0 0 1 55.92 184.43 L73.56 160.16 A62 62 0 0 0 146.44 160.16 Z" />
+        <path class="seg b2" d="M55.92 184.43 A92 92 0 0 1 18.0 110.0 L48.0 110.0 A62 62 0 0 0 73.56 160.16 Z" />
+        <path class="seg c1" d="M18.0 110.0 A92 92 0 0 1 55.92 35.57 L73.56 59.84 A62 62 0 0 0 48.0 110.0 Z" />
+        <path class="seg c2" d="M55.92 35.57 A92 92 0 0 1 110.0 18.0 L110.0 48.0 A62 62 0 0 0 73.56 59.84 Z" />
+      </g>
+      <g class="sb-inner">
+        <path class="seg a" d="M110.0 50.0 A60 60 0 0 1 145.27 158.54 L127.63 134.27 A30 30 0 0 0 110.0 80.0 Z" />
+        <path class="seg b" d="M145.27 158.54 A60 60 0 0 1 50.0 110.0 L80.0 110.0 A30 30 0 0 0 127.63 134.27 Z" />
+        <path class="seg c" d="M50.0 110.0 A60 60 0 0 1 110.0 50.0 L110.0 80.0 A30 30 0 0 0 80.0 110.0 Z" />
+      </g>
+      <text class="sb-center" x="110" y="114">100%</text>
+    </svg>
+    <figcaption class="sb-legend">
+      <span class="a">Housing</span>
+      <span class="b">Food</span>
+      <span class="c">Leisure</span>
+    </figcaption>
+  </figure>
+</body>
+</html>

--- a/submissions/examples/sunburst-chart-as/style.css
+++ b/submissions/examples/sunburst-chart-as/style.css
@@ -1,0 +1,95 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #1a1330, #0a0713 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #ece7f7;
+}
+
+.sunburst {
+  width: min(320px, 92vw);
+  margin: 0;
+  padding: 1.4rem 1.4rem 1.1rem;
+  box-sizing: border-box;
+  background: #150f28;
+  border: 1px solid #2f2450;
+  border-radius: 18px;
+  text-align: center;
+}
+
+.sb-title {
+  margin-bottom: 0.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.sunburst svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.seg {
+  stroke: #150f28;
+  stroke-width: 1.5;
+  transition: opacity 0.2s ease;
+}
+
+.seg:hover {
+  opacity: 0.82;
+}
+
+.seg.a { fill: #6366f1; }
+.seg.a1 { fill: #818cf8; }
+.seg.a2 { fill: #a5b4fc; }
+
+.seg.b { fill: #db2777; }
+.seg.b1 { fill: #ec4899; }
+.seg.b2 { fill: #f9a8d4; }
+
+.seg.c { fill: #0d9488; }
+.seg.c1 { fill: #14b8a6; }
+.seg.c2 { fill: #5eead4; }
+
+.sb-center {
+  fill: #ece7f7;
+  font-size: 15px;
+  font-weight: 700;
+  text-anchor: middle;
+}
+
+.sb-legend {
+  display: flex;
+  justify-content: center;
+  gap: 1.2rem;
+  margin-top: 0.9rem;
+  font-size: 0.8rem;
+  color: #b4abce;
+}
+
+.sb-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.sb-legend span::before {
+  content: "";
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+}
+
+.sb-legend .a::before { background: #6366f1; }
+.sb-legend .b::before { background: #db2777; }
+.sb-legend .c::before { background: #0d9488; }
+
+@media (prefers-reduced-motion: reduce) {
+  .seg {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a sunburst chart built for #43282. A two ring radial hierarchy of SVG annular sectors, inner categories with lighter shaded outer subcategories and a center total. Pure CSS. Closes #43282.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: three inner category sectors and six outer subcategory sectors in matching color families with a center total.
