### PR TITLE
feat: add dropdown menu fade example

### DIFF
--- a/submissions/examples/dropdown-menu-fade/README.md
+++ b/submissions/examples/dropdown-menu-fade/README.md
@@ -1,0 +1,14 @@
+# Dropdown Menu Fade
+
+A CSS-only dropdown reveal pattern for menus, profile actions, and compact command groups.
+
+## What it demonstrates
+
+- hover and `:focus-within` menu reveal
+- fade and slide motion without layout shift
+- keyboard focus styling and reduced-motion support
+
+## Files
+
+- `demo.html` - dropdown menu markup
+- `style.css` - menu reveal motion and interaction states

--- a/submissions/examples/dropdown-menu-fade/demo.html
+++ b/submissions/examples/dropdown-menu-fade/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dropdown Menu Fade</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-card" aria-labelledby="demo-title">
+    <p class="eyebrow">EaseMotion menu example</p>
+    <h1 id="demo-title">Dropdown menu fade</h1>
+    <p class="intro">A compact menu reveal pattern for toolbars, profile actions, and command menus.</p>
+
+    <div class="dropdown">
+      <button type="button">Workspace actions</button>
+      <ul class="menu" aria-label="Workspace actions">
+        <li><a href="#rename">Rename project</a></li>
+        <li><a href="#share">Share preview</a></li>
+        <li><a href="#archive">Archive workspace</a></li>
+      </ul>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/dropdown-menu-fade/style.css
+++ b/submissions/examples/dropdown-menu-fade/style.css
@@ -1,0 +1,148 @@
+:root {
+  --page: #f6f8fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #65758b;
+  --accent: #7c3aed;
+  --line: rgba(23, 32, 51, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background:
+    linear-gradient(135deg, rgba(124, 58, 237, 0.12), transparent 42%),
+    var(--page);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.demo-card {
+  width: min(680px, calc(100vw - 32px));
+  padding: 36px;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--surface);
+  box-shadow: 0 24px 70px rgba(23, 32, 51, 0.14);
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.15rem, 5vw, 3.7rem);
+  line-height: 1;
+}
+
+.intro {
+  max-width: 48ch;
+  margin: 16px 0 28px;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.dropdown {
+  position: relative;
+  width: min(320px, 100%);
+}
+
+button {
+  width: 100%;
+  min-height: 52px;
+  border: 0;
+  border-radius: 14px;
+  background: var(--ink);
+  color: #ffffff;
+  font: inherit;
+  font-weight: 900;
+  cursor: pointer;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    background-color 180ms ease;
+}
+
+button:hover,
+button:focus-visible,
+.dropdown:focus-within button {
+  outline: none;
+  background: var(--accent);
+  transform: translateY(-2px);
+  box-shadow: 0 16px 30px rgba(124, 58, 237, 0.24);
+}
+
+.menu {
+  position: absolute;
+  z-index: 2;
+  top: calc(100% + 10px);
+  left: 0;
+  right: 0;
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: var(--surface);
+  box-shadow: 0 18px 44px rgba(23, 32, 51, 0.18);
+  list-style: none;
+  opacity: 0;
+  transform: translateY(-8px) scale(0.98);
+  pointer-events: none;
+  transition:
+    opacity 180ms ease,
+    transform 180ms ease;
+}
+
+.dropdown:hover .menu,
+.dropdown:focus-within .menu {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.menu a {
+  display: block;
+  padding: 11px 12px;
+  border-radius: 10px;
+  color: var(--ink);
+  font-weight: 800;
+  text-decoration: none;
+  transition:
+    background-color 160ms ease,
+    color 160ms ease;
+}
+
+.menu a:hover,
+.menu a:focus-visible {
+  outline: none;
+  background: rgba(124, 58, 237, 0.10);
+  color: var(--accent);
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 28px 20px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  button,
+  .menu,
+  .menu a {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only dropdown menu fade example
- include hover and focus-within reveal behavior
- support keyboard focus and reduced-motion users

## Testing
- git diff --cached --check