### PR TITLE
Add mars rover component

### DIFF
--- a/submissions/examples/mars-rover-as/README.md
+++ b/submissions/examples/mars-rover-as/README.md
@@ -1,0 +1,22 @@
+# Mars Rover
+
+### What does this do?
+
+It shows a rover crossing the Martian surface. The six spoked wheels turn, the chassis rocks over the terrain, the camera eyes glow as they scan, the antenna sends a radio ping that expands and fades, the sample arm sweeps down and back, and dust puffs kick up behind the wheels. Under reduced motion the rover parks.
+
+### How is it used?
+
+```html
+<div class="rover">
+  <span class="panel"></span>
+  <span class="body"></span>
+  <span class="wheelr wa"></span>
+  <span class="wheelr wb"></span>
+</div>
+```
+
+Each wheel is a single element: a `repeating-conic-gradient` paints the spokes, a thick `border` gives the tyre, and `border-radius: 50%` makes it round, so a spoked wheel costs one element instead of eight. The solar panel is a `repeating-linear-gradient` of cell strips. The radio ping is one ring that scales out from the antenna while fading, so a broadcast reads without any extra markup.
+
+### Why is it useful?
+
+Space, science, and exploration themes use a rover. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/mars-rover-as/demo.html
+++ b/submissions/examples/mars-rover-as/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mars Rover</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="sky"></span>
+    <span class="ridge"></span>
+    <span class="ground"></span>
+    <div class="rover">
+      <span class="mast"></span>
+      <span class="head"></span>
+      <span class="eye el"></span>
+      <span class="eye er"></span>
+      <span class="panel"></span>
+      <span class="body"></span>
+      <span class="antenna"></span>
+      <span class="ping"></span>
+      <span class="arm2"></span>
+      <span class="axle"></span>
+      <span class="wheelr wa"></span>
+      <span class="wheelr wb"></span>
+      <span class="wheelr wc"></span>
+    </div>
+    <span class="dust d1"></span>
+    <span class="dust d2"></span>
+    <span class="dust d3"></span>
+    <span class="track"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/mars-rover-as/style.css
+++ b/submissions/examples/mars-rover-as/style.css
@@ -1,0 +1,287 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #d78a52, #7a3a22 62%, #46200f);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 360px;
+  height: 320px;
+}
+
+.sky {
+  position: absolute;
+  top: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 190px);
+  background: radial-gradient(circle at 68% 88%, rgba(255, 220, 170, 0.5), transparent 44%);
+  pointer-events: none;
+}
+
+.ridge {
+  position: absolute;
+  bottom: 84px;
+  left: -50vw;
+  right: -50vw;
+  height: 70px;
+  background:
+    radial-gradient(circle at 26% 100%, #8e4523 0 90px, transparent 90px),
+    radial-gradient(circle at 58% 100%, #964d29 0 66px, transparent 66px),
+    radial-gradient(circle at 84% 100%, #8e4523 0 78px, transparent 78px);
+}
+
+.ground {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 96px);
+  background:
+    radial-gradient(circle at 14% 8%, rgba(70, 30, 14, 0.5) 0 10px, transparent 10px),
+    radial-gradient(circle at 46% 16%, rgba(70, 30, 14, 0.4) 0 14px, transparent 14px),
+    radial-gradient(circle at 78% 6%, rgba(70, 30, 14, 0.45) 0 8px, transparent 8px),
+    linear-gradient(180deg, #b5643a, #6e3319);
+}
+
+.rover {
+  position: absolute;
+  bottom: 62px;
+  left: 50%;
+  width: 240px;
+  height: 190px;
+  margin-left: -120px;
+  z-index: 4;
+  animation: rockr 3.4s ease-in-out infinite;
+}
+
+.mast {
+  position: absolute;
+  top: 26px;
+  left: 62px;
+  width: 9px;
+  height: 62px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #cfd6dd, #8b959f);
+  z-index: 3;
+}
+
+.head {
+  position: absolute;
+  top: 4px;
+  left: 40px;
+  width: 60px;
+  height: 30px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, #e6ebf0, #97a2ac);
+  box-shadow: inset 0 -4px 6px rgba(40, 50, 60, 0.35);
+  z-index: 4;
+}
+
+.eye {
+  position: absolute;
+  top: 12px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid #5d6771;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 36% 32%, #9fe7ff, #16697f 72%);
+  z-index: 5;
+  animation: scanr 4s ease-in-out infinite;
+}
+
+.el { left: 48px; }
+
+.er {
+  left: 76px;
+  animation-delay: 0.3s;
+}
+
+.body {
+  position: absolute;
+  top: 88px;
+  left: 30px;
+  width: 168px;
+  height: 54px;
+  border-radius: 10px;
+  background: linear-gradient(180deg, #dfe5eb, #9aa5b0);
+  box-shadow: inset 0 -8px 12px rgba(40, 50, 60, 0.35);
+  z-index: 3;
+}
+
+.panel {
+  position: absolute;
+  top: 70px;
+  left: 16px;
+  width: 200px;
+  height: 20px;
+  border-radius: 4px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      #1f3f7a 0 14px,
+      #2f5ba8 14px 16px
+    );
+  box-shadow: 0 2px 0 rgba(255, 255, 255, 0.35);
+  z-index: 4;
+}
+
+.antenna {
+  position: absolute;
+  top: 44px;
+  left: 190px;
+  width: 5px;
+  height: 46px;
+  border-radius: 3px;
+  background: #cfd6dd;
+  z-index: 3;
+}
+
+.ping {
+  position: absolute;
+  top: 30px;
+  left: 180px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 2px solid rgba(140, 240, 200, 0.9);
+  opacity: 0;
+  z-index: 3;
+  animation: pingr 2.6s ease-out infinite;
+}
+
+.arm2 {
+  position: absolute;
+  top: 106px;
+  left: 186px;
+  width: 44px;
+  height: 8px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #b7c0c9, #7d8891);
+  transform-origin: 0 50%;
+  z-index: 2;
+  animation: probe 5s ease-in-out infinite;
+}
+
+.axle {
+  position: absolute;
+  top: 138px;
+  left: 40px;
+  width: 152px;
+  height: 8px;
+  border-radius: 4px;
+  background: #6f7a84;
+  z-index: 2;
+}
+
+.wheelr {
+  position: absolute;
+  top: 138px;
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  border: 6px solid #3a434c;
+  box-sizing: border-box;
+  background:
+    repeating-conic-gradient(#8a949e 0 14deg, #c3ccd4 14deg 28deg);
+  z-index: 3;
+  animation: rollr 2.6s linear infinite;
+}
+
+.wa { left: 22px; }
+.wb { left: 92px; }
+.wc { left: 162px; }
+
+.dust {
+  position: absolute;
+  bottom: 56px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: rgba(230, 170, 120, 0.55);
+  filter: blur(2px);
+  opacity: 0;
+  z-index: 3;
+  animation: puffr 3.2s ease-out infinite;
+}
+
+.d1 { left: 96px; }
+
+.d2 {
+  left: 74px;
+  animation-delay: 1.1s;
+}
+
+.d3 {
+  left: 118px;
+  animation-delay: 2.2s;
+}
+
+.track {
+  position: absolute;
+  bottom: 52px;
+  left: 20px;
+  width: 110px;
+  height: 8px;
+  border-radius: 4px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(80, 36, 16, 0.5) 0 5px,
+      transparent 5px 12px
+    );
+  z-index: 3;
+}
+
+@keyframes rockr {
+  0%, 100% { transform: translateY(0) rotate(-0.8deg); }
+  50% { transform: translateY(-4px) rotate(0.8deg); }
+}
+
+@keyframes rollr {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes scanr {
+  0%, 100% { box-shadow: none; }
+  50% { box-shadow: 0 0 12px rgba(120, 220, 255, 0.9); }
+}
+
+@keyframes pingr {
+  0% { transform: scale(0.4); opacity: 0.9; }
+  100% { transform: scale(2.4); opacity: 0; }
+}
+
+@keyframes probe {
+  0%, 100% { transform: rotate(6deg); }
+  50% { transform: rotate(26deg); }
+}
+
+@keyframes puffr {
+  0% { transform: translate(0, 0) scale(0.5); opacity: 0; }
+  25% { opacity: 0.8; }
+  100% { transform: translate(-60px, -30px) scale(2); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rover,
+  .wheelr,
+  .eye,
+  .ping,
+  .arm2,
+  .dust {
+    animation: none;
+  }
+
+  .dust,
+  .ping {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a mars rover built for #45007. Each wheel is one element: a repeating conic gradient paints the spokes, a thick border gives the tyre, and a 50% radius makes it round, so a spoked wheel costs one element instead of eight. The solar panel is a repeating linear gradient of cell strips. The radio ping is a single ring that scales out from the antenna while fading, so a broadcast reads without extra markup. Reduced motion fallback included. Pure CSS. Closes #45007.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a rover with a camera mast, a blue solar panel, a sample arm, an antenna ping and three spoked wheels, rolling over red terrain with wheel tracks behind it.
