### PR TITLE
ease-announce-bar-patterns-sp

### DIFF
--- a/submissions/examples/ease-announce-bar-patterns-sp/README.md
+++ b/submissions/examples/ease-announce-bar-patterns-sp/README.md
@@ -1,0 +1,80 @@
+# Announce Bar Pattern Library (5 variants)
+
+A pattern library showcasing **five reusable announce-bar layouts** using the EaseMotion `announce-bar` component — sticky promo, dismissible slide-down, rotating messages, sale countdown, and cookie-style consent.
+
+> Submission track: `submissions/examples/ease-announce-bar-patterns-sp/`  
+> Contributor suffix: `sp`  
+> Resolves: Issue #44483
+
+---
+
+## What does this do?
+
+EaseMotion CSS includes an `announce-bar` component, but beginners often lack real-world pattern examples. This library demonstrates five common announce-bar layouts in one demo page.
+
+---
+
+## Patterns included
+
+| # | Pattern | Key classes |
+|---|---------|-------------|
+| 1 | Sticky promo bar | `.ease-announce-bar.is-fixed.is-warning` |
+| 2 | Dismissible slide-down | `.ease-announce-bar-dismiss` + close label |
+| 3 | Rotating messages | `.ease-announce-bar.is-success` + JS cycle |
+| 4 | Sale countdown strip | `.ease-announce-bar.is-danger` + timer |
+| 5 | Cookie consent bar | Bottom-fixed bar with accept/decline |
+
+---
+
+## How is it used?
+
+1. Open `demo.html` in a browser (requires internet for CDN assets).
+2. Browse all 5 pattern cards with live previews.
+3. Interact with dismiss, rotate dots, countdown, and cookie buttons.
+4. Copy snippets for each pattern at the bottom.
+5. Read accessibility and variant modifier notes.
+
+---
+
+## Features
+
+- Sticky promo bar pattern (fixed top announcement)
+- Dismissible slide-down bar with close button
+- Rotating messages bar (multiple announcements cycling)
+- Sale countdown strip pattern
+- Cookie-style info / consent bar pattern
+- Uses EaseMotion announce-bar component classes
+- Entrance animations (built-in slide-down on `.ease-announce-bar`)
+- Copy-ready HTML snippet for each of the 5 variants
+- Responsive and clean demo page
+- Accessible labels, keyboard-friendly dismiss controls
+
+---
+
+## Tech stack
+
+| Asset | Source |
+|-------|--------|
+| EaseMotion CSS | jsDelivr CDN (`easemotion.min.css`) |
+| Rotating / countdown logic | Inline JS in `demo.html` |
+| Demo layout | `style.css` |
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | 5 pattern demos, copy snippets, interactions |
+| `style.css` | Demo layout, cookie bar, countdown styling |
+| `README.md` | This document |
+
+---
+
+## Compliance notes
+
+- Only **new files** inside `submissions/examples/ease-announce-bar-patterns-sp/`.
+- No modifications to `core/`, `components/`, workflows, or existing files.
+- All three required submission files included (`demo.html`, `style.css`, `README.md`).
+- Total contribution exceeds the 250-line minimum policy threshold.
+- Folder name carries the unique contributor suffix `-sp`.

--- a/submissions/examples/ease-announce-bar-patterns-sp/demo.html
+++ b/submissions/examples/ease-announce-bar-patterns-sp/demo.html
@@ -1,0 +1,382 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Announce Bar Pattern Library — EaseMotion CSS</title>
+  <meta
+    name="description"
+    content="Five reusable announce-bar patterns: sticky promo, dismissible slide-down, rotating messages, sale countdown, and cookie consent."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header class="ab-header ease-fade-in">
+    <p class="ab-eyebrow">EaseMotion CSS · Component Patterns</p>
+    <h1>Announce Bar Pattern Library</h1>
+    <p class="ab-subtitle">
+      Five reusable announce-bar layouts using
+      <code>.ease-announce-bar</code> — sticky promo, dismissible slide-down,
+      rotating messages, sale countdown, and cookie-style consent.
+    </p>
+  </header>
+
+  <main class="ab-main">
+    <div class="ab-pattern-list">
+      <!-- 1. Sticky promo -->
+      <article class="ab-pattern-card" aria-labelledby="pat-sticky-title">
+        <header class="ab-pattern-header">
+          <h2 id="pat-sticky-title">1 · Sticky promo bar</h2>
+          <span class="ab-pattern-tag">is-fixed</span>
+        </header>
+        <div class="ab-pattern-body">
+          <div class="ab-viewport-mock">
+            <div class="ease-announce-bar is-fixed is-warning" role="banner">
+              <div class="ease-announce-bar-content">
+                🎉 <strong>Spring Sale:</strong> 30% off all plans —
+                <a href="#">Shop now</a>
+              </div>
+            </div>
+            <div class="ab-mock-page">
+              Page content sits below the fixed announce bar.
+            </div>
+          </div>
+          <p class="ab-pattern-note">
+            Add <code>.is-fixed</code> for a sticky top promo strip.
+            Pair with <code>.is-warning</code> for sale urgency.
+          </p>
+        </div>
+      </article>
+
+      <!-- 2. Dismissible slide-down -->
+      <article class="ab-pattern-card" aria-labelledby="pat-dismiss-title">
+        <header class="ab-pattern-header">
+          <h2 id="pat-dismiss-title">2 · Dismissible slide-down</h2>
+          <span class="ab-pattern-tag">checkbox dismiss</span>
+        </header>
+        <div class="ab-pattern-body">
+          <div class="ab-demo-frame">
+            <input
+              type="checkbox"
+              id="dismiss-promo"
+              class="ease-announce-bar-dismiss"
+            />
+            <div class="ease-announce-bar is-info" role="region" aria-label="Announcement">
+              <div class="ease-announce-bar-content">
+                ✨ New: EaseMotion v1.2 is live —
+                <a href="#">See what's new</a>
+              </div>
+              <label
+                for="dismiss-promo"
+                class="ease-announce-bar-close"
+                aria-label="Dismiss announcement"
+              >&times;</label>
+            </div>
+          </div>
+          <p class="ab-pattern-note">
+            Pure CSS dismiss via hidden checkbox +
+            <code>.ease-announce-bar-dismiss</code>. Built-in slide-down entrance.
+          </p>
+        </div>
+      </article>
+
+      <!-- 3. Rotating messages -->
+      <article class="ab-pattern-card" aria-labelledby="pat-rotate-title">
+        <header class="ab-pattern-header">
+          <h2 id="pat-rotate-title">3 · Rotating messages</h2>
+          <span class="ab-pattern-tag">JS cycle</span>
+        </header>
+        <div class="ab-pattern-body">
+          <div class="ab-demo-frame">
+            <div class="ease-announce-bar is-success" id="rotate-bar" role="status" aria-live="polite">
+              <div class="ease-announce-bar-content">
+                <span class="ab-rotate-msg" id="rotate-msg">Free shipping on orders over $50</span>
+                <span class="ab-rotate-dots" id="rotate-dots" aria-hidden="true"></span>
+              </div>
+            </div>
+          </div>
+          <p class="ab-pattern-note">
+            Cycle multiple announcements with lightweight JS. Use
+            <code>aria-live="polite"</code> for screen reader updates.
+          </p>
+        </div>
+      </article>
+
+      <!-- 4. Sale countdown -->
+      <article class="ab-pattern-card" aria-labelledby="pat-countdown-title">
+        <header class="ab-pattern-header">
+          <h2 id="pat-countdown-title">4 · Sale countdown strip</h2>
+          <span class="ab-pattern-tag">is-danger</span>
+        </header>
+        <div class="ab-pattern-body">
+          <div class="ab-demo-frame">
+            <div class="ease-announce-bar is-danger" role="timer" aria-label="Sale countdown">
+              <div class="ease-announce-bar-content">
+                <strong>Flash Sale ends in</strong>
+                <span class="ab-countdown" id="countdown" aria-live="polite">
+                  <span class="ab-countdown-unit" id="cd-h">00</span>:
+                  <span class="ab-countdown-unit" id="cd-m">00</span>:
+                  <span class="ab-countdown-unit" id="cd-s">00</span>
+                </span>
+              </div>
+            </div>
+          </div>
+          <p class="ab-pattern-note">
+            <code>.is-danger</code> urgency styling + live countdown timer.
+            Resets to a 2-hour demo window on page load.
+          </p>
+        </div>
+      </article>
+
+      <!-- 5. Cookie consent -->
+      <article class="ab-pattern-card" aria-labelledby="pat-cookie-title">
+        <header class="ab-pattern-header">
+          <h2 id="pat-cookie-title">5 · Cookie-style info bar</h2>
+          <span class="ab-pattern-tag">bottom fixed</span>
+        </header>
+        <div class="ab-pattern-body">
+          <div class="ab-demo-frame ab-cookie-frame">
+            <div class="ab-demo-content">Page content above cookie bar</div>
+            <div class="ab-cookie-bar" id="cookie-bar" role="dialog" aria-label="Cookie consent">
+              <span>
+                We use cookies to improve your experience.
+                <a href="#" style="color:#a09af8">Privacy policy</a>
+              </span>
+              <div class="ab-cookie-actions">
+                <button type="button" class="ab-cookie-btn ab-cookie-accept" id="cookie-accept">
+                  Accept
+                </button>
+                <button type="button" class="ab-cookie-btn ab-cookie-decline" id="cookie-decline">
+                  Decline
+                </button>
+              </div>
+            </div>
+          </div>
+          <p class="ab-pattern-note">
+            Bottom-fixed consent bar with slide-up entrance. Extends announce-bar
+            layout patterns for cookie / GDPR notices.
+          </p>
+        </div>
+      </article>
+    </div>
+
+    <!-- Copy snippets -->
+    <section aria-labelledby="snippet-section-title">
+      <header class="ab-pattern-header" style="border:0;padding-left:0">
+        <h2 id="snippet-section-title">Copy-ready snippets</h2>
+      </header>
+
+      <div class="ab-snippet-wrap">
+        <header class="ab-snippet-header">
+          <h3>Sticky promo</h3>
+          <button type="button" class="ab-copy-btn" data-copy="snippet-sticky">Copy</button>
+        </header>
+        <pre class="ab-snippet-code" id="snippet-sticky">&lt;div class="ease-announce-bar is-fixed is-warning" role="banner"&gt;
+  &lt;div class="ease-announce-bar-content"&gt;
+    &lt;strong&gt;Sale:&lt;/strong&gt; 30% off — &lt;a href="#"&gt;Shop now&lt;/a&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</pre>
+      </div>
+
+      <div class="ab-snippet-wrap">
+        <header class="ab-snippet-header">
+          <h3>Dismissible slide-down</h3>
+          <button type="button" class="ab-copy-btn" data-copy="snippet-dismiss">Copy</button>
+        </header>
+        <pre class="ab-snippet-code" id="snippet-dismiss">&lt;input type="checkbox" id="bar-dismiss" class="ease-announce-bar-dismiss" /&gt;
+&lt;div class="ease-announce-bar is-info"&gt;
+  &lt;div class="ease-announce-bar-content"&gt;Your message here&lt;/div&gt;
+  &lt;label for="bar-dismiss" class="ease-announce-bar-close" aria-label="Dismiss"&gt;&times;&lt;/label&gt;
+&lt;/div&gt;</pre>
+      </div>
+
+      <div class="ab-snippet-wrap">
+        <header class="ab-snippet-header">
+          <h3>Rotating messages</h3>
+          <button type="button" class="ab-copy-btn" data-copy="snippet-rotate">Copy</button>
+        </header>
+        <pre class="ab-snippet-code" id="snippet-rotate">&lt;div class="ease-announce-bar is-success" role="status" aria-live="polite"&gt;
+  &lt;div class="ease-announce-bar-content"&gt;
+    &lt;span id="msg"&gt;Message 1&lt;/span&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+&lt;!-- Cycle messages with JS: messages[i++] --&gt;</pre>
+      </div>
+
+      <div class="ab-snippet-wrap">
+        <header class="ab-snippet-header">
+          <h3>Sale countdown</h3>
+          <button type="button" class="ab-copy-btn" data-copy="snippet-countdown">Copy</button>
+        </header>
+        <pre class="ab-snippet-code" id="snippet-countdown">&lt;div class="ease-announce-bar is-danger" role="timer"&gt;
+  &lt;div class="ease-announce-bar-content"&gt;
+    &lt;strong&gt;Sale ends in&lt;/strong&gt; &lt;span id="countdown"&gt;00:00:00&lt;/span&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</pre>
+      </div>
+
+      <div class="ab-snippet-wrap">
+        <header class="ab-snippet-header">
+          <h3>Cookie consent</h3>
+          <button type="button" class="ab-copy-btn" data-copy="snippet-cookie">Copy</button>
+        </header>
+        <pre class="ab-snippet-code" id="snippet-cookie">&lt;div class="ease-announce-bar ab-cookie-bar" role="dialog" aria-label="Cookie consent"&gt;
+  &lt;span&gt;We use cookies. &lt;a href="#"&gt;Learn more&lt;/a&gt;&lt;/span&gt;
+  &lt;button type="button"&gt;Accept&lt;/button&gt;
+  &lt;button type="button"&gt;Decline&lt;/button&gt;
+&lt;/div&gt;</pre>
+      </div>
+    </section>
+
+    <section class="ab-education" aria-labelledby="edu-title">
+      <h2 id="edu-title" class="ease-sr-only">Pattern guidance</h2>
+
+      <article class="ab-edu-card">
+        <h3>Component classes</h3>
+        <ul>
+          <li><code>.ease-announce-bar</code> — base bar with slide-down entrance</li>
+          <li><code>.ease-announce-bar-content</code> — message area</li>
+          <li><code>.ease-announce-bar-close</code> — dismiss label/button</li>
+          <li><code>.is-fixed</code> — sticky top positioning</li>
+        </ul>
+      </article>
+
+      <article class="ab-edu-card">
+        <h3>Variant modifiers</h3>
+        <ul>
+          <li><code>.is-info</code> — primary purple (default)</li>
+          <li><code>.is-success</code> — green confirmations</li>
+          <li><code>.is-warning</code> — amber promos</li>
+          <li><code>.is-danger</code> — red urgency / countdown</li>
+        </ul>
+      </article>
+
+      <article class="ab-edu-card">
+        <h3>Accessibility tips</h3>
+        <ul>
+          <li>Use <code>role="banner"</code> for site-wide promos.</li>
+          <li>Add <code>aria-label="Dismiss"</code> on close controls.</li>
+          <li>Rotating text needs <code>aria-live="polite"</code>.</li>
+          <li>Limit simultaneous bars — one announce strip per viewport.</li>
+        </ul>
+      </article>
+    </section>
+
+    <p class="ab-status" id="copy-status" role="status" aria-live="polite"></p>
+  </main>
+
+  <footer class="ab-footer">
+    <p>
+      Built for EaseMotion CSS ·
+      <code>submissions/examples/ease-announce-bar-patterns-sp</code> ·
+      Resolves Issue #44483
+    </p>
+  </footer>
+
+  <script>
+    (function () {
+      'use strict';
+
+      /* Rotating messages */
+      var messages = [
+        'Free shipping on orders over $50',
+        'New arrivals just dropped — shop the collection',
+        'Join our newsletter for 10% off your first order'
+      ];
+      var msgIndex = 0;
+      var msgEl = document.getElementById('rotate-msg');
+      var dotsEl = document.getElementById('rotate-dots');
+
+      if (msgEl && dotsEl) {
+        messages.forEach(function (_, i) {
+          var dot = document.createElement('button');
+          dot.type = 'button';
+          dot.className = 'ab-rotate-dot' + (i === 0 ? ' is-active' : '');
+          dot.setAttribute('aria-label', 'Message ' + (i + 1));
+          dot.addEventListener('click', function () {
+            msgIndex = i;
+            updateRotate();
+          });
+          dotsEl.appendChild(dot);
+        });
+
+        function updateRotate() {
+          msgEl.textContent = messages[msgIndex];
+          dotsEl.querySelectorAll('.ab-rotate-dot').forEach(function (d, i) {
+            d.classList.toggle('is-active', i === msgIndex);
+          });
+        }
+
+        setInterval(function () {
+          msgIndex = (msgIndex + 1) % messages.length;
+          updateRotate();
+        }, 4000);
+      }
+
+      /* Countdown — 2 hour demo window */
+      var endTime = Date.now() + 2 * 60 * 60 * 1000;
+      var cdH = document.getElementById('cd-h');
+      var cdM = document.getElementById('cd-m');
+      var cdS = document.getElementById('cd-s');
+
+      function pad(n) {
+        return n < 10 ? '0' + n : String(n);
+      }
+
+      function tickCountdown() {
+        var remaining = Math.max(0, endTime - Date.now());
+        var h = Math.floor(remaining / 3600000);
+        var m = Math.floor((remaining % 3600000) / 60000);
+        var s = Math.floor((remaining % 60000) / 1000);
+        if (cdH) cdH.textContent = pad(h);
+        if (cdM) cdM.textContent = pad(m);
+        if (cdS) cdS.textContent = pad(s);
+      }
+
+      tickCountdown();
+      setInterval(tickCountdown, 1000);
+
+      /* Cookie bar */
+      var cookieBar = document.getElementById('cookie-bar');
+      var cookieAccept = document.getElementById('cookie-accept');
+      var cookieDecline = document.getElementById('cookie-decline');
+
+      function hideCookie() {
+        if (cookieBar) cookieBar.classList.add('ab-cookie-hidden');
+      }
+
+      if (cookieAccept) cookieAccept.addEventListener('click', hideCookie);
+      if (cookieDecline) cookieDecline.addEventListener('click', hideCookie);
+
+      /* Copy buttons */
+      document.querySelectorAll('.ab-copy-btn[data-copy]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          var target = document.getElementById(btn.getAttribute('data-copy'));
+          if (!target || !navigator.clipboard) {
+            document.getElementById('copy-status').textContent = 'Clipboard not available.';
+            return;
+          }
+          navigator.clipboard.writeText(target.textContent).then(
+            function () {
+              document.getElementById('copy-status').textContent = 'Snippet copied!';
+            },
+            function () {
+              document.getElementById('copy-status').textContent = 'Copy failed.';
+            }
+          );
+        });
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-announce-bar-patterns-sp/style.css
+++ b/submissions/examples/ease-announce-bar-patterns-sp/style.css
@@ -1,0 +1,421 @@
+/* ============================================================
+   Announce Bar Pattern Library (5 variants) — style.css
+   submissions/examples/ease-announce-bar-patterns-sp
+   ============================================================ */
+
+body {
+  background:
+    radial-gradient(
+      900px 400px at 8% -6%,
+      rgba(108, 99, 255, 0.07),
+      transparent
+    ),
+    radial-gradient(
+      760px 360px at 92% 0%,
+      rgba(245, 158, 11, 0.06),
+      transparent
+    ),
+    var(--ease-color-bg, #f8fafc);
+  min-height: 100vh;
+}
+
+/* ── Header ─────────────────────────────────────────────────── */
+
+.ab-header {
+  max-width: 76rem;
+  margin: 0 auto;
+  padding: var(--ease-space-12, 3rem) var(--ease-space-6, 1.5rem)
+    var(--ease-space-6, 1.5rem);
+  text-align: center;
+}
+
+.ab-eyebrow {
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ease-color-primary-dark, #4b44cc);
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.ab-header h1 {
+  margin-bottom: var(--ease-space-3, 0.75rem);
+}
+
+.ab-subtitle {
+  max-width: 52rem;
+  margin: 0 auto;
+  color: var(--ease-color-muted, #475569);
+}
+
+/* ── Layout ─────────────────────────────────────────────────── */
+
+.ab-main {
+  max-width: 76rem;
+  margin: 0 auto;
+  padding: 0 var(--ease-space-6, 1.5rem) var(--ease-space-12, 3rem);
+}
+
+.ab-pattern-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-space-6, 1.5rem);
+  margin-bottom: var(--ease-space-8, 2rem);
+}
+
+/* ── Pattern cards ──────────────────────────────────────────── */
+
+.ab-pattern-card {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  overflow: hidden;
+  box-shadow: var(--ease-shadow-sm);
+}
+
+.ab-pattern-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ease-space-3, 0.75rem);
+  padding: var(--ease-space-4, 1rem) var(--ease-space-5, 1.25rem);
+  border-bottom: 1px solid var(--ease-color-neutral-100, #f1f5f9);
+}
+
+.ab-pattern-header h2 {
+  font-size: var(--ease-text-lg, 1.125rem);
+  margin: 0;
+}
+
+.ab-pattern-tag {
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.55rem;
+  border-radius: var(--ease-radius-full, 9999px);
+  background: var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.12));
+  color: var(--ease-color-primary-dark, #4b44cc);
+}
+
+.ab-pattern-body {
+  padding: var(--ease-space-5, 1.25rem);
+}
+
+.ab-pattern-note {
+  font-size: var(--ease-text-xs, 0.75rem);
+  color: var(--ease-color-muted, #475569);
+  line-height: 1.55;
+  margin: var(--ease-space-4, 1rem) 0 0;
+}
+
+.ab-pattern-note code {
+  font-family: var(--ease-font-mono, monospace);
+  font-size: 0.68rem;
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  padding: 0.05rem 0.3rem;
+  border-radius: var(--ease-radius-sm, 0.25rem);
+}
+
+/* Demo frame (contains live bar preview) */
+
+.ab-demo-frame {
+  border: 1px dashed var(--ease-color-neutral-300, #cbd5e1);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  background: var(--ease-color-neutral-50, #f8fafc);
+  overflow: hidden;
+  position: relative;
+  min-height: 3.5rem;
+}
+
+.ab-demo-frame.ab-frame-tall {
+  min-height: 6rem;
+}
+
+.ab-demo-content {
+  padding: var(--ease-space-4, 1rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #475569);
+  text-align: center;
+}
+
+/* Sticky promo — simulated viewport */
+
+.ab-viewport-mock {
+  position: relative;
+  border-radius: var(--ease-radius-md, 0.5rem);
+  overflow: hidden;
+  background: var(--ease-color-neutral-100, #f1f5f9);
+}
+
+.ab-viewport-mock .ease-announce-bar.is-fixed {
+  position: absolute;
+}
+
+.ab-mock-page {
+  padding: 3.5rem var(--ease-space-4, 1rem) var(--ease-space-4, 1rem);
+  min-height: 5rem;
+}
+
+/* Rotating messages */
+
+.ab-rotate-msg {
+  display: inline-block;
+  min-width: 14rem;
+}
+
+.ab-rotate-dots {
+  display: inline-flex;
+  gap: 0.35rem;
+  margin-left: 0.5rem;
+}
+
+.ab-rotate-dot {
+  width: 0.4rem;
+  height: 0.4rem;
+  border-radius: var(--ease-radius-full, 9999px);
+  background: rgba(255, 255, 255, 0.4);
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.ab-rotate-dot.is-active {
+  background: #ffffff;
+}
+
+.ab-rotate-dot:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
+}
+
+/* Countdown strip */
+
+.ab-countdown {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-left: 0.5rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.ab-countdown-unit {
+  background: rgba(0, 0, 0, 0.15);
+  padding: 0.15rem 0.4rem;
+  border-radius: var(--ease-radius-sm, 0.25rem);
+  font-size: 0.8rem;
+}
+
+/* Cookie bar — bottom fixed in demo frame */
+
+.ab-cookie-frame {
+  position: relative;
+  min-height: 8rem;
+}
+
+.ab-cookie-frame .ab-cookie-bar {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 2;
+}
+
+.ab-cookie-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: var(--ease-space-3, 0.75rem);
+  padding: var(--ease-space-3, 0.75rem) var(--ease-space-4, 1rem);
+  background: var(--ease-color-neutral-900, #0f172a);
+  color: #ffffff;
+  font-size: var(--ease-text-xs, 0.75rem);
+  animation: ab-kf-slide-up 0.4s ease both;
+}
+
+@keyframes ab-kf-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(100%);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.ab-cookie-actions {
+  display: flex;
+  gap: var(--ease-space-2, 0.5rem);
+}
+
+.ab-cookie-btn {
+  border: none;
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--ease-radius-sm, 0.25rem);
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.ab-cookie-accept {
+  background: var(--ease-color-primary, #6c63ff);
+  color: #ffffff;
+}
+
+.ab-cookie-decline {
+  background: transparent;
+  color: #ffffff;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+}
+
+.ab-cookie-btn:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
+}
+
+.ab-cookie-hidden {
+  display: none;
+}
+
+/* ── Snippets ───────────────────────────────────────────────── */
+
+.ab-snippet-wrap {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  overflow: hidden;
+  box-shadow: var(--ease-shadow-sm);
+  margin-bottom: var(--ease-space-5, 1.25rem);
+}
+
+.ab-snippet-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ease-space-3, 0.75rem);
+  padding: var(--ease-space-4, 1rem) var(--ease-space-5, 1.25rem);
+  border-bottom: 1px solid var(--ease-color-neutral-100, #f1f5f9);
+  background: var(--ease-color-neutral-50, #f8fafc);
+}
+
+.ab-snippet-header h3 {
+  font-size: var(--ease-text-base, 1rem);
+  margin: 0;
+}
+
+.ab-copy-btn {
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  background: var(--ease-color-surface, #ffffff);
+  color: var(--ease-color-primary-dark, #4b44cc);
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 600;
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--ease-radius-sm, 0.25rem);
+  cursor: pointer;
+}
+
+.ab-copy-btn:hover {
+  background: var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.15));
+}
+
+.ab-copy-btn:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+
+.ab-snippet-code {
+  margin: 0;
+  padding: var(--ease-space-4, 1rem) var(--ease-space-5, 1.25rem);
+  font-family: var(--ease-font-mono, monospace);
+  font-size: 0.65rem;
+  line-height: 1.55;
+  color: var(--ease-color-neutral-800, #1e293b);
+  overflow-x: auto;
+  white-space: pre;
+}
+
+.ab-education {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--ease-space-4, 1rem);
+  margin-bottom: var(--ease-space-5, 1.25rem);
+}
+
+.ab-edu-card {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  padding: var(--ease-space-5, 1.25rem);
+  box-shadow: var(--ease-shadow-sm);
+}
+
+.ab-edu-card h3 {
+  font-size: var(--ease-text-sm, 0.875rem);
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.ab-edu-card p,
+.ab-edu-card li {
+  font-size: var(--ease-text-xs, 0.75rem);
+  color: var(--ease-color-muted, #475569);
+  line-height: 1.6;
+}
+
+.ab-edu-card ul {
+  margin: 0;
+  padding-left: var(--ease-space-5, 1.25rem);
+}
+
+.ab-edu-card code {
+  font-family: var(--ease-font-mono, monospace);
+  font-size: 0.68rem;
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  padding: 0.05rem 0.3rem;
+  border-radius: var(--ease-radius-sm, 0.25rem);
+}
+
+.ab-status {
+  text-align: center;
+  min-height: 1.25rem;
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-success-dark, #15803d);
+  font-weight: 600;
+}
+
+.ab-footer {
+  text-align: center;
+  padding: var(--ease-space-8, 2rem) var(--ease-space-6, 1.5rem);
+  border-top: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+}
+
+.ab-footer p {
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #475569);
+  margin: 0;
+}
+
+.ab-footer code {
+  font-family: var(--ease-font-mono, monospace);
+  font-size: var(--ease-text-xs, 0.75rem);
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  padding: 0.1rem 0.35rem;
+  border-radius: var(--ease-radius-sm, 0.25rem);
+}
+
+@media (max-width: 56rem) {
+  .ab-education {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ab-cookie-bar {
+    animation-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
# #44483 issue resolved

## Description
This PR adds an Announce Bar Pattern Library (5 variants) under submissions/examples/ease-announce-bar-patterns-sp/.

## Features

- Sticky promo bar pattern (fixed top announcement)
- Dismissible slide-down bar with close button
- Rotating messages bar (multiple announcements cycling)
- Sale countdown strip pattern
- Cookie-style info / consent bar pattern
- Uses EaseMotion announce-bar component classes (.ease-announce-bar, .ease-announce-bar-content, .ease-announce-bar-close)
- Entrance animations (ease-slide-down, ease-fade-in) where appropriate
- Copy-ready HTML snippet for each of the 5 variants
- Responsive, accessible demo page with keyboard-friendly dismiss controls
