### PR TITLE
feat: add microscope

### DIFF
--- a/submissions/examples/microscope-as/README.md
+++ b/submissions/examples/microscope-as/README.md
@@ -1,0 +1,22 @@
+# Microscope
+
+### What does this do?
+
+It shows a lab microscope examining a slide. The focus knob turns back and forth, the objective lenses rack up and down with it, the illuminator glows up through the stage, and the cells on the slide jiggle under magnification. Under reduced motion everything holds still.
+
+### How is it used?
+
+```html
+<div class="scope">
+  <span class="tube"></span>
+  <span class="objective ob1"></span>
+  <span class="knob kb"></span>
+  <div class="stage"><span class="slide"><span class="cell cl1"></span></span></div>
+</div>
+```
+
+The knurled focus knob is a `repeating-conic-gradient` of fine ridges with an inset ring. Each objective lens stores its splay angle in a `--r` custom property, so the shared `focus` animation can rack them down without flattening the turret's fan. The illuminator is a `clip-path` cone of light shining up under the slide, whose cells jiggle with Brownian motion.
+
+### Why is it useful?
+
+Science, research, and inspection or "zoom in" themes use a microscope. This builds a working microscope with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/microscope-as/demo.html
+++ b/submissions/examples/microscope-as/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Microscope</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="scope">
+      <span class="eyepiece"></span>
+      <span class="tube"></span>
+      <span class="turret"></span>
+      <span class="objective ob1"></span>
+      <span class="objective ob2"></span>
+      <span class="arm"></span>
+      <span class="knob kb"></span>
+      <div class="stage">
+        <span class="slide">
+          <span class="cell cl1"></span>
+          <span class="cell cl2"></span>
+          <span class="cell cl3"></span>
+        </span>
+        <span class="light"></span>
+      </div>
+      <span class="base"></span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/microscope-as/style.css
+++ b/submissions/examples/microscope-as/style.css
@@ -1,0 +1,202 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 24%, #2b3a4d, #10161f 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  display: grid;
+  place-items: center;
+}
+
+.scope {
+  position: relative;
+  width: 280px;
+  height: 320px;
+}
+
+.eyepiece {
+  position: absolute;
+  top: 0;
+  left: 86px;
+  width: 34px;
+  height: 40px;
+  border-radius: 6px 6px 3px 3px;
+  background: linear-gradient(90deg, #8d99ab, #3d4756);
+  transform: rotate(-14deg);
+  z-index: 4;
+}
+
+.tube {
+  position: absolute;
+  top: 30px;
+  left: 82px;
+  width: 42px;
+  height: 106px;
+  border-radius: 8px;
+  background: linear-gradient(90deg, #a3aebe, #4b5666 60%, #333c49);
+  box-shadow: inset 0 4px 6px rgba(255, 255, 255, 0.3);
+  transform: rotate(-14deg);
+  z-index: 3;
+}
+
+.turret {
+  position: absolute;
+  top: 128px;
+  left: 66px;
+  width: 74px;
+  height: 26px;
+  border-radius: 10px;
+  background: linear-gradient(180deg, #77839a, #3a4352);
+  z-index: 4;
+}
+
+.objective {
+  position: absolute;
+  top: 148px;
+  width: 20px;
+  height: 40px;
+  border-radius: 4px 4px 6px 6px;
+  background: linear-gradient(90deg, #cfd7e2, #5a6472);
+  z-index: 3;
+  animation: focus 4s ease-in-out infinite;
+}
+
+.ob1 {
+  --r: -8deg;
+
+  left: 74px;
+}
+
+.ob2 {
+  --r: 8deg;
+
+  left: 104px;
+  animation-delay: 0.4s;
+}
+
+.arm {
+  position: absolute;
+  top: 96px;
+  right: 58px;
+  width: 34px;
+  height: 130px;
+  border-radius: 18px 8px 8px 18px;
+  background: linear-gradient(90deg, #5c6675, #39424f);
+  box-shadow: inset 0 3px 5px rgba(255, 255, 255, 0.22);
+  z-index: 2;
+}
+
+.knob {
+  position: absolute;
+  top: 150px;
+  right: 40px;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(from 0deg at 50% 50%, #8d99ab 0 6deg, #4b5666 6deg 12deg);
+  box-shadow: inset 0 0 0 6px #5c6675;
+  z-index: 5;
+  animation: turnk 4s ease-in-out infinite;
+}
+
+.stage {
+  position: absolute;
+  top: 196px;
+  left: 34px;
+  width: 172px;
+  height: 22px;
+  border-radius: 5px;
+  background: linear-gradient(180deg, #6f7a8c, #333c49);
+  z-index: 3;
+}
+
+.slide {
+  position: absolute;
+  top: -10px;
+  left: 44px;
+  width: 84px;
+  height: 18px;
+  border-radius: 3px;
+  background: rgba(200, 240, 255, 0.55);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
+  overflow: hidden;
+  z-index: 4;
+}
+
+.cell {
+  position: absolute;
+  top: 4px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #a5f0c8, #2fa870 74%);
+  animation: jiggle 2.4s ease-in-out infinite;
+}
+
+.cl1 { left: 12px; width: 10px; height: 10px; }
+.cl2 { left: 36px; width: 8px; height: 8px; animation-delay: 0.5s; }
+.cl3 { left: 58px; width: 9px; height: 9px; animation-delay: 1s; }
+
+.light {
+  position: absolute;
+  top: 26px;
+  left: 50%;
+  width: 60px;
+  height: 46px;
+  margin-left: -30px;
+  clip-path: polygon(38% 100%, 62% 100%, 100% 0, 0 0);
+  background: linear-gradient(0deg, rgba(120, 230, 255, 0.85), rgba(120, 230, 255, 0.1));
+  filter: blur(2px);
+  z-index: 2;
+  animation: shine 2s ease-in-out infinite;
+}
+
+.base {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 220px;
+  height: 46px;
+  margin-left: -110px;
+  border-radius: 14px 14px 10px 10px;
+  background: linear-gradient(180deg, #77839a, #2b3340);
+  box-shadow:
+    0 20px 36px rgba(0, 0, 0, 0.55),
+    inset 0 4px 6px rgba(255, 255, 255, 0.28);
+  z-index: 4;
+}
+
+@keyframes focus {
+  0%, 100% { transform: translateY(0) rotate(var(--r, 0deg)); }
+  50% { transform: translateY(5px) rotate(var(--r, 0deg)); }
+}
+
+@keyframes turnk {
+  0%, 100% { transform: rotate(0deg); }
+  50% { transform: rotate(72deg); }
+}
+
+@keyframes jiggle {
+  0%, 100% { transform: translate(0, 0); }
+  33% { transform: translate(3px, 2px); }
+  66% { transform: translate(-2px, -2px); }
+}
+
+@keyframes shine {
+  0%, 100% { opacity: 0.75; }
+  50% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .objective,
+  .knob,
+  .cell,
+  .light {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a microscope built for #44784. A knurled conic-gradient focus knob turns while the objectives rack down, each keeping its splay angle via a custom property, over a lit slide of jiggling cells, with a reduced motion fallback. Pure CSS. Closes #44784.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a microscope with an angled tube, two objectives on a turret, a knurled focus knob, and a lit slide with green cells.
