### PR TITLE
feat: add map pin

### DIFF
--- a/submissions/examples/map-pin-as/README.md
+++ b/submissions/examples/map-pin-as/README.md
@@ -1,0 +1,21 @@
+# Map Pin
+
+### What does this do?
+
+It shows a location pin dropping onto a stylized map. The pin falls in, bounces slightly as it lands, a ripple pulses out from its base, and its shadow grows on impact. The map behind it has faint roads and city blocks. Under reduced motion the pin rests in place with the ripple hidden.
+
+### How is it used?
+
+```html
+<div class="marker">
+  <span class="ripple"></span>
+  <div class="pin"><span class="dot"></span></div>
+  <span class="shadow"></span>
+</div>
+```
+
+The pin is a circle with one square corner rotated 45 degrees to form the classic teardrop, with a white dot in the middle. The `drop` animation falls it in with a small bounce, timed together with the expanding `ripple` and the growing `shadow` so they all land on the same beat.
+
+### Why is it useful?
+
+Maps, delivery apps, and location pickers use a marker. This builds a dropping map pin with pure CSS shapes and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/map-pin-as/demo.html
+++ b/submissions/examples/map-pin-as/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Map Pin</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="map">
+    <span class="road r1"></span>
+    <span class="road r2"></span>
+    <span class="block bk1"></span>
+    <span class="block bk2"></span>
+    <div class="marker">
+      <span class="ripple"></span>
+      <div class="pin">
+        <span class="dot"></span>
+      </div>
+      <span class="shadow"></span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/map-pin-as/style.css
+++ b/submissions/examples/map-pin-as/style.css
@@ -1,0 +1,125 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: #0c1017;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.map {
+  position: relative;
+  width: 300px;
+  height: 240px;
+  border-radius: 16px;
+  overflow: hidden;
+  background: linear-gradient(160deg, #24303f, #1a2431);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5);
+}
+
+.road {
+  position: absolute;
+  background: #38475c;
+}
+
+.r1 { top: 90px; left: -10px; right: -10px; height: 16px; transform: rotate(-8deg); }
+.r2 { top: -20px; bottom: -20px; left: 180px; width: 14px; transform: rotate(10deg); }
+
+.block {
+  position: absolute;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.bk1 { top: 30px; left: 40px; width: 70px; height: 40px; }
+.bk2 { top: 150px; left: 60px; width: 90px; height: 54px; }
+
+.marker {
+  position: absolute;
+  top: 74px;
+  left: 50%;
+  margin-left: -22px;
+  width: 44px;
+  height: 90px;
+}
+
+.ripple {
+  position: absolute;
+  bottom: 4px;
+  left: 50%;
+  width: 44px;
+  height: 44px;
+  margin-left: -22px;
+  border-radius: 50%;
+  background: rgba(255, 79, 110, 0.5);
+  animation: ripple 2.4s ease-out infinite;
+}
+
+.pin {
+  position: relative;
+  width: 44px;
+  height: 44px;
+  border-radius: 50% 50% 50% 0;
+  transform: rotate(-45deg);
+  transform-origin: 50% 100%;
+  background: radial-gradient(circle at 34% 30%, #ff8098, #e63056 72%);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.4);
+  animation: drop 2.4s ease-in-out infinite;
+}
+
+.dot {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 16px;
+  height: 16px;
+  margin: -8px 0 0 -8px;
+  border-radius: 50%;
+  background: #fff5f7;
+}
+
+.shadow {
+  position: absolute;
+  bottom: 8px;
+  left: 50%;
+  width: 30px;
+  height: 8px;
+  margin-left: -15px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.4);
+  filter: blur(2px);
+  animation: shade 2.4s ease-in-out infinite;
+}
+
+@keyframes drop {
+  0% { transform: rotate(-45deg) translateY(-40px) scale(0.9); }
+  18% { transform: rotate(-45deg) translateY(0) scale(1); }
+  30% { transform: rotate(-45deg) translateY(-8px) scale(1.02); }
+  42%, 100% { transform: rotate(-45deg) translateY(0) scale(1); }
+}
+
+@keyframes ripple {
+  0%, 20% { transform: scale(0.2); opacity: 0; }
+  40% { opacity: 0.6; }
+  100% { transform: scale(1.6); opacity: 0; }
+}
+
+@keyframes shade {
+  0% { transform: scale(0.4); opacity: 0.15; }
+  18% { transform: scale(1); opacity: 0.4; }
+  42%, 100% { transform: scale(1); opacity: 0.4; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pin,
+  .ripple,
+  .shadow {
+    animation: none;
+  }
+
+  .ripple {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a map pin built for #43856. A teardrop marker that drops in with a bounce onto a stylized map, with a pulsing ripple and a growing shadow timed to the landing, and a reduced motion fallback. Pure CSS. Closes #43856.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a red teardrop pin with a white center over a dark map with faint roads and blocks.
