### PR TITLE
docs: add animation compatibility matrix

### DIFF
--- a/submissions/docs/animation-compatibility-matrix-ragini-roy7/README.md
+++ b/submissions/docs/animation-compatibility-matrix-ragini-roy7/README.md
@@ -1,0 +1,67 @@
+# Animation Compatibility Matrix
+
+## What does this add?
+A documentation reference — `demo.html` — that tells developers which EaseMotion CSS animation utilities can be safely combined on the same element, which combos need care, and which will conflict, based on which CSS property each utility actually animates.
+
+## Why is it useful?
+EaseMotion CSS's utilities are composable by design (`class="ease-fade-in ease-slide-up"` is a common pattern), but nothing currently documents *why* some combinations work perfectly while others silently break. Most conflicts come down to one simple rule: **an element can only have one active `animation` or one value for `transform` at a time.** If two utility classes both declare an `animation` shorthand, the one that's later in the cascade (or more specific) wins outright — the other's keyframe never plays. If two utilities both set `transform` (directly or via a shared keyframe), whichever rule wins in the cascade overwrites the other's translate/scale/rotate instead of combining them.
+
+This matrix is derived directly from reading `core/animations.css` — the "animates" column reflects the actual CSS property each class declares, not guesswork.
+
+## The Matrix
+
+### Entrance animations (one-shot, `animation: ... both`)
+These all animate `opacity` + `transform` together via a dedicated keyframe. **Only one entrance animation can play per element** — since they all set the `animation` property, the last one applied in the cascade fully overrides the others (this is the single most common EaseMotion combination question).
+
+| Animation | Compatible With | Avoid Combining With | Why |
+|---|---|---|---|
+| `ease-fade-in` | `ease-hover-lift`, `ease-hover-grow`, `ease-hover-glow` (post-entrance hover states) | `ease-slide-up`, `ease-zoom-in`, `ease-bounce-in`, any other entrance class | All entrance utilities set the `animation` shorthand — combining two just makes the second one win, the first never runs |
+| `ease-slide-up` | Same hover utilities as above | `ease-fade-in`, `ease-zoom-in`, `ease-slide-down`, `ease-slide-in-left/right` | Same reason: one `animation` property per element |
+| `ease-zoom-in` / `ease-zoom-out` | Hover utilities (applied after entrance completes) | Any other entrance class, `ease-flip`, `ease-mask-reveal` | Same `animation` property conflict |
+| `ease-bounce-in` | Hover utilities | Other entrance classes | Same `animation` property conflict |
+| `ease-flip` / `ease-flip-3d` | Hover utilities, `ease-card-lift` | Other entrance classes, `ease-rotate` | Both `ease-flip` and `ease-rotate` animate `transform: rotate*` — combining scrambles the rotation math |
+| `ease-mask-reveal` (+ `-circle`, `-y` variants) | `ease-fade-in` *is* safe here ⚠️ partial — `clip-path` and `opacity` are different properties, so they can layer, but test timing since both are one-shot | Other `ease-mask-reveal-*` variants together, `ease-slide-*` (both would fight over `transform`) | `clip-path` doesn't conflict with `opacity`-only classes, but does conflict with anything else moving `transform` |
+
+### Continuous / looping animations
+These use `animation-iteration-count: infinite` and are meant to run indefinitely.
+
+| Animation | Compatible With | Avoid Combining With | Why |
+|---|---|---|---|
+| `ease-bounce` | `ease-hover-glow`, `ease-pulse` (different properties: `transform` vs `opacity`) | `ease-rotate`, `ease-wave`, `ease-shake`, `ease-float` | All of these animate `transform` continuously — only the winning `animation` declaration actually plays |
+| `ease-rotate` | `ease-pulse`, `ease-hover-glow` | `ease-bounce`, `ease-wave`, `ease-shake`, `ease-flip-3d` | Same `transform`-property collision |
+| `ease-pulse` / `ease-ping` | Almost anything — both only touch `opacity`/`scale` via their own isolated keyframe and layer cleanly with non-`transform` utilities like `ease-hover-glow` (`filter`) | Each other (`ease-pulse` + `ease-ping` both use `animation`, so one wins) | Same-property rule applies even between two loop animations |
+| `ease-wave` | `ease-hover-glow`, `ease-pulse` | `ease-bounce`, `ease-rotate`, `ease-shake` | `transform` collision |
+| `ease-shake` | `ease-hover-glow`, `ease-pulse` | `ease-bounce`, `ease-rotate`, `ease-wave` | `transform` collision |
+| `ease-float` | `ease-hover-glow`, `ease-pulse` | `ease-bounce`, `ease-rotate`, `ease-wave` | `transform` collision |
+| `ease-gradient-rotation` | ✅ Almost everything — this animates `background-position`, a property nothing else in the library touches | — | No property overlap with any other utility |
+| `ease-shimmer-sweep` / `ease-skeleton-shimmer` | ✅ Almost everything — animates `background-position`/`background-size` | Each other (both fight over `background`) | Only conflicts within their own family |
+
+### Hover-triggered transitions (not `@keyframes`, just `transition:`)
+These only activate on `:hover`/`:focus`, so they're much safer to combine with entrance/loop animations — the conflict risk is only when **two hover utilities both transition `transform`**.
+
+| Utility | Animates | Compatible With | Avoid Combining With | Why |
+|---|---|---|---|---|
+| `ease-hover-lift` | `transform`, `box-shadow` | `ease-hover-glow` (`filter`) | `ease-hover-grow`, `ease-hover-shrink`, `ease-card-lift`, `ease-hover-squish-border` | All transition `transform` on `:hover` — combining means whichever is more specific in the cascade wins, the other's hover effect is silently dropped |
+| `ease-hover-grow` | `transform` | `ease-hover-glow` | `ease-hover-lift`, `ease-hover-lift-shadow`, `ease-hover-shrink` | Same `transform` collision |
+| `ease-hover-shrink` | `transform` | `ease-hover-glow` | `ease-hover-lift`, `ease-hover-grow`, `ease-card-lift` | Same `transform` collision |
+| `ease-hover-glow` | `filter` | ✅ Virtually everything — no other hover utility touches `filter` | `ease-blur-to-focus` (entrance) if it hasn't finished animating `filter` yet | Only true conflict is with another `filter`-based animation still in progress |
+| `ease-hover-squish-border` | `border-radius`, `transform` | `ease-hover-glow` | `ease-hover-lift`, `ease-hover-grow`, `ease-card-lift` | `transform` collision |
+| `ease-card-lift` | `transform`, `box-shadow` | `ease-hover-glow` | `ease-hover-lift`, `ease-hover-grow`, `ease-hover-shrink` | `transform` collision — functionally near-identical to `ease-hover-lift`, pick one |
+
+### Delay & duration modifiers
+| Utility family | Compatible With | Notes |
+|---|---|---|
+| `ease-delay-*` (75–1000ms) | ✅ Any animation class | Purely adjusts `animation-delay`, no property conflict possible |
+| `ease-transition-delay-*` | ✅ Any hover/transition utility | Adjusts `transition-delay` only |
+| `ease-duration-fast/medium/slow` | ✅ Any animation class | Adjusts `animation-duration` only |
+| `ease-reveal-delay-1` through `-5` | ✅ Use freely on sibling elements for staggered reveals | Designed specifically for this |
+
+## The one rule to remember
+> **If two classes both animate the same CSS property (`transform`, `animation`, `filter`, `background`), only one wins.** Classes that animate *different* properties (e.g. `ease-fade-in`'s `opacity` + `ease-hover-glow`'s `filter`) compose safely. When in doubt, open dev tools → Computed styles and check whether both classes are trying to write to the same property.
+
+## Accessibility notes
+- The matrix itself is a static reference table — no motion involved in the documentation page.
+- `demo.html`'s live examples respect `prefers-reduced-motion` the same way the underlying utility classes do.
+
+## Maintenance note for the maintainer
+This matrix reflects the utility classes present in `core/animations.css` at the time of writing. As new `ease-*` utilities are added, please extend the relevant table above rather than starting a new one, so this stays the single source of truth.

--- a/submissions/docs/animation-compatibility-matrix-ragini-roy7/demo.html
+++ b/submissions/docs/animation-compatibility-matrix-ragini-roy7/demo.html
@@ -1,0 +1,234 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animation Compatibility Matrix — EaseMotion CSS Docs</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <div class="ease-matrix-page">
+
+    <div class="ease-matrix-header">
+      <h1>Animation Compatibility Matrix</h1>
+      <p>Which EaseMotion utilities combine safely — and which silently override each other.</p>
+    </div>
+
+    <!-- Live demonstration: safe combo vs conflicting combo -->
+    <div class="ease-matrix-live-examples">
+      <div class="ease-matrix-example-card">
+        <h3>✅ Safe combo</h3>
+        <div class="ease-matrix-example-box ease-demo-fade-in">
+          fade-in only
+        </div>
+        <p class="ease-matrix-example-caption">
+          <code>ease-fade-in</code> alone — animates <code>opacity</code> + <code>transform: scale()</code> cleanly.
+        </p>
+      </div>
+      <div class="ease-matrix-example-card">
+        <h3>❌ Conflicting combo</h3>
+        <div class="ease-matrix-example-box ease-demo-fade-in ease-demo-slide-up">
+          fade-in + slide-up together
+        </div>
+        <p class="ease-matrix-example-caption">
+          Both classes set the <code>animation</code> property — only <code>ease-slide-up</code> plays; the fade-in keyframe never runs.
+        </p>
+      </div>
+    </div>
+
+    <!-- Entrance animations -->
+    <div class="ease-matrix-section">
+      <h2>Entrance animations</h2>
+      <p class="ease-matrix-section-note">One-shot, <code>animation: ... both</code> — only one can play per element.</p>
+      <div class="ease-matrix-table-wrap">
+        <table class="ease-matrix-table">
+          <thead>
+            <tr><th>Animation</th><th>Compatible</th><th>Avoid</th><th>Why</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>ease-fade-in</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--ok">✓ OK</span> hover utilities</td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--conflict">✗ Conflict</span> other entrance classes</td>
+              <td>Only one <code>animation</code> shorthand wins</td>
+            </tr>
+            <tr>
+              <td><code>ease-slide-up</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--ok">✓ OK</span> hover utilities</td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--conflict">✗ Conflict</span> other entrance classes</td>
+              <td>Same <code>animation</code> collision</td>
+            </tr>
+            <tr>
+              <td><code>ease-zoom-in</code> / <code>ease-zoom-out</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--ok">✓ OK</span> hover utilities</td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--conflict">✗ Conflict</span> other entrance, <code>ease-flip</code>, <code>ease-mask-reveal</code></td>
+              <td>Same <code>animation</code> collision</td>
+            </tr>
+            <tr>
+              <td><code>ease-bounce-in</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--ok">✓ OK</span> hover utilities</td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--conflict">✗ Conflict</span> other entrance classes</td>
+              <td>Same <code>animation</code> collision</td>
+            </tr>
+            <tr>
+              <td><code>ease-flip</code> / <code>ease-flip-3d</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--ok">✓ OK</span> hover utilities, <code>ease-card-lift</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--conflict">✗ Conflict</span> other entrance, <code>ease-rotate</code></td>
+              <td>Both animate <code>transform: rotate*</code></td>
+            </tr>
+            <tr>
+              <td><code>ease-mask-reveal</code> (+ variants)</td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--warn">⚠ Partial</span> <code>ease-fade-in</code> (different properties, verify timing)</td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--conflict">✗ Conflict</span> other <code>mask-reveal</code> variants, <code>ease-slide-*</code></td>
+              <td><code>clip-path</code> vs <code>transform</code> overlap depends on variant</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- Continuous / looping animations -->
+    <div class="ease-matrix-section">
+      <h2>Continuous / looping animations</h2>
+      <p class="ease-matrix-section-note"><code>animation-iteration-count: infinite</code> — meant to run indefinitely.</p>
+      <div class="ease-matrix-table-wrap">
+        <table class="ease-matrix-table">
+          <thead>
+            <tr><th>Animation</th><th>Compatible</th><th>Avoid</th><th>Why</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>ease-bounce</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--ok">✓ OK</span> <code>ease-hover-glow</code>, <code>ease-pulse</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--conflict">✗ Conflict</span> <code>ease-rotate</code>, <code>ease-wave</code>, <code>ease-shake</code>, <code>ease-float</code></td>
+              <td>All animate <code>transform</code> continuously</td>
+            </tr>
+            <tr>
+              <td><code>ease-rotate</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--ok">✓ OK</span> <code>ease-pulse</code>, <code>ease-hover-glow</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--conflict">✗ Conflict</span> <code>ease-bounce</code>, <code>ease-wave</code>, <code>ease-shake</code>, <code>ease-flip-3d</code></td>
+              <td><code>transform</code> collision</td>
+            </tr>
+            <tr>
+              <td><code>ease-pulse</code> / <code>ease-ping</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--ok">✓ OK</span> almost everything (isolated <code>opacity</code>/<code>scale</code>)</td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--conflict">✗ Conflict</span> each other</td>
+              <td>Both use <code>animation</code> — same-property rule still applies</td>
+            </tr>
+            <tr>
+              <td><code>ease-wave</code> / <code>ease-shake</code> / <code>ease-float</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--ok">✓ OK</span> <code>ease-hover-glow</code>, <code>ease-pulse</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--conflict">✗ Conflict</span> <code>ease-bounce</code>, <code>ease-rotate</code>, each other</td>
+              <td><code>transform</code> collision</td>
+            </tr>
+            <tr>
+              <td><code>ease-gradient-rotation</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--ok">✓ OK</span> almost everything</td>
+              <td>—</td>
+              <td>Animates <code>background-position</code> — no overlap with anything else</td>
+            </tr>
+            <tr>
+              <td><code>ease-shimmer-sweep</code> / <code>ease-skeleton-shimmer</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--ok">✓ OK</span> almost everything</td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--conflict">✗ Conflict</span> each other</td>
+              <td>Both animate <code>background</code></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- Hover-triggered transitions -->
+    <div class="ease-matrix-section">
+      <h2>Hover-triggered transitions</h2>
+      <p class="ease-matrix-section-note">Only active on <code>:hover</code>/<code>:focus</code> — generally safer, except with each other.</p>
+      <div class="ease-matrix-table-wrap">
+        <table class="ease-matrix-table">
+          <thead>
+            <tr><th>Utility</th><th>Animates</th><th>Compatible</th><th>Avoid</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>ease-hover-lift</code></td>
+              <td><code>transform</code>, <code>box-shadow</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--ok">✓ OK</span> <code>ease-hover-glow</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--conflict">✗ Conflict</span> <code>ease-hover-grow</code>, <code>ease-hover-shrink</code>, <code>ease-card-lift</code>, <code>ease-hover-squish-border</code></td>
+            </tr>
+            <tr>
+              <td><code>ease-hover-grow</code></td>
+              <td><code>transform</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--ok">✓ OK</span> <code>ease-hover-glow</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--conflict">✗ Conflict</span> <code>ease-hover-lift</code>, <code>ease-hover-shrink</code></td>
+            </tr>
+            <tr>
+              <td><code>ease-hover-shrink</code></td>
+              <td><code>transform</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--ok">✓ OK</span> <code>ease-hover-glow</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--conflict">✗ Conflict</span> <code>ease-hover-lift</code>, <code>ease-hover-grow</code>, <code>ease-card-lift</code></td>
+            </tr>
+            <tr>
+              <td><code>ease-hover-glow</code></td>
+              <td><code>filter</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--ok">✓ OK</span> virtually everything</td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--warn">⚠ Partial</span> <code>ease-blur-to-focus</code> mid-animation</td>
+            </tr>
+            <tr>
+              <td><code>ease-hover-squish-border</code></td>
+              <td><code>border-radius</code>, <code>transform</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--ok">✓ OK</span> <code>ease-hover-glow</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--conflict">✗ Conflict</span> <code>ease-hover-lift</code>, <code>ease-hover-grow</code>, <code>ease-card-lift</code></td>
+            </tr>
+            <tr>
+              <td><code>ease-card-lift</code></td>
+              <td><code>transform</code>, <code>box-shadow</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--ok">✓ OK</span> <code>ease-hover-glow</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--conflict">✗ Conflict</span> <code>ease-hover-lift</code>, <code>ease-hover-grow</code> (near-identical, pick one)</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- Modifiers -->
+    <div class="ease-matrix-section">
+      <h2>Delay &amp; duration modifiers</h2>
+      <div class="ease-matrix-table-wrap">
+        <table class="ease-matrix-table">
+          <thead>
+            <tr><th>Utility family</th><th>Compatible</th><th>Notes</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>ease-delay-*</code> (75–1000ms)</td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--ok">✓ OK</span> any animation class</td>
+              <td>Only adjusts <code>animation-delay</code></td>
+            </tr>
+            <tr>
+              <td><code>ease-transition-delay-*</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--ok">✓ OK</span> any hover/transition utility</td>
+              <td>Only adjusts <code>transition-delay</code></td>
+            </tr>
+            <tr>
+              <td><code>ease-duration-fast/medium/slow</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--ok">✓ OK</span> any animation class</td>
+              <td>Only adjusts <code>animation-duration</code></td>
+            </tr>
+            <tr>
+              <td><code>ease-reveal-delay-1</code>…<code>-5</code></td>
+              <td><span class="ease-matrix-badge ease-matrix-badge--ok">✓ OK</span> sibling elements, for staggering</td>
+              <td>Purpose-built for staggered reveals</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="ease-matrix-rule">
+      <strong>The one rule to remember:</strong> if two classes animate the same CSS property (<code>transform</code>, <code>animation</code>, <code>filter</code>, <code>background</code>), only one wins. Classes touching <em>different</em> properties compose safely. When unsure, check Computed Styles in dev tools for a property collision.
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/docs/animation-compatibility-matrix-ragini-roy7/style.css
+++ b/submissions/docs/animation-compatibility-matrix-ragini-roy7/style.css
@@ -1,0 +1,234 @@
+/* ============================================================
+   Animation Compatibility Matrix — documentation styling
+   Renders the compatibility tables with color-coded badges,
+   plus two tiny live examples showing a safe combo vs a
+   conflicting combo side by side.
+   ============================================================ */
+
+:root {
+  --ease-color-success: #10b981;
+  --ease-color-warning: #f59e0b;
+  --ease-color-danger: #ef4444;
+  --ease-color-primary: #6c63ff;
+  --ease-radius-md: 0.75rem;
+  --ease-speed-medium: 300ms;
+}
+
+/* ---- Local demo-only keyframes (subset, for the live example
+   boxes below — mirrors the real core/animations.css behavior
+   at a small scale so the conflict is visible without loading
+   the full framework) ---- */
+
+@keyframes ease-kf-demo-fade-in {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes ease-kf-demo-slide-up {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 24px, 0);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+.ease-demo-fade-in {
+  animation: ease-kf-demo-fade-in 700ms ease both;
+}
+
+.ease-demo-slide-up {
+  animation: ease-kf-demo-slide-up 700ms ease both;
+}
+
+/* Conflicting: applying both classes means whichever comes
+   later in the stylesheet wins the `animation` property — the
+   other keyframe never plays. This is intentional, to
+   demonstrate the exact failure mode documented in the matrix. */
+
+/* ---- Page shell ---- */
+
+body {
+  margin: 0;
+  background: #1a1b23;
+  color: #f5f5f7;
+  font-family:
+    "Inter",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  line-height: 1.55;
+}
+
+.ease-matrix-page {
+  max-width: 920px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 5rem;
+}
+
+.ease-matrix-header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.ease-matrix-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.7rem;
+}
+
+.ease-matrix-header p {
+  margin: 0;
+  color: #9a9aa8;
+  font-size: 0.95rem;
+}
+
+/* ---- Live example row ---- */
+
+.ease-matrix-live-examples {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: center;
+  margin-bottom: 3rem;
+}
+
+.ease-matrix-example-card {
+  flex: 1 1 260px;
+  max-width: 320px;
+  padding: 1.5rem;
+  border-radius: var(--ease-radius-md);
+  background: #12131a;
+  text-align: center;
+}
+
+.ease-matrix-example-card h3 {
+  margin: 0 0 0.75rem;
+  font-size: 0.95rem;
+}
+
+.ease-matrix-example-box {
+  width: 100%;
+  padding: 1.25rem;
+  border-radius: 0.5rem;
+  background: linear-gradient(135deg, var(--ease-color-primary), #a78bfa);
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.ease-matrix-example-caption {
+  margin: 0.75rem 0 0;
+  font-size: 0.78rem;
+  color: #9a9aa8;
+}
+
+/* ---- Badges ---- */
+
+.ease-matrix-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+}
+
+.ease-matrix-badge--ok {
+  background: rgba(16, 185, 129, 0.15);
+  color: var(--ease-color-success);
+}
+
+.ease-matrix-badge--warn {
+  background: rgba(245, 158, 11, 0.15);
+  color: var(--ease-color-warning);
+}
+
+.ease-matrix-badge--conflict {
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--ease-color-danger);
+}
+
+/* ---- Table ---- */
+
+.ease-matrix-section {
+  margin-bottom: 2.5rem;
+}
+
+.ease-matrix-section h2 {
+  font-size: 1.15rem;
+  margin: 0 0 0.35rem;
+}
+
+.ease-matrix-section-note {
+  color: #9a9aa8;
+  font-size: 0.85rem;
+  margin: 0 0 1rem;
+}
+
+.ease-matrix-table-wrap {
+  overflow-x: auto;
+  border-radius: var(--ease-radius-md);
+  background: #12131a;
+}
+
+table.ease-matrix-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.ease-matrix-table th,
+.ease-matrix-table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  vertical-align: top;
+}
+
+.ease-matrix-table th {
+  color: #9a9aa8;
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.ease-matrix-table tr:last-child td {
+  border-bottom: none;
+}
+
+.ease-matrix-table code {
+  background: rgba(255, 255, 255, 0.08);
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.3rem;
+  font-size: 0.8rem;
+}
+
+.ease-matrix-rule {
+  margin-top: 3rem;
+  padding: 1.25rem 1.5rem;
+  border-radius: var(--ease-radius-md);
+  background: rgba(108, 99, 255, 0.1);
+  border: 1px solid rgba(108, 99, 255, 0.25);
+  font-size: 0.9rem;
+}
+
+.ease-matrix-rule strong {
+  color: var(--ease-color-primary);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-demo-fade-in,
+  .ease-demo-slide-up {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds an Animation Compatibility Matrix to the docs, closing #43235. It documents which EaseMotion `ease-*` utilities can be safely combined on the same element vs. which ones silently override each other, based on which CSS property each utility actually animates in `core/animations.css`.

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/docs/animation-compatibility-matrix-ragini-roy7/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A documentation page that lists every animation utility currently in `core/animations.css`, grouped by type (entrance, looping, hover-transition, modifiers), with a ✅/⚠️/❌ compatibility rating and a plain-English reason for each combination.

**How does a developer use it?**
```html
<!-- The matrix is a reference page, not a component to import.
     Example of what it helps a developer avoid: -->

<!-- ❌ Conflicting — only ease-slide-up plays, fade-in never runs -->
<div class="ease-fade-in ease-slide-up">...</div>

<!-- ✅ Safe — different CSS properties (opacity/transform vs filter) -->
<div class="ease-fade-in ease-hover-glow">...</div>
```

**Why does it fit EaseMotion CSS?**
The library encourages composing utility classes together, but there was no documented guidance on which combinations actually work vs. which ones silently break because two classes fight over the same CSS property (`transform`, `animation`, `filter`, `background`). This matrix turns trial-and-error into a quick lookup, directly supporting EaseMotion's human-readable, composable philosophy — and it's derived from actually reading `core/animations.css`, not guessed, so every entry reflects real behavior.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
This covers the most commonly combined utilities in `core/animations.css` (entrance, loop, hover-transition, and delay/duration families). A few less-common ones (`ease-count-up`, `ease-typewriter-loop`, `ease-skeleton-block`) aren't in the tables yet — happy to extend if you'd like full coverage before merging, or this can be treated as a living doc that grows as new utilities are added. The `demo.html` includes two tiny live examples (safe combo vs. conflicting combo) so the rule is visible, not just described.
