### PR TITLE
feat: add useMotionOrchestrator WAAPI hook

### DIFF
--- a/submissions/react/use-motion-orchestrator-kamalsharma001/README.md
+++ b/submissions/react/use-motion-orchestrator-kamalsharma001/README.md
@@ -1,0 +1,42 @@
+# useMotionOrchestrator
+
+## Props / API
+| Return value | Type | Description |
+|---|---|---|
+| `registerNode(id, node)` | function | Ref callback — call with `(id, domNode)` per list item |
+| `play(ids, keyframes)` | function | Triggers a staggered WAAPI animation across the given ids |
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `duration` | number (ms) | `400` | Per-item animation duration |
+| `stagger` | number (ms) | `60` | Delay added per item index |
+| `easing` | string | `cubic-bezier(...)` | WAAPI easing string |
+
+## Usage example
+```jsx
+import { useMotionOrchestrator } from './useMotionOrchestrator';
+
+function List({ items }) {
+  const { registerNode, play } = useMotionOrchestrator({ stagger: 80 });
+
+  useEffect(() => {
+    play(items.map(i => i.id), [
+      { opacity: 0, transform: 'translateY(12px)' },
+      { opacity: 1, transform: 'translateY(0)' },
+    ]);
+  }, [items]);
+
+  return items.map(item => (
+    <div key={item.id} ref={node => registerNode(item.id, node)}>
+      {item.label}
+    </div>
+  ));
+}
+```
+
+## Why is it useful?
+Unlike CSS-class-remount animation (the current `<Animate>` wrapper),
+this cleanly cancels and replaces in-flight animations when a list
+reorders or updates mid-animation — no visual tearing. It also respects
+`prefers-reduced-motion` (jumps to end state instantly) and cancels all
+running animations on unmount to avoid leaks.

--- a/submissions/react/use-motion-orchestrator-kamalsharma001/useMotionOrchestrator.jsx
+++ b/submissions/react/use-motion-orchestrator-kamalsharma001/useMotionOrchestrator.jsx
@@ -1,0 +1,66 @@
+import { useRef, useCallback, useEffect } from 'react';
+
+/**
+ * useMotionOrchestrator
+ * WAAPI-based orchestration hook: staggers animations across a list
+ * of items and cleanly cancels/replaces any in-flight animation on
+ * an item before starting a new one (safe for interrupted/reordered
+ * lists, unlike CSS-class remount-based animation).
+ */
+export function useMotionOrchestrator({
+  duration = 400,
+  stagger = 60,
+  easing = 'cubic-bezier(0.22, 1, 0.36, 1)',
+} = {}) {
+  const nodeMap = useRef(new Map());   // id -> DOM node
+  const animMap = useRef(new Map());   // id -> running Animation
+
+  const registerNode = useCallback((id, node) => {
+    if (node) nodeMap.current.set(id, node);
+    else nodeMap.current.delete(id);
+  }, []);
+
+  const reducedMotion = () =>
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const play = useCallback((ids, keyframes) => {
+    ids.forEach((id, index) => {
+      const node = nodeMap.current.get(id);
+      if (!node) return;
+
+      // Cancel any in-flight animation on this node first.
+      const prev = animMap.current.get(id);
+      if (prev) prev.cancel();
+
+      if (reducedMotion()) {
+        // Jump straight to the final frame, no motion.
+        const last = keyframes[keyframes.length - 1];
+        Object.assign(node.style, last);
+        return;
+      }
+
+      const anim = node.animate(keyframes, {
+        duration,
+        delay: index * stagger,
+        easing,
+        fill: 'forwards',
+      });
+
+      animMap.current.set(id, anim);
+      anim.finished
+        .then(() => animMap.current.delete(id))
+        .catch(() => {}); // swallow cancellation rejections
+    });
+  }, [duration, stagger, easing]);
+
+  // Cancel everything on unmount to avoid leaks / late callbacks.
+  useEffect(() => {
+    return () => {
+      animMap.current.forEach(anim => anim.cancel());
+      animMap.current.clear();
+    };
+  }, []);
+
+  return { registerNode, play };
+}


### PR DESCRIPTION
## Summary

Adds a reusable React hook for orchestrating staggered Web Animations API (WAAPI) animations across dynamic lists.

### Features

- WAAPI-based animations
- Configurable stagger timing
- Cancels interrupted animations
- Supports reordered lists
- Respects `prefers-reduced-motion`
- Cleans up animations on unmount

Closes #43920 

### How to review

Import the hook into a small React list component, register each item with `registerNode`, and call `play()` to verify staggered animations. Trigger rapid list updates to confirm that existing animations are cancelled and replaced without visual glitches.