### PR TITLE
Add swan component

### DIFF
--- a/submissions/examples/swan-as/README.md
+++ b/submissions/examples/swan-as/README.md
@@ -1,0 +1,24 @@
+# Swan
+
+### What does this do?
+
+It shows a swan gliding across a lake with its reflection shimmering in the water beneath it. The swan drifts from side to side, preens its wing now and then, blinks, and ripples spread from where it sits on the surface. Under reduced motion the swan holds still.
+
+### How is it used?
+
+```html
+<div class="glide">
+  <div class="swan">
+    <span class="bodys2"></span>
+    <span class="necks"></span>
+    <span class="beaks"></span>
+  </div>
+  <div class="mirror">...</div>
+</div>
+```
+
+The reflection is the same markup again inside a `mirror` wrapper that is flipped with `scaleY(-0.72)`, faded, and blurred. Squashing it rather than mirroring it exactly is what sells the foreshortening of a reflection on water. Because both copies sit inside one `glide` wrapper, the swan and its reflection always drift in perfect lockstep. The beak's black base and orange bill come from one hard-stop gradient.
+
+### Why is it useful?
+
+Lake, elegance, and calm or grace themes use a swan. This builds a gliding swan with a live reflection in pure CSS, no images, with a reduced motion fallback.

--- a/submissions/examples/swan-as/demo.html
+++ b/submissions/examples/swan-as/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Swan</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="glide">
+      <div class="swan">
+        <span class="tails"></span>
+        <span class="bodys2"></span>
+        <span class="wings2"></span>
+        <span class="necks"></span>
+        <span class="heads2"></span>
+        <span class="eyes2"></span>
+        <span class="beaks"></span>
+      </div>
+      <div class="mirror">
+        <span class="tails"></span>
+        <span class="bodys2"></span>
+        <span class="necks"></span>
+        <span class="heads2"></span>
+        <span class="beaks"></span>
+      </div>
+    </div>
+    <span class="ripples rp1"></span>
+    <span class="ripples rp2"></span>
+    <span class="lake"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/swan-as/style.css
+++ b/submissions/examples/swan-as/style.css
@@ -1,0 +1,202 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #cfe4f2, #93bdd8 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 320px;
+  overflow: hidden;
+  border-radius: 18px;
+  background: linear-gradient(180deg, #dcecf7, #a5cbe0 62%);
+  box-shadow: 0 24px 48px rgba(40, 80, 110, 0.3);
+}
+
+.lake {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 132px;
+  background: linear-gradient(#5fa8ce, #2f7ba6);
+  z-index: 2;
+}
+
+.lake::after {
+  content: "";
+  position: absolute;
+  top: 10px;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.45) 0 26px, transparent 26px 52px);
+}
+
+.glide {
+  position: absolute;
+  bottom: 108px;
+  left: 50%;
+  width: 190px;
+  height: 150px;
+  margin-left: -95px;
+  z-index: 3;
+  animation: driftS 6s ease-in-out infinite;
+}
+
+.swan,
+.mirror {
+  position: absolute;
+  left: 0;
+  width: 190px;
+  height: 130px;
+}
+
+.swan { bottom: 0; }
+
+.mirror {
+  top: 128px;
+  transform: scaleY(-0.72);
+  opacity: 0.3;
+  filter: blur(1.5px);
+  z-index: 1;
+}
+
+.bodys2 {
+  position: absolute;
+  bottom: 0;
+  left: 22px;
+  width: 140px;
+  height: 60px;
+  border-radius: 50% 50% 46% 46% / 70% 70% 30% 30%;
+  background: linear-gradient(180deg, #ffffff, #dae3ea 76%);
+  box-shadow: inset 0 -5px 10px rgba(150, 165, 180, 0.4);
+  z-index: 2;
+}
+
+.wings2 {
+  position: absolute;
+  bottom: 14px;
+  left: 44px;
+  width: 96px;
+  height: 46px;
+  border-radius: 60% 40% 50% 40% / 70% 60% 40% 30%;
+  background: linear-gradient(180deg, #fbfdff, #cdd8e2);
+  box-shadow: inset 0 -3px 6px rgba(140, 155, 170, 0.35);
+  transform-origin: 20% 80%;
+  z-index: 3;
+  animation: preen 5s ease-in-out infinite;
+}
+
+.tails {
+  position: absolute;
+  bottom: 22px;
+  left: 0;
+  width: 44px;
+  height: 32px;
+  clip-path: polygon(100% 20%, 0 0, 22% 50%, 0 100%);
+  background: linear-gradient(160deg, #ffffff, #d3dde6);
+  z-index: 1;
+}
+
+.necks {
+  position: absolute;
+  bottom: 40px;
+  right: 30px;
+  width: 22px;
+  height: 78px;
+  border-radius: 11px 11px 40% 40%;
+  background: linear-gradient(90deg, #ffffff, #dfe7ee);
+  transform: rotate(-14deg);
+  transform-origin: bottom center;
+  z-index: 2;
+}
+
+.heads2 {
+  position: absolute;
+  top: 4px;
+  right: 12px;
+  width: 40px;
+  height: 34px;
+  border-radius: 50% 50% 40% 50%;
+  background: linear-gradient(160deg, #ffffff, #e4ebf1);
+  z-index: 4;
+}
+
+.eyes2 {
+  position: absolute;
+  top: 14px;
+  right: 20px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #22303c;
+  z-index: 6;
+  animation: blinks2 4.5s ease-in-out infinite;
+}
+
+.beaks {
+  position: absolute;
+  top: 16px;
+  right: -12px;
+  width: 30px;
+  height: 14px;
+  clip-path: polygon(0 0, 100% 40%, 100% 66%, 0 100%);
+  background: linear-gradient(90deg, #2b2a2e 0 22%, #f0872b 24%);
+  z-index: 5;
+}
+
+.ripples {
+  position: absolute;
+  left: 50%;
+  width: 150px;
+  height: 18px;
+  margin-left: -75px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  opacity: 0;
+  z-index: 4;
+  animation: spreads 3.6s ease-out infinite;
+}
+
+.rp1 { bottom: 100px; }
+.rp2 { bottom: 100px; animation-delay: 1.8s; }
+
+@keyframes driftS {
+  0%, 100% { transform: translateX(-14px) translateY(0); }
+  50% { transform: translateX(14px) translateY(-4px); }
+}
+
+@keyframes preen {
+  0%, 78%, 100% { transform: rotate(0deg); }
+  88% { transform: rotate(-9deg); }
+}
+
+@keyframes blinks2 {
+  0%, 92%, 100% { transform: scaleY(1); }
+  96% { transform: scaleY(0.1); }
+}
+
+@keyframes spreads {
+  0% { transform: scale(0.4); opacity: 0.75; }
+  100% { transform: scale(1.7); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glide,
+  .wings2,
+  .eyes2,
+  .ripples {
+    animation: none;
+  }
+
+  .ripples {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a swan built for #44961. The reflection is the same markup flipped with scaleY(-0.72), faded and blurred, so squashing rather than exactly mirroring sells the foreshortening on water, and both copies live in one wrapper so they drift in lockstep. Reduced motion fallback included. Pure CSS. Closes #44961.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a white swan with an orange beak gliding on a lake, with a squashed blurred reflection beneath it and ripples at the waterline.
