### PR TITLE
feat: add card tilt hover example

### DIFF
--- a/submissions/examples/card-tilt-hover/README.md
+++ b/submissions/examples/card-tilt-hover/README.md
@@ -1,0 +1,14 @@
+# Card Tilt Hover
+
+A focused hover and focus-visible effect that gives a card subtle depth without changing surrounding layout.
+
+## Files
+
+- `demo.html` - linked preview card markup.
+- `style.css` - 3D tilt, sheen overlay, focus-visible state, and reduced-motion support.
+
+## Highlights
+
+- Uses `perspective` and `transform-style` for a lightweight depth effect.
+- Provides the same interaction on keyboard focus.
+- Falls back to a simpler lift when reduced motion is requested.

--- a/submissions/examples/card-tilt-hover/demo.html
+++ b/submissions/examples/card-tilt-hover/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Card Tilt Hover</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="stage" aria-labelledby="demo-title">
+    <p class="eyebrow">EaseMotion card pattern</p>
+    <h1 id="demo-title">Card tilt hover</h1>
+    <p class="intro">A subtle depth effect for feature cards, pricing tiles, and project previews.</p>
+
+    <a class="tilt-card" href="#" aria-label="View analytics card preview">
+      <span class="status">Live</span>
+      <strong>Analytics workspace</strong>
+      <span>Hover or focus to lift the card into view.</span>
+    </a>
+  </main>
+</body>
+</html>

--- a/submissions/examples/card-tilt-hover/style.css
+++ b/submissions/examples/card-tilt-hover/style.css
@@ -1,0 +1,124 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  perspective: 60rem;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #182033;
+  background: linear-gradient(135deg, #fff7ed 0%, #f8fafc 48%, #ecfeff 100%);
+}
+
+.stage {
+  width: min(92vw, 31rem);
+  padding: 2.25rem;
+  border: 1px solid rgba(249, 115, 22, 0.18);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 1.5rem 3.75rem rgba(15, 23, 42, 0.13);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #c2410c;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.1rem);
+  line-height: 1;
+}
+
+.intro {
+  margin: 1rem 0 2rem;
+  color: #526173;
+  line-height: 1.65;
+}
+
+.tilt-card {
+  position: relative;
+  display: grid;
+  gap: 0.75rem;
+  min-height: 11.5rem;
+  padding: 1.4rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 1rem;
+  color: #182033;
+  overflow: hidden;
+  text-decoration: none;
+  background:
+    linear-gradient(135deg, rgba(249, 115, 22, 0.18), transparent 45%),
+    #ffffff;
+  box-shadow: 0 1rem 2.4rem rgba(15, 23, 42, 0.12);
+  transform: rotateX(0) rotateY(0) translateY(0);
+  transform-style: preserve-3d;
+  transition: transform 240ms ease, box-shadow 240ms ease, border-color 180ms ease;
+}
+
+.tilt-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, transparent, rgba(255, 255, 255, 0.65), transparent);
+  opacity: 0;
+  transform: translateX(-45%);
+  transition: opacity 220ms ease, transform 320ms ease;
+}
+
+.tilt-card:hover,
+.tilt-card:focus-visible {
+  border-color: rgba(249, 115, 22, 0.38);
+  box-shadow: 0 1.5rem 3rem rgba(194, 65, 12, 0.17);
+  transform: rotateX(4deg) rotateY(-5deg) translateY(-0.35rem);
+}
+
+.tilt-card:hover::after,
+.tilt-card:focus-visible::after {
+  opacity: 1;
+  transform: translateX(45%);
+}
+
+.tilt-card:focus-visible {
+  outline: 0.18rem solid #fb923c;
+  outline-offset: 0.25rem;
+}
+
+.status {
+  width: max-content;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  color: #9a3412;
+  background: #ffedd5;
+  font-size: 0.78rem;
+  font-weight: 900;
+}
+
+strong {
+  font-size: 1.35rem;
+}
+
+.tilt-card span:last-child {
+  color: #64748b;
+  line-height: 1.55;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 1ms !important;
+  }
+
+  .tilt-card:hover,
+  .tilt-card:focus-visible {
+    transform: translateY(-0.2rem);
+  }
+}


### PR DESCRIPTION
## Summary
- add a card tilt hover motion example
- include matching focus-visible behavior
- document the 3D transform and reduced-motion fallback

## Verification
- git diff --cached --check