### PR TITLE
feat: add chess board

### DIFF
--- a/submissions/examples/chess-board-as/README.md
+++ b/submissions/examples/chess-board-as/README.md
@@ -1,0 +1,20 @@
+# Chess Board
+
+### What does this do?
+
+It shows a chess board in the starting position. An eight by eight grid alternates light and dark squares, Unicode chess pieces sit in their opening ranks, and file letters and rank numbers label the edges. White and black pieces are tinted for contrast on any square.
+
+### How is it used?
+
+```html
+<div class="board">
+  <span class="sq lt bp">&#9820;</span>
+  <span class="sq dk">&#9822;</span>
+</div>
+```
+
+The board is a `repeat(8, 1fr)` grid. Each square gets a `lt` or `dk` class for its color and holds a Unicode piece glyph, with `wp` and `bp` classes tinting white and black pieces so both read clearly on light and dark squares.
+
+### Why is it useful?
+
+Chess apps, tutorials, and puzzle sites need a board. This renders a full board and starting lineup with a pure CSS grid and Unicode pieces, no images or board engine.

--- a/submissions/examples/chess-board-as/demo.html
+++ b/submissions/examples/chess-board-as/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Chess Board</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="chess-wrap">
+    <div class="ranks"><span>8</span><span>7</span><span>6</span><span>5</span><span>4</span><span>3</span><span>2</span><span>1</span></div>
+    <div class="board" role="img" aria-label="Chess board in the starting position">
+      <span class="sq lt bp">♜</span><span class="sq dk bp">♞</span><span class="sq lt bp">♝</span><span class="sq dk bp">♛</span><span class="sq lt bp">♚</span><span class="sq dk bp">♝</span><span class="sq lt bp">♞</span><span class="sq dk bp">♜</span>
+      <span class="sq dk bp">♟</span><span class="sq lt bp">♟</span><span class="sq dk bp">♟</span><span class="sq lt bp">♟</span><span class="sq dk bp">♟</span><span class="sq lt bp">♟</span><span class="sq dk bp">♟</span><span class="sq lt bp">♟</span>
+      <span class="sq lt"></span><span class="sq dk"></span><span class="sq lt"></span><span class="sq dk"></span><span class="sq lt"></span><span class="sq dk"></span><span class="sq lt"></span><span class="sq dk"></span>
+      <span class="sq dk"></span><span class="sq lt"></span><span class="sq dk"></span><span class="sq lt"></span><span class="sq dk"></span><span class="sq lt"></span><span class="sq dk"></span><span class="sq lt"></span>
+      <span class="sq lt"></span><span class="sq dk"></span><span class="sq lt"></span><span class="sq dk"></span><span class="sq lt"></span><span class="sq dk"></span><span class="sq lt"></span><span class="sq dk"></span>
+      <span class="sq dk"></span><span class="sq lt"></span><span class="sq dk"></span><span class="sq lt"></span><span class="sq dk"></span><span class="sq lt"></span><span class="sq dk"></span><span class="sq lt"></span>
+      <span class="sq lt wp">♙</span><span class="sq dk wp">♙</span><span class="sq lt wp">♙</span><span class="sq dk wp">♙</span><span class="sq lt wp">♙</span><span class="sq dk wp">♙</span><span class="sq lt wp">♙</span><span class="sq dk wp">♙</span>
+      <span class="sq dk wp">♖</span><span class="sq lt wp">♘</span><span class="sq dk wp">♗</span><span class="sq lt wp">♕</span><span class="sq dk wp">♔</span><span class="sq lt wp">♗</span><span class="sq dk wp">♘</span><span class="sq lt wp">♖</span>
+    </div>
+    <div class="files"><span>a</span><span>b</span><span>c</span><span>d</span><span>e</span><span>f</span><span>g</span><span>h</span></div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/chess-board-as/style.css
+++ b/submissions/examples/chess-board-as/style.css
@@ -1,0 +1,73 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #1e2433, #0b0e15 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #9aa6bf;
+}
+
+.chess-wrap {
+  display: grid;
+  grid-template-columns: 18px auto;
+  grid-template-rows: auto 18px;
+  gap: 4px;
+}
+
+.board {
+  grid-column: 2;
+  grid-row: 1;
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  grid-template-rows: repeat(8, 1fr);
+  width: min(384px, 84vw);
+  aspect-ratio: 1;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.55);
+}
+
+.sq {
+  display: grid;
+  place-items: center;
+  font-size: min(9vw, 40px);
+  line-height: 1;
+  user-select: none;
+}
+
+.sq.lt { background: #ebecd0; }
+.sq.dk { background: #6f9f57; }
+
+.sq.wp {
+  color: #f7f8fb;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.55);
+}
+
+.sq.bp {
+  color: #1c1f26;
+  text-shadow: 0 1px 1px rgba(255, 255, 255, 0.25);
+}
+
+.ranks,
+.files {
+  display: grid;
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+
+.ranks {
+  grid-column: 1;
+  grid-row: 1;
+  grid-template-rows: repeat(8, 1fr);
+  place-items: center;
+}
+
+.files {
+  grid-column: 2;
+  grid-row: 2;
+  grid-template-columns: repeat(8, 1fr);
+  place-items: center;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a chess board built for #43300. An 8 by 8 CSS grid of alternating squares with all 32 Unicode pieces in the starting position, tinted for contrast, plus rank and file labels. Pure CSS. Closes #43300.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: 64 squares (32 light, 32 dark), 32 pieces in the starting position, and file and rank labels.
