### PR TITLE
feat: add roulette wheel

### DIFF
--- a/submissions/examples/roulette-wheel-as/README.md
+++ b/submissions/examples/roulette-wheel-as/README.md
@@ -1,0 +1,21 @@
+# Roulette Wheel
+
+### What does this do?
+
+It shows a roulette wheel that spins while a ball circles the rim the other way. Alternating red and black pockets with a single green zero make up the wheel, numbers ride around the inner edge, a wooden rim and metal hub frame it, and a pointer marks the top. Under reduced motion it holds still.
+
+### How is it used?
+
+```html
+<div class="rw-wheel">
+  <div class="rw-nums"><span class="rw-num" style="--a: 30deg;">32</span></div>
+  <span class="rw-hub"></span>
+</div>
+<div class="rw-ball-track"><span class="rw-ball"></span></div>
+```
+
+The pockets come from a `conic-gradient` of red, black, and one green wedge. Numbers are placed with a rotate then counter rotate transform by their `--a` angle. The wheel spins one way and the `rw-ball-track` spins in reverse so the ball travels opposite the wheel.
+
+### Why is it useful?
+
+Casino, games, and prize wheel features use a roulette wheel. This builds a spinning wheel with a counter rotating ball using pure CSS gradients and rotation, no images, with a reduced motion fallback.

--- a/submissions/examples/roulette-wheel-as/demo.html
+++ b/submissions/examples/roulette-wheel-as/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Roulette Wheel</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="roulette">
+    <span class="rw-pointer"></span>
+    <div class="rw-wheel">
+      <div class="rw-nums">
+        <span class="rw-num" style="--a: 0deg;">0</span>
+        <span class="rw-num" style="--a: 30deg;">32</span>
+        <span class="rw-num" style="--a: 60deg;">15</span>
+        <span class="rw-num" style="--a: 90deg;">19</span>
+        <span class="rw-num" style="--a: 120deg;">4</span>
+        <span class="rw-num" style="--a: 150deg;">21</span>
+        <span class="rw-num" style="--a: 180deg;">2</span>
+        <span class="rw-num" style="--a: 210deg;">25</span>
+        <span class="rw-num" style="--a: 240deg;">17</span>
+        <span class="rw-num" style="--a: 270deg;">34</span>
+        <span class="rw-num" style="--a: 300deg;">6</span>
+        <span class="rw-num" style="--a: 330deg;">27</span>
+      </div>
+      <span class="rw-hub"></span>
+    </div>
+    <div class="rw-ball-track">
+      <span class="rw-ball"></span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/roulette-wheel-as/style.css
+++ b/submissions/examples/roulette-wheel-as/style.css
@@ -1,0 +1,112 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #14321f, #071009 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.roulette {
+  position: relative;
+  width: 250px;
+  height: 250px;
+}
+
+.rw-pointer {
+  position: absolute;
+  top: -4px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  border-top: 16px solid #fbbf24;
+  z-index: 6;
+  filter: drop-shadow(0 2px 3px rgba(0, 0, 0, 0.5));
+}
+
+.rw-wheel {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background:
+    conic-gradient(
+      #16a34a 0 30deg,
+      #1f2937 30deg 60deg, #b91c1c 60deg 90deg,
+      #1f2937 90deg 120deg, #b91c1c 120deg 150deg,
+      #1f2937 150deg 180deg, #b91c1c 180deg 210deg,
+      #1f2937 210deg 240deg, #b91c1c 240deg 270deg,
+      #1f2937 270deg 300deg, #b91c1c 300deg 330deg,
+      #1f2937 330deg 360deg
+    );
+  border: 10px solid #6b4a1e;
+  box-shadow: 0 22px 44px rgba(0, 0, 0, 0.55), inset 0 0 0 4px #8a6428;
+  animation: rw-spin 6s cubic-bezier(0.2, 0.6, 0.1, 1) infinite;
+}
+
+.rw-nums {
+  position: absolute;
+  inset: 0;
+}
+
+.rw-num {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #fff;
+  transform:
+    translateX(-50%)
+    rotate(var(--a))
+    translateY(0)
+    rotate(calc(-1 * var(--a)));
+  transform-origin: 50% 103px;
+}
+
+.rw-hub {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 60px;
+  height: 60px;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 35%, #d8c28a, #8a6428 72%);
+  box-shadow: inset 0 0 0 5px #6b4a1e, 0 3px 6px rgba(0, 0, 0, 0.4);
+}
+
+.rw-ball-track {
+  position: absolute;
+  inset: 14px;
+  z-index: 5;
+  animation: rw-ball-spin 6s cubic-bezier(0.15, 0.7, 0.1, 1) infinite reverse;
+}
+
+.rw-ball {
+  position: absolute;
+  top: 4px;
+  left: 50%;
+  width: 12px;
+  height: 12px;
+  transform: translateX(-50%);
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #fff, #cbd5e1 75%);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+}
+
+@keyframes rw-spin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes rw-ball-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rw-wheel, .rw-ball-track {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a roulette wheel built for #43745. Conic gradient red, black, and green pockets with numbers, a wooden rim and hub, a pointer, and a ball spinning opposite the wheel, with a reduced motion fallback. Pure CSS. Closes #43745.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: red and black pockets with a green zero, twelve numbers, a hub and rim, a pointer, and a ball spinning in reverse.
