### PR TITLE
feat: add boombox

### DIFF
--- a/submissions/examples/boombox-as/README.md
+++ b/submissions/examples/boombox-as/README.md
@@ -1,0 +1,21 @@
+# Boombox
+
+### What does this do?
+
+It shows an eighties boombox playing a tape. Both speaker cones thump on alternating beats, the two cassette reels spin at different speeds, and a colored VU meter bounces between them. Under reduced motion the speakers, reels, and meter all rest.
+
+### How is it used?
+
+```html
+<div class="body">
+  <div class="speaker sl"><span class="cone"></span></div>
+  <div class="deck"><span class="reel rl"></span><span class="tape"></span></div>
+  <div class="vu"><span class="vb v1"></span></div>
+</div>
+```
+
+The speaker grilles are a `repeating-radial-gradient` of concentric rings, so each cone's ridges come from one property. The cassette reels use a `repeating-conic-gradient` for their spokes and spin at deliberately different durations, the way a real tape's take-up and supply reels do.
+
+### Why is it useful?
+
+Retro, music, and party themes use a boombox. This builds a playing boombox with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/boombox-as/demo.html
+++ b/submissions/examples/boombox-as/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Boombox</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="boombox">
+      <span class="handle"></span>
+      <div class="body">
+        <div class="speaker sl">
+          <span class="cone"></span>
+        </div>
+        <div class="speaker sr">
+          <span class="cone"></span>
+        </div>
+        <div class="deck">
+          <span class="reel rl"></span>
+          <span class="reel rr"></span>
+          <span class="tape"></span>
+        </div>
+        <div class="vu">
+          <span class="vb v1"></span>
+          <span class="vb v2"></span>
+          <span class="vb v3"></span>
+          <span class="vb v4"></span>
+          <span class="vb v5"></span>
+          <span class="vb v6"></span>
+        </div>
+        <span class="knob kl"></span>
+        <span class="knob kr"></span>
+      </div>
+      <span class="foot fl"></span>
+      <span class="foot fr"></span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/boombox-as/style.css
+++ b/submissions/examples/boombox-as/style.css
@@ -1,0 +1,205 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 24%, #2f2a3f, #100d18 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  display: grid;
+  place-items: center;
+}
+
+.boombox {
+  position: relative;
+  width: 330px;
+  height: 220px;
+}
+
+.handle {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 130px;
+  height: 44px;
+  margin-left: -65px;
+  border: 8px solid #3b4250;
+  border-bottom: none;
+  border-radius: 60px 60px 0 0;
+  box-sizing: border-box;
+}
+
+.body {
+  position: absolute;
+  top: 36px;
+  left: 0;
+  width: 330px;
+  height: 160px;
+  border-radius: 12px;
+  background: linear-gradient(160deg, #545c6c, #2b313c 72%);
+  box-shadow:
+    0 20px 38px rgba(0, 0, 0, 0.55),
+    inset 0 4px 6px rgba(255, 255, 255, 0.25);
+}
+
+.speaker {
+  position: absolute;
+  top: 24px;
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  background:
+    repeating-radial-gradient(circle at 50% 50%, #232932 0 3px, #39404d 3px 6px);
+  box-shadow:
+    inset 0 0 0 5px #1c2129,
+    inset 0 4px 8px rgba(0, 0, 0, 0.6);
+  animation: thump 0.7s ease-in-out infinite;
+}
+
+.sl { left: 16px; }
+.sr { right: 16px; animation-delay: 0.35s; }
+
+.cone {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 34px;
+  height: 34px;
+  margin: -17px 0 0 -17px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #8a94a5, #363d49 74%);
+}
+
+.deck {
+  position: absolute;
+  top: 30px;
+  left: 50%;
+  width: 104px;
+  height: 56px;
+  margin-left: -52px;
+  border-radius: 6px;
+  background: linear-gradient(160deg, #1d222b, #12161d);
+  box-shadow: inset 0 0 0 3px rgba(160, 175, 200, 0.35);
+  overflow: hidden;
+}
+
+.reel {
+  position: absolute;
+  top: 50%;
+  width: 30px;
+  height: 30px;
+  margin-top: -15px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(from 0deg at 50% 50%, #cfd7e2 0 3deg, transparent 3deg 45deg),
+    radial-gradient(circle at 50% 50%, #3a4250 0 8px, #262c36 8px);
+  box-shadow: inset 0 0 0 2px #6b7484;
+  animation: spin 1.6s linear infinite;
+}
+
+.rl { left: 12px; }
+.rr { right: 12px; animation-duration: 2.2s; }
+
+.tape {
+  position: absolute;
+  top: 50%;
+  left: 22px;
+  right: 22px;
+  height: 4px;
+  margin-top: -2px;
+  background: #8a94a5;
+}
+
+.vu {
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  width: 104px;
+  height: 34px;
+  margin-left: -52px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  padding: 0 4px;
+  box-sizing: border-box;
+  border-radius: 4px;
+  background: #171c24;
+  box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.7);
+}
+
+.vb {
+  width: 12px;
+  border-radius: 2px 2px 0 0;
+  background: linear-gradient(#6fe08a, #ffd23a 60%, #ff5a7a);
+  animation: eq 0.6s ease-in-out infinite alternate;
+}
+
+.v1 { height: 40%; animation-delay: 0s; }
+.v2 { height: 68%; animation-delay: 0.08s; }
+.v3 { height: 90%; animation-delay: 0.16s; }
+.v4 { height: 55%; animation-delay: 0.24s; }
+.v5 { height: 76%; animation-delay: 0.32s; }
+.v6 { height: 45%; animation-delay: 0.4s; }
+
+.knob {
+  position: absolute;
+  bottom: 18px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #e3e9f1, #79828f);
+  box-shadow: inset 0 0 0 3px rgba(0, 0, 0, 0.18);
+}
+
+.knob::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 50%;
+  width: 3px;
+  height: 8px;
+  margin-left: -1.5px;
+  border-radius: 2px;
+  background: #2f3743;
+}
+
+.kl { left: 40px; }
+.kr { right: 40px; }
+
+.foot {
+  position: absolute;
+  bottom: 0;
+  width: 34px;
+  height: 14px;
+  border-radius: 0 0 5px 5px;
+  background: #232830;
+}
+
+.fl { left: 34px; }
+.fr { right: 34px; }
+
+@keyframes thump {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.04); }
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes eq {
+  0% { transform: scaleY(0.35); }
+  100% { transform: scaleY(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .speaker,
+  .reel,
+  .vb {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a boombox built for #44697. Ringed speaker cones from a repeating radial gradient thump on alternating beats while conic-gradient cassette reels spin at different speeds and a colored VU meter bounces, with a reduced motion fallback. Pure CSS. Closes #44697.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a grey boombox with a carry handle, two ringed speaker cones, a cassette deck with spinning reels, and a colored VU meter.
