### PR TITLE
feat: add arcade cabinet

### DIFF
--- a/submissions/examples/arcade-cabinet-as/README.md
+++ b/submissions/examples/arcade-cabinet-as/README.md
@@ -1,0 +1,25 @@
+# Arcade Cabinet
+
+### What does this do?
+
+It shows an arcade cabinet with a game actually playing on its screen. Pixel invaders march side to side, the player ship strafes below them and fires a shot upward, CRT scanlines roll over the picture, the joystick wags, the buttons mash, and the marquee cycles through its colors. Under reduced motion the game freezes.
+
+### How is it used?
+
+```html
+<div class="cab">
+  <span class="marquee"></span>
+  <div class="screen">
+    <span class="invader iv1"></span>
+    <span class="ship"></span>
+    <span class="scan"></span>
+  </div>
+  <div class="controls"><span class="joy"></span><span class="btn b1"></span></div>
+</div>
+```
+
+The invaders and the ship are `clip-path` pixel silhouettes. The invaders `march` with a `steps()` timing so they hop rather than glide, like the real thing, and the ship's `strafe` and the shot's `fire` share the same duration so the shot always launches from the ship. The scanline overlay is a repeating gradient on top of the screen.
+
+### Why is it useful?
+
+Retro, gaming, and 404 or loading screens use an arcade cabinet. This builds a cabinet with a playable-looking game using pure CSS shapes and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/arcade-cabinet-as/demo.html
+++ b/submissions/examples/arcade-cabinet-as/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Arcade Cabinet</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="cab">
+      <span class="marquee"></span>
+      <div class="screen">
+        <span class="scan"></span>
+        <span class="invader iv1"></span>
+        <span class="invader iv2"></span>
+        <span class="invader iv3"></span>
+        <span class="shot"></span>
+        <span class="ship"></span>
+      </div>
+      <div class="controls">
+        <span class="joy"></span>
+        <span class="btn b1"></span>
+        <span class="btn b2"></span>
+      </div>
+      <span class="grill"></span>
+      <span class="coin"></span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/arcade-cabinet-as/style.css
+++ b/submissions/examples/arcade-cabinet-as/style.css
@@ -1,0 +1,224 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 22%, #1c2340, #090c18 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  display: grid;
+  place-items: center;
+}
+
+.cab {
+  position: relative;
+  width: 230px;
+  height: 340px;
+  padding: 12px;
+  box-sizing: border-box;
+  border-radius: 22px 22px 10px 10px;
+  background: linear-gradient(160deg, #4b2cc0, #2a1670);
+  box-shadow:
+    0 24px 46px rgba(0, 0, 0, 0.6),
+    inset 0 4px 6px rgba(190, 170, 255, 0.35);
+}
+
+.marquee {
+  position: absolute;
+  top: 14px;
+  left: 50%;
+  width: 190px;
+  height: 34px;
+  margin-left: -95px;
+  border-radius: 8px;
+  background: linear-gradient(90deg, #ff5a7a, #ffd23a, #4ec0ff, #6fe08a);
+  box-shadow: 0 0 18px rgba(255, 170, 220, 0.6);
+  animation: hue 5s linear infinite;
+}
+
+.screen {
+  position: absolute;
+  top: 58px;
+  left: 50%;
+  width: 186px;
+  height: 140px;
+  margin-left: -93px;
+  border-radius: 10px;
+  overflow: hidden;
+  background: radial-gradient(ellipse at 50% 40%, #0d2030, #04080f 80%);
+  box-shadow:
+    inset 0 0 0 5px #191f36,
+    inset 0 0 24px rgba(0, 0, 0, 0.9);
+}
+
+.scan {
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(180deg, rgba(255, 255, 255, 0.05) 0 1px, transparent 1px 3px);
+  z-index: 4;
+  pointer-events: none;
+}
+
+.invader {
+  position: absolute;
+  width: 20px;
+  height: 14px;
+  background: #6fe08a;
+  clip-path: polygon(
+    20% 0, 80% 0, 80% 20%, 100% 20%, 100% 70%, 80% 70%,
+    80% 100%, 60% 100%, 60% 80%, 40% 80%, 40% 100%, 20% 100%,
+    20% 70%, 0 70%, 0 20%, 20% 20%
+  );
+  animation: march 3s steps(4) infinite;
+}
+
+.iv1 { top: 20px; left: 32px; }
+.iv2 { top: 20px; left: 82px; background: #ffd23a; animation-delay: 0.1s; }
+.iv3 { top: 20px; left: 132px; background: #ff6a8b; animation-delay: 0.2s; }
+
+.ship {
+  position: absolute;
+  bottom: 12px;
+  left: 50%;
+  width: 30px;
+  height: 16px;
+  margin-left: -15px;
+  clip-path: polygon(50% 0, 60% 40%, 100% 100%, 0 100%, 40% 40%);
+  background: #4ec0ff;
+  animation: strafe 3s ease-in-out infinite;
+}
+
+.shot {
+  position: absolute;
+  bottom: 28px;
+  left: 50%;
+  width: 3px;
+  height: 12px;
+  margin-left: -1.5px;
+  border-radius: 2px;
+  background: #fff6a0;
+  box-shadow: 0 0 6px #ffe86b;
+  animation: fire 3s linear infinite;
+}
+
+.controls {
+  position: absolute;
+  bottom: 74px;
+  left: 50%;
+  width: 190px;
+  height: 52px;
+  margin-left: -95px;
+  border-radius: 8px;
+  background: linear-gradient(160deg, #372080, #23124f);
+  box-shadow: inset 0 3px 6px rgba(0, 0, 0, 0.5);
+}
+
+.joy {
+  position: absolute;
+  bottom: 12px;
+  left: 30px;
+  width: 7px;
+  height: 24px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #cfd7e2, #7d8896);
+  transform-origin: bottom center;
+  animation: wag 3s ease-in-out infinite;
+}
+
+.joy::after {
+  content: "";
+  position: absolute;
+  top: -11px;
+  left: 50%;
+  width: 20px;
+  height: 20px;
+  margin-left: -10px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #ff8fa0, #c01f3f);
+}
+
+.btn {
+  position: absolute;
+  bottom: 16px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  box-shadow: 0 3px 0 rgba(0, 0, 0, 0.4);
+  animation: mash 3s ease-in-out infinite;
+}
+
+.b1 { right: 58px; background: radial-gradient(circle at 36% 32%, #ffe89a, #e0a81c); }
+.b2 { right: 24px; background: radial-gradient(circle at 36% 32%, #a8e0ff, #2f8fd0); animation-delay: 0.4s; }
+
+.grill {
+  position: absolute;
+  bottom: 34px;
+  left: 50%;
+  width: 120px;
+  height: 16px;
+  margin-left: -60px;
+  border-radius: 4px;
+  background: repeating-linear-gradient(90deg, #1e1140 0 5px, #4a2ca0 5px 10px);
+}
+
+.coin {
+  position: absolute;
+  bottom: 12px;
+  left: 50%;
+  width: 30px;
+  height: 6px;
+  margin-left: -15px;
+  border-radius: 3px;
+  background: #170d33;
+  box-shadow: inset 0 2px 3px rgba(0, 0, 0, 0.8);
+}
+
+@keyframes march {
+  0%, 100% { transform: translateX(0); }
+  50% { transform: translateX(22px); }
+}
+
+@keyframes strafe {
+  0%, 100% { transform: translateX(-42px); }
+  50% { transform: translateX(42px); }
+}
+
+@keyframes fire {
+  0% { transform: translateY(0) translateX(-42px); opacity: 0; }
+  10% { opacity: 1; }
+  45% { transform: translateY(-74px) translateX(0); opacity: 1; }
+  50%, 100% { transform: translateY(-80px) translateX(0); opacity: 0; }
+}
+
+@keyframes wag {
+  0%, 100% { transform: rotate(-16deg); }
+  50% { transform: rotate(16deg); }
+}
+
+@keyframes mash {
+  0%, 84%, 100% { transform: translateY(0); }
+  90% { transform: translateY(3px); }
+}
+
+@keyframes hue {
+  to { filter: hue-rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .invader,
+  .ship,
+  .shot,
+  .joy,
+  .btn,
+  .marquee {
+    animation: none;
+  }
+
+  .shot {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an arcade cabinet built for #44585. Pixel invaders march with a stepped timing while the ship strafes and fires under CRT scanlines, with a hue-cycling marquee and a wagging joystick, and a reduced motion fallback. Pure CSS. Closes #44585.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a purple cabinet with a rainbow marquee, three pixel invaders and a ship firing a shot on a scanlined screen, and a joystick console.
