### PR TITLE
feat: add pinwheel

### DIFF
--- a/submissions/examples/pinwheel-as/README.md
+++ b/submissions/examples/pinwheel-as/README.md
@@ -1,0 +1,23 @@
+# Pinwheel
+
+### What does this do?
+
+It shows a colorful paper pinwheel on a stick. The four vanes spin steadily, and hovering or focusing the pinwheel makes it spin much faster, as if you blew on it. Under reduced motion the pinwheel stays still.
+
+### How is it used?
+
+```html
+<div class="pinwheel" tabindex="0">
+  <div class="vanes">
+    <span class="vane v1"></span>
+    <span class="hub"></span>
+  </div>
+  <span class="stick"></span>
+</div>
+```
+
+Each vane is a `clip-path` blade cut from a square and rotated ninety degrees from the next, in four different colors, all sharing a center hub. The `vanes` wrapper runs the `spin` animation at a steady pace; a `:hover` or `:focus` shortens the `animation-duration` so the whole pinwheel speeds up smoothly.
+
+### Why is it useful?
+
+Playful, spring, and loading states use a pinwheel. This builds an interactive spinning pinwheel with pure CSS shapes and animation, no images or JavaScript, with a reduced motion fallback.

--- a/submissions/examples/pinwheel-as/demo.html
+++ b/submissions/examples/pinwheel-as/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pinwheel</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="pinwheel" tabindex="0">
+      <div class="vanes">
+        <span class="vane v1"></span>
+        <span class="vane v2"></span>
+        <span class="vane v3"></span>
+        <span class="vane v4"></span>
+        <span class="hub"></span>
+      </div>
+      <span class="stick"></span>
+    </div>
+    <p class="hint">hover to spin faster</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/pinwheel-as/style.css
+++ b/submissions/examples/pinwheel-as/style.css
@@ -1,0 +1,91 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 22%, #d3ecff, #9cc9ee 72%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  display: grid;
+  justify-items: center;
+  gap: 14px;
+}
+
+.pinwheel {
+  position: relative;
+  width: 200px;
+  height: 260px;
+  outline: none;
+}
+
+.vanes {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 180px;
+  height: 180px;
+  margin-left: -90px;
+  animation: spin 3.5s linear infinite;
+  transition: none;
+}
+
+.vane {
+  position: absolute;
+  inset: 0;
+  clip-path: polygon(50% 50%, 100% 0, 100% 64%);
+  filter: drop-shadow(0 3px 5px rgba(0, 0, 0, 0.18));
+}
+
+.v1 { transform: rotate(0deg); background: linear-gradient(135deg, #ff6f91, #e23b6a); }
+.v2 { transform: rotate(90deg); background: linear-gradient(135deg, #ffd23a, #f0a500); }
+.v3 { transform: rotate(180deg); background: linear-gradient(135deg, #4ec0ff, #1f80c8); }
+.v4 { transform: rotate(270deg); background: linear-gradient(135deg, #6fe08a, #2fa657); }
+
+.hub {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 26px;
+  height: 26px;
+  margin: -13px 0 0 -13px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #fff3c0, #d9a52a);
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.6);
+  z-index: 2;
+}
+
+.stick {
+  position: absolute;
+  top: 88px;
+  left: 50%;
+  width: 8px;
+  height: 168px;
+  margin-left: -4px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #c98a4a, #8a5a28);
+}
+
+.pinwheel:hover .vanes,
+.pinwheel:focus .vanes {
+  animation-duration: 0.7s;
+}
+
+.hint {
+  margin: 0;
+  color: #3a5570;
+  font-size: 0.85rem;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vanes {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pinwheel built for #43977. A four-color paper pinwheel on a stick that spins steadily and speeds up on hover or focus, using no JavaScript, with a reduced motion fallback. Pure CSS. Closes #43977.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a four-vane pinwheel in pink, yellow, blue, and green on a wooden stick with a gold hub.
