### PR TITLE
feat: add playground swing

### DIFF
--- a/submissions/examples/playground-swing-as/README.md
+++ b/submissions/examples/playground-swing-as/README.md
@@ -1,0 +1,22 @@
+# Playground Swing
+
+### What does this do?
+
+It shows an empty playground swing rocking back and forth on its A-frame. The seat and both chains swing together as one unit, pivoting from the top beam, while a cloud drifts across a sunny sky. Under reduced motion the swing hangs still.
+
+### How is it used?
+
+```html
+<div class="frame"><span class="beam"></span><span class="leg l1"></span></div>
+<div class="swing">
+  <span class="chain cl"></span>
+  <span class="chain cr"></span>
+  <span class="seat"></span>
+</div>
+```
+
+The A-frame legs are two pairs of rotated bars sharing the top beam. The key detail is the `swing` wrapper: its `transform-origin` sits at the beam, not at the seat, so when it rotates the chains and seat arc around the crossbar exactly like a real swing instead of spinning in place. The chain links come from a repeating gradient.
+
+### Why is it useful?
+
+Playground, childhood, and park themes use a swing. This builds a rocking swing with pure CSS shapes and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/playground-swing-as/demo.html
+++ b/submissions/examples/playground-swing-as/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Playground Swing</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="sun"></span>
+    <span class="cloud"></span>
+    <div class="frame">
+      <span class="beam"></span>
+      <span class="leg l1"></span>
+      <span class="leg l2"></span>
+      <span class="leg l3"></span>
+      <span class="leg l4"></span>
+    </div>
+    <div class="swing">
+      <span class="chain cl"></span>
+      <span class="chain cr"></span>
+      <span class="seat"></span>
+    </div>
+    <span class="grass"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/playground-swing-as/style.css
+++ b/submissions/examples/playground-swing-as/style.css
@@ -1,0 +1,151 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #8fd4f2, #cfeefd);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 300px;
+  overflow: hidden;
+  border-radius: 18px;
+  background: linear-gradient(180deg, #8fd4f2, #d6f1fd 72%);
+  box-shadow: 0 24px 48px rgba(40, 90, 130, 0.3);
+}
+
+.sun {
+  position: absolute;
+  top: 24px;
+  right: 30px;
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 38%, #fff8d0, #ffd54a 74%);
+  box-shadow: 0 0 36px rgba(255, 214, 74, 0.85);
+}
+
+.cloud {
+  position: absolute;
+  top: 40px;
+  left: 26px;
+  width: 62px;
+  height: 22px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.95);
+  animation: drift 14s linear infinite;
+}
+
+.cloud::before,
+.cloud::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.95);
+}
+
+.cloud::before { left: 10px; width: 22px; height: 22px; }
+.cloud::after { left: 28px; width: 30px; height: 30px; bottom: 2px; }
+
+.frame {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  width: 230px;
+  height: 190px;
+  margin-left: -115px;
+  z-index: 2;
+}
+
+.beam {
+  position: absolute;
+  top: 0;
+  left: -6px;
+  right: -6px;
+  height: 14px;
+  border-radius: 7px;
+  background: linear-gradient(180deg, #f0784a, #c04a20);
+  box-shadow: 0 3px 5px rgba(0, 0, 0, 0.2);
+}
+
+.leg {
+  position: absolute;
+  top: 6px;
+  width: 12px;
+  height: 190px;
+  border-radius: 6px;
+  background: linear-gradient(90deg, #f0784a, #b8441c);
+  transform-origin: top center;
+}
+
+.l1 { left: 6px; transform: rotate(14deg); }
+.l2 { left: 6px; transform: rotate(-14deg); }
+.l3 { right: 6px; transform: rotate(14deg); }
+.l4 { right: 6px; transform: rotate(-14deg); }
+
+.swing {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  width: 90px;
+  height: 190px;
+  margin-left: -45px;
+  transform-origin: 50% 3%;
+  animation: swing 3s ease-in-out infinite;
+  z-index: 3;
+}
+
+.chain {
+  position: absolute;
+  top: 6px;
+  width: 4px;
+  height: 118px;
+  background: repeating-linear-gradient(180deg, #6f7a89 0 5px, #b7c1cd 5px 8px);
+}
+
+.cl { left: 12px; }
+.cr { right: 12px; }
+
+.seat {
+  position: absolute;
+  top: 122px;
+  left: 0;
+  width: 90px;
+  height: 14px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #5f7ee0, #2f4bb0);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+}
+
+.grass {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 54px;
+  background: linear-gradient(#7cc157, #4f9138);
+  z-index: 1;
+}
+
+@keyframes swing {
+  0%, 100% { transform: rotate(-22deg); }
+  50% { transform: rotate(22deg); }
+}
+
+@keyframes drift {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(30px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .swing,
+  .cloud {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a playground swing built for #44758. Chains and seat swing as one unit around a transform-origin placed at the crossbar so the arc is physically right, under a sunny sky, with a reduced motion fallback. Pure CSS. Closes #44758.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: an orange A-frame swing set with a blue seat hanging on chains, mid-swing, on grass under a sun and cloud.
