### PR TITLE
feat: add domino

### DIFF
--- a/submissions/examples/domino-as/README.md
+++ b/submissions/examples/domino-as/README.md
@@ -1,0 +1,21 @@
+# Domino
+
+### What does this do?
+
+It shows a set of domino tiles, each split into two halves by a center divider with pips arranged in the classic patterns. The tiles read as a double six, a five three, and a two four, and each lifts and tilts on hover.
+
+### How is it used?
+
+```html
+<div class="tile">
+  <div class="half"><span class="pip a"></span><span class="pip i"></span></div>
+  <span class="divider"></span>
+  <div class="half"><span class="pip a"></span><span class="pip e"></span><span class="pip i"></span></div>
+</div>
+```
+
+Each half is a three by three grid with named areas, and pips carry the class of the cell they sit in, so any value from zero to six is built by adding the right pips. A `divider` splits the tile, which lifts on hover.
+
+### Why is it useful?
+
+Board games, counters, and playful UIs use dominoes. This renders true domino tiles from CSS grid areas and gradient pips, no images, with a hover lift.

--- a/submissions/examples/domino-as/demo.html
+++ b/submissions/examples/domino-as/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Domino</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="dominoes">
+    <div class="tile">
+      <div class="half">
+        <span class="pip a"></span><span class="pip c"></span>
+        <span class="pip d"></span><span class="pip f"></span>
+        <span class="pip g"></span><span class="pip i"></span>
+      </div>
+      <span class="divider"></span>
+      <div class="half">
+        <span class="pip a"></span><span class="pip c"></span>
+        <span class="pip d"></span><span class="pip f"></span>
+        <span class="pip g"></span><span class="pip i"></span>
+      </div>
+    </div>
+
+    <div class="tile">
+      <div class="half">
+        <span class="pip a"></span><span class="pip c"></span>
+        <span class="pip e"></span>
+        <span class="pip g"></span><span class="pip i"></span>
+      </div>
+      <span class="divider"></span>
+      <div class="half">
+        <span class="pip a"></span>
+        <span class="pip e"></span>
+        <span class="pip i"></span>
+      </div>
+    </div>
+
+    <div class="tile">
+      <div class="half">
+        <span class="pip a"></span>
+        <span class="pip i"></span>
+      </div>
+      <span class="divider"></span>
+      <div class="half">
+        <span class="pip a"></span><span class="pip c"></span>
+        <span class="pip g"></span><span class="pip i"></span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/domino-as/style.css
+++ b/submissions/examples/domino-as/style.css
@@ -1,0 +1,75 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 0%, #14321f, #07160d 62%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.dominoes {
+  display: flex;
+  gap: 1.4rem;
+}
+
+.tile {
+  display: grid;
+  grid-template-rows: 1fr auto 1fr;
+  width: 84px;
+  height: 168px;
+  padding: 8px;
+  box-sizing: border-box;
+  background: linear-gradient(160deg, #fdfdfb, #e6e9ea);
+  border-radius: 12px;
+  box-shadow:
+    0 14px 26px rgba(0, 0, 0, 0.45),
+    inset 0 2px 3px rgba(255, 255, 255, 0.9);
+  transition: transform 0.2s ease;
+}
+
+.tile:hover {
+  transform: translateY(-8px) rotate(-2deg);
+}
+
+.half {
+  display: grid;
+  grid-template-areas:
+    "a . c"
+    "d e f"
+    "g . i";
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+  place-items: center;
+  padding: 6px;
+}
+
+.pip {
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 30%, #3a4150, #111827 75%);
+  box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.2);
+}
+
+.pip.a { grid-area: a; }
+.pip.c { grid-area: c; }
+.pip.d { grid-area: d; }
+.pip.e { grid-area: e; }
+.pip.f { grid-area: f; }
+.pip.g { grid-area: g; }
+.pip.i { grid-area: i; }
+
+.divider {
+  height: 3px;
+  margin: 0 6px;
+  border-radius: 2px;
+  background: #b9bfc9;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tile {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds domino tiles built for #43769. Three tiles with divider and pip patterns placed by CSS grid areas, lifting on hover. Pure CSS. Closes #43769.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: three domino tiles reading double six, five three, and two four with correct pip patterns.
