### PR TITLE
feat: add gradient dropdown component

### DIFF
--- a/submissions/examples/gradient-dropdown/README.md
+++ b/submissions/examples/gradient-dropdown/README.md
@@ -1,0 +1,37 @@
+# Gradient Dropdown (`ease-dropdown--gradient`)
+
+An animated gradient-bordered dropdown, built with **pure CSS** — no JavaScript required.
+
+## Files
+
+- `demo.html` — standalone live demo
+- `style.css` — the component
+
+## How it works
+
+- **No JS**: uses the native `<details>` / `<summary>` elements for open/close state, focus handling, and keyboard support (`Enter` / `Space` toggles, `Tab` moves through items) — all built into the browser for free.
+- **Animated gradient border**: `summary` has a shifting gradient background (`background-size: 300% 300%` + `ease-gradient-shift` keyframes moving `background-position`). An inset pseudo-element (`::before`) sits on top with a solid fill, leaving only a thin gradient "ring" visible.
+- **Looping animation control**: the gradient shimmer duration/looping follows `--ease-animation-duration` and `--ease-animation-iterations`, consistent with how EaseMotion's other looping utilities (`ease-bounce`, `ease-pulse`, etc.) expose iteration count.
+- **Menu entrance**: `.ease-dropdown__menu` fades and slides in via `ease-dropdown-open` when `[open]` is applied by the browser to `<details>`.
+- **Accessibility**:
+  - Fully keyboard operable natively (no `tabindex` hacks needed on the trigger).
+  - `role="menu"` / `role="menuitem"` on the panel and items for screen readers.
+  - Respects `prefers-reduced-motion`: disables the gradient shimmer and open transition.
+  - Focus states styled via `:focus-visible` on items.
+
+## Customization
+
+\`\`\`css
+.ease-dropdown--gradient {
+  --ease-dropdown-gradient: linear-gradient(115deg, #7f5af0, #2cb1bc, #ff6ac1, #7f5af0);
+  --ease-dropdown-bg: #14151c;
+  --ease-animation-duration: 6s;
+  --ease-animation-iterations: infinite;
+}
+\`\`\`
+
+Swap `--ease-dropdown-gradient` for any gradient to retheme instantly.
+
+## Naming
+
+Uses the `ease-` prefix (`ease-dropdown--gradient`, `ease-dropdown__menu`, `ease-dropdown__item`, `ease-gradient-shift` keyframe) to match EaseMotion CSS conventions per the issue requirements.

--- a/submissions/examples/gradient-dropdown/demo.html
+++ b/submissions/examples/gradient-dropdown/demo.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Gradient Dropdown — Demo</title>
+<link rel="stylesheet" href="style.css" />
+<style>
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #0b0d12;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, sans-serif;
+    padding: 2rem;
+  }
+  .demo-wrap {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.5rem;
+  }
+  .demo-wrap h1 {
+    color: #f2f2f7;
+    font-size: 1.4rem;
+    margin: 0;
+  }
+  .demo-wrap p {
+    color: rgba(242, 242, 247, 0.6);
+    font-size: 0.9rem;
+    margin: 0;
+    text-align: center;
+    max-width: 320px;
+  }
+</style>
+</head>
+<body>
+
+<div class="demo-wrap">
+  <h1>🎨 Gradient Dropdown</h1>
+  <p>Pure CSS, no JavaScript. Click or press Enter/Space (focus + keyboard works out of the box via &lt;details&gt;).</p>
+
+  <details class="ease-dropdown--gradient">
+    <summary aria-haspopup="true">
+      <span>Select a plan</span>
+      <span class="ease-dropdown__caret" aria-hidden="true"></span>
+    </summary>
+    <div class="ease-dropdown__menu" role="menu">
+      <div class="ease-dropdown__item" role="menuitem" tabindex="0">
+        <div>
+          <div>Starter</div>
+          <div class="ease-dropdown__item-desc">Free forever</div>
+        </div>
+      </div>
+      <div class="ease-dropdown__item" role="menuitem" tabindex="0">
+        <div>
+          <div>Pro</div>
+          <div class="ease-dropdown__item-desc">$12 / month</div>
+        </div>
+      </div>
+      <div class="ease-dropdown__item" role="menuitem" tabindex="0">
+        <div>
+          <div>Team</div>
+          <div class="ease-dropdown__item-desc">$29 / month</div>
+        </div>
+      </div>
+    </div>
+  </details>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/gradient-dropdown/style.css
+++ b/submissions/examples/gradient-dropdown/style.css
@@ -1,0 +1,165 @@
+/* ==========================================================================
+   ease-dropdown--gradient
+   Animated gradient dropdown, built pure CSS (no JS) using native
+   <details>/<summary> for accessibility and keyboard support.
+   Submission for: EaseMotion CSS
+   ========================================================================== */
+
+.ease-dropdown--gradient {
+  --ease-dropdown-radius: 14px;
+  --ease-dropdown-gradient: linear-gradient(
+    115deg,
+    #7f5af0,
+    #2cb1bc,
+    #ff6ac1,
+    #7f5af0
+  );
+  --ease-dropdown-bg: #14151c;
+  --ease-dropdown-menu-bg: #1b1d27;
+  --ease-dropdown-text: #f2f2f7;
+  --ease-dropdown-muted: rgba(242, 242, 247, 0.65);
+  --ease-dropdown-border-width: 2px;
+  --ease-animation-duration: 6s;
+  --ease-animation-iterations: infinite;
+  --ease-transition-speed: 260ms;
+  --ease-transition-ease: cubic-bezier(0.22, 1, 0.36, 1);
+
+  position: relative;
+  width: min(320px, 100%);
+  font-family: inherit;
+  color: var(--ease-dropdown-text);
+}
+
+.ease-dropdown--gradient > summary {
+  list-style: none;
+  cursor: pointer;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.85rem 1.1rem;
+  border-radius: var(--ease-dropdown-radius);
+  background: var(--ease-dropdown-bg);
+  font-weight: 600;
+  font-size: 0.95rem;
+
+  background-image: var(--ease-dropdown-gradient);
+  background-size: 300% 300%;
+  animation: ease-gradient-shift var(--ease-animation-duration) linear
+    var(--ease-animation-iterations);
+}
+
+.ease-dropdown--gradient > summary::before {
+  content: "";
+  position: absolute;
+  inset: var(--ease-dropdown-border-width);
+  border-radius: calc(var(--ease-dropdown-radius) - var(--ease-dropdown-border-width));
+  background: var(--ease-dropdown-bg);
+  z-index: 0;
+}
+
+.ease-dropdown--gradient > summary > * {
+  position: relative;
+  z-index: 1;
+}
+
+.ease-dropdown--gradient > summary::-webkit-details-marker {
+  display: none;
+}
+
+.ease-dropdown__caret {
+  position: relative;
+  z-index: 1;
+  width: 10px;
+  height: 10px;
+  border-right: 2px solid var(--ease-dropdown-text);
+  border-bottom: 2px solid var(--ease-dropdown-text);
+  transform: rotate(45deg);
+  transition: transform var(--ease-transition-speed) var(--ease-transition-ease);
+}
+
+.ease-dropdown--gradient[open] .ease-dropdown__caret {
+  transform: rotate(-135deg);
+}
+
+.ease-dropdown__menu {
+  margin-top: 0.6rem;
+  padding: 0.4rem;
+  border-radius: var(--ease-dropdown-radius);
+  background: var(--ease-dropdown-menu-bg);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+
+  animation: ease-dropdown-open var(--ease-transition-speed) var(--ease-transition-ease);
+}
+
+.ease-dropdown__item {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: calc(var(--ease-dropdown-radius) - 6px);
+  font-size: 0.9rem;
+  color: var(--ease-dropdown-text);
+  text-decoration: none;
+  cursor: pointer;
+  transition: background var(--ease-transition-speed) var(--ease-transition-ease),
+    transform var(--ease-transition-speed) var(--ease-transition-ease),
+    padding-left var(--ease-transition-speed) var(--ease-transition-ease);
+}
+
+.ease-dropdown__item:hover,
+.ease-dropdown__item:focus-visible {
+  background: linear-gradient(
+    90deg,
+    rgba(127, 90, 240, 0.25),
+    rgba(44, 177, 188, 0.15)
+  );
+  padding-left: 1rem;
+  outline: none;
+}
+
+.ease-dropdown__item-desc {
+  color: var(--ease-dropdown-muted);
+  font-size: 0.78rem;
+}
+
+@keyframes ease-gradient-shift {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+@keyframes ease-dropdown-open {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-dropdown--gradient > summary {
+    animation: none;
+    background-image: var(--ease-dropdown-gradient);
+    background-position: 0% 50%;
+  }
+  .ease-dropdown__menu {
+    animation: none;
+  }
+  .ease-dropdown__caret,
+  .ease-dropdown__item {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds an animated **Gradient Dropdown** component (`ease-dropdown--gradient`) inspired by neumorphism, as requested in the feature issue. Built entirely with **pure CSS** — no JavaScript required.

Closes #41696

## What's included

- Animated shifting gradient border/ring around the dropdown trigger
- Smooth fade + slide-in animation for the menu panel on open
- Fully keyboard accessible — built on native `<details>`/`<summary>`, so focus, `Enter`/`Space` toggling, and tab order all work out of the box without JS
- `role="menu"` / `role="menuitem"` for screen reader support
- Respects `prefers-reduced-motion` (disables shimmer + transition animations)
- Fully responsive, no fixed pixel widths beyond a max container size

## Implementation details

- **Gradient border**: `background-size: 300% 300%` combined with an `ease-gradient-shift` keyframe animating `background-position`, with an inset `::before` pseudo-element masking the center so only a gradient ring is visible.
- **Looping animation control**: shimmer speed/looping is driven by `--ease-animation-duration` and `--ease-animation-iterations`, matching the convention used by other looping EaseMotion utilities (`ease-bounce`, `ease-pulse`, etc.).
- **Menu open transition**: `ease-dropdown-open` keyframe fires automatically when the browser applies `[open]` to `<details>` — no JS state management needed.
- Naming follows the `ease-` prefix convention (`ease-dropdown--gradient`, `ease-dropdown__menu`, `ease-dropdown__item`).

## Changes
submissions/examples/gradient-dropdown-<your-suffix>/
├── demo.html
├── style.css
└── README.md

No core files, workflows, or configs modified — self-contained submission only.

## Checklist

- [x] Uses EaseMotion CSS naming conventions (`ease-*`)
- [x] Works without JavaScript (pure CSS)
- [x] Includes a live demo in `demo.html`
- [x] Includes `README.md`
- [x] Responsive
- [x] Accessible (keyboard navigable, ARIA roles, reduced-motion support)
- [x] No core files modified