### PR TITLE
feat: add piano

### DIFF
--- a/submissions/examples/piano-as/README.md
+++ b/submissions/examples/piano-as/README.md
@@ -1,0 +1,22 @@
+# Piano
+
+### What does this do?
+
+It shows a piano keyboard with ten white keys and seven black keys. The black keys sit in the correct gaps above the white keys, and both press down with a shadow and color change when clicked. White keys are labeled with their note names.
+
+### How is it used?
+
+```html
+<div class="piano">
+  <div class="keys">
+    <button type="button" class="white"><span>C</span></button>
+    <button type="button" class="black" style="--i: 1;"></button>
+  </div>
+</div>
+```
+
+White keys sit in a flexbox row. Each black key is absolutely positioned with `left: calc(var(--w) * var(--i) - var(--bw) / 2)`, where `--i` is the white key index it follows, so black keys land only in the real gaps. The `:active` state presses each key.
+
+### Why is it useful?
+
+Music apps, learning tools, and sound board demos need a keyboard. This builds a correct piano layout with pure CSS positioning and press feedback, ready to attach audio.

--- a/submissions/examples/piano-as/demo.html
+++ b/submissions/examples/piano-as/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Piano</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="piano">
+    <div class="keys">
+      <button type="button" class="white"><span>C</span></button>
+      <button type="button" class="white"><span>D</span></button>
+      <button type="button" class="white"><span>E</span></button>
+      <button type="button" class="white"><span>F</span></button>
+      <button type="button" class="white"><span>G</span></button>
+      <button type="button" class="white"><span>A</span></button>
+      <button type="button" class="white"><span>B</span></button>
+      <button type="button" class="white"><span>C</span></button>
+      <button type="button" class="white"><span>D</span></button>
+      <button type="button" class="white"><span>E</span></button>
+
+      <button type="button" class="black" style="--i: 1;" aria-label="C sharp"></button>
+      <button type="button" class="black" style="--i: 2;" aria-label="D sharp"></button>
+      <button type="button" class="black" style="--i: 4;" aria-label="F sharp"></button>
+      <button type="button" class="black" style="--i: 5;" aria-label="G sharp"></button>
+      <button type="button" class="black" style="--i: 6;" aria-label="A sharp"></button>
+      <button type="button" class="black" style="--i: 8;" aria-label="C sharp"></button>
+      <button type="button" class="black" style="--i: 9;" aria-label="D sharp"></button>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/piano-as/style.css
+++ b/submissions/examples/piano-as/style.css
@@ -1,0 +1,85 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #241c30, #0d0a14 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.piano {
+  --w: 44px;
+  --bw: 28px;
+
+  padding: 16px 16px 20px;
+  background: linear-gradient(180deg, #2a2233, #17121f);
+  border-radius: 12px 12px 14px 14px;
+  box-shadow: 0 26px 55px rgba(0, 0, 0, 0.55);
+  border-top: 4px solid #3a2f47;
+}
+
+.keys {
+  position: relative;
+  display: flex;
+  height: 190px;
+}
+
+.white {
+  width: var(--w);
+  height: 100%;
+  padding: 0;
+  border: 1px solid #cfd3dc;
+  border-radius: 0 0 6px 6px;
+  background: linear-gradient(180deg, #fdfdfd 0 88%, #e9ebf0);
+  cursor: pointer;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding-bottom: 10px;
+  box-shadow: inset 0 -3px 4px rgba(0, 0, 0, 0.08);
+  transition: background 0.06s ease, transform 0.06s ease;
+}
+
+.white + .white {
+  margin-left: -1px;
+}
+
+.white span {
+  font-size: 0.72rem;
+  color: #9aa1b2;
+}
+
+.white:active {
+  background: linear-gradient(180deg, #e6e9f2 0 88%, #d3d7e2);
+  transform: translateY(1px);
+  box-shadow: inset 0 -2px 6px rgba(0, 0, 0, 0.18);
+}
+
+.black {
+  position: absolute;
+  top: 0;
+  left: calc(var(--w) * var(--i) - var(--bw) / 2);
+  width: var(--bw);
+  height: 62%;
+  border: 0;
+  border-radius: 0 0 4px 4px;
+  background: linear-gradient(180deg, #33323a 0 82%, #17161c);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.5);
+  cursor: pointer;
+  z-index: 2;
+  transition: background 0.06s ease, height 0.06s ease;
+}
+
+.black:active {
+  background: linear-gradient(180deg, #4a4954 0 82%, #26252d);
+  height: 60%;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .white,
+  .black {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a piano built for #43295. Ten white keys in a flex row with seven black keys absolutely positioned by a `--i` index into the real gaps, both with press feedback. Pure CSS. Closes #43295.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: ten labeled white keys and seven shorter black keys placed only in the correct gaps, with ascending positions.
