### PR TITLE
feat: add sticky header shrink-on-scroll example

### DIFF
--- a/submissions/examples/sticky-header-shrink-kamalsharma001/README.md
+++ b/submissions/examples/sticky-header-shrink-kamalsharma001/README.md
@@ -1,0 +1,25 @@
+# Sticky Header Shrink on Scroll
+
+## 1. What does this do?
+A sticky header that reduces its height, padding, and logo size, and gains
+a shadow, once the page is scrolled past a small threshold.
+
+## 2. How is it used?
+Add the `is-scrolled` class to your header element via a scroll listener:
+
+```html
+<header class="site-header" id="siteHeader">...</header>
+<script>
+  window.addEventListener('scroll', () => {
+    document.getElementById('siteHeader')
+      .classList.toggle('is-scrolled', window.scrollY > 40);
+  });
+</script>
+```
+
+## 3. Why is it useful?
+It's a very common real-world navbar pattern (Stripe, Linear, etc.) that
+wasn't covered by the existing navbar component. It ties motion directly
+to scroll behavior, fitting EaseMotion CSS's animation-first philosophy,
+and degrades gracefully — the header still works fine with no JS, just
+without the shrink effect.

--- a/submissions/examples/sticky-header-shrink-kamalsharma001/demo.html
+++ b/submissions/examples/sticky-header-shrink-kamalsharma001/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Sticky Header Shrink Demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<header class="site-header" id="siteHeader">
+  <div class="header-inner">
+    <span class="logo">Brand</span>
+    <nav class="nav-links">
+      <a href="#">Home</a>
+      <a href="#">Features</a>
+      <a href="#">Contact</a>
+    </nav>
+  </div>
+</header>
+
+<main class="content">
+  <p>Scroll down to see the header shrink.</p>
+  <div class="spacer"></div>
+  <p>Keep scrolling…</p>
+  <div class="spacer"></div>
+  <p>End of demo content.</p>
+</main>
+
+<script>
+  const header = document.getElementById('siteHeader');
+  const onScroll = () => {
+    header.classList.toggle('is-scrolled', window.scrollY > 40);
+  };
+  window.addEventListener('scroll', onScroll, { passive: true });
+</script>
+
+</body>
+</html>

--- a/submissions/examples/sticky-header-shrink-kamalsharma001/style.css
+++ b/submissions/examples/sticky-header-shrink-kamalsharma001/style.css
@@ -1,0 +1,58 @@
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  background: #0f1117;
+  color: #e6e6e6;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: rgba(15, 17, 23, 0.9);
+  backdrop-filter: blur(8px);
+  transition: padding 0.3s ease, box-shadow 0.3s ease;
+  padding: 22px 32px;
+}
+
+.site-header.is-scrolled {
+  padding: 10px 32px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+}
+
+.header-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.logo {
+  font-weight: 700;
+  font-size: 1.4rem;
+  transition: font-size 0.3s ease;
+}
+
+.site-header.is-scrolled .logo {
+  font-size: 1.1rem;
+}
+
+.nav-links a {
+  color: #cfcfcf;
+  text-decoration: none;
+  margin-left: 24px;
+  font-size: 0.95rem;
+}
+
+.content {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 40px 32px;
+}
+
+.spacer {
+  height: 700px;
+}


### PR DESCRIPTION
## Summary

Adds a sticky header example that smoothly shrinks on scroll using CSS transitions and a lightweight JavaScript scroll listener.

### Features

- Sticky header
- Smooth height/padding transition
- Logo scaling
- Shadow on scroll
- Responsive example

Closes #43484 

### How to test

1. Open `demo.html`
2. Scroll down
3. Observe the header shrinking and shadow appearing.