### PR TITLE
feat: add atom

### DIFF
--- a/submissions/examples/atom-as/README.md
+++ b/submissions/examples/atom-as/README.md
@@ -1,0 +1,19 @@
+# Atom
+
+### What does this do?
+
+It shows an atom with a glowing nucleus and three electrons that orbit along elliptical paths tilted at different angles. Each electron follows its own ellipse at its own speed and color, over faint orbit rings. Under reduced motion the electrons hold still.
+
+### How is it used?
+
+```html
+<span class="ring o2"></span>
+<span class="orbit o2"><span class="electron"></span></span>
+<span class="nucleus"></span>
+```
+
+Each orbit ring is a rotated ellipse, and its electron follows the same ellipse using CSS motion paths: `offset-path` traces the ellipse and `offset-distance` animates from 0 to 100 percent. Rotating the orbit and ring together tilts each path.
+
+### Why is it useful?
+
+Science themes, loaders, and hero graphics use an orbiting atom. This builds one with CSS motion paths so electrons truly follow elliptical orbits, with no images or script and a reduced motion fallback.

--- a/submissions/examples/atom-as/demo.html
+++ b/submissions/examples/atom-as/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Atom</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="atom" role="img" aria-label="Atom with three orbiting electrons">
+    <span class="ring o1"></span>
+    <span class="ring o2"></span>
+    <span class="ring o3"></span>
+
+    <span class="orbit o1"><span class="electron"></span></span>
+    <span class="orbit o2"><span class="electron"></span></span>
+    <span class="orbit o3"><span class="electron"></span></span>
+
+    <span class="nucleus"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/atom-as/style.css
+++ b/submissions/examples/atom-as/style.css
@@ -1,0 +1,86 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 40%, #101a2e, #05070d 65%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.atom {
+  position: relative;
+  width: 200px;
+  height: 200px;
+}
+
+.ring {
+  position: absolute;
+  top: 56px;
+  left: 4px;
+  width: 192px;
+  height: 88px;
+  box-sizing: border-box;
+  border: 2px solid rgba(96, 165, 250, 0.4);
+  border-radius: 50%;
+}
+
+.ring.o1 { transform: rotate(0deg); }
+.ring.o2 { transform: rotate(60deg); }
+.ring.o3 { transform: rotate(120deg); }
+
+.orbit {
+  position: absolute;
+  inset: 0;
+}
+
+.orbit.o1 { transform: rotate(0deg); }
+.orbit.o2 { transform: rotate(60deg); }
+.orbit.o3 { transform: rotate(120deg); }
+
+.electron {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  margin: -7px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 38% 32%, #bae6fd, #0ea5e9 70%);
+  box-shadow: 0 0 10px rgba(56, 189, 248, 0.9);
+  offset-path: path("M 4 100 A 96 44 0 1 0 196 100 A 96 44 0 1 0 4 100");
+  animation: orbit-move 3s linear infinite;
+}
+
+.orbit.o2 .electron {
+  animation-duration: 3.8s;
+  background: radial-gradient(circle at 38% 32%, #ddd6fe, #8b5cf6 70%);
+  box-shadow: 0 0 10px rgba(139, 92, 246, 0.9);
+}
+
+.orbit.o3 .electron {
+  animation-duration: 4.6s;
+  background: radial-gradient(circle at 38% 32%, #fbcfe8, #ec4899 70%);
+  box-shadow: 0 0 10px rgba(236, 72, 153, 0.9);
+}
+
+.nucleus {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 34px;
+  height: 34px;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  background: radial-gradient(circle at 38% 32%, #fde68a, #f97316 70%);
+  box-shadow: 0 0 26px rgba(249, 115, 22, 0.85);
+}
+
+@keyframes orbit-move {
+  to { offset-distance: 100%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .electron {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an atom built for #43397. A glowing nucleus with three electrons following tilted elliptical orbits via CSS motion paths, over faint rings, with a reduced motion fallback. Pure CSS. Closes #43397.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a nucleus with three tilted elliptical orbits and three colored electrons riding their offset-path ellipses.
