### PR TITLE
feat: add harp

### DIFF
--- a/submissions/examples/harp-as/README.md
+++ b/submissions/examples/harp-as/README.md
@@ -1,0 +1,22 @@
+# Harp
+
+### What does this do?
+
+It shows a golden harp being played. Eleven strings of decreasing length span the frame, and they pluck in sequence from the long bass strings to the short high ones, each blurring wide and brightening for a moment as it vibrates. Music notes rise from the strings. Under reduced motion the strings rest and no notes float.
+
+### How is it used?
+
+```html
+<div class="harp">
+  <div class="strings"><span class="str s1"></span>...</div>
+  <span class="neck"></span>
+  <span class="pillar"></span>
+  <span class="board"></span>
+</div>
+```
+
+The frame is three bars: an upright pillar, a neck across the top, and a soundboard rotated to close the triangle. The strings hang from the neck with a length that shortens toward the treble end, so their lower tips trace the soundboard's diagonal. Each string's `pluck` animation scales it wide on the X axis and brightens it, which reads as a vibrating string, and staggered delays run the pluck up the harp like a glissando.
+
+### Why is it useful?
+
+Music, calm, and classical or fantasy themes use a harp. This builds a played harp with pure CSS shapes and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/harp-as/demo.html
+++ b/submissions/examples/harp-as/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Harp</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="note nt1"></span>
+    <span class="note nt2"></span>
+    <div class="harp">
+      <div class="strings">
+        <span class="str s1"></span>
+        <span class="str s2"></span>
+        <span class="str s3"></span>
+        <span class="str s4"></span>
+        <span class="str s5"></span>
+        <span class="str s6"></span>
+        <span class="str s7"></span>
+        <span class="str s8"></span>
+        <span class="str s9"></span>
+        <span class="str s10"></span>
+        <span class="str s11"></span>
+      </div>
+      <span class="neck"></span>
+      <span class="pillar"></span>
+      <span class="board"></span>
+      <span class="crown"></span>
+      <span class="base"></span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/harp-as/style.css
+++ b/submissions/examples/harp-as/style.css
@@ -1,0 +1,165 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 24%, #2b2136, #100a16 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 320px;
+  display: grid;
+  place-items: center;
+}
+
+.harp {
+  position: relative;
+  width: 230px;
+  height: 240px;
+  z-index: 2;
+}
+
+.strings {
+  position: absolute;
+  top: 22px;
+  left: 0;
+  width: 230px;
+  height: 190px;
+  z-index: 2;
+}
+
+.str {
+  position: absolute;
+  top: 0;
+  width: 2px;
+  border-radius: 1px;
+  background: linear-gradient(180deg, #ffe9a8, rgba(255, 233, 168, 0.5));
+  transform-origin: center;
+  animation: pluck 2.6s ease-in-out infinite;
+}
+
+.s1 { left: 16px; height: 176px; animation-delay: 0s; }
+.s2 { left: 32px; height: 163px; animation-delay: 0.12s; }
+.s3 { left: 48px; height: 150px; animation-delay: 0.24s; }
+.s4 { left: 64px; height: 137px; animation-delay: 0.36s; }
+.s5 { left: 80px; height: 124px; animation-delay: 0.48s; }
+.s6 { left: 96px; height: 111px; animation-delay: 0.6s; }
+.s7 { left: 112px; height: 98px; animation-delay: 0.72s; }
+.s8 { left: 128px; height: 85px; animation-delay: 0.84s; }
+.s9 { left: 144px; height: 72px; animation-delay: 0.96s; }
+.s10 { left: 160px; height: 59px; animation-delay: 1.08s; }
+.s11 { left: 176px; height: 46px; animation-delay: 1.2s; }
+
+.neck {
+  position: absolute;
+  top: 8px;
+  left: 4px;
+  width: 194px;
+  height: 20px;
+  border-radius: 10px;
+  background: linear-gradient(180deg, #e8c77a, #a8801f);
+  box-shadow: inset 0 3px 4px rgba(255, 240, 200, 0.5);
+  z-index: 3;
+}
+
+.pillar {
+  position: absolute;
+  top: 6px;
+  left: 0;
+  width: 22px;
+  height: 228px;
+  border-radius: 11px;
+  background: linear-gradient(90deg, #f0d798, #a8801f 60%, #7a5a10);
+  box-shadow: inset -4px 0 8px rgba(90, 60, 5, 0.5);
+  z-index: 4;
+}
+
+.board {
+  position: absolute;
+  top: 198px;
+  left: 10px;
+  width: 214px;
+  height: 20px;
+  border-radius: 10px;
+  background: linear-gradient(180deg, #d9b25e, #8a6320);
+  box-shadow: inset 0 3px 4px rgba(255, 240, 200, 0.4);
+  transform: rotate(-38deg);
+  transform-origin: left center;
+  z-index: 3;
+}
+
+.crown {
+  position: absolute;
+  top: -8px;
+  left: -4px;
+  width: 34px;
+  height: 34px;
+  border-radius: 50% 50% 40% 40%;
+  background: radial-gradient(circle at 36% 32%, #fff0b8, #c8961f);
+  z-index: 5;
+}
+
+.base {
+  position: absolute;
+  bottom: -6px;
+  left: -8px;
+  width: 60px;
+  height: 20px;
+  border-radius: 8px;
+  background: linear-gradient(180deg, #c8961f, #7a5a10);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.45);
+  z-index: 5;
+}
+
+.note {
+  position: absolute;
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: #ffe9a8;
+  opacity: 0;
+  animation: rise 3.4s ease-out infinite;
+  z-index: 3;
+}
+
+.note::after {
+  content: "";
+  position: absolute;
+  top: -14px;
+  right: -1px;
+  width: 3px;
+  height: 16px;
+  border-radius: 2px;
+  background: #ffe9a8;
+}
+
+.nt1 { top: 150px; left: 140px; animation-delay: 0.4s; }
+.nt2 { top: 170px; left: 100px; animation-delay: 2s; }
+
+@keyframes pluck {
+  0%, 70%, 100% { transform: scaleX(1); filter: brightness(1); }
+  76% { transform: scaleX(3); filter: brightness(1.8); }
+  84% { transform: scaleX(1.8); }
+}
+
+@keyframes rise {
+  0% { transform: translate(0, 0) rotate(0deg); opacity: 0; }
+  20% { opacity: 1; }
+  100% { transform: translate(50px, -120px) rotate(20deg); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .str,
+  .note {
+    animation: none;
+  }
+
+  .note {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a harp built for #44737. Eleven strings whose lengths trace the soundboard diagonal, plucking in sequence up the frame with a scaleX blur that reads as vibration, with a reduced motion fallback. Pure CSS. Closes #44737.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a gold triangular harp frame with a pillar, neck, and soundboard, strung with eleven strings of decreasing length.
