### PR TITLE
ease-cdn-semver-picker-sp

### DIFF
--- a/submissions/docs/ease-cdn-semver-picker-sp/README.md
+++ b/submissions/docs/ease-cdn-semver-picker-sp/README.md
@@ -1,0 +1,98 @@
+# CDN Semver Version Picker & Pinning Guide
+
+An interactive documentation tool that generates **version-pinned CDN links** for EaseMotion CSS across **jsDelivr** and **unpkg**, with clear guidance on version pinning versus tracking the latest release.
+
+> Submission track: `submissions/docs/ease-cdn-semver-picker-sp/`  
+> Contributor suffix: `sp`  
+> Resolves: Issue #43649
+
+---
+
+## What does this do?
+
+The EaseMotion README documents multiple CDN providers, but beginners often copy the `@main` link into production projects without understanding the risks of unpinned versions.
+
+This tool lets you:
+
+- Select a version (`v1.0.0`, `v1.1.0`, `v1.2.0`, or `main`)
+- Choose a CDN provider (jsDelivr / unpkg)
+- Pick a file (minified bundle, full bundle, granular `core/` files)
+- Get copy-ready `<link>` tags with the correct URL format
+- See a live risk meter that warns when your selection is unpinned
+
+---
+
+## How is it used?
+
+1. Open `demo.html` in a browser (requires internet for CDN assets).
+2. Pick a **version**, **provider**, and **file** in the left panel.
+3. Watch the **risk meter** — green for pinned, red for `@main`.
+4. Copy the generated **`<link>` tag** or **raw URL**.
+5. Check the **live preview** styled by your selected build.
+6. Read the **pin vs latest** panel and semver/caching notes.
+
+---
+
+## Features
+
+- Version selector with all published EaseMotion releases plus `main`
+- CDN provider toggle (jsDelivr / unpkg) with correct URL formats for each
+- File picker (`easemotion.min.css`, `easemotion.css`, granular `core/` files)
+- Auto-generated copy-to-clipboard snippets (link tag and raw URL)
+- Live risk meter — pinned (safe), unpinned (warning/danger)
+- "Pin vs latest" comparison panel explaining production risks of `@main`
+- Semver basics explainer (major / minor / patch) for beginners
+- Cache behavior notes (jsDelivr permanent version caching, ~12h branch cache)
+- Live preview section styled with the selected EaseMotion build
+- Responsive, accessible UI with keyboard-friendly radio controls
+
+---
+
+## URL formats generated
+
+| Selection | Generated URL format |
+|-----------|---------------------|
+| jsDelivr + pinned version | `cdn.jsdelivr.net/npm/easemotion-css@1.2.0/easemotion.min.css` |
+| jsDelivr + `main` | `cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css` |
+| unpkg + pinned version | `unpkg.com/easemotion-css@1.2.0/easemotion.min.css` |
+| unpkg + `main` | Falls back to `@latest` (unpkg serves npm releases only) |
+
+---
+
+## Why is it useful?
+
+- **Prevents production accidents** — makes the `@main` risk visible before copying.
+- **Correct URLs every time** — jsDelivr and unpkg formats differ; the tool handles both.
+- **Teaches semver** — major/minor/patch explained for beginners.
+- **Documents cache behavior** — explains why branch URLs update slowly.
+- **Self-contained** — no edits to `core/`, `components/`, or existing files.
+
+---
+
+## Tech stack
+
+| Asset | Source |
+|-------|--------|
+| EaseMotion CSS | jsDelivr CDN (`easemotion.min.css`) |
+| Link generator | Inline JS in `demo.html` |
+| Layout & risk styling | `style.css` |
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Picker UI, link generation, live preview, copy logic |
+| `style.css` | Panel layout, risk meter, snippet styling |
+| `README.md` | This document |
+
+---
+
+## Compliance notes
+
+- Only **new files** inside `submissions/docs/ease-cdn-semver-picker-sp/`.
+- No modifications to `core/`, `components/`, workflows, or existing files.
+- All three required submission files included (`demo.html`, `style.css`, `README.md`).
+- Total contribution exceeds the 250-line minimum policy threshold.
+- Folder name carries the unique contributor suffix `-sp`.

--- a/submissions/docs/ease-cdn-semver-picker-sp/demo.html
+++ b/submissions/docs/ease-cdn-semver-picker-sp/demo.html
@@ -1,0 +1,385 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CDN Semver Version Picker &amp; Pinning Guide — EaseMotion CSS</title>
+  <meta
+    name="description"
+    content="Generate version-pinned jsDelivr and unpkg CDN links for EaseMotion CSS and learn when to pin versus track latest."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header class="cp-header ease-fade-in">
+    <p class="cp-eyebrow">EaseMotion CSS · CDN Documentation Tool</p>
+    <h1>CDN Semver Version Picker &amp; Pinning Guide</h1>
+    <p class="cp-subtitle">
+      Pick a version, provider, and file — get a copy-ready CDN link with the
+      correct URL format. Learn when to pin a release and why shipping
+      <code>@main</code> to production is risky.
+    </p>
+  </header>
+
+  <main class="cp-main">
+    <div class="cp-layout">
+      <!-- ── Picker panel ─────────────────────────────────── -->
+      <aside class="cp-panel" aria-label="Link generator controls">
+        <h2 class="cp-panel-title">Build your CDN link</h2>
+
+        <div class="cp-field">
+          <span class="cp-field-label" id="version-label">Version</span>
+          <div class="cp-option-list" role="radiogroup" aria-labelledby="version-label">
+            <label class="cp-option is-selected">
+              <input type="radio" name="version" value="1.2.0" checked />
+              v1.2.0
+              <span class="cp-option-note cp-note-pinned">Pinned · latest release</span>
+            </label>
+            <label class="cp-option">
+              <input type="radio" name="version" value="1.1.0" />
+              v1.1.0
+              <span class="cp-option-note cp-note-pinned">Pinned</span>
+            </label>
+            <label class="cp-option">
+              <input type="radio" name="version" value="1.0.0" />
+              v1.0.0
+              <span class="cp-option-note cp-note-pinned">Pinned</span>
+            </label>
+            <label class="cp-option">
+              <input type="radio" name="version" value="main" />
+              main
+              <span class="cp-option-note cp-note-risky">Unpinned · moving</span>
+            </label>
+          </div>
+        </div>
+
+        <div class="cp-field">
+          <span class="cp-field-label" id="provider-label">CDN provider</span>
+          <div class="cp-option-list" role="radiogroup" aria-labelledby="provider-label">
+            <label class="cp-option is-selected">
+              <input type="radio" name="provider" value="jsdelivr" checked />
+              jsDelivr
+              <span class="cp-option-note cp-note-pinned">Recommended</span>
+            </label>
+            <label class="cp-option">
+              <input type="radio" name="provider" value="unpkg" />
+              unpkg
+              <span class="cp-option-note cp-note-latest">npm only</span>
+            </label>
+          </div>
+        </div>
+
+        <div class="cp-field">
+          <span class="cp-field-label" id="file-label">File</span>
+          <div class="cp-option-list" role="radiogroup" aria-labelledby="file-label">
+            <label class="cp-option is-selected">
+              <input type="radio" name="file" value="easemotion.min.css" checked />
+              easemotion.min.css
+              <span class="cp-option-note cp-note-pinned">Production</span>
+            </label>
+            <label class="cp-option">
+              <input type="radio" name="file" value="easemotion.css" />
+              easemotion.css
+              <span class="cp-option-note cp-note-latest">Debug</span>
+            </label>
+            <label class="cp-option">
+              <input type="radio" name="file" value="core/animations.css" />
+              core/animations.css
+              <span class="cp-option-note cp-note-latest">Granular</span>
+            </label>
+            <label class="cp-option">
+              <input type="radio" name="file" value="core/variables.css" />
+              core/variables.css
+              <span class="cp-option-note cp-note-latest">Granular</span>
+            </label>
+          </div>
+        </div>
+
+        <div class="cp-risk-meter cp-risk-safe" id="risk-meter" role="status" aria-live="polite">
+          ✓ Pinned version — safe for production. Updates only when you change the URL.
+        </div>
+      </aside>
+
+      <!-- ── Output column ────────────────────────────────── -->
+      <div class="cp-output">
+        <section class="cp-snippet-card" aria-labelledby="snippet-title">
+          <header class="cp-snippet-header">
+            <h2 id="snippet-title">Generated &lt;link&gt; tag</h2>
+            <span class="cp-provider-badge" id="provider-badge">jsDelivr</span>
+          </header>
+          <pre class="cp-snippet-code" id="snippet-code"></pre>
+          <footer class="cp-snippet-footer">
+            <p class="cp-snippet-hint" id="snippet-hint">
+              Paste inside your &lt;head&gt; tag.
+            </p>
+            <button type="button" class="cp-copy-btn" id="copy-snippet-btn">
+              Copy snippet
+            </button>
+          </footer>
+        </section>
+
+        <section class="cp-snippet-card" aria-labelledby="url-title">
+          <header class="cp-snippet-header">
+            <h2 id="url-title">Raw URL only</h2>
+          </header>
+          <pre class="cp-snippet-code" id="url-code"></pre>
+          <footer class="cp-snippet-footer">
+            <p class="cp-snippet-hint">For imports, bundlers, or quick testing.</p>
+            <button type="button" class="cp-copy-btn" id="copy-url-btn">
+              Copy URL
+            </button>
+          </footer>
+        </section>
+
+        <section class="cp-pin-panel" aria-labelledby="pin-title">
+          <div class="cp-pin-grid">
+            <div class="cp-pin-side cp-pin-good">
+              <h3 id="pin-title">✓ Pin a version (production)</h3>
+              <ul>
+                <li>URL always serves the exact same bytes — reproducible builds.</li>
+                <li>No surprise breaking changes when the repo updates.</li>
+                <li>jsDelivr caches pinned versions permanently — fastest response.</li>
+                <li>Upgrade deliberately: change the URL, test, then ship.</li>
+              </ul>
+            </div>
+            <div class="cp-pin-side cp-pin-bad">
+              <h3>⚠ Track @main (prototypes only)</h3>
+              <ul>
+                <li>Content changes whenever the default branch changes.</li>
+                <li>A refactor or class rename upstream can break your live site.</li>
+                <li>jsDelivr caches branch URLs up to 12 hours — updates are delayed and inconsistent across regions.</li>
+                <li>Fine for demos, CodePens, and issue reproductions — never production.</li>
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        <section class="cp-preview-card" aria-labelledby="preview-title">
+          <header class="cp-preview-header">
+            <h2 id="preview-title">Live preview</h2>
+            <p>
+              These elements are styled by the EaseMotion build selected above
+              (loaded on demand, replacing the previous stylesheet).
+            </p>
+          </header>
+          <div class="cp-preview-stage">
+            <button type="button" class="ease-btn ease-btn-primary">Primary button</button>
+            <button type="button" class="ease-btn ease-btn-outline">Outline button</button>
+            <span class="cp-preview-badge ease-pulse" id="preview-badge">v1.2.0 · jsDelivr</span>
+          </div>
+        </section>
+      </div>
+    </div>
+
+    <!-- ── Semver explainer ─────────────────────────────────── -->
+    <section class="cp-education" aria-labelledby="edu-title">
+      <h2 id="edu-title" class="ease-sr-only">Semver and caching guidance</h2>
+
+      <article class="cp-edu-card">
+        <h3>Semver in 30 seconds</h3>
+        <div class="cp-semver-diagram" aria-hidden="true">
+          <span class="cp-semver-part cp-semver-major">1</span>
+          <span>.</span>
+          <span class="cp-semver-part cp-semver-minor">2</span>
+          <span>.</span>
+          <span class="cp-semver-part cp-semver-patch">0</span>
+        </div>
+        <ul>
+          <li><strong>Major</strong> — breaking changes (classes removed or renamed).</li>
+          <li><strong>Minor</strong> — new features, backwards compatible.</li>
+          <li><strong>Patch</strong> — bug fixes only, safe to bump.</li>
+        </ul>
+      </article>
+
+      <article class="cp-edu-card">
+        <h3>URL formats per provider</h3>
+        <ul>
+          <li>jsDelivr (GitHub): <code>cdn.jsdelivr.net/gh/user/repo@version/file</code></li>
+          <li>jsDelivr (npm): <code>cdn.jsdelivr.net/npm/easemotion-css@version/file</code></li>
+          <li>unpkg (npm): <code>unpkg.com/easemotion-css@version/file</code></li>
+          <li>unpkg has no <code>@main</code> — it serves npm releases only.</li>
+        </ul>
+      </article>
+
+      <article class="cp-edu-card">
+        <h3>Cache behavior notes</h3>
+        <ul>
+          <li>Pinned version URLs are cached permanently at the edge.</li>
+          <li>Branch URLs (<code>@main</code>) refresh within ~12 hours, not instantly.</li>
+          <li>Purging a branch URL propagates slowly across regions.</li>
+          <li>If styles look stale after a push, the branch cache is the usual cause.</li>
+        </ul>
+      </article>
+    </section>
+
+    <p class="cp-status" id="copy-status" role="status" aria-live="polite"></p>
+  </main>
+
+  <footer class="cp-footer">
+    <p>
+      Built for EaseMotion CSS ·
+      <code>submissions/docs/ease-cdn-semver-picker-sp</code> ·
+      Resolves Issue #43649
+    </p>
+  </footer>
+
+  <script>
+    (function () {
+      'use strict';
+
+      var GH_REPO = 'SAPTARSHI-coder/EaseMotion-css';
+      var NPM_PKG = 'easemotion-css';
+
+      var state = {
+        version: '1.2.0',
+        provider: 'jsdelivr',
+        file: 'easemotion.min.css'
+      };
+
+      var snippetCode = document.getElementById('snippet-code');
+      var urlCode = document.getElementById('url-code');
+      var providerBadge = document.getElementById('provider-badge');
+      var previewBadge = document.getElementById('preview-badge');
+      var riskMeter = document.getElementById('risk-meter');
+      var snippetHint = document.getElementById('snippet-hint');
+      var copyStatus = document.getElementById('copy-status');
+
+      function buildUrl() {
+        if (state.provider === 'unpkg') {
+          // unpkg serves npm releases only; "main" falls back to latest.
+          var v = state.version === 'main' ? 'latest' : state.version;
+          return 'https://unpkg.com/' + NPM_PKG + '@' + v + '/' + state.file;
+        }
+        if (state.version === 'main') {
+          return 'https://cdn.jsdelivr.net/gh/' + GH_REPO + '@main/' + state.file;
+        }
+        return 'https://cdn.jsdelivr.net/npm/' + NPM_PKG + '@' + state.version + '/' + state.file;
+      }
+
+      function buildSnippet(url) {
+        return '<link\n  rel="stylesheet"\n  href="' + url + '"\n/>';
+      }
+
+      function updateRiskMeter() {
+        riskMeter.classList.remove('cp-risk-safe', 'cp-risk-warn', 'cp-risk-danger');
+
+        if (state.version === 'main') {
+          if (state.provider === 'unpkg') {
+            riskMeter.classList.add('cp-risk-warn');
+            riskMeter.textContent =
+              '⚠ unpkg has no @main — this link resolves to @latest (newest npm release). ' +
+              'Still unpinned: a new release changes what your site loads.';
+          } else {
+            riskMeter.classList.add('cp-risk-danger');
+            riskMeter.textContent =
+              '✗ @main is a moving target. Any push to the default branch can change or break ' +
+              'your styles, and the CDN cache may serve stale files for hours. Prototype only.';
+          }
+        } else {
+          riskMeter.classList.add('cp-risk-safe');
+          riskMeter.textContent =
+            '✓ Pinned to v' + state.version + ' — safe for production. ' +
+            'This URL will serve identical content forever.';
+        }
+      }
+
+      function updateSelectedStyles() {
+        document.querySelectorAll('.cp-option').forEach(function (label) {
+          var input = label.querySelector('input');
+          label.classList.toggle('is-selected', input.checked);
+        });
+      }
+
+      function loadPreviewStylesheet(url) {
+        // Only swap the preview stylesheet for full bundles; granular files
+        // would strip base styles from the page.
+        if (state.file.indexOf('core/') === 0) return;
+
+        var id = 'cp-preview-stylesheet';
+        var existing = document.getElementById(id);
+        var link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.id = id;
+        link.href = url;
+        link.addEventListener('load', function () {
+          if (existing) existing.remove();
+        });
+        document.head.appendChild(link);
+      }
+
+      function render() {
+        var url = buildUrl();
+        snippetCode.textContent = buildSnippet(url);
+        urlCode.textContent = url;
+        providerBadge.textContent = state.provider === 'unpkg' ? 'unpkg' : 'jsDelivr';
+        previewBadge.textContent =
+          (state.version === 'main' ? 'main' : 'v' + state.version) +
+          ' · ' + (state.provider === 'unpkg' ? 'unpkg' : 'jsDelivr');
+        snippetHint.textContent =
+          state.file.indexOf('core/') === 0
+            ? 'Granular file — load core/variables.css first for tokens.'
+            : 'Paste inside your <head> tag.';
+        updateRiskMeter();
+        updateSelectedStyles();
+        loadPreviewStylesheet(url);
+      }
+
+      document.querySelectorAll('input[name="version"]').forEach(function (input) {
+        input.addEventListener('change', function () {
+          state.version = input.value;
+          render();
+        });
+      });
+
+      document.querySelectorAll('input[name="provider"]').forEach(function (input) {
+        input.addEventListener('change', function () {
+          state.provider = input.value;
+          render();
+        });
+      });
+
+      document.querySelectorAll('input[name="file"]').forEach(function (input) {
+        input.addEventListener('change', function () {
+          state.file = input.value;
+          render();
+        });
+      });
+
+      function copyText(text, successMessage) {
+        if (!navigator.clipboard) {
+          copyStatus.textContent = 'Clipboard not available.';
+          return;
+        }
+        navigator.clipboard.writeText(text).then(
+          function () {
+            copyStatus.textContent = successMessage;
+          },
+          function () {
+            copyStatus.textContent = 'Copy failed — select text manually.';
+          }
+        );
+      }
+
+      document.getElementById('copy-snippet-btn').addEventListener('click', function () {
+        copyText(snippetCode.textContent, 'Link tag copied to clipboard!');
+      });
+
+      document.getElementById('copy-url-btn').addEventListener('click', function () {
+        copyText(urlCode.textContent, 'URL copied to clipboard!');
+      });
+
+      render();
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-cdn-semver-picker-sp/style.css
+++ b/submissions/docs/ease-cdn-semver-picker-sp/style.css
@@ -1,0 +1,501 @@
+/* ============================================================
+   CDN Semver Version Picker & Pinning Guide — style.css
+   submissions/docs/ease-cdn-semver-picker-sp
+   ============================================================ */
+
+body {
+  background:
+    radial-gradient(
+      900px 400px at 8% -6%,
+      rgba(108, 99, 255, 0.07),
+      transparent
+    ),
+    radial-gradient(
+      760px 360px at 92% 0%,
+      rgba(59, 130, 246, 0.06),
+      transparent
+    ),
+    var(--ease-color-bg, #f8fafc);
+  min-height: 100vh;
+}
+
+/* ── Header ─────────────────────────────────────────────────── */
+
+.cp-header {
+  max-width: 76rem;
+  margin: 0 auto;
+  padding: var(--ease-space-12, 3rem) var(--ease-space-6, 1.5rem)
+    var(--ease-space-6, 1.5rem);
+  text-align: center;
+}
+
+.cp-eyebrow {
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ease-color-primary-dark, #4b44cc);
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.cp-header h1 {
+  margin-bottom: var(--ease-space-3, 0.75rem);
+}
+
+.cp-subtitle {
+  max-width: 52rem;
+  margin: 0 auto;
+  color: var(--ease-color-muted, #475569);
+}
+
+/* ── Layout ─────────────────────────────────────────────────── */
+
+.cp-main {
+  max-width: 76rem;
+  margin: 0 auto;
+  padding: 0 var(--ease-space-6, 1.5rem) var(--ease-space-12, 3rem);
+}
+
+.cp-layout {
+  display: grid;
+  grid-template-columns: 20rem 1fr;
+  gap: var(--ease-space-5, 1.25rem);
+  margin-bottom: var(--ease-space-6, 1.5rem);
+  align-items: start;
+}
+
+/* ── Picker panel ───────────────────────────────────────────── */
+
+.cp-panel {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  padding: var(--ease-space-5, 1.25rem);
+  box-shadow: var(--ease-shadow-sm);
+  position: sticky;
+  top: var(--ease-space-4, 1rem);
+}
+
+.cp-panel-title {
+  font-size: var(--ease-text-base, 1rem);
+  margin: 0 0 var(--ease-space-4, 1rem);
+}
+
+.cp-field {
+  margin-bottom: var(--ease-space-5, 1.25rem);
+}
+
+.cp-field-label {
+  display: block;
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--ease-color-muted, #475569);
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.cp-option-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-space-2, 0.5rem);
+}
+
+.cp-option {
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-2, 0.5rem);
+  padding: 0.5rem 0.7rem;
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  cursor: pointer;
+  background: var(--ease-color-surface, #ffffff);
+}
+
+.cp-option:hover {
+  border-color: var(--ease-color-primary-light, #a09af8);
+}
+
+.cp-option input {
+  accent-color: var(--ease-color-primary, #6c63ff);
+}
+
+.cp-option input:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+
+.cp-option.is-selected {
+  border-color: var(--ease-color-primary, #6c63ff);
+  background: var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.08));
+}
+
+.cp-option-note {
+  margin-left: auto;
+  font-size: 0.62rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.12rem 0.4rem;
+  border-radius: var(--ease-radius-full, 9999px);
+}
+
+.cp-note-pinned {
+  background: rgba(34, 197, 94, 0.12);
+  color: #15803d;
+}
+
+.cp-note-latest {
+  background: rgba(245, 158, 11, 0.15);
+  color: #b45309;
+}
+
+.cp-note-risky {
+  background: rgba(239, 68, 68, 0.12);
+  color: #b91c1c;
+}
+
+/* ── Risk meter ─────────────────────────────────────────────── */
+
+.cp-risk-meter {
+  padding: var(--ease-space-3, 0.75rem);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 600;
+  line-height: 1.5;
+}
+
+.cp-risk-safe {
+  background: rgba(34, 197, 94, 0.1);
+  color: #15803d;
+  border: 1px solid rgba(34, 197, 94, 0.3);
+}
+
+.cp-risk-warn {
+  background: rgba(245, 158, 11, 0.1);
+  color: #b45309;
+  border: 1px solid rgba(245, 158, 11, 0.35);
+}
+
+.cp-risk-danger {
+  background: rgba(239, 68, 68, 0.08);
+  color: #b91c1c;
+  border: 1px solid rgba(239, 68, 68, 0.3);
+}
+
+/* ── Output column ──────────────────────────────────────────── */
+
+.cp-output {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-space-5, 1.25rem);
+}
+
+.cp-snippet-card {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  overflow: hidden;
+  box-shadow: var(--ease-shadow-sm);
+}
+
+.cp-snippet-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ease-space-3, 0.75rem);
+  padding: var(--ease-space-4, 1rem) var(--ease-space-5, 1.25rem);
+  border-bottom: 1px solid var(--ease-color-neutral-100, #f1f5f9);
+  background: var(--ease-color-neutral-50, #f8fafc);
+}
+
+.cp-snippet-header h2 {
+  font-size: var(--ease-text-base, 1rem);
+  margin: 0;
+}
+
+.cp-provider-badge {
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 700;
+  padding: 0.2rem 0.55rem;
+  border-radius: var(--ease-radius-full, 9999px);
+  background: var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.12));
+  color: var(--ease-color-primary-dark, #4b44cc);
+}
+
+.cp-snippet-code {
+  margin: 0;
+  padding: var(--ease-space-4, 1rem) var(--ease-space-5, 1.25rem);
+  font-family: var(--ease-font-mono, monospace);
+  font-size: 0.72rem;
+  line-height: 1.6;
+  color: var(--ease-color-neutral-800, #1e293b);
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.cp-snippet-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ease-space-3, 0.75rem);
+  padding: var(--ease-space-3, 0.75rem) var(--ease-space-5, 1.25rem);
+  border-top: 1px solid var(--ease-color-neutral-100, #f1f5f9);
+}
+
+.cp-snippet-hint {
+  font-size: var(--ease-text-xs, 0.75rem);
+  color: var(--ease-color-muted, #475569);
+  margin: 0;
+  flex: 1;
+  min-width: 12rem;
+}
+
+.cp-copy-btn {
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  background: var(--ease-color-surface, #ffffff);
+  color: var(--ease-color-primary-dark, #4b44cc);
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 600;
+  padding: 0.4rem 0.8rem;
+  border-radius: var(--ease-radius-sm, 0.25rem);
+  cursor: pointer;
+}
+
+.cp-copy-btn:hover {
+  background: var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.15));
+}
+
+.cp-copy-btn:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+
+/* ── Pin vs latest panel ────────────────────────────────────── */
+
+.cp-pin-panel {
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  overflow: hidden;
+  box-shadow: var(--ease-shadow-sm);
+}
+
+.cp-pin-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+
+.cp-pin-side {
+  padding: var(--ease-space-5, 1.25rem);
+}
+
+.cp-pin-side h3 {
+  font-size: var(--ease-text-sm, 0.875rem);
+  margin: 0 0 var(--ease-space-2, 0.5rem);
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.cp-pin-side ul {
+  margin: 0;
+  padding-left: var(--ease-space-5, 1.25rem);
+}
+
+.cp-pin-side li {
+  font-size: var(--ease-text-xs, 0.75rem);
+  color: var(--ease-color-muted, #475569);
+  line-height: 1.6;
+}
+
+.cp-pin-good {
+  background: rgba(34, 197, 94, 0.04);
+  border-right: 1px solid var(--ease-color-neutral-100, #f1f5f9);
+}
+
+.cp-pin-good h3 {
+  color: #15803d;
+}
+
+.cp-pin-bad {
+  background: rgba(239, 68, 68, 0.03);
+}
+
+.cp-pin-bad h3 {
+  color: #b91c1c;
+}
+
+/* ── Live preview ───────────────────────────────────────────── */
+
+.cp-preview-card {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  overflow: hidden;
+  box-shadow: var(--ease-shadow-sm);
+}
+
+.cp-preview-header {
+  padding: var(--ease-space-4, 1rem) var(--ease-space-5, 1.25rem);
+  border-bottom: 1px solid var(--ease-color-neutral-100, #f1f5f9);
+}
+
+.cp-preview-header h2 {
+  font-size: var(--ease-text-base, 1rem);
+  margin: 0 0 var(--ease-space-1, 0.25rem);
+}
+
+.cp-preview-header p {
+  font-size: var(--ease-text-xs, 0.75rem);
+  color: var(--ease-color-muted, #475569);
+  margin: 0;
+}
+
+.cp-preview-stage {
+  padding: var(--ease-space-6, 1.5rem);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: var(--ease-space-4, 1rem);
+  background: var(--ease-color-neutral-50, #f8fafc);
+}
+
+.cp-preview-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: var(--ease-radius-full, 9999px);
+  background: var(--ease-color-primary, #6c63ff);
+  color: #ffffff;
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+}
+
+/* ── Semver explainer ───────────────────────────────────────── */
+
+.cp-education {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--ease-space-4, 1rem);
+  margin-bottom: var(--ease-space-5, 1.25rem);
+}
+
+.cp-edu-card {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  padding: var(--ease-space-5, 1.25rem);
+  box-shadow: var(--ease-shadow-sm);
+}
+
+.cp-edu-card h3 {
+  font-size: var(--ease-text-sm, 0.875rem);
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.cp-edu-card p,
+.cp-edu-card li {
+  font-size: var(--ease-text-xs, 0.75rem);
+  color: var(--ease-color-muted, #475569);
+  line-height: 1.6;
+}
+
+.cp-edu-card ul {
+  margin: 0;
+  padding-left: var(--ease-space-5, 1.25rem);
+}
+
+.cp-edu-card code {
+  font-family: var(--ease-font-mono, monospace);
+  font-size: 0.68rem;
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  padding: 0.05rem 0.3rem;
+  border-radius: var(--ease-radius-sm, 0.25rem);
+}
+
+.cp-semver-diagram {
+  display: flex;
+  justify-content: center;
+  gap: 0.3rem;
+  font-family: var(--ease-font-mono, monospace);
+  font-size: var(--ease-text-lg, 1.125rem);
+  font-weight: 700;
+  margin: var(--ease-space-3, 0.75rem) 0;
+}
+
+.cp-semver-part {
+  padding: 0.2rem 0.5rem;
+  border-radius: var(--ease-radius-sm, 0.25rem);
+}
+
+.cp-semver-major {
+  background: rgba(239, 68, 68, 0.12);
+  color: #b91c1c;
+}
+
+.cp-semver-minor {
+  background: rgba(245, 158, 11, 0.15);
+  color: #b45309;
+}
+
+.cp-semver-patch {
+  background: rgba(34, 197, 94, 0.12);
+  color: #15803d;
+}
+
+.cp-status {
+  text-align: center;
+  min-height: 1.25rem;
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-success-dark, #15803d);
+  font-weight: 600;
+  margin-top: var(--ease-space-4, 1rem);
+}
+
+.cp-footer {
+  text-align: center;
+  padding: var(--ease-space-8, 2rem) var(--ease-space-6, 1.5rem);
+  border-top: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+}
+
+.cp-footer p {
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #475569);
+  margin: 0;
+}
+
+.cp-footer code {
+  font-family: var(--ease-font-mono, monospace);
+  font-size: var(--ease-text-xs, 0.75rem);
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  padding: 0.1rem 0.35rem;
+  border-radius: var(--ease-radius-sm, 0.25rem);
+}
+
+/* ── Responsive ─────────────────────────────────────────────── */
+
+@media (max-width: 60rem) {
+  .cp-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .cp-panel {
+    position: static;
+  }
+
+  .cp-education,
+  .cp-pin-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .cp-pin-good {
+    border-right: 0;
+    border-bottom: 1px solid var(--ease-color-neutral-100, #f1f5f9);
+  }
+}


### PR DESCRIPTION
# #43649 issue resolved

## Description
This PR adds a CDN Semver Version Picker & Pinning Guide under submissions/docs/ease-cdn-semver-picker-sp/.

## Features

- Version selector with all published EaseMotion releases plus main
- CDN provider toggle (jsDelivr / unpkg) with correct URL formats for each
- File picker (easemotion.min.css, easemotion.css, granular core/ files)
- Auto-generated copy-to-clipboard snippets
- "Pin vs latest" warning panel explaining production risks of @main
- Semver basics explainer (major / minor / patch) for beginners
- Cache behavior notes (jsDelivr global caching, purge delays)
- Live preview section styled with the selected EaseMotion build
- Responsive, accessible UI with keyboard-friendly controls