### PR TITLE
feat: add animated notification bell (ease-bell-pg365)

### DIFF
--- a/submissions/examples/ease-bell-pg365/README.md
+++ b/submissions/examples/ease-bell-pg365/README.md
@@ -1,0 +1,25 @@
+# Animated Notification Bell (ease-bell-pg365)
+
+## What does this do?
+
+A pure CSS notification bell icon that plays a smooth ring/shake animation on hover or focus, with an optional badge that pulses to draw attention to unread notifications.
+
+## How is it used?
+
+```html
+<div class="ease-bell-pg365-wrapper" tabindex="0" role="button" aria-label="3 unread notifications">
+  <span class="ease-bell-pg365" aria-hidden="true">🔔</span>
+  <span class="ease-bell-pg365-badge">3</span>
+</div>
+```
+
+- `.ease-bell-pg365-wrapper` — positions the badge relative to the bell and provides the hover/focus target.
+- `.ease-bell-pg365` — the bell glyph; rings on `:hover` / `:focus-visible` of the wrapper.
+- `.ease-bell-pg365-badge` — optional unread-count badge; omit it entirely when there are no unread notifications.
+- Add `.is-ringing` to the wrapper to make the bell ring continuously without needing hover (useful for driving the animation from JS when a new notification arrives).
+
+`prefers-reduced-motion: reduce` is respected — all animations are disabled for users who request reduced motion.
+
+## Why is this useful?
+
+Notification bells are a near-universal UI pattern (Gmail, YouTube, LinkedIn, etc.), and a lightweight, dependency-free, CSS-only implementation fits EaseMotion CSS's animation-first, zero-JS philosophy exactly. The component is self-contained (no external assets, no build step) and can be dropped into any project as-is.

--- a/submissions/examples/ease-bell-pg365/demo.html
+++ b/submissions/examples/ease-bell-pg365/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-bell-pg365 — Animated Notification Bell</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <div class="bell-pg365-demo">
+    <span class="label">Hover / focus — with unread badge</span>
+    <div class="ease-bell-pg365-wrapper" tabindex="0" role="button" aria-label="3 unread notifications">
+      <span class="ease-bell-pg365" aria-hidden="true">🔔</span>
+      <span class="ease-bell-pg365-badge">3</span>
+    </div>
+  </div>
+
+  <div class="bell-pg365-demo">
+    <span class="label">Hover / focus — no unread notifications</span>
+    <div class="ease-bell-pg365-wrapper" tabindex="0" role="button" aria-label="No unread notifications">
+      <span class="ease-bell-pg365" aria-hidden="true">🔔</span>
+    </div>
+  </div>
+
+  <div class="bell-pg365-demo">
+    <span class="label">Always ringing (.is-ringing)</span>
+    <div class="ease-bell-pg365-wrapper is-ringing" tabindex="0" role="button" aria-label="9 plus unread notifications">
+      <span class="ease-bell-pg365" aria-hidden="true">🔔</span>
+      <span class="ease-bell-pg365-badge">9+</span>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-bell-pg365/style.css
+++ b/submissions/examples/ease-bell-pg365/style.css
@@ -1,0 +1,128 @@
+/* ease-bell-pg365 — Animated Notification Bell
+   Pure CSS bell icon with a ring/shake animation on hover and an
+   optional pulsing badge for unread notification counts.
+   No JavaScript required. */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 3rem;
+  flex-wrap: wrap;
+  background: #0d0e0f;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #f5f5f5;
+}
+
+.bell-pg365-demo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.bell-pg365-demo span.label {
+  font-size: 0.85rem;
+  color: #9a9a9a;
+  letter-spacing: 0.02em;
+}
+
+/* Wrapper positions the badge relative to the bell and provides the
+   hover target so the whole hit-area (not just the emoji glyph)
+   triggers the animation. */
+.ease-bell-pg365-wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 50%;
+  background: #141414;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.ease-bell-pg365-wrapper:hover {
+  background: #1b1b1b;
+  border-color: rgba(232, 69, 60, 0.4);
+}
+
+.ease-bell-pg365-wrapper:focus-visible {
+  outline: 2px solid #c8f04d;
+  outline-offset: 2px;
+}
+
+.ease-bell-pg365 {
+  font-size: 1.8rem;
+  line-height: 1;
+  display: inline-block;
+  transform-origin: 50% 0%;
+  transition: transform 0.2s ease;
+}
+
+/* Ring/shake animation, triggered on hover or focus of the wrapper. */
+.ease-bell-pg365-wrapper:hover .ease-bell-pg365,
+.ease-bell-pg365-wrapper:focus-visible .ease-bell-pg365 {
+  animation: ease-bell-pg365-ring 0.6s ease-in-out;
+}
+
+/* `.is-ringing` lets the animation be triggered manually (e.g. by
+   toggling a class in JS) without relying on :hover. */
+.ease-bell-pg365-wrapper.is-ringing .ease-bell-pg365 {
+  animation: ease-bell-pg365-ring 0.6s ease-in-out infinite;
+}
+
+@keyframes ease-bell-pg365-ring {
+  0%   { transform: rotate(0deg); }
+  15%  { transform: rotate(14deg); }
+  30%  { transform: rotate(-12deg); }
+  45%  { transform: rotate(9deg); }
+  60%  { transform: rotate(-7deg); }
+  75%  { transform: rotate(4deg); }
+  90%  { transform: rotate(-2deg); }
+  100% { transform: rotate(0deg); }
+}
+
+/* Unread badge with a soft, attention-grabbing pulse. Omit the
+   `.ease-bell-pg365-badge` span entirely when there are no unread
+   notifications. */
+.ease-bell-pg365-badge {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
+  border-radius: 50%;
+  background: #e8453c;
+  color: #fff;
+  font-size: 0.65rem;
+  font-weight: 600;
+  line-height: 18px;
+  text-align: center;
+  box-shadow: 0 0 0 2px #141414;
+  animation: ease-bell-pg365-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes ease-bell-pg365-pulse {
+  0%, 100% { transform: scale(1); }
+  50%      { transform: scale(1.18); }
+}
+
+/* Respect reduced-motion preferences. */
+@media (prefers-reduced-motion: reduce) {
+  .ease-bell-pg365-wrapper:hover .ease-bell-pg365,
+  .ease-bell-pg365-wrapper:focus-visible .ease-bell-pg365,
+  .ease-bell-pg365-wrapper.is-ringing .ease-bell-pg365,
+  .ease-bell-pg365-badge {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Description
Adds a pure CSS animated notification bell component: a bell icon that plays a smooth ring/shake animation on hover/focus, with an optional badge that pulses to draw attention to unread notification counts. No JavaScript required.

## Files Added
- `submissions/examples/ease-bell-pg365/demo.html`
- `submissions/examples/ease-bell-pg365/style.css`
- `submissions/examples/ease-bell-pg365/README.md`

## Details
- `.ease-bell-pg365-wrapper` — positions the badge relative to the bell and provides the hover/focus target (full circular hit-area, not just the emoji glyph).
- `.ease-bell-pg365` — the bell glyph; rings via `@keyframes ease-bell-pg365-ring` on `:hover` / `:focus-visible`.
- `.ease-bell-pg365-badge` — optional unread-count badge with a soft pulse (`@keyframes ease-bell-pg365-pulse`); omit it when there are no unread notifications.
- `.is-ringing` modifier lets the ring animation be triggered continuously/manually (e.g. toggled from JS when a new notification arrives) without depending on hover.
- `prefers-reduced-motion: reduce` is respected — animations are disabled for users who request reduced motion.
- Appended the `-pg365` suffix per the naming-collision guidance in CONTRIBUTING.md, since other bell-themed submissions already exist in `submissions/examples/`.

Closes #42244

## Checklist
- [x] Added only new submission files inside `submissions/examples/ease-bell-pg365/`
- [x] No changes to core/ or components/ or any other existing files
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] `demo.html` is self-contained and works by opening directly in a browser (no server/CDN/framework)