### PR TITLE
feat: add radial progress ring with counting percentage label

### DIFF
--- a/submissions/examples/radial-progress-count-kamalsharma001/README.md
+++ b/submissions/examples/radial-progress-count-kamalsharma001/README.md
@@ -1,0 +1,26 @@
+# Radial Progress Ring with Counting Label
+
+## 1. What does this do?
+A circular progress ring (built with `conic-gradient` + `@property`) whose
+fill animates from 0 to a target percentage, synced with a numeric label
+that counts up alongside it.
+
+## 2. How is it used?
+
+```html
+<div class="ring" style="--target: 72;">
+  <span class="ring-label" data-target="72">0%</span>
+</div>
+```
+
+The ring's CSS `--target` variable drives the fill angle via a keyframe
+animation on `--angle` (enabled by `@property`). The label count-up runs
+via a small `requestAnimationFrame` loop reading the same `data-target`
+value, so both stay in sync.
+
+## 3. Why is it useful?
+Most radial progress examples animate only the ring. Pairing it with a
+synced counting number makes stats/dashboard sections feel more dynamic
+and complete — a small addition that reinforces EaseMotion CSS's
+animation-first philosophy by extending motion to the data itself, not
+just the shape.

--- a/submissions/examples/radial-progress-count-kamalsharma001/demo.html
+++ b/submissions/examples/radial-progress-count-kamalsharma001/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Radial Progress Ring with Counting Label</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<div class="rings">
+  <div class="ring" style="--target: 72;">
+    <span class="ring-label" data-target="72">0%</span>
+  </div>
+  <div class="ring" style="--target: 45;">
+    <span class="ring-label" data-target="45">0%</span>
+  </div>
+  <div class="ring" style="--target: 90;">
+    <span class="ring-label" data-target="90">0%</span>
+  </div>
+</div>
+
+<script>
+  document.querySelectorAll('.ring-label').forEach(label => {
+    const target = parseInt(label.dataset.target, 10);
+    let current = 0;
+    const duration = 1400;
+    const start = performance.now();
+
+    function tick(now) {
+      const progress = Math.min((now - start) / duration, 1);
+      current = Math.round(progress * target);
+      label.textContent = current + '%';
+      if (progress < 1) requestAnimationFrame(tick);
+    }
+    requestAnimationFrame(tick);
+  });
+</script>
+
+</body>
+</html>

--- a/submissions/examples/radial-progress-count-kamalsharma001/style.css
+++ b/submissions/examples/radial-progress-count-kamalsharma001/style.css
@@ -1,0 +1,47 @@
+@property --angle {
+  syntax: '<angle>';
+  inherits: false;
+  initial-value: 0deg;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0f1117;
+  font-family: system-ui, sans-serif;
+}
+
+.rings {
+  display: flex;
+  gap: 40px;
+}
+
+.ring {
+  --angle: 0deg;
+  --target-angle: calc(var(--target) * 3.6deg);
+  width: 140px;
+  height: 140px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background:
+    radial-gradient(circle closed-side, #0f1117 62%, transparent 63%),
+    conic-gradient(#6ee7b7 var(--angle), #262a35 0deg);
+  animation: fill-ring 1.4s ease forwards;
+}
+
+@keyframes fill-ring {
+  to { --angle: var(--target-angle); }
+}
+
+.ring-label {
+  color: #e6e6e6;
+  font-size: 1.4rem;
+  font-weight: 700;
+}


### PR DESCRIPTION
## Summary

Adds a radial progress ring example with a synchronized animated percentage label. This extends the existing conic-gradient approach by pairing the visual fill animation with a count-up effect for the displayed value.

### Features

- Animated conic-gradient progress ring
- Synchronized percentage count-up
- CSS `@property` for smooth angle animation
- Lightweight `requestAnimationFrame` counter
- Responsive demo

Closes #43621 

### How to test

1. Open `demo.html` in a browser.
2. Observe each progress ring animate from 0 to its target percentage.
3. Verify that the numeric label counts up in sync with the ring animation.

### Notes

This is a distinct variant from the existing conic-gradient radial progress example because it adds a synchronized animated counting label, making it suitable for dashboard and statistics interfaces.