### PR TITLE
feat: add ease-text-reveal-dark-mode-toggle component

### DIFF
--- a/submissions/examples/text-reveal-dark-mode-toggle-sathvika/README.md
+++ b/submissions/examples/text-reveal-dark-mode-toggle-sathvika/README.md
@@ -1,0 +1,47 @@
+﻿# Ease Text Reveal Dark Mode Toggle
+
+A dark/light mode toggle switch where the text label ("Light" / "Dark") animates in with a text-reveal transition as the toggle state changes. **Pure CSS, zero JavaScript** — state is handled entirely via the native `<input type="checkbox">` `:checked` pseudo-class.
+
+## CSS Custom Properties
+
+| Property                     | Default   | Description                          |
+|--------------------------------|-----------|------------------------------------------|
+| `--ease-toggle-duration`       | `0.4s`    | Transition duration                        |
+| `--ease-toggle-easing`         | `cubic-bezier(0.4, 0, 0.2, 1)` | Transition easing curve |
+| `--ease-toggle-track-light`    | `#e5e7eb` | Track background color (light/unchecked)   |
+| `--ease-toggle-track-dark`     | `#1f2937` | Track background color (dark/checked)      |
+| `--ease-toggle-thumb`          | `#ffffff` | Thumb (knob) color                         |
+| `--ease-toggle-accent`         | `#4f46e5` | Focus outline color                        |
+
+## Usage
+
+```html
+<label class="ease-toggle-wrapper">
+  <input type="checkbox" class="ease-toggle-input" id="darkModeToggle" />
+  <span class="ease-toggle-label">
+    <span class="ease-toggle-thumb"></span>
+  </span>
+  <span class="ease-toggle-text">
+    <span class="ease-toggle-text__option ease-toggle-text__option--light">Light</span>
+    <span class="ease-toggle-text__option ease-toggle-text__option--dark">Dark</span>
+  </span>
+</label>
+```
+
+Wrap the whole thing in a `<label>` so clicking anywhere (track, thumb, or text) toggles the checkbox — no JS event listeners needed. To actually apply a dark theme to your page, target `:has(.ease-toggle-input:checked)` on an ancestor, or add your own minimal JS if you need broader browser support than `:has()`.
+
+## Behavior
+
+- Both "Light" and "Dark" labels are stacked and clipped via `overflow: hidden`; the checked state slides the current label out and the new one in via `translateY`.
+- The thumb slides across the track, and the track background color crossfades, all driven by the `:checked` sibling selector.
+
+## Accessibility
+
+- Uses a real `<input type="checkbox">`, so it's natively keyboard operable (Tab + Space) and exposes correct state to screen readers.
+- Wrapping `<label>` ensures the whole control has a large, easy click target.
+- Visible `:focus-visible` outline on the hidden input reflects onto the visible track.
+- `prefers-reduced-motion: reduce` collapses all transitions to near-instant.
+
+## Why it fits EaseMotion CSS
+
+Uses `ease-` prefixed classes and CSS custom properties for theming, consistent with the framework's zero-dependency, animation-first, pure-CSS philosophy — this component requires no JavaScript whatsoever.

--- a/submissions/examples/text-reveal-dark-mode-toggle-sathvika/demo.html
+++ b/submissions/examples/text-reveal-dark-mode-toggle-sathvika/demo.html
@@ -1,0 +1,26 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Text Reveal Dark Mode Toggle Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: -apple-system, sans-serif; background: #f9fafb; padding: 60px; }
+  </style>
+</head>
+<body>
+  <h2>Ease Text Reveal Dark Mode Toggle</h2>
+  <p>Pure CSS — no JavaScript. State is handled entirely by the checkbox's native <code>:checked</code> pseudo-class.</p>
+
+  <label class="ease-toggle-wrapper">
+    <input type="checkbox" class="ease-toggle-input" id="darkModeToggle" />
+    <span class="ease-toggle-label">
+      <span class="ease-toggle-thumb"></span>
+    </span>
+    <span class="ease-toggle-text">
+      <span class="ease-toggle-text__option ease-toggle-text__option--light">Light</span>
+      <span class="ease-toggle-text__option ease-toggle-text__option--dark">Dark</span>
+    </span>
+  </label>
+</body>
+</html>

--- a/submissions/examples/text-reveal-dark-mode-toggle-sathvika/style.css
+++ b/submissions/examples/text-reveal-dark-mode-toggle-sathvika/style.css
@@ -1,0 +1,109 @@
+﻿:root {
+  --ease-toggle-duration: 0.4s;
+  --ease-toggle-easing: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-toggle-track-light: #e5e7eb;
+  --ease-toggle-track-dark: #1f2937;
+  --ease-toggle-thumb: #ffffff;
+  --ease-toggle-accent: #4f46e5;
+}
+
+.ease-toggle-wrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-family: inherit;
+}
+
+.ease-toggle-input {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.ease-toggle-label {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  width: 64px;
+  height: 32px;
+  border-radius: 999px;
+  background: var(--ease-toggle-track-light);
+  cursor: pointer;
+  transition: background-color var(--ease-toggle-duration) var(--ease-toggle-easing);
+}
+
+.ease-toggle-input:checked + .ease-toggle-label {
+  background: var(--ease-toggle-track-dark);
+}
+
+.ease-toggle-input:focus-visible + .ease-toggle-label {
+  outline: 3px solid var(--ease-toggle-accent);
+  outline-offset: 2px;
+}
+
+.ease-toggle-thumb {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: var(--ease-toggle-thumb);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  transition: transform var(--ease-toggle-duration) var(--ease-toggle-easing);
+}
+
+.ease-toggle-input:checked + .ease-toggle-label .ease-toggle-thumb {
+  transform: translateX(32px);
+}
+
+/* Text reveal: the word "Dark"/"Light" clips in via a growing
+   overflow-hidden wrapper + translateY, revealing the new label
+   text as the toggle state changes. */
+.ease-toggle-text {
+  position: relative;
+  display: inline-block;
+  height: 1.2em;
+  overflow: hidden;
+  min-width: 46px;
+}
+
+.ease-toggle-text__option {
+  display: block;
+  height: 1.2em;
+  line-height: 1.2em;
+  font-size: 14px;
+  font-weight: 600;
+  color: #374151;
+  transform: translateY(0);
+  transition: transform var(--ease-toggle-duration) var(--ease-toggle-easing),
+    opacity var(--ease-toggle-duration) var(--ease-toggle-easing);
+}
+
+.ease-toggle-text__option--dark {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translateY(100%);
+  opacity: 0;
+}
+
+.ease-toggle-input:checked ~ .ease-toggle-text .ease-toggle-text__option--light {
+  transform: translateY(-100%);
+  opacity: 0;
+}
+
+.ease-toggle-input:checked ~ .ease-toggle-text .ease-toggle-text__option--dark {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-toggle-label,
+  .ease-toggle-thumb,
+  .ease-toggle-text__option {
+    transition-duration: 0.01s;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds the `ease-text-reveal-dark-mode-toggle` component — a pure CSS dark/light mode toggle switch where the label text animates in with a text-reveal transition on state change. Resolves #42565

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/text-reveal-dark-mode-toggle-sathvika/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A dark/light mode toggle switch where the "Light"/"Dark" text label animates in with a clipped text-reveal transition as the toggle state changes. Built entirely with a native `<input type="checkbox">` and the `:checked` pseudo-class — **zero JavaScript**.

**How does a developer use it?**
```html
<label class="ease-toggle-wrapper">
  <input type="checkbox" class="ease-toggle-input" id="darkModeToggle" />
  <span class="ease-toggle-label">
    <span class="ease-toggle-thumb"></span>
  </span>
  <span class="ease-toggle-text">
    <span class="ease-toggle-text__option ease-toggle-text__option--light">Light</span>
    <span class="ease-toggle-text__option ease-toggle-text__option--dark">Dark</span>
  </span>
</label>
```

**Why does it fit EaseMotion CSS?**
Uses `ease-` prefixed classes and CSS custom properties for full theming, consistent with the framework's zero-dependency, pure-CSS philosophy. This component requires no JavaScript at all, not even for toggle logic.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome

---

## Notes for Maintainer
State is driven entirely by the checkbox's native `:checked` state via sibling selectors — both label options are stacked with `overflow: hidden` and slide via `translateY` on state change. Wrapped in a `<label>` for a full-width click target and native keyboard accessibility. To wire this up to an actual site-wide dark theme, consumers can target `:has(.ease-toggle-input:checked)` on an ancestor. Happy to adjust colors/timing if preferred.