### PR TITLE
feat: add checkbox primitive component

### DIFF
--- a/submissions/examples/checkbox-primitive-am/README.md
+++ b/submissions/examples/checkbox-primitive-am/README.md
@@ -1,0 +1,48 @@
+# Checkbox Primitive
+
+**1. What does this do?**
+A custom checkbox component with checked, indeterminate, disabled, two sizes
+(sm/lg), and three color variants (success/danger/warning) — the one core
+form primitive currently missing next to the existing radio and toggle
+components.
+
+**2. How is it used?**
+
+​```html
+<label class="checkbox-item">
+  <input type="checkbox" class="checkbox-input" checked />
+  <span class="checkbox-box"></span>
+  <span class="checkbox-text">Label</span>
+</label>
+​```
+
+Add `checkbox-sm` / `checkbox-lg` for size, or `checkbox-success` /
+`checkbox-danger` / `checkbox-warning` for color, on the `.checkbox-item`
+label. Wrap multiple items in `.checkbox-group` (vertical) or
+`.checkbox-group-horizontal`.
+
+**3. Why is this useful?**
+Every other form input — radio, toggle, select, textarea, file — already
+has a component in `forms.css` with a consistent size/color-variant API.
+Checkbox is the one missing primitive, and this mirrors that same API shape
+(`-sm`/`-lg`, `-success`/`-danger`/`-warning`, plus a warning variant not
+yet present on the sibling components) so it drops in next to the existing
+components with no naming inconsistency. It also covers the indeterminate
+("mixed") state, which none of the existing checkbox-themed submissions in
+this repo implement, and is fully keyboard/focus-visible and
+`prefers-reduced-motion` aware.
+
+## Notes for the maintainer
+
+- Native `<input type="checkbox">` has no HTML attribute for indeterminate —
+  `demo.html` sets it via `el.indeterminate = true` in a small inline script,
+  for the demo only. The CSS itself only relies on the `:indeterminate`
+  pseudo-class.
+- Checkmark and dash are drawn with plain CSS (`border` + `transform`), no
+  SVG or icon font.
+- Colors are local hard-coded values in this demo per the raw-CSS
+  submission rule; they match the existing `--ease-color-*` primary/success/
+  danger/warning values used by `.ease-radio` and `.ease-toggle` in
+  `components/forms.css`, so token-swapping on integration is a 1:1 mapping.
+
+Closes #<43759>

--- a/submissions/examples/checkbox-primitive-am/demo.html
+++ b/submissions/examples/checkbox-primitive-am/demo.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Checkbox Primitive — Demo</title>
+    <link rel="stylesheet" href="./style.css" />
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        max-width: 640px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+        color: #1e293b;
+      }
+      section {
+        margin-bottom: 2rem;
+      }
+      h2 {
+        font-size: 1rem;
+        color: #475569;
+        margin-bottom: 0.75rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Checkbox Primitive</h1>
+
+    <section>
+      <h2>Default states</h2>
+      <div class="checkbox-group">
+        <label class="checkbox-item">
+          <input type="checkbox" class="checkbox-input" />
+          <span class="checkbox-box"></span>
+          <span class="checkbox-text">Unchecked</span>
+        </label>
+        <label class="checkbox-item">
+          <input type="checkbox" class="checkbox-input" checked />
+          <span class="checkbox-box"></span>
+          <span class="checkbox-text">Checked</span>
+        </label>
+        <label class="checkbox-item">
+          <input
+            type="checkbox"
+            class="checkbox-input"
+            id="indeterminate-demo"
+          />
+          <span class="checkbox-box"></span>
+          <span class="checkbox-text">Indeterminate (mixed)</span>
+        </label>
+        <label class="checkbox-item">
+          <input type="checkbox" class="checkbox-input" disabled />
+          <span class="checkbox-box"></span>
+          <span class="checkbox-text">Disabled</span>
+        </label>
+        <label class="checkbox-item">
+          <input type="checkbox" class="checkbox-input" disabled checked />
+          <span class="checkbox-box"></span>
+          <span class="checkbox-text">Disabled + checked</span>
+        </label>
+      </div>
+    </section>
+
+    <section>
+      <h2>Sizes</h2>
+      <div
+        class="checkbox-group-horizontal"
+        style="display: flex; gap: 1.5rem"
+      >
+        <label class="checkbox-item checkbox-sm">
+          <input type="checkbox" class="checkbox-input" checked />
+          <span class="checkbox-box"></span>
+          <span class="checkbox-text">Small</span>
+        </label>
+        <label class="checkbox-item">
+          <input type="checkbox" class="checkbox-input" checked />
+          <span class="checkbox-box"></span>
+          <span class="checkbox-text">Default</span>
+        </label>
+        <label class="checkbox-item checkbox-lg">
+          <input type="checkbox" class="checkbox-input" checked />
+          <span class="checkbox-box"></span>
+          <span class="checkbox-text">Large</span>
+        </label>
+      </div>
+    </section>
+
+    <section>
+      <h2>Color variants</h2>
+      <div
+        class="checkbox-group-horizontal"
+        style="display: flex; gap: 1.5rem"
+      >
+        <label class="checkbox-item">
+          <input type="checkbox" class="checkbox-input" checked />
+          <span class="checkbox-box"></span>
+          <span class="checkbox-text">Primary</span>
+        </label>
+        <label class="checkbox-item checkbox-success">
+          <input type="checkbox" class="checkbox-input" checked />
+          <span class="checkbox-box"></span>
+          <span class="checkbox-text">Success</span>
+        </label>
+        <label class="checkbox-item checkbox-danger">
+          <input type="checkbox" class="checkbox-input" checked />
+          <span class="checkbox-box"></span>
+          <span class="checkbox-text">Danger</span>
+        </label>
+        <label class="checkbox-item checkbox-warning">
+          <input type="checkbox" class="checkbox-input" checked />
+          <span class="checkbox-box"></span>
+          <span class="checkbox-text">Warning</span>
+        </label>
+      </div>
+    </section>
+
+    <section>
+      <h2>Keyboard test</h2>
+      <p>
+        Tab to the box below — you should see a focus ring, not a checked
+        box.
+      </p>
+      <label class="checkbox-item">
+        <input type="checkbox" class="checkbox-input" />
+        <span class="checkbox-box"></span>
+        <span class="checkbox-text">Tab to me</span>
+      </label>
+    </section>
+
+    <script>
+      // Native <input> has no HTML attribute for the indeterminate state —
+      // it can only be set via the DOM property. Used here for the demo only.
+      document.getElementById("indeterminate-demo").indeterminate = true;
+    </script>
+  </body>
+</html>

--- a/submissions/examples/checkbox-primitive-am/style.css
+++ b/submissions/examples/checkbox-primitive-am/style.css
@@ -1,0 +1,175 @@
+/* ==========================================================
+   Checkbox Primitive — core-parity component
+   Mirrors the existing radio/toggle API shape:
+   sizes (sm/lg), color variants (success/danger/warning),
+   disabled + indeterminate states, focus-visible ring,
+   prefers-reduced-motion guard.
+   ========================================================== */
+
+:root {
+  --chk-color: #6c63ff;
+  --chk-color-contrast: #ffffff;
+  --chk-border: #9ca3af;
+  --chk-radius: 0.3rem;
+  --chk-size: 1.25rem;
+  --chk-speed: 150ms;
+}
+
+.checkbox-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.checkbox-group-horizontal {
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+
+.checkbox-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  cursor: pointer;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+/* Visually hidden native input — kept in the accessibility tree */
+.checkbox-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.checkbox-box {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--chk-size);
+  height: var(--chk-size);
+  flex-shrink: 0;
+  border: 2px solid var(--chk-border);
+  border-radius: var(--chk-radius);
+  background: transparent;
+  transition:
+    border-color var(--chk-speed) ease,
+    background var(--chk-speed) ease;
+}
+
+/* ── Checked state ── */
+.checkbox-input:checked + .checkbox-box {
+  background: var(--chk-color);
+  border-color: var(--chk-color);
+}
+
+.checkbox-input:checked + .checkbox-box::after {
+  content: "";
+  width: 0.3rem;
+  height: 0.6rem;
+  margin-top: -0.1rem;
+  border: solid var(--chk-color-contrast);
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg) scale(1);
+  animation: checkbox-tick var(--chk-speed) ease-out both;
+}
+
+@keyframes checkbox-tick {
+  from {
+    transform: rotate(45deg) scale(0);
+  }
+
+  to {
+    transform: rotate(45deg) scale(1);
+  }
+}
+
+/* ── Indeterminate state (set via el.indeterminate = true in JS) ── */
+.checkbox-input:indeterminate + .checkbox-box {
+  background: var(--chk-color);
+  border-color: var(--chk-color);
+}
+
+.checkbox-input:indeterminate + .checkbox-box::after {
+  content: "";
+  width: 0.6rem;
+  height: 2px;
+  background: var(--chk-color-contrast);
+  border: 0;
+  transform: none;
+  animation: none;
+}
+
+/* ── Focus-visible ring (keyboard only) ── */
+.checkbox-input:focus-visible + .checkbox-box {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.25);
+}
+
+/* ── Disabled ── */
+.checkbox-input:disabled ~ * {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ── Sizes ── */
+.checkbox-sm {
+  --chk-size: 1rem;
+}
+
+.checkbox-item.checkbox-sm .checkbox-box::after {
+  width: 0.22rem;
+  height: 0.45rem;
+}
+
+.checkbox-item.checkbox-sm
+  .checkbox-input:indeterminate
+  + .checkbox-box::after {
+  width: 0.45rem;
+  height: 2px;
+}
+
+.checkbox-lg {
+  --chk-size: 1.5rem;
+}
+
+.checkbox-item.checkbox-lg .checkbox-box::after {
+  width: 0.4rem;
+  height: 0.75rem;
+}
+
+.checkbox-item.checkbox-lg
+  .checkbox-input:indeterminate
+  + .checkbox-box::after {
+  width: 0.75rem;
+  height: 3px;
+}
+
+/* ── Color variants (same names as the existing radio/toggle components) ── */
+.checkbox-success {
+  --chk-color: #22c55e;
+}
+
+.checkbox-danger {
+  --chk-color: #ef4444;
+}
+
+.checkbox-warning {
+  --chk-color: #f59e0b;
+}
+
+/* ── Reduced motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .checkbox-box,
+  .checkbox-input:checked + .checkbox-box::after {
+    transition: none;
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a base `.checkbox-*` primitive component (sizes, color variants, indeterminate/disabled/focus-visible states) to fill the one form-input gap in the existing `forms.css` set — every other primitive (radio, toggle, select, textarea) already has a matching component.

Closes #43759

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (`submissions/examples/checkbox-primitive-am/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A custom checkbox component with checked, indeterminate, disabled, two sizes (sm/lg), and three color variants (success/danger/warning).

**How does a developer use it?**
```html
<label class="checkbox-item">
  <input type="checkbox" class="checkbox-input" checked />
  <span class="checkbox-box"></span>
  <span class="checkbox-text">Label</span>
</label>
```
Add `checkbox-sm` / `checkbox-lg` for size, or `checkbox-success` / `checkbox-danger` / `checkbox-warning` for color, on the `.checkbox-item` label.

**Why does it fit EaseMotion CSS?**
Every other form input — radio, toggle, select, textarea, file — already has a component in `forms.css` with a consistent size/color-variant API. This mirrors that same shape so it drops in with no naming inconsistency, and covers the indeterminate ("mixed") state that no existing checkbox-themed submission in this repo implements.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*



---

## Notes for Maintainer
- Native `<input type="checkbox">` has no HTML attribute for indeterminate — `demo.html` sets it via `el.indeterminate = true` in JS for demo purposes only; the CSS itself only relies on the `:indeterminate` pseudo-class.
- Checkmark/dash are drawn with plain CSS (border + transform), no SVG or icon font.
- Colors are local hard-coded values per the raw-CSS submission rule; they match the existing `--ease-color-*` values used by `.ease-radio`/`.ease-toggle`, so token-swapping on integration should be a 1:1 mapping.
- Includes a `warning` color variant not yet present on the sibling `.ease-radio`/`.ease-toggle` components — flagging in case you'd rather keep it consistent and drop it, or add `warning` to the siblings too.


---

> **Reminder:** Only the repository maintainer may merge pull requests.
> Do not self-merge, even if you have write access.
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
>
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [[Discord Server](https://discord.gg/hWSdGrccBU)](https://discord.gg/hWSdGrccBU)!