### PR TITLE
feat: add AriaButton component for command palette

### DIFF
--- a/submissions/react/fixed-42240-intermediate/AriaButton.jsx
+++ b/submissions/react/fixed-42240-intermediate/AriaButton.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+const AriaButton = ({ onClick, children, ariaLabel, className, style, ...props }) => {
+  const label = ariaLabel || children || 'Button';
+  return (
+    <button 
+      onClick={onClick}
+      aria-label={label}
+      className={`ease-hover-lift ${className || ''}`}
+      style={{ padding: '8px 16px', borderRadius: '4px', border: 'none', cursor: 'pointer', transition: 'all 0.2s ease', ...style }}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+};
+export default AriaButton;

--- a/submissions/react/fixed-42240-intermediate/README.md
+++ b/submissions/react/fixed-42240-intermediate/README.md
@@ -1,0 +1,7 @@
+# AriaButton - Fixed Version
+## Related Issue
+Fixes #42240
+## Labels
+- `level:intermediate`
+- `type:accessibility`
+- `gssoc:approved`

--- a/submissions/react/fixed-42240-intermediate/style.css
+++ b/submissions/react/fixed-42240-intermediate/style.css
@@ -1,0 +1,2 @@
+.ease-hover-lift { transition: transform 0.2s ease, box-shadow 0.2s ease; }
+.ease-hover-lift:hover { transform: translateY(-2px); box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15); }


### PR DESCRIPTION
## New Component: AriaButton with ARIA Labels

### Description
This PR adds a fixed version of buttons with proper ARIA labels for accessibility in the Command Palette component.

### Changes
- Created `AriaButton.jsx` with aria-label support
- Added `style.css` with hover animation
- Added README.md documenting the fix

### Related Issue
Fixes #42240

### Labels
- `level:intermediate`
- `type:accessibility`
- `gssoc:approved`

## Type of Change
- [x] New component

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR