### PR TITLE
feat: add parallax subscribe form

### DIFF
--- a/submissions/examples/parallax-subscribe-form-jp/README.md
+++ b/submissions/examples/parallax-subscribe-form-jp/README.md
@@ -1,0 +1,46 @@
+# Parallax Subscribe Form
+
+## What does this do?
+
+This submission creates a responsive and accessible newsletter subscribe form with layered 3D parallax motion using only HTML and CSS.
+
+## How is it used?
+
+```html
+<div class="card-jp ease-fade-in-jp ease-hover-lift-jp">
+  <div class="grid-jp" aria-hidden="true"></div>
+
+  <div class="content-jp">
+    <h2>Useful ideas, delivered with less noise.</h2>
+
+    <form class="form-jp">
+      <label for="email">Email address</label>
+      <div class="row-jp">
+        <input id="email" type="email" required>
+        <button class="ease-hover-grow-jp">Subscribe</button>
+      </div>
+    </form>
+  </div>
+</div>
+```
+
+Customize the motion with EaseMotion-style variables:
+
+```css
+:root {
+  --ease-duration-jp: 700ms;
+  --ease-fast-jp: 260ms;
+  --ease-curve-jp: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-depth-jp: 58px;
+  --ease-accent-jp: #7c6cff;
+  --ease-accent-2-jp: #38d9c5;
+}
+```
+
+Open `demo.html` directly in a browser. No JavaScript, server, CDN, or external framework is required.
+
+## Why is it useful?
+
+Subscribe forms are common on landing pages, dashboards, product sites, and blogs. This version adds visual depth without sacrificing accessibility.
+
+It fits EaseMotion CSS because it uses reusable motion variables and keyframes, supports mouse and keyboard focus, provides semantic labels and visible focus states, adapts to mobile layouts, respects `prefers-reduced-motion`, and requires no JavaScript.

--- a/submissions/examples/parallax-subscribe-form-jp/demo.html
+++ b/submissions/examples/parallax-subscribe-form-jp/demo.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="description" content="Pure CSS parallax subscribe form for EaseMotion CSS.">
+<title>Parallax Subscribe Form</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="shell-jp">
+  <header>
+    <p class="eyebrow-jp">EaseMotion CSS submission</p>
+    <h1>Parallax Subscribe Form</h1>
+    <p class="lead-jp">A responsive, accessible newsletter form with layered 3D motion and zero JavaScript.</p>
+  </header>
+
+  <section class="stage-jp" aria-label="Newsletter subscription">
+    <div class="card-jp ease-fade-in-jp ease-hover-lift-jp">
+      <div class="grid-jp" aria-hidden="true"></div>
+      <div class="orb-jp orb-a-jp" aria-hidden="true"></div>
+      <div class="orb-jp orb-b-jp" aria-hidden="true"></div>
+
+      <div class="content-jp">
+        <span class="badge-jp"><i aria-hidden="true"></i>Weekly product notes</span>
+        <h2>Useful ideas, delivered with less noise.</h2>
+        <p>One concise update each week about motion design, accessible UI, and practical CSS.</p>
+
+        <form class="form-jp" action="#" method="post">
+          <label for="email">Email address</label>
+          <div class="row-jp">
+            <input id="email" name="email" type="email" autocomplete="email" placeholder="you@example.com" required>
+            <button type="submit" class="ease-hover-grow-jp">Subscribe <span aria-hidden="true">→</span></button>
+          </div>
+          <small>No spam. Unsubscribe at any time.</small>
+        </form>
+      </div>
+
+      <aside class="metric-jp" aria-hidden="true"><strong>12K+</strong><span>Readers</span></aside>
+      <div class="signal-jp" aria-hidden="true"><i></i><i></i><i></i></div>
+    </div>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/parallax-subscribe-form-jp/style.css
+++ b/submissions/examples/parallax-subscribe-form-jp/style.css
@@ -1,0 +1,59 @@
+:root{
+  color-scheme:dark;
+  --ease-duration-jp:700ms;
+  --ease-fast-jp:260ms;
+  --ease-curve-jp:cubic-bezier(.22,1,.36,1);
+  --ease-depth-jp:58px;
+  --ease-accent-jp:#7c6cff;
+  --ease-accent-2-jp:#38d9c5;
+  font-family:Inter,ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;
+  background:#070a13;color:#f5f7ff
+}
+*{box-sizing:border-box}
+body{min-height:100vh;margin:0;display:grid;place-items:center;background:
+radial-gradient(circle at 12% 18%,rgb(124 108 255/.16),transparent 28rem),
+radial-gradient(circle at 88% 82%,rgb(56 217 197/.12),transparent 26rem),#070a13}
+.shell-jp{width:min(100% - 2rem,72rem);padding:clamp(2.5rem,7vw,6rem) 0}
+header{max-width:46rem;margin-bottom:2rem}
+.eyebrow-jp{margin:0 0 .75rem;color:#aaa2ff;font-size:.76rem;font-weight:800;letter-spacing:.14em;text-transform:uppercase}
+h1{max-width:10ch;margin:0;font-size:clamp(2.7rem,8vw,6.2rem);line-height:.94;letter-spacing:-.055em}
+.lead-jp{max-width:42rem;margin:1.25rem 0 0;color:#a4aec4;font-size:clamp(1rem,2vw,1.14rem);line-height:1.7}
+.stage-jp{perspective:1300px}
+.card-jp{position:relative;isolation:isolate;min-height:31rem;overflow:hidden;border:1px solid rgb(255 255 255/.12);border-radius:2rem;background:linear-gradient(145deg,rgb(255 255 255/.07),transparent 45%),#10162a;box-shadow:inset 0 1px rgb(255 255 255/.08),0 2rem 6rem rgb(0 0 0/.35);transform-style:preserve-3d;transition:transform var(--ease-duration-jp) var(--ease-curve-jp),box-shadow var(--ease-duration-jp)}
+.ease-fade-in-jp{animation:ease-enter-jp 800ms var(--ease-curve-jp) both}
+.ease-hover-lift-jp:hover,.ease-hover-lift-jp:focus-within{transform:rotateX(3deg) rotateY(-4deg) translateY(-.4rem);box-shadow:inset 0 1px rgb(255 255 255/.09),1.5rem 2.5rem 6rem rgb(0 0 0/.42)}
+.grid-jp,.orb-jp,.content-jp,.metric-jp,.signal-jp{position:absolute;transform-style:preserve-3d;transition:transform var(--ease-duration-jp) var(--ease-curve-jp)}
+.grid-jp{inset:-8%;z-index:-3;background:linear-gradient(rgb(255 255 255/.04) 1px,transparent 1px),linear-gradient(90deg,rgb(255 255 255/.04) 1px,transparent 1px);background-size:36px 36px;mask-image:linear-gradient(to bottom right,#000,transparent 75%);transform:translateZ(-80px) scale(1.16)}
+.orb-jp{z-index:-2;width:18rem;aspect-ratio:1;border-radius:50%;filter:blur(12px)}
+.orb-a-jp{top:-7rem;right:-4rem;background:radial-gradient(circle at 35% 30%,#b3a8ff,#6957f3 50%,transparent 72%);opacity:.58;transform:translateZ(-20px)}
+.orb-b-jp{left:-6rem;bottom:-8rem;background:radial-gradient(circle at 50% 45%,#67f5df,#147b88 52%,transparent 72%);opacity:.38;transform:translateZ(-35px)}
+.content-jp{inset:0;z-index:2;display:flex;flex-direction:column;justify-content:center;padding:clamp(1.5rem,6vw,4.5rem);transform:translateZ(var(--ease-depth-jp))}
+.badge-jp{display:inline-flex;width:max-content;align-items:center;gap:.55rem;margin-bottom:1.4rem;padding:.55rem .75rem;border:1px solid rgb(255 255 255/.13);border-radius:999px;background:rgb(255 255 255/.06);font-size:.73rem;font-weight:750}
+.badge-jp i{width:.5rem;aspect-ratio:1;border-radius:50%;background:var(--ease-accent-2-jp);box-shadow:0 0 1rem rgb(56 217 197/.8);animation:ease-pulse-jp 1.8s ease-in-out infinite}
+.content-jp h2{max-width:13ch;margin:0;font-size:clamp(2.2rem,6vw,4.8rem);line-height:.96;letter-spacing:-.05em}
+.content-jp>p{max-width:38rem;margin:1.2rem 0 1.8rem;color:#b4bdd0;line-height:1.7}
+.form-jp{width:min(100%,43rem)}
+.form-jp label{display:block;margin-bottom:.55rem;font-size:.82rem;font-weight:700}
+.row-jp{display:grid;grid-template-columns:1fr auto;gap:.75rem}
+.row-jp input,.row-jp button{min-height:3.5rem;border-radius:.9rem;font:inherit}
+.row-jp input{width:100%;border:1px solid rgb(255 255 255/.14);background:rgb(6 10 20/.68);color:#fff;padding:0 1rem;outline:none;transition:border-color var(--ease-fast-jp),box-shadow var(--ease-fast-jp)}
+.row-jp input:focus{border-color:#a99fff;box-shadow:0 0 0 .25rem rgb(124 108 255/.16)}
+.row-jp button{border:0;padding:0 1.25rem;background:linear-gradient(135deg,#8878ff,#6957ef);color:#fff;font-weight:800;cursor:pointer;transition:transform var(--ease-fast-jp) var(--ease-curve-jp)}
+.ease-hover-grow-jp:hover{transform:scale(1.035)}
+.row-jp button:focus-visible{outline:3px solid #c6c0ff;outline-offset:3px}
+.form-jp small{display:block;margin-top:.75rem;color:#7f899f}
+.metric-jp{top:1.35rem;right:1.35rem;z-index:3;display:grid;padding:.9rem 1rem;border:1px solid rgb(255 255 255/.12);border-radius:1rem;background:rgb(9 15 29/.58);transform:translateZ(85px)}
+.metric-jp strong{font-size:1.2rem}.metric-jp span{color:#9da7ba;font-size:.65rem;text-transform:uppercase}
+.signal-jp{right:2rem;bottom:1.75rem;z-index:3;display:flex;align-items:end;gap:.3rem;height:3rem;transform:translateZ(95px)}
+.signal-jp i{width:.36rem;border-radius:999px;background:linear-gradient(to top,#38d9c5,#a79dff);animation:ease-bars-jp .9s ease-in-out infinite alternate}
+.signal-jp i:nth-child(1){height:45%}.signal-jp i:nth-child(2){height:85%;animation-delay:-.3s}.signal-jp i:nth-child(3){height:62%;animation-delay:-.6s}
+.card-jp:hover .grid-jp,.card-jp:focus-within .grid-jp{transform:translate3d(-.8rem,-.4rem,-80px) scale(1.18)}
+.card-jp:hover .orb-a-jp,.card-jp:focus-within .orb-a-jp{transform:translate3d(-1rem,.7rem,-20px) scale(1.08)}
+.card-jp:hover .orb-b-jp,.card-jp:focus-within .orb-b-jp{transform:translate3d(1rem,-.6rem,-35px) scale(1.1)}
+.card-jp:hover .content-jp,.card-jp:focus-within .content-jp{transform:translate3d(.35rem,-.25rem,70px)}
+@keyframes ease-enter-jp{from{opacity:0;transform:translateY(1.5rem) rotateX(4deg)}to{opacity:1;transform:none}}
+@keyframes ease-pulse-jp{0%,100%{opacity:.55;transform:scale(.85)}50%{opacity:1;transform:scale(1.15)}}
+@keyframes ease-bars-jp{from{transform:scaleY(.45)}to{transform:scaleY(1)}}
+@media(max-width:700px){.card-jp{min-height:35rem}.row-jp{grid-template-columns:1fr}.row-jp button{width:100%}}
+@media(max-width:500px){.content-jp{justify-content:flex-end;padding-bottom:4.5rem}.metric-jp{left:1rem;right:auto}}
+@media(prefers-reduced-motion:reduce){.ease-fade-in-jp,.badge-jp i,.signal-jp i{animation:none}.card-jp,.grid-jp,.orb-jp,.content-jp,.metric-jp,.signal-jp,.row-jp button{transition:none}.ease-hover-lift-jp:hover,.ease-hover-lift-jp:focus-within,.card-jp:hover *,.card-jp:focus-within *{transform:none}}


### PR DESCRIPTION
## Pull Request Description

Adds a **Parallax Subscribe Form** component for Issue #41403.

This submission provides a responsive and accessible newsletter subscription form with layered 3D depth, floating interface elements, smooth EaseMotion-style animations, keyboard-focus interaction, and a reduced-motion fallback.

**Closes #41403**

---

## Type of Change

* [x] ✨ New animation / hover effect
* [x] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

* [x] All changes are inside `submissions/examples/parallax-subscribe-form-jp/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, and why it fits EaseMotion CSS
* [x] **No changes to `core/`**
* [x] **No changes to `components/`**
* [x] One feature per PR with no unrelated changes

---

## Feature Description

**What does this add?**

A pure-CSS newsletter subscribe form with layered 3D parallax motion, floating decorative elements, responsive styling, and accessible keyboard interaction.

**How does a developer use it?**

```html
<div class="card-jp ease-fade-in-jp ease-hover-lift-jp">
  <div class="grid-jp" aria-hidden="true"></div>

  <div class="content-jp">
    <h2>Useful ideas, delivered with less noise.</h2>

    <form class="form-jp">
      <label for="email">Email address</label>

      <div class="row-jp">
        <input
          id="email"
          name="email"
          type="email"
          placeholder="you@example.com"
          required
        />

        <button type="submit" class="ease-hover-grow-jp">
          Subscribe
        </button>
      </div>
    </form>
  </div>
</div>
```

The animation can be customized using EaseMotion-style CSS variables:

```css
:root {
  --ease-duration-jp: 700ms;
  --ease-fast-jp: 260ms;
  --ease-curve-jp: cubic-bezier(0.22, 1, 0.36, 1);
  --ease-depth-jp: 58px;
  --ease-accent-jp: #7c6cff;
  --ease-accent-2-jp: #38d9c5;
}
```

**Why does it fit EaseMotion CSS?**

The component follows EaseMotion CSS's animation-first philosophy by using motion to create meaningful visual hierarchy.

The background grid, decorative orbs, content, metric card, and signal bars occupy separate depth planes. Hover and keyboard focus move these layers independently, creating a polished parallax effect without JavaScript.

The implementation is readable, reusable, responsive, accessible, and dependency-free.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [ ] Firefox
* [x] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The implementation is completely isolated inside:

```text
submissions/examples/parallax-subscribe-form-jp/
```

It includes only:

```text
demo.html
style.css
README.md
```

The component includes:

* CSS perspective and preserved 3D depth;
* independent layered transforms;
* EaseMotion-style variables and keyframes;
* hover and `:focus-within` interaction;
* semantic form labels;
* email validation through the native `email` input type;
* visible focus states;
* responsive mobile behavior;
* reduced-motion support;
* no JavaScript or external dependencies.

---

> **Reminder:** Only the repository maintainer may merge pull requests.
> Do not self-merge, even if you have write access.
