### PR TITLE
feat: add vending machine

### DIFF
--- a/submissions/examples/vending-machine-as/README.md
+++ b/submissions/examples/vending-machine-as/README.md
@@ -1,0 +1,23 @@
+# Vending Machine
+
+### What does this do?
+
+It shows a red drink vending machine stocked with colored cans on three shelves, a keypad, and a screen. Hovering or focusing the machine vends a can: it drops down inside the cabinet and lands in the tray at the bottom. It works with no JavaScript. Under reduced motion the can simply appears in the tray.
+
+### How is it used?
+
+```html
+<div class="machine" tabindex="0">
+  <div class="cabinet">
+    <div class="window">...<span class="drop"></span></div>
+    <div class="panel">...</div>
+  </div>
+  <div class="tray"><span class="prize"></span></div>
+</div>
+```
+
+The cabinet is a flex layout with a glass window of stocked cans and a control panel. On `:hover` or `:focus`, a hidden `drop` can runs the `vend` animation falling through the cabinet, and the `prize` can runs `land`, appearing and bouncing into the collection tray, timed so the handoff looks like one continuous drop.
+
+### Why is it useful?
+
+Store, reward, and gacha style interfaces use a vending machine. This builds an interactive vending machine with pure CSS and animation, no images or JavaScript, with a reduced motion fallback.

--- a/submissions/examples/vending-machine-as/demo.html
+++ b/submissions/examples/vending-machine-as/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vending Machine</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="machine" tabindex="0">
+    <div class="cabinet">
+      <div class="window">
+        <span class="shelf">
+          <span class="can c1"></span>
+          <span class="can c2"></span>
+          <span class="can c3"></span>
+        </span>
+        <span class="shelf">
+          <span class="can c4"></span>
+          <span class="can c5"></span>
+          <span class="can c6"></span>
+        </span>
+        <span class="shelf">
+          <span class="can c7"></span>
+          <span class="can c8"></span>
+          <span class="can c9"></span>
+        </span>
+        <span class="drop"></span>
+      </div>
+      <div class="panel">
+        <span class="screen"></span>
+        <span class="keys"></span>
+        <span class="slot"></span>
+      </div>
+    </div>
+    <div class="tray">
+      <span class="prize"></span>
+    </div>
+    <p class="hint">hover to vend</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/vending-machine-as/style.css
+++ b/submissions/examples/vending-machine-as/style.css
@@ -1,0 +1,171 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 20%, #23304a, #0e1420 72%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.machine {
+  position: relative;
+  display: grid;
+  justify-items: center;
+  gap: 14px;
+  outline: none;
+}
+
+.cabinet {
+  display: flex;
+  width: 240px;
+  height: 300px;
+  padding: 12px;
+  box-sizing: border-box;
+  gap: 12px;
+  border-radius: 18px;
+  background: linear-gradient(160deg, #e8433f, #b3211f);
+  box-shadow:
+    0 20px 40px rgba(0, 0, 0, 0.5),
+    inset 0 3px 6px rgba(255, 255, 255, 0.25);
+}
+
+.window {
+  position: relative;
+  flex: 1;
+  display: grid;
+  grid-template-rows: repeat(3, 1fr);
+  gap: 8px;
+  padding: 10px;
+  border-radius: 10px;
+  background: linear-gradient(160deg, #2a3242, #1a2130);
+  box-shadow: inset 0 0 0 3px rgba(0, 0, 0, 0.3);
+  overflow: hidden;
+}
+
+.shelf {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-around;
+  border-bottom: 3px solid rgba(255, 255, 255, 0.12);
+}
+
+.can {
+  width: 20px;
+  height: 34px;
+  border-radius: 4px;
+  box-shadow: inset -3px 0 4px rgba(0, 0, 0, 0.3);
+}
+
+.c1, .c5, .c9 { background: linear-gradient(#ffd23a, #e0a100); }
+.c2, .c6, .c7 { background: linear-gradient(#4ec0ff, #1f7fc0); }
+.c3, .c4, .c8 { background: linear-gradient(#6fe08a, #2fa053); }
+
+.drop {
+  position: absolute;
+  top: 14px;
+  left: 22px;
+  width: 20px;
+  height: 34px;
+  border-radius: 4px;
+  background: linear-gradient(#ff8f6b, #d43c2e);
+  opacity: 0;
+}
+
+.panel {
+  display: grid;
+  align-content: start;
+  gap: 10px;
+  width: 62px;
+}
+
+.screen {
+  height: 30px;
+  border-radius: 5px;
+  background: linear-gradient(160deg, #1a2532, #0d141d);
+  box-shadow: inset 0 0 8px rgba(90, 200, 120, 0.5);
+  border: 2px solid #7a1513;
+  box-sizing: border-box;
+}
+
+.keys {
+  height: 54px;
+  border-radius: 5px;
+  background:
+    repeating-linear-gradient(90deg, #4a1210 0 14px, #6a1a18 14px 20px),
+    repeating-linear-gradient(180deg, #4a1210 0 14px, #6a1a18 14px 20px);
+  box-shadow: inset 0 0 0 2px rgba(0, 0, 0, 0.3);
+}
+
+.slot {
+  height: 8px;
+  border-radius: 4px;
+  background: #3a0f0e;
+}
+
+.tray {
+  position: relative;
+  width: 240px;
+  height: 40px;
+  border-radius: 8px;
+  background: linear-gradient(#7a1513, #4a0f0d);
+  box-shadow: inset 0 4px 10px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+}
+
+.prize {
+  position: absolute;
+  top: -46px;
+  left: 28px;
+  width: 22px;
+  height: 36px;
+  border-radius: 4px;
+  background: linear-gradient(#ff8f6b, #d43c2e);
+  opacity: 0;
+}
+
+.machine:hover .drop,
+.machine:focus .drop {
+  animation: vend 1.6s ease-in forwards;
+}
+
+.machine:hover .prize,
+.machine:focus .prize {
+  animation: land 1.6s ease-in forwards;
+}
+
+.hint {
+  margin: 0;
+  color: #8b96ad;
+  font-size: 0.85rem;
+}
+
+@keyframes vend {
+  0% { transform: translateY(0); opacity: 1; }
+  70% { transform: translateY(220px); opacity: 1; }
+  71%, 100% { opacity: 0; }
+}
+
+@keyframes land {
+  0%, 68% { transform: translateY(0); opacity: 0; }
+  72% { opacity: 1; }
+  85% { transform: translateY(48px); opacity: 1; }
+  92% { transform: translateY(40px); }
+  100% { transform: translateY(44px); opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .machine:hover .drop,
+  .machine:focus .drop,
+  .machine:hover .prize,
+  .machine:focus .prize {
+    animation: none;
+  }
+
+  .machine:hover .prize,
+  .machine:focus .prize {
+    opacity: 1;
+    transform: translateY(44px);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a vending machine built for #43952. A stocked drink machine where hovering or focusing drops a can down the cabinet and bounces it into the tray, using no JavaScript, with a reduced motion fallback. Pure CSS. Closes #43952.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with screenshots of the idle and vending states: nine colored cans on three shelves, and on hover a can drops and lands in the collection tray.
