### PR TITLE
feat: add pareto chart

### DIFF
--- a/submissions/examples/pareto-chart-as/README.md
+++ b/submissions/examples/pareto-chart-as/README.md
@@ -1,0 +1,20 @@
+# Pareto Chart
+
+### What does this do?
+
+It shows a Pareto chart: descending frequency bars with a cumulative percentage line drawn over them, plus an 80 percent reference line. Together they highlight the vital few causes that make up most of the total, the classic 80/20 view.
+
+### How is it used?
+
+```html
+<svg viewBox="0 0 300 210">
+  <rect class="pb" x="15" y="28.8" width="38" height="151.2" rx="3" />
+  <polyline class="pt-line" points="34,104 92,57 150,32 208,19 266,12" />
+</svg>
+```
+
+Bars are SVG `rect` elements sized by count and sorted high to low, while the `pt-line` polyline traces the running cumulative percentage with marker dots. A dashed `pt-80` line marks the 80 percent threshold.
+
+### Why is it useful?
+
+Pareto charts are a staple of quality and prioritization work, showing where to focus effort first. This renders one from inline SVG bars and a line styled with CSS, with no charting library.

--- a/submissions/examples/pareto-chart-as/demo.html
+++ b/submissions/examples/pareto-chart-as/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pareto Chart</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <figure class="pareto">
+    <figcaption class="pt-title">Complaints by cause</figcaption>
+    <svg viewBox="0 0 300 210" role="img" aria-label="Pareto chart of complaint causes with a cumulative line">
+      <g class="pt-grid">
+        <line x1="0" y1="12" x2="300" y2="12" />
+        <line x1="0" y1="96" x2="300" y2="96" />
+        <line x1="0" y1="180" x2="300" y2="180" />
+      </g>
+      <line class="pt-80" x1="0" y1="45.6" x2="300" y2="45.6" />
+
+      <g class="pt-bars">
+        <rect class="pb" x="15.0" y="28.8" width="38" height="151.2" rx="3" />
+        <rect class="pb" x="73.0" y="85.9" width="38" height="94.1" rx="3" />
+        <rect class="pb" x="131.0" y="129.6" width="38" height="50.4" rx="3" />
+        <rect class="pb" x="189.0" y="153.1" width="38" height="26.9" rx="3" />
+        <rect class="pb" x="247.0" y="166.6" width="38" height="13.4" rx="3" />
+      </g>
+
+      <polyline class="pt-line" points="34,104.4 92,57.4 150,32.2 208,18.7 266,12.0" />
+      <g class="pt-dots">
+        <circle cx="34" cy="104.4" r="3.5" />
+        <circle cx="92" cy="57.4" r="3.5" />
+        <circle cx="150" cy="32.2" r="3.5" />
+        <circle cx="208" cy="18.7" r="3.5" />
+        <circle cx="266" cy="12.0" r="3.5" />
+      </g>
+
+      <g class="pt-x">
+        <text x="34" y="196">Late</text>
+        <text x="92" y="196">Wrong</text>
+        <text x="150" y="196">Damaged</text>
+        <text x="208" y="196">Missing</text>
+        <text x="266" y="196">Other</text>
+      </g>
+    </svg>
+    <figcaption class="pt-legend">
+      <span class="bar">Count</span>
+      <span class="line">Cumulative %</span>
+    </figcaption>
+  </figure>
+</body>
+</html>

--- a/submissions/examples/pareto-chart-as/style.css
+++ b/submissions/examples/pareto-chart-as/style.css
@@ -1,0 +1,98 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #131c2f, #090c14 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e6ebf6;
+}
+
+.pareto {
+  width: min(430px, 95vw);
+  margin: 0;
+  padding: 1.4rem 1.5rem 1.2rem;
+  box-sizing: border-box;
+  background: #111a2c;
+  border: 1px solid #26314a;
+  border-radius: 16px;
+}
+
+.pt-title {
+  margin-bottom: 0.8rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.pareto svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  overflow: visible;
+}
+
+.pt-grid line {
+  stroke: #212c44;
+  stroke-width: 1;
+}
+
+.pt-80 {
+  stroke: #f59e0b;
+  stroke-width: 1.5;
+  stroke-dasharray: 5 4;
+  opacity: 0.7;
+}
+
+.pb {
+  fill: #3b82f6;
+}
+
+.pt-bars .pb:first-child {
+  fill: #6366f1;
+}
+
+.pt-line {
+  fill: none;
+  stroke: #f59e0b;
+  stroke-width: 2.5;
+  stroke-linejoin: round;
+}
+
+.pt-dots circle {
+  fill: #fde68a;
+  stroke: #f59e0b;
+  stroke-width: 2;
+}
+
+.pt-x text {
+  fill: #97a2ba;
+  font-size: 9px;
+  text-anchor: middle;
+}
+
+.pt-legend {
+  display: flex;
+  justify-content: center;
+  gap: 1.4rem;
+  margin-top: 0.8rem;
+  font-size: 0.8rem;
+  color: #aab4c8;
+}
+
+.pt-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.pt-legend span::before {
+  content: "";
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+}
+
+.pt-legend .bar::before { background: #3b82f6; }
+.pt-legend .line::before { background: #f59e0b; border-radius: 50%; }


### PR DESCRIPTION
## Pull Request Description

Adds a Pareto chart built for #43287. Descending SVG count bars with a cumulative percentage polyline and marker dots over an 80 percent reference line. Pure CSS. Closes #43287.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: five descending bars (heights 151 to 13) with a rising cumulative line, five dots, and a dashed 80 percent line.
