### PR TITLE
feat: integrate documentation navigation bar into EaseMotion Studio (…

### DIFF
--- a/submissions/examples/studio-docs-nav-ak/README.md
+++ b/submissions/examples/studio-docs-nav-ak/README.md
@@ -1,0 +1,89 @@
+# Studio Docs Navigation — Issue #43232
+
+## What does this do?
+
+Adds an integrated documentation navigation bar to EaseMotion Studio so users can
+quickly jump to any docs section without leaving or losing their current Studio state.
+The header gains:
+
+- A **Docs dropdown** (desktop) with grouped quick links to Getting Started,
+  Utilities, Animations, Components, Motion Engine, and Cheat Sheet — each opening
+  in a new tab so the Studio state is preserved.
+- A **hamburger → slide-down drawer** (mobile, < 768 px) that exposes the same links
+  in a touch-friendly list.
+- Flat shortcut links to **Animations** and **Animation Builder** always visible in
+  the header on tablet+.
+
+## How is it used?
+
+Drop the `.studio-header` markup into the Studio `<header>` element and include
+the corresponding CSS. The JS is minimal — two toggle functions wired to click
+and keyboard events:
+
+```html
+<!-- Docs trigger button (inside <nav class="studio-nav">) -->
+<div class="studio-nav__dropdown" id="docsDropdown">
+  <button class="studio-nav__trigger"
+          aria-haspopup="true"
+          aria-expanded="false"
+          aria-controls="docsMenu"
+          id="docsMenuBtn">
+    Docs
+    <svg class="chevron">…</svg>
+  </button>
+
+  <div class="studio-nav__menu" id="docsMenu" role="menu" hidden>
+    <!-- grouped menu-item links -->
+    <a href="../index.html#getting-started" class="menu-item" role="menuitem"
+       target="_blank" rel="noopener">
+      <span class="menu-item__icon">🚀</span>
+      <span>
+        <strong>Getting Started</strong>
+        <small>Installation &amp; quick setup</small>
+      </span>
+    </a>
+    …
+  </div>
+</div>
+```
+
+```js
+// Toggle open/close
+docsBtn.addEventListener('click', (e) => {
+  e.stopPropagation();
+  docsMenu.hidden ? openMenu() : closeMenu();
+});
+document.addEventListener('click', (e) => {
+  if (!dropdown.contains(e.target)) closeMenu();
+});
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') closeMenu();
+});
+```
+
+Doc links use `target="_blank" rel="noopener"` so the Studio tab stays active.
+
+### Responsive behaviour
+
+| Viewport    | What shows                                              |
+|-------------|---------------------------------------------------------|
+| ≥ 900 px    | Docs dropdown + flat Animations & Builder links         |
+| 768–900 px  | Docs dropdown only (flat links hidden)                  |
+| < 768 px    | Hamburger → slide-down mobile drawer, no dropdown       |
+
+## Why is it useful?
+
+Right now users must switch tabs or use browser back-navigation to reference
+installation guides, utility classes, or component examples while experimenting
+in Studio. This creates a learning interruption — especially for new users who
+need documentation most while they explore.
+
+Integrating docs navigation directly into the Studio header solves this without:
+
+- Changing any existing functionality
+- Modifying `core/` or `components/`
+- Requiring a build step (pure HTML + CSS + vanilla JS)
+
+It aligns with EaseMotion's philosophy of keeping things accessible and
+self-contained — users get a seamless experience where documentation is one
+click away, not one tab switch away.

--- a/submissions/examples/studio-docs-nav-ak/demo.html
+++ b/submissions/examples/studio-docs-nav-ak/demo.html
@@ -1,0 +1,321 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EaseMotion Studio — Integrated Docs Navigation (#43232)</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <!-- ══════════════════════════════════════════════════════════
+       STUDIO HEADER — with integrated Docs dropdown navigation
+       ══════════════════════════════════════════════════════════ -->
+  <header class="studio-header" role="banner">
+
+    <!-- Brand -->
+    <a href="../index.html" class="studio-logo" aria-label="EaseMotion CSS — back to docs home">
+      <svg class="studio-logo__icon" viewBox="0 0 48 48" fill="none" aria-hidden="true">
+        <circle cx="24" cy="24" r="20" stroke="#6c63ff" stroke-width="3"/>
+        <path d="M14 24 Q19 14 24 24 Q29 34 34 24" stroke="#6c63ff" stroke-width="2.5" stroke-linecap="round" fill="none"/>
+      </svg>
+      <span class="studio-logo__name">EaseMotion</span>
+      <span class="studio-logo__badge">Studio</span>
+    </a>
+
+    <!-- ── Primary nav ───────────────────────────────────────── -->
+    <nav class="studio-nav" aria-label="Studio primary navigation">
+
+      <!-- Docs dropdown -->
+      <div class="studio-nav__dropdown" id="docsDropdown">
+        <button
+          class="studio-nav__trigger"
+          aria-haspopup="true"
+          aria-expanded="false"
+          aria-controls="docsMenu"
+          id="docsMenuBtn"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
+            <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/>
+            <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>
+          </svg>
+          Docs
+          <svg class="chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+            <path d="m6 9 6 6 6-6"/>
+          </svg>
+        </button>
+
+        <div class="studio-nav__menu" id="docsMenu" role="menu" aria-labelledby="docsMenuBtn" hidden>
+
+          <div class="menu-section">
+            <span class="menu-section__label">Learn</span>
+            <a href="../index.html#getting-started" class="menu-item" role="menuitem" target="_blank" rel="noopener">
+              <span class="menu-item__icon">🚀</span>
+              <span>
+                <strong>Getting Started</strong>
+                <small>Installation &amp; quick setup</small>
+              </span>
+            </a>
+            <a href="../index.html#utilities" class="menu-item" role="menuitem" target="_blank" rel="noopener">
+              <span class="menu-item__icon">🔧</span>
+              <span>
+                <strong>Utilities</strong>
+                <small>Layout, spacing &amp; visual helpers</small>
+              </span>
+            </a>
+          </div>
+
+          <div class="menu-divider" role="separator"></div>
+
+          <div class="menu-section">
+            <span class="menu-section__label">Motion</span>
+            <a href="../index.html#animations" class="menu-item" role="menuitem" target="_blank" rel="noopener">
+              <span class="menu-item__icon">✨</span>
+              <span>
+                <strong>Animations</strong>
+                <small>All ease-* animation classes</small>
+              </span>
+            </a>
+            <a href="../animations-preview.html" class="menu-item" role="menuitem" target="_blank" rel="noopener">
+              <span class="menu-item__icon">🎬</span>
+              <span>
+                <strong>Animation Preview</strong>
+                <small>Browse &amp; preview every animation</small>
+              </span>
+            </a>
+            <a href="../animation-combo.html" class="menu-item" role="menuitem" target="_blank" rel="noopener">
+              <span class="menu-item__icon">⚡</span>
+              <span>
+                <strong>Animation Builder</strong>
+                <small>Compose animation sequences</small>
+              </span>
+            </a>
+          </div>
+
+          <div class="menu-divider" role="separator"></div>
+
+          <div class="menu-section">
+            <span class="menu-section__label">Reference</span>
+            <a href="../index.html#components" class="menu-item" role="menuitem" target="_blank" rel="noopener">
+              <span class="menu-item__icon">🧩</span>
+              <span>
+                <strong>Components</strong>
+                <small>Buttons, cards, forms &amp; more</small>
+              </span>
+            </a>
+            <a href="../index.html#engine" class="menu-item" role="menuitem" target="_blank" rel="noopener">
+              <span class="menu-item__icon">⚙️</span>
+              <span>
+                <strong>Motion Engine</strong>
+                <small>em= attribute &amp; JS runtime API</small>
+              </span>
+            </a>
+            <a href="../cheatsheet.html" class="menu-item" role="menuitem" target="_blank" rel="noopener">
+              <span class="menu-item__icon">📋</span>
+              <span>
+                <strong>Cheat Sheet</strong>
+                <small>All classes at a glance</small>
+              </span>
+            </a>
+          </div>
+
+        </div><!-- /.studio-nav__menu -->
+      </div><!-- /.studio-nav__dropdown -->
+
+      <!-- Flat nav links -->
+      <a href="../animations-preview.html" class="studio-nav__link" target="_blank" rel="noopener">Animations</a>
+      <a href="../animation-combo.html" class="studio-nav__link" target="_blank" rel="noopener">Builder</a>
+
+    </nav>
+
+    <!-- ── Header actions ────────────────────────────────────── -->
+    <div class="studio-header__actions">
+      <a
+        href="https://discord.gg/hWSdGrccBU"
+        class="studio-header__icon-btn"
+        aria-label="Join Discord"
+        target="_blank"
+        rel="noopener noreferrer"
+        title="Discord"
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057c.002.022.015.043.033.054a19.9 19.9 0 0 0 5.993 3.03.077.077 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>
+        </svg>
+      </a>
+
+      <a
+        href="https://github.com/SAPTARSHI-coder/EaseMotion-css"
+        class="studio-header__icon-btn"
+        aria-label="View on GitHub"
+        target="_blank"
+        rel="noopener noreferrer"
+        title="GitHub"
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/>
+        </svg>
+      </a>
+
+      <!-- Mobile: hamburger to toggle mobile docs menu -->
+      <button class="studio-header__hamburger" id="mobileMenuBtn" aria-label="Toggle docs menu" aria-expanded="false" aria-controls="mobileDocs">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" aria-hidden="true">
+          <line x1="3" y1="6" x2="21" y2="6"/>
+          <line x1="3" y1="12" x2="21" y2="12"/>
+          <line x1="3" y1="18" x2="21" y2="18"/>
+        </svg>
+      </button>
+    </div>
+
+  </header>
+
+  <!-- ══════════════════════════════════════════════════════════
+       MOBILE DOCS DRAWER
+       ══════════════════════════════════════════════════════════ -->
+  <nav class="mobile-docs" id="mobileDocs" aria-label="Docs navigation" hidden>
+    <div class="mobile-docs__inner">
+      <p class="mobile-docs__heading">Documentation</p>
+
+      <a href="../index.html#getting-started" class="mobile-docs__link" target="_blank" rel="noopener">
+        🚀 Getting Started
+      </a>
+      <a href="../index.html#utilities" class="mobile-docs__link" target="_blank" rel="noopener">
+        🔧 Utilities
+      </a>
+      <a href="../index.html#animations" class="mobile-docs__link" target="_blank" rel="noopener">
+        ✨ Animations
+      </a>
+      <a href="../animations-preview.html" class="mobile-docs__link" target="_blank" rel="noopener">
+        🎬 Animation Preview
+      </a>
+      <a href="../animation-combo.html" class="mobile-docs__link" target="_blank" rel="noopener">
+        ⚡ Animation Builder
+      </a>
+      <a href="../index.html#components" class="mobile-docs__link" target="_blank" rel="noopener">
+        🧩 Components
+      </a>
+      <a href="../index.html#engine" class="mobile-docs__link" target="_blank" rel="noopener">
+        ⚙️ Motion Engine
+      </a>
+      <a href="../cheatsheet.html" class="mobile-docs__link" target="_blank" rel="noopener">
+        📋 Cheat Sheet
+      </a>
+    </div>
+  </nav>
+
+  <!-- ══════════════════════════════════════════════════════════
+       STUDIO BODY (placeholder to simulate Studio context)
+       ══════════════════════════════════════════════════════════ -->
+  <main class="studio-body">
+    <div class="studio-hero">
+      <h1 class="studio-hero__title">EaseMotion Studio</h1>
+      <p class="studio-hero__sub">
+        Pick an animation, tune duration and easing, preview it live.
+      </p>
+    </div>
+
+    <!-- Demo info card -->
+    <div class="demo-callout">
+      <span class="demo-callout__icon">💡</span>
+      <div>
+        <strong>What this demo shows (issue #43232)</strong><br>
+        The header above includes a <strong>Docs dropdown</strong> with quick links to
+        Getting Started, Utilities, Animations, Components, and Motion Engine — all
+        opening in a new tab so your current Studio state is preserved.
+        On mobile (&lt; 768 px), the hamburger button reveals a slide-down drawer
+        with the same links. Resize the window to test the responsive behaviour.
+      </div>
+    </div>
+
+    <!-- Live animation preview card -->
+    <div class="preview-card" id="previewCard">
+      <p class="preview-card__label">Live preview — class applied: <code id="appliedClass">ease-fade-in</code></p>
+      <div class="preview-box" id="previewBox">
+        <div class="preview-target ease-fade-in" id="previewTarget">Aa</div>
+      </div>
+
+      <div class="controls">
+        <label class="ctrl-label" for="animPicker">Animation</label>
+        <select id="animPicker" class="ctrl-select">
+          <option value="ease-fade-in">ease-fade-in</option>
+          <option value="ease-slide-up">ease-slide-up</option>
+          <option value="ease-bounce">ease-bounce</option>
+          <option value="ease-spin-slow">ease-spin-slow</option>
+          <option value="ease-pulse-slow">ease-pulse-slow</option>
+        </select>
+
+        <button class="ctrl-btn" id="replayBtn" aria-label="Replay animation">▶ Replay</button>
+      </div>
+    </div>
+
+  </main>
+
+  <script>
+    /* ── Docs dropdown toggle ──────────────────────────────── */
+    const docsBtn  = document.getElementById('docsMenuBtn');
+    const docsMenu = document.getElementById('docsMenu');
+    const dropdown = document.getElementById('docsDropdown');
+
+    function openMenu() {
+      docsMenu.hidden = false;
+      docsBtn.setAttribute('aria-expanded', 'true');
+    }
+    function closeMenu() {
+      docsMenu.hidden = true;
+      docsBtn.setAttribute('aria-expanded', 'false');
+    }
+
+    docsBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      docsMenu.hidden ? openMenu() : closeMenu();
+    });
+
+    // Close when clicking outside
+    document.addEventListener('click', (e) => {
+      if (!dropdown.contains(e.target)) closeMenu();
+    });
+
+    // Close on Escape
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') closeMenu();
+    });
+
+    /* ── Mobile drawer toggle ──────────────────────────────── */
+    const mobileBtn  = document.getElementById('mobileMenuBtn');
+    const mobileDocs = document.getElementById('mobileDocs');
+
+    mobileBtn.addEventListener('click', () => {
+      const isOpen = !mobileDocs.hidden;
+      mobileDocs.hidden = isOpen;
+      mobileBtn.setAttribute('aria-expanded', String(!isOpen));
+    });
+
+    /* ── Replay animation demo ─────────────────────────────── */
+    const picker  = document.getElementById('animPicker');
+    const target  = document.getElementById('previewTarget');
+    const label   = document.getElementById('appliedClass');
+    const replayB = document.getElementById('replayBtn');
+
+    const ANIM_CLASSES = [
+      'ease-fade-in','ease-slide-up','ease-bounce',
+      'ease-spin-slow','ease-pulse-slow'
+    ];
+
+    function replay() {
+      const cls = picker.value;
+      // Remove all known anim classes, then re-add to retrigger
+      ANIM_CLASSES.forEach(c => target.classList.remove(c));
+      label.textContent = cls;
+      // Force reflow to restart animation
+      void target.offsetWidth;
+      target.classList.add(cls);
+    }
+
+    picker.addEventListener('change', replay);
+    replayB.addEventListener('click', replay);
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/studio-docs-nav-ak/style.css
+++ b/submissions/examples/studio-docs-nav-ak/style.css
@@ -1,0 +1,559 @@
+/* =============================================================
+   Studio Docs Navigation — EaseMotion CSS
+   Issue #43232 — integrated documentation nav bar for Studio
+   Contributor: ak
+   ============================================================= */
+
+/* ── Reset & tokens ─────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg:        #0b1121;
+  --surface:   #141e33;
+  --surface-2: #1e2d4a;
+  --border:    rgba(255, 255, 255, 0.08);
+  --primary:   #6c63ff;
+  --primary-g: #a09af8;
+  --accent:    #8b5cf6;
+  --text:      #e2e8f0;
+  --muted:     #94a3b8;
+  --success:   #22c55e;
+  --radius:    12px;
+  --header-h:  64px;
+  --sans:      'Inter', system-ui, sans-serif;
+  --mono:      'JetBrains Mono', monospace;
+
+  /* Dropdown geometry */
+  --menu-w:    340px;
+  --menu-top:  calc(var(--header-h) - 8px);
+}
+
+html { scroll-behavior: smooth; }
+
+body {
+  font-family: var(--sans);
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  line-height: 1.6;
+}
+
+/* ── Studio Header ──────────────────────────────────────────── */
+.studio-header {
+  height: var(--header-h);
+  padding: 0 1.75rem;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  background: rgba(11, 17, 33, 0.85);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 200;
+}
+
+/* ── Logo ───────────────────────────────────────────────────── */
+.studio-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  text-decoration: none;
+  flex-shrink: 0;
+}
+
+.studio-logo__icon {
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+}
+
+.studio-logo__name {
+  font-size: 1.1rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  white-space: nowrap;
+}
+
+.studio-logo__badge {
+  font-size: 0.65rem;
+  font-weight: 600;
+  background: var(--primary);
+  color: #fff;
+  padding: 0.15rem 0.5rem;
+  border-radius: 99px;
+  letter-spacing: 0.05em;
+  -webkit-text-fill-color: #fff;
+  white-space: nowrap;
+}
+
+/* ── Primary nav ────────────────────────────────────────────── */
+.studio-nav {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-left: 0.5rem;
+}
+
+/* Flat nav links */
+.studio-nav__link {
+  padding: 0.4rem 0.75rem;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--muted);
+  text-decoration: none;
+  transition: color 0.15s ease, background 0.15s ease;
+  white-space: nowrap;
+}
+
+.studio-nav__link:hover {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.studio-nav__link:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+/* ── Docs dropdown ──────────────────────────────────────────── */
+.studio-nav__dropdown {
+  position: relative;
+}
+
+/* Trigger button */
+.studio-nav__trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--muted);
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: color 0.15s ease, background 0.15s ease;
+  white-space: nowrap;
+  font-family: var(--sans);
+}
+
+.studio-nav__trigger:hover,
+.studio-nav__trigger[aria-expanded="true"] {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.studio-nav__trigger[aria-expanded="true"] .chevron {
+  transform: rotate(180deg);
+}
+
+.chevron {
+  transition: transform 0.2s ease;
+  flex-shrink: 0;
+}
+
+.studio-nav__trigger:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+/* Dropdown panel */
+.studio-nav__menu {
+  position: absolute;
+  top: calc(100% + 10px);
+  left: 0;
+  width: var(--menu-w);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.45),
+    0 2px 8px rgba(0, 0, 0, 0.3),
+    0 0 0 1px rgba(108, 99, 255, 0.1);
+  padding: 0.75rem;
+  animation: menu-in 0.15s ease both;
+  z-index: 300;
+}
+
+@keyframes menu-in {
+  from { opacity: 0; transform: translateY(-6px) scale(0.98); }
+  to   { opacity: 1; transform: translateY(0)   scale(1); }
+}
+
+/* Section grouping */
+.menu-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.menu-section__label {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(108, 99, 255, 0.75);
+  padding: 0.4rem 0.6rem 0.2rem;
+}
+
+/* Menu item */
+.menu-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.65rem;
+  padding: 0.55rem 0.6rem;
+  border-radius: 8px;
+  text-decoration: none;
+  color: var(--text);
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+.menu-item:hover {
+  background: rgba(108, 99, 255, 0.12);
+}
+
+.menu-item:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: -2px;
+  border-radius: 8px;
+}
+
+.menu-item__icon {
+  font-size: 1rem;
+  line-height: 1.4;
+  flex-shrink: 0;
+  width: 20px;
+  text-align: center;
+}
+
+.menu-item strong {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--text);
+}
+
+.menu-item small {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--muted);
+  margin-top: 0.1rem;
+}
+
+/* Divider between sections */
+.menu-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 0.5rem 0;
+}
+
+/* ── Header actions ─────────────────────────────────────────── */
+.studio-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: auto;
+}
+
+.studio-header__icon-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  color: var(--muted);
+  text-decoration: none;
+  background: none;
+  border: 1px solid transparent;
+  cursor: pointer;
+  font-family: var(--sans);
+  transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+
+.studio-header__icon-btn:hover {
+  color: var(--text);
+  border-color: var(--border);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.studio-header__icon-btn:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+/* Hamburger — mobile only */
+.studio-header__hamburger {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  color: var(--muted);
+  background: none;
+  border: 1px solid var(--border);
+  cursor: pointer;
+  font-family: var(--sans);
+  transition: color 0.15s, background 0.15s;
+}
+
+.studio-header__hamburger:hover {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+/* ── Mobile docs drawer ─────────────────────────────────────── */
+.mobile-docs {
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  padding: 1rem 1.25rem;
+  animation: drawer-in 0.2s ease both;
+}
+
+@keyframes drawer-in {
+  from { opacity: 0; transform: translateY(-8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.mobile-docs__inner {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+.mobile-docs__heading {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(108, 99, 255, 0.75);
+  margin-bottom: 0.5rem;
+}
+
+.mobile-docs__link {
+  display: block;
+  padding: 0.55rem 0.75rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--text);
+  text-decoration: none;
+  transition: background 0.12s ease;
+}
+
+.mobile-docs__link:hover {
+  background: rgba(108, 99, 255, 0.1);
+}
+
+.mobile-docs__link:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+/* ── Studio body ────────────────────────────────────────────── */
+.studio-body {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+/* Hero */
+.studio-hero__title {
+  font-size: clamp(1.75rem, 4vw, 2.8rem);
+  font-weight: 700;
+  background: linear-gradient(135deg, #fff 30%, var(--primary-g));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 0.5rem;
+}
+
+.studio-hero__sub {
+  color: var(--muted);
+  font-size: 1rem;
+}
+
+/* Callout */
+.demo-callout {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  background: rgba(108, 99, 255, 0.08);
+  border: 1px solid rgba(108, 99, 255, 0.25);
+  border-radius: var(--radius);
+  padding: 1rem 1.25rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.demo-callout__icon { font-size: 1.2rem; flex-shrink: 0; }
+.demo-callout strong { color: var(--text); }
+
+/* Preview card */
+.preview-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.preview-card__label {
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.preview-card__label code {
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  color: var(--primary-g);
+  background: rgba(108, 99, 255, 0.12);
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+}
+
+.preview-box {
+  min-height: 140px;
+  background: var(--surface-2);
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.preview-target {
+  width: 80px;
+  height: 80px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+/* Inline keyframes to make the demo self-contained */
+@keyframes ease-fade-in-kf  { from { opacity: 0; } to { opacity: 1; } }
+@keyframes ease-slide-up-kf { from { opacity: 0; transform: translateY(20px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes ease-bounce-kf   { 0%,100% { transform: translateY(0); } 50% { transform: translateY(-18px); } }
+@keyframes ease-spin-kf     { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+@keyframes ease-pulse-kf    { 0%,100% { opacity: 1; } 50% { opacity: 0.45; } }
+
+.ease-fade-in  { animation: ease-fade-in-kf  0.5s ease both; }
+.ease-slide-up { animation: ease-slide-up-kf 0.55s ease both; }
+.ease-bounce   { animation: ease-bounce-kf   1s ease-in-out infinite; }
+.ease-spin-slow { animation: ease-spin-kf    2.5s linear infinite; }
+.ease-pulse-slow { animation: ease-pulse-kf  2s ease-in-out infinite; }
+
+/* Controls */
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.ctrl-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.ctrl-select {
+  flex: 1;
+  min-width: 160px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 8px;
+  padding: 0.5rem 2rem 0.5rem 0.75rem;
+  font-family: var(--sans);
+  font-size: 0.875rem;
+  outline: none;
+  cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  transition: border-color 0.15s ease;
+}
+
+.ctrl-select:focus,
+.ctrl-select:hover { border-color: var(--primary); }
+
+.ctrl-btn {
+  padding: 0.5rem 1.1rem;
+  border-radius: 8px;
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  font-family: var(--sans);
+  font-size: 0.875rem;
+  font-weight: 600;
+  white-space: nowrap;
+  transition: background 0.15s ease, transform 0.1s ease;
+}
+
+.ctrl-btn:hover { background: #5b54db; }
+.ctrl-btn:active { transform: scale(0.96); }
+.ctrl-btn:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+/* ── Responsive ─────────────────────────────────────────────── */
+/* Tablet: hide flat nav links, keep Docs dropdown */
+@media (max-width: 900px) {
+  .studio-nav__link { display: none; }
+}
+
+/* Mobile: hide Docs dropdown + flat links, show hamburger */
+@media (max-width: 768px) {
+  .studio-nav { display: none; }
+  .studio-header__hamburger { display: flex; }
+
+  .studio-header {
+    padding: 0 1rem;
+    gap: 0.75rem;
+  }
+
+  .studio-logo__name { font-size: 1rem; }
+}
+
+/* ── Reduced motion ─────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .studio-nav__menu,
+  .mobile-docs,
+  .chevron,
+  .studio-nav__link,
+  .studio-nav__trigger,
+  .menu-item,
+  .mobile-docs__link,
+  .ctrl-btn,
+  .ctrl-select {
+    transition: none;
+    animation: none;
+  }
+}


### PR DESCRIPTION
Summary

Closes #43232

Currently, once users enter EaseMotion Studio, all documentation sections become inaccessible without switching tabs or using browser navigation. This submission adds an integrated docs navigation bar to the Studio header so users can reference any docs section without losing their Studio state.

Changes

Added submissions/examples/studio-docs-nav-ak/ with three files:

demo.html — self-contained Studio mockup demonstrating the full navigation. Includes a live animation preview widget so it feels like the real Studio context.
style.css — complete styling for the header, dropdown, mobile drawer, and all interactive states.
README.md — documents what it does, how to use it, and why it fits EaseMotion.
Features implemented

Docs dropdown in the header, grouped into three sections: Learn (Getting Started, Utilities), Motion (Animations, Preview, Builder), and Reference (Components, Motion Engine, Cheat Sheet)
All doc links open in a new tab — Studio state is always preserved
Animated dropdown with click-outside and Escape key dismissal
Hamburger → slide-down mobile drawer with the same links (< 768px)
Flat shortcut links to Animations and Builder visible on tablet+
Full keyboard focus states on all interactive elements
prefers-reduced-motion guard
Responsive behaviour

Viewport	What shows
≥ 900px	Docs dropdown + flat Animations & Builder links
768–900px	Docs dropdown only
< 768px	Hamburger → mobile drawer
Checklist

 Files placed inside submissions/examples/studio-docs-nav-ak/
 All three required files included: demo.html, style.css, README.md
 demo.html is self-contained — works by opening directly in a browser, no server or CDN needed
 One PR, one focused feature
 No files in core/ or components/ were modified
 Folder name follows naming convention with unique suffix (-ak)