### PR TITLE
fix: scope file-input focus ring to :focus-visible only

### DIFF
--- a/submissions/docs/focus-visible-regression-fix-kamalsharma001/README.md
+++ b/submissions/docs/focus-visible-regression-fix-kamalsharma001/README.md
@@ -1,0 +1,34 @@
+# Fix: Focus-visible Regression
+
+## 1. What does this do?
+
+Demonstrates that `.ease-input:focus`
+restores focus rings for every mouse click,
+and shows how restricting the selector to
+
+```css
+[type="file"]:focus-visible
+```
+
+preserves the intended accessibility behavior.
+
+---
+
+## 2. Proposed Fix
+
+```diff
+- .ease-input:focus {
++ .ease-input[type="file"]:focus-visible {
+```
+
+Use existing design tokens instead of hardcoded colors.
+
+---
+
+## 3. Why is it useful?
+
+The framework already documents
+`:focus-visible` usage.
+
+This restores that behavior while preserving
+the original file-input fix.

--- a/submissions/docs/focus-visible-regression-fix-kamalsharma001/demo.html
+++ b/submissions/docs/focus-visible-regression-fix-kamalsharma001/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Bug: Focus Visible Regression</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<h2>Current behavior (Bug)</h2>
+
+<input
+  class="input-buggy"
+  type="text"
+  placeholder="Click me"
+/>
+
+<input
+  class="input-buggy"
+  type="file"
+/>
+
+<h2>Fixed behavior</h2>
+
+<input
+  class="input-fixed"
+  type="text"
+  placeholder="Click me"
+/>
+
+<input
+  class="input-fixed"
+  type="file"
+/>
+
+<p class="note">
+Click both rows using the mouse.
+Only the file input should display a focus ring in the fixed example.
+Keyboard <kbd>Tab</kbd> navigation still works correctly.
+</p>
+
+</body>
+</html>

--- a/submissions/docs/focus-visible-regression-fix-kamalsharma001/style.css
+++ b/submissions/docs/focus-visible-regression-fix-kamalsharma001/style.css
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Bug: Focus Visible Regression</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<h2>Current behavior (Bug)</h2>
+
+<input
+  class="input-buggy"
+  type="text"
+  placeholder="Click me"
+/>
+
+<input
+  class="input-buggy"
+  type="file"
+/>
+
+<h2>Fixed behavior</h2>
+
+<input
+  class="input-fixed"
+  type="text"
+  placeholder="Click me"
+/>
+
+<input
+  class="input-fixed"
+  type="file"
+/>
+
+<p class="note">
+Click both rows using the mouse.
+Only the file input should display a focus ring in the fixed example.
+Keyboard <kbd>Tab</kbd> navigation still works correctly.
+</p>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Documents a regression where `.ease-input:focus`
reintroduces mouse-click focus rings for all inputs
instead of using the documented `:focus-visible`
behavior.

Adds a demonstration and proposes scoping the rule
to file inputs only.

Closes #43944 

### How to review

1. Open `demo.html`.
2. Click both rows using the mouse.
3. Compare the focus-ring behavior.
4. Review the proposed diff in `README.md`.