### PR TITLE
Add typewriter component

### DIFF
--- a/submissions/examples/typewriter-as/README.md
+++ b/submissions/examples/typewriter-as/README.md
@@ -1,0 +1,22 @@
+# Typewriter
+
+### What does this do?
+
+It shows a typewriter writing a page. The key rows press down in a rippling order, the hammer taps up at the paper, the typed lines appear one step at a time, and when the page fills the carriage return lever swings and the platen knobs roll the paper up. Under reduced motion the page sits finished and still.
+
+### How is it used?
+
+```html
+<div class="tw">
+  <span class="paper"></span>
+  <span class="lines"></span>
+  <span class="keys krow1"></span>
+  <span class="lever"></span>
+</div>
+```
+
+The typed text is revealed with `clip-path: inset(0 100% 0 0)` animating to zero on a `steps(9)` timing function, so the lines appear a chunk at a time like a machine striking characters rather than sliding smoothly into view. Each key row is one element: a `radial-gradient` keycap tiled by `background-size`, so a full row of keys costs no markup, and the three rows share one press keyframe with staggered delays so the ripple runs across the keyboard.
+
+### Why is it useful?
+
+Writing, blog, and retro themes use a typewriter. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/typewriter-as/demo.html
+++ b/submissions/examples/typewriter-as/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Typewriter</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="tw">
+      <span class="paper"></span>
+      <span class="lines"></span>
+      <span class="roller"></span>
+      <span class="knob kl"></span>
+      <span class="knob kr"></span>
+      <span class="bodyt"></span>
+      <span class="hammer"></span>
+      <span class="keys krow1"></span>
+      <span class="keys krow2"></span>
+      <span class="keys krow3"></span>
+      <span class="spacebar"></span>
+      <span class="lever"></span>
+    </div>
+    <span class="deskt"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/typewriter-as/style.css
+++ b/submissions/examples/typewriter-as/style.css
@@ -1,0 +1,218 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 38%, #3b3630, #14120f 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 330px;
+}
+
+.tw {
+  position: absolute;
+  bottom: 62px;
+  left: 50%;
+  width: 280px;
+  height: 240px;
+  margin-left: -140px;
+}
+
+.paper {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 150px;
+  height: 116px;
+  margin-left: -75px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #fbf7ec, #ded7c4);
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.4);
+  z-index: 2;
+}
+
+.lines {
+  position: absolute;
+  top: 26px;
+  left: 50%;
+  width: 118px;
+  height: 52px;
+  margin-left: -59px;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      #6c6558 0 4px,
+      transparent 4px 18px
+    );
+  z-index: 3;
+  transform-origin: 0 0;
+  animation: typet 4.4s steps(9) infinite;
+}
+
+.roller {
+  position: absolute;
+  top: 104px;
+  left: 50%;
+  width: 220px;
+  height: 26px;
+  margin-left: -110px;
+  border-radius: 13px;
+  background: linear-gradient(180deg, #4a453c, #23211c);
+  z-index: 4;
+}
+
+.knob {
+  position: absolute;
+  top: 96px;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(#6f675a 0 14deg, #3d382f 14deg 28deg);
+  border: 4px solid #2a2620;
+  box-sizing: border-box;
+  z-index: 5;
+  animation: rollt 4.4s ease-in-out infinite;
+}
+
+.kl { left: 6px; }
+.kr { right: 6px; }
+
+.hammer {
+  position: absolute;
+  top: 92px;
+  left: 50%;
+  width: 8px;
+  height: 42px;
+  margin-left: -4px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #9aa0a8, #4b5058);
+  transform-origin: 50% 100%;
+  z-index: 1;
+  animation: strikeh 0.55s ease-in-out infinite;
+}
+
+.bodyt {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 280px;
+  height: 118px;
+  border-radius: 14px 14px 10px 10px;
+  background: linear-gradient(180deg, #3f4a52, #232a30);
+  box-shadow:
+    inset 0 -10px 18px rgba(0, 0, 0, 0.45),
+    0 16px 30px rgba(0, 0, 0, 0.5);
+  z-index: 4;
+}
+
+.keys {
+  position: absolute;
+  height: 26px;
+  border-radius: 6px;
+  background-image: radial-gradient(circle 10px at 14px 13px, #efe9dc 98%, transparent 100%);
+  background-size: 28px 26px;
+  z-index: 5;
+  animation: presskt 0.55s ease-in-out infinite;
+}
+
+.krow1 {
+  bottom: 78px;
+  left: 28px;
+  width: 224px;
+}
+
+.krow2 {
+  bottom: 50px;
+  left: 42px;
+  width: 196px;
+  animation-delay: 0.18s;
+}
+
+.krow3 {
+  bottom: 22px;
+  left: 56px;
+  width: 168px;
+  animation-delay: 0.36s;
+}
+
+.spacebar {
+  position: absolute;
+  bottom: 4px;
+  left: 50%;
+  width: 140px;
+  height: 12px;
+  margin-left: -70px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, #efe9dc, #b7b0a1);
+  z-index: 5;
+}
+
+.lever {
+  position: absolute;
+  top: 96px;
+  right: 44px;
+  width: 54px;
+  height: 6px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #9aa0a8, #4b5058);
+  transform-origin: 100% 50%;
+  z-index: 5;
+  animation: returnt 4.4s ease-in-out infinite;
+}
+
+.deskt {
+  position: absolute;
+  bottom: 30px;
+  left: -50vw;
+  right: -50vw;
+  height: 32px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      #6b4f34 0 40px,
+      #5d442c 40px 42px
+    );
+}
+
+@keyframes typet {
+  0% { clip-path: inset(0 100% 0 0); }
+  75%, 100% { clip-path: inset(0 0 0 0); }
+}
+
+@keyframes rollt {
+  0%, 74% { transform: rotate(0deg); }
+  86%, 100% { transform: rotate(-42deg); }
+}
+
+@keyframes strikeh {
+  0%, 100% { transform: rotate(0deg) translateY(0); }
+  50% { transform: rotate(0deg) translateY(-10px); }
+}
+
+@keyframes presskt {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(2px); }
+}
+
+@keyframes returnt {
+  0%, 74% { transform: rotate(0deg); }
+  84% { transform: rotate(-26deg); }
+  94%, 100% { transform: rotate(0deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lines,
+  .knob,
+  .hammer,
+  .keys,
+  .lever {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a typewriter built for #45079. The typed text is revealed with `clip-path: inset(0 100% 0 0)` animating to zero on a `steps(9)` timing function, so the lines appear a chunk at a time like a machine striking characters rather than sliding smoothly into view. Each key row is a single element with a radial gradient keycap tiled by `background-size`, so a full row of keys costs no markup, and the three rows share one press keyframe with staggered delays so the ripple runs across the keyboard. Reduced motion fallback included. Pure CSS. Closes #45079.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a typewriter with a sheet of paper carrying typed lines, a platen with knurled knobs, three rows of round keycaps, a spacebar and a return lever, on a wooden desk.
