### PR TITLE
feat: add terminal window

### DIFF
--- a/submissions/examples/terminal-window-as/README.md
+++ b/submissions/examples/terminal-window-as/README.md
@@ -1,0 +1,24 @@
+# Terminal Window
+
+### What does this do?
+
+It shows a terminal window with a traffic light title bar and a console session inside: colored shell prompts, typed commands, program output with success and warning colors, and a blinking cursor on the final prompt line.
+
+### How is it used?
+
+```html
+<div class="term">
+  <div class="term-bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span></div>
+  <div class="term-body">
+    <p class="line"><span class="pr">arhan@dev</span><span class="dollar">$</span> npm run build</p>
+    <p class="out ok">&#10003; built in 1.82s</p>
+    <p class="line">... <span class="cursor"></span></p>
+  </div>
+</div>
+```
+
+The title bar holds three colored dots. Inside, prompt parts (`pr`, `path`, `dollar`) and output classes (`ok`, `warn`, `muted`) color the monospace text, and a `cursor` span blinks with a keyframe.
+
+### Why is it useful?
+
+Docs, landing pages, and tutorials show commands in a terminal for a familiar developer feel. This provides a styled terminal with a prompt and a blinking cursor using only CSS, no highlighting script.

--- a/submissions/examples/terminal-window-as/demo.html
+++ b/submissions/examples/terminal-window-as/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Terminal Window</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="term">
+    <div class="term-bar">
+      <span class="dot r"></span>
+      <span class="dot y"></span>
+      <span class="dot g"></span>
+      <span class="term-title">bash &mdash; project</span>
+    </div>
+
+    <div class="term-body">
+      <p class="line"><span class="pr">arhan@dev</span><span class="sep">:</span><span class="path">~/app</span><span class="dollar">$</span> npm run build</p>
+      <p class="out">&gt; app@1.4.0 build</p>
+      <p class="out">&gt; vite build</p>
+      <p class="out muted">vite v5.2.0 building for production...</p>
+      <p class="out ok">&#10003; 214 modules transformed.</p>
+      <p class="out">dist/index.html <span class="muted">0.9 kB</span></p>
+      <p class="out">dist/assets/app.css <span class="muted">12.4 kB</span></p>
+      <p class="out ok">&#10003; built in 1.82s</p>
+      <p class="line"><span class="pr">arhan@dev</span><span class="sep">:</span><span class="path">~/app</span><span class="dollar">$</span> git status</p>
+      <p class="out warn">On branch main &mdash; nothing to commit</p>
+      <p class="line"><span class="pr">arhan@dev</span><span class="sep">:</span><span class="path">~/app</span><span class="dollar">$</span> <span class="cursor"></span></p>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/terminal-window-as/style.css
+++ b/submissions/examples/terminal-window-as/style.css
@@ -1,0 +1,93 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(160deg, #2a2140, #12101c);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.term {
+  width: min(460px, 96vw);
+  border-radius: 12px;
+  overflow: hidden;
+  background: #0c0f16;
+  box-shadow: 0 26px 55px rgba(0, 0, 0, 0.55);
+  border: 1px solid #222836;
+}
+
+.term-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0.6rem 0.9rem;
+  background: #171b24;
+  border-bottom: 1px solid #222836;
+}
+
+.dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.dot.r { background: #ff5f57; }
+.dot.y { background: #febc2e; }
+.dot.g { background: #28c840; }
+
+.term-title {
+  margin-left: auto;
+  margin-right: auto;
+  padding-right: 44px;
+  font-size: 0.78rem;
+  color: #7d8794;
+  font-family: system-ui, sans-serif;
+}
+
+.term-body {
+  padding: 1rem 1.1rem 1.2rem;
+  font-family: ui-monospace, Consolas, "Courier New", monospace;
+  font-size: 0.86rem;
+  line-height: 1.6;
+  color: #cbd3e1;
+}
+
+.term-body p {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+}
+
+.pr { color: #56d364; font-weight: 600; }
+.sep { color: #7d8794; }
+.path { color: #58a6ff; }
+.dollar { color: #cbd3e1; margin: 0 0.4rem 0 0.15rem; }
+
+.out { color: #9aa4b2; }
+.out.muted { color: #6b7280; }
+.out.ok { color: #56d364; }
+.out.warn { color: #e3b341; }
+
+.muted { color: #6b7280; }
+
+.cursor {
+  display: inline-block;
+  width: 9px;
+  height: 1.05em;
+  vertical-align: text-bottom;
+  background: #56d364;
+  animation: term-blink 1.05s step-end infinite;
+}
+
+@keyframes term-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cursor {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a terminal window built for #43293. A traffic light title bar and a monospace console with colored prompts, command output in success and warning colors, and a blinking cursor. Pure CSS. Closes #43293.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a three dot title bar, three colored prompts, success and warning output lines, and a blinking cursor.
