### PR TITLE
Add waffle component

### DIFF
--- a/submissions/examples/waffle-as/README.md
+++ b/submissions/examples/waffle-as/README.md
@@ -1,0 +1,23 @@
+# Waffle
+
+### What does this do?
+
+It shows a stack of waffles on a plate with syrup, a pat of butter and berries. The stack settles gently, the butter softens and sinks, the syrup drips stretch and pull back, and the berries pulse. Under reduced motion the plate holds still.
+
+### How is it used?
+
+```html
+<div class="stack">
+  <span class="wafl w3"></span>
+  <span class="wafl w2"></span>
+  <span class="wafl w1"></span>
+  <span class="grid"></span>
+  <span class="syrup"></span>
+</div>
+```
+
+The waffle pockets are two crossed `repeating-linear-gradient`s over the top waffle, so the whole grid is one property rather than a lattice of elements. Each syrup drip stretches from `transform-origin: 50% 0`, so it grows downward off the waffle edge instead of expanding from its own middle, and the butter uses a squashing `scaleY` to read as melting rather than shrinking.
+
+### Why is it useful?
+
+Breakfast, cafe, and menu themes use waffles. This builds a stack with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/waffle-as/demo.html
+++ b/submissions/examples/waffle-as/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Waffle</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="platew"></span>
+    <div class="stack">
+      <span class="wafl w3"></span>
+      <span class="wafl w2"></span>
+      <span class="wafl w1"></span>
+      <span class="grid"></span>
+      <span class="syrup"></span>
+      <span class="butter"></span>
+      <span class="berry bz1"></span>
+      <span class="berry bz2"></span>
+      <span class="berry bz3"></span>
+      <span class="drip dp1"></span>
+      <span class="drip dp2"></span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/waffle-as/style.css
+++ b/submissions/examples/waffle-as/style.css
@@ -1,0 +1,186 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 36%, #4b3a2a, #191108 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 320px;
+}
+
+.platew {
+  position: absolute;
+  bottom: 42px;
+  left: 50%;
+  width: 310px;
+  height: 34px;
+  margin-left: -155px;
+  border-radius: 50%;
+  background: linear-gradient(180deg, #eae4d6, #9c9585);
+  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.45);
+}
+
+.stack {
+  position: absolute;
+  bottom: 62px;
+  left: 50%;
+  width: 240px;
+  height: 150px;
+  margin-left: -120px;
+  animation: settlew 4s ease-in-out infinite;
+}
+
+.wafl {
+  position: absolute;
+  left: 0;
+  width: 240px;
+  height: 34px;
+  border-radius: 14px;
+  background: linear-gradient(180deg, #e0a851, #b0762c);
+  box-shadow: inset 0 -6px 10px rgba(90, 45, 6, 0.4);
+}
+
+.w3 { bottom: 0; }
+
+.w2 {
+  bottom: 24px;
+  left: 6px;
+  width: 228px;
+}
+
+.w1 {
+  bottom: 48px;
+  left: 2px;
+  width: 236px;
+  height: 40px;
+  z-index: 2;
+}
+
+.grid {
+  position: absolute;
+  bottom: 52px;
+  left: 10px;
+  width: 220px;
+  height: 32px;
+  border-radius: 8px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(102, 52, 4, 0.75) 0 5px,
+      transparent 5px 27px
+    ),
+    repeating-linear-gradient(
+      180deg,
+      rgba(102, 52, 4, 0.75) 0 5px,
+      transparent 5px 14px
+    );
+  z-index: 3;
+}
+
+.syrup {
+  position: absolute;
+  bottom: 76px;
+  left: 58px;
+  width: 124px;
+  height: 24px;
+  border-radius: 40% 40% 50% 50% / 60% 60% 40% 40%;
+  background: linear-gradient(180deg, #b96a1c, #8a4a10);
+  box-shadow: inset 0 4px 8px rgba(255, 200, 130, 0.35);
+  z-index: 4;
+}
+
+.drip {
+  position: absolute;
+  width: 12px;
+  height: 22px;
+  border-radius: 0 0 8px 8px;
+  background: linear-gradient(180deg, #b96a1c, #8a4a10);
+  z-index: 4;
+  transform-origin: 50% 0;
+  animation: oozew 4.6s ease-in-out infinite;
+}
+
+.dp1 { bottom: 58px; left: 42px; }
+
+.dp2 {
+  bottom: 60px;
+  right: 52px;
+  animation-delay: 2.3s;
+}
+
+.butter {
+  position: absolute;
+  bottom: 88px;
+  left: 50%;
+  width: 54px;
+  height: 26px;
+  margin-left: -27px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, #ffe98a, #e8c236);
+  box-shadow: 0 3px 6px rgba(120, 80, 10, 0.4);
+  z-index: 5;
+  animation: meltw 4.6s ease-in-out infinite;
+}
+
+.berry {
+  position: absolute;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #7b3cc4, #37146b 72%);
+  box-shadow: inset -3px -3px 6px rgba(0, 0, 0, 0.35);
+  z-index: 5;
+  animation: pulsew 3s ease-in-out infinite;
+}
+
+.bz1 { bottom: 92px; left: 30px; }
+
+.bz2 {
+  bottom: 100px;
+  left: 62px;
+  width: 18px;
+  height: 18px;
+  animation-delay: 0.6s;
+}
+
+.bz3 {
+  bottom: 94px;
+  right: 34px;
+  animation-delay: 1.2s;
+}
+
+@keyframes settlew {
+  0%, 100% { transform: translateY(0) rotate(-0.6deg); }
+  50% { transform: translateY(-5px) rotate(0.6deg); }
+}
+
+@keyframes oozew {
+  0%, 100% { transform: scaleY(0.8); }
+  50% { transform: scaleY(1.35); }
+}
+
+@keyframes meltw {
+  0%, 100% { transform: scaleY(1) translateY(0); }
+  50% { transform: scaleY(0.82) translateY(3px); }
+}
+
+@keyframes pulsew {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.08); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stack,
+  .drip,
+  .butter,
+  .berry {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a waffle stack built for #45068. The waffle pockets are two crossed repeating gradients over the top waffle, so the whole grid is one property rather than a lattice of elements. Each syrup drip stretches from a `transform-origin: 50% 0`, so it grows downward off the waffle edge instead of expanding from its own middle, and the butter uses a squashing scaleY so it reads as melting rather than shrinking. Reduced motion fallback included. Pure CSS. Closes #45068.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: three stacked waffles on a plate with visible pockets, syrup pooling with drips down the side, a pat of butter and three berries.
