### PR TITLE
feat: add jukebox

### DIFF
--- a/submissions/examples/jukebox-as/README.md
+++ b/submissions/examples/jukebox-as/README.md
@@ -1,0 +1,22 @@
+# Jukebox
+
+### What does this do?
+
+It shows a retro jukebox playing a record. The rainbow arch light cycles through its colors, a vinyl record spins behind the glass, the selection keys press themselves in sequence, and an equalizer bounces along the bottom. Under reduced motion everything holds still.
+
+### How is it used?
+
+```html
+<div class="jukebox">
+  <span class="arch"></span>
+  <div class="window"><span class="record"></span></div>
+  <div class="grille"></div>
+  <div class="bars"><span class="bar bl1"></span></div>
+</div>
+```
+
+The glowing arch is a gradient border painted with two `background` layers and `border-box` clipping, cycled with a `hue-rotate` filter. The record is a `repeating-radial-gradient` of grooves with a label, spinning behind a rounded glass window, and the equalizer bars scale on staggered delays.
+
+### Why is it useful?
+
+Retro, music, and diner themes use a jukebox. This builds a playing jukebox with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/jukebox-as/demo.html
+++ b/submissions/examples/jukebox-as/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Jukebox</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="jukebox">
+      <span class="arch"></span>
+      <div class="window">
+        <span class="record"></span>
+        <span class="glassjb"></span>
+      </div>
+      <div class="grille"></div>
+      <div class="panel">
+        <span class="key k1"></span>
+        <span class="key k2"></span>
+        <span class="key k3"></span>
+        <span class="key k4"></span>
+        <span class="key k5"></span>
+      </div>
+      <div class="bars">
+        <span class="bar bl1"></span>
+        <span class="bar bl2"></span>
+        <span class="bar bl3"></span>
+        <span class="bar bl4"></span>
+        <span class="bar bl5"></span>
+        <span class="bar bl6"></span>
+      </div>
+      <span class="base"></span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/jukebox-as/style.css
+++ b/submissions/examples/jukebox-as/style.css
@@ -1,0 +1,206 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 22%, #2c1b3e, #100a1a 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  display: grid;
+  place-items: center;
+}
+
+.jukebox {
+  position: relative;
+  width: 240px;
+  height: 330px;
+  padding: 0 0 14px;
+  box-sizing: border-box;
+  border-radius: 120px 120px 16px 16px / 100px 100px 16px 16px;
+  background: linear-gradient(160deg, #7a2f3f, #48192a);
+  box-shadow:
+    0 22px 44px rgba(0, 0, 0, 0.6),
+    inset 0 4px 6px rgba(255, 200, 200, 0.25);
+  overflow: hidden;
+}
+
+.arch {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  right: 10px;
+  height: 120px;
+  border-radius: 110px 110px 0 0 / 96px 96px 0 0;
+  border: 8px solid transparent;
+  border-bottom: none;
+  background:
+    linear-gradient(#48192a, #48192a) padding-box,
+    linear-gradient(90deg, #ffd23a, #ff5a7a, #4ec0ff, #6fe08a) border-box;
+  animation: hue 4s linear infinite;
+}
+
+.window {
+  position: absolute;
+  top: 44px;
+  left: 50%;
+  width: 130px;
+  height: 96px;
+  margin-left: -65px;
+  border-radius: 65px 65px 8px 8px / 56px 56px 8px 8px;
+  overflow: hidden;
+  background: radial-gradient(circle at 50% 60%, #33243f, #150e1e);
+  box-shadow: inset 0 0 0 3px rgba(255, 220, 140, 0.4);
+  z-index: 3;
+}
+
+.record {
+  position: absolute;
+  bottom: -34px;
+  left: 50%;
+  width: 92px;
+  height: 92px;
+  margin-left: -46px;
+  border-radius: 50%;
+  background:
+    repeating-radial-gradient(circle at 50% 50%, #1c1c22 0 3px, #2a2a33 3px 6px);
+  box-shadow: inset 0 0 0 2px #33333d;
+  animation: spin 3s linear infinite;
+}
+
+.record::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 28px;
+  height: 28px;
+  margin: -14px 0 0 -14px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #ffd66b, #d4832a);
+}
+
+.glassjb {
+  position: absolute;
+  top: 6px;
+  left: 14px;
+  width: 34px;
+  height: 48px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.22);
+  filter: blur(4px);
+  transform: rotate(-18deg);
+  z-index: 2;
+}
+
+.grille {
+  position: absolute;
+  top: 152px;
+  left: 50%;
+  width: 170px;
+  height: 46px;
+  margin-left: -85px;
+  border-radius: 8px;
+  background:
+    repeating-linear-gradient(90deg, #2d1621 0 6px, #6b3040 6px 12px);
+  box-shadow: inset 0 0 0 3px rgba(255, 210, 120, 0.35);
+  z-index: 3;
+}
+
+.panel {
+  position: absolute;
+  top: 210px;
+  left: 50%;
+  width: 190px;
+  height: 34px;
+  margin-left: -95px;
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  align-items: center;
+  border-radius: 8px;
+  background: linear-gradient(#2a1520, #1a0d14);
+  box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.6);
+  z-index: 3;
+}
+
+.key {
+  width: 26px;
+  height: 18px;
+  border-radius: 3px;
+  background: linear-gradient(#f6efe2, #cfc4ae);
+  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.35);
+  animation: press 3s ease-in-out infinite;
+}
+
+.k2 { animation-delay: 0.5s; }
+.k3 { animation-delay: 1s; }
+.k4 { animation-delay: 1.5s; }
+.k5 { animation-delay: 2s; }
+
+.bars {
+  position: absolute;
+  bottom: 26px;
+  left: 50%;
+  width: 150px;
+  height: 44px;
+  margin-left: -75px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  z-index: 3;
+}
+
+.bar {
+  width: 16px;
+  border-radius: 3px 3px 0 0;
+  background: linear-gradient(#ffd23a, #ff5a7a);
+  animation: eq 0.9s ease-in-out infinite alternate;
+}
+
+.bl1 { height: 40%; animation-delay: 0s; }
+.bl2 { height: 70%; animation-delay: 0.15s; }
+.bl3 { height: 50%; animation-delay: 0.3s; }
+.bl4 { height: 90%; animation-delay: 0.45s; }
+.bl5 { height: 60%; animation-delay: 0.6s; }
+.bl6 { height: 35%; animation-delay: 0.75s; }
+
+.base {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 20px;
+  background: linear-gradient(#3a1220, #240b14);
+  z-index: 4;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes eq {
+  0% { transform: scaleY(0.4); }
+  100% { transform: scaleY(1); }
+}
+
+@keyframes press {
+  0%, 88%, 100% { transform: translateY(0); }
+  92% { transform: translateY(3px); }
+}
+
+@keyframes hue {
+  to { filter: hue-rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .record,
+  .bar,
+  .key,
+  .arch {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a jukebox built for #44575. A retro jukebox with a hue-cycling gradient-border arch, a spinning grooved record, self-pressing keys, and a bouncing equalizer, with a reduced motion fallback. Pure CSS. Closes #44575.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a red jukebox with a rainbow arch, a spinning vinyl record behind glass, a speaker grille, keys, and an equalizer.
