### PR TITLE
feat: add bump chart

### DIFF
--- a/submissions/examples/bump-chart-as/README.md
+++ b/submissions/examples/bump-chart-as/README.md
@@ -1,0 +1,19 @@
+# Bump Chart
+
+### What does this do?
+
+It shows a bump chart tracking how four teams change rank across five weeks. Each team is a colored line that moves up and down between rank rows and crosses the others as positions swap, with dots and a legend.
+
+### How is it used?
+
+```html
+<svg viewBox="0 0 300 180">
+  <polyline class="s a" points="40,30 100,70 160,30 220,30 280,70" />
+</svg>
+```
+
+Rank rows are evenly spaced gridlines, and each series is a `polyline` whose points sit on the rank of that team at each week. Series classes `a` to `d` set the colors, and dots mark notable positions.
+
+### Why is it useful?
+
+Bump charts show ranking changes over time far more clearly than a table, common in sports, charts, and leaderboards. This renders one from inline SVG polylines styled with CSS, no charting library.

--- a/submissions/examples/bump-chart-as/demo.html
+++ b/submissions/examples/bump-chart-as/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bump Chart</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <figure class="bump">
+    <figcaption class="bp-title">Team rankings</figcaption>
+    <svg viewBox="0 0 300 180" role="img" aria-label="Bump chart of team rankings over five weeks">
+      <g class="bp-rankgrid">
+        <line x1="30" y1="30" x2="290" y2="30" />
+        <line x1="30" y1="70" x2="290" y2="70" />
+        <line x1="30" y1="110" x2="290" y2="110" />
+        <line x1="30" y1="150" x2="290" y2="150" />
+      </g>
+      <g class="bp-rank">
+        <text x="22" y="33">1</text><text x="22" y="73">2</text>
+        <text x="22" y="113">3</text><text x="22" y="153">4</text>
+      </g>
+
+      <polyline class="s a" points="40,30 100,70 160,30 220,30 280,70" />
+      <polyline class="s b" points="40,70 100,30 160,110 220,70 280,30" />
+      <polyline class="s c" points="40,110 100,110 160,70 220,150 280,110" />
+      <polyline class="s d" points="40,150 100,150 160,150 220,110 280,150" />
+
+      <g class="bp-dots">
+        <circle class="a" cx="40" cy="30" r="5" /><circle class="a" cx="160" cy="30" r="5" /><circle class="a" cx="220" cy="30" r="5" />
+        <circle class="b" cx="100" cy="30" r="5" /><circle class="b" cx="280" cy="30" r="5" />
+        <circle class="c" cx="160" cy="70" r="5" />
+        <circle class="d" cx="220" cy="110" r="5" />
+      </g>
+
+      <g class="bp-x">
+        <text x="40" y="172">W1</text><text x="100" y="172">W2</text><text x="160" y="172">W3</text>
+        <text x="220" y="172">W4</text><text x="280" y="172">W5</text>
+      </g>
+    </svg>
+    <figcaption class="bp-legend">
+      <span class="a">Alpha</span><span class="b">Bravo</span>
+      <span class="c">Comet</span><span class="d">Delta</span>
+    </figcaption>
+  </figure>
+</body>
+</html>

--- a/submissions/examples/bump-chart-as/style.css
+++ b/submissions/examples/bump-chart-as/style.css
@@ -1,0 +1,100 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #131b2e, #080b12 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e6ebf6;
+}
+
+.bump {
+  width: min(400px, 94vw);
+  margin: 0;
+  padding: 1.4rem 1.4rem 1.1rem;
+  box-sizing: border-box;
+  background: #111a2c;
+  border: 1px solid #26314a;
+  border-radius: 16px;
+}
+
+.bp-title {
+  margin-bottom: 0.6rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.bump svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  overflow: visible;
+}
+
+.bp-rankgrid line {
+  stroke: #1f2a42;
+  stroke-width: 1;
+}
+
+.bp-rank text {
+  fill: #6f7c98;
+  font-size: 10px;
+  text-anchor: end;
+}
+
+.s {
+  fill: none;
+  stroke-width: 3;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.s.a { stroke: #6366f1; }
+.s.b { stroke: #22d3ee; }
+.s.c { stroke: #f59e0b; }
+.s.d { stroke: #f472b6; }
+
+.bp-dots .a { fill: #6366f1; }
+.bp-dots .b { fill: #22d3ee; }
+.bp-dots .c { fill: #f59e0b; }
+.bp-dots .d { fill: #f472b6; }
+
+.bp-dots circle {
+  stroke: #111a2c;
+  stroke-width: 2;
+}
+
+.bp-x text {
+  fill: #7a86a2;
+  font-size: 10px;
+  text-anchor: middle;
+}
+
+.bp-legend {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 0.9rem;
+  font-size: 0.8rem;
+  color: #aab4c8;
+}
+
+.bp-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.bp-legend span::before {
+  content: "";
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.bp-legend .a::before { background: #6366f1; }
+.bp-legend .b::before { background: #22d3ee; }
+.bp-legend .c::before { background: #f59e0b; }
+.bp-legend .d::before { background: #f472b6; }


### PR DESCRIPTION
## Pull Request Description

Adds a bump chart built for #43729. Four ranking polylines crossing between rank rows over five weeks, with dots, rank and week labels, and a legend. Pure CSS. Closes #43729.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: four ranking lines in distinct colors crossing between four rank rows across five weeks with a legend.
