### PR TITLE
feat: add magnet

### DIFF
--- a/submissions/examples/magnet-as/README.md
+++ b/submissions/examples/magnet-as/README.md
@@ -1,0 +1,22 @@
+# Magnet
+
+### What does this do?
+
+It shows a horseshoe magnet with iron filings scattered below it. Hovering or focusing the magnet energizes it: the field lines appear and pulse between the poles, and the filings snap upward and rotate to align themselves with the field. It works with no JavaScript. Under reduced motion the filings snap without easing.
+
+### How is it used?
+
+```html
+<div class="magnet" tabindex="0">
+  <span class="arc"></span>
+  <span class="polen"></span>
+  <span class="field fd1"></span>
+  <span class="filing fg1"></span>
+</div>
+```
+
+The horseshoe is one element: a circle with a thick border and a transparent bottom edge, which leaves exactly the U shape. The field lines reuse the same trick at larger radii with a dashed border. Each filing gets its own `transform` on hover, translating toward the nearest pole and rotating to lie along the field, so the scatter resolves into a coherent pattern rather than every piece moving the same way.
+
+### Why is it useful?
+
+Science, attraction, and "pull" or magnetism metaphors use a magnet. This builds an interactive magnet with pure CSS shapes and transitions, no images or JavaScript, with a reduced motion fallback.

--- a/submissions/examples/magnet-as/demo.html
+++ b/submissions/examples/magnet-as/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Magnet</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="magnet" tabindex="0">
+      <span class="arc"></span>
+      <span class="polen"></span>
+      <span class="poles"></span>
+      <span class="field fd1"></span>
+      <span class="field fd2"></span>
+      <span class="field fd3"></span>
+      <span class="filing fg1"></span>
+      <span class="filing fg2"></span>
+      <span class="filing fg3"></span>
+      <span class="filing fg4"></span>
+      <span class="filing fg5"></span>
+      <span class="filing fg6"></span>
+    </div>
+    <p class="hint">hover to energize</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/magnet-as/style.css
+++ b/submissions/examples/magnet-as/style.css
@@ -1,0 +1,187 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 24%, #2c3444, #101520 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  display: grid;
+  justify-items: center;
+  gap: 16px;
+}
+
+.magnet {
+  position: relative;
+  width: 260px;
+  height: 260px;
+  outline: none;
+}
+
+.arc {
+  position: absolute;
+  top: 26px;
+  left: 50%;
+  width: 180px;
+  height: 92px;
+  margin-left: -90px;
+  border: 44px solid #c9392b;
+  border-bottom: none;
+  border-radius: 90px 90px 0 0;
+  box-sizing: border-box;
+  box-shadow: inset 0 6px 8px rgba(255, 180, 170, 0.35);
+  z-index: 3;
+}
+
+.arc::before,
+.arc::after {
+  content: "";
+  position: absolute;
+  bottom: -66px;
+  width: 44px;
+  height: 66px;
+  background: #c9392b;
+  box-shadow: inset 0 0 6px rgba(120, 20, 10, 0.3);
+}
+
+.arc::before { left: -44px; }
+.arc::after { right: -44px; }
+
+.polen,
+.poles {
+  position: absolute;
+  top: 156px;
+  width: 44px;
+  height: 62px;
+  background: linear-gradient(180deg, #d8dee6, #9aa3ad);
+  box-shadow: inset 0 3px 5px rgba(255, 255, 255, 0.6);
+  z-index: 4;
+}
+
+.polen {
+  left: 50%;
+  margin-left: -90px;
+  border-radius: 0 0 6px 6px;
+}
+
+.poles {
+  left: 50%;
+  margin-left: 46px;
+  border-radius: 0 0 6px 6px;
+}
+
+.polen::after,
+.poles::after {
+  content: "N";
+  position: absolute;
+  bottom: 6px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 20px;
+  font-weight: 700;
+  color: #414b57;
+}
+
+.poles::after {
+  content: "S";
+}
+
+.field {
+  position: absolute;
+  top: 172px;
+  left: 50%;
+  border-radius: 50%;
+  border: 2px dashed rgba(120, 200, 255, 0.75);
+  border-bottom-color: transparent;
+  opacity: 0;
+  z-index: 2;
+  transition: opacity 0.4s ease;
+}
+
+.fd1 {
+  width: 150px;
+  height: 90px;
+  margin-left: -75px;
+}
+
+.fd2 {
+  width: 196px;
+  height: 124px;
+  margin-left: -98px;
+  top: 158px;
+}
+
+.fd3 {
+  width: 244px;
+  height: 160px;
+  margin-left: -122px;
+  top: 142px;
+}
+
+.filing {
+  position: absolute;
+  width: 14px;
+  height: 4px;
+  border-radius: 2px;
+  background: #8d99a8;
+  z-index: 5;
+  transition: transform 0.6s cubic-bezier(0.34, 1.3, 0.5, 1);
+}
+
+.fg1 { top: 244px; left: 22px; }
+.fg2 { top: 250px; left: 76px; }
+.fg3 { top: 246px; left: 124px; }
+.fg4 { top: 252px; left: 168px; }
+.fg5 { top: 244px; left: 212px; }
+.fg6 { top: 250px; left: 244px; }
+
+.magnet:hover .field,
+.magnet:focus .field {
+  opacity: 1;
+  animation: pulsem 1.6s ease-in-out infinite;
+}
+
+.magnet:hover .fg1,
+.magnet:focus .fg1 { transform: translate(24px, -34px) rotate(52deg); }
+
+.magnet:hover .fg2,
+.magnet:focus .fg2 { transform: translate(6px, -30px) rotate(78deg); }
+
+.magnet:hover .fg3,
+.magnet:focus .fg3 { transform: translate(-8px, -26px) rotate(96deg); }
+
+.magnet:hover .fg4,
+.magnet:focus .fg4 { transform: translate(4px, -28px) rotate(-96deg); }
+
+.magnet:hover .fg5,
+.magnet:focus .fg5 { transform: translate(-16px, -32px) rotate(-74deg); }
+
+.magnet:hover .fg6,
+.magnet:focus .fg6 { transform: translate(-38px, -36px) rotate(-50deg); }
+
+.hint {
+  margin: 0;
+  color: #8b96ad;
+  font-size: 0.85rem;
+}
+
+@keyframes pulsem {
+  0%, 100% { opacity: 0.55; }
+  50% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .filing {
+    transition: none;
+  }
+
+  .magnet:hover .field,
+  .magnet:focus .field {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a magnet built for #44888. The horseshoe is a thick bottomless border arch with two legs, and on hover each filing gets its own translate and rotate so the scatter resolves into a coherent field pattern rather than every piece moving alike. Reduced motion fallback included. Pure CSS. Closes #44888.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot of the energized state: a red horseshoe magnet with N and S pole faces, dashed field lines between the poles, and iron filings pulled up and aligned.
