### PR TITLE
feat: add fade in skeleton example showcase (#41432)

### DIFF
--- a/submissions/examples/fade-in-skeleton-agy/README.md
+++ b/submissions/examples/fade-in-skeleton-agy/README.md
@@ -1,0 +1,54 @@
+# Fade In Skeleton Component
+
+This component provides a premium **Fade In Skeleton** loading placeholder designed for modern Cyberpunk dashboards, presenting custom shimmer linear gradients and glowing neon outlines.
+
+---
+
+### 1. What does this do?
+
+It creates glowing card placeholder layers with shifting neon shimmer wave gradients that fade out smoothly to reveal loaded profile content when assets are ready.
+
+---
+
+### 2. How is it used?
+
+Wrap skeleton placeholder layout items inside the `.ease-skeleton-layer` container class, and your final content elements inside the `.ease-loaded-layer` class, inside the base `.ease-skeleton-card` parent:
+
+```html
+<!-- Main Parent slot -->
+<div class="ease-skeleton-card" aria-busy="true">
+  <!-- Loading skeleton view -->
+  <div class="ease-skeleton-layer">
+    <div class="ease-sk-block ease-sk-avatar"></div>
+    <div class="ease-sk-block ease-sk-title"></div>
+    <div class="ease-sk-block ease-sk-text"></div>
+  </div>
+
+  <!-- Loaded content view -->
+  <div class="ease-loaded-layer">
+    <img src="avatar.png" alt="user photo" />
+    <h4>User Name</h4>
+    <p>Operational data description</p>
+  </div>
+</div>
+```
+
+---
+
+### 3. Why is it useful?
+
+It fits EaseMotion CSS's core philosophy of **enhanced loading transition aesthetics** by replacing simple gray flashes with high-quality, neon glow shimmer outlines.
+
+It provides visual continuity across asset states, reducing perceived loading delays on modern dashboards. The component is also designed with accessibility first, maintaining `aria-busy="true"` tags during shimmers and automatically disabling translations/shimmers for users who enable `prefers-reduced-motion` settings.
+
+---
+
+### Technical Breakdown
+
+#### Customization Options
+
+The animation shimmers and glowing frames can be adjusted in the playground:
+
+- **Speeds**: `--shimmer-speed: 3.5s` (Slow), `1.8s` (Normal), `0.8s` (Fast), `0s` (Static).
+- **Glow**: Adjusts `--glow-blur: 12px` (Subtle) to `25px` (Hyper).
+- **Accents**: Custom CSS color variables mapping dual primary/secondary gradients.

--- a/submissions/examples/fade-in-skeleton-agy/demo.html
+++ b/submissions/examples/fade-in-skeleton-agy/demo.html
@@ -1,0 +1,427 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EaseMotion CSS — Fade In Skeleton Showcase (Neon Style)</title>
+
+    <!-- Link to the main EaseMotion CSS framework in the root directory -->
+    <link rel="stylesheet" href="../../../easemotion.css" />
+
+    <!-- Link to our component-specific styles -->
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <!-- Hidden CSS state controller for Load Trigger -->
+    <input type="checkbox" id="loaded-checkbox" class="state-input" />
+
+    <!-- Hidden CSS state controllers for Color Accents -->
+    <input
+      type="radio"
+      id="accent-cyber"
+      name="accent-color-select"
+      checked
+      class="state-input"
+    />
+    <input
+      type="radio"
+      id="accent-matrix"
+      name="accent-color-select"
+      class="state-input"
+    />
+    <input
+      type="radio"
+      id="accent-violet"
+      name="accent-color-select"
+      class="state-input"
+    />
+    <input
+      type="radio"
+      id="accent-amber"
+      name="accent-color-select"
+      class="state-input"
+    />
+
+    <!-- Hidden CSS state controllers for Background Skin -->
+    <input
+      type="radio"
+      id="theme-oled"
+      name="theme-skin-select"
+      checked
+      class="state-input"
+    />
+    <input
+      type="radio"
+      id="theme-glass"
+      name="theme-skin-select"
+      class="state-input"
+    />
+
+    <!-- Hidden CSS state controllers for Shimmer speeds -->
+    <input
+      type="radio"
+      id="speed-slow"
+      name="shimmer-speed-select"
+      class="state-input"
+    />
+    <input
+      type="radio"
+      id="speed-normal"
+      name="shimmer-speed-select"
+      checked
+      class="state-input"
+    />
+    <input
+      type="radio"
+      id="speed-fast"
+      name="shimmer-speed-select"
+      class="state-input"
+    />
+    <input
+      type="radio"
+      id="speed-static"
+      name="shimmer-speed-select"
+      class="state-input"
+    />
+
+    <!-- Hidden CSS state controllers for Neon Glow Intensity -->
+    <input
+      type="radio"
+      id="glow-stealth"
+      name="glow-select"
+      class="state-input"
+    />
+    <input
+      type="radio"
+      id="glow-subtle"
+      name="glow-select"
+      class="state-input"
+    />
+    <input
+      type="radio"
+      id="glow-hyper"
+      name="glow-select"
+      checked
+      class="state-input"
+    />
+
+    <!-- Dashboard Navigation -->
+    <header class="app-header">
+      <div class="logo-group">
+        <div class="logo-icon">E</div>
+        <span class="logo-title">EaseMotion CSS</span>
+      </div>
+      <div style="font-size: 0.75rem; color: #64748b; font-weight: 500">
+        Component Track:
+        <span style="color: var(--accent-primary)"
+          >submissions/examples/fade-in-skeleton-agy</span
+        >
+      </div>
+    </header>
+
+    <!-- Main Dashboard Container -->
+    <main class="dashboard-grid">
+      <!-- Left Workspace: Skeleton Content Area -->
+      <div class="showcase-container">
+        <!-- Showcase Card: Dashboard Hub -->
+        <section class="showcase-card">
+          <h2>Cyberpunk Content Hub</h2>
+          <p class="card-subtitle">
+            Use the load simulator to toggle between shimmer skeletons and
+            loaded elements.
+          </p>
+
+          <!-- Simulate Load Bar -->
+          <div class="simulate-bar">
+            <span class="simulate-label">Simulator Status:</span>
+            <!-- Checkbox labeled button controller -->
+            <label
+              for="loaded-checkbox"
+              class="simulate-btn"
+              id="simulate-toggle-btn"
+              >Toggle Loaded State</label
+            >
+          </div>
+
+          <!-- Dashboard User Grid -->
+          <div class="profile-grid-display">
+            <!-- Card Slot 1 -->
+            <div class="ease-skeleton-card" aria-busy="true">
+              <!-- Skeleton View layer -->
+              <div class="ease-skeleton-layer">
+                <div class="loaded-header">
+                  <div class="ease-sk-block ease-sk-avatar"></div>
+                  <div
+                    style="display: flex; flex-direction: column; gap: 0.5rem"
+                  >
+                    <div class="ease-sk-block ease-sk-title"></div>
+                    <div
+                      class="ease-sk-block ease-sk-tag"
+                      style="width: 80px"
+                    ></div>
+                  </div>
+                </div>
+                <div style="width: 100%; margin-top: 1rem">
+                  <div class="ease-sk-block ease-sk-text"></div>
+                  <div class="ease-sk-block ease-sk-text"></div>
+                  <div class="ease-sk-block ease-sk-text-short"></div>
+                </div>
+                <div
+                  class="ease-sk-block ease-sk-footer"
+                  style="margin-top: 1.5rem"
+                ></div>
+              </div>
+
+              <!-- Loaded View layer -->
+              <div class="ease-loaded-layer">
+                <div class="loaded-header">
+                  <div class="loaded-avatar">JD</div>
+                  <div class="loaded-identity">
+                    <h4>Jane Doe</h4>
+                    <p>Lead System Engineer</p>
+                  </div>
+                </div>
+                <p class="loaded-body" style="margin-top: 1rem">
+                  Jane monitors thermal node outputs and telemetry vectors for
+                  orbital satellite rigs, maintaining global tracking grids.
+                </p>
+                <div class="loaded-footer" style="margin-top: 1.5rem">
+                  <span class="loaded-badge">Operational</span>
+                  <span style="color: #64748b">Telemetry Live</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Card Slot 2 -->
+            <div class="ease-skeleton-card" aria-busy="true">
+              <!-- Skeleton View layer -->
+              <div class="ease-skeleton-layer">
+                <div class="loaded-header">
+                  <div class="ease-sk-block ease-sk-avatar"></div>
+                  <div
+                    style="display: flex; flex-direction: column; gap: 0.5rem"
+                  >
+                    <div class="ease-sk-block ease-sk-title"></div>
+                    <div
+                      class="ease-sk-block ease-sk-tag"
+                      style="width: 80px"
+                    ></div>
+                  </div>
+                </div>
+                <div style="width: 100%; margin-top: 1rem">
+                  <div class="ease-sk-block ease-sk-text"></div>
+                  <div class="ease-sk-block ease-sk-text"></div>
+                  <div class="ease-sk-block ease-sk-text-short"></div>
+                </div>
+                <div
+                  class="ease-sk-block ease-sk-footer"
+                  style="margin-top: 1.5rem"
+                ></div>
+              </div>
+
+              <!-- Loaded View layer -->
+              <div class="ease-loaded-layer">
+                <div class="loaded-header">
+                  <div class="loaded-avatar">AK</div>
+                  <div class="loaded-identity">
+                    <h4>Alex Kemp</h4>
+                    <p>Core Compiler Architect</p>
+                  </div>
+                </div>
+                <p class="loaded-body" style="margin-top: 1rem">
+                  Alex optimizes system compiler chains, compressing asset
+                  pipelines for ultra-low latency server rendering clusters.
+                </p>
+                <div class="loaded-footer" style="margin-top: 1.5rem">
+                  <span class="loaded-badge">Active</span>
+                  <span style="color: #64748b">Clusters Up</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Card Slot 3 -->
+            <div class="ease-skeleton-card" aria-busy="true">
+              <!-- Skeleton View layer -->
+              <div class="ease-skeleton-layer">
+                <div class="loaded-header">
+                  <div class="ease-sk-block ease-sk-avatar"></div>
+                  <div
+                    style="display: flex; flex-direction: column; gap: 0.5rem"
+                  >
+                    <div class="ease-sk-block ease-sk-title"></div>
+                    <div
+                      class="ease-sk-block ease-sk-tag"
+                      style="width: 80px"
+                    ></div>
+                  </div>
+                </div>
+                <div style="width: 100%; margin-top: 1rem">
+                  <div class="ease-sk-block ease-sk-text"></div>
+                  <div class="ease-sk-block ease-sk-text"></div>
+                  <div class="ease-sk-block ease-sk-text-short"></div>
+                </div>
+                <div
+                  class="ease-sk-block ease-sk-footer"
+                  style="margin-top: 1.5rem"
+                ></div>
+              </div>
+
+              <!-- Loaded View layer -->
+              <div class="ease-loaded-layer">
+                <div class="loaded-header">
+                  <div class="loaded-avatar">MX</div>
+                  <div class="loaded-identity">
+                    <h4>Max Vance</h4>
+                    <p>Cyber Security Lead</p>
+                  </div>
+                </div>
+                <p class="loaded-body" style="margin-top: 1rem">
+                  Max leads incident responses, deploying firewall vectors and
+                  monitoring subnets for unverified database hooks.
+                </p>
+                <div class="loaded-footer" style="margin-top: 1.5rem">
+                  <span class="loaded-badge">Secured</span>
+                  <span style="color: #64748b">Subnets Clean</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <!-- Right Workspace: Sidebar Controllers -->
+      <aside class="control-sidebar">
+        <!-- Panel 1: Playground Controller -->
+        <section class="sidebar-card">
+          <h3>
+            <svg
+              style="width: 1.125rem; height: 1.125rem"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4"
+              />
+            </svg>
+            Playground Settings
+          </h3>
+
+          <div class="selector-grid">
+            <!-- Shimmer Speeds -->
+            <div class="selector-section">
+              <span class="selector-title">Shimmer Speed</span>
+              <div class="pill-row">
+                <label for="speed-static" class="pill-label">Static</label>
+                <label for="speed-slow" class="pill-label">Slow</label>
+                <label for="speed-normal" class="pill-label">Normal</label>
+                <label for="speed-fast" class="pill-label">Fast</label>
+              </div>
+            </div>
+
+            <!-- Glow Intensity -->
+            <div class="selector-section">
+              <span class="selector-title">Neon Glow Outline</span>
+              <div class="pill-row">
+                <label for="glow-stealth" class="pill-label">Stealth</label>
+                <label for="glow-subtle" class="pill-label">Subtle</label>
+                <label for="glow-hyper" class="pill-label">Hyper</label>
+              </div>
+            </div>
+
+            <!-- Color Accent Swatches -->
+            <div class="selector-section">
+              <span class="selector-title">Glow Accent Color</span>
+              <div class="color-circle-row">
+                <label
+                  for="accent-cyber"
+                  class="color-circle circle-cyber"
+                  title="Cyberpunk Accent"
+                  id="label-accent-cyber"
+                ></label>
+                <label
+                  for="accent-matrix"
+                  class="color-circle circle-matrix"
+                  title="Matrix Accent"
+                  id="label-accent-matrix"
+                ></label>
+                <label
+                  for="accent-violet"
+                  class="color-circle circle-violet"
+                  title="Violet Accent"
+                  id="label-accent-violet"
+                ></label>
+                <label
+                  for="accent-amber"
+                  class="color-circle circle-amber"
+                  title="Amber Accent"
+                  id="label-accent-amber"
+                ></label>
+              </div>
+            </div>
+
+            <!-- Theme Background Selector -->
+            <div class="selector-section">
+              <span class="selector-title">Dashboard Background skin</span>
+              <div class="pill-row">
+                <label for="theme-oled" class="pill-label">OLED Black</label>
+                <label for="theme-glass" class="pill-label">Slate Glass</label>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <!-- Panel 2: Code Integration details -->
+        <section class="sidebar-card">
+          <h3>
+            <svg
+              style="width: 1.125rem; height: 1.125rem"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"
+              />
+            </svg>
+            Implementation
+          </h3>
+          <pre
+            class="code-box"
+          ><code>&lt;<span class="code-keyword">div</span> <span class="code-attr">class</span>=<span class="code-val">"ease-skeleton-card"</span>&gt;
+  &lt;<span class="code-keyword">div</span> <span class="code-attr">class</span>=<span class="code-val">"ease-sk-block ease-sk-avatar"</span>&gt;&lt;/<span class="code-keyword">div</span>&gt;
+  &lt;<span class="code-keyword">div</span> <span class="code-attr">class</span>=<span class="code-val">"ease-sk-block ease-sk-title"</span>&gt;&lt;/<span class="code-keyword">div</span>&gt;
+&lt;/<span class="code-keyword">div</span>&gt;</code></pre>
+        </section>
+      </aside>
+    </main>
+
+    <script>
+      // Accessibility Helper for State Updates
+      const checkbox = document.getElementById("loaded-checkbox");
+      const cards = document.querySelectorAll(".ease-skeleton-card");
+      const btn = document.getElementById("simulate-toggle-btn");
+
+      if (checkbox && cards && btn) {
+        checkbox.addEventListener("change", function () {
+          const isLoaded = this.checked;
+
+          // Update ARIA roles & labels dynamically
+          cards.forEach((card) => {
+            card.setAttribute("aria-busy", !isLoaded);
+          });
+
+          btn.textContent = isLoaded
+            ? "Reset Simulator"
+            : "Toggle Loaded State";
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/submissions/examples/fade-in-skeleton-agy/style.css
+++ b/submissions/examples/fade-in-skeleton-agy/style.css
@@ -1,0 +1,698 @@
+/* ==========================================================================
+   EaseMotion CSS — Fade In Skeleton (style.css)
+   Inspired by Neon design patterns & glassmorphism shimmers
+   ========================================================================== */
+
+/* ── Fonts & Imports ─────────────────────────────────────────────────────── */
+@import url("https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap");
+
+:root {
+  /* System Fonts */
+  --ease-font-sans: "Outfit", sans-serif;
+  --ease-font-mono: "JetBrains Mono", monospace;
+
+  /* Cyberpunk Space Theme Base Colors */
+  --color-bg-space: #030305;
+  --color-slate-900: #090d16;
+  --color-slate-800: #151b26;
+  --color-slate-700: #222c3c;
+  --color-slate-400: #94a3b8;
+  --color-slate-100: #f1f5f9;
+
+  /* Neon Swatch Colors */
+  --color-neon-pink: #fd2678;
+  --color-neon-cyan: #00f2fe;
+  --color-neon-pink-alpha: rgba(253, 38, 120, 0.18);
+  --color-neon-cyan-alpha: rgba(0, 242, 254, 0.18);
+
+  /* Dynamic Customizer Variables (Controlled via CSS states) */
+  --accent-primary: var(--color-neon-pink);
+  --accent-secondary: var(--color-neon-cyan);
+  --accent-primary-alpha: var(--color-neon-pink-alpha);
+  --accent-secondary-alpha: var(--color-neon-cyan-alpha);
+  --theme-bg: var(--color-bg-space);
+  --card-bg: rgba(9, 13, 22, 0.7);
+  --card-border: rgba(255, 255, 255, 0.05);
+  --text-heading: #ffffff;
+  --text-body: #64748b;
+
+  /* Customizer Dials */
+  --shimmer-speed: 1.8s;
+  --sk-bg-color: rgba(255, 255, 255, 0.03);
+  --glow-blur: 15px;
+  --glow-spread: 0px;
+}
+
+/* ── Reset & Core Styling ────────────────────────────────────────────────── */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--ease-font-sans);
+  background-color: var(--theme-bg);
+  color: var(--text-body);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow-x: hidden;
+  line-height: 1.5;
+  transition: background-color 0.5s ease;
+}
+
+/* Hide native inputs used for states */
+.state-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* ── Dynamic State Configuration Engine ──────────────────────────────────── */
+
+/* 1. Theme Background Skins */
+#theme-oled:checked ~ body,
+body:has(#theme-oled:checked) {
+  --theme-bg: var(--color-bg-space);
+  --card-bg: rgba(9, 13, 22, 0.75);
+  --card-border: rgba(255, 255, 255, 0.04);
+  --text-heading: #ffffff;
+  --text-body: #64748b;
+}
+
+#theme-glass:checked ~ body,
+body:has(#theme-glass:checked) {
+  --theme-bg: #0f172a;
+  --card-bg: rgba(30, 41, 59, 0.6);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-heading: #f8fafc;
+  --text-body: #94a3b8;
+}
+
+/* 2. Color Swatches */
+#accent-cyber:checked ~ body,
+body:has(#accent-cyber:checked) {
+  --accent-primary: #fd2678;
+  --accent-secondary: #00f2fe;
+  --accent-primary-alpha: rgba(253, 38, 120, 0.18);
+  --accent-secondary-alpha: rgba(0, 242, 254, 0.18);
+}
+#accent-matrix:checked ~ body,
+body:has(#accent-matrix:checked) {
+  --accent-primary: #00ff66;
+  --accent-secondary: #00ff00;
+  --accent-primary-alpha: rgba(0, 255, 102, 0.18);
+  --accent-secondary-alpha: rgba(0, 255, 0, 0.18);
+}
+#accent-violet:checked ~ body,
+body:has(#accent-violet:checked) {
+  --accent-primary: #8b5cf6;
+  --accent-secondary: #a78bfa;
+  --accent-primary-alpha: rgba(139, 92, 246, 0.18);
+  --accent-secondary-alpha: rgba(167, 139, 250, 0.18);
+}
+#accent-amber:checked ~ body,
+body:has(#accent-amber:checked) {
+  --accent-primary: #f59e0b;
+  --accent-secondary: #fbbf24;
+  --accent-primary-alpha: rgba(245, 158, 11, 0.18);
+  --accent-secondary-alpha: rgba(251, 191, 36, 0.18);
+}
+
+/* 3. Shimmer Speeds */
+#speed-static:checked ~ body,
+body:has(#speed-static:checked) {
+  --shimmer-speed: 0s;
+}
+#speed-slow:checked ~ body,
+body:has(#speed-slow:checked) {
+  --shimmer-speed: 3.5s;
+}
+#speed-normal:checked ~ body,
+body:has(#speed-normal:checked) {
+  --shimmer-speed: 1.8s;
+}
+#speed-fast:checked ~ body,
+body:has(#speed-fast:checked) {
+  --shimmer-speed: 0.8s;
+}
+
+/* 4. Glow Intensity Dials */
+#glow-stealth:checked ~ body,
+body:has(#glow-stealth:checked) {
+  --glow-blur: 0px;
+  --glow-spread: 0px;
+}
+#glow-subtle:checked ~ body,
+body:has(#glow-subtle:checked) {
+  --glow-blur: 12px;
+  --glow-spread: 0px;
+}
+#glow-hyper:checked ~ body,
+body:has(#glow-hyper:checked) {
+  --glow-blur: 25px;
+  --glow-spread: 1px;
+}
+
+/* Customizer pill selected labels */
+#theme-oled:checked ~ .dashboard-grid [for="theme-oled"],
+#theme-glass:checked ~ .dashboard-grid [for="theme-glass"],
+#accent-cyber:checked ~ .dashboard-grid [for="accent-cyber"],
+#accent-matrix:checked ~ .dashboard-grid [for="accent-matrix"],
+#accent-violet:checked ~ .dashboard-grid [for="accent-violet"],
+#accent-amber:checked ~ .dashboard-grid [for="accent-amber"],
+#speed-static:checked ~ .dashboard-grid [for="speed-static"],
+#speed-slow:checked ~ .dashboard-grid [for="speed-slow"],
+#speed-normal:checked ~ .dashboard-grid [for="speed-normal"],
+#speed-fast:checked ~ .dashboard-grid [for="speed-fast"],
+#glow-stealth:checked ~ .dashboard-grid [for="glow-stealth"],
+#glow-subtle:checked ~ .dashboard-grid [for="glow-subtle"],
+#glow-hyper:checked ~ .dashboard-grid [for="glow-hyper"] {
+  border-color: var(--accent-primary);
+  background: rgba(255, 255, 255, 0.05);
+  box-shadow: 0 0 10px var(--accent-primary-alpha);
+  color: var(--accent-primary);
+}
+
+/* ── App Navigation Header ──────────────────────────────────────────────── */
+.app-header {
+  background: rgba(0, 0, 0, 0.15);
+  backdrop-filter: blur(16px);
+  border-bottom: 1px solid var(--card-border);
+  padding: 1.25rem 2.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.logo-group {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.logo-icon {
+  width: 2.25rem;
+  height: 2.25rem;
+  background: linear-gradient(
+    135deg,
+    var(--accent-primary),
+    var(--accent-secondary)
+  );
+  border-radius: 0.75rem;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  color: #fff;
+  box-shadow: 0 0 15px var(--accent-primary-alpha);
+  transition: all 0.4s ease;
+}
+
+.logo-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  color: var(--text-heading);
+}
+
+/* ── Dashboard Grid ─────────────────────────────────────────────────────── */
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: 1fr 380px;
+  gap: 2.5rem;
+  max-width: 1440px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 2.5rem;
+  flex: 1;
+}
+
+@media (max-width: 1024px) {
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── Showcase Card Board ─────────────────────────────────────────────────── */
+.showcase-container {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.showcase-card {
+  background: var(--card-bg);
+  backdrop-filter: blur(16px);
+  border: 1px solid var(--card-border);
+  border-radius: 1.5rem;
+  padding: 2.5rem;
+  position: relative;
+  overflow: hidden;
+  transition: all 0.4s ease;
+}
+
+.showcase-card h2 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  color: var(--text-heading);
+  letter-spacing: -0.02em;
+}
+
+.showcase-card p.card-subtitle {
+  font-size: 0.95rem;
+  color: var(--text-body);
+  margin-bottom: 2.5rem;
+}
+
+/* Toggle simulated load button */
+.simulate-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--card-border);
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  margin-bottom: 2rem;
+}
+
+.simulate-label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-heading);
+}
+
+.simulate-btn {
+  background: linear-gradient(
+    135deg,
+    var(--accent-primary),
+    var(--accent-secondary)
+  );
+  color: #fff;
+  border: none;
+  font-family: var(--ease-font-sans);
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.5rem 1.25rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  box-shadow: 0 0 12px var(--accent-primary-alpha);
+  transition: all 0.3s ease;
+}
+
+/* Profile Card Grid Layout */
+.profile-grid-display {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+/* ── Neon Outline Pulse Cards ────────────────────────────────────────────── */
+.ease-skeleton-card {
+  position: relative;
+  background: var(--card-bg);
+  border: 1px solid var(--accent-primary-alpha);
+  border-radius: 1.25rem;
+  padding: 1.75rem;
+  height: 240px;
+  overflow: hidden;
+  box-shadow: 0 0 var(--glow-blur) var(--glow-spread)
+    var(--accent-primary-alpha);
+  transition:
+    border-color 0.4s ease,
+    box-shadow 0.4s ease;
+}
+
+/* Dual glow variant for secondary visual indicators */
+.ease-skeleton-card:nth-child(even) {
+  border-color: var(--accent-secondary-alpha);
+  box-shadow: 0 0 var(--glow-blur) var(--glow-spread)
+    var(--accent-secondary-alpha);
+}
+
+/* ── Content Fade In / Switch Viewport Layers ────────────────────────────── */
+
+/* Wrapper layer containment */
+.ease-skeleton-layer,
+.ease-loaded-layer {
+  position: absolute;
+  top: 1.75rem;
+  left: 1.75rem;
+  right: 1.75rem;
+  bottom: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.ease-skeleton-layer {
+  opacity: 1;
+  visibility: visible;
+  transition:
+    opacity 0.4s ease,
+    visibility 0.4s ease;
+}
+
+.ease-loaded-layer {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(10px);
+  transition:
+    opacity 0.5s ease,
+    transform 0.5s cubic-bezier(0.16, 1, 0.3, 1),
+    visibility 0.5s ease;
+}
+
+/* Toggle matches using check state of #loaded-checkbox */
+#loaded-checkbox:checked ~ .dashboard-grid .ease-skeleton-layer {
+  opacity: 0;
+  visibility: hidden;
+}
+
+#loaded-checkbox:checked ~ .dashboard-grid .ease-loaded-layer {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+#loaded-checkbox:checked ~ .dashboard-grid .ease-skeleton-card {
+  border-color: var(--card-border);
+  box-shadow: none;
+}
+
+#loaded-checkbox:checked ~ .dashboard-grid .ease-skeleton-card:hover {
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 var(--glow-blur) var(--glow-spread)
+    var(--accent-primary-alpha);
+}
+
+/* ── Skeleton Block Layout Elements ─────────────────────────────────────── */
+.ease-sk-block {
+  position: relative;
+  background: linear-gradient(
+    90deg,
+    var(--sk-bg-color) 25%,
+    var(--accent-primary-alpha) 50%,
+    var(--sk-bg-color) 75%
+  );
+  background-size: 200% 100%;
+  animation: neon-shimmer-pulse var(--shimmer-speed) infinite linear;
+  border-radius: 0.5rem;
+}
+
+/* Secondary track nodes shimmer color overrides */
+.ease-skeleton-card:nth-child(even) .ease-sk-block {
+  background: linear-gradient(
+    90deg,
+    var(--sk-bg-color) 25%,
+    var(--accent-secondary-alpha) 50%,
+    var(--sk-bg-color) 75%
+  );
+  background-size: 200% 100%;
+}
+
+.ease-sk-avatar {
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 50%;
+}
+
+.ease-sk-title {
+  width: 120px;
+  height: 1.125rem;
+  border-radius: 0.35rem;
+}
+
+.ease-sk-tag {
+  width: 60px;
+  height: 1.25rem;
+  border-radius: 0.25rem;
+}
+
+.ease-sk-text {
+  width: 100%;
+  height: 0.85rem;
+  border-radius: 0.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.ease-sk-text-short {
+  width: 70%;
+  height: 0.85rem;
+  border-radius: 0.25rem;
+}
+
+.ease-sk-footer {
+  width: 100px;
+  height: 1.25rem;
+  border-radius: 0.25rem;
+}
+
+/* ── Rich Loaded content elements ────────────────────────────────────────── */
+.loaded-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.loaded-avatar {
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 50%;
+  background: linear-gradient(
+    135deg,
+    var(--accent-primary),
+    var(--accent-secondary)
+  );
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  color: #fff;
+  border: 2.5px solid var(--accent-primary-alpha);
+  box-shadow: 0 0 10px var(--accent-primary-alpha);
+  font-size: 1.15rem;
+}
+
+.ease-skeleton-card:nth-child(even) .loaded-avatar {
+  border-color: var(--accent-secondary-alpha);
+  box-shadow: 0 0 10px var(--accent-secondary-alpha);
+}
+
+.loaded-identity h4 {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-heading);
+}
+
+.loaded-identity p {
+  font-size: 0.75rem;
+  color: var(--accent-primary);
+  font-weight: 500;
+}
+
+.ease-skeleton-card:nth-child(even) .loaded-identity p {
+  color: var(--accent-secondary);
+}
+
+.loaded-body {
+  font-size: 0.875rem;
+  color: var(--text-body);
+  line-height: 1.5;
+}
+
+.loaded-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-top: 1px solid var(--card-border);
+  padding-top: 0.75rem;
+  font-size: 0.75rem;
+}
+
+.loaded-badge {
+  background: var(--accent-primary-alpha);
+  color: var(--accent-primary);
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  font-weight: 600;
+}
+
+.ease-skeleton-card:nth-child(even) .loaded-badge {
+  background: var(--accent-secondary-alpha);
+  color: var(--accent-secondary);
+}
+
+/* ── Sidebar customizer controls ────────────────────────────────────────── */
+.control-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.sidebar-card {
+  background: var(--card-bg);
+  backdrop-filter: blur(16px);
+  border: 1px solid var(--card-border);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+}
+
+.sidebar-card h3 {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin-bottom: 1.25rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-bottom: 1px solid var(--card-border);
+  padding-bottom: 0.75rem;
+  color: var(--text-heading);
+}
+
+.selector-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.selector-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.selector-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #64748b;
+}
+
+.pill-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(60px, 1fr));
+  gap: 0.5rem;
+}
+
+.pill-label {
+  padding: 0.5rem;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid var(--card-border);
+  border-radius: 0.5rem;
+  text-align: center;
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.25s ease;
+  color: var(--text-body);
+}
+
+.pill-label:hover {
+  border-color: rgba(255, 255, 255, 0.15);
+  color: var(--text-heading);
+}
+
+/* Color Circle Swatches */
+.color-circle-row {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.color-circle {
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  cursor: pointer;
+  border: 2px solid transparent;
+  transition: all 0.25s ease;
+}
+
+.circle-cyber {
+  background: linear-gradient(135deg, #fd2678, #00f2fe);
+}
+.circle-matrix {
+  background: linear-gradient(135deg, #00ff66, #00ff00);
+}
+.circle-violet {
+  background: linear-gradient(135deg, #8b5cf6, #a78bfa);
+}
+.circle-amber {
+  background: linear-gradient(135deg, #f59e0b, #fbbf24);
+}
+
+#accent-cyber:checked ~ .dashboard-grid [for="accent-cyber"],
+#accent-matrix:checked ~ .dashboard-grid [for="accent-matrix"],
+#accent-violet:checked ~ .dashboard-grid [for="accent-violet"],
+#accent-amber:checked ~ .dashboard-grid [for="accent-amber"] {
+  border-color: var(--text-heading);
+  transform: scale(1.15);
+  box-shadow: 0 0 10px var(--accent-primary-alpha);
+}
+
+/* ── Code Display Box ───────────────────────────────────────────────────── */
+.code-box {
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid var(--card-border);
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  overflow-x: auto;
+  font-family: var(--ease-font-mono);
+  font-size: 0.75rem;
+  color: #38bdf8;
+  line-height: 1.6;
+}
+
+.code-keyword {
+  color: #f43f5e;
+}
+.code-attr {
+  color: #f59e0b;
+}
+.code-val {
+  color: #10b981;
+}
+
+/* ── Keyframe Animations ─────────────────────────────────────────────────── */
+@keyframes neon-shimmer-pulse {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+/* ── Accessibility & Reduced Motion ──────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-delay: 0s !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .ease-sk-block {
+    animation: none !important;
+    background: var(--sk-bg-color) !important;
+  }
+
+  .ease-skeleton-card {
+    transition: none !important;
+    box-shadow: 0 0 10px var(--accent-primary-alpha) !important;
+  }
+
+  .ease-skeleton-layer,
+  .ease-loaded-layer {
+    transition: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
### Description
This Pull Request resolves SAPTARSHI-coder/EaseMotion-css#41432 by adding a new component submission for the **Fade In Skeleton Component** under `submissions/examples/fade-in-skeleton-agy/`.

### Cyberpunk Shimmer Waves & Loaded Transition Fades
The component features a custom pure CSS customizable playground (variables for shimmer speeds, glow blur intensity values, neon color swatches, and background skins):
- Linear gradient shimmers: background wave gradient shifts smoothly across elements using simple keyframes.
- Neon glow outlines: pulses card frames with custom box shadow glows linked to selected themes.
- Visibility layers: hides skeleton layers and reveals loaded content using smooth opacity / translateY coordinates on click.
- Responsive & Accessible: full mobile support, keyboard toggle event hooks, proper `aria-busy` states, and `prefers-reduced-motion` compliance.

### Changes Included
- `submissions/examples/fade-in-skeleton-agy/demo.html`: Cyberpunk social card grid hub.
- `submissions/examples/fade-in-skeleton-agy/style.css`: Shimmer pulse keyframes, outline glows, visibility filters, customizer rules, layouts.
- `submissions/examples/fade-in-skeleton-agy/README.md`: Component documentation.

Closes #41432