### PR TITLE
feat(submission): keep performance doc inside docs layout (#44519)

### DIFF
--- a/submissions/examples/keep-performance-in-docs-ksk/README.md
+++ b/submissions/examples/keep-performance-in-docs-ksk/README.md
@@ -1,0 +1,47 @@
+# Keep Performance Doc inside Docs Layout (`keep-performance-in-docs-ksk`)
+
+1. What does this do?  
+Showcases the integration of the Performance Guide markdown document directly into the core `docs/index.html` single-page navigation layout.
+
+2. How is it used?  
+The maintainer can copy the section structure `<section id="performance">` from this demo into `docs/index.html` right before the `#contributing` section, update the sidebar anchor to `#performance`, and append the style rules from `style.css` to `docs/docs.css`.
+
+3. Why is it useful?  
+It maintains user layout persistence (preventing users from dropping out of the sidebar navigation frame when clicking the Performance Guide) and ensures style and UX coherence across all document views.
+
+---
+*Created for ECSoC-26 / GSSoC-26 — Resolves #44519.*
+
+## Required Core Changes
+
+### 1. Update Sidebar Link (`docs/index.html`)
+Change the raw file reference to a hash anchor link:
+```diff
+- <li><a href="PERFORMANCE.md">Performance Guide</a></li>
++ <li><a href="#performance">Performance Guide</a></li>
+```
+
+### 2. Embed Section Content (`docs/index.html`)
+Insert the HTML-converted content of `PERFORMANCE.md` inside a new `<section id="performance">` element:
+```html
+<hr class="docs-divider" />
+<section id="performance" class="docs-section">
+  <!-- Content here -->
+</section>
+```
+
+### 3. Add List & Block Styles (`docs/docs.css`)
+Append the following styles to support ordered/unordered lists and block elements inside `.docs-content`:
+```css
+.docs-content ul,
+.docs-content ol {
+  color: var(--page-text-muted, #8b949e);
+  line-height: 1.75;
+  margin-top: 0.5rem;
+  margin-bottom: 1rem;
+  padding-left: 1.5rem;
+}
+.docs-content ul { list-style-type: disc; }
+.docs-content ol { list-style-type: decimal; }
+.docs-content li { margin-bottom: 0.4rem; }
+```

--- a/submissions/examples/keep-performance-in-docs-ksk/demo.html
+++ b/submissions/examples/keep-performance-in-docs-ksk/demo.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Docs Performance Section Integration Showcase</title>
+  <!-- Link directly to project docs CSS resources to simulate real layout -->
+  <link rel="stylesheet" href="../../../docs/easemotion.min.css">
+  <link rel="stylesheet" href="../../../docs/docs.css">
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <header class="docs-header">
+    <div class="docs-logo">
+      <span style="font-weight:800;font-size:1.2rem;color:#fff;">EaseMotion <span style="color:#6c63ff;">CSS</span></span>
+    </div>
+    <ul class="docs-header-links">
+      <li><a href="#getting-started">Getting Started</a></li>
+      <li><a href="#performance" class="active">Performance</a></li>
+      <li><a href="#contributing">Contributing</a></li>
+    </ul>
+  </header>
+
+  <div class="docs-shell">
+    <!-- Mocked Sidebar containing the updated hash navigation -->
+    <aside class="docs-sidebar">
+      <div class="sidebar-group">
+        <div class="sidebar-group-label">Introduction</div>
+        <ul class="sidebar-nav">
+          <li><a href="#getting-started">Getting Started</a></li>
+        </ul>
+      </div>
+      <div class="sidebar-group">
+        <div class="sidebar-group-label">Performance</div>
+        <ul class="sidebar-nav">
+          <li><a href="#performance" class="active">Performance Guide</a></li>
+        </ul>
+      </div>
+      <div class="sidebar-group">
+        <div class="sidebar-group-label">Contributing</div>
+        <ul class="sidebar-nav">
+          <li><a href="#contributing">How to Contribute</a></li>
+        </ul>
+      </div>
+    </aside>
+
+    <!-- Main Content Area containing the integrated Performance section -->
+    <main class="docs-content">
+      <section id="getting-started" class="docs-section">
+        <h2 class="docs-h2">Getting Started</h2>
+        <p class="docs-p">Welcome to the documentation. Toggle navigation options using the sidebar.</p>
+      </section>
+
+      <hr class="docs-divider" />
+
+      <!-- The newly integrated Performance Guide section -->
+      <section id="performance" class="docs-section">
+        <h2 class="docs-h2" id="performance-guide">Performance Guide</h2>
+        <p class="docs-p">
+          Performance is a fundamental aspect of EaseMotion CSS. Every contribution should aim to keep the library lightweight, maintainable, and efficient.
+        </p>
+
+        <h3 class="docs-h3" id="why-performance-matters">Why Performance Matters</h3>
+        <p class="docs-p">
+          A high-performance CSS library provides faster page rendering, smooth animations, better user experience, and a reduced bundle size.
+        </p>
+
+        <h3 class="docs-h3" id="layout-best-practices">Layout Best Practices</h3>
+        <p class="docs-p">
+          Efficient layouts improve rendering speed and responsiveness.
+        </p>
+        <div class="docs-info">
+          <span class="docs-info-icon">💡</span>
+          <div>
+            <strong>Recommendation:</strong> Use semantic HTML, prefer Flexbox/CSS Grid, and keep layouts fully responsive.
+          </div>
+        </div>
+
+        <h3 class="docs-h3" id="animation-performance">Animation Performance</h3>
+        <p class="docs-p">
+          Always prioritize animating GPU-friendly properties to guarantee a locked 60fps experience.
+        </p>
+        <ul class="docs-ul">
+          <li>Animate using <code>transform</code> (scale, translation, rotation).</li>
+          <li>Animate using <code>opacity</code>.</li>
+          <li>Avoid animating properties that trigger layout shifts (width, height, margins).</li>
+        </ul>
+        
+        <div class="docs-code">
+          <span class="docs-code-lang">css</span>
+          <pre><code>/* GPU Optimized */
+.card {
+  transform: translateY(-12px);
+  opacity: 0.95;
+  transition: transform 0.3s ease;
+}</code></pre>
+        </div>
+
+        <h3 class="docs-h3" id="css-optimization">CSS Optimization</h3>
+        <p class="docs-p">
+          Keep your selectors simple, avoid excessive nesting, and reuse utility classes.
+        </p>
+      </section>
+
+      <hr class="docs-divider" />
+
+      <section id="contributing" class="docs-section">
+        <h2 class="docs-h2">How to Contribute</h2>
+        <p class="docs-p">Contributions follow a curated process via sandbox submissions.</p>
+      </section>
+    </main>
+  </div>
+</body>
+</html>

--- a/submissions/examples/keep-performance-in-docs-ksk/style.css
+++ b/submissions/examples/keep-performance-in-docs-ksk/style.css
@@ -1,0 +1,47 @@
+/* ============================================================
+   EaseMotion CSS — Docs Performance Integration Style
+   submissions/examples/keep-performance-in-docs-ksk/style.css
+   ============================================================ */
+
+/* ponytail: clean, standard document layout overrides */
+
+/* Styles for lists in the main documentation body */
+.docs-content ul,
+.docs-content ol {
+  color: var(--page-text-muted, #8b949e);
+  line-height: 1.75;
+  margin-top: 0.5rem;
+  margin-bottom: 1rem;
+  padding-left: 1.5rem;
+}
+
+.docs-content ul {
+  list-style-type: disc;
+}
+
+.docs-content ol {
+  list-style-type: decimal;
+}
+
+.docs-content li {
+  margin-bottom: 0.4rem;
+}
+
+/* Informational / Warning blocks inside docs */
+.docs-info {
+  background: var(--info-bg, rgba(56, 139, 253, 0.1));
+  border-left: 4px solid var(--info-border, #1f6feb);
+  padding: 1rem;
+  border-radius: 6px;
+  display: flex;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--page-text-muted, #c9d1d9);
+}
+
+.docs-info-icon {
+  font-size: 1.2rem;
+  line-height: 1;
+}


### PR DESCRIPTION
Closes #44519.

This PR adds an integration showcase under `submissions/examples/keep-performance-in-docs-ksk/` demonstrating how to integrate the Performance Guide directly inside the core documentation single-page layout.

#### **Key Features Showcase**
1. **Sidebar Navigation Preservation**: Illustrates the layout structure with active state updates for `#performance`.
2. **Standard Document Styles**: Includes list stylings (`ul`, `ol`, `li`) and callout styling classes suitable for `.docs-content`.
3. **Actionable Migration Guidelines**: The `README.md` details the exact HTML/CSS updates the maintainer should apply to merge this change into the core layout.