### PR TITLE
fix: add input validation and HTML escaping to contributor wall builder (#43974)

### DIFF
--- a/scripts/build-contributor-wall.py
+++ b/scripts/build-contributor-wall.py
@@ -3,11 +3,13 @@ Build the contributor wall HTML for README.md.
 Reads /tmp/contributors.json, replaces content between
 <!-- CONTRIBUTOR-WALL-START --> and <!-- CONTRIBUTOR-WALL-END --> markers.
 """
+import html
 import json
 import re
 import sys
 
 COLS = 12
+EXPECTED_COUNT = 551
 INPUT = "/tmp/contributors.json"
 README = "README.md"
 START_MARKER = "<!-- CONTRIBUTOR-WALL-START -->"
@@ -22,13 +24,15 @@ def build_wall(contributors):
         for c in row:
             login = c["login"]
             count = c["contributions"]
+            # Escape HTML to prevent injection
+            safe_login = html.escape(login)
             cells += (
                 f'<td align="center">'
-                f'<a href="https://github.com/{login}">'
-                f'<img src="https://avatars.githubusercontent.com/{login}?s=64" '
-                f'width="52" height="52" alt="{login}" '
+                f'<a href="https://github.com/{safe_login}">'
+                f'<img src="https://avatars.githubusercontent.com/{safe_login}?s=64" '
+                f'width="52" height="52" alt="{safe_login}" '
                 f'style="border-radius:50%;margin:4px"/>'
-                f"<br/><sub><b>{login}</b></sub>"
+                f"<br/><sub><b>{safe_login}</b></sub>"
                 f"<br/><sub>{count} commits</sub>"
                 f"</a></td>"
             )
@@ -52,12 +56,20 @@ def main():
     with open(INPUT) as f:
         contributors = json.load(f)
 
-    # Slice to exactly 551 contributors to match the official count
-    contributors = contributors[:551]
-
     if not contributors:
         print("ERROR: No contributors found in JSON.", file=sys.stderr)
         sys.exit(1)
+
+    # Input validation before slicing
+    if len(contributors) < EXPECTED_COUNT:
+        print(
+            f"WARNING: Only {len(contributors)} contributors found, expected {EXPECTED_COUNT}",
+            file=sys.stderr
+        )
+    
+    # Slice to exactly the expected count if we have enough
+    if len(contributors) >= EXPECTED_COUNT:
+        contributors = contributors[:EXPECTED_COUNT]
 
     wall = build_wall(contributors)
 


### PR DESCRIPTION
## Description
Fixes #43974 - Missing input validation in contributor wall builder when contributor count changes

## Changes Made
- ✅ Added `EXPECTED_COUNT = 551` constant for validation
- ✅ Added input validation before slicing to check contributor count
- ✅ Added warning message to stderr when count is below expected value
- ✅ Added HTML escaping using `html.escape()` to prevent injection attacks
- ✅ Applied escaping to all contributor login references in generated HTML

## Why This Matters
**Before:** Script silently truncated to 551 contributors without validation, causing maintainers to miss data inconsistencies
**After:** Script alerts maintainers when contributor count falls below expected value and prevents XSS vulnerabilities

## Testing
- ✅ Script compiles without syntax errors
- ✅ Maintains backward compatibility when count >= 551
- ✅ Shows clear warning when count < 551
- ✅ HTML escaping prevents potential XSS injection

## Checklist
- [x] Code follows project style guidelines
- [x] Changes address all issue requirements
- [x] No breaking changes introduced
- [x] Security improvements implemented (HTML escaping)
- [x] Meaningful commit messages
