### PR TITLE
feat: add birdhouse

### DIFF
--- a/submissions/examples/birdhouse-as/README.md
+++ b/submissions/examples/birdhouse-as/README.md
@@ -1,0 +1,24 @@
+# Birdhouse
+
+### What does this do?
+
+It shows a wooden birdhouse hanging from a branch. A little yellow bird pops up into the entrance hole, flutters its wing, then ducks back down inside, over and over, while the whole house sways on its hanger. Under reduced motion the house and bird hold still.
+
+### How is it used?
+
+```html
+<div class="house">
+  <span class="roof rl"></span>
+  <div class="front">
+    <span class="hole"></span>
+    <div class="birdb"><span class="wingb"></span></div>
+    <span class="perch"></span>
+  </div>
+</div>
+```
+
+The bird hides inside because the `front` panel clips it with `overflow: hidden`: the `peek` animation simply translates the bird down out of the visible area and back up into the hole, so it appears to be popping out of the house rather than fading in. The two roof panels are one shape rotated in opposite directions from their inner edges, so they meet cleanly at the ridge.
+
+### Why is it useful?
+
+Garden, home, and notification or "new message" themes use a birdhouse. This builds a birdhouse with a peeking bird in pure CSS, no images, with a reduced motion fallback.

--- a/submissions/examples/birdhouse-as/demo.html
+++ b/submissions/examples/birdhouse-as/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Birdhouse</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="branchb"></span>
+    <div class="house">
+      <span class="roof"></span>
+      <span class="ridge"></span>
+      <div class="front">
+        <span class="hole"></span>
+        <div class="birdb">
+          <span class="wingb"></span>
+          <span class="eyeb"></span>
+          <span class="beakb"></span>
+        </div>
+        <span class="perch"></span>
+      </div>
+      <span class="hanger"></span>
+    </div>
+    <span class="leafb lb1"></span>
+    <span class="leafb lb2"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/birdhouse-as/style.css
+++ b/submissions/examples/birdhouse-as/style.css
@@ -1,0 +1,199 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 24%, #cfeafc, #8cc0dd 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 320px;
+}
+
+.branchb {
+  position: absolute;
+  top: 30px;
+  left: -20px;
+  right: -20px;
+  height: 16px;
+  border-radius: 8px;
+  background: linear-gradient(180deg, #8a5a34, #4f3018);
+  z-index: 1;
+}
+
+.leafb {
+  position: absolute;
+  width: 44px;
+  height: 22px;
+  border-radius: 60% 10% 60% 10%;
+  background: linear-gradient(160deg, #63c451, #2f7a2a);
+  z-index: 2;
+}
+
+.lb1 { top: 40px; left: 40px; transform: rotate(18deg); }
+.lb2 { top: 42px; right: 46px; transform: rotate(-18deg) scaleX(-1); }
+
+.hanger {
+  position: absolute;
+  top: -26px;
+  left: 50%;
+  width: 5px;
+  height: 30px;
+  margin-left: -2.5px;
+  background: #7a5230;
+  z-index: 1;
+}
+
+.house {
+  position: absolute;
+  top: 72px;
+  left: 50%;
+  width: 190px;
+  height: 190px;
+  margin-left: -95px;
+  transform-origin: 50% -20%;
+  animation: swayh 5s ease-in-out infinite;
+  z-index: 3;
+}
+
+.roof {
+  position: absolute;
+  top: 4px;
+  left: 50%;
+  width: 190px;
+  height: 62px;
+  margin-left: -95px;
+  clip-path: polygon(50% 0, 100% 100%, 0 100%);
+  background: linear-gradient(180deg, #e0603a, #a13618);
+  filter: drop-shadow(0 5px 6px rgba(0, 0, 0, 0.28));
+  z-index: 5;
+}
+
+.ridge {
+  position: absolute;
+  top: -4px;
+  left: 50%;
+  width: 16px;
+  height: 16px;
+  margin-left: -8px;
+  border-radius: 50%;
+  background: #8c2f14;
+  z-index: 6;
+}
+
+.front {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 140px;
+  height: 130px;
+  margin-left: -70px;
+  border-radius: 6px;
+  background:
+    repeating-linear-gradient(90deg, #d9a05e 0 22px, #c08a48 22px 24px);
+  box-shadow:
+    inset 0 4px 6px rgba(255, 235, 200, 0.5),
+    0 12px 24px rgba(0, 0, 0, 0.28);
+  z-index: 4;
+  overflow: hidden;
+}
+
+.hole {
+  position: absolute;
+  top: 26px;
+  left: 50%;
+  width: 62px;
+  height: 62px;
+  margin-left: -31px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 30%, #4a3218, #1c1208 74%);
+  box-shadow: inset 0 4px 8px rgba(0, 0, 0, 0.7);
+  z-index: 5;
+}
+
+.birdb {
+  position: absolute;
+  top: 40px;
+  left: 50%;
+  width: 46px;
+  height: 46px;
+  margin-left: -23px;
+  border-radius: 50% 50% 46% 46%;
+  background: radial-gradient(circle at 36% 30%, #ffe07a, #e0a018 74%);
+  z-index: 6;
+  animation: peek 4s ease-in-out infinite;
+}
+
+.eyeb {
+  position: absolute;
+  top: 14px;
+  left: 12px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #2f2312;
+  box-shadow: 14px 0 0 #2f2312;
+}
+
+.beakb {
+  position: absolute;
+  top: 24px;
+  left: 50%;
+  width: 14px;
+  height: 10px;
+  margin-left: -7px;
+  clip-path: polygon(50% 100%, 0 0, 100% 0);
+  background: #e07a1a;
+}
+
+.wingb {
+  position: absolute;
+  top: 20px;
+  right: -4px;
+  width: 20px;
+  height: 16px;
+  border-radius: 50% 40% 50% 40%;
+  background: #d9931a;
+  transform-origin: left center;
+  animation: flapb 0.6s ease-in-out infinite alternate;
+}
+
+.perch {
+  position: absolute;
+  top: 96px;
+  left: 50%;
+  width: 10px;
+  height: 30px;
+  margin-left: -5px;
+  border-radius: 5px;
+  background: linear-gradient(90deg, #a3703f, #6d4523);
+  z-index: 6;
+}
+
+@keyframes peek {
+  0%, 30%, 100% { transform: translateY(34px); }
+  50%, 80% { transform: translateY(0); }
+}
+
+@keyframes flapb {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(-26deg); }
+}
+
+@keyframes swayh {
+  0%, 100% { transform: rotate(-1.6deg); }
+  50% { transform: rotate(1.6deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .house,
+  .birdb,
+  .wingb {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a birdhouse built for #44873. The bird hides because the front panel clips it with overflow hidden, so the peek animation translates it down out of sight and back up into the hole, making it pop out of the house rather than fade in. Reduced motion fallback included. Pure CSS. Closes #44873.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a wooden birdhouse with a red peaked roof hanging from a leafy branch, with a yellow bird peeking out of the entrance hole.
