### PR TITLE
feat: add dreamcatcher

### DIFF
--- a/submissions/examples/dreamcatcher-as/README.md
+++ b/submissions/examples/dreamcatcher-as/README.md
@@ -1,0 +1,20 @@
+# Dreamcatcher
+
+### What does this do?
+
+It shows a dreamcatcher hanging under the stars. The hoop sways gently on its cord, the three feathers swing beneath it on staggered timings, the bead at the center of the web glows and fades, and stars twinkle behind it. Under reduced motion everything hangs still.
+
+### How is it used?
+
+```html
+<div class="catcher">
+  <div class="hoop"><span class="web"></span><span class="web2"></span><span class="bead"></span></div>
+  <div class="dangle dg1"><span class="string"></span><span class="feather"></span></div>
+</div>
+```
+
+The woven web costs two elements, not dozens: a `repeating-conic-gradient` draws every radial thread from the center, and a `repeating-radial-gradient` draws the concentric rings that cross them, both clipped to the hoop by `overflow: hidden`. Each feather hangs from a `transform-origin` at the top of its string, so it swings from where it is tied rather than pivoting about its middle.
+
+### Why is it useful?
+
+Boho, sleep, and calm or spiritual themes use a dreamcatcher. This builds a swaying dreamcatcher with a gradient-woven web, no images, with a reduced motion fallback.

--- a/submissions/examples/dreamcatcher-as/demo.html
+++ b/submissions/examples/dreamcatcher-as/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dreamcatcher</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="cordd"></span>
+    <div class="catcher">
+      <div class="hoop">
+        <span class="web"></span>
+        <span class="web2"></span>
+        <span class="bead"></span>
+      </div>
+      <div class="dangle dg1">
+        <span class="string"></span>
+        <span class="beadd"></span>
+        <span class="feather"></span>
+      </div>
+      <div class="dangle dg2">
+        <span class="string"></span>
+        <span class="beadd"></span>
+        <span class="feather"></span>
+      </div>
+      <div class="dangle dg3">
+        <span class="string"></span>
+        <span class="beadd"></span>
+        <span class="feather"></span>
+      </div>
+    </div>
+    <span class="star ss1"></span>
+    <span class="star ss2"></span>
+    <span class="star ss3"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/dreamcatcher-as/style.css
+++ b/submissions/examples/dreamcatcher-as/style.css
@@ -1,0 +1,201 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 22%, #34285c, #100b1e 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 300px;
+  height: 360px;
+}
+
+.star {
+  position: absolute;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: #fff;
+  animation: twinkle 2.6s ease-in-out infinite;
+}
+
+.ss1 { top: 40px; left: 40px; }
+.ss2 { top: 90px; right: 44px; animation-delay: 0.8s; }
+.ss3 { top: 30px; right: 90px; animation-delay: 1.6s; }
+
+.cordd {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 4px;
+  height: 34px;
+  margin-left: -2px;
+  background: linear-gradient(#c9a06a, #8a6a3a);
+  z-index: 2;
+}
+
+.catcher {
+  position: absolute;
+  top: 30px;
+  left: 50%;
+  width: 200px;
+  height: 320px;
+  margin-left: -100px;
+  transform-origin: 50% 2%;
+  animation: swayd 6s ease-in-out infinite;
+  z-index: 3;
+}
+
+.hoop {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 180px;
+  height: 180px;
+  margin-left: -90px;
+  border-radius: 50%;
+  border: 9px solid #b5814a;
+  box-sizing: border-box;
+  overflow: hidden;
+  box-shadow:
+    inset 0 0 0 2px rgba(255, 220, 170, 0.35),
+    0 0 26px rgba(190, 150, 110, 0.3);
+  background: radial-gradient(circle at 50% 50%, rgba(160, 200, 255, 0.08), transparent 70%);
+}
+
+.web {
+  position: absolute;
+  inset: -9px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 0deg at 50% 50%,
+      rgba(230, 240, 255, 0.75) 0 0.6deg,
+      transparent 0.6deg 30deg
+    );
+}
+
+.web2 {
+  position: absolute;
+  inset: -9px;
+  border-radius: 50%;
+  background:
+    repeating-radial-gradient(
+      circle at 50% 50%,
+      transparent 0 22px,
+      rgba(230, 240, 255, 0.55) 22px 23px
+    );
+}
+
+.bead {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 14px;
+  height: 14px;
+  margin: -7px 0 0 -7px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #9fe3ff, #2f7fb8);
+  box-shadow: 0 0 12px rgba(120, 210, 255, 0.9);
+  animation: glowb 3s ease-in-out infinite;
+}
+
+.dangle {
+  position: absolute;
+  top: 170px;
+  width: 24px;
+  transform-origin: 50% 0;
+  animation: swayf 3.4s ease-in-out infinite;
+}
+
+.dg1 { left: 26px; animation-delay: 0s; }
+.dg2 { left: 50%; margin-left: -12px; animation-delay: 0.5s; }
+.dg3 { right: 26px; animation-delay: 1s; }
+
+.string {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 2px;
+  margin-left: -1px;
+  background: #c9a06a;
+}
+
+.dg1 .string { height: 38px; }
+.dg2 .string { height: 56px; }
+.dg3 .string { height: 44px; }
+
+.beadd {
+  position: absolute;
+  left: 50%;
+  width: 12px;
+  height: 12px;
+  margin-left: -6px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #ffd3a0, #c9803a);
+}
+
+.dg1 .beadd { top: 34px; }
+.dg2 .beadd { top: 52px; }
+.dg3 .beadd { top: 40px; }
+
+.feather {
+  position: absolute;
+  left: 50%;
+  width: 22px;
+  height: 66px;
+  margin-left: -11px;
+  border-radius: 50% 50% 46% 46% / 34% 34% 66% 66%;
+  background:
+    linear-gradient(180deg, #6fd0e8 0 46%, #f0f6fa 48%);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+}
+
+.feather::after {
+  content: "";
+  position: absolute;
+  top: 6px;
+  left: 50%;
+  width: 1.5px;
+  bottom: 4px;
+  margin-left: -0.75px;
+  background: rgba(70, 100, 120, 0.55);
+}
+
+.dg1 .feather { top: 44px; }
+.dg2 .feather { top: 62px; }
+.dg3 .feather { top: 50px; }
+
+@keyframes swayd {
+  0%, 100% { transform: rotate(-2deg); }
+  50% { transform: rotate(2deg); }
+}
+
+@keyframes swayf {
+  0%, 100% { transform: rotate(-5deg); }
+  50% { transform: rotate(5deg); }
+}
+
+@keyframes glowb {
+  0%, 100% { box-shadow: 0 0 12px rgba(120, 210, 255, 0.9); }
+  50% { box-shadow: 0 0 24px rgba(160, 230, 255, 1); }
+}
+
+@keyframes twinkle {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.2; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .catcher,
+  .dangle,
+  .bead,
+  .star {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a dreamcatcher built for #44871. The whole woven web is two elements: a conic gradient for the radial threads and a radial gradient for the crossing rings, clipped to the hoop. Feathers swing from a transform-origin at the top of each string. Reduced motion fallback included. Pure CSS. Closes #44871.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a wooden hoop with a gradient-drawn web of radial threads and concentric rings, a glowing center bead, and three hanging feathers under twinkling stars.
