### PR TITLE
feat: add toaster

### DIFF
--- a/submissions/examples/toaster-as/README.md
+++ b/submissions/examples/toaster-as/README.md
@@ -1,0 +1,21 @@
+# Toaster
+
+### What does this do?
+
+It shows a chrome toaster with two slices in the slots. Hovering or focusing it toasts them: the elements glow orange inside, the browning dial turns, and the two slices pop up out of the slots with a springy bounce, one just after the other. It works with no JavaScript. Under reduced motion the toast pops without easing.
+
+### How is it used?
+
+```html
+<div class="toaster" tabindex="0">
+  <span class="toast tl"></span>
+  <span class="toast tr"></span>
+  <div class="body"><span class="slot sl"></span><span class="lever"></span><span class="glow"></span></div>
+</div>
+```
+
+The toast slices sit behind the toaster body in the stacking order, so they are hidden in the slots until they rise. On `:hover` or `:focus` their `top` transitions upward with a springy `cubic-bezier`, the second slice offset by a small `transition-delay` so they pop in sequence, while the heating `glow` fades in and the lever rises.
+
+### Why is it useful?
+
+Kitchen, morning, and "ready" or completion themes use a toaster. This builds an interactive toaster with pure CSS shapes and transitions, no images or JavaScript, with a reduced motion fallback.

--- a/submissions/examples/toaster-as/demo.html
+++ b/submissions/examples/toaster-as/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Toaster</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="toaster" tabindex="0">
+      <span class="toast tl"></span>
+      <span class="toast tr"></span>
+      <div class="body">
+        <span class="slot sl"></span>
+        <span class="slot sr"></span>
+        <span class="lever"></span>
+        <span class="dial"></span>
+        <span class="glow"></span>
+        <span class="shine"></span>
+      </div>
+      <span class="foot fl"></span>
+      <span class="foot fr"></span>
+    </div>
+    <p class="hint">hover to toast</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/toaster-as/style.css
+++ b/submissions/examples/toaster-as/style.css
@@ -1,0 +1,196 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 24%, #3a4450, #161c24 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  display: grid;
+  justify-items: center;
+  gap: 14px;
+}
+
+.toaster {
+  position: relative;
+  width: 240px;
+  height: 220px;
+  outline: none;
+}
+
+.body {
+  position: absolute;
+  bottom: 12px;
+  left: 50%;
+  width: 200px;
+  height: 120px;
+  margin-left: -100px;
+  border-radius: 18px 18px 12px 12px;
+  background: linear-gradient(160deg, #e6ebf1, #a3aebc 70%, #7d8896);
+  box-shadow:
+    0 18px 32px rgba(0, 0, 0, 0.5),
+    inset 0 4px 6px rgba(255, 255, 255, 0.7),
+    inset 0 -8px 14px rgba(90, 100, 115, 0.35);
+  z-index: 3;
+}
+
+.slot {
+  position: absolute;
+  top: 10px;
+  width: 62px;
+  height: 10px;
+  border-radius: 5px;
+  background: #2a323c;
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.8);
+}
+
+.sl { left: 22px; }
+.sr { right: 22px; }
+
+.glow {
+  position: absolute;
+  top: 10px;
+  left: 22px;
+  width: 156px;
+  height: 10px;
+  border-radius: 5px;
+  background: linear-gradient(90deg, #ff6a1a, #ffb03a, #ff6a1a);
+  opacity: 0;
+  transition: opacity 0.4s ease;
+}
+
+.lever {
+  position: absolute;
+  top: 34px;
+  right: -8px;
+  width: 20px;
+  height: 14px;
+  border-radius: 4px;
+  background: linear-gradient(#4d5866, #2c343f);
+  transition: transform 0.4s ease;
+}
+
+.lever::before {
+  content: "";
+  position: absolute;
+  top: 4px;
+  left: -12px;
+  width: 14px;
+  height: 6px;
+  border-radius: 3px;
+  background: #3a434f;
+}
+
+.dial {
+  position: absolute;
+  bottom: 24px;
+  right: 26px;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #f2f5f8, #8d97a5);
+  box-shadow: inset 0 0 0 3px rgba(0, 0, 0, 0.15);
+  transition: transform 0.5s ease;
+}
+
+.dial::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 50%;
+  width: 3px;
+  height: 9px;
+  margin-left: -1.5px;
+  border-radius: 2px;
+  background: #38414d;
+}
+
+.shine {
+  position: absolute;
+  top: 30px;
+  left: 22px;
+  width: 30px;
+  height: 62px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.4);
+  filter: blur(4px);
+  transform: rotate(-12deg);
+}
+
+.toast {
+  position: absolute;
+  top: 92px;
+  width: 60px;
+  height: 60px;
+  border-radius: 8px 8px 6px 6px;
+  background: linear-gradient(160deg, #f0c169, #cf8f34);
+  box-shadow: inset 0 0 0 4px rgba(230, 190, 120, 0.7);
+  z-index: 2;
+  transition: top 0.45s cubic-bezier(0.3, 1.6, 0.5, 1);
+}
+
+.toast::after {
+  content: "";
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  right: 10px;
+  bottom: 14px;
+  border-radius: 4px;
+  background: rgba(160, 105, 30, 0.25);
+}
+
+.tl { left: 42px; }
+.tr { right: 42px; transition-delay: 0.08s; }
+
+.foot {
+  position: absolute;
+  bottom: 0;
+  width: 26px;
+  height: 14px;
+  border-radius: 4px;
+  background: #2f3742;
+  z-index: 2;
+}
+
+.fl { left: 42px; }
+.fr { right: 42px; }
+
+.toaster:hover .toast,
+.toaster:focus .toast {
+  top: 20px;
+}
+
+.toaster:hover .glow,
+.toaster:focus .glow {
+  opacity: 0.9;
+}
+
+.toaster:hover .lever,
+.toaster:focus .lever {
+  transform: translateY(-22px);
+}
+
+.toaster:hover .dial,
+.toaster:focus .dial {
+  transform: rotate(150deg);
+}
+
+.hint {
+  margin: 0;
+  color: #8b96ad;
+  font-size: 0.85rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .toast,
+  .lever,
+  .dial,
+  .glow {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a toaster built for #44580. Hovering or focusing glows the heating elements, turns the dial, and springs two slices up out of the slots in sequence, using stacking order to hide them inside, with a reduced motion fallback. Pure CSS. Closes #44580.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot of the hovered state: two toast slices popped above a chrome toaster with the heating elements glowing orange.
