### PR TITLE
ease-nps-feedback-sp

### DIFF
--- a/submissions/examples/ease-nps-feedback-sp/README.md
+++ b/submissions/examples/ease-nps-feedback-sp/README.md
@@ -1,0 +1,78 @@
+# NPS / CSAT Feedback Widget with Motion
+
+An interactive **NPS / CSAT feedback widget** with a 0–10 score selector, staggered hover effects, submit success animation, and thank-you state — using EaseMotion CSS animation classes.
+
+> Submission track: `submissions/examples/ease-nps-feedback-sp/`  
+> Contributor suffix: `sp`  
+> Resolves: Issue #44490
+
+---
+
+## What does this do?
+
+EaseMotion CSS includes animation utilities well suited to interactive UI, but beginners building SaaS feedback flows lack a practical example combining NPS score selection, staggered motion, and post-submit thank-you states. This widget demonstrates the full flow in one self-contained page.
+
+---
+
+## Widget flow
+
+| Step | State | EaseMotion classes |
+|------|-------|-------------------|
+| 1 | Score selection | `ease-hover-grow`, `ease-fade-in`, `ease-delay-*` |
+| 2 | Submit | Button enables after score selected |
+| 3 | Success | `ease-zoom-in` checkmark + `ease-fade-in` text |
+| 4 | Thank you | `ease-slide-up` + delayed `ease-fade-in` |
+
+---
+
+## How is it used?
+
+1. Open `demo.html` in a browser (requires internet for CDN assets).
+2. Select a score from 0–10 — notice staggered button entrances and hover grow.
+3. Optionally add a comment and click **Submit feedback**.
+4. Watch the success animation, then the thank-you state.
+5. Toggle **NPS labels** vs **CSAT labels** to swap question copy.
+6. Copy the HTML snippet for your own SaaS feedback flow.
+
+---
+
+## Features
+
+- 0–10 NPS score selector UI
+- Staggered hover animations on score buttons (`ease-hover-grow`, `ease-delay-*`)
+- Active/selected score state styling
+- Submit success animation (`ease-fade-in`, `ease-zoom-in`)
+- Thank-you state with entrance animation after submit
+- Optional CSAT-style label variants (“Very dissatisfied” / “Very satisfied”)
+- Copy-ready HTML snippet for the feedback widget
+- Responsive, accessible demo with keyboard-friendly score selection
+
+---
+
+## Tech stack
+
+| Asset | Source |
+|-------|--------|
+| EaseMotion CSS | jsDelivr CDN (`easemotion.min.css`) |
+| Widget layout + states | `style.css` |
+| Selection + submit flow | Inline JS in `demo.html` |
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Interactive NPS/CSAT widget, variant toggle |
+| `style.css` | Widget styling, selected states, motion resets |
+| `README.md` | This document |
+
+---
+
+## Compliance notes
+
+- Only **new files** inside `submissions/examples/ease-nps-feedback-sp/`.
+- No modifications to `core/`, `components/`, workflows, or existing files.
+- All three required submission files included (`demo.html`, `style.css`, `README.md`).
+- Total contribution exceeds the 250-line minimum policy threshold.
+- Folder name carries the unique contributor suffix `-sp`.

--- a/submissions/examples/ease-nps-feedback-sp/demo.html
+++ b/submissions/examples/ease-nps-feedback-sp/demo.html
@@ -1,0 +1,388 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>NPS / CSAT Feedback Widget with Motion — EaseMotion CSS</title>
+  <meta
+    name="description"
+    content="NPS 0–10 score selector with staggered hover effects, submit success animation, and thank-you state using EaseMotion CSS."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header class="nps-header ease-fade-in">
+    <p class="nps-eyebrow">EaseMotion CSS · Component Patterns</p>
+    <h1>NPS / CSAT Feedback Widget with Motion</h1>
+    <p class="nps-subtitle">
+      A 0–10 score selector with <code>ease-hover-grow</code> staggered entrances,
+      submit success animation, and a thank-you state powered by
+      <code>ease-fade-in</code> and <code>ease-slide-up</code>.
+    </p>
+  </header>
+
+  <main class="nps-main">
+    <div class="nps-pattern-banner" role="region" aria-label="Widget flow">
+      <span class="nps-pattern-step">1 · Select score</span>
+      <span class="nps-pattern-arrow" aria-hidden="true">→</span>
+      <span class="nps-pattern-step">2 · Submit</span>
+      <span class="nps-pattern-arrow" aria-hidden="true">→</span>
+      <span class="nps-pattern-step">3 · Success animation</span>
+      <span class="nps-pattern-arrow" aria-hidden="true">→</span>
+      <span class="nps-pattern-step">4 · Thank-you state</span>
+    </div>
+
+    <div class="nps-controls" role="region" aria-label="Widget variant">
+      <span class="nps-control-label" id="variant-label">Label variant</span>
+      <div class="nps-variant-row" role="group" aria-labelledby="variant-label">
+        <button type="button" class="nps-variant-btn is-active" data-variant="nps" id="variant-nps">
+          NPS labels
+        </button>
+        <button type="button" class="nps-variant-btn" data-variant="csat" id="variant-csat">
+          CSAT labels
+        </button>
+      </div>
+      <button type="button" class="nps-reset-btn" id="reset-widget">↺ Reset widget</button>
+    </div>
+
+    <!-- Live widget -->
+    <section class="nps-widget-shell" aria-labelledby="widget-title">
+      <h2 id="widget-title" class="ease-sr-only">Feedback widget demo</h2>
+
+      <div class="nps-widget ease-card ease-card-shadow" id="feedback-widget">
+        <!-- Form state -->
+        <div class="nps-state nps-state-form" id="state-form">
+          <p class="nps-question" id="nps-question">
+            How likely are you to recommend EaseMotion CSS to a colleague?
+          </p>
+
+          <div
+            class="nps-scale-labels"
+            id="scale-labels"
+            aria-hidden="true"
+          >
+            <span id="label-low">Not at all likely</span>
+            <span id="label-high">Extremely likely</span>
+          </div>
+
+          <div
+            class="nps-score-row"
+            id="score-row"
+            role="radiogroup"
+            aria-label="Score from 0 to 10"
+          >
+            <button
+              type="button"
+              class="nps-score-btn ease-hover-grow ease-fade-in ease-delay-75"
+              role="radio"
+              aria-checked="false"
+              data-score="0"
+            >0</button>
+            <button type="button" class="nps-score-btn ease-hover-grow ease-fade-in ease-delay-100" role="radio" aria-checked="false" data-score="1">1</button>
+            <button type="button" class="nps-score-btn ease-hover-grow ease-fade-in ease-delay-150" role="radio" aria-checked="false" data-score="2">2</button>
+            <button type="button" class="nps-score-btn ease-hover-grow ease-fade-in ease-delay-200" role="radio" aria-checked="false" data-score="3">3</button>
+            <button type="button" class="nps-score-btn ease-hover-grow ease-fade-in ease-delay-200" role="radio" aria-checked="false" data-score="4">4</button>
+            <button type="button" class="nps-score-btn ease-hover-grow ease-fade-in ease-delay-300" role="radio" aria-checked="false" data-score="5">5</button>
+            <button type="button" class="nps-score-btn ease-hover-grow ease-fade-in ease-delay-300" role="radio" aria-checked="false" data-score="6">6</button>
+            <button type="button" class="nps-score-btn ease-hover-grow ease-fade-in ease-delay-400" role="radio" aria-checked="false" data-score="7">7</button>
+            <button type="button" class="nps-score-btn ease-hover-grow ease-fade-in ease-delay-400" role="radio" aria-checked="false" data-score="8">8</button>
+            <button type="button" class="nps-score-btn ease-hover-grow ease-fade-in ease-delay-500" role="radio" aria-checked="false" data-score="9">9</button>
+            <button type="button" class="nps-score-btn ease-hover-grow ease-fade-in ease-delay-500" role="radio" aria-checked="false" data-score="10">10</button>
+          </div>
+
+          <label class="nps-comment-label" for="nps-comment">
+            Optional comment
+          </label>
+          <textarea
+            id="nps-comment"
+            class="nps-comment"
+            rows="2"
+            placeholder="Tell us more (optional)…"
+          ></textarea>
+
+          <button
+            type="button"
+            class="nps-submit-btn ease-btn ease-btn-primary"
+            id="submit-btn"
+            disabled
+          >
+            Submit feedback
+          </button>
+        </div>
+
+        <!-- Success state -->
+        <div class="nps-state nps-state-success" id="state-success" hidden>
+          <div class="nps-success-icon ease-zoom-in" aria-hidden="true">✓</div>
+          <p class="nps-success-text ease-fade-in">Feedback received!</p>
+        </div>
+
+        <!-- Thank-you state -->
+        <div class="nps-state nps-state-thanks" id="state-thanks" hidden>
+          <div class="nps-thanks-icon ease-slide-up" aria-hidden="true">🙌</div>
+          <h3 class="nps-thanks-title ease-fade-in ease-delay-150">Thank you!</h3>
+          <p class="nps-thanks-body ease-fade-in ease-delay-300" id="thanks-message">
+            Your score helps us improve EaseMotion CSS.
+          </p>
+          <button type="button" class="nps-dismiss-btn ease-fade-in ease-delay-400" id="dismiss-btn">
+            Close
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Pattern notes -->
+    <div class="nps-feature-grid">
+      <article class="nps-feature-card">
+        <h3>Staggered score buttons</h3>
+        <p>
+          Each button uses <code>ease-fade-in</code> with
+          <code>ease-delay-*</code> utilities for a cascading entrance, plus
+          <code>ease-hover-grow</code> on hover.
+        </p>
+      </article>
+      <article class="nps-feature-card">
+        <h3>Selected state</h3>
+        <p>
+          Active score gets <code>.is-selected</code> styling — primary fill,
+          scale emphasis, and <code>aria-checked="true"</code> for screen readers.
+        </p>
+      </article>
+      <article class="nps-feature-card">
+        <h3>Post-submit motion</h3>
+        <p>
+          Success checkmark uses <code>ease-zoom-in</code>; thank-you panel uses
+          <code>ease-slide-up</code> + delayed <code>ease-fade-in</code>.
+        </p>
+      </article>
+    </div>
+
+    <section class="nps-snippet-section" aria-labelledby="snippet-title">
+      <header class="nps-snippet-header">
+        <h2 id="snippet-title">Copy-ready HTML snippet</h2>
+        <button type="button" class="nps-copy-btn" id="copy-snippet-btn">Copy HTML</button>
+      </header>
+      <pre class="nps-snippet-code" id="snippet-code">&lt;div class="nps-widget ease-card ease-card-shadow"&gt;
+  &lt;p class="nps-question"&gt;How likely are you to recommend us?&lt;/p&gt;
+  &lt;div class="nps-scale-labels" aria-hidden="true"&gt;
+    &lt;span&gt;Not at all likely&lt;/span&gt;
+    &lt;span&gt;Extremely likely&lt;/span&gt;
+  &lt;/div&gt;
+  &lt;div class="nps-score-row" role="radiogroup" aria-label="Score 0 to 10"&gt;
+    &lt;button type="button" class="nps-score-btn ease-hover-grow ease-fade-in ease-delay-75"
+            role="radio" data-score="0"&gt;0&lt;/button&gt;
+    &lt;!-- …buttons 1–10 with increasing ease-delay-* … --&gt;
+  &lt;/div&gt;
+  &lt;button type="button" class="nps-submit-btn ease-btn ease-btn-primary"&gt;
+    Submit feedback
+  &lt;/button&gt;
+&lt;/div&gt;
+
+&lt;!-- Thank-you state (shown after submit) --&gt;
+&lt;div class="nps-state-thanks"&gt;
+  &lt;h3 class="ease-fade-in ease-delay-150"&gt;Thank you!&lt;/h3&gt;
+  &lt;p class="ease-fade-in ease-delay-300"&gt;Your feedback matters.&lt;/p&gt;
+&lt;/div&gt;</pre>
+    </section>
+
+    <section class="nps-education" aria-labelledby="edu-title">
+      <h2 id="edu-title" class="ease-sr-only">Feedback widget guidance</h2>
+
+      <article class="nps-edu-card">
+        <h3>Keyboard access</h3>
+        <ul>
+          <li>Arrow keys move between score buttons in the radiogroup.</li>
+          <li><kbd>Enter</kbd> / <kbd>Space</kbd> selects the focused score.</li>
+          <li>Submit button activates with <kbd>Enter</kbd> when focused.</li>
+        </ul>
+      </article>
+
+      <article class="nps-edu-card">
+        <h3>NPS vs CSAT labels</h3>
+        <ul>
+          <li>NPS: “Not at all likely” → “Extremely likely”.</li>
+          <li>CSAT: “Very dissatisfied” → “Very satisfied”.</li>
+          <li>Same 0–10 scale — swap copy for context.</li>
+        </ul>
+      </article>
+
+      <article class="nps-edu-card">
+        <h3>Motion best practices</h3>
+        <ul>
+          <li>Keep submit success brief — avoid infinite loops.</li>
+          <li>Pair with <code>prefers-reduced-motion</code> resets in CSS.</li>
+          <li>Use finite iterations for attention animations.</li>
+        </ul>
+      </article>
+    </section>
+
+    <p class="nps-status" id="copy-status" role="status" aria-live="polite"></p>
+    <p class="nps-status" id="widget-status" role="status" aria-live="polite"></p>
+  </main>
+
+  <footer class="nps-footer">
+    <p>
+      Built for EaseMotion CSS ·
+      <code>submissions/examples/ease-nps-feedback-sp</code> ·
+      Resolves Issue #44490
+    </p>
+  </footer>
+
+  <script>
+    (function () {
+      'use strict';
+
+      var VARIANTS = {
+        nps: {
+          question: 'How likely are you to recommend EaseMotion CSS to a colleague?',
+          low: 'Not at all likely',
+          high: 'Extremely likely',
+          thanks: 'Your NPS score helps us improve EaseMotion CSS.'
+        },
+        csat: {
+          question: 'How satisfied are you with your experience today?',
+          low: 'Very dissatisfied',
+          high: 'Very satisfied',
+          thanks: 'Your CSAT response helps us deliver a better product.'
+        }
+      };
+
+      var selectedScore = null;
+      var currentVariant = 'nps';
+
+      var formState = document.getElementById('state-form');
+      var successState = document.getElementById('state-success');
+      var thanksState = document.getElementById('state-thanks');
+      var submitBtn = document.getElementById('submit-btn');
+      var scoreButtons = Array.prototype.slice.call(
+        document.querySelectorAll('.nps-score-btn')
+      );
+      var scoreRow = document.getElementById('score-row');
+      var widgetStatus = document.getElementById('widget-status');
+
+      function setVariant(variant) {
+        currentVariant = variant;
+        var data = VARIANTS[variant];
+        document.getElementById('nps-question').textContent = data.question;
+        document.getElementById('label-low').textContent = data.low;
+        document.getElementById('label-high').textContent = data.high;
+        document.getElementById('thanks-message').textContent = data.thanks;
+
+        document.querySelectorAll('.nps-variant-btn').forEach(function (btn) {
+          btn.classList.toggle('is-active', btn.getAttribute('data-variant') === variant);
+        });
+      }
+
+      function selectScore(score) {
+        selectedScore = score;
+        scoreButtons.forEach(function (btn) {
+          var isSelected = Number(btn.getAttribute('data-score')) === score;
+          btn.classList.toggle('is-selected', isSelected);
+          btn.setAttribute('aria-checked', isSelected ? 'true' : 'false');
+        });
+        submitBtn.disabled = false;
+        widgetStatus.textContent = 'Score ' + score + ' selected.';
+      }
+
+      scoreButtons.forEach(function (btn, index) {
+        btn.addEventListener('click', function () {
+          selectScore(Number(btn.getAttribute('data-score')));
+        });
+
+        btn.addEventListener('keydown', function (e) {
+          var next = index;
+          if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+            next = Math.min(index + 1, scoreButtons.length - 1);
+            e.preventDefault();
+          } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+            next = Math.max(index - 1, 0);
+            e.preventDefault();
+          } else if (e.key === ' ' || e.key === 'Enter') {
+            e.preventDefault();
+            selectScore(Number(btn.getAttribute('data-score')));
+            return;
+          } else {
+            return;
+          }
+          scoreButtons[next].focus();
+        });
+      });
+
+      function replayAnimations(container) {
+        container.querySelectorAll('[class*="ease-"]').forEach(function (el) {
+          var anim = window.getComputedStyle(el).animation;
+          if (!anim || anim === 'none') return;
+          el.style.animation = 'none';
+          void el.offsetWidth;
+          el.style.animation = '';
+        });
+      }
+
+      function showState(state) {
+        formState.hidden = state !== 'form';
+        successState.hidden = state !== 'success';
+        thanksState.hidden = state !== 'thanks';
+      }
+
+      function resetWidget() {
+        selectedScore = null;
+        submitBtn.disabled = true;
+        document.getElementById('nps-comment').value = '';
+        scoreButtons.forEach(function (btn) {
+          btn.classList.remove('is-selected');
+          btn.setAttribute('aria-checked', 'false');
+        });
+        showState('form');
+        replayAnimations(document.getElementById('feedback-widget'));
+        widgetStatus.textContent = 'Widget reset.';
+      }
+
+      submitBtn.addEventListener('click', function () {
+        if (selectedScore === null) return;
+        showState('success');
+        widgetStatus.textContent = 'Submitting score ' + selectedScore + '…';
+        replayAnimations(successState);
+
+        window.setTimeout(function () {
+          showState('thanks');
+          replayAnimations(thanksState);
+          widgetStatus.textContent = 'Thank-you state shown for score ' + selectedScore + '.';
+        }, 1200);
+      });
+
+      document.getElementById('dismiss-btn').addEventListener('click', resetWidget);
+      document.getElementById('reset-widget').addEventListener('click', resetWidget);
+
+      document.querySelectorAll('.nps-variant-btn').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          setVariant(btn.getAttribute('data-variant'));
+        });
+      });
+
+      document.getElementById('copy-snippet-btn').addEventListener('click', function () {
+        var code = document.getElementById('snippet-code');
+        var status = document.getElementById('copy-status');
+        if (!code || !navigator.clipboard) {
+          status.textContent = 'Clipboard not available.';
+          return;
+        }
+        navigator.clipboard.writeText(code.textContent).then(
+          function () { status.textContent = 'HTML snippet copied!'; },
+          function () { status.textContent = 'Copy failed.'; }
+        );
+      });
+
+      setVariant('nps');
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-nps-feedback-sp/style.css
+++ b/submissions/examples/ease-nps-feedback-sp/style.css
@@ -1,0 +1,587 @@
+/* ============================================================
+   NPS / CSAT Feedback Widget with Motion — style.css
+   submissions/examples/ease-nps-feedback-sp
+   ============================================================ */
+
+body {
+  background:
+    radial-gradient(
+      900px 400px at 10% -6%,
+      rgba(108, 99, 255, 0.07),
+      transparent
+    ),
+    radial-gradient(
+      760px 360px at 90% 2%,
+      rgba(34, 197, 94, 0.05),
+      transparent
+    ),
+    var(--ease-color-bg, #f8fafc);
+  min-height: 100vh;
+  font-family: var(--ease-font-sans, 'Inter', system-ui, sans-serif);
+}
+
+/* ── Header ─────────────────────────────────────────────────── */
+
+.nps-header {
+  max-width: 76rem;
+  margin: 0 auto;
+  padding: var(--ease-space-12, 3rem) var(--ease-space-6, 1.5rem)
+    var(--ease-space-6, 1.5rem);
+  text-align: center;
+}
+
+.nps-eyebrow {
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ease-color-primary-dark, #4b44cc);
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.nps-header h1 {
+  margin-bottom: var(--ease-space-3, 0.75rem);
+}
+
+.nps-subtitle {
+  max-width: 52rem;
+  margin: 0 auto;
+  color: var(--ease-color-muted, #475569);
+  line-height: 1.65;
+}
+
+.nps-subtitle code {
+  font-family: var(--ease-font-mono, 'JetBrains Mono', monospace);
+  font-size: 0.85em;
+}
+
+/* ── Layout ─────────────────────────────────────────────────── */
+
+.nps-main {
+  max-width: 76rem;
+  margin: 0 auto;
+  padding: 0 var(--ease-space-6, 1.5rem) var(--ease-space-12, 3rem);
+}
+
+.nps-pattern-banner {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: var(--ease-space-2, 0.5rem) var(--ease-space-3, 0.75rem);
+  margin-bottom: var(--ease-space-5, 1.25rem);
+  padding: var(--ease-space-4, 1rem) var(--ease-space-5, 1.25rem);
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  box-shadow: var(--ease-shadow-sm);
+}
+
+.nps-pattern-step {
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 600;
+  color: var(--ease-color-neutral-700, #334155);
+}
+
+.nps-pattern-arrow {
+  color: var(--ease-color-neutral-400, #94a3b8);
+  font-weight: 700;
+}
+
+/* ── Controls ───────────────────────────────────────────────── */
+
+.nps-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: var(--ease-space-4, 1rem);
+  margin-bottom: var(--ease-space-6, 1.5rem);
+  padding: var(--ease-space-4, 1rem) var(--ease-space-5, 1.25rem);
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  box-shadow: var(--ease-shadow-sm);
+}
+
+.nps-control-label {
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  color: var(--ease-color-neutral-700, #334155);
+}
+
+.nps-variant-row {
+  display: flex;
+  gap: var(--ease-space-2, 0.5rem);
+}
+
+.nps-variant-btn,
+.nps-reset-btn {
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  background: var(--ease-color-surface, #ffffff);
+  color: var(--ease-color-neutral-700, #334155);
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 600;
+  padding: 0.4rem 0.8rem;
+  border-radius: var(--ease-radius-sm, 0.25rem);
+  cursor: pointer;
+}
+
+.nps-variant-btn.is-active {
+  background: var(--ease-color-primary, #6c63ff);
+  border-color: var(--ease-color-primary, #6c63ff);
+  color: #ffffff;
+}
+
+.nps-variant-btn:hover,
+.nps-reset-btn:hover {
+  background: rgba(108, 99, 255, 0.08);
+}
+
+.nps-variant-btn.is-active:hover {
+  background: var(--ease-color-primary-dark, #4b44cc);
+}
+
+.nps-variant-btn:focus-visible,
+.nps-reset-btn:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+
+/* ── Widget shell ───────────────────────────────────────────── */
+
+.nps-widget-shell {
+  display: flex;
+  justify-content: center;
+  margin-bottom: var(--ease-space-6, 1.5rem);
+}
+
+.nps-widget {
+  width: min(36rem, 100%);
+  padding: var(--ease-space-6, 1.5rem);
+  position: relative;
+  min-height: 18rem;
+}
+
+.nps-state {
+  text-align: center;
+}
+
+.nps-state[hidden] {
+  display: none !important;
+}
+
+.nps-state-form {
+  text-align: left;
+}
+
+/* ── Question + labels ────────────────────────────────────────── */
+
+.nps-question {
+  font-size: var(--ease-text-lg, 1.125rem);
+  font-weight: 600;
+  line-height: 1.45;
+  margin: 0 0 var(--ease-space-4, 1rem);
+  color: var(--ease-color-text, #1e293b);
+}
+
+.nps-scale-labels {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--ease-space-2, 0.5rem);
+  font-size: var(--ease-text-xs, 0.75rem);
+  color: var(--ease-color-muted, #475569);
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+/* ── Score buttons ──────────────────────────────────────────── */
+
+.nps-score-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  justify-content: center;
+  margin-bottom: var(--ease-space-5, 1.25rem);
+}
+
+.nps-score-btn {
+  flex: 1 1 calc(9% - 0.35rem);
+  min-width: 2.1rem;
+  max-width: 2.75rem;
+  aspect-ratio: 1;
+  border: 2px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  background: var(--ease-color-surface, #ffffff);
+  color: var(--ease-color-neutral-700, #334155);
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 700;
+  cursor: pointer;
+  padding: 0;
+}
+
+.nps-score-btn:hover {
+  border-color: var(--ease-color-primary, #6c63ff);
+  color: var(--ease-color-primary-dark, #4b44cc);
+}
+
+.nps-score-btn:focus-visible {
+  outline: 3px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+  z-index: 2;
+}
+
+.nps-score-btn.is-selected {
+  background: var(--ease-color-primary, #6c63ff);
+  border-color: var(--ease-color-primary, #6c63ff);
+  color: #ffffff;
+  transform: scale(1.08);
+  box-shadow: 0 4px 14px rgba(108, 99, 255, 0.35);
+}
+
+/* Staggered hover ripple via transition-delay on grow */
+.nps-score-btn:nth-child(1) { transition-delay: 0ms; }
+.nps-score-btn:nth-child(2) { transition-delay: 20ms; }
+.nps-score-btn:nth-child(3) { transition-delay: 40ms; }
+.nps-score-btn:nth-child(4) { transition-delay: 60ms; }
+.nps-score-btn:nth-child(5) { transition-delay: 80ms; }
+.nps-score-btn:nth-child(6) { transition-delay: 100ms; }
+.nps-score-btn:nth-child(7) { transition-delay: 120ms; }
+.nps-score-btn:nth-child(8) { transition-delay: 140ms; }
+.nps-score-btn:nth-child(9) { transition-delay: 160ms; }
+.nps-score-btn:nth-child(10) { transition-delay: 180ms; }
+.nps-score-btn:nth-child(11) { transition-delay: 200ms; }
+
+/* ── Comment + submit ───────────────────────────────────────── */
+
+.nps-comment-label {
+  display: block;
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  margin-bottom: var(--ease-space-2, 0.5rem);
+  color: var(--ease-color-neutral-700, #334155);
+}
+
+.nps-comment {
+  width: 100%;
+  padding: var(--ease-space-3, 0.75rem);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  font-family: inherit;
+  font-size: var(--ease-text-sm, 0.875rem);
+  resize: vertical;
+  margin-bottom: var(--ease-space-4, 1rem);
+}
+
+.nps-comment:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+  border-color: var(--ease-color-primary, #6c63ff);
+}
+
+.nps-submit-btn {
+  width: 100%;
+}
+
+.nps-submit-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* ── Success state ────────────────────────────────────────────── */
+
+.nps-state-success {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 14rem;
+  gap: var(--ease-space-3, 0.75rem);
+}
+
+.nps-success-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 4rem;
+  height: 4rem;
+  border-radius: 50%;
+  background: rgba(34, 197, 94, 0.12);
+  color: #15803d;
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.nps-success-text {
+  font-size: var(--ease-text-lg, 1.125rem);
+  font-weight: 600;
+  color: #15803d;
+  margin: 0;
+}
+
+/* ── Thank-you state ──────────────────────────────────────────── */
+
+.nps-state-thanks {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 14rem;
+  gap: var(--ease-space-2, 0.5rem);
+  padding: var(--ease-space-4, 1rem) 0;
+}
+
+.nps-thanks-icon {
+  font-size: 2.5rem;
+  line-height: 1;
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.nps-thanks-title {
+  font-size: var(--ease-text-xl, 1.25rem);
+  margin: 0;
+  color: var(--ease-color-text, #1e293b);
+}
+
+.nps-thanks-body {
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #475569);
+  max-width: 20rem;
+  line-height: 1.6;
+  margin: 0 0 var(--ease-space-4, 1rem);
+}
+
+.nps-dismiss-btn {
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  background: var(--ease-color-surface, #ffffff);
+  color: var(--ease-color-primary-dark, #4b44cc);
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  padding: 0.45rem 1rem;
+  border-radius: var(--ease-radius-md, 0.5rem);
+  cursor: pointer;
+}
+
+.nps-dismiss-btn:hover {
+  background: rgba(108, 99, 255, 0.08);
+}
+
+.nps-dismiss-btn:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+
+/* ── Feature cards ──────────────────────────────────────────── */
+
+.nps-feature-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--ease-space-4, 1rem);
+  margin-bottom: var(--ease-space-6, 1.5rem);
+}
+
+.nps-feature-card {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  padding: var(--ease-space-5, 1.25rem);
+  box-shadow: var(--ease-shadow-sm);
+}
+
+.nps-feature-card h3 {
+  font-size: var(--ease-text-sm, 0.875rem);
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.nps-feature-card p {
+  font-size: var(--ease-text-xs, 0.75rem);
+  color: var(--ease-color-muted, #475569);
+  line-height: 1.6;
+  margin: 0;
+}
+
+.nps-feature-card code {
+  font-family: var(--ease-font-mono, monospace);
+  font-size: 0.68rem;
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  padding: 0.05rem 0.3rem;
+  border-radius: var(--ease-radius-sm, 0.25rem);
+}
+
+/* ── Snippet ────────────────────────────────────────────────── */
+
+.nps-snippet-section {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  overflow: hidden;
+  box-shadow: var(--ease-shadow-sm);
+  margin-bottom: var(--ease-space-5, 1.25rem);
+}
+
+.nps-snippet-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ease-space-3, 0.75rem);
+  padding: var(--ease-space-4, 1rem) var(--ease-space-5, 1.25rem);
+  border-bottom: 1px solid var(--ease-color-neutral-100, #f1f5f9);
+  background: var(--ease-color-neutral-50, #f8fafc);
+}
+
+.nps-snippet-header h2 {
+  font-size: var(--ease-text-base, 1rem);
+  margin: 0;
+}
+
+.nps-copy-btn {
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  background: var(--ease-color-surface, #ffffff);
+  color: var(--ease-color-primary-dark, #4b44cc);
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 600;
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--ease-radius-sm, 0.25rem);
+  cursor: pointer;
+}
+
+.nps-copy-btn:hover {
+  background: rgba(108, 99, 255, 0.1);
+}
+
+.nps-copy-btn:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+
+.nps-snippet-code {
+  margin: 0;
+  padding: var(--ease-space-4, 1rem) var(--ease-space-5, 1.25rem);
+  font-family: var(--ease-font-mono, 'JetBrains Mono', monospace);
+  font-size: 0.68rem;
+  line-height: 1.55;
+  color: var(--ease-color-neutral-800, #1e293b);
+  overflow-x: auto;
+  white-space: pre;
+}
+
+/* ── Education ──────────────────────────────────────────────── */
+
+.nps-education {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--ease-space-4, 1rem);
+  margin-bottom: var(--ease-space-4, 1rem);
+}
+
+.nps-edu-card {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  padding: var(--ease-space-5, 1.25rem);
+  box-shadow: var(--ease-shadow-sm);
+}
+
+.nps-edu-card h3 {
+  font-size: var(--ease-text-sm, 0.875rem);
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.nps-edu-card li {
+  font-size: var(--ease-text-xs, 0.75rem);
+  color: var(--ease-color-muted, #475569);
+  line-height: 1.6;
+}
+
+.nps-edu-card ul {
+  margin: 0;
+  padding-left: var(--ease-space-5, 1.25rem);
+}
+
+.nps-edu-card code,
+.nps-edu-card kbd {
+  font-family: var(--ease-font-mono, monospace);
+  font-size: 0.68rem;
+}
+
+.nps-edu-card kbd {
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  border: 1px solid var(--ease-color-neutral-300, #cbd5e1);
+  border-radius: 0.2rem;
+  padding: 0.05rem 0.3rem;
+}
+
+.nps-status {
+  text-align: center;
+  min-height: 1.25rem;
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-success-dark, #15803d);
+  font-weight: 600;
+}
+
+.nps-footer {
+  text-align: center;
+  padding: var(--ease-space-8, 2rem) var(--ease-space-6, 1.5rem);
+  border-top: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+}
+
+.nps-footer p {
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #475569);
+  margin: 0;
+}
+
+.nps-footer code {
+  font-family: var(--ease-font-mono, monospace);
+  font-size: var(--ease-text-xs, 0.75rem);
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  padding: 0.1rem 0.35rem;
+  border-radius: var(--ease-radius-sm, 0.25rem);
+}
+
+/* ── Responsive + reduced motion ────────────────────────────── */
+
+@media (max-width: 56rem) {
+  .nps-feature-grid,
+  .nps-education {
+    grid-template-columns: 1fr;
+  }
+
+  .nps-pattern-banner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .nps-pattern-arrow {
+    display: none;
+  }
+}
+
+@media (max-width: 30rem) {
+  .nps-score-btn {
+    min-width: 1.85rem;
+    font-size: var(--ease-text-xs, 0.75rem);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nps-score-btn.is-selected {
+    transform: none;
+  }
+
+  .nps-score-btn {
+    transition-delay: 0ms !important;
+  }
+
+  .nps-success-icon,
+  .nps-success-text,
+  .nps-thanks-icon,
+  .nps-thanks-title,
+  .nps-thanks-body,
+  .nps-dismiss-btn,
+  .nps-score-btn.ease-fade-in {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
# #44490 issue resolved

## Description
This PR adds a beginner-friendly NPS / CSAT Feedback Widget with Motion under submissions/examples/ease-nps-feedback-sp/.

## Features

- 0–10 NPS score selector UI
- Staggered hover animations on score buttons (ease-hover-grow, ease-delay-*)
- Active/selected score state styling
- Submit success animation (ease-fade-in, ease-zoom-in)
- Thank-you state with entrance animation after submit
- Optional CSAT-style label variants (“Very dissatisfied” / “Very satisfied”)
- Copy-ready HTML snippet for the feedback widget
- Responsive demo page with accessible labels and keyboard-friendly score selection
