### PR TITLE
Add pretzel component

### DIFF
--- a/submissions/examples/pretzel-as/README.md
+++ b/submissions/examples/pretzel-as/README.md
@@ -1,0 +1,22 @@
+# Pretzel
+
+### What does this do?
+
+It shows a warm salted pretzel resting on a napkin. It bobs and tilts slowly, the salt crystals glint one after another, and steam drifts up off it. Under reduced motion it holds still.
+
+### How is it used?
+
+```html
+<div class="pretzel">
+  <span class="ring"></span>
+  <span class="arm al"></span>
+  <span class="arm ar"></span>
+  <span class="salt sa1"></span>
+</div>
+```
+
+The pretzel is a ring plus a crossed pair of strands. The ring is one element with a thick `border` and `border-radius: 50%`, so its dough thickness is the border width. The two crossed arms are rounded bars, and each one keeps its own tilt in an `--ap` custom property rather than in a shared rule, so the pretzel twist stays intact. The salt does the same with `--sp`: the glint keyframe rebuilds `rotate(var(--sp))` on every step, so the shared animation never wipes each crystal's angle.
+
+### Why is it useful?
+
+Bakery, snack, and food menu themes use a pretzel. This builds one with pure CSS borders and gradients, no images, with a reduced motion fallback.

--- a/submissions/examples/pretzel-as/demo.html
+++ b/submissions/examples/pretzel-as/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pretzel</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="steam st1"></span>
+    <span class="steam st2"></span>
+    <span class="steam st3"></span>
+    <div class="pretzel">
+      <span class="ring"></span>
+      <span class="arm al"></span>
+      <span class="arm ar"></span>
+      <span class="salt sa1"></span>
+      <span class="salt sa2"></span>
+      <span class="salt sa3"></span>
+      <span class="salt sa4"></span>
+      <span class="salt sa5"></span>
+      <span class="salt sa6"></span>
+      <span class="salt sa7"></span>
+    </div>
+    <span class="napkin"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/pretzel-as/style.css
+++ b/submissions/examples/pretzel-as/style.css
@@ -1,0 +1,209 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 42%, #3b2c22, #171010 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 330px;
+}
+
+.napkin {
+  position: absolute;
+  bottom: 44px;
+  left: 50%;
+  width: 280px;
+  height: 40px;
+  margin-left: -140px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, #efe4d2, #c9bda6);
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.4);
+  transform: rotate(-2deg);
+}
+
+.pretzel {
+  position: absolute;
+  top: 66px;
+  left: 50%;
+  width: 220px;
+  height: 190px;
+  margin-left: -110px;
+  z-index: 3;
+  animation: bobp 4s ease-in-out infinite;
+}
+
+.ring {
+  position: absolute;
+  top: 34px;
+  left: 12px;
+  width: 196px;
+  height: 152px;
+  box-sizing: border-box;
+  border: 24px solid #b3762f;
+  border-radius: 50%;
+  background: transparent;
+  box-shadow:
+    inset 0 0 0 2px rgba(90, 45, 10, 0.35),
+    0 0 0 2px rgba(90, 45, 10, 0.35),
+    0 10px 18px rgba(0, 0, 0, 0.35);
+}
+
+.arm {
+  position: absolute;
+  bottom: 22px;
+  left: 50%;
+  width: 22px;
+  height: 165px;
+  border-radius: 11px;
+  background: linear-gradient(90deg, #cf9142, #93601f);
+  box-shadow:
+    inset -4px 0 6px rgba(90, 45, 10, 0.35),
+    0 0 0 2px rgba(90, 45, 10, 0.35);
+  transform-origin: 50% 100%;
+  transform: rotate(var(--ap, 0deg));
+}
+
+.al {
+  margin-left: 29px;
+
+  --ap: -40deg;
+}
+
+.ar {
+  margin-left: -51px;
+
+  --ap: 40deg;
+}
+
+.salt {
+  position: absolute;
+  width: 7px;
+  height: 6px;
+  border-radius: 2px;
+  background: #fdfbf4;
+  box-shadow: 0 0 5px rgba(255, 255, 255, 0.5);
+  z-index: 4;
+  transform: rotate(var(--sp, 0deg));
+  animation: glintp 2.8s ease-in-out infinite;
+}
+
+.sa1 {
+  top: 46px;
+  left: 66px;
+
+  --sp: 20deg;
+}
+
+.sa2 {
+  top: 40px;
+  right: 78px;
+
+  --sp: -30deg;
+
+  animation-delay: 0.4s;
+}
+
+.sa3 {
+  top: 92px;
+  left: 24px;
+
+  --sp: -14deg;
+
+  animation-delay: 0.8s;
+}
+
+.sa4 {
+  top: 104px;
+  right: 22px;
+
+  --sp: 40deg;
+
+  animation-delay: 1.2s;
+}
+
+.sa5 {
+  top: 166px;
+  left: 78px;
+
+  --sp: 8deg;
+
+  animation-delay: 1.6s;
+}
+
+.sa6 {
+  top: 170px;
+  right: 74px;
+
+  --sp: -42deg;
+
+  animation-delay: 2s;
+}
+
+.sa7 {
+  top: 74px;
+  left: 108px;
+
+  --sp: 30deg;
+
+  animation-delay: 2.4s;
+}
+
+.steam {
+  position: absolute;
+  top: 44px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.55);
+  filter: blur(4px);
+  opacity: 0;
+  z-index: 2;
+  animation: risep 4.4s ease-out infinite;
+}
+
+.st1 { left: 108px; }
+
+.st2 {
+  left: 158px;
+  animation-delay: 1.4s;
+}
+
+.st3 {
+  left: 206px;
+  animation-delay: 2.8s;
+}
+
+@keyframes bobp {
+  0%, 100% { transform: translateY(0) rotate(-1.5deg); }
+  50% { transform: translateY(-8px) rotate(1.5deg); }
+}
+
+@keyframes glintp {
+  0%, 100% { opacity: 0.75; transform: rotate(var(--sp, 0deg)) scale(1); }
+  50% { opacity: 1; transform: rotate(var(--sp, 0deg)) scale(1.25); }
+}
+
+@keyframes risep {
+  0% { transform: translateY(0) scale(0.6); opacity: 0; }
+  25% { opacity: 0.8; }
+  100% { transform: translateY(-70px) translateX(16px) scale(1.7); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pretzel,
+  .salt,
+  .steam {
+    animation: none;
+  }
+
+  .steam {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pretzel built for #44998. The loop is one element with a thick border and a 50% radius, so the dough thickness is just the border width and the hole is free. The twist is two strands pivoted from separate points on the belly, each leaning outward from a `transform-origin` at its own base, so they cross in the middle and the tips come to rest on the upper arcs the way a real pretzel is folded. Each strand and each salt crystal keeps its angle in a custom property that the shared keyframes read back, so animating them never flattens the rotations. Reduced motion fallback included. Pure CSS. Closes #44998.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a golden brown pretzel with a crossed twist and three holes, salt crystals on the dough, sitting on a napkin with steam above it.
