### PR TITLE
feat:add-touch-target-spacing-guide

### DIFF
--- a/submissions/examples/touch-target-spacing-guide-bb26/README.md
+++ b/submissions/examples/touch-target-spacing-guide-bb26/README.md
@@ -1,0 +1,20 @@
+# Touch Target Spacing Guide
+
+## What does this do?
+
+This submission adds a responsive touch-target spacing guide for action groups, filters, and compact mobile controls.
+
+## How is it used?
+
+Use `.control-group` around buttons and keep each control at a comfortable tap size with visible focus states.
+
+```html
+<div class="control-group">
+  <button type="button">Save</button>
+  <button type="button">Share</button>
+</div>
+```
+
+## Why is it useful?
+
+It helps EaseMotion demonstrate accessible control density for mobile layouts while preserving motion, spacing, and keyboard clarity.

--- a/submissions/examples/touch-target-spacing-guide-bb26/demo.html
+++ b/submissions/examples/touch-target-spacing-guide-bb26/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Touch Target Spacing Guide</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="target-shell">
+    <section class="target-copy" aria-labelledby="target-title">
+      <p class="eyebrow">Mobile accessibility</p>
+      <h1 id="target-title">Design controls that are easy to tap, scan, and trust.</h1>
+      <p>
+        A spacing guide for toolbars, filters, and action groups where compact
+        layouts still need generous target sizes and visible focus states.
+      </p>
+    </section>
+
+    <section class="target-board" aria-label="Touch target spacing examples">
+      <div class="control-group primary-actions" aria-label="Primary actions">
+        <button type="button">Save</button>
+        <button type="button">Share</button>
+        <button type="button">Archive</button>
+      </div>
+
+      <div class="control-group filter-actions" aria-label="Filter controls">
+        <button type="button" aria-pressed="true">Open</button>
+        <button type="button">Assigned</button>
+        <button type="button">Blocked</button>
+        <button type="button">Done</button>
+      </div>
+
+      <div class="target-ruler" aria-label="Touch target sizing reference">
+        <span>44px minimum target</span>
+        <span>8px spacing buffer</span>
+        <span>Focus ring offset</span>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/touch-target-spacing-guide-bb26/style.css
+++ b/submissions/examples/touch-target-spacing-guide-bb26/style.css
@@ -1,0 +1,209 @@
+:root {
+  --ink: #111827;
+  --muted: #637083;
+  --surface: #f7f9fc;
+  --card: #ffffff;
+  --line: #d8e0eb;
+  --accent: #0f766e;
+  --accent-dark: #115e59;
+  --blue: #2563eb;
+  --orange: #c2410c;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(15, 118, 110, 0.12), transparent 36%),
+    linear-gradient(315deg, rgba(37, 99, 235, 0.12), transparent 32%),
+    var(--surface);
+}
+
+.target-shell {
+  min-height: 100vh;
+  width: min(1080px, calc(100% - 36px));
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: minmax(260px, 0.85fr) minmax(380px, 1.15fr);
+  gap: 36px;
+  align-items: center;
+  padding: 36px 0;
+}
+
+.target-copy {
+  display: grid;
+  gap: 14px;
+}
+
+.eyebrow,
+h1,
+p {
+  margin: 0;
+}
+
+.eyebrow {
+  color: var(--accent-dark);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 13ch;
+  font-size: clamp(2rem, 7vw, 4.7rem);
+  line-height: 0.97;
+  letter-spacing: 0;
+}
+
+.target-copy p:last-child {
+  max-width: 52ch;
+  color: var(--muted);
+  line-height: 1.75;
+}
+
+.target-board {
+  display: grid;
+  gap: 20px;
+  padding: 24px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 24px 60px rgba(17, 24, 39, 0.14);
+}
+
+.control-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #f9fbfd;
+  animation: groupEnter 580ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.filter-actions {
+  animation-delay: 120ms;
+}
+
+button {
+  min-width: 92px;
+  min-height: 48px;
+  padding: 0 18px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--ink);
+  background: var(--card);
+  font: inherit;
+  font-weight: 850;
+  cursor: pointer;
+  transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease, background 180ms ease;
+}
+
+button:hover {
+  transform: translateY(-2px);
+  border-color: rgba(15, 118, 110, 0.45);
+  box-shadow: 0 12px 26px rgba(17, 24, 39, 0.12);
+}
+
+button:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.34);
+  outline-offset: 4px;
+}
+
+.primary-actions button:first-child,
+button[aria-pressed="true"] {
+  color: #ffffff;
+  border-color: var(--accent);
+  background: var(--accent);
+}
+
+.target-ruler {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+
+.target-ruler span {
+  min-height: 58px;
+  display: grid;
+  place-items: center;
+  padding: 10px;
+  border: 1px dashed rgba(15, 118, 110, 0.45);
+  border-radius: 8px;
+  color: var(--accent-dark);
+  background: rgba(15, 118, 110, 0.08);
+  font-size: 0.9rem;
+  font-weight: 850;
+  text-align: center;
+}
+
+.target-ruler span:nth-child(2) {
+  color: var(--blue);
+  border-color: rgba(37, 99, 235, 0.42);
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.target-ruler span:nth-child(3) {
+  color: var(--orange);
+  border-color: rgba(194, 65, 12, 0.42);
+  background: rgba(194, 65, 12, 0.08);
+}
+
+@keyframes groupEnter {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .control-group {
+    animation: none;
+  }
+
+  button {
+    transition-duration: 1ms;
+  }
+
+  button:hover {
+    transform: none;
+  }
+}
+
+@media (max-width: 820px) {
+  .target-shell {
+    grid-template-columns: 1fr;
+  }
+
+  h1 {
+    max-width: 100%;
+    font-size: clamp(2rem, 12vw, 3.8rem);
+  }
+}
+
+@media (max-width: 560px) {
+  .target-board {
+    padding: 16px;
+  }
+
+  button {
+    flex: 1 1 100%;
+  }
+
+  .target-ruler {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
# Related Issue
Closes #44473 

# Summary
Adds a responsive touch-target spacing guide for action groups, filters, and compact mobile controls.

# Changes Made
- Added a self-contained touch-target spacing demo.
- Added primary action and filter button groups.
- Added minimum target sizing and spacing reference markers.
- Added visible keyboard focus states.
- Added pressed-state styling with `aria-pressed`.
- Added reduced-motion-safe interaction behavior.
- Added README documentation with usage guidance.

# Testing
- Verified the demo opens directly from `demo.html`.
- Verified the folder contains exactly `demo.html`, `style.css`, and `README.md`.
- Checked mobile responsive behavior through media queries.
- Checked focus-visible styles for keyboard navigation.
- Checked reduced-motion fallback is included.

# Screenshots
Add screenshots after opening `submissions/examples/touch-target-spacing-guide-bb26/demo.html`.

# Impact
This gives EaseMotion a useful accessibility-focused pattern for mobile-friendly controls, dense toolbars, and filter groups.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered