### PR TITLE
feat: add elastic command palette

### DIFF
--- a/submissions/examples/elastic-command-palette-jp/README.md
+++ b/submissions/examples/elastic-command-palette-jp/README.md
@@ -1,0 +1,63 @@
+# Elastic Command Palette with Staggered Shortcut Motion
+
+## What does this do?
+
+This submission creates a pure-CSS command palette that expands from a compact launcher with elastic motion and reveals command items through staggered transitions.
+
+## How is it used?
+
+```html
+<details class="palette-controller-jp" open>
+  <summary class="palette-launcher-jp">
+    Open command palette
+  </summary>
+
+  <div class="palette-backdrop-jp">
+    <section class="command-palette-jp">
+      <label class="search-field-jp">
+        <span class="sr-only-jp">Search commands</span>
+        <input type="search" placeholder="Search commands…" />
+      </label>
+
+      <button class="command-item-jp" type="button">
+        <span class="command-copy-jp">
+          <strong>Open dashboard</strong>
+          <small>View your workspace overview</small>
+        </span>
+        <kbd>D</kbd>
+      </button>
+    </section>
+  </div>
+</details>
+```
+
+Customize the motion system through CSS variables:
+
+```css
+:root {
+  --palette-duration-jp: 640ms;
+  --palette-easing-jp: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --palette-stagger-jp: 65ms;
+  --palette-width-jp: 38rem;
+  --palette-accent-jp: #8b7cff;
+}
+```
+
+The open and closed state is handled by native `details` and `summary` elements. Each command receives a staggered animation delay.
+
+Open `demo.html` directly in a browser. No server, JavaScript, CDN, or external framework is required.
+
+## Why is it useful?
+
+Command palettes are common in admin dashboards, developer tools, productivity apps, documentation sites, and SaaS interfaces.
+
+This example fits EaseMotion CSS because it:
+
+- uses elastic motion to explain palette expansion;
+- stages commands in a clear visual sequence;
+- displays readable command names and shortcut badges;
+- uses keyboard-reachable native controls;
+- includes visible focus states;
+- adapts to mobile layouts;
+- respects `prefers-reduced-motion`;
+- requires zero JavaScript and zero external dependencies.

--- a/submissions/examples/elastic-command-palette-jp/demo.html
+++ b/submissions/examples/elastic-command-palette-jp/demo.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Pure-CSS elastic command palette with staggered shortcut motion." />
+  <title>Elastic Command Palette</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page-shell-jp">
+    <section class="intro-jp">
+      <p class="eyebrow-jp">EaseMotion CSS submission</p>
+      <h1>Elastic Command Palette</h1>
+      <p class="lead-jp">
+        A searchable, keyboard-reachable command interface with elastic open motion,
+        staggered command items, shortcut badges, and no JavaScript.
+      </p>
+    </section>
+
+    <details class="palette-controller-jp" open>
+      <summary class="palette-launcher-jp">
+        <span class="launcher-icon-jp" aria-hidden="true">⌘</span>
+        <span class="open-label-jp">Open command palette</span>
+        <span class="close-label-jp">Close command palette</span>
+        <kbd>Ctrl K</kbd>
+      </summary>
+
+      <div class="palette-backdrop-jp">
+        <section class="command-palette-jp" aria-labelledby="palette-title">
+          <header class="palette-header-jp">
+            <div>
+              <p class="palette-kicker-jp">Quick actions</p>
+              <h2 id="palette-title">What do you want to do?</h2>
+            </div>
+            <span class="status-dot-jp" aria-hidden="true"></span>
+          </header>
+
+          <label class="search-field-jp" for="command-search">
+            <span class="search-icon-jp" aria-hidden="true">⌕</span>
+            <span class="sr-only-jp">Search commands</span>
+            <input id="command-search" type="search" placeholder="Search commands…" />
+          </label>
+
+          <div class="command-group-jp">
+            <p class="group-label-jp">Navigation</p>
+
+            <button class="command-item-jp" type="button">
+              <span class="command-icon-jp" aria-hidden="true">◫</span>
+              <span class="command-copy-jp">
+                <strong>Open dashboard</strong>
+                <small>View your workspace overview</small>
+              </span>
+              <kbd>D</kbd>
+            </button>
+
+            <button class="command-item-jp" type="button">
+              <span class="command-icon-jp" aria-hidden="true">⌕</span>
+              <span class="command-copy-jp">
+                <strong>Search projects</strong>
+                <small>Find repositories and workspaces</small>
+              </span>
+              <kbd>/</kbd>
+            </button>
+          </div>
+
+          <div class="command-group-jp">
+            <p class="group-label-jp">Actions</p>
+
+            <button class="command-item-jp" type="button">
+              <span class="command-icon-jp" aria-hidden="true">＋</span>
+              <span class="command-copy-jp">
+                <strong>Create new task</strong>
+                <small>Add an item to your current project</small>
+              </span>
+              <kbd>N</kbd>
+            </button>
+
+            <button class="command-item-jp" type="button">
+              <span class="command-icon-jp" aria-hidden="true">⚙</span>
+              <span class="command-copy-jp">
+                <strong>Open settings</strong>
+                <small>Manage preferences and integrations</small>
+              </span>
+              <kbd>S</kbd>
+            </button>
+
+            <button class="command-item-jp" type="button">
+              <span class="command-icon-jp" aria-hidden="true">◐</span>
+              <span class="command-copy-jp">
+                <strong>Toggle theme</strong>
+                <small>Switch interface appearance</small>
+              </span>
+              <kbd>T</kbd>
+            </button>
+          </div>
+
+          <footer class="palette-footer-jp">
+            <span><kbd>↑</kbd><kbd>↓</kbd> Navigate</span>
+            <span><kbd>Enter</kbd> Select</span>
+            <span><kbd>Esc</kbd> Close</span>
+          </footer>
+        </section>
+      </div>
+    </details>
+  </main>
+</body>
+</html>

--- a/submissions/examples/elastic-command-palette-jp/style.css
+++ b/submissions/examples/elastic-command-palette-jp/style.css
@@ -1,0 +1,255 @@
+:root {
+  color-scheme: dark;
+  --palette-duration-jp: 640ms;
+  --palette-easing-jp: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --palette-stagger-jp: 65ms;
+  --palette-width-jp: 38rem;
+  --palette-accent-jp: #8b7cff;
+  --palette-surface-jp: #111522;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #070910;
+  color: #f7f8ff;
+}
+* { box-sizing: border-box; }
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(circle at 14% 14%, rgb(139 124 255 / 16%), transparent 27rem),
+    radial-gradient(circle at 86% 84%, rgb(48 218 189 / 10%), transparent 24rem),
+    #070910;
+}
+.page-shell-jp {
+  width: min(100% - 2rem, 74rem);
+  margin-inline: auto;
+  padding: clamp(2.5rem, 7vw, 6rem) 0;
+}
+.intro-jp { max-width: 46rem; }
+.eyebrow-jp {
+  margin: 0 0 .75rem;
+  color: #b6afff;
+  font-size: .74rem;
+  font-weight: 800;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+}
+h1 {
+  max-width: 10ch;
+  margin: 0;
+  font-size: clamp(2.8rem, 8vw, 6.2rem);
+  line-height: .93;
+  letter-spacing: -.06em;
+}
+.lead-jp {
+  max-width: 43rem;
+  margin: 1.2rem 0 0;
+  color: #9ba5b8;
+  line-height: 1.7;
+}
+.palette-controller-jp { margin-top: 2rem; }
+.palette-launcher-jp {
+  position: relative;
+  z-index: 10;
+  display: inline-flex;
+  align-items: center;
+  gap: .7rem;
+  min-height: 3rem;
+  padding: .65rem .8rem;
+  border: 1px solid rgb(255 255 255 / 12%);
+  border-radius: .9rem;
+  background: rgb(255 255 255 / 6%);
+  cursor: pointer;
+  list-style: none;
+  backdrop-filter: blur(12px);
+}
+.palette-launcher-jp::-webkit-details-marker { display: none; }
+.palette-launcher-jp kbd,
+.command-item-jp kbd,
+.palette-footer-jp kbd {
+  border: 1px solid rgb(255 255 255 / 12%);
+  border-bottom-color: rgb(255 255 255 / 24%);
+  border-radius: .4rem;
+  background: rgb(255 255 255 / 7%);
+  color: #c9cfdb;
+  font: inherit;
+  font-size: .66rem;
+  padding: .25rem .38rem;
+}
+.close-label-jp { display: none; }
+.palette-controller-jp[open] .open-label-jp { display: none; }
+.palette-controller-jp[open] .close-label-jp { display: inline; }
+.palette-backdrop-jp {
+  position: fixed;
+  inset: 0;
+  z-index: 8;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: rgb(5 8 16 / 68%);
+  backdrop-filter: blur(10px);
+}
+.command-palette-jp {
+  width: min(100%, var(--palette-width-jp));
+  max-height: min(80vh, 44rem);
+  overflow: auto;
+  padding: 1rem;
+  border: 1px solid rgb(255 255 255 / 12%);
+  border-radius: 1.4rem;
+  background:
+    radial-gradient(circle at 100% 0%, rgb(139 124 255 / 16%), transparent 15rem),
+    linear-gradient(145deg, rgb(255 255 255 / 6%), transparent),
+    var(--palette-surface-jp);
+  box-shadow: 0 2.5rem 7rem rgb(0 0 0 / 44%);
+  transform-origin: center top;
+  animation: palette-open-jp var(--palette-duration-jp) var(--palette-easing-jp) both;
+}
+.palette-header-jp {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: .4rem .35rem 1rem;
+}
+.palette-kicker-jp {
+  margin: 0 0 .35rem;
+  color: #a8a0ff;
+  font-size: .67rem;
+  font-weight: 800;
+  letter-spacing: .11em;
+  text-transform: uppercase;
+}
+.palette-header-jp h2 { margin: 0; font-size: clamp(1.4rem, 4vw, 2rem); }
+.status-dot-jp {
+  width: .62rem;
+  aspect-ratio: 1;
+  margin-top: .55rem;
+  border-radius: 50%;
+  background: #49dfb7;
+  box-shadow: 0 0 0 .25rem rgb(73 223 183 / 12%);
+}
+.search-field-jp {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: .65rem;
+  padding: 0 .85rem;
+  border: 1px solid rgb(255 255 255 / 11%);
+  border-radius: .9rem;
+  background: rgb(255 255 255 / 5%);
+}
+.search-field-jp input {
+  min-height: 3.25rem;
+  width: 100%;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: white;
+  font: inherit;
+}
+.search-field-jp:focus-within {
+  border-color: var(--palette-accent-jp);
+  box-shadow: 0 0 0 .24rem rgb(139 124 255 / 13%);
+}
+.command-group-jp { margin-top: 1rem; }
+.group-label-jp {
+  margin: 0 0 .45rem;
+  padding: 0 .35rem;
+  color: #747f93;
+  font-size: .64rem;
+  font-weight: 800;
+  letter-spacing: .11em;
+  text-transform: uppercase;
+}
+.command-item-jp {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: .75rem;
+  width: 100%;
+  min-height: 4rem;
+  padding: .7rem .75rem;
+  border: 1px solid transparent;
+  border-radius: .9rem;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  opacity: 0;
+  transform: translateY(.8rem) scale(.98);
+  animation: command-enter-jp 420ms var(--palette-easing-jp) forwards;
+}
+.command-item-jp:nth-of-type(2) { animation-delay: calc(var(--palette-stagger-jp) * 1); }
+.command-group-jp:nth-of-type(2) .command-item-jp:nth-of-type(1) { animation-delay: calc(var(--palette-stagger-jp) * 2); }
+.command-group-jp:nth-of-type(2) .command-item-jp:nth-of-type(2) { animation-delay: calc(var(--palette-stagger-jp) * 3); }
+.command-group-jp:nth-of-type(2) .command-item-jp:nth-of-type(3) { animation-delay: calc(var(--palette-stagger-jp) * 4); }
+.command-item-jp:hover,
+.command-item-jp:focus-visible {
+  border-color: rgb(139 124 255 / 24%);
+  background: rgb(139 124 255 / 10%);
+  outline: none;
+}
+.command-item-jp:focus-visible {
+  box-shadow: 0 0 0 .22rem rgb(139 124 255 / 15%);
+}
+.command-icon-jp {
+  display: grid;
+  width: 2.25rem;
+  aspect-ratio: 1;
+  place-items: center;
+  border-radius: .7rem;
+  background: rgb(255 255 255 / 7%);
+  color: #bdb7ff;
+}
+.command-copy-jp { min-width: 0; display: grid; gap: .2rem; }
+.command-copy-jp strong,
+.command-copy-jp small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.command-copy-jp small { color: #808ba0; font-size: .72rem; }
+.palette-footer-jp {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .75rem 1rem;
+  margin-top: 1rem;
+  padding: .75rem .35rem .1rem;
+  border-top: 1px solid rgb(255 255 255 / 8%);
+  color: #7f899b;
+  font-size: .67rem;
+}
+.palette-launcher-jp:focus-visible {
+  outline: 3px solid rgb(174 164 255 / 42%);
+  outline-offset: 3px;
+}
+.sr-only-jp {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+@keyframes palette-open-jp {
+  0% { opacity: 0; transform: translateY(-1.2rem) scale(.82); }
+  55% { opacity: 1; transform: translateY(.2rem) scale(1.035); }
+  78% { transform: translateY(-.08rem) scale(.99); }
+  100% { opacity: 1; transform: none; }
+}
+@keyframes command-enter-jp {
+  to { opacity: 1; transform: none; }
+}
+@media (max-width: 560px) {
+  .palette-footer-jp { display: grid; }
+  .command-item-jp { grid-template-columns: auto 1fr; }
+  .command-item-jp > kbd { grid-column: 2; justify-self: end; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .command-palette-jp,
+  .command-item-jp {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an **Elastic Command Palette with Staggered Shortcut Motion** for Issue #44992.

This submission provides a responsive, pure-CSS command palette with a compact launcher, elastic opening animation, searchable command interface, staggered command-item entrances, keyboard shortcut badges, category separators, visible focus states, and reduced-motion support.

**Closes #44992**

---

## Type of Change

* [x] New animation / hover effect
* [x] New component
* [ ] Documentation improvement
* [ ] Bug fix
* [ ] Other

---

## Submission Checklist

* [x] All changes are inside `submissions/examples/elastic-command-palette-jp/`
* [x] Includes `demo.html`
* [x] Includes `style.css`
* [x] Includes `README.md`
* [x] Demo opens directly in a browser
* [x] Palette opens and closes without JavaScript
* [x] At least five commands are included
* [x] Command items use staggered motion
* [x] Keyboard shortcut badges are displayed
* [x] Search and command controls have visible focus states
* [x] Responsive mobile behavior is included
* [x] Reduced-motion handling is included
* [x] No external dependencies are used
* [x] No shared framework files were modified
* [x] No unrelated changes are included

---

## Feature Description

### What does this add?

A reusable command palette that expands from a compact launcher into a searchable interface using elastic motion.

The demo includes:

* Open dashboard — `D`
* Search projects — `/`
* Create new task — `N`
* Open settings — `S`
* Toggle theme — `T`

### How does it work?

The open and closed state uses native `details` and `summary` elements:

```html
<details class="palette-controller-jp" open>
  <summary class="palette-launcher-jp">
    Open command palette
  </summary>

  <div class="palette-backdrop-jp">
    <section class="command-palette-jp">
      <!-- Search field and commands -->
    </section>
  </div>
</details>
```

Each command uses a progressively larger animation delay, producing staggered entrance motion.

### Customizable variables

```css
:root {
  --palette-duration-jp: 640ms;
  --palette-easing-jp: cubic-bezier(0.34, 1.56, 0.64, 1);
  --palette-stagger-jp: 65ms;
  --palette-width-jp: 38rem;
  --palette-accent-jp: #8b7cff;
}
```

### Accessibility

* The launcher uses a native keyboard-accessible summary control.
* The search field has an accessible label.
* Shortcut badges supplement rather than replace command names.
* Every command uses a native button.
* Focus-visible styling is included.
* The open state does not trap keyboard focus.
* Reduced-motion users receive the complete interface without elastic or staggered movement.

---

## Files Added

```text
submissions/examples/elastic-command-palette-jp/
├── demo.html
├── style.css
└── README.md
```

---

## Browser Testing

Check only browsers personally tested:

* [ ] Chrome
* [ ] Firefox
* [ ] Edge
* [ ] Safari

---

## Notes for Maintainer

The implementation is completely isolated inside the approved Standard Track submission folder.

It uses only semantic HTML, native `details` and `summary` state, CSS custom properties, keyframes, responsive media queries, and scoped styles.

No JavaScript, CDN, framework, icon library, or external dependency is included.
