### PR TITLE
fix: correct duplicate dark color tokens in variables.css

### DIFF
--- a/submissions/docs/color-dark-token-fix-kamalsharma001/README.md
+++ b/submissions/docs/color-dark-token-fix-kamalsharma001/README.md
@@ -1,0 +1,32 @@
+# Fix: Duplicate dark color tokens
+
+## 1. What does this do?
+
+Demonstrates the bug where the `--ease-color-success-dark`,
+`--ease-color-danger-dark`, and `--ease-color-warning-dark`
+tokens are identical to their base colors, and shows the corrected
+values side by side.
+
+---
+
+## 2. Proposed fix
+
+```diff
+- --ease-color-success-dark: #15803d;
++ --ease-color-success-dark: #14532d;
+
+- --ease-color-danger-dark: #b91c1c;
++ --ease-color-danger-dark: #7f1d1d;
+
+- --ease-color-warning-dark: #b45309;
++ --ease-color-warning-dark: #78350f;
+```
+
+---
+
+## 3. Why is it useful?
+
+Components using the `-dark` variants currently render exactly the same
+as the base colors. Updating these tokens restores the intended darker
+state and keeps the design token system consistent with the existing
+`primary-dark` and `secondary-dark` tokens.

--- a/submissions/docs/color-dark-token-fix-kamalsharma001/demo.html
+++ b/submissions/docs/color-dark-token-fix-kamalsharma001/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Bug: Duplicate dark color tokens</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<h2>Before (current core/variables.css values)</h2>
+
+<div class="row">
+  <div class="swatch" style="background:#15803d">
+    success
+  </div>
+
+  <div class="swatch" style="background:#15803d">
+    success-dark (bug: identical)
+  </div>
+
+  <div class="swatch" style="background:#b91c1c">
+    danger
+  </div>
+
+  <div class="swatch" style="background:#b91c1c">
+    danger-dark (bug: identical)
+  </div>
+
+  <div class="swatch" style="background:#b45309">
+    warning
+  </div>
+
+  <div class="swatch" style="background:#b45309">
+    warning-dark (bug: identical)
+  </div>
+</div>
+
+<h2>After (proposed fix)</h2>
+
+<div class="row">
+  <div class="swatch" style="background:#15803d">
+    success
+  </div>
+
+  <div class="swatch" style="background:#14532d">
+    success-dark (fixed)
+  </div>
+
+  <div class="swatch" style="background:#b91c1c">
+    danger
+  </div>
+
+  <div class="swatch" style="background:#7f1d1d">
+    danger-dark (fixed)
+  </div>
+
+  <div class="swatch" style="background:#b45309">
+    warning
+  </div>
+
+  <div class="swatch" style="background:#78350f">
+    warning-dark (fixed)
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/docs/color-dark-token-fix-kamalsharma001/style.css
+++ b/submissions/docs/color-dark-token-fix-kamalsharma001/style.css
@@ -1,0 +1,26 @@
+body {
+  font-family: system-ui, sans-serif;
+  background: #0f1117;
+  color: #e6e6e6;
+  padding: 32px;
+}
+
+.row {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 32px;
+}
+
+.swatch {
+  width: 160px;
+  height: 90px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: white;
+  font-size: .8rem;
+  padding: 8px;
+}


### PR DESCRIPTION
## Summary

Adds a documentation/demo illustrating that the `-dark` variants of the success, danger, and warning color tokens currently resolve to the same values as their base tokens. The README also includes a proposed diff with darker replacement values.

Closes #43933 

### How to review

1. Open `submissions/docs/color-dark-token-fix-kamalsharma001/demo.html`.
2. Compare the "Before" and "After" color swatches.
3. Review the proposed token changes in `README.md`.