### PR TITLE
feat: add dolphin

### DIFF
--- a/submissions/examples/dolphin-as/README.md
+++ b/submissions/examples/dolphin-as/README.md
@@ -1,0 +1,23 @@
+# Dolphin
+
+### What does this do?
+
+It shows a dolphin leaping in an arc out of the sea and back in. It nose-dives on entry and points upward on the way out, its tail fluke beats and its flipper paddles, and a splash ring bursts at the waterline each time it re-enters. Under reduced motion the dolphin holds still.
+
+### How is it used?
+
+```html
+<div class="arc">
+  <div class="dolphin">
+    <span class="body"></span>
+    <span class="dorsal"></span>
+    <span class="tailfin"></span>
+  </div>
+</div>
+```
+
+The leap is split across two nested elements running on the same clock: the outer `arc` handles the parabolic travel with `translate`, while the inner `dolphin` handles the `pitch` rotation from nose-up to nose-down. Separating position from rotation this way means the body always points along its flight path, which one combined animation would make very hard to tune.
+
+### Why is it useful?
+
+Ocean, freedom, and joyful or playful themes use a dolphin. This builds a leaping dolphin with pure CSS shapes and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/dolphin-as/demo.html
+++ b/submissions/examples/dolphin-as/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dolphin</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="sun"></span>
+    <div class="arc">
+      <div class="dolphin">
+        <span class="tailfin"></span>
+        <span class="body"></span>
+        <span class="belly"></span>
+        <span class="dorsal"></span>
+        <span class="flipper"></span>
+        <span class="snout"></span>
+        <span class="eye"></span>
+        <span class="smile"></span>
+      </div>
+    </div>
+    <span class="splash sp1"></span>
+    <span class="splash sp2"></span>
+    <span class="sea"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/dolphin-as/style.css
+++ b/submissions/examples/dolphin-as/style.css
@@ -1,0 +1,230 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #ffd9a8, #ffb27a 70%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+  overflow: hidden;
+  border-radius: 18px;
+  background: linear-gradient(180deg, #ffdcb0, #ffb98a 66%);
+  box-shadow: 0 24px 48px rgba(150, 80, 40, 0.3);
+}
+
+.sun {
+  position: absolute;
+  top: 40px;
+  right: 44px;
+  width: 58px;
+  height: 58px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 38%, #fff6d0, #ff9a4a 76%);
+  box-shadow: 0 0 44px rgba(255, 150, 70, 0.7);
+}
+
+.arc {
+  position: absolute;
+  bottom: 96px;
+  left: 50%;
+  width: 0;
+  height: 0;
+  z-index: 3;
+  animation: leap 4s ease-in-out infinite;
+}
+
+.dolphin {
+  position: absolute;
+  bottom: 0;
+  left: -80px;
+  width: 170px;
+  height: 78px;
+  animation: pitch 4s ease-in-out infinite;
+  transform-origin: 50% 50%;
+}
+
+.body {
+  position: absolute;
+  bottom: 0;
+  left: 24px;
+  width: 132px;
+  height: 62px;
+  border-radius: 50% 46% 46% 50% / 62% 58% 42% 38%;
+  background: linear-gradient(160deg, #7fb6dd, #33689e 74%);
+  box-shadow: inset -8px -6px 16px rgba(20, 60, 100, 0.35);
+  z-index: 2;
+}
+
+.belly {
+  position: absolute;
+  bottom: 0;
+  left: 44px;
+  width: 92px;
+  height: 30px;
+  border-radius: 50% 50% 46% 46% / 70% 70% 30% 30%;
+  background: linear-gradient(160deg, #f0f7fb, #cbdfee);
+  z-index: 3;
+}
+
+.snout {
+  position: absolute;
+  bottom: 26px;
+  right: 0;
+  width: 46px;
+  height: 20px;
+  border-radius: 30% 60% 60% 20% / 40% 60% 40% 40%;
+  background: linear-gradient(160deg, #79b0d8, #3a72a8);
+  z-index: 2;
+}
+
+.dorsal {
+  position: absolute;
+  bottom: 52px;
+  left: 66px;
+  width: 40px;
+  height: 30px;
+  clip-path: polygon(0 100%, 76% 0, 100% 100%);
+  background: linear-gradient(160deg, #6ba7d2, #2f639a);
+  z-index: 2;
+}
+
+.flipper {
+  position: absolute;
+  bottom: -14px;
+  left: 68px;
+  width: 42px;
+  height: 26px;
+  clip-path: polygon(0 0, 100% 18%, 34% 100%);
+  background: linear-gradient(160deg, #5e9ac8, #2a5c92);
+  transform-origin: 10% 10%;
+  z-index: 1;
+  animation: paddle 1.2s ease-in-out infinite alternate;
+}
+
+.tailfin {
+  position: absolute;
+  bottom: 10px;
+  left: 0;
+  width: 50px;
+  height: 46px;
+  clip-path: polygon(100% 50%, 12% 0, 34% 50%, 12% 100%);
+  background: linear-gradient(160deg, #6ba7d2, #2f639a);
+  transform-origin: right center;
+  z-index: 1;
+  animation: fluke 0.9s ease-in-out infinite alternate;
+}
+
+.eye {
+  position: absolute;
+  bottom: 36px;
+  right: 46px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #17293b;
+  z-index: 4;
+  animation: blink 4.5s ease-in-out infinite;
+}
+
+.smile {
+  position: absolute;
+  bottom: 22px;
+  right: 34px;
+  width: 24px;
+  height: 12px;
+  border-bottom: 3px solid #1d4468;
+  border-radius: 0 0 50% 50%;
+  z-index: 4;
+}
+
+.sea {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 106px;
+  background: linear-gradient(#3f9fcf, #1a5f94);
+  z-index: 4;
+}
+
+.sea::after {
+  content: "";
+  position: absolute;
+  top: 10px;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.5) 0 26px, transparent 26px 52px);
+}
+
+.splash {
+  position: absolute;
+  bottom: 92px;
+  left: 50%;
+  width: 90px;
+  height: 20px;
+  margin-left: -45px;
+  border-radius: 50%;
+  border: 3px solid rgba(255, 255, 255, 0.75);
+  border-bottom: none;
+  opacity: 0;
+  z-index: 5;
+  animation: burst 4s ease-out infinite;
+}
+
+.sp2 { animation-delay: 2s; }
+
+@keyframes leap {
+  0% { transform: translate(-96px, 30px); }
+  50% { transform: translate(0, -84px); }
+  100% { transform: translate(96px, 30px); }
+}
+
+@keyframes pitch {
+  0% { transform: rotate(-32deg); }
+  50% { transform: rotate(0deg); }
+  100% { transform: rotate(32deg); }
+}
+
+@keyframes fluke {
+  0% { transform: rotate(-12deg); }
+  100% { transform: rotate(12deg); }
+}
+
+@keyframes paddle {
+  0% { transform: rotate(-8deg); }
+  100% { transform: rotate(10deg); }
+}
+
+@keyframes burst {
+  0%, 88% { transform: scale(0.3); opacity: 0; }
+  92% { opacity: 0.9; }
+  100% { transform: scale(1.5); opacity: 0; }
+}
+
+@keyframes blink {
+  0%, 92%, 100% { transform: scaleY(1); }
+  96% { transform: scaleY(0.1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .arc,
+  .dolphin,
+  .tailfin,
+  .flipper,
+  .eye,
+  .splash {
+    animation: none;
+  }
+
+  .splash {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a dolphin built for #44863. The leap splits travel and rotation across two nested elements on one clock, so the body always points along its flight path, with a beating fluke and a splash ring on re-entry. Reduced motion fallback included. Pure CSS. Closes #44863.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot at the top of the arc: a blue dolphin with a dorsal fin, pectoral flipper, tail fluke, and pale belly, above the sea at sunset.
