### PR TITLE
feat: add postage stamp

### DIFF
--- a/submissions/examples/stamp-as/README.md
+++ b/submissions/examples/stamp-as/README.md
@@ -1,0 +1,22 @@
+# Postage Stamp
+
+### What does this do?
+
+It shows a postage stamp with the classic perforated edge, a small illustrated scene inside its frame, a country name and denomination, and a tilted circular postmark. The perforations are punched entirely with a CSS mask, so the whole stamp is drawn with no images.
+
+### How is it used?
+
+```html
+<div class="stamp">
+  <div class="stamp-inner">
+    <div class="scene">...</div>
+    <div class="stamp-meta"><span class="country">HELVETIA</span><span class="value">85</span></div>
+  </div>
+</div>
+```
+
+The `stamp` uses a tiled `radial-gradient` mask to cut a grid of holes; the inset `stamp-inner` panel covers the interior holes so only the perforated border remains. Inside, CSS shapes build the scene and a `postmark` circle sits on top.
+
+### Why is it useful?
+
+Philately apps, travel themes, and playful UIs use a stamp motif. This delivers a full stamp with a real perforated edge and postmark using only CSS masks and shapes, no images.

--- a/submissions/examples/stamp-as/demo.html
+++ b/submissions/examples/stamp-as/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Postage Stamp</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="stamp-scene">
+    <div class="stamp">
+      <div class="stamp-inner">
+        <div class="scene">
+          <span class="sun"></span>
+          <span class="mtn one"></span>
+          <span class="mtn two"></span>
+          <span class="ground"></span>
+        </div>
+        <div class="stamp-meta">
+          <span class="country">HELVETIA</span>
+          <span class="value">85</span>
+        </div>
+        <span class="postmark">
+          <b>POSTED</b>
+          <em>2026</em>
+        </span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/stamp-as/style.css
+++ b/submissions/examples/stamp-as/style.css
@@ -1,0 +1,143 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: repeating-linear-gradient(45deg, #b9c3d6 0 22px, #aeb9cd 22px 44px);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.stamp-scene {
+  filter: drop-shadow(0 12px 20px rgba(0, 0, 0, 0.35));
+}
+
+.stamp {
+  position: relative;
+  width: 208px;
+  height: 248px;
+}
+
+.stamp::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: #f7f4ea;
+  -webkit-mask: radial-gradient(circle 6px at 8px 8px, #0000 96%, #000) -8px -8px / 16px 16px;
+  mask: radial-gradient(circle 6px at 8px 8px, #0000 96%, #000) -8px -8px / 16px 16px;
+}
+
+.stamp-inner {
+  position: relative;
+  z-index: 1;
+  margin: 12px;
+  height: calc(100% - 24px);
+  box-sizing: border-box;
+  padding: 12px;
+  border: 1px solid #cbb46a;
+  background: #fbf9f2;
+  display: grid;
+  grid-template-rows: 1fr auto;
+  overflow: hidden;
+}
+
+.scene {
+  position: relative;
+  border-radius: 4px;
+  overflow: hidden;
+  background: linear-gradient(180deg, #8fd0e8 0 62%, #cfeaf2 62% 100%);
+}
+
+.sun {
+  position: absolute;
+  top: 16%;
+  right: 18%;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #ffe9a8, #ffcf5c);
+  box-shadow: 0 0 22px rgba(255, 207, 92, 0.8);
+}
+
+.mtn {
+  position: absolute;
+  bottom: 34%;
+  width: 0;
+  height: 0;
+  border-style: solid;
+}
+
+.mtn.one {
+  left: 8%;
+  border-width: 0 60px 74px 60px;
+  border-color: transparent transparent #4f7a53 transparent;
+}
+
+.mtn.two {
+  right: 6%;
+  border-width: 0 46px 56px 46px;
+  border-color: transparent transparent #6a9b6f transparent;
+}
+
+.ground {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 38%;
+  background: linear-gradient(180deg, #7bb07f, #558a5a);
+}
+
+.stamp-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 8px;
+}
+
+.country {
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  color: #4a4030;
+}
+
+.value {
+  display: grid;
+  place-items: center;
+  min-width: 30px;
+  height: 30px;
+  padding: 0 6px;
+  border-radius: 6px;
+  background: #b23a48;
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 800;
+}
+
+.postmark {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  display: grid;
+  place-items: center;
+  width: 58px;
+  height: 58px;
+  border-radius: 50%;
+  border: 2px solid rgba(40, 40, 60, 0.5);
+  color: rgba(40, 40, 60, 0.6);
+  transform: rotate(-14deg);
+  line-height: 1;
+}
+
+.postmark b {
+  font-size: 0.5rem;
+  letter-spacing: 0.1em;
+}
+
+.postmark em {
+  font-style: normal;
+  font-size: 0.62rem;
+  font-weight: 700;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a postage stamp built for #43304. A perforated edge punched with a CSS mask on a background layer, an illustrated scene, country and denomination, and a tilted postmark. Pure CSS. Closes #43304.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a stamp with perforations only around the border, an inner mountain scene, a HELVETIA 85 denomination, and a postmark.
