### PR TITLE
feat: add ecg monitor

### DIFF
--- a/submissions/examples/ecg-monitor-as/README.md
+++ b/submissions/examples/ecg-monitor-as/README.md
@@ -1,0 +1,21 @@
+# ECG Monitor
+
+### What does this do?
+
+It shows a heart monitor with a glowing green ECG trace scrolling across a gridded screen, a BPM readout, an oxygen value, and a heart icon that beats. The classic PQRST heartbeat waveform repeats and slides continuously. Under reduced motion the trace and heart hold still.
+
+### How is it used?
+
+```html
+<div class="ecg-screen">
+  <svg class="ecg-trace" viewBox="0 0 300 80" preserveAspectRatio="none">
+    <polyline points="0,40 56,52 62,12 68,54 74,40 ..." />
+  </svg>
+</div>
+```
+
+The screen uses layered `repeating-linear-gradient` for the grid. The waveform is one SVG `polyline` tiled several beats wide, sliding left by one beat with `ecg-scroll` so it loops seamlessly, and a glow gives the trace its phosphor look.
+
+### Why is it useful?
+
+Health apps, dashboards, and status screens use a heartbeat trace. This builds a scrolling ECG monitor with pure CSS and an SVG polyline, no images or script, with a reduced motion fallback.

--- a/submissions/examples/ecg-monitor-as/demo.html
+++ b/submissions/examples/ecg-monitor-as/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ECG Monitor</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="ecg">
+    <div class="ecg-top">
+      <span class="ecg-heart">&#10084;</span>
+      <span class="ecg-bpm"><b>72</b> BPM</span>
+      <span class="ecg-o2">SpO&#8322; 98%</span>
+    </div>
+    <div class="ecg-screen">
+      <svg class="ecg-trace" viewBox="0 0 300 80" preserveAspectRatio="none" aria-label="Heartbeat trace">
+        <polyline points="0,40 22,40 30,33 38,40 50,40 56,52 62,12 68,54 74,40 92,40 102,31 116,40 150,40 150,40 172,40 180,33 188,40 200,40 206,52 212,12 218,54 224,40 242,40 252,31 266,40 300,40 300,40 322,40 330,33 338,40 350,40 356,52 362,12 368,54 374,40 392,40 402,31 416,40 450,40 450,40 472,40 480,33 488,40 500,40 506,52 512,12 518,54 524,40 542,40 552,31 566,40 600,40 600,40 622,40 630,33 638,40 650,40 656,52 662,12 668,54 674,40 692,40 702,31 716,40 750,40" />
+      </svg>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ecg-monitor-as/style.css
+++ b/submissions/examples/ecg-monitor-as/style.css
@@ -1,0 +1,107 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #101822, #06090e 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #cfeee0;
+}
+
+.ecg {
+  width: min(400px, 94vw);
+  padding: 1.1rem 1.2rem 1.2rem;
+  box-sizing: border-box;
+  background: #0b1016;
+  border: 1px solid #17303a;
+  border-radius: 16px;
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.5);
+}
+
+.ecg-top {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  margin-bottom: 0.9rem;
+}
+
+.ecg-heart {
+  font-size: 1.3rem;
+  color: #22c55e;
+  animation: ecg-beat 0.84s ease-in-out infinite;
+}
+
+.ecg-bpm {
+  font-size: 0.9rem;
+  color: #7fe9b6;
+  font-variant-numeric: tabular-nums;
+}
+
+.ecg-bpm b {
+  font-size: 1.4rem;
+  color: #eafff4;
+}
+
+.ecg-o2 {
+  margin-left: auto;
+  font-size: 0.8rem;
+  color: #5aa2c4;
+  font-variant-numeric: tabular-nums;
+}
+
+.ecg-screen {
+  position: relative;
+  height: 140px;
+  border-radius: 10px;
+  overflow: hidden;
+  background:
+    linear-gradient(#0a1a14, #071310),
+    repeating-linear-gradient(90deg, transparent 0 19px, rgba(52, 211, 153, 0.08) 19px 20px),
+    repeating-linear-gradient(0deg, transparent 0 19px, rgba(52, 211, 153, 0.08) 19px 20px);
+  background-blend-mode: normal;
+}
+
+.ecg-screen::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    repeating-linear-gradient(90deg, transparent 0 19px, rgba(52, 211, 153, 0.09) 19px 20px),
+    repeating-linear-gradient(0deg, transparent 0 19px, rgba(52, 211, 153, 0.09) 19px 20px);
+  pointer-events: none;
+}
+
+.ecg-trace {
+  position: relative;
+  width: 200%;
+  height: 100%;
+  z-index: 1;
+}
+
+.ecg-trace polyline {
+  fill: none;
+  stroke: #34f5a0;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  filter: drop-shadow(0 0 4px rgba(52, 245, 160, 0.9));
+  animation: ecg-scroll 2.5s linear infinite;
+}
+
+@keyframes ecg-scroll {
+  to { transform: translateX(-150px); }
+}
+
+@keyframes ecg-beat {
+  0%, 100% { transform: scale(1); }
+  14% { transform: scale(1.28); }
+  28% { transform: scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ecg-trace polyline, .ecg-heart {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an ECG monitor built for #43741. A scrolling PQRST heartbeat polyline glowing over a gridded screen, with a beating heart and BPM and SpO2 readouts, and a reduced motion fallback. Pure CSS. Closes #43741.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a glowing green ECG trace with QRS spikes scrolling on a grid, a beating heart, and 72 BPM with SpO2 98 percent.
