### PR TITLE
feat: add radial bar chart

### DIFF
--- a/submissions/examples/radial-bar-chart-as/README.md
+++ b/submissions/examples/radial-bar-chart-as/README.md
@@ -1,0 +1,19 @@
+# Radial Bar Chart
+
+### What does this do?
+
+It shows a radial bar chart, sometimes called a racetrack chart. Each metric is a concentric ring that fills clockwise to its own percentage over a faint track, with a two column legend naming each ring and its value.
+
+### How is it used?
+
+```html
+<svg viewBox="0 0 200 200">
+  <circle class="a" cx="100" cy="100" r="76" pathLength="100" style="--v: 82;" />
+</svg>
+```
+
+Each bar is an SVG `circle` with `pathLength="100"`, so `stroke-dasharray: calc(var(--v) * 1) 100` fills it to that percentage. The whole SVG is rotated so the rings start at the top, and rounded caps give the bars a soft end.
+
+### Why is it useful?
+
+Radial bar charts compare several progress values in a compact circular form, common on fitness and dashboard cards. This renders one from inline SVG rings driven by a single custom property each, with no charting library.

--- a/submissions/examples/radial-bar-chart-as/demo.html
+++ b/submissions/examples/radial-bar-chart-as/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Radial Bar Chart</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <figure class="radial">
+    <figcaption class="rb-title">Goal progress</figcaption>
+    <svg viewBox="0 0 200 200" role="img" aria-label="Radial bar chart of four goals">
+      <g class="rb-track">
+        <circle cx="100" cy="100" r="76" />
+        <circle cx="100" cy="100" r="60" />
+        <circle cx="100" cy="100" r="44" />
+        <circle cx="100" cy="100" r="28" />
+      </g>
+      <g class="rb-bars">
+        <circle class="a" cx="100" cy="100" r="76" pathLength="100" style="--v: 82;" />
+        <circle class="b" cx="100" cy="100" r="60" pathLength="100" style="--v: 64;" />
+        <circle class="c" cx="100" cy="100" r="44" pathLength="100" style="--v: 45;" />
+        <circle class="d" cx="100" cy="100" r="28" pathLength="100" style="--v: 30;" />
+      </g>
+    </svg>
+    <figcaption class="rb-legend">
+      <span class="a">Steps <b>82%</b></span>
+      <span class="b">Water <b>64%</b></span>
+      <span class="c">Sleep <b>45%</b></span>
+      <span class="d">Focus <b>30%</b></span>
+    </figcaption>
+  </figure>
+</body>
+</html>

--- a/submissions/examples/radial-bar-chart-as/style.css
+++ b/submissions/examples/radial-bar-chart-as/style.css
@@ -1,0 +1,93 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #171f33, #090c14 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e6ebf6;
+}
+
+.radial {
+  width: min(320px, 92vw);
+  margin: 0;
+  padding: 1.4rem 1.4rem 1.1rem;
+  box-sizing: border-box;
+  background: #111a2c;
+  border: 1px solid #26314a;
+  border-radius: 18px;
+  text-align: center;
+}
+
+.rb-title {
+  margin-bottom: 0.4rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.radial svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  transform: rotate(-90deg);
+}
+
+.rb-track circle {
+  fill: none;
+  stroke: #212c44;
+  stroke-width: 12;
+}
+
+.rb-bars circle {
+  fill: none;
+  stroke-width: 12;
+  stroke-linecap: round;
+  stroke-dasharray: calc(var(--v) * 1) 100;
+  transition: stroke-dasharray 0.6s ease;
+}
+
+.rb-bars .a { stroke: #6366f1; }
+.rb-bars .b { stroke: #22d3ee; }
+.rb-bars .c { stroke: #f59e0b; }
+.rb-bars .d { stroke: #f472b6; }
+
+.rb-legend {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem 1rem;
+  margin-top: 0.9rem;
+  font-size: 0.8rem;
+  color: #aab4c8;
+}
+
+.rb-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.rb-legend span::before {
+  content: "";
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+}
+
+.rb-legend b {
+  margin-left: auto;
+  color: #e6ebf6;
+  font-variant-numeric: tabular-nums;
+}
+
+.rb-legend .a::before { background: #6366f1; }
+.rb-legend .b::before { background: #22d3ee; }
+.rb-legend .c::before { background: #f59e0b; }
+.rb-legend .d::before { background: #f472b6; }
+
+@media (prefers-reduced-motion: reduce) {
+  .rb-bars circle {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a radial bar chart built for #43368. Four concentric SVG rings filling to a `--v` percentage over faint tracks with rounded caps, plus a legend. Pure CSS. Closes #43368.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: four concentric rings filling to 82, 64, 45, and 30 percent over tracks with a two column legend.
