### PR TITLE
feat: add ladybug

### DIFF
--- a/submissions/examples/ladybug-as/README.md
+++ b/submissions/examples/ladybug-as/README.md
@@ -1,0 +1,24 @@
+# Ladybug
+
+### What does this do?
+
+It shows a ladybug sitting on a leaf, its antennae waggling and its body bobbing as it crawls. Hovering or focusing the ladybug opens its spotted shell: the two halves swing apart like real elytra and the translucent flight wings appear underneath. It works with no JavaScript. Under reduced motion the shell opens without easing.
+
+### How is it used?
+
+```html
+<div class="bug" tabindex="0">
+  <span class="underwing"></span>
+  <div class="shell">
+    <span class="half left"><span class="dot d1"></span></span>
+    <span class="half right">...</span>
+  </div>
+  <span class="head"></span>
+</div>
+```
+
+The shell is two half-ellipses, each hinged at the body's centre line via `transform-origin`, so a `:hover` rotation swings them outward the way a real ladybug's wing cases open. The spots live inside each half with `overflow: hidden`, so they travel with the shell and get clipped correctly at the edge, and the flight wings simply fade in underneath.
+
+### Why is it useful?
+
+Nature, garden, and luck or spring themes use a ladybug. This builds an interactive ladybug with pure CSS shapes and transitions, no images or JavaScript, with a reduced motion fallback.

--- a/submissions/examples/ladybug-as/demo.html
+++ b/submissions/examples/ladybug-as/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ladybug</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="bug" tabindex="0">
+      <span class="leg lg1"></span>
+      <span class="leg lg2"></span>
+      <span class="leg lg3"></span>
+      <span class="leg lg4"></span>
+      <span class="leg lg5"></span>
+      <span class="leg lg6"></span>
+      <span class="underwing uw"></span>
+      <div class="shell">
+        <span class="half left">
+          <span class="dot d1"></span>
+          <span class="dot d2"></span>
+          <span class="dot d3"></span>
+        </span>
+        <span class="half right">
+          <span class="dot d1"></span>
+          <span class="dot d2"></span>
+          <span class="dot d3"></span>
+        </span>
+      </div>
+      <span class="head"></span>
+      <span class="eye el"></span>
+      <span class="eye er"></span>
+      <span class="antenna al"></span>
+      <span class="antenna ar"></span>
+    </div>
+    <span class="leaf"></span>
+    <p class="hint">hover to open wings</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ladybug-as/style.css
+++ b/submissions/examples/ladybug-as/style.css
@@ -1,0 +1,237 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 26%, #cdeec0, #7fbb6e 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 300px;
+  display: grid;
+  align-content: center;
+  justify-items: center;
+  gap: 18px;
+}
+
+.leaf {
+  position: absolute;
+  bottom: 42px;
+  left: 50%;
+  width: 240px;
+  height: 60px;
+  margin-left: -120px;
+  border-radius: 60% 10% 60% 10%;
+  background: linear-gradient(160deg, #63c451, #2f7a2a);
+  z-index: 1;
+}
+
+.bug {
+  position: relative;
+  width: 190px;
+  height: 170px;
+  outline: none;
+  z-index: 3;
+  animation: crawl 4s ease-in-out infinite;
+}
+
+.shell {
+  position: absolute;
+  top: 34px;
+  left: 50%;
+  width: 150px;
+  height: 122px;
+  margin-left: -75px;
+  z-index: 3;
+}
+
+.half {
+  position: absolute;
+  top: 0;
+  width: 75px;
+  height: 122px;
+  overflow: hidden;
+  background: radial-gradient(circle at 36% 26%, #ff6b5a, #cc1f18 74%);
+  box-shadow: inset 0 3px 6px rgba(255, 190, 180, 0.4);
+  transition: transform 0.5s cubic-bezier(0.34, 1.3, 0.5, 1);
+}
+
+.left {
+  left: 0;
+  border-radius: 75px 0 0 75px / 61px 0 0 61px;
+  transform-origin: right center;
+}
+
+.right {
+  right: 0;
+  border-radius: 0 75px 75px 0 / 0 61px 61px 0;
+  transform-origin: left center;
+}
+
+.dot {
+  position: absolute;
+  border-radius: 50%;
+  background: #17110f;
+}
+
+.left .d1 { top: 22px; left: 20px; width: 20px; height: 20px; }
+.left .d2 { top: 62px; left: 36px; width: 16px; height: 16px; }
+.left .d3 { top: 90px; left: 12px; width: 13px; height: 13px; }
+
+.right .d1 { top: 22px; right: 20px; width: 20px; height: 20px; }
+.right .d2 { top: 62px; right: 36px; width: 16px; height: 16px; }
+.right .d3 { top: 90px; right: 12px; width: 13px; height: 13px; }
+
+.underwing {
+  position: absolute;
+  top: 42px;
+  left: 50%;
+  width: 170px;
+  height: 108px;
+  margin-left: -85px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 30%, rgba(220, 240, 255, 0.9), rgba(160, 200, 235, 0.55));
+  opacity: 0;
+  transition: opacity 0.4s ease;
+  z-index: 2;
+}
+
+.head {
+  position: absolute;
+  top: 8px;
+  left: 50%;
+  width: 74px;
+  height: 46px;
+  margin-left: -37px;
+  border-radius: 40px 40px 16px 16px / 36px 36px 12px 12px;
+  background: radial-gradient(circle at 40% 30%, #3a3230, #14100f 74%);
+  z-index: 4;
+}
+
+.eye {
+  position: absolute;
+  top: 22px;
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  background: #fdfdfb;
+  z-index: 5;
+}
+
+.el { left: 68px; }
+.er { right: 68px; }
+
+.eye::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #17110f;
+}
+
+.antenna {
+  position: absolute;
+  top: -6px;
+  width: 4px;
+  height: 22px;
+  border-radius: 2px;
+  background: #17110f;
+  transform-origin: bottom center;
+  z-index: 4;
+  animation: waggle 1.6s ease-in-out infinite;
+}
+
+.al { left: 66px; transform: rotate(-22deg); }
+.ar { right: 66px; transform: rotate(22deg); animation-name: waggle-rev; }
+
+.antenna::after {
+  content: "";
+  position: absolute;
+  top: -5px;
+  left: -2px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #17110f;
+}
+
+.leg {
+  position: absolute;
+  width: 5px;
+  height: 34px;
+  border-radius: 3px;
+  background: #17110f;
+  transform-origin: top center;
+  z-index: 1;
+  animation: step 0.8s ease-in-out infinite alternate;
+}
+
+.lg1 { top: 48px; left: 22px; transform: rotate(38deg); }
+.lg2 { top: 78px; left: 12px; transform: rotate(66deg); animation-delay: 0.13s; }
+.lg3 { top: 108px; left: 20px; transform: rotate(108deg); animation-delay: 0.26s; }
+.lg4 { top: 48px; right: 22px; transform: rotate(-38deg); animation-delay: 0.4s; }
+.lg5 { top: 78px; right: 12px; transform: rotate(-66deg); animation-delay: 0.53s; }
+.lg6 { top: 108px; right: 20px; transform: rotate(-108deg); animation-delay: 0.66s; }
+
+.bug:hover .left,
+.bug:focus .left {
+  transform: translateX(-34px) rotate(-20deg);
+}
+
+.bug:hover .right,
+.bug:focus .right {
+  transform: translateX(34px) rotate(20deg);
+}
+
+.bug:hover .underwing,
+.bug:focus .underwing {
+  opacity: 1;
+}
+
+.hint {
+  margin: 0;
+  color: #2f5c39;
+  font-size: 0.85rem;
+  z-index: 4;
+}
+
+@keyframes crawl {
+  0%, 100% { transform: translateY(0) rotate(-1deg); }
+  50% { transform: translateY(-6px) rotate(1deg); }
+}
+
+@keyframes waggle {
+  0%, 100% { transform: rotate(-22deg); }
+  50% { transform: rotate(-34deg); }
+}
+
+@keyframes waggle-rev {
+  0%, 100% { transform: rotate(22deg); }
+  50% { transform: rotate(34deg); }
+}
+
+@keyframes step {
+  0% { filter: brightness(1); }
+  100% { filter: brightness(1.6); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bug,
+  .antenna,
+  .leg {
+    animation: none;
+  }
+
+  .half,
+  .underwing {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a ladybug built for #44765. Hovering or focusing splays the two spotted wing cases apart to reveal the flight wings beneath, with the spots clipped inside each half so they travel with it, using no JavaScript, with a reduced motion fallback. Pure CSS. Closes #44765.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with screenshots of both states: closed, a red spotted ladybug on a leaf; hovered, the shell halves open outward revealing pale flight wings.
