### PR TITLE
Add ship wheel component

### DIFF
--- a/submissions/examples/ship-wheel-as/README.md
+++ b/submissions/examples/ship-wheel-as/README.md
@@ -1,0 +1,22 @@
+# Ship Wheel
+
+### What does this do?
+
+It shows a ship's helm turning slowly over the sea. The wheel rotates on its own, and hovering or focusing it spins it up to full speed as if someone grabbed a handle. The brass cap glows, the light around the wheel breathes, and the water texture drifts past behind it. Under reduced motion the wheel holds still.
+
+### How is it used?
+
+```html
+<div class="helm" tabindex="0">
+  <span class="handle h1"></span>
+  <span class="rimh"></span>
+  <span class="spokes"></span>
+  <span class="hubh"></span>
+</div>
+```
+
+The six spokes are one element: a `repeating-conic-gradient` cuts a wooden wedge every 60 degrees, so no spoke markup is needed at all. The rim is a bordered circle, so its thickness is just the border width. Each handle is placed with `rotate(var(--hh)) translateY(-128px)`, rotating first and then pushing outward, so a single value both aims the handle and sets how far out it sits. The spin lives on the wrapper, so it never overwrites the handles' own transforms, and `tabindex="0"` makes the speed up reachable by keyboard as well as by mouse.
+
+### Why is it useful?
+
+Nautical, navigation, and adventure themes use a ship's wheel. This builds one with pure CSS gradients and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/ship-wheel-as/demo.html
+++ b/submissions/examples/ship-wheel-as/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ship Wheel</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="glowh"></span>
+    <div class="helm" tabindex="0">
+      <span class="handle h1"></span>
+      <span class="handle h2"></span>
+      <span class="handle h3"></span>
+      <span class="handle h4"></span>
+      <span class="handle h5"></span>
+      <span class="handle h6"></span>
+      <span class="rimh"></span>
+      <span class="spokes"></span>
+      <span class="hubh"></span>
+      <span class="caph"></span>
+    </div>
+    <span class="rope"></span>
+    <span class="waves"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ship-wheel-as/style.css
+++ b/submissions/examples/ship-wheel-as/style.css
@@ -1,0 +1,200 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 40%, #1b3a54, #081522 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 340px;
+}
+
+.waves {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 54px);
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.06) 0 3px,
+      transparent 3px 34px
+    ),
+    linear-gradient(180deg, #14415e, #0a2337);
+  animation: driftw 6s linear infinite;
+}
+
+.glowh {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 300px;
+  height: 300px;
+  margin: -150px 0 0 -150px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 200, 120, 0.16), transparent 66%);
+  filter: blur(6px);
+  animation: pulseh 4s ease-in-out infinite;
+}
+
+.helm {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 260px;
+  height: 260px;
+  margin: -130px 0 0 -130px;
+  border-radius: 50%;
+  outline: none;
+  z-index: 3;
+  animation: turnh 26s linear infinite;
+}
+
+.helm:hover,
+.helm:focus-visible {
+  animation-duration: 4s;
+}
+
+.rimh {
+  position: absolute;
+  top: 30px;
+  left: 30px;
+  width: 200px;
+  height: 200px;
+  box-sizing: border-box;
+  border: 20px solid #9c672f;
+  border-radius: 50%;
+  background: transparent;
+  box-shadow:
+    inset 0 0 0 3px rgba(70, 40, 12, 0.5),
+    0 0 0 3px rgba(70, 40, 12, 0.5),
+    0 8px 22px rgba(0, 0, 0, 0.45);
+  z-index: 3;
+}
+
+.spokes {
+  position: absolute;
+  top: 44px;
+  left: 44px;
+  width: 172px;
+  height: 172px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 0deg,
+      #a97136 0 5deg,
+      transparent 5deg 55deg,
+      #a97136 55deg 60deg,
+      transparent 60deg 60deg
+    );
+  z-index: 2;
+}
+
+.hubh {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 62px;
+  height: 62px;
+  margin: -31px 0 0 -31px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #c98f47, #7c4d1c 72%);
+  box-shadow: inset 0 -5px 10px rgba(50, 26, 6, 0.55);
+  z-index: 4;
+}
+
+.caph {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 24px;
+  height: 24px;
+  margin: -12px 0 0 -12px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #ffe0a0, #b8862f 72%);
+  box-shadow: 0 0 10px rgba(255, 200, 120, 0.6);
+  z-index: 5;
+}
+
+.handle {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 18px;
+  height: 56px;
+  margin: -28px 0 0 -9px;
+  border-radius: 9px 9px 6px 6px;
+  background: linear-gradient(180deg, #c08243, #7d4c19);
+  box-shadow: inset -3px 0 5px rgba(60, 32, 8, 0.5);
+  transform: rotate(var(--hh, 0deg)) translateY(-128px);
+  z-index: 2;
+}
+
+.h1 {
+  --hh: 0deg;
+}
+
+.h2 {
+  --hh: 60deg;
+}
+
+.h3 {
+  --hh: 120deg;
+}
+
+.h4 {
+  --hh: 180deg;
+}
+
+.h5 {
+  --hh: 240deg;
+}
+
+.h6 {
+  --hh: 300deg;
+}
+
+.rope {
+  position: absolute;
+  bottom: 22px;
+  left: 50%;
+  width: 260px;
+  height: 12px;
+  margin-left: -130px;
+  border-radius: 6px;
+  background:
+    repeating-linear-gradient(
+      66deg,
+      #c9a15f 0 6px,
+      #8f6a31 6px 12px
+    );
+  z-index: 2;
+}
+
+@keyframes turnh {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes pulseh {
+  0%, 100% { opacity: 0.7; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.06); }
+}
+
+@keyframes driftw {
+  to { background-position: 34px 0, 0 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .helm,
+  .glowh,
+  .waves {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a ship wheel built for #45012. The six spokes are one element: a repeating conic gradient cuts a wooden wedge every 60 degrees, so no spoke markup is needed. Each handle is placed with `rotate(var(--hh)) translateY(-128px)`, rotating first and then pushing outward, so one value both aims the handle and sets how far out it sits. The spin lives on the wrapper, so it never overwrites the handles' own transforms, and hovering or focusing the wheel shortens the animation duration so it speeds up under the hand. `tabindex="0"` makes that reachable by keyboard too. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45012.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a wooden ship's helm with six handles, a bordered rim, conic gradient spokes and a glowing brass cap, turning above the sea.
