### PR TITLE
Add lotus component

### DIFF
--- a/submissions/examples/lotus-as/README.md
+++ b/submissions/examples/lotus-as/README.md
@@ -1,0 +1,23 @@
+# Lotus
+
+### What does this do?
+
+It shows a lotus flower closed as a bud on a pond. Hovering or focusing it makes the flower bloom: nineteen petals across three rings sweep open, the outer ring reaching furthest and the inner ring barely parting, revealing the golden heart. It works with no JavaScript. Under reduced motion the flower opens without easing.
+
+### How is it used?
+
+```html
+<div class="lotus" tabindex="0">
+  <div class="bloom">
+    <span class="petl o po1"></span>
+    <span class="petl m pm1"></span>
+    <span class="heart"></span>
+  </div>
+</div>
+```
+
+Every petal stores its angle around the flower in a `--pa` custom property and transforms as `rotate(var(--pa)) translateY(...)` — rotating first, then pushing outward, so one value both aims the petal and sets it on its ring. Closed, all three rings are pulled in and scaled down so they nest into a bud; on `:hover` each ring translates out by a different distance, which is what gives the bloom its layered depth rather than a flat fan.
+
+### Why is it useful?
+
+Calm, wellness, and reveal or "open up" interactions use a lotus. This builds a blooming lotus with pure CSS shapes, custom properties, and transitions, no images or JavaScript, with a reduced motion fallback.

--- a/submissions/examples/lotus-as/demo.html
+++ b/submissions/examples/lotus-as/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Lotus</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="pad pd1"></span>
+    <span class="pad pd2"></span>
+    <div class="lotus" tabindex="0">
+      <div class="bloom">
+        <span class="petl o po1"></span>
+        <span class="petl o po2"></span>
+        <span class="petl o po3"></span>
+        <span class="petl o po4"></span>
+        <span class="petl o po5"></span>
+        <span class="petl o po6"></span>
+        <span class="petl o po7"></span>
+        <span class="petl o po8"></span>
+        <span class="petl m pm1"></span>
+        <span class="petl m pm2"></span>
+        <span class="petl m pm3"></span>
+        <span class="petl m pm4"></span>
+        <span class="petl m pm5"></span>
+        <span class="petl m pm6"></span>
+        <span class="petl i pi1"></span>
+        <span class="petl i pi2"></span>
+        <span class="petl i pi3"></span>
+        <span class="petl i pi4"></span>
+        <span class="petl i pi5"></span>
+        <span class="heart"></span>
+      </div>
+    </div>
+    <span class="ripplel rl1"></span>
+    <span class="ripplel rl2"></span>
+    <span class="pond"></span>
+    <p class="hint">hover to bloom</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/lotus-as/style.css
+++ b/submissions/examples/lotus-as/style.css
@@ -1,0 +1,198 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 24%, #cfe9e4, #6fa8a0 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 320px;
+  display: grid;
+  place-items: center;
+  gap: 14px;
+}
+
+.pond {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 110px);
+  background: linear-gradient(#4fa8ae 0 110px, #23707a 110px);
+  z-index: 1;
+}
+
+.pad {
+  position: absolute;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 34%, #5bb85f, #2c7a3c 76%);
+  z-index: 2;
+}
+
+.pad::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 45%;
+  height: 3px;
+  background: rgba(20, 70, 30, 0.4);
+  transform: rotate(28deg);
+}
+
+.pd1 { bottom: 70px; left: 26px; width: 88px; height: 34px; }
+.pd2 { bottom: 58px; right: 22px; width: 70px; height: 28px; }
+
+.lotus {
+  position: relative;
+  width: 240px;
+  height: 240px;
+  display: grid;
+  place-items: center;
+  outline: none;
+  z-index: 4;
+  animation: floatl 5s ease-in-out infinite;
+}
+
+.bloom {
+  position: relative;
+  width: 0;
+  height: 0;
+}
+
+.petl {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  border-radius: 50% 50% 40% 40% / 62% 62% 38% 38%;
+  transform-origin: 50% 100%;
+  transition: transform 0.7s cubic-bezier(0.34, 1.28, 0.5, 1);
+}
+
+.o {
+  width: 40px;
+  height: 96px;
+  margin: 0 0 0 -20px;
+  background: linear-gradient(180deg, #ffd7ea, #ef7ab0 82%);
+  transform: rotate(var(--pa, 0deg)) translateY(-16px) scale(0.5);
+  z-index: 1;
+}
+
+.m {
+  width: 34px;
+  height: 76px;
+  margin: 0 0 0 -17px;
+  background: linear-gradient(180deg, #ffe6f2, #f492c1 82%);
+  transform: rotate(var(--pa, 0deg)) translateY(-12px) scale(0.5);
+  z-index: 2;
+}
+
+.i {
+  width: 26px;
+  height: 56px;
+  margin: 0 0 0 -13px;
+  background: linear-gradient(180deg, #fff3f8, #f9b3d4 82%);
+  transform: rotate(var(--pa, 0deg)) translateY(-8px) scale(0.5);
+  z-index: 3;
+}
+
+.po1 { --pa: 0deg; }
+.po2 { --pa: 45deg; }
+.po3 { --pa: 90deg; }
+.po4 { --pa: 135deg; }
+.po5 { --pa: 180deg; }
+.po6 { --pa: 225deg; }
+.po7 { --pa: 270deg; }
+.po8 { --pa: 315deg; }
+.pm1 { --pa: 30deg; }
+.pm2 { --pa: 90deg; }
+.pm3 { --pa: 150deg; }
+.pm4 { --pa: 210deg; }
+.pm5 { --pa: 270deg; }
+.pm6 { --pa: 330deg; }
+.pi1 { --pa: 36deg; }
+.pi2 { --pa: 108deg; }
+.pi3 { --pa: 180deg; }
+.pi4 { --pa: 252deg; }
+.pi5 { --pa: 324deg; }
+
+.heart {
+  position: absolute;
+  top: -18px;
+  left: -18px;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #ffe89a, #d9a52a 74%);
+  box-shadow: 0 0 14px rgba(240, 200, 90, 0.8);
+  z-index: 4;
+}
+
+.lotus:hover .o,
+.lotus:focus .o {
+  transform: rotate(var(--pa, 0deg)) translateY(-62px) scale(1);
+}
+
+.lotus:hover .m,
+.lotus:focus .m {
+  transform: rotate(var(--pa, 0deg)) translateY(-46px) scale(1);
+}
+
+.lotus:hover .i,
+.lotus:focus .i {
+  transform: rotate(var(--pa, 0deg)) translateY(-30px) scale(1);
+}
+
+.ripplel {
+  position: absolute;
+  bottom: 84px;
+  left: 50%;
+  width: 130px;
+  height: 20px;
+  margin-left: -65px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  opacity: 0;
+  z-index: 3;
+  animation: spreadl 3.4s ease-out infinite;
+}
+
+.rl2 { animation-delay: 1.7s; }
+
+.hint {
+  margin: 0;
+  color: #1f5a58;
+  font-size: 0.85rem;
+  z-index: 5;
+}
+
+@keyframes floatl {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-8px); }
+}
+
+@keyframes spreadl {
+  0% { transform: scale(0.4); opacity: 0.75; }
+  100% { transform: scale(1.7); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lotus,
+  .ripplel {
+    animation: none;
+  }
+
+  .petl {
+    transition: none;
+  }
+
+  .ripplel {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a lotus built for #44978. Each petal holds its ring angle in a custom property and rotates before translating outward, so one value aims it and places it; closed, all three rings pull in and scale down to nest as a bud, and on hover each ring travels a different distance which gives the bloom layered depth rather than a flat fan. Reduced motion fallback included. Pure CSS. Closes #44978.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot of the hovered state: a pink lotus bloomed open with three layered rings of petals around a golden heart, on a pond with lily pads.
