### PR TITLE
feat: add modal backdrop zoom example

### DIFF
--- a/submissions/examples/modal-backdrop-zoom/README.md
+++ b/submissions/examples/modal-backdrop-zoom/README.md
@@ -1,0 +1,14 @@
+# Modal Backdrop Zoom
+
+A modal-style overlay preview that combines a soft backdrop fade with a focused dialog zoom.
+
+## Files
+
+- `demo.html` - preview overlay, backdrop, and dialog markup.
+- `style.css` - backdrop fade, dialog zoom, and reduced-motion handling.
+
+## Highlights
+
+- Separates backdrop and dialog motion for a clearer entrance pattern.
+- Keeps the dialog centered in a fixed preview area.
+- Removes animation when reduced motion is requested.

--- a/submissions/examples/modal-backdrop-zoom/demo.html
+++ b/submissions/examples/modal-backdrop-zoom/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Modal Backdrop Zoom</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="scene" aria-labelledby="demo-title">
+    <p class="eyebrow">EaseMotion overlay</p>
+    <h1 id="demo-title">Modal backdrop zoom</h1>
+    <p class="intro">A CSS-only preview of a modal entering with a soft backdrop and focused content zoom.</p>
+
+    <section class="modal-preview" aria-label="Preview modal">
+      <div class="backdrop"></div>
+      <article class="dialog">
+        <span class="pill">Preview ready</span>
+        <h2>Publish changes?</h2>
+        <p>Review the final motion pass before making this update visible.</p>
+        <button type="button">Continue</button>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/modal-backdrop-zoom/style.css
+++ b/submissions/examples/modal-backdrop-zoom/style.css
@@ -1,0 +1,132 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #182033;
+  background: linear-gradient(135deg, #f8fafc 0%, #fdf2f8 48%, #eef2ff 100%);
+}
+
+.scene {
+  width: min(92vw, 32rem);
+  padding: 2.2rem;
+  border: 1px solid rgba(190, 24, 93, 0.16);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 1.5rem 3.75rem rgba(15, 23, 42, 0.13);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #be185d;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.1rem);
+  line-height: 1;
+}
+
+.intro {
+  margin: 1rem 0 2rem;
+  color: #526173;
+  line-height: 1.65;
+}
+
+.modal-preview {
+  position: relative;
+  min-height: 16rem;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  border-radius: 1rem;
+  background: linear-gradient(135deg, #e2e8f0, #f8fafc);
+}
+
+.backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.52);
+  animation: backdrop-fade 1600ms ease-in-out infinite alternate;
+}
+
+.dialog {
+  position: relative;
+  width: min(88%, 22rem);
+  padding: 1.35rem;
+  border-radius: 1rem;
+  background: #ffffff;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.28);
+  transform-origin: center;
+  animation: dialog-zoom 1600ms ease-in-out infinite alternate;
+}
+
+.pill {
+  display: inline-flex;
+  margin-bottom: 0.9rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  color: #be185d;
+  background: #fce7f3;
+  font-size: 0.78rem;
+  font-weight: 900;
+}
+
+h2 {
+  margin: 0;
+  font-size: 1.45rem;
+}
+
+.dialog p {
+  margin: 0.7rem 0 1rem;
+  color: #64748b;
+  line-height: 1.55;
+}
+
+button {
+  border: 0;
+  border-radius: 999px;
+  padding: 0.75rem 1rem;
+  color: #ffffff;
+  background: #be185d;
+  font: inherit;
+  font-weight: 800;
+}
+
+@keyframes backdrop-fade {
+  from {
+    opacity: 0.6;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes dialog-zoom {
+  from {
+    opacity: 0.92;
+    transform: translateY(0.45rem) scale(0.96);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .backdrop,
+  .dialog {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a modal backdrop zoom motion example
- separate backdrop fade and dialog scale motion
- document the overlay and reduced-motion fallback

## Verification
- git diff --cached --check