### PR TITLE
feat: add claw machine

### DIFF
--- a/submissions/examples/claw-machine-as/README.md
+++ b/submissions/examples/claw-machine-as/README.md
@@ -1,0 +1,23 @@
+# Claw Machine
+
+### What does this do?
+
+It shows an arcade claw machine running a full grab on a loop. The joystick tilts, the button presses, the rig slides along its rail, the cable reels out as the claw drops into the pile of prizes, the prongs pinch shut, and everything lifts back up. Under reduced motion the claw rests at the top.
+
+### How is it used?
+
+```html
+<div class="cabinet">
+  <div class="rig">
+    <span class="cable"></span>
+    <div class="claw"><span class="prong lp"></span><span class="prong rp"></span></div>
+  </div>
+  <div class="pile"><span class="toy t1"></span></div>
+</div>
+```
+
+The whole grab is choreographed by giving every part the same six second duration and lining up their keyframe percentages: the `rig` slides first, then the `cable` stretches with `scaleY` while the `claw` translates down, then the prongs `pinch` closed, and the sequence reverses. Because the timings share one clock, the parts stay in step without any JavaScript.
+
+### Why is it useful?
+
+Arcade, prize, and gacha themes use a claw machine. This builds a full claw grab cycle with pure CSS animation, no images, with a reduced motion fallback.

--- a/submissions/examples/claw-machine-as/demo.html
+++ b/submissions/examples/claw-machine-as/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Claw Machine</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="machine">
+      <div class="cabinet">
+        <span class="rail"></span>
+        <div class="rig">
+          <span class="cable"></span>
+          <div class="claw">
+            <span class="prong lp"></span>
+            <span class="prong rp"></span>
+            <span class="hub"></span>
+          </div>
+        </div>
+        <div class="pile">
+          <span class="toy t1"></span>
+          <span class="toy t2"></span>
+          <span class="toy t3"></span>
+          <span class="toy t4"></span>
+          <span class="toy t5"></span>
+        </div>
+        <span class="chute"></span>
+        <span class="glassy"></span>
+      </div>
+      <div class="console">
+        <span class="stick"></span>
+        <span class="btn"></span>
+        <span class="coin"></span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/claw-machine-as/style.css
+++ b/submissions/examples/claw-machine-as/style.css
@@ -1,0 +1,254 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 22%, #2d2050, #120c22 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  display: grid;
+  place-items: center;
+}
+
+.machine {
+  display: grid;
+  justify-items: center;
+}
+
+.cabinet {
+  position: relative;
+  width: 240px;
+  height: 250px;
+  border-radius: 14px 14px 0 0;
+  overflow: hidden;
+  background: linear-gradient(160deg, #1e2b47, #101a2e);
+  box-shadow:
+    inset 0 0 0 8px #e2456f,
+    0 -6px 20px rgba(226, 69, 111, 0.4);
+}
+
+.rail {
+  position: absolute;
+  top: 18px;
+  left: 14px;
+  right: 14px;
+  height: 8px;
+  border-radius: 4px;
+  background: linear-gradient(#8b96a5, #55606e);
+}
+
+.rig {
+  position: absolute;
+  top: 22px;
+  left: 50%;
+  width: 60px;
+  margin-left: -30px;
+  animation: slide 6s ease-in-out infinite;
+  z-index: 3;
+}
+
+.cable {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 3px;
+  height: 40px;
+  margin-left: -1.5px;
+  background: #a9b3c1;
+  transform-origin: top center;
+  animation: reel 6s ease-in-out infinite;
+}
+
+.claw {
+  position: absolute;
+  top: 36px;
+  left: 50%;
+  width: 56px;
+  height: 46px;
+  margin-left: -28px;
+  animation: lower 6s ease-in-out infinite;
+}
+
+.hub {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 22px;
+  height: 14px;
+  margin-left: -11px;
+  border-radius: 4px;
+  background: linear-gradient(#c3ccd8, #7a8593);
+}
+
+.prong {
+  position: absolute;
+  top: 10px;
+  width: 10px;
+  height: 36px;
+  border-radius: 0 0 6px 6px;
+  background: linear-gradient(#b9c3cf, #6f7a89);
+  transform-origin: top center;
+  animation: pinch 6s ease-in-out infinite;
+}
+
+.lp { left: 8px; }
+.rp { right: 8px; animation-name: pinch-rev; }
+
+.pile {
+  position: absolute;
+  bottom: 10px;
+  left: 74px;
+  right: 10px;
+  height: 70px;
+}
+
+.toy {
+  position: absolute;
+  bottom: 0;
+  border-radius: 50%;
+  box-shadow: inset -3px -3px 6px rgba(0, 0, 0, 0.25);
+}
+
+.t1 { left: 0; width: 36px; height: 36px; background: radial-gradient(circle at 36% 32%, #ffa8c0, #e2456f); }
+.t2 { left: 30px; width: 42px; height: 42px; background: radial-gradient(circle at 36% 32%, #a8e0ff, #2f8fd0); }
+.t3 { left: 68px; width: 34px; height: 34px; background: radial-gradient(circle at 36% 32%, #ffe89a, #e0a81c); }
+.t4 { left: 98px; width: 40px; height: 40px; background: radial-gradient(circle at 36% 32%, #c6f5c9, #3fa85a); }
+.t5 { left: 134px; width: 32px; height: 32px; background: radial-gradient(circle at 36% 32%, #d8bcff, #8a4fd0); }
+
+.chute {
+  position: absolute;
+  bottom: 8px;
+  left: 12px;
+  width: 54px;
+  height: 34px;
+  border-radius: 6px;
+  background: #0a1120;
+  box-shadow: inset 0 3px 8px rgba(0, 0, 0, 0.8);
+  z-index: 1;
+}
+
+.glassy {
+  position: absolute;
+  top: 18px;
+  left: 20px;
+  width: 44px;
+  height: 120px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.1);
+  filter: blur(6px);
+  transform: rotate(-14deg);
+  z-index: 4;
+}
+
+.console {
+  position: relative;
+  width: 260px;
+  height: 76px;
+  border-radius: 0 0 14px 14px;
+  background: linear-gradient(160deg, #e2456f, #a52348);
+  box-shadow: 0 20px 36px rgba(0, 0, 0, 0.55);
+}
+
+.stick {
+  position: absolute;
+  top: 12px;
+  left: 44px;
+  width: 8px;
+  height: 30px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #cfd7e2, #7d8896);
+  transform-origin: bottom center;
+  animation: joy 6s ease-in-out infinite;
+}
+
+.stick::after {
+  content: "";
+  position: absolute;
+  top: -12px;
+  left: 50%;
+  width: 22px;
+  height: 22px;
+  margin-left: -11px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #ff8fa0, #c01f3f);
+}
+
+.btn {
+  position: absolute;
+  top: 26px;
+  right: 54px;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #ffe89a, #e0a81c);
+  box-shadow: 0 3px 0 rgba(0, 0, 0, 0.35);
+  animation: press 6s ease-in-out infinite;
+}
+
+.coin {
+  position: absolute;
+  bottom: 12px;
+  right: 26px;
+  width: 24px;
+  height: 6px;
+  border-radius: 3px;
+  background: #6d1230;
+  box-shadow: inset 0 2px 3px rgba(0, 0, 0, 0.7);
+}
+
+@keyframes slide {
+  0%, 10% { transform: translateX(-64px); }
+  22%, 62% { transform: translateX(52px); }
+  76%, 100% { transform: translateX(-64px); }
+}
+
+@keyframes lower {
+  0%, 26% { transform: translateY(0); }
+  40%, 48% { transform: translateY(102px); }
+  62%, 100% { transform: translateY(0); }
+}
+
+@keyframes reel {
+  0%, 26% { transform: scaleY(1); }
+  40%, 48% { transform: scaleY(3.6); }
+  62%, 100% { transform: scaleY(1); }
+}
+
+@keyframes pinch {
+  0%, 36% { transform: rotate(-16deg); }
+  44%, 58% { transform: rotate(4deg); }
+  70%, 100% { transform: rotate(-16deg); }
+}
+
+@keyframes pinch-rev {
+  0%, 36% { transform: rotate(16deg); }
+  44%, 58% { transform: rotate(-4deg); }
+  70%, 100% { transform: rotate(16deg); }
+}
+
+@keyframes joy {
+  0%, 8% { transform: rotate(-14deg); }
+  22%, 60% { transform: rotate(12deg); }
+  74%, 100% { transform: rotate(-14deg); }
+}
+
+@keyframes press {
+  0%, 24% { transform: translateY(0); }
+  28%, 34% { transform: translateY(4px); }
+  40%, 100% { transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rig,
+  .cable,
+  .claw,
+  .prong,
+  .stick,
+  .btn {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a claw machine built for #44583. A full grab cycle where the joystick, button, rig slide, cable reel, claw drop, and prong pinch all share one six second clock so they stay in step, with a reduced motion fallback. Pure CSS. Closes #44583.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a pink claw machine cabinet with a rail-mounted claw on a cable, five colored prize balls, a prize chute, and a joystick console.
