### PR TITLE
feat:add-validation-summary-panel

### DIFF
--- a/submissions/examples/validation-summary-panel-bb26/README.md
+++ b/submissions/examples/validation-summary-panel-bb26/README.md
@@ -1,0 +1,21 @@
+# Validation Summary Panel
+
+## What does this do?
+
+This submission adds an accessible validation summary panel that lists form errors, links them to fields, and keeps each invalid control visually clear.
+
+## How is it used?
+
+Place the summary before the form fields and connect each summary link to the matching field id.
+
+```html
+<aside class="summary-panel" role="status" aria-live="polite">
+  <strong>3 fields need attention</strong>
+  <a href="#email">Email format is incomplete</a>
+</aside>
+<input id="email" aria-invalid="true">
+```
+
+## Why is it useful?
+
+It gives EaseMotion a production-focused form feedback pattern that improves keyboard navigation, error recovery, and reduced-motion accessibility.

--- a/submissions/examples/validation-summary-panel-bb26/demo.html
+++ b/submissions/examples/validation-summary-panel-bb26/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Validation Summary Panel</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="validation-shell">
+    <section class="form-card" aria-labelledby="validation-title">
+      <div class="form-copy">
+        <p class="eyebrow">Accessible form feedback</p>
+        <h1 id="validation-title">Show every form issue before users hunt for it.</h1>
+      </div>
+
+      <aside class="summary-panel" role="status" aria-live="polite">
+        <strong>3 fields need attention</strong>
+        <a href="#email">Email format is incomplete</a>
+        <a href="#workspace">Workspace name is too short</a>
+        <a href="#plan">Plan selection is required</a>
+      </aside>
+
+      <form class="demo-form">
+        <label for="email">Work email</label>
+        <input id="email" type="email" value="sam@" aria-invalid="true">
+        <span class="field-note error-note">Use a complete address such as sam@example.com.</span>
+
+        <label for="workspace">Workspace name</label>
+        <input id="workspace" type="text" value="UX" aria-invalid="true">
+        <span class="field-note error-note">Use at least three characters.</span>
+
+        <label for="plan">Plan</label>
+        <select id="plan" aria-invalid="true">
+          <option>Choose a plan</option>
+          <option>Team</option>
+          <option>Business</option>
+        </select>
+
+        <button type="button">Review details</button>
+      </form>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/validation-summary-panel-bb26/style.css
+++ b/submissions/examples/validation-summary-panel-bb26/style.css
@@ -1,0 +1,223 @@
+:root {
+  --ink: #18212f;
+  --muted: #647084;
+  --surface: #f7f9fc;
+  --card: #ffffff;
+  --line: #d8e0eb;
+  --error: #b91c1c;
+  --error-soft: #fee2e2;
+  --accent: #4338ca;
+  --success: #047857;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(67, 56, 202, 0.11), transparent 36%),
+    linear-gradient(315deg, rgba(4, 120, 87, 0.12), transparent 32%),
+    var(--surface);
+}
+
+.validation-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 28px;
+}
+
+.form-card {
+  width: min(980px, 100%);
+  display: grid;
+  grid-template-columns: minmax(260px, 0.85fr) minmax(360px, 1.15fr);
+  gap: 24px;
+  padding: 28px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 24px 56px rgba(24, 33, 47, 0.14);
+}
+
+.form-copy {
+  display: grid;
+  align-content: start;
+  gap: 14px;
+}
+
+.eyebrow,
+h1,
+p {
+  margin: 0;
+}
+
+.eyebrow {
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 13ch;
+  font-size: clamp(2rem, 7vw, 4.6rem);
+  line-height: 0.98;
+  letter-spacing: 0;
+}
+
+.summary-panel {
+  grid-column: 2;
+  display: grid;
+  gap: 10px;
+  align-self: start;
+  padding: 18px;
+  border: 1px solid rgba(185, 28, 28, 0.3);
+  border-left: 8px solid var(--error);
+  border-radius: 8px;
+  background: var(--error-soft);
+  animation: summaryEnter 560ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.summary-panel strong {
+  color: var(--error);
+  font-size: 1rem;
+}
+
+.summary-panel a {
+  color: #7f1d1d;
+  font-weight: 750;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 4px;
+}
+
+.summary-panel a:focus-visible {
+  outline: 3px solid rgba(67, 56, 202, 0.34);
+  outline-offset: 3px;
+  border-radius: 4px;
+}
+
+.demo-form {
+  grid-column: 2;
+  display: grid;
+  gap: 10px;
+}
+
+label {
+  font-weight: 850;
+}
+
+input,
+select,
+button {
+  width: 100%;
+  min-height: 48px;
+  border-radius: 8px;
+  font: inherit;
+}
+
+input,
+select {
+  border: 1px solid var(--line);
+  padding: 0 14px;
+  background: #fff;
+  color: var(--ink);
+  transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+}
+
+input[aria-invalid="true"],
+select[aria-invalid="true"] {
+  border-color: var(--error);
+  box-shadow: inset 5px 0 0 var(--error);
+}
+
+input:focus,
+select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px rgba(67, 56, 202, 0.16);
+  transform: translateY(-1px);
+}
+
+.field-note {
+  margin: -4px 0 8px;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.error-note {
+  color: var(--error);
+}
+
+button {
+  margin-top: 8px;
+  border: 0;
+  color: #fff;
+  background: var(--accent);
+  font-weight: 850;
+  cursor: pointer;
+  transition: transform 180ms ease, box-shadow 180ms ease;
+}
+
+button:hover,
+button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 28px rgba(67, 56, 202, 0.28);
+}
+
+button:focus-visible {
+  outline: 3px solid rgba(67, 56, 202, 0.34);
+  outline-offset: 3px;
+}
+
+@keyframes summaryEnter {
+  from {
+    opacity: 0;
+    transform: translateY(-14px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .summary-panel {
+    animation: none;
+  }
+
+  input,
+  select,
+  button {
+    transition-duration: 1ms;
+  }
+
+  input:focus,
+  select:focus,
+  button:hover,
+  button:focus-visible {
+    transform: none;
+  }
+}
+
+@media (max-width: 780px) {
+  .form-card {
+    grid-template-columns: 1fr;
+  }
+
+  .summary-panel,
+  .demo-form {
+    grid-column: 1;
+  }
+
+  h1 {
+    max-width: 100%;
+    font-size: clamp(2rem, 12vw, 3.7rem);
+  }
+}


### PR DESCRIPTION
# Related Issue
Closes #44468

# Summary
Adds an accessible validation summary panel that lists form issues and connects them to invalid fields.

# Changes Made
- Added a form demo with invalid email, workspace, and plan fields.
- Added a summary panel with linked validation messages.
- Added `aria-invalid`, `role="status"`, and `aria-live` usage.
- Added clear invalid field styling and focus-visible states.
- Added reduced-motion handling.
- Added README usage documentation.

# Testing
- Verified the demo is self-contained and browser-openable.
- Verified only `demo.html`, `style.css`, and `README.md` are present.
- Checked semantic form labels and invalid field states.
- Checked keyboard focus styling.
- Checked responsive behavior and reduced-motion CSS.

# Screenshots
Add screenshots after opening `submissions/examples/validation-summary-panel-bb26/demo.html`.

# Impact
This gives EaseMotion a useful accessibility pattern for real-world form validation and error recovery.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered