### PR TITLE
Add mushroom component

### DIFF
--- a/submissions/examples/mushroom-as/README.md
+++ b/submissions/examples/mushroom-as/README.md
@@ -1,0 +1,21 @@
+# Mushroom
+
+### What does this do?
+
+It shows two spotted toadstools growing out of the forest floor. They sway from their bases on separate offsets, the grass blades bend, and spores drift up and fade. Under reduced motion the patch is still.
+
+### How is it used?
+
+```html
+<div class="shroom big">
+  <span class="cap"></span>
+  <span class="stem"></span>
+  <span class="ring"></span>
+</div>
+```
+
+The cap and its white spots are one element: six hard stop `radial-gradient` circles are painted over the red base, so they clip to the dome shape for free and never spill off the edge, and the dome itself is an asymmetric `border-radius` rather than a clip path. The two mushrooms share the same markup and CSS, sized only by the parent's width and height, because every inner part is measured in percentages. Both sway from `transform-origin: 50% 100%` so they hinge at the soil rather than pivoting mid air.
+
+### Why is it useful?
+
+Forest, garden, and fantasy themes use toadstools. This builds a patch with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/mushroom-as/demo.html
+++ b/submissions/examples/mushroom-as/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mushroom</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="shroom big">
+      <span class="cap"></span>
+      <span class="stem"></span>
+      <span class="ring"></span>
+    </div>
+    <div class="shroom small">
+      <span class="cap"></span>
+      <span class="stem"></span>
+      <span class="ring"></span>
+    </div>
+    <span class="grassm gm1"></span>
+    <span class="grassm gm2"></span>
+    <span class="grassm gm3"></span>
+    <span class="spore sr1"></span>
+    <span class="spore sr2"></span>
+    <span class="spore sr3"></span>
+    <span class="soil"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/mushroom-as/style.css
+++ b/submissions/examples/mushroom-as/style.css
@@ -1,0 +1,182 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 34%, #24402f, #0d1810 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 320px;
+}
+
+.soil {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 72px);
+  background:
+    radial-gradient(circle at 16% 4%, rgba(30, 60, 34, 0.6) 0 12px, transparent 12px),
+    radial-gradient(circle at 62% 8%, rgba(30, 60, 34, 0.5) 0 16px, transparent 16px),
+    linear-gradient(180deg, #3f5c3c, #22331f);
+  z-index: 4;
+}
+
+.shroom {
+  position: absolute;
+  transform-origin: 50% 100%;
+  z-index: 3;
+  animation: swayms 4.4s ease-in-out infinite;
+}
+
+.big {
+  bottom: 66px;
+  left: 50%;
+  width: 200px;
+  height: 190px;
+  margin-left: -110px;
+}
+
+.small {
+  bottom: 62px;
+  right: 26px;
+  width: 120px;
+  height: 116px;
+  animation-delay: 1.4s;
+  z-index: 2;
+}
+
+.cap {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 58%;
+  border-radius: 50% 50% 46% 46% / 78% 78% 26% 26%;
+  background:
+    radial-gradient(circle at 26% 30%, #fff6f2 0 15px, transparent 15px),
+    radial-gradient(circle at 62% 22%, #fff6f2 0 18px, transparent 18px),
+    radial-gradient(circle at 82% 44%, #fff6f2 0 12px, transparent 12px),
+    radial-gradient(circle at 44% 56%, #fff6f2 0 13px, transparent 13px),
+    radial-gradient(circle at 12% 62%, #fff6f2 0 9px, transparent 9px),
+    radial-gradient(circle at 68% 66%, #fff6f2 0 10px, transparent 10px),
+    radial-gradient(circle at 40% 26%, #f0604f, #b7202a 78%);
+  box-shadow:
+    inset 0 -10px 18px rgba(120, 20, 20, 0.4),
+    0 12px 24px rgba(0, 0, 0, 0.45);
+  z-index: 3;
+}
+
+.stem {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 34%;
+  height: 52%;
+  margin-left: -17%;
+  border-radius: 14px 14px 22px 22px;
+  background: linear-gradient(90deg, #fdf6e4, #d6c8a6);
+  box-shadow: inset -8px 0 12px rgba(120, 100, 60, 0.25);
+  z-index: 2;
+}
+
+.ring {
+  position: absolute;
+  top: 52%;
+  left: 50%;
+  width: 52%;
+  height: 12px;
+  margin-left: -26%;
+  border-radius: 8px;
+  background: linear-gradient(180deg, #fffdf6, #cfc19f);
+  z-index: 3;
+}
+
+.grassm {
+  position: absolute;
+  bottom: 58px;
+  width: 12px;
+  height: 44px;
+  border-radius: 6px 6px 0 0;
+  background: linear-gradient(180deg, #63a352, #2c5730);
+  transform-origin: 50% 100%;
+  z-index: 5;
+  animation: swayg 3.2s ease-in-out infinite;
+}
+
+.gm1 {
+  left: 34px;
+  transform: rotate(-8deg);
+}
+
+.gm2 {
+  left: 58px;
+  height: 30px;
+  animation-delay: 0.7s;
+}
+
+.gm3 {
+  right: 34px;
+  height: 36px;
+  animation-delay: 1.4s;
+}
+
+.spore {
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: rgba(255, 240, 210, 0.9);
+  box-shadow: 0 0 8px rgba(255, 240, 200, 0.8);
+  opacity: 0;
+  z-index: 6;
+  animation: driftms 5s ease-out infinite;
+}
+
+.sr1 { bottom: 150px; left: 90px; }
+
+.sr2 {
+  bottom: 130px;
+  left: 160px;
+  animation-delay: 1.7s;
+}
+
+.sr3 {
+  bottom: 140px;
+  right: 70px;
+  animation-delay: 3.4s;
+}
+
+@keyframes swayms {
+  0%, 100% { transform: rotate(-2deg); }
+  50% { transform: rotate(2deg); }
+}
+
+@keyframes swayg {
+  0%, 100% { transform: rotate(-6deg); }
+  50% { transform: rotate(6deg); }
+}
+
+@keyframes driftms {
+  0% { transform: translate(0, 0) scale(0.6); opacity: 0; }
+  25% { opacity: 1; }
+  100% { transform: translate(26px, -90px) scale(1.2); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shroom,
+  .grassm,
+  .spore {
+    animation: none;
+  }
+
+  .spore {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a mushroom patch built for #45087. The cap and its white spots are one element: six hard stop radial gradients are painted over the red base, so the spots clip to the dome for free and never spill off the edge, and the dome itself is an asymmetric border-radius rather than a clip path. The two mushrooms share the same markup and CSS and are sized only by the parent's width and height, because every inner part is measured in percentages. Both sway from a `transform-origin: 50% 100%` so they hinge at the soil rather than pivoting mid air. Reduced motion fallback included. Pure CSS. Closes #45087.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a large and a small red toadstool with white spots, cream stems and skirt rings, on a mossy floor with grass and drifting spores.
