### PR TITLE
fix: increase header logo size for better visibility (issue #43263)

### DIFF
--- a/submissions/examples/fix-header-logo-size-ak/README.md
+++ b/submissions/examples/fix-header-logo-size-ak/README.md
@@ -1,0 +1,50 @@
+# Fix: Header Logo Too Small — Issue #43263
+
+## What does this do?
+
+Fixes the header logo being too small (24 px) and difficult to notice. The updated size is **48 px** on desktop, scaling down gracefully to **36 px** on mobile viewports, keeping the logo clearly visible while staying proportional to the navigation links.
+
+## How is it used?
+
+Replace the small logo `<img>` or `<svg>` in the site header with the corrected size class:
+
+```html
+<!-- Before (too small) -->
+<a href="/" class="brand-logo" aria-label="EaseMotion CSS Home">
+  <svg class="logo-icon logo-icon--small" ...></svg>
+  <span class="brand-name">EaseMotion</span>
+</a>
+
+<!-- After (fixed) -->
+<a href="/" class="brand-logo" aria-label="EaseMotion CSS Home">
+  <svg class="logo-icon logo-icon--fixed" ...></svg>
+  <span class="brand-name">EaseMotion</span>
+</a>
+```
+
+Key CSS rules applied:
+
+```css
+/* Fixed logo — desktop */
+.logo-icon--fixed {
+  width: 48px;
+  height: 48px;
+  flex-shrink: 0;
+}
+
+/* Responsive — mobile */
+@media (max-width: 480px) {
+  .logo-icon--fixed {
+    width: 36px;
+    height: 36px;
+  }
+}
+```
+
+- Aspect ratio is preserved because `width` and `height` are set to equal values on the SVG/image, and the SVG uses a square `viewBox`.
+- Vertical alignment is handled via `display: flex; align-items: center` on the `.brand-logo` anchor.
+- `flex-shrink: 0` prevents the logo from collapsing when nav links crowd the header.
+
+## Why is it useful?
+
+The logo is the primary branding element in the header. When it is too small, users on first visit may not register the project name or associate it with the EaseMotion identity. Increasing the logo to 48 px brings it in line with standard header logo sizes (40–56 px as suggested in the issue) without disrupting the layout balance. The responsive rule ensures the fix does not overflow on narrow screens, and the `prefers-reduced-motion` guard disables transitions for users who have motion sensitivity.

--- a/submissions/examples/fix-header-logo-size-ak/demo.html
+++ b/submissions/examples/fix-header-logo-size-ak/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fix: Header Logo Size — EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <!-- ============================================================
+         BEFORE: Logo too small and hard to notice
+         ============================================================ -->
+    <section class="demo-section">
+      <p class="demo-label">❌ Before — Logo too small (24px)</p>
+      <header class="site-header">
+        <a href="#" class="brand-logo brand-logo--small" aria-label="EaseMotion CSS Home">
+          <svg class="logo-icon logo-icon--small" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <circle cx="24" cy="24" r="20" stroke="#6c63ff" stroke-width="3.5" />
+            <path d="M14 24 Q19 14 24 24 Q29 34 34 24" stroke="#6c63ff" stroke-width="3" stroke-linecap="round" fill="none" />
+          </svg>
+          <span class="brand-name">EaseMotion</span>
+        </a>
+        <nav class="nav-links" aria-label="Primary navigation">
+          <a href="#" class="nav-link">Docs</a>
+          <a href="#" class="nav-link">Components</a>
+          <a href="#" class="nav-link">GitHub</a>
+        </nav>
+      </header>
+    </section>
+
+    <!-- ============================================================
+         AFTER: Logo at 48px — clearly visible and balanced
+         ============================================================ -->
+    <section class="demo-section">
+      <p class="demo-label">✅ After — Logo fixed (48px, responsive)</p>
+      <header class="site-header">
+        <a href="#" class="brand-logo brand-logo--fixed" aria-label="EaseMotion CSS Home">
+          <svg class="logo-icon logo-icon--fixed" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <circle cx="24" cy="24" r="20" stroke="#6c63ff" stroke-width="3.5" />
+            <path d="M14 24 Q19 14 24 24 Q29 34 34 24" stroke="#6c63ff" stroke-width="3" stroke-linecap="round" fill="none" />
+          </svg>
+          <span class="brand-name">EaseMotion</span>
+        </a>
+        <nav class="nav-links" aria-label="Primary navigation">
+          <a href="#" class="nav-link">Docs</a>
+          <a href="#" class="nav-link">Components</a>
+          <a href="#" class="nav-link">GitHub</a>
+        </nav>
+      </header>
+    </section>
+
+    <!-- ============================================================
+         Responsive check label
+         ============================================================ -->
+    <p class="responsive-note">↔ Resize the window to verify the logo scales gracefully on small screens.</p>
+  </body>
+</html>

--- a/submissions/examples/fix-header-logo-size-ak/style.css
+++ b/submissions/examples/fix-header-logo-size-ak/style.css
@@ -1,0 +1,154 @@
+/* =============================================================
+   Fix: Header Logo Size — EaseMotion CSS
+   Issue #43263 — logo too small and difficult to notice
+   Contributor: ak
+   ============================================================= */
+
+/* ── Page chrome ────────────────────────────────────────────── */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #f8f9fb;
+  color: #1e293b;
+  padding: 2rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+  min-height: 100vh;
+}
+
+/* ── Demo wrapper ───────────────────────────────────────────── */
+.demo-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.demo-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #64748b;
+  letter-spacing: 0.02em;
+}
+
+.responsive-note {
+  font-size: 0.8rem;
+  color: #94a3b8;
+  text-align: center;
+  margin-top: 0.5rem;
+}
+
+/* ── Shared header shell ────────────────────────────────────── */
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1.5rem;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+  gap: 1rem;
+}
+
+/* ── Brand logo link ────────────────────────────────────────── */
+.brand-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  text-decoration: none;
+  color: #1e293b;
+  transition: opacity 150ms ease;
+}
+
+.brand-logo:hover {
+  opacity: 0.8;
+}
+
+.brand-logo:focus-visible {
+  outline: 2px solid #6c63ff;
+  outline-offset: 4px;
+  border-radius: 4px;
+}
+
+.brand-name {
+  font-weight: 700;
+  font-size: 1.125rem;
+  letter-spacing: -0.02em;
+  white-space: nowrap;
+}
+
+/* ── BEFORE: undersized logo (24 px) ────────────────────────── */
+.logo-icon--small {
+  width: 24px;   /* too small — hard to notice */
+  height: 24px;
+  flex-shrink: 0;
+}
+
+/* ── AFTER: fixed logo size (48 px default) ─────────────────── */
+.logo-icon--fixed {
+  width: 48px;   /* clearly visible, matches nav height */
+  height: 48px;
+  flex-shrink: 0;
+}
+
+/* ── Navigation links ───────────────────────────────────────── */
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+}
+
+.nav-link {
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #64748b;
+  transition: color 150ms ease;
+  white-space: nowrap;
+}
+
+.nav-link:hover {
+  color: #6c63ff;
+}
+
+.nav-link:focus-visible {
+  outline: 2px solid #6c63ff;
+  outline-offset: 3px;
+  border-radius: 3px;
+}
+
+/* ── Responsive: shrink logo on small screens ───────────────── */
+@media (max-width: 480px) {
+  .logo-icon--fixed {
+    width: 36px;   /* graceful scale-down, still visible */
+    height: 36px;
+  }
+
+  .brand-name {
+    font-size: 1rem;
+  }
+
+  .nav-links {
+    gap: 0.75rem;
+  }
+
+  .nav-link {
+    font-size: 0.8rem;
+  }
+}
+
+/* ── Respect reduced-motion preference ──────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .brand-logo,
+  .nav-link {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #43263 — the header logo was too small (24px), making it hard to notice and hurting brand visibility.

## Changes

Added a self-contained demo under `submissions/examples/fix-header-logo-size-ak/` with:

- **`demo.html`** — side-by-side Before (24px) vs After (48px) comparison inside a realistic header
- **`style.css`** — logo size increased to 48px on desktop, scales to 36px on mobile; aspect ratio preserved; vertical alignment via flexbox; `flex-shrink: 0`; `prefers-reduced-motion` guard included
- **`README.md`** — documents the fix

## Checklist

- [x] Files placed inside `submissions/examples/fix-header-logo-size-ak/`
- [x] All three required files included: `demo.html`, `style.css`, `README.md`
- [x] `demo.html` is self-contained, no server/CDN needed
- [x] One PR, one focused fix
- [x] Did not modify any files in `core/` or `components/`
- [x] Folder name follows naming convention with unique suffix (`-ak`)
