### PR TITLE
feat: add light bulb

### DIFF
--- a/submissions/examples/light-bulb-as/README.md
+++ b/submissions/examples/light-bulb-as/README.md
@@ -1,0 +1,20 @@
+# Light Bulb
+
+### What does this do?
+
+It shows a light bulb you can switch on and off. Flipping the toggle lights the glass warm yellow, heats the filament to orange, casts a pulsing glow, and even warms the page background; switching off returns it to a cold grey bulb. It is all driven by a checkbox and `:has()`, no JavaScript.
+
+### How is it used?
+
+```html
+<div class="lamp">
+  <div class="bulb"><span class="glow"></span><div class="glass"><svg class="filament">...</svg></div><span class="base"></span></div>
+  <label class="switch"><input type="checkbox" checked /><span class="track"><span class="knob"></span></span></label>
+</div>
+```
+
+The filament is an SVG path, and the whole on state is driven from the toggle: `.lamp:has(.switch input:checked)` lights the glass, filament, and glow, while `body:has(...)` warms the background.
+
+### Why is it useful?
+
+Smart home controls, idea prompts, and dark or light demos use a bulb. This gives an interactive bulb with a glow and a working switch styled entirely with CSS and no script.

--- a/submissions/examples/light-bulb-as/demo.html
+++ b/submissions/examples/light-bulb-as/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Light Bulb</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="lamp">
+    <div class="bulb">
+      <span class="glow"></span>
+      <div class="glass">
+        <svg class="filament" viewBox="0 0 60 60" aria-hidden="true">
+          <path d="M22 44 L22 30 Q22 22 26 22 Q30 22 30 30 Q30 38 34 38 Q38 38 38 30 L38 44" />
+        </svg>
+      </div>
+      <span class="base"></span>
+    </div>
+
+    <label class="switch">
+      <input type="checkbox" checked />
+      <span class="track"><span class="knob"></span></span>
+      <span class="switch-label">Light</span>
+    </label>
+  </div>
+</body>
+</html>

--- a/submissions/examples/light-bulb-as/style.css
+++ b/submissions/examples/light-bulb-as/style.css
@@ -1,0 +1,160 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: #0a0c12;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e6ebf6;
+  transition: background 0.4s ease;
+}
+
+body:has(.switch input:checked) {
+  background: radial-gradient(circle at 50% 34%, #29240f, #0a0c12 62%);
+}
+
+.lamp {
+  display: grid;
+  justify-items: center;
+  gap: 2.4rem;
+}
+
+.bulb {
+  position: relative;
+  display: grid;
+  justify-items: center;
+}
+
+.glow {
+  position: absolute;
+  top: -34px;
+  left: 50%;
+  width: 220px;
+  height: 220px;
+  margin-left: -110px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 214, 102, 0.55), transparent 60%);
+  opacity: 0;
+  transition: opacity 0.4s ease;
+}
+
+.lamp:has(.switch input:checked) .glow {
+  opacity: 1;
+  animation: bulb-pulse 2.2s ease-in-out infinite;
+}
+
+.glass {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  place-items: center;
+  width: 120px;
+  height: 120px;
+  border-radius: 50% 50% 48% 48%;
+  background: radial-gradient(circle at 42% 34%, #3a3f4c, #23262f 72%);
+  box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.5);
+  transition: background 0.4s ease, box-shadow 0.4s ease;
+}
+
+.lamp:has(.switch input:checked) .glass {
+  background: radial-gradient(circle at 42% 34%, #fff3c4, #ffd257 76%);
+  box-shadow: inset 0 0 24px rgba(255, 180, 60, 0.6), 0 0 40px rgba(255, 210, 90, 0.55);
+}
+
+.filament {
+  width: 74px;
+  height: 74px;
+  fill: none;
+  stroke: #55596a;
+  stroke-width: 3;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  transition: stroke 0.35s ease, filter 0.35s ease;
+}
+
+.lamp:has(.switch input:checked) .filament {
+  stroke: #ff7a1a;
+  filter: drop-shadow(0 0 5px rgba(255, 170, 60, 0.9));
+}
+
+.base {
+  position: relative;
+  z-index: 1;
+  width: 46px;
+  height: 34px;
+  margin-top: -6px;
+  border-radius: 3px 3px 5px 5px;
+  background:
+    repeating-linear-gradient(180deg, #9aa1ad 0 5px, #6b7280 5px 9px);
+}
+
+.switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.7rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.switch input {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+
+.track {
+  position: relative;
+  width: 54px;
+  height: 30px;
+  border-radius: 999px;
+  background: #2a3040;
+  transition: background 0.25s ease;
+}
+
+.knob {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: #cbd5e1;
+  transition: transform 0.25s ease, background 0.25s ease;
+}
+
+.switch input:checked + .track {
+  background: #f59e0b;
+}
+
+.switch input:checked + .track .knob {
+  transform: translateX(24px);
+  background: #fffbeb;
+}
+
+.switch input:focus-visible + .track {
+  outline: 2px solid #f59e0b;
+  outline-offset: 2px;
+}
+
+.switch-label {
+  font-size: 0.85rem;
+  color: #aab4c8;
+}
+
+@keyframes bulb-pulse {
+  0%, 100% { opacity: 0.85; transform: scale(0.98); }
+  50% { opacity: 1; transform: scale(1.03); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glow, .knob, .track, .glass, .filament, body {
+    transition: none;
+  }
+
+  .lamp:has(.switch input:checked) .glow {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a light bulb built for #43735. An interactive bulb whose toggle lights the glass, filament, and glow and warms the background via `:has()`, with a reduced motion fallback. Pure CSS, no JavaScript. Closes #43735.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium: with the toggle on the glass is warm, the filament orange, and the glow opacity near 1; clicking it off drops the glow opacity to 0. Screenshot of the lit state included.
