### PR TITLE
feat: add headphones

### DIFF
--- a/submissions/examples/headphones-as/README.md
+++ b/submissions/examples/headphones-as/README.md
@@ -1,0 +1,21 @@
+# Headphones
+
+### What does this do?
+
+It shows a pair of over-ear headphones playing music. The ear cups thump to the beat, one just after the other, the driver in each cup glows in time, and rings of sound ripple out from both sides. Under reduced motion the cups rest and the ripples are hidden.
+
+### How is it used?
+
+```html
+<div class="cans">
+  <span class="band"></span>
+  <div class="cup left"><span class="pad"></span><span class="disc"></span></div>
+  <div class="cup right">...</div>
+</div>
+```
+
+The headband is a thick half-circle border with no bottom edge, so one element gives the whole arc. Each cup runs the `thump` animation with the right side offset by half a beat, and the glowing driver inside pulses on the same clock, so the two sides feel like they are alternating with the music.
+
+### Why is it useful?
+
+Music, podcast, and focus or listening themes use headphones. This builds animated headphones with pure CSS shapes and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/headphones-as/demo.html
+++ b/submissions/examples/headphones-as/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Headphones</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="cans">
+      <span class="band"></span>
+      <div class="cup left">
+        <span class="pad"></span>
+        <span class="disc"></span>
+      </div>
+      <div class="cup right">
+        <span class="pad"></span>
+        <span class="disc"></span>
+      </div>
+      <span class="arm la"></span>
+      <span class="arm ra"></span>
+    </div>
+    <span class="beat bt1"></span>
+    <span class="beat bt2"></span>
+    <span class="beat bt3"></span>
+    <span class="beat bt4"></span>
+    <span class="cable"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/headphones-as/style.css
+++ b/submissions/examples/headphones-as/style.css
@@ -1,0 +1,153 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 26%, #1c3350, #080f18 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 300px;
+  display: grid;
+  place-items: center;
+}
+
+.cans {
+  position: relative;
+  width: 240px;
+  height: 190px;
+  z-index: 2;
+}
+
+.band {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 200px;
+  height: 100px;
+  margin-left: -100px;
+  border: 16px solid #3a4657;
+  border-bottom: none;
+  border-radius: 100px 100px 0 0;
+  box-sizing: border-box;
+  box-shadow: inset 0 6px 6px rgba(255, 255, 255, 0.18);
+}
+
+.band::after {
+  content: "";
+  position: absolute;
+  top: 4px;
+  left: 24px;
+  right: 24px;
+  height: 8px;
+  border-radius: 4px;
+  background: #55637a;
+}
+
+.arm {
+  position: absolute;
+  top: 84px;
+  width: 12px;
+  height: 34px;
+  border-radius: 6px;
+  background: linear-gradient(90deg, #55637a, #2f3a49);
+}
+
+.la { left: 14px; }
+.ra { right: 14px; }
+
+.cup {
+  position: absolute;
+  top: 106px;
+  width: 76px;
+  height: 92px;
+  border-radius: 38px / 46px;
+  background: linear-gradient(160deg, #4a5769, #232c39);
+  box-shadow:
+    0 12px 24px rgba(0, 0, 0, 0.5),
+    inset 0 3px 5px rgba(255, 255, 255, 0.22);
+  animation: thump 0.8s ease-in-out infinite;
+}
+
+.left { left: 0; }
+.right { right: 0; animation-delay: 0.4s; }
+
+.pad {
+  position: absolute;
+  inset: 8px;
+  border-radius: 30px / 38px;
+  background: radial-gradient(circle at 40% 34%, #6d7a8c, #2a323d 76%);
+}
+
+.disc {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 34px;
+  height: 34px;
+  margin: -17px 0 0 -17px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #6fe0ff, #1f7fb8 72%);
+  box-shadow: 0 0 14px rgba(90, 200, 255, 0.8);
+  animation: glow 0.8s ease-in-out infinite;
+}
+
+.right .disc { animation-delay: 0.4s; }
+
+.beat {
+  position: absolute;
+  border-radius: 50%;
+  border: 2px solid rgba(110, 200, 255, 0.6);
+  opacity: 0;
+  animation: ripple 2s ease-out infinite;
+}
+
+.bt1 { top: 150px; left: 24px; width: 76px; height: 92px; animation-delay: 0s; }
+.bt2 { top: 150px; left: 24px; width: 76px; height: 92px; animation-delay: 1s; }
+.bt3 { top: 150px; right: 24px; width: 76px; height: 92px; animation-delay: 0.4s; }
+.bt4 { top: 150px; right: 24px; width: 76px; height: 92px; animation-delay: 1.4s; }
+
+.cable {
+  position: absolute;
+  bottom: 10px;
+  left: 50%;
+  width: 4px;
+  height: 60px;
+  margin-left: -60px;
+  border-radius: 2px;
+  background: #3a4657;
+  transform: rotate(8deg);
+  z-index: 1;
+}
+
+@keyframes thump {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.05); }
+}
+
+@keyframes glow {
+  0%, 100% { box-shadow: 0 0 14px rgba(90, 200, 255, 0.8); }
+  50% { box-shadow: 0 0 26px rgba(120, 220, 255, 1); }
+}
+
+@keyframes ripple {
+  0% { transform: scale(1); opacity: 0.7; }
+  100% { transform: scale(1.7); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cup,
+  .disc,
+  .beat {
+    animation: none;
+  }
+
+  .beat {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds headphones built for #44695. Over-ear cups that thump on alternating beats with glowing drivers and sound ripples, the headband drawn as a single bottomless border arc, with a reduced motion fallback. Pure CSS. Closes #44695.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: over-ear headphones with an arced band, padded cups with glowing blue drivers, and sound ripples.
