### PR TITLE
feat: add gooey/metaball SVG filter merge example

### DIFF
--- a/submissions/examples/gooey-merge-blobs-kamalsharma001/README.md
+++ b/submissions/examples/gooey-merge-blobs-kamalsharma001/README.md
@@ -1,0 +1,24 @@
+# Gooey Merge Blobs
+
+## 1. What does this do?
+A cluster of "blob" elements that visually fuse into one gooey shape when
+close together, and separate cleanly into distinct circles when spread
+apart — the classic metaball/gooey SVG-filter effect.
+
+## 2. How is it used?
+```html
+<div class="goo-stage">
+  <div class="blob main"></div>
+  <div class="blob sub"></div>
+</div>
+```
+Apply `filter: url(#goo)` (an SVG `<feGaussianBlur>` + `<feColorMatrix>`
+pair, defined inline in the HTML) to the wrapping container. Toggle a
+class to move sub-elements via `transform`; the filter handles the
+merge/split visual automatically.
+
+## 3. Why is it useful?
+Adds a distinctive, physically-tactile motion effect (FAB menus,
+notification merges, playful loading indicators) not achievable with
+plain CSS transitions. Includes a `prefers-reduced-motion` fallback that
+disables the filter and crossfades instead, so it degrades gracefully.

--- a/submissions/examples/gooey-merge-blobs-kamalsharma001/demo.html
+++ b/submissions/examples/gooey-merge-blobs-kamalsharma001/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Gooey Merge Effect</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<svg width="0" height="0" style="position:absolute">
+  <filter id="goo">
+    <feGaussianBlur in="SourceGraphic" stdDeviation="10" result="blur" />
+    <feColorMatrix in="blur" mode="matrix"
+      values="1 0 0 0 0
+              0 1 0 0 0
+              0 0 1 0 0
+              0 0 0 19 -9" result="goo" />
+    <feComposite in="SourceGraphic" in2="goo" operator="atop" />
+  </filter>
+</svg>
+
+<div class="goo-stage" id="stage">
+  <div class="blob main"></div>
+  <div class="blob sub sub-1"></div>
+  <div class="blob sub sub-2"></div>
+  <div class="blob sub sub-3"></div>
+</div>
+
+<button class="toggle-btn" id="toggleBtn">Toggle merge</button>
+
+<script>
+  const stage = document.getElementById('stage');
+  const btn = document.getElementById('toggleBtn');
+  btn.addEventListener('click', () => stage.classList.toggle('is-open'));
+</script>
+
+</body>
+</html>

--- a/submissions/examples/gooey-merge-blobs-kamalsharma001/style.css
+++ b/submissions/examples/gooey-merge-blobs-kamalsharma001/style.css
@@ -1,0 +1,61 @@
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 40px;
+  background: #0f1117;
+  font-family: system-ui, sans-serif;
+}
+
+.goo-stage {
+  position: relative;
+  width: 220px;
+  height: 220px;
+  filter: url(#goo);
+}
+
+/* Reduced-motion / no-filter-support fallback: crossfade instead of merge */
+@media (prefers-reduced-motion: reduce) {
+  .goo-stage { filter: none; }
+  .sub { transition: opacity 0.2s ease !important; }
+}
+
+.blob {
+  position: absolute;
+  border-radius: 50%;
+  background: #6ee7b7;
+  transition: transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.main {
+  width: 70px;
+  height: 70px;
+  top: 75px;
+  left: 75px;
+}
+
+.sub {
+  width: 46px;
+  height: 46px;
+  top: 87px;
+  left: 87px;
+  transform: scale(0);
+}
+
+.goo-stage.is-open .sub-1 { transform: translate(-70px, -40px) scale(1); }
+.goo-stage.is-open .sub-2 { transform: translate(70px, -40px) scale(1); }
+.goo-stage.is-open .sub-3 { transform: translate(0, 80px) scale(1); }
+
+.toggle-btn {
+  padding: 10px 20px;
+  border-radius: 8px;
+  border: none;
+  background: #262a35;
+  color: #e6e6e6;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary

Adds an interactive gooey/metaball merge animation using SVG filters.

### Features

- SVG gooey filter
- Interactive merge/split animation
- Toggle button
- Reduced motion fallback

Closes #43903 

### How to test

1. Open `submissions/examples/gooey-merge-blobs-kamalsharma001/demo.html`.
2. Click **Toggle merge**.
3. Observe the blobs smoothly merging and separating with the SVG gooey filter.