### PR TITLE
Fix brand logo redirect folder example #41338

### DIFF
--- a/submissions/examples/fix-brand-logo-sp/README.md
+++ b/submissions/examples/fix-brand-logo-sp/README.md
@@ -1,0 +1,6 @@
+# Fix Brand Logo Redirect Example
+
+This directory demonstrates the solution implemented for issue #41338.
+
+## The Fix
+When navigating nested structural routes (such as `/playground/index.html`), a relative target attribute like `href="index.html"` incorrectly resolves relative to the active subfolder context. By switching to an absolute site directory link root (`href="/EaseMotion-css/"`), the navigation anchor guarantees a reliable, successful redirection straight back to the landing homepage index from anywhere in the app structure.

--- a/submissions/examples/fix-brand-logo-sp/demo.html
+++ b/submissions/examples/fix-brand-logo-sp/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Brand Logo Redirect Fix Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <!-- Header layout matching the Animation Studio page -->
+    <header class="site-header">
+        <div class="logo-container">
+            <!-- 
+              FIX: Changed from a relative href="index.html" 
+              to an absolute home path so it always goes back to the true site root 
+            -->
+            <a href="/EaseMotion-css/" aria-label="Home" class="brand-logo-link">
+                <span class="logo-text">EaseMotion <span class="badge">Studio</span></span>
+            </a>
+        </div>
+        
+        <nav class="nav-right">
+            <a href="https://github.com/saptarshi-coder/EaseMotion-css" class="github-btn">GitHub</a>
+        </nav>
+    </header>
+
+    <main class="demo-content">
+        <div class="explanation-card">
+            <h3>Simulated Subfolder Page (/playground/index.html)</h3>
+            <hr>
+            <p>
+                <strong>The Bug:</strong> Using a relative path like <code>href="index.html"</code> makes the browser search inside the current <code>/playground/</code> folder, causing a broken or dead-end redirect.
+            </p>
+            <p>
+                <strong>The Fix:</strong> Updating the attribute to use the absolute base site path (<code>href="/EaseMotion-css/"</code>) ensures that clicking the logo always targets the main homepage layout, regardless of directory depth.
+            </p>
+        </div>
+    </main>
+
+</body>
+</html>

--- a/submissions/examples/fix-brand-logo-sp/style.css
+++ b/submissions/examples/fix-brand-logo-sp/style.css
@@ -1,0 +1,76 @@
+body {
+    margin: 0;
+    font-family: system-ui, -apple-system, sans-serif;
+    background-color: #0d1117;
+    color: #c9d1d9;
+}
+
+.site-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 2rem;
+    background-color: #0b0e14;
+    border-bottom: 1px solid #21262d;
+}
+
+.brand-logo-link {
+    color: #58a6ff;
+    text-decoration: none;
+    font-size: 1.25rem;
+    font-weight: bold;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.brand-logo-link:hover {
+    opacity: 0.85;
+}
+
+.badge {
+    background-color: #6f42c1;
+    color: #ffffff;
+    font-size: 0.75rem;
+    padding: 0.2rem 0.5rem;
+    border-radius: 12px;
+    margin-left: 0.4rem;
+}
+
+.github-btn {
+    background-color: #21262d;
+    color: #c9d1d9;
+    text-decoration: none;
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    border: 1px solid #30363d;
+    font-size: 0.9rem;
+}
+
+.github-btn:hover {
+    background-color: #30363d;
+}
+
+.demo-content {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 75vh;
+}
+
+.explanation-card {
+    background-color: #161b22;
+    border: 1px solid #30363d;
+    padding: 2.5rem;
+    border-radius: 8px;
+    max-width: 550px;
+    line-height: 1.6;
+}
+
+code {
+    background-color: #21262d;
+    padding: 0.2rem 0.4rem;
+    border-radius: 4px;
+    color: #ff7b72;
+    font-family: monospace;
+}


### PR DESCRIPTION
## Pull Request Description

This submission adds a standalone example showcasing the fix for the brand logo link redirect issue. When navigating nested routes (such as the `/playground/` folder), the original relative path link targets broke by looking within the local directory. By utilizing an absolute base URL redirection approach (`href="/EaseMotion-css/"`), the header text ensures a reliable return path directly back to the site home directory regardless of view depth.

Closes #41338

---

## Type of Change

- [ ] 🐛 Bug fix in an existing submission
- [x] Other (Standalone Bug-fix replication folder)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/fix-brand-logo-sp/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS