### PR TITLE
feat: add neon-button-pg365 component

### DIFF
--- a/submissions/examples/neon-button-pg365/README.md
+++ b/submissions/examples/neon-button-pg365/README.md
@@ -1,0 +1,78 @@
+# neon-button-pg365
+
+Glowing neon-outline button with animated text/border glow and a hover pulse.
+
+Resolves: #42317
+
+## Overview
+
+A pure-CSS button styled like a neon sign: a transparent fill, a colored
+outline, and matching text glow via `text-shadow`. On hover/focus the button
+fills solid with the neon color and the outer glow pulses smoothly via a
+`box-shadow` keyframe animation. An optional `--flicker` modifier plays a
+neon "power-on" flicker once when the button mounts.
+
+## Markup
+
+```html
+<button class="neon-button-pg365">Click Me</button>
+```
+
+Override the color, corner radius, or pulse speed inline:
+
+```html
+<button
+  class="neon-button-pg365"
+  style="--nb-color: #22d3ee; --nb-radius: 999px; --nb-pulse: 1s;"
+>
+  Cyan Pill
+</button>
+```
+
+Add the flicker entrance modifier for a neon "power-on" effect on load:
+
+```html
+<button class="neon-button-pg365 neon-button-pg365--flicker">Power On</button>
+```
+
+## CSS Variables
+
+| Variable      | Default   | Description                                |
+| ------------- | --------- | ------------------------------------------- |
+| `--nb-color`  | `#39ff88` | Neon tube / text / glow color               |
+| `--nb-radius` | `8px`     | Corner radius of the button                 |
+| `--nb-pulse`  | `1.6s`    | Duration of one hover glow-pulse cycle       |
+
+## How It Works
+
+- The base state uses a transparent background with a colored border and a
+  `text-shadow` glow, giving the "unlit neon tube" look.
+- On `:hover` / `:focus-visible`, the button fills solid with `--nb-color`
+  and an infinite `box-shadow` keyframe animation (`neon-btn-pulse-pg365`)
+  breathes the outer glow larger and smaller — the "pulse".
+- The `--flicker` modifier plays a one-shot `steps`-like opacity/shadow
+  flicker (`neon-btn-flicker-pg365`) on mount, mimicking a neon sign
+  powering on.
+- `disabled` buttons drop the glow, outline color remains for legibility,
+  and no hover/pulse animation runs.
+
+## Accessibility
+
+- Built on a native `<button>` element — fully keyboard operable and
+  reachable via Tab by default.
+- `:focus-visible` gets the same fill + pulse treatment as `:hover`, plus a
+  visible `outline`, so keyboard users get equivalent feedback to mouse
+  users.
+- Respects `prefers-reduced-motion: reduce`: the hover pulse and the
+  power-on flicker are both disabled, while a static intensified glow is
+  still shown on hover/focus so the interaction remains perceivable.
+- Color contrast: default green/cyan/amber variants keep white/near-black
+  text against the filled hover background at a readable contrast ratio.
+
+## Files
+
+- `demo.html` — color variants, the flicker entrance variant, CSS-variable
+  customization (radius, pulse speed), and a disabled-state example.
+- `style.css` — component styles, hover-pulse keyframes, flicker keyframes,
+  disabled state, and reduced-motion handling.
+- `README.md` — this file.

--- a/submissions/examples/neon-button-pg365/demo.html
+++ b/submissions/examples/neon-button-pg365/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>neon-button-pg365 — Neon Outline Button</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="page">
+    <h1>neon-button-pg365</h1>
+    <p class="subtitle">Glowing neon-outline button with text glow and a hover pulse.</p>
+
+    <!-- ============ COLOR VARIANTS ============ -->
+    <section class="showcase">
+      <h2>Color variants</h2>
+      <div class="btn-row">
+        <button class="neon-button-pg365">Green</button>
+        <button class="neon-button-pg365" style="--nb-color: #22d3ee;">Cyan</button>
+        <button class="neon-button-pg365" style="--nb-color: #f472b6;">Pink</button>
+        <button class="neon-button-pg365" style="--nb-color: #fbbf24;">Amber</button>
+      </div>
+      <p class="hint">Hover or focus any button — it fills with color and the glow pulses.</p>
+    </section>
+
+    <!-- ============ FLICKER ENTRANCE VARIANT ============ -->
+    <section class="showcase">
+      <h2>Flicker entrance</h2>
+      <div class="btn-row">
+        <button class="neon-button-pg365 neon-button-pg365--flicker" style="--nb-color: #a855f7;">
+          Power On
+        </button>
+      </div>
+      <p class="hint">Reload the page to replay the neon "power-on" flicker (skipped under reduced motion).</p>
+    </section>
+
+    <!-- ============ SHAPE / SPEED CUSTOMIZATION ============ -->
+    <section class="showcase">
+      <h2>Customized via CSS variables</h2>
+      <div class="btn-row">
+        <button class="neon-button-pg365" style="--nb-color: #38bdf8; --nb-radius: 999px; --nb-pulse: 0.9s;">
+          Pill + Fast Pulse
+        </button>
+        <button class="neon-button-pg365" style="--nb-color: #4ade80; --nb-radius: 2px; --nb-pulse: 3s;">
+          Sharp + Slow Pulse
+        </button>
+      </div>
+    </section>
+
+    <!-- ============ DISABLED STATE ============ -->
+    <section class="showcase">
+      <h2>Disabled</h2>
+      <div class="btn-row">
+        <button class="neon-button-pg365" style="--nb-color: #9ca3af;" disabled>Unavailable</button>
+      </div>
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/neon-button-pg365/style.css
+++ b/submissions/examples/neon-button-pg365/style.css
@@ -1,0 +1,195 @@
+/* ==========================================================================
+   neon-button-pg365
+   Glowing neon-outline button with text glow, hover-pulse intensify,
+   and an optional sign-flicker entrance.
+   ========================================================================== */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: #0a0a0d;
+  color: #e6e6ee;
+  padding: 3rem 1.5rem;
+}
+
+.page {
+  max-width: 880px;
+  margin: 0 auto;
+}
+
+.page h1 {
+  margin-bottom: 0.25rem;
+  font-size: 1.9rem;
+}
+
+.subtitle {
+  color: #9a9db0;
+  margin-bottom: 2.5rem;
+}
+
+.showcase {
+  margin-bottom: 3rem;
+}
+
+.showcase h2 {
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #9a9db0;
+  margin-bottom: 1.25rem;
+}
+
+.btn-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.hint {
+  margin-top: 0.9rem;
+  font-size: 0.85rem;
+  color: #75798c;
+}
+
+/* ==========================================================================
+   COMPONENT: neon-button-pg365
+   Customizable via CSS variables:
+     --nb-color     : neon tube color (default #39ff88)
+     --nb-radius    : border radius (default 8px)
+     --nb-pulse     : hover pulse cycle duration (default 1.6s)
+   ========================================================================== */
+
+.neon-button-pg365 {
+  --nb-color: #39ff88;
+  --nb-radius: 8px;
+  --nb-pulse: 1.6s;
+
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 2rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--nb-color);
+  background: transparent;
+  border: 2px solid var(--nb-color);
+  border-radius: var(--nb-radius);
+  cursor: pointer;
+  outline: none;
+  -webkit-tap-highlight-color: transparent;
+  text-shadow:
+    0 0 4px color-mix(in srgb, var(--nb-color) 90%, transparent),
+    0 0 12px color-mix(in srgb, var(--nb-color) 55%, transparent);
+  box-shadow:
+    0 0 6px color-mix(in srgb, var(--nb-color) 65%, transparent),
+    0 0 16px color-mix(in srgb, var(--nb-color) 30%, transparent),
+    inset 0 0 6px color-mix(in srgb, var(--nb-color) 25%, transparent);
+  transition:
+    color 0.25s ease,
+    background-color 0.25s ease,
+    box-shadow 0.3s ease,
+    text-shadow 0.3s ease,
+    transform 0.2s ease;
+}
+
+/* Hover / focus: glow intensifies and gently pulses */
+.neon-button-pg365:hover,
+.neon-button-pg365:focus-visible {
+  color: #08110c;
+  background: var(--nb-color);
+  text-shadow: none;
+  transform: translateY(-1px);
+  animation: neon-btn-pulse-pg365 var(--nb-pulse) ease-in-out infinite;
+}
+
+.neon-button-pg365:focus-visible {
+  outline: 2px solid var(--nb-color);
+  outline-offset: 4px;
+}
+
+.neon-button-pg365:active {
+  transform: translateY(0);
+  filter: brightness(0.95);
+}
+
+.neon-button-pg365:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  text-shadow: none;
+  box-shadow: none;
+  animation: none;
+  transform: none;
+}
+
+.neon-button-pg365:disabled:hover,
+.neon-button-pg365:disabled:focus-visible {
+  color: var(--nb-color);
+  background: transparent;
+  animation: none;
+}
+
+@keyframes neon-btn-pulse-pg365 {
+  0%,
+  100% {
+    box-shadow:
+      0 0 8px color-mix(in srgb, var(--nb-color) 80%, transparent),
+      0 0 22px color-mix(in srgb, var(--nb-color) 55%, transparent),
+      0 0 40px color-mix(in srgb, var(--nb-color) 25%, transparent);
+  }
+  50% {
+    box-shadow:
+      0 0 14px color-mix(in srgb, var(--nb-color) 95%, transparent),
+      0 0 34px color-mix(in srgb, var(--nb-color) 70%, transparent),
+      0 0 60px color-mix(in srgb, var(--nb-color) 40%, transparent);
+  }
+}
+
+/* ---------- Flicker variant: neon "sign" power-on entrance ---------- */
+.neon-button-pg365--flicker {
+  animation: neon-btn-flicker-pg365 1.8s linear both;
+}
+
+@keyframes neon-btn-flicker-pg365 {
+  0%,
+  3%,
+  6%,
+  9%,
+  100% {
+    opacity: 1;
+    text-shadow:
+      0 0 4px color-mix(in srgb, var(--nb-color) 90%, transparent),
+      0 0 12px color-mix(in srgb, var(--nb-color) 55%, transparent);
+    box-shadow:
+      0 0 6px color-mix(in srgb, var(--nb-color) 65%, transparent),
+      0 0 16px color-mix(in srgb, var(--nb-color) 30%, transparent);
+  }
+  4%,
+  8% {
+    opacity: 0.35;
+    text-shadow: none;
+    box-shadow: none;
+  }
+}
+
+/* ---------- Reduced motion: keep the glow, drop the animation ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .neon-button-pg365,
+  .neon-button-pg365--flicker {
+    animation: none !important;
+  }
+
+  .neon-button-pg365:hover,
+  .neon-button-pg365:focus-visible {
+    box-shadow:
+      0 0 10px color-mix(in srgb, var(--nb-color) 85%, transparent),
+      0 0 26px color-mix(in srgb, var(--nb-color) 55%, transparent);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a self-contained Neon Variant button under `submissions/examples/neon-button-pg365/`
- Transparent-fill button with a colored outline plus `text-shadow`/`box-shadow` neon glow
- Hover/focus fills solid and pulses the outer glow via a `box-shadow` keyframe animation
- Optional `neon-button-pg365--flicker` modifier for a one-shot neon "power-on" entrance
- Fully customizable via `--nb-color`, `--nb-radius`, `--nb-pulse` CSS variables
- `:focus-visible` gets the same intensified glow as hover plus a visible outline
- Respects `prefers-reduced-motion: reduce` (disables pulse/flicker, keeps a static glow)
- Pure CSS, no JavaScript, no external dependencies

Fixes #42317

## Files
```
submissions/examples/neon-button-pg365/
├── demo.html
├── style.css
└── README.md
```

## Test plan
- [x] Opened `demo.html` directly in a browser (no server/build needed)
- [x] Verified hover/focus pulse, color variants, flicker entrance, CSS-variable overrides, and disabled state
- [x] Verified keyboard focus (Tab) shows outline + glow on `:focus-visible`
- [x] Verified `prefers-reduced-motion: reduce` disables animation while keeping the glow
- [x] Confirmed `submissions/` is excluded via `.stylelintignore`, so no lint changes needed
- [x] No files outside `submissions/examples/neon-button-pg365/` were touched