### PR TITLE
ease-animate-playground-sp

### DIFF
--- a/submissions/react/ease-animate-playground-sp/AnimatePlayground.jsx
+++ b/submissions/react/ease-animate-playground-sp/AnimatePlayground.jsx
@@ -1,0 +1,386 @@
+import React, { useState, useMemo, useCallback } from 'react';
+import './style.css';
+
+/**
+ * Animate — React wrapper for EaseMotion CSS animations.
+ * Maps declarative props to ease-* utility classes.
+ *
+ * Props:
+ *   type      — animation name (fade-in, slide-up, zoom-in, bounce, spin…)
+ *   duration  — 'fast' | 'medium' | 'slow' | number (ms)
+ *   delay     — delay in ms
+ *   hover     — hover effect (grow, lift, glow, shimmer…)
+ *   tag       — HTML element tag (default: 'div')
+ *   className — additional CSS classes
+ */
+export function Animate({
+  type,
+  duration = 'medium',
+  delay = 0,
+  hover,
+  tag: Tag = 'div',
+  className = '',
+  style = {},
+  children,
+  ...props
+}) {
+  const classes = [];
+
+  if (type) {
+    const animClass = type === 'spin' ? 'ease-rotate' : `ease-${type}`;
+    classes.push(animClass);
+  }
+
+  if (duration === 'fast' || duration === 'medium' || duration === 'slow') {
+    classes.push(`ease-duration-${duration}`);
+  }
+
+  if (hover) {
+    classes.push(`ease-hover-${hover}`);
+  }
+
+  if (className) {
+    classes.push(className);
+  }
+
+  const inlineStyle = { ...style };
+
+  if (delay > 0) {
+    inlineStyle.animationDelay = `${delay}ms`;
+  }
+
+  if (typeof duration === 'number') {
+    inlineStyle.animationDuration = `${duration}ms`;
+  }
+
+  return (
+    <Tag className={classes.filter(Boolean).join(' ')} style={inlineStyle} {...props}>
+      {children}
+    </Tag>
+  );
+}
+
+/* ── Playground configuration ─────────────────────────────── */
+
+const ANIMATION_TYPES = [
+  { value: 'fade-in', label: 'Fade In' },
+  { value: 'slide-up', label: 'Slide Up' },
+  { value: 'slide-down', label: 'Slide Down' },
+  { value: 'slide-in-left', label: 'Slide Left' },
+  { value: 'slide-in-right', label: 'Slide Right' },
+  { value: 'zoom-in', label: 'Zoom In' },
+  { value: 'zoom-out', label: 'Zoom Out' },
+  { value: 'bounce', label: 'Bounce' },
+  { value: 'spin', label: 'Spin' },
+  { value: 'pulse', label: 'Pulse' },
+  { value: 'shake', label: 'Shake' },
+];
+
+const DURATION_OPTIONS = [
+  { value: 'fast', label: 'fast (150ms)' },
+  { value: 'medium', label: 'medium (300ms)' },
+  { value: 'slow', label: 'slow (600ms)' },
+  { value: 'custom', label: 'custom (ms)' },
+];
+
+const HOVER_OPTIONS = [
+  { value: '', label: 'None' },
+  { value: 'grow', label: 'grow' },
+  { value: 'lift', label: 'lift' },
+  { value: 'glow', label: 'glow' },
+  { value: 'shimmer', label: 'shimmer' },
+  { value: 'scale', label: 'scale' },
+];
+
+const TAG_OPTIONS = ['div', 'section', 'article', 'span', 'button'];
+
+const PRESETS = [
+  {
+    name: 'Hero entrance',
+    type: 'fade-in',
+    duration: 'medium',
+    delay: 0,
+    hover: '',
+    tag: 'div',
+    className: '',
+  },
+  {
+    name: 'Staggered card',
+    type: 'slide-up',
+    duration: 'medium',
+    delay: 200,
+    hover: 'lift',
+    tag: 'div',
+    className: 'ease-card',
+  },
+  {
+    name: 'CTA button',
+    type: 'zoom-in',
+    duration: 'fast',
+    delay: 300,
+    hover: 'grow',
+    tag: 'button',
+    className: 'ease-btn ease-btn-primary',
+  },
+  {
+    name: 'Attention shake',
+    type: 'shake',
+    duration: 'slow',
+    delay: 0,
+    hover: '',
+    tag: 'div',
+    className: '',
+  },
+];
+
+const PROPS_REFERENCE = [
+  { prop: 'type', type: 'string', def: '—', desc: "Animation name (e.g. 'fade-in', 'slide-up', 'zoom-in')" },
+  { prop: 'duration', type: "'fast' | 'medium' | 'slow' | number", def: "'medium'", desc: 'Duration keyword or milliseconds' },
+  { prop: 'delay', type: 'number', def: '0', desc: 'Delay in ms before animation starts' },
+  { prop: 'hover', type: 'string', def: '—', desc: "Hover effect (e.g. 'lift', 'glow', 'grow')" },
+  { prop: 'tag', type: 'string', def: "'div'", desc: 'HTML tag to render' },
+  { prop: 'className', type: 'string', def: "''", desc: 'Additional CSS classes' },
+];
+
+function buildJsx({ type, duration, delay, hover, tag, className, customDuration }) {
+  const props = [];
+  if (type) props.push(`type="${type}"`);
+  if (duration === 'custom' && customDuration) {
+    props.push(`duration={${customDuration}}`);
+  } else if (duration && duration !== 'medium') {
+    props.push(`duration="${duration}"`);
+  }
+  if (delay > 0) props.push(`delay={${delay}}`);
+  if (hover) props.push(`hover="${hover}"`);
+  if (tag && tag !== 'div') props.push(`tag="${tag}"`);
+  if (className) props.push(`className="${className}"`);
+
+  const propsStr = props.length ? ' ' + props.join(' ') : '';
+  return `<Animate${propsStr}>\n  Your content here\n</Animate>`;
+}
+
+/**
+ * AnimatePlayground — interactive props explorer for the Animate wrapper.
+ */
+export default function AnimatePlayground() {
+  const [type, setType] = useState('fade-in');
+  const [duration, setDuration] = useState('medium');
+  const [customDuration, setCustomDuration] = useState(400);
+  const [delay, setDelay] = useState(0);
+  const [hover, setHover] = useState('');
+  const [tag, setTag] = useState('div');
+  const [className, setClassName] = useState('ap-preview-card');
+  const [previewKey, setPreviewKey] = useState(0);
+  const [copyStatus, setCopyStatus] = useState('');
+
+  const resolvedDuration = duration === 'custom' ? customDuration : duration;
+
+  const jsxOutput = useMemo(
+    () => buildJsx({ type, duration, delay, hover, tag, className, customDuration }),
+    [type, duration, delay, hover, tag, className, customDuration]
+  );
+
+  const applyPreset = useCallback((preset) => {
+    setType(preset.type);
+    setDuration(preset.duration);
+    setDelay(preset.delay);
+    setHover(preset.hover);
+    setTag(preset.tag);
+    setClassName(preset.className || 'ap-preview-card');
+    setPreviewKey((k) => k + 1);
+  }, []);
+
+  const replay = useCallback(() => {
+    setPreviewKey((k) => k + 1);
+  }, []);
+
+  const copyJsx = useCallback(() => {
+    navigator.clipboard.writeText(jsxOutput).then(
+      () => setCopyStatus('JSX copied to clipboard!'),
+      () => setCopyStatus('Copy failed — select manually.')
+    );
+  }, [jsxOutput]);
+
+  return (
+    <div className="ap-root">
+      <header className="ap-header ease-fade-in">
+        <p className="ap-eyebrow">EaseMotion CSS · React Integration</p>
+        <h1>&lt;Animate&gt; Props Playground</h1>
+        <p className="ap-subtitle">
+          Adjust props live and watch the animation update. Copy the generated JSX
+          into your own React project.
+        </p>
+      </header>
+
+      <div className="ap-layout">
+        {/* ── Controls ─────────────────────────────────── */}
+        <aside className="ap-panel" aria-label="Animate props controls">
+          <h2 className="ap-panel-title">Props</h2>
+
+          <div className="ap-control">
+            <label htmlFor="ap-type">type</label>
+            <select id="ap-type" value={type} onChange={(e) => setType(e.target.value)}>
+              {ANIMATION_TYPES.map((a) => (
+                <option key={a.value} value={a.value}>{a.label}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="ap-control">
+            <label htmlFor="ap-duration">duration</label>
+            <select
+              id="ap-duration"
+              value={duration}
+              onChange={(e) => setDuration(e.target.value)}
+            >
+              {DURATION_OPTIONS.map((d) => (
+                <option key={d.value} value={d.value}>{d.label}</option>
+              ))}
+            </select>
+          </div>
+
+          {duration === 'custom' && (
+            <div className="ap-control">
+              <label htmlFor="ap-custom-dur">
+                custom ms
+                <span className="ap-value">{customDuration}ms</span>
+              </label>
+              <input
+                id="ap-custom-dur"
+                type="range"
+                min="100"
+                max="2000"
+                step="50"
+                value={customDuration}
+                onChange={(e) => setCustomDuration(Number(e.target.value))}
+              />
+            </div>
+          )}
+
+          <div className="ap-control">
+            <label htmlFor="ap-delay">
+              delay (ms)
+              <span className="ap-value">{delay}ms</span>
+            </label>
+            <input
+              id="ap-delay"
+              type="range"
+              min="0"
+              max="1000"
+              step="50"
+              value={delay}
+              onChange={(e) => setDelay(Number(e.target.value))}
+            />
+          </div>
+
+          <div className="ap-control">
+            <label htmlFor="ap-hover">hover</label>
+            <select id="ap-hover" value={hover} onChange={(e) => setHover(e.target.value)}>
+              {HOVER_OPTIONS.map((h) => (
+                <option key={h.value} value={h.value}>{h.label}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="ap-control">
+            <label htmlFor="ap-tag">tag</label>
+            <select id="ap-tag" value={tag} onChange={(e) => setTag(e.target.value)}>
+              {TAG_OPTIONS.map((t) => (
+                <option key={t} value={t}>{t}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="ap-control">
+            <label htmlFor="ap-class">className</label>
+            <input
+              id="ap-class"
+              type="text"
+              className="ap-text-input"
+              value={className}
+              onChange={(e) => setClassName(e.target.value)}
+              placeholder="ease-card"
+            />
+          </div>
+
+          <section className="ap-presets">
+            <h3 className="ap-group-title">Presets</h3>
+            <div className="ap-preset-list">
+              {PRESETS.map((p) => (
+                <button
+                  key={p.name}
+                  type="button"
+                  className="ap-preset"
+                  onClick={() => applyPreset(p)}
+                >
+                  {p.name}
+                </button>
+              ))}
+            </div>
+          </section>
+
+          <button type="button" className="ap-btn-replay" onClick={replay}>
+            ↺ Replay animation
+          </button>
+        </aside>
+
+        {/* ── Preview + output ─────────────────────────── */}
+        <section className="ap-preview-area">
+          <article className="ap-preview-card-wrap">
+            <h2 className="ap-section-title">Live preview</h2>
+            <div className="ap-stage">
+              <Animate
+                key={previewKey}
+                type={type}
+                duration={resolvedDuration}
+                delay={delay}
+                hover={hover || undefined}
+                tag={tag}
+                className={className}
+              >
+                {tag === 'button' ? 'Get Started →' : 'Animate me'}
+              </Animate>
+            </div>
+          </article>
+
+          <article className="ap-jsx-output">
+            <div className="ap-jsx-header">
+              <h2 className="ap-section-title">Generated JSX</h2>
+              <button type="button" className="ease-btn ease-btn-primary ease-btn-sm" onClick={copyJsx}>
+                Copy JSX
+              </button>
+            </div>
+            <pre className="ap-pre"><code>{jsxOutput}</code></pre>
+            <p className="ap-status" role="status" aria-live="polite">{copyStatus}</p>
+          </article>
+
+          <article className="ap-props-table-wrap">
+            <h2 className="ap-section-title">Props reference</h2>
+            <div className="ap-table-scroll">
+              <table className="ap-table">
+                <thead>
+                  <tr>
+                    <th>Prop</th>
+                    <th>Type</th>
+                    <th>Default</th>
+                    <th>Description</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {PROPS_REFERENCE.map((row) => (
+                    <tr key={row.prop}>
+                      <td><code>{row.prop}</code></td>
+                      <td><code>{row.type}</code></td>
+                      <td><code>{row.def}</code></td>
+                      <td>{row.desc}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </article>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/submissions/react/ease-animate-playground-sp/README.md
+++ b/submissions/react/ease-animate-playground-sp/README.md
@@ -1,0 +1,159 @@
+# EaseMotion React `<Animate>` Props Playground
+
+An interactive React component submission that lets developers **experiment with all `<Animate>` wrapper props visually** — type, duration, delay, hover, tag, and className — with live preview and copy-ready JSX output.
+
+> Submission track: `submissions/react/ease-animate-playground-sp/`  
+> Contributor suffix: `sp`  
+> Resolves: Issue #43350
+
+---
+
+## What does this do?
+
+EaseMotion CSS ships a React `<Animate>` wrapper pattern in `examples/react-vite/`. This submission provides:
+
+1. A production-ready **`Animate` component** that maps props to `ease-*` classes
+2. An interactive **`AnimatePlayground`** UI to explore every prop combination
+3. **Copy-ready JSX** for pasting into your own React projects
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `AnimatePlayground.jsx` | `Animate` wrapper + interactive playground (default export) |
+| `style.css` | Playground layout styles |
+| `README.md` | This document |
+
+---
+
+## Installation
+
+```bash
+npm install easemotion-css
+```
+
+Copy `AnimatePlayground.jsx` and `style.css` into your React project.
+
+In your entry file:
+
+```jsx
+import 'easemotion-css/easemotion.min.css';
+import './style.css'; /* playground styles, optional */
+```
+
+---
+
+## Usage
+
+### Use the playground component directly
+
+```jsx
+import AnimatePlayground from './AnimatePlayground';
+
+function App() {
+  return <AnimatePlayground />;
+}
+```
+
+### Use only the Animate wrapper
+
+```jsx
+import { Animate } from './AnimatePlayground';
+
+function Hero() {
+  return (
+    <Animate type="fade-in" delay={200} hover="grow">
+      <div className="ease-card">Hello World</div>
+    </Animate>
+  );
+}
+```
+
+### Staggered list (from README pattern)
+
+```jsx
+{['A', 'B', 'C'].map((item, i) => (
+  <Animate key={item} type="slide-up" delay={i * 100} hover="lift">
+    <div className="ease-card">{item}</div>
+  </Animate>
+))}
+```
+
+### Re-mount to replay animation
+
+```jsx
+<Animate key={isOpen ? 'open' : 'closed'} type="zoom-in" duration={300}>
+  {isOpen && <Modal />}
+</Animate>
+```
+
+---
+
+## Props reference
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `type` | `string` | — | Animation name (`fade-in`, `slide-up`, `zoom-in`, `bounce`, `spin`…) |
+| `duration` | `'fast' \| 'medium' \| 'slow' \| number` | `'medium'` | Duration keyword or custom ms |
+| `delay` | `number` | `0` | Delay in ms before animation starts |
+| `hover` | `string` | — | Hover effect (`grow`, `lift`, `glow`, `shimmer`) |
+| `tag` | `string` | `'div'` | HTML element to render |
+| `className` | `string` | `''` | Additional CSS classes |
+
+### Animation type mapping
+
+| `type` prop | EaseMotion class |
+|-------------|------------------|
+| `fade-in` | `ease-fade-in` |
+| `slide-up` | `ease-slide-up` |
+| `zoom-in` | `ease-zoom-in` |
+| `bounce` | `ease-bounce` |
+| `spin` | `ease-rotate` |
+| `pulse` | `ease-pulse` |
+| `shake` | `ease-shake` |
+
+---
+
+## Playground features
+
+- Interactive controls for all 6 props
+- 4 quick presets (Hero, Staggered card, CTA button, Attention shake)
+- Live animation preview with replay button
+- Generated JSX with copy-to-clipboard
+- Built-in props reference table
+
+---
+
+## Try with Vite (quick start)
+
+```bash
+npm create vite@latest my-app -- --template react
+cd my-app
+npm install easemotion-css
+```
+
+Replace `src/App.jsx` content:
+
+```jsx
+import 'easemotion-css/easemotion.min.css';
+import AnimatePlayground from './AnimatePlayground';
+import './style.css';
+
+export default function App() {
+  return <AnimatePlayground />;
+}
+```
+
+Copy `AnimatePlayground.jsx` and `style.css` into `src/`, then:
+
+```bash
+npm run dev
+```
+
+---
+
+## Compliance notes
+
+- Only **new files** inside `submissions/react/`.
+- Uses official `easemotion-css` package — no core edits.
+- Folder name carries unique contributor suffix `-sp`.

--- a/submissions/react/ease-animate-playground-sp/style.css
+++ b/submissions/react/ease-animate-playground-sp/style.css
@@ -1,0 +1,321 @@
+/* ============================================================
+   EaseMotion <Animate> Props Playground — style.css
+   submissions/react/ease-animate-playground-sp
+   ============================================================ */
+
+.ap-root {
+  min-height: 100vh;
+  background:
+    radial-gradient(
+      900px 400px at 15% -5%,
+      var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.1)),
+      transparent
+    ),
+    var(--ease-color-bg, #f8fafc);
+  font-family: var(--ease-font-sans, 'Inter', system-ui, sans-serif);
+}
+
+/* ── Header ─────────────────────────────────────────────────── */
+
+.ap-header {
+  max-width: 64rem;
+  margin: 0 auto;
+  padding: var(--ease-space-10, 2.5rem) var(--ease-space-6, 1.5rem)
+    var(--ease-space-6, 1.5rem);
+  text-align: center;
+}
+
+.ap-eyebrow {
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ease-color-primary, #6c63ff);
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.ap-header h1 {
+  font-size: var(--ease-text-3xl, 1.875rem);
+  margin-bottom: var(--ease-space-3, 0.75rem);
+}
+
+.ap-subtitle {
+  max-width: 40rem;
+  margin: 0 auto;
+  color: var(--ease-color-muted, #475569);
+  font-size: var(--ease-text-sm, 0.875rem);
+}
+
+/* ── Layout ─────────────────────────────────────────────────── */
+
+.ap-layout {
+  display: grid;
+  grid-template-columns: 18rem 1fr;
+  gap: var(--ease-space-6, 1.5rem);
+  max-width: 64rem;
+  margin: 0 auto;
+  padding: 0 var(--ease-space-6, 1.5rem) var(--ease-space-12, 3rem);
+  align-items: start;
+}
+
+/* ── Control panel ──────────────────────────────────────────── */
+
+.ap-panel {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  box-shadow: var(--ease-shadow-md);
+  padding: var(--ease-space-5, 1.25rem);
+  position: sticky;
+  top: var(--ease-space-4, 1rem);
+}
+
+.ap-panel-title {
+  font-size: var(--ease-text-lg, 1.125rem);
+  margin-bottom: var(--ease-space-4, 1rem);
+}
+
+.ap-control {
+  margin-bottom: var(--ease-space-3, 0.75rem);
+}
+
+.ap-control label {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 600;
+  font-family: var(--ease-font-mono, monospace);
+  color: var(--ease-color-primary-dark, #4b44cc);
+  margin-bottom: var(--ease-space-1, 0.25rem);
+}
+
+.ap-value {
+  font-weight: 500;
+  color: var(--ease-color-muted, #475569);
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  border-radius: var(--ease-radius-sm, 0.25rem);
+  padding: 0.05rem 0.35rem;
+}
+
+.ap-control select,
+.ap-text-input {
+  width: 100%;
+  font-size: var(--ease-text-sm, 0.875rem);
+  padding: var(--ease-space-2, 0.5rem) var(--ease-space-3, 0.75rem);
+  border: 1px solid var(--ease-color-neutral-300, #cbd5e1);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  background: var(--ease-color-neutral-50, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+}
+
+.ap-control select:focus,
+.ap-text-input:focus {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+
+.ap-control input[type='range'] {
+  width: 100%;
+  accent-color: var(--ease-color-primary, #6c63ff);
+}
+
+.ap-group-title {
+  font-size: var(--ease-text-xs, 0.75rem);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ease-color-muted, #475569);
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.ap-presets {
+  padding-top: var(--ease-space-3, 0.75rem);
+  margin-top: var(--ease-space-3, 0.75rem);
+  border-top: 1px solid var(--ease-color-neutral-100, #f1f5f9);
+}
+
+.ap-preset-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ease-space-2, 0.5rem);
+}
+
+.ap-preset {
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 600;
+  color: var(--ease-color-primary-dark, #4b44cc);
+  background: var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.15));
+  border: none;
+  border-radius: var(--ease-radius-full, 9999px);
+  padding: 0.3rem 0.7rem;
+  cursor: pointer;
+  transition: transform var(--ease-speed-fast, 150ms) var(--ease-ease-bounce);
+}
+
+.ap-preset:hover {
+  transform: translateY(-1px);
+}
+
+.ap-preset:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+
+.ap-btn-replay {
+  width: 100%;
+  margin-top: var(--ease-space-3, 0.75rem);
+  padding: var(--ease-space-2, 0.5rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  color: var(--ease-color-muted, #475569);
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  cursor: pointer;
+}
+
+.ap-btn-replay:hover {
+  background: var(--ease-color-neutral-200, #e2e8f0);
+}
+
+/* ── Preview ────────────────────────────────────────────────── */
+
+.ap-preview-area {
+  display: grid;
+  gap: var(--ease-space-4, 1rem);
+}
+
+.ap-section-title {
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--ease-color-muted, #475569);
+  margin-bottom: var(--ease-space-3, 0.75rem);
+}
+
+.ap-preview-card-wrap,
+.ap-jsx-output,
+.ap-props-table-wrap {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  padding: var(--ease-space-5, 1.25rem);
+  box-shadow: var(--ease-shadow-sm);
+}
+
+.ap-stage {
+  min-height: 10rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--ease-color-neutral-50, #f8fafc);
+  border: 1px dashed var(--ease-color-neutral-300, #cbd5e1);
+  border-radius: var(--ease-radius-md, 0.5rem);
+}
+
+.ap-preview-card {
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  color: var(--ease-color-text, #1e293b);
+  background: var(--ease-color-surface, #ffffff);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  box-shadow: var(--ease-shadow-md);
+  padding: var(--ease-space-4, 1rem) var(--ease-space-6, 1.5rem);
+  text-align: center;
+}
+
+/* ── JSX output ─────────────────────────────────────────────── */
+
+.ap-jsx-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ease-space-4, 1rem);
+  margin-bottom: var(--ease-space-3, 0.75rem);
+}
+
+.ap-jsx-header .ap-section-title {
+  margin-bottom: 0;
+}
+
+.ap-pre {
+  margin: 0;
+  background: var(--ease-color-neutral-900, #0f172a);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  padding: var(--ease-space-4, 1rem);
+  overflow-x: auto;
+}
+
+.ap-pre code {
+  font-family: var(--ease-font-mono, monospace);
+  font-size: var(--ease-text-sm, 0.875rem);
+  line-height: 1.7;
+  color: var(--ease-color-neutral-100, #f1f5f9);
+  white-space: pre;
+}
+
+.ap-status {
+  min-height: 1.25rem;
+  font-size: var(--ease-text-xs, 0.75rem);
+  color: var(--ease-color-success-dark, #15803d);
+  margin: var(--ease-space-2, 0.5rem) 0 0;
+}
+
+/* ── Props table ────────────────────────────────────────────── */
+
+.ap-table-scroll {
+  overflow-x: auto;
+}
+
+.ap-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--ease-text-sm, 0.875rem);
+}
+
+.ap-table th,
+.ap-table td {
+  padding: var(--ease-space-2, 0.5rem) var(--ease-space-3, 0.75rem);
+  text-align: left;
+  border-bottom: 1px solid var(--ease-color-neutral-100, #f1f5f9);
+}
+
+.ap-table th {
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ease-color-muted, #475569);
+  background: var(--ease-color-neutral-50, #f8fafc);
+}
+
+.ap-table code {
+  font-family: var(--ease-font-mono, monospace);
+  font-size: var(--ease-text-xs, 0.75rem);
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  border-radius: var(--ease-radius-sm, 0.25rem);
+  padding: 0.05rem 0.3rem;
+}
+
+/* ── Responsive ─────────────────────────────────────────────── */
+
+@media (max-width: 52rem) {
+  .ap-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .ap-panel {
+    position: static;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ap-preset {
+    transition-duration: 0.01ms;
+  }
+
+  .ap-preset:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
# #43350 resolved

## Description
Adds an interactive React submission under submissions/react/ease-animate-playground-sp/ that lets developers experiment with all <Animate> wrapper props visually before using them in their own projects.

## Features
- Interactive controls for type, duration, delay, hover, tag, and className props
- Live animation preview using the Animate wrapper pattern
- 4 preset animation combinations for quick testing
- Copy-to-clipboard JSX output for the current configuration
- Built-in props reference table matching README documentation
- Responsive, accessible UI with replay control