### PR TITLE
feat: add pyramid chart

### DIFF
--- a/submissions/examples/pyramid-chart-as/README.md
+++ b/submissions/examples/pyramid-chart-as/README.md
@@ -1,0 +1,20 @@
+# Pyramid Chart
+
+### What does this do?
+
+It shows a pyramid chart of hierarchy levels. Stacked trapezoid bands widen toward the base, each a named level in its own color, next to a legend giving the share of each level. It reads as a classic learning or hierarchy pyramid.
+
+### How is it used?
+
+```html
+<div class="py-stack">
+  <span class="py-level l1">Create</span>
+  <span class="py-level l5">Remember</span>
+</div>
+```
+
+Each level sets its width with a `--w` custom property, from a narrow apex to a full width base, and a `clip-path` angles the sides so the bands read as trapezoids. The stack centers the bands so they form a symmetric pyramid.
+
+### Why is it useful?
+
+Pyramid charts show layered hierarchies and proportions from top to bottom, common in learning models, org levels, and needs hierarchies. This renders one with pure CSS widths and clip paths, no charting library.

--- a/submissions/examples/pyramid-chart-as/demo.html
+++ b/submissions/examples/pyramid-chart-as/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pyramid Chart</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <figure class="pyramid">
+    <figcaption class="py-title">Learning pyramid</figcaption>
+    <div class="py-body">
+      <div class="py-stack">
+        <span class="py-level l1">Create</span>
+        <span class="py-level l2">Evaluate</span>
+        <span class="py-level l3">Analyze</span>
+        <span class="py-level l4">Apply</span>
+        <span class="py-level l5">Remember</span>
+      </div>
+      <ul class="py-legend">
+        <li><i class="l1"></i>Create <b>5%</b></li>
+        <li><i class="l2"></i>Evaluate <b>12%</b></li>
+        <li><i class="l3"></i>Analyze <b>20%</b></li>
+        <li><i class="l4"></i>Apply <b>28%</b></li>
+        <li><i class="l5"></i>Remember <b>35%</b></li>
+      </ul>
+    </div>
+  </figure>
+</body>
+</html>

--- a/submissions/examples/pyramid-chart-as/style.css
+++ b/submissions/examples/pyramid-chart-as/style.css
@@ -1,0 +1,88 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #1b1330, #0a0713 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #ece7f7;
+}
+
+.pyramid {
+  width: min(420px, 95vw);
+  margin: 0;
+  padding: 1.4rem 1.5rem 1.4rem;
+  box-sizing: border-box;
+  background: #150f28;
+  border: 1px solid #2f2450;
+  border-radius: 16px;
+}
+
+.py-title {
+  margin-bottom: 1rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.py-body {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 1.2rem;
+  align-items: center;
+}
+
+.py-stack {
+  display: grid;
+  gap: 4px;
+  width: 210px;
+  justify-items: center;
+}
+
+.py-level {
+  display: grid;
+  place-items: center;
+  width: var(--w, 100%);
+  height: 38px;
+  font-size: 0.76rem;
+  font-weight: 700;
+  color: #fff;
+  clip-path: polygon(8% 0, 92% 0, 100% 100%, 0 100%);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+}
+
+.l1 { background: #f43f5e; --w: 40%; }
+.l2 { background: #f97316; --w: 55%; }
+.l3 { background: #eab308; --w: 70%; }
+.l4 { background: #22c55e; --w: 85%; }
+.l5 { background: #6366f1; --w: 100%; }
+
+.py-legend {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.55rem;
+  font-size: 0.8rem;
+  color: #cbc3e0;
+}
+
+.py-legend li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.py-legend i {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.py-legend b {
+  margin-left: auto;
+  color: #fff;
+  font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pyramid chart built for #43379. Stacked trapezoid bands widening to the base, each sized by a `--w` custom property and clipped to angle its sides, with a legend. Pure CSS. Closes #43379.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: five trapezoid bands widening from 84 to 210 px with labels and a percentage legend.
