### PR TITLE
feat: add venn diagram

### DIFF
--- a/submissions/examples/venn-diagram-as/README.md
+++ b/submissions/examples/venn-diagram-as/README.md
@@ -1,0 +1,22 @@
+# Venn Diagram
+
+### What does this do?
+
+It shows a three circle Venn diagram. The circles overlap in the classic arrangement and blend where they meet, so the pairwise and central intersections show as brighter regions. Labels name each set and the center sweet spot.
+
+### How is it used?
+
+```html
+<div class="vn-stage">
+  <span class="circle a"></span>
+  <span class="circle b"></span>
+  <span class="circle c"></span>
+  <span class="label center">Unicorn</span>
+</div>
+```
+
+Each `circle` is a translucent disc positioned to overlap the others, with `mix-blend-mode: screen` so overlapping areas add up to lighter colors on the dark stage. Labels sit above the circles with a higher `z-index`.
+
+### Why is it useful?
+
+Venn diagrams explain overlap between sets, common in skills, audiences, and feature comparisons. This builds one purely with CSS circles and blend modes, with no images or SVG.

--- a/submissions/examples/venn-diagram-as/demo.html
+++ b/submissions/examples/venn-diagram-as/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Venn Diagram</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <figure class="venn">
+    <figcaption class="vn-title">The sweet spot</figcaption>
+    <div class="vn-stage">
+      <span class="circle a"></span>
+      <span class="circle b"></span>
+      <span class="circle c"></span>
+
+      <span class="label la">Design</span>
+      <span class="label lb">Code</span>
+      <span class="label lc">Product</span>
+      <span class="label center">Unicorn</span>
+    </div>
+  </figure>
+</body>
+</html>

--- a/submissions/examples/venn-diagram-as/style.css
+++ b/submissions/examples/venn-diagram-as/style.css
@@ -1,0 +1,83 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #10141f, #05070c 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #eef2fb;
+}
+
+.venn {
+  margin: 0;
+  padding: 1.4rem 1.6rem 1.6rem;
+  background: #0b0e16;
+  border: 1px solid #1e2434;
+  border-radius: 18px;
+  text-align: center;
+}
+
+.vn-title {
+  margin-bottom: 1rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.vn-stage {
+  position: relative;
+  width: 280px;
+  height: 260px;
+  margin: 0 auto;
+}
+
+.circle {
+  position: absolute;
+  width: 160px;
+  height: 160px;
+  border-radius: 50%;
+  mix-blend-mode: screen;
+  filter: blur(0.2px);
+}
+
+.circle.a {
+  top: 6px;
+  left: 60px;
+  background: #6d28d9;
+}
+
+.circle.b {
+  bottom: 10px;
+  left: 12px;
+  background: #0e7490;
+}
+
+.circle.c {
+  bottom: 10px;
+  right: 12px;
+  background: #b45309;
+}
+
+.label {
+  position: absolute;
+  font-size: 0.82rem;
+  font-weight: 700;
+  z-index: 2;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.7);
+}
+
+.la { top: 44px; left: 50%; transform: translateX(-50%); color: #d6bcfa; }
+.lb { bottom: 58px; left: 40px; color: #7dd3e8; }
+.lc { bottom: 58px; right: 40px; color: #fbbf77; }
+
+.center {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 0.86rem;
+  color: #fff;
+  padding: 3px 8px;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.35);
+}


### PR DESCRIPTION
## Pull Request Description

Adds a Venn diagram built for #43376. Three translucent circles overlapping with screen blend so intersections brighten, with set and center labels. Pure CSS. Closes #43376.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: three overlapping circles with screen blend intersections and labels including a center sweet spot.
