### PR TITLE
fix: prevent duplicate reminder comments from assignment bot

### DIFF
--- a/submissions/docs/43813-bot-reminder-fix-ms/README.md
+++ b/submissions/docs/43813-bot-reminder-fix-ms/README.md
@@ -1,0 +1,12 @@
+# Prevent Duplicate Reminder Comments from Assignment Bot
+
+Resolves #43813.
+
+### What does this do?
+Fixes a bug in the `.github/scripts/issueReminder.js` workflow where the GitHub Actions bot would post duplicate "Hey @user! Thanks for your interest..." comments every time a user posted a comment matching a trigger phrase, instead of only doing it once.
+
+### How is it used?
+The fixed script is provided in this directory. The maintainer can safely copy `issueReminder.js` over the existing script located at `.github/scripts/issueReminder.js`.
+
+### Why is it useful?
+Users often reply multiple times with "I want to work on this!" or "assign me" before figuring out the correct `/claim` command. The bot replying multiple times to the same user litters the issue timeline and creates unnecessary notification spam. This fix introduces a check against existing comments to ensure the bot only sends the welcome template once per user per issue.

--- a/submissions/docs/43813-bot-reminder-fix-ms/demo.html
+++ b/submissions/docs/43813-bot-reminder-fix-ms/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Assignment Bot Fix Showcase</title>
+  <link rel="stylesheet" href="../../../easemotion.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="margin: 0; display: flex; align-items: center; justify-content: center; min-height: 100vh; background: #e2e8f0; padding: 1rem;">
+  
+  <div class="ease-docs-card ease-fade-in-up">
+    <h2>Duplicate Reminder Bot Fix</h2>
+    <p>This PR provides the fixed <code>issueReminder.js</code> script.</p>
+    <div class="ease-docs-terminal">
+      <span style="color: #10b981">✓ Fetched issue comments</span><br>
+      <span style="color: #38bdf8">ℹ Found existing reminder for @user</span><br>
+      <span style="color: #64748b">→ Skipping duplicate comment creation</span>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/docs/43813-bot-reminder-fix-ms/issueReminder.js
+++ b/submissions/docs/43813-bot-reminder-fix-ms/issueReminder.js
@@ -1,0 +1,100 @@
+// tell commentoer how to use bot commands
+module.exports = async ({ github, context }) => {
+  //Guard clauses: Ignore PRs and Bots
+  if (context.payload.issue.pull_request) return;
+  if (context.payload.comment.user.type === 'Bot') return;
+
+  const { owner, repo } = context.repo;
+  const issueNumber = context.payload.issue.number;
+
+  // Fetch the latest issue state to prevent race conditions on closed issues
+  const { data: issue } = await github.rest.issues.get({
+    owner, repo, issue_number: issueNumber
+  });
+
+  if (issue.state === 'closed') return;
+
+  const commentBody = context.payload.comment.body.toLowerCase();
+
+  if (commentBody.includes('/claim') || commentBody.includes('/assign')) {
+    return;
+  }
+
+// predefined comments
+  const triggerPhrases = [
+    'assign this issue to me',
+    'assign this to me',
+    'please assign me',
+    'can i work on this',
+    'can i take this',
+    'i would like to work on this',
+    'i want to work on this',
+    "i'd like to work on this",
+    'id like to work on this',
+    'i want to take this issue',
+    'i want to fix this',
+    'i want to contribute',
+    'let me work on this',
+    'let me take this',
+    'can i be assigned',
+    'assign me to this',
+    'assign me this',
+    'work on this',
+    "i'll work on this",
+    'ill work on this',
+    'i can work on this',
+    'i am interested in this',
+    'assign',
+    "i'm interested in this"
+  ];
+
+  // Check if the comment contains any of the trigger phrases
+  const needsReminder = triggerPhrases.some(phrase => commentBody.includes(phrase));
+  if (!needsReminder) {
+    return;
+  }
+
+  // Gather context variables
+  const commenter = context.payload.comment.user.login;
+  const issueAuthor = context.payload.issue.user.login;
+
+
+  // Check if the commenter is already assigned
+  const assignees = context.payload.issue.assignees.map(a => a.login.toLowerCase());
+  if (assignees.includes(commenter.toLowerCase())) return;
+
+  // Prevent duplicate reminders to the same commenter
+  const { data: comments } = await github.rest.issues.listComments({
+    owner,
+    repo,
+    issue_number: issueNumber
+  });
+
+  const hasReminded = comments.some(c => 
+    c.user.type === 'Bot' && 
+    c.body.includes(`Hey @${commenter}! 👋 Thanks for your interest in contributing!`)
+  );
+
+  if (hasReminded) return;
+
+  const bodyLines = [
+    `Hey @${commenter}! 👋 Thanks for your interest in contributing!`,
+    ``,
+    `To keep our workflow organized, we use an automated assignment system. If you'd like to take this on, please use our bot command:`,
+    ``,
+    `## How to Claim an Issue`,
+    `💬 Reply to this issue with exactly: \`/claim\``,
+    ``,
+    `## 📋 Things to Remember`,
+    `- You can hold a **maximum of 25 active assigned issues** at a time.`,
+    `- Make sure to read our **[CONTRIBUTING.md](https://github.com/${owner}/${repo}/blob/main/CONTRIBUTING.md)**.`
+  ];
+
+  // Post comment
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    body: bodyLines.join('\n'),
+  });
+};

--- a/submissions/docs/43813-bot-reminder-fix-ms/style.css
+++ b/submissions/docs/43813-bot-reminder-fix-ms/style.css
@@ -1,0 +1,26 @@
+.ease-docs-card {
+  background: white;
+  padding: 3rem;
+  border-radius: 1rem;
+  box-shadow: 0 10px 25px -5px rgba(0,0,0,0.1);
+  max-width: 600px;
+  width: 100%;
+  font-family: system-ui, sans-serif;
+}
+.ease-docs-card h2 {
+  margin-top: 0;
+  color: #0f172a;
+}
+.ease-docs-card p {
+  color: #64748b;
+  margin-bottom: 2rem;
+}
+.ease-docs-terminal {
+  background: #0f172a;
+  color: #38bdf8;
+  padding: 1.5rem;
+  border-radius: 0.5rem;
+  font-family: monospace;
+  font-size: 0.875rem;
+  line-height: 1.5;
+}


### PR DESCRIPTION
Resolves #43813. Prevent duplicate reminder comments from assignment bot in \submissions/docs/\.