### PR TITLE
Fix #44668: Implement CSS variable architecture for class composition

### DIFF
--- a/submissions/examples/easemotion-composition/README.md
+++ b/submissions/examples/easemotion-composition/README.md
@@ -1,0 +1,15 @@
+# Fix: EaseMotion Class Composition Conflict
+
+## Description
+This submission fixes issue #44668, where applying multiple `ease-` animation utility classes to a single element caused only the last declared animation to execute. 
+
+The original codebase used the `animation` shorthand property inside each class, causing the CSS cascade to completely overwrite previous animation definitions.
+
+## The Solution
+Instead of splitting properties (which still suffers from cascade overwrites) or using structural wrapper nesting, this fix introduces **CSS Custom Properties (Variables)**. 
+
+A base attribute selector prepares the element to listen for multiple independent animation layers. The individual utility classes then safely activate their specific animation variables without wiping out others.
+
+## How to Test
+1. Open `demo.html` in any modern browser.
+2. Observe the composite element: it will smoothly fade in **and** slide up simultaneously.

--- a/submissions/examples/easemotion-composition/demo.html
+++ b/submissions/examples/easemotion-composition/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion Composition Fix Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- The fix allows these two classes to run together smoothly on one element -->
+  <div class="card ease-fade-in ease-slide-up">
+    <h2>It Works! 🎉</h2>
+    <p>This element is successfully fading in and sliding up at the exact same time.</p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/easemotion-composition/style.css
+++ b/submissions/examples/easemotion-composition/style.css
@@ -1,0 +1,55 @@
+/* ==========================================
+   FIX CORE: EaseMotion Variable Architecture
+   ========================================== */
+
+/* Base hook for any element using an EaseMotion utility class */
+[class*="ease-"] {
+  /* Pre-define multiple animation tracks using safe comma separation.
+     They fall back to 'none' until explicitly turned on by a utility class. */
+  animation: 
+    var(--ease-fade-name, none) var(--ease-fade-dur, 0.5s) var(--ease-fade-tf, ease) forwards,
+    var(--ease-slide-name, none) var(--ease-slide-dur, 0.5s) var(--ease-slide-tf, ease-out) forwards;
+}
+
+/* Utility Classes: Only assign variables, preventing cascade stomping */
+.ease-fade-in {
+  --ease-fade-name: fadeIn;
+}
+
+.ease-slide-up {
+  --ease-slide-name: slideUp;
+}
+
+/* ==========================================
+   KEYFRAMES & DEMO STYLING
+   ========================================== */
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes slideUp {
+  from { transform: translateY(30px); }
+  to { transform: translateY(0); }
+}
+
+/* Layout layout styles for the demo */
+body {
+  font-family: system-ui, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background-color: #f4f4f7;
+  margin: 0;
+}
+
+.card {
+  width: 300px;
+  padding: 24px;
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+  text-align: center;
+}


### PR DESCRIPTION
## 🎯 Purpose of this PR
This PR addresses issue #44668, where applying multiple `ease-` animation classes to a single element resulted in only the last declared animation playing. 

## 🛠️ Problem / Context
The previous codebase implementation relied heavily on the `animation` shorthand property inside individual utility classes. Because of the CSS cascade, applying two shorthand rules (e.g., `class="ease-fade-in ease-slide-up"`) caused the latter class to completely overwrite the former. Splitting properties (`animation-name`, `animation-duration`) would still result in cascade overwrites on the same element.

## 🚀 Solution Provided
I implemented a modern **CSS Custom Properties (Variables)** layered architecture within a dedicated submissions folder to demonstrate the fix without breaking backward compatibility:

1. **Base Attribute Setup:** Created a global attribute selector rule `[class*="ease-"]` that sets up multi-layered, comma-separated animation tracks defaulting to `none`.
2. **Atomic Utility Classes:** Refactored the utility classes to *only* update their specific custom variables instead of redefining the root `animation` shorthand. 
3. This allows multiple utility motion classes to be smoothly stacked and executed simultaneously on a single DOM element.

## 📂 Files Included
As per the repository guidelines, all implementation files are self-contained inside the `submissions/` directory:
* `submissions/fixes/easemotion-composition/README.md` — Overview of the bug and fix details.
* `submissions/fixes/easemotion-composition/style.css` — Core CSS architectural fix and demo keyframes.
* `submissions/fixes/easemotion-composition/demo.html` — Interactive proof-of-concept showing a card simultaneously fading in and sliding up.

## 🧪 How to Verify / Test
1. Clone or checkout this branch: `git checkout fix-easemotion-composition`
2. Navigate to `submissions/fixes/easemotion-composition/`
3. Launch `demo.html` in any modern web browser.
4. Verify that the card container correctly renders both the `fadeIn` and `slideUp` keyframe animations simultaneously.

Closes #44668