### PR TITLE
feat: add lollipop chart

### DIFF
--- a/submissions/examples/lollipop-chart-as/README.md
+++ b/submissions/examples/lollipop-chart-as/README.md
@@ -1,0 +1,21 @@
+# Lollipop Chart
+
+### What does this do?
+
+It shows a lollipop chart, a lighter take on the bar chart where each value is a thin stem topped by a round dot. Six categories rise to different heights set by a `--h` custom property, each with its value above the dot and a label below.
+
+### How is it used?
+
+```html
+<div class="lp-col" style="--h: 82%;">
+  <span class="lp-val">4.9k</span>
+  <span class="lp-stem"></span>
+  <span class="lp-dot"></span>
+</div>
+```
+
+Each column sets its height with `--h`. The `lp-stem` grows from the baseline to that height, the `lp-dot` sits at the top with `bottom: var(--h)`, and the value label floats just above, so one property positions the whole lollipop.
+
+### Why is it useful?
+
+Lollipop charts reduce the ink of full bars while keeping the comparison clear, good for rankings and category counts. This renders one with pure CSS from a single height custom property per column, no charting library.

--- a/submissions/examples/lollipop-chart-as/demo.html
+++ b/submissions/examples/lollipop-chart-as/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Lollipop Chart</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <figure class="lollipop">
+    <figcaption class="lp-title">Downloads by platform</figcaption>
+    <div class="lp-plot">
+      <div class="lp-col" style="--h: 82%;"><span class="lp-val">4.9k</span><span class="lp-stem"></span><span class="lp-dot"></span></div>
+      <div class="lp-col" style="--h: 64%;"><span class="lp-val">3.8k</span><span class="lp-stem"></span><span class="lp-dot"></span></div>
+      <div class="lp-col" style="--h: 48%;"><span class="lp-val">2.9k</span><span class="lp-stem"></span><span class="lp-dot"></span></div>
+      <div class="lp-col" style="--h: 71%;"><span class="lp-val">4.2k</span><span class="lp-stem"></span><span class="lp-dot"></span></div>
+      <div class="lp-col" style="--h: 35%;"><span class="lp-val">2.1k</span><span class="lp-stem"></span><span class="lp-dot"></span></div>
+      <div class="lp-col" style="--h: 22%;"><span class="lp-val">1.3k</span><span class="lp-stem"></span><span class="lp-dot"></span></div>
+    </div>
+    <div class="lp-x">
+      <span>iOS</span><span>Android</span><span>Web</span><span>Mac</span><span>Win</span><span>Linux</span>
+    </div>
+  </figure>
+</body>
+</html>

--- a/submissions/examples/lollipop-chart-as/style.css
+++ b/submissions/examples/lollipop-chart-as/style.css
@@ -1,0 +1,83 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #141d30, #090c14 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e6ebf6;
+}
+
+.lollipop {
+  width: min(420px, 95vw);
+  margin: 0;
+  padding: 1.5rem 1.6rem 1.3rem;
+  box-sizing: border-box;
+  background: #111a2c;
+  border: 1px solid #26314a;
+  border-radius: 16px;
+}
+
+.lp-title {
+  margin-bottom: 1.2rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.lp-plot {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  align-items: end;
+  height: 200px;
+  border-bottom: 2px solid #26314a;
+}
+
+.lp-col {
+  position: relative;
+  height: 100%;
+}
+
+.lp-stem {
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  width: 3px;
+  height: var(--h, 40%);
+  transform: translateX(-50%);
+  background: linear-gradient(180deg, #6366f1, #312e81);
+  border-radius: 2px;
+}
+
+.lp-dot {
+  position: absolute;
+  left: 50%;
+  bottom: var(--h, 40%);
+  width: 18px;
+  height: 18px;
+  transform: translate(-50%, 50%);
+  border-radius: 50%;
+  background: radial-gradient(circle at 38% 32%, #a5b4fc, #4f46e5 70%);
+  box-shadow: 0 0 12px rgba(99, 102, 241, 0.5);
+}
+
+.lp-val {
+  position: absolute;
+  left: 50%;
+  bottom: calc(var(--h, 40%) + 16px);
+  transform: translateX(-50%);
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #c7d0e4;
+  white-space: nowrap;
+}
+
+.lp-x {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  margin-top: 0.6rem;
+  font-size: 0.72rem;
+  color: #8593ad;
+  text-align: center;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a lollipop chart built for #43373. Six thin stems topped by dots at value heights set by a `--h` custom property, with value and category labels. Pure CSS. Closes #43373.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: six lollipops at different heights with value labels above the dots and category labels below.
