### PR TITLE
Add butterfly component

### DIFF
--- a/submissions/examples/butterfly-as/README.md
+++ b/submissions/examples/butterfly-as/README.md
@@ -1,0 +1,21 @@
+# Butterfly
+
+### What does this do?
+
+It shows a butterfly hovering over a flower. All four wings beat, the whole insect drifts up and sideways as it flies, pollen sparkles blink around it, and the flower rocks below. Under reduced motion the wings settle open.
+
+### How is it used?
+
+```html
+<div class="fly">
+  <span class="wing wtl"></span>
+  <span class="wing wtr"></span>
+  <span class="bodyf"></span>
+</div>
+```
+
+The wing beat is a `rotateY` rather than a scale, so each wing turns edge on and reads as folding through space instead of squashing flat. What makes that work for both sides from one keyframe is `transform-origin: var(--ox) 50%`: the left wings hinge at their right edge (`--ox: 100%`) and the right wings at their left edge (`--ox: 0%`), so a single `flapf` animation drives all four and each still pivots at the body. The lower wings carry a small delay so the pairs do not beat in lockstep.
+
+### Why is it useful?
+
+Nature, spring, and playful landing page themes use a butterfly. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/butterfly-as/demo.html
+++ b/submissions/examples/butterfly-as/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Butterfly</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="fly">
+      <span class="wing wtl"></span>
+      <span class="wing wtr"></span>
+      <span class="wing wbl"></span>
+      <span class="wing wbr"></span>
+      <span class="bodyf"></span>
+      <span class="head"></span>
+      <span class="ant al"></span>
+      <span class="ant ar"></span>
+    </div>
+    <span class="sparkf sf1"></span>
+    <span class="sparkf sf2"></span>
+    <span class="sparkf sf3"></span>
+    <span class="flowerb"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/butterfly-as/style.css
+++ b/submissions/examples/butterfly-as/style.css
@@ -1,0 +1,206 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 36%, #2b2350, #100c1f 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 320px;
+}
+
+.fly {
+  position: absolute;
+  top: 60px;
+  left: 50%;
+  width: 240px;
+  height: 170px;
+  margin-left: -120px;
+  z-index: 4;
+  animation: flutterf 5s ease-in-out infinite;
+}
+
+.bodyf {
+  position: absolute;
+  top: 34px;
+  left: 50%;
+  width: 16px;
+  height: 100px;
+  margin-left: -8px;
+  border-radius: 8px 8px 10px 10px;
+  background: linear-gradient(180deg, #4b3f6b, #241d3a);
+  z-index: 5;
+}
+
+.head {
+  position: absolute;
+  top: 20px;
+  left: 50%;
+  width: 22px;
+  height: 22px;
+  margin-left: -11px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #6a5b91, #2b2247 74%);
+  z-index: 6;
+}
+
+.ant {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 4px;
+  height: 30px;
+  border-radius: 2px;
+  background: #6a5b91;
+  transform-origin: 50% 100%;
+  z-index: 5;
+}
+
+.al {
+  margin-left: -8px;
+  transform: rotate(-24deg);
+}
+
+.ar {
+  margin-left: 4px;
+  transform: rotate(24deg);
+}
+
+.wing {
+  position: absolute;
+  transform-origin: var(--ox, 100%) 50%;
+  box-shadow: inset 0 0 0 2px rgba(30, 20, 50, 0.45);
+  animation: flapf 1.4s ease-in-out infinite;
+  z-index: 3;
+}
+
+.wtl,
+.wtr {
+  top: 4px;
+  width: 104px;
+  height: 88px;
+  background:
+    radial-gradient(circle at 30% 34%, #ffe9a8 0 12px, transparent 12px),
+    radial-gradient(circle at 58% 62%, #ff9ad2 0 10px, transparent 10px),
+    linear-gradient(150deg, #ff7bb0, #8a3ce0);
+}
+
+.wtl {
+  left: 12px;
+  border-radius: 60% 30% 40% 70% / 70% 40% 60% 30%;
+
+  --ox: 100%;
+}
+
+.wtr {
+  right: 12px;
+  border-radius: 30% 60% 70% 40% / 40% 70% 30% 60%;
+
+  --ox: 0%;
+}
+
+.wbl,
+.wbr {
+  top: 78px;
+  width: 84px;
+  height: 76px;
+  background:
+    radial-gradient(circle at 46% 40%, #a8f0ff 0 9px, transparent 9px),
+    linear-gradient(150deg, #b25ce8, #4a2ba8);
+  animation-delay: 0.08s;
+}
+
+.wbl {
+  left: 30px;
+  border-radius: 50% 30% 60% 40% / 40% 30% 70% 60%;
+
+  --ox: 100%;
+}
+
+.wbr {
+  right: 30px;
+  border-radius: 30% 50% 40% 60% / 30% 40% 60% 70%;
+
+  --ox: 0%;
+}
+
+.sparkf {
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #ffe9a8;
+  box-shadow: 0 0 8px rgba(255, 230, 160, 0.9);
+  opacity: 0;
+  z-index: 2;
+  animation: twinklef 3.4s ease-in-out infinite;
+}
+
+.sf1 { top: 50px; left: 44px; }
+
+.sf2 {
+  top: 96px;
+  right: 40px;
+  animation-delay: 1.1s;
+}
+
+.sf3 {
+  top: 170px;
+  left: 62px;
+  animation-delay: 2.2s;
+}
+
+.flowerb {
+  position: absolute;
+  bottom: 30px;
+  left: 50%;
+  width: 60px;
+  height: 60px;
+  margin-left: -30px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 50% 50%, #ffd75e 0 12px, transparent 12px),
+    repeating-conic-gradient(from 0deg, #ff8fbe 0 36deg, #e2559a 36deg 72deg);
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.4);
+  z-index: 2;
+  animation: bloomb 5s ease-in-out infinite;
+}
+
+@keyframes flapf {
+  0%, 100% { transform: rotateY(0deg); }
+  50% { transform: rotateY(62deg); }
+}
+
+@keyframes flutterf {
+  0%, 100% { transform: translate(0, 0) rotate(-2deg); }
+  50% { transform: translate(10px, -22px) rotate(2deg); }
+}
+
+@keyframes twinklef {
+  0%, 100% { opacity: 0; transform: scale(0.6); }
+  50% { opacity: 1; transform: scale(1.2); }
+}
+
+@keyframes bloomb {
+  0%, 100% { transform: scale(1) rotate(0deg); }
+  50% { transform: scale(1.06) rotate(12deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fly,
+  .wing,
+  .sparkf,
+  .flowerb {
+    animation: none;
+  }
+
+  .sparkf {
+    opacity: 0.8;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a butterfly built for #45089. The wing beat is a rotateY rather than a scale, so each wing turns edge on and reads as folding through space instead of squashing flat. What makes one keyframe work for both sides is `transform-origin: var(--ox) 50%`: the left wings hinge at their right edge and the right wings at their left edge, so a single `flapf` animation drives all four and each still pivots at the body. The lower wings carry a small delay so the pairs do not beat in lockstep. Reduced motion fallback included. Pure CSS. Closes #45089.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot, including a frame with the wings held open: four patterned wings, a segmented body, curled antennae and a flower below.
