### PR TITLE
fix: increase auto-merge check timeout from 5 to 10 minutes to prevent false timeouts

### DIFF
--- a/.github/workflows/auto-merge-submissions.yml
+++ b/.github/workflows/auto-merge-submissions.yml
@@ -469,8 +469,8 @@ jobs:
           while true; do
             current_time=$(date +%s)
             elapsed=$((current_time - start_time))
-            if [ $elapsed -gt 300 ]; then
-              echo "❌ Timeout: Checks did not complete within 5 minutes. Releasing runner."
+            if [ $elapsed -gt 600 ]; then
+              echo "❌ Timeout: Checks did not complete within 10 minutes. Releasing runner."
               exit 1
             fi
             
@@ -522,12 +522,12 @@ jobs:
               break
             fi
             
-            # If no other checks exist, check if we have waited more than 90 seconds
+            # If no other checks exist, check if we have waited more than 180 seconds
             if [ "$other_checks_exist" = "false" ]; then
               current_time=$(date +%s)
               elapsed=$((current_time - start_time))
-              if [ $elapsed -gt 90 ]; then
-                echo "No other check runs detected after 90 seconds. Assuming no checks are required."
+              if [ $elapsed -gt 180 ]; then
+                echo "No other check runs detected after 3 minutes. Assuming no checks are required."
                 break
               fi
               echo "No other active checks found yet. Waiting to see if any are registered..."


### PR DESCRIPTION
## Pull Request Description

Fixes the Auto-Merge workflow timing out prematurely before CI checks have a chance to complete (as seen in job run #86704581637, triggered by PR #44259).

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## What Changed

In `.github/workflows/auto-merge-submissions.yml`:

1. **Overall timeout**: Increased from `300s` (5 min) → `600s` (10 min) to give CI checks (Stylelint, Vitest, etc.) sufficient time to complete.
2. **No-checks-found wait**: Increased from `90s` → `180s` to give GitHub Actions more time to register check runs before assuming none are required.

## Root Cause

The "Wait for checks to pass" step was timing out after 5 minutes while CI checks were still `in_progress`. The logs showed:
