### PR TITLE
feat: add slope chart

### DIFF
--- a/submissions/examples/slope-chart-as/README.md
+++ b/submissions/examples/slope-chart-as/README.md
@@ -1,0 +1,20 @@
+# Slope Chart
+
+### What does this do?
+
+It shows a slope chart comparing each category between two points in time. Two vertical axes hold the start and end values, and a line connects each category's dots across them, colored green when it rose and red when it fell, with labels on both sides.
+
+### How is it used?
+
+```html
+<svg viewBox="0 0 300 190">
+  <line class="up" x1="64" y1="124" x2="236" y2="66" />
+  <circle class="up" cx="64" cy="124" r="4" />
+</svg>
+```
+
+Each category is one SVG `line` from its left value to its right value, with `circle` dots at each end. An `up` or `down` class colors the slope by direction, and text labels sit beside each axis.
+
+### Why is it useful?
+
+Slope charts make gains and losses across categories obvious in a compact form, common in before and after comparisons. This renders one from inline SVG lines styled with CSS, no charting library.

--- a/submissions/examples/slope-chart-as/demo.html
+++ b/submissions/examples/slope-chart-as/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Slope Chart</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <figure class="slope">
+    <figcaption class="sl-head">
+      <span>2024</span>
+      <span class="sl-title">Traffic share</span>
+      <span>2026</span>
+    </figcaption>
+    <svg viewBox="0 0 300 190" role="img" aria-label="Slope chart comparing traffic share between two years">
+      <line class="sl-axis" x1="64" y1="18" x2="64" y2="172" />
+      <line class="sl-axis" x1="236" y1="18" x2="236" y2="172" />
+
+      <g class="sl-lines">
+        <line class="up" x1="64" y1="124.2" x2="236" y2="65.8" />
+        <line class="down" x1="64" y1="87.7" x2="236" y2="97.9" />
+        <line class="up" x1="64" y1="62.9" x2="236" y2="51.2" />
+        <line class="down" x1="64" y1="102.3" x2="236" y2="124.2" />
+        <line class="down" x1="64" y1="77.5" x2="236" y2="83.3" />
+      </g>
+
+      <g class="sl-dots">
+        <circle class="up" cx="64" cy="124.2" r="4" /><circle class="up" cx="236" cy="65.8" r="4" />
+        <circle class="down" cx="64" cy="87.7" r="4" /><circle class="down" cx="236" cy="97.9" r="4" />
+        <circle class="up" cx="64" cy="62.9" r="4" /><circle class="up" cx="236" cy="51.2" r="4" />
+        <circle class="down" cx="64" cy="102.3" r="4" /><circle class="down" cx="236" cy="124.2" r="4" />
+        <circle class="down" cx="64" cy="77.5" r="4" /><circle class="down" cx="236" cy="83.3" r="4" />
+      </g>
+
+      <g class="sl-lbl left">
+        <text x="56" y="127">Search</text>
+        <text x="56" y="91">Email</text>
+        <text x="56" y="66">Social</text>
+        <text x="56" y="105">Ads</text>
+        <text x="56" y="81">Direct</text>
+      </g>
+      <g class="sl-lbl right">
+        <text x="244" y="69">Search</text>
+        <text x="244" y="101">Email</text>
+        <text x="244" y="54">Social</text>
+        <text x="244" y="127">Ads</text>
+        <text x="244" y="86">Direct</text>
+      </g>
+    </svg>
+  </figure>
+</body>
+</html>

--- a/submissions/examples/slope-chart-as/style.css
+++ b/submissions/examples/slope-chart-as/style.css
@@ -1,0 +1,67 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #131b2e, #080b12 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e6ebf6;
+}
+
+.slope {
+  width: min(400px, 94vw);
+  margin: 0;
+  padding: 1.3rem 1.4rem 1.1rem;
+  box-sizing: border-box;
+  background: #111a2c;
+  border: 1px solid #26314a;
+  border-radius: 16px;
+}
+
+.sl-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.6rem;
+  font-size: 0.8rem;
+  color: #8593ad;
+}
+
+.sl-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #e6ebf6;
+}
+
+.slope svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  overflow: visible;
+}
+
+.sl-axis {
+  stroke: #2a3550;
+  stroke-width: 1.5;
+}
+
+.sl-lines line {
+  stroke-width: 2.5;
+  stroke-linecap: round;
+}
+
+.sl-lines .up { stroke: #34d399; }
+.sl-lines .down { stroke: #fb7185; }
+
+.sl-dots .up { fill: #34d399; }
+.sl-dots .down { fill: #fb7185; }
+
+.sl-lbl text {
+  font-size: 9px;
+  fill: #b7c0d4;
+}
+
+.sl-lbl.left text { text-anchor: end; }
+.sl-lbl.right text { text-anchor: start; }


### PR DESCRIPTION
## Pull Request Description

Adds a slope chart built for #43727. Two axes with category lines connecting start and end values, colored by direction, with dots and labels. Pure CSS. Closes #43727.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: two axes with five category slopes (two green risers, three red fallers) and labels on both sides.
