### PR TITLE
ease-ios-viewport-jump-sp

### DIFF
--- a/submissions/docs/ease-gssoc-claim-simulator-sp/README.md
+++ b/submissions/docs/ease-gssoc-claim-simulator-sp/README.md
@@ -1,0 +1,56 @@
+# GSSoC Issue Claim & Cooldown Simulator
+
+An interactive documentation tool that lets contributors **practice this repository's GSSoC workflow** before participating — claim limits, 24-hour inactivity cooldown, valid labels, and the pre-PR spam checklist.
+
+> Submission track: `submissions/docs/ease-gssoc-claim-simulator-sp/`  
+> Contributor suffix: `sp`  
+> Resolves: Issue #44491
+
+---
+
+## What does this do?
+
+Beginners often violate GSSoC contribution rules unknowingly:
+
+- Claiming too many issues at once
+- Going inactive and losing assignments
+- Using wrong labels or submission tracks
+- Opening PRs without following the spam-policy checklist
+
+This simulator lets you practice safely in the browser — no GitHub account required.
+
+## How is it used?
+
+1. Open `demo.html` in a browser.
+2. **Claim simulator** — click "Simulate /claim" on sample issues (max 2 active).
+3. **Cooldown timer** — start the demo 24h timer (30 seconds = 24 hours) and watch unassign warnings.
+4. **Label picker** — select your issue type and see recommended labels.
+5. **Spam checklist** — complete all 8 items for PR-ready feedback.
+6. **Templates** — copy `/claim`, `/unclaim`, and progress comment text.
+
+## Features
+
+- Interactive issue claim simulator with 2-active-issues limit
+- Simulated 24-hour cooldown timer with warning and unassign states
+- Valid label picker (documentation, component, animation, scss, react, enhancement)
+- Pre-PR spam-policy checklist with pass/fail feedback
+- Workflow walkthrough: find → claim → work → PR → review
+- Common mistake warnings
+- Copy-ready issue comment templates
+- GSSoC contribution etiquette notes
+- Responsive layout with keyboard-friendly controls
+- Uses EaseMotion CSS CDN (`easemotion.min.css`)
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Simulator UI and interaction logic |
+| `style.css` | Layout and presentation using `--ease-*` tokens |
+| `README.md` | This document |
+
+## Compliance notes
+
+- Only **new files** inside `submissions/docs/`.
+- No edits to `core/`, `components/`, or existing project files.
+- Self-contained — no backend, no build step.

--- a/submissions/docs/ease-gssoc-claim-simulator-sp/demo.html
+++ b/submissions/docs/ease-gssoc-claim-simulator-sp/demo.html
@@ -1,0 +1,525 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>GSSoC Issue Claim &amp; Cooldown Simulator</title>
+  <meta
+    name="description"
+    content="Practice EaseMotion CSS GSSoC claim workflow — 2-issue limit, 24-hour cooldown, labels, and pre-PR spam checklist."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header class="gcs-header ease-fade-in">
+    <p class="gcs-eyebrow">EaseMotion CSS · GSSoC Documentation</p>
+    <h1>Issue Claim &amp; Cooldown Simulator</h1>
+    <p class="gcs-subtitle">
+      Practice this repository's contribution workflow before you participate —
+      claim limits, inactivity cooldown, valid labels, and the pre-PR spam checklist.
+    </p>
+  </header>
+
+  <main class="gcs-layout">
+  <!-- Workflow steps -->
+  <nav class="gcs-workflow" aria-label="Contribution workflow steps">
+    <ol class="gcs-steps" id="workflow-steps">
+      <li class="gcs-step active" data-step="0"><span>1</span> Find issue</li>
+      <li class="gcs-step" data-step="1"><span>2</span> Claim</li>
+      <li class="gcs-step" data-step="2"><span>3</span> Work</li>
+      <li class="gcs-step" data-step="3"><span>4</span> Open PR</li>
+      <li class="gcs-step" data-step="4"><span>5</span> Review</li>
+    </ol>
+  </nav>
+
+  <div class="gcs-grid">
+    <!-- Claim simulator -->
+    <section class="gcs-card" aria-labelledby="claim-title">
+      <h2 id="claim-title">Issue claim simulator</h2>
+      <p class="gcs-hint">
+        Rule: maximum <strong>2 active issues</strong> per contributor. Comment
+        <code>/claim</code> on an open issue to simulate assignment.
+      </p>
+
+      <div class="gcs-stats ease-flex ease-gap-4" role="status" aria-live="polite">
+        <div class="gcs-stat">
+          <span class="gcs-stat-label">Active claims</span>
+          <span class="gcs-stat-value" id="active-count">0 / 2</span>
+        </div>
+        <div class="gcs-stat">
+          <span class="gcs-stat-label">Cooldown</span>
+          <span class="gcs-stat-value" id="cooldown-status">None</span>
+        </div>
+      </div>
+
+      <div class="gcs-issue-pool" id="issue-pool" role="list" aria-label="Available issues">
+        <!-- injected -->
+      </div>
+
+      <div class="gcs-active-panel" id="active-panel" hidden>
+        <h3 class="gcs-group-title">Your active issues</h3>
+        <ul class="gcs-active-list" id="active-list"></ul>
+      </div>
+
+      <div class="gcs-alert gcs-alert-warn" id="limit-alert" hidden role="alert">
+        Limit reached — complete or <code>/unclaim</code> an issue before claiming another.
+      </div>
+    </section>
+
+    <!-- Cooldown timer -->
+    <section class="gcs-card" aria-labelledby="timer-title">
+      <h2 id="timer-title">24-hour inactivity timer</h2>
+      <p class="gcs-hint">
+        If no PR progress is made within <strong>24 hours</strong>, the bot unassigns you
+        and reopens the issue for others.
+      </p>
+
+      <div class="gcs-timer-wrap">
+        <div class="gcs-timer-ring" id="timer-ring" aria-hidden="true">
+          <span class="gcs-timer-text" id="timer-display">24:00:00</span>
+        </div>
+        <p class="gcs-timer-label" id="timer-label">No active timer</p>
+      </div>
+
+      <div class="gcs-control-row">
+        <button type="button" class="ease-btn ease-btn-primary" id="btn-start-timer">
+          Start 24h demo timer
+        </button>
+        <button type="button" class="ease-btn ease-btn-outline" id="btn-reset-timer">
+          Reset
+        </button>
+        <button type="button" class="ease-btn ease-btn-success" id="btn-submit-pr">
+          Simulate PR opened
+        </button>
+      </div>
+
+      <div class="gcs-alert gcs-alert-danger" id="unassign-alert" hidden role="alert">
+        Unassigned due to inactivity — issue is open for others to claim.
+      </div>
+    </section>
+
+    <!-- Label picker -->
+    <section class="gcs-card" aria-labelledby="label-title">
+      <h2 id="label-title">Valid label picker</h2>
+      <p class="gcs-hint">Choose labels that match your issue type before opening a PR.</p>
+
+      <fieldset class="gcs-fieldset">
+        <legend class="gcs-legend">Issue type</legend>
+        <div class="gcs-label-grid" role="radiogroup" aria-label="Issue type">
+          <label class="gcs-label-chip">
+            <input type="radio" name="issue-type" value="documentation" checked />
+            <span>documentation</span>
+          </label>
+          <label class="gcs-label-chip">
+            <input type="radio" name="issue-type" value="component" />
+            <span>component</span>
+          </label>
+          <label class="gcs-label-chip">
+            <input type="radio" name="issue-type" value="animation" />
+            <span>animation</span>
+          </label>
+          <label class="gcs-label-chip">
+            <input type="radio" name="issue-type" value="scss" />
+            <span>scss</span>
+          </label>
+          <label class="gcs-label-chip">
+            <input type="radio" name="issue-type" value="react" />
+            <span>react</span>
+          </label>
+          <label class="gcs-label-chip">
+            <input type="radio" name="issue-type" value="enhancement" />
+            <span>enhancement</span>
+          </label>
+        </div>
+      </fieldset>
+
+      <div class="gcs-label-result" id="label-result">
+        <p>Recommended labels:</p>
+        <div class="gcs-tags" id="recommended-tags"></div>
+      </div>
+    </section>
+
+    <!-- Spam checklist -->
+    <section class="gcs-card gcs-card-wide" aria-labelledby="checklist-title">
+      <h2 id="checklist-title">Pre-PR spam-policy checklist</h2>
+      <p class="gcs-hint">Complete every item — failing checks may label your PR <code>gssoc:invalid</code>.</p>
+
+      <ul class="gcs-checklist" id="spam-checklist">
+        <li>
+          <label class="gcs-check-item">
+            <input type="checkbox" data-rule="submissions" />
+            <span>Files only inside <code>submissions/</code> — never <code>core/</code> or <code>components/</code></span>
+          </label>
+        </li>
+        <li>
+          <label class="gcs-check-item">
+            <input type="checkbox" data-rule="suffix" />
+            <span>Folder name includes your unique suffix (e.g. <code>-sp</code>)</span>
+          </label>
+        </li>
+        <li>
+          <label class="gcs-check-item">
+            <input type="checkbox" data-rule="files" />
+            <span>All required files present (demo.html, style.css, README.md for docs track)</span>
+          </label>
+        </li>
+        <li>
+          <label class="gcs-check-item">
+            <input type="checkbox" data-rule="lines" />
+            <span>250+ lines OR complete required file set</span>
+          </label>
+        </li>
+        <li>
+          <label class="gcs-check-item">
+            <input type="checkbox" data-rule="claim" />
+            <span>Issue claimed with <code>/claim</code> before opening PR</span>
+          </label>
+        </li>
+        <li>
+          <label class="gcs-check-item">
+            <input type="checkbox" data-rule="labels" />
+            <span>Correct labels selected for issue type</span>
+          </label>
+        </li>
+        <li>
+          <label class="gcs-check-item">
+            <input type="checkbox" data-rule="spam" />
+            <span>No duplicate PRs, bump comments, or "please merge" spam</span>
+          </label>
+        </li>
+        <li>
+          <label class="gcs-check-item">
+            <input type="checkbox" data-rule="squash" />
+            <span>One feature per PR · squashed commits</span>
+          </label>
+        </li>
+      </ul>
+
+      <p class="gcs-check-result" id="check-result" role="status" aria-live="polite">
+        Check all items to unlock PR-ready status.
+      </p>
+    </section>
+
+    <!-- Templates & mistakes -->
+    <section class="gcs-card gcs-card-wide" aria-labelledby="templates-title">
+      <h2 id="templates-title">Copy-ready comment templates</h2>
+
+      <div class="gcs-template-grid">
+        <article class="gcs-template">
+          <h3>Claim an issue</h3>
+          <pre class="gcs-pre"><code id="tpl-claim">/claim</code></pre>
+          <button type="button" class="ease-btn ease-btn-sm ease-btn-outline gcs-copy" data-copy="claim">Copy</button>
+        </article>
+        <article class="gcs-template">
+          <h3>Unclaim when stuck</h3>
+          <pre class="gcs-pre"><code id="tpl-unclaim">/unclaim</code></pre>
+          <button type="button" class="ease-btn ease-btn-sm ease-btn-outline gcs-copy" data-copy="unclaim">Copy</button>
+        </article>
+        <article class="gcs-template">
+          <h3>Progress update</h3>
+          <pre class="gcs-pre"><code id="tpl-progress">Working on this — PR will be opened within 24 hours.</code></pre>
+          <button type="button" class="ease-btn ease-btn-sm ease-btn-outline gcs-copy" data-copy="progress">Copy</button>
+        </article>
+      </div>
+
+      <h3 class="gcs-group-title">Common mistakes</h3>
+      <ul class="gcs-mistakes">
+        <li class="gcs-mistake-warn">Claiming more than 2 issues without finishing current work</li>
+        <li class="gcs-mistake-warn">Going inactive for 24+ hours without opening a PR</li>
+        <li class="gcs-mistake-warn">Commenting "assign me" instead of exact <code>/claim</code></li>
+        <li class="gcs-mistake-warn">Opening PRs that edit <code>core/</code> during contribution freeze</li>
+        <li class="gcs-mistake-warn">Missing labels or wrong submission track folder</li>
+      </ul>
+
+      <details class="gcs-details">
+        <summary>GSSoC contribution etiquette for this repo</summary>
+        <ul>
+          <li>Read CONTRIBUTING.md before your first claim.</li>
+          <li>One focused feature per pull request.</li>
+          <li>Do not ping maintainers — reviews happen on a rolling basis.</li>
+          <li>Use <code>/unclaim</code> if you cannot finish — frees the issue for others.</li>
+          <li>Only the maintainer merges PRs; never self-merge.</li>
+        </ul>
+      </details>
+    </section>
+  </div>
+
+  <p class="gcs-status" id="copy-status" role="status" aria-live="polite"></p>
+  </main>
+
+  <footer class="gcs-footer">
+    <p>
+      Built for EaseMotion CSS ·
+      <code>submissions/docs/ease-gssoc-claim-simulator-sp</code> ·
+      Resolves Issue #44491
+    </p>
+  </footer>
+
+  <script>
+    (function () {
+      'use strict';
+
+      var MAX_ACTIVE = 2;
+      var DEMO_SECONDS = 30;
+      var REAL_HOURS = 24;
+
+      var SAMPLE_ISSUES = [
+        { id: 44410, title: 'Add hover card lift example', labels: ['animation', 'good first issue'] },
+        { id: 44422, title: 'Documentation: SCSS mixin guide', labels: ['documentation', 'scss'] },
+        { id: 44435, title: 'React animation wrapper demo', labels: ['react', 'component'] },
+        { id: 44491, title: 'GSSoC claim simulator tool', labels: ['documentation', 'GSSoC-26'] }
+      ];
+
+      var activeClaims = [];
+      var timerId = null;
+      var secondsLeft = 0;
+      var timerIssueId = null;
+
+      var LABEL_MAP = {
+        documentation: ['documentation', 'GSSoC-26', 'gssoc:approved'],
+        component: ['component', 'GSSoC-26', 'good first issue'],
+        animation: ['animation', 'GSSoC-26'],
+        scss: ['scss', 'documentation', 'GSSoC-26'],
+        react: ['react', 'component', 'GSSoC-26'],
+        enhancement: ['enhancement', 'GSSoC-26']
+      };
+
+      var els = {
+        pool: document.getElementById('issue-pool'),
+        activeList: document.getElementById('active-list'),
+        activePanel: document.getElementById('active-panel'),
+        activeCount: document.getElementById('active-count'),
+        cooldownStatus: document.getElementById('cooldown-status'),
+        limitAlert: document.getElementById('limit-alert'),
+        timerDisplay: document.getElementById('timer-display'),
+        timerLabel: document.getElementById('timer-label'),
+        timerRing: document.getElementById('timer-ring'),
+        unassignAlert: document.getElementById('unassign-alert'),
+        recommendedTags: document.getElementById('recommended-tags'),
+        checkResult: document.getElementById('check-result'),
+        copyStatus: document.getElementById('copy-status'),
+        workflowSteps: document.querySelectorAll('.gcs-step')
+      };
+
+      function formatTime(sec) {
+        var h = Math.floor(sec / 3600);
+        var m = Math.floor((sec % 3600) / 60);
+        var s = sec % 60;
+        return [h, m, s].map(function (n) { return String(n).padStart(2, '0'); }).join(':');
+      }
+
+      function setWorkflowStep(index) {
+        els.workflowSteps.forEach(function (step, i) {
+          step.classList.toggle('active', i <= index);
+          step.classList.toggle('done', i < index);
+        });
+      }
+
+      function renderIssues() {
+        els.pool.innerHTML = '';
+        SAMPLE_ISSUES.forEach(function (issue) {
+          var claimed = activeClaims.some(function (c) { return c.id === issue.id; });
+          var card = document.createElement('article');
+          card.className = 'gcs-issue' + (claimed ? ' is-claimed' : '');
+          card.setAttribute('role', 'listitem');
+          card.innerHTML =
+            '<div class="gcs-issue-head">' +
+            '<strong>#' + issue.id + '</strong>' +
+            '<span class="gcs-issue-tags">' + issue.labels.map(function (l) {
+              return '<span class="gcs-tag">' + l + '</span>';
+            }).join('') + '</span></div>' +
+            '<p>' + issue.title + '</p>' +
+            '<button type="button" class="ease-btn ease-btn-sm ' +
+            (claimed ? 'ease-btn-outline' : 'ease-btn-primary') + '" ' +
+            (claimed ? 'data-unclaim="' + issue.id + '"' : 'data-claim="' + issue.id + '"') + '>' +
+            (claimed ? 'Unclaim' : 'Simulate /claim') + '</button>';
+          els.pool.appendChild(card);
+        });
+
+        els.pool.querySelectorAll('[data-claim]').forEach(function (btn) {
+          btn.addEventListener('click', function () {
+            claimIssue(Number(btn.getAttribute('data-claim')));
+          });
+        });
+        els.pool.querySelectorAll('[data-unclaim]').forEach(function (btn) {
+          btn.addEventListener('click', function () {
+            unclaimIssue(Number(btn.getAttribute('data-unclaim')));
+          });
+        });
+      }
+
+      function renderActive() {
+        els.activeCount.textContent = activeClaims.length + ' / ' + MAX_ACTIVE;
+        els.activePanel.hidden = activeClaims.length === 0;
+        els.limitAlert.hidden = activeClaims.length < MAX_ACTIVE;
+        els.activeList.innerHTML = activeClaims.map(function (c) {
+          return '<li><strong>#' + c.id + '</strong> — ' + c.title + '</li>';
+        }).join('');
+        els.cooldownStatus.textContent = timerId ? 'Running' : 'None';
+        setWorkflowStep(activeClaims.length > 0 ? 1 : 0);
+      }
+
+      function claimIssue(id) {
+        if (activeClaims.length >= MAX_ACTIVE) {
+          els.limitAlert.hidden = false;
+          els.copyStatus.textContent = 'Cannot claim — 2 active issue limit reached.';
+          return;
+        }
+        if (activeClaims.some(function (c) { return c.id === id; })) return;
+
+        var issue = SAMPLE_ISSUES.find(function (i) { return i.id === id; });
+        if (!issue) return;
+
+        activeClaims.push(issue);
+        els.limitAlert.hidden = true;
+        els.copyStatus.textContent = 'Assigned to #' + id + ' — you have 24 hours to open a PR.';
+        renderIssues();
+        renderActive();
+      }
+
+      function unclaimIssue(id) {
+        activeClaims = activeClaims.filter(function (c) { return c.id !== id; });
+        if (timerIssueId === id) resetTimer();
+        els.unassignAlert.hidden = true;
+        els.copyStatus.textContent = 'Unclaimed #' + id + ' — issue reopened for others.';
+        renderIssues();
+        renderActive();
+      }
+
+      function updateTimerRing() {
+        var pct = secondsLeft / DEMO_SECONDS;
+        els.timerRing.style.setProperty('--gcs-pct', String(pct));
+        els.timerDisplay.textContent = formatTime(Math.ceil(secondsLeft * (REAL_HOURS * 3600 / DEMO_SECONDS)));
+
+        if (secondsLeft <= DEMO_SECONDS * 0.25) {
+          els.timerRing.classList.add('is-warning');
+        }
+        if (secondsLeft <= DEMO_SECONDS * 0.1) {
+          els.timerRing.classList.add('is-danger');
+        }
+      }
+
+      function startTimer() {
+        if (!activeClaims.length) {
+          els.copyStatus.textContent = 'Claim an issue first, then start the timer.';
+          return;
+        }
+        resetTimer(false);
+        timerIssueId = activeClaims[0].id;
+        secondsLeft = DEMO_SECONDS;
+        els.timerLabel.textContent = 'Demo: 30s = 24h inactivity window for #' + timerIssueId;
+        els.unassignAlert.hidden = true;
+        els.cooldownStatus.textContent = 'Running';
+        setWorkflowStep(2);
+        updateTimerRing();
+
+        timerId = setInterval(function () {
+          secondsLeft -= 1;
+          updateTimerRing();
+          if (secondsLeft <= 0) {
+            clearInterval(timerId);
+            timerId = null;
+            autoUnassign();
+          }
+        }, 1000);
+      }
+
+      function autoUnassign() {
+        if (!timerIssueId) return;
+        unclaimIssue(timerIssueId);
+        timerIssueId = null;
+        els.unassignAlert.hidden = false;
+        els.timerLabel.textContent = 'Timer expired — unassigned due to inactivity';
+        els.timerRing.classList.remove('is-warning', 'is-danger');
+        els.cooldownStatus.textContent = 'Expired';
+      }
+
+      function resetTimer(clearLabel) {
+        if (timerId) clearInterval(timerId);
+        timerId = null;
+        secondsLeft = 0;
+        timerIssueId = null;
+        els.timerDisplay.textContent = '24:00:00';
+        els.timerRing.style.setProperty('--gcs-pct', '1');
+        els.timerRing.classList.remove('is-warning', 'is-danger');
+        if (clearLabel !== false) {
+          els.timerLabel.textContent = 'No active timer';
+          els.cooldownStatus.textContent = 'None';
+        }
+      }
+
+      function simulatePr() {
+        if (!activeClaims.length) {
+          els.copyStatus.textContent = 'Claim an issue before simulating a PR.';
+          return;
+        }
+        resetTimer();
+        setWorkflowStep(3);
+        els.copyStatus.textContent = 'PR opened — inactivity timer cleared. Awaiting maintainer review.';
+        setTimeout(function () { setWorkflowStep(4); }, 800);
+      }
+
+      function renderLabels() {
+        var type = document.querySelector('input[name="issue-type"]:checked').value;
+        var labels = LABEL_MAP[type] || [];
+        els.recommendedTags.innerHTML = labels.map(function (l) {
+          return '<span class="gcs-tag gcs-tag-primary">' + l + '</span>';
+        }).join('');
+      }
+
+      function updateChecklist() {
+        var boxes = document.querySelectorAll('#spam-checklist input[type="checkbox"]');
+        var done = 0;
+        boxes.forEach(function (box) { if (box.checked) done += 1; });
+        var total = boxes.length;
+        if (done === total) {
+          els.checkResult.textContent = 'All checks passed — you are PR-ready!';
+          els.checkResult.className = 'gcs-check-result is-pass';
+          setWorkflowStep(3);
+        } else {
+          els.checkResult.textContent = done + ' / ' + total + ' complete — finish the checklist before opening a PR.';
+          els.checkResult.className = 'gcs-check-result';
+        }
+      }
+
+      document.getElementById('btn-start-timer').addEventListener('click', startTimer);
+      document.getElementById('btn-reset-timer').addEventListener('click', function () { resetTimer(); });
+      document.getElementById('btn-submit-pr').addEventListener('click', simulatePr);
+
+      document.querySelectorAll('input[name="issue-type"]').forEach(function (radio) {
+        radio.addEventListener('change', renderLabels);
+      });
+
+      document.querySelectorAll('#spam-checklist input').forEach(function (box) {
+        box.addEventListener('change', updateChecklist);
+      });
+
+      document.querySelectorAll('.gcs-copy').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          var key = btn.getAttribute('data-copy');
+          var text = document.getElementById('tpl-' + key).textContent;
+          navigator.clipboard.writeText(text).then(
+            function () { els.copyStatus.textContent = 'Copied ' + key + ' template!'; },
+            function () { els.copyStatus.textContent = 'Copy failed — select text manually.'; }
+          );
+        });
+      });
+
+      renderIssues();
+      renderActive();
+      renderLabels();
+      updateChecklist();
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-gssoc-claim-simulator-sp/style.css
+++ b/submissions/docs/ease-gssoc-claim-simulator-sp/style.css
@@ -1,0 +1,504 @@
+/* ============================================================
+   GSSoC Issue Claim & Cooldown Simulator — style.css
+   submissions/docs/ease-gssoc-claim-simulator-sp
+   ============================================================ */
+
+body {
+  background:
+    radial-gradient(
+      900px 400px at 8% -5%,
+      var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.1)),
+      transparent
+    ),
+    radial-gradient(
+      700px 350px at 95% 0%,
+      rgba(34, 197, 94, 0.06),
+      transparent
+    ),
+    var(--ease-color-bg, #f8fafc);
+  min-height: 100vh;
+}
+
+/* ── Header ─────────────────────────────────────────────────── */
+
+.gcs-header {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: var(--ease-space-12, 3rem) var(--ease-space-6, 1.5rem)
+    var(--ease-space-4, 1rem);
+  text-align: center;
+}
+
+.gcs-eyebrow {
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ease-color-primary, #6c63ff);
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.gcs-header h1 {
+  margin-bottom: var(--ease-space-3, 0.75rem);
+}
+
+.gcs-subtitle {
+  max-width: 44rem;
+  margin: 0 auto;
+  color: var(--ease-color-muted, #475569);
+}
+
+/* ── Layout ─────────────────────────────────────────────────── */
+
+.gcs-layout {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: var(--ease-space-4, 1rem) var(--ease-space-6, 1.5rem)
+    var(--ease-space-12, 3rem);
+}
+
+.gcs-workflow {
+  margin-bottom: var(--ease-space-6, 1.5rem);
+}
+
+.gcs-steps {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ease-space-2, 0.5rem);
+  list-style: none;
+  padding: 0;
+  justify-content: center;
+}
+
+.gcs-step {
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-2, 0.5rem);
+  padding: var(--ease-space-2, 0.5rem) var(--ease-space-3, 0.75rem);
+  border-radius: var(--ease-radius-full, 9999px);
+  background: var(--ease-color-surface, #fff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #475569);
+  transition: all var(--ease-speed-fast, 150ms) var(--ease-ease);
+}
+
+.gcs-step span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: var(--ease-radius-full, 9999px);
+  background: var(--ease-color-neutral-200, #e2e8f0);
+  font-weight: 700;
+  font-size: var(--ease-text-xs, 0.75rem);
+}
+
+.gcs-step.active {
+  border-color: var(--ease-color-primary, #6c63ff);
+  color: var(--ease-color-neutral-800, #1e293b);
+}
+
+.gcs-step.active span {
+  background: var(--ease-color-primary, #6c63ff);
+  color: #fff;
+}
+
+.gcs-step.done {
+  opacity: 0.7;
+}
+
+.gcs-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--ease-space-6, 1.5rem);
+}
+
+.gcs-card-wide {
+  grid-column: 1 / -1;
+}
+
+/* ── Cards ──────────────────────────────────────────────────── */
+
+.gcs-card {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  box-shadow: var(--ease-shadow-md);
+  padding: var(--ease-space-6, 1.5rem);
+}
+
+.gcs-card h2 {
+  font-size: var(--ease-text-xl, 1.25rem);
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.gcs-group-title {
+  font-size: var(--ease-text-base, 1rem);
+  margin: var(--ease-space-4, 1rem) 0 var(--ease-space-2, 0.5rem);
+}
+
+.gcs-hint {
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #475569);
+  margin-bottom: var(--ease-space-4, 1rem);
+}
+
+/* ── Stats ──────────────────────────────────────────────────── */
+
+.gcs-stats {
+  margin-bottom: var(--ease-space-4, 1rem);
+}
+
+.gcs-stat {
+  flex: 1;
+  padding: var(--ease-space-3, 0.75rem);
+  background: var(--ease-color-neutral-50, #f8fafc);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+}
+
+.gcs-stat-label {
+  display: block;
+  font-size: var(--ease-text-xs, 0.75rem);
+  color: var(--ease-color-muted, #475569);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.gcs-stat-value {
+  font-size: var(--ease-text-lg, 1.125rem);
+  font-weight: 700;
+  color: var(--ease-color-primary-dark, #4b44cc);
+}
+
+/* ── Issues ─────────────────────────────────────────────────── */
+
+.gcs-issue-pool {
+  display: grid;
+  gap: var(--ease-space-3, 0.75rem);
+}
+
+.gcs-issue {
+  padding: var(--ease-space-4, 1rem);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  background: var(--ease-color-neutral-50, #f8fafc);
+}
+
+.gcs-issue.is-claimed {
+  border-color: var(--ease-color-success, #15803d);
+  background: rgba(21, 128, 61, 0.05);
+}
+
+.gcs-issue-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--ease-space-2, 0.5rem);
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.gcs-issue p {
+  margin-bottom: var(--ease-space-3, 0.75rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+}
+
+.gcs-active-list {
+  margin: 0;
+  padding-left: var(--ease-space-5, 1.25rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+}
+
+.gcs-tag {
+  display: inline-block;
+  padding: 0.1rem 0.45rem;
+  border-radius: var(--ease-radius-full, 9999px);
+  background: var(--ease-color-neutral-200, #e2e8f0);
+  font-size: var(--ease-text-xs, 0.75rem);
+  margin-right: 0.25rem;
+}
+
+.gcs-tag-primary {
+  background: var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.15));
+  color: var(--ease-color-primary-dark, #4b44cc);
+}
+
+.gcs-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ease-space-2, 0.5rem);
+  margin-top: var(--ease-space-2, 0.5rem);
+}
+
+/* ── Timer ──────────────────────────────────────────────────── */
+
+.gcs-timer-wrap {
+  text-align: center;
+  margin: var(--ease-space-4, 1rem) 0;
+}
+
+.gcs-timer-ring {
+  --gcs-pct: 1;
+  width: 9rem;
+  height: 9rem;
+  margin: 0 auto var(--ease-space-3, 0.75rem);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: conic-gradient(
+    var(--ease-color-primary, #6c63ff) calc(var(--gcs-pct) * 360deg),
+    var(--ease-color-neutral-200, #e2e8f0) 0
+  );
+  transition: background var(--ease-speed-fast, 150ms) linear;
+}
+
+.gcs-timer-ring.is-warning {
+  background: conic-gradient(
+    var(--ease-color-warning, #b45309) calc(var(--gcs-pct) * 360deg),
+    var(--ease-color-neutral-200, #e2e8f0) 0
+  );
+}
+
+.gcs-timer-ring.is-danger {
+  background: conic-gradient(
+    var(--ease-color-danger, #b91c1c) calc(var(--gcs-pct) * 360deg),
+    var(--ease-color-neutral-200, #e2e8f0) 0
+  );
+}
+
+.gcs-timer-text {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 7rem;
+  height: 7rem;
+  border-radius: 50%;
+  background: var(--ease-color-surface, #fff);
+  font-family: var(--ease-font-mono, monospace);
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+}
+
+.gcs-timer-label {
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #475569);
+}
+
+.gcs-control-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ease-space-2, 0.5rem);
+  justify-content: center;
+}
+
+/* ── Labels ─────────────────────────────────────────────────── */
+
+.gcs-fieldset {
+  border: 0;
+  padding: 0;
+  margin: 0 0 var(--ease-space-4, 1rem);
+}
+
+.gcs-legend {
+  font-weight: 600;
+  font-size: var(--ease-text-sm, 0.875rem);
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.gcs-label-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ease-space-2, 0.5rem);
+}
+
+.gcs-label-chip {
+  cursor: pointer;
+}
+
+.gcs-label-chip input {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+
+.gcs-label-chip span {
+  display: inline-block;
+  padding: var(--ease-space-2, 0.5rem) var(--ease-space-3, 0.75rem);
+  border: 2px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-full, 9999px);
+  font-size: var(--ease-text-sm, 0.875rem);
+  transition: all var(--ease-speed-fast, 150ms) var(--ease-ease);
+}
+
+.gcs-label-chip input:focus-visible + span {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+
+.gcs-label-chip input:checked + span {
+  border-color: var(--ease-color-primary, #6c63ff);
+  background: var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.15));
+  color: var(--ease-color-primary-dark, #4b44cc);
+  font-weight: 600;
+}
+
+/* ── Checklist ──────────────────────────────────────────────── */
+
+.gcs-checklist {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: var(--ease-space-2, 0.5rem);
+}
+
+.gcs-check-item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--ease-space-3, 0.75rem);
+  padding: var(--ease-space-3, 0.75rem);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  background: var(--ease-color-neutral-50, #f8fafc);
+  cursor: pointer;
+  font-size: var(--ease-text-sm, 0.875rem);
+}
+
+.gcs-check-item input {
+  margin-top: 0.2rem;
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--ease-color-primary, #6c63ff);
+}
+
+.gcs-check-result {
+  margin-top: var(--ease-space-4, 1rem);
+  padding: var(--ease-space-3, 0.75rem);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+}
+
+.gcs-check-result.is-pass {
+  background: rgba(21, 128, 61, 0.1);
+  color: var(--ease-color-success-dark, #15803d);
+}
+
+/* ── Alerts ─────────────────────────────────────────────────── */
+
+.gcs-alert {
+  margin-top: var(--ease-space-4, 1rem);
+  padding: var(--ease-space-3, 0.75rem);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+}
+
+.gcs-alert-warn {
+  background: rgba(180, 83, 9, 0.1);
+  border: 1px solid var(--ease-color-warning, #b45309);
+  color: var(--ease-color-warning-dark, #b45309);
+}
+
+.gcs-alert-danger {
+  background: rgba(185, 28, 28, 0.08);
+  border: 1px solid var(--ease-color-danger, #b91c1c);
+  color: var(--ease-color-danger-dark, #b91c1c);
+}
+
+/* ── Templates ──────────────────────────────────────────────── */
+
+.gcs-template-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--ease-space-4, 1rem);
+  margin-bottom: var(--ease-space-4, 1rem);
+}
+
+.gcs-template {
+  padding: var(--ease-space-4, 1rem);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  background: var(--ease-color-neutral-50, #f8fafc);
+}
+
+.gcs-template h3 {
+  font-size: var(--ease-text-sm, 0.875rem);
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.gcs-pre {
+  background: var(--ease-color-neutral-900, #0f172a);
+  color: #e2e8f0;
+  padding: var(--ease-space-3, 0.75rem);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  font-size: var(--ease-text-xs, 0.75rem);
+  overflow-x: auto;
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.gcs-mistakes {
+  padding-left: var(--ease-space-5, 1.25rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #475569);
+}
+
+.gcs-mistake-warn {
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.gcs-details {
+  margin-top: var(--ease-space-4, 1rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+}
+
+.gcs-details summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--ease-color-primary, #6c63ff);
+}
+
+.gcs-details ul {
+  margin-top: var(--ease-space-2, 0.5rem);
+  padding-left: var(--ease-space-5, 1.25rem);
+}
+
+/* ── Footer & status ────────────────────────────────────────── */
+
+.gcs-status {
+  text-align: center;
+  margin-top: var(--ease-space-4, 1rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-success-dark, #15803d);
+  min-height: 1.25rem;
+}
+
+.gcs-footer {
+  text-align: center;
+  padding: var(--ease-space-8, 2rem) var(--ease-space-6, 1.5rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #475569);
+}
+
+/* ── Responsive ─────────────────────────────────────────────── */
+
+@media (max-width: 900px) {
+  .gcs-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .gcs-template-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gcs-step,
+  .gcs-label-chip span,
+  .gcs-timer-ring {
+    transition: none;
+  }
+}

--- a/submissions/docs/ease-ios-viewport-jump-sp/README.md
+++ b/submissions/docs/ease-ios-viewport-jump-sp/README.md
@@ -1,0 +1,44 @@
+# iOS Safari 100vh + Fixed Navbar Jump with Entrance Animations
+
+A documentation showcase that reproduces and documents the **viewport jump** when `ease-fade-in` hero sections use `100vh` on mobile Safari — where the collapsing URL bar changes viewport height mid-animation.
+
+> Submission track: `submissions/docs/ease-ios-viewport-jump-sp/`  
+> Contributor suffix: `sp`
+
+---
+
+## What does this do?
+
+On iOS Safari, `100vh` heroes with `ease-fade-in` and a fixed navbar visibly jump when the URL bar collapses. This showcase reproduces the issue and documents workaround patterns.
+
+## How is it used?
+
+1. Open `demo.html` in a browser (best on iOS Safari).
+2. Review the **live viewport readout** (innerHeight, vh, dvh, svh).
+3. Click **Simulate iOS URL bar collapse** to see broken vs fixed heroes.
+4. Compare **Broken 100vh** vs **Fixed 100dvh/svh** phone frames.
+5. Copy workaround snippets from the tabbed panel.
+
+## Features
+
+- Reproducible `ease-fade-in` hero + `100vh` + fixed navbar jump demo
+- Side-by-side broken vs fixed comparison
+- Live viewport height readout panel
+- Workaround patterns: `100dvh`, `100svh`, `-webkit-fill-available`, JS `--vh`
+- Browser support notes and educational content
+- Copy-ready CSS snippets
+- Responsive, accessible UI
+- Uses EaseMotion CSS CDN
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Interactive viewport jump demo |
+| `style.css` | Lab layout and phone frame styling |
+| `README.md` | This document |
+
+## Compliance notes
+
+- Only **new files** inside `submissions/docs/`.
+- No edits to `core/`, `components/`, or existing project files.

--- a/submissions/docs/ease-ios-viewport-jump-sp/demo.html
+++ b/submissions/docs/ease-ios-viewport-jump-sp/demo.html
@@ -1,0 +1,298 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>iOS Safari 100vh + Fixed Navbar Jump — Showcase</title>
+  <meta
+    name="description"
+    content="Reproduces viewport jump when ease-fade-in heroes use 100vh on mobile Safari, with workaround patterns."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <!-- Fixed navbar demo (shared concept) -->
+  <nav class="ivj-navbar ease-navbar" aria-label="Demo fixed navbar">
+    <div class="ivj-navbar-inner">
+      <span class="ivj-logo">EaseMotion</span>
+      <span class="ivj-nav-hint" id="nav-hint">Fixed navbar</span>
+    </div>
+  </nav>
+
+  <header class="ivj-header ease-fade-in">
+    <p class="ivj-eyebrow">EaseMotion CSS · Mobile Safari Lab</p>
+    <h1>iOS Safari 100vh + Navbar Jump</h1>
+    <p class="ivj-subtitle">
+      <code>ease-fade-in</code> heroes sized with <code>100vh</code> jump when iOS Safari
+      collapses the URL bar. Compare broken vs fixed viewport units live.
+    </p>
+  </header>
+
+  <main class="ivj-layout">
+    <!-- Viewport readout -->
+    <section class="ivj-card ivj-card-wide" aria-labelledby="readout-title">
+      <h2 id="readout-title">Live viewport height readout</h2>
+      <div class="ivj-metrics" role="status" aria-live="polite">
+        <div class="ivj-metric">
+          <span class="ivj-metric-label">window.innerHeight</span>
+          <span class="ivj-metric-value" id="val-inner">—</span>
+        </div>
+        <div class="ivj-metric">
+          <span class="ivj-metric-label">100vh (computed)</span>
+          <span class="ivj-metric-value" id="val-vh">—</span>
+        </div>
+        <div class="ivj-metric">
+          <span class="ivj-metric-label">100dvh</span>
+          <span class="ivj-metric-value" id="val-dvh">—</span>
+        </div>
+        <div class="ivj-metric">
+          <span class="ivj-metric-label">100svh</span>
+          <span class="ivj-metric-value" id="val-svh">—</span>
+        </div>
+      </div>
+
+      <div class="ivj-controls">
+        <button type="button" class="ease-btn ease-btn-primary" id="btn-simulate">
+          Simulate iOS URL bar collapse
+        </button>
+        <button type="button" class="ease-btn ease-btn-outline" id="btn-reset-vp">
+          Reset viewport
+        </button>
+        <p class="ivj-hint">
+          On real iOS Safari, the URL bar shrinks on scroll — changing <code>100vh</code> mid-animation.
+          Use this button to simulate the height change on desktop.
+        </p>
+      </div>
+    </section>
+
+    <div class="ivj-compare">
+      <!-- Broken -->
+      <section class="ivj-card ivj-panel-broken" aria-labelledby="broken-title">
+        <div class="ivj-panel-head">
+          <h2 id="broken-title">Broken — 100vh hero</h2>
+          <span class="ivj-badge ivj-badge-bad">Jumps on iOS</span>
+        </div>
+        <p class="ivj-hint">
+          Hero uses <code>height: 100vh</code> + <code>ease-fade-in</code>. When viewport
+          shrinks, content reflows and the fixed navbar appears to jump.
+        </p>
+
+        <div class="ivj-phone-frame">
+          <div class="ivj-phone-screen">
+            <div class="ivj-mini-nav">Nav</div>
+            <div class="ivj-hero ivj-hero-broken ease-fade-in" id="hero-broken">
+              <div class="ivj-hero-content">
+                <h3>Hero</h3>
+                <p>100vh full screen</p>
+                <span class="ivj-hero-height" id="broken-height">—</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Fixed -->
+      <section class="ivj-card ivj-panel-fixed" aria-labelledby="fixed-title">
+        <div class="ivj-panel-head">
+          <h2 id="fixed-title">Fixed — 100dvh / svh</h2>
+          <span class="ivj-badge ivj-badge-good">Stable on iOS</span>
+        </div>
+        <p class="ivj-hint">
+          Hero uses <code>min-height: 100dvh</code> with <code>100svh</code> fallback.
+          Dynamic viewport units account for the URL bar.
+        </p>
+
+        <div class="ivj-phone-frame">
+          <div class="ivj-phone-screen">
+            <div class="ivj-mini-nav">Nav</div>
+            <div class="ivj-hero ivj-hero-fixed ease-fade-in" id="hero-fixed">
+              <div class="ivj-hero-content">
+                <h3>Hero</h3>
+                <p>100dvh stable</p>
+                <span class="ivj-hero-height" id="fixed-height">—</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <!-- Snippets -->
+    <section class="ivj-card ivj-card-wide" aria-labelledby="snippet-title">
+      <h2 id="snippet-title">Copy-ready workaround snippets</h2>
+
+      <div class="ivj-snippet-tabs" role="tablist" aria-label="Workaround snippets">
+        <button type="button" class="ivj-tab active" data-snippet="dvh" role="tab">100dvh</button>
+        <button type="button" class="ivj-tab" data-snippet="svh" role="tab">100svh</button>
+        <button type="button" class="ivj-tab" data-snippet="webkit" role="tab">-webkit-fill-available</button>
+        <button type="button" class="ivj-tab" data-snippet="jsvh" role="tab">JS --vh fallback</button>
+      </div>
+
+      <pre class="ivj-pre"><code id="snippet-code"></code></pre>
+      <button type="button" class="ease-btn ease-btn-outline" id="btn-copy">Copy snippet</button>
+      <p class="ivj-status" id="copy-status" role="status" aria-live="polite"></p>
+
+      <details class="ivj-details">
+        <summary>iOS Safari URL bar behavior &amp; animation timing</summary>
+        <ul>
+          <li><code>100vh</code> on iOS includes the area behind the URL bar — then shrinks when it collapses.</li>
+          <li><code>100dvh</code> (dynamic viewport height) tracks the current visible viewport.</li>
+          <li><code>100svh</code> (small viewport height) uses the smallest possible viewport — safest for full-screen heroes.</li>
+          <li>Pair stable viewport units with <code>ease-fade-in</code> instead of animating height itself.</li>
+          <li>Test on a real iPhone — desktop DevTools cannot fully reproduce URL bar collapse.</li>
+          <li>Support: <code>dvh</code>/<code>svh</code> in Safari 15.4+, Chrome 108+, Firefox 101+.</li>
+        </ul>
+      </details>
+    </section>
+  </main>
+
+  <footer class="ivj-footer">
+    <p>
+      Built for EaseMotion CSS ·
+      <code>submissions/docs/ease-ios-viewport-jump-sp</code>
+    </p>
+  </footer>
+
+  <script>
+    (function () {
+      'use strict';
+
+      var SNIPPETS = {
+        dvh:
+          '/* Dynamic viewport — tracks URL bar collapse */\n' +
+          '.ease-hero {\n' +
+          '  min-height: 100dvh;\n' +
+          '  display: flex;\n' +
+          '  align-items: center;\n' +
+          '  justify-content: center;\n' +
+          '}\n\n' +
+          '<section class="ease-hero ease-fade-in">\n' +
+          '  <h1>Jump-free hero</h1>\n' +
+          '</section>',
+        svh:
+          '/* Small viewport — always fits visible area */\n' +
+          '.ease-hero {\n' +
+          '  min-height: 100svh;\n' +
+          '  min-height: 100dvh; /* progressive enhancement */\n' +
+          '}',
+        webkit:
+          '/* Legacy iOS fallback */\n' +
+          '.ease-hero {\n' +
+          '  min-height: 100vh;\n' +
+          '  min-height: -webkit-fill-available;\n' +
+          '  min-height: 100dvh;\n' +
+          '}',
+        jsvh:
+          '/* JS custom property fallback for older browsers */\n' +
+          'function setVh() {\n' +
+          '  document.documentElement.style.setProperty(\n' +
+          '    "--vh", window.innerHeight * 0.01 + "px"\n' +
+          '  );\n' +
+          '}\n' +
+          'setVh();\n' +
+          'window.addEventListener("resize", setVh);\n\n' +
+          '/* CSS */\n' +
+          '.ease-hero {\n' +
+          '  min-height: calc(var(--vh, 1vh) * 100);\n' +
+          '}'
+      };
+
+      var probeVh = document.createElement('div');
+      probeVh.style.cssText = 'position:fixed;height:100vh;visibility:hidden;pointer-events:none;';
+      document.body.appendChild(probeVh);
+
+      var probeDvh = document.createElement('div');
+      probeDvh.style.cssText = 'position:fixed;height:100dvh;visibility:hidden;pointer-events:none;';
+      document.body.appendChild(probeDvh);
+
+      var probeSvh = document.createElement('div');
+      probeSvh.style.cssText = 'position:fixed;height:100svh;visibility:hidden;pointer-events:none;';
+      document.body.appendChild(probeSvh);
+
+      var simulating = false;
+      var activeSnippet = 'dvh';
+
+      function updateReadout() {
+        var inner = window.innerHeight;
+        var vhPx = probeVh.offsetHeight;
+        var dvhPx = probeDvh.offsetHeight;
+        var svhPx = probeSvh.offsetHeight;
+
+        document.getElementById('val-inner').textContent = inner + 'px';
+        document.getElementById('val-vh').textContent = vhPx + 'px';
+        document.getElementById('val-dvh').textContent = dvhPx + 'px';
+        document.getElementById('val-svh').textContent = svhPx + 'px';
+
+        var brokenHero = document.getElementById('hero-broken');
+        var fixedHero = document.getElementById('hero-fixed');
+        document.getElementById('broken-height').textContent = brokenHero.offsetHeight + 'px';
+        document.getElementById('fixed-height').textContent = fixedHero.offsetHeight + 'px';
+
+        var diff = Math.abs(vhPx - inner);
+        document.getElementById('nav-hint').textContent =
+          diff > 2 ? 'Navbar jump risk: ' + diff + 'px mismatch' : 'Viewport stable';
+      }
+
+      function simulateCollapse() {
+        simulating = !simulating;
+        var frames = document.querySelectorAll('.ivj-phone-screen');
+        frames.forEach(function (frame) {
+          frame.classList.toggle('ivj-collapsed', simulating);
+        });
+        document.getElementById('btn-simulate').textContent =
+          simulating ? 'Restore URL bar' : 'Simulate iOS URL bar collapse';
+        updateReadout();
+      }
+
+      function resetViewport() {
+        simulating = false;
+        document.querySelectorAll('.ivj-phone-screen').forEach(function (f) {
+          f.classList.remove('ivj-collapsed');
+        });
+        document.getElementById('btn-simulate').textContent = 'Simulate iOS URL bar collapse';
+        updateReadout();
+      }
+
+      function renderSnippet(key) {
+        activeSnippet = key;
+        document.getElementById('snippet-code').textContent = SNIPPETS[key] || '';
+        document.querySelectorAll('.ivj-tab').forEach(function (tab) {
+          tab.classList.toggle('active', tab.getAttribute('data-snippet') === key);
+        });
+      }
+
+      document.getElementById('btn-simulate').addEventListener('click', simulateCollapse);
+      document.getElementById('btn-reset-vp').addEventListener('click', resetViewport);
+
+      document.querySelectorAll('.ivj-tab').forEach(function (tab) {
+        tab.addEventListener('click', function () {
+          renderSnippet(tab.getAttribute('data-snippet'));
+        });
+      });
+
+      document.getElementById('btn-copy').addEventListener('click', function () {
+        navigator.clipboard.writeText(SNIPPETS[activeSnippet]).then(
+          function () { document.getElementById('copy-status').textContent = 'Snippet copied!'; },
+          function () { document.getElementById('copy-status').textContent = 'Copy failed.'; }
+        );
+      });
+
+      window.addEventListener('resize', updateReadout);
+      renderSnippet('dvh');
+      updateReadout();
+
+      setInterval(updateReadout, 1000);
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-ios-viewport-jump-sp/style.css
+++ b/submissions/docs/ease-ios-viewport-jump-sp/style.css
@@ -1,0 +1,376 @@
+/* ============================================================
+   iOS Safari 100vh Viewport Jump — style.css
+   submissions/docs/ease-ios-viewport-jump-sp
+   ============================================================ */
+
+body {
+  background:
+    radial-gradient(
+      900px 400px at 10% -5%,
+      var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.1)),
+      transparent
+    ),
+    var(--ease-color-bg, #f8fafc);
+  min-height: 100vh;
+  padding-top: 3.5rem;
+}
+
+/* ── Fixed navbar ───────────────────────────────────────────── */
+
+.ivj-navbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  background: var(--ease-color-surface, #fff);
+  border-bottom: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  box-shadow: var(--ease-shadow-sm);
+}
+
+.ivj-navbar-inner {
+  max-width: 76rem;
+  margin: 0 auto;
+  padding: var(--ease-space-3, 0.75rem) var(--ease-space-6, 1.5rem);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.ivj-logo {
+  font-weight: 700;
+  color: var(--ease-color-primary, #6c63ff);
+}
+
+.ivj-nav-hint {
+  font-size: var(--ease-text-xs, 0.75rem);
+  color: var(--ease-color-muted, #475569);
+  font-family: var(--ease-font-mono, monospace);
+}
+
+/* ── Header ─────────────────────────────────────────────────── */
+
+.ivj-header {
+  max-width: 76rem;
+  margin: 0 auto;
+  padding: var(--ease-space-8, 2rem) var(--ease-space-6, 1.5rem)
+    var(--ease-space-4, 1rem);
+  text-align: center;
+}
+
+.ivj-eyebrow {
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ease-color-primary, #6c63ff);
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.ivj-header h1 {
+  margin-bottom: var(--ease-space-3, 0.75rem);
+}
+
+.ivj-subtitle {
+  max-width: 44rem;
+  margin: 0 auto;
+  color: var(--ease-color-muted, #475569);
+}
+
+/* ── Layout ─────────────────────────────────────────────────── */
+
+.ivj-layout {
+  max-width: 76rem;
+  margin: 0 auto;
+  padding: var(--ease-space-4, 1rem) var(--ease-space-6, 1.5rem)
+    var(--ease-space-12, 3rem);
+}
+
+.ivj-card-wide {
+  margin-bottom: var(--ease-space-6, 1.5rem);
+}
+
+.ivj-compare {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--ease-space-6, 1.5rem);
+  margin-bottom: var(--ease-space-6, 1.5rem);
+}
+
+/* ── Cards ──────────────────────────────────────────────────── */
+
+.ivj-card {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  box-shadow: var(--ease-shadow-md);
+  padding: var(--ease-space-6, 1.5rem);
+}
+
+.ivj-card h2 {
+  font-size: var(--ease-text-xl, 1.25rem);
+}
+
+.ivj-hint {
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #475569);
+  margin: var(--ease-space-2, 0.5rem) 0 var(--ease-space-4, 1rem);
+}
+
+.ivj-panel-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ease-space-2, 0.5rem);
+}
+
+.ivj-panel-broken {
+  border-top: 4px solid var(--ease-color-danger, #b91c1c);
+}
+
+.ivj-panel-fixed {
+  border-top: 4px solid var(--ease-color-success, #15803d);
+}
+
+.ivj-badge {
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 700;
+  padding: 0.2rem 0.6rem;
+  border-radius: var(--ease-radius-full, 9999px);
+  text-transform: uppercase;
+}
+
+.ivj-badge-bad {
+  background: rgba(185, 28, 28, 0.1);
+  color: var(--ease-color-danger-dark, #b91c1c);
+}
+
+.ivj-badge-good {
+  background: rgba(21, 128, 61, 0.1);
+  color: var(--ease-color-success-dark, #15803d);
+}
+
+/* ── Metrics ────────────────────────────────────────────────── */
+
+.ivj-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--ease-space-3, 0.75rem);
+  margin: var(--ease-space-4, 1rem) 0;
+}
+
+.ivj-metric {
+  padding: var(--ease-space-3, 0.75rem);
+  background: var(--ease-color-neutral-50, #f8fafc);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  text-align: center;
+}
+
+.ivj-metric-label {
+  display: block;
+  font-size: var(--ease-text-xs, 0.75rem);
+  color: var(--ease-color-muted, #475569);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: var(--ease-space-1, 0.25rem);
+}
+
+.ivj-metric-value {
+  font-size: var(--ease-text-lg, 1.125rem);
+  font-weight: 800;
+  font-family: var(--ease-font-mono, monospace);
+  color: var(--ease-color-primary-dark, #4b44cc);
+}
+
+.ivj-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--ease-space-3, 0.75rem);
+}
+
+.ivj-controls .ivj-hint {
+  flex: 1 1 100%;
+  margin: 0;
+}
+
+/* ── Phone frame demo ───────────────────────────────────────── */
+
+.ivj-phone-frame {
+  display: flex;
+  justify-content: center;
+}
+
+.ivj-phone-screen {
+  width: 100%;
+  max-width: 280px;
+  height: 420px;
+  border: 3px solid var(--ease-color-neutral-800, #1e293b);
+  border-radius: 1.5rem;
+  overflow: hidden;
+  background: var(--ease-color-neutral-900, #0f172a);
+  display: flex;
+  flex-direction: column;
+  transition: height 0.4s var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+}
+
+.ivj-phone-screen.ivj-collapsed {
+  height: 360px;
+}
+
+.ivj-mini-nav {
+  flex-shrink: 0;
+  padding: var(--ease-space-2, 0.5rem);
+  background: var(--ease-color-surface, #fff);
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 700;
+  text-align: center;
+  border-bottom: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+}
+
+.ivj-hero {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(
+    135deg,
+    var(--ease-color-primary, #6c63ff) 0%,
+    var(--ease-color-secondary, #8b5cf6) 100%
+  );
+  color: #fff;
+  text-align: center;
+  transition: min-height 0.4s var(--ease-ease);
+}
+
+.ivj-hero-broken {
+  min-height: 100%;
+  height: 100%;
+}
+
+.ivj-phone-screen.ivj-collapsed .ivj-hero-broken {
+  min-height: calc(100% + 60px);
+}
+
+.ivj-hero-fixed {
+  min-height: 100%;
+  min-height: 100dvh;
+  min-height: 100svh;
+}
+
+.ivj-hero-content h3 {
+  margin-bottom: var(--ease-space-1, 0.25rem);
+  color: #fff;
+}
+
+.ivj-hero-content p {
+  margin-bottom: var(--ease-space-2, 0.5rem);
+  opacity: 0.9;
+  font-size: var(--ease-text-sm, 0.875rem);
+}
+
+.ivj-hero-height {
+  display: inline-block;
+  font-family: var(--ease-font-mono, monospace);
+  font-size: var(--ease-text-xs, 0.75rem);
+  background: rgba(0, 0, 0, 0.25);
+  padding: 0.2rem 0.5rem;
+  border-radius: var(--ease-radius-sm, 0.25rem);
+}
+
+/* ── Snippets ───────────────────────────────────────────────── */
+
+.ivj-snippet-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ease-space-2, 0.5rem);
+  margin-bottom: var(--ease-space-4, 1rem);
+}
+
+.ivj-tab {
+  padding: var(--ease-space-2, 0.5rem) var(--ease-space-3, 0.75rem);
+  border: 2px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-full, 9999px);
+  background: var(--ease-color-surface, #fff);
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.ivj-tab:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+
+.ivj-tab.active {
+  border-color: var(--ease-color-primary, #6c63ff);
+  background: var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.15));
+  color: var(--ease-color-primary-dark, #4b44cc);
+}
+
+.ivj-pre {
+  background: var(--ease-color-neutral-900, #0f172a);
+  color: #e2e8f0;
+  padding: var(--ease-space-4, 1rem);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  font-size: var(--ease-text-xs, 0.75rem);
+  line-height: 1.55;
+  overflow-x: auto;
+  margin-bottom: var(--ease-space-4, 1rem);
+  max-height: 14rem;
+}
+
+.ivj-status {
+  margin-top: var(--ease-space-2, 0.5rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-success-dark, #15803d);
+  min-height: 1.25rem;
+}
+
+.ivj-details {
+  margin-top: var(--ease-space-6, 1.5rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #475569);
+}
+
+.ivj-details summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--ease-color-primary, #6c63ff);
+}
+
+.ivj-details ul {
+  margin-top: var(--ease-space-2, 0.5rem);
+  padding-left: var(--ease-space-5, 1.25rem);
+}
+
+.ivj-details li {
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+/* ── Footer ─────────────────────────────────────────────────── */
+
+.ivj-footer {
+  text-align: center;
+  padding: var(--ease-space-8, 2rem) var(--ease-space-6, 1.5rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #475569);
+}
+
+/* ── Responsive ───────────────────────────────────────────── */
+
+@media (max-width: 900px) {
+  .ivj-compare,
+  .ivj-metrics {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ivj-phone-screen,
+  .ivj-hero {
+    transition: none;
+  }
+}

--- a/submissions/docs/ease-layer-override-lab-sp/README.md
+++ b/submissions/docs/ease-layer-override-lab-sp/README.md
@@ -1,0 +1,57 @@
+# @layer Override Playground for Custom Theming
+
+An interactive documentation lab that proves **custom `@layer easemotion-components` overrides win without `!important`** — helping users understand EaseMotion's cascade layer architecture.
+
+> Submission track: `submissions/docs/ease-layer-override-lab-sp/`  
+> Contributor suffix: `sp`  
+> Resolves: Issue #44492
+
+---
+
+## What does this do?
+
+The EaseMotion README documents `@layer easemotion-base`, `easemotion-components`, and `easemotion-utilities`, but beginners often reach for `!important` when customizing buttons, cards, or tabs.
+
+This lab lets you:
+
+- Preview EaseMotion components with default framework styles
+- Edit and apply `@layer easemotion-components` overrides live
+- Compare default vs overridden side by side
+- See why wrong-layer CSS fails
+- See why unlayered utility overrides lose to `!important` utilities
+- Copy ready-to-use override snippets
+
+## How is it used?
+
+1. Open `demo.html` in a browser.
+2. Read the **cascade layer stack** diagram.
+3. Pick a **preset** (button color, card border, tab underline, wrong layer, unlayered).
+4. Click **Apply override** to inject CSS into the live preview.
+5. Compare the **Default** and **With override** panels.
+6. **Copy snippet** for your own project's theme stylesheet.
+
+## Features
+
+- Live component preview (button, card, tabs, utility box)
+- Custom `@layer easemotion-components` override editor
+- Side-by-side default vs overridden comparison
+- Wrong-layer failure demonstration (`easemotion-base`)
+- Unlayered vs `!important` utility demonstration
+- Copy-ready override CSS snippets
+- Educational notes on cascade layer architecture
+- Responsive, accessible UI with keyboard-friendly controls
+- Uses EaseMotion CSS CDN (`easemotion.min.css`)
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Interactive lab UI, presets, and override injection |
+| `style.css` | Lab chrome layout (not component overrides) |
+| `README.md` | This document |
+
+## Compliance notes
+
+- Only **new files** inside `submissions/docs/`.
+- No edits to `core/`, `components/`, or existing project files.
+- Self-contained — no backend, no build step.

--- a/submissions/docs/ease-layer-override-lab-sp/demo.html
+++ b/submissions/docs/ease-layer-override-lab-sp/demo.html
@@ -1,0 +1,392 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>@layer Override Playground — EaseMotion CSS</title>
+  <meta
+    name="description"
+    content="Live lab proving @layer easemotion-components overrides win without !important."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
+  <!-- Framework loads first — components live in @layer easemotion-components -->
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header class="lol-header ease-fade-in">
+    <p class="lol-eyebrow">EaseMotion CSS · Cascade Layers Lab</p>
+    <h1>@layer Override Playground</h1>
+    <p class="lol-subtitle">
+      See how <code>@layer easemotion-components</code> theming overrides beat framework
+      defaults — without <code>!important</code>. Compare correct layer overrides vs
+      wrong-layer and unlayered attempts.
+    </p>
+  </header>
+
+  <main class="lol-layout">
+    <!-- Layer architecture -->
+    <section class="lol-card lol-card-wide" aria-labelledby="arch-title">
+      <h2 id="arch-title">EaseMotion cascade layer stack</h2>
+      <div class="lol-layer-stack" role="list" aria-label="Layer priority low to high">
+        <div class="lol-layer lol-layer-low" role="listitem">
+          <span>easemotion-base</span>
+          <small>Reset, typography</small>
+        </div>
+        <div class="lol-layer lol-layer-mid" role="listitem">
+          <span>easemotion-components</span>
+          <small>Buttons, cards, tabs — <strong>override here</strong></small>
+        </div>
+        <div class="lol-layer lol-layer-high" role="listitem">
+          <span>easemotion-utilities</span>
+          <small>Layout utilities (often uses !important)</small>
+        </div>
+        <div class="lol-layer lol-layer-top" role="listitem">
+          <span>unlayered CSS</span>
+          <small>Beats layers — but loses to utility !important</small>
+        </div>
+      </div>
+      <p class="lol-note">
+        Declared in <code>easemotion.css</code>:
+        <code>@layer easemotion-base, easemotion-components, easemotion-utilities;</code>
+      </p>
+    </section>
+
+    <div class="lol-grid">
+      <!-- Editor -->
+      <section class="lol-card" aria-labelledby="editor-title">
+        <h2 id="editor-title">Override editor</h2>
+        <p class="lol-hint">Pick a preset or edit CSS, then apply to the preview.</p>
+
+        <fieldset class="lol-fieldset">
+          <legend class="lol-legend">Preset examples</legend>
+          <div class="lol-preset-row" role="radiogroup" aria-label="Override presets">
+            <label class="lol-preset">
+              <input type="radio" name="preset" value="button" checked />
+              <span>Button color</span>
+            </label>
+            <label class="lol-preset">
+              <input type="radio" name="preset" value="card" />
+              <span>Card border</span>
+            </label>
+            <label class="lol-preset">
+              <input type="radio" name="preset" value="tabs" />
+              <span>Tab underline</span>
+            </label>
+            <label class="lol-preset">
+              <input type="radio" name="preset" value="wrong" />
+              <span>Wrong layer (fails)</span>
+            </label>
+            <label class="lol-preset">
+              <input type="radio" name="preset" value="unlayered" />
+              <span>Unlayered (utility loses)</span>
+            </label>
+          </div>
+        </fieldset>
+
+        <label for="css-editor" class="lol-legend">Custom CSS</label>
+        <textarea
+          id="css-editor"
+          class="lol-editor"
+          rows="14"
+          spellcheck="false"
+          aria-label="CSS override editor"
+        ></textarea>
+
+        <div class="lol-actions">
+          <button type="button" class="ease-btn ease-btn-primary" id="btn-apply">
+            Apply override
+          </button>
+          <button type="button" class="ease-btn ease-btn-outline" id="btn-reset">
+            Reset to default
+          </button>
+          <button type="button" class="ease-btn ease-btn-success" id="btn-copy">
+            Copy snippet
+          </button>
+        </div>
+
+        <p class="lol-status" id="editor-status" role="status" aria-live="polite"></p>
+      </section>
+
+      <!-- Comparison -->
+      <section class="lol-card" aria-labelledby="compare-title">
+        <h2 id="compare-title">Live comparison</h2>
+        <p class="lol-hint" id="compare-hint">
+          Correct <code>@layer easemotion-components</code> overrides win at equal specificity.
+        </p>
+
+        <div class="lol-compare">
+          <article class="lol-preview" aria-label="Default framework styles">
+            <h3>Default</h3>
+            <div class="lol-preview-body" id="preview-default">
+              <button type="button" class="ease-btn ease-btn-primary">Primary button</button>
+              <div class="ease-card lol-card-demo">
+                <div class="ease-card-header"><strong>Card title</strong></div>
+                <div class="ease-card-body"><p>Default border and surface.</p></div>
+              </div>
+              <div class="ease-tabs lol-tabs-demo">
+                <input type="radio" name="tab-default" id="td1" class="ease-tab-input" checked />
+                <input type="radio" name="tab-default" id="td2" class="ease-tab-input" />
+                <div class="ease-tabs-nav">
+                  <label for="td1" class="ease-tab-label">Overview</label>
+                  <label for="td2" class="ease-tab-label">Settings</label>
+                </div>
+                <div class="ease-tab-panel">Tab content area</div>
+              </div>
+            </div>
+          </article>
+
+          <article class="lol-preview lol-preview-overridden" aria-label="With override applied">
+            <h3>With override <span class="lol-badge" id="override-badge">layer</span></h3>
+            <div class="lol-preview-body" id="preview-override">
+              <button type="button" class="ease-btn ease-btn-primary" id="demo-btn">
+                Primary button
+              </button>
+              <div class="ease-card lol-card-demo" id="demo-card">
+                <div class="ease-card-header"><strong>Card title</strong></div>
+                <div class="ease-card-body"><p>Custom themed border.</p></div>
+              </div>
+              <div class="ease-tabs lol-tabs-demo" id="demo-tabs">
+                <input type="radio" name="tab-override" id="to1" class="ease-tab-input" checked />
+                <input type="radio" name="tab-override" id="to2" class="ease-tab-input" />
+                <div class="ease-tabs-nav">
+                  <label for="to1" class="ease-tab-label">Overview</label>
+                  <label for="to2" class="ease-tab-label">Settings</label>
+                </div>
+                <div class="ease-tab-panel">Tab content area</div>
+              </div>
+              <div class="lol-utility-test ease-center" id="utility-box">
+                <span>ease-center utility</span>
+              </div>
+            </div>
+          </article>
+        </div>
+
+        <div class="lol-verdict" id="verdict" role="status" aria-live="polite">
+          Select a preset and click Apply to see the cascade result.
+        </div>
+      </section>
+    </div>
+
+    <!-- Snippets -->
+    <section class="lol-card lol-card-wide" aria-labelledby="snippet-title">
+      <h2 id="snippet-title">Copy-ready override snippets</h2>
+      <div class="lol-snippet-grid">
+        <article>
+          <h3>Button theme</h3>
+          <pre class="lol-pre"><code id="snip-button">@layer easemotion-components {
+  .ease-btn-primary {
+    background-color: #0d9488;
+    border-color: #0d9488;
+  }
+  .ease-btn-primary:hover {
+    background-color: #0f766e;
+    border-color: #0f766e;
+  }
+}</code></pre>
+        </article>
+        <article>
+          <h3>Card border</h3>
+          <pre class="lol-pre"><code id="snip-card">@layer easemotion-components {
+  .ease-card {
+    border: 2px solid #8b5cf6;
+    box-shadow: 0 8px 24px rgba(139, 92, 246, 0.15);
+  }
+}</code></pre>
+        </article>
+        <article>
+          <h3>Tab underline</h3>
+          <pre class="lol-pre"><code id="snip-tabs">@layer easemotion-components {
+  .ease-tabs-nav {
+    border-bottom-color: #e2e8f0;
+  }
+  .ease-tab-input:nth-of-type(1):checked
+    ~ .ease-tabs-nav .ease-tab-label:nth-of-type(1) {
+    color: #6c63ff;
+    box-shadow: inset 0 -3px 0 #6c63ff;
+  }
+}</code></pre>
+        </article>
+      </div>
+
+      <details class="lol-details">
+        <summary>Why not use !important?</summary>
+        <ul>
+          <li>Layer overrides keep specificity flat and maintainable.</li>
+          <li><code>!important</code> fights the framework and breaks composability.</li>
+          <li>Put theme rules in <code>@layer easemotion-components</code> or a layer declared after EaseMotion layers.</li>
+          <li>Load your override stylesheet <strong>after</strong> <code>easemotion.css</code>.</li>
+        </ul>
+      </details>
+    </section>
+  </main>
+
+  <footer class="lol-footer">
+    <p>
+      Built for EaseMotion CSS ·
+      <code>submissions/docs/ease-layer-override-lab-sp</code> ·
+      Resolves Issue #44492
+    </p>
+  </footer>
+
+  <!-- Dynamic override injection target -->
+  <style id="lol-override-style" data-lol="override"></style>
+
+  <script>
+    (function () {
+      'use strict';
+
+      var PRESETS = {
+        button: {
+          badge: 'components layer',
+          hint: 'Same specificity as framework — later source in the same layer wins.',
+          verdict: 'Override applied in @layer easemotion-components — button turns teal without !important.',
+          css:
+            '@layer easemotion-components {\n' +
+            '  .ease-btn-primary {\n' +
+            '    background-color: #0d9488;\n' +
+            '    border-color: #0d9488;\n' +
+            '  }\n' +
+            '  .ease-btn-primary:hover {\n' +
+            '    background-color: #0f766e;\n' +
+            '    border-color: #0f766e;\n' +
+            '  }\n' +
+            '}'
+        },
+        card: {
+          badge: 'components layer',
+          hint: 'Card border and shadow themed inside the components layer.',
+          verdict: 'Card border override wins — purple accent applied cleanly.',
+          css:
+            '@layer easemotion-components {\n' +
+            '  .ease-card {\n' +
+            '    border: 2px solid #8b5cf6;\n' +
+            '    box-shadow: 0 8px 24px rgba(139, 92, 246, 0.15);\n' +
+            '  }\n' +
+            '}'
+        },
+        tabs: {
+          badge: 'components layer',
+          hint: 'Tab active indicator customized in the components layer.',
+          verdict: 'Tab underline override wins — active tab shows custom inset shadow.',
+          css:
+            '@layer easemotion-components {\n' +
+            '  .ease-tabs-nav {\n' +
+            '    border-bottom-color: #cbd5e1;\n' +
+            '  }\n' +
+            '  #demo-tabs .ease-tab-input:nth-of-type(1):checked\n' +
+            '    ~ .ease-tabs-nav .ease-tab-label:nth-of-type(1) {\n' +
+            '    color: #6c63ff;\n' +
+            '    box-shadow: inset 0 -3px 0 #6c63ff;\n' +
+            '  }\n' +
+            '}'
+        },
+        wrong: {
+          badge: 'base layer — fails',
+          hint: 'Rules in an earlier layer cannot beat easemotion-components.',
+          verdict: 'Wrong layer — easemotion-base loses to easemotion-components. No visible change.',
+          css:
+            '@layer easemotion-base {\n' +
+            '  .ease-btn-primary {\n' +
+            '    background-color: #f97316;\n' +
+            '    border-color: #f97316;\n' +
+            '  }\n' +
+            '  .ease-card {\n' +
+            '    border-color: #f97316;\n' +
+            '  }\n' +
+            '}'
+        },
+        unlayered: {
+          badge: 'unlayered vs !important',
+          hint: 'Unlayered display:block loses to .ease-center { display:flex !important }.',
+          verdict:
+            'Unlayered .ease-center { display:block } loses — utilities use !important. ' +
+            'Use @layer for component theming instead.',
+          css:
+            '/* Component override (unlayered — works but not recommended) */\n' +
+            '.ease-btn-primary {\n' +
+            '  background-color: #ea580c;\n' +
+            '  border-color: #ea580c;\n' +
+            '}\n\n' +
+            '/* Utility override attempt — FAILS against !important */\n' +
+            '#utility-box.ease-center {\n' +
+            '  display: block;\n' +
+            '  text-align: left;\n' +
+            '}'
+        }
+      };
+
+      var editor = document.getElementById('css-editor');
+      var overrideStyle = document.getElementById('lol-override-style');
+      var statusEl = document.getElementById('editor-status');
+      var verdictEl = document.getElementById('verdict');
+      var hintEl = document.getElementById('compare-hint');
+      var badgeEl = document.getElementById('override-badge');
+      var activePreset = 'button';
+
+      function getPreset() {
+        var checked = document.querySelector('input[name="preset"]:checked');
+        return checked ? checked.value : 'button';
+      }
+
+      function loadPreset(key) {
+        var preset = PRESETS[key];
+        if (!preset) return;
+        activePreset = key;
+        editor.value = preset.css;
+        hintEl.textContent = preset.hint;
+        badgeEl.textContent = preset.badge;
+        verdictEl.textContent = 'Preset loaded — click Apply override.';
+        verdictEl.className = 'lol-verdict';
+      }
+
+      function applyOverride() {
+        overrideStyle.textContent = editor.value;
+        var preset = PRESETS[activePreset];
+        verdictEl.textContent = preset ? preset.verdict : 'Custom override applied.';
+        verdictEl.className = 'lol-verdict is-' + (activePreset === 'wrong' ? 'fail' : 'pass');
+        statusEl.textContent = 'Override injected into #lol-override-style.';
+      }
+
+      function resetOverride() {
+        overrideStyle.textContent = '';
+        editor.value = PRESETS.button.css;
+        activePreset = 'button';
+        document.querySelector('input[name="preset"][value="button"]').checked = true;
+        hintEl.textContent = PRESETS.button.hint;
+        badgeEl.textContent = PRESETS.button.badge;
+        verdictEl.textContent = 'Reset — showing default EaseMotion framework styles.';
+        verdictEl.className = 'lol-verdict';
+        statusEl.textContent = 'Overrides cleared.';
+      }
+
+      document.querySelectorAll('input[name="preset"]').forEach(function (radio) {
+        radio.addEventListener('change', function () {
+          loadPreset(radio.value);
+        });
+      });
+
+      document.getElementById('btn-apply').addEventListener('click', applyOverride);
+      document.getElementById('btn-reset').addEventListener('click', resetOverride);
+
+      document.getElementById('btn-copy').addEventListener('click', function () {
+        navigator.clipboard.writeText(editor.value).then(
+          function () { statusEl.textContent = 'Snippet copied to clipboard!'; },
+          function () { statusEl.textContent = 'Copy failed — select text manually.'; }
+        );
+      });
+
+      loadPreset('button');
+      applyOverride();
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-layer-override-lab-sp/style.css
+++ b/submissions/docs/ease-layer-override-lab-sp/style.css
@@ -1,0 +1,389 @@
+/* ============================================================
+   @layer Override Playground — style.css
+   submissions/docs/ease-layer-override-lab-sp
+   Lab chrome only — component overrides injected via JS
+   ============================================================ */
+
+/* Lab UI lives outside EaseMotion layers (unlayered page chrome) */
+
+body {
+  background:
+    radial-gradient(
+      880px 380px at 12% -8%,
+      var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.12)),
+      transparent
+    ),
+    radial-gradient(
+      640px 320px at 92% 2%,
+      rgba(13, 148, 136, 0.08),
+      transparent
+    ),
+    var(--ease-color-bg, #f8fafc);
+  min-height: 100vh;
+}
+
+/* ── Header ─────────────────────────────────────────────────── */
+
+.lol-header {
+  max-width: 76rem;
+  margin: 0 auto;
+  padding: var(--ease-space-12, 3rem) var(--ease-space-6, 1.5rem)
+    var(--ease-space-4, 1rem);
+  text-align: center;
+}
+
+.lol-eyebrow {
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ease-color-primary, #6c63ff);
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.lol-header h1 {
+  margin-bottom: var(--ease-space-3, 0.75rem);
+}
+
+.lol-subtitle {
+  max-width: 46rem;
+  margin: 0 auto;
+  color: var(--ease-color-muted, #475569);
+  font-size: var(--ease-text-base, 1rem);
+}
+
+/* ── Layout ─────────────────────────────────────────────────── */
+
+.lol-layout {
+  max-width: 76rem;
+  margin: 0 auto;
+  padding: var(--ease-space-4, 1rem) var(--ease-space-6, 1.5rem)
+    var(--ease-space-12, 3rem);
+}
+
+.lol-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.1fr);
+  gap: var(--ease-space-6, 1.5rem);
+  margin-bottom: var(--ease-space-6, 1.5rem);
+}
+
+.lol-card-wide {
+  margin-bottom: var(--ease-space-6, 1.5rem);
+}
+
+/* ── Cards ──────────────────────────────────────────────────── */
+
+.lol-card {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  box-shadow: var(--ease-shadow-md);
+  padding: var(--ease-space-6, 1.5rem);
+}
+
+.lol-card h2 {
+  font-size: var(--ease-text-xl, 1.25rem);
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.lol-hint {
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #475569);
+  margin-bottom: var(--ease-space-4, 1rem);
+}
+
+.lol-note {
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #475569);
+  margin-top: var(--ease-space-4, 1rem);
+}
+
+/* ── Layer stack diagram ────────────────────────────────────── */
+
+.lol-layer-stack {
+  display: grid;
+  gap: var(--ease-space-2, 0.5rem);
+  margin-top: var(--ease-space-4, 1rem);
+}
+
+.lol-layer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ease-space-4, 1rem);
+  padding: var(--ease-space-3, 0.75rem) var(--ease-space-4, 1rem);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  font-size: var(--ease-text-sm, 0.875rem);
+}
+
+.lol-layer span {
+  font-weight: 700;
+  font-family: var(--ease-font-mono, monospace);
+}
+
+.lol-layer small {
+  color: var(--ease-color-muted, #475569);
+  text-align: right;
+}
+
+.lol-layer-low {
+  background: var(--ease-color-neutral-50, #f8fafc);
+}
+
+.lol-layer-mid {
+  background: rgba(108, 99, 255, 0.08);
+  border-color: var(--ease-color-primary-light, #a09af8);
+}
+
+.lol-layer-high {
+  background: rgba(139, 92, 246, 0.08);
+}
+
+.lol-layer-top {
+  background: rgba(13, 148, 136, 0.1);
+  border-color: #0d9488;
+}
+
+/* ── Editor ─────────────────────────────────────────────────── */
+
+.lol-fieldset {
+  border: 0;
+  padding: 0;
+  margin: 0 0 var(--ease-space-4, 1rem);
+}
+
+.lol-legend {
+  display: block;
+  font-weight: 600;
+  font-size: var(--ease-text-sm, 0.875rem);
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.lol-preset-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ease-space-2, 0.5rem);
+}
+
+.lol-preset {
+  cursor: pointer;
+}
+
+.lol-preset input {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+
+.lol-preset span {
+  display: inline-block;
+  padding: var(--ease-space-2, 0.5rem) var(--ease-space-3, 0.75rem);
+  border: 2px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-full, 9999px);
+  font-size: var(--ease-text-xs, 0.75rem);
+  transition: all var(--ease-speed-fast, 150ms) var(--ease-ease);
+}
+
+.lol-preset input:focus-visible + span {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+
+.lol-preset input:checked + span {
+  border-color: var(--ease-color-primary, #6c63ff);
+  background: var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.15));
+  color: var(--ease-color-primary-dark, #4b44cc);
+  font-weight: 600;
+}
+
+.lol-editor {
+  width: 100%;
+  font-family: var(--ease-font-mono, 'JetBrains Mono', monospace);
+  font-size: var(--ease-text-xs, 0.75rem);
+  line-height: 1.55;
+  padding: var(--ease-space-3, 0.75rem);
+  border: 1px solid var(--ease-color-neutral-300, #cbd5e1);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  background: var(--ease-color-neutral-900, #0f172a);
+  color: #e2e8f0;
+  resize: vertical;
+  min-height: 12rem;
+  margin-bottom: var(--ease-space-4, 1rem);
+}
+
+.lol-editor:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+
+.lol-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ease-space-2, 0.5rem);
+}
+
+.lol-status {
+  margin-top: var(--ease-space-3, 0.75rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-success-dark, #15803d);
+  min-height: 1.25rem;
+}
+
+/* ── Comparison previews ────────────────────────────────────── */
+
+.lol-compare {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--ease-space-4, 1rem);
+}
+
+.lol-preview {
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  overflow: hidden;
+  background: var(--ease-color-neutral-50, #f8fafc);
+}
+
+.lol-preview h3 {
+  font-size: var(--ease-text-sm, 0.875rem);
+  padding: var(--ease-space-3, 0.75rem);
+  background: var(--ease-color-surface, #fff);
+  border-bottom: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-2, 0.5rem);
+}
+
+.lol-preview-overridden h3 {
+  background: rgba(108, 99, 255, 0.06);
+}
+
+.lol-badge {
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 600;
+  padding: 0.1rem 0.5rem;
+  border-radius: var(--ease-radius-full, 9999px);
+  background: var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.15));
+  color: var(--ease-color-primary-dark, #4b44cc);
+}
+
+.lol-preview-body {
+  padding: var(--ease-space-4, 1rem);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-space-4, 1rem);
+}
+
+.lol-card-demo {
+  max-width: 100%;
+}
+
+.lol-tabs-demo {
+  max-width: 100%;
+}
+
+.lol-utility-test {
+  min-height: 3rem;
+  padding: var(--ease-space-2, 0.5rem);
+  border: 1px dashed var(--ease-color-neutral-300, #cbd5e1);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  font-size: var(--ease-text-xs, 0.75rem);
+  background: var(--ease-color-surface, #fff);
+}
+
+.lol-verdict {
+  margin-top: var(--ease-space-4, 1rem);
+  padding: var(--ease-space-3, 0.75rem);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  font-weight: 600;
+}
+
+.lol-verdict.is-pass {
+  background: rgba(21, 128, 61, 0.1);
+  color: var(--ease-color-success-dark, #15803d);
+}
+
+.lol-verdict.is-fail {
+  background: rgba(180, 83, 9, 0.1);
+  color: var(--ease-color-warning-dark, #b45309);
+}
+
+/* ── Snippets ───────────────────────────────────────────────── */
+
+.lol-snippet-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--ease-space-4, 1rem);
+  margin-top: var(--ease-space-4, 1rem);
+}
+
+.lol-snippet-grid h3 {
+  font-size: var(--ease-text-sm, 0.875rem);
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.lol-pre {
+  background: var(--ease-color-neutral-900, #0f172a);
+  color: #e2e8f0;
+  padding: var(--ease-space-3, 0.75rem);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  font-size: var(--ease-text-xs, 0.75rem);
+  overflow-x: auto;
+  line-height: 1.5;
+}
+
+.lol-details {
+  margin-top: var(--ease-space-6, 1.5rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+}
+
+.lol-details summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--ease-color-primary, #6c63ff);
+}
+
+.lol-details ul {
+  margin-top: var(--ease-space-2, 0.5rem);
+  padding-left: var(--ease-space-5, 1.25rem);
+  color: var(--ease-color-muted, #475569);
+}
+
+/* ── Footer ─────────────────────────────────────────────────── */
+
+.lol-footer {
+  text-align: center;
+  padding: var(--ease-space-8, 2rem) var(--ease-space-6, 1.5rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #475569);
+}
+
+/* ── Responsive ───────────────────────────────────────────── */
+
+@media (max-width: 960px) {
+  .lol-grid,
+  .lol-compare,
+  .lol-snippet-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .lol-layer {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .lol-layer small {
+    text-align: left;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lol-preset span {
+    transition: none;
+  }
+}

--- a/submissions/docs/ease-loop-cpu-spike-sp/README.md
+++ b/submissions/docs/ease-loop-cpu-spike-sp/README.md
@@ -1,0 +1,54 @@
+# Multiple Looping Animations CPU Spike on Low-End Devices
+
+A documentation showcase that demonstrates **CPU performance impact** when a page contains 10+ simultaneous `.ease-ping` / `.ease-pulse` looping animations — with a live performance warning panel and safer alternatives.
+
+> Submission track: `submissions/docs/ease-loop-cpu-spike-sp/`  
+> Contributor suffix: `sp`  
+> Resolves: Issue #44495
+
+---
+
+## What does this do?
+
+EaseMotion makes it easy to add expressive looping animations, but stacking many infinite loops on one dashboard can cause CPU spikes and jank on low-end mobile devices.
+
+This guide lets contributors:
+
+- View 10+ simultaneous `.ease-ping` / `.ease-pulse` elements
+- See a live performance warning panel (loop count, paint load, severity)
+- Compare heavy loop overload vs optimized patterns
+- Learn safer alternatives and copy HTML snippets
+
+## How is it used?
+
+1. Open `demo.html` in a browser.
+2. Review the **live performance panel** (loop count, severity, frame estimate).
+3. Adjust the **loop count slider** (0–24) and click **Apply count**.
+4. Compare **Heavy** (infinite loops) vs **Optimized** (capped + one-shot).
+5. Check **prefers-reduced-motion** status on your system.
+6. Copy performance-safe snippets from the tabbed panel.
+
+## Features
+
+- Demo with 10+ looping `.ease-ping` / `.ease-pulse` elements
+- Live performance warning panel with severity indicator
+- Side-by-side heavy vs optimized comparison
+- Safer patterns: `ease-fade-in` one-shot, capped `--ease-animation-iterations`
+- `prefers-reduced-motion` fallback demonstration
+- Copy-ready HTML snippets
+- Responsive, accessible UI
+- Uses EaseMotion CSS CDN (`easemotion.min.css`)
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Interactive CPU spike demo and snippets |
+| `style.css` | Lab layout and dashboard badge styling |
+| `README.md` | This document |
+
+## Compliance notes
+
+- Only **new files** inside `submissions/docs/`.
+- No edits to `core/`, `components/`, or existing project files.
+- Self-contained — no backend, no build step.

--- a/submissions/docs/ease-loop-cpu-spike-sp/demo.html
+++ b/submissions/docs/ease-loop-cpu-spike-sp/demo.html
@@ -1,0 +1,350 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Looping Animation CPU Spike — Performance Guide</title>
+  <meta
+    name="description"
+    content="Demonstrates CPU impact of 10+ simultaneous ease-ping and ease-pulse loops with safer alternatives."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header class="lcp-header ease-fade-in">
+    <p class="lcp-eyebrow">EaseMotion CSS · Performance Lab</p>
+    <h1>Multiple Looping Animations CPU Spike</h1>
+    <p class="lcp-subtitle">
+      Stacking <code>.ease-ping</code> and <code>.ease-pulse</code> across a dashboard
+      can spike CPU on low-end devices. Compare heavy loops vs optimized patterns.
+    </p>
+  </header>
+
+  <main class="lcp-layout">
+    <!-- Performance panel -->
+    <section class="lcp-card lcp-card-wide" aria-labelledby="perf-title">
+      <h2 id="perf-title">Live performance warning panel</h2>
+
+      <div class="lcp-metrics" role="status" aria-live="polite">
+        <div class="lcp-metric">
+          <span class="lcp-metric-label">Active infinite loops</span>
+          <span class="lcp-metric-value" id="loop-count">0</span>
+        </div>
+        <div class="lcp-metric">
+          <span class="lcp-metric-label">Est. paint load</span>
+          <span class="lcp-metric-value" id="paint-load">Low</span>
+        </div>
+        <div class="lcp-metric">
+          <span class="lcp-metric-label">Severity</span>
+          <span class="lcp-metric-value lcp-severity" id="severity">Safe</span>
+        </div>
+        <div class="lcp-metric">
+          <span class="lcp-metric-label">Frame budget (~60fps)</span>
+          <span class="lcp-metric-value" id="frame-est">~16ms</span>
+        </div>
+      </div>
+
+      <div class="lcp-controls">
+        <label for="loop-slider" class="lcp-slider-label">
+          Heavy panel loop count: <strong id="slider-val">12</strong>
+        </label>
+        <input
+          type="range"
+          id="loop-slider"
+          class="lcp-slider"
+          min="0"
+          max="24"
+          value="12"
+          aria-valuemin="0"
+          aria-valuemax="24"
+          aria-valuenow="12"
+        />
+        <button type="button" class="ease-btn ease-btn-primary" id="btn-apply-count">
+          Apply count
+        </button>
+      </div>
+
+      <div class="lcp-alert" id="perf-warning" role="alert">
+        Keep simultaneous infinite loops under 3 on mobile dashboards.
+      </div>
+    </section>
+
+    <div class="lcp-compare">
+      <!-- Heavy -->
+      <section class="lcp-card lcp-panel-heavy" aria-labelledby="heavy-title">
+        <div class="lcp-panel-head">
+          <h2 id="heavy-title">Heavy — infinite loops</h2>
+          <span class="lcp-badge lcp-badge-bad">High CPU risk</span>
+        </div>
+        <p class="lcp-hint">
+          Dashboard badges all use <code>.ease-ping</code> and <code>.ease-pulse</code> with
+          default <code>infinite</code> iterations.
+        </p>
+        <div class="lcp-badge-grid" id="heavy-grid" aria-label="Heavy looping badges"></div>
+      </section>
+
+      <!-- Optimized -->
+      <section class="lcp-card lcp-panel-opt" aria-labelledby="opt-title">
+        <div class="lcp-panel-head">
+          <h2 id="opt-title">Optimized — capped &amp; one-shot</h2>
+          <span class="lcp-badge lcp-badge-good">Low CPU risk</span>
+        </div>
+        <p class="lcp-hint">
+          One notification ping, capped pulses, and <code>ease-fade-in</code> entrances.
+        </p>
+        <div class="lcp-badge-grid lcp-opt-grid" aria-label="Optimized animation badges">
+          <div class="lcp-dash-item ease-fade-in">
+            <span class="lcp-dot lcp-dot-primary ease-ping" aria-label="Live status ping"></span>
+            <span>Live status (1 ping)</span>
+          </div>
+          <div class="lcp-dash-item" style="--ease-animation-iterations: 3;">
+            <span class="lcp-dot lcp-dot-warning ease-pulse">3</span>
+            <span>Alerts (pulse ×3)</span>
+          </div>
+          <div class="lcp-dash-item" style="--ease-animation-iterations: 2;">
+            <span class="lcp-dot lcp-dot-danger ease-pulse">!</span>
+            <span>Critical (pulse ×2)</span>
+          </div>
+          <div class="lcp-dash-item ease-fade-in">
+            <span class="lcp-dot lcp-dot-info">✓</span>
+            <span>Synced (fade-in only)</span>
+          </div>
+          <div class="lcp-dash-item ease-fade-in ease-reveal-delay-1">
+            <span class="lcp-dot lcp-dot-success">↑</span>
+            <span>Upload done (one-shot)</span>
+          </div>
+          <div class="lcp-dash-item ease-fade-in ease-reveal-delay-2">
+            <span class="lcp-dot lcp-dot-neutral">◎</span>
+            <span>Idle (static)</span>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <!-- Reduced motion -->
+    <section class="lcp-card lcp-card-wide" aria-labelledby="prm-title">
+      <h2 id="prm-title">prefers-reduced-motion fallback</h2>
+      <p class="lcp-hint">
+        EaseMotion respects <code>prefers-reduced-motion: reduce</code> globally — looping
+        animations are shortened to near-instant in <code>easemotion.css</code>.
+      </p>
+      <div class="lcp-rm-demo">
+        <span class="lcp-dot lcp-dot-primary ease-ping">●</span>
+        <span class="lcp-dot lcp-dot-warning ease-pulse">●</span>
+        <span class="lcp-dot lcp-dot-danger ease-bounce">●</span>
+        <p id="rm-status">Your system: <strong>animations enabled</strong></p>
+      </div>
+    </section>
+
+    <!-- Snippets -->
+    <section class="lcp-card lcp-card-wide" aria-labelledby="snippet-title">
+      <h2 id="snippet-title">Copy-ready performance-safe snippets</h2>
+
+      <div class="lcp-snippet-tabs" role="tablist" aria-label="Snippet types">
+        <button type="button" class="lcp-tab active" data-snippet="cap" role="tab">
+          Cap iterations
+        </button>
+        <button type="button" class="lcp-tab" data-snippet="oneshot" role="tab">
+          One-shot entrance
+        </button>
+        <button type="button" class="lcp-tab" data-snippet="single" role="tab">
+          Single live ping
+        </button>
+        <button type="button" class="lcp-tab" data-snippet="global" role="tab">
+          Global cap
+        </button>
+      </div>
+
+      <pre class="lcp-pre"><code id="snippet-code"></code></pre>
+      <button type="button" class="ease-btn ease-btn-outline" id="btn-copy">Copy snippet</button>
+      <p class="lcp-status" id="copy-status" role="status" aria-live="polite"></p>
+
+      <details class="lcp-details">
+        <summary>CPU / paint cost guidelines</summary>
+        <ul>
+          <li>Each infinite loop triggers continuous compositor + paint work every frame.</li>
+          <li>Cap dashboard loops to <strong>1–3 simultaneous infinite</strong> animations.</li>
+          <li>Use <code>--ease-animation-iterations: 3</code> for attention without eternal cost.</li>
+          <li>Prefer <code>ease-fade-in</code> / <code>ease-slide-up</code> for one-shot entrances.</li>
+          <li>Test on throttled CPU in DevTools → Performance → CPU 4× slowdown.</li>
+          <li>Always verify <code>prefers-reduced-motion</code> behavior.</li>
+        </ul>
+      </details>
+    </section>
+  </main>
+
+  <footer class="lcp-footer">
+    <p>
+      Built for EaseMotion CSS ·
+      <code>submissions/docs/ease-loop-cpu-spike-sp</code> ·
+      Resolves Issue #44495
+    </p>
+  </footer>
+
+  <script>
+    (function () {
+      'use strict';
+
+      var SNIPPETS = {
+        cap:
+          '<!-- Cap loops per element with CSS variable -->\n' +
+          '<span class="ease-pulse" style="--ease-animation-iterations: 3;">\n' +
+          '  3 alerts\n' +
+          '</span>',
+        oneshot:
+          '<!-- One-shot entrance — no infinite loop -->\n' +
+          '<div class="ease-card ease-fade-in">\n' +
+          '  <p>New item appeared once.</p>\n' +
+          '</div>',
+        single:
+          '<!-- Only ONE live ping on the page -->\n' +
+          '<span class="ease-ping lcp-live-dot" aria-label="Live"></span>\n' +
+          '<!-- All other status dots: static or fade-in -->',
+        global:
+          '/* Cap ALL looping utilities project-wide */\n' +
+          ':root {\n' +
+          '  --ease-animation-iterations: 3;\n' +
+          '}\n\n' +
+          '/* .ease-ping, .ease-pulse, .ease-bounce\n' +
+          '   all respect this token by default */'
+      };
+
+      var heavyGrid = document.getElementById('heavy-grid');
+      var loopCountEl = document.getElementById('loop-count');
+      var paintLoadEl = document.getElementById('paint-load');
+      var severityEl = document.getElementById('severity');
+      var frameEstEl = document.getElementById('frame-est');
+      var perfWarning = document.getElementById('perf-warning');
+      var slider = document.getElementById('loop-slider');
+      var sliderVal = document.getElementById('slider-val');
+      var activeSnippet = 'cap';
+      var rafId = null;
+      var lastFrame = 0;
+      var frameDeltas = [];
+
+      var TYPES = [
+        { cls: 'ease-ping', label: 'Ping', color: 'primary' },
+        { cls: 'ease-pulse', label: 'Pulse', color: 'warning' },
+        { cls: 'ease-ping', label: 'Ping', color: 'danger' },
+        { cls: 'ease-pulse', label: 'Pulse', color: 'info' }
+      ];
+
+      function buildHeavyGrid(count) {
+        heavyGrid.innerHTML = '';
+        for (var i = 0; i < count; i++) {
+          var t = TYPES[i % TYPES.length];
+          var item = document.createElement('div');
+          item.className = 'lcp-dash-item';
+          item.innerHTML =
+            '<span class="lcp-dot lcp-dot-' + t.color + ' ' + t.cls + '">' +
+            (i + 1) + '</span><span>' + t.label + ' #' + (i + 1) + '</span>';
+          heavyGrid.appendChild(item);
+        }
+        updateMetrics(count);
+      }
+
+      function getSeverity(count) {
+        if (count <= 2) return { label: 'Safe', cls: 'lcp-sev-safe' };
+        if (count <= 5) return { label: 'Caution', cls: 'lcp-sev-warn' };
+        if (count <= 10) return { label: 'High', cls: 'lcp-sev-high' };
+        return { label: 'Critical', cls: 'lcp-sev-critical' };
+      }
+
+      function getPaintLoad(count) {
+        if (count <= 2) return 'Low';
+        if (count <= 6) return 'Medium';
+        if (count <= 12) return 'High';
+        return 'Very High';
+      }
+
+      function updateMetrics(count) {
+        var sev = getSeverity(count);
+        loopCountEl.textContent = String(count);
+        paintLoadEl.textContent = getPaintLoad(count);
+        severityEl.textContent = sev.label;
+        severityEl.className = 'lcp-metric-value lcp-severity ' + sev.cls;
+
+        perfWarning.className = 'lcp-alert lcp-alert-' +
+          (count > 10 ? 'critical' : count > 5 ? 'warn' : 'info');
+        perfWarning.textContent =
+          count > 10
+            ? 'Critical: ' + count + ' infinite loops — expect jank on low-end mobile devices.'
+            : count > 5
+              ? 'Warning: ' + count + ' loops — consider capping with --ease-animation-iterations.'
+              : 'Safe range — keep simultaneous infinite loops under 3 on production dashboards.';
+      }
+
+      function trackFrames() {
+        var now = performance.now();
+        if (lastFrame) {
+          frameDeltas.push(now - lastFrame);
+          if (frameDeltas.length > 30) frameDeltas.shift();
+          var avg = frameDeltas.reduce(function (a, b) { return a + b; }, 0) / frameDeltas.length;
+          frameEstEl.textContent = '~' + avg.toFixed(1) + 'ms';
+          frameEstEl.className = 'lcp-metric-value' + (avg > 20 ? ' lcp-frame-bad' : '');
+        }
+        lastFrame = now;
+        rafId = requestAnimationFrame(trackFrames);
+      }
+
+      function renderSnippet(key) {
+        activeSnippet = key;
+        document.getElementById('snippet-code').textContent = SNIPPETS[key] || '';
+        document.querySelectorAll('.lcp-tab').forEach(function (tab) {
+          tab.classList.toggle('active', tab.getAttribute('data-snippet') === key);
+        });
+      }
+
+      function checkReducedMotion() {
+        var reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        document.getElementById('rm-status').innerHTML =
+          'Your system: <strong>' +
+          (reduced ? 'reduced motion ON — loops minimized' : 'animations enabled') +
+          '</strong>';
+      }
+
+      slider.addEventListener('input', function () {
+        sliderVal.textContent = slider.value;
+        slider.setAttribute('aria-valuenow', slider.value);
+      });
+
+      document.getElementById('btn-apply-count').addEventListener('click', function () {
+        buildHeavyGrid(Number(slider.value));
+      });
+
+      document.querySelectorAll('.lcp-tab').forEach(function (tab) {
+        tab.addEventListener('click', function () {
+          renderSnippet(tab.getAttribute('data-snippet'));
+        });
+      });
+
+      document.getElementById('btn-copy').addEventListener('click', function () {
+        navigator.clipboard.writeText(SNIPPETS[activeSnippet]).then(
+          function () { document.getElementById('copy-status').textContent = 'Snippet copied!'; },
+          function () { document.getElementById('copy-status').textContent = 'Copy failed.'; }
+        );
+      });
+
+      buildHeavyGrid(12);
+      renderSnippet('cap');
+      checkReducedMotion();
+      window.matchMedia('(prefers-reduced-motion: reduce)').addEventListener('change', checkReducedMotion);
+      rafId = requestAnimationFrame(trackFrames);
+
+      window.addEventListener('beforeunload', function () {
+        if (rafId) cancelAnimationFrame(rafId);
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-loop-cpu-spike-sp/style.css
+++ b/submissions/docs/ease-loop-cpu-spike-sp/style.css
@@ -1,0 +1,366 @@
+/* ============================================================
+   Looping Animation CPU Spike Guide — style.css
+   submissions/docs/ease-loop-cpu-spike-sp
+   ============================================================ */
+
+body {
+  background:
+    radial-gradient(
+      900px 400px at 8% -5%,
+      var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.1)),
+      transparent
+    ),
+    radial-gradient(
+      700px 350px at 95% 0%,
+      rgba(239, 68, 68, 0.06),
+      transparent
+    ),
+    var(--ease-color-bg, #f8fafc);
+  min-height: 100vh;
+}
+
+/* ── Header ─────────────────────────────────────────────────── */
+
+.lcp-header {
+  max-width: 76rem;
+  margin: 0 auto;
+  padding: var(--ease-space-12, 3rem) var(--ease-space-6, 1.5rem)
+    var(--ease-space-4, 1rem);
+  text-align: center;
+}
+
+.lcp-eyebrow {
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ease-color-primary, #6c63ff);
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.lcp-header h1 {
+  margin-bottom: var(--ease-space-3, 0.75rem);
+}
+
+.lcp-subtitle {
+  max-width: 44rem;
+  margin: 0 auto;
+  color: var(--ease-color-muted, #475569);
+}
+
+/* ── Layout ─────────────────────────────────────────────────── */
+
+.lcp-layout {
+  max-width: 76rem;
+  margin: 0 auto;
+  padding: var(--ease-space-4, 1rem) var(--ease-space-6, 1.5rem)
+    var(--ease-space-12, 3rem);
+}
+
+.lcp-card-wide {
+  margin-bottom: var(--ease-space-6, 1.5rem);
+}
+
+.lcp-compare {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--ease-space-6, 1.5rem);
+  margin-bottom: var(--ease-space-6, 1.5rem);
+}
+
+/* ── Cards ──────────────────────────────────────────────────── */
+
+.lcp-card {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  box-shadow: var(--ease-shadow-md);
+  padding: var(--ease-space-6, 1.5rem);
+}
+
+.lcp-card h2 {
+  font-size: var(--ease-text-xl, 1.25rem);
+}
+
+.lcp-hint {
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #475569);
+  margin: var(--ease-space-2, 0.5rem) 0 var(--ease-space-4, 1rem);
+}
+
+.lcp-panel-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ease-space-2, 0.5rem);
+}
+
+.lcp-panel-heavy {
+  border-top: 4px solid var(--ease-color-danger, #b91c1c);
+}
+
+.lcp-panel-opt {
+  border-top: 4px solid var(--ease-color-success, #15803d);
+}
+
+.lcp-badge {
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 700;
+  padding: 0.2rem 0.6rem;
+  border-radius: var(--ease-radius-full, 9999px);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.lcp-badge-bad {
+  background: rgba(185, 28, 28, 0.1);
+  color: var(--ease-color-danger-dark, #b91c1c);
+}
+
+.lcp-badge-good {
+  background: rgba(21, 128, 61, 0.1);
+  color: var(--ease-color-success-dark, #15803d);
+}
+
+/* ── Metrics ────────────────────────────────────────────────── */
+
+.lcp-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--ease-space-3, 0.75rem);
+  margin: var(--ease-space-4, 1rem) 0;
+}
+
+.lcp-metric {
+  padding: var(--ease-space-3, 0.75rem);
+  background: var(--ease-color-neutral-50, #f8fafc);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  text-align: center;
+}
+
+.lcp-metric-label {
+  display: block;
+  font-size: var(--ease-text-xs, 0.75rem);
+  color: var(--ease-color-muted, #475569);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: var(--ease-space-1, 0.25rem);
+}
+
+.lcp-metric-value {
+  font-size: var(--ease-text-xl, 1.25rem);
+  font-weight: 800;
+  font-family: var(--ease-font-mono, monospace);
+}
+
+.lcp-sev-safe { color: var(--ease-color-success-dark, #15803d); }
+.lcp-sev-warn { color: var(--ease-color-warning-dark, #b45309); }
+.lcp-sev-high { color: #ea580c; }
+.lcp-sev-critical { color: var(--ease-color-danger-dark, #b91c1c); }
+
+.lcp-frame-bad {
+  color: var(--ease-color-danger-dark, #b91c1c);
+}
+
+/* ── Controls ───────────────────────────────────────────────── */
+
+.lcp-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--ease-space-4, 1rem);
+  margin-bottom: var(--ease-space-4, 1rem);
+}
+
+.lcp-slider-label {
+  font-size: var(--ease-text-sm, 0.875rem);
+  min-width: 12rem;
+}
+
+.lcp-slider {
+  flex: 1;
+  min-width: 10rem;
+  accent-color: var(--ease-color-primary, #6c63ff);
+}
+
+.lcp-alert {
+  padding: var(--ease-space-3, 0.75rem);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+}
+
+.lcp-alert-info {
+  background: rgba(59, 130, 246, 0.1);
+  color: var(--ease-color-info-dark, #1d4ed8);
+  border: 1px solid var(--ease-color-info, #3b82f6);
+}
+
+.lcp-alert-warn {
+  background: rgba(180, 83, 9, 0.1);
+  color: var(--ease-color-warning-dark, #b45309);
+  border: 1px solid var(--ease-color-warning, #b45309);
+}
+
+.lcp-alert-critical {
+  background: rgba(185, 28, 28, 0.1);
+  color: var(--ease-color-danger-dark, #b91c1c);
+  border: 1px solid var(--ease-color-danger, #b91c1c);
+}
+
+/* ── Badge grid ─────────────────────────────────────────────── */
+
+.lcp-badge-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(7.5rem, 1fr));
+  gap: var(--ease-space-3, 0.75rem);
+}
+
+.lcp-dash-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--ease-space-2, 0.5rem);
+  padding: var(--ease-space-3, 0.75rem);
+  background: var(--ease-color-neutral-50, #f8fafc);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  font-size: var(--ease-text-xs, 0.75rem);
+  text-align: center;
+}
+
+.lcp-dot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: var(--ease-radius-full, 9999px);
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 700;
+  color: #fff;
+}
+
+.lcp-dot-primary { background: var(--ease-color-primary, #6c63ff); }
+.lcp-dot-warning { background: var(--ease-color-warning, #b45309); }
+.lcp-dot-danger  { background: var(--ease-color-danger, #b91c1c); }
+.lcp-dot-info    { background: var(--ease-color-info, #3b82f6); }
+.lcp-dot-success { background: var(--ease-color-success, #15803d); }
+.lcp-dot-neutral { background: var(--ease-color-neutral-500, #64748b); }
+
+.lcp-opt-grid .lcp-dash-item {
+  background: rgba(21, 128, 61, 0.04);
+  border-color: rgba(21, 128, 61, 0.2);
+}
+
+/* ── Reduced motion demo ────────────────────────────────────── */
+
+.lcp-rm-demo {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--ease-space-4, 1rem);
+  padding: var(--ease-space-4, 1rem);
+  background: var(--ease-color-neutral-50, #f8fafc);
+  border-radius: var(--ease-radius-md, 0.5rem);
+}
+
+.lcp-rm-demo p {
+  margin: 0;
+  font-size: var(--ease-text-sm, 0.875rem);
+}
+
+/* ── Snippets ───────────────────────────────────────────────── */
+
+.lcp-snippet-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ease-space-2, 0.5rem);
+  margin-bottom: var(--ease-space-4, 1rem);
+}
+
+.lcp-tab {
+  padding: var(--ease-space-2, 0.5rem) var(--ease-space-3, 0.75rem);
+  border: 2px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-full, 9999px);
+  background: var(--ease-color-surface, #fff);
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.lcp-tab:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+
+.lcp-tab.active {
+  border-color: var(--ease-color-primary, #6c63ff);
+  background: var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.15));
+  color: var(--ease-color-primary-dark, #4b44cc);
+}
+
+.lcp-pre {
+  background: var(--ease-color-neutral-900, #0f172a);
+  color: #e2e8f0;
+  padding: var(--ease-space-4, 1rem);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  font-size: var(--ease-text-xs, 0.75rem);
+  line-height: 1.55;
+  overflow-x: auto;
+  margin-bottom: var(--ease-space-4, 1rem);
+}
+
+.lcp-status {
+  margin-top: var(--ease-space-2, 0.5rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-success-dark, #15803d);
+  min-height: 1.25rem;
+}
+
+.lcp-details {
+  margin-top: var(--ease-space-6, 1.5rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #475569);
+}
+
+.lcp-details summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--ease-color-primary, #6c63ff);
+}
+
+.lcp-details ul {
+  margin-top: var(--ease-space-2, 0.5rem);
+  padding-left: var(--ease-space-5, 1.25rem);
+}
+
+.lcp-details li {
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+/* ── Footer ─────────────────────────────────────────────────── */
+
+.lcp-footer {
+  text-align: center;
+  padding: var(--ease-space-8, 2rem) var(--ease-space-6, 1.5rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #475569);
+}
+
+/* ── Responsive ───────────────────────────────────────────── */
+
+@media (max-width: 900px) {
+  .lcp-compare,
+  .lcp-metrics {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lcp-tab {
+    transition: none;
+  }
+}

--- a/submissions/docs/ease-reveal-cls-issue-sp/README.md
+++ b/submissions/docs/ease-reveal-cls-issue-sp/README.md
@@ -1,0 +1,55 @@
+# ease-reveal Fires Before Images Load (Layout Shift)
+
+A documentation showcase that demonstrates **CLS (Cumulative Layout Shift)** when `ease-reveal` triggers before image dimensions are known — plus documented fix patterns.
+
+> Submission track: `submissions/docs/ease-reveal-cls-issue-sp/`  
+> Contributor suffix: `sp`  
+> Resolves: Issue #44494
+
+---
+
+## What does this do?
+
+EaseMotion's scroll reveal (`core/reveal.js` + `.ease-reveal` classes) can activate before async images reserve layout space. When images load later, content jumps — hurting Core Web Vitals CLS scores.
+
+This showcase lets contributors:
+
+- Reproduce the CLS issue with delayed image loading
+- Compare broken vs fixed implementations side by side
+- View live CLS scores via `PerformanceObserver`
+- Learn fix patterns and copy HTML snippets
+
+## How is it used?
+
+1. Open `demo.html` in a browser.
+2. Click **Replay demo** to reload images with a 2.5s delay.
+3. Watch the **Broken** panel caption jump when the image loads.
+4. Compare with the **Fixed** panel (aspect-ratio + skeleton).
+5. Toggle **Delay reveal until images load** on the fixed panel.
+6. Copy snippets for your own CLS-safe reveal usage.
+
+## Features
+
+- Reproducible `ease-reveal` + unloaded image CLS demo
+- Side-by-side broken vs fixed comparison
+- CLS impact visualization panel
+- Fix patterns: `width`/`height`, `aspect-ratio`, skeleton placeholders
+- Delayed reveal trigger (wait for `load` event)
+- Educational notes on CLS and reveal timing
+- Copy-ready HTML snippets
+- Responsive, accessible UI
+- Uses EaseMotion CSS CDN + `core/reveal.js`
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Interactive CLS demo and snippet tabs |
+| `style.css` | Lab layout and broken/fixed visual styling |
+| `README.md` | This document |
+
+## Compliance notes
+
+- Only **new files** inside `submissions/docs/`.
+- No edits to `core/`, `components/`, or existing project files.
+- Self-contained — no backend, no build step.

--- a/submissions/docs/ease-reveal-cls-issue-sp/demo.html
+++ b/submissions/docs/ease-reveal-cls-issue-sp/demo.html
@@ -1,0 +1,406 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-reveal CLS Issue — Layout Shift Showcase</title>
+  <meta
+    name="description"
+    content="Demonstrates CLS when ease-reveal fires before images load, with fix patterns for CLS-safe reveal usage."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header class="cls-header ease-fade-in">
+    <p class="cls-eyebrow">EaseMotion CSS · Core Web Vitals Lab</p>
+    <h1>ease-reveal + Images = Layout Shift?</h1>
+    <p class="cls-subtitle">
+      <code>core/reveal.js</code> can activate <code>.ease-reveal</code> before async images
+      reserve space. This showcase reproduces the CLS problem and documents fix patterns.
+    </p>
+  </header>
+
+  <main class="cls-layout">
+    <!-- CLS panel -->
+    <section class="cls-card cls-card-wide" aria-labelledby="cls-title">
+      <h2 id="cls-title">CLS impact panel</h2>
+      <div class="cls-metrics" role="status" aria-live="polite">
+        <div class="cls-metric">
+          <span class="cls-metric-label">Broken CLS score</span>
+          <span class="cls-metric-value cls-bad" id="cls-broken">0.000</span>
+        </div>
+        <div class="cls-metric">
+          <span class="cls-metric-label">Fixed CLS score</span>
+          <span class="cls-metric-value cls-good" id="cls-fixed">0.000</span>
+        </div>
+        <div class="cls-metric">
+          <span class="cls-metric-label">Image load delay</span>
+          <span class="cls-metric-value" id="load-delay">2.5s</span>
+        </div>
+      </div>
+      <div class="cls-controls">
+        <button type="button" class="ease-btn ease-btn-primary" id="btn-replay">
+          Replay demo (reload images)
+        </button>
+        <label class="cls-toggle">
+          <input type="checkbox" id="delay-reveal" />
+          <span>Delay reveal until images load (fixed panel only)</span>
+        </label>
+      </div>
+      <p class="cls-hint">
+        Scores use <code>PerformanceObserver</code> layout-shift entries. Google recommends
+        CLS &lt; 0.1 for good Core Web Vitals.
+      </p>
+    </section>
+
+  <div class="cls-compare-grid">
+    <!-- Broken -->
+    <section class="cls-card cls-panel-broken" aria-labelledby="broken-title">
+      <div class="cls-panel-head">
+        <h2 id="broken-title">Broken — no reserved space</h2>
+        <span class="cls-badge cls-badge-bad">High CLS risk</span>
+      </div>
+      <p class="cls-hint">
+        Image has no <code>width</code>/<code>height</code> or <code>aspect-ratio</code>.
+        Reveal fires on scroll; image loads later and pushes content.
+      </p>
+
+      <article class="ease-card cls-gallery-card ease-reveal ease-reveal-up" id="broken-card">
+        <div class="ease-card-header">
+          <strong>Gallery card</strong>
+        </div>
+        <div class="ease-card-body">
+          <div class="cls-img-wrap cls-img-broken">
+            <img
+              id="broken-img"
+              alt="Landscape photo loading without dimensions"
+              class="cls-img"
+              decoding="async"
+            />
+          </div>
+          <p>Caption appears below the image — watch it jump when the image loads.</p>
+        </div>
+      </article>
+
+      <details class="cls-details">
+        <summary>Why this breaks</summary>
+        <ul>
+          <li><code>.ease-reveal</code> starts at <code>opacity: 0</code> but still occupies zero image height.</li>
+          <li><code>reveal.js</code> adds <code>.ease-reveal-active</code> on intersect — before the image loads.</li>
+          <li>When the image arrives, layout height changes → cumulative layout shift.</li>
+        </ul>
+      </details>
+    </section>
+
+    <!-- Fixed -->
+    <section class="cls-card cls-panel-fixed" aria-labelledby="fixed-title">
+      <div class="cls-panel-head">
+        <h2 id="fixed-title">Fixed — CLS-safe patterns</h2>
+        <span class="cls-badge cls-badge-good">Low CLS risk</span>
+      </div>
+      <p class="cls-hint">
+        Uses <code>aspect-ratio</code>, skeleton placeholder, and optional delayed reveal
+        until <code>load</code> event.
+      </p>
+
+      <article
+        class="ease-card cls-gallery-card ease-reveal ease-reveal-up"
+        id="fixed-card"
+        data-cls-safe
+      >
+        <div class="ease-card-header">
+          <strong>Gallery card (fixed)</strong>
+        </div>
+        <div class="ease-card-body">
+          <div class="cls-img-wrap cls-img-fixed">
+            <span class="ease-skeleton cls-skeleton" id="fixed-skeleton" aria-hidden="true"></span>
+            <img
+              id="fixed-img"
+              alt="Landscape photo with reserved aspect ratio"
+              class="cls-img"
+              width="640"
+              height="360"
+              decoding="async"
+            />
+          </div>
+          <p>Caption stays stable — space reserved before the image appears.</p>
+        </div>
+      </article>
+
+      <details class="cls-details" open>
+        <summary>Fix patterns used</summary>
+        <ul>
+          <li><strong>aspect-ratio</strong> on wrapper (<code>16 / 9</code>)</li>
+          <li><strong>width / height</strong> attributes on <code>&lt;img&gt;</code></li>
+          <li><strong>Skeleton</strong> placeholder until image loads</li>
+          <li><strong>Delayed reveal</strong> — wait for <code>load</code> before adding active class</li>
+        </ul>
+      </details>
+    </section>
+  </div>
+
+  <!-- Snippets -->
+  <section class="cls-card cls-card-wide" aria-labelledby="snippet-title">
+    <h2 id="snippet-title">Copy-ready HTML snippets</h2>
+
+    <div class="cls-snippet-tabs" role="tablist" aria-label="Fix pattern snippets">
+      <button type="button" class="cls-tab active" data-snippet="aspect" role="tab">
+        aspect-ratio
+      </button>
+      <button type="button" class="cls-tab" data-snippet="dimensions" role="tab">
+        width / height
+      </button>
+      <button type="button" class="cls-tab" data-snippet="skeleton" role="tab">
+        skeleton
+      </button>
+      <button type="button" class="cls-tab" data-snippet="delayed" role="tab">
+        delayed reveal
+      </button>
+    </div>
+
+    <pre class="cls-pre"><code id="snippet-code"></code></pre>
+    <button type="button" class="ease-btn ease-btn-outline" id="btn-copy-snippet">
+      Copy snippet
+    </button>
+    <p class="cls-status" id="copy-status" role="status" aria-live="polite"></p>
+
+    <details class="cls-details">
+      <summary>Best practices for ease-reveal + media</summary>
+      <ul>
+        <li>Always reserve space for images, video, and embeds before reveal animates.</li>
+        <li>Prefer <code>aspect-ratio</code> + <code>object-fit: cover</code> for responsive galleries.</li>
+        <li>Use <code>ease-skeleton</code> components while async content loads.</li>
+        <li>For heavy pages, delay <code>.ease-reveal-active</code> until critical images fire <code>load</code>.</li>
+        <li>Test with throttled network in DevTools → Performance → Experience.</li>
+      </ul>
+    </details>
+  </section>
+  </main>
+
+  <footer class="cls-footer">
+    <p>
+      Built for EaseMotion CSS ·
+      <code>submissions/docs/ease-reveal-cls-issue-sp</code> ·
+      Resolves Issue #44494
+    </p>
+  </footer>
+
+  <!-- reveal.js from framework -->
+  <script src="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/core/reveal.js"></script>
+
+  <script>
+    (function () {
+      'use strict';
+
+      var IMAGE_URL =
+        'https://picsum.photos/seed/easemotion-cls/640/360';
+      var LOAD_DELAY_MS = 2500;
+
+      var SNIPPETS = {
+        aspect:
+          '<!-- Reserve space with aspect-ratio wrapper -->\n' +
+          '<article class="ease-card ease-reveal ease-reveal-up">\n' +
+          '  <div class="img-frame" style="aspect-ratio: 16/9;">\n' +
+          '    <img src="photo.jpg" alt="Description"\n' +
+          '         style="width:100%;height:100%;object-fit:cover;" />\n' +
+          '  </div>\n' +
+          '  <p>Stable caption below image.</p>\n' +
+          '</article>\n' +
+          '<script src="easemotion-css/core/reveal.js"><\/script>',
+        dimensions:
+          '<!-- Explicit width + height prevent reflow -->\n' +
+          '<article class="ease-card ease-reveal ease-reveal-up">\n' +
+          '  <img src="photo.jpg" alt="Description"\n' +
+          '       width="640" height="360"\n' +
+          '       style="max-width:100%;height:auto;" />\n' +
+          '  <p>Stable caption below image.</p>\n' +
+          '</article>',
+        skeleton:
+          '<!-- Skeleton until image loads -->\n' +
+          '<div class="img-frame" style="aspect-ratio:16/9;position:relative;">\n' +
+          '  <span class="ease-skeleton" style="position:absolute;inset:0;"></span>\n' +
+          '  <img src="photo.jpg" alt="Description"\n' +
+          '       onload="this.previousElementSibling.remove()"\n' +
+          '       style="width:100%;height:100%;object-fit:cover;" />\n' +
+          '</div>',
+        delayed:
+          '<!-- Delay .ease-reveal-active until images load -->\n' +
+          '<article class="ease-reveal ease-reveal-up" id="gallery-card">\n' +
+          '  <img id="hero-img" data-src="photo.jpg" alt="Hero" />\n' +
+          '</article>\n' +
+          '<script>\n' +
+          '  var card = document.getElementById("gallery-card");\n' +
+          '  var img = document.getElementById("hero-img");\n' +
+          '  img.addEventListener("load", function () {\n' +
+          '    card.classList.add("ease-reveal-active");\n' +
+          '  });\n' +
+          '  img.src = img.dataset.src;\n' +
+          '<\/script>'
+      };
+
+      var clsBroken = 0;
+      var clsFixed = 0;
+      var brokenImg = document.getElementById('broken-img');
+      var fixedImg = document.getElementById('fixed-img');
+      var fixedSkeleton = document.getElementById('fixed-skeleton');
+      var fixedCard = document.getElementById('fixed-card');
+      var brokenCard = document.getElementById('broken-card');
+      var delayRevealCheck = document.getElementById('delay-reveal');
+      var activeSnippet = 'aspect';
+
+      function formatCls(n) {
+        return n.toFixed(3);
+      }
+
+      function updateClsDisplay() {
+        document.getElementById('cls-broken').textContent = formatCls(clsBroken);
+        document.getElementById('cls-fixed').textContent = formatCls(clsFixed);
+      }
+
+      function observeCls(targetId, isBroken) {
+        if (!('PerformanceObserver' in window)) return;
+
+        try {
+          var po = new PerformanceObserver(function (list) {
+            list.getEntries().forEach(function (entry) {
+              if (entry.hadRecentInput) return;
+              var sources = entry.sources || [];
+              var inTarget = sources.some(function (src) {
+                var node = src.node;
+                if (!node) return false;
+                var panel = document.getElementById(targetId);
+                return panel && panel.contains(node);
+              });
+              if (!inTarget && sources.length > 0) return;
+              if (isBroken) {
+                clsBroken += entry.value;
+              } else {
+                clsFixed += entry.value;
+              }
+              updateClsDisplay();
+            });
+          });
+          po.observe({ type: 'layout-shift', buffered: true });
+        } catch (e) {
+          /* layout-shift not supported */
+        }
+      }
+
+      function resetRevealState() {
+        [brokenCard, fixedCard].forEach(function (card) {
+          card.classList.remove('ease-reveal-active');
+        });
+        fixedSkeleton.hidden = false;
+        fixedImg.style.opacity = '0';
+      }
+
+      function loadImagesDelayed() {
+        brokenImg.removeAttribute('src');
+        fixedImg.removeAttribute('src');
+        brokenImg.style.visibility = 'hidden';
+        fixedImg.style.opacity = '0';
+
+        setTimeout(function () {
+          brokenImg.src = IMAGE_URL + '?broken=' + Date.now();
+          fixedImg.src = IMAGE_URL + '?fixed=' + Date.now();
+        }, LOAD_DELAY_MS);
+      }
+
+      function setupBrokenImage() {
+        brokenImg.addEventListener('load', function () {
+          brokenImg.style.visibility = 'visible';
+        });
+      }
+
+      function setupFixedImage() {
+        fixedImg.addEventListener('load', function () {
+          fixedSkeleton.hidden = true;
+          fixedImg.style.opacity = '1';
+
+          if (delayRevealCheck.checked) {
+            fixedCard.classList.add('ease-reveal-active');
+          }
+        });
+      }
+
+      function applyDelayedRevealMode() {
+        if (delayRevealCheck.checked) {
+          fixedCard.classList.remove('ease-reveal-active');
+        }
+      }
+
+      function replayDemo() {
+        clsBroken = 0;
+        clsFixed = 0;
+        updateClsDisplay();
+        resetRevealState();
+        applyDelayedRevealMode();
+        loadImagesDelayed();
+
+        setTimeout(function () {
+          if (!brokenCard.classList.contains('ease-reveal-active')) {
+            brokenCard.classList.add('ease-reveal-active');
+          }
+          if (!delayRevealCheck.checked) {
+            fixedCard.classList.add('ease-reveal-active');
+          }
+        }, 400);
+      }
+
+      function renderSnippet(key) {
+        activeSnippet = key;
+        document.getElementById('snippet-code').textContent = SNIPPETS[key] || '';
+        document.querySelectorAll('.cls-tab').forEach(function (tab) {
+          tab.classList.toggle('active', tab.getAttribute('data-snippet') === key);
+        });
+      }
+
+      document.getElementById('btn-replay').addEventListener('click', replayDemo);
+
+      delayRevealCheck.addEventListener('change', function () {
+        applyDelayedRevealMode();
+        document.getElementById('copy-status').textContent =
+          delayRevealCheck.checked
+            ? 'Fixed panel will reveal only after image load event.'
+            : 'Fixed panel reveals on scroll (space still reserved).';
+      });
+
+      document.querySelectorAll('.cls-tab').forEach(function (tab) {
+        tab.addEventListener('click', function () {
+          renderSnippet(tab.getAttribute('data-snippet'));
+        });
+      });
+
+      document.getElementById('btn-copy-snippet').addEventListener('click', function () {
+        navigator.clipboard.writeText(SNIPPETS[activeSnippet]).then(
+          function () {
+            document.getElementById('copy-status').textContent = 'Snippet copied!';
+          },
+          function () {
+            document.getElementById('copy-status').textContent = 'Copy failed.';
+          }
+        );
+      });
+
+      observeCls('broken-card', true);
+      observeCls('fixed-card', false);
+      setupBrokenImage();
+      setupFixedImage();
+      renderSnippet('aspect');
+      document.getElementById('load-delay').textContent = (LOAD_DELAY_MS / 1000) + 's';
+
+      replayDemo();
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-reveal-cls-issue-sp/style.css
+++ b/submissions/docs/ease-reveal-cls-issue-sp/style.css
@@ -1,0 +1,334 @@
+/* ============================================================
+   ease-reveal CLS Issue Showcase — style.css
+   submissions/docs/ease-reveal-cls-issue-sp
+   ============================================================ */
+
+body {
+  background:
+    radial-gradient(
+      900px 400px at 5% -5%,
+      var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.1)),
+      transparent
+    ),
+    radial-gradient(
+      700px 350px at 98% 0%,
+      rgba(185, 28, 28, 0.05),
+      transparent
+    ),
+    var(--ease-color-bg, #f8fafc);
+  min-height: 100vh;
+}
+
+/* ── Header ─────────────────────────────────────────────────── */
+
+.cls-header {
+  max-width: 76rem;
+  margin: 0 auto;
+  padding: var(--ease-space-12, 3rem) var(--ease-space-6, 1.5rem)
+    var(--ease-space-4, 1rem);
+  text-align: center;
+}
+
+.cls-eyebrow {
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ease-color-primary, #6c63ff);
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.cls-header h1 {
+  margin-bottom: var(--ease-space-3, 0.75rem);
+}
+
+.cls-subtitle {
+  max-width: 44rem;
+  margin: 0 auto;
+  color: var(--ease-color-muted, #475569);
+}
+
+/* ── Layout ─────────────────────────────────────────────────── */
+
+.cls-layout {
+  max-width: 76rem;
+  margin: 0 auto;
+  padding: var(--ease-space-4, 1rem) var(--ease-space-6, 1.5rem)
+    var(--ease-space-12, 3rem);
+}
+
+.cls-card-wide {
+  margin-bottom: var(--ease-space-6, 1.5rem);
+}
+
+.cls-compare-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--ease-space-6, 1.5rem);
+  margin-bottom: var(--ease-space-6, 1.5rem);
+}
+
+/* ── Cards ──────────────────────────────────────────────────── */
+
+.cls-card {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  box-shadow: var(--ease-shadow-md);
+  padding: var(--ease-space-6, 1.5rem);
+}
+
+.cls-card h2 {
+  font-size: var(--ease-text-xl, 1.25rem);
+}
+
+.cls-hint {
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #475569);
+  margin: var(--ease-space-2, 0.5rem) 0 var(--ease-space-4, 1rem);
+}
+
+.cls-panel-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ease-space-2, 0.5rem);
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.cls-panel-broken {
+  border-top: 4px solid var(--ease-color-danger, #b91c1c);
+}
+
+.cls-panel-fixed {
+  border-top: 4px solid var(--ease-color-success, #15803d);
+}
+
+.cls-badge {
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 700;
+  padding: 0.2rem 0.6rem;
+  border-radius: var(--ease-radius-full, 9999px);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.cls-badge-bad {
+  background: rgba(185, 28, 28, 0.1);
+  color: var(--ease-color-danger-dark, #b91c1c);
+}
+
+.cls-badge-good {
+  background: rgba(21, 128, 61, 0.1);
+  color: var(--ease-color-success-dark, #15803d);
+}
+
+/* ── CLS metrics ────────────────────────────────────────────── */
+
+.cls-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--ease-space-4, 1rem);
+  margin: var(--ease-space-4, 1rem) 0;
+}
+
+.cls-metric {
+  padding: var(--ease-space-4, 1rem);
+  background: var(--ease-color-neutral-50, #f8fafc);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  text-align: center;
+}
+
+.cls-metric-label {
+  display: block;
+  font-size: var(--ease-text-xs, 0.75rem);
+  color: var(--ease-color-muted, #475569);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--ease-space-1, 0.25rem);
+}
+
+.cls-metric-value {
+  font-size: var(--ease-text-2xl, 1.5rem);
+  font-weight: 800;
+  font-family: var(--ease-font-mono, monospace);
+}
+
+.cls-bad {
+  color: var(--ease-color-danger-dark, #b91c1c);
+}
+
+.cls-good {
+  color: var(--ease-color-success-dark, #15803d);
+}
+
+.cls-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--ease-space-4, 1rem);
+  margin-top: var(--ease-space-4, 1rem);
+}
+
+.cls-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-2, 0.5rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  cursor: pointer;
+}
+
+.cls-toggle input {
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--ease-color-primary, #6c63ff);
+}
+
+/* ── Gallery demo ───────────────────────────────────────────── */
+
+.cls-gallery-card {
+  margin-bottom: var(--ease-space-4, 1rem);
+}
+
+.cls-img-wrap {
+  margin-bottom: var(--ease-space-3, 0.75rem);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  overflow: hidden;
+  background: var(--ease-color-neutral-100, #f1f5f9);
+}
+
+/* Broken: no reserved height */
+.cls-img-broken {
+  min-height: 0;
+}
+
+.cls-img-broken .cls-img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+/* Fixed: reserved aspect ratio */
+.cls-img-fixed {
+  position: relative;
+  aspect-ratio: 16 / 9;
+}
+
+.cls-img-fixed .cls-img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: opacity var(--ease-speed-medium, 300ms) var(--ease-ease);
+}
+
+.cls-skeleton {
+  position: absolute;
+  inset: 0;
+  border-radius: 0;
+}
+
+.cls-skeleton[hidden] {
+  display: none;
+}
+
+/* ── Snippets ───────────────────────────────────────────────── */
+
+.cls-snippet-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ease-space-2, 0.5rem);
+  margin-bottom: var(--ease-space-4, 1rem);
+}
+
+.cls-tab {
+  padding: var(--ease-space-2, 0.5rem) var(--ease-space-3, 0.75rem);
+  border: 2px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-full, 9999px);
+  background: var(--ease-color-surface, #fff);
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--ease-speed-fast, 150ms) var(--ease-ease);
+}
+
+.cls-tab:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+
+.cls-tab.active {
+  border-color: var(--ease-color-primary, #6c63ff);
+  background: var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.15));
+  color: var(--ease-color-primary-dark, #4b44cc);
+}
+
+.cls-pre {
+  background: var(--ease-color-neutral-900, #0f172a);
+  color: #e2e8f0;
+  padding: var(--ease-space-4, 1rem);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  font-size: var(--ease-text-xs, 0.75rem);
+  line-height: 1.55;
+  overflow-x: auto;
+  margin-bottom: var(--ease-space-4, 1rem);
+  max-height: 16rem;
+}
+
+.cls-status {
+  margin-top: var(--ease-space-2, 0.5rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-success-dark, #15803d);
+  min-height: 1.25rem;
+}
+
+/* ── Details ────────────────────────────────────────────────── */
+
+.cls-details {
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #475569);
+}
+
+.cls-details summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--ease-color-primary, #6c63ff);
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.cls-details ul {
+  padding-left: var(--ease-space-5, 1.25rem);
+  margin-top: var(--ease-space-2, 0.5rem);
+}
+
+.cls-details li {
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+/* ── Footer ─────────────────────────────────────────────────── */
+
+.cls-footer {
+  text-align: center;
+  padding: var(--ease-space-8, 2rem) var(--ease-space-6, 1.5rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #475569);
+}
+
+/* ── Responsive ───────────────────────────────────────────── */
+
+@media (max-width: 900px) {
+  .cls-compare-grid,
+  .cls-metrics {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cls-tab,
+  .cls-img-fixed .cls-img {
+    transition: none;
+  }
+}


### PR DESCRIPTION
# #44534 issue resolved

## Description
This PR adds a beginner-friendly iOS Safari 100vh + Fixed Navbar Jump showcase under submissions/docs/ease-ios-viewport-jump-sp/.

## Features

- Reproduces viewport jump when ease-fade-in heroes use 100vh on mobile Safari
- Side-by-side broken (100vh) vs fixed (100dvh/svh) comparison
- Live viewport height readout panel (vh vs dvh vs svh)
- Workaround patterns: 100dvh, 100svh, -webkit-fill-available, JS --vh fallback
- Copy-ready CSS snippets for jump-free full-screen heroes

<!-- trigger-refresh -->