### PR TITLE
Add taco component

### DIFF
--- a/submissions/examples/taco-as/README.md
+++ b/submissions/examples/taco-as/README.md
@@ -1,0 +1,22 @@
+# Taco
+
+### What does this do?
+
+It shows a loaded taco on a plate. The whole taco rocks slowly as if someone is about to pick it up, and the cheese shreds shimmer in sequence. Under reduced motion it sits still.
+
+### How is it used?
+
+```html
+<div class="taco">
+  <span class="lettuce"></span>
+  <span class="meat"></span>
+  <span class="shell"></span>
+  <span class="cheese cs1"></span>
+</div>
+```
+
+The lettuce and the meat are each one element: overlapping hard stop `radial-gradient` circles give them a lumpy chopped edge without a pile of child nodes. The shell is a single element whose `border-radius` curves only the bottom two corners, so it reads as a folded tortilla. Every cheese shred and tomato cube keeps its tilt in a custom property (`--ct`, `--tt`) that the shimmer keyframe reads back inside `rotate()`, so the shared animation never flattens the angles.
+
+### Why is it useful?
+
+Food, menu, and restaurant themes use a taco. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/taco-as/demo.html
+++ b/submissions/examples/taco-as/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Taco</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="taco">
+      <span class="lettuce"></span>
+      <span class="meat"></span>
+      <span class="tomato tm1"></span>
+      <span class="tomato tm2"></span>
+      <span class="tomato tm3"></span>
+      <span class="shell"></span>
+      <span class="cheese cs1"></span>
+      <span class="cheese cs2"></span>
+      <span class="cheese cs3"></span>
+      <span class="cheese cs4"></span>
+    </div>
+    <span class="plate2"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/taco-as/style.css
+++ b/submissions/examples/taco-as/style.css
@@ -1,0 +1,176 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 38%, #4a3320, #1b1208 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+}
+
+.taco {
+  position: absolute;
+  top: 60px;
+  left: 50%;
+  width: 260px;
+  height: 150px;
+  margin-left: -130px;
+  animation: wobblet 3.6s ease-in-out infinite;
+}
+
+.shell {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 260px;
+  height: 130px;
+  border-radius: 0 0 130px 130px / 0 0 120px 120px;
+  background: linear-gradient(180deg, #f5c352, #d18b1c);
+  box-shadow:
+    inset 0 -14px 22px rgba(120, 60, 0, 0.35),
+    0 12px 24px rgba(0, 0, 0, 0.4);
+  z-index: 4;
+}
+
+.lettuce {
+  position: absolute;
+  bottom: 112px;
+  left: 14px;
+  width: 232px;
+  height: 60px;
+  border-radius: 30px;
+  background:
+    radial-gradient(circle at 12% 40%, #6fc45a 0 22px, transparent 22px),
+    radial-gradient(circle at 34% 26%, #58ac46 0 24px, transparent 24px),
+    radial-gradient(circle at 58% 34%, #6fc45a 0 24px, transparent 24px),
+    radial-gradient(circle at 82% 30%, #58ac46 0 22px, transparent 22px),
+    transparent;
+  z-index: 3;
+}
+
+.meat {
+  position: absolute;
+  bottom: 104px;
+  left: 26px;
+  width: 208px;
+  height: 46px;
+  border-radius: 24px;
+  background:
+    radial-gradient(circle at 20% 50%, #8a4a24 0 16px, transparent 16px),
+    radial-gradient(circle at 46% 40%, #7a3f1e 0 18px, transparent 18px),
+    radial-gradient(circle at 74% 52%, #8a4a24 0 16px, transparent 16px),
+    #6b3618;
+  z-index: 2;
+}
+
+.tomato {
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #f0533c, #b6291c);
+  z-index: 3;
+  transform: rotate(var(--tt, 0deg));
+}
+
+.tm1 {
+  bottom: 146px;
+  left: 54px;
+
+  --tt: 16deg;
+}
+
+.tm2 {
+  bottom: 156px;
+  left: 122px;
+
+  --tt: -22deg;
+}
+
+.tm3 {
+  bottom: 144px;
+  left: 186px;
+
+  --tt: 34deg;
+}
+
+.cheese {
+  position: absolute;
+  width: 22px;
+  height: 6px;
+  border-radius: 3px;
+  background: #ffd84a;
+  z-index: 5;
+  transform: rotate(var(--ct, 0deg));
+  animation: shimmerc 2.6s ease-in-out infinite;
+}
+
+.cs1 {
+  bottom: 132px;
+  left: 36px;
+
+  --ct: -30deg;
+}
+
+.cs2 {
+  bottom: 170px;
+  left: 96px;
+
+  --ct: 18deg;
+
+  animation-delay: 0.6s;
+}
+
+.cs3 {
+  bottom: 168px;
+  left: 158px;
+
+  --ct: -12deg;
+
+  animation-delay: 1.2s;
+}
+
+.cs4 {
+  bottom: 134px;
+  left: 210px;
+
+  --ct: 26deg;
+
+  animation-delay: 1.8s;
+}
+
+.plate2 {
+  position: absolute;
+  bottom: 66px;
+  left: 50%;
+  width: 280px;
+  height: 26px;
+  margin-left: -140px;
+  border-radius: 50%;
+  background: linear-gradient(180deg, #e8e2d4, #9b9384);
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.45);
+}
+
+@keyframes wobblet {
+  0%, 100% { transform: rotate(-2deg) translateY(0); }
+  50% { transform: rotate(2deg) translateY(-6px); }
+}
+
+@keyframes shimmerc {
+  0%, 100% { opacity: 0.8; transform: rotate(var(--ct, 0deg)) scale(1); }
+  50% { opacity: 1; transform: rotate(var(--ct, 0deg)) scale(1.15); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .taco,
+  .cheese {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a taco built for #45064. The lettuce and the meat are each a single element whose lumpy chopped edge comes from overlapping hard stop radial gradients, so no child nodes are needed for the filling. The shell is one element whose border-radius curves only the bottom two corners, so it reads as a folded tortilla, and it is layered in front of the fillings so they poke up over the rim. Every cheese shred and tomato cube keeps its tilt in a custom property that the shimmer keyframe reads back inside `rotate()`, so the shared animation never flattens the angles. Reduced motion fallback included. Pure CSS. Closes #45064.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a folded tortilla on a plate with lettuce, meat, tomato and cheese showing above the rim.
