### PR TITLE
feat: add snow globe

### DIFF
--- a/submissions/examples/snow-globe-as/README.md
+++ b/submissions/examples/snow-globe-as/README.md
@@ -1,0 +1,24 @@
+# Snow Globe
+
+### What does this do?
+
+It shows a snow globe with a little cabin and pine trees inside, snow drifting gently down. Hovering or focusing it shakes the globe and sends the snow swirling back up before it settles again. It works with no JavaScript. Under reduced motion the globe stays still and the snow is hidden.
+
+### How is it used?
+
+```html
+<div class="globe" tabindex="0">
+  <div class="dome">
+    <span class="hut"></span>
+    <div class="snow"><span class="flake fk1"></span></div>
+    <span class="glassg"></span>
+  </div>
+  <span class="baseg"></span>
+</div>
+```
+
+The dome clips everything with `overflow: hidden`, so the scene and the snow stay inside the glass. Each flake normally runs a slow `driftdown`; on `:hover` the animation *name* is swapped to a faster `flurry` that first throws the flakes back up before letting them fall, while the dome itself runs a brief `shake`. Swapping the keyframes rather than the element is what makes the shake feel like it disturbed the snow.
+
+### Why is it useful?
+
+Winter, holiday, and nostalgic or keepsake themes use a snow globe. This builds an interactive snow globe with pure CSS shapes and animation, no images or JavaScript, with a reduced motion fallback.

--- a/submissions/examples/snow-globe-as/demo.html
+++ b/submissions/examples/snow-globe-as/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Snow Globe</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="globe" tabindex="0">
+      <div class="dome">
+        <span class="sky"></span>
+        <span class="tree tl"></span>
+        <span class="tree tc"></span>
+        <span class="tree tr"></span>
+        <span class="hut">
+          <span class="roof"></span>
+          <span class="window"></span>
+        </span>
+        <span class="hill"></span>
+        <div class="snow">
+          <span class="flake fk1"></span>
+          <span class="flake fk2"></span>
+          <span class="flake fk3"></span>
+          <span class="flake fk4"></span>
+          <span class="flake fk5"></span>
+          <span class="flake fk6"></span>
+          <span class="flake fk7"></span>
+          <span class="flake fk8"></span>
+          <span class="flake fk9"></span>
+          <span class="flake fk10"></span>
+          <span class="flake fk11"></span>
+          <span class="flake fk12"></span>
+          <span class="flake fk13"></span>
+          <span class="flake fk14"></span>
+          <span class="flake fk15"></span>
+          <span class="flake fk16"></span>
+        </div>
+        <span class="glassg"></span>
+      </div>
+      <span class="collar"></span>
+      <span class="baseg"></span>
+    </div>
+    <p class="hint">hover to shake</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/snow-globe-as/style.css
+++ b/submissions/examples/snow-globe-as/style.css
@@ -1,0 +1,245 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 24%, #2b3a52, #0e141f 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  display: grid;
+  justify-items: center;
+  gap: 14px;
+}
+
+.globe {
+  display: grid;
+  justify-items: center;
+  outline: none;
+  animation: none;
+}
+
+.dome {
+  position: relative;
+  width: 220px;
+  height: 220px;
+  border-radius: 50%;
+  overflow: hidden;
+  background: radial-gradient(circle at 38% 26%, #b9dcf2, #5b93bd 76%);
+  box-shadow:
+    inset 0 0 0 5px rgba(230, 245, 255, 0.5),
+    inset -14px -12px 30px rgba(30, 70, 110, 0.4),
+    0 0 30px rgba(150, 210, 250, 0.35);
+  z-index: 3;
+}
+
+.sky {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(220, 240, 255, 0.35), transparent 60%);
+}
+
+.hill {
+  position: absolute;
+  bottom: -14px;
+  left: -10px;
+  right: -10px;
+  height: 78px;
+  border-radius: 50% 50% 0 0 / 44px 44px 0 0;
+  background: linear-gradient(#f4fbff, #cfe4f2);
+  z-index: 4;
+}
+
+.tree {
+  position: absolute;
+  width: 0;
+  height: 0;
+  z-index: 3;
+}
+
+.tree::after {
+  content: "";
+  position: absolute;
+  bottom: -8px;
+  left: -4px;
+  width: 8px;
+  height: 12px;
+  border-radius: 2px;
+  background: #5c3a1e;
+}
+
+.tl {
+  bottom: 62px;
+  left: 42px;
+  border-left: 22px solid transparent;
+  border-right: 22px solid transparent;
+  border-bottom: 58px solid #2f7a4a;
+}
+
+.tc {
+  bottom: 74px;
+  left: 152px;
+  border-left: 17px solid transparent;
+  border-right: 17px solid transparent;
+  border-bottom: 46px solid #276a40;
+}
+
+.tr {
+  bottom: 58px;
+  left: 178px;
+  border-left: 14px solid transparent;
+  border-right: 14px solid transparent;
+  border-bottom: 38px solid #2f7a4a;
+}
+
+.hut {
+  position: absolute;
+  bottom: 60px;
+  left: 88px;
+  width: 56px;
+  height: 44px;
+  border-radius: 4px;
+  background: linear-gradient(160deg, #a5652f, #6d4523);
+  z-index: 3;
+}
+
+.roof {
+  position: absolute;
+  top: -26px;
+  left: -8px;
+  width: 0;
+  height: 0;
+  border-left: 36px solid transparent;
+  border-right: 36px solid transparent;
+  border-bottom: 28px solid #c0392b;
+}
+
+.window {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  width: 18px;
+  height: 16px;
+  margin-left: -9px;
+  border-radius: 3px;
+  background: #ffd76b;
+  box-shadow: 0 0 10px rgba(255, 215, 107, 0.9);
+}
+
+.snow {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  pointer-events: none;
+}
+
+.flake {
+  position: absolute;
+  top: -10px;
+  border-radius: 50%;
+  background: #fff;
+  opacity: 0.9;
+  animation-name: driftdown;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+}
+
+.fk1 { left: 27%; width: 6px; height: 6px; animation-duration: 3.04s; animation-delay: 1.25s; }
+.fk2 { left: 67%; width: 7px; height: 7px; animation-duration: 3.89s; animation-delay: 2.97s; }
+.fk3 { left: 71%; width: 4px; height: 4px; animation-duration: 2.57s; animation-delay: 1.58s; }
+.fk4 { left: 7%; width: 4px; height: 4px; animation-duration: 2.94s; animation-delay: 1.76s; }
+.fk5 { left: 24%; width: 5px; height: 5px; animation-duration: 3.79s; animation-delay: 0.7s; }
+.fk6 { left: 90%; width: 7px; height: 7px; animation-duration: 2.28s; animation-delay: 2.99s; }
+.fk7 { left: 84%; width: 7px; height: 7px; animation-duration: 3.08s; animation-delay: 2.87s; }
+.fk8 { left: 94%; width: 6px; height: 6px; animation-duration: 2.43s; animation-delay: 2.86s; }
+.fk9 { left: 8%; width: 4px; height: 4px; animation-duration: 2.51s; animation-delay: 2.45s; }
+.fk10 { left: 14%; width: 6px; height: 6px; animation-duration: 3.11s; animation-delay: 1.66s; }
+.fk11 { left: 57%; width: 4px; height: 4px; animation-duration: 3.17s; animation-delay: 0.56s; }
+.fk12 { left: 66%; width: 5px; height: 5px; animation-duration: 3.93s; animation-delay: 0.7s; }
+.fk13 { left: 32%; width: 4px; height: 4px; animation-duration: 3.55s; animation-delay: 2.41s; }
+.fk14 { left: 21%; width: 7px; height: 7px; animation-duration: 3.32s; animation-delay: 1.68s; }
+.fk15 { left: 38%; width: 7px; height: 7px; animation-duration: 2.88s; animation-delay: 0.44s; }
+.fk16 { left: 47%; width: 7px; height: 7px; animation-duration: 2.93s; animation-delay: 1.35s; }
+
+.glassg {
+  position: absolute;
+  top: 18px;
+  left: 26px;
+  width: 54px;
+  height: 84px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.4);
+  filter: blur(6px);
+  transform: rotate(-18deg);
+  z-index: 6;
+}
+
+.collar {
+  width: 190px;
+  height: 20px;
+  margin-top: -8px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, #d9a52a, #8a6510);
+  z-index: 4;
+}
+
+.baseg {
+  width: 220px;
+  height: 46px;
+  border-radius: 10px 10px 14px 14px;
+  background: linear-gradient(180deg, #8a5a2c, #4f3117);
+  box-shadow: 0 20px 36px rgba(0, 0, 0, 0.55);
+  z-index: 2;
+}
+
+.globe:hover .dome,
+.globe:focus .dome {
+  animation: shake 0.5s ease-in-out 3;
+}
+
+.globe:hover .flake,
+.globe:focus .flake {
+  animation-name: flurry;
+  animation-duration: 1.6s;
+  animation-timing-function: ease-in;
+}
+
+.hint {
+  margin: 0;
+  color: #93a3b8;
+  font-size: 0.85rem;
+}
+
+@keyframes driftdown {
+  0% { transform: translate(0, 0); }
+  100% { transform: translate(14px, 240px); }
+}
+
+@keyframes flurry {
+  0% { transform: translate(0, 210px) scale(0.6); }
+  30% { transform: translate(-10px, 40px) scale(1); }
+  100% { transform: translate(16px, 240px) scale(1); }
+}
+
+@keyframes shake {
+  0%, 100% { transform: translateX(0) rotate(0deg); }
+  25% { transform: translateX(-6px) rotate(-2deg); }
+  75% { transform: translateX(6px) rotate(2deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .flake {
+    animation: none;
+    opacity: 0;
+  }
+
+  .globe:hover .dome,
+  .globe:focus .dome,
+  .globe:hover .flake,
+  .globe:focus .flake {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a snow globe built for #44867. Hover swaps the flakes' animation name from a slow drift to a flurry that throws the snow back up before it resettles, while the dome shakes, so the shake actually appears to disturb the snow. Reduced motion fallback included. Pure CSS. Closes #44867.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a glass snow globe with a cabin, lit window, and pine trees on a snowy hill, on a gold collar and wooden base.
