### PR TITLE
feat: add ease-keyboard-shortcut-badge component

### DIFF
--- a/submissions/examples/ease-keyboard-shortcut-badge-ij/README.md
+++ b/submissions/examples/ease-keyboard-shortcut-badge-ij/README.md
@@ -1,0 +1,17 @@
+# ease-keyboard-shortcut-badge
+
+A tactile, 3D-styled keyboard shortcut (`<kbd>`) badge that physically depresses when clicked.
+
+## Usage
+Open demo.html in a browser. Use the `.ease-kbd` class on `<kbd>` elements. Group them with separators inside a `.ease-kbd-group` container.
+
+## Custom Properties
+| Property | Default | Description |
+|---|---|---|
+| --kbd-bg | #f8fafc | Badge background color |
+| --kbd-border | #cbd5e1 | Badge border color |
+| --kbd-shadow | #94a3b8 | 3D depth shadow color |
+| --kbd-text | #334155 | Text color |
+
+## Notes
+The component uses `box-shadow` to create the 3D depth. On `:active`, it uses `transform: translateY(4px)` while simultaneously reducing the `box-shadow` offset to 0, perfectly simulating a physical key press without any JavaScript.

--- a/submissions/examples/ease-keyboard-shortcut-badge-ij/demo.html
+++ b/submissions/examples/ease-keyboard-shortcut-badge-ij/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ease Keyboard Shortcut Badge</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="ease-kbd-group">
+        <kbd class="ease-kbd">Ctrl</kbd>
+        <span>+</span>
+        <kbd class="ease-kbd">K</kbd>
+    </div>
+    
+    <div class="ease-kbd-group" style="margin-left: 24px;">
+        <kbd class="ease-kbd">⌘</kbd>
+        <span>+</span>
+        <kbd class="ease-kbd">Shift</kbd>
+        <span>+</span>
+        <kbd class="ease-kbd">P</kbd>
+    </div>
+</body>
+</html>

--- a/submissions/examples/ease-keyboard-shortcut-badge-ij/style.css
+++ b/submissions/examples/ease-keyboard-shortcut-badge-ij/style.css
@@ -1,0 +1,59 @@
+:root {
+  --kbd-bg: #f8fafc;
+  --kbd-border: #cbd5e1;
+  --kbd-shadow: #94a3b8;
+  --kbd-text: #334155;
+  --kbd-bg-active: #f1f5f9;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #ffffff;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  gap: 12px;
+  padding: 20px;
+}
+
+.ease-kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  height: 32px;
+  padding: 0 10px;
+  background-color: var(--kbd-bg);
+  color: var(--kbd-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border: 1px solid var(--kbd-border);
+  border-radius: 6px;
+  box-shadow: 0 4px 0 var(--kbd-shadow), 0 5px 5px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  user-select: none;
+  transition: all 0.1s cubic-bezier(0.4, 0, 0.2, 1);
+  /* Text styling */
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* 3D push effect */
+.ease-kbd:active {
+  transform: translateY(4px);
+  box-shadow: 0 0 0 var(--kbd-shadow), 0 1px 2px rgba(0, 0, 0, 0.1);
+  background-color: var(--kbd-bg-active);
+}
+
+.ease-kbd-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #64748b;
+  font-size: 0.875rem;
+  font-weight: 500;
+}


### PR DESCRIPTION
## Pull Request Description

Adds the `ease-keyboard-shortcut-badge` component, a tactile, 3D-styled `<kbd>` element that physically depresses when clicked to simulate real hardware keys.

Closes #44313.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A clean, monospaced keyboard shortcut badge design with a satisfying 3D press effect. 

**How does a developer use it?**

Wrap text inside standard `<kbd>` HTML tags and apply the `.ease-kbd` class. Group them logically using the `.ease-kbd-group` wrapper for proper spacing alongside separators (like `+`).

```html
<div class="ease-kbd-group">
    <kbd class="ease-kbd">Ctrl</kbd>
    <span>+</span>
    <kbd class="ease-kbd">K</kbd>
</div>
