### PR TITLE
feat: add mouse ripple trail demo (submissions/examples)

### DIFF
--- a/submissions/examples/mouse-ripple-trail-aaniya/README.md
+++ b/submissions/examples/mouse-ripple-trail-aaniya/README.md
@@ -1,0 +1,13 @@
+# Ease Ripple Trail
+
+## What does this do?
+A glowing purple droplet ripple trail that smoothly follows the user's cursor across the page, without blocking clicks, text selection, or any other page interaction.
+
+## How is it used?
+```html
+<div class="ease-ripple-container" id="rippleContainer"></div>
+```
+Include the container once near the top of `<body>`, then include `style.css` and the pointer-tracking script from `demo.html`. Each `.ease-ripple-dot` span is created dynamically on `pointermove` and removed automatically after its fade animation ends (`animationend` listener), so there's no DOM node buildup during long sessions.
+
+## Why is it useful?
+It's a lightweight, purely decorative motion layer that reinforces EaseMotion CSS's fluid, motion-first design philosophy on the landing page. Mouse movement is throttled (~40ms) to avoid flooding the DOM or straining the browser's main thread, and the layer uses `pointer-events: none` so it never interferes with real page interaction — buttons, links, and text selection all keep working normally underneath it.

--- a/submissions/examples/mouse-ripple-trail-aaniya/demo.html
+++ b/submissions/examples/mouse-ripple-trail-aaniya/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Ease Ripple Trail — Demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <div class="ease-ripple-container" id="rippleContainer"></div>
+
+  <main class="demo-content">
+    <h1>Ease Ripple Trail</h1>
+    <p>Move your mouse anywhere on this page to see a glowing purple droplet trail follow your cursor.</p>
+    <button class="demo-btn">This button is still fully clickable</button>
+    <p class="demo-text">Text remains selectable — the ripple layer never blocks interaction.</p>
+  </main>
+
+  <script>
+    const container = document.getElementById('rippleContainer');
+    let lastTime = 0;
+    const throttleMs = 40; // throttle ripple creation for performance
+
+    function createRipple(x, y) {
+      const drop = document.createElement('span');
+      drop.className = 'ease-ripple-dot';
+      drop.style.left = x + 'px';
+      drop.style.top = y + 'px';
+      container.appendChild(drop);
+
+      // cleanup after animation ends to avoid DOM node leaks
+      drop.addEventListener('animationend', () => {
+        drop.remove();
+      });
+    }
+
+    window.addEventListener('pointermove', (e) => {
+      const now = performance.now();
+      if (now - lastTime < throttleMs) return;
+      lastTime = now;
+      createRipple(e.clientX, e.clientY);
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/mouse-ripple-trail-aaniya/style.css
+++ b/submissions/examples/mouse-ripple-trail-aaniya/style.css
@@ -1,0 +1,87 @@
+/* Ease Ripple Trail - raw demo styles (maintainer will standardize naming) */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #0d0b14;
+  color: #f1f1f7;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  overflow-x: hidden;
+}
+
+/* Non-intrusive full-viewport layer for the ripple trail */
+.ease-ripple-container {
+  position: fixed;
+  inset: 0;
+  pointer-events: none; /* never blocks clicks, text selection, etc. */
+  z-index: 9999;
+  overflow: hidden;
+}
+
+.ease-ripple-dot {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  background: radial-gradient(circle, rgba(168, 85, 247, 0.9) 0%, rgba(168, 85, 247, 0.25) 60%, transparent 80%);
+  box-shadow: 0 0 12px 4px rgba(168, 85, 247, 0.55);
+  animation: ease-ripple-fade 700ms ease-out forwards;
+}
+
+@keyframes ease-ripple-fade {
+  0% {
+    opacity: 0.9;
+    transform: translate(-50%, -50%) scale(0.4);
+  }
+  60% {
+    opacity: 0.5;
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(1.6);
+  }
+}
+
+/* Demo page content, unrelated to the feature itself */
+.demo-content {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 96px 24px;
+  text-align: center;
+}
+
+.demo-content h1 {
+  font-size: 2.2rem;
+  margin-bottom: 12px;
+  color: #c084fc;
+}
+
+.demo-content p {
+  line-height: 1.6;
+  color: #cfcbe0;
+}
+
+.demo-btn {
+  margin-top: 24px;
+  padding: 12px 28px;
+  border: none;
+  border-radius: 8px;
+  background: #7c3aed;
+  color: white;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.demo-btn:hover {
+  background: #9333ea;
+}
+
+.demo-text {
+  margin-top: 24px;
+  user-select: text;
+}


### PR DESCRIPTION
Closes #33786
## Pull Request Description
Adds a self-contained, glowing purple mouse-tracking ripple/droplet trail for the EaseMotion CSS landing page, per issue #33786. Closes #33786.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/mouse-ripple-trail-aaniya/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A non-intrusive, glowing purple ripple/droplet trail that smoothly follows the user's mouse cursor across the page.

**How does a developer use it?**
```html
<div class="ease-ripple-container" id="rippleContainer"></div>
```
Include the container once in `<body>`, then link `style.css` and the pointer-tracking script from `demo.html`. Ripple dots are generated on `pointermove` and self-remove after their animation ends.

**Why does it fit EaseMotion CSS?**
It reinforces the framework's fluid, motion-first design philosophy as a purely decorative ambient layer, while staying fully non-intrusive — `pointer-events: none` means buttons, links, and text selection all keep working normally underneath it.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Mouse movement is throttled to ~40ms between ripple spawns to avoid straining the main thread, and each `.ease-ripple-dot` cleans itself up via an `animationend` listener to prevent DOM node buildup during long sessions. Happy to adjust the throttle timing, dot size, or fade duration if you'd like a different feel.