### PR TITLE
feat: add parachute

### DIFF
--- a/submissions/examples/parachute-as/README.md
+++ b/submissions/examples/parachute-as/README.md
@@ -1,0 +1,21 @@
+# Parachute
+
+### What does this do?
+
+It shows a parachute drifting down through a blue sky. The striped canopy swings gently from side to side, the payload and suspension lines swing with it, and clouds drift by in the background. Under reduced motion the parachute and clouds hold still.
+
+### How is it used?
+
+```html
+<div class="parachute">
+  <span class="canopy"></span>
+  <span class="line l1"></span>
+  <span class="payload"></span>
+</div>
+```
+
+The canopy is the top half of a rounded shape filled with a `repeating-conic-gradient`, which paints the alternating orange and yellow gores, plus a scalloped lower lip drawn by `::after`. Four suspension lines fan out to the payload, and the whole rig runs the `sway` animation, rocking around a pivot near the top so it swings like a real descent.
+
+### Why is it useful?
+
+Delivery, drop, and adventure themes use a parachute. This builds a swinging parachute with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/parachute-as/demo.html
+++ b/submissions/examples/parachute-as/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Parachute</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="cloud cl1"></span>
+    <span class="cloud cl2"></span>
+    <div class="parachute">
+      <span class="canopy"></span>
+      <span class="line l1"></span>
+      <span class="line l2"></span>
+      <span class="line l3"></span>
+      <span class="line l4"></span>
+      <span class="payload"></span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/parachute-as/style.css
+++ b/submissions/examples/parachute-as/style.css
@@ -1,0 +1,139 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #7cc0ee, #b8e2fb 70%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 300px;
+  height: 340px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #7cc0ee, #cdeafc 78%);
+  box-shadow: 0 24px 48px rgba(30, 60, 90, 0.3);
+}
+
+.cloud {
+  position: absolute;
+  height: 26px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.9);
+  animation: drift 13s linear infinite;
+}
+
+.cloud::before,
+.cloud::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.cl1 { top: 60px; left: 30px; width: 64px; }
+.cl1::before { left: 10px; width: 24px; height: 24px; }
+.cl1::after { left: 30px; width: 32px; height: 32px; bottom: 2px; }
+
+.cl2 { top: 250px; right: 30px; width: 52px; animation-duration: 17s; animation-delay: -5s; }
+.cl2::before { left: 8px; width: 20px; height: 20px; }
+.cl2::after { left: 24px; width: 26px; height: 26px; bottom: 2px; }
+
+.parachute {
+  position: absolute;
+  top: 40px;
+  left: 50%;
+  margin-left: -80px;
+  width: 160px;
+  height: 210px;
+  transform-origin: 50% 12%;
+  animation: sway 5s ease-in-out infinite;
+  z-index: 2;
+}
+
+.canopy {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 160px;
+  height: 82px;
+  border-radius: 80px 80px 6px 6px / 80px 80px 10px 10px;
+  background:
+    repeating-conic-gradient(
+      from 180deg at 50% 100%,
+      #ff6f61 0 22.5deg,
+      #ffd23a 22.5deg 45deg
+    );
+  box-shadow: inset 0 -6px 12px rgba(0, 0, 0, 0.15);
+}
+
+.canopy::after {
+  content: "";
+  position: absolute;
+  left: 6px;
+  right: 6px;
+  bottom: -6px;
+  height: 14px;
+  border-radius: 0 0 50% 50% / 0 0 100% 100%;
+  background: repeating-linear-gradient(90deg, #ff6f61 0 20px, #ffd23a 20px 40px);
+}
+
+.line {
+  position: absolute;
+  top: 80px;
+  width: 2px;
+  height: 96px;
+  background: rgba(90, 90, 90, 0.6);
+  transform-origin: top center;
+}
+
+.l1 { left: 14px; transform: rotate(20deg); }
+.l2 { left: 58px; transform: rotate(7deg); }
+.l3 { right: 58px; transform: rotate(-7deg); }
+.l4 { right: 14px; transform: rotate(-20deg); }
+
+.payload {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 44px;
+  height: 40px;
+  margin-left: -22px;
+  border-radius: 8px 8px 10px 10px;
+  background: linear-gradient(160deg, #b5651d, #7c4212);
+  box-shadow: inset 0 3px 4px rgba(255, 255, 255, 0.2);
+}
+
+.payload::before {
+  content: "";
+  position: absolute;
+  top: -8px;
+  left: 50%;
+  width: 16px;
+  height: 10px;
+  margin-left: -8px;
+  border-radius: 6px 6px 0 0;
+  background: #5e3410;
+}
+
+@keyframes sway {
+  0%, 100% { transform: rotate(-5deg) translateY(0); }
+  50% { transform: rotate(5deg) translateY(-8px); }
+}
+
+@keyframes drift {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(28px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .parachute,
+  .cloud {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a parachute built for #43958. A striped canopy on four suspension lines carrying a crate, swinging around a pivot near the top while clouds drift by, with a reduced motion fallback. Pure CSS. Closes #43958.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: an orange and yellow striped parachute canopy on four lines carrying a crate, swinging in a cloudy sky.
