### PR TITLE
feat: add dartboard

### DIFF
--- a/submissions/examples/dartboard-as/README.md
+++ b/submissions/examples/dartboard-as/README.md
@@ -1,0 +1,23 @@
+# Dartboard
+
+### What does this do?
+
+It shows a dartboard with twenty alternating cream and black segments, red and green double and triple rings, a green outer bull and red inner bull, and a dart that flies in and sticks near the center on a loop. Under reduced motion the dart is already stuck.
+
+### How is it used?
+
+```html
+<div class="dartboard">
+  <span class="segments"></span>
+  <span class="rings"></span>
+  <span class="bull-green"></span>
+  <span class="bull-red"></span>
+  <span class="dart">...</span>
+</div>
+```
+
+The segments come from a `repeating-conic-gradient`, and a second red and green conic is masked with a `radial-gradient` into two ring bands for the double and triple. The bull is two centered circles, and the dart is a CSS tip, shaft, and flight that animates in.
+
+### Why is it useful?
+
+Games, scoring, and target or goal metaphors use a dartboard. This builds one with pure CSS conic gradients and masks plus an animated dart, no images, with a reduced motion fallback.

--- a/submissions/examples/dartboard-as/demo.html
+++ b/submissions/examples/dartboard-as/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dartboard</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="dartboard" role="img" aria-label="Dartboard with a dart near the bullseye">
+    <span class="segments"></span>
+    <span class="rings"></span>
+    <span class="bull-green"></span>
+    <span class="bull-red"></span>
+    <span class="dart">
+      <span class="dart-tip"></span>
+      <span class="dart-shaft"></span>
+      <span class="dart-flight"></span>
+    </span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/dartboard-as/style.css
+++ b/submissions/examples/dartboard-as/style.css
@@ -1,0 +1,135 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #1c2430, #0a0d13 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.dartboard {
+  position: relative;
+  width: 260px;
+  height: 260px;
+  border-radius: 50%;
+  background: #0d0d0d;
+  border: 10px solid #17110a;
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.55);
+}
+
+.segments {
+  position: absolute;
+  inset: 6px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from -9deg,
+      #f0dfbc 0 18deg,
+      #2a2620 18deg 36deg
+    );
+}
+
+.rings {
+  position: absolute;
+  inset: 6px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from -9deg,
+      #d7392f 0 18deg,
+      #2f9e56 18deg 36deg
+    );
+  -webkit-mask: radial-gradient(
+    circle,
+    #0000 0 43px,
+    #000 43px 52px,
+    #0000 52px 92px,
+    #000 92px 100px,
+    #0000 100px
+  );
+  mask: radial-gradient(
+    circle,
+    #0000 0 43px,
+    #000 43px 52px,
+    #0000 52px 92px,
+    #000 92px 100px,
+    #0000 100px
+  );
+}
+
+.bull-green {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 34px;
+  height: 34px;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  background: #2f9e56;
+  box-shadow: inset 0 0 0 2px #1e6b3a;
+}
+
+.bull-red {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 16px;
+  height: 16px;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 35%, #ff6b5e, #c0271c);
+}
+
+.dart {
+  position: absolute;
+  top: 30%;
+  left: 62%;
+  transform: rotate(38deg);
+  transform-origin: left center;
+  z-index: 3;
+  animation: dart-hit 2.6s ease-out infinite;
+}
+
+.dart-tip {
+  position: absolute;
+  left: -6px;
+  top: -2px;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-right: 8px solid #cbd5e1;
+}
+
+.dart-shaft {
+  position: absolute;
+  left: 0;
+  top: -1.5px;
+  width: 60px;
+  height: 3px;
+  border-radius: 2px;
+  background: linear-gradient(90deg, #94a3b8, #475569);
+}
+
+.dart-flight {
+  position: absolute;
+  left: 52px;
+  top: -9px;
+  width: 0;
+  height: 0;
+  border-top: 9px solid transparent;
+  border-bottom: 9px solid transparent;
+  border-right: 18px solid #ef4444;
+}
+
+@keyframes dart-hit {
+  0% { transform: rotate(38deg) translateX(60px); opacity: 0; }
+  18% { transform: rotate(38deg) translateX(0); opacity: 1; }
+  100% { transform: rotate(38deg) translateX(0); opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dart {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a dartboard built for #43752. Conic gradient segments with masked red and green double and triple rings, a bullseye, and an animated dart, with a reduced motion fallback. Pure CSS. Closes #43752.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: twenty segments, masked red and green double and triple rings, a green and red bullseye, and a dart near the center.
