### PR TITLE
feat: add bubble chart

### DIFF
--- a/submissions/examples/bubble-chart-as/README.md
+++ b/submissions/examples/bubble-chart-as/README.md
@@ -1,0 +1,20 @@
+# Bubble Chart
+
+### What does this do?
+
+It shows a bubble chart, a scatter plot where each point also carries a third value as its size. Bubbles are placed by two axes (reach and growth) with their radius encoding revenue, each in its own translucent color with a label, over a gridded frame with a midline on each axis.
+
+### How is it used?
+
+```html
+<svg viewBox="0 0 290 210">
+  <circle class="b e" cx="230" cy="82" r="32" />
+  <circle class="b c" cx="186" cy="118" r="15" />
+</svg>
+```
+
+Each bubble is an SVG `circle` positioned with `cx` and `cy` and sized with `r` for the third dimension. Class `a` through `f` sets the translucent fill and stroke, and bubbles brighten on hover.
+
+### Why is it useful?
+
+Bubble charts compare items across three dimensions at once, common in market, portfolio, and research views. This renders one from inline SVG circles styled with CSS, with no charting library.

--- a/submissions/examples/bubble-chart-as/demo.html
+++ b/submissions/examples/bubble-chart-as/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bubble Chart</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <figure class="bubble">
+    <figcaption class="bu-title">Market segments</figcaption>
+    <svg viewBox="0 0 290 210" role="img" aria-label="Bubble chart of market segments sized by revenue">
+      <g class="bu-grid">
+        <line x1="34" y1="20" x2="34" y2="176" />
+        <line x1="34" y1="176" x2="278" y2="176" />
+        <line x1="34" y1="98" x2="278" y2="98" stroke-dasharray="2 4" />
+        <line x1="156" y1="20" x2="156" y2="176" stroke-dasharray="2 4" />
+      </g>
+
+      <g class="bu-dots">
+        <circle class="bub a" cx="78" cy="140" r="20" />
+        <circle class="bub b" cx="128" cy="86" r="28" />
+        <circle class="bub c" cx="186" cy="118" r="15" />
+        <circle class="bub d" cx="164" cy="56" r="23" />
+        <circle class="bub e" cx="230" cy="82" r="32" />
+        <circle class="bub f" cx="96" cy="64" r="13" />
+      </g>
+
+      <g class="bu-labels">
+        <text x="78" y="144">A</text>
+        <text x="128" y="90">B</text>
+        <text x="186" y="122">C</text>
+        <text x="164" y="60">D</text>
+        <text x="230" y="86">E</text>
+        <text x="96" y="68">F</text>
+      </g>
+
+      <g class="bu-axis">
+        <text x="150" y="198">Reach &rarr;</text>
+        <text x="14" y="100" transform="rotate(-90 14 100)">Growth &rarr;</text>
+      </g>
+    </svg>
+    <figcaption class="bu-note">Bubble size = revenue</figcaption>
+  </figure>
+</body>
+</html>

--- a/submissions/examples/bubble-chart-as/style.css
+++ b/submissions/examples/bubble-chart-as/style.css
@@ -1,0 +1,82 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #151d31, #0a0e18 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e6ebf6;
+}
+
+.bubble {
+  width: min(400px, 94vw);
+  margin: 0;
+  padding: 1.4rem 1.5rem 1.1rem;
+  box-sizing: border-box;
+  background: #111a2c;
+  border: 1px solid #26314a;
+  border-radius: 16px;
+}
+
+.bu-title {
+  margin-bottom: 0.6rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.bubble svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  overflow: visible;
+}
+
+.bu-grid line {
+  stroke: #2a3550;
+  stroke-width: 1;
+}
+
+.bub {
+  fill-opacity: 0.55;
+  stroke-width: 2;
+  transition: fill-opacity 0.2s ease;
+}
+
+.bub:hover {
+  fill-opacity: 0.8;
+}
+
+.bub.a { fill: #6366f1; stroke: #818cf8; }
+.bub.b { fill: #ec4899; stroke: #f472b6; }
+.bub.c { fill: #f59e0b; stroke: #fbbf24; }
+.bub.d { fill: #10b981; stroke: #34d399; }
+.bub.e { fill: #0ea5e9; stroke: #38bdf8; }
+.bub.f { fill: #a855f7; stroke: #c084fc; }
+
+.bu-labels text {
+  fill: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  text-anchor: middle;
+}
+
+.bu-axis text {
+  fill: #7a86a2;
+  font-size: 10px;
+  text-anchor: middle;
+}
+
+.bu-note {
+  margin-top: 0.5rem;
+  font-size: 0.76rem;
+  color: #8593ad;
+  text-align: right;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bub {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a bubble chart built for #43290. Six translucent SVG bubbles sized by a third value over a gridded two axis frame, each labeled and colored, brightening on hover. Pure CSS. Closes #43290.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: six bubbles of varied radii in six distinct colors over a gridded frame with axis labels.
