### PR TITLE
feat: add keyboard layout

### DIFF
--- a/submissions/examples/keyboard-layout-as/README.md
+++ b/submissions/examples/keyboard-layout-as/README.md
@@ -1,0 +1,20 @@
+# Keyboard Layout
+
+### What does this do?
+
+It shows a full QWERTY keyboard: a number row, three letter rows with the correct staggered modifier keys, and a bottom row with a wide space bar. Every key is a keycap that presses down when clicked, and modifier keys are wider and dimmed.
+
+### How is it used?
+
+```html
+<div class="keyboard">
+  <div class="krow"><kbd>Q</kbd><kbd>W</kbd><kbd class="w15 dim">\</kbd></div>
+  <div class="krow"><kbd class="dim">Alt</kbd><kbd class="space">Space</kbd></div>
+</div>
+```
+
+Keys are `kbd` elements sized from a single `--u` unit, so the whole board scales together. Width classes like `w15` and `w22` set the wider modifier and Enter keys, and the space bar flexes to fill its row. The `:active` state presses each cap.
+
+### Why is it useful?
+
+Typing tutors, shortcut guides, and settings screens show a keyboard. This builds a full, scalable QWERTY layout with press feedback using only CSS, no images.

--- a/submissions/examples/keyboard-layout-as/demo.html
+++ b/submissions/examples/keyboard-layout-as/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Keyboard Layout</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="keyboard">
+    <div class="krow">
+      <kbd>~</kbd><kbd>1</kbd><kbd>2</kbd><kbd>3</kbd><kbd>4</kbd><kbd>5</kbd><kbd>6</kbd><kbd>7</kbd><kbd>8</kbd><kbd>9</kbd><kbd>0</kbd><kbd>-</kbd><kbd>=</kbd><kbd class="w2 dim">Bksp</kbd>
+    </div>
+    <div class="krow">
+      <kbd class="w15 dim">Tab</kbd><kbd>Q</kbd><kbd>W</kbd><kbd>E</kbd><kbd>R</kbd><kbd>T</kbd><kbd>Y</kbd><kbd>U</kbd><kbd>I</kbd><kbd>O</kbd><kbd>P</kbd><kbd>[</kbd><kbd>]</kbd><kbd class="w15 dim">\</kbd>
+    </div>
+    <div class="krow">
+      <kbd class="w18 dim">Caps</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd><kbd>F</kbd><kbd>G</kbd><kbd>H</kbd><kbd>J</kbd><kbd>K</kbd><kbd>L</kbd><kbd>;</kbd><kbd>'</kbd><kbd class="w22 dim accent">Enter</kbd>
+    </div>
+    <div class="krow">
+      <kbd class="w24 dim">Shift</kbd><kbd>Z</kbd><kbd>X</kbd><kbd>C</kbd><kbd>V</kbd><kbd>B</kbd><kbd>N</kbd><kbd>M</kbd><kbd>,</kbd><kbd>.</kbd><kbd>/</kbd><kbd class="w28 dim">Shift</kbd>
+    </div>
+    <div class="krow">
+      <kbd class="w15 dim">Ctrl</kbd><kbd class="dim">Alt</kbd><kbd class="space">Space</kbd><kbd class="dim">Alt</kbd><kbd class="w15 dim">Ctrl</kbd>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/keyboard-layout-as/style.css
+++ b/submissions/examples/keyboard-layout-as/style.css
@@ -1,0 +1,81 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #1c2130, #0a0d14 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.keyboard {
+  --u: clamp(20px, 5.4vw, 40px);
+
+  display: grid;
+  gap: 6px;
+  padding: 14px;
+  background: linear-gradient(160deg, #262b38, #171a23);
+  border-radius: 12px;
+  box-shadow:
+    0 26px 55px rgba(0, 0, 0, 0.55),
+    inset 0 2px 3px rgba(255, 255, 255, 0.06);
+}
+
+.krow {
+  display: flex;
+  gap: 6px;
+}
+
+kbd {
+  display: grid;
+  place-items: center;
+  width: var(--u);
+  height: var(--u);
+  font-family: inherit;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: #e7ecf6;
+  background: linear-gradient(180deg, #3b4252, #2b3140);
+  border-radius: 6px;
+  box-shadow:
+    0 2px 0 #1c2029,
+    inset 0 1px 1px rgba(255, 255, 255, 0.12);
+  cursor: pointer;
+  transition: transform 0.05s ease, box-shadow 0.05s ease;
+  user-select: none;
+}
+
+kbd.dim {
+  background: linear-gradient(180deg, #2d3341, #232836);
+  color: #aeb6c6;
+  font-size: 0.64rem;
+}
+
+kbd.accent {
+  background: linear-gradient(180deg, #4f6bd6, #3b52c0);
+  color: #fff;
+}
+
+kbd:active {
+  transform: translateY(2px);
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.4);
+}
+
+.w15 { width: calc(var(--u) * 1.5 + 3px); }
+.w18 { width: calc(var(--u) * 1.8 + 4px); }
+.w2 { width: calc(var(--u) * 2 + 6px); }
+.w22 { width: calc(var(--u) * 2.2 + 8px); }
+.w24 { width: calc(var(--u) * 2.4 + 8px); }
+.w28 { width: calc(var(--u) * 2.8 + 12px); }
+
+.space {
+  flex: 1;
+  min-width: calc(var(--u) * 6);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  kbd {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a keyboard layout built for #43317. A full QWERTY board sized from a single `--u` unit, with staggered modifier keys, a blue Enter, a wide space bar, and press feedback. Pure CSS. Closes #43317.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: five rows totaling 58 keys with a full QWERTY layout and a wide space bar.
