### PR TITLE
feat: add dragonfly

### DIFF
--- a/submissions/examples/dragonfly-as/README.md
+++ b/submissions/examples/dragonfly-as/README.md
@@ -1,0 +1,22 @@
+# Dragonfly
+
+### What does this do?
+
+It shows a dragonfly hovering over a pond. Its four translucent wings beat so fast they blur, the body drifts and tilts as it hovers, and the reeds bend in the breeze. Under reduced motion the dragonfly and reeds hold still.
+
+### How is it used?
+
+```html
+<div class="fly">
+  <span class="wing wtl"></span>
+  <span class="thorax"></span>
+  <span class="tail"></span>
+  <span class="head"></span>
+</div>
+```
+
+Each wing stores its own resting angle in a `--wr` custom property, so one shared `beat` animation can flatten every wing with `scaleY` without wiping out its angle. Beating the lower pair on a small delay behind the upper pair gives the flight the staggered look real dragonflies have. The segmented tail comes from a repeating gradient.
+
+### Why is it useful?
+
+Nature, pond, and summer themes use a dragonfly. This builds a hovering dragonfly with pure CSS shapes, custom properties, and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/dragonfly-as/demo.html
+++ b/submissions/examples/dragonfly-as/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dragonfly</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="reed rd1"></span>
+    <span class="reed rd2"></span>
+    <div class="fly">
+      <span class="wing wtl"></span>
+      <span class="wing wtr"></span>
+      <span class="wing wbl"></span>
+      <span class="wing wbr"></span>
+      <span class="thorax"></span>
+      <span class="tail"></span>
+      <span class="head"></span>
+      <span class="eye el"></span>
+      <span class="eye er"></span>
+    </div>
+    <span class="water"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/dragonfly-as/style.css
+++ b/submissions/examples/dragonfly-as/style.css
@@ -1,0 +1,192 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #cdeefb, #8fd6ea 72%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+  overflow: hidden;
+  border-radius: 18px;
+  background: linear-gradient(180deg, #d6f2fc, #9adfef 78%);
+  box-shadow: 0 24px 48px rgba(40, 100, 120, 0.3);
+}
+
+.reed {
+  position: absolute;
+  bottom: 40px;
+  width: 8px;
+  border-radius: 4px;
+  background: linear-gradient(#5cb84a, #2f7a2a);
+  transform-origin: bottom center;
+  animation: bend 5s ease-in-out infinite;
+}
+
+.rd1 { left: 44px; height: 150px; }
+.rd2 { right: 56px; height: 116px; animation-delay: 1.2s; }
+
+.fly {
+  position: absolute;
+  top: 96px;
+  left: 50%;
+  width: 200px;
+  height: 90px;
+  margin-left: -100px;
+  animation: hover 4s ease-in-out infinite;
+  z-index: 3;
+}
+
+.thorax {
+  position: absolute;
+  top: 38px;
+  left: 74px;
+  width: 34px;
+  height: 20px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 30%, #7ee0d0, #1e9a92 72%);
+  z-index: 3;
+}
+
+.tail {
+  position: absolute;
+  top: 42px;
+  left: 104px;
+  width: 88px;
+  height: 12px;
+  border-radius: 6px;
+  background:
+    repeating-linear-gradient(90deg, #24a89e 0 12px, #12706c 12px 16px);
+  z-index: 2;
+}
+
+.tail::after {
+  content: "";
+  position: absolute;
+  top: 1px;
+  right: -8px;
+  width: 12px;
+  height: 10px;
+  border-radius: 50%;
+  background: #12706c;
+}
+
+.head {
+  position: absolute;
+  top: 36px;
+  left: 56px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 30%, #8fe8d8, #1e9a92 74%);
+  z-index: 4;
+}
+
+.eye {
+  position: absolute;
+  top: 36px;
+  width: 14px;
+  height: 16px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 30%, #2a3a4a, #0d1620 74%);
+  z-index: 5;
+}
+
+.el { left: 52px; }
+.er { left: 64px; }
+
+.wing {
+  position: absolute;
+  width: 92px;
+  height: 20px;
+  border-radius: 50% 50% 50% 50% / 60% 60% 40% 40%;
+  background: linear-gradient(90deg, rgba(190, 240, 255, 0.85), rgba(140, 210, 240, 0.35));
+  box-shadow: inset 0 0 0 1px rgba(120, 190, 220, 0.5);
+  animation: beat 0.16s ease-in-out infinite alternate;
+  z-index: 1;
+}
+
+.wtl {
+  --wr: -16deg;
+
+  top: 22px;
+  left: 0;
+  transform-origin: right center;
+}
+
+.wtr {
+  --wr: 16deg;
+
+  top: 22px;
+  left: 88px;
+  transform-origin: left center;
+}
+
+.wbl {
+  --wr: 14deg;
+
+  top: 48px;
+  left: 4px;
+  width: 82px;
+  transform-origin: right center;
+  animation-delay: 0.08s;
+}
+
+.wbr {
+  --wr: -14deg;
+
+  top: 48px;
+  left: 88px;
+  width: 82px;
+  transform-origin: left center;
+  animation-delay: 0.08s;
+}
+
+.water {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 48px;
+  background: linear-gradient(#4fc3e8, #1d7fa8);
+  z-index: 1;
+}
+
+.water::after {
+  content: "";
+  position: absolute;
+  top: 8px;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.55) 0 22px, transparent 22px 44px);
+}
+
+@keyframes beat {
+  0% { transform: rotate(var(--wr, 0deg)) scaleY(1); }
+  100% { transform: rotate(var(--wr, 0deg)) scaleY(0.28); }
+}
+
+@keyframes hover {
+  0%, 100% { transform: translate(0, 0) rotate(-2deg); }
+  50% { transform: translate(14px, -18px) rotate(2deg); }
+}
+
+@keyframes bend {
+  0%, 100% { transform: rotate(-3deg); }
+  50% { transform: rotate(3deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fly,
+  .wing,
+  .reed {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a dragonfly built for #44763. Four wings each holding their rest angle in a custom property so one shared beat animation can blur them without losing their fan, with the lower pair delayed, over a reedy pond, with a reduced motion fallback. Pure CSS. Closes #44763.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a teal dragonfly with compound eyes, a segmented tail, and four translucent wings hovering over reeds and water.
