### PR TITLE
feat: add rubber band tally counter component (#42259)

### DIFF
--- a/submissions/examples/rubber-band-tally-counter/README.md
+++ b/submissions/examples/rubber-band-tally-counter/README.md
@@ -1,0 +1,19 @@
+# Rubber Band Tally Counter
+
+A CSS-only animated tally counter component with a smooth rubber band stretching effect.
+
+## Features
+
+- Pure CSS animation
+- No JavaScript required
+- Smooth elastic motion
+- Responsive design
+- Accessibility-friendly reduced motion support
+
+## Usage
+
+```html
+<div class="ease-rubber-band-counter">
+  <span class="counter-value">2500</span>
+  <span class="counter-label">Users Joined</span>
+</div>

--- a/submissions/examples/rubber-band-tally-counter/demo.html
+++ b/submissions/examples/rubber-band-tally-counter/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Rubber Band Tally Counter</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+
+<body>
+
+  <main class="container">
+
+    <h1>Rubber Band Tally Counter</h1>
+
+    <div class="ease-rubber-band-counter" aria-label="Tally counter">
+      <span class="counter-value">2500</span>
+      <span class="counter-label">Users Joined</span>
+    </div>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/rubber-band-tally-counter/style.css
+++ b/submissions/examples/rubber-band-tally-counter/style.css
@@ -1,0 +1,86 @@
+:root {
+    --ease-primary: #2563eb;
+    --ease-secondary: #dbeafe;
+    --ease-text: #1e293b;
+  }
+  
+  * {
+    box-sizing: border-box;
+  }
+  
+  body {
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-family: Arial, sans-serif;
+    background: #f8fafc;
+  }
+  
+  .container {
+    text-align: center;
+  }
+  
+  .ease-rubber-band-counter {
+    padding: 2.5rem 4rem;
+    background: white;
+    border-radius: 24px;
+    box-shadow: 0 15px 35px rgba(0,0,0,.1);
+    animation: ease-rubber-band 2.5s infinite;
+  }
+  
+  .counter-value {
+    display: block;
+    font-size: 3rem;
+    font-weight: 800;
+    color: var(--ease-primary);
+  }
+  
+  .counter-label {
+    display: block;
+    margin-top: .5rem;
+    color: var(--ease-text);
+    font-size: 1rem;
+  }
+  
+  
+  @keyframes ease-rubber-band {
+  
+    0% {
+      transform: scale3d(1, 1, 1);
+    }
+  
+    30% {
+      transform: scale3d(1.25, .75, 1);
+    }
+  
+    40% {
+      transform: scale3d(.75, 1.25, 1);
+    }
+  
+    50% {
+      transform: scale3d(1.15, .85, 1);
+    }
+  
+    65% {
+      transform: scale3d(.95, 1.05, 1);
+    }
+  
+    75% {
+      transform: scale3d(1.05, .95, 1);
+    }
+  
+    100% {
+      transform: scale3d(1, 1, 1);
+    }
+  
+  }
+  
+  
+  @media (prefers-reduced-motion: reduce) {
+  
+    .ease-rubber-band-counter {
+      animation: none;
+    }
+  
+  }


### PR DESCRIPTION
## Pull Request Description

Added a new **Rubber Band Tally Counter** component to EaseMotion CSS.  
This component provides a reusable CSS-only animated counter card with a smooth elastic rubber band effect for landing pages and dashboard interfaces.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

--- Issue #42259

## Feature Description

**What does this add?**

Adds an `ease-rubber-band-tally-counter` component with a playful rubber band scaling animation using pure CSS keyframes.

**How does a developer use it?**

```html
<div class="ease-rubber-band-counter">
  <span class="counter-value">2500</span>
  <span class="counter-label">Users Joined</span>
</div>