### PR TITLE
feat: add underline-draw-follow-button

### DIFF
--- a/submissions/examples/underline-draw-follow-button-realtushartyagi/README.md
+++ b/submissions/examples/underline-draw-follow-button-realtushartyagi/README.md
@@ -1,0 +1,9 @@
+# [FEATURE] Add Underline Draw Follow Button Component
+
+A underline-draw-follow-button component for EaseMotion CSS.
+
+## Usage
+Include `style.css` and use the `.underline-draw-follow-button` class.
+
+## Author
+[realtushartyagi](https://github.com/realtushartyagi)

--- a/submissions/examples/underline-draw-follow-button-realtushartyagi/demo.html
+++ b/submissions/examples/underline-draw-follow-button-realtushartyagi/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>[FEATURE] Add Underline Draw Follow Button Component</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="underline-draw-follow-button">
+    <!-- Implement your animation/component here -->
+    <h1>underline-draw-follow-button</h1>
+  </div>
+</body>
+</html>

--- a/submissions/examples/underline-draw-follow-button-realtushartyagi/style.css
+++ b/submissions/examples/underline-draw-follow-button-realtushartyagi/style.css
@@ -1,0 +1,9 @@
+/* EaseMotion CSS Component: underline-draw-follow-button */
+.underline-draw-follow-button {
+  /* Using EaseMotion CSS variables/keyframes */
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  /* Add your custom styles and animations */
+}


### PR DESCRIPTION
Fixes #41710

## 💡 Feature Request: underline-draw-follow-button

Added the `underline-draw-follow-button` component to the EaseMotion CSS library.

### Checklist
- [x] Uses EaseMotion CSS variables/keyframes (`ease-*` classes)
- [x] Works without JavaScript (pure CSS preferred)
- [x] Includes a live demo in `demo.html`
- [x] Has a `README.md`
- [x] Responsive and accessible
