### PR TITLE
feat: add rubiks cube

### DIFF
--- a/submissions/examples/rubiks-cube-as/README.md
+++ b/submissions/examples/rubiks-cube-as/README.md
@@ -1,0 +1,22 @@
+# Rubik's Cube
+
+### What does this do?
+
+It shows a solved Rubik's cube rendered in real 3D and spinning slowly, so each of its six colored faces rotates into view in turn. Every face is a proper three by three grid of tiles on a black body. Under reduced motion the cube stops at a fixed angle that still shows three faces.
+
+### How is it used?
+
+```html
+<div class="scene">
+  <div class="cube">
+    <div class="face front"><span></span>...</div>
+    <div class="face top"><span></span>...</div>
+  </div>
+</div>
+```
+
+The `scene` sets a `perspective` and the `cube` uses `transform-style: preserve-3d`. Each of the six faces is a nine-cell grid pushed out to a side of the cube with a `rotate` plus `translateZ(75px)`, half the cube width. The `spin` animation rotates the whole cube around its vertical axis at a fixed tilt so all faces pass the camera.
+
+### Why is it useful?
+
+Puzzle, gaming, and playful loading screens use a cube. This builds a true 3D Rubik's cube with pure CSS transforms, no images or JavaScript, with a reduced motion fallback.

--- a/submissions/examples/rubiks-cube-as/demo.html
+++ b/submissions/examples/rubiks-cube-as/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Rubik's Cube</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="cube">
+      <div class="face front">
+        <span></span><span></span><span></span>
+        <span></span><span></span><span></span>
+        <span></span><span></span><span></span>
+      </div>
+      <div class="face back">
+        <span></span><span></span><span></span>
+        <span></span><span></span><span></span>
+        <span></span><span></span><span></span>
+      </div>
+      <div class="face right">
+        <span></span><span></span><span></span>
+        <span></span><span></span><span></span>
+        <span></span><span></span><span></span>
+      </div>
+      <div class="face left">
+        <span></span><span></span><span></span>
+        <span></span><span></span><span></span>
+        <span></span><span></span><span></span>
+      </div>
+      <div class="face top">
+        <span></span><span></span><span></span>
+        <span></span><span></span><span></span>
+        <span></span><span></span><span></span>
+      </div>
+      <div class="face bottom">
+        <span></span><span></span><span></span>
+        <span></span><span></span><span></span>
+        <span></span><span></span><span></span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/rubiks-cube-as/style.css
+++ b/submissions/examples/rubiks-cube-as/style.css
@@ -1,0 +1,72 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 25%, #1c2233, #080a12 72%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  width: 200px;
+  height: 200px;
+  perspective: 720px;
+}
+
+.cube {
+  position: relative;
+  width: 150px;
+  height: 150px;
+  margin: 25px auto;
+  transform-style: preserve-3d;
+  animation: spin 9s linear infinite;
+}
+
+.face {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 150px;
+  height: 150px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+  gap: 6px;
+  padding: 6px;
+  box-sizing: border-box;
+  border-radius: 10px;
+  background: #14161d;
+}
+
+.face span {
+  border-radius: 6px;
+  box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.4);
+}
+
+.front { transform: translateZ(75px); }
+.back { transform: rotateY(180deg) translateZ(75px); }
+.right { transform: rotateY(90deg) translateZ(75px); }
+.left { transform: rotateY(-90deg) translateZ(75px); }
+.top { transform: rotateX(90deg) translateZ(75px); }
+.bottom { transform: rotateX(-90deg) translateZ(75px); }
+
+.front span { background: #d1352b; }
+.back span { background: #ff8a1e; }
+.right span { background: #1667d1; }
+.left span { background: #22a45a; }
+.top span { background: #f4f5f7; }
+.bottom span { background: #f7d020; }
+
+@keyframes spin {
+  0% { transform: rotateX(-26deg) rotateY(0deg); }
+  100% { transform: rotateX(-26deg) rotateY(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cube {
+    animation: none;
+    transform: rotateX(-26deg) rotateY(-38deg);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a Rubik's cube built for #43868. A real 3D cube with six nine-tile faces built from perspective transforms, spinning around its vertical axis, with a reduced motion fallback. Pure CSS. Closes #43868.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a 3D cube showing a red front, green left, and white top face, each a 3x3 grid on a black body.
