### PR TITLE
feat: add wind chime

### DIFF
--- a/submissions/examples/wind-chime-as/README.md
+++ b/submissions/examples/wind-chime-as/README.md
@@ -1,0 +1,22 @@
+# Wind Chime
+
+### What does this do?
+
+It shows a wind chime hanging from a hook. The whole chime sways in the breeze, its five metal tubes tilt on staggered timings so the motion ripples along the row, the clapper and sail swing beneath, and faint rings pulse out as the tubes are struck. Under reduced motion everything hangs still.
+
+### How is it used?
+
+```html
+<div class="chime">
+  <span class="disc"></span>
+  <span class="tube tb1"></span>
+  <span class="clapper"></span>
+  <span class="sail"></span>
+</div>
+```
+
+The clapper and sail hang far below their pivots, which is achieved by pushing `transform-origin` well outside the element itself (`50% -130px`). That makes them swing on a long invisible string from the disc rather than spinning about their own centers. Each tube keeps its rest tilt in a `--tt` custom property so one `tilt` animation can rock them all around their own angles.
+
+### Why is it useful?
+
+Calm, garden, and ambient or meditative themes use a wind chime. This builds a swaying wind chime with pure CSS shapes and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/wind-chime-as/demo.html
+++ b/submissions/examples/wind-chime-as/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Wind Chime</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="hook"></span>
+    <div class="chime">
+      <span class="disc"></span>
+      <span class="tube tb1"></span>
+      <span class="tube tb2"></span>
+      <span class="tube tb3"></span>
+      <span class="tube tb4"></span>
+      <span class="tube tb5"></span>
+      <span class="clapper"></span>
+      <span class="sail"></span>
+    </div>
+    <span class="ping pg1"></span>
+    <span class="ping pg2"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/wind-chime-as/style.css
+++ b/submissions/examples/wind-chime-as/style.css
@@ -1,0 +1,170 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 22%, #ffe7c4, #dfa877 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 300px;
+  height: 340px;
+}
+
+.hook {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 4px;
+  height: 44px;
+  margin-left: -2px;
+  background: linear-gradient(90deg, #b7c1cd, #6f7a89);
+  z-index: 2;
+}
+
+.hook::before {
+  content: "";
+  position: absolute;
+  top: -10px;
+  left: -9px;
+  width: 22px;
+  height: 22px;
+  border: 4px solid #8a94a3;
+  border-radius: 50%;
+  border-bottom-color: transparent;
+  box-sizing: border-box;
+}
+
+.chime {
+  position: absolute;
+  top: 44px;
+  left: 50%;
+  width: 200px;
+  height: 280px;
+  margin-left: -100px;
+  transform-origin: 50% 4%;
+  animation: swing 4.4s ease-in-out infinite;
+  z-index: 3;
+}
+
+.disc {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 130px;
+  height: 16px;
+  margin-left: -65px;
+  border-radius: 8px;
+  background: linear-gradient(180deg, #a3703f, #6d4523);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.25);
+  z-index: 4;
+}
+
+.tube {
+  position: absolute;
+  top: 14px;
+  width: 14px;
+  border-radius: 7px;
+  background: linear-gradient(90deg, #f0f4f8 0 18%, #b9c4d0 46%, #78838f);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  transform-origin: top center;
+  animation: tilt 2.6s ease-in-out infinite;
+  z-index: 3;
+}
+
+.tube::before {
+  content: "";
+  position: absolute;
+  top: -10px;
+  left: 50%;
+  width: 1px;
+  height: 12px;
+  margin-left: -0.5px;
+  background: rgba(80, 90, 100, 0.6);
+}
+
+.tb1 { --tt: -5deg; left: 18px; height: 118px; animation-delay: 0s; }
+.tb2 { --tt: -2.5deg; left: 54px; height: 148px; animation-delay: 0.22s; }
+.tb3 { --tt: 0deg; left: 93px; height: 172px; animation-delay: 0.44s; }
+.tb4 { --tt: 2.5deg; left: 132px; height: 142px; animation-delay: 0.66s; }
+.tb5 { --tt: 5deg; left: 168px; height: 112px; animation-delay: 0.88s; }
+
+.clapper {
+  position: absolute;
+  top: 130px;
+  left: 50%;
+  width: 44px;
+  height: 44px;
+  margin-left: -22px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 30%, #d9a86a, #8a5a2c 74%);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.28);
+  transform-origin: 50% -130px;
+  z-index: 5;
+  animation: knock 2.6s ease-in-out infinite;
+}
+
+.sail {
+  position: absolute;
+  top: 190px;
+  left: 50%;
+  width: 54px;
+  height: 60px;
+  margin-left: -27px;
+  clip-path: polygon(50% 0, 100% 78%, 50% 100%, 0 78%);
+  background: linear-gradient(160deg, #63c4b8, #2a8a80);
+  transform-origin: 50% -190px;
+  z-index: 5;
+  animation: knock 2.6s ease-in-out infinite;
+}
+
+.ping {
+  position: absolute;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.8);
+  opacity: 0;
+  z-index: 2;
+  animation: ring 2.6s ease-out infinite;
+}
+
+.pg1 { top: 130px; left: 40px; width: 40px; height: 40px; }
+.pg2 { top: 150px; right: 44px; width: 34px; height: 34px; animation-delay: 1.3s; }
+
+@keyframes swing {
+  0%, 100% { transform: rotate(-3deg); }
+  50% { transform: rotate(3deg); }
+}
+
+@keyframes tilt {
+  0%, 100% { transform: rotate(var(--tt, 0deg)); }
+  50% { transform: rotate(calc(var(--tt, 0deg) * -1 - 3deg)); }
+}
+
+@keyframes knock {
+  0%, 100% { transform: rotate(6deg); }
+  50% { transform: rotate(-6deg); }
+}
+
+@keyframes ring {
+  0%, 40% { transform: scale(0.3); opacity: 0; }
+  50% { opacity: 0.85; }
+  100% { transform: scale(1.8); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chime,
+  .tube,
+  .clapper,
+  .sail,
+  .ping {
+    animation: none;
+  }
+
+  .ping {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a wind chime built for #44869. The clapper and sail swing on long invisible strings by pushing transform-origin outside the elements themselves, while five tubes rock around their own rest tilts held in custom properties. Reduced motion fallback included. Pure CSS. Closes #44869.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a wind chime with a hook, wooden disc, five graduated metal tubes, a round clapper, and a teal sail.
