### PR TITLE
feat: add tooltip popover lift example

### DIFF
--- a/submissions/examples/tooltip-popover-lift/README.md
+++ b/submissions/examples/tooltip-popover-lift/README.md
@@ -1,0 +1,14 @@
+# Tooltip Popover Lift
+
+A small CSS-only tooltip interaction that lifts the trigger button and reveals contextual help above it.
+
+## Files
+
+- `demo.html` - accessible markup for the trigger button and tooltip text.
+- `style.css` - hover, focus-visible, tooltip arrow, and reduced-motion handling.
+
+## Highlights
+
+- Works with mouse hover and keyboard focus.
+- Keeps the tooltip non-interactive with `pointer-events: none`.
+- Uses a reduced-motion media query for users who prefer less animation.

--- a/submissions/examples/tooltip-popover-lift/demo.html
+++ b/submissions/examples/tooltip-popover-lift/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tooltip Popover Lift</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="demo-card" aria-labelledby="demo-title">
+    <p class="eyebrow">EaseMotion tooltip example</p>
+    <h1 id="demo-title">Tooltip popover lift</h1>
+    <p class="intro">
+      A CSS-only tooltip reveal pattern for compact buttons, toolbar actions, and sharing controls.
+    </p>
+
+    <div class="tooltip-trigger">
+      <button type="button" aria-describedby="tooltip-copy">Copy link</button>
+      <span class="tooltip" id="tooltip-copy" role="tooltip">
+        Copies the shareable project URL
+      </span>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/tooltip-popover-lift/style.css
+++ b/submissions/examples/tooltip-popover-lift/style.css
@@ -1,0 +1,120 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #111827;
+  background:
+    radial-gradient(circle at top left, rgba(20, 184, 166, 0.22), transparent 32rem),
+    linear-gradient(135deg, #f8fafc 0%, #eef2ff 100%);
+}
+
+.demo-card {
+  width: min(92vw, 28rem);
+  padding: 2rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 1.5rem 4rem rgba(15, 23, 42, 0.14);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #0f766e;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.2rem);
+  line-height: 1;
+}
+
+.intro {
+  margin: 1rem 0 2rem;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.tooltip-trigger {
+  position: relative;
+  display: inline-flex;
+  justify-content: center;
+}
+
+button {
+  border: 0;
+  border-radius: 999px;
+  padding: 0.85rem 1.35rem;
+  color: #ffffff;
+  background: #0f172a;
+  font: inherit;
+  font-weight: 800;
+  cursor: pointer;
+  box-shadow: 0 0.9rem 1.8rem rgba(15, 23, 42, 0.22);
+  transition: transform 180ms ease, box-shadow 180ms ease, background 180ms ease;
+}
+
+button:hover,
+button:focus-visible {
+  background: #0f766e;
+  transform: translateY(-0.18rem);
+  box-shadow: 0 1.2rem 2rem rgba(15, 118, 110, 0.25);
+}
+
+button:focus-visible {
+  outline: 0.18rem solid #2dd4bf;
+  outline-offset: 0.25rem;
+}
+
+.tooltip {
+  position: absolute;
+  bottom: calc(100% + 0.8rem);
+  left: 50%;
+  width: max-content;
+  max-width: 15rem;
+  padding: 0.65rem 0.85rem;
+  border-radius: 0.7rem;
+  color: #f8fafc;
+  background: #111827;
+  font-size: 0.88rem;
+  line-height: 1.35;
+  text-align: center;
+  opacity: 0;
+  transform: translate(-50%, 0.45rem) scale(0.96);
+  pointer-events: none;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+.tooltip::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  width: 0.75rem;
+  height: 0.75rem;
+  background: #111827;
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+
+.tooltip-trigger:hover .tooltip,
+.tooltip-trigger:focus-within .tooltip {
+  opacity: 1;
+  transform: translate(-50%, 0) scale(1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only tooltip popover lift example
- include hover and keyboard focus reveal states
- document the example files and accessibility notes

## Verification
- git diff --cached --check