### PR TITLE
feat: add marimekko chart

### DIFF
--- a/submissions/examples/marimekko-chart-as/README.md
+++ b/submissions/examples/marimekko-chart-as/README.md
@@ -1,0 +1,21 @@
+# Marimekko Chart
+
+### What does this do?
+
+It shows a Marimekko (Mekko) chart: a set of stacked bars where each column has a different width for one dimension and stacks to full height for another. Here the column widths show each region's share of revenue and the stacked segments show the tier mix within each region, with axis labels and a legend.
+
+### How is it used?
+
+```html
+<div class="mk-col" style="--w: 34;">
+  <span class="seg a" style="--h: 50%;">50</span>
+  <span class="seg b" style="--h: 30%;">30</span>
+  <span class="seg c" style="--h: 20%;">20</span>
+</div>
+```
+
+Each column takes its width from `flex: var(--w) 0 0`, so wider columns represent larger regions, and each segment takes `height: var(--h)` to fill the column to 100 percent. The x labels share the same `--w` so they line up under their columns.
+
+### Why is it useful?
+
+Marimekko charts encode two proportions at once, showing both segment size and category share, common in market and revenue analysis. This renders one purely with flexbox from width and height custom properties, no charting library.

--- a/submissions/examples/marimekko-chart-as/demo.html
+++ b/submissions/examples/marimekko-chart-as/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Marimekko Chart</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <figure class="mekko">
+    <figcaption class="mk-title">Revenue by region and tier</figcaption>
+    <div class="mk-plot">
+      <div class="mk-col" style="--w: 34;">
+        <span class="seg a" style="--h: 50%;">50</span>
+        <span class="seg b" style="--h: 30%;">30</span>
+        <span class="seg c" style="--h: 20%;">20</span>
+      </div>
+      <div class="mk-col" style="--w: 26;">
+        <span class="seg a" style="--h: 40%;">40</span>
+        <span class="seg b" style="--h: 35%;">35</span>
+        <span class="seg c" style="--h: 25%;">25</span>
+      </div>
+      <div class="mk-col" style="--w: 22;">
+        <span class="seg a" style="--h: 30%;">30</span>
+        <span class="seg b" style="--h: 45%;">45</span>
+        <span class="seg c" style="--h: 25%;">25</span>
+      </div>
+      <div class="mk-col" style="--w: 18;">
+        <span class="seg a" style="--h: 25%;">25</span>
+        <span class="seg b" style="--h: 30%;">30</span>
+        <span class="seg c" style="--h: 45%;">45</span>
+      </div>
+    </div>
+    <div class="mk-x">
+      <span style="--w: 34;">NA</span>
+      <span style="--w: 26;">EU</span>
+      <span style="--w: 22;">APAC</span>
+      <span style="--w: 18;">LATAM</span>
+    </div>
+    <figcaption class="mk-legend">
+      <span class="a">Enterprise</span>
+      <span class="b">Team</span>
+      <span class="c">Free</span>
+    </figcaption>
+  </figure>
+</body>
+</html>

--- a/submissions/examples/marimekko-chart-as/style.css
+++ b/submissions/examples/marimekko-chart-as/style.css
@@ -1,0 +1,93 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #101a2e, #080b12 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e6ebf6;
+}
+
+.mekko {
+  width: min(430px, 95vw);
+  margin: 0;
+  padding: 1.5rem 1.6rem 1.4rem;
+  box-sizing: border-box;
+  background: #111a2c;
+  border: 1px solid #263149;
+  border-radius: 16px;
+}
+
+.mk-title {
+  margin-bottom: 1.1rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.mk-plot {
+  display: flex;
+  gap: 4px;
+  height: 210px;
+}
+
+.mk-col {
+  flex: var(--w) 0 0;
+  display: flex;
+  flex-direction: column;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.seg {
+  display: grid;
+  place-items: center;
+  height: var(--h);
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #0b1020;
+}
+
+.seg.a { background: #6366f1; color: #fff; }
+.seg.b { background: #22d3ee; }
+.seg.c { background: #f59e0b; }
+
+.mk-x {
+  display: flex;
+  gap: 4px;
+  margin-top: 0.5rem;
+  font-size: 0.74rem;
+  color: #8593ad;
+}
+
+.mk-x span {
+  flex: var(--w) 0 0;
+  text-align: center;
+}
+
+.mk-legend {
+  display: flex;
+  justify-content: center;
+  gap: 1.3rem;
+  margin-top: 1rem;
+  font-size: 0.8rem;
+  color: #aab4c8;
+}
+
+.mk-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.mk-legend span::before {
+  content: "";
+  width: 11px;
+  height: 11px;
+  border-radius: 3px;
+}
+
+.mk-legend .a::before { background: #6366f1; }
+.mk-legend .b::before { background: #22d3ee; }
+.mk-legend .c::before { background: #f59e0b; }


### PR DESCRIPTION
## Pull Request Description

Adds a Marimekko chart built for #43381. Variable width columns from `flex: var(--w)` each stacked to 100 percent by `--h` segments, with aligned axis labels and a legend. Pure CSS. Closes #43381.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: four columns of decreasing width (124 to 66 px) each stacked to full height with three labeled segments and aligned axis labels.
