### PR TITLE
Add popcorn machine component

### DIFF
--- a/submissions/examples/popcorn-machine-as/README.md
+++ b/submissions/examples/popcorn-machine-as/README.md
@@ -1,0 +1,22 @@
+# Popcorn Machine
+
+### What does this do?
+
+It shows a red popcorn cart. Kernels pop out of the kettle one after another, arc through the air while tumbling, and drop into the pile below. The wheels roll. Under reduced motion the popping stops.
+
+### How is it used?
+
+```html
+<div class="cabin">
+  <span class="kettle"></span>
+  <span class="pile"></span>
+  <span class="kernel k1"></span>
+  <span class="kernel k2"></span>
+</div>
+```
+
+Every kernel shares one `popk` keyframe. What makes each arc different is two custom properties on the kernel itself: `--dx` for how far sideways it lands and `--kr` for how far it tumbles. The keyframe reads `translate(var(--dx), 66px) rotate(var(--kr))`, so one animation produces five distinct arcs instead of five near duplicate keyframe blocks. The popped pile is a stack of hard stop `radial-gradient` circles painted into one ellipse, so it clips to a mound for free.
+
+### Why is it useful?
+
+Cinema, carnival, and snack themes use a popcorn cart. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/popcorn-machine-as/demo.html
+++ b/submissions/examples/popcorn-machine-as/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Popcorn Machine</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="cart">
+      <div class="cabin">
+        <span class="stripes"></span>
+        <span class="glass"></span>
+        <span class="kettle"></span>
+        <span class="kbar"></span>
+        <span class="pile"></span>
+        <span class="kernel k1"></span>
+        <span class="kernel k2"></span>
+        <span class="kernel k3"></span>
+        <span class="kernel k4"></span>
+        <span class="kernel k5"></span>
+      </div>
+      <span class="sign">POPCORN</span>
+      <div class="base"></div>
+      <span class="wheelp wl"></span>
+      <span class="wheelp wr"></span>
+    </div>
+    <span class="floor"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/popcorn-machine-as/style.css
+++ b/submissions/examples/popcorn-machine-as/style.css
@@ -1,0 +1,254 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 34%, #2f3d5c, #131926 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 380px;
+}
+
+.cart {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  width: 240px;
+  height: 340px;
+  margin-left: -120px;
+}
+
+.cabin {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 240px;
+  height: 190px;
+  border-radius: 10px;
+  border: 7px solid #d3232a;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #fff6e6, #ffe9c8);
+  overflow: hidden;
+  z-index: 3;
+}
+
+.stripes {
+  position: absolute;
+  inset: 0;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(211, 35, 42, 0.12) 0 12px,
+      transparent 12px 24px
+    );
+}
+
+.glass {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background:
+    linear-gradient(115deg, rgba(255, 255, 255, 0.55) 0 26%, transparent 26% 40%),
+    linear-gradient(115deg, rgba(255, 255, 255, 0.3) 0 12%, transparent 12% 30%);
+  z-index: 6;
+  pointer-events: none;
+}
+
+.kettle {
+  position: absolute;
+  top: 24px;
+  left: 50%;
+  width: 84px;
+  height: 54px;
+  margin-left: -42px;
+  border-radius: 8px 8px 26px 26px;
+  background: linear-gradient(180deg, #97a3b4, #5a6779);
+  box-shadow: inset 0 -6px 10px rgba(0, 0, 0, 0.3);
+  z-index: 4;
+}
+
+.kbar {
+  position: absolute;
+  top: 16px;
+  left: 50%;
+  width: 120px;
+  height: 8px;
+  margin-left: -60px;
+  border-radius: 4px;
+  background: #444f5e;
+  z-index: 3;
+}
+
+.pile {
+  position: absolute;
+  bottom: -14px;
+  left: 50%;
+  width: 220px;
+  height: 74px;
+  margin-left: -110px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 20% 40%, #fffdf5 0 12px, #e6cf9e 12px 14px, transparent 14px),
+    radial-gradient(circle at 38% 22%, #fffdf5 0 14px, #e6cf9e 14px 16px, transparent 16px),
+    radial-gradient(circle at 56% 36%, #fffdf5 0 13px, #e6cf9e 13px 15px, transparent 15px),
+    radial-gradient(circle at 74% 24%, #fffdf5 0 12px, #e6cf9e 12px 14px, transparent 14px),
+    radial-gradient(circle at 88% 44%, #fffdf5 0 11px, #e6cf9e 11px 13px, transparent 13px),
+    radial-gradient(circle at 30% 60%, #fffdf5 0 14px, #e6cf9e 14px 16px, transparent 16px),
+    radial-gradient(circle at 66% 62%, #fffdf5 0 14px, #e6cf9e 14px 16px, transparent 16px),
+    radial-gradient(circle at 8% 62%, #fffdf5 0 12px, #e6cf9e 12px 14px, transparent 14px),
+    #f6e6c6;
+  z-index: 2;
+}
+
+.kernel {
+  position: absolute;
+  top: 60px;
+  left: 50%;
+  width: 20px;
+  height: 20px;
+  margin-left: -10px;
+  border-radius: 46% 54% 40% 60% / 52% 44% 56% 48%;
+  background: #fffdf5;
+  box-shadow:
+    -5px -3px 0 -1px #fff8e6,
+    5px -4px 0 -2px #fff8e6,
+    0 5px 0 -2px #fdf0d6;
+  z-index: 5;
+  opacity: 0;
+  animation: popk 2.4s ease-in-out infinite;
+}
+
+.k1 {
+  --dx: -66px;
+  --kr: -140deg;
+}
+
+.k2 {
+  --dx: -30px;
+  --kr: 120deg;
+
+  animation-delay: 0.5s;
+}
+
+.k3 {
+  --dx: 8px;
+  --kr: -80deg;
+
+  animation-delay: 1s;
+}
+
+.k4 {
+  --dx: 44px;
+  --kr: 160deg;
+
+  animation-delay: 1.5s;
+}
+
+.k5 {
+  --dx: 76px;
+  --kr: -190deg;
+
+  animation-delay: 2s;
+}
+
+.sign {
+  position: absolute;
+  top: 196px;
+  left: 50%;
+  width: 220px;
+  height: 34px;
+  margin-left: -110px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, #e33a3a, #b21c22);
+  color: #ffe9b8;
+  font-weight: 700;
+  font-size: 18px;
+  letter-spacing: 4px;
+  text-align: center;
+  line-height: 34px;
+  z-index: 4;
+}
+
+.base {
+  position: absolute;
+  top: 226px;
+  left: 50%;
+  width: 220px;
+  height: 78px;
+  margin-left: -110px;
+  border-radius: 6px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      #d3232a 0 18px,
+      #f6f1e6 18px 36px
+    );
+  z-index: 3;
+}
+
+.wheelp {
+  position: absolute;
+  top: 296px;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  border: 6px solid #2f3746;
+  box-sizing: border-box;
+  background:
+    repeating-conic-gradient(#8d97a6 0 12deg, #b9c2ce 12deg 24deg);
+  z-index: 2;
+  animation: rollp 4s linear infinite;
+}
+
+.wl { left: 16px; }
+.wr { right: 16px; }
+
+.floor {
+  position: absolute;
+  bottom: 22px;
+  left: -50vw;
+  right: -50vw;
+  height: 3px;
+  background: rgba(255, 255, 255, 0.14);
+}
+
+@keyframes popk {
+  0% { transform: translate(0, 0) scale(0.2) rotate(0deg); opacity: 0; }
+  12% { opacity: 1; }
+
+  45% {
+    transform: translate(calc(var(--dx, 0px) * 0.6), -34px) scale(1)
+      rotate(calc(var(--kr, 0deg) * 0.5));
+    opacity: 1;
+  }
+
+  95% { opacity: 1; }
+
+  100% {
+    transform: translate(var(--dx, 0px), 66px) scale(1) rotate(var(--kr, 0deg));
+    opacity: 0;
+  }
+}
+
+@keyframes rollp {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .kernel,
+  .wheelp {
+    animation: none;
+  }
+
+  .kernel {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a popcorn machine built for #44986. Every kernel shares one `popk` keyframe. What makes each arc different is two custom properties on the kernel itself, `--dx` for how far sideways it lands and `--kr` for how far it tumbles, which the keyframe reads inside `translate()` and `rotate()`. One animation therefore produces five distinct arcs instead of five near duplicate keyframe blocks. The popped pile is a stack of hard stop radial gradients painted into one ellipse, so it clips to a mound for free. Reduced motion fallback included. Pure CSS. Closes #44986.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a red and cream striped popcorn cart with a kettle, a mound of popped kernels behind the glass, a POPCORN sign, and rolling wheels.
