### PR TITLE
feat: add Bounce OTP Input component

### DIFF
--- a/submissions/examples/bounce-otp-input-ym/README.md
+++ b/submissions/examples/bounce-otp-input-ym/README.md
@@ -1,0 +1,61 @@
+## EaseMotion tokens used
+
+Defined at the top of `style.css`, scoped so they won't collide with the rest
+of the library:
+
+| Token | Purpose |
+|---|---|
+| `--ease-bounce-in` | Overshoot/"pop" curve (back-ease) for the entrance and focus bounce |
+| `--ease-bounce-settle` | Smooth deceleration for border/shadow/button transitions |
+| `--ease-bounce-shake` | Reserved curve for an error-shake state, if extended later |
+
+Keyframes:
+- `otp-bounce-in` — the staggered entrance bounce for each digit box
+- `otp-focus-bounce` — the extra pop when a box receives focus
+
+## A note on "pure CSS"
+
+The issue asks for pure CSS where possible. Everything here — the bounce
+animations, focus states, and filled-state styling — is 100% CSS. One thing
+CSS genuinely cannot do on its own is auto-advance focus to the next box
+after a digit is typed; that specific behavior requires a few lines of JS in
+any real implementation. Rather than fake it, this component ships as a
+clean, fully-functional no-JS input group: users tab or click between boxes
+normally. If auto-advance is wanted later, it can be layered on top without
+touching these styles.
+
+## How to use
+
+1. Copy `style.css` into your project (or merge its rules into your existing
+   EaseMotion CSS stylesheet).
+2. Copy the markup structure from `demo.html`'s `<form class="bounce-otp-card">`
+   block into your page.
+3. Give each `<input>` a `style="--i:N;"` (0 through 5) to preserve the
+   staggered entrance order.
+4. Swap `+91 98765 43210` in the subtitle for the real destination (phone or
+   email) at render time.
+
+## Accessibility
+
+- Each digit box has its own visually-hidden `<label>` ("Digit 1 of 6", etc.)
+  so screen readers announce position within the code, not just "edit text".
+- `inputmode="numeric"` and `pattern="[0-9]*"` bring up a numeric keyboard on
+  mobile without any JS.
+- `autocomplete="one-time-code"` on the first box lets browsers/OSes offer
+  to autofill an SMS code.
+- Clear visible focus state (color + glow ring) on the active box.
+- Respects `prefers-reduced-motion`: entrance and focus bounce animations are
+  disabled, boxes simply appear at full opacity for users who request less
+  motion.
+
+## Responsive behavior
+
+Below 420px, card padding tightens and digit boxes shrink slightly with a
+smaller gap between them, so all six stay comfortably tappable on narrow
+phone screens.
+
+## Browser support
+
+Uses standard CSS (flexbox, custom properties, `:not(:placeholder-shown)`
+for the filled state). No JavaScript, no build step — works in all current
+evergreen browsers.

--- a/submissions/examples/bounce-otp-input-ym/demo.html
+++ b/submissions/examples/bounce-otp-input-ym/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bounce OTP Input — EaseMotion CSS Demo</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:wght@600&family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #fdf1e4;
+      padding: 40px 16px;
+    }
+  </style>
+</head>
+<body>
+
+  <form class="bounce-otp-card" aria-labelledby="otp-title" onsubmit="return false;">
+    <h2 class="bounce-otp-card__title" id="otp-title">Verify your order</h2>
+    <p class="bounce-otp-card__subtitle">
+      Enter the 6-digit code we sent to <strong>+91 98765 43210</strong>
+    </p>
+
+    <div class="bounce-otp" role="group" aria-labelledby="otp-title">
+      <label class="sr-only" for="digit-1">Digit 1 of 6</label>
+      <input class="bounce-otp__digit" style="--i:0;" type="text" id="digit-1" inputmode="numeric" pattern="[0-9]*" maxlength="1" autocomplete="one-time-code" placeholder="•" />
+
+      <label class="sr-only" for="digit-2">Digit 2 of 6</label>
+      <input class="bounce-otp__digit" style="--i:1;" type="text" id="digit-2" inputmode="numeric" pattern="[0-9]*" maxlength="1" placeholder="•" />
+
+      <label class="sr-only" for="digit-3">Digit 3 of 6</label>
+      <input class="bounce-otp__digit" style="--i:2;" type="text" id="digit-3" inputmode="numeric" pattern="[0-9]*" maxlength="1" placeholder="•" />
+
+      <label class="sr-only" for="digit-4">Digit 4 of 6</label>
+      <input class="bounce-otp__digit" style="--i:3;" type="text" id="digit-4" inputmode="numeric" pattern="[0-9]*" maxlength="1" placeholder="•" />
+
+      <label class="sr-only" for="digit-5">Digit 5 of 6</label>
+      <input class="bounce-otp__digit" style="--i:4;" type="text" id="digit-5" inputmode="numeric" pattern="[0-9]*" maxlength="1" placeholder="•" />
+
+      <label class="sr-only" for="digit-6">Digit 6 of 6</label>
+      <input class="bounce-otp__digit" style="--i:5;" type="text" id="digit-6" inputmode="numeric" pattern="[0-9]*" maxlength="1" placeholder="•" />
+    </div>
+
+    <p class="bounce-otp-card__resend">
+      Didn't get it? <a href="#">Resend code</a>
+    </p>
+
+    <button type="submit" class="bounce-otp-submit">Confirm &amp; track order</button>
+  </form>
+
+</body>
+</html>

--- a/submissions/examples/bounce-otp-input-ym/style.css
+++ b/submissions/examples/bounce-otp-input-ym/style.css
@@ -1,0 +1,215 @@
+/* =========================================================
+   Bounce OTP Input — EaseMotion CSS component
+   Pure CSS. No JavaScript required.
+   ========================================================= */
+
+:root {
+  /* --- EaseMotion easing tokens (component-scoped) --- */
+  --ease-bounce-in: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-bounce-settle: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-bounce-shake: cubic-bezier(0.36, 0.07, 0.19, 0.97);
+
+  /* --- Palette (food delivery: warm, appetizing) --- */
+  --otp-bg: #fff8f0;
+  --otp-card: #ffffff;
+  --otp-border: #f0ddc8;
+  --otp-tomato: #ff5b3a;
+  --otp-mango: #ffb020;
+  --otp-basil: #3c8a5b;
+  --otp-text: #3a2b22;
+  --otp-muted: #9a8676;
+}
+
+.bounce-otp-card {
+  --radius: 18px;
+  max-width: 420px;
+  margin: 0 auto;
+  padding: 32px 28px;
+  background: var(--otp-card);
+  border: 1px solid var(--otp-border);
+  border-radius: var(--radius);
+  text-align: center;
+  font-family: "Inter", system-ui, sans-serif;
+  color: var(--otp-text);
+  box-shadow: 0 20px 40px rgba(255, 91, 58, 0.08);
+}
+
+.bounce-otp-card__title {
+  font-family: "Fraunces", Georgia, serif;
+  font-weight: 600;
+  font-size: 1.4rem;
+  margin: 0 0 6px;
+  color: var(--otp-text);
+}
+
+.bounce-otp-card__subtitle {
+  font-size: 0.88rem;
+  color: var(--otp-muted);
+  margin: 0 0 26px;
+  line-height: 1.5;
+}
+
+.bounce-otp-card__subtitle strong {
+  color: var(--otp-tomato);
+  font-weight: 600;
+}
+
+/* --- OTP digit group --- */
+.bounce-otp {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin: 0 0 22px;
+}
+
+.bounce-otp__digit {
+  width: 46px;
+  height: 54px;
+  border-radius: 12px;
+  border: 2px solid var(--otp-border);
+  background: var(--otp-bg);
+  text-align: center;
+  font-family: "Inter", sans-serif;
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: var(--otp-text);
+  caret-color: var(--otp-tomato);
+
+  /* staggered entrance bounce, one per box via --i */
+  opacity: 0;
+  animation: otp-bounce-in 0.6s var(--ease-bounce-in) forwards;
+  animation-delay: calc(var(--i) * 0.08s);
+
+  transition: border-color 0.25s var(--ease-bounce-settle),
+    box-shadow 0.25s var(--ease-bounce-settle),
+    transform 0.25s var(--ease-bounce-settle);
+}
+
+@keyframes otp-bounce-in {
+  0% {
+    opacity: 0;
+    transform: translateY(-24px) scale(0.5);
+  }
+  60% {
+    opacity: 1;
+    transform: translateY(4px) scale(1.08);
+  }
+  80% {
+    transform: translateY(-2px) scale(0.98);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* Bounce again whenever a digit is focused or freshly filled */
+.bounce-otp__digit:focus {
+  outline: none;
+  border-color: var(--otp-tomato);
+  box-shadow: 0 0 0 4px rgba(255, 91, 58, 0.15);
+  transform: scale(1.08);
+  animation: otp-focus-bounce 0.4s var(--ease-bounce-in);
+}
+
+@keyframes otp-focus-bounce {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.18);
+  }
+  100% {
+    transform: scale(1.08);
+  }
+}
+
+.bounce-otp__digit:not(:placeholder-shown) {
+  border-color: var(--otp-basil);
+  background: #f4fbf6;
+}
+
+/* --- Resend row --- */
+.bounce-otp-card__resend {
+  font-size: 0.85rem;
+  color: var(--otp-muted);
+  margin: 0 0 22px;
+}
+
+.bounce-otp-card__resend a {
+  color: var(--otp-tomato);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.bounce-otp-card__resend a:hover,
+.bounce-otp-card__resend a:focus-visible {
+  text-decoration: underline;
+}
+
+/* --- Submit button --- */
+.bounce-otp-submit {
+  width: 100%;
+  padding: 12px 20px;
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--otp-tomato), var(--otp-mango));
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 0.35s var(--ease-bounce-in), box-shadow 0.35s var(--ease-bounce-settle);
+}
+
+.bounce-otp-submit:hover,
+.bounce-otp-submit:focus-visible {
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 10px 24px rgba(255, 91, 58, 0.3);
+}
+
+.bounce-otp-submit:active {
+  transform: scale(0.97);
+}
+
+/* --- Utility --- */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* --- Responsive --- */
+@media (max-width: 420px) {
+  .bounce-otp-card {
+    padding: 24px 16px;
+    max-width: 100%;
+  }
+
+  .bounce-otp {
+    gap: 6px;
+  }
+
+  .bounce-otp__digit {
+    width: 40px;
+    height: 48px;
+    font-size: 1.2rem;
+  }
+}
+
+/* --- Reduced motion --- */
+@media (prefers-reduced-motion: reduce) {
+  .bounce-otp__digit,
+  .bounce-otp__digit:focus,
+  .bounce-otp-submit {
+    animation: none !important;
+    transition: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
Resolves #41902

## What this does
Adds a `bounce-otp-input` component to the EaseMotion CSS library, inspired by Food Delivery design patterns. A 6-digit OTP input group where each box staggers in with a playful bounce on load and pops again on focus.

## Details
- Pure CSS, no JavaScript required
- Staggered entrance bounce per digit box via a `--i` custom property, plus a focus bounce and a green "filled" state
- Uses custom `ease-bounce-in` and `ease-bounce-settle` easing tokens with `otp-bounce-in` and `otp-focus-bounce` keyframes
- Follows the `submissions/examples/<name>/` structure (demo.html, style.css, README.md)
- Numeric keyboard on mobile via `inputmode`/`pattern`, per-box screen reader labels, `autocomplete="one-time-code"` on the first box, and respects `prefers-reduced-motion`

Note: auto-advancing focus to the next box after typing a digit is normally JS-driven; since the issue calls for pure CSS, that behavior was intentionally left out rather than faked — boxes are tabbed/clicked between normally.