### PR TITLE
feat: add step chart

### DIFF
--- a/submissions/examples/step-chart-as/README.md
+++ b/submissions/examples/step-chart-as/README.md
@@ -1,0 +1,19 @@
+# Step Chart
+
+### What does this do?
+
+It shows a step chart of a value that holds then jumps, like server load sampled over a week. The line moves in horizontal then vertical segments (a staircase) instead of sloping, with a soft fill beneath and marker dots at key steps.
+
+### How is it used?
+
+```html
+<svg viewBox="0 0 312 170">
+  <polyline class="sc-line" points="16,104 63,104 109,104 109,71 156,71 ..." />
+</svg>
+```
+
+The `sc-line` polyline alternates a horizontal segment at the current value and a vertical segment to the next value, so the data reads as discrete steps. A `polygon` fills the area below, and `circle` dots mark selected steps.
+
+### Why is it useful?
+
+Step charts suit values that stay constant between changes, like pricing tiers, load, or inventory. This renders one from an SVG polyline and area with pure CSS styling, no charting library.

--- a/submissions/examples/step-chart-as/demo.html
+++ b/submissions/examples/step-chart-as/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Step Chart</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <figure class="step">
+    <figcaption class="sc-head">
+      <span class="sc-title">Server load</span>
+      <span class="sc-now">88%</span>
+    </figcaption>
+    <svg viewBox="0 0 312 170" role="img" aria-label="Step chart of server load over time">
+      <g class="sc-grid">
+        <line x1="16" y1="18" x2="296" y2="18" />
+        <line x1="16" y1="84" x2="296" y2="84" />
+        <line x1="16" y1="150" x2="296" y2="150" />
+      </g>
+      <polygon class="sc-area" points="16.0,150 16.0,103.8 62.7,103.8 62.7,103.8 109.3,103.8 109.3,70.8 156.0,70.8 156.0,81.4 202.7,81.4 202.7,52.3 249.3,52.3 249.3,62.9 296.0,62.9 296.0,33.8 296.0,150" />
+      <polyline class="sc-line" points="16.0,103.8 62.7,103.8 62.7,103.8 109.3,103.8 109.3,70.8 156.0,70.8 156.0,81.4 202.7,81.4 202.7,52.3 249.3,52.3 249.3,62.9 296.0,62.9 296.0,33.8" />
+      <g class="sc-dots">
+        <circle cx="109.3" cy="70.8" r="3.4" />
+        <circle cx="202.7" cy="52.3" r="3.4" />
+        <circle cx="296.0" cy="33.8" r="3.4" />
+      </g>
+      <g class="sc-x">
+        <text x="16" y="164">Mon</text>
+        <text x="109.3" y="164">Wed</text>
+        <text x="202.7" y="164">Fri</text>
+        <text x="296" y="164" text-anchor="end">Sun</text>
+      </g>
+    </svg>
+  </figure>
+</body>
+</html>

--- a/submissions/examples/step-chart-as/style.css
+++ b/submissions/examples/step-chart-as/style.css
@@ -1,0 +1,75 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #131b2e, #080b12 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e6ebf6;
+}
+
+.step {
+  width: min(400px, 94vw);
+  margin: 0;
+  padding: 1.4rem 1.4rem 1rem;
+  box-sizing: border-box;
+  background: #111a2c;
+  border: 1px solid #26314a;
+  border-radius: 16px;
+}
+
+.sc-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 0.8rem;
+}
+
+.sc-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.sc-now {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #34d399;
+  font-variant-numeric: tabular-nums;
+}
+
+.step svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  overflow: visible;
+}
+
+.sc-grid line {
+  stroke: #22304a;
+  stroke-width: 1;
+  stroke-dasharray: 2 4;
+}
+
+.sc-area {
+  fill: rgba(52, 211, 153, 0.14);
+}
+
+.sc-line {
+  fill: none;
+  stroke: #34d399;
+  stroke-width: 2.5;
+  stroke-linejoin: round;
+}
+
+.sc-dots circle {
+  fill: #d1fae5;
+  stroke: #059669;
+  stroke-width: 2;
+}
+
+.sc-x text {
+  fill: #7a86a2;
+  font-size: 10px;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a step chart built for #43725. An SVG staircase polyline with a soft area fill, gridlines, step dots, and day labels. Pure CSS. Closes #43725.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a green staircase step line with an area fill, three gridlines, step dots, and day labels.
