### PR TITLE
Add camera component

### DIFF
--- a/submissions/examples/camera-as/README.md
+++ b/submissions/examples/camera-as/README.md
@@ -1,0 +1,22 @@
+# Camera
+
+### What does this do?
+
+It shows a camera taking a shot on a loop. The shutter button presses down, the lens zooms in, the bulb charges and the whole frame flashes white, then everything settles back and the dial turns for the next shot. Under reduced motion the camera sits still and never flashes.
+
+### How is it used?
+
+```html
+<div class="cam">
+  <span class="bodyc"></span>
+  <span class="lens"></span>
+  <span class="glassl"></span>
+  <span class="shutter"></span>
+</div>
+```
+
+The whole sequence is timed rather than triggered: every part runs the same 5 second cycle, and each keyframe holds still until the moment of the shot. The shutter presses at 50%, the bulb's glow `box-shadow` peaks at 50%, and the white overlay only reaches full opacity between 46% and 60%, so the flash lands on the press instead of drifting out of sync. The lens rings are nested circles and the grip texture is one `repeating-linear-gradient`.
+
+### Why is it useful?
+
+Photography, gallery, and portfolio themes use a camera. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback that also suppresses the flash for anyone sensitive to it.

--- a/submissions/examples/camera-as/demo.html
+++ b/submissions/examples/camera-as/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Camera</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="flash"></span>
+    <div class="cam">
+      <span class="bodyc"></span>
+      <span class="grip"></span>
+      <span class="bulb"></span>
+      <span class="lens"></span>
+      <span class="ringl"></span>
+      <span class="glassl"></span>
+      <span class="finder"></span>
+      <span class="dial"></span>
+      <span class="shutter"></span>
+      <span class="strap sl"></span>
+      <span class="strap sr"></span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/camera-as/style.css
+++ b/submissions/examples/camera-as/style.css
@@ -1,0 +1,235 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 40%, #2e3440, #12151b 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+  overflow: hidden;
+  border-radius: 16px;
+}
+
+.flash {
+  position: absolute;
+  inset: 0;
+  background: #fff;
+  opacity: 0;
+  z-index: 9;
+  pointer-events: none;
+  animation: popf 5s ease-out infinite;
+}
+
+.cam {
+  position: absolute;
+  top: 60px;
+  left: 50%;
+  width: 260px;
+  height: 170px;
+  margin-left: -130px;
+  animation: liftc 5s ease-in-out infinite;
+}
+
+.bodyc {
+  position: absolute;
+  top: 24px;
+  left: 0;
+  width: 260px;
+  height: 140px;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #3f4753, #232a33);
+  box-shadow:
+    inset 0 -10px 18px rgba(0, 0, 0, 0.45),
+    0 16px 30px rgba(0, 0, 0, 0.5);
+  z-index: 2;
+}
+
+.grip {
+  position: absolute;
+  top: 34px;
+  left: 12px;
+  width: 54px;
+  height: 118px;
+  border-radius: 12px;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      #2b323b 0 4px,
+      #454e59 4px 8px
+    );
+  z-index: 3;
+}
+
+.lens {
+  position: absolute;
+  top: 46px;
+  left: 50%;
+  width: 106px;
+  height: 106px;
+  margin-left: -53px;
+  border-radius: 50%;
+  background: linear-gradient(180deg, #566070, #2b323b);
+  box-shadow: inset 0 -6px 12px rgba(0, 0, 0, 0.5);
+  z-index: 4;
+  animation: zoomc 5s ease-in-out infinite;
+}
+
+.ringl {
+  position: absolute;
+  top: 56px;
+  left: 50%;
+  width: 86px;
+  height: 86px;
+  margin-left: -43px;
+  border-radius: 50%;
+  border: 5px solid #8b95a3;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 36% 30%, #2a4a6e, #0b1522 74%);
+  z-index: 5;
+}
+
+.glassl {
+  position: absolute;
+  top: 68px;
+  left: 50%;
+  width: 46px;
+  height: 46px;
+  margin-left: -23px;
+  border-radius: 50%;
+  background:
+    linear-gradient(130deg, rgba(255, 255, 255, 0.65) 0 34%, transparent 34%),
+    radial-gradient(circle at 60% 60%, #3f7fb8, #0d1c2c 78%);
+  z-index: 6;
+  animation: glintc 5s ease-in-out infinite;
+}
+
+.finder {
+  position: absolute;
+  top: 0;
+  right: 42px;
+  width: 56px;
+  height: 30px;
+  border-radius: 6px 6px 0 0;
+  background: linear-gradient(180deg, #4c5563, #2f3742);
+  z-index: 1;
+}
+
+.bulb {
+  position: absolute;
+  top: 4px;
+  left: 40px;
+  width: 34px;
+  height: 22px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, #e8eef5, #9aa5b3);
+  box-shadow: 0 0 0 3px #333c46;
+  z-index: 3;
+  animation: chargec 5s ease-in-out infinite;
+}
+
+.dial {
+  position: absolute;
+  top: 34px;
+  right: 24px;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(#7d8794 0 12deg, #59636f 12deg 24deg);
+  border: 3px solid #333c46;
+  box-sizing: border-box;
+  z-index: 5;
+  animation: turnc 5s ease-in-out infinite;
+}
+
+.shutter {
+  position: absolute;
+  top: 8px;
+  right: 108px;
+  width: 26px;
+  height: 16px;
+  border-radius: 5px;
+  background: linear-gradient(180deg, #e05a4a, #9d2b21);
+  z-index: 4;
+  animation: pressc 5s ease-in-out infinite;
+}
+
+.strap {
+  position: absolute;
+  top: 40px;
+  width: 60px;
+  height: 12px;
+  border-radius: 6px;
+  background: linear-gradient(90deg, #6b4a2a, #3d2a17);
+  z-index: 1;
+}
+
+.sl {
+  left: -40px;
+  transform: rotate(-38deg);
+}
+
+.sr {
+  right: -40px;
+  transform: rotate(38deg);
+}
+
+@keyframes liftc {
+  0%, 100% { transform: translateY(0) rotate(-1deg); }
+  46% { transform: translateY(-8px) rotate(1deg); }
+  52% { transform: translateY(-4px) rotate(0deg); }
+}
+
+@keyframes zoomc {
+  0%, 40%, 100% { transform: scale(1); }
+  48% { transform: scale(1.06); }
+}
+
+@keyframes glintc {
+  0%, 44%, 100% { opacity: 0.85; }
+  50% { opacity: 1; }
+}
+
+@keyframes chargec {
+  0%, 42%, 100% { box-shadow: 0 0 0 3px #333c46; }
+  50% { box-shadow: 0 0 0 3px #333c46, 0 0 26px 8px rgba(255, 255, 255, 0.9); }
+}
+
+@keyframes turnc {
+  0%, 30% { transform: rotate(0deg); }
+  60%, 100% { transform: rotate(40deg); }
+}
+
+@keyframes pressc {
+  0%, 44%, 100% { transform: translateY(0); }
+  50% { transform: translateY(5px); }
+}
+
+@keyframes popf {
+  0%, 46% { opacity: 0; }
+  50% { opacity: 0.85; }
+  60%, 100% { opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cam,
+  .lens,
+  .glassl,
+  .bulb,
+  .dial,
+  .shutter,
+  .flash {
+    animation: none;
+  }
+
+  .flash {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a camera built for #45077. The whole sequence is timed rather than triggered: every part runs the same 5 second cycle and each keyframe holds still until the moment of the shot, so the shutter press, the bulb glow and the white overlay all peak at 50% and the flash lands on the press instead of drifting out of sync. The lens is nested circles and the grip texture is one repeating gradient. The reduced motion fallback stops the animation and pins the flash overlay to zero opacity, so nobody sensitive to flashing gets one. Pure CSS. Closes #45077.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a dark camera body with a ribbed grip, a multi ring lens with a glass highlight, a viewfinder, a red shutter button, a knurled dial and two strap lugs.
