### PR TITLE
feat: add Glitter Loader component (closes #41451)

### DIFF
--- a/submissions/examples/glitter-loader-pp/README.md
+++ b/submissions/examples/glitter-loader-pp/README.md
@@ -1,0 +1,90 @@
+# Glitter Loader
+
+A polished, SaaS-dashboard inspired loading component for EaseMotion CSS, built with pure CSS (no JavaScript).
+
+## Required Questions
+
+1. **What does this do?**
+   It provides a set of five reusable, glitter-themed loading indicators (ring, burst, shimmer bar, orb, and grid) that communicate an in-progress state with a premium, polished motion feel.
+
+2. **How is it used?**
+   Drop the relevant class onto a container element and add the expected child markup. Examples:
+
+   ```html
+   <!-- Rotating glitter ring -->
+   <div class="glitter-ring" role="status" aria-label="Loading">
+     <span class="core">LOAD</span>
+   </div>
+
+   <!-- Radial sparkle burst -->
+   <div class="glitter-burst" role="status" aria-label="Loading">
+     <span></span><span></span><span></span><span></span>
+     <span></span><span></span><span></span><span></span>
+   </div>
+
+   <!-- Indeterminate shimmer bar -->
+   <div class="glitter-shimmer" role="progressbar" aria-label="Loading progress"></div>
+
+   <!-- Breathing orb with floating specks -->
+   <div class="glitter-orb" role="status" aria-label="Loading">
+     <span class="orb"></span>
+     <span></span><span></span><span></span><span></span>
+   </div>
+
+   <!-- Twinkling dot grid -->
+   <div class="glitter-grid" role="status" aria-label="Loading">
+     <span></span> <!-- repeat 25 times -->
+   </div>
+   ```
+
+3. **Why is it useful?**
+   Loaders are among the most commonly needed UI elements. A well-crafted Glitter variant gives contributors a polished, drop-in building block that follows EaseMotion's motion-first philosophy, uses framework-style variables and keyframes, and stays accessible and responsive without any JavaScript.
+
+## Features
+
+- **Five distinct variants** — ring, burst, shimmer bar, orb, and grid — covering different loading contexts (full-screen, inline, progress, data tables).
+- **Pure CSS** — no JavaScript, no external libraries, no CDN dependencies.
+- **Responsive** — sizes are driven by CSS custom properties and scale gracefully.
+- **Accessible** — uses `role="status"` / `role="progressbar"`, `aria-label`, and a visually-hidden helper; honors `prefers-reduced-motion`.
+- **Themeable** — all colors and speeds are exposed as CSS variables so the maintainer can swap in `--ease-color-*` and `--ease-speed-*` tokens.
+- **Self-contained** — `demo.html` works by opening directly in a browser.
+
+## Variants Overview
+
+| Variant | Best for | Motion |
+|---------|----------|--------|
+| `.glitter-ring` | Buttons / cards while fetching | Rotating conic ring + comet spark |
+| `.glitter-burst` | Center-of-screen loading | Radial sparkle pulse |
+| `.glitter-shimmer` | Indeterminate progress | Sliding glitter sweep |
+| `.glitter-orb` | Hero / splash loading | Breathing orb + floating specks |
+| `.glitter-grid` | Data / table loading | Staggered twinkle grid |
+
+## Accessibility Notes
+
+- Each loader exposes an ARIA role and label so screen readers announce the loading state.
+- A `.sr-only` paragraph provides a human-readable fallback message.
+- Under `prefers-reduced-motion: reduce`, all animations are neutralized to a static, visible state.
+
+## Customization
+
+Override the CSS variables defined at the top of `style.css`:
+
+```css
+.glitter-ring {
+  --size: 120px;   /* larger ring */
+  --thick: 10px;   /* thicker stroke */
+}
+```
+
+Or change the palette globally:
+
+```css
+:root {
+  --glit-accent: #ff7ad9;
+  --glit-accent-2: #7afcff;
+}
+```
+
+## How to Preview
+
+Open `demo.html` directly in any modern browser — no build step or server required.

--- a/submissions/examples/glitter-loader-pp/demo.html
+++ b/submissions/examples/glitter-loader-pp/demo.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Glitter Loader — EaseMotion CSS Submission</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+
+<body>
+
+  <header>
+    <h1 class="page-title">Glitter Loader</h1>
+    <p class="page-subtitle">
+      A polished, SaaS-dashboard inspired loading component built with pure CSS.
+      Five glitter variants, fully responsive, accessible, and JavaScript-free.
+    </p>
+  </header>
+
+  <main class="gallery">
+
+    <!-- VARIANT 1: Glitter Ring -->
+    <section class="card">
+      <h2>Glitter Ring</h2>
+      <div class="glitter-ring" role="status" aria-label="Loading">
+        <span class="core">LOAD</span>
+      </div>
+      <p class="hint">Rotating conic ring with a sparkling comet trail.</p>
+      <p class="sr-only">Content is loading, please wait.</p>
+    </section>
+
+    <!-- VARIANT 2: Glitter Burst -->
+    <section class="card">
+      <h2>Glitter Burst</h2>
+      <div class="glitter-burst" role="status" aria-label="Loading">
+        <span></span><span></span><span></span><span></span>
+        <span></span><span></span><span></span><span></span>
+      </div>
+      <p class="hint">Radial sparkle dots pulsing outward from center.</p>
+      <p class="sr-only">Content is loading, please wait.</p>
+    </section>
+
+    <!-- VARIANT 3: Glitter Shimmer -->
+    <section class="card">
+      <h2>Glitter Shimmer</h2>
+      <div class="glitter-shimmer" role="progressbar" aria-label="Loading progress"></div>
+      <p class="hint">Indeterminate progress bar with a glittering sweep.</p>
+      <p class="sr-only">Loading in progress.</p>
+    </section>
+
+    <!-- VARIANT 4: Glitter Orb -->
+    <section class="card">
+      <h2>Glitter Orb</h2>
+      <div class="glitter-orb" role="status" aria-label="Loading">
+        <span class="orb"></span>
+        <span></span><span></span><span></span><span></span>
+      </div>
+      <p class="hint">Breathing orb with floating glitter specks.</p>
+      <p class="sr-only">Content is loading, please wait.</p>
+    </section>
+
+    <!-- VARIANT 5: Glitter Grid -->
+    <section class="card">
+      <h2>Glitter Grid</h2>
+      <div class="glitter-grid" role="status" aria-label="Loading">
+        <span></span><span></span><span></span><span></span><span></span>
+        <span></span><span></span><span></span><span></span><span></span>
+        <span></span><span></span><span></span><span></span><span></span>
+        <span></span><span></span><span></span><span></span><span></span>
+        <span></span><span></span><span></span><span></span><span></span>
+      </div>
+      <p class="hint">Staggered twinkling dot grid for data-loading states.</p>
+      <p class="sr-only">Content is loading, please wait.</p>
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/glitter-loader-pp/style.css
+++ b/submissions/examples/glitter-loader-pp/style.css
@@ -1,0 +1,426 @@
+/* =========================================================================
+   Glitter Loader — submissions/examples/glitter-loader-pp/style.css
+   -------------------------------------------------------------------------
+   A polished, SaaS-dashboard inspired loading component built with pure CSS.
+   No JavaScript. No external dependencies. Uses EaseMotion-style variables
+   and keyframes so the maintainer can standardize it into the framework.
+
+   This file intentionally does NOT use the `ease-` prefix. The maintainer
+   will rename classes and swap hard-coded values for CSS variables.
+
+   Variants included:
+     1. .glitter-ring        — rotating ring with sparkling trail
+     2. .glitter-burst       — radial sparkle dots that pulse outward
+     3. .glitter-shimmer     — indeterminate progress bar with glitter sweep
+     4. .glitter-orb         — breathing orb with floating glitter specks
+     5. .glitter-grid        — staggered twinkling dot grid
+   ========================================================================= */
+
+:root {
+  /* Motion tokens (mirror EaseMotion conventions) */
+  --glit-speed-fast: 0.8s;
+  --glit-speed-med: 1.4s;
+  --glit-speed-slow: 2.4s;
+
+  --glit-ease-bounce: cubic-bezier(0.68, -0.55, 0.27, 1.55);
+  --glit-ease-smooth: cubic-bezier(0.22, 1, 0.36, 1);
+  --glit-ease-in-out: cubic-bezier(0.45, 0, 0.55, 1);
+
+  /* Palette (will be replaced by --ease-color-* by maintainer) */
+  --glit-bg: #0b1020;
+  --glit-surface: #141b33;
+  --glit-accent: #7c5cff;
+  --glit-accent-2: #22d3ee;
+  --glit-accent-3: #f472b6;
+  --glit-spark: #fff7d6;
+  --glit-text: #e6e9f5;
+  --glit-muted: #8b93b5;
+}
+
+/* -------------------------------------------------------------------------
+   Base page styling (demo only — not part of the component contract)
+   ------------------------------------------------------------------------- */
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Segoe UI", system-ui, -apple-system, Arial, sans-serif;
+  background:
+    radial-gradient(1200px 600px at 20% -10%, rgba(124, 92, 255, 0.18), transparent 60%),
+    radial-gradient(900px 500px at 100% 0%, rgba(34, 211, 238, 0.14), transparent 55%),
+    var(--glit-bg);
+  color: var(--glit-text);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 48px 20px 80px;
+}
+
+.page-title {
+  font-size: clamp(1.6rem, 4vw, 2.4rem);
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  margin: 0 0 6px;
+  background: linear-gradient(90deg, var(--glit-accent), var(--glit-accent-2), var(--glit-accent-3));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.page-subtitle {
+  margin: 0 0 40px;
+  color: var(--glit-muted);
+  font-size: 0.95rem;
+  max-width: 560px;
+  text-align: center;
+  line-height: 1.5;
+}
+
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 28px;
+  width: 100%;
+  max-width: 1080px;
+}
+
+.card {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.01));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  padding: 28px 20px 22px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(6px);
+}
+
+.card h2 {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--glit-text);
+  letter-spacing: 0.3px;
+}
+
+.card .hint {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--glit-muted);
+  text-align: center;
+  line-height: 1.4;
+}
+
+/* =========================================================================
+   VARIANT 1 — Glitter Ring
+   A rotating conic ring with a sparkling comet trail.
+   ========================================================================= */
+.glitter-ring {
+  --size: 96px;
+  --thick: 8px;
+  position: relative;
+  width: var(--size);
+  height: var(--size);
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+}
+
+.glitter-ring::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: conic-gradient(
+    from 0deg,
+    transparent 0deg,
+    var(--glit-accent) 60deg,
+    var(--glit-accent-2) 120deg,
+    var(--glit-spark) 150deg,
+    transparent 200deg,
+    transparent 360deg
+  );
+  -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - var(--thick)), #000 calc(100% - var(--thick)));
+  mask: radial-gradient(farthest-side, transparent calc(100% - var(--thick)), #000 calc(100% - var(--thick)));
+  animation: glit-ring-spin var(--glit-speed-med) linear infinite;
+}
+
+.glitter-ring::after {
+  content: "";
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--glit-spark);
+  box-shadow: 0 0 12px 4px rgba(255, 247, 214, 0.8);
+  top: 4px;
+  left: 50%;
+  transform: translateX(-50%);
+  animation: glit-ring-spin var(--glit-speed-med) linear infinite;
+}
+
+.glitter-ring .core {
+  width: calc(var(--size) - var(--thick) * 3);
+  height: calc(var(--size) - var(--thick) * 3);
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, rgba(255, 255, 255, 0.18), rgba(124, 92, 255, 0.12));
+  display: grid;
+  place-items: center;
+  font-size: 0.7rem;
+  color: var(--glit-muted);
+  letter-spacing: 1px;
+}
+
+@keyframes glit-ring-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* =========================================================================
+   VARIANT 2 — Glitter Burst
+   Radial sparkle dots that pulse outward from the center.
+   ========================================================================= */
+.glitter-burst {
+  --size: 96px;
+  position: relative;
+  width: var(--size);
+  height: var(--size);
+  display: grid;
+  place-items: center;
+}
+
+.glitter-burst span {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 10px;
+  height: 10px;
+  margin: -5px 0 0 -5px;
+  border-radius: 50%;
+  background: var(--glit-spark);
+  box-shadow: 0 0 10px 2px rgba(255, 247, 214, 0.7);
+  opacity: 0;
+  animation: glit-burst var(--glit-speed-med) var(--glit-ease-out, ease-out) infinite;
+}
+
+.glitter-burst span:nth-child(1) { --angle: 0deg;   background: var(--glit-accent); }
+.glitter-burst span:nth-child(2) { --angle: 45deg;  background: var(--glit-accent-2); }
+.glitter-burst span:nth-child(3) { --angle: 90deg;  background: var(--glit-accent-3); }
+.glitter-burst span:nth-child(4) { --angle: 135deg; background: var(--glit-accent); }
+.glitter-burst span:nth-child(5) { --angle: 180deg; background: var(--glit-accent-2); }
+.glitter-burst span:nth-child(6) { --angle: 225deg; background: var(--glit-accent-3); }
+.glitter-burst span:nth-child(7) { --angle: 270deg; background: var(--glit-accent); }
+.glitter-burst span:nth-child(8) { --angle: 315deg; background: var(--glit-accent-2); }
+
+.glitter-burst span:nth-child(2) { animation-delay: 0.12s; }
+.glitter-burst span:nth-child(3) { animation-delay: 0.24s; }
+.glitter-burst span:nth-child(4) { animation-delay: 0.36s; }
+.glitter-burst span:nth-child(5) { animation-delay: 0.48s; }
+.glitter-burst span:nth-child(6) { animation-delay: 0.60s; }
+.glitter-burst span:nth-child(7) { animation-delay: 0.72s; }
+.glitter-burst span:nth-child(8) { animation-delay: 0.84s; }
+
+@keyframes glit-burst {
+  0% {
+    transform: rotate(var(--angle)) translateX(0) scale(0.4);
+    opacity: 0;
+  }
+  20% {
+    opacity: 1;
+  }
+  100% {
+    transform: rotate(var(--angle)) translateX(38px) scale(1);
+    opacity: 0;
+  }
+}
+
+/* =========================================================================
+   VARIANT 3 — Glitter Shimmer (indeterminate bar)
+   A progress bar with a glittering light sweep.
+   ========================================================================= */
+.glitter-shimmer {
+  --w: 220px;
+  --h: 12px;
+  position: relative;
+  width: var(--w);
+  height: var(--h);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.glitter-shimmer::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: 40%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, transparent, var(--glit-accent), var(--glit-accent-2), transparent);
+  animation: glit-shimmer-slide var(--glit-speed-med) var(--glit-ease-in-out) infinite;
+}
+
+.glitter-shimmer::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    radial-gradient(2px 2px at 20% 50%, var(--glit-spark), transparent),
+    radial-gradient(2px 2px at 50% 50%, var(--glit-spark), transparent),
+    radial-gradient(2px 2px at 80% 50%, var(--glit-spark), transparent);
+  background-repeat: no-repeat;
+  opacity: 0.9;
+  animation: glit-shimmer-twinkle var(--glit-speed-fast) steps(1) infinite;
+}
+
+@keyframes glit-shimmer-slide {
+  0%   { transform: translateX(-120%); }
+  100% { transform: translateX(320%); }
+}
+
+@keyframes glit-shimmer-twinkle {
+  0%, 100% { opacity: 0.25; }
+  50%      { opacity: 1; }
+}
+
+/* =========================================================================
+   VARIANT 4 — Glitter Orb
+   A breathing orb with floating glitter specks around it.
+   ========================================================================= */
+.glitter-orb {
+  --size: 96px;
+  position: relative;
+  width: var(--size);
+  height: var(--size);
+  display: grid;
+  place-items: center;
+}
+
+.glitter-orb .orb {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, #fff, var(--glit-accent) 55%, var(--glit-accent-2));
+  box-shadow: 0 0 24px 6px rgba(124, 92, 255, 0.55);
+  animation: glit-orb-breathe var(--glit-speed-slow) var(--glit-ease-smooth) infinite;
+}
+
+.glitter-orb span {
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--glit-spark);
+  box-shadow: 0 0 8px 2px rgba(255, 247, 214, 0.8);
+  opacity: 0;
+  animation: glit-orb-float var(--glit-speed-slow) var(--glit-ease-smooth) infinite;
+}
+
+.glitter-orb span:nth-child(2) { --ox: -34px; --oy: -10px; animation-delay: 0.2s; }
+.glitter-orb span:nth-child(3) { --ox: 30px;  --oy: -22px; animation-delay: 0.5s; }
+.glitter-orb span:nth-child(4) { --ox: 36px;  --oy: 18px;  animation-delay: 0.8s; }
+.glitter-orb span:nth-child(5) { --ox: -28px; --oy: 24px;  animation-delay: 1.1s; }
+
+@keyframes glit-orb-breathe {
+  0%, 100% { transform: scale(0.92); }
+  50%      { transform: scale(1.08); }
+}
+
+@keyframes glit-orb-float {
+  0%   { transform: translate(0, 0) scale(0.6); opacity: 0; }
+  30%  { opacity: 1; }
+  100% { transform: translate(var(--ox), var(--oy)) scale(1); opacity: 0; }
+}
+
+/* =========================================================================
+   VARIANT 5 — Glitter Grid
+   A staggered twinkling dot grid (great for "loading data" states).
+   ========================================================================= */
+.glitter-grid {
+  --cols: 5;
+  display: grid;
+  grid-template-columns: repeat(var(--cols), 12px);
+  gap: 10px;
+}
+
+.glitter-grid span {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  background: var(--glit-accent-2);
+  opacity: 0.25;
+  animation: glit-grid-twinkle var(--glit-speed-med) var(--glit-ease-in-out) infinite;
+}
+
+.glitter-grid span:nth-child(1)  { animation-delay: 0.00s; }
+.glitter-grid span:nth-child(2)  { animation-delay: 0.08s; }
+.glitter-grid span:nth-child(3)  { animation-delay: 0.16s; }
+.glitter-grid span:nth-child(4)  { animation-delay: 0.24s; }
+.glitter-grid span:nth-child(5)  { animation-delay: 0.32s; }
+.glitter-grid span:nth-child(6)  { animation-delay: 0.10s; }
+.glitter-grid span:nth-child(7)  { animation-delay: 0.18s; }
+.glitter-grid span:nth-child(8)  { animation-delay: 0.26s; }
+.glitter-grid span:nth-child(9)  { animation-delay: 0.34s; }
+.glitter-grid span:nth-child(10) { animation-delay: 0.42s; }
+.glitter-grid span:nth-child(11) { animation-delay: 0.20s; }
+.glitter-grid span:nth-child(12) { animation-delay: 0.28s; }
+.glitter-grid span:nth-child(13) { animation-delay: 0.36s; }
+.glitter-grid span:nth-child(14) { animation-delay: 0.44s; }
+.glitter-grid span:nth-child(15) { animation-delay: 0.52s; }
+.glitter-grid span:nth-child(16) { animation-delay: 0.30s; }
+.glitter-grid span:nth-child(17) { animation-delay: 0.38s; }
+.glitter-grid span:nth-child(18) { animation-delay: 0.46s; }
+.glitter-grid span:nth-child(19) { animation-delay: 0.54s; }
+.glitter-grid span:nth-child(20) { animation-delay: 0.62s; }
+.glitter-grid span:nth-child(21) { animation-delay: 0.40s; }
+.glitter-grid span:nth-child(22) { animation-delay: 0.48s; }
+.glitter-grid span:nth-child(23) { animation-delay: 0.56s; }
+.glitter-grid span:nth-child(24) { animation-delay: 0.64s; }
+.glitter-grid span:nth-child(25) { animation-delay: 0.72s; }
+
+@keyframes glit-grid-twinkle {
+  0%, 100% { opacity: 0.2; transform: scale(0.8); }
+  50%      { opacity: 1; transform: scale(1.1); box-shadow: 0 0 10px 2px rgba(34, 211, 238, 0.6); }
+}
+
+/* =========================================================================
+   Accessibility — respect reduced motion preferences
+   ========================================================================= */
+@media (prefers-reduced-motion: reduce) {
+  .glitter-ring::before,
+  .glitter-ring::after,
+  .glitter-burst span,
+  .glitter-shimmer::before,
+  .glitter-shimmer::after,
+  .glitter-orb .orb,
+  .glitter-orb span,
+  .glitter-grid span {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+  }
+
+  .glitter-ring::before { opacity: 0.9; }
+  .glitter-burst span { opacity: 0.6; }
+  .glitter-shimmer::before { width: 100%; transform: none; }
+  .glitter-orb .orb { transform: scale(1); }
+  .glitter-grid span { opacity: 0.7; }
+}
+
+/* Visually-hidden helper for screen-reader text */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
Closes #41451. Adds a pure-CSS SaaS-style Glitter Loader with 5 variants (ring, burst, shimmer bar, orb, grid). Self-contained in submissions/examples/glitter-loader-pp/ with demo.html, style.css, README.md (~595 lines). Responsive, accessible, reduced-motion aware, no JS, no edits to core files.