### PR TITLE
feat: add cascading-charts-widget component (#42560)

### DIFF
--- a/submissions/examples/cascading-charts-widget/README.md
+++ b/submissions/examples/cascading-charts-widget/README.md
@@ -1,0 +1,61 @@
+# Cascading Charts Widget
+
+An analytics dashboard widget featuring four chart types — bar chart, donut chart, line chart, and stat cards — all with **cascading staggered animations** that reveal data progressively. Built with pure HTML and CSS.
+
+## Features
+
+- **Bar Chart** — 7 monthly bars with staggered `scaleY` rise animation and spring overshoot
+- **Donut Chart** — 4-segment SVG donut with sequential stroke-dashoffset animation
+- **Line Chart** — SVG path with `stroke-dashoffset` draw-on effect and area fill fade-in
+- **Stat Cards** — 3 KPI cards with inline progress bars that grow from 0
+- **Sequential delays** — every element has a calculated `animation-delay` for cascade effect
+- **Hover states** — bars brighten on hover; cards lift with shadow
+- **Pure CSS** — zero JavaScript
+
+## File Structure
+
+```
+cascading-charts-widget/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+## How the Cascading Animation Works
+
+Each chart uses **staggered `animation-delay`** values that increment by a fixed interval (0.1–0.15s):
+
+```css
+.bar-item:nth-child(1) .bar { animation-delay: 0.05s; }
+.bar-item:nth-child(2) .bar { animation-delay: 0.15s; }
+.bar-item:nth-child(3) .bar { animation-delay: 0.25s; }
+/* ... */
+```
+
+### Animation Techniques
+
+| Chart | Technique |
+|---|---|
+| Bar | `scaleY(0) → scaleY(1)` with `cubic-bezier(0.34, 1.56, 0.64, 1)` spring |
+| Donut | SVG `stroke-dashoffset: 440 → 0` on each segment |
+| Line | `stroke-dashoffset: 600 → 0` on `<path>` |
+| Stat | `width: 0 → var(--w)` on the fill bar |
+
+## Usage
+
+Open `demo.html` in any modern browser. All charts animate in on page load.
+
+## Customization
+
+Override CSS custom properties to change the color palette:
+
+```css
+:root {
+  --accent-1: #your-primary;
+  --accent-2: #your-secondary;
+  --accent-3: #your-tertiary;
+  --accent-4: #your-quaternary;
+}
+```
+
+Adjust `animation-delay` increments to change the cascade speed.

--- a/submissions/examples/cascading-charts-widget/demo.html
+++ b/submissions/examples/cascading-charts-widget/demo.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Cascading Charts Widget</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="container">
+  <h1>Cascading Charts</h1>
+  <p class="subtitle">Staggered animation reveals — Analytics Dashboard</p>
+
+  <div class="charts-grid">
+
+    <!-- Bar Chart -->
+    <div class="chart-card">
+      <div class="chart-header">
+        <h2>Monthly Revenue</h2>
+        <span class="chart-badge">2026</span>
+      </div>
+      <div class="bar-chart">
+        <div class="bar-item" data-height="65">
+          <div class="bar" style="--bar-h: 65%"><span class="bar-label">Jan</span></div>
+        </div>
+        <div class="bar-item" data-height="80">
+          <div class="bar" style="--bar-h: 80%"><span class="bar-label">Feb</span></div>
+        </div>
+        <div class="bar-item" data-height="55">
+          <div class="bar" style="--bar-h: 55%"><span class="bar-label">Mar</span></div>
+        </div>
+        <div class="bar-item" data-height="92">
+          <div class="bar" style="--bar-h: 92%"><span class="bar-label">Apr</span></div>
+        </div>
+        <div class="bar-item" data-height="78">
+          <div class="bar" style="--bar-h: 78%"><span class="bar-label">May</span></div>
+        </div>
+        <div class="bar-item" data-height="100">
+          <div class="bar" style="--bar-h: 100%"><span class="bar-label">Jun</span></div>
+        </div>
+        <div class="bar-item" data-height="85">
+          <div class="bar" style="--bar-h: 85%"><span class="bar-label">Jul</span></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Donut Chart -->
+    <div class="chart-card">
+      <div class="chart-header">
+        <h2>Traffic Sources</h2>
+        <span class="chart-badge">Live</span>
+      </div>
+      <div class="donut-wrapper">
+        <svg class="donut-svg" viewBox="0 0 200 200">
+          <circle class="donut-ring" cx="100" cy="100" r="70" stroke-dasharray="0 440" stroke-dashoffset="0"/>
+          <circle class="donut-segment seg-1" cx="100" cy="100" r="70" stroke-dasharray="0 440" stroke-dashoffset="0"/>
+          <circle class="donut-segment seg-2" cx="100" cy="100" r="70" stroke-dasharray="0 440" stroke-dashoffset="0"/>
+          <circle class="donut-segment seg-3" cx="100" cy="100" r="70" stroke-dasharray="0 440" stroke-dashoffset="0"/>
+          <circle class="donut-segment seg-4" cx="100" cy="100" r="70" stroke-dasharray="0 440" stroke-dashoffset="0"/>
+        </svg>
+        <div class="donut-center">
+          <span class="donut-value">10.2k</span>
+          <span class="donut-label">visitors</span>
+        </div>
+      </div>
+      <div class="donut-legend">
+        <div class="legend-item"><span class="legend-dot" style="background:#6c63ff"></span>Organic 45%</div>
+        <div class="legend-item"><span class="legend-dot" style="background:#a855f7"></span>Direct 28%</div>
+        <div class="legend-item"><span class="legend-dot" style="background:#ec4899"></span>Referral 18%</div>
+        <div class="legend-item"><span class="legend-dot" style="background:#06b6d4"></span>Social 9%</div>
+      </div>
+    </div>
+
+    <!-- Line Chart -->
+    <div class="chart-card">
+      <div class="chart-header">
+        <h2>Active Users</h2>
+        <span class="chart-badge trending">+12.4%</span>
+      </div>
+      <div class="line-chart-wrapper">
+        <svg class="line-svg" viewBox="0 0 320 120" preserveAspectRatio="none">
+          <!-- Grid lines -->
+          <line x1="0" y1="30" x2="320" y2="30" class="grid-line"/>
+          <line x1="0" y1="60" x2="320" y2="60" class="grid-line"/>
+          <line x1="0" y1="90" x2="320" y2="90" class="grid-line"/>
+          <!-- Area fill -->
+          <path class="area-fill" d="M0,100 L40,80 L80,88 L120,55 L160,65 L200,35 L240,45 L280,20 L320,28 L320,120 L0,120 Z"/>
+          <!-- Line -->
+          <path class="line-path" d="M0,100 L40,80 L80,88 L120,55 L160,65 L200,35 L240,45 L280,20 L320,28"/>
+          <!-- Dots -->
+          <circle cx="0" cy="100" r="4" class="dot"/>
+          <circle cx="40" cy="80" r="4" class="dot"/>
+          <circle cx="80" cy="88" r="4" class="dot"/>
+          <circle cx="120" cy="55" r="4" class="dot"/>
+          <circle cx="160" cy="65" r="4" class="dot"/>
+          <circle cx="200" cy="35" r="4" class="dot"/>
+          <circle cx="240" cy="45" r="4" class="dot"/>
+          <circle cx="280" cy="20" r="4" class="dot"/>
+          <circle cx="320" cy="28" r="4" class="dot"/>
+          <!-- X labels -->
+          <text x="0" y="115" class="x-label">Mon</text>
+          <text x="40" y="115" class="x-label">Tue</text>
+          <text x="80" y="115" class="x-label">Wed</text>
+          <text x="120" y="115" class="x-label">Thu</text>
+          <text x="160" y="115" class="x-label">Fri</text>
+          <text x="200" y="115" class="x-label">Sat</text>
+          <text x="240" y="115" class="x-label">Sun</text>
+          <text x="280" y="115" class="x-label">Mon</text>
+        </svg>
+      </div>
+    </div>
+
+    <!-- Stat Cards Row -->
+    <div class="chart-card stat-row">
+      <div class="stat">
+        <span class="stat-value">8,421</span>
+        <span class="stat-label">Total Users</span>
+        <div class="stat-bar"><div class="stat-fill" style="--w: 84%"></div></div>
+      </div>
+      <div class="stat">
+        <span class="stat-value">2,847</span>
+        <span class="stat-label">Subscribers</span>
+        <div class="stat-bar"><div class="stat-fill" style="--w: 62%"></div></div>
+      </div>
+      <div class="stat">
+        <span class="stat-value">99.2%</span>
+        <span class="stat-label">Uptime</span>
+        <div class="stat-bar"><div class="stat-fill" style="--w: 99%"></div></div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/cascading-charts-widget/style.css
+++ b/submissions/examples/cascading-charts-widget/style.css
@@ -1,0 +1,401 @@
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+:root {
+  --bg: #f0f4f8;
+  --card-bg: #ffffff;
+  --card-shadow: 0 4px 24px rgba(0, 0, 0, 0.07);
+  --accent-1: #6c63ff;
+  --accent-2: #a855f7;
+  --accent-3: #ec4899;
+  --accent-4: #06b6d4;
+  --text-dark: #1a1a2e;
+  --text-muted: #64748b;
+  --bar-bg: #e2e8f0;
+  --grid-color: #e2e8f0;
+}
+
+body {
+  font-family: 'Segoe UI', Arial, sans-serif;
+  background: var(--bg);
+  background-image:
+    radial-gradient(circle at 20% 80%, rgba(108, 99, 255, 0.05) 0%, transparent 50%),
+    radial-gradient(circle at 80% 20%, rgba(168, 85, 247, 0.04) 0%, transparent 50%);
+  min-height: 100vh;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 40px 20px;
+}
+
+.container {
+  max-width: 1000px;
+  width: 100%;
+  text-align: center;
+}
+
+h1 {
+  font-size: 2.2rem;
+  font-weight: 700;
+  color: var(--text-dark);
+  margin-bottom: 8px;
+  margin-top: 20px;
+}
+
+.subtitle {
+  color: var(--text-muted);
+  font-size: 1rem;
+  margin-bottom: 40px;
+}
+
+/* ─── Charts Grid ───────────────────────────────────────── */
+.charts-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 24px;
+  text-align: left;
+}
+
+/* ─── Chart Card ────────────────────────────────────────── */
+.chart-card {
+  background: var(--card-bg);
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: var(--card-shadow);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.chart-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.1);
+}
+
+.chart-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.chart-header h2 {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--text-dark);
+}
+
+.chart-badge {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--accent-1);
+  background: rgba(108, 99, 255, 0.1);
+  padding: 3px 10px;
+  border-radius: 20px;
+  letter-spacing: 0.5px;
+}
+
+.chart-badge.trending {
+  color: #059669;
+  background: rgba(5, 150, 105, 0.1);
+}
+
+/* ─── Bar Chart ─────────────────────────────────────────── */
+.bar-chart {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 8px;
+  height: 140px;
+  padding-top: 10px;
+}
+
+.bar-item {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  height: 100%;
+  cursor: pointer;
+}
+
+.bar {
+  width: 100%;
+  height: var(--bar-h);
+  background: linear-gradient(180deg, var(--accent-1) 0%, rgba(108, 99, 255, 0.6) 100%);
+  border-radius: 6px 6px 0 0;
+  position: relative;
+  transform-origin: bottom center;
+  animation: bar-rise 0.7s cubic-bezier(0.34, 1.56, 0.64, 1) backwards;
+  transition: filter 0.2s, transform 0.2s;
+}
+
+.bar-item:nth-child(1) .bar { animation-delay: 0.05s; }
+.bar-item:nth-child(2) .bar { animation-delay: 0.15s; }
+.bar-item:nth-child(3) .bar { animation-delay: 0.25s; }
+.bar-item:nth-child(4) .bar { animation-delay: 0.35s; }
+.bar-item:nth-child(5) .bar { animation-delay: 0.45s; }
+.bar-item:nth-child(6) .bar { animation-delay: 0.55s; }
+.bar-item:nth-child(7) .bar { animation-delay: 0.65s; }
+
+@keyframes bar-rise {
+  from {
+    transform: scaleY(0) translateY(20px);
+    opacity: 0;
+  }
+  to {
+    transform: scaleY(1) translateY(0);
+    opacity: 1;
+  }
+}
+
+.bar-item:hover .bar {
+  filter: brightness(1.15) saturate(1.2);
+  transform: scaleY(1.03);
+}
+
+.bar-label {
+  position: absolute;
+  bottom: -20px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+  font-weight: 600;
+}
+
+/* ─── Donut Chart ───────────────────────────────────────── */
+.donut-wrapper {
+  position: relative;
+  width: 180px;
+  height: 180px;
+  margin: 0 auto 20px;
+}
+
+.donut-svg {
+  transform: rotate(-90deg);
+  width: 100%;
+  height: 100%;
+}
+
+.donut-ring {
+  fill: none;
+  stroke: var(--bar-bg);
+  stroke-width: 28;
+  stroke-dasharray: 440;
+  stroke-dashoffset: 0;
+}
+
+.donut-segment {
+  fill: none;
+  stroke-width: 28;
+  stroke-linecap: butt;
+  animation: donut-fill 1.5s ease-out forwards;
+  transform-origin: center;
+}
+
+.seg-1 { stroke: var(--accent-1); stroke-dasharray: calc(440 * 0.45) 440; animation-delay: 0.1s; }
+.seg-2 { stroke: var(--accent-2); stroke-dasharray: calc(440 * 0.28) 440; animation-delay: 0.3s; }
+.seg-3 { stroke: var(--accent-3); stroke-dasharray: calc(440 * 0.18) 440; animation-delay: 0.5s; }
+.seg-4 { stroke: var(--accent-4); stroke-dasharray: calc(440 * 0.09) 440; animation-delay: 0.7s; }
+
+@keyframes donut-fill {
+  from { stroke-dashoffset: 440; }
+  to { stroke-dashoffset: 0; }
+}
+
+.donut-center {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  animation: fade-up 0.6s ease-out 1s backwards;
+}
+
+@keyframes fade-up {
+  from { opacity: 0; transform: translate(-50%, -40%); }
+  to { opacity: 1; transform: translate(-50%, -50%); }
+}
+
+.donut-value {
+  display: block;
+  font-size: 1.6rem;
+  font-weight: 800;
+  color: var(--text-dark);
+  line-height: 1;
+}
+
+.donut-label {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-top: 4px;
+  font-weight: 600;
+}
+
+/* ─── Donut Legend ─────────────────────────────────────── */
+.donut-legend {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  font-weight: 600;
+  animation: fade-up 0.5s ease-out backwards;
+}
+
+.legend-item:nth-child(1) { animation-delay: 0.8s; }
+.legend-item:nth-child(2) { animation-delay: 0.95s; }
+.legend-item:nth-child(3) { animation-delay: 1.1s; }
+.legend-item:nth-child(4) { animation-delay: 1.25s; }
+
+.legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* ─── Line Chart ────────────────────────────────────────── */
+.line-chart-wrapper {
+  height: 120px;
+  overflow: hidden;
+}
+
+.line-svg {
+  width: 100%;
+  height: 100%;
+}
+
+.grid-line {
+  stroke: var(--grid-color);
+  stroke-width: 1;
+  stroke-dasharray: 4 4;
+}
+
+.area-fill {
+  fill: url(#area-gradient);
+  opacity: 0;
+  animation: area-reveal 1.2s ease-out 0.3s forwards;
+}
+
+.line-path {
+  fill: none;
+  stroke: var(--accent-1);
+  stroke-width: 3;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-dasharray: 600;
+  stroke-dashoffset: 600;
+  animation: line-draw 1.8s cubic-bezier(0.4, 0, 0.2, 1) 0.3s forwards;
+  filter: drop-shadow(0 0 6px rgba(108, 99, 255, 0.4));
+}
+
+@keyframes line-draw {
+  to { stroke-dashoffset: 0; }
+}
+
+@keyframes area-reveal {
+  to { opacity: 0.15; }
+}
+
+.dot {
+  fill: var(--card-bg);
+  stroke: var(--accent-1);
+  stroke-width: 2;
+  opacity: 0;
+  animation: dot-pop 0.3s ease-out forwards;
+  animation-delay: 0.3s;
+}
+
+.dot:nth-child(1) { animation-delay: 0.1s; }
+.dot:nth-child(2) { animation-delay: 0.25s; }
+.dot:nth-child(3) { animation-delay: 0.4s; }
+.dot:nth-child(4) { animation-delay: 0.55s; }
+.dot:nth-child(5) { animation-delay: 0.7s; }
+.dot:nth-child(6) { animation-delay: 0.85s; }
+.dot:nth-child(7) { animation-delay: 1.0s; }
+.dot:nth-child(8) { animation-delay: 1.15s; }
+.dot:nth-child(9) { animation-delay: 1.3s; }
+
+@keyframes dot-pop {
+  0% { opacity: 0; transform: scale(0); }
+  60% { transform: scale(1.5); }
+  100% { opacity: 1; transform: scale(1); }
+}
+
+.x-label {
+  fill: var(--text-muted);
+  font-size: 9px;
+  font-weight: 600;
+}
+
+/* ─── Stat Row ──────────────────────────────────────────── */
+.stat-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  align-items: center;
+}
+
+.stat {
+  text-align: center;
+  animation: fade-up 0.5s ease-out backwards;
+}
+
+.stat:nth-child(1) { animation-delay: 0.1s; }
+.stat:nth-child(2) { animation-delay: 0.2s; }
+.stat:nth-child(3) { animation-delay: 0.3s; }
+
+.stat-value {
+  display: block;
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: var(--text-dark);
+  margin-bottom: 4px;
+}
+
+.stat-label {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+
+.stat-bar {
+  height: 6px;
+  background: var(--bar-bg);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.stat-fill {
+  height: 100%;
+  width: 0;
+  background: linear-gradient(90deg, var(--accent-1), var(--accent-3));
+  border-radius: 3px;
+  animation: stat-grow 1s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation-delay: 0.4s;
+}
+
+@keyframes stat-grow {
+  to { width: var(--w); }
+}
+
+/* ─── Responsive ───────────────────────────────────────── */
+@media (max-width: 720px) {
+  .charts-grid { grid-template-columns: 1fr; }
+  h1 { font-size: 1.6rem; }
+  .stat-row { grid-template-columns: 1fr; gap: 20px; }
+}


### PR DESCRIPTION
## Summary

Adds **Cascading Charts Widget** — analytics dashboard with 4 chart types, all revealing via cascade animations.

- **Bar Chart**: 7 bars with staggered `scaleY` spring rise
- **Donut Chart**: 4-segment SVG with `stroke-dashoffset` animation
- **Line Chart**: SVG path draw-on with area fill fade-in
- **Stat Cards**: 3 KPIs with inline progress bar grow animation

Fixes #42560