### PR TITLE
feat: add Cascading Rating Stars component

### DIFF
--- a/submissions/examples/cascading-rating-stars-ym/README.md
+++ b/submissions/examples/cascading-rating-stars-ym/README.md
@@ -1,0 +1,80 @@
+# Cascading Rating Stars
+
+A pure-CSS star rating component for **EaseMotion CSS**, styled with a
+gaming/arcade motion language: hovering or selecting a star triggers a
+cascading pop-and-glow animation across all stars up to that point — no
+JavaScript required.
+
+## Preview
+
+Open `demo.html` in any browser to see it live.
+
+- Hover over any star → it and all stars before it "cascade" — popping in
+  with a staggered bounce (`animation-delay` driven by a `--i` custom
+  property per star).
+- Click a star → the rating locks in via native radio buttons, the selected
+  stars keep a pulsing amber glow, and a live status line below updates
+  ("3 / 5 — decent", etc.) using `:has()` — still no JS.
+- Built on the classic pure-CSS star-rating trick: stars are marked up
+  5→1 in the HTML but visually reversed with `flex-direction: row-reverse`,
+  so `~` sibling selectors can light up "this star and everything before it."
+
+## Files
+
+cascading-rating-stars-ym/
+├── demo.html   → standalone live demo (loads style.css)
+├── style.css   → component styles, tokens, and keyframes
+└── README.md   → this file
+
+## EaseMotion tokens used
+
+Defined at the top of `style.css`, scoped so they won't collide with the rest
+of the library:
+
+| Token | Purpose |
+|---|---|
+| `--ease-cascade-out` | Base easing for color/state transitions |
+| `--ease-cascade-pop` | Overshoot/"pop" curve (back-ease) used for the star bounce |
+| `--ease-cascade-glow` | Slow ease used for the pulsing glow on the selected rating |
+
+Keyframes:
+- `cascade-pop` — the staggered scale/rotate bounce on hover and selection
+- `cascade-glow` — the ambient pulsing glow on the locked-in rating
+
+## How to use
+
+1. Copy `style.css` into your project (or merge its rules into your existing
+   EaseMotion CSS stylesheet).
+2. Copy the markup structure from `demo.html`'s `<section class="cascading-rating-card">`
+   block into your page.
+3. Keep the stars in **5→1 HTML order** with `flex-direction: row-reverse` in
+   the CSS — this is what makes the sibling-selector cascade work.
+4. Give each `<input>`/`<label>` pair a unique `name`/`id` per rating widget
+   on the page (e.g. `rating-2`, `star5-2`, …) if you're using more than one.
+
+## Accessibility
+
+- Built on native `<input type="radio">` + `<label>` inside a `<fieldset>`/`<legend>`,
+  so it's fully keyboard operable (Tab + Arrow keys + Space) and understood
+  natively by screen readers as a radio group.
+- Each star label includes a visually-hidden (`sr-only`) text description
+  ("3 stars") for screen reader users, since the star glyph itself is
+  decorative.
+- The live readout is marked `role="status"` so rating changes are announced.
+- Visible focus outline on the currently focused star via `:focus-visible`.
+- Respects `prefers-reduced-motion`: the pop and glow animations are disabled
+  for users who request less motion, while the rating still functions.
+
+## Responsive behavior
+
+Below 420px, the card padding tightens, star size scales down slightly, and
+gaps between stars shrink so the full row stays comfortably tappable on
+small screens.
+
+## Browser support
+
+Uses standard CSS (flexbox, custom properties, `:has()`, the radio
+sibling-selector trick). `:has()` is supported in all current evergreen
+browsers (Chrome/Edge 105+, Safari 15.4+, Firefox 121+); on older browsers
+the readout text simply won't update, while star selection and animation
+still work normally. No JavaScript, no build step.

--- a/submissions/examples/cascading-rating-stars-ym/demo.html
+++ b/submissions/examples/cascading-rating-stars-ym/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cascading Rating Stars — EaseMotion CSS Demo</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: radial-gradient(circle at 50% 0%, #171f38, #05070d 70%);
+      padding: 40px 16px;
+    }
+  </style>
+</head>
+<body>
+
+  <section class="cascading-rating-card" aria-labelledby="rating-title">
+    <h2 class="cascading-rating-card__title" id="rating-title">Rate this level</h2>
+    <p class="cascading-rating-card__subtitle">How did that boss fight feel?</p>
+
+    <fieldset class="cascading-rating" style="border:0; margin:0; padding:0;">
+      <legend class="sr-only">Star rating, 1 to 5</legend>
+
+      <input type="radio" name="rating" id="star5" class="cascading-rating__input" value="5" />
+      <label for="star5" class="cascading-star" style="--i:4;">
+        ★<span class="sr-only">5 stars</span>
+      </label>
+
+      <input type="radio" name="rating" id="star4" class="cascading-rating__input" value="4" />
+      <label for="star4" class="cascading-star" style="--i:3;">
+        ★<span class="sr-only">4 stars</span>
+      </label>
+
+      <input type="radio" name="rating" id="star3" class="cascading-rating__input" value="3" checked />
+      <label for="star3" class="cascading-star" style="--i:2;">
+        ★<span class="sr-only">3 stars</span>
+      </label>
+
+      <input type="radio" name="rating" id="star2" class="cascading-rating__input" value="2" />
+      <label for="star2" class="cascading-star" style="--i:1;">
+        ★<span class="sr-only">2 stars</span>
+      </label>
+
+      <input type="radio" name="rating" id="star1" class="cascading-rating__input" value="1" />
+      <label for="star1" class="cascading-star" style="--i:0;">
+        ★<span class="sr-only">1 star</span>
+      </label>
+    </fieldset>
+
+    <p class="cascading-rating-card__readout" role="status"></p>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/cascading-rating-stars-ym/style.css
+++ b/submissions/examples/cascading-rating-stars-ym/style.css
@@ -1,0 +1,200 @@
+/* =========================================================
+   Cascading Rating Stars — EaseMotion CSS component
+   Pure CSS. No JavaScript required.
+   ========================================================= */
+
+:root {
+  /* --- EaseMotion easing tokens (component-scoped) --- */
+  --ease-cascade-out: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-cascade-pop: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-cascade-glow: cubic-bezier(0.45, 0, 0.55, 1);
+
+  /* --- Palette --- */
+  --arcade-bg: #0b0e17;
+  --arcade-surface: #141a2b;
+  --arcade-border: #232c46;
+  --arcade-cyan: #2ee6ff;
+  --arcade-magenta: #ff2e88;
+  --arcade-amber: #ffcc33;
+  --arcade-text: #eef2ff;
+  --arcade-muted: #7c88b8;
+  --star-dim: #2a3153;
+}
+
+.cascading-rating-card {
+  --radius: 16px;
+  max-width: 420px;
+  margin: 0 auto;
+  padding: 32px 28px;
+  background: var(--arcade-surface);
+  border: 1px solid var(--arcade-border);
+  border-radius: var(--radius);
+  text-align: center;
+  font-family: "Inter", system-ui, sans-serif;
+  color: var(--arcade-text);
+  box-shadow: 0 0 0 1px rgba(46, 230, 255, 0.05), 0 20px 50px rgba(0, 0, 0, 0.45);
+}
+
+.cascading-rating-card__title {
+  font-family: "Orbitron", "Inter", sans-serif;
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin: 0 0 4px;
+  color: var(--arcade-cyan);
+}
+
+.cascading-rating-card__subtitle {
+  font-size: 0.85rem;
+  color: var(--arcade-muted);
+  margin: 0 0 22px;
+}
+
+/* --- Star group --- */
+.cascading-rating {
+  display: flex;
+  flex-direction: row-reverse;
+  justify-content: center;
+  gap: 10px;
+  margin: 0 0 16px;
+}
+
+.cascading-rating__input {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.cascading-star {
+  position: relative;
+  font-size: 2.4rem;
+  line-height: 1;
+  color: var(--star-dim);
+  cursor: pointer;
+  user-select: none;
+  transition: color 0.3s var(--ease-cascade-out);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Focus visibility on the radio, applied to the following label */
+.cascading-rating__input:focus-visible + .cascading-star {
+  outline: 2px solid var(--arcade-cyan);
+  outline-offset: 4px;
+  border-radius: 4px;
+}
+
+/* --- Hover preview cascade --- */
+.cascading-rating:hover .cascading-star {
+  color: var(--star-dim);
+}
+
+.cascading-star:hover,
+.cascading-star:hover ~ .cascading-star {
+  color: var(--arcade-amber);
+  animation: cascade-pop 0.45s var(--ease-cascade-pop) both;
+  animation-delay: calc(var(--i) * 0.05s);
+}
+
+/* --- Selected rating cascade (persists after click) --- */
+.cascading-rating__input:checked ~ .cascading-star {
+  color: var(--arcade-amber);
+  animation: cascade-pop 0.5s var(--ease-cascade-pop) both,
+    cascade-glow 2.4s var(--ease-cascade-glow) 0.5s infinite alternate;
+  animation-delay: calc(var(--i) * 0.06s), calc(var(--i) * 0.06s + 0.5s);
+}
+
+@keyframes cascade-pop {
+  0% {
+    transform: scale(0.4) rotate(-8deg);
+    filter: drop-shadow(0 0 0 transparent);
+  }
+  55% {
+    transform: scale(1.35) rotate(4deg);
+  }
+  100% {
+    transform: scale(1) rotate(0deg);
+    filter: drop-shadow(0 0 7px rgba(255, 204, 51, 0.75));
+  }
+}
+
+@keyframes cascade-glow {
+  0% {
+    filter: drop-shadow(0 0 4px rgba(255, 204, 51, 0.4));
+  }
+  100% {
+    filter: drop-shadow(0 0 12px rgba(255, 204, 51, 0.85));
+  }
+}
+
+/* --- Live readout via :has() --- */
+.cascading-rating-card__readout {
+  min-height: 1.2em;
+  font-size: 0.85rem;
+  color: var(--arcade-muted);
+  letter-spacing: 0.02em;
+}
+
+.cascading-rating-card__readout::before {
+  content: "Tap a star to rate";
+}
+
+.cascading-rating-card:has(#star1:checked) .cascading-rating-card__readout::before {
+  content: "1 / 5 — needs work";
+  color: var(--arcade-magenta);
+}
+.cascading-rating-card:has(#star2:checked) .cascading-rating-card__readout::before {
+  content: "2 / 5 — not great";
+  color: var(--arcade-magenta);
+}
+.cascading-rating-card:has(#star3:checked) .cascading-rating-card__readout::before {
+  content: "3 / 5 — decent";
+  color: var(--arcade-cyan);
+}
+.cascading-rating-card:has(#star4:checked) .cascading-rating-card__readout::before {
+  content: "4 / 5 — great";
+  color: var(--arcade-cyan);
+}
+.cascading-rating-card:has(#star5:checked) .cascading-rating-card__readout::before {
+  content: "5 / 5 — legendary";
+  color: var(--arcade-amber);
+}
+
+/* --- Responsive --- */
+@media (max-width: 420px) {
+  .cascading-rating-card {
+    padding: 24px 16px;
+    max-width: 100%;
+  }
+
+  .cascading-star {
+    font-size: 2rem;
+  }
+
+  .cascading-rating {
+    gap: 6px;
+  }
+}
+
+/* --- Reduced motion --- */
+@media (prefers-reduced-motion: reduce) {
+  .cascading-star,
+  .cascading-star:hover,
+  .cascading-star:hover ~ .cascading-star,
+  .cascading-rating__input:checked ~ .cascading-star {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
Resolves #41927

## What this does
Adds a `cascading-rating-stars` component to the EaseMotion CSS library, inspired by Gaming design patterns. A 5-star rating widget where hovering or selecting a star triggers a cascading pop-and-glow animation across all preceding stars.

## Details
- Pure CSS, no JavaScript required
- Built on the classic radio-input + `~` sibling-selector star rating pattern, with a live status readout powered by `:has()`
- Uses custom `ease-cascade-out`, `ease-cascade-pop`, and `ease-cascade-glow` easing tokens with `cascade-pop` and `cascade-glow` keyframes
- Follows the `submissions/examples/<name>/` structure (demo.html, style.css, README.md)
- Fully keyboard accessible via native radio group + fieldset/legend, visible focus states, respects `prefers-reduced-motion`