### PR TITLE
feat: add particle signature pad - music player design (closes #42418)

### DIFF
--- a/submissions/examples/particle-signature-pad-priya/README.md
+++ b/submissions/examples/particle-signature-pad-priya/README.md
@@ -1,0 +1,52 @@
+# Particle Signature Pad — Music Player Design (CSS-Only)
+
+A "sign to unlock" backstage-pass signature pad styled for a music streaming / concert-ticket experience. Signing draws a cursive signature stroke-by-stroke while musical note particles (♪ ♫) burst outward and fade — all with pure CSS, no JavaScript.
+
+## What does this do?
+The pad presents a mock music player card (spinning vinyl, mini equalizer, track info). Clicking **"Sign & Unlock Track"** triggers a sequenced animation: the signature line draws itself via an animated SVG stroke, glowing musical-note particles scatter outward along the path, and the button morphs into an "unlocked" confirmation state.
+
+## How is it used?
+The interaction is driven entirely by a hidden radio input toggled via a `<label>`, using the general sibling combinator (`~`) to cascade state changes — the same pure-CSS state-machine pattern used elsewhere in EaseMotion CSS's signature-pad variants.
+
+```html
+<input type="radio" id="state-idle" name="pad-state" checked class="state-control" />
+<input type="radio" id="state-signing" name="pad-state" class="state-control" />
+
+<div class="player-container">
+  <div class="player-card">
+    <!-- header, signature pad, particle emitters... -->
+    <label for="state-signing" class="action-btn">Sign & Unlock Track</label>
+    <label for="state-idle" class="reset-link">Clear & Reset Pad</label>
+  </div>
+</div>
+```
+
+Each particle emitter is a small wrapper positioned along the signature path; each `.particle` span carries a musical note glyph (♪/♫) plus `--dx`, `--dy`, and `--rot` custom properties that control its scatter direction, distance, and rotation:
+
+```html
+<div class="particle-emitter" style="left: 20%; top: 60%; --delay: 0.2s">
+  <span class="particle" style="--dx: -14px; --dy: -10px; --rot: -20deg">♪</span>
+</div>
+```
+
+## Features
+* **Sequenced Animation:** SVG signature stroke draws over ~2.4s, followed by a flourish swoop, timed particle bursts, and a final "unlocked" state — all choreographed purely with `animation-delay`.
+* **Musical Note Particles:** Unlike a generic dot/spark particle, each particle is an actual ♪ or ♫ glyph that scatters and rotates outward, tying the effect directly to the music-player theme.
+* **Ambient Motion:** A spinning vinyl icon and a gently bouncing mini equalizer animate continuously in the header, independent of the signing interaction.
+* **Zero JavaScript:** State is fully managed via a hidden `radio` input + CSS sibling selectors.
+* **Accessible:** Reduced-motion users get all animations disabled via `prefers-reduced-motion`; decorative elements are marked `aria-hidden`.
+* **Responsive:** Card padding and pad height scale down for small screens.
+
+## Variable Reference Map
+
+| CSS Parameter | Default Value | Purpose |
+| :--- | :--- | :--- |
+| `--mp-accent-pink` | `#ff4fd8` | Primary signature stroke / accent color. |
+| `--mp-accent-purple` | `#a855f7` | Card glow and button gradient start. |
+| `--mp-accent-cyan` | `#22d3ee` | Secondary stroke color / "unlocked" state color. |
+| `--mp-surface` | `#1c1030` | Card background surface. |
+
+## Accessibility Notes
+* Decorative elements (`eq-bars`, `pad-wave-bg`) are marked `aria-hidden="true"`.
+* All animation (vinyl spin, equalizer bounce, signature draw, particle scatter) is disabled under `prefers-reduced-motion: reduce`, with the signature shown instantly drawn instead.
+* Interactive elements are real `<label for="...">` controls tied to a hidden radio input, so they remain keyboard and screen-reader operable without any JavaScript.

--- a/submissions/examples/particle-signature-pad-priya/demo.html
+++ b/submissions/examples/particle-signature-pad-priya/demo.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Particle Signature Pad — Music Player Design — EaseMotion CSS</title>
+    <!-- Load EaseMotion CSS via relative path -->
+    <link rel="stylesheet" href="../../../easemotion.css" />
+    <!-- Load component specific styles -->
+    <link rel="stylesheet" href="./style.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <!-- Hidden state controls for interactive pure-CSS flow -->
+    <input type="radio" id="state-idle" name="pad-state" checked class="state-control" />
+    <input type="radio" id="state-signing" name="pad-state" class="state-control" />
+
+    <div class="player-container">
+      <div class="player-card">
+        <!-- Header: vinyl + track info + mini equalizer -->
+        <div class="player-header">
+          <div class="vinyl"></div>
+          <div class="track-info">
+            <span class="track-title">Midnight Backstage</span>
+            <span class="track-artist">The Aurora Keys</span>
+          </div>
+          <div class="eq-bars" aria-hidden="true">
+            <span></span><span></span><span></span><span></span>
+          </div>
+        </div>
+
+        <!-- Interactive Signature Pad Wrapper -->
+        <div class="signature-pad-wrapper">
+          <div class="pad-wave-bg" aria-hidden="true">
+            <span></span><span></span><span></span><span></span><span></span>
+            <span></span><span></span><span></span><span></span><span></span>
+            <span></span><span></span><span></span><span></span><span></span>
+          </div>
+
+          <!-- Instruction Overlay -->
+          <div class="instruction-overlay">
+            <svg viewBox="0 0 24 24" width="30" height="30" fill="none" stroke="currentColor" stroke-width="1.5">
+              <path d="M12 20h9M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z" />
+            </svg>
+            <p>Sign below to unlock your backstage pass</p>
+          </div>
+
+          <!-- The SVG Signature Path -->
+          <svg class="signature-svg" viewBox="0 0 400 150" fill="none">
+            <path
+              class="signature-path main-path"
+              d="M 80,100 C 70,60 60,30 90,30 C 110,30 100,70 70,120 C 50,150 40,110 50,90 C 60,70 90,60 120,60 C 130,60 135,75 140,75 C 145,75 150,65 155,65 C 160,65 165,75 170,75 C 175,75 180,60 185,60 C 190,60 195,75 200,75 C 205,75 210,65 215,65 C 220,65 225,75 230,75 C 235,75 240,55 245,55 C 250,55 255,75 260,75 C 265,75 270,70 280,60"
+            />
+            <path
+              class="signature-path swoop-path"
+              d="M 60,110 C 120,110 180,115 240,110 C 280,105 320,95 340,80 C 350,70 330,85 300,95 C 250,110 180,115 110,110 C 70,105 50,100 65,95"
+            />
+          </svg>
+
+          <!-- Particle Emitters positioned along the signature path, each
+               particle rendered as a floating musical note glyph -->
+          <div class="particle-emitter" style="left: 20%; top: 60%; --delay: 0.2s">
+            <span class="particle" style="--dx: -14px; --dy: -10px; --rot: -20deg">♪</span>
+            <span class="particle" style="--dx: 10px; --dy: -16px; --rot: 15deg">♫</span>
+            <span class="particle" style="--dx: -6px; --dy: 12px; --rot: 30deg">♪</span>
+          </div>
+          <div class="particle-emitter" style="left: 21.5%; top: 20%; --delay: 0.5s">
+            <span class="particle" style="--dx: -16px; --dy: -10px; --rot: 25deg">♫</span>
+            <span class="particle" style="--dx: 16px; --dy: -6px; --rot: -18deg">♪</span>
+            <span class="particle" style="--dx: 5px; --dy: 16px; --rot: 12deg">♪</span>
+          </div>
+          <div class="particle-emitter" style="left: 17.5%; top: 80%; --delay: 0.8s">
+            <span class="particle" style="--dx: -8px; --dy: -14px; --rot: 20deg">♪</span>
+            <span class="particle" style="--dx: 14px; --dy: 8px; --rot: -10deg">♫</span>
+            <span class="particle" style="--dx: -10px; --dy: 10px; --rot: 18deg">♪</span>
+          </div>
+          <div class="particle-emitter" style="left: 30%; top: 40%; --delay: 1.1s">
+            <span class="particle" style="--dx: -15px; --dy: -15px; --rot: -22deg">♫</span>
+            <span class="particle" style="--dx: 15px; --dy: -8px; --rot: 16deg">♪</span>
+            <span class="particle" style="--dx: 8px; --dy: 15px; --rot: 24deg">♪</span>
+          </div>
+          <div class="particle-emitter" style="left: 42.5%; top: 50%; --delay: 1.4s">
+            <span class="particle" style="--dx: -10px; --dy: -10px; --rot: 14deg">♪</span>
+            <span class="particle" style="--dx: 13px; --dy: -13px; --rot: -20deg">♫</span>
+            <span class="particle" style="--dx: -6px; --dy: 16px; --rot: 22deg">♪</span>
+          </div>
+          <div class="particle-emitter" style="left: 55%; top: 45%; --delay: 1.8s">
+            <span class="particle" style="--dx: -13px; --dy: -6px; --rot: -16deg">♫</span>
+            <span class="particle" style="--dx: 11px; --dy: -15px; --rot: 20deg">♪</span>
+            <span class="particle" style="--dx: 13px; --dy: 11px; --rot: 12deg">♪</span>
+          </div>
+          <div class="particle-emitter" style="left: 65%; top: 40%; --delay: 2.2s">
+            <span class="particle" style="--dx: -16px; --dy: -8px; --rot: 18deg">♪</span>
+            <span class="particle" style="--dx: 9px; --dy: -13px; --rot: -14deg">♫</span>
+            <span class="particle" style="--dx: 4px; --dy: 16px; --rot: 26deg">♪</span>
+          </div>
+          <div class="particle-emitter" style="left: 30%; top: 73%; --delay: 2.5s">
+            <span class="particle" style="--dx: -10px; --dy: -10px; --rot: -20deg">♫</span>
+            <span class="particle" style="--dx: 11px; --dy: -6px; --rot: 18deg">♪</span>
+            <span class="particle" style="--dx: -4px; --dy: 13px; --rot: 14deg">♪</span>
+          </div>
+          <div class="particle-emitter" style="left: 60%; top: 73%; --delay: 2.8s">
+            <span class="particle" style="--dx: -13px; --dy: -8px; --rot: 22deg">♪</span>
+            <span class="particle" style="--dx: 15px; --dy: -15px; --rot: -16deg">♫</span>
+            <span class="particle" style="--dx: 2px; --dy: 16px; --rot: 20deg">♪</span>
+          </div>
+          <div class="particle-emitter" style="left: 85%; top: 53%; --delay: 3.1s">
+            <span class="particle" style="--dx: -16px; --dy: -16px; --rot: -24deg">♫</span>
+            <span class="particle" style="--dx: 16px; --dy: -10px; --rot: 20deg">♪</span>
+            <span class="particle" style="--dx: 5px; --dy: 16px; --rot: 15deg">♪</span>
+          </div>
+        </div>
+
+        <!-- Action buttons linked to radio states -->
+        <div class="action-footer">
+          <label for="state-signing" class="action-btn">
+            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M12 20h9M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z" />
+            </svg>
+            Sign & Unlock Track
+          </label>
+          <label for="state-idle" class="reset-link">Clear & Reset Pad</label>
+          <div class="unlock-status">
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.5">
+              <path d="M20 6L9 17l-5-5" />
+            </svg>
+            Track Unlocked — Enjoy the show
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/particle-signature-pad-priya/style.css
+++ b/submissions/examples/particle-signature-pad-priya/style.css
@@ -1,0 +1,416 @@
+/* ============================================================
+   Particle Signature Pad — Music Player Design (Issue #42418)
+   "Sign to unlock" backstage-pass style signature pad for a
+   music streaming / concert-ticket UI. Pure CSS, no JavaScript —
+   state is driven entirely by a hidden radio input + sibling
+   selectors, same pattern used elsewhere in EaseMotion CSS.
+   ============================================================ */
+
+:root {
+  --mp-bg: #120a1f;
+  --mp-surface: #1c1030;
+  --mp-border: #33204f;
+  --mp-accent-pink: #ff4fd8;
+  --mp-accent-purple: #a855f7;
+  --mp-accent-cyan: #22d3ee;
+  --mp-text-light: #f5f3ff;
+  --mp-text-muted: #b9a8dd;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background-color: var(--ease-color-bg, var(--mp-bg));
+  color: var(--ease-color-text, var(--mp-text-light));
+  font-family: var(--ease-font-sans, "Inter", sans-serif);
+}
+
+/* Hide the state-control radio input off-screen (a11y-safe hiding) */
+.state-control {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.player-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  max-width: 440px;
+  padding: var(--ease-space-4, 16px);
+  box-sizing: border-box;
+}
+
+/* Card */
+.player-card {
+  width: 100%;
+  background: var(--ease-color-surface, var(--mp-surface));
+  border: 1px solid var(--mp-border);
+  border-radius: var(--ease-radius-lg, 18px);
+  box-shadow: 0 20px 50px -10px rgba(168, 85, 247, 0.35);
+  padding: var(--ease-space-6, 24px);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-space-5, 20px);
+  position: relative;
+  overflow: hidden;
+}
+
+/* Header — vinyl icon + track info */
+.player-header {
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-3, 12px);
+}
+
+.vinyl {
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at center, var(--mp-surface) 0 8px, #000 8px 9px, #111 9px 22px, #000 22px 23px);
+  flex-shrink: 0;
+  animation: spin-vinyl 4s linear infinite;
+}
+
+@keyframes spin-vinyl {
+  to { transform: rotate(360deg); }
+}
+
+.track-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.track-title {
+  font-size: var(--ease-text-sm, 14px);
+  font-weight: 700;
+  color: var(--mp-text-light);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.track-artist {
+  font-size: var(--ease-text-xs, 12px);
+  color: var(--mp-text-muted);
+}
+
+/* Mini equalizer bars — always gently animating in the header */
+.eq-bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 3px;
+  height: 18px;
+  margin-left: auto;
+}
+
+.eq-bars span {
+  width: 3px;
+  background: linear-gradient(180deg, var(--mp-accent-cyan), var(--mp-accent-pink));
+  border-radius: 2px;
+  animation: eq-bounce 1.2s ease-in-out infinite;
+}
+
+.eq-bars span:nth-child(1) { height: 40%; animation-delay: 0s; }
+.eq-bars span:nth-child(2) { height: 100%; animation-delay: 0.2s; }
+.eq-bars span:nth-child(3) { height: 65%; animation-delay: 0.4s; }
+.eq-bars span:nth-child(4) { height: 85%; animation-delay: 0.1s; }
+
+@keyframes eq-bounce {
+  0%, 100% { transform: scaleY(0.4); }
+  50% { transform: scaleY(1); }
+}
+
+/* Signature Pad Area */
+.signature-pad-wrapper {
+  position: relative;
+  height: 170px;
+  background: #0b0614;
+  border: 1px solid var(--mp-border);
+  border-radius: var(--ease-radius-md, 10px);
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition:
+    border-color var(--ease-speed-medium, 300ms) var(--ease-ease),
+    box-shadow var(--ease-speed-medium, 300ms) var(--ease-ease);
+}
+
+.signature-pad-wrapper:hover {
+  border-color: var(--mp-accent-pink);
+  box-shadow: 0 0 14px rgba(255, 79, 216, 0.2);
+}
+
+/* Soft waveform backdrop */
+.pad-wave-bg {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-evenly;
+  padding: 0 12px;
+  opacity: 0.15;
+  pointer-events: none;
+}
+
+.pad-wave-bg span {
+  width: 3px;
+  border-radius: 2px;
+  background: var(--mp-accent-purple);
+}
+
+.pad-wave-bg span:nth-child(odd) { height: 30%; }
+.pad-wave-bg span:nth-child(even) { height: 60%; }
+.pad-wave-bg span:nth-child(3n) { height: 85%; }
+
+.instruction-overlay {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--ease-space-2, 8px);
+  color: var(--mp-text-muted);
+  pointer-events: none;
+  transition: opacity var(--ease-speed-medium, 300ms) var(--ease-ease);
+  z-index: 10;
+  text-align: center;
+  padding: 0 var(--ease-space-4, 16px);
+}
+
+.instruction-overlay p {
+  margin: 0;
+  font-size: var(--ease-text-sm, 14px);
+}
+
+/* Signature SVG */
+.signature-svg {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  z-index: 2;
+  pointer-events: none;
+}
+
+.signature-path {
+  stroke: var(--mp-accent-pink);
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  filter: drop-shadow(0 0 5px rgba(255, 79, 216, 0.6));
+}
+
+.signature-path.main-path {
+  stroke-dasharray: 1000;
+  stroke-dashoffset: 1000;
+}
+
+.signature-path.swoop-path {
+  stroke: var(--mp-accent-cyan);
+  stroke-width: 2;
+  stroke-dasharray: 500;
+  stroke-dashoffset: 500;
+  filter: drop-shadow(0 0 4px rgba(34, 211, 238, 0.5));
+}
+
+/* Particle "musical note" emitters */
+.particle-emitter {
+  position: absolute;
+  pointer-events: none;
+  z-index: 5;
+}
+
+.particle {
+  position: absolute;
+  top: 0;
+  left: 0;
+  font-size: 14px;
+  line-height: 1;
+  color: var(--mp-accent-cyan);
+  opacity: 0;
+  text-shadow: 0 0 8px var(--mp-accent-cyan);
+}
+
+.particle-emitter:nth-child(3n) .particle {
+  color: var(--mp-accent-pink);
+  text-shadow: 0 0 8px var(--mp-accent-pink);
+}
+
+/* Footer */
+.action-footer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--ease-space-3, 12px);
+}
+
+.action-btn {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: var(--ease-space-2, 8px);
+  width: 100%;
+  padding: var(--ease-space-3, 12px) var(--ease-space-5, 20px);
+  border-radius: var(--ease-radius-md, 10px);
+  font-size: var(--ease-text-base, 16px);
+  font-weight: 700;
+  cursor: pointer;
+  box-sizing: border-box;
+  text-align: center;
+  user-select: none;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: linear-gradient(135deg, var(--mp-accent-purple) 0%, var(--mp-accent-pink) 100%);
+  color: #ffffff;
+  box-shadow: 0 4px 14px rgba(255, 79, 216, 0.3);
+  transition: all var(--ease-speed-fast, 150ms) var(--ease-ease);
+}
+
+.action-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px rgba(255, 79, 216, 0.45);
+}
+
+.action-btn:active {
+  transform: translateY(0);
+}
+
+.reset-link {
+  font-size: var(--ease-text-sm, 14px);
+  color: var(--mp-text-muted);
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+  transition: color var(--ease-speed-fast, 150ms) var(--ease-ease);
+  user-select: none;
+}
+
+.reset-link:hover {
+  color: var(--mp-accent-cyan);
+}
+
+.unlock-status {
+  display: none;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--ease-text-xs, 12px);
+  font-weight: 700;
+  color: var(--mp-accent-cyan);
+}
+
+/* ============================================================
+   ACTIVE SIGNING STATE (Pure CSS state machine)
+   ============================================================ */
+
+#state-signing:checked ~ .player-container .instruction-overlay {
+  opacity: 0;
+}
+
+#state-signing:checked ~ .player-container .signature-pad-wrapper {
+  border-color: rgba(255, 79, 216, 0.6);
+  box-shadow:
+    inset 0 0 16px rgba(255, 79, 216, 0.12),
+    0 0 16px rgba(255, 79, 216, 0.2);
+}
+
+#state-signing:checked ~ .player-container .signature-path.main-path {
+  animation: draw-cursive-sig 2.4s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+#state-signing:checked ~ .player-container .signature-path.swoop-path {
+  animation: draw-cursive-sig 1s cubic-bezier(0.22, 1, 0.36, 1) 2.2s forwards;
+}
+
+@keyframes draw-cursive-sig {
+  to { stroke-dashoffset: 0; }
+}
+
+/* Musical note particles burst outward and fade, each with its own
+   randomized direction/delay supplied via inline custom properties */
+#state-signing:checked ~ .player-container .particle {
+  animation: note-scatter 0.9s ease-out var(--delay) forwards;
+}
+
+@keyframes note-scatter {
+  0% {
+    transform: translate(0, 0) scale(0) rotate(0deg);
+    opacity: 0;
+  }
+  15% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate(var(--dx), var(--dy)) scale(1.3) rotate(var(--rot, 25deg));
+    opacity: 0;
+  }
+}
+
+#state-signing:checked ~ .player-container .action-btn {
+  pointer-events: none;
+  background: linear-gradient(135deg, #0891b2 0%, var(--mp-accent-cyan) 100%);
+  box-shadow: 0 4px 14px rgba(34, 211, 238, 0.35);
+  animation: btn-to-unlocked 0.5s ease-out 3.2s forwards;
+}
+
+@keyframes btn-to-unlocked {
+  to {
+    box-shadow: 0 4px 14px rgba(34, 211, 238, 0.45);
+  }
+}
+
+#state-signing:checked ~ .player-container .unlock-status {
+  display: flex;
+  opacity: 0;
+  transform: translateY(4px);
+  animation: fade-in-status 0.5s var(--ease-ease-bounce, cubic-bezier(0.34, 1.56, 0.64, 1)) 3.4s forwards;
+}
+
+@keyframes fade-in-status {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Reduced motion compliance */
+@media (prefers-reduced-motion: reduce) {
+  .vinyl,
+  .eq-bars span {
+    animation: none !important;
+  }
+  #state-signing:checked ~ .player-container .signature-path {
+    stroke-dashoffset: 0 !important;
+    animation: none !important;
+  }
+  #state-signing:checked ~ .player-container .particle {
+    animation: none !important;
+    opacity: 0 !important;
+  }
+  #state-signing:checked ~ .player-container .action-btn,
+  #state-signing:checked ~ .player-container .unlock-status {
+    animation: none !important;
+  }
+}
+
+/* Responsive */
+@media (max-width: 480px) {
+  .player-card {
+    padding: var(--ease-space-4, 16px);
+    border-radius: var(--ease-radius-md, 12px);
+  }
+  .signature-pad-wrapper {
+    height: 140px;
+  }
+}


### PR DESCRIPTION
## Summary
Closes #42418 — adds a `particle-signature-pad` component themed for a music player / concert-ticket UI: a "sign to unlock" pad where signing draws a cursive signature stroke-by-stroke while musical note particles (♪ ♫) burst outward and fade.

## What's included
- `submissions/examples/particle-signature-pad-priya/style.css`
- `submissions/examples/particle-signature-pad-priya/demo.html`
- `submissions/examples/particle-signature-pad-priya/README.md`

## Requirements checklist
- [x] Pure CSS, no JavaScript — state driven by a hidden radio input + sibling selectors
- [x] Uses EaseMotion CSS variables (`--ease-color-bg`, `--ease-space-*`, `--ease-radius-*`, `--ease-ease-bounce`, etc.) with sensible fallbacks
- [x] Live demo included in `demo.html`
- [x] Documented `README.md` with usage snippets and variable reference table
- [x] Responsive (card padding/pad height scale down on small screens)
- [x] Accessible — real `<label for="">` controls (keyboard/screen-reader operable), `aria-hidden` on decorative elements, full `prefers-reduced-motion` support

## Design notes
Distinct from the existing banking-themed signature pad (`particle-signature-pad-am`): themed around a spinning vinyl record, ambient equalizer bars, and actual musical note glyphs (♪/♫) as the particle effect instead of generic sparks, tying the animation directly to the music-player brief. Sequenced over ~3.5s: signature draw → flourish swoop → particle burst → button unlock state.

## Testing
Tested locally in Chrome — verified the full sign sequence plays correctly (signature draw, particle burst, unlock state), and the "Clear & Reset Pad" control correctly resets to the idle state.