### PR TITLE
feat: add Space-themed Fade-in Range Slider component (#41446)

### DIFF
--- a/submissions/examples/fade-in-range-slider-space/README.md
+++ b/submissions/examples/fade-in-range-slider-space/README.md
@@ -1,0 +1,52 @@
+# Fade In Range Slider
+
+An ultra-premium, space cockpit-themed `<input type="range">` visualizer featuring smooth entrance animations, glowing state visualizers, and a dual-preset interactive simulator.
+
+## 1. What does this do?
+This component overrides the default browser range input track and thumb geometry with custom glowing states and starry thumbs, incorporating a CSS-only fade-in entrance transition when loaded.
+
+## 2. How is it used?
+
+To add a space-themed range input, add this markup block to your layout:
+```html
+<div class="slider-wrapper slider-fade-in fade-delay-1">
+  <div class="slider-label-area">
+    <span class="slider-title">WARP ENGINE SPEED</span>
+    <span class="slider-value-display">45%</span>
+  </div>
+  <div class="slider-input-container">
+    <!-- Native Range Input -->
+    <input type="range" class="space-slider speed-slider" min="0" max="100" value="45" aria-label="Warp Engine Speed">
+    
+    <!-- Decorative Ticks -->
+    <div class="slider-ticks">
+      <span class="tick"></span>
+      <span class="tick"></span>
+      <span class="tick"></span>
+      <span class="tick"></span>
+      <span class="tick"></span>
+    </div>
+  </div>
+</div>
+```
+
+## 3. Why is it useful?
+Default browser range sliders are difficult to style consistently across browsers, and standard web dashboards often suffer from plain layouts. 
+
+This component fits EaseMotion's philosophy by:
+- **Clean Cross-Browser Architecture:** Targets Webkit/Blink and Mozilla rendering engines separately to ensure pixel-perfect track height, border-radius, and thumb positioning across systems.
+- **Fade-in Composability:** Seamlessly fades in range groups sequentially (`fade-delay-1`, `fade-delay-2`, etc.) to create an elegant user cockpit boot sequence.
+- **Pure CSS Customizer Bindings:** Binds selection radios to CSS variables to switch the HUD's accent hue (Cyan, Purple, Red) and flight telemetry states (Stealth Mode vs Hyperdrive override alerts) without JavaScript.
+
+## 4. Customization Token API
+
+The cockpit interface can be configured directly inside parent container scopes using CSS Custom Properties:
+
+| Property | Description | Default Preset | Available Presets |
+|---|---|---|---|
+| `--space-hud-accent` | Accent color of slider thumb, glows, and values | `var(--space-color-cyan)` | Presets: `#color-cyan`, `#color-purple`, `#color-red` |
+| `--slider-track-height` | Runway track height thickness | `6px` | Length value |
+| `--slider-thumb-size` | Diameter of circular star thumb | `20px` | Length value |
+
+---
+*Created as a submission for GSSOC-26 / ECSoC-26 under submissions/examples/fade-in-range-slider-space/*

--- a/submissions/examples/fade-in-range-slider-space/demo.html
+++ b/submissions/examples/fade-in-range-slider-space/demo.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fade In Range Slider - Space UI Component</title>
+  <link rel="stylesheet" href="style.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600;800;900&family=Rajdhani:wght@500;600;700&family=Share+Tech+Mono&display=swap" rel="stylesheet" />
+</head>
+<body class="space-cockpit-theme">
+
+  <!-- Interactive Controls Binding (Pure CSS Sibling Bindings) -->
+  <!-- 1. Ship Mode Selectors -->
+  <input type="radio" id="mode-cruise" name="ship-mode" class="ctrl-mode-cruise" checked />
+  <input type="radio" id="mode-hyper" name="ship-mode" class="ctrl-mode-hyper" />
+  <input type="radio" id="mode-stealth" name="ship-mode" class="ctrl-mode-stealth" />
+
+  <!-- 2. HUD Palette Selectors -->
+  <input type="radio" id="color-cyan" name="hud-color" class="ctrl-color-cyan" checked />
+  <input type="radio" id="color-purple" name="hud-color" class="ctrl-color-purple" />
+  <input type="radio" id="color-red" name="hud-color" class="ctrl-color-red" />
+
+
+  <!-- Space Star Background Layer -->
+  <div class="stars-bg"></div>
+  <div class="nebula-bg"></div>
+
+  <div class="cockpit-container">
+    
+    <!-- Header Console -->
+    <header class="console-header">
+      <div class="console-logo">
+        <span class="logo-main">AETHERIS</span><span class="logo-sub">COMMAND BRIDGE v1.2</span>
+      </div>
+      <div class="console-status">
+        <span class="status-indicator animate-pulse"></span>
+        <span class="status-lbl">ORBITAL SYSTEMS STEADY</span>
+      </div>
+    </header>
+
+    <!-- Main Grid Dashboard Layout -->
+    <main class="console-grid">
+
+      <!-- Left Column: Primary Calibration Sliders -->
+      <section class="console-card primary-sliders-card">
+        <div class="card-header">
+          <span class="tag">FLIGHT ENGINE CALIBRATION</span>
+          <h2>Warp Drive Engine Settings</h2>
+        </div>
+        
+        <div class="card-body sliders-container">
+          
+          <!-- Slider 1: Warp Engine Velocity -->
+          <div class="slider-wrapper slider-fade-in fade-delay-1">
+            <div class="slider-label-area">
+              <span class="slider-title">WARP FIELD VELOCITY</span>
+              <span class="slider-value-display val-warp">45%</span>
+            </div>
+            <div class="slider-input-container">
+              <input type="range" class="space-slider speed-slider" min="0" max="100" value="45" id="slider-speed" aria-label="Warp Engine Velocity" />
+              <!-- Floating Slider Tick Tracks -->
+              <div class="slider-ticks">
+                <span class="tick"></span><span class="tick"></span><span class="tick"></span><span class="tick"></span><span class="tick"></span>
+              </div>
+            </div>
+            <div class="slider-meta">
+              <span>WARP COEFFICIENT: 0.45c</span>
+              <span>THRUST OUTPUT: OPTIMAL</span>
+            </div>
+          </div>
+
+          <!-- Slider 2: Oxygen Reserves Regulator -->
+          <div class="slider-wrapper slider-fade-in fade-delay-2">
+            <div class="slider-label-area">
+              <span class="slider-title">OXYGEN INJECTOR MIXTURE</span>
+              <span class="slider-value-display val-o2">85%</span>
+            </div>
+            <div class="slider-input-container">
+              <input type="range" class="space-slider o2-slider" min="0" max="100" value="85" id="slider-o2" aria-label="Oxygen Reserve Regulator" />
+              <div class="slider-ticks">
+                <span class="tick"></span><span class="tick"></span><span class="tick"></span><span class="tick"></span><span class="tick"></span>
+              </div>
+            </div>
+            <div class="slider-meta">
+              <span>FLOW RATE: 8.5 L/min</span>
+              <span>CABIN PRESSURE: NOMINAL</span>
+            </div>
+          </div>
+
+          <!-- Slider 3: Deflector Shield Energy -->
+          <div class="slider-wrapper slider-fade-in fade-delay-3">
+            <div class="slider-label-area">
+              <span class="slider-title">SHIELD INTRUSION THRESHOLD</span>
+              <span class="slider-value-display val-shield">60%</span>
+            </div>
+            <div class="slider-input-container">
+              <input type="range" class="space-slider shield-slider" min="0" max="100" value="60" id="slider-shield" aria-label="Shield Level Control" />
+              <div class="slider-ticks">
+                <span class="tick"></span><span class="tick"></span><span class="tick"></span><span class="tick"></span><span class="tick"></span>
+              </div>
+            </div>
+            <div class="slider-meta">
+              <span>FREQUENCY: 440 GHz</span>
+              <span>STATUS: DEFLECTING</span>
+            </div>
+          </div>
+
+        </div>
+        <div class="card-footer">
+          <p>Range sliders feature native browser overriding with custom glowing tracks and star-like thumbs.</p>
+        </div>
+      </section>
+
+      <!-- Right Column: Control Sandbox Panel -->
+      <section class="console-card sandbox-controls-card">
+        <div class="card-header">
+          <span class="tag">SHIP TELEMETRY</span>
+          <h2>HUD Interactive Sandbox</h2>
+        </div>
+
+        <div class="card-body controls-layout">
+          <!-- Ship Mode Selector Segment -->
+          <div class="control-section">
+            <span class="section-title">CHOOSE STELLAR FLIGHT MODE</span>
+            <div class="selection-grid">
+              <label for="mode-cruise" class="mode-btn label-cruise">
+                <span class="btn-icon">🌌</span> Cruising Mode
+              </label>
+              <label for="mode-hyper" class="mode-btn label-hyper">
+                <span class="btn-icon">🚀</span> Hyperdrive Active
+              </label>
+              <label for="mode-stealth" class="mode-btn label-stealth">
+                <span class="btn-icon">🛰️</span> Stealth Mode
+              </label>
+            </div>
+            <p class="description-text">Hyperdrive overrides colors with active red alert gradients; Stealth dims all telemetry elements.</p>
+          </div>
+
+          <!-- HUD Color Selector Segment -->
+          <div class="control-section">
+            <span class="section-title">SELECT HUD SPECTRAL HUD HUE</span>
+            <div class="selection-grid">
+              <label for="color-cyan" class="color-btn label-cyan">Cyber Cyan</label>
+              <label for="color-purple" class="color-btn label-purple">Nebula Purple</label>
+              <label for="color-red" class="color-btn label-red">Supernova Red</label>
+            </div>
+            <p class="description-text">Switches color accents across slider glow, thumbs, and text indicators.</p>
+          </div>
+
+          <!-- Active Metrics Display Card -->
+          <div class="metrics-display-card">
+            <div class="metric-row">
+              <span>ACTIVE HULL GRADIENT:</span>
+              <span class="hud-status-value dynamic-gradient-text">ACTIVE</span>
+            </div>
+            <div class="metric-row">
+              <span>RADAR EMISSIONS:</span>
+              <span class="hud-status-value dynamic-radar-status">NORMAL</span>
+            </div>
+            <div class="metric-row">
+              <span>REACTOR COOLANT:</span>
+              <span class="hud-status-value">STEADY</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="card-footer">
+          <p>Uses CSS variables and checkbox state logic to switch spaceship telemetry HUD in real-time.</p>
+        </div>
+      </section>
+
+    </main>
+
+    <!-- Footer -->
+    <footer class="console-footer">
+      <p>Aetheris Command Bridge HUD • Custom Space Range Sliders • Pure CSS Animation System</p>
+    </footer>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/fade-in-range-slider-space/style.css
+++ b/submissions/examples/fade-in-range-slider-space/style.css
@@ -1,0 +1,703 @@
+/* ==========================================================================
+   EaseMotion CSS — Fade In Range Slider Stylesheet
+   Premium Space Cockpit HUD & Range Input Controls overrides
+   ========================================================================== */
+
+/* ── Global HUD Variable Registry ──────────────────────────────────────── */
+:root {
+  /* Color Presets */
+  --space-color-cyan: #00e5ff;
+  --space-color-purple: #bd00ff;
+  --space-color-red: #ff3c3c;
+  
+  /* Active Theme Token (Modified by radio state checks) */
+  --space-hud-accent: var(--space-color-cyan);
+  --space-hud-glow: rgba(0, 229, 255, 0.4);
+  --space-hud-glow-dim: rgba(0, 229, 255, 0.1);
+  
+  --space-color-bg: #030308;
+  --space-color-card: rgba(10, 10, 20, 0.8);
+  --space-color-border: rgba(255, 255, 255, 0.08);
+
+  /* Slider Metric Sizes */
+  --slider-track-height: 6px;
+  --slider-thumb-size: 20px;
+
+  /* Animation Tokens */
+  --space-transition-medium: 0.3s;
+  --space-timing-smooth: cubic-bezier(0.25, 1, 0.5, 1);
+  --space-timing-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* ── Space Cockpit Background Decorations ────────────────────────────────── */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--space-color-bg);
+  color: #e2e8f0;
+  font-family: 'Rajdhani', sans-serif;
+  min-height: 100vh;
+  overflow-x: hidden;
+  position: relative;
+  letter-spacing: 0.05em;
+}
+
+/* Simulated starry background overlay */
+.stars-bg {
+  position: fixed;
+  inset: 0;
+  background-image: 
+    radial-gradient(1px 1px at 20px 30px, #eee, transparent),
+    radial-gradient(1px 1px at 40px 70px, #fff, transparent),
+    radial-gradient(1.5px 1.5px at 50px 160px, #ddd, transparent),
+    radial-gradient(2px 2px at 80px 120px, #fff, transparent),
+    radial-gradient(1px 1px at 110px 210px, #ccc, transparent),
+    radial-gradient(1.5px 1.5px at 140px 290px, #fff, transparent);
+  background-size: 550px 550px;
+  opacity: 0.3;
+  z-index: 1;
+  pointer-events: none;
+}
+
+/* Cosmic purple nebula sweep */
+.nebula-bg {
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(
+    circle at 80% 20%, 
+    rgba(189, 0, 255, 0.08) 0%, 
+    transparent 50%
+  ), radial-gradient(
+    circle at 20% 80%, 
+    rgba(0, 229, 255, 0.06) 0%, 
+    transparent 50%
+  );
+  z-index: 2;
+  pointer-events: none;
+}
+
+/* ── Spaceship Dashboard Container ──────────────────────────────────────── */
+.cockpit-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+  position: relative;
+  z-index: 10;
+}
+
+.console-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 2px solid rgba(255, 255, 255, 0.05);
+  padding-bottom: 1.5rem;
+  margin-bottom: 2.5rem;
+}
+
+.console-logo {
+  display: flex;
+  flex-direction: column;
+  line-height: 1;
+}
+
+.logo-main {
+  font-family: 'Orbitron', sans-serif;
+  font-weight: 900;
+  font-size: 1.8rem;
+  color: #ffffff;
+  text-shadow: 0 0 10px var(--space-hud-accent);
+  transition: text-shadow var(--space-transition-medium) ease;
+}
+
+.logo-sub {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.75rem;
+  color: var(--space-color-text-muted, #64748b);
+  letter-spacing: 0.25em;
+  margin-top: 0.35rem;
+}
+
+.console-status {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--space-color-border);
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.8rem;
+}
+
+.status-indicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: var(--space-hud-accent);
+  box-shadow: 0 0 8px var(--space-hud-accent);
+  transition: all var(--space-transition-medium) ease;
+}
+
+.animate-pulse {
+  animation: pulse-indicator 2s infinite ease-in-out;
+}
+
+@keyframes pulse-indicator {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+/* Grid Layout */
+.console-grid {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 2rem;
+  margin-bottom: 3rem;
+}
+
+/* Console Card structure */
+.console-card {
+  background: var(--space-color-card);
+  border: 1px solid var(--space-color-border);
+  border-radius: 8px;
+  padding: 1.75rem;
+  box-shadow: 0 15px 45px rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(12px);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  transition: border-color var(--space-transition-medium) ease;
+}
+
+.console-card:hover {
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+.tag {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.75rem;
+  color: var(--space-hud-accent);
+  background: var(--space-hud-glow-dim);
+  padding: 2px 6px;
+  border-radius: 2px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  transition: all var(--space-transition-medium) ease;
+}
+
+.card-header h2 {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: #ffffff;
+  margin-top: 0.6rem;
+  letter-spacing: 0.05em;
+}
+
+.card-body {
+  padding: 2rem 0;
+}
+
+.card-footer {
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  padding-top: 1.25rem;
+  font-size: 0.85rem;
+  color: #64748b;
+  line-height: 1.5;
+}
+
+/* ── Fade In Entrance Animations ────────────────────────────────────────── */
+.slider-fade-in {
+  opacity: 0;
+  transform: translateY(16px);
+  animation: fade-in-up var(--space-transition-medium) var(--space-timing-smooth) forwards;
+}
+
+.fade-delay-1 { animation-delay: 0.1s; }
+.fade-delay-2 { animation-delay: 0.25s; }
+.fade-delay-3 { animation-delay: 0.4s; }
+
+@keyframes fade-in-up {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ── Custom Range Slider Override Engine ───────────────────────────────── */
+.sliders-container {
+  display: flex;
+  flex-direction: column;
+  gap: 2.25rem;
+  width: 100%;
+}
+
+.slider-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.slider-label-area {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.slider-title {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.8rem;
+  color: #94a3b8;
+  letter-spacing: 0.1em;
+}
+
+.slider-value-display {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 1.1rem;
+  font-weight: 800;
+  color: #ffffff;
+  text-shadow: 0 0 6px var(--space-hud-accent);
+  transition: text-shadow var(--space-transition-medium) ease;
+}
+
+.slider-input-container {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: var(--slider-thumb-size);
+}
+
+/* Styling range inputs */
+.space-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  background: transparent;
+  outline: none;
+  position: relative;
+  z-index: 10;
+  cursor: pointer;
+}
+
+/* ──── Webkit/Blink Runway overrides ──── */
+.space-slider::-webkit-slider-runnable-track {
+  width: 100%;
+  height: var(--slider-track-height);
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.02);
+  transition: all 0.2s ease;
+}
+
+.space-slider:focus::-webkit-slider-runnable-track,
+.space-slider:hover::-webkit-slider-runnable-track {
+  background: rgba(255, 255, 255, 0.09);
+  box-shadow: 0 0 4px var(--space-hud-glow-dim);
+}
+
+/* Webkit Star Thumb Visualizer */
+.space-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: var(--slider-thumb-size);
+  height: var(--slider-thumb-size);
+  border-radius: 50%;
+  background-color: #ffffff;
+  border: 2px solid var(--space-hud-accent);
+  box-shadow: 
+    0 0 8px var(--space-hud-accent),
+    0 0 16px var(--space-hud-accent);
+  transform: translateY(calc(-50% + var(--slider-track-height) / 2));
+  transition: all 0.25s var(--space-timing-bounce);
+}
+
+.space-slider:hover::-webkit-slider-thumb {
+  transform: translateY(calc(-50% + var(--slider-track-height) / 2)) scale(1.15);
+  box-shadow: 
+    0 0 12px var(--space-hud-accent),
+    0 0 24px var(--space-hud-accent);
+}
+
+.space-slider:active::-webkit-slider-thumb {
+  transform: translateY(calc(-50% + var(--slider-track-height) / 2)) scale(1.25);
+  background-color: var(--space-hud-accent);
+  border-color: #ffffff;
+}
+
+/* ──── Firefox Runway overrides ──── */
+.space-slider::-moz-range-track {
+  width: 100%;
+  height: var(--slider-track-height);
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.02);
+  transition: all 0.2s ease;
+}
+
+.space-slider::-moz-range-thumb {
+  width: var(--slider-thumb-size);
+  height: var(--slider-thumb-size);
+  border-radius: 50%;
+  background-color: #ffffff;
+  border: 2px solid var(--space-hud-accent);
+  box-shadow: 
+    0 0 8px var(--space-hud-accent),
+    0 0 16px var(--space-hud-accent);
+  transition: all 0.25s var(--space-timing-bounce);
+  cursor: pointer;
+}
+
+.space-slider:hover::-moz-range-thumb {
+  transform: scale(1.15);
+  box-shadow: 
+    0 0 12px var(--space-hud-accent),
+    0 0 24px var(--space-hud-accent);
+}
+
+.space-slider:active::-moz-range-thumb {
+  transform: scale(1.25);
+  background-color: var(--space-hud-accent);
+  border-color: #ffffff;
+}
+
+/* Slider Tick Tapes decoration */
+.slider-ticks {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  transform: translateY(-50%);
+  pointer-events: none;
+  z-index: 5;
+  padding: 0 calc(var(--slider-thumb-size) / 2);
+}
+
+.tick {
+  width: 2px;
+  height: 10px;
+  background-color: rgba(255, 255, 255, 0.15);
+  border-radius: 1px;
+}
+
+.slider-meta {
+  display: flex;
+  justify-content: space-between;
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.7rem;
+  color: #475569;
+}
+
+/* ── HUD Telemetry Simulator (Controls panels) ────────────────────────── */
+.controls-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.control-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  padding-bottom: 1.5rem;
+}
+
+.control-section:last-of-type {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.section-title {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.8rem;
+  color: #94a3b8;
+  letter-spacing: 0.1em;
+}
+
+.selection-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  gap: 0.5rem;
+}
+
+.mode-btn,
+.color-btn {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--space-color-border);
+  color: #64748b;
+  padding: 0.65rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-align: center;
+  cursor: pointer;
+  user-select: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  transition: all 0.2s var(--space-timing-smooth);
+}
+
+.mode-btn:hover,
+.color-btn:hover {
+  border-color: rgba(255, 255, 255, 0.2);
+  color: #ffffff;
+}
+
+.btn-icon {
+  font-size: 0.95rem;
+}
+
+.description-text {
+  font-size: 0.75rem;
+  color: #475569;
+  line-height: 1.4;
+}
+
+/* Metrics Dashboard Display Panel */
+.metrics-display-card {
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid var(--space-color-border);
+  border-radius: 4px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin-top: 0.5rem;
+}
+
+.metric-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+.hud-status-value {
+  font-weight: 700;
+  color: var(--space-hud-accent);
+}
+
+.dynamic-gradient-text {
+  background: linear-gradient(90deg, #ffffff, var(--space-hud-accent));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+/* Credit Footers */
+.console-footer {
+  text-align: center;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  padding-top: 1.5rem;
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.8rem;
+  color: #475569;
+}
+
+/* Hide Radio Inputs */
+.ctrl-mode-cruise,
+.ctrl-mode-hyper,
+.ctrl-mode-stealth,
+.ctrl-color-cyan,
+.ctrl-color-purple,
+.ctrl-color-red {
+  display: none;
+}
+
+
+/* ==================== SIBLING STATE BINDINGS (INTERACTIVE LOGIC) ==================== */
+
+/* ── 1. HUD Accent Palette Changes ── */
+#color-cyan:checked ~ * {
+  --space-hud-accent: var(--space-color-cyan);
+  --space-hud-glow: rgba(0, 229, 255, 0.4);
+  --space-hud-glow-dim: rgba(0, 229, 255, 0.08);
+}
+#color-cyan:checked ~ * .label-cyan {
+  background: rgba(0, 229, 255, 0.1);
+  border-color: var(--space-color-cyan);
+  color: var(--space-color-cyan);
+  text-shadow: 0 0 6px rgba(0, 229, 255, 0.4);
+}
+
+#color-purple:checked ~ * {
+  --space-hud-accent: var(--space-color-purple);
+  --space-hud-glow: rgba(189, 0, 255, 0.4);
+  --space-hud-glow-dim: rgba(189, 0, 255, 0.08);
+}
+#color-purple:checked ~ * .label-purple {
+  background: rgba(189, 0, 255, 0.1);
+  border-color: var(--space-color-purple);
+  color: var(--space-color-purple);
+  text-shadow: 0 0 6px rgba(189, 0, 255, 0.4);
+}
+
+#color-red:checked ~ * {
+  --space-hud-accent: var(--space-color-red);
+  --space-hud-glow: rgba(255, 60, 60, 0.4);
+  --space-hud-glow-dim: rgba(255, 60, 60, 0.08);
+}
+#color-red:checked ~ * .label-red {
+  background: rgba(255, 60, 60, 0.1);
+  border-color: var(--space-color-red);
+  color: var(--space-color-red);
+  text-shadow: 0 0 6px rgba(255, 60, 60, 0.4);
+}
+
+/* ── 2. Ship Telemetry Mode Changes ── */
+
+/* Cruising Mode Active Selector styles */
+#mode-cruise:checked ~ * .label-cruise {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: #ffffff;
+  color: #ffffff;
+}
+
+/* Hyperdrive Active State overrides color scheme to blinking red alerts */
+#mode-hyper:checked ~ * {
+  --space-hud-accent: var(--space-color-red);
+  --space-hud-glow: rgba(255, 60, 60, 0.5);
+  --space-hud-glow-dim: rgba(255, 60, 60, 0.1);
+}
+
+#mode-hyper:checked ~ * .label-hyper {
+  background: rgba(255, 60, 60, 0.15);
+  border-color: var(--space-color-red);
+  color: var(--space-color-red);
+  text-shadow: 0 0 8px rgba(255, 60, 60, 0.5);
+  animation: alarm-pulse 1.5s infinite ease-in-out;
+}
+
+#mode-hyper:checked ~ * .space-slider::-webkit-slider-thumb {
+  animation: alarm-pulse-shadow 1.5s infinite ease-in-out;
+}
+#mode-hyper:checked ~ * .space-slider::-moz-range-thumb {
+  animation: alarm-pulse-shadow 1.5s infinite ease-in-out;
+}
+
+#mode-hyper:checked ~ * .dynamic-radar-status::after {
+  content: " OVERDRIVE ACTIVE";
+  color: var(--space-color-red);
+  font-weight: bold;
+}
+#mode-hyper:checked ~ * .dynamic-radar-status {
+  font-size: 0px;
+}
+#mode-hyper:checked ~ * .dynamic-radar-status::after {
+  font-size: 0.8rem;
+}
+
+@keyframes alarm-pulse {
+  0%, 100% { border-color: var(--space-color-red); box-shadow: 0 0 4px var(--space-color-red); }
+  50% { border-color: #ffffff; box-shadow: 0 0 12px var(--space-color-red); }
+}
+
+@keyframes alarm-pulse-shadow {
+  0%, 100% { box-shadow: 0 0 8px var(--space-color-red); }
+  50% { box-shadow: 0 0 20px var(--space-color-red), 0 0 30px var(--space-color-red); }
+}
+
+/* Stealth Mode Dims all HUD telemetry brightness */
+#mode-stealth:checked ~ * {
+  --space-hud-accent: #475569;
+  --space-hud-glow: rgba(71, 85, 105, 0.1);
+  --space-hud-glow-dim: rgba(71, 85, 105, 0.02);
+}
+
+#mode-stealth:checked ~ * .label-stealth {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: #94a3b8;
+  color: #ffffff;
+}
+
+#mode-stealth:checked ~ * .logo-main {
+  text-shadow: none;
+  opacity: 0.4;
+}
+
+#mode-stealth:checked ~ * .slider-value-display {
+  text-shadow: none;
+  color: #475569;
+}
+
+#mode-stealth:checked ~ * .space-slider::-webkit-slider-thumb {
+  box-shadow: 0 0 2px rgba(255, 255, 255, 0.2);
+  border-color: #475569;
+}
+#mode-stealth:checked ~ * .space-slider::-moz-range-thumb {
+  box-shadow: 0 0 2px rgba(255, 255, 255, 0.2);
+  border-color: #475569;
+}
+
+#mode-stealth:checked ~ * .dynamic-radar-status::after {
+  content: " SILENT STEALTH";
+  color: #475569;
+}
+#mode-stealth:checked ~ * .dynamic-radar-status {
+  font-size: 0px;
+}
+#mode-stealth:checked ~ * .dynamic-radar-status::after {
+  font-size: 0.8rem;
+}
+
+
+/* ==================== RESPONSIVE LAYOUTS ==================== */
+@media (max-width: 900px) {
+  .console-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 600px) {
+  .console-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+  
+  .console-status {
+    align-self: flex-start;
+  }
+  
+  .console-card {
+    padding: 1.25rem;
+  }
+}
+
+
+/* ==================== ACCESSIBILITY & REDUCED MOTION ==================== */
+@media (prefers-reduced-motion: reduce) {
+  /* Cancel indicators pulsating */
+  .status-indicator {
+    animation: none !important;
+  }
+
+  /* Disable Hyperdrive alarms pulsing visual details */
+  #mode-hyper:checked ~ * .label-hyper,
+  #mode-hyper:checked ~ * .space-slider::-webkit-slider-thumb,
+  #mode-hyper:checked ~ * .space-slider::-moz-range-thumb {
+    animation: none !important;
+  }
+
+  /* Cancel animations of entrance fades */
+  .slider-fade-in {
+    opacity: 1 !important;
+    transform: none !important;
+    animation: none !important;
+  }
+
+  /* Decrease heavy glowing shadows */
+  .space-slider::-webkit-slider-thumb,
+  .space-slider::-moz-range-thumb {
+    box-shadow: 0 0 4px var(--space-hud-accent) !important;
+  }
+}


### PR DESCRIPTION
Fixes #41446

This pull request introduces the `fade-in-range-slider-space` component under standard HTML/CSS track:
- **Folders Created**: `submissions/examples/fade-in-range-slider-space/`
- **Files Created**: `demo.html`, `style.css`, `README.md`
- **Features Included**:
  1. **Spaceship Bridge Control UI**: Implemented Warp Drive Engine settings dashboard containing primary sliders (speed, oxygen levels, deflector shields).
  2. **Cross-Browser Range Customization**: Overrode default runnable track and thumb properties targeting both Webkit and Gecko layout engines with stellar style guidelines.
  3. **Sequential Fade-in Sequence**: Composited CSS entrance keyframes using delay presets to fade in sliders cleanly.
  4. **Pure CSS Sibling HUD Bindings**: Enabled color schema HUD presets (Cyan, Purple, Red) and flight controls (Stealth Mode vs Overdrive Alarms) using CSS selectors.
  5. **Reduced Motion Compatibility**: Automatically disables active pulsations, alarm animations, and structural transitions when `prefers-reduced-motion` is active.

Over 900+ lines of changes submitted cleanly to avoid conflicts. Please review and merge.