### PR TITLE
feat: add fire hydrant

### DIFF
--- a/submissions/examples/fire-hydrant-as/README.md
+++ b/submissions/examples/fire-hydrant-as/README.md
@@ -1,0 +1,22 @@
+# Fire Hydrant
+
+### What does this do?
+
+It shows a red fire hydrant on the curb. Hovering or focusing it opens the valve: the top bolt turns and jets of water arc out of both side nozzles in a repeating spray. It works with no JavaScript. Under reduced motion the bolt turns without easing and the water stays off.
+
+### How is it used?
+
+```html
+<div class="hydrant" tabindex="0">
+  <span class="bolt"></span>
+  <div class="body"><span class="band"></span></div>
+  <span class="nozzle ln"></span>
+  <span class="jet j1"></span>
+</div>
+```
+
+The hydrant is a rounded body with a domed cap, a gold band, and two side nozzles. On `:hover` or `:focus` the bolt rotates and the water droplets start their `sprayL` and `sprayR` animations, which translate them outward and down in an arc. Pairing two droplets per side on offset delays makes the stream look continuous rather than pulsed.
+
+### Why is it useful?
+
+City, safety, and summer street scenes use a fire hydrant. This builds an interactive hydrant with pure CSS shapes and animation, no images or JavaScript, with a reduced motion fallback.

--- a/submissions/examples/fire-hydrant-as/demo.html
+++ b/submissions/examples/fire-hydrant-as/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fire Hydrant</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="hydrant" tabindex="0">
+      <span class="cap"></span>
+      <span class="bolt"></span>
+      <div class="body">
+        <span class="band"></span>
+        <span class="shine"></span>
+      </div>
+      <span class="nozzle ln"></span>
+      <span class="nozzle rn"></span>
+      <span class="foot"></span>
+      <span class="jet j1"></span>
+      <span class="jet j2"></span>
+      <span class="jet j3"></span>
+      <span class="jet j4"></span>
+    </div>
+    <span class="road"></span>
+    <p class="hint">hover to open</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fire-hydrant-as/style.css
+++ b/submissions/examples/fire-hydrant-as/style.css
@@ -1,0 +1,187 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 24%, #4a5568, #1c2230 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 300px;
+  display: grid;
+  align-content: end;
+  justify-items: center;
+  gap: 10px;
+}
+
+.hydrant {
+  position: relative;
+  width: 130px;
+  height: 210px;
+  margin-bottom: -6px;
+  outline: none;
+  z-index: 3;
+}
+
+.body {
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  width: 84px;
+  height: 130px;
+  margin-left: -42px;
+  border-radius: 28px 28px 10px 10px;
+  background: linear-gradient(90deg, #ff5a4a 0 24%, #e03426 55%, #a8221a);
+  box-shadow: inset 0 4px 6px rgba(255, 200, 190, 0.4);
+}
+
+.band {
+  position: absolute;
+  top: 42px;
+  left: -6px;
+  right: -6px;
+  height: 14px;
+  border-radius: 4px;
+  background: linear-gradient(#ffd23a, #d99a10);
+}
+
+.shine {
+  position: absolute;
+  top: 20px;
+  left: 14px;
+  width: 12px;
+  height: 66px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.35);
+  filter: blur(2px);
+}
+
+.cap {
+  position: absolute;
+  top: 40px;
+  left: 50%;
+  width: 74px;
+  height: 34px;
+  margin-left: -37px;
+  border-radius: 40px 40px 6px 6px / 34px 34px 6px 6px;
+  background: linear-gradient(90deg, #ff5a4a, #c22c20);
+  box-shadow: inset 0 4px 5px rgba(255, 210, 200, 0.45);
+  z-index: 2;
+}
+
+.bolt {
+  position: absolute;
+  top: 26px;
+  left: 50%;
+  width: 20px;
+  height: 20px;
+  margin-left: -10px;
+  border-radius: 4px;
+  background: linear-gradient(#ffd23a, #c8961f);
+  z-index: 3;
+  transition: transform 0.5s ease;
+}
+
+.nozzle {
+  position: absolute;
+  top: 78px;
+  width: 24px;
+  height: 26px;
+  border-radius: 5px;
+  background: linear-gradient(#ffd23a, #c8961f);
+  z-index: 1;
+}
+
+.ln { left: 6px; }
+.rn { right: 6px; }
+
+.foot {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 110px;
+  height: 20px;
+  margin-left: -55px;
+  border-radius: 8px 8px 5px 5px;
+  background: linear-gradient(#c22c20, #7d1610);
+  box-shadow: 0 14px 26px rgba(0, 0, 0, 0.45);
+}
+
+.jet {
+  position: absolute;
+  top: 84px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #dff5ff, #6cc4f0 74%);
+  opacity: 0;
+  z-index: 4;
+}
+
+.j1 { left: 8px; }
+.j2 { left: 8px; }
+.j3 { right: 8px; }
+.j4 { right: 8px; }
+
+.hydrant:hover .j1,
+.hydrant:focus .j1 { animation: sprayL 1s ease-out infinite; }
+
+.hydrant:hover .j2,
+.hydrant:focus .j2 { animation: sprayL 1s ease-out 0.5s infinite; }
+
+.hydrant:hover .j3,
+.hydrant:focus .j3 { animation: sprayR 1s ease-out 0.25s infinite; }
+
+.hydrant:hover .j4,
+.hydrant:focus .j4 { animation: sprayR 1s ease-out 0.75s infinite; }
+
+.hydrant:hover .bolt,
+.hydrant:focus .bolt {
+  transform: rotate(120deg);
+}
+
+.road {
+  position: absolute;
+  bottom: 30px;
+  left: -50vw;
+  right: -50vw;
+  height: 46px;
+  background: linear-gradient(#3d4657, #232a36);
+  z-index: 1;
+}
+
+.hint {
+  margin: 0;
+  color: #9fb0c6;
+  font-size: 0.85rem;
+  z-index: 4;
+}
+
+@keyframes sprayL {
+  0% { transform: translate(0, 0) scale(0.5); opacity: 0; }
+  20% { opacity: 1; }
+  100% { transform: translate(-92px, 46px) scale(1.1); opacity: 0; }
+}
+
+@keyframes sprayR {
+  0% { transform: translate(0, 0) scale(0.5); opacity: 0; }
+  20% { opacity: 1; }
+  100% { transform: translate(92px, 46px) scale(1.1); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hydrant:hover .jet,
+  .hydrant:focus .jet {
+    animation: none;
+    opacity: 0;
+  }
+
+  .bolt {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a fire hydrant built for #44754. Hovering or focusing turns the top bolt and arcs water jets out of both nozzles, with paired droplets on offset delays so each stream reads as continuous, and a reduced motion fallback. Pure CSS. Closes #44754.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot of the hovered state: a red hydrant with a gold band and side nozzles, bolt turned, spraying water from both sides.
