### PR TITLE
Add sandcastle component

### DIFF
--- a/submissions/examples/sandcastle-as/README.md
+++ b/submissions/examples/sandcastle-as/README.md
@@ -1,0 +1,22 @@
+# Sandcastle
+
+### What does this do?
+
+It shows a sandcastle on a beach at sunset. The flag flaps on its pole, waves lap up the sand and pull back, the castle settles slightly as the sand shifts, the sun pulses, and a gull drifts across the sky. Under reduced motion the beach goes quiet.
+
+### How is it used?
+
+```html
+<div class="castle">
+  <span class="towr tl"></span>
+  <span class="towr tc"></span>
+  <span class="wallsc"></span>
+  <span class="flagsc"></span>
+</div>
+```
+
+The battlements are a single `clip-path` polygon that cuts the crenellations straight out of the wall, so the notched top costs no extra elements. The flag flaps from `transform-origin: 0 50%` at the pole using a `skewY`, so the cloth bends away from its anchor instead of pivoting as a rigid board, and its swallowtail notch is another clip-path. The shells are `repeating-conic-gradient` fans anchored at their hinge.
+
+### Why is it useful?
+
+Beach, summer, and holiday themes use a sandcastle. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/sandcastle-as/demo.html
+++ b/submissions/examples/sandcastle-as/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sandcastle</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="sunsc"></span>
+    <span class="seasc"></span>
+    <span class="sandsc"></span>
+    <div class="castle">
+      <span class="towr tl"></span>
+      <span class="towr tr"></span>
+      <span class="towr tc"></span>
+      <span class="wallsc"></span>
+      <span class="gate"></span>
+      <span class="flagpole"></span>
+      <span class="flagsc"></span>
+      <span class="shell1"></span>
+      <span class="shell2"></span>
+    </div>
+    <span class="wave wv1"></span>
+    <span class="wave wv2"></span>
+    <span class="gull"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/sandcastle-as/style.css
+++ b/submissions/examples/sandcastle-as/style.css
@@ -1,0 +1,249 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #ffd08a, #ff9a5c 46%, #f2e0b6);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 360px;
+  height: 320px;
+}
+
+.sunsc {
+  position: absolute;
+  top: 16px;
+  right: 40px;
+  width: 74px;
+  height: 74px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 36%, #fff6d0, #ffd357 72%);
+  box-shadow: 0 0 50px rgba(255, 220, 130, 0.9);
+  animation: glowsc 5s ease-in-out infinite;
+}
+
+.seasc {
+  position: absolute;
+  bottom: 96px;
+  left: -50vw;
+  right: -50vw;
+  height: 74px;
+  background:
+    repeating-linear-gradient(
+      92deg,
+      rgba(255, 255, 255, 0.22) 0 4px,
+      transparent 4px 32px
+    ),
+    linear-gradient(180deg, #2f9fbf, #1c6f92);
+}
+
+.sandsc {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 110px);
+  background:
+    radial-gradient(circle at 18% 6%, rgba(180, 140, 80, 0.35) 0 5px, transparent 5px),
+    radial-gradient(circle at 54% 12%, rgba(180, 140, 80, 0.3) 0 4px, transparent 4px),
+    radial-gradient(circle at 82% 8%, rgba(180, 140, 80, 0.35) 0 6px, transparent 6px),
+    linear-gradient(180deg, #f0d9a4, #d9b876);
+  z-index: 3;
+}
+
+.wave {
+  position: absolute;
+  left: 50%;
+  width: 300px;
+  height: 16px;
+  margin-left: -150px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.75);
+  filter: blur(2px);
+  z-index: 4;
+  animation: lapsc 5s ease-in-out infinite;
+}
+
+.wv1 { bottom: 104px; }
+
+.wv2 {
+  bottom: 92px;
+  width: 260px;
+  margin-left: -130px;
+  animation-delay: 1.6s;
+}
+
+.castle {
+  position: absolute;
+  bottom: 104px;
+  left: 50%;
+  width: 250px;
+  height: 170px;
+  margin-left: -125px;
+  z-index: 5;
+  animation: settlesc 6s ease-in-out infinite;
+}
+
+.towr {
+  position: absolute;
+  bottom: 0;
+  width: 60px;
+  border-radius: 6px 6px 0 0;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      rgba(150, 110, 50, 0.18) 0 3px,
+      transparent 3px 16px
+    ),
+    linear-gradient(180deg, #f3dcab, #cfa967);
+  box-shadow: inset -8px 0 12px rgba(120, 80, 20, 0.25);
+}
+
+.tl {
+  left: 0;
+  height: 108px;
+}
+
+.tr {
+  right: 0;
+  height: 108px;
+}
+
+.tc {
+  left: 50%;
+  width: 76px;
+  height: 150px;
+  margin-left: -38px;
+  z-index: 2;
+}
+
+.wallsc {
+  position: absolute;
+  bottom: 0;
+  left: 44px;
+  width: 162px;
+  height: 66px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(150, 110, 50, 0.16) 0 2px,
+      transparent 2px 26px
+    ),
+    linear-gradient(180deg, #e9cd93, #b98f4c);
+  clip-path: polygon(0 18px, 16px 18px, 16px 0, 40px 0, 40px 18px, 64px 18px, 64px 0, 88px 0, 88px 18px, 112px 18px, 112px 0, 136px 0, 136px 18px, 162px 18px, 162px 100%, 0 100%);
+  z-index: 1;
+}
+
+.gate {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 42px;
+  height: 50px;
+  margin-left: -21px;
+  border-radius: 21px 21px 0 0;
+  background: linear-gradient(180deg, #8a6432, #5d4220);
+  z-index: 3;
+}
+
+.flagpole {
+  position: absolute;
+  bottom: 150px;
+  left: 50%;
+  width: 4px;
+  height: 40px;
+  margin-left: -2px;
+  background: #8a6432;
+  z-index: 3;
+}
+
+.flagsc {
+  position: absolute;
+  bottom: 172px;
+  left: 50%;
+  width: 40px;
+  height: 20px;
+  margin-left: 2px;
+  clip-path: polygon(0 0, 100% 0, 78% 50%, 100% 100%, 0 100%);
+  background: linear-gradient(90deg, #e8443c, #b31f28);
+  transform-origin: 0 50%;
+  z-index: 3;
+  animation: flapsc 1.8s ease-in-out infinite;
+}
+
+.shell1 {
+  position: absolute;
+  bottom: 4px;
+  left: -22px;
+  width: 22px;
+  height: 18px;
+  border-radius: 12px 12px 4px 4px;
+  background:
+    repeating-conic-gradient(from 200deg at 50% 100%, #ffd7dd 0 8deg, #f5a9b8 8deg 16deg);
+  z-index: 4;
+}
+
+.shell2 {
+  position: absolute;
+  bottom: 2px;
+  right: -28px;
+  width: 18px;
+  height: 15px;
+  border-radius: 10px 10px 3px 3px;
+  background:
+    repeating-conic-gradient(from 200deg at 50% 100%, #fff0d2 0 9deg, #e8c68a 9deg 18deg);
+  z-index: 4;
+}
+
+.gull {
+  position: absolute;
+  top: 54px;
+  left: 40px;
+  width: 30px;
+  height: 12px;
+  border-radius: 50% 50% 0 0 / 100% 100% 0 0;
+  border-top: 3px solid rgba(70, 60, 50, 0.7);
+  box-shadow: 34px 8px 0 -1px transparent;
+  animation: flysc 9s linear infinite;
+}
+
+@keyframes glowsc {
+  0%, 100% { transform: scale(1); opacity: 0.95; }
+  50% { transform: scale(1.05); opacity: 1; }
+}
+
+@keyframes lapsc {
+  0%, 100% { transform: translateY(0) scaleX(1); opacity: 0.5; }
+  50% { transform: translateY(6px) scaleX(1.08); opacity: 0.9; }
+}
+
+@keyframes settlesc {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-3px); }
+}
+
+@keyframes flapsc {
+  0%, 100% { transform: skewY(0deg) scaleX(1); }
+  50% { transform: skewY(-6deg) scaleX(0.92); }
+}
+
+@keyframes flysc {
+  0% { transform: translate(0, 0); }
+  50% { transform: translate(240px, -18px); }
+  100% { transform: translate(0, 0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sunsc,
+  .wave,
+  .castle,
+  .flagsc,
+  .gull {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a sandcastle built for #45081. The battlements are a single clip-path polygon that cuts the crenellations straight out of the wall, so the notched top costs no extra elements. The flag flaps from a `transform-origin: 0 50%` at the pole using a skewY, so the cloth bends away from its anchor instead of pivoting as a rigid board, and its swallowtail notch is another clip-path. The shells are repeating conic gradients anchored at their hinge. Reduced motion fallback included. Pure CSS. Closes #45081.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a three tower sandcastle with a crenellated wall, an arched gate and a red flag, sitting on sand in front of the sea at sunset, with shells and a gull.
