### PR TITLE
feat: add sudoku

### DIFF
--- a/submissions/examples/sudoku-as/README.md
+++ b/submissions/examples/sudoku-as/README.md
@@ -1,0 +1,21 @@
+# Sudoku
+
+### What does this do?
+
+It shows a Sudoku puzzle grid: nine by nine cells with thicker lines dividing the nine three by three boxes, given clues in bold and empty cells left blank, plus one highlighted selected cell. The header names the puzzle and its difficulty.
+
+### How is it used?
+
+```html
+<div class="sk-grid">
+  <span class="sk given">5</span>
+  <span class="sk br"></span>
+  <span class="sk bb sel"></span>
+</div>
+```
+
+The grid is a `repeat(9, ...)` CSS grid with thin cell borders. Cells that end a box column or row add a `br` or `bb` class for a thicker divider, `given` bolds the starting clues, and `sel` highlights the active cell.
+
+### Why is it useful?
+
+Puzzle apps, brain games, and grid demos need a Sudoku board. This renders a full nine by nine grid with box dividers and clue styling using pure CSS, no script or images.

--- a/submissions/examples/sudoku-as/demo.html
+++ b/submissions/examples/sudoku-as/demo.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sudoku</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="sudoku">
+    <div class="sk-head">
+      <span class="sk-title">Sudoku</span>
+      <span class="sk-diff">Medium</span>
+    </div>
+    <div class="sk-grid">
+      <span class="sk given">5</span>
+      <span class="sk given">3</span>
+      <span class="sk br"></span>
+      <span class="sk"></span>
+      <span class="sk given">7</span>
+      <span class="sk br"></span>
+      <span class="sk"></span>
+      <span class="sk"></span>
+      <span class="sk"></span>
+      <span class="sk given">6</span>
+      <span class="sk"></span>
+      <span class="sk br"></span>
+      <span class="sk given">1</span>
+      <span class="sk given">9</span>
+      <span class="sk br given">5</span>
+      <span class="sk"></span>
+      <span class="sk"></span>
+      <span class="sk"></span>
+      <span class="sk bb"></span>
+      <span class="sk bb given">9</span>
+      <span class="sk br bb given">8</span>
+      <span class="sk bb"></span>
+      <span class="sk bb"></span>
+      <span class="sk br bb"></span>
+      <span class="sk bb"></span>
+      <span class="sk bb given">6</span>
+      <span class="sk bb"></span>
+      <span class="sk given">8</span>
+      <span class="sk"></span>
+      <span class="sk br"></span>
+      <span class="sk"></span>
+      <span class="sk given">6</span>
+      <span class="sk br"></span>
+      <span class="sk"></span>
+      <span class="sk"></span>
+      <span class="sk given">3</span>
+      <span class="sk given">4</span>
+      <span class="sk"></span>
+      <span class="sk br"></span>
+      <span class="sk given">8</span>
+      <span class="sk sel"></span>
+      <span class="sk br given">3</span>
+      <span class="sk"></span>
+      <span class="sk"></span>
+      <span class="sk given">1</span>
+      <span class="sk bb given">7</span>
+      <span class="sk bb"></span>
+      <span class="sk br bb"></span>
+      <span class="sk bb"></span>
+      <span class="sk bb given">2</span>
+      <span class="sk br bb"></span>
+      <span class="sk bb"></span>
+      <span class="sk bb"></span>
+      <span class="sk bb given">6</span>
+      <span class="sk"></span>
+      <span class="sk given">6</span>
+      <span class="sk br"></span>
+      <span class="sk"></span>
+      <span class="sk"></span>
+      <span class="sk br"></span>
+      <span class="sk given">2</span>
+      <span class="sk given">8</span>
+      <span class="sk"></span>
+      <span class="sk"></span>
+      <span class="sk"></span>
+      <span class="sk br"></span>
+      <span class="sk given">4</span>
+      <span class="sk given">1</span>
+      <span class="sk br given">9</span>
+      <span class="sk"></span>
+      <span class="sk"></span>
+      <span class="sk given">5</span>
+      <span class="sk"></span>
+      <span class="sk"></span>
+      <span class="sk br"></span>
+      <span class="sk"></span>
+      <span class="sk given">8</span>
+      <span class="sk br"></span>
+      <span class="sk"></span>
+      <span class="sk given">7</span>
+      <span class="sk given">9</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/sudoku-as/style.css
+++ b/submissions/examples/sudoku-as/style.css
@@ -1,0 +1,68 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #182031, #0a0e15 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e6ebf6;
+}
+
+.sudoku {
+  padding: 1.2rem;
+  background: #111a2a;
+  border: 1px solid #263149;
+  border-radius: 16px;
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.5);
+}
+
+.sk-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 0.9rem;
+}
+
+.sk-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.sk-diff {
+  font-size: 0.78rem;
+  color: #fbbf24;
+}
+
+.sk-grid {
+  display: grid;
+  grid-template-columns: repeat(9, 34px);
+  grid-template-rows: repeat(9, 34px);
+  background: #0d1420;
+  border: 3px solid #3a4a66;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.sk {
+  display: grid;
+  place-items: center;
+  font-size: 1rem;
+  font-variant-numeric: tabular-nums;
+  color: #8aa2d6;
+  border-right: 1px solid #1e2942;
+  border-bottom: 1px solid #1e2942;
+}
+
+.sk.br { border-right: 2px solid #3a4a66; }
+.sk.bb { border-bottom: 2px solid #3a4a66; }
+
+.sk.given {
+  color: #eef2fb;
+  font-weight: 700;
+}
+
+.sk.sel {
+  background: rgba(99, 102, 241, 0.28);
+}


### PR DESCRIPTION
## Pull Request Description

Adds a Sudoku board built for #43755. A 9 by 9 CSS grid with thicker 3 by 3 box dividers, bold given clues, and a highlighted cell. Pure CSS. Closes #43755.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: 81 cells with thicker box dividers, 30 bold given clues, and one highlighted selected cell.
