### PR TITLE
feat(chip): add reduced motion accessibility support

### DIFF
--- a/submissions/examples/feat-chip-reduced-motion/README.md
+++ b/submissions/examples/feat-chip-reduced-motion/README.md
@@ -1,0 +1,26 @@
+# Chip Reduced Motion Accessibility Support
+
+## Description
+This submission enhances the `chip` component with full support for the
+`prefers-reduced-motion: reduce` CSS media query.
+
+When a user enables reduced motion in their operating system or browser,
+all animations, transitions, and transform-based hover effects are safely
+disabled. This prevents discomfort and nausea for users with vestibular
+disorders or motion sensitivities, ensuring WCAG 2.1 Success Criterion 2.3.3
+compliance.
+
+## Changes
+- `style.css`: Adds base component styles with smooth transitions and a keyframe
+  entry animation (90+ lines total), plus a `@media (prefers-reduced-motion: reduce)`
+  block that removes all motion.
+- `demo.html`: Full HTML5 boilerplate demonstrating the component with instructions
+  on how to test the reduced motion behavior.
+- `README.md`: Documents the feature, accessibility rationale, and usage.
+
+## How to Test
+1. Open `demo.html` in a browser.
+2. Enable reduced motion via OS settings or browser DevTools > Rendering tab.
+3. Hover over the component and observe that no transform or transition occurs.
+
+Fixes #43682

--- a/submissions/examples/feat-chip-reduced-motion/demo.html
+++ b/submissions/examples/feat-chip-reduced-motion/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Chip Reduced Motion Support - EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+    <style>
+        body {
+            font-family: system-ui, -apple-system, sans-serif;
+            background: #f3f4f6;
+            padding: 3rem;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 2rem;
+            min-height: 100vh;
+        }
+        .notice {
+            background: #eff6ff;
+            border-left: 4px solid #3b82f6;
+            color: #1e40af;
+            padding: 1.25rem 1.5rem;
+            border-radius: 6px;
+            max-width: 600px;
+            width: 100%;
+            font-size: 0.9rem;
+        }
+        .notice code {
+            background: #dbeafe;
+            padding: 0.1rem 0.3rem;
+            border-radius: 3px;
+        }
+        @media (prefers-reduced-motion: reduce) {
+            .notice { border-left-color: #10b981; background: #ecfdf5; color: #065f46; }
+        }
+    </style>
+</head>
+<body>
+    <div class="notice">
+        <strong>How to test:</strong> Enable <code>prefers-reduced-motion</code> in your browser's DevTools
+        (Rendering tab) or in your OS accessibility settings. Hover effects, transitions,
+        and enter animations will be disabled when this preference is active.
+    </div>
+    <div class="ease-chip" tabindex="0" role="region" aria-label="Chip component demo">
+        <div class="ease-chip-title">Chip Component</div>
+        <div class="ease-chip-body">
+            This component respects your motion preferences. When
+            <code>prefers-reduced-motion: reduce</code> is active, all CSS transitions,
+            keyframe animations, and hover transform effects are disabled to prevent
+            discomfort for users with vestibular disorders.
+        </div>
+        <div class="ease-chip-cta" tabindex="0" role="button">
+            Interactive Element
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/feat-chip-reduced-motion/style.css
+++ b/submissions/examples/feat-chip-reduced-motion/style.css
@@ -1,0 +1,105 @@
+/*
+ * Feature: chip Reduced Motion Support
+ * Respects the user's prefers-reduced-motion media query preference.
+ * Ensures animations are disabled for users who have this setting enabled.
+ * This improves accessibility for users with vestibular disorders.
+ */
+
+.ease-chip {
+    position: relative;
+    box-sizing: border-box;
+    background-color: var(--ease-surface, #ffffff);
+    color: var(--ease-on-surface, #1f2937);
+    border: 1px solid var(--ease-border, #d1d5db);
+    border-radius: var(--ease-radius-md, 6px);
+    padding: 1.25rem 1.5rem;
+    transition: background-color 0.25s ease,
+                border-color 0.25s ease,
+                box-shadow 0.25s ease,
+                transform 0.25s ease,
+                opacity 0.25s ease;
+    animation: ease-chip-enter 0.3s ease forwards;
+}
+
+@keyframes ease-chip-enter {
+    from {
+        opacity: 0;
+        transform: translateY(6px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.ease-chip:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.08);
+}
+
+.ease-chip:focus-visible {
+    outline: 2px solid var(--ease-primary, #3b82f6);
+    outline-offset: 2px;
+}
+
+.ease-chip-title {
+    font-size: 1.1rem;
+    font-weight: 700;
+    margin-bottom: 0.5rem;
+    color: var(--ease-on-surface, #111827);
+}
+
+.ease-chip-body {
+    font-size: 0.9375rem;
+    line-height: 1.6;
+    color: var(--ease-on-surface-muted, #6b7280);
+}
+
+.ease-chip-cta {
+    display: inline-block;
+    margin-top: 1rem;
+    padding: 0.5rem 1.25rem;
+    background-color: var(--ease-primary, #3b82f6);
+    color: #ffffff;
+    border-radius: var(--ease-radius-sm, 4px);
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s ease, transform 0.15s ease;
+}
+
+.ease-chip-cta:hover {
+    background-color: var(--ease-primary-dark, #2563eb);
+    transform: scale(1.03);
+}
+
+/*
+ * Reduced Motion Overrides
+ * Strips all transitions, animations, and transform effects
+ * for users who prefer minimal motion.
+ */
+@media (prefers-reduced-motion: reduce) {
+    .ease-chip {
+        transition: none !important;
+        animation: none !important;
+        transform: none !important;
+    }
+
+    .ease-chip:hover {
+        transform: none !important;
+        box-shadow: 0 0 0 2px var(--ease-primary, #3b82f6) !important;
+    }
+
+    @keyframes ease-chip-enter {
+        from { opacity: 1; transform: none; }
+        to { opacity: 1; transform: none; }
+    }
+
+    .ease-chip-cta {
+        transition: none !important;
+    }
+
+    .ease-chip-cta:hover {
+        transform: none !important;
+        outline: 2px solid var(--ease-primary-dark, #2563eb);
+    }
+}


### PR DESCRIPTION
### Description
Fixes #43682.

Adds `@media (prefers-reduced-motion: reduce)` support to the `chip` component.
When users enable reduced motion at the OS or browser level, all CSS transitions,
keyframe entry animations, and transform-based hover effects are disabled to prevent
discomfort for users with vestibular disorders.

### Changes Made
- `style.css`: 90+ lines of CSS. Base styles include smooth transitions and a
  keyframe entry animation. A dedicated `@media (prefers-reduced-motion: reduce)`
  block overrides all motion-related properties with `none`.
- `demo.html`: Full HTML5 boilerplate with testing instructions and an interactive
  component demonstration.
- `README.md`: Documents the accessibility rationale, WCAG criterion, and testing steps.

### Checklist
- [x] I have followed the contribution guidelines
- [x] `demo.html` has `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` tags
- [x] `style.css` has original, meaningful CSS (90+ lines)
- [x] `README.md` included
- [x] Files placed in `submissions/examples/feat-chip-reduced-motion/`
- [x] No edits to `core/` or `components/`
- [x] Single commit following conventional-commit format
- [x] Only files inside `submissions/` directory are modified
