### PR TITLE
feat: add retro tv

### DIFF
--- a/submissions/examples/retro-tv-as/README.md
+++ b/submissions/examples/retro-tv-as/README.md
@@ -1,0 +1,22 @@
+# Retro TV
+
+### What does this do?
+
+It shows an old wooden television set showing test-card color bars. Static crawls over the picture, a bright tracking band rolls slowly down the screen, the channel flips every few seconds (the bars shift color and the tuning dial clicks around), and the power light blinks. Under reduced motion the picture holds steady.
+
+### How is it used?
+
+```html
+<div class="tube">
+  <span class="bars"></span>
+  <span class="static"></span>
+  <span class="roll"></span>
+  <span class="curve"></span>
+</div>
+```
+
+The color bars are a single hard-stop `linear-gradient` with seven bands. Static is two fine repeating gradients layered on top, and the `roll` band sweeps down with a moving `top` to mimic a CRT losing vertical hold. The channel change is a `steps(1)` animation, so the picture and the dial jump instantly rather than fading, the way a real set clicks over.
+
+### Why is it useful?
+
+Retro, media, and 404 or offline states use an old TV. This builds a working retro TV with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/retro-tv-as/demo.html
+++ b/submissions/examples/retro-tv-as/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Retro TV</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="tv">
+      <span class="ant la"></span>
+      <span class="ant ra"></span>
+      <div class="set">
+        <div class="tube">
+          <span class="bars"></span>
+          <span class="static"></span>
+          <span class="roll"></span>
+          <span class="curve"></span>
+        </div>
+        <div class="panel">
+          <span class="dial d1"></span>
+          <span class="dial d2"></span>
+          <span class="grill"></span>
+          <span class="led"></span>
+        </div>
+      </div>
+      <span class="leg ll"></span>
+      <span class="leg rl"></span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/retro-tv-as/style.css
+++ b/submissions/examples/retro-tv-as/style.css
@@ -1,0 +1,219 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 24%, #33291f, #140f0a 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  display: grid;
+  place-items: center;
+}
+
+.tv {
+  position: relative;
+  width: 300px;
+  height: 280px;
+}
+
+.ant {
+  position: absolute;
+  top: 4px;
+  left: 50%;
+  width: 4px;
+  height: 66px;
+  border-radius: 2px;
+  background: linear-gradient(#c9d2dd, #7c8794);
+  transform-origin: bottom center;
+}
+
+.la { transform: rotate(-28deg) translateX(-6px); }
+.ra { transform: rotate(28deg) translateX(6px); }
+
+.ant::after {
+  content: "";
+  position: absolute;
+  top: -6px;
+  left: 50%;
+  width: 10px;
+  height: 10px;
+  margin-left: -5px;
+  border-radius: 50%;
+  background: #dfe6ee;
+}
+
+.set {
+  position: absolute;
+  top: 64px;
+  left: 0;
+  width: 300px;
+  height: 190px;
+  display: flex;
+  gap: 10px;
+  padding: 12px;
+  box-sizing: border-box;
+  border-radius: 16px;
+  background: linear-gradient(160deg, #a5652f, #6b3d18 72%);
+  box-shadow:
+    0 20px 38px rgba(0, 0, 0, 0.6),
+    inset 0 4px 6px rgba(255, 220, 180, 0.35);
+}
+
+.tube {
+  position: relative;
+  flex: 1;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #0a0f14;
+  box-shadow: inset 0 0 0 6px #2a2018;
+}
+
+.bars {
+  position: absolute;
+  inset: 6px;
+  border-radius: 8px;
+  background: linear-gradient(
+    90deg,
+    #e8e8e8 0 14.28%,
+    #e8e14a 14.28% 28.56%,
+    #4ad0e8 28.56% 42.84%,
+    #4ae86a 42.84% 57.12%,
+    #e84ad0 57.12% 71.4%,
+    #e8564a 71.4% 85.68%,
+    #4a5ae8 85.68% 100%
+  );
+  animation: flick 5s steps(1) infinite;
+}
+
+.static {
+  position: absolute;
+  inset: 6px;
+  border-radius: 8px;
+  background:
+    repeating-linear-gradient(0deg, rgba(255, 255, 255, 0.12) 0 1px, transparent 1px 2px),
+    repeating-linear-gradient(90deg, rgba(0, 0, 0, 0.18) 0 1px, transparent 1px 3px);
+  opacity: 0.7;
+  z-index: 2;
+}
+
+.roll {
+  position: absolute;
+  left: 6px;
+  right: 6px;
+  height: 26px;
+  background: linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0));
+  z-index: 3;
+  animation: rollv 3.4s linear infinite;
+}
+
+.curve {
+  position: absolute;
+  inset: 6px;
+  border-radius: 8px;
+  background: radial-gradient(ellipse at 34% 26%, rgba(255, 255, 255, 0.22), transparent 46%);
+  z-index: 4;
+  pointer-events: none;
+}
+
+.panel {
+  position: relative;
+  width: 66px;
+  border-radius: 10px;
+  background: linear-gradient(160deg, #8a5326, #5c3313);
+  box-shadow: inset 0 0 0 3px rgba(255, 220, 180, 0.2);
+}
+
+.dial {
+  position: absolute;
+  left: 50%;
+  width: 34px;
+  height: 34px;
+  margin-left: -17px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #f0e2cf, #9c8161);
+  box-shadow: inset 0 0 0 3px rgba(0, 0, 0, 0.2);
+}
+
+.dial::after {
+  content: "";
+  position: absolute;
+  top: 4px;
+  left: 50%;
+  width: 3px;
+  height: 10px;
+  margin-left: -1.5px;
+  border-radius: 2px;
+  background: #4a3520;
+}
+
+.d1 { top: 14px; }
+.d2 { top: 58px; animation: turn 5s steps(1) infinite; }
+
+.grill {
+  position: absolute;
+  bottom: 34px;
+  left: 12px;
+  right: 12px;
+  height: 34px;
+  border-radius: 4px;
+  background: repeating-linear-gradient(180deg, #3f2a12 0 3px, #7a4d22 3px 6px);
+}
+
+.led {
+  position: absolute;
+  bottom: 14px;
+  left: 50%;
+  width: 12px;
+  height: 12px;
+  margin-left: -6px;
+  border-radius: 50%;
+  background: #ff5a3a;
+  box-shadow: 0 0 10px rgba(255, 90, 58, 0.9);
+  animation: blink 1.4s steps(1) infinite;
+}
+
+.leg {
+  position: absolute;
+  bottom: 0;
+  width: 18px;
+  height: 30px;
+  border-radius: 0 0 6px 6px;
+  background: linear-gradient(#5c3313, #3a2009);
+  transform-origin: top center;
+}
+
+.ll { left: 46px; transform: rotate(10deg); }
+.rl { right: 46px; transform: rotate(-10deg); }
+
+@keyframes flick {
+  0%, 45% { filter: hue-rotate(0deg) brightness(1); }
+  50%, 95% { filter: hue-rotate(120deg) brightness(0.9); }
+}
+
+@keyframes rollv {
+  0% { top: -26px; }
+  100% { top: 100%; }
+}
+
+@keyframes turn {
+  0%, 45% { transform: rotate(0deg); }
+  50%, 100% { transform: rotate(90deg); }
+}
+
+@keyframes blink {
+  0%, 60% { opacity: 1; }
+  61%, 100% { opacity: 0.35; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bars,
+  .roll,
+  .led,
+  .d2 {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a retro TV built for #44699. A wooden set showing gradient color bars under crawling static with a rolling tracking band, and a stepped channel-flip that jumps the picture and dial instantly, with a reduced motion fallback. Pure CSS. Closes #44699.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a wooden TV with rabbit-ear antenna showing color test bars with static, plus tuning dials, a speaker grille, and a red power light.
