### PR TITLE
Add narwhal component

### DIFF
--- a/submissions/examples/narwhal-as/README.md
+++ b/submissions/examples/narwhal-as/README.md
@@ -1,0 +1,24 @@
+# Narwhal
+
+### What does this do?
+
+It shows a narwhal swimming under the ice. It rises and dips as it moves, the tail flukes waggle, the flipper paddles, the eye blinks, and bubbles trail up behind it. Under reduced motion it holds position.
+
+### How is it used?
+
+```html
+<div class="narw">
+  <span class="bodyn"></span>
+  <span class="tusk"></span>
+  <div class="tailn">
+    <span class="fluke fkl"></span>
+    <span class="fluke fkr"></span>
+  </div>
+</div>
+```
+
+The tusk is one element: a `clip-path` tapers a bar into a spike and a `repeating-linear-gradient` cuts the spiral grooves across it, so the whole horn is a single node. The tail is two flukes that keep their spread angles in a `--fr` custom property and hinge from a shared `transform-origin` at the tail root, while the waggle runs on their wrapper, so the flukes keep their V shape instead of being flattened by the animation.
+
+### Why is it useful?
+
+Ocean, arctic, and playful mascot themes use a narwhal. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/narwhal-as/demo.html
+++ b/submissions/examples/narwhal-as/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Narwhal</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="raysn"></span>
+    <span class="icen"></span>
+    <div class="narw">
+      <span class="bodyn"></span>
+      <span class="belly"></span>
+      <span class="tusk"></span>
+      <span class="eyen"></span>
+      <span class="finn"></span>
+      <div class="tailn">
+        <span class="fluke fkl"></span>
+        <span class="fluke fkr"></span>
+      </div>
+      <span class="speck sp1"></span>
+      <span class="speck sp2"></span>
+      <span class="speck sp3"></span>
+    </div>
+    <span class="bubn bn1"></span>
+    <span class="bubn bn2"></span>
+    <span class="bubn bn3"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/narwhal-as/style.css
+++ b/submissions/examples/narwhal-as/style.css
@@ -1,0 +1,261 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #1a6a8e, #062033 78%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 360px;
+  height: 300px;
+}
+
+.raysn {
+  position: absolute;
+  top: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 200px);
+  background:
+    repeating-linear-gradient(
+      98deg,
+      rgba(190, 240, 255, 0.07) 0 22px,
+      transparent 22px 86px
+    );
+  pointer-events: none;
+}
+
+.icen {
+  position: absolute;
+  top: -18px;
+  left: -50vw;
+  right: -50vw;
+  height: 56px;
+  background:
+    radial-gradient(circle at 24% 100%, #e6f6ff 0 44px, transparent 44px),
+    radial-gradient(circle at 58% 100%, #d3ecfb 0 36px, transparent 36px),
+    radial-gradient(circle at 86% 100%, #e6f6ff 0 40px, transparent 40px),
+    #f2fbff;
+}
+
+.narw {
+  position: absolute;
+  top: 110px;
+  left: 50%;
+  width: 300px;
+  height: 130px;
+  margin-left: -150px;
+  z-index: 3;
+  animation: swimn 5s ease-in-out infinite;
+}
+
+.bodyn {
+  position: absolute;
+  top: 26px;
+  left: 60px;
+  width: 190px;
+  height: 76px;
+  border-radius: 46% 54% 50% 50% / 56% 60% 40% 44%;
+  background: linear-gradient(180deg, #8fa9d8, #4c66a3);
+  box-shadow: inset 0 -10px 18px rgba(20, 40, 80, 0.45);
+  z-index: 3;
+}
+
+.belly {
+  position: absolute;
+  top: 66px;
+  left: 78px;
+  width: 150px;
+  height: 34px;
+  border-radius: 50%;
+  background: linear-gradient(180deg, #cfe0f5, #9db3d8);
+  z-index: 4;
+}
+
+.speck {
+  position: absolute;
+  width: 12px;
+  height: 8px;
+  border-radius: 50%;
+  background: rgba(40, 60, 110, 0.5);
+  z-index: 5;
+  transform: rotate(var(--kr, 0deg));
+}
+
+.sp1 {
+  top: 40px;
+  left: 108px;
+
+  --kr: 14deg;
+}
+
+.sp2 {
+  top: 34px;
+  left: 152px;
+
+  --kr: -22deg;
+}
+
+.sp3 {
+  top: 46px;
+  left: 196px;
+
+  --kr: 8deg;
+}
+
+.tusk {
+  position: absolute;
+  top: 34px;
+  left: 224px;
+  width: 100px;
+  height: 12px;
+  border-radius: 6px 3px 3px 6px;
+  background:
+    repeating-linear-gradient(
+      116deg,
+      rgba(160, 140, 100, 0.4) 0 3px,
+      transparent 3px 12px
+    ),
+    linear-gradient(90deg, #f3ead4, #fffdf6);
+  clip-path: polygon(0 0, 100% 42%, 100% 58%, 0 100%);
+  z-index: 5;
+}
+
+.eyen {
+  position: absolute;
+  top: 46px;
+  left: 214px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #16233d;
+  box-shadow: inset -2px -2px 0 rgba(255, 255, 255, 0.35);
+  z-index: 6;
+  animation: blinkn 4.6s ease-in-out infinite;
+}
+
+.finn {
+  position: absolute;
+  top: 84px;
+  left: 138px;
+  width: 56px;
+  height: 26px;
+  border-radius: 0 0 40px 12px;
+  background: linear-gradient(180deg, #6f8ac2, #3c5488);
+  transform-origin: 50% 0;
+  z-index: 2;
+  animation: paddlen 2.4s ease-in-out infinite;
+}
+
+.tailn {
+  position: absolute;
+  top: 48px;
+  left: 16px;
+  width: 40px;
+  height: 40px;
+  transform-origin: 100% 50%;
+  z-index: 2;
+  animation: waggle 2.4s ease-in-out infinite;
+}
+
+.fluke {
+  position: absolute;
+  left: -30px;
+  width: 72px;
+  height: 30px;
+  background: linear-gradient(90deg, #3c5488, #7c96cd);
+  transform-origin: 100% 50%;
+  transform: rotate(var(--fr, 0deg));
+}
+
+.fkl {
+  top: -6px;
+  border-radius: 30px 8px 8px 30px;
+
+  --fr: -22deg;
+}
+
+.fkr {
+  top: 20px;
+  border-radius: 30px 8px 8px 30px;
+
+  --fr: 22deg;
+}
+
+.bubn {
+  position: absolute;
+  border-radius: 50%;
+  border: 2px solid rgba(220, 245, 255, 0.8);
+  background: rgba(190, 235, 255, 0.18);
+  opacity: 0;
+  z-index: 2;
+  animation: floatn 5.4s ease-in infinite;
+}
+
+.bn1 {
+  top: 130px;
+  right: 34px;
+  width: 12px;
+  height: 12px;
+}
+
+.bn2 {
+  top: 150px;
+  right: 66px;
+  width: 8px;
+  height: 8px;
+  animation-delay: 1.8s;
+}
+
+.bn3 {
+  top: 120px;
+  right: 96px;
+  width: 16px;
+  height: 16px;
+  animation-delay: 3.6s;
+}
+
+@keyframes swimn {
+  0%, 100% { transform: translateY(0) rotate(-2deg); }
+  50% { transform: translateY(-18px) rotate(2deg); }
+}
+
+@keyframes waggle {
+  0%, 100% { transform: rotate(-12deg); }
+  50% { transform: rotate(12deg); }
+}
+
+@keyframes paddlen {
+  0%, 100% { transform: rotate(-8deg); }
+  50% { transform: rotate(10deg); }
+}
+
+@keyframes blinkn {
+  0%, 92%, 100% { transform: scaleY(1); }
+  96% { transform: scaleY(0.1); }
+}
+
+@keyframes floatn {
+  0% { transform: translateY(0) scale(0.6); opacity: 0; }
+  20% { opacity: 1; }
+  100% { transform: translateY(-140px) translateX(-20px) scale(1.1); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .narw,
+  .tailn,
+  .finn,
+  .eyen,
+  .bubn {
+    animation: none;
+  }
+
+  .bubn {
+    opacity: 0.7;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a narwhal built for #45096. The tusk is one element: a clip-path tapers a bar into a spike and a repeating gradient cuts the spiral grooves across it, so the whole horn is a single node. The tail is two flukes that keep their spread angles in a `--fr` custom property and hinge from a shared transform-origin at the tail root, while the waggle runs on their wrapper, so the flukes keep their V shape instead of being flattened by the animation. Reduced motion fallback included. Pure CSS. Closes #45096.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a narwhal with a pale belly, speckled back, a grooved spiral tusk, a paddling flipper and a V shaped tail, swimming under an ice sheet with light rays and bubbles.
