### PR TITLE
feat: add zoom-tooltip-pg365 submission

### DIFF
--- a/submissions/examples/zoom-tooltip-pg365/README.md
+++ b/submissions/examples/zoom-tooltip-pg365/README.md
@@ -1,0 +1,35 @@
+# Zoom Tooltip
+
+## What does this do?
+A tooltip that pops in with a **zoom / scale-in** animation instead of a
+plain fade — it grows from a small dot into full size on hover or keyboard
+focus, and shrinks back out on dismiss, with a small caret arrow pointing
+at the trigger element.
+
+## How is it used?
+```html
+<div class="zoom-tooltip zoom-tooltip--top" tabindex="0">
+  Hover me
+  <span class="tooltip">Tooltip text</span>
+</div>
+
+<button class="zoom-tooltip zoom-tooltip--right">
+  Icon
+  <span class="tooltip">Save changes</span>
+</button>
+```
+
+Four placement modifiers are available: `zoom-tooltip--top`,
+`zoom-tooltip--bottom`, `zoom-tooltip--left`, and `zoom-tooltip--right`.
+Each positions the tooltip bubble and its caret arrow, and sets the correct
+`transform-origin` so the zoom animation scales outward from the edge
+closest to the trigger (e.g. from the bottom edge for the `--top`
+variant), rather than from a generic center point.
+
+## Why is this useful?
+Most tooltip implementations only fade or slide in. A zoom/scale-in gives
+the tooltip a more tactile, "popping" feel that draws the eye without
+being as jarring as a slide, which fits EaseMotion CSS's animation-first,
+JS-free philosophy. It works with `:hover` and `:focus-visible`, so it's
+fully usable via keyboard and requires zero JavaScript. The animation is
+also disabled under `prefers-reduced-motion: reduce` for accessibility.

--- a/submissions/examples/zoom-tooltip-pg365/demo.html
+++ b/submissions/examples/zoom-tooltip-pg365/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Zoom Tooltip Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <div class="demo-grid">
+
+    <div class="zoom-tooltip zoom-tooltip--top" tabindex="0">
+      Hover (top)
+      <span class="tooltip">Zoom tooltip on top</span>
+    </div>
+
+    <div class="zoom-tooltip zoom-tooltip--bottom" tabindex="0">
+      Hover (bottom)
+      <span class="tooltip">Zoom tooltip on bottom</span>
+    </div>
+
+    <div class="zoom-tooltip zoom-tooltip--left" tabindex="0">
+      Hover (left)
+      <span class="tooltip">Zoom tooltip on left</span>
+    </div>
+
+    <div class="zoom-tooltip zoom-tooltip--right" tabindex="0">
+      Hover (right)
+      <span class="tooltip">Zoom tooltip on right</span>
+    </div>
+
+    <button class="zoom-tooltip zoom-tooltip--top">
+      Icon Button
+      <span class="tooltip">Save changes</span>
+    </button>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/zoom-tooltip-pg365/style.css
+++ b/submissions/examples/zoom-tooltip-pg365/style.css
@@ -1,0 +1,137 @@
+/* Zoom Tooltip
+   A tooltip that appears with a zoom / scale-in animation on hover and
+   keyboard focus, instead of a plain fade or slide. Pure CSS, no
+   JavaScript, four placement variants with a matching caret arrow. */
+
+.zoom-tooltip {
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+  font-family: system-ui, sans-serif;
+  padding: 0.6rem 1.1rem;
+  border-radius: 6px;
+  background: #2a2a3a;
+  color: #fff;
+  border: none;
+}
+
+.zoom-tooltip .tooltip {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  transform: scale(0.4);
+  transform-origin: var(--zt-origin, center bottom);
+  background: #111;
+  color: #fff;
+  padding: 0.4rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  line-height: 1.3;
+  white-space: nowrap;
+  transition: opacity 0.2s ease, transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+  z-index: 10;
+}
+
+.zoom-tooltip .tooltip::after {
+  content: "";
+  position: absolute;
+  border: 5px solid transparent;
+}
+
+.zoom-tooltip:hover .tooltip,
+.zoom-tooltip:focus-visible .tooltip {
+  opacity: 1;
+  pointer-events: auto;
+  transform: scale(1);
+}
+
+/* Top (default) */
+.zoom-tooltip--top .tooltip {
+  bottom: 100%;
+  left: 50%;
+  margin-bottom: 10px;
+  transform: translateX(-50%) scale(0.4);
+  --zt-origin: center bottom;
+}
+.zoom-tooltip--top:hover .tooltip,
+.zoom-tooltip--top:focus-visible .tooltip {
+  transform: translateX(-50%) scale(1);
+}
+.zoom-tooltip--top .tooltip::after {
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-top-color: #111;
+}
+
+/* Bottom */
+.zoom-tooltip--bottom .tooltip {
+  top: 100%;
+  left: 50%;
+  margin-top: 10px;
+  transform: translateX(-50%) scale(0.4);
+  --zt-origin: center top;
+}
+.zoom-tooltip--bottom:hover .tooltip,
+.zoom-tooltip--bottom:focus-visible .tooltip {
+  transform: translateX(-50%) scale(1);
+}
+.zoom-tooltip--bottom .tooltip::after {
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-bottom-color: #111;
+}
+
+/* Left */
+.zoom-tooltip--left .tooltip {
+  right: 100%;
+  top: 50%;
+  margin-right: 10px;
+  transform: translateY(-50%) scale(0.4);
+  --zt-origin: right center;
+}
+.zoom-tooltip--left:hover .tooltip,
+.zoom-tooltip--left:focus-visible .tooltip {
+  transform: translateY(-50%) scale(1);
+}
+.zoom-tooltip--left .tooltip::after {
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  border-left-color: #111;
+}
+
+/* Right */
+.zoom-tooltip--right .tooltip {
+  left: 100%;
+  top: 50%;
+  margin-left: 10px;
+  transform: translateY(-50%) scale(0.4);
+  --zt-origin: left center;
+}
+.zoom-tooltip--right:hover .tooltip,
+.zoom-tooltip--right:focus-visible .tooltip {
+  transform: translateY(-50%) scale(1);
+}
+.zoom-tooltip--right .tooltip::after {
+  right: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  border-right-color: #111;
+}
+
+.demo-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3rem;
+  padding: 4rem;
+}
+
+/* Respect reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .zoom-tooltip .tooltip {
+    transition: opacity 0.2s ease;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Fixes #42402

Adds a `zoom-tooltip` component under `submissions/examples/zoom-tooltip-pg365/`, per the requested Tooltip — Zoom Variant feature.

- Pure CSS, no JavaScript — tooltip scales in from `0.4` to `1` on `:hover` and `:focus-visible` with an ease-out-back style easing curve, instead of a plain fade.
- Four placement modifiers (`zoom-tooltip--top/--bottom/--left/--right`), each with a matching caret arrow and a `transform-origin` set toward the trigger so the zoom scales outward from the correct edge.
- Keyboard accessible via `:focus-visible`.
- Respects `prefers-reduced-motion: reduce` (disables the scale transform, keeps a simple opacity fade).

## Files
```
submissions/examples/zoom-tooltip-pg365/
├── demo.html
├── style.css
└── README.md
```

Structure and naming follow the conventions used by recently merged tooltip submissions (e.g. `ease-tooltip-fade-k553`, `swing-hover-tooltip`, `pulse-active-tooltip`), and CONTRIBUTING.md's Standard (HTML/CSS) track — self-contained, opens directly in a browser, no CDNs/frameworks, raw (non-`ease-*`) class names for maintainer standardization.

## Test plan
- [x] Opened `demo.html` directly in a browser — all four tooltip placements zoom in on hover/focus and zoom back out on dismiss.
- [x] Verified keyboard focus (`Tab`) triggers the same animation via `:focus-visible`.
- [x] `submissions/` is excluded from the repo's stylelint config (`.stylelintignore`), consistent with CONTRIBUTING.md's note that submission CSS doesn't need `ease-*` naming.
- [x] No files outside `submissions/examples/zoom-tooltip-pg365/` were touched.