### PR TITLE
feat: add printer

### DIFF
--- a/submissions/examples/printer-as/README.md
+++ b/submissions/examples/printer-as/README.md
@@ -1,0 +1,21 @@
+# Printer
+
+### What does this do?
+
+It shows a desktop printer printing a page on a loop. A sheet with text lines rises up out of the top slot, pauses fully printed, then the cycle repeats, while a green status light blinks. Under reduced motion the page rests fully printed and the light stays on.
+
+### How is it used?
+
+```html
+<div class="printer">
+  <span class="tray"></span>
+  <div class="output"><div class="page"><span class="ln l1"></span></div></div>
+  <div class="cabinet"><span class="slot"></span><span class="led"></span></div>
+</div>
+```
+
+The cabinet sits in front with a higher stacking order, so the lower part of the page is hidden behind it and only the emerged portion shows above the slot. The `page` runs the `feed` animation, sliding up from behind the cabinet to fully out and back, and the status `led` blinks with a stepped animation to signal activity.
+
+### Why is it useful?
+
+Office, export, and document workflows use a printer. This builds a printing printer with pure CSS shapes and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/printer-as/demo.html
+++ b/submissions/examples/printer-as/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Printer</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="printer">
+      <span class="tray"></span>
+      <div class="output">
+        <div class="page">
+          <span class="ln l1"></span>
+          <span class="ln l2"></span>
+          <span class="ln l3"></span>
+          <span class="ln l4"></span>
+          <span class="ln l5"></span>
+        </div>
+      </div>
+      <div class="cabinet">
+        <span class="slot"></span>
+        <span class="led"></span>
+        <span class="btn"></span>
+        <span class="screen"></span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/printer-as/style.css
+++ b/submissions/examples/printer-as/style.css
@@ -1,0 +1,168 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 24%, #26313f, #0f151d 72%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  display: grid;
+  place-items: center;
+}
+
+.printer {
+  position: relative;
+  width: 240px;
+  height: 240px;
+}
+
+.tray {
+  position: absolute;
+  top: 6px;
+  left: 50%;
+  width: 150px;
+  height: 40px;
+  margin-left: -75px;
+  border-radius: 8px 8px 0 0;
+  background: linear-gradient(160deg, #495a6e, #35424f);
+  transform: perspective(220px) rotateX(28deg);
+  z-index: 1;
+}
+
+.tray::after {
+  content: "";
+  position: absolute;
+  top: 8px;
+  left: 50%;
+  width: 116px;
+  height: 22px;
+  margin-left: -58px;
+  border-radius: 4px;
+  background: linear-gradient(#f4f6f8, #dfe4ea);
+}
+
+.output {
+  position: absolute;
+  bottom: 96px;
+  left: 50%;
+  width: 158px;
+  height: 130px;
+  margin-left: -79px;
+  z-index: 1;
+}
+
+.page {
+  position: absolute;
+  bottom: 0;
+  left: 4px;
+  width: 150px;
+  height: 130px;
+  border-radius: 3px;
+  background: linear-gradient(160deg, #ffffff, #eef1f5);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3);
+  padding: 16px 14px;
+  box-sizing: border-box;
+  display: grid;
+  align-content: start;
+  gap: 9px;
+  animation: feed 4s ease-in-out infinite;
+}
+
+.ln {
+  height: 5px;
+  border-radius: 3px;
+  background: #c3ccd8;
+}
+
+.l1 { width: 90%; }
+.l2 { width: 70%; }
+.l3 { width: 82%; }
+.l4 { width: 60%; }
+.l5 { width: 74%; }
+
+.cabinet {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 240px;
+  height: 108px;
+  margin-left: -120px;
+  border-radius: 12px;
+  background: linear-gradient(160deg, #5a6b80, #38434f);
+  box-shadow:
+    0 18px 34px rgba(0, 0, 0, 0.5),
+    inset 0 3px 5px rgba(255, 255, 255, 0.2);
+  z-index: 3;
+}
+
+.slot {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  width: 168px;
+  height: 8px;
+  margin-left: -84px;
+  border-radius: 4px;
+  background: #10161d;
+  box-shadow: inset 0 2px 3px rgba(0, 0, 0, 0.7);
+}
+
+.led {
+  position: absolute;
+  bottom: 24px;
+  left: 26px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #37e07a;
+  box-shadow: 0 0 10px rgba(55, 224, 122, 0.9);
+  animation: blink 1.2s steps(1) infinite;
+}
+
+.btn {
+  position: absolute;
+  bottom: 24px;
+  left: 50px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #2a3844;
+  box-shadow: inset 0 0 0 2px rgba(0, 0, 0, 0.3);
+}
+
+.screen {
+  position: absolute;
+  bottom: 20px;
+  right: 24px;
+  width: 56px;
+  height: 22px;
+  border-radius: 4px;
+  background: linear-gradient(160deg, #1a3a2a, #0c1f16);
+  box-shadow: inset 0 0 8px rgba(60, 220, 120, 0.5);
+}
+
+@keyframes feed {
+  0%, 12% { transform: translateY(118px); }
+  60%, 78% { transform: translateY(0); }
+  96%, 100% { transform: translateY(118px); }
+}
+
+@keyframes blink {
+  0%, 50% { opacity: 1; }
+  50.01%, 100% { opacity: 0.25; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .page,
+  .led {
+    animation: none;
+  }
+
+  .page {
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a printer built for #43983. A desktop printer that feeds a text page up out of its top slot and back on a loop with a blinking status light, using stacking order to hide the page inside the body, with a reduced motion fallback. Pure CSS. Closes #43983.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a grey printer with a printed page of text lines emerging from the top slot and a green status light.
