### PR TITLE
feat(submission): add perspective-gdpr-modal component (#42490)

### DIFF
--- a/submissions/examples/perspective-gdpr-modal-ksk/README.md
+++ b/submissions/examples/perspective-gdpr-modal-ksk/README.md
@@ -1,0 +1,13 @@
+# Perspective GDPR Modal (`perspective-gdpr-modal-ksk`)
+
+1. What does this do?  
+Displays a cookie consent modal that enters from a 3D perspective flip angle (`rotateX(25deg) → rotateX(0deg)`) using a springy cubic-bezier transition, triggered purely via a checkbox hack.
+
+2. How is it used?  
+Pair a hidden `.gdpr-toggle` checkbox with a `.gdpr-trigger-label` button. The `.gdpr-backdrop` and `.gdpr-modal` activate on `:checked` state. Clicking the backdrop label or action buttons unchecks the toggle to close.
+
+3. Why is it useful?  
+Provides a legally-compliant, accessible GDPR cookie consent UI with toggle-style preference controls, all without any JavaScript.
+
+---
+*Created for ECSoC-26 / GSSoC-26 — Resolves #42490.*

--- a/submissions/examples/perspective-gdpr-modal-ksk/demo.html
+++ b/submissions/examples/perspective-gdpr-modal-ksk/demo.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Perspective GDPR Modal Showcase</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      background-color: #060813;
+      color: #f8fafc;
+      font-family: system-ui, -apple-system, sans-serif;
+      min-height: 100vh;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 20px;
+      box-sizing: border-box;
+    }
+    .wrapper {
+      text-align: center;
+      margin-bottom: 2rem;
+      max-width: 480px;
+    }
+    .wrapper h1 {
+      font-size: 2rem;
+      margin: 0 0 0.5rem;
+      font-weight: 800;
+      background: linear-gradient(135deg, #6c63ff, #38dbff);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+    .wrapper p {
+      color: #5a657d;
+      margin: 0;
+      font-size: 0.95rem;
+      line-height: 1.5;
+    }
+  </style>
+</head>
+<body>
+  <!-- Portfolio page background -->
+  <div class="wrapper">
+    <h1>Perspective GDPR Modal</h1>
+    <p>A cookie consent modal that flips down from a 3D perspective angle on entry. Pure CSS, no JavaScript required.</p>
+  </div>
+
+  <!-- Checkbox toggle controller (CSS hack) -->
+  <input type="checkbox" id="gdpr-toggle" class="gdpr-toggle">
+
+  <!-- Trigger Button -->
+  <label for="gdpr-toggle" class="gdpr-trigger-label">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="12" cy="12" r="10"></circle>
+      <line x1="12" y1="8" x2="12" y2="12"></line>
+      <line x1="12" y1="16" x2="12.01" y2="16"></line>
+    </svg>
+    Open Privacy Settings
+  </label>
+
+  <!-- Modal Backdrop + Card -->
+  <div class="gdpr-backdrop">
+    <!-- Backdrop click area to close -->
+    <label for="gdpr-toggle" class="gdpr-close-area"></label>
+
+    <div class="gdpr-modal">
+      <!-- Icon -->
+      <div class="gdpr-icon">
+        <svg viewBox="0 0 24 24">
+          <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
+        </svg>
+      </div>
+
+      <!-- Heading -->
+      <h2 class="gdpr-title">We value your privacy</h2>
+      <p class="gdpr-body">
+        We use cookies to personalize content, analyze traffic, and improve your experience. 
+        By clicking "Accept All", you consent to our use of cookies. Read more in our 
+        <a href="#">Privacy Policy</a> and <a href="#">Cookie Policy</a>.
+      </p>
+
+      <!-- Cookie preference toggles -->
+      <div class="gdpr-options">
+        <!-- Essential (always on) -->
+        <div class="gdpr-option">
+          <div class="gdpr-option-info">
+            <span class="gdpr-option-name">Essential Cookies</span>
+            <span class="gdpr-option-desc">Required for the site to function</span>
+          </div>
+          <input type="checkbox" id="cookie-essential" class="gdpr-switch-input" checked disabled>
+          <label for="cookie-essential" class="gdpr-switch-label"></label>
+        </div>
+
+        <!-- Analytics -->
+        <div class="gdpr-option">
+          <div class="gdpr-option-info">
+            <span class="gdpr-option-name">Analytics Cookies</span>
+            <span class="gdpr-option-desc">Help us understand site usage</span>
+          </div>
+          <input type="checkbox" id="cookie-analytics" class="gdpr-switch-input" checked>
+          <label for="cookie-analytics" class="gdpr-switch-label"></label>
+        </div>
+
+        <!-- Marketing -->
+        <div class="gdpr-option">
+          <div class="gdpr-option-info">
+            <span class="gdpr-option-name">Marketing Cookies</span>
+            <span class="gdpr-option-desc">Used to deliver personalized ads</span>
+          </div>
+          <input type="checkbox" id="cookie-marketing" class="gdpr-switch-input">
+          <label for="cookie-marketing" class="gdpr-switch-label"></label>
+        </div>
+      </div>
+
+      <!-- Action Buttons (use label to close modal) -->
+      <div class="gdpr-actions">
+        <label for="gdpr-toggle" class="gdpr-btn gdpr-btn-reject">Reject All</label>
+        <label for="gdpr-toggle" class="gdpr-btn gdpr-btn-accept">Accept All</label>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/perspective-gdpr-modal-ksk/style.css
+++ b/submissions/examples/perspective-gdpr-modal-ksk/style.css
@@ -1,0 +1,263 @@
+/* ============================================================
+   EaseMotion CSS — Perspective GDPR Modal (Portfolio Design)
+   submissions/examples/perspective-gdpr-modal-ksk/style.css
+   ============================================================ */
+
+/* ponytail: hardware-accelerated 3D perspective entry animation, checkbox hack for JS-free open/close */
+
+/* ── Trigger Button ─────────────────────────────────────── */
+.gdpr-trigger-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 24px;
+  background: linear-gradient(135deg, #6c63ff, #38dbff);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.95rem;
+  border-radius: 10px;
+  cursor: pointer;
+  user-select: none;
+  box-shadow: 0 6px 20px rgba(108, 99, 255, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.gdpr-trigger-label:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 28px rgba(108, 99, 255, 0.45);
+}
+
+/* Hide checkbox controller */
+.gdpr-toggle {
+  display: none;
+}
+
+/* ── Backdrop ───────────────────────────────────────────── */
+.gdpr-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  box-sizing: border-box;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.35s ease;
+}
+
+/* ── Modal Card ─────────────────────────────────────────── */
+.gdpr-modal {
+  background: #0f111a;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 20px;
+  padding: 2.5rem;
+  max-width: 500px;
+  width: 100%;
+  box-sizing: border-box;
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(108, 99, 255, 0.1);
+  transform: perspective(900px) rotateX(25deg) scale(0.85);
+  opacity: 0;
+  transform-origin: top center;
+  transition: transform 0.45s cubic-bezier(0.175, 0.885, 0.32, 1.275),
+              opacity 0.35s ease;
+}
+
+/* ── Open State (checkbox hack) ─────────────────────────── */
+.gdpr-toggle:checked ~ .gdpr-backdrop {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.gdpr-toggle:checked ~ .gdpr-backdrop .gdpr-modal {
+  transform: perspective(900px) rotateX(0deg) scale(1);
+  opacity: 1;
+}
+
+/* ── Modal Content ──────────────────────────────────────── */
+.gdpr-icon {
+  width: 48px;
+  height: 48px;
+  background: linear-gradient(135deg, #6c63ff22, #38dbff22);
+  border: 1px solid rgba(108, 99, 255, 0.3);
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 1.25rem;
+}
+
+.gdpr-icon svg {
+  width: 24px;
+  height: 24px;
+  stroke: #6c63ff;
+  fill: none;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.gdpr-title {
+  color: #fff;
+  font-size: 1.35rem;
+  font-weight: 800;
+  margin: 0 0 0.6rem;
+  letter-spacing: -0.01em;
+}
+
+.gdpr-body {
+  color: #64748b;
+  font-size: 0.9rem;
+  line-height: 1.7;
+  margin: 0 0 1.75rem;
+}
+
+.gdpr-body a {
+  color: #6c63ff;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.gdpr-body a:hover {
+  text-decoration: underline;
+}
+
+/* ── Cookie Toggles ─────────────────────────────────────── */
+.gdpr-options {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 1.75rem;
+}
+
+.gdpr-option {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #161929;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+  padding: 14px 16px;
+}
+
+.gdpr-option-info {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.gdpr-option-name {
+  color: #e2e8f0;
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+
+.gdpr-option-desc {
+  color: #475569;
+  font-size: 0.78rem;
+}
+
+/* Toggle pill switch (pure CSS) */
+.gdpr-switch-input {
+  display: none;
+}
+
+.gdpr-switch-label {
+  width: 44px;
+  height: 24px;
+  background: #2d3248;
+  border-radius: 99px;
+  position: relative;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.25s ease;
+}
+
+.gdpr-switch-label::after {
+  content: '';
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  background: #4b5563;
+  border-radius: 50%;
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), background 0.25s ease;
+}
+
+.gdpr-switch-input:checked + .gdpr-switch-label {
+  background: #6c63ff;
+}
+
+.gdpr-switch-input:checked + .gdpr-switch-label::after {
+  transform: translateX(20px);
+  background: #fff;
+}
+
+/* Disabled (essential) toggle */
+.gdpr-switch-input:disabled + .gdpr-switch-label {
+  background: #6c63ff;
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.gdpr-switch-input:disabled + .gdpr-switch-label::after {
+  transform: translateX(20px);
+  background: #fff;
+}
+
+/* ── Action Buttons ─────────────────────────────────────── */
+.gdpr-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.gdpr-btn {
+  flex: 1;
+  min-width: 120px;
+  padding: 12px 18px;
+  border-radius: 10px;
+  font-weight: 700;
+  font-size: 0.9rem;
+  cursor: pointer;
+  text-align: center;
+  user-select: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  border: none;
+}
+
+.gdpr-btn-accept {
+  background: linear-gradient(135deg, #6c63ff, #38dbff);
+  color: #fff;
+  box-shadow: 0 4px 14px rgba(108, 99, 255, 0.3);
+}
+
+.gdpr-btn-accept:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(108, 99, 255, 0.45);
+}
+
+.gdpr-btn-reject {
+  background: #1e2235;
+  color: #94a3b8;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.gdpr-btn-reject:hover {
+  background: #262b42;
+  color: #e2e8f0;
+  transform: translateY(-2px);
+}
+
+/* ── Close via backdrop click ───────────────────────────── */
+.gdpr-close-area {
+  position: absolute;
+  inset: 0;
+  cursor: pointer;
+  z-index: -1;
+}


### PR DESCRIPTION
Closes #42490.

Adds a self-contained GDPR cookie consent modal under `submissions/examples/perspective-gdpr-modal-ksk/`.

#### Key Features

1. **3D Perspective Entry Animation** — Modal card flips in from `rotateX(25deg) → rotateX(0deg)` with a springy `cubic-bezier(0.175, 0.885, 0.32, 1.275)` transition, giving a satisfying portfolio-style reveal.
2. **Checkbox Hack (Zero JS)** — A hidden `<input type="checkbox">` drives the entire open/close state via `:checked` CSS selectors. No JavaScript required.
3. **Pure CSS Toggle Switches** — Individual cookie preference controls (Essential, Analytics, Marketing) are implemented as animated pill switches using the checkbox + label pattern.
4. **Backdrop Click to Close** — An absolutely-positioned `<label>` covers the backdrop so clicking outside the modal closes it naturally.
5. **Dark Portfolio Theme** — Deep slate backgrounds, purple/cyan gradient accents, and glassmorphism backdrop blur.

#### File Breakdown
| File | Description |
|------|-------------|
| `style.css` | All animations, layout, toggle switches, and modal states |
| `demo.html` | Self-contained showcase page with trigger button and full modal |
| `README.md` | Usage guide referencing issue `#42490` |