### PR TITLE
feat: add tic tac toe

### DIFF
--- a/submissions/examples/tic-tac-toe-as/README.md
+++ b/submissions/examples/tic-tac-toe-as/README.md
@@ -1,0 +1,21 @@
+# Tic Tac Toe
+
+### What does this do?
+
+It shows a finished tic tac toe board where X has won on the diagonal. X marks are drawn as two crossed bars, O marks as rings, and a glowing line strikes through the winning three, drawing itself across the board.
+
+### How is it used?
+
+```html
+<div class="ttt-board">
+  <span class="cell x"></span>
+  <span class="cell o"></span>
+  <span class="win-line"></span>
+</div>
+```
+
+The board is a three by three grid. Each cell shows an X (two rotated `::before` and `::after` bars) or an O (a bordered circle). The `win-line` is a rotated bar that scales in from its start to strike the winning row.
+
+### Why is it useful?
+
+Games, empty states, and playful UIs use tic tac toe. This renders a board with X and O marks and an animated winning strike using pure CSS, no images or script.

--- a/submissions/examples/tic-tac-toe-as/demo.html
+++ b/submissions/examples/tic-tac-toe-as/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tic Tac Toe</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="ttt-card">
+    <div class="ttt-head">
+      <span class="turn x">X wins!</span>
+    </div>
+    <div class="ttt-board">
+      <span class="cell x"></span>
+      <span class="cell o"></span>
+      <span class="cell x"></span>
+      <span class="cell o"></span>
+      <span class="cell x"></span>
+      <span class="cell o"></span>
+      <span class="cell"></span>
+      <span class="cell"></span>
+      <span class="cell x"></span>
+      <span class="win-line"></span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/tic-tac-toe-as/style.css
+++ b/submissions/examples/tic-tac-toe-as/style.css
@@ -1,0 +1,102 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #1a2233, #0a0e15 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e6ebf6;
+}
+
+.ttt-card {
+  padding: 1.5rem;
+  background: #121a2a;
+  border: 1px solid #263149;
+  border-radius: 18px;
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.5);
+}
+
+.ttt-head {
+  margin-bottom: 1rem;
+  text-align: center;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.turn.x {
+  color: #38bdf8;
+}
+
+.ttt-board {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(3, 74px);
+  grid-template-rows: repeat(3, 74px);
+  gap: 8px;
+  padding: 8px;
+  background: #0d1420;
+  border-radius: 12px;
+}
+
+.cell {
+  position: relative;
+  border-radius: 8px;
+  background: #172033;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.4);
+}
+
+.cell.x::before,
+.cell.x::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 44px;
+  height: 6px;
+  border-radius: 3px;
+  background: #38bdf8;
+  box-shadow: 0 0 8px rgba(56, 189, 248, 0.5);
+}
+
+.cell.x::before { transform: translate(-50%, -50%) rotate(45deg); }
+.cell.x::after { transform: translate(-50%, -50%) rotate(-45deg); }
+
+.cell.o::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 42px;
+  height: 42px;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  border: 6px solid #f472b6;
+  box-shadow: 0 0 8px rgba(244, 114, 182, 0.4);
+}
+
+.win-line {
+  position: absolute;
+  top: 41px;
+  left: 41px;
+  width: 214px;
+  height: 5px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #34d399, #22d3ee);
+  transform-origin: left center;
+  transform: rotate(45deg);
+  box-shadow: 0 0 12px rgba(52, 211, 153, 0.7);
+  animation: ttt-draw 0.7s ease-out both;
+}
+
+@keyframes ttt-draw {
+  from { transform: rotate(45deg) scaleX(0); }
+  to { transform: rotate(45deg) scaleX(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .win-line {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a tic tac toe board built for #43748. X marks from crossed bars and O rings on a grid, with a glowing winning line that draws across the diagonal. Pure CSS. Closes #43748.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a board with four X marks and three O rings and a glowing diagonal winning line.
