### PR TITLE
Add donut component

### DIFF
--- a/submissions/examples/donut-as/README.md
+++ b/submissions/examples/donut-as/README.md
@@ -1,0 +1,22 @@
+# Donut
+
+### What does this do?
+
+It shows a frosted donut floating above its shadow. It bobs and tilts on its own, the sprinkles pulse in sequence, and hovering or focusing it makes the whole donut spin instead. Under reduced motion it holds still.
+
+### How is it used?
+
+```html
+<div class="donut" tabindex="0">
+  <span class="dough"></span>
+  <span class="icing"></span>
+  <span class="sprink s1"></span>
+  <span class="hole"></span>
+</div>
+```
+
+Every sprinkle is placed with `rotate(var(--sd)) translateY(-72px)`, rotating first and then pushing outward, so one custom property both aims the sprinkle around the ring and sets how far from the centre it lands. The pulse keyframe rebuilds that same `rotate(...) translateY(...)` on each step, so the shared animation scales the sprinkle without throwing away its position. The icing gets its uneven poured edge from an asymmetric `border-radius` rather than a clip path.
+
+### Why is it useful?
+
+Bakery, dessert, and playful landing page themes use a donut. This builds one with pure CSS gradients and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/donut-as/demo.html
+++ b/submissions/examples/donut-as/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Donut</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="donut" tabindex="0">
+      <span class="dough"></span>
+      <span class="icing"></span>
+      <span class="sprink s1"></span>
+      <span class="sprink s2"></span>
+      <span class="sprink s3"></span>
+      <span class="sprink s4"></span>
+      <span class="sprink s5"></span>
+      <span class="sprink s6"></span>
+      <span class="sprink s7"></span>
+      <span class="sprink s8"></span>
+      <span class="hole"></span>
+    </div>
+    <span class="shadowd"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/donut-as/style.css
+++ b/submissions/examples/donut-as/style.css
@@ -1,0 +1,181 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 40%, #3b2b45, #17111d 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 320px;
+}
+
+.donut {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 230px;
+  height: 230px;
+  margin: -115px 0 0 -115px;
+  outline: none;
+  animation: floatd 4s ease-in-out infinite;
+}
+
+.donut:hover,
+.donut:focus-visible {
+  animation: spind 3s linear infinite;
+}
+
+.dough {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 30%, #e8a961, #b26f2a 74%);
+  box-shadow:
+    inset 0 -12px 20px rgba(90, 45, 6, 0.4),
+    0 16px 30px rgba(0, 0, 0, 0.45);
+}
+
+.icing {
+  position: absolute;
+  inset: 8px;
+  border-radius: 52% 48% 50% 50% / 48% 52% 50% 50%;
+  background: radial-gradient(circle at 34% 28%, #ff9dd0, #e0509b 76%);
+  box-shadow:
+    inset 0 -10px 16px rgba(150, 30, 90, 0.35),
+    0 6px 0 -2px rgba(224, 80, 155, 0.6);
+  z-index: 2;
+}
+
+.hole {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 74px;
+  height: 74px;
+  margin: -37px 0 0 -37px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 40%, #2a1f31, #17111d);
+  box-shadow: inset 0 6px 12px rgba(0, 0, 0, 0.6);
+  z-index: 4;
+}
+
+.sprink {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 16px;
+  height: 6px;
+  margin: -3px 0 0 -8px;
+  border-radius: 3px;
+  transform: rotate(var(--sd, 0deg)) translateY(-72px);
+  z-index: 3;
+  animation: popd 2.8s ease-in-out infinite;
+}
+
+.s1 {
+  background: #ffe066;
+
+  --sd: 12deg;
+}
+
+.s2 {
+  background: #6fd3ff;
+
+  --sd: 58deg;
+
+  animation-delay: 0.3s;
+}
+
+.s3 {
+  background: #8affb0;
+
+  --sd: 104deg;
+
+  animation-delay: 0.6s;
+}
+
+.s4 {
+  background: #fff3f7;
+
+  --sd: 150deg;
+
+  animation-delay: 0.9s;
+}
+
+.s5 {
+  background: #ffb066;
+
+  --sd: 196deg;
+
+  animation-delay: 1.2s;
+}
+
+.s6 {
+  background: #c39bff;
+
+  --sd: 242deg;
+
+  animation-delay: 1.5s;
+}
+
+.s7 {
+  background: #6fd3ff;
+
+  --sd: 288deg;
+
+  animation-delay: 1.8s;
+}
+
+.s8 {
+  background: #ffe066;
+
+  --sd: 334deg;
+
+  animation-delay: 2.1s;
+}
+
+.shadowd {
+  position: absolute;
+  bottom: 26px;
+  left: 50%;
+  width: 220px;
+  height: 22px;
+  margin-left: -110px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse, rgba(0, 0, 0, 0.5), transparent 70%);
+  filter: blur(3px);
+  animation: shrinkd 4s ease-in-out infinite;
+}
+
+@keyframes floatd {
+  0%, 100% { transform: translateY(0) rotate(-3deg); }
+  50% { transform: translateY(-16px) rotate(3deg); }
+}
+
+@keyframes spind {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes popd {
+  0%, 100% { transform: rotate(var(--sd, 0deg)) translateY(-72px) scale(1); }
+  50% { transform: rotate(var(--sd, 0deg)) translateY(-72px) scale(1.25); }
+}
+
+@keyframes shrinkd {
+  0%, 100% { transform: scaleX(1); opacity: 0.8; }
+  50% { transform: scaleX(0.86); opacity: 0.55; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .donut,
+  .sprink,
+  .shadowd {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a donut built for #45066. Every sprinkle is placed with `rotate(var(--sd)) translateY(-72px)`, rotating first and then pushing outward, so one custom property both aims the sprinkle around the ring and sets how far from the centre it lands. The pulse keyframe rebuilds that same rotate and translate on each step, so scaling a sprinkle never throws away its position. The icing gets its uneven poured edge from an asymmetric border-radius rather than a clip path, and hovering or focusing the donut swaps the float animation for a spin. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45066.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a pink frosted donut with eight coloured sprinkles, a golden dough rim and a hole, floating over a soft shadow.
