### PR TITLE
Add sushi component

### DIFF
--- a/submissions/examples/sushi-as/README.md
+++ b/submissions/examples/sushi-as/README.md
@@ -1,0 +1,21 @@
+# Sushi
+
+### What does this do?
+
+It shows two maki rolls and a nigiri on a bamboo mat. Each piece bobs on its own offset so the plate feels alive, and steam drifts up off the rice. Under reduced motion everything settles.
+
+### How is it used?
+
+```html
+<div class="roll r1">
+  <span class="nori"></span>
+  <span class="rice"></span>
+  <span class="fill"></span>
+</div>
+```
+
+The rice grains are a stack of hard stop `radial-gradient` circles painted into the rice disc, so they clip to the round shape for free instead of needing a dozen grain elements. The filling gets its green wrap from a plain `box-shadow` spread rather than a second element. The bamboo mat is one `repeating-linear-gradient`, and the salmon on the nigiri gets its fatty stripes from a second repeating gradient layered over the base colour.
+
+### Why is it useful?
+
+Food, menu, and restaurant themes use sushi. This builds a plate of it with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/sushi-as/demo.html
+++ b/submissions/examples/sushi-as/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sushi</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="mat"></span>
+    <div class="roll r1">
+      <span class="nori"></span>
+      <span class="rice"></span>
+      <span class="fill"></span>
+    </div>
+    <div class="roll r2">
+      <span class="nori"></span>
+      <span class="rice"></span>
+      <span class="fill"></span>
+    </div>
+    <div class="nigiri">
+      <span class="rice2"></span>
+      <span class="fish"></span>
+      <span class="band"></span>
+    </div>
+    <span class="sticks"></span>
+    <span class="steamn sn1"></span>
+    <span class="steamn sn2"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/sushi-as/style.css
+++ b/submissions/examples/sushi-as/style.css
@@ -1,0 +1,183 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 40%, #2c3140, #12141b 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+}
+
+.mat {
+  position: absolute;
+  bottom: 60px;
+  left: 50%;
+  width: 300px;
+  height: 44px;
+  margin-left: -150px;
+  border-radius: 8px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      #b8843f 0 8px,
+      #8a5f26 8px 11px
+    );
+  box-shadow: 0 14px 26px rgba(0, 0, 0, 0.45);
+}
+
+.roll {
+  position: absolute;
+  bottom: 92px;
+  width: 92px;
+  height: 92px;
+  animation: bobs 3.4s ease-in-out infinite;
+}
+
+.r1 { left: 30px; }
+
+.r2 {
+  left: 130px;
+  animation-delay: 0.6s;
+}
+
+.nori {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: linear-gradient(160deg, #1f3327, #0d1a13);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.4);
+}
+
+.rice {
+  position: absolute;
+  inset: 8px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.9) 0 6px, transparent 6px),
+    radial-gradient(circle at 62% 40%, rgba(255, 255, 255, 0.85) 0 7px, transparent 7px),
+    radial-gradient(circle at 40% 68%, rgba(255, 255, 255, 0.85) 0 7px, transparent 7px),
+    radial-gradient(circle at 72% 72%, rgba(255, 255, 255, 0.8) 0 6px, transparent 6px),
+    #f6f1e2;
+}
+
+.fill {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 34px;
+  height: 34px;
+  margin: -17px 0 0 -17px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #ff9d6a, #e5522a 70%);
+  box-shadow: 0 0 0 5px #6fbf62;
+}
+
+.nigiri {
+  position: absolute;
+  bottom: 96px;
+  right: 16px;
+  width: 96px;
+  height: 74px;
+  animation: bobs 3.4s ease-in-out infinite;
+  animation-delay: 1.2s;
+}
+
+.rice2 {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 96px;
+  height: 46px;
+  border-radius: 24px 24px 18px 18px;
+  background: linear-gradient(180deg, #fbf7ec, #ddd3ba);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.4);
+}
+
+.fish {
+  position: absolute;
+  bottom: 30px;
+  left: -4px;
+  width: 104px;
+  height: 32px;
+  border-radius: 20px 20px 14px 14px;
+  background:
+    repeating-linear-gradient(
+      104deg,
+      rgba(255, 255, 255, 0.55) 0 4px,
+      transparent 4px 16px
+    ),
+    linear-gradient(180deg, #ff9d63, #e8622f);
+  transform: rotate(-3deg);
+}
+
+.band {
+  position: absolute;
+  bottom: 26px;
+  left: 40px;
+  width: 18px;
+  height: 44px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #23392c, #0f1d15);
+}
+
+.sticks {
+  position: absolute;
+  bottom: 46px;
+  left: 50%;
+  width: 250px;
+  height: 8px;
+  margin-left: -125px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #d9b877, #a67c37);
+  box-shadow: 0 12px 0 -2px #c1a165;
+  transform: rotate(-2deg);
+}
+
+.steamn {
+  position: absolute;
+  bottom: 180px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.4);
+  filter: blur(4px);
+  opacity: 0;
+  animation: rises 4.2s ease-out infinite;
+}
+
+.sn1 { left: 76px; }
+
+.sn2 {
+  left: 176px;
+  animation-delay: 2.1s;
+}
+
+@keyframes bobs {
+  0%, 100% { transform: translateY(0) rotate(-1deg); }
+  50% { transform: translateY(-8px) rotate(1deg); }
+}
+
+@keyframes rises {
+  0% { transform: translateY(0) scale(0.6); opacity: 0; }
+  25% { opacity: 0.8; }
+  100% { transform: translateY(-80px) translateX(18px) scale(1.8); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .roll,
+  .nigiri,
+  .steamn {
+    animation: none;
+  }
+
+  .steamn {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds sushi built for #45062. The rice grains are a stack of hard stop radial gradients painted into the rice disc, so they clip to the round shape for free instead of needing a dozen grain elements, and the filling gets its green wrap from a box-shadow spread rather than a second element. The bamboo mat is one repeating gradient and the salmon gets its fatty stripes from a second repeating gradient over the base colour. Reduced motion fallback included. Pure CSS. Closes #45062.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: two maki rolls with nori, rice and a salmon centre, plus a salmon nigiri with a nori band, on a bamboo mat with chopsticks.
