### PR TITLE
feat: add line-clamp-fade SCSS mixin

### DIFF
--- a/submissions/scss/line-clamp-fade-kamalsharma001/README.md
+++ b/submissions/scss/line-clamp-fade-kamalsharma001/README.md
@@ -1,0 +1,38 @@
+# line-clamp-fade
+
+## 1. What does this do?
+An SCSS mixin that clamps text to a fixed number of lines and fades the
+final line out into the background color, instead of cutting it off with
+a hard ellipsis.
+
+## 2. How is it used?
+
+```scss
+@use 'line-clamp-fade' as *;
+
+.card-excerpt {
+  @include line-clamp-fade($lines: 3, $fade-color: #ffffff);
+}
+
+// Optional "Read more" expanded state
+.card-excerpt.is-expanded {
+  @include line-clamp-fade-expanded;
+}
+```
+
+```html
+<p class="card-excerpt">
+  Long paragraph text that will be clamped to three lines with a
+  smooth fade at the bottom edge instead of an abrupt "..." cut-off...
+</p>
+<button onclick="this.previousElementSibling.classList.toggle('is-expanded')">
+  Read more
+</button>
+```
+
+## 3. Why is it useful?
+Saves contributors from hand-writing `-webkit-line-clamp` boilerplate every
+time, and the gradient fade looks more deliberate and polished than a bare
+ellipsis — fitting EaseMotion CSS's animation-first, curated design
+philosophy. The optional expand mixin also makes it trivial to pair with a
+"Read more" toggle.

--- a/submissions/scss/line-clamp-fade-kamalsharma001/_line-clamp-fade.scss
+++ b/submissions/scss/line-clamp-fade-kamalsharma001/_line-clamp-fade.scss
@@ -1,0 +1,47 @@
+// ============================================
+// line-clamp-fade
+// Clamps text to N lines with a soft gradient
+// fade instead of a hard ellipsis cut-off.
+// ============================================
+
+@mixin line-clamp-fade(
+  $lines: 3,
+  $fade-color: #ffffff,
+  $line-height: 1.5em,
+  $fade-height: 1.5em
+) {
+  position: relative;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: $lines;
+  line-height: $line-height;
+  max-height: calc(#{$line-height} * #{$lines});
+
+  &::after {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: $fade-height;
+    background: linear-gradient(
+      to bottom,
+      rgba($fade-color, 0),
+      rgba($fade-color, 1)
+    );
+    pointer-events: none;
+  }
+}
+
+// Optional helper: toggled "expanded" state, e.g. via a
+// .is-expanded class added by a "Read more" button
+@mixin line-clamp-fade-expanded {
+  -webkit-line-clamp: unset;
+  max-height: none;
+
+  &::after {
+    opacity: 0;
+    transition: opacity 0.2s ease;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a reusable SCSS mixin for multi-line text clamping with a smooth gradient fade-out edge.

### Features

- Configurable number of lines
- Custom fade color
- Configurable line height
- Optional expanded state mixin
- Reusable SCSS partial

Closes #43559 

### How to test

Import `_line-clamp-fade.scss` into a sample SCSS file using `@use`, apply the `line-clamp-fade` mixin to a text element, compile with `npx sass`, and verify the clamped text with the gradient fade. Reviewers can also inspect the mixin logic directly.