### PR TITLE
feat: add network graph

### DIFF
--- a/submissions/examples/network-graph-as/README.md
+++ b/submissions/examples/network-graph-as/README.md
@@ -1,0 +1,21 @@
+# Network Graph
+
+### What does this do?
+
+It shows a live network graph. A bright central hub connects to six outer nodes, with extra links between neighbors. Every node throbs on its own beat, and a packet of light travels along each link from source to target, so the graph looks like data moving through a network. Under reduced motion the nodes rest and the packets are hidden.
+
+### How is it used?
+
+```html
+<div class="graph">
+  <span class="link lk1"><i class="pulse"></i></span>
+  <span class="node n1 hub"></span>
+  <span class="node n2"></span>
+</div>
+```
+
+Each link is a thin bar rotated from its source node toward its target, with `left`, `width`, and `transform: rotate()` precomputed from the node coordinates. Inside each link a `pulse` runs the `travel` animation from one end to the other on a staggered delay, and every node runs `throb` to scale gently in and out.
+
+### Why is it useful?
+
+Dashboards, infrastructure views, and social or graph data use a node network. This builds an animated network graph with pure CSS transforms, no images, canvas, or JavaScript, with a reduced motion fallback.

--- a/submissions/examples/network-graph-as/demo.html
+++ b/submissions/examples/network-graph-as/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Network Graph</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="graph">
+    <span class="link lk1"><i class="pulse"></i></span>
+    <span class="link lk2"><i class="pulse"></i></span>
+    <span class="link lk3"><i class="pulse"></i></span>
+    <span class="link lk4"><i class="pulse"></i></span>
+    <span class="link lk5"><i class="pulse"></i></span>
+    <span class="link lk6"><i class="pulse"></i></span>
+    <span class="link lk7"><i class="pulse"></i></span>
+    <span class="link lk8"><i class="pulse"></i></span>
+    <span class="link lk9"><i class="pulse"></i></span>
+    <span class="node n1 hub"></span>
+    <span class="node n2"></span>
+    <span class="node n3"></span>
+    <span class="node n4"></span>
+    <span class="node n5"></span>
+    <span class="node n6"></span>
+    <span class="node n7"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/network-graph-as/style.css
+++ b/submissions/examples/network-graph-as/style.css
@@ -1,0 +1,107 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 30%, #0e1a2e, #05080f 72%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.graph {
+  position: relative;
+  width: 320px;
+  height: 320px;
+}
+
+.link {
+  position: absolute;
+  height: 2px;
+  margin-top: -1px;
+  transform-origin: 0 50%;
+  background: linear-gradient(90deg, rgba(90, 200, 255, 0.15), rgba(90, 200, 255, 0.45));
+  overflow: hidden;
+}
+
+.pulse {
+  position: absolute;
+  top: -2px;
+  left: 0;
+  width: 12px;
+  height: 6px;
+  border-radius: 3px;
+  background: #7fe3ff;
+  box-shadow: 0 0 8px #45c8ff;
+  animation: travel 2.6s linear infinite;
+}
+
+.lk1 { left: 150px; top: 150px; width: 127.3px; transform: rotate(-135deg); }
+.lk2 { left: 150px; top: 150px; width: 128.1px; transform: rotate(-38.66deg); }
+.lk3 { left: 150px; top: 150px; width: 130px; transform: rotate(22.62deg); }
+.lk4 { left: 150px; top: 150px; width: 120.4px; transform: rotate(85.24deg); }
+.lk5 { left: 150px; top: 150px; width: 116.6px; transform: rotate(149.04deg); }
+.lk6 { left: 150px; top: 150px; width: 60.8px; transform: rotate(-9.46deg); }
+.lk7 { left: 60px; top: 60px; width: 190.3px; transform: rotate(3.01deg); }
+.lk8 { left: 270px; top: 200px; width: 84.9px; transform: rotate(-135deg); }
+.lk9 { left: 160px; top: 270px; width: 125.3px; transform: rotate(-151.39deg); }
+
+.lk2 .pulse { animation-delay: 0.4s; }
+.lk3 .pulse { animation-delay: 0.8s; }
+.lk4 .pulse { animation-delay: 1.2s; }
+.lk5 .pulse { animation-delay: 1.6s; }
+.lk6 .pulse { animation-delay: 2s; }
+.lk7 .pulse { animation-delay: 0.6s; }
+.lk8 .pulse { animation-delay: 1s; }
+.lk9 .pulse { animation-delay: 1.4s; }
+
+.node {
+  position: absolute;
+  width: 22px;
+  height: 22px;
+  margin: -11px 0 0 -11px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #9fe6ff, #2f8fd0 72%);
+  box-shadow: 0 0 10px rgba(70, 180, 240, 0.7);
+  z-index: 2;
+  animation: throb 2.8s ease-in-out infinite;
+}
+
+.hub {
+  width: 34px;
+  height: 34px;
+  margin: -17px 0 0 -17px;
+  background: radial-gradient(circle at 36% 32%, #b8f0ff, #1f6fb8 72%);
+  box-shadow: 0 0 18px rgba(90, 200, 255, 0.9);
+}
+
+.n1 { left: 150px; top: 150px; }
+.n2 { left: 60px; top: 60px; animation-delay: 0.3s; }
+.n3 { left: 250px; top: 70px; animation-delay: 0.6s; }
+.n4 { left: 270px; top: 200px; animation-delay: 0.9s; }
+.n5 { left: 160px; top: 270px; animation-delay: 1.2s; }
+.n6 { left: 50px; top: 210px; animation-delay: 1.5s; }
+.n7 { left: 210px; top: 140px; animation-delay: 1.8s; }
+
+@keyframes travel {
+  0% { left: 0; opacity: 0; }
+  10% { opacity: 1; }
+  90% { opacity: 1; }
+  100% { left: 100%; opacity: 0; }
+}
+
+@keyframes throb {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.18); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pulse,
+  .node {
+    animation: none;
+  }
+
+  .pulse {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a network graph built for #43864. A hub-and-spoke node graph where each link carries a traveling light packet and every node throbs, with links positioned by precomputed rotations, and a reduced motion fallback. Pure CSS. Closes #43864.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a bright central hub linked to six glowing nodes with connecting edges and traveling light packets.
