### PR TITLE
ease-ios-viewport-jump-sp

### DIFF
--- a/submissions/docs/ease-ios-viewport-jump-sp/README.md
+++ b/submissions/docs/ease-ios-viewport-jump-sp/README.md
@@ -1,0 +1,89 @@
+# iOS Safari 100vh + Fixed Navbar Jump with Entrance Animations
+
+A documentation showcase that reproduces and explains the **iOS Safari viewport jump** when `ease-fade-in` hero sections use `100vh` with fixed navbars — plus tested workaround patterns.
+
+> Submission track: `submissions/docs/ease-ios-viewport-jump-sp/`  
+> Contributor suffix: `sp`  
+> Resolves: Issue #44493
+
+---
+
+## What does this do?
+
+EaseMotion hero entrances like `ease-fade-in` combined with `100vh` layouts and fixed navbars can cause visible layout jumps on iOS Safari when browser chrome shows or hides. This guide documents the root cause (dynamic viewport behavior) and provides iOS-safe CSS patterns.
+
+---
+
+## Demos included
+
+| Panel | Pattern | Behavior |
+|-------|---------|----------|
+| Broken | `min-height: 100%` (≈ `100vh`) | Hero grows when URL bar hides — content jumps |
+| Fixed | `100svh` + `safe-area-inset` | Hero height stays stable — no jump |
+
+---
+
+## How is it used?
+
+1. Open `demo.html` in a browser (test on real iOS Safari for full accuracy).
+2. Click **Toggle Safari chrome** to simulate URL bar hide/show.
+3. Compare broken vs fixed phone mockups side by side.
+4. Try **Landscape** orientation and **Replay ease-fade-in**.
+5. Copy the iOS-safe hero CSS snippet.
+
+---
+
+## Features
+
+- Reproducible demo of 100vh jump with fixed navbar + `ease-fade-in` hero
+- Side-by-side comparison (Broken vs Fixed layout)
+- Workaround patterns: `100dvh`, `100svh`, `-webkit-fill-available`, safe-area insets
+- Fixed navbar positioning fixes for iOS Safari
+- Educational notes on dynamic viewport units vs static `100vh`
+- Mobile viewport simulation panel with resize/orientation toggle
+- Copy-ready CSS snippets for iOS-safe hero + entrance animation combos
+- Responsive demo page with accessible labels and readable contrast
+
+---
+
+## Tech stack
+
+| Asset | Source |
+|-------|--------|
+| EaseMotion CSS | jsDelivr CDN (`easemotion.min.css`) |
+| Phone mockups + workarounds | `style.css` |
+| Chrome/orientation simulation | Inline JS in `demo.html` |
+
+---
+
+## Key workarounds
+
+```css
+.ios-safe-hero {
+  min-height: 100svh;
+  min-height: 100dvh;
+  padding-top: calc(3rem + env(safe-area-inset-top, 0px));
+}
+```
+
+Include `viewport-fit=cover` in the viewport meta tag for `env(safe-area-inset-*)` to work.
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Side-by-side mockups, controls, copy snippet |
+| `style.css` | Broken vs fixed layouts, phone chrome simulation |
+| `README.md` | This document |
+
+---
+
+## Compliance notes
+
+- Only **new files** inside `submissions/docs/ease-ios-viewport-jump-sp/`.
+- No modifications to `core/`, `components/`, workflows, or existing files.
+- All three required submission files included (`demo.html`, `style.css`, `README.md`).
+- Total contribution exceeds the 250-line minimum policy threshold.
+- Folder name carries the unique contributor suffix `-sp`.

--- a/submissions/docs/ease-ios-viewport-jump-sp/demo.html
+++ b/submissions/docs/ease-ios-viewport-jump-sp/demo.html
@@ -1,0 +1,312 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+  />
+  <title>iOS Safari 100vh + Fixed Navbar Jump — EaseMotion CSS</title>
+  <meta
+    name="description"
+    content="Document the iOS Safari 100vh viewport jump with ease-fade-in heroes and fixed navbars — plus tested workarounds."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header class="ios-header ease-fade-in">
+    <p class="ios-eyebrow">EaseMotion CSS · Mobile Safari Guide</p>
+    <h1>iOS Safari 100vh + Fixed Navbar Jump</h1>
+    <p class="ios-subtitle">
+      <code>ease-fade-in</code> hero sections with <code>100vh</code> and fixed
+      navbars can jump when Safari's browser chrome shows or hides. Compare broken
+      vs fixed layouts and copy iOS-safe CSS snippets.
+    </p>
+  </header>
+
+  <main class="ios-main">
+    <div class="ios-controls" role="region" aria-label="Simulation controls">
+      <button type="button" class="ios-ctrl-btn ios-ctrl-primary" id="toggle-chrome-btn">
+        Toggle Safari chrome (URL bar)
+      </button>
+      <button type="button" class="ios-ctrl-btn" id="toggle-orient-btn">
+        Toggle orientation
+      </button>
+      <button type="button" class="ios-ctrl-btn" id="replay-btn">
+        ↺ Replay ease-fade-in
+      </button>
+      <span class="ios-chrome-state" id="chrome-state" aria-live="polite">
+        Chrome visible
+      </span>
+    </div>
+
+    <p class="ios-sim-note">
+      Desktop simulation: collapsing the URL bar expands the layout viewport —
+      mirroring how <code>100vh</code> recalculates on real iOS Safari. Test on a
+      physical iPhone for full accuracy.
+    </p>
+
+    <div class="ios-compare-grid">
+      <!-- Broken -->
+      <article class="ios-device-wrap ios-broken" aria-labelledby="broken-title">
+        <header class="ios-device-header">
+          <h2 id="broken-title">⚠ Broken · <code>100vh</code></h2>
+          <span class="ios-device-tag ios-tag-bad">Layout jump</span>
+        </header>
+        <div class="ios-device ios-device-portrait" id="device-broken">
+          <div class="ios-status-bar" aria-hidden="true">
+            <span>9:41</span>
+            <span>●●●</span>
+          </div>
+          <div class="ios-url-bar" id="url-bar-broken" aria-hidden="true">
+            easemotion.dev
+          </div>
+          <div class="ios-viewport" id="viewport-broken">
+            <nav class="ios-nav ios-nav-broken" aria-label="Fixed navbar broken">
+              <span class="ios-nav-logo">Ease</span>
+              <span class="ios-nav-links">Menu</span>
+            </nav>
+            <section class="ios-hero ios-hero-broken ease-fade-in" id="hero-broken">
+              <h3>Hero · 100vh</h3>
+              <p>Height tracks layout viewport — jumps when chrome hides.</p>
+            </section>
+            <section class="ios-content">
+              <p>Content below the hero shifts when the hero resizes.</p>
+            </section>
+          </div>
+          <div class="ios-home-indicator" aria-hidden="true"></div>
+        </div>
+        <p class="ios-device-note">
+          <code>min-height: 100%</code> of layout viewport ≈ classic
+          <code>100vh</code> bug on iOS.
+        </p>
+      </article>
+
+      <!-- Fixed -->
+      <article class="ios-device-wrap ios-fixed" aria-labelledby="fixed-title">
+        <header class="ios-device-header">
+          <h2 id="fixed-title">✓ Fixed · <code>100svh</code> + safe-area</h2>
+          <span class="ios-device-tag ios-tag-good">Stable</span>
+        </header>
+        <div class="ios-device ios-device-portrait" id="device-fixed">
+          <div class="ios-status-bar" aria-hidden="true">
+            <span>9:41</span>
+            <span>●●●</span>
+          </div>
+          <div class="ios-url-bar" id="url-bar-fixed" aria-hidden="true">
+            easemotion.dev
+          </div>
+          <div class="ios-viewport" id="viewport-fixed">
+            <nav class="ios-nav ios-nav-fixed" aria-label="Fixed navbar safe">
+              <span class="ios-nav-logo">Ease</span>
+              <span class="ios-nav-links">Menu</span>
+            </nav>
+            <section class="ios-hero ios-hero-fixed ease-fade-in" id="hero-fixed">
+              <h3>Hero · 100svh</h3>
+              <p>Small viewport height stays stable when chrome toggles.</p>
+            </section>
+            <section class="ios-content">
+              <p>Content position stays put — no jump on chrome hide.</p>
+            </section>
+          </div>
+          <div class="ios-home-indicator" aria-hidden="true"></div>
+        </div>
+        <p class="ios-device-note">
+          Uses <code>100svh</code>, <code>100dvh</code> fallback, and
+          <code>env(safe-area-inset-top)</code> on the navbar.
+        </p>
+      </article>
+    </div>
+
+    <section class="ios-workarounds" aria-labelledby="workaround-title">
+      <h2 id="workaround-title">Workaround patterns</h2>
+      <div class="ios-workaround-grid">
+        <article class="ios-wa-card">
+          <h3><code>100svh</code></h3>
+          <p>Small viewport — stable when browser chrome appears/disappears. Best for full-screen heroes.</p>
+        </article>
+        <article class="ios-wa-card">
+          <h3><code>100dvh</code></h3>
+          <p>Dynamic viewport — tracks visible area. Use when you want chrome-aware sizing intentionally.</p>
+        </article>
+        <article class="ios-wa-card">
+          <h3><code>-webkit-fill-available</code></h3>
+          <p>Legacy iOS fallback when dynamic viewport units are unavailable.</p>
+        </article>
+        <article class="ios-wa-card">
+          <h3><code>env(safe-area-inset-*)</code></h3>
+          <p>Pad fixed navbars for notch / home indicator with <code>viewport-fit=cover</code>.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="ios-snippet-section" aria-labelledby="snippet-title">
+      <header class="ios-snippet-header">
+        <h2 id="snippet-title">Copy-ready iOS-safe hero CSS</h2>
+        <button type="button" class="ios-copy-btn" id="copy-snippet-btn">Copy CSS</button>
+      </header>
+      <pre class="ios-snippet-code" id="snippet-code">/* viewport-fit=cover required in &lt;meta name="viewport"&gt; */
+:root {
+  --ios-nav-h: 3rem;
+}
+
+.ios-safe-nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 50;
+  padding-top: env(safe-area-inset-top, 0px);
+  height: calc(var(--ios-nav-h) + env(safe-area-inset-top, 0px));
+  background: var(--ease-color-surface, #fff);
+}
+
+.ios-safe-hero {
+  /* Stable hero — no 100vh jump on iOS Safari */
+  min-height: 100svh;
+  min-height: 100dvh;
+  padding-top: calc(var(--ios-nav-h) + env(safe-area-inset-top, 0px));
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+@supports (-webkit-touch-callout: none) {
+  .ios-safe-hero {
+    min-height: -webkit-fill-available;
+  }
+}
+
+@supports not (height: 100svh) {
+  .ios-safe-hero {
+    min-height: 100vh;
+  }
+}
+
+/* Pair with EaseMotion entrance */
+.ios-safe-hero.ease-fade-in {
+  animation: ease-kf-fade-in var(--ease-speed-medium) var(--ease-ease) both;
+}</pre>
+    </section>
+
+    <section class="ios-education" aria-labelledby="edu-title">
+      <h2 id="edu-title" class="ease-sr-only">Viewport guidance</h2>
+      <article class="ios-edu-card">
+        <h3>Why it jumps</h3>
+        <ul>
+          <li>iOS Safari's <code>100vh</code> includes hidden browser chrome area.</li>
+          <li>When the URL bar collapses, layout viewport grows.</li>
+          <li>Fixed nav + tall hero = visible content shift.</li>
+        </ul>
+      </article>
+      <article class="ios-edu-card">
+        <h3>Not the animation</h3>
+        <ul>
+          <li><code>ease-fade-in</code> draws attention to the jump but isn't the cause.</li>
+          <li>Opacity/transform animations don't change layout height.</li>
+          <li>Fix the viewport units first, then add motion.</li>
+        </ul>
+      </article>
+      <article class="ios-edu-card">
+        <h3>Testing checklist</h3>
+        <ul>
+          <li>Test on real iPhone Safari — simulators miss chrome behavior.</li>
+          <li>Scroll to collapse URL bar; rotate portrait ↔ landscape.</li>
+          <li>Verify fixed navbar doesn't overlap notch content.</li>
+        </ul>
+      </article>
+    </section>
+
+    <p class="ios-status" id="copy-status" role="status" aria-live="polite"></p>
+  </main>
+
+  <footer class="ios-footer">
+    <p>
+      Built for EaseMotion CSS ·
+      <code>submissions/docs/ease-ios-viewport-jump-sp</code> ·
+      Resolves Issue #44493
+    </p>
+  </footer>
+
+  <script>
+    (function () {
+      'use strict';
+
+      var chromeVisible = true;
+      var isLandscape = false;
+
+      var toggleChromeBtn = document.getElementById('toggle-chrome-btn');
+      var toggleOrientBtn = document.getElementById('toggle-orient-btn');
+      var replayBtn = document.getElementById('replay-btn');
+      var chromeState = document.getElementById('chrome-state');
+
+      function setChrome(visible) {
+        chromeVisible = visible;
+        document.querySelectorAll('.ios-url-bar').forEach(function (bar) {
+          bar.classList.toggle('is-hidden', !visible);
+        });
+        document.querySelectorAll('.ios-viewport').forEach(function (vp) {
+          vp.classList.toggle('is-expanded', !visible);
+        });
+        chromeState.textContent = visible ? 'Chrome visible' : 'Chrome hidden — watch broken hero jump';
+      }
+
+      function setOrientation(landscape) {
+        isLandscape = landscape;
+        document.querySelectorAll('.ios-device').forEach(function (dev) {
+          dev.classList.toggle('ios-device-landscape', landscape);
+          dev.classList.toggle('ios-device-portrait', !landscape);
+        });
+        toggleOrientBtn.textContent = landscape ? 'Portrait' : 'Landscape';
+      }
+
+      function replayAnimations() {
+        ['hero-broken', 'hero-fixed'].forEach(function (id) {
+          var el = document.getElementById(id);
+          if (!el) return;
+          el.classList.remove('ease-fade-in');
+          void el.offsetWidth;
+          el.classList.add('ease-fade-in');
+        });
+      }
+
+      toggleChromeBtn.addEventListener('click', function () {
+        setChrome(!chromeVisible);
+      });
+
+      toggleOrientBtn.addEventListener('click', function () {
+        setOrientation(!isLandscape);
+      });
+
+      replayBtn.addEventListener('click', replayAnimations);
+
+      document.getElementById('copy-snippet-btn').addEventListener('click', function () {
+        var code = document.getElementById('snippet-code');
+        if (!code || !navigator.clipboard) {
+          document.getElementById('copy-status').textContent = 'Clipboard not available.';
+          return;
+        }
+        navigator.clipboard.writeText(code.textContent).then(
+          function () {
+            document.getElementById('copy-status').textContent = 'CSS snippet copied!';
+          },
+          function () {
+            document.getElementById('copy-status').textContent = 'Copy failed.';
+          }
+        );
+      });
+
+      setChrome(true);
+      setOrientation(false);
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-ios-viewport-jump-sp/style.css
+++ b/submissions/docs/ease-ios-viewport-jump-sp/style.css
@@ -1,0 +1,581 @@
+/* ============================================================
+   iOS Safari 100vh + Fixed Navbar Jump — style.css
+   submissions/docs/ease-ios-viewport-jump-sp
+   ============================================================ */
+
+body {
+  background:
+    radial-gradient(
+      900px 400px at 10% -6%,
+      rgba(59, 130, 246, 0.06),
+      transparent
+    ),
+    radial-gradient(
+      760px 360px at 90% 0%,
+      rgba(108, 99, 255, 0.05),
+      transparent
+    ),
+    var(--ease-color-bg, #f8fafc);
+  min-height: 100vh;
+  font-family: var(--ease-font-sans, 'Inter', system-ui, sans-serif);
+}
+
+/* ── Header ─────────────────────────────────────────────────── */
+
+.ios-header {
+  max-width: 76rem;
+  margin: 0 auto;
+  padding: var(--ease-space-12, 3rem) var(--ease-space-6, 1.5rem)
+    var(--ease-space-6, 1.5rem);
+  text-align: center;
+}
+
+.ios-eyebrow {
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #2563eb;
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.ios-header h1 {
+  margin-bottom: var(--ease-space-3, 0.75rem);
+}
+
+.ios-subtitle {
+  max-width: 52rem;
+  margin: 0 auto;
+  color: var(--ease-color-muted, #475569);
+  line-height: 1.65;
+}
+
+.ios-subtitle code {
+  font-family: var(--ease-font-mono, 'JetBrains Mono', monospace);
+  font-size: 0.85em;
+}
+
+/* ── Main ───────────────────────────────────────────────────── */
+
+.ios-main {
+  max-width: 76rem;
+  margin: 0 auto;
+  padding: 0 var(--ease-space-6, 1.5rem) var(--ease-space-12, 3rem);
+}
+
+.ios-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: var(--ease-space-3, 0.75rem);
+  margin-bottom: var(--ease-space-4, 1rem);
+  padding: var(--ease-space-4, 1rem) var(--ease-space-5, 1.25rem);
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  box-shadow: var(--ease-shadow-sm);
+}
+
+.ios-ctrl-btn {
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  background: var(--ease-color-surface, #ffffff);
+  color: var(--ease-color-neutral-700, #334155);
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 600;
+  padding: 0.45rem 0.85rem;
+  border-radius: var(--ease-radius-sm, 0.25rem);
+  cursor: pointer;
+}
+
+.ios-ctrl-primary {
+  background: var(--ease-color-primary, #6c63ff);
+  border-color: var(--ease-color-primary, #6c63ff);
+  color: #ffffff;
+}
+
+.ios-ctrl-btn:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+
+.ios-chrome-state {
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 600;
+  color: var(--ease-color-muted, #475569);
+  padding: 0.35rem 0.65rem;
+  background: var(--ease-color-neutral-50, #f8fafc);
+  border-radius: var(--ease-radius-full, 9999px);
+}
+
+.ios-sim-note {
+  text-align: center;
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #475569);
+  margin: 0 0 var(--ease-space-6, 1.5rem);
+  max-width: 44rem;
+  margin-left: auto;
+  margin-right: auto;
+  line-height: 1.55;
+}
+
+.ios-sim-note code {
+  font-family: var(--ease-font-mono, monospace);
+  font-size: 0.85em;
+}
+
+/* ── Compare grid ───────────────────────────────────────────── */
+
+.ios-compare-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--ease-space-5, 1.25rem);
+  margin-bottom: var(--ease-space-6, 1.5rem);
+}
+
+.ios-device-wrap {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  padding: var(--ease-space-4, 1rem);
+  box-shadow: var(--ease-shadow-sm);
+}
+
+.ios-device-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ease-space-2, 0.5rem);
+  margin-bottom: var(--ease-space-3, 0.75rem);
+}
+
+.ios-device-header h2 {
+  font-size: var(--ease-text-sm, 0.875rem);
+  margin: 0;
+}
+
+.ios-device-header code {
+  font-family: var(--ease-font-mono, monospace);
+  font-size: 0.9em;
+}
+
+.ios-device-tag {
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 700;
+  padding: 0.2rem 0.5rem;
+  border-radius: var(--ease-radius-full, 9999px);
+}
+
+.ios-tag-bad {
+  background: rgba(239, 68, 68, 0.1);
+  color: #b91c1c;
+}
+
+.ios-tag-good {
+  background: rgba(34, 197, 94, 0.12);
+  color: #15803d;
+}
+
+.ios-device-note {
+  font-size: var(--ease-text-xs, 0.75rem);
+  color: var(--ease-color-muted, #475569);
+  margin: var(--ease-space-3, 0.75rem) 0 0;
+  line-height: 1.5;
+}
+
+.ios-device-note code {
+  font-family: var(--ease-font-mono, monospace);
+  font-size: 0.9em;
+}
+
+/* ── Phone mockup ───────────────────────────────────────────── */
+
+.ios-device {
+  --ios-vp-h: 22rem;
+  --ios-vp-expanded: 25rem;
+  --ios-hero-svh: 22rem;
+
+  margin: 0 auto;
+  max-width: 16rem;
+  border-radius: 1.75rem;
+  border: 3px solid #1e293b;
+  background: #0f172a;
+  overflow: hidden;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.2);
+  transition:
+    max-width 0.4s ease,
+    border-radius 0.4s ease;
+}
+
+.ios-device-landscape {
+  max-width: 24rem;
+  border-radius: 1.25rem;
+}
+
+.ios-status-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.35rem 0.85rem 0.2rem;
+  font-size: 0.6rem;
+  font-weight: 600;
+  color: #ffffff;
+  background: #0f172a;
+}
+
+.ios-url-bar {
+  margin: 0 0.5rem 0.35rem;
+  padding: 0.3rem 0.5rem;
+  background: #334155;
+  border-radius: 0.4rem;
+  font-size: 0.58rem;
+  color: #e2e8f0;
+  text-align: center;
+  transition:
+    opacity 0.3s ease,
+    max-height 0.35s ease,
+    margin 0.35s ease,
+    padding 0.35s ease;
+  max-height: 2rem;
+  overflow: hidden;
+}
+
+.ios-url-bar.is-hidden {
+  opacity: 0;
+  max-height: 0;
+  margin-bottom: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.ios-viewport {
+  height: var(--ios-vp-h);
+  overflow-y: auto;
+  overflow-x: hidden;
+  background: #f8fafc;
+  transition: height 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  -webkit-overflow-scrolling: touch;
+}
+
+.ios-viewport.is-expanded {
+  height: var(--ios-vp-expanded);
+}
+
+.ios-home-indicator {
+  height: 0.85rem;
+  background: #0f172a;
+  position: relative;
+}
+
+.ios-home-indicator::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 4rem;
+  height: 0.2rem;
+  background: #64748b;
+  border-radius: 9999px;
+}
+
+/* ── Nav + hero ─────────────────────────────────────────────── */
+
+.ios-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.75rem;
+  background: rgba(255, 255, 255, 0.95);
+  border-bottom: 1px solid #e2e8f0;
+  font-size: 0.7rem;
+  font-weight: 600;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  backdrop-filter: blur(6px);
+}
+
+.ios-nav-broken {
+  /* Simulates fixed nav without safe-area — can feel cramped on notch devices */
+  padding-top: 0.5rem;
+}
+
+.ios-nav-fixed {
+  padding-top: max(0.5rem, env(safe-area-inset-top, 0.5rem));
+  padding-left: max(0.75rem, env(safe-area-inset-left, 0px));
+  padding-right: max(0.75rem, env(safe-area-inset-right, 0px));
+}
+
+.ios-nav-logo {
+  color: var(--ease-color-primary, #6c63ff);
+}
+
+.ios-nav-links {
+  color: #64748b;
+}
+
+.ios-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 1rem;
+  transition: min-height 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.ios-hero h3 {
+  font-size: 0.85rem;
+  margin: 0 0 0.35rem;
+  color: #1e293b;
+}
+
+.ios-hero p {
+  font-size: 0.62rem;
+  color: #64748b;
+  margin: 0;
+  line-height: 1.45;
+  max-width: 11rem;
+}
+
+/* Broken: grows with viewport = jump */
+.ios-hero-broken {
+  min-height: 100%;
+  background: linear-gradient(160deg, rgba(108, 99, 255, 0.12), rgba(59, 130, 246, 0.08));
+  border-bottom: 2px solid rgba(239, 68, 68, 0.25);
+}
+
+.ios-broken .ios-viewport.is-expanded .ios-hero-broken {
+  box-shadow: inset 0 -4px 0 rgba(239, 68, 68, 0.35);
+}
+
+/* Fixed: stable small viewport height */
+.ios-hero-fixed {
+  min-height: var(--ios-hero-svh);
+  background: linear-gradient(160deg, rgba(34, 197, 94, 0.1), rgba(108, 99, 255, 0.08));
+  border-bottom: 2px solid rgba(34, 197, 94, 0.3);
+  padding-bottom: max(0.5rem, env(safe-area-inset-bottom, 0px));
+}
+
+.ios-content {
+  padding: 0.75rem;
+  font-size: 0.62rem;
+  color: #475569;
+  line-height: 1.5;
+  min-height: 4rem;
+  background: #ffffff;
+}
+
+.ios-content p {
+  margin: 0;
+}
+
+/* Landscape adjustments */
+.ios-device-landscape {
+  --ios-vp-h: 14rem;
+  --ios-vp-expanded: 16rem;
+  --ios-hero-svh: 14rem;
+}
+
+/* ── Workarounds ──────────────────────────────────────────────── */
+
+.ios-workarounds {
+  margin-bottom: var(--ease-space-6, 1.5rem);
+}
+
+.ios-workarounds h2 {
+  font-size: var(--ease-text-lg, 1.125rem);
+  margin: 0 0 var(--ease-space-4, 1rem);
+  text-align: center;
+}
+
+.ios-workaround-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--ease-space-4, 1rem);
+}
+
+.ios-wa-card {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  padding: var(--ease-space-4, 1rem);
+  box-shadow: var(--ease-shadow-sm);
+}
+
+.ios-wa-card h3 {
+  font-size: var(--ease-text-sm, 0.875rem);
+  margin: 0 0 var(--ease-space-2, 0.5rem);
+}
+
+.ios-wa-card h3 code {
+  font-family: var(--ease-font-mono, monospace);
+}
+
+.ios-wa-card p {
+  font-size: var(--ease-text-xs, 0.75rem);
+  color: var(--ease-color-muted, #475569);
+  line-height: 1.55;
+  margin: 0;
+}
+
+/* ── Snippet ────────────────────────────────────────────────── */
+
+.ios-snippet-section {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  overflow: hidden;
+  box-shadow: var(--ease-shadow-sm);
+  margin-bottom: var(--ease-space-5, 1.25rem);
+}
+
+.ios-snippet-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ease-space-3, 0.75rem);
+  padding: var(--ease-space-4, 1rem) var(--ease-space-5, 1.25rem);
+  border-bottom: 1px solid var(--ease-color-neutral-100, #f1f5f9);
+  background: var(--ease-color-neutral-50, #f8fafc);
+}
+
+.ios-snippet-header h2 {
+  font-size: var(--ease-text-base, 1rem);
+  margin: 0;
+}
+
+.ios-copy-btn {
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  background: var(--ease-color-surface, #ffffff);
+  color: var(--ease-color-primary-dark, #4b44cc);
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 600;
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--ease-radius-sm, 0.25rem);
+  cursor: pointer;
+}
+
+.ios-copy-btn:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+
+.ios-snippet-code {
+  margin: 0;
+  padding: var(--ease-space-4, 1rem) var(--ease-space-5, 1.25rem);
+  font-family: var(--ease-font-mono, 'JetBrains Mono', monospace);
+  font-size: 0.65rem;
+  line-height: 1.55;
+  color: var(--ease-color-neutral-800, #1e293b);
+  overflow-x: auto;
+  white-space: pre;
+}
+
+/* ── Education ──────────────────────────────────────────────── */
+
+.ios-education {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--ease-space-4, 1rem);
+  margin-bottom: var(--ease-space-4, 1rem);
+}
+
+.ios-edu-card {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  padding: var(--ease-space-5, 1.25rem);
+  box-shadow: var(--ease-shadow-sm);
+}
+
+.ios-edu-card h3 {
+  font-size: var(--ease-text-sm, 0.875rem);
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.ios-edu-card li {
+  font-size: var(--ease-text-xs, 0.75rem);
+  color: var(--ease-color-muted, #475569);
+  line-height: 1.6;
+}
+
+.ios-edu-card ul {
+  margin: 0;
+  padding-left: var(--ease-space-5, 1.25rem);
+}
+
+.ios-edu-card code {
+  font-family: var(--ease-font-mono, monospace);
+  font-size: 0.68rem;
+}
+
+.ios-status {
+  text-align: center;
+  min-height: 1.25rem;
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-success-dark, #15803d);
+  font-weight: 600;
+}
+
+.ios-footer {
+  text-align: center;
+  padding: var(--ease-space-8, 2rem) var(--ease-space-6, 1.5rem);
+  border-top: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+}
+
+.ios-footer p {
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #475569);
+  margin: 0;
+}
+
+.ios-footer code {
+  font-family: var(--ease-font-mono, monospace);
+  font-size: var(--ease-text-xs, 0.75rem);
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  padding: 0.1rem 0.35rem;
+  border-radius: var(--ease-radius-sm, 0.25rem);
+}
+
+/* ── Responsive ─────────────────────────────────────────────── */
+
+@media (max-width: 56rem) {
+  .ios-compare-grid,
+  .ios-workaround-grid,
+  .ios-education {
+    grid-template-columns: 1fr;
+  }
+
+  .ios-workaround-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 30rem) {
+  .ios-workaround-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .ios-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ios-viewport,
+  .ios-hero,
+  .ios-url-bar,
+  .ios-device {
+    transition: none !important;
+  }
+
+  .ios-hero.ease-fade-in {
+    animation: none !important;
+    opacity: 1 !important;
+  }
+}


### PR DESCRIPTION
# #44510 issue resolved

## Description
This PR adds a comprehensive documentation showcase for the iOS Safari 100vh + Fixed Navbar Jump with Entrance Animations bug under submissions/docs/ease-ios-viewport-jump-sp/.

## Features

- Reproducible demo of 100vh jump with fixed navbar + ease-fade-in hero
- Side-by-side comparison (Broken vs Fixed layout)
- Workaround patterns: 100dvh, 100svh, -webkit-fill-available, safe-area insets
- Fixed navbar positioning fixes for iOS Safari
- Educational notes on dynamic viewport units vs static 100vh
- Mobile viewport simulation panel with resize/orientation toggle
- Copy-ready CSS snippets for iOS-safe hero + entrance animation combos
- Responsive demo page (test on real iOS Safari recommended)
- Accessible labels and readable contrast