### PR TITLE
feat #44919: implement user profile dashboard component workspace

### DIFF
--- a/submissions/examples/profile-dashboard-demos/README.md
+++ b/submissions/examples/profile-dashboard-demos/README.md
@@ -1,0 +1,16 @@
+# Responsive User Profile Dashboard Demo
+
+## Description
+This submission addresses enhancement issue #44919 by introducing a responsive administrative-tier User Profile Dashboard. It showcases how developers can use the `EaseMotion` utility animation structure to elevate dashboard analytics, profile overviews, and live stream activity indicators.
+
+## Architecture & Layout
+* **Dashboard Layout Matrix:** Uses an asymmetrical responsive layout (CSS Grid combined with adaptive Flexbox widgets) that repositions components dynamically across viewport mutations.
+* **Component Breakdown:**
+  * **Profile Details Hub:** Contains user identity card metrics alongside an interactive edit toggle state.
+  * **Aggregated Metrics Grid:** Displays distinct user production values (Contributions, Projects, Follower Reach).
+  * **Recent Activity Stream:** Chronological timeline display evaluating workflow updates.
+* **Composed Core Motion:** Elements use high-performance transform and opacity hooks to execute fluid simultaneous animations.
+
+## How to Run & Verify
+1. Access the local path `submissions/examples/profile-dashboard-demo/` within your project tree.
+2. Launch `demo.html` in your choice of standard browser context to view the entrance mechanics.

--- a/submissions/examples/profile-dashboard-demos/demo.html
+++ b/submissions/examples/profile-dashboard-demos/demo.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>User Profile Dashboard</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="dashboard-container">
+    
+    <!-- Profile Card Element -->
+    <section class="profile-card ease-fade-in ease-slide-up">
+      <div class="avatar-wrapper">
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>
+      </div>
+      <h1 class="profile-name">Alex Morgan</h1>
+      <p class="profile-handle">@alexm_dev</p>
+      <p class="profile-bio">Core Infrastructure Engineer specialized in constructing deterministic, high-throughput modern UI design matrices.</p>
+      <button class="btn-edit-profile">Edit Profile</button>
+    </section>
+
+    <!-- Main Content Workspace -->
+    <div class="main-content">
+      
+      <!-- Statistics Metrics Panel Row -->
+      <div class="stats-grid">
+        <div class="stat-box ease-fade-in ease-slide-up">
+          <div class="stat-label">Contributions</div>
+          <div class="stat-value">1,428</div>
+        </div>
+        <div class="stat-box ease-fade-in ease-slide-up">
+          <div class="stat-label">Total Projects</div>
+          <div class="stat-value">34</div>
+        </div>
+        <div class="stat-box ease-fade-in ease-slide-up">
+          <div class="stat-label">Followers</div>
+          <div class="stat-value">9.8k</div>
+        </div>
+      </div>
+
+      <!-- Recent Activity Stream Block -->
+      <section class="activity-panel ease-fade-in ease-slide-up">
+        <h2 class="panel-title">Recent Activity</h2>
+        
+        <div class="activity-list">
+          <div class="activity-item">
+            <svg class="activity-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"></path></svg>
+            <div class="activity-details">
+              <p>Created new production branch <code>feature/analytics-pipeline</code></p>
+              <div class="activity-time">2 hours ago</div>
+            </div>
+          </div>
+
+          <div class="activity-item">
+            <svg class="activity-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"></path></svg>
+            <div class="activity-details">
+              <p>Merged Pull Request <strong>#1204</strong> adjusting flexbox layout thresholds</p>
+              <div class="activity-time">5 hours ago</div>
+            </div>
+          </div>
+
+          <div class="activity-item">
+            <svg class="activity-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"></path></svg>
+            <div class="activity-details">
+              <p>Reviewed engineering updates submitted for cross-browser animation loops</p>
+              <div class="activity-time">Yesterday</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/profile-dashboard-demos/style.css
+++ b/submissions/examples/profile-dashboard-demos/style.css
@@ -1,0 +1,208 @@
+/* ==========================================
+   GLOBAL STYLES & CORE ENGINE
+   ========================================== */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background-color: #f1f5f9;
+  color: #334155;
+  line-height: 1.5;
+  padding: 2.5rem 1.5rem;
+}
+
+/* Core setup mapping for compound EaseMotion classes */
+[class*="ease-"] {
+  animation: 
+    var(--ease-fade-name, none) var(--ease-fade-dur, 0.5s) var(--ease-fade-tf, ease) forwards,
+    var(--ease-slide-name, none) var(--ease-slide-dur, 0.55s) var(--ease-slide-tf, cubic-bezier(0.215, 0.61, 0.355, 1)) forwards;
+}
+
+.ease-fade-in { --ease-fade-name: fadeIn; }
+.ease-slide-up { --ease-slide-name: slideUp; }
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes slideUp {
+  from { transform: translateY(30px); }
+  to { transform: translateY(0); }
+}
+
+/* ==========================================
+   DASHBOARD GRID CONTAINER
+   ========================================== */
+.dashboard-container {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 2rem;
+}
+
+@media (max-width: 868px) {
+  .dashboard-container {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ==========================================
+   SIDEBAR COMPONENT: PROFILE CARD
+   ========================================== */
+.profile-card {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 2rem;
+  text-align: center;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.avatar-wrapper {
+  width: 100px;
+  height: 100px;
+  background: #e2e8f0;
+  border-radius: 50%;
+  margin-bottom: 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #64748b;
+}
+
+.profile-name {
+  font-size: 1.25rem;
+  color: #0f172a;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+
+.profile-handle {
+  font-size: 0.875rem;
+  color: #64748b;
+  margin-bottom: 1rem;
+}
+
+.profile-bio {
+  font-size: 0.9rem;
+  color: #475569;
+  margin-bottom: 1.5rem;
+}
+
+.btn-edit-profile {
+  width: 100%;
+  padding: 0.625rem;
+  background: #ffffff;
+  border: 1px solid #cbd5e1;
+  color: #334155;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.btn-edit-profile:hover {
+  background: #f8fafc;
+  border-color: #94a3b8;
+}
+
+/* ==========================================
+   MAIN CONTENT COMPONENT PANELS
+   ========================================== */
+.main-content {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+/* Metrics Dashboard Stats Grid */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.25rem;
+}
+
+.stat-box {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 1.5rem;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+}
+
+.stat-label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #64748b;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+.stat-value {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+/* Activity Panel Component */
+.activity-panel {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 2rem;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+}
+
+.panel-title {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: #0f172a;
+  margin-bottom: 1.5rem;
+}
+
+.activity-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.activity-item {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.95rem;
+}
+
+.activity-icon {
+  width: 24px;
+  height: 24px;
+  color: #3b82f6;
+  flex-shrink: 0;
+}
+
+.activity-details p {
+  color: #334155;
+}
+
+.activity-time {
+  font-size: 0.8rem;
+  color: #94a3b8;
+  margin-top: 0.25rem;
+}
+
+/* Orchestrated Stagger Layout System */
+.dashboard-container > :nth-child(1) { animation-delay: 0.05s; }
+.stats-grid > :nth-child(1) { animation-delay: 0.12s; }
+.stats-grid > :nth-child(2) { animation-delay: 0.20s; }
+.stats-grid > :nth-child(3) { animation-delay: 0.28s; }
+.activity-panel { animation-delay: 0.36s; }


### PR DESCRIPTION
## 🎯 Purpose of this PR
This PR addresses enhancement issue #44919 by introducing a responsive administrative-tier User Profile Dashboard layout block inside the submissions directory to demonstrate real-world utility of the `EaseMotion` animation ecosystem.

## 🛠️ Solutions & Architecture Provided
* **Dashboard Layout Matrix:** Employs an asymmetrical grid structure combined with flexbox layouts that rearrange fluidly between mobile viewports and multi-column desktop screens.
* **Component Breakdown:**
  * **Profile Hub:** Features user metadata, descriptive bio text, and a clean action button.
  * **Analytics Summary Row:** Displays aggregated counter modules for rapid workflow health visualization.
  * **Activity Timeline:** Renders a clean chronological event stream built entirely with semantic HTML and local inline SVG vectors.
* **Composed Core Motion:** Leverages the advanced custom properties animation architecture, ensuring entering panels animate both their opacity (`.ease-fade-in`) and position (`.ease-slide-up`) simultaneously without encountering cascade overwrites.

## 📂 Files Included
All implementation files are housed cleanly inside the required submissions path:
* `submissions/examples/profile-dashboard-demos/README.md` — Overview of components, responsive behavior, and layout guidelines.
* `submissions/examples/profile-dashboard-demos/style.css` — Core dashboard layout engine, atomic variable configurations, and element cosmetics.
* `submissions/examples/profile-dashboard-demos/demo.html` — The structural layout file initializing the profile dashboard.

## 🧪 How to Verify / Test
1. Switch to this branch context: `git checkout feat-user-profile-dashboard`
2. Open `submissions/examples/profile-dashboard-demos/demo.html` in any modern web browser.
3. Observe the fluid entry animation sequence across all card panels.
4. Scale your viewport width down to smartphone dimensions to verify the sidebar drops correctly into a singular responsive stack.

Closes #44919