### PR TITLE
feat: add Neon Progress Ring component (#41452)

### DIFF
--- a/submissions/examples/neon-progress-ring-glow/README.md
+++ b/submissions/examples/neon-progress-ring-glow/README.md
@@ -1,0 +1,87 @@
+# Neon Progress Ring Component
+
+An ultra-premium, CSS-only circular and semi-circular dashboard indicator system featuring breathing glows, dynamic numeric animations, and customizable neon spectral emissions.
+
+## 1. What does this do?
+This component provides a series of self-contained, responsive neon progress indicators (circular rings, nested concentric progress displays, and semi-circular gauges) that leverage CSS Houdini custom properties to transition values smoothly without JavaScript.
+
+## 2. How is it used?
+
+### Single Standard Circular Ring
+To render a standard neon ring (default Cyan, 75% progress):
+```html
+<div class="neon-ring-container color-cyan" style="--target: 75; --percentage: 75;">
+  <div class="neon-ring" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100">
+    <div class="neon-ring-track"></div>
+    <div class="neon-ring-bar"></div>
+    <div class="neon-ring-glow-effect"></div>
+    <div class="ring-center">
+      <span class="percentage-value">75%</span>
+      <span class="percentage-label">CPU LOAD</span>
+    </div>
+  </div>
+</div>
+```
+
+### Semicircle Gauge Visualizer
+To render a 180-degree gauge (71% speed):
+```html
+<div class="neon-gauge-container color-yellow" style="--target: 71; --percentage: 71;">
+  <div class="neon-gauge" role="progressbar" aria-valuenow="71" aria-valuemin="0" aria-valuemax="100">
+    <div class="neon-gauge-track"></div>
+    <div class="neon-gauge-bar"></div>
+    <div class="neon-gauge-glow-effect"></div>
+    <div class="gauge-center">
+      <span class="gauge-value">710</span>
+      <span class="gauge-unit">MB/s</span>
+      <span class="gauge-label">DOWNLOAD SPEED</span>
+    </div>
+  </div>
+</div>
+```
+
+### Concentric Multi-layered Group
+To nest concentric tracks inside one group:
+```html
+<div class="concentric-ring-group">
+  <!-- Outer Layer -->
+  <div class="neon-ring-container size-lg color-cyan" style="--target: 85; --percentage: 85;">
+    <div class="neon-ring concentric-outer">
+      <div class="neon-ring-track"></div>
+      <div class="neon-ring-bar"></div>
+      <div class="neon-ring-glow-effect"></div>
+    </div>
+  </div>
+  <!-- Middle Layer -->
+  <div class="neon-ring-container size-md color-magenta" style="--target: 62; --percentage: 62;">
+    <div class="neon-ring concentric-middle">
+      <div class="neon-ring-track"></div>
+      <div class="neon-ring-bar"></div>
+      <div class="neon-ring-glow-effect"></div>
+    </div>
+  </div>
+</div>
+```
+
+## 3. Why is it useful?
+In premium web design and dashboard aesthetics, circular progress visualizers are standard requirements. 
+
+This component fits EaseMotion's philosophy in three ways:
+- **Zero-Dependency Engine:** Operates entirely in CSS, bypassing the need for heavy JS libraries (like D3 or Chart.js) or inline SVG math manipulation.
+- **Houdini Optimization:** Registers custom properties to permit native browser hardware-accelerated transitions of integers and layout computations.
+- **Responsive and Accessible Design:** Includes custom media query support to automatically snap animations and diminish glows for users prioritizing `prefers-reduced-motion: reduce`, alongside standard ARIA progress bar semantics.
+
+## 4. Customization Token API
+
+You can override custom property tokens directly in inline styles or scoped stylesheet selectors:
+
+| Property | Description | Default Value | Available Preset Themes |
+|---|---|---|---|
+| `--target` | Target integer value of progress (0-100) | `0` | Any integer `0-100` |
+| `--percentage` | Holds current transitioning progress value | `0` | Registered integer property |
+| `--ring-thickness` | Track boundary width | `12px` | Length unit |
+| `--glow-radius` | Glow dispersion amount | `12px` | Length unit |
+| `--neon-color` | Solid base color of glow & stroke | `var(--ease-color-cyan)` | Presets: `.color-cyan`, `.color-magenta`, `.color-green`, `.color-yellow` |
+
+---
+*Created as a submission for GSSoC-26 / ECSoC-26 under submissions/examples/neon-progress-ring-glow/*

--- a/submissions/examples/neon-progress-ring-glow/demo.html
+++ b/submissions/examples/neon-progress-ring-glow/demo.html
@@ -1,0 +1,286 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Neon Progress Ring - Cyberpunk UI Component</title>
+  <link rel="stylesheet" href="style.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600;800;900&family=Rajdhani:wght@500;600;700&family=Share+Tech+Mono&display=swap" rel="stylesheet" />
+</head>
+<body class="cyber-theme-dark">
+
+  <!-- Background Decorative Cyber Grids -->
+  <div class="cyber-grid"></div>
+  <div class="cyber-scanlines"></div>
+
+  <div class="dashboard-wrapper">
+    <!-- Header Component -->
+    <header class="dash-header">
+      <div class="dash-logo">
+        <span class="logo-neon-text">EASE</span><span class="logo-accent-text">MOTION</span>
+        <span class="logo-subtext">NEON PROGRESS SYSTEM v1.2</span>
+      </div>
+      <div class="dash-meta-badge animate-blink">
+        <span class="badge-dot"></span> SYSTEM ONLINE
+      </div>
+    </header>
+
+    <!-- Main Grid Layout -->
+    <main class="dash-grid">
+      
+      <!-- Card 1: Standard Neon Rings -->
+      <section class="dash-card cyber-card-cyan">
+        <div class="card-header">
+          <span class="card-tag">SYSTEM METRICS</span>
+          <h2>Standard Neon Rings</h2>
+        </div>
+        <div class="card-body ring-showcase">
+          <!-- Cyan Ring (CPU Load) -->
+          <div class="ring-wrapper">
+            <div class="neon-ring-container color-cyan" style="--target: 78; --percentage: 78;">
+              <div class="neon-ring" role="progressbar" aria-valuenow="78" aria-valuemin="0" aria-valuemax="100" aria-label="CPU Load Monitor">
+                <div class="neon-ring-track"></div>
+                <div class="neon-ring-bar"></div>
+                <div class="neon-ring-glow-effect"></div>
+                <div class="ring-center">
+                  <span class="percentage-value">78%</span>
+                  <span class="percentage-label">CPU</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Magenta Ring (Memory Usage) -->
+          <div class="ring-wrapper">
+            <div class="neon-ring-container color-magenta" style="--target: 64; --percentage: 64;">
+              <div class="neon-ring" role="progressbar" aria-valuenow="64" aria-valuemin="0" aria-valuemax="100" aria-label="Memory Usage Monitor">
+                <div class="neon-ring-track"></div>
+                <div class="neon-ring-bar"></div>
+                <div class="neon-ring-glow-effect"></div>
+                <div class="ring-center">
+                  <span class="percentage-value">64%</span>
+                  <span class="percentage-label">RAM</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Green Ring (Thermal Status) -->
+          <div class="ring-wrapper">
+            <div class="neon-ring-container color-green" style="--target: 42; --percentage: 42;">
+              <div class="neon-ring" role="progressbar" aria-valuenow="42" aria-valuemin="0" aria-valuemax="100" aria-label="Thermal Load Monitor">
+                <div class="neon-ring-track"></div>
+                <div class="neon-ring-bar"></div>
+                <div class="neon-ring-glow-effect"></div>
+                <div class="ring-center">
+                  <span class="percentage-value">42%</span>
+                  <span class="percentage-label">TEMP</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="card-footer">
+          <p>Standard progress rings using premium drop-shadow filters and circular gradients.</p>
+        </div>
+      </section>
+
+      <!-- Card 2: Concentric Nested Rings -->
+      <section class="dash-card cyber-card-magenta">
+        <div class="card-header">
+          <span class="card-tag">STORAGE GROUPS</span>
+          <h2>Concentric Neon Rings</h2>
+        </div>
+        <div class="card-body concentric-showcase">
+          <!-- Concentric Ring Container -->
+          <div class="concentric-ring-group" aria-label="Storage allocation details across three drives">
+            <!-- Outer Ring (SSD 1) -->
+            <div class="neon-ring-container size-lg color-cyan" style="--target: 85; --percentage: 85;">
+              <div class="neon-ring concentric-outer">
+                <div class="neon-ring-track"></div>
+                <div class="neon-ring-bar"></div>
+                <div class="neon-ring-glow-effect"></div>
+              </div>
+            </div>
+            <!-- Middle Ring (SSD 2) -->
+            <div class="neon-ring-container size-md color-magenta" style="--target: 62; --percentage: 62;">
+              <div class="neon-ring concentric-middle">
+                <div class="neon-ring-track"></div>
+                <div class="neon-ring-bar"></div>
+                <div class="neon-ring-glow-effect"></div>
+              </div>
+            </div>
+            <!-- Inner Ring (Backup Drive) -->
+            <div class="neon-ring-container size-sm color-yellow" style="--target: 39; --percentage: 39;">
+              <div class="neon-ring concentric-inner">
+                <div class="neon-ring-track"></div>
+                <div class="neon-ring-bar"></div>
+                <div class="neon-ring-glow-effect"></div>
+              </div>
+            </div>
+            <!-- Central Display Core -->
+            <div class="concentric-center-core">
+              <span class="core-title">TOTAL</span>
+              <span class="core-value">62%</span>
+              <span class="core-subtext">3.8 TB</span>
+            </div>
+          </div>
+
+          <!-- Legend -->
+          <div class="concentric-legend">
+            <div class="legend-item"><span class="legend-dot dot-cyan"></span> SSD Primary (85%)</div>
+            <div class="legend-item"><span class="legend-dot dot-magenta"></span> NVMe Storage (62%)</div>
+            <div class="legend-item"><span class="legend-dot dot-yellow"></span> External Backup (39%)</div>
+          </div>
+        </div>
+        <div class="card-footer">
+          <p>Nested rings occupy minimal screen space while delivering rich multi-layered data indicators.</p>
+        </div>
+      </section>
+
+      <!-- Card 3: Neon Gauge Semicircle -->
+      <section class="dash-card cyber-card-yellow">
+        <div class="card-header">
+          <span class="card-tag">BANDWIDTH THROTTLE</span>
+          <h2>Neon Semicircle Gauge</h2>
+        </div>
+        <div class="card-body gauge-showcase">
+          <div class="neon-gauge-container color-yellow" style="--target: 71; --percentage: 71;">
+            <div class="neon-gauge" role="progressbar" aria-valuenow="71" aria-valuemin="0" aria-valuemax="100" aria-label="Bandwidth Speedometer">
+              <div class="neon-gauge-track"></div>
+              <div class="neon-gauge-bar"></div>
+              <div class="neon-gauge-glow-effect"></div>
+              <div class="gauge-center">
+                <span class="gauge-value">710</span>
+                <span class="gauge-unit">MB/s</span>
+                <span class="gauge-label">DOWNLOAD SPEED</span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="card-footer">
+          <p>A 180-degree semi-circular speedometer visualizer suited for dashboard indicators.</p>
+        </div>
+      </section>
+
+      <!-- Card 4: Pure CSS Play Area (Interactive Sandbox) -->
+      <section class="dash-card cyber-card-green dash-full-width">
+        <div class="card-header">
+          <span class="card-tag">CALIBRATION CONSOLE</span>
+          <h2>Interactive Customizer (Pure CSS Sandbox)</h2>
+        </div>
+        
+        <!-- Interactive Controls Pipeline using CSS Radio/Checkbox Binding -->
+        <!-- Percentage Triggers -->
+        <input type="radio" id="val-10" name="ctrl-val" class="css-radio-val" />
+        <input type="radio" id="val-30" name="ctrl-val" class="css-radio-val" />
+        <input type="radio" id="val-50" name="ctrl-val" class="css-radio-val" checked />
+        <input type="radio" id="val-75" name="ctrl-val" class="css-radio-val" />
+        <input type="radio" id="val-100" name="ctrl-val" class="css-radio-val" />
+
+        <!-- Neon Hue Triggers -->
+        <input type="radio" id="hue-cyan" name="ctrl-hue" class="css-radio-hue" checked />
+        <input type="radio" id="hue-magenta" name="ctrl-hue" class="css-radio-hue" />
+        <input type="radio" id="hue-green" name="ctrl-hue" class="css-radio-hue" />
+        <input type="radio" id="hue-yellow" name="ctrl-hue" class="css-radio-hue" />
+
+        <!-- Glow State Triggers -->
+        <input type="radio" id="glow-none" name="ctrl-glow" class="css-radio-glow" />
+        <input type="radio" id="glow-low" name="ctrl-glow" class="css-radio-glow" />
+        <input type="radio" id="glow-medium" name="ctrl-glow" class="css-radio-glow" checked />
+        <input type="radio" id="glow-high" name="ctrl-glow" class="css-radio-glow" />
+
+        <div class="card-body sandbox-grid">
+          
+          <!-- Sandbox Sidebar Controls -->
+          <div class="sandbox-controls">
+            
+            <!-- Value Selectors -->
+            <div class="control-group">
+              <span class="control-label">CALIBRATE TARGET VALUES</span>
+              <div class="btn-group-css">
+                <label for="val-10" class="btn-label label-10">10%</label>
+                <label for="val-30" class="btn-label label-30">30%</label>
+                <label for="val-50" class="btn-label label-50">50%</label>
+                <label for="val-75" class="btn-label label-75">75%</label>
+                <label for="val-100" class="btn-label label-100">100%</label>
+              </div>
+            </div>
+
+            <!-- Neon Colors Selectors -->
+            <div class="control-group">
+              <span class="control-label">SELECT SPECTRAL EMISSION</span>
+              <div class="btn-group-css">
+                <label for="hue-cyan" class="btn-label hue-label-cyan">Cyan</label>
+                <label for="hue-magenta" class="btn-label hue-label-magenta">Magenta</label>
+                <label for="hue-green" class="btn-label hue-label-green">Green</label>
+                <label for="hue-yellow" class="btn-label hue-label-yellow">Yellow</label>
+              </div>
+            </div>
+
+            <!-- Glow Mode Selectors -->
+            <div class="control-group">
+              <span class="control-label">GLOW RADIANCE POWER</span>
+              <div class="btn-group-css">
+                <label for="glow-none" class="btn-label glow-label-none">Offline</label>
+                <label for="glow-low" class="btn-label glow-label-low">Dim</label>
+                <label for="glow-medium" class="btn-label glow-label-medium">Standard</label>
+                <label for="glow-high" class="btn-label glow-label-high">Overdrive</label>
+              </div>
+            </div>
+
+          </div>
+
+          <!-- Sandbox Central Display -->
+          <div class="sandbox-display">
+            <!-- Dynamic Sandbox Neon Ring -->
+            <div class="sandbox-ring-wrapper">
+              <div class="neon-ring-container interactive-ring">
+                <div class="neon-ring" role="progressbar" aria-live="polite" aria-label="Interactive demo status ring">
+                  <div class="neon-ring-track"></div>
+                  <div class="neon-ring-bar"></div>
+                  <div class="neon-ring-glow-effect"></div>
+                  <div class="ring-center">
+                    <span class="percentage-value dynamic-value-display">50%</span>
+                    <span class="percentage-label dynamic-status-text">STEADY</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            
+            <!-- Realtime CSS Parameters Output Panel -->
+            <div class="sandbox-code-card">
+              <div class="code-header">
+                <span class="terminal-dot red"></span>
+                <span class="terminal-dot yellow"></span>
+                <span class="terminal-dot green"></span>
+                <span class="terminal-title">REALTIME TOKEN DUMP</span>
+              </div>
+              <pre class="code-dump"><code>/* Interactive Node State variables */
+.neon-ring-container {
+  <span class="code-var-percentage">--percentage: 50;</span>
+  <span class="code-var-glow">--glow-radius: 12px;</span>
+  <span class="code-var-hue">--neon-color: var(--ease-color-cyan);</span>
+}</code></pre>
+            </div>
+
+          </div>
+
+        </div>
+        <div class="card-footer">
+          <p>Harnesses CSS sibling combinators (<code>:checked ~ .container</code>) and custom properties to build dynamic, JS-free user controls.</p>
+        </div>
+      </section>
+
+    </main>
+
+    <!-- Footer -->
+    <footer class="dash-footer-credits">
+      <p>EaseMotion Neon Progress Rings • Built for ultra-premium dark dashboards • Pure CSS implementation</p>
+    </footer>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/neon-progress-ring-glow/style.css
+++ b/submissions/examples/neon-progress-ring-glow/style.css
@@ -1,0 +1,975 @@
+/* ==========================================================================
+   EaseMotion CSS — Neon Progress Ring Style Sheet
+   Ultra-premium Cyberpunk Dashboard UI & Visualizer Tokens
+   ========================================================================== */
+
+/* ── Houdini Custom Property Registration ──────────────────────────────── */
+/* Enables CSS to animate integer transitions smoothly without Javascript */
+@property --percentage {
+  syntax: '<integer>';
+  inherits: true;
+  initial-value: 0;
+}
+
+@property --glow-opacity {
+  syntax: '<number>';
+  inherits: true;
+  initial-value: 0.8;
+}
+
+/* ── Core Variables and Design Tokens ──────────────────────────────────── */
+:root {
+  /* Neon Palette Definitions */
+  --ease-color-cyan: #00f0ff;
+  --ease-color-magenta: #ff007f;
+  --ease-color-green: #39ff14;
+  --ease-color-yellow: #ffb700;
+  
+  --ease-color-bg-dark: #05050c;
+  --ease-color-card-dark: rgba(13, 13, 27, 0.75);
+  --ease-color-card-border: rgba(0, 240, 255, 0.15);
+  
+  /* Dimensions */
+  --ring-default-size: 160px;
+  --ring-thickness: 12px;
+  
+  /* Animations */
+  --ease-motion-duration: 2s;
+  --ease-timing-smooth: cubic-bezier(0.25, 1, 0.5, 1);
+  --ease-bounce-bezier: cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* ── Base & Cyberpunk Decoration Styles ────────────────────────────────── */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--ease-color-bg-dark);
+  color: #f1f5f9;
+  font-family: 'Rajdhani', sans-serif;
+  min-height: 100vh;
+  overflow-x: hidden;
+  position: relative;
+  letter-spacing: 0.05em;
+}
+
+/* Futuristic grid overlay background */
+.cyber-grid {
+  position: fixed;
+  inset: 0;
+  background-image: 
+    linear-gradient(rgba(18, 18, 48, 0.3) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(18, 18, 48, 0.3) 1px, transparent 1px);
+  background-size: 30px 30px;
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* Cyber CRT Scanline overlay */
+.cyber-scanlines {
+  position: fixed;
+  inset: 0;
+  background: linear-gradient(
+    rgba(18, 16, 16, 0) 50%, 
+    rgba(0, 0, 0, 0.25) 50%
+  ), linear-gradient(
+    90deg, 
+    rgba(255, 0, 0, 0.06), 
+    rgba(0, 255, 0, 0.02), 
+    rgba(0, 0, 255, 0.06)
+  );
+  background-size: 100% 4px, 6px 100%;
+  pointer-events: none;
+  z-index: 2;
+}
+
+/* ── Dashboard Layout & Components ─────────────────────────────────────── */
+.dashboard-wrapper {
+  position: relative;
+  z-index: 10;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+
+.dash-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 2px solid rgba(0, 240, 255, 0.1);
+  padding-bottom: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.dash-logo {
+  font-family: 'Orbitron', sans-serif;
+  font-weight: 900;
+  font-size: 1.8rem;
+  display: flex;
+  flex-direction: column;
+  line-height: 1;
+}
+
+.logo-neon-text {
+  color: var(--ease-color-cyan);
+  text-shadow: 0 0 8px rgba(0, 240, 255, 0.6);
+}
+
+.logo-accent-text {
+  color: var(--ease-color-magenta);
+  text-shadow: 0 0 8px rgba(ff, 0, 127, 0.6);
+  font-size: 1.4rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+}
+
+.logo-subtext {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.75rem;
+  color: #64748b;
+  margin-top: 0.35rem;
+  letter-spacing: 0.2em;
+}
+
+.dash-meta-badge {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.85rem;
+  color: var(--ease-color-cyan);
+  background: rgba(0, 240, 255, 0.1);
+  border: 1px solid rgba(0, 240, 255, 0.3);
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.badge-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: var(--ease-color-cyan);
+  box-shadow: 0 0 8px var(--ease-color-cyan);
+}
+
+.animate-blink {
+  animation: ease-kf-blink 2s infinite ease-in-out;
+}
+
+@keyframes ease-kf-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+/* Grid Layout */
+.dash-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.dash-full-width {
+  grid-column: 1 / -1;
+}
+
+/* Card Component */
+.dash-card {
+  background-color: var(--ease-color-card-dark);
+  border: 1px solid var(--ease-color-card-border);
+  border-radius: 8px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  backdrop-filter: blur(8px);
+  box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.5);
+  transition: all 0.3s var(--ease-timing-smooth);
+  position: relative;
+  overflow: hidden;
+}
+
+.dash-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 4px;
+  background: linear-gradient(90deg, transparent, var(--ease-color-cyan), transparent);
+  transition: all 0.3s ease;
+}
+
+.cyber-card-cyan {
+  --ease-color-card-border: rgba(0, 240, 255, 0.15);
+}
+.cyber-card-cyan::before {
+  background: linear-gradient(90deg, transparent, var(--ease-color-cyan), transparent);
+}
+
+.cyber-card-magenta {
+  --ease-color-card-border: rgba(255, 0, 127, 0.15);
+}
+.cyber-card-magenta::before {
+  background: linear-gradient(90deg, transparent, var(--ease-color-magenta), transparent);
+}
+
+.cyber-card-yellow {
+  --ease-color-card-border: rgba(255, 183, 0, 0.15);
+}
+.cyber-card-yellow::before {
+  background: linear-gradient(90deg, transparent, var(--ease-color-yellow), transparent);
+}
+
+.cyber-card-green {
+  --ease-color-card-border: rgba(57, 255, 20, 0.15);
+}
+.cyber-card-green::before {
+  background: linear-gradient(90deg, transparent, var(--ease-color-green), transparent);
+}
+
+.dash-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.7);
+  border-color: rgba(0, 240, 255, 0.3);
+}
+
+.card-header {
+  margin-bottom: 1.5rem;
+}
+
+.card-tag {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.75rem;
+  color: var(--ease-color-cyan);
+  background: rgba(0, 240, 255, 0.05);
+  padding: 0.2rem 0.5rem;
+  border-radius: 2px;
+  border: 1px solid rgba(0, 240, 255, 0.15);
+}
+
+.card-header h2 {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin-top: 0.5rem;
+  color: #ffffff;
+}
+
+.card-body {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1.5rem 0;
+  min-height: 220px;
+}
+
+.card-footer {
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  padding-top: 1rem;
+  font-size: 0.85rem;
+  color: #94a3b8;
+  line-height: 1.5;
+}
+
+/* ── Standard Neon Progress Ring Component Styles ──────────────────────── */
+.ring-showcase {
+  display: flex;
+  justify-content: space-around;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  width: 100%;
+}
+
+.ring-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.neon-ring-container {
+  /* Set initial configuration and support customization */
+  --percentage-val: var(--percentage, 0);
+  --neon-color: var(--ease-color-cyan);
+  --glow-radius: 12px;
+  
+  position: relative;
+  width: var(--ring-default-size);
+  height: var(--ring-default-size);
+}
+
+/* Set local colors */
+.color-cyan {
+  --neon-color: var(--ease-color-cyan);
+}
+.color-magenta {
+  --neon-color: var(--ease-color-magenta);
+}
+.color-green {
+  --neon-color: var(--ease-color-green);
+}
+.color-yellow {
+  --neon-color: var(--ease-color-yellow);
+}
+
+.neon-ring {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+}
+
+/* Conic gradient track */
+.neon-ring-track {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle, 
+    transparent calc(100% - var(--ring-thickness) - 1px), 
+    rgba(255, 255, 255, 0.03) calc(100% - var(--ring-thickness)), 
+    rgba(255, 255, 255, 0.05) 100%
+  );
+  border: 1px solid rgba(255, 255, 255, 0.02);
+}
+
+/* Interactive Fill Bar using Conic-gradient */
+.neon-ring-bar {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: conic-gradient(
+    from 0deg,
+    var(--neon-color) 0%,
+    var(--neon-color) calc(var(--percentage-val) * 1%),
+    transparent calc(var(--percentage-val) * 1%),
+    transparent 100%
+  );
+  /* Use mask to hollow out the center and create a border track */
+  -webkit-mask: radial-gradient(circle, transparent calc(100% - var(--ring-thickness)), black calc(100% - var(--ring-thickness)));
+  mask: radial-gradient(circle, transparent calc(100% - var(--ring-thickness)), black calc(100% - var(--ring-thickness)));
+  z-index: 2;
+  transition: background 0.3s ease;
+  animation: fill-animation var(--ease-motion-duration) var(--ease-timing-smooth) forwards;
+}
+
+/* High Fidelity Glow Layer */
+.neon-ring-glow-effect {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: conic-gradient(
+    from 0deg,
+    var(--neon-color) 0%,
+    var(--neon-color) calc(var(--percentage-val) * 1%),
+    transparent calc(var(--percentage-val) * 1%),
+    transparent 100%
+  );
+  -webkit-mask: radial-gradient(circle, transparent calc(100% - var(--ring-thickness)), black calc(100% - var(--ring-thickness)));
+  mask: radial-gradient(circle, transparent calc(100% - var(--ring-thickness)), black calc(100% - var(--ring-thickness)));
+  filter: blur(var(--glow-radius));
+  opacity: var(--glow-opacity, 0.85);
+  z-index: 1;
+  transition: all 0.3s ease;
+  animation: 
+    fill-animation var(--ease-motion-duration) var(--ease-timing-smooth) forwards,
+    breathing-glow 3s infinite ease-in-out;
+}
+
+/* Central Numeric Panel */
+.ring-center {
+  position: absolute;
+  inset: var(--ring-thickness);
+  background-color: #0b0b18;
+  border-radius: 50%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 3;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: inset 0 0 16px rgba(0, 0, 0, 0.8);
+}
+
+.percentage-value {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 1.6rem;
+  font-weight: 800;
+  color: #ffffff;
+  text-shadow: 0 0 6px var(--neon-color);
+  counter-reset: pct var(--percentage-val);
+  animation: fill-animation var(--ease-motion-duration) var(--ease-timing-smooth) forwards;
+}
+
+.percentage-value::after {
+  content: counter(pct) "%";
+}
+
+.percentage-label {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.7rem;
+  color: #64748b;
+  margin-top: 2px;
+  letter-spacing: 0.15em;
+}
+
+/* Animations declarations */
+@keyframes fill-animation {
+  from {
+    --percentage: 0;
+  }
+  to {
+    --percentage: var(--target);
+  }
+}
+
+@keyframes breathing-glow {
+  0%, 100% {
+    --glow-opacity: 0.7;
+    filter: blur(var(--glow-radius));
+  }
+  50% {
+    --glow-opacity: 0.95;
+    filter: blur(calc(var(--glow-radius) * 1.3));
+  }
+}
+
+/* ── Concentric Nested Ring Layout Styles ───────────────────────────────── */
+.concentric-showcase {
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.concentric-ring-group {
+  position: relative;
+  width: 220px;
+  height: 220px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* Size mappings for nested structures */
+.concentric-ring-group .size-lg {
+  position: absolute;
+  width: 220px;
+  height: 220px;
+  --ring-thickness: 10px;
+}
+
+.concentric-ring-group .size-md {
+  position: absolute;
+  width: 175px;
+  height: 175px;
+  --ring-thickness: 10px;
+}
+
+.concentric-ring-group .size-sm {
+  position: absolute;
+  width: 130px;
+  height: 130px;
+  --ring-thickness: 10px;
+}
+
+/* Central core indicator */
+.concentric-center-core {
+  position: absolute;
+  width: 90px;
+  height: 90px;
+  background: #080812;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 5;
+  box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.9);
+}
+
+.core-title {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.65rem;
+  color: #64748b;
+  letter-spacing: 0.2em;
+}
+
+.core-value {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 1.3rem;
+  font-weight: 900;
+  color: #ffffff;
+  text-shadow: 0 0 8px var(--ease-color-cyan);
+}
+
+.core-subtext {
+  font-size: 0.65rem;
+  color: #475569;
+  margin-top: 1px;
+}
+
+.concentric-legend {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  align-self: flex-start;
+  width: 100%;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.85rem;
+  color: #94a3b8;
+}
+
+.legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.dot-cyan { background-color: var(--ease-color-cyan); box-shadow: 0 0 6px var(--ease-color-cyan); }
+.dot-magenta { background-color: var(--ease-color-magenta); box-shadow: 0 0 6px var(--ease-color-magenta); }
+.dot-yellow { background-color: var(--ease-color-yellow); box-shadow: 0 0 6px var(--ease-color-yellow); }
+
+/* ── Neon Semicircle Gauge Styles ──────────────────────────────────────── */
+.gauge-showcase {
+  padding-top: 2rem;
+}
+
+.neon-gauge-container {
+  --percentage-val: var(--percentage, 0);
+  --neon-color: var(--ease-color-cyan);
+  --glow-radius: 12px;
+  
+  position: relative;
+  width: 220px;
+  height: 110px; /* Half height */
+  overflow: hidden;
+}
+
+.neon-gauge {
+  width: 220px;
+  height: 220px; /* Keep full circle size for rotation geometry */
+  border-radius: 50%;
+  position: relative;
+}
+
+.neon-gauge-track {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  /* Conic arc starting at 270deg (left side) and spanning 180deg */
+  background: conic-gradient(
+    from 270deg,
+    rgba(255, 255, 255, 0.04) 0deg,
+    rgba(255, 255, 255, 0.04) 180deg,
+    transparent 180deg
+  );
+  -webkit-mask: radial-gradient(circle, transparent calc(100% - var(--ring-thickness)), black calc(100% - var(--ring-thickness)));
+  mask: radial-gradient(circle, transparent calc(100% - var(--ring-thickness)), black calc(100% - var(--ring-thickness)));
+}
+
+.neon-gauge-bar {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  /* Map 0-100 percentage to 0-180deg arc */
+  background: conic-gradient(
+    from 270deg,
+    var(--neon-color) 0deg,
+    var(--neon-color) calc(var(--percentage-val) * 1.8deg),
+    transparent calc(var(--percentage-val) * 1.8deg),
+    transparent 360deg
+  );
+  -webkit-mask: radial-gradient(circle, transparent calc(100% - var(--ring-thickness)), black calc(100% - var(--ring-thickness)));
+  mask: radial-gradient(circle, transparent calc(100% - var(--ring-thickness)), black calc(100% - var(--ring-thickness)));
+  z-index: 2;
+  animation: fill-animation var(--ease-motion-duration) var(--ease-timing-smooth) forwards;
+}
+
+.neon-gauge-glow-effect {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: conic-gradient(
+    from 270deg,
+    var(--neon-color) 0deg,
+    var(--neon-color) calc(var(--percentage-val) * 1.8deg),
+    transparent calc(var(--percentage-val) * 1.8deg),
+    transparent 360deg
+  );
+  -webkit-mask: radial-gradient(circle, transparent calc(100% - var(--ring-thickness)), black calc(100% - var(--ring-thickness)));
+  mask: radial-gradient(circle, transparent calc(100% - var(--ring-thickness)), black calc(100% - var(--ring-thickness)));
+  filter: blur(var(--glow-radius));
+  opacity: 0.8;
+  z-index: 1;
+  animation: 
+    fill-animation var(--ease-motion-duration) var(--ease-timing-smooth) forwards,
+    breathing-glow 3s infinite ease-in-out;
+}
+
+.gauge-center {
+  position: absolute;
+  left: var(--ring-thickness);
+  right: var(--ring-thickness);
+  top: var(--ring-thickness);
+  bottom: 0;
+  border-radius: 110px 110px 0 0;
+  background: #080812;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-bottom: none;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: center;
+  padding-bottom: 5px;
+  z-index: 3;
+  box-shadow: inset 0 6px 12px rgba(0, 0, 0, 0.8);
+}
+
+.gauge-value {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 2.2rem;
+  font-weight: 800;
+  line-height: 1;
+  color: #ffffff;
+  text-shadow: 0 0 10px var(--neon-color);
+}
+
+.gauge-unit {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.85rem;
+  color: var(--neon-color);
+  margin-top: 2px;
+}
+
+.gauge-label {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.65rem;
+  color: #475569;
+  letter-spacing: 0.15em;
+  margin-top: 6px;
+  margin-bottom: 2px;
+}
+
+/* ── Pure CSS Sandbox Control Pipeline & Logic ─────────────────────────── */
+.sandbox-grid {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 2rem;
+  width: 100%;
+}
+
+.sandbox-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 6px;
+  padding: 1.25rem;
+}
+
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.control-label {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.75rem;
+  color: #64748b;
+  letter-spacing: 0.1em;
+}
+
+.btn-group-css {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(45px, 1fr));
+  gap: 0.35rem;
+}
+
+.btn-label {
+  display: inline-block;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 4px;
+  color: #94a3b8;
+  padding: 0.4rem 0.2rem;
+  font-size: 0.8rem;
+  text-align: center;
+  cursor: pointer;
+  user-select: none;
+  font-family: 'Share Tech Mono', monospace;
+  transition: all 0.2s ease;
+}
+
+.btn-label:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+}
+
+/* Hide raw CSS radio triggers */
+.css-radio-val,
+.css-radio-hue,
+.css-radio-glow {
+  display: none;
+}
+
+/* ──── CSS radio selectors mapping for visual feedback ──── */
+/* 1. Value Selectors Active States */
+#val-10:checked ~ * .label-10,
+#val-30:checked ~ * .label-30,
+#val-50:checked ~ * .label-50,
+#val-75:checked ~ * .label-75,
+#val-100:checked ~ * .label-100 {
+  background: rgba(0, 240, 255, 0.1);
+  border-color: var(--ease-color-cyan);
+  color: var(--ease-color-cyan);
+  text-shadow: 0 0 4px rgba(0, 240, 255, 0.5);
+}
+
+/* 2. Color Selectors Active States */
+#hue-cyan:checked ~ * .hue-label-cyan {
+  background: rgba(0, 240, 255, 0.15);
+  border-color: var(--ease-color-cyan);
+  color: var(--ease-color-cyan);
+}
+#hue-magenta:checked ~ * .hue-label-magenta {
+  background: rgba(255, 0, 127, 0.15);
+  border-color: var(--ease-color-magenta);
+  color: var(--ease-color-magenta);
+}
+#hue-green:checked ~ * .hue-label-green {
+  background: rgba(57, 255, 20, 0.15);
+  border-color: var(--ease-color-green);
+  color: var(--ease-color-green);
+}
+#hue-yellow:checked ~ * .hue-label-yellow {
+  background: rgba(255, 183, 0, 0.15);
+  border-color: var(--ease-color-yellow);
+  color: var(--ease-color-yellow);
+}
+
+/* 3. Glow Mode Selectors Active States */
+#glow-none:checked ~ * .glow-label-none,
+#glow-low:checked ~ * .glow-label-low,
+#glow-medium:checked ~ * .glow-label-medium,
+#glow-high:checked ~ * .glow-label-high {
+  background: rgba(57, 255, 20, 0.1);
+  border-color: var(--ease-color-green);
+  color: var(--ease-color-green);
+}
+
+/* ──── CSS radio selectors mapping for dynamic styling of Sandbox Ring ──── */
+/* 1. Binding Percentage */
+#val-10:checked ~ * .interactive-ring { --percentage-val: 10; --target: 10; }
+#val-30:checked ~ * .interactive-ring { --percentage-val: 30; --target: 30; }
+#val-50:checked ~ * .interactive-ring { --percentage-val: 50; --target: 50; }
+#val-75:checked ~ * .interactive-ring { --percentage-val: 75; --target: 75; }
+#val-100:checked ~ * .interactive-ring { --percentage-val: 100; --target: 100; }
+
+/* 2. Binding Colors */
+#hue-cyan:checked ~ * .interactive-ring { --neon-color: var(--ease-color-cyan); }
+#hue-magenta:checked ~ * .interactive-ring { --neon-color: var(--ease-color-magenta); }
+#hue-green:checked ~ * .interactive-ring { --neon-color: var(--ease-color-green); }
+#hue-yellow:checked ~ * .interactive-ring { --neon-color: var(--ease-color-yellow); }
+
+/* 3. Binding Glow radius */
+#glow-none:checked ~ * .interactive-ring { --glow-radius: 0px; --glow-opacity: 0; }
+#glow-low:checked ~ * .interactive-ring { --glow-radius: 6px; --glow-opacity: 0.6; }
+#glow-medium:checked ~ * .interactive-ring { --glow-radius: 12px; --glow-opacity: 0.85; }
+#glow-high:checked ~ * .interactive-ring { --glow-radius: 24px; --glow-opacity: 1.0; }
+
+/* ──── CSS radio selectors mapping for dynamic string variables ──── */
+/* Display Values override */
+#val-10:checked ~ * .dynamic-value-display::after { content: "10%"; }
+#val-30:checked ~ * .dynamic-value-display::after { content: "30%"; }
+#val-50:checked ~ * .dynamic-value-display::after { content: "50%"; }
+#val-75:checked ~ * .dynamic-value-display::after { content: "75%"; }
+#val-100:checked ~ * .dynamic-value-display::after { content: "100%"; }
+
+/* Dynamic Status Texts */
+#val-10:checked ~ * .dynamic-status-text::after { content: "STANDBY"; color: #475569; }
+#val-30:checked ~ * .dynamic-status-text::after { content: "NOMINAL"; color: #94a3b8; }
+#val-50:checked ~ * .dynamic-status-text::after { content: "STEADY"; color: var(--ease-color-cyan); }
+#val-75:checked ~ * .dynamic-status-text::after { content: "WARNING"; color: var(--ease-color-yellow); }
+#val-100:checked ~ * .dynamic-status-text::after { content: "OVERLOAD"; color: var(--ease-color-magenta); }
+
+/* ──── CSS radio selectors mapping for dynamic Realtime Token Code Block ──── */
+#val-10:checked ~ * .code-var-percentage::after { content: "--percentage: 10;"; color: #00f0ff; }
+#val-30:checked ~ * .code-var-percentage::after { content: "--percentage: 30;"; color: #00f0ff; }
+#val-50:checked ~ * .code-var-percentage::after { content: "--percentage: 50;"; color: #00f0ff; }
+#val-75:checked ~ * .code-var-percentage::after { content: "--percentage: 75;"; color: #00f0ff; }
+#val-100:checked ~ * .code-var-percentage::after { content: "--percentage: 100;"; color: #00f0ff; }
+
+#hue-cyan:checked ~ * .code-var-hue::after { content: "--neon-color: #00f0ff;"; color: var(--ease-color-cyan); }
+#hue-magenta:checked ~ * .code-var-hue::after { content: "--neon-color: #ff007f;"; color: var(--ease-color-magenta); }
+#hue-green:checked ~ * .code-var-hue::after { content: "--neon-color: #39ff14;"; color: var(--ease-color-green); }
+#hue-yellow:checked ~ * .code-var-hue::after { content: "--neon-color: #ffb700;"; color: var(--ease-color-yellow); }
+
+#glow-none:checked ~ * .code-var-glow::after { content: "--glow-radius: 0px;"; color: #64748b; }
+#glow-low:checked ~ * .code-var-glow::after { content: "--glow-radius: 6px;"; color: #64748b; }
+#glow-medium:checked ~ * .code-var-glow::after { content: "--glow-radius: 12px;"; color: #64748b; }
+#glow-high:checked ~ * .code-var-glow::after { content: "--glow-radius: 24px;"; color: #64748b; }
+
+/* Clear dynamic text default slots since CSS overrides them */
+.dynamic-value-display,
+.dynamic-status-text,
+.code-var-percentage,
+.code-var-hue,
+.code-var-glow {
+  font-family: inherit;
+}
+.dynamic-value-display::after,
+.dynamic-status-text::after,
+.code-var-percentage::after,
+.code-var-hue::after,
+.code-var-glow::after {
+  display: inline-block;
+}
+.dynamic-value-display { font-size: 0px; }
+.dynamic-value-display::after { font-size: 1.6rem; }
+.dynamic-status-text { font-size: 0px; }
+.dynamic-status-text::after { font-size: 0.7rem; }
+
+/* Sandbox Display & Code Card layout */
+.sandbox-display {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.sandbox-ring-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1rem;
+}
+
+.sandbox-code-card {
+  background: #030308;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 6px;
+  width: 320px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.9);
+}
+
+.code-header {
+  background: rgba(255, 255, 255, 0.02);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 0.5rem 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.terminal-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+
+.terminal-dot.red { background-color: #ef4444; }
+.terminal-dot.yellow { background-color: #eab308; }
+.terminal-dot.green { background-color: #22c55e; }
+
+.terminal-title {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.65rem;
+  color: #475569;
+  margin-left: 0.5rem;
+  letter-spacing: 0.1em;
+}
+
+.code-dump {
+  padding: 1rem;
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.8rem;
+  color: #94a3b8;
+  line-height: 1.5;
+}
+
+.code-dump code {
+  font-family: inherit;
+}
+
+.code-dump span {
+  display: block;
+}
+
+/* ── Footers and Details ───────────────────────────────────────────────── */
+.dash-footer-credits {
+  text-align: center;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  padding-top: 1.5rem;
+  margin-top: 3rem;
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.8rem;
+  color: #475569;
+}
+
+/* ── Responsive Styling ────────────────────────────────────────────────── */
+@media (max-width: 900px) {
+  .sandbox-grid {
+    grid-template-columns: 1fr;
+  }
+  
+  .sandbox-display {
+    flex-direction: column;
+    align-items: center;
+  }
+}
+
+@media (max-width: 600px) {
+  .dash-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+  
+  .dash-meta-badge {
+    align-self: flex-start;
+  }
+  
+  .dash-card {
+    padding: 1rem;
+  }
+}
+
+/* ── Accessibility & Reduced Motion Configuration ──────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  /* Cancel interactive filling animations */
+  .neon-ring-bar,
+  .neon-ring-glow-effect,
+  .neon-gauge-bar,
+  .neon-gauge-glow-effect,
+  .percentage-value {
+    animation-duration: 0.001s !important;
+  }
+  
+  /* Disable blinking decorations */
+  .animate-blink {
+    animation: none !important;
+  }
+  
+  /* Disable breathing glow changes */
+  .neon-ring-glow-effect,
+  .neon-gauge-glow-effect {
+    animation: none !important;
+    filter: blur(8px) !important;
+    opacity: 0.7 !important;
+  }
+}


### PR DESCRIPTION
Fixes #41452

This pull request introduces the `neon-progress-ring-glow` component inside the standard HTML/CSS track:
- **Folders Created**: `submissions/examples/neon-progress-ring-glow/`
- **Files Created**: `demo.html`, `style.css`, `README.md`
- **Features Included**:
  1. **Circular Progress Indicators**: Custom neon styling (Cyan, Magenta, Green, Yellow) for dashboard metrics.
  2. **Concentric Nested Rings**: Multi-layered nested circular metrics displaying storage groups.
  3. **Semicircular Gauge Indicator**: Speedometer visualizer with gauge tracks.
  4. **CSS Houdini Integration**: Animate progress changes smoothly without JS using registered custom properties (`@property --percentage`).
  5. **Pure CSS Sandbox Customizer**: Sibling selectors and hidden radios to change progress values, glow state, and spectral emission in real-time.
  6. **Accessibility Compliance**: Full ARIA roles (`role="progressbar"`), live region announcements, and media queries for `prefers-reduced-motion`.

Over 1300+ lines of changes submitted cleanly to avoid conflicts. Please review and merge.