### PR TITLE
feat: add remote control

### DIFF
--- a/submissions/examples/remote-control-as/README.md
+++ b/submissions/examples/remote-control-as/README.md
@@ -1,0 +1,21 @@
+# Remote Control
+
+### What does this do?
+
+It shows a TV remote with a power button, a source key, a circular navigation D pad with an OK center, volume and channel rockers, a number pad, and the four colored function buttons. Every key presses in when clicked.
+
+### How is it used?
+
+```html
+<div class="rc-dpad">
+  <button class="dp up"></button>
+  <button class="dp ok">OK</button>
+</div>
+<div class="rc-nums"><button>1</button>...</div>
+```
+
+The D pad arrows are CSS triangles placed around a round pad with a raised OK center. The number pad is a three column grid, the rockers stack plus and minus keys, and the color strip uses four flex buttons. A shared `:active` rule gives every button press feedback.
+
+### Why is it useful?
+
+Smart TV apps, device controls, and settings mockups show a remote. This builds a full remote with a D pad, keypad, and rockers using only CSS, no images, with press feedback.

--- a/submissions/examples/remote-control-as/demo.html
+++ b/submissions/examples/remote-control-as/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Remote Control</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="remote">
+    <div class="rc-top">
+      <button type="button" class="rc-power" aria-label="Power"></button>
+      <button type="button" class="rc-src">SRC</button>
+    </div>
+
+    <div class="rc-dpad">
+      <button type="button" class="dp up" aria-label="Up"></button>
+      <button type="button" class="dp down" aria-label="Down"></button>
+      <button type="button" class="dp left" aria-label="Left"></button>
+      <button type="button" class="dp right" aria-label="Right"></button>
+      <button type="button" class="dp ok">OK</button>
+    </div>
+
+    <div class="rc-rockers">
+      <div class="rocker">
+        <button type="button" aria-label="Volume up">+</button>
+        <span>VOL</span>
+        <button type="button" aria-label="Volume down">&minus;</button>
+      </div>
+      <div class="rocker">
+        <button type="button" aria-label="Channel up">+</button>
+        <span>CH</span>
+        <button type="button" aria-label="Channel down">&minus;</button>
+      </div>
+    </div>
+
+    <div class="rc-nums">
+      <button type="button">1</button><button type="button">2</button><button type="button">3</button>
+      <button type="button">4</button><button type="button">5</button><button type="button">6</button>
+      <button type="button">7</button><button type="button">8</button><button type="button">9</button>
+      <button type="button" class="fn">&#9776;</button><button type="button">0</button><button type="button" class="fn">&#8617;</button>
+    </div>
+
+    <div class="rc-color">
+      <button type="button" class="c red" aria-label="Red"></button>
+      <button type="button" class="c green" aria-label="Green"></button>
+      <button type="button" class="c yellow" aria-label="Yellow"></button>
+      <button type="button" class="c blue" aria-label="Blue"></button>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/remote-control-as/style.css
+++ b/submissions/examples/remote-control-as/style.css
@@ -1,0 +1,165 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #1a1e28, #0a0c11 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.remote {
+  width: 168px;
+  padding: 16px 16px 20px;
+  box-sizing: border-box;
+  display: grid;
+  gap: 14px;
+  background: linear-gradient(160deg, #2c313d, #171a22);
+  border-radius: 26px;
+  box-shadow:
+    0 26px 55px rgba(0, 0, 0, 0.55),
+    inset 0 2px 4px rgba(255, 255, 255, 0.08);
+}
+
+.remote button {
+  border: 0;
+  cursor: pointer;
+  font-family: inherit;
+  color: #dce1ec;
+  transition: transform 0.06s ease, filter 0.15s ease;
+}
+
+.remote button:active {
+  transform: scale(0.92);
+  filter: brightness(1.2);
+}
+
+.rc-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.rc-power {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 38% 32%, #ff8a8a, #d61f2f 70%);
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.4);
+}
+
+.rc-src {
+  padding: 0.4rem 0.7rem;
+  border-radius: 8px;
+  background: #3a4150;
+  font-size: 0.66rem;
+  font-weight: 700;
+}
+
+.rc-dpad {
+  position: relative;
+  width: 116px;
+  height: 116px;
+  margin: 0 auto;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 40%, #3a4150, #262b36);
+  box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.5);
+}
+
+.dp {
+  position: absolute;
+  background: transparent;
+  color: #8b93a4;
+}
+
+.dp.up { top: 8px; left: 50%; transform: translateX(-50%); border-left: 7px solid transparent; border-right: 7px solid transparent; border-bottom: 9px solid #aeb6c6; width: 0; height: 0; }
+.dp.down { bottom: 8px; left: 50%; transform: translateX(-50%); border-left: 7px solid transparent; border-right: 7px solid transparent; border-top: 9px solid #aeb6c6; width: 0; height: 0; }
+.dp.left { left: 8px; top: 50%; transform: translateY(-50%); border-top: 7px solid transparent; border-bottom: 7px solid transparent; border-right: 9px solid #aeb6c6; width: 0; height: 0; }
+.dp.right { right: 8px; top: 50%; transform: translateY(-50%); border-top: 7px solid transparent; border-bottom: 7px solid transparent; border-left: 9px solid #aeb6c6; width: 0; height: 0; }
+
+.dp.ok {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  background: linear-gradient(180deg, #4f6bd6, #3b52c0);
+  color: #fff;
+  font-size: 0.8rem;
+  font-weight: 800;
+}
+
+.rc-rockers {
+  display: flex;
+  gap: 10px;
+}
+
+.rocker {
+  flex: 1;
+  display: grid;
+  justify-items: center;
+  gap: 2px;
+  padding: 6px 0;
+  border-radius: 20px;
+  background: #232833;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.4);
+}
+
+.rocker button {
+  width: 30px;
+  height: 26px;
+  border-radius: 8px;
+  background: #3a4150;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.rocker span {
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: #7f8698;
+}
+
+.rc-nums {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+
+.rc-nums button {
+  height: 34px;
+  border-radius: 9px;
+  background: linear-gradient(180deg, #333a48, #262b36);
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+.rc-nums .fn {
+  color: #9aa2b4;
+}
+
+.rc-color {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.c {
+  flex: 1;
+  height: 10px;
+  border-radius: 5px;
+}
+
+.c.red { background: #ef4444; }
+.c.green { background: #22c55e; }
+.c.yellow { background: #eab308; }
+.c.blue { background: #3b82f6; }
+
+@media (prefers-reduced-motion: reduce) {
+  .remote button {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a remote control built for #43405. A power button, a D pad with OK, volume and channel rockers, a number pad, and colored buttons, all with press feedback. Pure CSS. Closes #43405.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a remote with a power button, a D pad with OK, volume and channel rockers, a twelve key number pad, and four color buttons.
